### PR TITLE
[ Navigation Screen ] adds notifications base system

### DIFF
--- a/packages/edit-navigation/src/components/layout/index.js
+++ b/packages/edit-navigation/src/components/layout/index.js
@@ -13,6 +13,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import Notices from '../notices';
 import MenusEditor from '../menus-editor';
 import MenuLocationsEditor from '../menu-locations-editor';
 
@@ -22,7 +23,7 @@ export default function Layout( { blockEditorSettings } ) {
 			<SlotFillProvider>
 				<DropZoneProvider>
 					<FocusReturnProvider>
-						{ /* <Notices /> */ }
+						<Notices />
 						<TabPanel
 							className="edit-navigation-layout__tab-panel"
 							tabs={ [

--- a/packages/edit-navigation/src/components/menu-editor/use-navigation-blocks.js
+++ b/packages/edit-navigation/src/components/menu-editor/use-navigation-blocks.js
@@ -9,6 +9,7 @@ import { groupBy, isEqual, difference } from 'lodash';
 import { createBlock } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useState, useRef, useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 function createBlockFromMenuItem( menuItem, innerBlocks = [] ) {
 	return createBlock(
@@ -37,7 +38,7 @@ export default function useNavigationBlocks( menuId ) {
 	);
 
 	const { saveMenuItem } = useDispatch( 'core' );
-
+	const { createSuccessNotice } = useDispatch( 'core/notices' );
 	const [ blocks, setBlocks ] = useState( [] );
 
 	const menuItemsRef = useRef( {} );
@@ -53,6 +54,9 @@ export default function useNavigationBlocks( menuId ) {
 
 		const createMenuItemBlocks = ( items ) => {
 			const innerBlocks = [];
+			if ( ! items ) {
+				return;
+			}
 			for ( const item of items ) {
 				let menuItemInnerBlocks = [];
 				if ( itemsByParentID[ item.id ]?.length ) {
@@ -128,6 +132,10 @@ export default function useNavigationBlocks( menuId ) {
 		for ( const deletedClientId of deletedClientIds ) {
 			// TODO - delete menu items.
 		}
+
+		createSuccessNotice( __( 'Navigation saved.' ), {
+			type: 'snackbar',
+		} );
 	};
 
 	return [ blocks, setBlocks, saveBlocks ];

--- a/packages/edit-navigation/src/components/notices/index.js
+++ b/packages/edit-navigation/src/components/notices/index.js
@@ -1,0 +1,23 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+import { SnackbarList } from '@wordpress/components';
+
+export default function Notices() {
+	const notices = useSelect(
+		( select ) =>
+			select( 'core/notices' )
+				.getNotices()
+				.filter( ( notice ) => notice.type === 'snackbar' ),
+		[]
+	);
+	const { removeNotice } = useDispatch( 'core/notices' );
+	return (
+		<SnackbarList
+			className="edit-navigation-notices"
+			notices={ notices }
+			onRemove={ removeNotice }
+		/>
+	);
+}

--- a/packages/edit-navigation/src/components/notices/style.scss
+++ b/packages/edit-navigation/src/components/notices/style.scss
@@ -1,0 +1,4 @@
+.components-snackbar-list.edit-navigation-notices {
+	position: fixed;
+	bottom: 20px;
+}

--- a/packages/edit-navigation/src/index.js
+++ b/packages/edit-navigation/src/index.js
@@ -6,6 +6,7 @@ import { map } from 'lodash';
 /**
  * WordPress dependencies
  */
+import '@wordpress/notices';
 import {
 	registerCoreBlocks,
 	__experimentalRegisterExperimentalCoreBlocks,

--- a/packages/edit-navigation/src/style.scss
+++ b/packages/edit-navigation/src/style.scss
@@ -2,3 +2,4 @@
 @import "./components/menu-editor/style.scss";
 @import "./components/menus-editor/style.scss";
 @import "./components/delete-menu-button/style.scss";
+@import "./components/notices/style.scss";


### PR DESCRIPTION
Advances #21344

## Description
Adds the base needed to enable notifications on the navigation screen.

## How has this been tested?
I added a sample notification for saving menus.

## Screenshots <!-- if applicable -->

<img width="1067" alt="Screenshot 2020-05-13 at 20 00 17" src="https://user-images.githubusercontent.com/107534/81842258-62775280-9554-11ea-90a2-22d397d6447b.png">


## Types of changes
Non breaking changes. 
Also fixes a bug in master with empty menus, apparently brought by #21671 
