### PR TITLE
API Fetch: Remove deprecated useApiFetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9732,8 +9732,6 @@
 			"version": "file:packages/api-fetch",
 			"requires": {
 				"@babel/runtime": "^7.9.2",
-				"@wordpress/deprecated": "file:packages/deprecated",
-				"@wordpress/element": "file:packages/element",
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/url": "file:packages/url"
 			}

--- a/packages/api-fetch/package.json
+++ b/packages/api-fetch/package.json
@@ -23,8 +23,6 @@
 	"react-native": "src/index",
 	"dependencies": {
 		"@babel/runtime": "^7.9.2",
-		"@wordpress/deprecated": "file:../deprecated",
-		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/url": "file:../url"
 	},

--- a/packages/api-fetch/src/index.js
+++ b/packages/api-fetch/src/index.js
@@ -2,8 +2,6 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useEffect, useState } from '@wordpress/element';
-import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -158,48 +156,6 @@ function apiFetch( options ) {
 	} );
 }
 
-/**
- * Function that fetches data using apiFetch, and updates the status.
- *
- * @param {string} path Query path.
- */
-function useApiFetch( path ) {
-	deprecated( 'useApiFetch', {
-		version: '8.1.0',
-		alternative: 'apiFetch',
-		plugin: 'Gutenberg',
-	} );
-
-	// Indicate the fetching status
-	const [ isLoading, setIsLoading ] = useState( true );
-	const [ data, setData ] = useState( null );
-	const [ error, setError ] = useState( null );
-
-	useEffect( () => {
-		setIsLoading( true );
-		setData( null );
-		setError( null );
-
-		apiFetch( { path } )
-			.then( ( fetchedData ) => {
-				setData( fetchedData );
-				// We've stopped fetching
-				setIsLoading( false );
-			} )
-			.catch( ( err ) => {
-				setError( err );
-				// We've stopped fetching
-				setIsLoading( false );
-			} );
-	}, [ path ] );
-
-	return {
-		isLoading,
-		data,
-		error,
-	};
-}
-
 apiFetch.use = registerMiddleware;
 apiFetch.setFetchHandler = setFetchHandler;
 
@@ -208,7 +164,5 @@ apiFetch.createPreloadingMiddleware = createPreloadingMiddleware;
 apiFetch.createRootURLMiddleware = createRootURLMiddleware;
 apiFetch.fetchAllMiddleware = fetchAllMiddleware;
 apiFetch.mediaUploadMiddleware = mediaUploadMiddleware;
-
-apiFetch.useApiFetch = useApiFetch;
 
 export default apiFetch;


### PR DESCRIPTION
This pull request seeks to remove a function which had been deprecated and scheduled for removal as part of Gutenberg 8.1. It is currently causing lint errors on the `master` branch:

```
/Users/andrew/Documents/Code/gutenberg/packages/api-fetch/src/index.js
  168:3  error  Deprecated functions must be removed before releasing this version  no-restricted-syntax
```

**Testing Instructions:**

Verify there are no regressions in the operation of the editor. There should be no references to `useApiFetch` in code. It was previously used in the Navigation block and reverted as part of #21721.