### PR TITLE
Lib: Make WP_Block->available_context public.

### DIFF
--- a/lib/class-wp-block.php
+++ b/lib/class-wp-block.php
@@ -46,7 +46,7 @@ class WP_Block {
 	 * @var array
 	 * @access protected
 	 */
-	protected $available_context;
+	public $available_context;
 
 	/**
 	 * List of inner blocks (of this same class)


### PR DESCRIPTION
See https://github.com/WordPress/gutenberg/pull/22199#discussion_r423707686.