### PR TITLE
Rename a complementary area component property

### DIFF
--- a/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
+++ b/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
@@ -36,7 +36,7 @@ const SettingsSidebar = () => {
 	}
 	return (
 		<PluginSidebarEditPost
-			complementaryAreaIdentifier={ sidebarName }
+			identifier={ sidebarName }
 			header={ <SettingsHeader sidebarName={ sidebarName } /> }
 			closeLabel={ __( 'Close settings' ) }
 			headerClassName="edit-post-sidebar__panel-tabs"

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -15,7 +15,7 @@ function Sidebar() {
 			<ComplementaryArea.Slot scope="core/edit-site" />
 			<ComplementaryArea
 				scope="core/edit-site"
-				complementaryAreaIdentifier="edit-site/block-inspector"
+				identifier="edit-site/block-inspector"
 				title={ __( 'Block Inspector' ) }
 				icon={ cog }
 			>
@@ -23,7 +23,7 @@ function Sidebar() {
 			</ComplementaryArea>
 			<ComplementaryArea
 				scope="core/edit-site"
-				complementaryAreaIdentifier="edit-site/global-styles"
+				identifier="edit-site/global-styles"
 				title={ __( 'Global Styles' ) }
 				icon={ pencil }
 			>

--- a/packages/interface/src/components/complementary-area/README.md
+++ b/packages/interface/src/components/complementary-area/README.md
@@ -25,7 +25,7 @@ Label of the button that allows to close the complementary area.
 - Required: No
 - Default: "Close plugin"
 
-### complementaryAreaIdentifier
+### identifier
 
 Identifier of the complementary area. The string is saved on the store and allows to identify which of the sidebars is active.
 
@@ -57,7 +57,7 @@ The icon to render.
 
 ### name
 
-Name of the complementary area. The name of the complementarity area is concatenated with the name of the plugin to form the identifier of the complementary area. The name of the plugin is extracted from the plugin context where the sidebar is rendered. If there is no plugin context available or there is a need to specify a custom identifier, please use the `complementaryAreaIdentifier` property instead.
+Name of the complementary area. The name of the complementarity area is concatenated with the name of the plugin to form the identifier of the complementary area. The name of the plugin is extracted from the plugin context where the sidebar is rendered. If there is no plugin context available or there is a need to specify a custom identifier, please use the `identifier` property instead.
 
 - Type: `String`
 - Required: No

--- a/packages/interface/src/components/complementary-area/index.js
+++ b/packages/interface/src/components/complementary-area/index.js
@@ -36,7 +36,7 @@ function ComplementaryArea( {
 	children,
 	className,
 	closeLabel = __( 'Close plugin' ),
-	complementaryAreaIdentifier,
+	identifier,
 	header,
 	headerClassName,
 	icon,
@@ -53,13 +53,11 @@ function ComplementaryArea( {
 				'core/interface'
 			);
 			return {
-				isActive:
-					getActiveComplementaryArea( scope ) ===
-					complementaryAreaIdentifier,
-				isPinned: isItemPinned( scope, complementaryAreaIdentifier ),
+				isActive: getActiveComplementaryArea( scope ) === identifier,
+				isPinned: isItemPinned( scope, identifier ),
 			};
 		},
-		[ complementaryAreaIdentifier, scope ]
+		[ identifier, scope ]
 	);
 	const { enableComplementaryArea, disableComplementaryArea } = useDispatch(
 		'core/interface'
@@ -75,10 +73,7 @@ function ComplementaryArea( {
 						onClick={ () =>
 							isActive
 								? disableComplementaryArea( scope )
-								: enableComplementaryArea(
-										scope,
-										complementaryAreaIdentifier
-								  )
+								: enableComplementaryArea( scope, identifier )
 						}
 						isPressed={ isActive }
 						aria-expanded={ isActive }
@@ -117,7 +112,7 @@ function ComplementaryArea( {
 										onClick={ () =>
 											( isPinned ? unpinItem : pinItem )(
 												scope,
-												complementaryAreaIdentifier
+												identifier
 											)
 										}
 										isPressed={ isPinned }
@@ -137,9 +132,8 @@ function ComplementaryArea( {
 const ComplementaryAreaWrapped = withPluginContext( ( context, ownProps ) => {
 	return {
 		icon: ownProps.icon || context.icon,
-		complementaryAreaIdentifier:
-			ownProps.complementaryAreaIdentifier ||
-			`${ context.name }/${ ownProps.name }`,
+		identifier:
+			ownProps.identifier || `${ context.name }/${ ownProps.name }`,
 	};
 } )( ComplementaryArea );
 


### PR DESCRIPTION
## Description
This PR renames property complementaryAreaIdentifier to identifier following a suggestion from @gziolo.
