### PR TITLE
Fix deprecated version for register_pattern

### DIFF
--- a/lib/class-wp-block-patterns-registry.php
+++ b/lib/class-wp-block-patterns-registry.php
@@ -164,7 +164,7 @@ class WP_Patterns_Registry {
  * @return boolean True if the pattern was registered with success and false otherwise.
  */
 function register_pattern( $pattern_name, $pattern_properties ) {
-	_deprecated_function( __FUNCTION__, 'Gutenberg 8.3.0', 'register_block_pattern()' );
+	_deprecated_function( __FUNCTION__, 'Gutenberg 8.1.0', 'register_block_pattern()' );
 	return register_block_pattern( $pattern_name, $pattern_properties );
 }
 


### PR DESCRIPTION
## Description
As per https://github.com/WordPress/gutenberg/pull/21970#discussion_r420965307 and https://github.com/WordPress/gutenberg/pull/22177, the version number here should be 8.1.

This is a very small PR to update that.