### PR TITLE
Fix the crash in nav screen because of no items

### DIFF
--- a/packages/edit-navigation/src/components/menu-editor/use-navigation-blocks.js
+++ b/packages/edit-navigation/src/components/menu-editor/use-navigation-blocks.js
@@ -53,6 +53,9 @@ export default function useNavigationBlocks( menuId ) {
 
 		const createMenuItemBlocks = ( items ) => {
 			const innerBlocks = [];
+			if ( ! items ) {
+				return;
+			}
 			for ( const item of items ) {
 				let menuItemInnerBlocks = [];
 				if ( itemsByParentID[ item.id ]?.length ) {


### PR DESCRIPTION
## Description
Fixes a crash on the navigation screen page when a navigation does not have any menu items.

## How has this been tested?
Tested locally.

## Types of changes
Non breaking changes, simply bail early if there are no items.
