### PR TITLE
Moves the menus state higher in the component tree

### DIFF
--- a/packages/edit-navigation/src/components/layout/index.js
+++ b/packages/edit-navigation/src/components/layout/index.js
@@ -15,8 +15,11 @@ import { __ } from '@wordpress/i18n';
  */
 import MenusEditor from '../menus-editor';
 import MenuLocationsEditor from '../menu-locations-editor';
+import useMenus from './use-menus.js';
 
 export default function Layout( { blockEditorSettings } ) {
+	const [ menus, setMenus, currentMenu, setCurrentMenu ] = useMenus();
+
 	return (
 		<>
 			<SlotFillProvider>
@@ -43,10 +46,14 @@ export default function Layout( { blockEditorSettings } ) {
 											blockEditorSettings={
 												blockEditorSettings
 											}
+											menus={ menus }
+											setMenus={ setMenus }
+											currentMenu={ currentMenu }
+											setCurrentMenu={ setCurrentMenu }
 										/>
 									) }
 									{ tab.name === 'menu-locations' && (
-										<MenuLocationsEditor />
+										<MenuLocationsEditor menus={ menus } />
 									) }
 								</>
 							) }

--- a/packages/edit-navigation/src/components/layout/use-menus.js
+++ b/packages/edit-navigation/src/components/layout/use-menus.js
@@ -1,0 +1,21 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { useState, useEffect } from '@wordpress/element';
+
+export default function useMenus() {
+	const wpMenus = useSelect( ( select ) => select( 'core' ).getMenus() );
+
+	const [ currentMenu, setCurrentMenu ] = useState( 0 );
+	const [ menus, setMenus ] = useState( null );
+
+	useEffect( () => {
+		if ( wpMenus?.length ) {
+			setMenus( wpMenus );
+			setCurrentMenu( wpMenus[ 0 ].id );
+		}
+	}, [ wpMenus ] );
+
+	return [ menus, setMenus, currentMenu, setCurrentMenu ];
+}

--- a/packages/edit-navigation/src/components/menu-locations-editor/index.js
+++ b/packages/edit-navigation/src/components/menu-locations-editor/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
 import {
 	SelectControl,
 	Button,
@@ -16,9 +15,7 @@ import { __ } from '@wordpress/i18n';
  */
 import useMenuLocations from './use-menu-locations';
 
-export default function MenuLocationsEditor() {
-	const menus = useSelect( ( select ) => select( 'core' ).getMenus() );
-
+export default function MenuLocationsEditor( { menus } ) {
 	const [
 		menuLocations,
 		saveMenuLocations,

--- a/packages/edit-navigation/src/components/menus-editor/index.js
+++ b/packages/edit-navigation/src/components/menus-editor/index.js
@@ -1,8 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
-import { useState, useEffect } from '@wordpress/element';
 import { Card, CardBody, Spinner, SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
@@ -11,20 +9,14 @@ import { __ } from '@wordpress/i18n';
  */
 import MenuEditor from '../menu-editor';
 
-export default function MenusEditor( { blockEditorSettings } ) {
-	const menus = useSelect( ( select ) => select( 'core' ).getMenus() );
-
-	const [ menuId, setMenuId ] = useState( 0 );
-	const [ stateMenus, setStateMenus ] = useState( null );
-
-	useEffect( () => {
-		if ( menus?.length ) {
-			setStateMenus( menus );
-			setMenuId( menus[ 0 ].id );
-		}
-	}, [ menus ] );
-
-	if ( ! stateMenus ) {
+export default function MenusEditor( {
+	blockEditorSettings,
+	menus,
+	setMenus,
+	currentMenu,
+	setCurrentMenu,
+} ) {
+	if ( ! menus ) {
 		return <Spinner />;
 	}
 
@@ -35,27 +27,27 @@ export default function MenusEditor( { blockEditorSettings } ) {
 					<SelectControl
 						className="edit-navigation-menus-editor__menu-select-control"
 						label={ __( 'Select navigation to edit:' ) }
-						options={ stateMenus.map( ( menu ) => ( {
+						options={ menus.map( ( menu ) => ( {
 							value: menu.id,
 							label: menu.name,
 						} ) ) }
 						onChange={ ( selectedMenuId ) =>
-							setMenuId( selectedMenuId )
+							setCurrentMenu( selectedMenuId )
 						}
 					/>
 				</CardBody>
 			</Card>
-			{ !! menuId && (
+			{ !! currentMenu && (
 				<MenuEditor
-					menuId={ menuId }
+					menuId={ currentMenu }
 					blockEditorSettings={ blockEditorSettings }
 					onDeleteMenu={ ( deletedMenu ) => {
-						const newStateMenus = stateMenus.filter( ( menu ) => {
+						const newStateMenus = menus.filter( ( menu ) => {
 							return menu.id !== deletedMenu;
 						} );
-						setStateMenus( newStateMenus );
+						setMenus( newStateMenus );
 						if ( newStateMenus.length ) {
-							setMenuId( newStateMenus[ 0 ].id );
+							setCurrentMenu( newStateMenus[ 0 ].id );
 						}
 					} }
 				/>


### PR DESCRIPTION
## Description
Closes #22340

## How has this been tested?
Tested locally by:

- enable the Navigation(beta) experiment
- make sure you have set a theme that supports menus
- add a few menus from Appearance -> Menus
- go to the experimental navigation screen
- delete a menu
- go to menu locations
- go back to menu editor
- check that the deleted menu is not back in the menu list (top select)

## Screenshots
![delete-persists](https://user-images.githubusercontent.com/107534/81922704-2809c600-95e5-11ea-9f44-29e5a3917d20.gif)

## Types of changes
Non breaking change. I moved the menus state in the `Layout` component. This doesn't make me happiest, as `Layout` should not handle this data. However, until we fix `core/data` to refresh properly it is a decent solution.
