### PR TITLE
Use a light block DOM for the Cover block

### DIFF
--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -92,9 +92,6 @@ const BlockComponent = forwardRef(
 		 * When a block becomes selected, transition focus to an inner tabbable.
 		 */
 		const focusTabbable = () => {
-			if ( ! wrapper.current ) {
-				return;
-			}
 			// Focus is captured by the wrapper node, so while focus transition
 			// should only consider tabbables within editable display, since it
 			// may be the wrapper itself or a side control which triggered the

--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -92,6 +92,9 @@ const BlockComponent = forwardRef(
 		 * When a block becomes selected, transition focus to an inner tabbable.
 		 */
 		const focusTabbable = () => {
+			if ( ! wrapper.current ) {
+				return;
+			}
 			// Focus is captured by the wrapper node, so while focus transition
 			// should only consider tabbables within editable display, since it
 			// may be the wrapper itself or a side control which triggered the

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -517,6 +517,7 @@ function CoverEdit( {
 					/>
 				) }
 				<InnerBlocks
+					__experimentalTagName="div"
 					__experimentalPassedProps={ {
 						className: 'wp-block-cover__inner-container',
 					} }

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -30,6 +30,7 @@ import {
 	MediaReplaceFlow,
 	withColors,
 	ColorPalette,
+	__experimentalBlock as Block,
 	__experimentalUseGradient,
 	__experimentalPanelColorGradientSettings as PanelColorGradientSettings,
 	__experimentalUnitControl as UnitControl,
@@ -227,7 +228,6 @@ function CoverEdit( {
 	attributes,
 	setAttributes,
 	isSelected,
-	className,
 	noticeUI,
 	overlayColor,
 	setOverlayColor,
@@ -418,39 +418,39 @@ function CoverEdit( {
 		return (
 			<>
 				{ controls }
-				<MediaPlaceholder
-					icon={ placeholderIcon }
-					className={ className }
-					labels={ {
-						title: label,
-						instructions: __(
-							'Upload an image or video file, or pick one from your media library.'
-						),
-					} }
-					onSelect={ onSelectMedia }
-					accept="image/*,video/*"
-					allowedTypes={ ALLOWED_MEDIA_TYPES }
-					notices={ noticeUI }
-					onError={ ( message ) => {
-						removeAllNotices();
-						createErrorNotice( message );
-					} }
-				>
-					<div className="wp-block-cover__placeholder-background-options">
-						<ColorPalette
-							disableCustomColors={ true }
-							value={ overlayColor.color }
-							onChange={ setOverlayColor }
-							clearable={ false }
-						/>
-					</div>
-				</MediaPlaceholder>
+				<Block.div className="is-placeholder">
+					<MediaPlaceholder
+						icon={ placeholderIcon }
+						labels={ {
+							title: label,
+							instructions: __(
+								'Upload an image or video file, or pick one from your media library.'
+							),
+						} }
+						onSelect={ onSelectMedia }
+						accept="image/*,video/*"
+						allowedTypes={ ALLOWED_MEDIA_TYPES }
+						notices={ noticeUI }
+						onError={ ( message ) => {
+							removeAllNotices();
+							createErrorNotice( message );
+						} }
+					>
+						<div className="wp-block-cover__placeholder-background-options">
+							<ColorPalette
+								disableCustomColors={ true }
+								value={ overlayColor.color }
+								onChange={ setOverlayColor }
+								clearable={ false }
+							/>
+						</div>
+					</MediaPlaceholder>
+				</Block.div>
 			</>
 		);
 	}
 
 	const classes = classnames(
-		className,
 		dimRatioToClass( dimRatio ),
 		{
 			'is-dark-theme': isDark,
@@ -469,58 +469,60 @@ function CoverEdit( {
 	return (
 		<>
 			{ controls }
-			<ResizableCover
-				showHandle={ isSelected }
-				className="block-library-cover__resize-container"
-				onResizeStart={ () => {
-					setAttributes( { minHeightUnit: 'px' } );
-					toggleSelection( false );
-				} }
-				onResize={ setTemporaryMinHeight }
-				onResizeStop={ ( newMinHeight ) => {
-					toggleSelection( true );
-					setAttributes( { minHeight: newMinHeight } );
-					setTemporaryMinHeight( null );
-				} }
-			>
-				<div data-url={ url } style={ style } className={ classes }>
-					{ IMAGE_BACKGROUND_TYPE === backgroundType && (
-						// Used only to programmatically check if the image is dark or not
-						<img
-							ref={ isDarkElement }
-							aria-hidden
-							alt=""
-							style={ {
-								display: 'none',
-							} }
-							src={ url }
-						/>
-					) }
-					{ url && gradientValue && dimRatio !== 0 && (
-						<span
-							aria-hidden="true"
-							className={ classnames(
-								'wp-block-cover__gradient-background',
-								gradientClass
-							) }
-							style={ { background: gradientValue } }
-						/>
-					) }
-					{ VIDEO_BACKGROUND_TYPE === backgroundType && (
-						<video
-							ref={ isDarkElement }
-							className="wp-block-cover__video-background"
-							autoPlay
-							muted
-							loop
-							src={ url }
-						/>
-					) }
-					<div className="wp-block-cover__inner-container">
-						<InnerBlocks template={ INNER_BLOCKS_TEMPLATE } />
-					</div>
-				</div>
-			</ResizableCover>
+			<Block.div className={ classes } data-url={ url } style={ style }>
+				<ResizableCover
+					className="block-library-cover__resize-container"
+					onResizeStart={ () => {
+						setAttributes( { minHeightUnit: 'px' } );
+						toggleSelection( false );
+					} }
+					onResize={ setTemporaryMinHeight }
+					onResizeStop={ ( newMinHeight ) => {
+						toggleSelection( true );
+						setAttributes( { minHeight: newMinHeight } );
+						setTemporaryMinHeight( null );
+					} }
+					showHandle={ isSelected }
+				/>
+				{ IMAGE_BACKGROUND_TYPE === backgroundType && (
+					// Used only to programmatically check if the image is dark or not
+					<img
+						ref={ isDarkElement }
+						aria-hidden
+						alt=""
+						style={ {
+							display: 'none',
+						} }
+						src={ url }
+					/>
+				) }
+				{ url && gradientValue && dimRatio !== 0 && (
+					<span
+						aria-hidden="true"
+						className={ classnames(
+							'wp-block-cover__gradient-background',
+							gradientClass
+						) }
+						style={ { background: gradientValue } }
+					/>
+				) }
+				{ VIDEO_BACKGROUND_TYPE === backgroundType && (
+					<video
+						ref={ isDarkElement }
+						className="wp-block-cover__video-background"
+						autoPlay
+						muted
+						loop
+						src={ url }
+					/>
+				) }
+				<InnerBlocks
+					__experimentalPassedProps={ {
+						className: 'wp-block-cover__inner-container',
+					} }
+					template={ INNER_BLOCKS_TEMPLATE }
+				/>
+			</Block.div>
 		</>
 	);
 }

--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -20,9 +20,6 @@
 	.wp-block-cover__inner-container {
 		// Avoid text align inherit from cover image align.
 		text-align: left;
-	}
-
-	.wp-block-cover__inner-container > .block-editor-inner-blocks > .block-editor-block-list__layout {
 		margin-left: 0;
 		margin-right: 0;
 	}

--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -1,5 +1,13 @@
-.wp-block-cover-image,
 .wp-block-cover {
+	position: relative;
+
+	// Override default cover styles
+	// because we're not ready yet to show the cover block.
+	&.is-placeholder {
+		min-height: auto !important;
+		padding: 0 !important;
+	}
+
 	&.components-placeholder h2 {
 		color: inherit;
 	}
@@ -25,15 +33,21 @@
 }
 
 [data-align="left"] > .wp-block-cover,
-[data-align="right"] > .wp-block-cover,
-[data-align="left"] > .wp-block-cover-image,
-[data-align="right"] > .wp-block-cover-image {
+[data-align="right"] > .wp-block-cover {
 	max-width: $content-width / 2;
 	width: 100%;
 }
 
 .block-library-cover__reset-button {
 	margin-left: auto;
+}
+
+.block-library-cover__resize-container {
+	position: absolute !important;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
 }
 
 .block-library-cover__resize-container:not(.is-resizing) {

--- a/packages/block-library/src/cover/index.js
+++ b/packages/block-library/src/cover/index.js
@@ -26,6 +26,7 @@ export const settings = {
 	supports: {
 		align: true,
 		html: false,
+		lightBlockWrapper: true,
 	},
 	example: {
 		attributes: {

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -9,7 +9,6 @@
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	overflow: hidden;
 	padding: $grid-unit-20;
 
 	&.has-parallax {


### PR DESCRIPTION
 - This allows us to match the frontend making it easier for themes to style the Cover in the editor.
 - it simplifies the implementation of Block Tools like padding #21492 

**Testing instructions**

 - Check that the cover works as expected
 - Resizing works
 - Video background work
 - Alignment work
