### PR TITLE
Use alternate display for the popover in alignment matrix.

### DIFF
--- a/packages/components/src/dropdown/index.js
+++ b/packages/components/src/dropdown/index.js
@@ -103,6 +103,7 @@ class Dropdown extends Component {
 						expandOnMobile={ expandOnMobile }
 						headerTitle={ headerTitle }
 						focusOnMount={ focusOnMount }
+						isAlternate
 						{ ...popoverProps }
 						className={ classnames(
 							'components-dropdown__content',


### PR DESCRIPTION
Updates the border to be consistent with the toolbar design:

![image](https://user-images.githubusercontent.com/548849/81934872-fc400d80-95ef-11ea-84d1-00ac9fffeec2.png)
