### PR TITLE
Block Editor: Add BlockContext component to type-checking

### DIFF
--- a/packages/block-editor/tsconfig.json
+++ b/packages/block-editor/tsconfig.json
@@ -4,6 +4,9 @@
 		"rootDir": "src",
 		"declarationDir": "build-types"
 	},
+	"references": [
+		{ "path": "../element" }
+	],
 	// NOTE: This package is being progressively typed. You are encouraged to
 	// expand this array with files which can be type-checked. At some point in
 	// the future, this can be simplified to an `includes` of `src/**/*`.

--- a/packages/block-editor/tsconfig.json
+++ b/packages/block-editor/tsconfig.json
@@ -8,6 +8,7 @@
 	// expand this array with files which can be type-checked. At some point in
 	// the future, this can be simplified to an `includes` of `src/**/*`.
 	"files": [
+		"src/components/block-context/index.js",
 		"src/utils/dom.js"
 	]
 }


### PR DESCRIPTION
Closes #21666

This pull request seeks to opt in the BlockContext component (introduced in #21467) to be type-checked. It was previously planned for #21467 but removed due to blocking incompatibilities of #21767. These incompatibilities have since been resolved in #21781, so the type-checking can once again be enabled.

**Testing Instructions:**

Ensure type checking passes:

```
npm run build:package-types
```