### PR TITLE
More accurate dependency list for useGenericPreviewBlock hook

### DIFF
--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -77,7 +77,7 @@ const useGenericPreviewBlock = ( block, type ) =>
 						innerBlocks: type.example.innerBlocks,
 				  } )
 				: cloneBlock( block ),
-		[ block, type ]
+		[ type.example ? block.name : block, type ]
 	);
 
 function BlockStyles( { clientId, onSwitch = noop, onHoverClassName = noop } ) {


### PR DESCRIPTION
## Description

This is a follow up to https://github.com/WordPress/gutenberg/pull/21993 where the dependencies list was slightly off. Namely, `useMemo()` is always recomputed when the `block` argument changes, even if we only use `block.name`. This PR fixes that. 

## How has this been tested?
Tested locally with the same test plan as in #21973

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
