### PR TITLE
POC: Hide UI elements not needed to edit only a single block

### DIFF
--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -25,6 +25,7 @@ function HeaderToolbar( { onToggleInserter, isInserterOpen } ) {
 		isInserterVisible,
 		isTextModeEnabled,
 		previewDeviceType,
+		isSingleBlockMode,
 	} = useSelect(
 		( select ) => ( {
 			hasFixedToolbar: select( 'core/edit-post' ).isFeatureActive(
@@ -40,6 +41,9 @@ function HeaderToolbar( { onToggleInserter, isInserterOpen } ) {
 			previewDeviceType: select(
 				'core/edit-post'
 			).__experimentalGetPreviewDeviceType(),
+			isSingleBlockMode: select( 'core/edit-post' ).isFeatureActive(
+				'singleBlockMode'
+			),
 		} ),
 		[]
 	);
@@ -53,6 +57,19 @@ function HeaderToolbar( { onToggleInserter, isInserterOpen } ) {
 		  __( 'Document and block tools' )
 		: /* translators: accessibility text for the editor toolbar when Top Toolbar is off */
 		  __( 'Document tools' );
+
+	if ( isSingleBlockMode ) {
+		return (
+			<NavigableToolbar
+				className="edit-post-header-toolbar"
+				aria-label={ toolbarAriaLabel }
+			>
+				<div className="edit-post-header-toolbar__block-toolbar edit-post-header-toolbar__block-toolbar_single-block-mode">
+					<BlockToolbar hideDragHandle />
+				</div>
+			</NavigableToolbar>
+		);
+	}
 
 	return (
 		<NavigableToolbar

--- a/packages/edit-post/src/components/header/header-toolbar/style.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.scss
@@ -82,6 +82,11 @@
 	}
 }
 
+// Block toolbar when fixed to the top of the screen.
+.edit-post-header-toolbar__block-toolbar_single-block-mode {
+	top: 0 !important;
+}
+
 .edit-post-header-toolbar .edit-post-header-toolbar__inserter-toggle {
 	margin-right: $grid-unit-10;
 	// Special dimensions for this button.

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -29,6 +29,7 @@ function Header( {
 		isPublishSidebarOpened,
 		isSaving,
 		getBlockSelectionStart,
+		isSingleBlockMode,
 	} = useSelect(
 		( select ) => ( {
 			shortcut: select(
@@ -48,6 +49,9 @@ function Header( {
 			deviceType: select(
 				'core/edit-post'
 			).__experimentalGetPreviewDeviceType(),
+			isSingleBlockMode: select( 'core/edit-post' ).isFeatureActive(
+				'singleBlockMode'
+			),
 		} ),
 		[]
 	);
@@ -63,6 +67,17 @@ function Header( {
 						? 'edit-post/block'
 						: 'edit-post/document'
 				);
+
+	if ( isSingleBlockMode ) {
+		return (
+			<div className="edit-post-header__toolbar">
+				<HeaderToolbar
+					onToggleInserter={ onToggleInserter }
+					isInserterOpen={ isInserterOpen }
+				/>
+			</div>
+		);
+	}
 
 	return (
 		<div className="edit-post-header">

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -50,6 +50,7 @@ import SettingsSidebar from '../sidebar/settings-sidebar';
 import MetaBoxes from '../meta-boxes';
 import WelcomeGuide from '../welcome-guide';
 import ActionsPanel from './actions-panel';
+import SingleBlockModeLayout from './single-block-mode';
 
 const interfaceLabels = {
 	leftSidebar: __( 'Block Library' ),
@@ -74,6 +75,7 @@ function Layout() {
 		previousShortcut,
 		nextShortcut,
 		hasBlockSelected,
+		isSingleBlockMode,
 	} = useSelect( ( select ) => {
 		return {
 			hasFixedToolbar: select( 'core/edit-post' ).isFeatureActive(
@@ -103,6 +105,9 @@ function Layout() {
 			nextShortcut: select(
 				'core/keyboard-shortcuts'
 			).getAllShortcutRawKeyCombinations( 'core/edit-post/next-region' ),
+			isSingleBlockMode: select( 'core/edit-post' ).isFeatureActive(
+				'singleBlockMode'
+			),
 		};
 	}, [] );
 	const sidebarIsOpened =
@@ -144,6 +149,10 @@ function Layout() {
 		},
 		[ entitiesSavedStatesCallback ]
 	);
+
+	if ( isSingleBlockMode ) {
+		return <SingleBlockModeLayout />;
+	}
 
 	return (
 		<>

--- a/packages/edit-post/src/components/layout/single-block-mode.js
+++ b/packages/edit-post/src/components/layout/single-block-mode.js
@@ -1,0 +1,163 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	LocalAutosaveMonitor,
+	EditorKeyboardShortcutsRegister,
+} from '@wordpress/editor';
+import { useSelect } from '@wordpress/data';
+import {
+	ScrollLock,
+	Popover,
+	FocusReturnProvider,
+} from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
+import {
+	ComplementaryArea,
+	FullscreenMode,
+	InterfaceSkeleton,
+} from '@wordpress/interface';
+import { useState, useCallback } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import VisualEditor from '../visual-editor';
+import EditPostKeyboardShortcuts from '../keyboard-shortcuts';
+import BrowserURL from '../browser-url';
+import Header from '../header';
+import SettingsSidebar from '../sidebar/settings-sidebar';
+import ActionsPanel from './actions-panel';
+
+const interfaceLabels = {
+	leftSidebar: __( 'Block Library' ),
+};
+
+function Layout() {
+	const isMobileViewport = useViewportMatch( 'medium', '<' );
+
+	const {
+		mode,
+		editorSidebarOpened,
+		pluginSidebarOpened,
+		publishSidebarOpened,
+		hasActiveMetaboxes,
+		hasFixedToolbar,
+		previousShortcut,
+		nextShortcut,
+	} = useSelect( ( select ) => {
+		return {
+			hasFixedToolbar: select( 'core/edit-post' ).isFeatureActive(
+				'fixedToolbar'
+			),
+			editorSidebarOpened: select(
+				'core/edit-post'
+			).isEditorSidebarOpened(),
+			pluginSidebarOpened: select(
+				'core/edit-post'
+			).isPluginSidebarOpened(),
+			publishSidebarOpened: select(
+				'core/edit-post'
+			).isPublishSidebarOpened(),
+			mode: select( 'core/edit-post' ).getEditorMode(),
+			hasActiveMetaboxes: select( 'core/edit-post' ).hasMetaBoxes(),
+			previousShortcut: select(
+				'core/keyboard-shortcuts'
+			).getAllShortcutRawKeyCombinations(
+				'core/edit-post/previous-region'
+			),
+			nextShortcut: select(
+				'core/keyboard-shortcuts'
+			).getAllShortcutRawKeyCombinations( 'core/edit-post/next-region' ),
+		};
+	}, [] );
+	const sidebarIsOpened =
+		editorSidebarOpened || pluginSidebarOpened || publishSidebarOpened;
+	const className = classnames( 'edit-post-layout', 'is-mode-' + mode, {
+		'is-sidebar-opened': sidebarIsOpened,
+		'has-fixed-toolbar': hasFixedToolbar,
+		'has-metaboxes': hasActiveMetaboxes,
+	} );
+
+	// Local state for save panel.
+	// Note 'thruthy' callback implies an open panel.
+	const [
+		entitiesSavedStatesCallback,
+		setEntitiesSavedStatesCallback,
+	] = useState( false );
+	const closeEntitiesSavedStates = useCallback(
+		( arg ) => {
+			if ( typeof entitiesSavedStatesCallback === 'function' ) {
+				entitiesSavedStatesCallback( arg );
+			}
+			setEntitiesSavedStatesCallback( false );
+		},
+		[ entitiesSavedStatesCallback ]
+	);
+
+	return (
+		<>
+			<FullscreenMode isActive={ true } />
+			<BrowserURL />
+			<LocalAutosaveMonitor />
+			<EditPostKeyboardShortcuts />
+			<EditorKeyboardShortcutsRegister />
+			<FocusReturnProvider>
+				<InterfaceSkeleton
+					className={ className }
+					labels={ interfaceLabels }
+					header={
+						<Header
+							isInserterOpen={ false }
+							setEntitiesSavedStatesCallback={
+								setEntitiesSavedStatesCallback
+							}
+						/>
+					}
+					sidebar={
+						sidebarIsOpened && (
+							<>
+								<SettingsSidebar />
+								<ComplementaryArea.Slot scope="core/edit-post" />
+							</>
+						)
+					}
+					content={
+						<>
+							<VisualEditor />
+							{ isMobileViewport && sidebarIsOpened && (
+								<ScrollLock />
+							) }
+						</>
+					}
+					actions={
+						<ActionsPanel
+							closeEntitiesSavedStates={
+								closeEntitiesSavedStates
+							}
+							isEntitiesSavedStatesOpen={
+								entitiesSavedStatesCallback
+							}
+							setEntitiesSavedStatesCallback={
+								setEntitiesSavedStatesCallback
+							}
+						/>
+					}
+					shortcuts={ {
+						previous: previousShortcut,
+						next: nextShortcut,
+					} }
+				/>
+				<Popover.Slot />
+			</FocusReturnProvider>
+		</>
+	);
+}
+
+export default Layout;


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

This PR tries to solve the issue specified in this ticket: https://github.com/WordPress/gutenberg/issues/21874

By adding a feature flag via LocalStorage, we can hide some elements of the UI that are not wanted to edit a single block.

On this first example, I have only removed the Header Toolbar, pinging the Block Toolbar at the top. There are other elements that will need to be removed too:

- Post Title.
- Default Block Appender.
- Document settings panel.
- Some options from the block toolbar "more options" `...` dropdown panel.

**Note:** I don't really like how this looks. It seems quite disruptive. I'm still showing it on this PR to know if there are other better options to achieve the same result.

I thought about having a different entry-point alt together, with a package `edit-block` (homologue to `edit-post` or `edit-site`), but not sure how to make it work without modifications on core to call it.

## How has this been tested?
- Run the local environment.
- Set a new feature flag `"singleBlockMode": true` to `core/edit-post: feature:`
- Set Chrome (or the current browser) to display as mobile.
- Check that the PostHeader is not there, and the block-toolbar is at the top.

## Screenshots <!-- if applicable -->

![Screenshot 2020-05-14 at 14 36 58](https://user-images.githubusercontent.com/9772967/81951520-88a8fb00-9605-11ea-8464-95981fbfbeec.png)

cc @hypest @youknowriad 

<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
