### PR TITLE
Block Library: Post Author: Refactor edit to use block context

### DIFF
--- a/packages/block-library/src/post-author/block.json
+++ b/packages/block-library/src/post-author/block.json
@@ -30,5 +30,5 @@
 			"type": "string"
 		}
 	},
-	"context": [ "postId" ]
+	"context": [ "postType", "postId" ]
 }

--- a/packages/block-library/src/post-author/edit.js
+++ b/packages/block-library/src/post-author/edit.js
@@ -34,20 +34,25 @@ function PostAuthorEdit( {
 } ) {
 	const { postType, postId } = context;
 
-	const { authorId, authorDetails, authors } = useSelect( ( select ) => {
-		const { getEditedEntityRecord, getUser, getAuthors } = select( 'core' );
-		const _authorId = getEditedEntityRecord(
-			'postType',
-			postType,
-			postId
-		)?.author;
+	const { authorId, authorDetails, authors } = useSelect(
+		( select ) => {
+			const { getEditedEntityRecord, getUser, getAuthors } = select(
+				'core'
+			);
+			const _authorId = getEditedEntityRecord(
+				'postType',
+				postType,
+				postId
+			)?.author;
 
-		return {
-			authorId: _authorId,
-			authorDetails: _authorId ? getUser( _authorId ) : null,
-			authors: getAuthors(),
-		};
-	} );
+			return {
+				authorId: _authorId,
+				authorDetails: _authorId ? getUser( _authorId ) : null,
+				authors: getAuthors(),
+			};
+		},
+		[ postType, postId ]
+	);
 
 	const { editEntityRecord } = useDispatch( 'core' );
 

--- a/packages/block-library/src/post-author/edit.js
+++ b/packages/block-library/src/post-author/edit.js
@@ -36,11 +36,11 @@ function PostAuthorEdit( {
 
 	const { authorId, authorDetails, authors } = useSelect( ( select ) => {
 		const { getEditedEntityRecord, getUser, getAuthors } = select( 'core' );
-		const { author: _authorId } = getEditedEntityRecord(
+		const _authorId = getEditedEntityRecord(
 			'postType',
 			postType,
 			postId
-		);
+		)?.author;
 
 		return {
 			authorId: _authorId,

--- a/packages/block-library/src/post-author/edit.js
+++ b/packages/block-library/src/post-author/edit.js
@@ -7,9 +7,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import apiFetch from '@wordpress/api-fetch';
-import { useRef, useState } from '@wordpress/element';
-import { useEntityProp } from '@wordpress/core-data';
+import { useRef } from '@wordpress/element';
 import {
 	AlignmentToolbar,
 	BlockControls,
@@ -21,32 +19,39 @@ import {
 	withFontSizes,
 } from '@wordpress/block-editor';
 import { PanelBody, SelectControl, ToggleControl } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 const DEFAULT_AVATAR_SIZE = 24;
 
-async function getAuthorDetails( authorId, setAuthorDetails ) {
-	const authorDetails = await apiFetch( {
-		path: '/wp/v2/users/' + authorId + '?context=edit',
-	} );
-	setAuthorDetails( authorDetails );
-}
-
-function PostAuthorDisplay( {
-	postAuthor,
-	setPostAuthor,
-	authorDetails,
-	setAuthorDetails,
-	props,
+function PostAuthorEdit( {
+	isSelected,
+	fontSize,
+	setFontSize,
+	context,
+	attributes,
+	setAttributes,
 } ) {
+	const { postType, postId } = context;
+
+	const { authorId, authorDetails, authors } = useSelect( ( select ) => {
+		const { getEditedEntityRecord, getUser, getAuthors } = select( 'core' );
+		const { author: _authorId } = getEditedEntityRecord(
+			'postType',
+			postType,
+			postId
+		);
+
+		return {
+			authorId: _authorId,
+			authorDetails: _authorId ? getUser( _authorId ) : null,
+			authors: getAuthors(),
+		};
+	} );
+
+	const { editEntityRecord } = useDispatch( 'core' );
+
 	const ref = useRef();
-
-	const { authors } = useSelect( ( select ) => ( {
-		authors: select( 'core' ).getAuthors(),
-	} ) );
-
-	const { isSelected, fontSize, setFontSize } = props;
 	const {
 		TextColor,
 		BackgroundColor,
@@ -73,7 +78,7 @@ function PostAuthorDisplay( {
 		[ fontSize.size ]
 	);
 
-	const { align, showAvatar, showBio, byline } = props.attributes;
+	const { align, showAvatar, showBio, byline } = attributes;
 
 	const avatarSizes = [];
 	if ( authorDetails ) {
@@ -86,8 +91,8 @@ function PostAuthorDisplay( {
 	}
 
 	let avatarSize = DEFAULT_AVATAR_SIZE;
-	if ( !! props.attributes.avatarSize ) {
-		avatarSize = props.attributes.avatarSize;
+	if ( !! attributes.avatarSize ) {
+		avatarSize = attributes.avatarSize;
 	}
 
 	const blockClassNames = classnames( 'wp-block-post-author', {
@@ -103,32 +108,33 @@ function PostAuthorDisplay( {
 				<PanelBody title={ __( 'Author Settings' ) }>
 					<SelectControl
 						label={ __( 'Author' ) }
-						value={ postAuthor }
+						value={ authorId }
 						options={ authors.map( ( { id, name } ) => {
 							return {
 								value: id,
 								label: name,
 							};
 						} ) }
-						onChange={ ( newAuthorId ) => {
-							setPostAuthor( newAuthorId );
-							getAuthorDetails( newAuthorId, setAuthorDetails );
+						onChange={ ( nextAuthorId ) => {
+							editEntityRecord( 'postType', postType, postId, {
+								author: nextAuthorId,
+							} );
 						} }
 					/>
 					<ToggleControl
 						label={ __( 'Show avatar' ) }
 						checked={ showAvatar }
 						onChange={ () =>
-							props.setAttributes( { showAvatar: ! showAvatar } )
+							setAttributes( { showAvatar: ! showAvatar } )
 						}
 					/>
 					{ showAvatar && (
 						<SelectControl
 							label={ __( 'Avatar size' ) }
-							value={ props.attributes.avatarSize }
+							value={ attributes.avatarSize }
 							options={ avatarSizes }
 							onChange={ ( size ) => {
-								props.setAttributes( {
+								setAttributes( {
 									avatarSize: Number( size ),
 								} );
 							} }
@@ -138,7 +144,7 @@ function PostAuthorDisplay( {
 						label={ __( 'Show bio' ) }
 						checked={ showBio }
 						onChange={ () =>
-							props.setAttributes( { showBio: ! showBio } )
+							setAttributes( { showBio: ! showBio } )
 						}
 					/>
 				</PanelBody>
@@ -156,7 +162,7 @@ function PostAuthorDisplay( {
 				<AlignmentToolbar
 					value={ align }
 					onChange={ ( nextAlign ) => {
-						props.setAttributes( { align: nextAlign } );
+						setAttributes( { align: nextAlign } );
 					} }
 				/>
 				<BlockColorsStyleSelector
@@ -202,16 +208,16 @@ function PostAuthorDisplay( {
 									] }
 									value={ byline }
 									onChange={ ( value ) =>
-										props.setAttributes( { byline: value } )
+										setAttributes( { byline: value } )
 									}
 								/>
 							) }
 							<p className="wp-block-post-author__name">
-								{ authorDetails.name }
+								{ authorDetails?.name }
 							</p>
 							{ showBio && (
 								<p className={ 'wp-block-post-author__bio' }>
-									{ authorDetails.description }
+									{ authorDetails?.description }
 								</p>
 							) }
 						</div>
@@ -219,34 +225,6 @@ function PostAuthorDisplay( {
 				</BackgroundColor>
 			</TextColor>
 		</>
-	);
-}
-
-function PostAuthorEdit( props ) {
-	const [ postAuthor, setPostAuthor ] = useEntityProp(
-		'postType',
-		'post',
-		'author'
-	);
-
-	const [ authorDetails, setAuthorDetails ] = useState( false );
-
-	if ( ! postAuthor ) {
-		return 'Post Author Placeholder';
-	}
-
-	if ( ! authorDetails ) {
-		getAuthorDetails( postAuthor, setAuthorDetails );
-	}
-
-	return (
-		<PostAuthorDisplay
-			postAuthor={ postAuthor }
-			setPostAuthor={ setPostAuthor }
-			authorDetails={ authorDetails }
-			setAuthorDetails={ setAuthorDetails }
-			props={ props }
-		/>
 	);
 }
 


### PR DESCRIPTION
Previously: #21696
Related: #19894

This pull request seeks to refactor the Post Author block to use block context within the editor implementation, replacing `useEntityProp` with equivalent entity selectors / action dispatches operating from context `postId` and `postType` values.

**Implementation notes:**

A few general refactoring changes have been applied to the Post Author block based on comments at https://github.com/WordPress/gutenberg/pull/19894#discussion_r425195717, https://github.com/WordPress/gutenberg/pull/19894#discussion_r425201413, https://github.com/WordPress/gutenberg/pull/19894#discussion_r425221033.

The two components of the file have been merged to one. There was previous discussion of this at https://github.com/WordPress/gutenberg/pull/19894#discussion_r417386420. This was done largely out of removing this early return condition. I do not believe it should ever be the case that a post would not have an author associated with it. There may be a delay in loading details about that author, but we should still be able to render most of the elements of the block (inspector controls, etc). A placeholder, if applicable, could ideally be limited to just substituting the block list elements. Perhaps this could be split again to another smaller component, if necessary.

**Testing instructions:**

Repeat Testing Instructions from #19894, verifying there are no regressions in behavior.