### PR TITLE
[RNMobile] Correct Buttons appender

### DIFF
--- a/packages/block-library/src/buttons/editor.native.scss
+++ b/packages/block-library/src/buttons/editor.native.scss
@@ -3,7 +3,6 @@
 }
 
 .appenderContainer {
-	flex: 1;
 	margin: $block-selected-margin;
 }
 


### PR DESCRIPTION
## Description

Fixes: https://github.com/wordpress-mobile/gutenberg-mobile/issues/2227

[ANDROID only]
Fixed weird behaviour where after adding two buttons _(only if these buttons take the whole width and appender has to drop below to the next line)_, appender (+) was not clickable.

## How has this been tested?

1. Add Buttons block
2. Type `Hello Hello Hello` in first Button
3. Press (+) appender to add next Button
4. Expect that appender drop to the next line
5. Press (+) appender
6. Expect appender is clickable and another Button was added

## Screenshots <!-- if applicable -->

before | after
--- | ---
![a_bug](https://user-images.githubusercontent.com/22746080/81957908-834fae80-960d-11ea-99f5-8d18033c9257.gif) | ![a_fix](https://user-images.githubusercontent.com/22746080/81957912-85b20880-960d-11ea-8e04-6c3ce20ff451.gif)

## Types of changes

Remove `flex` from appender.


## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [X] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
