### PR TITLE
Edit Site: New page based navigation.

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -193,7 +193,7 @@ function gutenberg_get_post_from_context() {
  * @return string String of rendered HTML.
  */
 function gutenberg_render_block_with_assigned_block_context( $pre_render, $parsed_block ) {
-	global $post;
+	global $post, $wp_query;
 
 	/*
 	 * If a non-null value is provided, a filter has run at an earlier priority
@@ -218,7 +218,15 @@ function gutenberg_render_block_with_assigned_block_context( $pre_render, $parse
 		 * it should be included to consistently fulfill the expectation.
 		 */
 		'postType' => $post->post_type,
+
+		'query'    => array( 'categoryIds' => array() ),
 	);
+
+	if ( isset( $wp_query->tax_query->queried_terms['category']['terms'] ) ) {
+		foreach ( $wp_query->tax_query->queried_terms['category']['terms'] as $category_id ) {
+			$context['query']['categoryIds'][] = $category_id;
+		}
+	}
 
 	/**
 	 * Filters the default context provided to a rendered block.

--- a/lib/demo-block-templates/category.html
+++ b/lib/demo-block-templates/category.html
@@ -1,0 +1,20 @@
+<!-- wp:cover {"minHeight":360,"customGradient":"linear-gradient(253deg,rgba(6,147,227,1) 0%,rgb(84,121,221) 100%)","align":"full"} -->
+<div
+	class="wp-block-cover alignfull has-background-dim has-background-gradient"
+	style="background:linear-gradient(253deg,rgba(6,147,227,1) 0%,rgb(84,121,221) 100%);min-height:360px"
+>
+	<div class="wp-block-cover__inner-container">
+		<!-- wp:paragraph {"align":"center"} -->
+		<p class="has-text-align-center">
+			<em>Category Template</em>
+		</p>
+		<!-- /wp:paragraph -->
+	</div>
+</div>
+<!-- /wp:cover -->
+
+<!-- wp:query-loop -->
+<!-- wp:post-title /-->
+
+<!-- wp:post-content /-->
+<!-- /wp:query-loop -->

--- a/lib/demo-block-templates/index.html
+++ b/lib/demo-block-templates/index.html
@@ -1,0 +1,12 @@
+<!-- wp:cover {"minHeight":360,"customGradient":"linear-gradient(253deg,rgba(6,147,227,1) 0%,rgb(84,121,221) 100%)","align":"full"} -->
+<div
+	class="wp-block-cover alignfull has-background-dim has-background-gradient"
+	style="background:linear-gradient(253deg,rgba(6,147,227,1) 0%,rgb(84,121,221) 100%);min-height:360px"
+>
+	<div class="wp-block-cover__inner-container">
+		<!-- wp:post-title /-->
+	</div>
+</div>
+<!-- /wp:cover -->
+
+<!-- wp:post-content /-->

--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -168,6 +168,14 @@ function gutenberg_edit_site_init( $hook ) {
 	$settings['templatePartIds'] = array_values( $template_part_ids );
 	$settings['styles']          = gutenberg_get_editor_styles();
 
+	$settings['page'] = array(
+		'path'    => '/',
+		'context' => array(
+			'postType' => 'page',
+			'postId'   => get_option( 'page_on_front' ),
+		),
+	);
+
 	// This is so other parts of the code can hook their own settings.
 	// Example: Global Styles.
 	global $post;

--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -168,11 +168,16 @@ function gutenberg_edit_site_init( $hook ) {
 	$settings['templatePartIds'] = array_values( $template_part_ids );
 	$settings['styles']          = gutenberg_get_editor_styles();
 
-	$settings['page'] = array(
+	$settings['showOnFront'] = get_option( 'show_on_front' );
+	$settings['page']        = array(
 		'path'    => '/',
-		'context' => array(
+		'context' => 'page' === $settings['showOnFront'] ? array(
 			'postType' => 'page',
 			'postId'   => get_option( 'page_on_front' ),
+		) : array(
+			'query' => array(
+				'categoryIds' => array(),
+			),
 		),
 	);
 

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -299,12 +299,12 @@ function gutenberg_find_template_post_and_parts( $template_type, $template_hiera
 					'no_found_rows'  => true,
 				)
 			);
-			$current_template_post = $template_query->have_posts() ? $template_query->next_post() : null;
+			$current_template_post = $template_query->have_posts() ? $template_query->next_post() : $current_template_post;
 
 			// Only create auto-draft of block template for editing
 			// in admin screens, when necessary, because the underlying
 			// file has changed.
-			if ( ! $current_template_post || $current_template_post->post_content !== $file_contents ) {
+			if ( ! $current_template_post->ID || $current_template_post->post_content !== $file_contents ) {
 				$current_template_post->post_content = $file_contents;
 				$current_template_post = get_post(
 					wp_insert_post( $current_template_post )

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -304,8 +304,10 @@ function gutenberg_find_template_post_and_parts( $template_type, $template_hiera
 			// Only create auto-draft of block template for editing
 			// in admin screens, when necessary, because the underlying
 			// file has changed.
-			if ( ! $current_template_post->ID || $current_template_post->post_content !== $file_contents ) {
-				$current_template_post->post_content = $file_contents;
+			if ( is_array( $current_template_post ) || $current_template_post->post_content !== $file_contents ) {
+				if ( ! is_array( $current_template_post ) ) {
+					$current_template_post->post_content = $file_contents;
+				}
 				$current_template_post = get_post(
 					wp_insert_post( $current_template_post )
 				);

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -102,11 +102,14 @@ function gutenberg_override_query_template( $template, $type, array $templates =
 		if ( isset( $_GET['_wp-find-template'] ) ) {
 			wp_send_json_success( $current_template['template_post'] );
 		}
-	} elseif ( 'index' === $type ) {
-		if ( isset( $_GET['_wp-find-template'] ) ) {
-			wp_send_json_error( array( 'message' => __( 'No matching template found.', 'gutenberg' ) ) );
+	} else {
+		if ( 'index' === $type ) {
+			if ( isset( $_GET['_wp-find-template'] ) ) {
+				wp_send_json_error( array( 'message' => __( 'No matching template found.', 'gutenberg' ) ) );
+			}
+		} else {
+			return false; // So that the template loader keeps looking for templates.
 		}
-		return false; // So that the template loader keeps looking for templates.
 	}
 
 	// Add hooks for template canvas.

--- a/lib/templates.php
+++ b/lib/templates.php
@@ -187,8 +187,7 @@ function filter_rest_wp_template_query( $args, $request ) {
 
 		foreach ( $template_types as $template_type ) {
 			// Skip 'embed' for now because it is not a regular template type.
-			// Skip 'index' because it's a fallback that we handle differently.
-			if ( in_array( $template_type, array( 'embed', 'index' ), true ) ) {
+			if ( in_array( $template_type, array( 'embed' ), true ) ) {
 				continue;
 			}
 
@@ -197,7 +196,8 @@ function filter_rest_wp_template_query( $args, $request ) {
 				$template_ids[] = $current_template['template_post']->ID;
 			}
 		}
-		$args['post__in'] = $template_ids;
+		$args['post__in']    = $template_ids;
+		$args['post_status'] = array( 'publish', 'auto-draft' );
 	}
 
 	return $args;

--- a/packages/block-library/src/query-loop/block.json
+++ b/packages/block-library/src/query-loop/block.json
@@ -1,5 +1,5 @@
 {
 	"name": "core/query-loop",
 	"category": "layout",
-	"context": [ "queryId", "query" ]
+	"context": [ "queryId", "query", "queryContext" ]
 }

--- a/packages/block-library/src/query-loop/edit.js
+++ b/packages/block-library/src/query-loop/edit.js
@@ -25,6 +25,7 @@ export default function QueryLoopEdit( { clientId, context: { query } } ) {
 				...query,
 				offset: query.per_page * ( page - 1 ) + query.offset,
 				page,
+				categories: query.categoryIds,
 			} ),
 			blocks: select( 'core/block-editor' ).getBlocks( clientId ),
 		} ),

--- a/packages/block-library/src/query-loop/index.js
+++ b/packages/block-library/src/query-loop/index.js
@@ -17,9 +17,7 @@ export { metadata, name };
 export const settings = {
 	title: __( 'Query Loop' ),
 	icon: loop,
-	parent: [ 'core/query' ],
 	supports: {
-		inserter: false,
 		reusable: false,
 		html: false,
 	},

--- a/packages/block-library/src/query-loop/index.php
+++ b/packages/block-library/src/query-loop/index.php
@@ -15,16 +15,18 @@
  * @return string Returns the output of the query, structured using the layout defined by the block's inner blocks.
  */
 function render_block_core_query_loop( $attributes, $content, $block ) {
-	$page_key = 'query-' . $block->context['queryId'] . '-page';
+	$page_key = isset( $block->context['queryId'] ) ? 'query-' . $block->context['queryId'] . '-page' : 'query-page';
 	$page     = empty( $_GET[ $page_key ] ) ? 1 : filter_var( $_GET[ $page_key ], FILTER_VALIDATE_INT );
-	$posts    = get_posts(
-		array(
-			'post_type'      => 'post',
-			'posts_per_page' => $block->context['query']['per_page'],
-			'offset'         => $block->context['query']['per_page'] * ( $page - 1 ) + $block->context['query']['offset'],
-			'category__in'   => $block->context['query']['categoryIds'],
-		)
+
+	$query = array(
+		'post_type'    => 'post',
+		'offset'       => isset( $block->context['query']['perPage'] ) ? ( $block->context['query']['perPage'] * ( $page - 1 ) + $block->context['query']['offset'] ) : 0,
+		'category__in' => $block->context['query']['categoryIds'],
 	);
+	if ( isset( $block->context['query']['perPage'] ) ) {
+		$query['posts_per_page'] = $block->context['query']['perPage'];
+	}
+	$posts = get_posts( $query );
 
 	$content = '';
 	foreach ( $posts as $post ) {

--- a/packages/block-library/src/query-loop/index.php
+++ b/packages/block-library/src/query-loop/index.php
@@ -22,6 +22,7 @@ function render_block_core_query_loop( $attributes, $content, $block ) {
 			'post_type'      => 'post',
 			'posts_per_page' => $block->context['query']['per_page'],
 			'offset'         => $block->context['query']['per_page'] * ( $page - 1 ) + $block->context['query']['offset'],
+			'category__in'   => $block->context['query']['categoryIds'],
 		)
 	);
 

--- a/packages/block-library/src/query-pagination/block.json
+++ b/packages/block-library/src/query-pagination/block.json
@@ -1,5 +1,5 @@
 {
 	"name": "core/query-pagination",
 	"category": "layout",
-	"context": [ "queryId", "query" ]
+	"context": [ "queryId", "query", "queryContext" ]
 }

--- a/packages/block-library/src/query-pagination/edit.js
+++ b/packages/block-library/src/query-pagination/edit.js
@@ -12,10 +12,11 @@ import { useQueryContext } from '../query';
 
 export default function QueryPaginationEdit( {
 	context: {
-		query: { pages },
+		query: { pages = 1 },
+		queryContext,
 	},
 } ) {
-	const [ { page }, setQueryContext ] = useQueryContext();
+	const [ { page }, setQueryContext ] = useQueryContext() || queryContext;
 
 	let previous;
 	if ( page > 1 ) {

--- a/packages/block-library/src/query-pagination/index.js
+++ b/packages/block-library/src/query-pagination/index.js
@@ -14,9 +14,7 @@ export { metadata, name };
 
 export const settings = {
 	title: __( 'Query Pagination' ),
-	parent: [ 'core/query' ],
 	supports: {
-		inserter: false,
 		reusable: false,
 		html: false,
 	},

--- a/packages/block-library/src/query-pagination/index.php
+++ b/packages/block-library/src/query-pagination/index.php
@@ -15,7 +15,7 @@
  * @return string Returns the pagination for the query.
  */
 function render_block_core_query_pagination( $attributes, $content, $block ) {
-	$page_key = 'query-' . $block->context['queryId'] . '-page';
+	$page_key = isset( $block->context['queryId'] ) ? 'query-' . $block->context['queryId'] . '-page' : 'query-page';
 	$page     = empty( $_GET[ $page_key ] ) ? 1 : filter_var( $_GET[ $page_key ], FILTER_VALIDATE_INT );
 
 	$content = '';
@@ -26,7 +26,7 @@ function render_block_core_query_pagination( $attributes, $content, $block ) {
 			__( 'Previous', 'gutenberg' )
 		);
 	}
-	if ( $page < $block->context['query']['pages'] ) {
+	if ( $page < ( isset( $block->context['query']['pages'] ) ? $block->context['query']['pages'] : 1 ) ) {
 		$content .= sprintf(
 			'<div><a href="%s">%s</a></div>',
 			esc_url( add_query_arg( $page_key, $page + 1 ) ),

--- a/packages/block-library/src/query/block.json
+++ b/packages/block-library/src/query/block.json
@@ -10,7 +10,8 @@
 			"default": {
 				"per_page": 3,
 				"pages": 1,
-				"offset": 0
+				"offset": 0,
+				"categoryIds": []
 			}
 		}
 	},

--- a/packages/block-library/src/query/block.json
+++ b/packages/block-library/src/query/block.json
@@ -8,7 +8,7 @@
 		"query": {
 			"type": "object",
 			"default": {
-				"per_page": 3,
+				"perPage": 3,
 				"pages": 1,
 				"offset": 0,
 				"categoryIds": []

--- a/packages/block-library/src/query/edit/query-toolbar.js
+++ b/packages/block-library/src/query/edit/query-toolbar.js
@@ -54,9 +54,9 @@ export default function QueryToolbar( { query, setQuery } ) {
 							label={ __( 'Posts per Page' ) }
 							min={ 1 }
 							allowReset
-							value={ query.per_page }
+							value={ query.perPage }
 							onChange={ ( value ) =>
-								setQuery( { per_page: value ?? -1 } )
+								setQuery( { perPage: value ?? -1 } )
 							}
 						/>
 						<RangeControl

--- a/packages/e2e-tests/fixtures/blocks/core__query.json
+++ b/packages/e2e-tests/fixtures/blocks/core__query.json
@@ -5,9 +5,10 @@
         "isValid": true,
         "attributes": {
             "query": {
-                "per_page": 3,
+                "perPage": 3,
                 "pages": 1,
-                "offset": 0
+                "offset": 0,
+                "categoryIds": []
             }
         },
         "innerBlocks": [],

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -18,6 +18,7 @@ import {
 } from '@wordpress/components';
 import { EntityProvider } from '@wordpress/core-data';
 import {
+	BlockContextProvider,
 	BlockSelectionClearer,
 	BlockBreadcrumb,
 	__unstableEditorStyles as EditorStyles,
@@ -100,65 +101,71 @@ function Editor( { settings: _settings } ) {
 							type={ settings.templateType }
 							id={ settings.templateId }
 						>
-							<Context.Provider value={ context }>
-								<FocusReturnProvider>
-									<KeyboardShortcuts.Register />
-									<InterfaceSkeleton
-										sidebar={ ! isMobile && <Sidebar /> }
-										header={
-											<Header
-												openEntitiesSavedStates={
-													openEntitiesSavedStates
-												}
-											/>
-										}
-										content={
-											<BlockSelectionClearer
-												className="edit-site-visual-editor"
-												style={ inlineStyles }
-											>
-												<Notices />
-												<Popover.Slot name="block-toolbar" />
-												<BlockEditor />
-												<KeyboardShortcuts />
-											</BlockSelectionClearer>
-										}
-										actions={
-											<>
-												<EntitiesSavedStates
-													isOpen={
-														isEntitiesSavedStatesOpen
-													}
-													close={
-														closeEntitiesSavedStates
+							<BlockContextProvider
+								value={ settings.page.context }
+							>
+								<Context.Provider value={ context }>
+									<FocusReturnProvider>
+										<KeyboardShortcuts.Register />
+										<InterfaceSkeleton
+											sidebar={
+												! isMobile && <Sidebar />
+											}
+											header={
+												<Header
+													openEntitiesSavedStates={
+														openEntitiesSavedStates
 													}
 												/>
-												{ ! isEntitiesSavedStatesOpen && (
-													<div className="edit-site-editor__toggle-save-panel">
-														<Button
-															isSecondary
-															className="edit-site-editor__toggle-save-panel-button"
-															onClick={
-																openEntitiesSavedStates
-															}
-															aria-expanded={
-																false
-															}
-														>
-															{ __(
-																'Open save panel'
-															) }
-														</Button>
-													</div>
-												) }
-											</>
-										}
-										footer={ <BlockBreadcrumb /> }
-									/>
-									<Popover.Slot />
-									<PluginArea />
-								</FocusReturnProvider>
-							</Context.Provider>
+											}
+											content={
+												<BlockSelectionClearer
+													className="edit-site-visual-editor"
+													style={ inlineStyles }
+												>
+													<Notices />
+													<Popover.Slot name="block-toolbar" />
+													<BlockEditor />
+													<KeyboardShortcuts />
+												</BlockSelectionClearer>
+											}
+											actions={
+												<>
+													<EntitiesSavedStates
+														isOpen={
+															isEntitiesSavedStatesOpen
+														}
+														close={
+															closeEntitiesSavedStates
+														}
+													/>
+													{ ! isEntitiesSavedStatesOpen && (
+														<div className="edit-site-editor__toggle-save-panel">
+															<Button
+																isSecondary
+																className="edit-site-editor__toggle-save-panel-button"
+																onClick={
+																	openEntitiesSavedStates
+																}
+																aria-expanded={
+																	false
+																}
+															>
+																{ __(
+																	'Open save panel'
+																) }
+															</Button>
+														</div>
+													) }
+												</>
+											}
+											footer={ <BlockBreadcrumb /> }
+										/>
+										<Popover.Slot />
+										<PluginArea />
+									</FocusReturnProvider>
+								</Context.Provider>
+							</BlockContextProvider>
 						</EntityProvider>
 					</EntityProvider>
 				</DropZoneProvider>

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -89,6 +89,31 @@ function Editor( { settings: _settings } ) {
 		[]
 	);
 
+	const blockContext = useMemo( () => {
+		if ( ! settings.page.context.queryContext )
+			return settings.page.context;
+
+		return {
+			...settings.page.context,
+			queryContext: [
+				settings.page.context.queryContext,
+				( newQueryContext ) =>
+					setSettings( ( prevSettings ) => ( {
+						...prevSettings,
+						page: {
+							...prevSettings.page,
+							context: {
+								...prevSettings.page.context,
+								queryContext: {
+									...prevSettings.page.context.queryContext,
+									...newQueryContext,
+								},
+							},
+						},
+					} ) ),
+			],
+		};
+	}, [ settings.page.context ] );
 	return template ? (
 		<>
 			<EditorStyles styles={ settings.styles } />
@@ -101,9 +126,7 @@ function Editor( { settings: _settings } ) {
 							type={ settings.templateType }
 							id={ settings.templateId }
 						>
-							<BlockContextProvider
-								value={ settings.page.context }
-							>
+							<BlockContextProvider value={ blockContext }>
 								<Context.Provider value={ context }>
 									<FocusReturnProvider>
 										<KeyboardShortcuts.Register />

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -2,13 +2,18 @@
  * WordPress dependencies
  */
 import { useCallback } from '@wordpress/element';
+import { addQueryArgs } from '@wordpress/url';
 import {
 	BlockNavigationDropdown,
 	ToolSelector,
 	Inserter,
 	__experimentalPreviewOptions as PreviewOptions,
 } from '@wordpress/block-editor';
-import { useSelect, useDispatch } from '@wordpress/data';
+import {
+	__experimentalResolveSelect as resolveSelect,
+	useSelect,
+	useDispatch,
+} from '@wordpress/data';
 import {
 	PinnedItems,
 	__experimentalMainDashboardButton as MainDashboardButton,
@@ -19,11 +24,17 @@ import {
  */
 import { useEditorContext } from '../editor';
 import MoreMenu from './more-menu';
+import PageSwitcher from '../page-switcher';
 import TemplateSwitcher from '../template-switcher';
 import SaveButton from '../save-button';
 import UndoButton from './undo-redo/undo';
 import RedoButton from './undo-redo/redo';
 import FullscreenModeClose from './fullscreen-mode-close';
+
+/**
+ * Browser dependencies
+ */
+const { fetch } = window;
 
 const inserterToggleProps = { isPrimary: true };
 
@@ -56,6 +67,33 @@ export default function Header( { openEntitiesSavedStates } ) {
 			} ) ),
 		[]
 	);
+	const setActivePage = useCallback( async ( newPage ) => {
+		try {
+			const { success, data } = await fetch(
+				addQueryArgs( newPage.path, { '_wp-find-template': true } )
+			).then( ( res ) => res.json() );
+			if ( success ) {
+				let newTemplateId = data.ID;
+				if ( newTemplateId === null ) {
+					newTemplateId = (
+						await resolveSelect( 'core' ).getEntityRecords(
+							'postType',
+							'wp_template',
+							{
+								resolved: true,
+								slug: data.post_name,
+							}
+						)
+					 )[ 0 ].id;
+				}
+				setSettings( ( prevSettings ) => ( {
+					...prevSettings,
+					page: newPage,
+					templateId: newTemplateId,
+				} ) );
+			}
+		} catch ( err ) {}
+	}, [] );
 
 	const deviceType = useSelect( ( select ) => {
 		return select( 'core/edit-site' ).__experimentalGetPreviewDeviceType();
@@ -79,6 +117,10 @@ export default function Header( { openEntitiesSavedStates } ) {
 				<ToolSelector />
 				<UndoButton />
 				<RedoButton />
+				<PageSwitcher
+					activePage={ settings.page }
+					onActivePageChange={ setActivePage }
+				/>
 				<TemplateSwitcher
 					ids={ settings.templateIds }
 					templatePartIds={ settings.templatePartIds }

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -118,6 +118,7 @@ export default function Header( { openEntitiesSavedStates } ) {
 				<UndoButton />
 				<RedoButton />
 				<PageSwitcher
+					showOnFront={ settings.showOnFront }
 					activePage={ settings.page }
 					onActivePageChange={ setActivePage }
 				/>

--- a/packages/edit-site/src/components/page-switcher/index.js
+++ b/packages/edit-site/src/components/page-switcher/index.js
@@ -1,0 +1,81 @@
+/**
+ * WordPress dependencies
+ */
+import { getPath, getQueryString } from '@wordpress/url';
+import { useSelect } from '@wordpress/data';
+import {
+	DropdownMenu,
+	MenuGroup,
+	MenuItemsChoice,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+function getPathFromLink( link ) {
+	const path = getPath( link );
+	const queryString = getQueryString( link );
+	let value = '/';
+	if ( path ) value += path;
+	if ( queryString ) value += `?${ queryString }`;
+	return value;
+}
+export default function PageSwitcher( { activePage, onActivePageChange } ) {
+	const { pages = [], categories = [] } = useSelect( ( select ) => {
+		const { getEntityRecords } = select( 'core' );
+		return {
+			pages: getEntityRecords( 'postType', 'page' )?.map( ( _page ) => {
+				const path = getPathFromLink( _page.link );
+				return {
+					label: _page.title.rendered,
+					value: path,
+					context: { postType: 'page', postId: _page.id },
+				};
+			} ),
+			categories: getEntityRecords( 'taxonomy', 'category' )?.map(
+				( category ) => {
+					const path = getPathFromLink( category.link );
+					return {
+						label: category.name,
+						value: path,
+						context: { query: { categoryId: category.id } },
+					};
+				}
+			),
+		};
+	}, [] );
+	const onPageSelect = ( newPath ) => {
+		const { value: path, context } = [ ...pages, ...categories ].find(
+			( choice ) => choice.value === newPath
+		);
+		onActivePageChange( { path, context } );
+	};
+	return (
+		<DropdownMenu
+			icon={ null }
+			label={ __( 'Switch Page' ) }
+			toggleProps={ {
+				children: [ ...pages, ...categories ].find(
+					( choice ) => choice.value === activePage.path
+				)?.label,
+			} }
+		>
+			{ () => (
+				<>
+					<MenuGroup label={ __( 'Pages' ) }>
+						<MenuItemsChoice
+							choices={ pages }
+							value={ activePage.path }
+							onSelect={ onPageSelect }
+						/>
+					</MenuGroup>
+					<MenuGroup label={ __( 'Categories' ) }>
+						<MenuItemsChoice
+							choices={ categories }
+							value={ activePage.path }
+							onSelect={ onPageSelect }
+						/>
+					</MenuGroup>
+				</>
+			) }
+		</DropdownMenu>
+	);
+}


### PR DESCRIPTION
Closes #19257

## Description

This PR adds a new way of navigating in the site editor.

It adds a new page switcher dropdown that lets you select from your list of pages and category pages. The list can be expanded to include other pages in the future. The idea is to have one option for every unique URL path that the site exposes, except for post permalinks. A next step here would be to add a Post section that lets you load the single post page with a specific post context using a nested dropdown with the link UI.

Selecting a page switches the current template to the one resolved for that page and sets the correct root block context, so that post and query blocks work as expected. This flow is shown in the GIF below, where switching to the contact page makes the Post Title block render its title. Category pages also work like this, but the query blocks still need some work to read root context so that part is not testable just yet.

The next step would be to modify the template switcher so that it not only switches the current template but also provides a way to assign it to the current page.

This PR also:

- Fixes some subtle bugs that were introduced by the new API refactors and optimizes template `auto-draft` creation so that they are only recreated when the underlying block template files have changed.
- Adds a fallback `index` template to the demo templates to facilitate testing.

## How has this been tested?

The flow that is shown in the GIF where switching pages in the site editor will update the current template and root block context was tested with a combination of different templates and pages to verify that the correct template is resolved for each page and that the root block context is set correctly.

## Screenshots

![gif](https://user-images.githubusercontent.com/19157096/81984740-1676ed00-95ea-11ea-8277-5a42601796ee.gif)

## Types of Changes

*New Feature:* The site editor now has a page switcher for navigating between pages instead of templates.

## Checklist:

- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->