### PR TITLE
Testing: Replace require.requireActual with jest.requireActual

### DIFF
--- a/packages/components/src/disabled/test/index.js
+++ b/packages/components/src/disabled/test/index.js
@@ -14,7 +14,7 @@ import { Component } from '@wordpress/element';
 import Disabled from '../';
 
 jest.mock( '@wordpress/dom', () => {
-	const focus = require.requireActual( '../../../../dom/src' ).focus;
+	const focus = jest.requireActual( '../../../../dom/src' ).focus;
 
 	return {
 		focus: {

--- a/packages/compose/src/higher-order/with-global-events/test/index.js
+++ b/packages/compose/src/higher-order/with-global-events/test/index.js
@@ -15,7 +15,7 @@ import withGlobalEvents from '../';
 import Listener from '../listener';
 
 jest.mock( '../listener', () => {
-	const ActualListener = require.requireActual( '../listener' ).default;
+	const ActualListener = jest.requireActual( '../listener' ).default;
 
 	return class extends ActualListener {
 		constructor() {

--- a/packages/jest-preset-default/scripts/setup-test-framework.js
+++ b/packages/jest-preset-default/scripts/setup-test-framework.js
@@ -7,12 +7,12 @@ require( '@wordpress/jest-console' );
 let mockEnzymeSetup = false;
 
 jest.mock( 'enzyme', () => {
-	const actualEnzyme = require.requireActual( 'enzyme' );
+	const actualEnzyme = jest.requireActual( 'enzyme' );
 	if ( ! mockEnzymeSetup ) {
 		mockEnzymeSetup = true;
 
 		// configure enzyme 3 for React, from docs: http://airbnb.io/enzyme/docs/installation/index.html
-		const Adapter = require.requireActual( 'enzyme-adapter-react-16' );
+		const Adapter = jest.requireActual( 'enzyme-adapter-react-16' );
 		actualEnzyme.configure( { adapter: new Adapter() } );
 	}
 	return actualEnzyme;

--- a/packages/priority-queue/src/test/index.js
+++ b/packages/priority-queue/src/test/index.js
@@ -5,7 +5,7 @@ import { createQueue } from '../';
 import requestIdleCallback from '../request-idle-callback';
 
 jest.mock( '../request-idle-callback', () => {
-	const emitter = new ( require.requireActual( 'events' ).EventEmitter )();
+	const emitter = new ( jest.requireActual( 'events' ).EventEmitter )();
 
 	return Object.assign(
 		( callback ) =>

--- a/packages/scripts/utils/test/index.js
+++ b/packages/scripts/utils/test/index.js
@@ -14,14 +14,14 @@ import {
 } from '../process';
 
 jest.mock( '../package', () => {
-	const module = require.requireActual( '../package' );
+	const module = jest.requireActual( '../package' );
 
 	jest.spyOn( module, 'getPackagePath' );
 
 	return module;
 } );
 jest.mock( '../process', () => {
-	const module = require.requireActual( '../process' );
+	const module = jest.requireActual( '../process' );
 
 	jest.spyOn( module, 'exit' );
 	jest.spyOn( module, 'getArgsFromCLI' );

--- a/packages/url/src/test/index.native.js
+++ b/packages/url/src/test/index.native.js
@@ -4,7 +4,7 @@
 import './index.test';
 
 jest.mock( './fixtures/wpt-data.json', () => {
-	const data = require.requireActual( './fixtures/wpt-data.json' );
+	const data = jest.requireActual( './fixtures/wpt-data.json' );
 
 	/**
 	 * Test items to exclude by input. Ideally this should be empty, but are


### PR DESCRIPTION
This pull request seeks to update tests to replace all instances of `require.requireActual` with `jest.requireActual`. Apparently this has been deprecated for many years, and is removed as part of the newly-released Jest 26 (see https://github.com/facebook/jest/pull/9854, [Release Notes](https://jestjs.io/blog/2020/05/05/jest-26)). These changes should behave identically, and put us in a better position for a seamless future upgrade to Jest 26.

**Testing Instructions:**

Ensure unit tests pass:

```
npm run test-unit
```