### PR TITLE
feat: Option to display Read More link for latest posts block

### DIFF
--- a/packages/block-library/src/latest-posts/block.json
+++ b/packages/block-library/src/latest-posts/block.json
@@ -37,6 +37,10 @@
 			"type": "number",
 			"default": 55
 		},
+		"displayReadMore": {
+			"type": "boolean",
+			"default": false
+		},
 		"displayPostDate": {
 			"type": "boolean",
 			"default": false

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -99,6 +99,7 @@ class LatestPostsEdit extends Component {
 			categories,
 			postsToShow,
 			excerptLength,
+			displayReadMore,
 			featuredImageAlign,
 			featuredImageSizeSlug,
 			featuredImageSizeWidth,
@@ -164,15 +165,30 @@ class LatestPostsEdit extends Component {
 					) }
 					{ displayPostContent &&
 						displayPostContentRadio === 'excerpt' && (
-							<RangeControl
-								label={ __( 'Max number of words in excerpt' ) }
-								value={ excerptLength }
-								onChange={ ( value ) =>
-									setAttributes( { excerptLength: value } )
-								}
-								min={ MIN_EXCERPT_LENGTH }
-								max={ MAX_EXCERPT_LENGTH }
-							/>
+							<>
+								<RangeControl
+									label={ __(
+										'Max number of words in excerpt'
+									) }
+									value={ excerptLength }
+									onChange={ ( value ) =>
+										setAttributes( {
+											excerptLength: value,
+										} )
+									}
+									min={ MIN_EXCERPT_LENGTH }
+									max={ MAX_EXCERPT_LENGTH }
+								/>
+								<ToggleControl
+									label={ __( 'Display Read More Link' ) }
+									checked={ displayReadMore }
+									onChange={ ( value ) =>
+										setAttributes( {
+											displayReadMore: value,
+										} )
+									}
+								/>
+							</>
 						) }
 				</PanelBody>
 
@@ -372,16 +388,33 @@ class LatestPostsEdit extends Component {
 									.join( ' ' ) }
 								{ /* translators: excerpt truncation character, default …  */ }
 								{ __( ' … ' ) }
-								<a
-									href={ post.link }
-									target="_blank"
-									rel="noopener noreferrer"
-								>
-									{ __( 'Read more' ) }
-								</a>
+								{ displayReadMore ? (
+									<a
+										href={ post.link }
+										target="_blank"
+										rel="noopener noreferrer"
+									>
+										{ __( 'Read more' ) }
+									</a>
+								) : null }
 							</>
 						) : (
-							excerpt
+							<>
+								{ displayReadMore ? (
+									<>
+										{ excerpt }
+										<a
+											href={ post.link }
+											target="_blank"
+											rel="noopener noreferrer"
+										>
+											{ __( 'Read more' ) }
+										</a>
+									</>
+								) : (
+									excerpt
+								) }
+							</>
 						);
 
 						return (

--- a/packages/e2e-tests/fixtures/blocks/core__latest-posts.json
+++ b/packages/e2e-tests/fixtures/blocks/core__latest-posts.json
@@ -1,24 +1,25 @@
 [
-    {
-        "clientId": "_clientId_0",
-        "name": "core/latest-posts",
-        "isValid": true,
-        "attributes": {
-            "postsToShow": 5,
-            "displayPostContent": false,
-            "displayPostContentRadio": "excerpt",
-            "excerptLength": 55,
-            "displayPostDate": false,
-            "postLayout": "list",
-            "columns": 3,
-            "order": "desc",
-            "orderBy": "date",
-            "displayFeaturedImage": false,
-            "featuredImageSizeSlug": "thumbnail",
-            "featuredImageSizeWidth": null,
-            "featuredImageSizeHeight": null
-        },
-        "innerBlocks": [],
-        "originalContent": ""
-    }
+	{
+		"clientId": "_clientId_0",
+		"name": "core/latest-posts",
+		"isValid": true,
+		"attributes": {
+			"postsToShow": 5,
+			"displayPostContent": false,
+			"displayPostContentRadio": "excerpt",
+			"excerptLength": 55,
+			"displayReadMore": false,
+			"displayPostDate": false,
+			"postLayout": "list",
+			"columns": 3,
+			"order": "desc",
+			"orderBy": "date",
+			"displayFeaturedImage": false,
+			"featuredImageSizeSlug": "thumbnail",
+			"featuredImageSizeWidth": null,
+			"featuredImageSizeHeight": null
+		},
+		"innerBlocks": [],
+		"originalContent": ""
+	}
 ]

--- a/packages/e2e-tests/fixtures/blocks/core__latest-posts__displayPostDate.json
+++ b/packages/e2e-tests/fixtures/blocks/core__latest-posts__displayPostDate.json
@@ -1,24 +1,25 @@
 [
-    {
-        "clientId": "_clientId_0",
-        "name": "core/latest-posts",
-        "isValid": true,
-        "attributes": {
-            "postsToShow": 5,
-            "displayPostContent": false,
-            "displayPostContentRadio": "excerpt",
-            "excerptLength": 55,
-            "displayPostDate": true,
-            "postLayout": "list",
-            "columns": 3,
-            "order": "desc",
-            "orderBy": "date",
-            "displayFeaturedImage": false,
-            "featuredImageSizeSlug": "thumbnail",
-            "featuredImageSizeWidth": null,
-            "featuredImageSizeHeight": null
-        },
-        "innerBlocks": [],
-        "originalContent": ""
-    }
+	{
+		"clientId": "_clientId_0",
+		"name": "core/latest-posts",
+		"isValid": true,
+		"attributes": {
+			"postsToShow": 5,
+			"displayPostContent": false,
+			"displayPostContentRadio": "excerpt",
+			"excerptLength": 55,
+			"displayReadMore": false,
+			"displayPostDate": true,
+			"postLayout": "list",
+			"columns": 3,
+			"order": "desc",
+			"orderBy": "date",
+			"displayFeaturedImage": false,
+			"featuredImageSizeSlug": "thumbnail",
+			"featuredImageSizeWidth": null,
+			"featuredImageSizeHeight": null
+		},
+		"innerBlocks": [],
+		"originalContent": ""
+	}
 ]


### PR DESCRIPTION
## Description
This commit solves the issue #22269
## How has this been tested?
Manually in the browser 

## Screenshots <!-- if applicable -->
![Screen Shot 2020-05-15 at 1 57 02 AM](https://user-images.githubusercontent.com/39377174/82000180-68059300-964f-11ea-8f2b-cc7fe2cbec4e.png)

## Types of changes
- The commit adds a new feature to the block named: latest posts. 
- An option as a toggle button to display or hide the Read More link regardless if the excerpt is trimmed or not 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
