### PR TITLE
Add standard notices to nav menu page

### DIFF
--- a/packages/edit-navigation/src/components/notices/index.js
+++ b/packages/edit-navigation/src/components/notices/index.js
@@ -31,16 +31,16 @@ export default function EditNavigationNotices() {
 		<>
 			<NoticeList
 				notices={ nonDismissibleNotices }
-				className="components-editor-notices__pinned"
+				className="edit-navigation-notices__notice-list"
 			/>
 			<NoticeList
 				notices={ dismissibleNotices }
-				className="components-editor-notices__dismissible"
+				className="edit-navigation-notices__notice-list"
 				onRemove={ removeNotice }
 			/>
 			<SnackbarList
 				notices={ snackbarNotices }
-				className="components-editor-notices__snackbar"
+				className="edit-navigation-notices__snackbar-list"
 				onRemove={ removeNotice }
 			/>
 		</>

--- a/packages/edit-navigation/src/components/notices/index.js
+++ b/packages/edit-navigation/src/components/notices/index.js
@@ -1,23 +1,48 @@
 /**
+ * External dependencies
+ */
+import { filter } from 'lodash';
+
+/**
  * WordPress dependencies
  */
+import { NoticeList, SnackbarList } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { SnackbarList } from '@wordpress/components';
 
-export default function Notices() {
+export default function EditNavigationNotices() {
+	const { removeNotice } = useDispatch( 'core/notices' );
 	const notices = useSelect(
-		( select ) =>
-			select( 'core/notices' )
-				.getNotices()
-				.filter( ( notice ) => notice.type === 'snackbar' ),
+		( select ) => select( 'core/notices' ).getNotices(),
 		[]
 	);
-	const { removeNotice } = useDispatch( 'core/notices' );
+	const dismissibleNotices = filter( notices, {
+		isDismissible: true,
+		type: 'default',
+	} );
+	const nonDismissibleNotices = filter( notices, {
+		isDismissible: false,
+		type: 'default',
+	} );
+	const snackbarNotices = filter( notices, {
+		type: 'snackbar',
+	} );
+
 	return (
-		<SnackbarList
-			className="edit-navigation-notices"
-			notices={ notices }
-			onRemove={ removeNotice }
-		/>
+		<>
+			<NoticeList
+				notices={ nonDismissibleNotices }
+				className="components-editor-notices__pinned"
+			/>
+			<NoticeList
+				notices={ dismissibleNotices }
+				className="components-editor-notices__dismissible"
+				onRemove={ removeNotice }
+			/>
+			<SnackbarList
+				notices={ snackbarNotices }
+				className="components-editor-notices__snackbar"
+				onRemove={ removeNotice }
+			/>
+		</>
 	);
 }

--- a/packages/edit-navigation/src/components/notices/style.scss
+++ b/packages/edit-navigation/src/components/notices/style.scss
@@ -1,4 +1,18 @@
-.components-snackbar-list.edit-navigation-notices {
+.edit-navigation-notices__snackbar-list {
 	position: fixed;
 	bottom: 20px;
+}
+
+.edit-navigation-notices__notice-list {
+	margin-left: -20px;
+
+	// Notices have some unusual margin and padding by default, reset that.
+	.components-notice {
+		margin: 0;
+		padding-right: 12px;
+
+		.components-button {
+			align-self: initial;
+		}
+	}
 }

--- a/packages/edit-navigation/src/components/notices/style.scss
+++ b/packages/edit-navigation/src/components/notices/style.scss
@@ -4,13 +4,20 @@
 }
 
 .edit-navigation-notices__notice-list {
-	margin-left: -20px;
+	// The page has a 10px left margin at narrower widths, reverse that so that the notice sits flush.
+	margin-left: -10px;
+
+	@include break-medium {
+		// The page has a 20px left margin at wider widths, reverse that so that the notice sits flush.
+		margin-left: -20px;
+	}
 
 	// Notices have some unusual margin and padding by default, reset that.
 	.components-notice {
 		margin: 0;
 		padding-right: 12px;
 
+		// Make sure the close button is centered.
 		.components-button {
 			align-self: initial;
 		}


### PR DESCRIPTION
## Description
Builds on #22326 to add non-snackbar notices to the nav menus page.

To be used in #22309.

## How has this been tested?
1. Run `wp.data.dispatch( 'core/notices' ).createErrorNotice( 'Hello world!' )` in browser dev tools
2. Observe error notice
3. Run `wp.data.dispatch( 'core/notices' ).createInfoNotice( 'Hello world!' )` in browser dev tools
4. Observe info notice.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
<img width="911" alt="Screenshot 2020-05-15 at 1 45 59 pm" src="https://user-images.githubusercontent.com/677833/82015921-720cad80-96b2-11ea-9d20-e402aea3be07.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
