### PR TITLE
Remove insert block delay from e2e tests

### DIFF
--- a/packages/block-editor/src/components/inner-blocks/use-inner-block-template-sync.js
+++ b/packages/block-editor/src/components/inner-blocks/use-inner-block-template-sync.js
@@ -6,7 +6,7 @@ import { isEqual } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { useRef, useEffect } from '@wordpress/element';
+import { useRef, useLayoutEffect } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { synchronizeBlocksWithTemplate } from '@wordpress/blocks';
 
@@ -44,7 +44,7 @@ export default function useInnerBlockTemplateSync(
 
 	// Maintain a reference to the previous value so we can do a deep equality check.
 	const existingTemplate = useRef( null );
-	useEffect( () => {
+	useLayoutEffect( () => {
 		// Only synchronize innerBlocks with template if innerBlocks are empty or
 		// a locking all exists directly on the block.
 		if ( innerBlocks.length === 0 || templateLock === 'all' ) {

--- a/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
+++ b/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useEffect } from '@wordpress/element';
+import { useLayoutEffect } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 
@@ -49,7 +49,7 @@ export default function useNestedSettingsUpdate(
 		[ clientId ]
 	);
 
-	useEffect( () => {
+	useLayoutEffect( () => {
 		const newSettings = {
 			allowedBlocks,
 			templateLock:

--- a/packages/e2e-test-utils/src/insert-block.js
+++ b/packages/e2e-test-utils/src/insert-block.js
@@ -2,7 +2,6 @@
  * Internal dependencies
  */
 import { searchForBlock } from './search-for-block';
-import { getAllBlocks } from './get-all-blocks';
 
 /**
  * Opens the inserter, searches for the given term, then selects the first
@@ -11,30 +10,9 @@ import { getAllBlocks } from './get-all-blocks';
  * @param {string} searchTerm The text to search the inserter for.
  */
 export async function insertBlock( searchTerm ) {
-	const oldBlocks = getAllBlocks();
-
 	await searchForBlock( searchTerm );
 	const insertButton = (
 		await page.$x( `//button//span[contains(text(), '${ searchTerm }')]` )
 	 )[ 0 ];
 	await insertButton.click();
-
-	const waitForBlocksToChange = ( delay = 20 ) =>
-		new Promise( ( resolve, reject ) => {
-			let elapsedTime = 0;
-			const pendingBlockList = setInterval( () => {
-				const blocks = getAllBlocks();
-				// Reference will change when the selector updates.
-				if ( blocks !== oldBlocks ) {
-					clearInterval( pendingBlockList );
-					resolve();
-				}
-				elapsedTime += delay;
-				if ( elapsedTime > 600 ) {
-					clearInterval( pendingBlockList );
-					reject( `Block ${ searchTerm } was never inserted.` );
-				}
-			}, delay );
-		} );
-	await waitForBlocksToChange();
 }


### PR DESCRIPTION
This delay was added in #21368 to stabilize  e2e tests but ideally, it's not needed and may hide real bugs.