### PR TITLE
Fix: Button border radius 0 does not appear, and undefined border appears as 0

### DIFF
--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -43,7 +43,7 @@ $blocks-button__height: 56px;
 // the first selector is required for old buttons markup
 
 .wp-block-button.no-border-radius,
-.wp-block-button__link.wp-block-button.no-border-radius {
+.wp-block-button__link.no-border-radius {
 	border-radius: 0 !important;
 }
 

--- a/packages/components/src/range-control/utils.js
+++ b/packages/components/src/range-control/utils.js
@@ -35,7 +35,7 @@ export function floatClamp( value, min, max ) {
  */
 export function useControlledRangeValue( { min, max, value: valueProp } ) {
 	const [ value, setValue ] = useControlledState(
-		floatClamp( valueProp, min, max )
+		valueProp || valueProp === 0 ? floatClamp( valueProp, min, max ) : null
 	);
 
 	const setClampValue = useCallback(

--- a/packages/components/src/range-control/utils.js
+++ b/packages/components/src/range-control/utils.js
@@ -23,7 +23,7 @@ import { useControlledState } from '../utils/hooks';
  * @return {number} A (float) number
  */
 export function floatClamp( value, min, max ) {
-	if ( ! isFinite( value ) ) {
+	if ( typeof value !== 'number' ) {
 		return null;
 	}
 
@@ -35,7 +35,7 @@ export function floatClamp( value, min, max ) {
  */
 export function useControlledRangeValue( { min, max, value: valueProp } ) {
 	const [ value, setValue ] = useControlledState(
-		valueProp || valueProp === 0 ? floatClamp( valueProp, min, max ) : null
+		floatClamp( valueProp, min, max )
 	);
 
 	const setClampValue = useCallback(


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/22367
This PR fixes a wrong CSS rule that made the border 0 radius in button not appear as expected.

It also fixes a bug, when the border-radius is not set (it is undefined and the theme value set with CSS is being used) we were displaying 0 as the border-radius by default, in that case, we should show the input empty.



## How has this been tested?
I enabled 2019 theme.
I added a button I set the border-radius to 0 and verified it appeared as expected on the editor and on the front end.
I added a button in 2019 (by default the button has some border) I verified the border did not appear as 0.

