### PR TITLE
Editor: Fix "Attempt Recovery" error boundary handler

### DIFF
--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -217,7 +217,7 @@ function EditorProvider( {
 		} );
 	}
 
-	if ( ! isReady ) {
+	if ( ! isReady && ! recovery ) {
 		return null;
 	}
 


### PR DESCRIPTION
This pull request seeks to resolve an issue where "Attempt Recovery" (shown in the top-level error boundary) will never work correctly.

![image](https://user-images.githubusercontent.com/1779930/82098939-fd4a6b00-96d3-11ea-91b7-67c28736cd5f.png)

**Status:** In progress. The change in a27c055  fixes the issue. However, I'm not particularly confident this is the best solution.

The issue:

- When "Attempt Recovery" is pressed, the editor is unmounted and then re-rendered in a "recovery" mode.
- When rendered in recovery mode, `EditorProvider` skips most of its state initialization, since the state will have been preserved from before the error happens.
- As of #16402, an editor "tear down" mechanism was added to unset part of the editor state when the `EditorProvider` component unmounts (notably, the `isReady` state).
- Thus, the editor will never render because it will be stuck in this `! isReady` state and never initialize out of it ([source](https://github.com/WordPress/gutenberg/blob/01d2de2c4a752a426fbbf7a3656a37b274ed9d3b/packages/editor/src/components/provider/index.js#L197-L199))

The fix:

- Expand `! isReady` to `! isReady || recovery`, such that the editor renders in recovery mode

Possible alternatives:

- Get rid of `isReady` altogether
- Don't unset `isReady` when performing editor teardown
- Don't tear down any editor state on unmount
- Tear down everything when unmounting editor, and always initialize state when mounting editor
- Don't [unmount editor](https://github.com/WordPress/gutenberg/blob/01d2de2c4a752a426fbbf7a3656a37b274ed9d3b/packages/edit-post/src/index.js#L44) when rebooting
- When skipping initialization during reboot mount, also set `isReady`