### PR TITLE
Fix Post Author block render issues

### DIFF
--- a/packages/block-library/src/post-author/index.php
+++ b/packages/block-library/src/post-author/index.php
@@ -94,10 +94,6 @@ function post_author_build_css_font_sizes( $attributes ) {
  * @return string Returns the rendered author block.
  */
 function render_block_core_post_author( $attributes, $content, $block ) {
-	if ( empty( $attributes ) ) {
-		return '';
-	}
-
 	if ( ! isset( $block->context['postId'] ) ) {
 		return '';
 	}

--- a/packages/block-library/src/post-author/index.php
+++ b/packages/block-library/src/post-author/index.php
@@ -130,7 +130,7 @@ function render_block_core_post_author( $attributes, $content, $block ) {
 		: '';
 
 	return sprintf( '<div %1$s %2$s>', $class_attribute, $style_attribute ) .
-		( $attributes['showAvatar'] ? '<div class="wp-block-post-author__avatar">' . $avatar . '</div>' : '' ) .
+		( ! empty( $attributes['showAvatar'] ) ? '<div class="wp-block-post-author__avatar">' . $avatar . '</div>' : '' ) .
 		'<div class="wp-block-post-author__content">' .
 			( ! empty( $byline ) ? '<p class="wp-block-post-author__byline">' . $byline . '</p>' : '' ) .
 			'<p class="wp-block-post-author__name">' . get_the_author_meta( 'display_name', $author_id ) . '</p>' .


### PR DESCRIPTION
Quick bugfix for a couple of Post Author block render issues mentioned by @carolinan in slack. See https://wordpress.slack.com/archives/C02QB2JS7/p1589603738405100

- The block would not display if no attributes had been set
- There was a PHP warning if the Show Avatar setting had not been toggled. 