### PR TITLE
Fix navigation block placeholder overlap on Nav Menus page

### DIFF
--- a/packages/edit-navigation/src/style.scss
+++ b/packages/edit-navigation/src/style.scss
@@ -1,3 +1,9 @@
+*,
+*::before,
+*::after {
+	box-sizing: border-box;
+}
+
 @import "./components/layout/style.scss";
 @import "./components/menu-editor/style.scss";
 @import "./components/menus-editor/style.scss";


### PR DESCRIPTION
## Description
The placeholder on the navigation block is overlapping its panel on the nav menus page, which this PR fixes (see screenshots).

The placeholder uses a `width: 100%` in addition to padding, which with the default of `box-sizing: content-box` causes an overlap. Enabling `box-sizing: border-box` for elements in the nav menus page resolves the issue.

## How has this been tested?
1. Visit the nav menus page (wp-admin/admin.php?page=gutenberg-navigation)
2. Create a new menu
3. Observe the placeholder.

## Screenshots <!-- if applicable -->
### Before
<img width="650" alt="Screenshot 2020-05-18 at 2 25 37 pm" src="https://user-images.githubusercontent.com/677833/82182081-45f16680-9916-11ea-9f5d-4b6b78a1e68b.png">

### After
<img width="640" alt="Screenshot 2020-05-18 at 2 26 00 pm" src="https://user-images.githubusercontent.com/677833/82182091-4a1d8400-9916-11ea-991b-f25f52a5727f.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
