### PR TITLE
Components: Fix SlotFill infinite loop

### DIFF
--- a/packages/components/src/slot-fill/bubbles-virtually/fill.js
+++ b/packages/components/src/slot-fill/bubbles-virtually/fill.js
@@ -15,7 +15,7 @@ function useForceUpdate() {
 
 export default function Fill( { name, children } ) {
 	const slot = useSlot( name );
-	const ref = useRef( useForceUpdate() );
+	const ref = useRef( { rerender: useForceUpdate() } );
 
 	useEffect( () => {
 		// We register fills so we can keep track of their existance.

--- a/packages/components/src/slot-fill/bubbles-virtually/fill.js
+++ b/packages/components/src/slot-fill/bubbles-virtually/fill.js
@@ -1,16 +1,21 @@
 /**
  * WordPress dependencies
  */
-import { useRef, useEffect, createPortal } from '@wordpress/element';
+import { useRef, useState, useEffect, createPortal } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import useSlot from './use-slot';
 
+function useForceUpdate() {
+	const [ , setState ] = useState( {} );
+	return () => setState( {} );
+}
+
 export default function Fill( { name, children } ) {
 	const slot = useSlot( name );
-	const ref = useRef();
+	const ref = useRef( useForceUpdate() );
 
 	useEffect( () => {
 		// We register fills so we can keep track of their existance.

--- a/packages/components/src/slot-fill/bubbles-virtually/slot-fill-provider.js
+++ b/packages/components/src/slot-fill/bubbles-virtually/slot-fill-provider.js
@@ -49,6 +49,7 @@ function useSlotRegistry() {
 				slot.fillProps = fillProps;
 				const slotFills = fills[ name ];
 				if ( slotFills ) {
+					// Force update fills
 					slotFills.map( ( fill ) => fill.current() );
 				}
 			}

--- a/packages/components/src/slot-fill/bubbles-virtually/slot-fill-provider.js
+++ b/packages/components/src/slot-fill/bubbles-virtually/slot-fill-provider.js
@@ -50,7 +50,7 @@ function useSlotRegistry() {
 				const slotFills = fills[ name ];
 				if ( slotFills ) {
 					// Force update fills
-					slotFills.map( ( fill ) => fill.current() );
+					slotFills.map( ( fill ) => fill.current.rerender() );
 				}
 			}
 		},

--- a/packages/components/src/slot-fill/bubbles-virtually/slot-fill-provider.js
+++ b/packages/components/src/slot-fill/bubbles-virtually/slot-fill-provider.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { useMemo, useCallback, useState } from '@wordpress/element';
+import isShallowEqual from '@wordpress/is-shallow-equal';
 
 /**
  * Internal dependencies
@@ -14,13 +15,13 @@ function useSlotRegistry() {
 
 	const registerSlot = useCallback( ( name, ref, fillProps ) => {
 		setSlots( ( prevSlots ) => {
-			const currentSlot = prevSlots[ name ] || {};
+			const slot = prevSlots[ name ] || {};
 			return {
 				...prevSlots,
 				[ name ]: {
-					...currentSlot,
-					ref: ref || currentSlot.ref,
-					fillProps: fillProps || currentSlot.fillProps || {},
+					...slot,
+					ref: ref || slot.ref,
+					fillProps: fillProps || slot.fillProps || {},
 				},
 			};
 		} );
@@ -37,6 +38,23 @@ function useSlotRegistry() {
 			return prevSlots;
 		} );
 	}, [] );
+
+	const updateSlot = useCallback(
+		( name, fillProps ) => {
+			const slot = slots[ name ];
+			if ( ! slot ) {
+				return;
+			}
+			if ( ! isShallowEqual( slot.fillProps, fillProps ) ) {
+				slot.fillProps = fillProps;
+				const slotFills = fills[ name ];
+				if ( slotFills ) {
+					slotFills.map( ( fill ) => fill.current() );
+				}
+			}
+		},
+		[ slots, fills ]
+	);
 
 	const registerFill = useCallback( ( name, ref ) => {
 		setFills( ( prevFills ) => ( {
@@ -65,8 +83,7 @@ function useSlotRegistry() {
 			slots,
 			fills,
 			registerSlot,
-			// Just for readability
-			updateSlot: registerSlot,
+			updateSlot,
 			unregisterSlot,
 			registerFill,
 			unregisterFill,

--- a/packages/components/src/slot-fill/bubbles-virtually/slot.js
+++ b/packages/components/src/slot-fill/bubbles-virtually/slot.js
@@ -2,13 +2,11 @@
  * WordPress dependencies
  */
 import { useRef, useLayoutEffect, useContext } from '@wordpress/element';
-import isShallowEqual from '@wordpress/is-shallow-equal';
 
 /**
  * Internal dependencies
  */
 import SlotFillContext from './slot-fill-context';
-import useSlot from './use-slot';
 
 export default function Slot( {
 	name,
@@ -18,7 +16,6 @@ export default function Slot( {
 } ) {
 	const registry = useContext( SlotFillContext );
 	const ref = useRef();
-	const slot = useSlot( name );
 
 	useLayoutEffect( () => {
 		registry.registerSlot( name, ref, fillProps );
@@ -31,12 +28,10 @@ export default function Slot( {
 		// of fillProps.
 	}, [ registry.registerSlot, registry.unregisterSlot, name ] );
 
-	// fillProps may be an update that interact with the layout, so
-	// we useLayoutEffect
+	// fillProps may be an update that interacts with the layout, so we
+	// useLayoutEffect
 	useLayoutEffect( () => {
-		if ( slot.fillProps && ! isShallowEqual( slot.fillProps, fillProps ) ) {
-			registry.updateSlot( name, ref, fillProps );
-		}
+		registry.updateSlot( name, fillProps );
 	} );
 
 	return <Component ref={ ref } { ...props } />;

--- a/packages/components/src/slot-fill/bubbles-virtually/use-slot.js
+++ b/packages/components/src/slot-fill/bubbles-virtually/use-slot.js
@@ -16,8 +16,8 @@ export default function useSlot( name ) {
 	const fills = useMemo( () => slotFills || [], [ slotFills ] );
 
 	const updateSlot = useCallback(
-		( slotRef, slotFillProps ) => {
-			registry.updateSlot( name, slotRef, slotFillProps );
+		( fillProps ) => {
+			registry.updateSlot( name, fillProps );
 		},
 		[ name, registry.updateSlot ]
 	);


### PR DESCRIPTION
Closes #22258

## Description

`updateSlot` was causing an infinite loop when switching between desktop and mobile screen sizes with a toolbar open. So, instead of updating the context state as usual, which also re-renders the `Slot` component (which would call `updateSlot` again), this silently updates the slot `fillProps` and force a re-render only on the fills.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Follow the instructions on #22258

## Screenshots <!-- if applicable -->

<details><summary>Before</summary>

![May-18-2020 04-20-15](https://user-images.githubusercontent.com/3068563/82185079-0a777d80-98bf-11ea-9b2a-e08c9ea98f47.gif)

</details>

<details><summary>After</summary>

![May-18-2020 04-20-52](https://user-images.githubusercontent.com/3068563/82185089-106d5e80-98bf-11ea-8786-b59b84d4d2a0.gif)

</details>

## Types of changes

Bug fix