### PR TITLE
Avoid circular dependency issue in `AutoBlockPreview`

### DIFF
--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -10,7 +10,7 @@ import { useResizeObserver, pure } from '@wordpress/compose';
 import BlockList from '../block-list';
 
 // This is used to avoid rendering the block list if the sizes change.
-const MemoizedBlockList = pure( BlockList );
+let MemoizedBlockList;
 
 function AutoBlockPreview( { viewportWidth, __experimentalPadding } ) {
 	const [
@@ -21,6 +21,9 @@ function AutoBlockPreview( { viewportWidth, __experimentalPadding } ) {
 		containtResizeListener,
 		{ height: contentHeight },
 	] = useResizeObserver();
+
+	// Initialize on render instead of module top level, to avoid circular dependency issues.
+	MemoizedBlockList = MemoizedBlockList || pure( BlockList );
 
 	const scale =
 		( containerWidth - 2 * __experimentalPadding ) / viewportWidth;


### PR DESCRIPTION
## Description
`AutoBlockPreview` is part of a circular dependency involving `BlockList`. Because of this, and depending on ordering in the output code (ordering can change due to tree-shaking and module concatenation), `MemoizedBlockList` could get initialized while `BlockList` was still `undefined`.

This was causing problems for some consumers.

In this change, we delay initialization until the first render, to work around the circular dependency.

## How has this been tested?
Unit tests and smoke tests.

## Types of changes
Small bug fix.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [X] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
