### PR TITLE
Fix `npm run dev` error

### DIFF
--- a/packages/scripts/scripts/start.js
+++ b/packages/scripts/scripts/start.js
@@ -23,7 +23,7 @@ if ( hasArgInCLI( '--webpack--devtool' ) ) {
 
 const { status } = spawn(
 	resolveBin( 'webpack' ),
-	getWebpackArgs().push( '--watch' ),
+	[ ...getWebpackArgs(), '--watch' ],
 	{
 		stdio: 'inherit',
 	}


### PR DESCRIPTION
## Description

This line in https://github.com/WordPress/gutenberg/pull/22310 broke `npm run dev`:
https://github.com/WordPress/gutenberg/commit/af09721809036dcd813ae0f1121c55f72b05c0f2#diff-5c0db16c2ebb7877736c68e4cc9b9ad3R26

The problem was due to the fact that `push` returns a number - so we're not passing a list anymore. This PR is a one-liner fix to prevent the following error:

```
Build Progress: [==============================] 100%
[1] 
[1] > gutenberg@8.1.0 dev:packages core/plugins/gutenberg
[1] > node ./bin/packages/watch.js
[1] 
[0] child_process.js:425
[0]     throw new ERR_INVALID_ARG_TYPE('options', 'object', options);
[0]     ^
[0] 
[0] TypeError [ERR_INVALID_ARG_TYPE]: The "options" argument must be of type object. Received type number (1)
```


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
