### PR TITLE
Ellipsis menu in block navigator

### DIFF
--- a/packages/block-editor/src/components/block-navigation/block.js
+++ b/packages/block-editor/src/components/block-navigation/block.js
@@ -20,7 +20,6 @@ import {
 } from '../block-mover/button';
 import DescenderLines from './descender-lines';
 import BlockNavigationBlockContents from './block-contents';
-import BlockToolbar from '../block-toolbar';
 import BlockSettingsMenu from '../block-settings-menu';
 
 export default function BlockNavigationBlock( {
@@ -83,8 +82,9 @@ export default function BlockNavigationBlock( {
 							{ ...props }
 						/>
 
-						<BlockSettingsMenu clientIds={ [ clientId ] } />
-						{ /*<BlockToolbar />*/ }
+						{ level > 1 && (
+							<BlockSettingsMenu clientIds={ [ clientId ] } />
+						) }
 					</div>
 				) }
 			</TreeGridCell>

--- a/packages/block-editor/src/components/block-navigation/block.js
+++ b/packages/block-editor/src/components/block-navigation/block.js
@@ -50,6 +50,10 @@ export default function BlockNavigationBlock( {
 	const {
 		__experimentalWithEllipsisMenu: withEllipsisMenu,
 	} = useBlockNavigationContext();
+	const ellipsisMenuClassName = classnames(
+		'block-editor-block-navigation-block__menu-cell',
+		{ 'is-visible': hasVisibleMovers }
+	);
 
 	return (
 		<BlockNavigationLeaf
@@ -85,10 +89,6 @@ export default function BlockNavigationBlock( {
 							level={ level }
 							{ ...props }
 						/>
-
-						{ withEllipsisMenu && level > 1 && (
-							<BlockSettingsMenu clientIds={ [ clientId ] } />
-						) }
 					</div>
 				) }
 			</TreeGridCell>
@@ -113,6 +113,17 @@ export default function BlockNavigationBlock( {
 						) }
 					</TreeGridCell>
 				</>
+			) }
+
+			{ withEllipsisMenu && level > 1 && (
+				<TreeGridCell className={ ellipsisMenuClassName }>
+					{ ( props ) => (
+						<BlockSettingsMenu
+							clientIds={ [ clientId ] }
+							{ ...props }
+						/>
+					) }
+				</TreeGridCell>
 			) }
 		</BlockNavigationLeaf>
 	);

--- a/packages/block-editor/src/components/block-navigation/block.js
+++ b/packages/block-editor/src/components/block-navigation/block.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __experimentalTreeGridCell as TreeGridCell } from '@wordpress/components';
-
+import { moreVertical } from '@wordpress/icons';
 import { useState } from '@wordpress/element';
 
 /**
@@ -20,7 +20,7 @@ import {
 } from '../block-mover/button';
 import DescenderLines from './descender-lines';
 import BlockNavigationBlockContents from './block-contents';
-import BlockSettingsMenu from '../block-settings-menu';
+import BlockSettingsDropdown from '../block-settings-menu/block-settings-dropdown';
 import { useBlockNavigationContext } from './context';
 
 export default function BlockNavigationBlock( {
@@ -118,8 +118,9 @@ export default function BlockNavigationBlock( {
 			{ withEllipsisMenu && level > 1 && (
 				<TreeGridCell className={ ellipsisMenuClassName }>
 					{ ( props ) => (
-						<BlockSettingsMenu
+						<BlockSettingsDropdown
 							clientIds={ [ clientId ] }
+							icon={ moreVertical }
 							{ ...props }
 						/>
 					) }

--- a/packages/block-editor/src/components/block-navigation/block.js
+++ b/packages/block-editor/src/components/block-navigation/block.js
@@ -49,6 +49,7 @@ export default function BlockNavigationBlock( {
 	);
 	const {
 		__experimentalWithEllipsisMenu: withEllipsisMenu,
+		__experimentalWithEllipsisMenuMinLevel: ellipsisMenuMinLevel,
 	} = useBlockNavigationContext();
 	const ellipsisMenuClassName = classnames(
 		'block-editor-block-navigation-block__menu-cell',
@@ -115,7 +116,7 @@ export default function BlockNavigationBlock( {
 				</>
 			) }
 
-			{ withEllipsisMenu && level > 1 && (
+			{ withEllipsisMenu && level >= ellipsisMenuMinLevel && (
 				<TreeGridCell className={ ellipsisMenuClassName }>
 					{ ( props ) => (
 						<BlockSettingsDropdown

--- a/packages/block-editor/src/components/block-navigation/block.js
+++ b/packages/block-editor/src/components/block-navigation/block.js
@@ -21,6 +21,7 @@ import {
 import DescenderLines from './descender-lines';
 import BlockNavigationBlockContents from './block-contents';
 import BlockSettingsMenu from '../block-settings-menu';
+import { useBlockNavigationContext } from './context';
 
 export default function BlockNavigationBlock( {
 	block,
@@ -46,6 +47,9 @@ export default function BlockNavigationBlock( {
 		'block-editor-block-navigation-block__mover-cell',
 		{ 'is-visible': hasVisibleMovers }
 	);
+	const {
+		__experimentalWithEllipsisMenu: withEllipsisMenu,
+	} = useBlockNavigationContext();
 
 	return (
 		<BlockNavigationLeaf
@@ -82,7 +86,7 @@ export default function BlockNavigationBlock( {
 							{ ...props }
 						/>
 
-						{ level > 1 && (
+						{ withEllipsisMenu && level > 1 && (
 							<BlockSettingsMenu clientIds={ [ clientId ] } />
 						) }
 					</div>

--- a/packages/block-editor/src/components/block-navigation/block.js
+++ b/packages/block-editor/src/components/block-navigation/block.js
@@ -20,6 +20,8 @@ import {
 } from '../block-mover/button';
 import DescenderLines from './descender-lines';
 import BlockNavigationBlockContents from './block-contents';
+import BlockToolbar from '../block-toolbar';
+import BlockSettingsMenu from '../block-settings-menu';
 
 export default function BlockNavigationBlock( {
 	block,
@@ -80,6 +82,9 @@ export default function BlockNavigationBlock( {
 							level={ level }
 							{ ...props }
 						/>
+
+						<BlockSettingsMenu clientIds={ [ clientId ] } />
+						{ /*<BlockToolbar />*/ }
 					</div>
 				) }
 			</TreeGridCell>

--- a/packages/block-editor/src/components/block-navigation/context.js
+++ b/packages/block-editor/src/components/block-navigation/context.js
@@ -6,6 +6,7 @@ import { createContext, useContext } from '@wordpress/element';
 export const BlockNavigationContext = createContext( {
 	__experimentalWithBlockNavigationSlots: false,
 	__experimentalWithEllipsisMenu: false,
+	__experimentalWithEllipsisMenuMinLevel: 0,
 } );
 
 export const useBlockNavigationContext = () =>

--- a/packages/block-editor/src/components/block-navigation/context.js
+++ b/packages/block-editor/src/components/block-navigation/context.js
@@ -5,6 +5,7 @@ import { createContext, useContext } from '@wordpress/element';
 
 export const BlockNavigationContext = createContext( {
 	__experimentalWithBlockNavigationSlots: false,
+	__experimentalWithEllipsisMenu: false,
 } );
 
 export const useBlockNavigationContext = () =>

--- a/packages/block-editor/src/components/block-navigation/dropdown.js
+++ b/packages/block-editor/src/components/block-navigation/dropdown.js
@@ -56,6 +56,7 @@ function BlockNavigationDropdownToggle( { isEnabled, onToggle, isOpen } ) {
 function BlockNavigationDropdown( {
 	isDisabled,
 	__experimentalWithBlockNavigationSlots,
+	__experimentalWithEllipsisMenu,
 } ) {
 	const hasBlocks = useSelect(
 		( select ) => !! select( 'core/block-editor' ).getBlockCount(),
@@ -78,6 +79,9 @@ function BlockNavigationDropdown( {
 					onSelect={ onClose }
 					__experimentalWithBlockNavigationSlots={
 						__experimentalWithBlockNavigationSlots
+					}
+					__experimentalWithEllipsisMenu={
+						__experimentalWithEllipsisMenu
 					}
 				/>
 			) }

--- a/packages/block-editor/src/components/block-navigation/index.js
+++ b/packages/block-editor/src/components/block-navigation/index.js
@@ -20,6 +20,7 @@ function BlockNavigation( {
 	rootBlocks,
 	selectedBlockClientId,
 	selectBlock,
+	__experimentalWithEllipsisMenu,
 	__experimentalWithBlockNavigationSlots,
 } ) {
 	if ( ! rootBlocks || rootBlocks.length === 0 ) {
@@ -41,6 +42,9 @@ function BlockNavigation( {
 					blocks={ [ rootBlock ] }
 					selectedBlockClientId={ selectedBlockClientId }
 					selectBlock={ selectBlock }
+					__experimentalWithEllipsisMenu={
+						__experimentalWithEllipsisMenu
+					}
 					__experimentalWithBlockNavigationSlots={
 						__experimentalWithBlockNavigationSlots
 					}
@@ -52,6 +56,9 @@ function BlockNavigation( {
 					blocks={ rootBlocks }
 					selectedBlockClientId={ selectedBlockClientId }
 					selectBlock={ selectBlock }
+					__experimentalWithEllipsisMenu={
+						__experimentalWithEllipsisMenu
+					}
 					__experimentalWithBlockNavigationSlots={
 						__experimentalWithBlockNavigationSlots
 					}

--- a/packages/block-editor/src/components/block-navigation/index.js
+++ b/packages/block-editor/src/components/block-navigation/index.js
@@ -20,8 +20,9 @@ function BlockNavigation( {
 	rootBlocks,
 	selectedBlockClientId,
 	selectBlock,
-	__experimentalWithEllipsisMenu,
 	__experimentalWithBlockNavigationSlots,
+	__experimentalWithEllipsisMenu,
+	__experimentalWithEllipsisMenuMinLevel,
 } ) {
 	if ( ! rootBlocks || rootBlocks.length === 0 ) {
 		return null;
@@ -45,6 +46,9 @@ function BlockNavigation( {
 					__experimentalWithEllipsisMenu={
 						__experimentalWithEllipsisMenu
 					}
+					__experimentalWithEllipsisMenuMinLevel={
+						__experimentalWithEllipsisMenuMinLevel
+					}
 					__experimentalWithBlockNavigationSlots={
 						__experimentalWithBlockNavigationSlots
 					}
@@ -58,6 +62,9 @@ function BlockNavigation( {
 					selectBlock={ selectBlock }
 					__experimentalWithEllipsisMenu={
 						__experimentalWithEllipsisMenu
+					}
+					__experimentalWithEllipsisMenuMinLevel={
+						__experimentalWithEllipsisMenuMinLevel
 					}
 					__experimentalWithBlockNavigationSlots={
 						__experimentalWithBlockNavigationSlots

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -67,9 +67,14 @@ $tree-item-height: 36px;
 			opacity: 1;
 			@include edit-post__fade-in-animation;
 		}
+	}
 
-		.components-toolbar {
-			border: 0;
+	.block-editor-block-navigation-block__menu-cell {
+		&,
+		.components-button.has-icon {
+			width: 24px;
+			min-width: 24px;
+			padding: 0;
 		}
 	}
 

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -106,6 +106,10 @@ $tree-item-height: 36px;
 	.block-editor-block-navigation-block__contents-container,
 	.block-editor-block-navigation-appender__container {
 		display: flex;
+
+		.components-toolbar {
+			border: 0;
+		}
 	}
 
 	.block-editor-block-navigator-descender-line {

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -67,9 +67,7 @@ $tree-item-height: 36px;
 			opacity: 1;
 			@include edit-post__fade-in-animation;
 		}
-	}
 
-	.block-editor-block-navigation-block__menu-cell {
 		&,
 		.components-button.has-icon {
 			width: 24px;

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -57,6 +57,7 @@ $tree-item-height: 36px;
 		border-radius: $border-width;
 	}
 
+	.block-editor-block-navigation-block__menu-cell,
 	.block-editor-block-navigation-block__mover-cell {
 		width: $button-size;
 		opacity: 0;
@@ -65,6 +66,10 @@ $tree-item-height: 36px;
 		&.is-visible {
 			opacity: 1;
 			@include edit-post__fade-in-animation;
+		}
+
+		.components-toolbar {
+			border: 0;
 		}
 	}
 
@@ -106,10 +111,6 @@ $tree-item-height: 36px;
 	.block-editor-block-navigation-block__contents-container,
 	.block-editor-block-navigation-appender__container {
 		display: flex;
-
-		.components-toolbar {
-			border: 0;
-		}
 	}
 
 	.block-editor-block-navigator-descender-line {

--- a/packages/block-editor/src/components/block-navigation/tree.js
+++ b/packages/block-editor/src/components/block-navigation/tree.js
@@ -22,16 +22,22 @@ import { BlockNavigationContext } from './context';
 export default function BlockNavigationTree( {
 	__experimentalWithBlockNavigationSlots,
 	__experimentalWithEllipsisMenu,
+	__experimentalWithEllipsisMenuMinLevel,
 	...props
 } ) {
 	const contextValue = useMemo(
 		() => ( {
 			__experimentalWithBlockNavigationSlots,
 			__experimentalWithEllipsisMenu,
+			__experimentalWithEllipsisMenuMinLevel:
+				typeof __experimentalWithEllipsisMenuMinLevel === 'number'
+					? __experimentalWithEllipsisMenuMinLevel
+					: 0,
 		} ),
 		[
 			__experimentalWithBlockNavigationSlots,
 			__experimentalWithEllipsisMenu,
+			__experimentalWithEllipsisMenuMinLevel,
 		]
 	);
 

--- a/packages/block-editor/src/components/block-navigation/tree.js
+++ b/packages/block-editor/src/components/block-navigation/tree.js
@@ -21,11 +21,18 @@ import { BlockNavigationContext } from './context';
  */
 export default function BlockNavigationTree( {
 	__experimentalWithBlockNavigationSlots,
+	__experimentalWithEllipsisMenu,
 	...props
 } ) {
 	const contextValue = useMemo(
-		() => ( { __experimentalWithBlockNavigationSlots } ),
-		[ __experimentalWithBlockNavigationSlots ]
+		() => ( {
+			__experimentalWithBlockNavigationSlots,
+			__experimentalWithEllipsisMenu,
+		} ),
+		[
+			__experimentalWithBlockNavigationSlots,
+			__experimentalWithEllipsisMenu,
+		]
 	);
 
 	return (

--- a/packages/block-editor/src/components/block-settings-menu-controls/index.js
+++ b/packages/block-editor/src/components/block-settings-menu-controls/index.js
@@ -13,14 +13,16 @@ const { Fill: BlockSettingsMenuControls, Slot } = createSlotFill(
 	'BlockSettingsMenuControls'
 );
 
-const BlockSettingsMenuControlsSlot = ( { fillProps } ) => {
+const BlockSettingsMenuControlsSlot = ( { fillProps, clientIds = null } ) => {
 	const { selectedBlocks } = useSelect( ( select ) => {
 		const { getBlocksByClientId, getSelectedBlockClientIds } = select(
 			'core/block-editor'
 		);
+		const ids =
+			clientIds !== null ? clientIds : getSelectedBlockClientIds();
 		return {
 			selectedBlocks: map(
-				getBlocksByClientId( getSelectedBlockClientIds() ),
+				getBlocksByClientId( ids ),
 				( block ) => block.name
 			),
 		};

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -1,0 +1,173 @@
+/**
+ * External dependencies
+ */
+import { castArray, flow } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __, _n } from '@wordpress/i18n';
+import {
+	DropdownMenu,
+	MenuGroup,
+	MenuItem,
+	ClipboardButton,
+} from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { moreHorizontal } from '@wordpress/icons';
+import { useState } from '@wordpress/element';
+import { serialize } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import BlockActions from '../block-actions';
+import BlockModeToggle from './block-mode-toggle';
+import BlockHTMLConvertButton from './block-html-convert-button';
+import BlockUnknownConvertButton from './block-unknown-convert-button';
+import __experimentalBlockSettingsMenuFirstItem from './block-settings-menu-first-item';
+import BlockSettingsMenuControls from '../block-settings-menu-controls';
+
+const POPOVER_PROPS = {
+	className: 'block-editor-block-settings-menu__popover',
+	position: 'bottom right',
+	isAlternate: true,
+};
+
+export function BlockSettingsDropdown( { clientIds, ...props } ) {
+	const blockClientIds = castArray( clientIds );
+	const count = blockClientIds.length;
+	const firstBlockClientId = blockClientIds[ 0 ];
+
+	const shortcuts = useSelect( ( select ) => {
+		const { getShortcutRepresentation } = select(
+			'core/keyboard-shortcuts'
+		);
+		return {
+			duplicate: getShortcutRepresentation(
+				'core/block-editor/duplicate'
+			),
+			remove: getShortcutRepresentation( 'core/block-editor/remove' ),
+			insertAfter: getShortcutRepresentation(
+				'core/block-editor/insert-after'
+			),
+			insertBefore: getShortcutRepresentation(
+				'core/block-editor/insert-before'
+			),
+		};
+	}, [] );
+
+	const [ hasCopied, setHasCopied ] = useState();
+
+	return (
+		<BlockActions clientIds={ clientIds }>
+			{ ( {
+				canDuplicate,
+				canInsertDefaultBlock,
+				isLocked,
+				onDuplicate,
+				onInsertAfter,
+				onInsertBefore,
+				onRemove,
+				blocks,
+			} ) => (
+				<DropdownMenu
+					icon={ moreHorizontal }
+					label={ __( 'More options' ) }
+					className="block-editor-block-settings-menu"
+					popoverProps={ POPOVER_PROPS }
+					noIcons
+					{ ...props }
+				>
+					{ ( { onClose } ) => (
+						<>
+							<MenuGroup>
+								<__experimentalBlockSettingsMenuFirstItem.Slot
+									fillProps={ { onClose } }
+								/>
+								{ count === 1 && (
+									<BlockUnknownConvertButton
+										clientId={ firstBlockClientId }
+									/>
+								) }
+								{ count === 1 && (
+									<BlockHTMLConvertButton
+										clientId={ firstBlockClientId }
+									/>
+								) }
+								<ClipboardButton
+									text={ () => serialize( blocks ) }
+									role="menuitem"
+									className="components-menu-item__button"
+									onCopy={ () => {
+										setHasCopied( true );
+									} }
+									onFinishCopy={ () => setHasCopied( false ) }
+								>
+									{ hasCopied
+										? __( 'Copied!' )
+										: __( 'Copy' ) }
+								</ClipboardButton>
+								{ canDuplicate && (
+									<MenuItem
+										onClick={ flow( onClose, onDuplicate ) }
+										shortcut={ shortcuts.duplicate }
+									>
+										{ __( 'Duplicate' ) }
+									</MenuItem>
+								) }
+								{ canInsertDefaultBlock && (
+									<>
+										<MenuItem
+											onClick={ flow(
+												onClose,
+												onInsertBefore
+											) }
+											shortcut={ shortcuts.insertBefore }
+										>
+											{ __( 'Insert Before' ) }
+										</MenuItem>
+										<MenuItem
+											onClick={ flow(
+												onClose,
+												onInsertAfter
+											) }
+											shortcut={ shortcuts.insertAfter }
+										>
+											{ __( 'Insert After' ) }
+										</MenuItem>
+									</>
+								) }
+								{ count === 1 && (
+									<BlockModeToggle
+										clientId={ firstBlockClientId }
+										onToggle={ onClose }
+									/>
+								) }
+							</MenuGroup>
+							<BlockSettingsMenuControls.Slot
+								fillProps={ { onClose } }
+							/>
+							<MenuGroup>
+								{ ! isLocked && (
+									<MenuItem
+										onClick={ flow( onClose, onRemove ) }
+										shortcut={ shortcuts.remove }
+									>
+										{ _n(
+											'Remove Block',
+											'Remove Blocks',
+											count
+										) }
+									</MenuItem>
+								) }
+							</MenuGroup>
+						</>
+					) }
+				</DropdownMenu>
+			) }
+		</BlockActions>
+	);
+}
+
+export default BlockSettingsDropdown;

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -147,6 +147,7 @@ export function BlockSettingsDropdown( { clientIds, ...props } ) {
 							</MenuGroup>
 							<BlockSettingsMenuControls.Slot
 								fillProps={ { onClose } }
+								clientIds={ clientIds }
 							/>
 							<MenuGroup>
 								{ ! isLocked && (

--- a/packages/block-editor/src/components/block-settings-menu/index.js
+++ b/packages/block-editor/src/components/block-settings-menu/index.js
@@ -11,14 +11,15 @@ import {
  */
 import BlockSettingsDropdown from './block-settings-dropdown';
 
-export function BlockSettingsMenu( { clientIds } ) {
+export function BlockSettingsMenu( { clientIds, ...props } ) {
 	return (
 		<ToolbarGroup>
 			<ToolbarItem>
-				{ ( { toggleProps } ) => (
+				{ ( toggleProps ) => (
 					<BlockSettingsDropdown
 						clientIds={ clientIds }
 						toggleProps={ toggleProps }
+						{ ...props }
 					/>
 				) }
 			</ToolbarItem>

--- a/packages/block-editor/src/components/block-settings-menu/index.js
+++ b/packages/block-editor/src/components/block-settings-menu/index.js
@@ -1,206 +1,28 @@
 /**
- * External dependencies
- */
-import { castArray, flow } from 'lodash';
-
-/**
  * WordPress dependencies
  */
-import { __, _n } from '@wordpress/i18n';
 import {
 	ToolbarGroup,
 	__experimentalToolbarItem as ToolbarItem,
-	DropdownMenu,
-	MenuGroup,
-	MenuItem,
-	ClipboardButton,
 } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
-import { moreHorizontal } from '@wordpress/icons';
-import { useState } from '@wordpress/element';
-import { serialize } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
-import BlockActions from '../block-actions';
-import BlockModeToggle from './block-mode-toggle';
-import BlockHTMLConvertButton from './block-html-convert-button';
-import BlockUnknownConvertButton from './block-unknown-convert-button';
-import __experimentalBlockSettingsMenuFirstItem from './block-settings-menu-first-item';
-import BlockSettingsMenuControls from '../block-settings-menu-controls';
-
-const POPOVER_PROPS = {
-	className: 'block-editor-block-settings-menu__popover',
-	position: 'bottom right',
-	isAlternate: true,
-};
+import BlockSettingsDropdown from './block-settings-dropdown';
 
 export function BlockSettingsMenu( { clientIds } ) {
-	const blockClientIds = castArray( clientIds );
-	const count = blockClientIds.length;
-	const firstBlockClientId = blockClientIds[ 0 ];
-
-	const shortcuts = useSelect( ( select ) => {
-		const { getShortcutRepresentation } = select(
-			'core/keyboard-shortcuts'
-		);
-		return {
-			duplicate: getShortcutRepresentation(
-				'core/block-editor/duplicate'
-			),
-			remove: getShortcutRepresentation( 'core/block-editor/remove' ),
-			insertAfter: getShortcutRepresentation(
-				'core/block-editor/insert-after'
-			),
-			insertBefore: getShortcutRepresentation(
-				'core/block-editor/insert-before'
-			),
-		};
-	}, [] );
-
-	const [ hasCopied, setHasCopied ] = useState();
-
 	return (
-		<BlockActions clientIds={ clientIds }>
-			{ ( {
-				canDuplicate,
-				canInsertDefaultBlock,
-				isLocked,
-				onDuplicate,
-				onInsertAfter,
-				onInsertBefore,
-				onRemove,
-				blocks,
-			} ) => (
-				<ToolbarGroup>
-					<ToolbarItem>
-						{ ( toggleProps ) => (
-							<DropdownMenu
-								icon={ moreHorizontal }
-								label={ __( 'More options' ) }
-								className="block-editor-block-settings-menu"
-								popoverProps={ POPOVER_PROPS }
-								toggleProps={ toggleProps }
-								noIcons
-							>
-								{ ( { onClose } ) => (
-									<>
-										<MenuGroup>
-											<__experimentalBlockSettingsMenuFirstItem.Slot
-												fillProps={ { onClose } }
-											/>
-											{ count === 1 && (
-												<BlockUnknownConvertButton
-													clientId={
-														firstBlockClientId
-													}
-												/>
-											) }
-											{ count === 1 && (
-												<BlockHTMLConvertButton
-													clientId={
-														firstBlockClientId
-													}
-												/>
-											) }
-											<ClipboardButton
-												text={ () =>
-													serialize( blocks )
-												}
-												role="menuitem"
-												className="components-menu-item__button"
-												onCopy={ () => {
-													setHasCopied( true );
-												} }
-												onFinishCopy={ () =>
-													setHasCopied( false )
-												}
-											>
-												{ hasCopied
-													? __( 'Copied!' )
-													: __( 'Copy' ) }
-											</ClipboardButton>
-											{ canDuplicate && (
-												<MenuItem
-													onClick={ flow(
-														onClose,
-														onDuplicate
-													) }
-													shortcut={
-														shortcuts.duplicate
-													}
-												>
-													{ __( 'Duplicate' ) }
-												</MenuItem>
-											) }
-											{ canInsertDefaultBlock && (
-												<>
-													<MenuItem
-														onClick={ flow(
-															onClose,
-															onInsertBefore
-														) }
-														shortcut={
-															shortcuts.insertBefore
-														}
-													>
-														{ __(
-															'Insert Before'
-														) }
-													</MenuItem>
-													<MenuItem
-														onClick={ flow(
-															onClose,
-															onInsertAfter
-														) }
-														shortcut={
-															shortcuts.insertAfter
-														}
-													>
-														{ __( 'Insert After' ) }
-													</MenuItem>
-												</>
-											) }
-											{ count === 1 && (
-												<BlockModeToggle
-													clientId={
-														firstBlockClientId
-													}
-													onToggle={ onClose }
-												/>
-											) }
-										</MenuGroup>
-										<BlockSettingsMenuControls.Slot
-											fillProps={ { onClose } }
-										/>
-										<MenuGroup>
-											{ ! isLocked && (
-												<MenuItem
-													onClick={ flow(
-														onClose,
-														onRemove
-													) }
-													shortcut={
-														shortcuts.remove
-													}
-												>
-													{ _n(
-														'Remove Block',
-														'Remove Blocks',
-														count
-													) }
-												</MenuItem>
-											) }
-										</MenuGroup>
-									</>
-								) }
-							</DropdownMenu>
-						) }
-					</ToolbarItem>
-				</ToolbarGroup>
-			) }
-		</BlockActions>
+		<ToolbarGroup>
+			<ToolbarItem>
+				{ ( { toggleProps } ) => (
+					<BlockSettingsDropdown
+						clientIds={ clientIds }
+						toggleProps={ toggleProps }
+					/>
+				) }
+			</ToolbarItem>
+		</ToolbarGroup>
 	);
 }
 

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -86,7 +86,6 @@ function Navigation( {
 
 	const { navigatorToolbarButton, navigatorModal } = useBlockNavigator(
 		clientId,
-		true,
 		true
 	);
 

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -86,6 +86,7 @@ function Navigation( {
 
 	const { navigatorToolbarButton, navigatorModal } = useBlockNavigator(
 		clientId,
+		true,
 		true
 	);
 

--- a/packages/edit-navigation/src/components/menu-editor/navigation-structure-panel.js
+++ b/packages/edit-navigation/src/components/menu-editor/navigation-structure-panel.js
@@ -26,6 +26,7 @@ export default function NavigationStructurePanel( { blocks, initialOpen } ) {
 						selectedBlockClientId={ selectedBlockClientIds[ 0 ] }
 						selectBlock={ selectBlock }
 						__experimentalWithBlockNavigationSlots={ true }
+						__experimentalWithEllipsisMenu={ true }
 						showNestedBlocks
 						showAppender
 						showBlockMovers

--- a/packages/edit-navigation/src/components/menu-editor/navigation-structure-panel.js
+++ b/packages/edit-navigation/src/components/menu-editor/navigation-structure-panel.js
@@ -27,6 +27,7 @@ export default function NavigationStructurePanel( { blocks, initialOpen } ) {
 						selectBlock={ selectBlock }
 						__experimentalWithBlockNavigationSlots={ true }
 						__experimentalWithEllipsisMenu={ true }
+						__experimentalWithEllipsisMenuMinLevel={ 2 }
 						showNestedBlocks
 						showAppender
 						showBlockMovers

--- a/packages/edit-navigation/src/components/menu-editor/navigation-structure-panel.js
+++ b/packages/edit-navigation/src/components/menu-editor/navigation-structure-panel.js
@@ -25,8 +25,8 @@ export default function NavigationStructurePanel( { blocks, initialOpen } ) {
 						blocks={ blocks }
 						selectedBlockClientId={ selectedBlockClientIds[ 0 ] }
 						selectBlock={ selectBlock }
-						__experimentalWithBlockNavigationSlots={ true }
-						__experimentalWithEllipsisMenu={ true }
+						__experimentalWithBlockNavigationSlots
+						__experimentalWithEllipsisMenu
 						__experimentalWithEllipsisMenuMinLevel={ 2 }
 						showNestedBlocks
 						showAppender

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -77,7 +77,10 @@ function HeaderToolbar( { onToggleInserter, isInserterOpen } ) {
 			<EditorHistoryUndo />
 			<EditorHistoryRedo />
 			<TableOfContents hasOutlineItemsDisabled={ isTextModeEnabled } />
-			<BlockNavigationDropdown isDisabled={ isTextModeEnabled } />
+			<BlockNavigationDropdown
+				isDisabled={ isTextModeEnabled }
+				__experimentalWithEllipsisMenu
+			/>
 			{ displayBlockToolbar && (
 				<div className="edit-post-header-toolbar__block-toolbar">
 					<BlockToolbar hideDragHandle />


### PR DESCRIPTION
## Description

This is a first attempt at adding an ellipsis menu to block navigation. The menu only offers a few basic options in this initial PR.

A follow-up PR will bring in more menu items. I propose merging/reviewing these PRs in the following order:

1. #22427 - introduce very basic ellipsis menu to the block navigation
1. #22463 - allow the block to define additional ellipsis menu items
1. #22463 - introduce an abstraction that takes care of the toolbar items and ellipsis menu items at the same time

Related issue: https://github.com/WordPress/gutenberg/issues/22089 

## How has this been tested?
1. Enable the experimental navigation screen in Gutenberg experiments
1. Go to Navigation (beta)
1. Add a few menu items
1. Confirm the ellipsis menu is there and that it offers a few basic options.

## Screenshots

<img width="567" alt="Zrzut ekranu 2020-05-20 o 12 32 48" src="https://user-images.githubusercontent.com/205419/82436392-09e50f80-9a96-11ea-96a5-635f2f17af12.png">

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
