### PR TITLE
Use the new deleteEntityRecord to delete menus

### DIFF
--- a/packages/edit-navigation/src/components/delete-menu-button/index.js
+++ b/packages/edit-navigation/src/components/delete-menu-button/index.js
@@ -1,20 +1,10 @@
 /**
  * WordPress dependencies
  */
-import apiFetch from '@wordpress/api-fetch';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-export default function DeleteMenuButton( { menuId, onDelete } ) {
-	const deleteMenu = async ( recordId ) => {
-		const path = `/__experimental/menus/${ recordId }?force=true`;
-		const deletedRecord = await apiFetch( {
-			path,
-			method: 'DELETE',
-		} );
-		return deletedRecord.previous;
-	};
-
+export default function DeleteMenuButton( { onDelete } ) {
 	const askToDelete = async () => {
 		if (
 			// eslint-disable-next-line no-alert
@@ -22,8 +12,7 @@ export default function DeleteMenuButton( { menuId, onDelete } ) {
 				__( 'Are you sure you want to delete this navigation?' )
 			)
 		) {
-			const deletedMenu = await deleteMenu( menuId );
-			onDelete( deletedMenu.id );
+			onDelete();
 		}
 	};
 

--- a/packages/edit-navigation/src/components/menus-editor/index.js
+++ b/packages/edit-navigation/src/components/menus-editor/index.js
@@ -41,13 +41,10 @@ export default function MenusEditor( { blockEditorSettings } ) {
 	}, [ hasLoadedMenus ] );
 
 	const [ menuId, setMenuId ] = useState();
-	const [ stateMenus, setStateMenus ] = useState();
 	const [ showCreateMenuPanel, setShowCreateMenuPanel ] = useState( false );
 
 	useEffect( () => {
 		if ( menus?.length ) {
-			setStateMenus( menus );
-
 			// Only set menuId if it's currently unset.
 			if ( ! menuId ) {
 				setMenuId( menus[ 0 ].id );
@@ -59,7 +56,7 @@ export default function MenusEditor( { blockEditorSettings } ) {
 		return <Spinner />;
 	}
 
-	const hasMenus = !! stateMenus?.length;
+	const hasMenus = !! menus?.length;
 	const isCreateMenuPanelVisible =
 		hasCompletedFirstLoad && ( ! hasMenus || showCreateMenuPanel );
 
@@ -77,7 +74,7 @@ export default function MenusEditor( { blockEditorSettings } ) {
 							<SelectControl
 								className="edit-navigation-menus-editor__menu-select-control"
 								label={ __( 'Select navigation to edit:' ) }
-								options={ stateMenus?.map( ( menu ) => ( {
+								options={ menus?.map( ( menu ) => ( {
 									value: menu.id,
 									label: menu.name,
 								} ) ) }
@@ -98,7 +95,7 @@ export default function MenusEditor( { blockEditorSettings } ) {
 			</Card>
 			{ isCreateMenuPanelVisible && (
 				<CreateMenuArea
-					menus={ stateMenus }
+					menus={ menus }
 					onCancel={
 						// User can only cancel out of menu creation if there
 						// are other menus to fall back to showing.

--- a/packages/edit-navigation/src/components/menus-editor/index.js
+++ b/packages/edit-navigation/src/components/menus-editor/index.js
@@ -115,6 +115,7 @@ export default function MenusEditor( { blockEditorSettings } ) {
 					blockEditorSettings={ blockEditorSettings }
 					onDeleteMenu={ async () => {
 						await deleteMenu( menuId, 'force=true' );
+						setMenuId( false );
 					} }
 				/>
 			) }

--- a/packages/edit-navigation/src/components/menus-editor/index.js
+++ b/packages/edit-navigation/src/components/menus-editor/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useState, useEffect } from '@wordpress/element';
 import {
 	Button,
@@ -31,6 +31,8 @@ export default function MenusEditor( { blockEditorSettings } ) {
 	const [ hasCompletedFirstLoad, setHasCompletedFirstLoad ] = useState(
 		false
 	);
+
+	const { deleteMenu } = useDispatch( 'core' );
 
 	useEffect( () => {
 		if ( ! hasCompletedFirstLoad && hasLoadedMenus ) {
@@ -114,16 +116,8 @@ export default function MenusEditor( { blockEditorSettings } ) {
 				<NavigationEditor
 					menuId={ menuId }
 					blockEditorSettings={ blockEditorSettings }
-					onDeleteMenu={ ( deletedMenu ) => {
-						const newStateMenus = stateMenus.filter( ( menu ) => {
-							return menu.id !== deletedMenu;
-						} );
-						setStateMenus( newStateMenus );
-						if ( newStateMenus.length ) {
-							setMenuId( newStateMenus[ 0 ].id );
-						} else {
-							setMenuId();
-						}
+					onDeleteMenu={ async () => {
+						await deleteMenu( menuId, '' );
 					} }
 				/>
 			) }

--- a/packages/edit-navigation/src/components/menus-editor/index.js
+++ b/packages/edit-navigation/src/components/menus-editor/index.js
@@ -38,7 +38,7 @@ export default function MenusEditor( { blockEditorSettings } ) {
 		if ( ! hasCompletedFirstLoad && hasLoadedMenus ) {
 			setHasCompletedFirstLoad( true );
 		}
-	}, [ hasLoadedMenus ] );
+	}, [ menus, hasLoadedMenus ] );
 
 	const [ menuId, setMenuId ] = useState();
 	const [ showCreateMenuPanel, setShowCreateMenuPanel ] = useState( false );
@@ -114,7 +114,7 @@ export default function MenusEditor( { blockEditorSettings } ) {
 					menuId={ menuId }
 					blockEditorSettings={ blockEditorSettings }
 					onDeleteMenu={ async () => {
-						await deleteMenu( menuId, '' );
+						await deleteMenu( menuId, 'force=true' );
 					} }
 				/>
 			) }


### PR DESCRIPTION
## Description
Closes #22340 This PR implements deleting menus using entity delete. It depends on #21557

## How has this been tested?
Tested locally by:

1. Creating menus
2. Deleting menus
