### PR TITLE
Buttons: allow split and merge

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -304,7 +304,7 @@ function RichTextWrapper(
 			}
 
 			// If there's pasted blocks, append a block with non empty content
-			/// after the caret. Otherwise, do append and empty block if there
+			/// after the caret. Otherwise, do append an empty block if there
 			// is no `onSplitMiddle` prop, but if there is and the content is
 			// empty, the middle block is enough to set focus in.
 			if (

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -303,11 +303,15 @@ function RichTextWrapper(
 				blocks.push( onSplitMiddle() );
 			}
 
-			// If there's pasted blocks, append a block with the content after the
-			// caret. Otherwise, do append and empty block if there is no
-			// `onSplitMiddle` prop, but if there is and the content is empty, the
-			// middle block is enough to set focus in.
-			if ( hasPastedBlocks || ! onSplitMiddle || ! isEmpty( after ) ) {
+			// If there's pasted blocks, append a block with non empty content
+			/// after the caret. Otherwise, do append and empty block if there
+			// is no `onSplitMiddle` prop, but if there is and the content is
+			// empty, the middle block is enough to set focus in.
+			if (
+				hasPastedBlocks
+					? ! isEmpty( after )
+					: ! onSplitMiddle || ! isEmpty( after )
+			) {
 				blocks.push(
 					onSplit(
 						toHTMLString( {

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -191,16 +191,12 @@ function ButtonEdit( props ) {
 							: undefined,
 						...colorProps.style,
 					} }
-					onSplit={ ( value ) => {
-						if ( ! value ) {
-							return createBlock( 'core/button' );
-						}
-
-						return createBlock( 'core/button', {
+					onSplit={ ( value ) =>
+						createBlock( 'core/button', {
 							...attributes,
 							text: value,
-						} );
-					} }
+						} )
+					}
 					onReplace={ onReplace }
 					onMerge={ mergeBlocks }
 					identifier="text"

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -27,6 +27,7 @@ import {
 } from '@wordpress/block-editor';
 import { rawShortcut, displayShortcut } from '@wordpress/keycodes';
 import { link } from '@wordpress/icons';
+import { createBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -123,7 +124,14 @@ function URLPicker( {
 }
 
 function ButtonEdit( props ) {
-	const { attributes, setAttributes, className, isSelected } = props;
+	const {
+		attributes,
+		setAttributes,
+		className,
+		isSelected,
+		onReplace,
+		mergeBlocks,
+	} = props;
 	const {
 		borderRadius,
 		linkTarget,
@@ -183,6 +191,19 @@ function ButtonEdit( props ) {
 							: undefined,
 						...colorProps.style,
 					} }
+					onSplit={ ( value ) => {
+						if ( ! value ) {
+							return createBlock( 'core/button' );
+						}
+
+						return createBlock( 'core/button', {
+							...attributes,
+							text: value,
+						} );
+					} }
+					onReplace={ onReplace }
+					onMerge={ mergeBlocks }
+					identifier="text"
 				/>
 			</Block.div>
 			<URLPicker

--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -44,7 +44,8 @@ export const settings = {
 	edit,
 	save,
 	deprecated,
-	merge: ( { text: textA = '' }, { text: textB = '' } ) => ( {
-		text: textA + textB,
+	merge: ( a, { text = '' } ) => ( {
+		...a,
+		text: a.text + text,
 	} ),
 };

--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -44,4 +44,7 @@ export const settings = {
 	edit,
 	save,
 	deprecated,
+	merge: ( { text: textA = '' }, { text: textB = '' } ) => ( {
+		text: textA + textB,
+	} ),
 };

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/copy-cut-paste-whole-blocks.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/copy-cut-paste-whole-blocks.test.js.snap
@@ -21,10 +21,6 @@ exports[`Multi-block selection should copy and paste individual blocks 2`] = `
 
 <!-- wp:paragraph -->
 <p>Here is a unique string so we can test copying.</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p></p>
 <!-- /wp:paragraph -->"
 `;
 
@@ -41,10 +37,6 @@ exports[`Multi-block selection should cut and paste individual blocks 2`] = `
 
 <!-- wp:paragraph -->
 <p>Yet another unique string.</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p></p>
 <!-- /wp:paragraph -->"
 `;
 


### PR DESCRIPTION
## Description

Allows buttons to be split with enter and backspace. Currently these insert line breaks which doesn't make much sense in the context of buttons.

![button-split](https://user-images.githubusercontent.com/4710635/82252936-49094880-9950-11ea-9a42-6764b4a22ee8.gif)


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
