### PR TITLE
Build Tooling: Restore Playground GitHub Pages deploy

### DIFF
--- a/.github/workflows/storybook-pages.yml
+++ b/.github/workflows/storybook-pages.yml
@@ -1,0 +1,32 @@
+name: Storybook GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: master
+
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Build Storybook
+        run: npm run storybook:build
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./playground/dist


### PR DESCRIPTION
Closes #21669

This pull request seeks to attempt to restore the Storybook ("Playground") deployment to GitHub Pages. The version currently available at [wordpress.github.io/gutenberg](https://wordpress.github.io/gutenberg/) is several weeks out of date at this point, due to the changes in Travis build introduced in the commit at edc4ac62abb3702e525d46476fa342f11e82b0fc. As discussed in #21669, I have strong reservations against reintroducing personal token-based deployment. This pull request seeks to attempt to use GitHub Actions-based action [GitHub Actions for GitHub Pages](https://github.com/peaceiris/actions-gh-pages), using the `github_token` available by default with GitHub Actions.

It's not entirely clear if we can expect this to work out of the box, due to the issues with `github_token` discussed in #21669 and also [summarized as needing special accommodations](https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-first-deployment-with-github_token) in the action documentation. The documentation seems to indicate it only requires a "first-time" setup. If this is the case, it's a reasonable compromise to consider.

**Testing Instructions:**

I assume we won't be able to test this except by verifying the results _after_ it's merged 😃 