### PR TITLE
Change inserter search placeholder text color

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -88,6 +88,10 @@ $block-inserter-tabs-height: 44px;
 			background: $white;
 			box-shadow: 0 0 0 $border-width-focus $theme-color;
 		}
+
+		&::placeholder {
+			color: #6c6f75;
+		}
 	}
 }
 

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -90,7 +90,7 @@ $block-inserter-tabs-height: 44px;
 		}
 
 		&::placeholder {
-			color: #6c6f75;
+			color: $dark-gray-400;
 		}
 	}
 }


### PR DESCRIPTION
## Description
This PR changes the placeholder text color on the block inserter's search field from #72777c to #6c6f75. The previous color combination [is failing AA success criteria with a ratio of 4.11](https://contrastchecker.com/?c=72777C&b=F3F4F5). New color combination [achieves passing score 4.57](https://contrastchecker.com/?c=6c6f75&b=F3F4F5).

## How has this been tested?
Tested on Firefox/macOS. Contrast ratio tested with https://webaim.org/resources/contrastchecker/ and https://contrastchecker.com

## Screenshots <!-- if applicable -->

Previous (#72777c):

<img width="340" alt="Screen Shot 2020-05-18 at 16 32 35" src="https://user-images.githubusercontent.com/3276087/82261755-3a596c00-9925-11ea-910d-0f665a0fefa5.png">

Proposed (#6c6f75):

<img width="339" alt="Screen Shot 2020-05-18 at 16 27 35" src="https://user-images.githubusercontent.com/3276087/82261783-48a78800-9925-11ea-8dd1-0355e9fa4cde.png">

**UPDATE:**

Using `$dark-gray-400` (#606A73) instead. We now have a passing 5.01 contrast ratio.

<img width="340" alt="Screen Shot 2020-05-19 at 11 01 51" src="https://user-images.githubusercontent.com/3276087/82349915-4e9e7700-99c0-11ea-91e8-47d0f4d403e4.png">


## Types of changes
Visual, bug fix.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
