### PR TITLE
e2e-test: Fix dirty state e2e test

### DIFF
--- a/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
@@ -233,8 +233,6 @@ describe( 'Multi-entity editor states', () => {
 			removeErrorMocks();
 		} );
 
-		// Todo: Solve issue affecting test
-		// eslint-disable-next-line jest/no-disabled-tests
 		it( 'should only dirty the parent entity when editing the parent', async () => {
 			// Clear selection so that the bock is not addded to template part.
 			await clickBreadcrumbItem( 'Document' );

--- a/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
@@ -234,7 +234,7 @@ describe( 'Multi-entity editor states', () => {
 		} );
 
 		it( 'should only dirty the parent entity when editing the parent', async () => {
-			// Clear selection so that the bock is not addded to template part.
+			// Clear selection so that the block is not added to the template part.
 			await clickBreadcrumbItem( 'Document' );
 
 			// Add paragraph block to the end of the document.

--- a/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
@@ -127,6 +127,13 @@ const openEntitySavePanel = async () => {
 	return true;
 };
 
+const clickBreadcrumbItem = async ( item ) => {
+	const [ breadcrumbItem ] = await page.$x(
+		`//button[contains(@class, "block-editor-block-breadcrumb__button")][contains(text(), "${ item }")]`
+	);
+	await breadcrumbItem.click();
+};
+
 const isEntityDirty = async ( name ) => {
 	const isOpen = await openEntitySavePanel();
 	if ( ! isOpen ) {
@@ -228,7 +235,11 @@ describe( 'Multi-entity editor states', () => {
 
 		// Todo: Solve issue affecting test
 		// eslint-disable-next-line jest/no-disabled-tests
-		it.skip( 'should only dirty the parent entity when editing the parent', async () => {
+		it( 'should only dirty the parent entity when editing the parent', async () => {
+			// Clear selection so that the bock is not addded to template part.
+			await clickBreadcrumbItem( 'Document' );
+
+			// Add paragraph block to the end of the document.
 			await page.click( '.block-editor-button-block-appender' );
 			await page.waitForSelector( '.block-editor-inserter__menu' );
 			await page.click( 'button.editor-block-list-item-paragraph' );


### PR DESCRIPTION
## Description
Fixes test skipped in #22447.

In #22140, a change was made to the inserter to insert the block at the current selection. Since the e2e test had selected test inside a nested template part, the block was being inserted there, though it was supposed to be inserted at the end of the document. Before that PR, the behavior was to insert it at the end of the document, and not at the current selection.

The fix is to select the document in the block breadcrumb before adding the block. This clears any selection so that adding the block block dirties the root entity and not a nested entity.

## How has this been tested?
e2e tests should pass.

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
