### PR TITLE
Edit Site: Page and Template switchers improvements.

### DIFF
--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -192,6 +192,7 @@ function gutenberg_edit_site_init( $hook ) {
 		'/',
 		'/wp/v2/types?context=edit',
 		'/wp/v2/taxonomies?per_page=-1&context=edit',
+		'/wp/v2/pages?per_page=-1&context=edit',
 		'/wp/v2/themes?status=active',
 		sprintf( '/wp/v2/templates/%s?context=edit', $current_template_id ),
 		array( '/wp/v2/media', 'OPTIONS' ),

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -126,24 +126,29 @@ export default function Header( {
 				<ToolSelector />
 				<UndoButton />
 				<RedoButton />
-				<PageSwitcher
-					showOnFront={ settings.showOnFront }
-					activePage={ settings.page }
-					onActivePageChange={ setActivePage }
-				/>
-				<TemplateSwitcher
-					ids={ settings.templateIds }
-					templatePartIds={ settings.templatePartIds }
-					activeId={ settings.templateId }
-					homeId={ settings.homeTemplateId }
-					isTemplatePart={
-						settings.templateType === 'wp_template_part'
-					}
-					onActiveIdChange={ setActiveTemplateId }
-					onActiveTemplatePartIdChange={ setActiveTemplatePartId }
-					onAddTemplateId={ addTemplateId }
-				/>
 				<BlockNavigationDropdown />
+				<div className="edit-site-header__toolbar-switchers">
+					<PageSwitcher
+						showOnFront={ settings.showOnFront }
+						activePage={ settings.page }
+						onActivePageChange={ setActivePage }
+					/>
+					<div className="edit-site-header__toolbar-switchers-separator">
+						/
+					</div>
+					<TemplateSwitcher
+						ids={ settings.templateIds }
+						templatePartIds={ settings.templatePartIds }
+						activeId={ settings.templateId }
+						homeId={ settings.homeTemplateId }
+						isTemplatePart={
+							settings.templateType === 'wp_template_part'
+						}
+						onActiveIdChange={ setActiveTemplateId }
+						onActiveTemplatePartIdChange={ setActiveTemplatePartId }
+						onAddTemplateId={ addTemplateId }
+					/>
+				</div>
 			</div>
 			<div className="edit-site-header__actions">
 				<PreviewOptions

--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -15,6 +15,16 @@
 		margin-left: 5px;
 	}
 }
+
+.edit-site-header__toolbar-switchers {
+	align-items: center;
+	display: flex;
+}
+
+.edit-site-header__toolbar-switchers-separator {
+	margin: 0 -6px 0;
+}
+
 .edit-site-header__actions {
 	display: flex;
 	margin-right: 8px;

--- a/packages/edit-site/src/components/page-switcher/index.js
+++ b/packages/edit-site/src/components/page-switcher/index.js
@@ -26,7 +26,7 @@ export default function PageSwitcher( {
 	const { pages = [], categories = [], posts = [] } = useSelect(
 		( select ) => {
 			const { getEntityRecords } = select( 'core' );
-			return {
+			const pageGroups = {
 				pages: getEntityRecords( 'postType', 'page' )?.map(
 					( _page ) => {
 						const path = getPathFromLink( _page.link );
@@ -50,19 +50,20 @@ export default function PageSwitcher( {
 						};
 					}
 				),
-				posts: [
-					{
-						label: __( 'All Posts' ),
-						value: '/',
-						context: {
-							query: { categoryIds: [] },
-							queryContext: { page: 1 },
-						},
-					},
-				],
+				posts: [],
 			};
+			if ( showOnFront === 'posts' )
+				pageGroups.posts.unshift( {
+					label: __( 'All Posts' ),
+					value: '/',
+					context: {
+						query: { categoryIds: [] },
+						queryContext: { page: 1 },
+					},
+				} );
+			return pageGroups;
 		},
-		[]
+		[ showOnFront ]
 	);
 	const onPageSelect = ( newPath ) => {
 		const { value: path, context } = [ ...pages, ...categories ].find(
@@ -85,12 +86,7 @@ export default function PageSwitcher( {
 					<MenuGroup label={ __( 'Pages' ) }>
 						<MenuItemsChoice
 							choices={ pages }
-							value={
-								activePage.path !== '/' ||
-								showOnFront === 'page'
-									? activePage.path
-									: undefined
-							}
+							value={ activePage.path }
 							onSelect={ onPageSelect }
 						/>
 					</MenuGroup>
@@ -104,12 +100,7 @@ export default function PageSwitcher( {
 					<MenuGroup label={ __( 'Posts' ) }>
 						<MenuItemsChoice
 							choices={ posts }
-							value={
-								activePage.path !== '/' ||
-								showOnFront === 'posts'
-									? activePage.path
-									: undefined
-							}
+							value={ activePage.path }
 							onSelect={ onPageSelect }
 						/>
 					</MenuGroup>


### PR DESCRIPTION
## Description

This PR improves a few things related to the page and template switchers:

- It preloads pages for the page switcher to load faster.
- It hides the "All Posts" option in the page switcher if the front page is not set to display the latest posts.
- It groups both switchers, separated by a slash, and positions them at the end of their toolbar group so that when they expand, it's not so jarring.

## How has this been tested?

It was verified that the page and template switchers still work as expected.

## Screenshots

<img width="657" alt="Screen Shot 2020-05-18 at 5 41 25 PM" src="https://user-images.githubusercontent.com/19157096/82272262-e94e7580-992e-11ea-8d3a-0e8f16de1d0e.png">

## Checklist:

- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->