### PR TITLE
Add dark theme colors to pullquote and quote 

### DIFF
--- a/packages/block-library/src/pullquote/theme.scss
+++ b/packages/block-library/src/pullquote/theme.scss
@@ -1,6 +1,12 @@
 .wp-block-pullquote {
 	border-top: 4px solid $dark-gray-500;
 	border-bottom: 4px solid $dark-gray-500;
+
+	.is-dark-theme & {
+		border-top: 4px solid $light-gray-500;
+		border-bottom: 4px solid $light-gray-500;
+	}
+
 	margin-bottom: $default-block-margin;
 	color: $dark-gray-600;
 
@@ -8,6 +14,11 @@
 	footer,
 	&__citation {
 		color: $dark-gray-600;
+
+		.is-dark-theme & {
+			color: $light-gray-600;
+		}
+
 		text-transform: uppercase;
 		font-size: $default-font-size;
 		font-style: normal;

--- a/packages/block-library/src/quote/theme.scss
+++ b/packages/block-library/src/quote/theme.scss
@@ -1,5 +1,8 @@
 .wp-block-quote {
 	border-left: 4px solid $black;
+	.is-dark-theme & {
+		border-left: 4px solid $white;
+	}
 	margin: 0 0 $default-block-margin 0;
 	padding-left: 1em;
 
@@ -7,6 +10,11 @@
 	footer,
 	&__citation {
 		color: $dark-gray-300;
+
+		.is-dark-theme & {
+			color: $light-gray-300;
+		}
+
 		font-size: $default-font-size;
 		margin-top: 1em;
 		position: relative;
@@ -16,7 +24,13 @@
 	&.has-text-align-right,
 	&.has-text-align-right {
 		border-left: none;
+
 		border-right: 4px solid $black;
+
+		.is-dark-theme & {
+			border-right: 4px solid $white;
+		}
+
 		padding-left: 0;
 		padding-right: 1em;
 	}


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
Closes https://github.com/WordPress/gutenberg/issues/16732

This pull request adds dark theme colors to pullquote and quote blocks to address visibility issues on themes that enable `dark-editor-style`. I changed the colors of the borders to ones suggested in [this comment](https://github.com/WordPress/gutenberg/issues/16732#issuecomment-529561510) by @kjellr. I also noticed that the citation in both blocks were using dark gray and changed both to be a light gray instead. 
 
## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
I enabled the TwentyTwenty theme and changed the background colors to enable the darkmode. I then made the code changes, verified the changes and then changed the background back to a lighter color to ensure no harm was done to the default light theme. 

## Screenshots <!-- if applicable -->
Before
![image](https://user-images.githubusercontent.com/65560592/82273346-25cfa080-9932-11ea-8cbe-994eecfbfe19.png)

After
<img width="1013" alt="Screen Shot 2020-05-18 at 6 06 48 PM" src="https://user-images.githubusercontent.com/65560592/82273443-5dd6e380-9932-11ea-9d9f-4e54d87474bd.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Feature: Darkmode for quote and pull quote blocks 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
Follow-up issue https://github.com/WordPress/gutenberg/issues/16826 for general color contrast
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
