### PR TITLE
[Mobile] Link to existing content - (iOS only for now)

### DIFF
--- a/packages/block-editor/src/components/existing-content-picker/index.native.js
+++ b/packages/block-editor/src/components/existing-content-picker/index.native.js
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import { View, TouchableWithoutFeedback } from 'react-native';
+import { requestLinkToExistingContent } from 'react-native-gutenberg-bridge';
+
+export default function ExistingContentPicker( {
+	currentUrl = '',
+	onOpen,
+	onResult,
+	onCancel,
+	children,
+} ) {
+	const requestLink = () => {
+		onOpen();
+		requestLinkToExistingContent( {
+			currentUrl,
+			callback: ( result ) =>
+				result ? onResult( result ) : onCancel(),
+		} );
+	};
+	return (
+		<TouchableWithoutFeedback onPress={ requestLink }>
+			<View>{ children }</View>
+		</TouchableWithoutFeedback>
+	);
+}

--- a/packages/block-editor/src/components/index.native.js
+++ b/packages/block-editor/src/components/index.native.js
@@ -37,6 +37,7 @@ export { default as __experimentalPanelColorGradientSettings } from './colors-gr
 
 export { BottomSheetSettings, BlockSettingsButton } from './block-settings';
 export { default as VideoPlayer, VIDEO_ASPECT_RATIO } from './video-player';
+export { default as ExistingContentPicker } from './existing-content-picker';
 
 // Content Related Components
 export {

--- a/packages/components/src/mobile/bottom-sheet/cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/cell.native.js
@@ -229,9 +229,9 @@ class BottomSheetCell extends Component {
 					placeholderTextColor={ '#87a6bc' }
 					onChangeText={ onChangeValue }
 					editable={ isValueEditable }
-					pointerEvents={
-						this.state.isEditingValue ? 'auto' : 'none'
-					}
+					// pointerEvents={
+					// 	this.state.isEditingValue ? 'auto' : 'none'
+					// }
 					onFocus={ startEditing }
 					onBlur={ finishEditing }
 					onSubmitEditing={ onSubmit }

--- a/packages/components/src/mobile/bottom-sheet/cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/cell.native.js
@@ -110,6 +110,8 @@ class BottomSheetCell extends Component {
 			customActionButton,
 			type,
 			step,
+			onFocus = () => undefined,
+			onBlur = () => undefined,
 			...valueProps
 		} = this.props;
 
@@ -160,11 +162,13 @@ class BottomSheetCell extends Component {
 
 		const finishEditing = () => {
 			this.setState( { isEditingValue: false } );
+			onBlur();
 		};
 
 		const startEditing = () => {
 			if ( this.state.isEditingValue === false ) {
 				this.setState( { isEditingValue: true } );
+				onFocus();
 			}
 		};
 

--- a/packages/components/src/mobile/bottom-sheet/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet/index.native.js
@@ -34,6 +34,7 @@ import PickerCell from './picker-cell';
 import SwitchCell from './switch-cell';
 import RangeCell from './range-cell';
 import ColorCell from './color-cell';
+import LinkCell from './link-cell';
 import KeyboardAvoidingView from './keyboard-avoiding-view';
 import { BottomSheetProvider } from './bottom-sheet-context';
 
@@ -424,5 +425,6 @@ ThemedBottomSheet.PickerCell = PickerCell;
 ThemedBottomSheet.SwitchCell = SwitchCell;
 ThemedBottomSheet.RangeCell = RangeCell;
 ThemedBottomSheet.ColorCell = ColorCell;
+ThemedBottomSheet.LinkCell = LinkCell;
 
 export default ThemedBottomSheet;

--- a/packages/components/src/mobile/bottom-sheet/link-cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/link-cell.native.js
@@ -1,0 +1,75 @@
+/**
+ * External dependencies
+ */
+import { View } from 'react-native';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Platform, useState } from '@wordpress/element';
+import { Icon } from '@wordpress/components';
+import { link, chevronRight } from '@wordpress/icons';
+import { ExistingContentPicker } from '@wordpress/block-editor';
+import { withPreferredColorScheme } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import styles from './styles.scss';
+import platformStyles from './cellStyles.scss';
+import Cell from './cell';
+
+function LinkCell( {
+	value,
+	onChangeValue,
+	onSubmit,
+	onPickerOpen,
+	onPickerResult,
+	onPickerCancel,
+	getStylesFromColorScheme,
+} ) {
+	const iconStyle = getStylesFromColorScheme( styles.icon, styles.iconDark );
+
+	const [ isUrlFocused, setIsUrlFocused ] = useState();
+	const shouldShowExistingContentPicker = ! ( value && isUrlFocused );
+
+	return (
+		<Cell
+			icon={ link }
+			label={ __( 'URL' ) }
+			value={ value }
+			placeholder={ __( 'Add URL' ) }
+			autoCapitalize="none"
+			autoCorrect={ false }
+			keyboardType="url"
+			onChangeValue={ onChangeValue }
+			onSubmit={ onSubmit }
+			/* eslint-disable-next-line jsx-a11y/no-autofocus */
+			autoFocus={ Platform.OS === 'ios' }
+			onFocus={ () => setIsUrlFocused( true ) }
+			onBlur={ () => setIsUrlFocused( false ) }
+		>
+			{ shouldShowExistingContentPicker && (
+				<>
+					<View style={ platformStyles.labelIconSeparator } />
+					<ExistingContentPicker
+						currentUrl={ value }
+						onOpen={ onPickerOpen }
+						onResult={ onPickerResult }
+						onCancel={ onPickerCancel }
+					>
+						<Icon
+							icon={ chevronRight }
+							size={ 24 }
+							color={ iconStyle.color }
+							isPressed={ false }
+						/>
+					</ExistingContentPicker>
+				</>
+			) }
+		</Cell>
+	);
+}
+
+export default withPreferredColorScheme( LinkCell );


### PR DESCRIPTION
## Description
This PR adds an existing content picker and refactors the link editing modal to utilize it. This is part of the work to address this issue: https://github.com/wordpress-mobile/gutenberg-mobile/issues/2194.

## How has this been tested?
This has been tested by editing and creating new links within a paragraph block, and selecting the picker from the URL field in the bottomsheet modal.

## Screenshots <!-- if applicable -->
tbd

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
