### PR TITLE
chore: Use value instead of __experimentalBlocks on widget area InnerBlocks

### DIFF
--- a/packages/block-library/src/widget-area/edit/inner-blocks.js
+++ b/packages/block-library/src/widget-area/edit/inner-blocks.js
@@ -11,7 +11,7 @@ export default function WidgetAreaInnerBlocks() {
 	);
 	return (
 		<InnerBlocks
-			__experimentalBlocks={ blocks }
+			value={ blocks }
 			onInput={ onInput }
 			onChange={ onChange }
 			templateLock={ false }


### PR DESCRIPTION
Since https://github.com/WordPress/gutenberg/pull/22140 has been created the property __experimentalBlocks on InnerBlocks was changed to value.
This PR fixes the issue.



## How has this been tested?
I verified the blocks on the widget screen load and update as expected.