### PR TITLE
Fix CSS bleed in button component.

### DIFF
--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -6,6 +6,12 @@
 
 	& .components-button {
 		font-family: $default-font;
+		font-size: $default-font-size;
+		padding: 6px 12px;
+
+		&.is-tertiary {
+			padding: 6px;
+		}
 	}
 
 	flex: 1 1 auto;

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -4,6 +4,9 @@
 	// Default background color so that grey .edit-post-editor-regions__content color doesn't show through.
 	background-color: $white;
 
+	// The button element easily inherits styles that are meant for the editor style.
+	// These rules enhance the specificity to reduce that inheritance.
+	// This is duplicated in edit-site.
 	& .components-button {
 		font-family: $default-font;
 		font-size: $default-font-size;

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -55,6 +55,19 @@ body.toplevel_page_gutenberg-edit-site {
 	.interface-interface-skeleton__content {
 		background-color: $light-gray-700;
 	}
+
+	// The button element easily inherits styles that are meant for the editor style.
+	// These rules enhance the specificity to reduce that inheritance.
+	// This is duplicated in visual-editor.
+	& .components-button {
+		font-family: $default-font;
+		font-size: $default-font-size;
+		padding: 6px 12px;
+
+		&.is-tertiary {
+			padding: 6px;
+		}
+	}
 }
 
 /**


### PR DESCRIPTION
Alternative to #22263. This fixes a CSS bleed issue for the button component when used inside the editing canvas.

When an editor style is added, which restyles the `button` element, it bleeds into the button component. This addresses that.

Example CSS:

```
input,
button,
textarea {
	padding: 12px 18px;
	font-size: 18px;
}
```

#22263 took a slightly more dangerous approach that might cause issues, but this approach should be rather safe, as it's adding to an existing rule that fixes the same issue but for fonts.

Before:

<img width="625" alt="Screenshot 2020-05-19 at 12 26 00" src="https://user-images.githubusercontent.com/1204802/82315923-5fed8080-99cc-11ea-9a71-c49b63706f56.png">

After:

<img width="476" alt="Screenshot 2020-05-19 at 12 35 10" src="https://user-images.githubusercontent.com/1204802/82316579-4dc01200-99cd-11ea-9f07-9502ac44730c.png">

