### PR TITLE
Add block areas tabbed sidebar to the widgets screen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20870,7 +20870,7 @@
 				},
 				"node-pre-gyp": {
 					"version": "0.12.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
 					"integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
 					"dev": true,
 					"optional": true,
@@ -20901,7 +20901,7 @@
 				},
 				"nopt": {
 					"version": "4.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
 					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 					"dev": true,
 					"optional": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10291,6 +10291,7 @@
 				"@wordpress/keycodes": "file:packages/keycodes",
 				"@wordpress/media-utils": "file:packages/media-utils",
 				"@wordpress/notices": "file:packages/notices",
+				"classnames": "^2.2.5",
 				"lodash": "^4.17.15",
 				"rememo": "^3.0.0"
 			}
@@ -20869,7 +20870,7 @@
 				},
 				"node-pre-gyp": {
 					"version": "0.12.0",
-					"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
 					"dev": true,
 					"optional": true,
@@ -20900,7 +20901,7 @@
 				},
 				"nopt": {
 					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 					"dev": true,
 					"optional": true,

--- a/packages/block-editor/src/components/block-list/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-list/block-contextual-toolbar.js
@@ -2,6 +2,8 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { hasBlockSupport } from '@wordpress/blocks';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -10,6 +12,24 @@ import NavigableToolbar from '../navigable-toolbar';
 import { BlockToolbar } from '../';
 
 function BlockContextualToolbar( { focusOnMount, ...props } ) {
+	const { blockType } = useSelect( ( select ) => {
+		const { getBlockName, getSelectedBlockClientIds } = select(
+			'core/block-editor'
+		);
+		const { getBlockType } = select( 'core/blocks' );
+		const selectedBlockClientIds = getSelectedBlockClientIds();
+		const selectedBlockClientId = selectedBlockClientIds[ 0 ];
+		return {
+			blockType:
+				selectedBlockClientId &&
+				getBlockType( getBlockName( selectedBlockClientId ) ),
+		};
+	} );
+	if ( blockType ) {
+		if ( ! hasBlockSupport( blockType, '__experimentalToolbar', true ) ) {
+			return null;
+		}
+	}
 	return (
 		<div className="block-editor-block-contextual-toolbar-wrapper">
 			<NavigableToolbar

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -8,6 +8,8 @@ import classnames from 'classnames';
 import { useSelect } from '@wordpress/data';
 import { useRef } from '@wordpress/element';
 import { useViewportMatch } from '@wordpress/compose';
+import { hasBlockSupport } from '@wordpress/blocks';
+
 /**
  * Internal dependencies
  */
@@ -23,12 +25,15 @@ export default function BlockToolbar( { hideDragHandle } ) {
 	const {
 		blockClientIds,
 		blockClientId,
+		blockType,
 		hasFixedToolbar,
 		isValid,
 		mode,
 		moverDirection,
 	} = useSelect( ( select ) => {
+		const { getBlockType } = select( 'core/blocks' );
 		const {
+			getBlockName,
 			getBlockMode,
 			getSelectedBlockClientIds,
 			isBlockValid,
@@ -46,6 +51,9 @@ export default function BlockToolbar( { hideDragHandle } ) {
 		return {
 			blockClientIds: selectedBlockClientIds,
 			blockClientId: selectedBlockClientId,
+			blockType:
+				selectedBlockClientId &&
+				getBlockType( getBlockName( selectedBlockClientId ) ),
 			hasFixedToolbar: getSettings().hasFixedToolbar,
 			rootClientId: blockRootClientId,
 			isValid:
@@ -72,6 +80,12 @@ export default function BlockToolbar( { hideDragHandle } ) {
 
 	const displayHeaderToolbar =
 		useViewportMatch( 'medium', '<' ) || hasFixedToolbar;
+
+	if ( blockType ) {
+		if ( ! hasBlockSupport( blockType, '__experimentalToolbar', true ) ) {
+			return null;
+		}
+	}
 
 	const shouldShowMovers = displayHeaderToolbar || showMovers;
 

--- a/packages/block-library/src/widget-area/block.json
+++ b/packages/block-library/src/widget-area/block.json
@@ -12,6 +12,7 @@
 	"supports": {
 		"html": false,
 		"inserter": false,
-		"customClassName": false
+		"customClassName": false,
+		"__experimentalToolbar": false
 	}
 }

--- a/packages/edit-widgets/package.json
+++ b/packages/edit-widgets/package.json
@@ -43,6 +43,7 @@
 		"@wordpress/keycodes": "file:../keycodes",
 		"@wordpress/media-utils": "file:../media-utils",
 		"@wordpress/notices": "file:../notices",
+		"classnames": "^2.2.5",
 		"lodash": "^4.17.15",
 		"rememo": "^3.0.0"
 	},

--- a/packages/edit-widgets/src/components/sidebar/block-areas.js
+++ b/packages/edit-widgets/src/components/sidebar/block-areas.js
@@ -1,0 +1,71 @@
+/**
+ * WordPress dependencies
+ */
+import { useDispatch, useSelect } from '@wordpress/data';
+import { widget } from '@wordpress/icons';
+import { BlockIcon } from '@wordpress/block-editor';
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+function BlockArea( { clientId } ) {
+	const { name } = useSelect(
+		( select ) => {
+			return select( 'core/block-editor' ).getBlockAttributes( clientId );
+		},
+		[ clientId ]
+	);
+	const { selectBlock } = useDispatch( 'core/block-editor' );
+	return (
+		<li>
+			<Button
+				onClick={ () => {
+					selectBlock( clientId );
+				} }
+			>
+				{ name }
+				<span className="edit-widgets-block-areas__edit">
+					{ __( 'Edit' ) }
+				</span>
+			</Button>
+		</li>
+	);
+}
+
+export default function BlockAreas() {
+	const blockOrder = useSelect( ( select ) => {
+		return select( 'core/block-editor' ).getBlockOrder();
+	} );
+	const hasBlockAreas = blockOrder.length > 0;
+	return (
+		<>
+			<div className="edit-widgets-block-areas">
+				<div className="edit-widgets-block-areas__top-container">
+					<BlockIcon icon={ widget } />
+					<div>
+						<p>
+							{ __(
+								'Block areas (also known as “Widget Areas”) are global locations in your site’s layout that can accept blocks. These vary by theme, but are typically places like your sidebar or footer.'
+							) }
+						</p>
+						<span>
+							{ hasBlockAreas
+								? __(
+										'Your theme contains the following block areas:'
+								  )
+								: __(
+										'Your theme does not contain block areas.'
+								  ) }
+						</span>
+					</div>
+				</div>
+				{ hasBlockAreas && (
+					<ul>
+						{ blockOrder.map( ( clientId ) => (
+							<BlockArea key={ clientId } clientId={ clientId } />
+						) ) }
+					</ul>
+				) }
+			</div>
+		</>
+	);
+}

--- a/packages/edit-widgets/src/components/sidebar/block-areas.js
+++ b/packages/edit-widgets/src/components/sidebar/block-areas.js
@@ -2,25 +2,37 @@
  * WordPress dependencies
  */
 import { useDispatch, useSelect } from '@wordpress/data';
-import { widget } from '@wordpress/icons';
+import { blockDefault } from '@wordpress/icons';
 import { BlockIcon } from '@wordpress/block-editor';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 function BlockArea( { clientId } ) {
-	const { name } = useSelect(
+	const { name, selectedBlock } = useSelect(
 		( select ) => {
-			return select( 'core/block-editor' ).getBlockAttributes( clientId );
+			const { getBlockAttributes, getBlockSelectionStart } = select(
+				'core/block-editor'
+			);
+			return {
+				name: getBlockAttributes( clientId ).name,
+				selectedBlock: getBlockSelectionStart(),
+			};
 		},
 		[ clientId ]
 	);
 	const { selectBlock } = useDispatch( 'core/block-editor' );
+	const isSelected = selectedBlock === clientId;
 	return (
 		<li>
 			<Button
-				onClick={ () => {
-					selectBlock( clientId );
-				} }
+				aria-expanded={ isSelected }
+				onClick={
+					isSelected
+						? undefined
+						: () => {
+								selectBlock( clientId );
+						  }
+				}
 			>
 				{ name }
 				<span className="edit-widgets-block-areas__edit">
@@ -40,22 +52,20 @@ export default function BlockAreas() {
 		<>
 			<div className="edit-widgets-block-areas">
 				<div className="edit-widgets-block-areas__top-container">
-					<BlockIcon icon={ widget } />
+					<BlockIcon icon={ blockDefault } />
 					<div>
 						<p>
 							{ __(
-								'Block areas (also known as “Widget Areas”) are global locations in your site’s layout that can accept blocks. These vary by theme, but are typically places like your sidebar or footer.'
+								'Block Areas (also known as "Widget Areas") are global parts in your site\'s layout that can accept blocks. These vary by theme, but are typically parts like your Sidebar or Footer.'
 							) }
 						</p>
-						<span>
-							{ hasBlockAreas
-								? __(
-										'Your theme contains the following block areas:'
-								  )
-								: __(
-										'Your theme does not contain block areas.'
-								  ) }
-						</span>
+						{ ! hasBlockAreas && (
+							<p>
+								{ __(
+									'Your theme does not contain block areas.'
+								) }
+							</p>
+						) }
 					</div>
 				</div>
 				{ hasBlockAreas && (

--- a/packages/edit-widgets/src/components/sidebar/index.js
+++ b/packages/edit-widgets/src/components/sidebar/index.js
@@ -1,22 +1,137 @@
 /**
+ * External dependencies
+ */
+import { map } from 'lodash';
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { useEffect } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
 import { ComplementaryArea } from '@wordpress/interface';
 import { BlockInspector } from '@wordpress/block-editor';
 import { cog } from '@wordpress/icons';
+import { Button } from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import BlockAreas from './block-areas';
+
+const CORE_WIDGET_COMPLEMENTARY_AREAS = {
+	'edit-widgets/block-areas': __( 'Block areas' ),
+	'edit-widgets/block-inspector': __( 'Block' ),
+};
+
+function ComplementaryAreaHeader( { activeComplementaryArea } ) {
+	const { enableComplementaryArea } = useDispatch( 'core/interface' );
+	return (
+		<ul>
+			{ map( CORE_WIDGET_COMPLEMENTARY_AREAS, ( label, identifier ) => {
+				const isActive = identifier === activeComplementaryArea;
+				return (
+					<li key={ identifier }>
+						<Button
+							onClick={ () =>
+								enableComplementaryArea(
+									'core/edit-widgets',
+									identifier
+								)
+							}
+							className={ classnames(
+								'edit-widgets-sidebar__panel-tab',
+								{
+									'is-active': isActive,
+								}
+							) }
+							aria-label={
+								isActive
+									? // translators: %s: sidebar label e.g: "Block areas".
+									  sprintf( __( '%s (selected)' ), label )
+									: label
+							}
+							data-label={ label }
+						>
+							{ label }
+						</Button>
+					</li>
+				);
+			} ) }
+		</ul>
+	);
+}
 
 export default function Sidebar() {
+	const { enableComplementaryArea } = useDispatch( 'core/interface' );
+	const { currentArea, hasBlockSelected, isGeneralSidebarOpen } = useSelect(
+		( select ) => {
+			let activeArea = select(
+				'core/interface'
+			).getActiveComplementaryArea( 'core/edit-widgets' );
+			const isSidebarOpen = !! activeArea;
+			const selectionStart = select(
+				'core/block-editor'
+			).getBlockSelectionStart();
+			if ( ! CORE_WIDGET_COMPLEMENTARY_AREAS[ activeArea ] ) {
+				if ( ! selectionStart ) {
+					activeArea = 'edit-widgets/block-areas';
+				} else {
+					activeArea = 'edit-widgets/block-inspector';
+				}
+			}
+			return {
+				currentArea: activeArea,
+				hasBlockSelected: !! selectionStart,
+				isGeneralSidebarOpen: isSidebarOpen,
+			};
+		},
+		[]
+	);
+
+	// currentArea, and isGeneralSidebarOpen are intentionally left out from the dependencies,
+	// because we want to run the effect when a block is selected/unselected and not when the sidebar state changes.
+	useEffect( () => {
+		if (
+			hasBlockSelected &&
+			currentArea === 'edit-widgets/block-areas' &&
+			isGeneralSidebarOpen
+		) {
+			enableComplementaryArea(
+				'core/edit-widgets',
+				'edit-widgets/block-inspector'
+			);
+		}
+		if (
+			! hasBlockSelected &&
+			currentArea === 'edit-widgets/block-inspector' &&
+			isGeneralSidebarOpen
+		) {
+			enableComplementaryArea(
+				'core/edit-widgets',
+				'edit-widgets/block-areas'
+			);
+		}
+	}, [ hasBlockSelected, enableComplementaryArea ] );
+
 	return (
 		<ComplementaryArea
 			className="edit-widgets-sidebar"
-			smallScreenTitle={ __( 'Widget Areas' ) }
+			header={
+				<ComplementaryAreaHeader
+					activeComplementaryArea={ currentArea }
+				/>
+			}
+			headerClassName="edit-widgets-sidebar__panel-tabs"
 			scope="core/edit-widgets"
-			complementaryAreaIdentifier="edit-widgets/block-inspector"
-			title={ __( 'Block' ) }
+			identifier={ currentArea }
 			icon={ cog }
 		>
-			<BlockInspector showNoBlockSelectedMessage={ false } />
+			{ currentArea === 'edit-widgets/block-areas' && <BlockAreas /> }
+			{ currentArea === 'edit-widgets/block-inspector' && (
+				<BlockInspector />
+			) }
 		</ComplementaryArea>
 	);
 }

--- a/packages/edit-widgets/src/components/sidebar/index.js
+++ b/packages/edit-widgets/src/components/sidebar/index.js
@@ -65,36 +65,40 @@ function ComplementaryAreaHeader( { activeComplementaryArea } ) {
 
 export default function Sidebar() {
 	const { enableComplementaryArea } = useDispatch( 'core/interface' );
-	const { currentArea, hasBlockSelected, isGeneralSidebarOpen } = useSelect(
-		( select ) => {
-			let activeArea = select(
-				'core/interface'
-			).getActiveComplementaryArea( 'core/edit-widgets' );
-			const isSidebarOpen = !! activeArea;
-			const selectionStart = select(
-				'core/block-editor'
-			).getBlockSelectionStart();
-			if ( ! CORE_WIDGET_COMPLEMENTARY_AREAS[ activeArea ] ) {
-				if ( ! selectionStart ) {
-					activeArea = 'edit-widgets/block-areas';
-				} else {
-					activeArea = 'edit-widgets/block-inspector';
-				}
+	const {
+		currentArea,
+		hasSelectedNonAreaBlock,
+		isGeneralSidebarOpen,
+	} = useSelect( ( select ) => {
+		let activeArea = select( 'core/interface' ).getActiveComplementaryArea(
+			'core/edit-widgets'
+		);
+		const isSidebarOpen = !! activeArea;
+		const { getBlockSelectionStart, getBlockRootClientId } = select(
+			'core/block-editor'
+		);
+		const selectionStart = getBlockSelectionStart();
+		if ( ! CORE_WIDGET_COMPLEMENTARY_AREAS[ activeArea ] ) {
+			if ( ! selectionStart ) {
+				activeArea = 'edit-widgets/block-areas';
+			} else {
+				activeArea = 'edit-widgets/block-inspector';
 			}
-			return {
-				currentArea: activeArea,
-				hasBlockSelected: !! selectionStart,
-				isGeneralSidebarOpen: isSidebarOpen,
-			};
-		},
-		[]
-	);
+		}
+		return {
+			currentArea: activeArea,
+			hasSelectedNonAreaBlock: !! (
+				selectionStart && getBlockRootClientId( selectionStart )
+			),
+			isGeneralSidebarOpen: isSidebarOpen,
+		};
+	}, [] );
 
 	// currentArea, and isGeneralSidebarOpen are intentionally left out from the dependencies,
 	// because we want to run the effect when a block is selected/unselected and not when the sidebar state changes.
 	useEffect( () => {
 		if (
-			hasBlockSelected &&
+			hasSelectedNonAreaBlock &&
 			currentArea === 'edit-widgets/block-areas' &&
 			isGeneralSidebarOpen
 		) {
@@ -104,7 +108,7 @@ export default function Sidebar() {
 			);
 		}
 		if (
-			! hasBlockSelected &&
+			! hasSelectedNonAreaBlock &&
 			currentArea === 'edit-widgets/block-inspector' &&
 			isGeneralSidebarOpen
 		) {
@@ -113,7 +117,7 @@ export default function Sidebar() {
 				'edit-widgets/block-areas'
 			);
 		}
-	}, [ hasBlockSelected, enableComplementaryArea ] );
+	}, [ hasSelectedNonAreaBlock, enableComplementaryArea ] );
 
 	return (
 		<ComplementaryArea

--- a/packages/edit-widgets/src/components/sidebar/style.scss
+++ b/packages/edit-widgets/src/components/sidebar/style.scss
@@ -1,0 +1,114 @@
+.components-panel__header.edit-widgets-sidebar__panel-tabs {
+	justify-content: flex-start;
+	padding-left: 0;
+	padding-right: $grid-unit-05;
+	border-top: 0;
+	margin-top: 0;
+
+	ul {
+		display: flex;
+	}
+	li {
+		margin: 0;
+	}
+	.components-button.has-icon {
+		display: none;
+		margin-left: auto;
+
+		@include break-medium() {
+			display: flex;
+		}
+	}
+}
+
+.components-button.edit-widgets-sidebar__panel-tab {
+	border-radius: 0;
+	height: 50px - $border-width;
+	background: transparent;
+	border: none;
+	box-shadow: none;
+	cursor: pointer;
+	display: inline-block;
+	padding: 3px 15px; // Use padding to offset the is-active border, this benefits Windows High Contrast mode
+	margin-left: 0;
+	font-weight: 400;
+	color: $dark-gray-900;
+
+	// This pseudo-element "duplicates" the tab label and sets the text to bold.
+	// This ensures that the tab doesn't change width when selected.
+	// See: https://github.com/WordPress/gutenberg/pull/9793
+	&::after {
+		content: attr(data-label);
+		display: block;
+		font-weight: 600;
+		height: 0;
+		overflow: hidden;
+		speak: none;
+		visibility: hidden;
+	}
+
+	&.is-active {
+		// The transparent shadow ensures no jumpiness when focus animates on an active tab.
+		box-shadow: inset 0 0 0 $border-width-focus transparent, inset 0 0 -$border-width-tab 0 0 $theme-color;
+		font-weight: 600;
+		position: relative;
+
+		// This border appears in Windows High Contrast mode instead of the box-shadow.
+		&::before {
+			content: "";
+			position: absolute;
+			top: 0;
+			bottom: 1px;
+			right: 0;
+			left: 0;
+			border-bottom: $border-width-tab solid transparent;
+		}
+	}
+
+	&:focus {
+		box-shadow: inset 0 0 0 $border-width-focus $theme-color;
+	}
+
+	&.is-active:focus {
+		box-shadow: inset 0 0 0 $border-width-focus $theme-color, inset 0 0 -$border-width-tab 0 0 $theme-color;
+	}
+}
+
+.edit-widgets-block-areas__top-container {
+	display: flex;
+	padding: $grid-unit-20;
+	.block-editor-block-icon {
+		margin-right: $grid-unit-20;
+	}
+}
+
+.edit-widgets-block-areas {
+	ul {
+		list-style: none;
+		margin-bottom: -$border-width;
+	}
+
+	li {
+		margin: 0;
+		border-bottom: $border-width solid $light-gray-500;
+		&:first-child {
+			border-top: $border-width solid $light-gray-500;
+		}
+
+		button {
+			display: block;
+			width: 100%;
+			font-weight: 600;
+			padding: $grid-unit-20;
+			height: auto;
+			text-align: left;
+		}
+	}
+}
+
+.edit-widgets-block-areas__edit {
+	float: right;
+	/* Mimics the default link style in common.css */
+	color: #0073aa;
+	font-weight: 400;
+}

--- a/packages/edit-widgets/src/style.scss
+++ b/packages/edit-widgets/src/style.scss
@@ -2,6 +2,7 @@
 
 @import "./components/customizer-edit-widgets-initializer/style.scss";
 @import "./components/header/style.scss";
+@import "./components/sidebar/style.scss";
 @import "./components/notices/style.scss";
 
 // In order to use mix-blend-mode, this element needs to have an explicitly set background-color


### PR DESCRIPTION
## Description
This PR adds the block areas tabbed sidebar to the widgets screen.
This change tries to follow the design suggested by @mapk and makes the screen more similar to edit-post.

## How has this been tested?
I enabled the "Twenty Seventeen" theme.
I loaded the widgets screen.
I verified the block areas sidebar was available and I was able to select block areas by pressing on its list of block areas.
I verified when I selected a block the sidebar tab changed to block.
I verified when I unselected a block the sidebar tab changed to block areas.