### PR TITLE
FSE: Add entity editor to post content block

### DIFF
--- a/packages/block-library/src/post-content/block.json
+++ b/packages/block-library/src/post-content/block.json
@@ -1,5 +1,5 @@
 {
 	"name": "core/post-content",
 	"category": "layout",
-	"context": [ "postId" ]
+	"context": [ "postId", "postType" ]
 }

--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -8,8 +8,7 @@ import { EntityProvider } from '@wordpress/core-data';
  */
 import PostContentInnerBlocks from './inner-blocks';
 
-export default function PostContentEdit( { context } ) {
-	const { postId, postType } = context;
+export default function PostContentEdit( { context: { postId, postType } } ) {
 	if ( postId && postType ) {
 		return (
 			<EntityProvider kind="postType" type={ postType } id={ postId }>

--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { EntityProvider } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -12,9 +11,7 @@ import PostContentInnerBlocks from './inner-blocks';
 export default function PostContentEdit( { context: { postId, postType } } ) {
 	if ( postId && postType ) {
 		return (
-			<EntityProvider kind="postType" type={ postType } id={ postId }>
-				<PostContentInnerBlocks postType={ postType } />
-			</EntityProvider>
+			<PostContentInnerBlocks postType={ postType } postId={ postId } />
 		);
 	}
 	return <p>{ __( 'This is a placeholder for post content.' ) }</p>;

--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { EntityProvider } from '@wordpress/core-data';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -16,7 +17,5 @@ export default function PostContentEdit( { context: { postId, postType } } ) {
 			</EntityProvider>
 		);
 	}
-	return (
-		<p>{ 'Try setting the active page or post via the page selector.' }</p>
-	);
+	return <p>{ __( 'This is a placeholder for post content.' ) }</p>;
 }

--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -1,9 +1,23 @@
-export default function PostContentEdit() {
+/**
+ * WordPress dependencies
+ */
+import { EntityProvider } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import PostContentInnerBlocks from './inner-blocks';
+
+export default function PostContentEdit( { context } ) {
+	const { postId, postType } = context;
+	if ( postId && postType ) {
+		return (
+			<EntityProvider kind="postType" type={ postType } id={ postId }>
+				<PostContentInnerBlocks postType={ postType } />
+			</EntityProvider>
+		);
+	}
 	return (
-		<p>
-			{
-				'Welcome to WordPress and the wonderful world of blocks. This content represents how a post would look when editing block templates.'
-			}
-		</p>
+		<p>{ 'Try setting the active page or post via the page selector.' }</p>
 	);
 }

--- a/packages/block-library/src/post-content/inner-blocks.js
+++ b/packages/block-library/src/post-content/inner-blocks.js
@@ -4,10 +4,12 @@
 import { useEntityBlockEditor } from '@wordpress/core-data';
 import { InnerBlocks } from '@wordpress/block-editor';
 
-export default function PostContentInnerBlocks( { postType } ) {
+export default function PostContentInnerBlocks( { postType, postId } ) {
 	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
 		'postType',
-		postType
+		postType,
+		{},
+		postId
 	);
 	return (
 		<InnerBlocks

--- a/packages/block-library/src/post-content/inner-blocks.js
+++ b/packages/block-library/src/post-content/inner-blocks.js
@@ -1,0 +1,22 @@
+/**
+ * WordPress dependencies
+ */
+import { useEntityBlockEditor } from '@wordpress/core-data';
+import { InnerBlocks } from '@wordpress/block-editor';
+
+export default function PostContentInnerBlocks( { postType } ) {
+	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
+		'postType',
+		postType,
+		{
+			initialEdits: { status: 'publish' },
+		}
+	);
+	return (
+		<InnerBlocks
+			value={ blocks }
+			onInput={ onInput }
+			onChange={ onChange }
+		/>
+	);
+}

--- a/packages/block-library/src/post-content/inner-blocks.js
+++ b/packages/block-library/src/post-content/inner-blocks.js
@@ -4,6 +4,13 @@
 import { useEntityBlockEditor } from '@wordpress/core-data';
 import { InnerBlocks } from '@wordpress/block-editor';
 
+/**
+ * Renders the content of the current post in a controlled inner block area.
+ *
+ * @param {Object} Props Component props.
+ * @param {string} Props.postType The postType to use for the entity blocks.
+ * @return {Function} Controlled InnerBlocks of the current post.
+ */
 export default function PostContentInnerBlocks( { postType } ) {
 	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
 		'postType',

--- a/packages/block-library/src/post-content/inner-blocks.js
+++ b/packages/block-library/src/post-content/inner-blocks.js
@@ -4,20 +4,10 @@
 import { useEntityBlockEditor } from '@wordpress/core-data';
 import { InnerBlocks } from '@wordpress/block-editor';
 
-/**
- * Renders the content of the current post in a controlled inner block area.
- *
- * @param {Object} Props Component props.
- * @param {string} Props.postType The postType to use for the entity blocks.
- * @return {Function} Controlled InnerBlocks of the current post.
- */
 export default function PostContentInnerBlocks( { postType } ) {
 	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
 		'postType',
-		postType,
-		{
-			initialEdits: { status: 'publish' },
-		}
+		postType
 	);
 	return (
 		<InnerBlocks

--- a/packages/block-library/src/post-content/inner-blocks.js
+++ b/packages/block-library/src/post-content/inner-blocks.js
@@ -8,8 +8,7 @@ export default function PostContentInnerBlocks( { postType, postId } ) {
 	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
 		'postType',
 		postType,
-		{},
-		postId
+		{ id: postId }
 	);
 	return (
 		<InnerBlocks

--- a/packages/core-data/src/entity-provider.js
+++ b/packages/core-data/src/entity-provider.js
@@ -74,16 +74,17 @@ export function useEntityId( kind, type ) {
  * specified property of the nearest provided
  * entity of the specified type.
  *
- * @param {string} kind The entity kind.
- * @param {string} type The entity type.
- * @param {string} prop The property name.
+ * @param {string} kind  The entity kind.
+ * @param {string} type  The entity type.
+ * @param {string} prop  The property name.
+ * @param {string} [_id] A fallback entity ID to use if no entity provider exists.
  *
  * @return {[*, Function]} A tuple where the first item is the
  *                          property value and the second is the
  *                          setter.
  */
-export function useEntityProp( kind, type, prop ) {
-	const id = useEntityId( kind, type );
+export function useEntityProp( kind, type, prop, _id ) {
+	const id = useEntityId( kind, type ) || _id;
 	const { value, fullValue } = useSelect(
 		( select ) => {
 			const { getEntityRecord, getEditedEntityRecord } = select( 'core' );
@@ -128,18 +129,26 @@ export function useEntityProp( kind, type, prop ) {
  * @param {Object} [options.initialEdits]          Initial edits object for the entity record.
  * @param {string} [options.blocksProp='blocks']   The name of the entity prop that holds the blocks array.
  * @param {string} [options.contentProp='content'] The name of the entity prop that holds the serialized blocks.
+ * @param {string} [_id]                           A fallback entity ID to use if no entity provider exists.
  *
  * @return {[WPBlock[], Function, Function]} The block array and setters.
  */
 export function useEntityBlockEditor(
 	kind,
 	type,
-	{ initialEdits, blocksProp = 'blocks', contentProp = 'content' } = {}
+	{ initialEdits, blocksProp = 'blocks', contentProp = 'content' } = {},
+	_id
 ) {
-	const [ content, setContent ] = useEntityProp( kind, type, contentProp );
+	const id = useEntityId( kind, type ) || _id;
+
+	const [ content, setContent ] = useEntityProp(
+		kind,
+		type,
+		contentProp,
+		id
+	);
 
 	const { editEntityRecord } = useDispatch( 'core' );
-	const id = useEntityId( kind, type );
 	const initialBlocks = useMemo( () => {
 		if ( initialEdits ) {
 			editEntityRecord( kind, type, id, initialEdits, {
@@ -157,7 +166,8 @@ export function useEntityBlockEditor(
 	const [ blocks = initialBlocks, onInput ] = useEntityProp(
 		kind,
 		type,
-		blocksProp
+		blocksProp,
+		id
 	);
 
 	const onChange = useCallback(

--- a/packages/core-data/src/entity-provider.js
+++ b/packages/core-data/src/entity-provider.js
@@ -85,7 +85,7 @@ export function useEntityId( kind, type ) {
  */
 export function useEntityProp( kind, type, prop, _id ) {
 	const providerId = useEntityId( kind, type );
-	const id = _id || providerId;
+	const id = _id ?? providerId;
 
 	const { value, fullValue } = useSelect(
 		( select ) => {
@@ -146,7 +146,7 @@ export function useEntityBlockEditor(
 	} = {}
 ) {
 	const providerId = useEntityId( kind, type );
-	const id = _id || providerId;
+	const id = _id ?? providerId;
 
 	const [ content, setContent ] = useEntityProp(
 		kind,

--- a/packages/core-data/src/entity-provider.js
+++ b/packages/core-data/src/entity-provider.js
@@ -77,14 +77,16 @@ export function useEntityId( kind, type ) {
  * @param {string} kind  The entity kind.
  * @param {string} type  The entity type.
  * @param {string} prop  The property name.
- * @param {string} [_id] A fallback entity ID to use if no entity provider exists.
+ * @param {string} [_id] An entity ID to use instead of the context-provided one.
  *
  * @return {[*, Function]} A tuple where the first item is the
  *                          property value and the second is the
  *                          setter.
  */
 export function useEntityProp( kind, type, prop, _id ) {
-	const id = useEntityId( kind, type ) || _id;
+	const providerId = useEntityId( kind, type );
+	const id = _id || providerId;
+
 	const { value, fullValue } = useSelect(
 		( select ) => {
 			const { getEntityRecord, getEditedEntityRecord } = select( 'core' );
@@ -129,17 +131,22 @@ export function useEntityProp( kind, type, prop, _id ) {
  * @param {Object} [options.initialEdits]          Initial edits object for the entity record.
  * @param {string} [options.blocksProp='blocks']   The name of the entity prop that holds the blocks array.
  * @param {string} [options.contentProp='content'] The name of the entity prop that holds the serialized blocks.
- * @param {string} [_id]                           A fallback entity ID to use if no entity provider exists.
+ * @param {string} [options.id]                    An entity ID to use instead of the context-provided one.
  *
  * @return {[WPBlock[], Function, Function]} The block array and setters.
  */
 export function useEntityBlockEditor(
 	kind,
 	type,
-	{ initialEdits, blocksProp = 'blocks', contentProp = 'content' } = {},
-	_id
+	{
+		initialEdits,
+		blocksProp = 'blocks',
+		contentProp = 'content',
+		id: _id,
+	} = {}
 ) {
-	const id = useEntityId( kind, type ) || _id;
+	const providerId = useEntityId( kind, type );
+	const id = _id || providerId;
 
 	const [ content, setContent ] = useEntityProp(
 		kind,


### PR DESCRIPTION
## Description
Allows the user to view and edit the content of a post content block. The post content block will use whatever post ID / post type is set via block context.

## How has this been tested?
Locally in edit site. To test yourself:
1. checkout locally
2. make sure you have a template with the post content block in it. (i.e. `single` or `index`)
3. select a page from the left-most header dropdown menu
4. Select that template from the right-most header dropdown menu
5. The post content block should load with the content of the page
6. If you edit the page content, the sidebar will say that the page needs to be saved.

## Screenshots <!-- if applicable -->
![2020-05-19 11 32 52](https://user-images.githubusercontent.com/6265975/82365137-1b121b80-99c5-11ea-9874-b339f0ad1d78.gif)


## Types of changes
New feature/enhancement

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
