### PR TITLE
wp-env: better run command errors

### DIFF
--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -40,6 +40,7 @@ const withSpinner = ( command ) => ( ...args ) => {
 				spinner.fail( error.message );
 				process.exit( 1 );
 			} else if (
+				typeof error === 'object' &&
 				'exitCode' in error &&
 				'err' in error &&
 				'out' in error
@@ -56,7 +57,9 @@ const withSpinner = ( command ) => ( ...args ) => {
 				process.exit( error.exitCode );
 			} else {
 				// Error is an unknown error. That means there was a bug in our code.
-				spinner.fail( error.message );
+				spinner.fail(
+					typeof error === 'string' ? error : error.message
+				);
 				// Disable reason: Using console.error() means we get a stack trace.
 				// eslint-disable-next-line no-console
 				console.error( error );

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -40,6 +40,7 @@ const withSpinner = ( command ) => ( ...args ) => {
 				spinner.fail( error.message );
 				process.exit( 1 );
 			} else if (
+				error &&
 				typeof error === 'object' &&
 				'exitCode' in error &&
 				'err' in error &&
@@ -55,7 +56,7 @@ const withSpinner = ( command ) => ( ...args ) => {
 					process.stderr.write( error.err );
 				}
 				process.exit( error.exitCode );
-			} else {
+			} else if ( error ) {
 				// Error is an unknown error. That means there was a bug in our code.
 				spinner.fail(
 					typeof error === 'string' ? error : error.message
@@ -63,6 +64,9 @@ const withSpinner = ( command ) => ( ...args ) => {
 				// Disable reason: Using console.error() means we get a stack trace.
 				// eslint-disable-next-line no-console
 				console.error( error );
+				process.exit( 1 );
+			} else {
+				spinner.fail( 'An unknown error occured.' );
 				process.exit( 1 );
 			}
 		}

--- a/packages/env/lib/commands/run.js
+++ b/packages/env/lib/commands/run.js
@@ -40,7 +40,13 @@ module.exports = async function run( { container, command, spinner, debug } ) {
 		console.error(
 			process.stdout.isTTY ? `\n\n${ result.err }\n\n` : result.err
 		);
-		throw result.err;
+		// Some tools (like composer) may send messages to stderr. Those messages
+		// do not always mean that we need to abort the process. For example,
+		// composer will say "Nothing to install or update" on stderr when your
+		// local composer packages are up to date.
+		if ( result.exitCode !== 0 ) {
+			throw result.err;
+		}
 	}
 
 	spinner.text = `Ran \`${ command }\` in '${ container }'.`;


### PR DESCRIPTION
## Description
When I was integrating phpunit, I noticed that `npm run test-php` failed locally. See a short conversation about the error here: https://github.com/WordPress/gutenberg/pull/21537#issuecomment-627605360

The gist of it is that:
1. wp-env incorrectly assumes that every caught error will be an object, causing a poor error message
2. composer sends the message "Nothing to install or update" to `stderr` when your local packages are already up to date. This causes wp-env to exit with 1, stopping the script before it can continue to lint and test php.

The fix:
1. Make error handling code more robust so that it doesn't check for properties on a string.
2. Only _throw_ errors to exit the script if the command in the docker environment exited with a non-0 code. Essentially, even if there is data in `result.err`, we will not fail the script if the exit code is 0.

## How has this been tested?
1. Tested that `npm run test-php` works locally having already installed composer deps
2. Tested that failing scripts (e.g. a failing phpunit test) still cause wp-env to exist with a non-0 exit code.

## Types of changes
bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
