### PR TITLE
wp-env: Set wp tests domain to localhost url

### DIFF
--- a/packages/env/lib/config.js
+++ b/packages/env/lib/config.js
@@ -131,7 +131,6 @@ module.exports = {
 				config: {
 					WP_DEBUG: true,
 					SCRIPT_DEBUG: true,
-					WP_TESTS_DOMAIN: 'example.org',
 					WP_PHP_BINARY: 'php',
 				},
 				mappings: {},
@@ -143,6 +142,12 @@ module.exports = {
 		config.port = getNumberFromEnvVariable( 'WP_ENV_PORT' ) || config.port;
 		config.testsPort =
 			getNumberFromEnvVariable( 'WP_ENV_TESTS_PORT' ) || config.testsPort;
+
+		// In the future, we should clean this up and integrate it with multi-
+		// environment support instead of hardcoding it to the test port.
+		if ( config.config.WP_TESTS_DOMAIN === undefined ) {
+			config.config.WP_TESTS_DOMAIN = `localhost:${ config.testsPort }`;
+		}
 
 		if ( config.core !== null && typeof config.core !== 'string' ) {
 			throw new ValidationError(


### PR DESCRIPTION
## Description
Writing an e2e test yesterday, I noticed that `npm run test-e2e:watch` was wailing because it was visiting `example.com` instead of `localhost:8889`. This is caused by #20090, which set `WP_TESTS_DOMAIN` to `example.com`.

This PR fixes that by setting the test domain to the localhost WordPress url.

## How has this been tested?
After cleaning and restarting wordpress locally, the test domain was set to the localhost URL, and the e2e tests started working again.

## Types of changes
bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
