### PR TITLE
Scripts: Support split Jest configuration for test commands

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -7,6 +7,7 @@
 - New `--webpack-no-externals` flag added to `build` and `start` scripts. It disables scripts' assets generation, and omits the list of default externals ([#22310](https://github.com/WordPress/gutenberg/pull/22310)).
 - New `--webpack-bundle-analyzer` flag added to `build` and `start` scripts. It enables visualization for the size of webpack output files with an interactive zoomable treemap ([#22310](https://github.com/WordPress/gutenberg/pull/22310)).
 - New `--webpack--devtool` flag added to `start` script. It controls how source maps are generated. See options at https://webpack.js.org/configuration/devtool/#devtool ([#22310](https://github.com/WordPress/gutenberg/pull/22310)).
+- The `test-e2e` and `test-unit` scripts will now disambiguate custom configurations, preferring a `jest-e2e.config.js`, `jest-e2e.config.json`, `jest-unit.config.js`, or `jest-unit.config.json` Jest configuration file if present, falling back to `jest.config.js` or `jest.config.json`. This allows for configurations which should only apply to one or the other test variant.
 
 ### Breaking Changes
 

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -425,6 +425,12 @@ We enforce that all tests run serially in the current process using [--runInBand
 
 It uses [Jest](https://jestjs.io/) behind the scenes and you are able to use all of its [CLI options](https://jestjs.io/docs/en/cli.html). You can also run `./node_modules/.bin/wp-scripts test:e2e --help` or `npm run test:e2e:help` (as mentioned above) to view all of the available options. Learn more in the [Advanced Usage](#advanced-usage) section.
 
+Should there be any situation where you want to provide your own Jest config, you can do so.
+
+* the command receives a `--config` argument. Example: `wp-scripts test-e2e --config my-jest-config.js`.
+* there is a file called `jest-e2e.config.js`, `jest-e2e.config.json`, `jest.config.js`, or `jest.config.json` in the top-level directory of your package (at the same level than your `package.json`).
+* a `jest` object can be provided in the `package.json` file with the test configuration.
+
 ### `test-unit-js`
 
 _Alias_: `test-unit-jest`
@@ -460,6 +466,12 @@ Jest will look for test files with any of the following popular naming conventio
 #### Advanced information
 
 It uses [Jest](https://jestjs.io/) behind the scenes and you are able to use all of its [CLI options](https://jestjs.io/docs/en/cli.html). You can also run `./node_modules/.bin/wp-scripts test:unit --help` or `npm run test:unit:help` (as mentioned above) to view all of the available options. By default, it uses the set of recommended options defined in [@wordpress/jest-preset-default](https://www.npmjs.com/package/@wordpress/jest-preset-default) npm package. You can override them with your own options as described in [Jest documentation](https://jestjs.io/docs/en/configuration). Learn more in the [Advanced Usage](#advanced-usage) section.
+
+Should there be any situation where you want to provide your own Jest config, you can do so.
+
+* the command receives a `--config` argument. Example: `wp-scripts test-unit --config my-jest-config.js`.
+* there is a file called `jest-unit.config.js`, `jest-unit.config.json`, `jest.config.js`, or `jest.config.json` in the top-level directory of your package (at the same level than your `package.json`).
+* a `jest` object can be provided in the `package.json` file with the test configuration.
 
 ## Passing Node.js options
 

--- a/packages/scripts/scripts/test-e2e.js
+++ b/packages/scripts/scripts/test-e2e.js
@@ -20,12 +20,12 @@ const { sync: spawn } = require( 'cross-spawn' );
  * Internal dependencies
  */
 const {
+	getJestOverrideConfigFile,
 	fromConfigRoot,
 	getArgFromCLI,
 	getArgsFromCLI,
 	hasArgInCLI,
 	hasProjectFile,
-	hasJestConfig,
 } = require( '../utils' );
 
 const result = spawn( 'node', [ require.resolve( 'puppeteer/install' ) ], {
@@ -46,11 +46,10 @@ if (
 	process.env.JEST_PUPPETEER_CONFIG = fromConfigRoot( 'puppeteer.config.js' );
 }
 
-const config = ! hasJestConfig()
-	? [
-			'--config',
-			JSON.stringify( require( fromConfigRoot( 'jest-e2e.config.js' ) ) ),
-	  ]
+const configFile = getJestOverrideConfigFile( 'e2e' );
+
+const config = configFile
+	? [ '--config', JSON.stringify( require( configFile ) ) ]
 	: [];
 
 const hasRunInBand = hasArgInCLI( '--runInBand' ) || hasArgInCLI( '-i' );

--- a/packages/scripts/scripts/test-unit-jest.js
+++ b/packages/scripts/scripts/test-unit-jest.js
@@ -18,15 +18,12 @@ const jest = require( 'jest' );
 /**
  * Internal dependencies
  */
-const { fromConfigRoot, getArgsFromCLI, hasJestConfig } = require( '../utils' );
+const { getJestOverrideConfigFile, getArgsFromCLI } = require( '../utils' );
 
-const config = ! hasJestConfig()
-	? [
-			'--config',
-			JSON.stringify(
-				require( fromConfigRoot( 'jest-unit.config.js' ) )
-			),
-	  ]
+const configFile = getJestOverrideConfigFile( 'unit' );
+
+const config = configFile
+	? [ '--config', JSON.stringify( require( configFile ) ) ]
 	: [];
 
 jest.run( [ ...config, ...getArgsFromCLI() ] );

--- a/packages/scripts/utils/config.js
+++ b/packages/scripts/utils/config.js
@@ -29,14 +29,13 @@ const hasBabelConfig = () =>
  * Returns path to a Jest configuration which should be provided as the explicit
  * configuration when there is none available for discovery by Jest in the
  * project environment. Returns undefined if Jest should be allowed to discover
- * an available configuration. Optionally accepts a suffix for configurations
- * which can differ by variant.
+ * an available configuration.
  *
  * This can be used in cases where multiple possible configurations are
  * supported. Since Jest will only discover `jest.config.js`, or `jest` package
  * directive, such custom configurations must be specified explicitly.
  *
- * @param {string=} suffix Optional suffix of configuration file to accept.
+ * @param {"e2e"|"unit"} suffix Suffix of configuration file to accept.
  *
  * @return {string=} Override or fallback configuration file path.
  */
@@ -47,11 +46,11 @@ const getJestOverrideConfigFile = ( suffix ) =>
 			() => undefined,
 		],
 		[
-			() => suffix && hasProjectFile( `jest-${ suffix }.config.js` ),
+			() => hasProjectFile( `jest-${ suffix }.config.js` ),
 			() => fromProjectRoot( `jest-${ suffix }.config.js` ),
 		],
 		[ () => hasJestConfig(), () => undefined ],
-		[ () => true, () => fromConfigRoot( 'jest-e2e.config.js' ) ],
+		[ () => true, () => fromConfigRoot( `jest-${ suffix }.config.js` ) ],
 	] )();
 
 const hasJestConfig = () =>

--- a/packages/scripts/utils/config.js
+++ b/packages/scripts/utils/config.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 const { basename } = require( 'path' );
-const { cond } = require( 'lodash' );
 
 /**
  * Internal dependencies
@@ -39,19 +38,19 @@ const hasBabelConfig = () =>
  *
  * @return {string=} Override or fallback configuration file path.
  */
-const getJestOverrideConfigFile = ( suffix ) =>
-	cond( [
-		[
-			() => hasArgInCLI( '-c' ) || hasArgInCLI( '--config' ),
-			() => undefined,
-		],
-		[
-			() => hasProjectFile( `jest-${ suffix }.config.js` ),
-			() => fromProjectRoot( `jest-${ suffix }.config.js` ),
-		],
-		[ () => hasJestConfig(), () => undefined ],
-		[ () => true, () => fromConfigRoot( `jest-${ suffix }.config.js` ) ],
-	] )();
+function getJestOverrideConfigFile( suffix ) {
+	if ( hasArgInCLI( '-c' ) || hasArgInCLI( '--config' ) ) {
+		return;
+	}
+
+	if ( hasProjectFile( `jest-${ suffix }.config.js` ) ) {
+		return fromProjectRoot( `jest-${ suffix }.config.js` );
+	}
+
+	if ( ! hasJestConfig() ) {
+		return fromConfigRoot( `jest-${ suffix }.config.js` );
+	}
+}
 
 const hasJestConfig = () =>
 	hasProjectFile( 'jest.config.js' ) ||

--- a/packages/scripts/utils/config.js
+++ b/packages/scripts/utils/config.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 const { basename } = require( 'path' );
+const { cond } = require( 'lodash' );
 
 /**
  * Internal dependencies
@@ -12,7 +13,7 @@ const {
 	hasArgInCLI,
 	hasFileArgInCLI,
 } = require( './cli' );
-const { fromConfigRoot, hasProjectFile } = require( './file' );
+const { fromConfigRoot, fromProjectRoot, hasProjectFile } = require( './file' );
 const { hasPackageProp } = require( './package' );
 
 // See https://babeljs.io/docs/en/config-files#configuration-file-types
@@ -24,9 +25,36 @@ const hasBabelConfig = () =>
 	hasProjectFile( '.babelrc' ) ||
 	hasPackageProp( 'babel' );
 
+/**
+ * Returns path to a Jest configuration which should be provided as the explicit
+ * configuration when there is none available for discovery by Jest in the
+ * project environment. Returns undefined if Jest should be allowed to discover
+ * an available configuration. Optionally accepts a suffix for configurations
+ * which can differ by variant.
+ *
+ * This can be used in cases where multiple possible configurations are
+ * supported. Since Jest will only discover `jest.config.js`, or `jest` package
+ * directive, such custom configurations must be specified explicitly.
+ *
+ * @param {string=} suffix Optional suffix of configuration file to accept.
+ *
+ * @return {string=} Override or fallback configuration file path.
+ */
+const getJestOverrideConfigFile = ( suffix ) =>
+	cond( [
+		[
+			() => hasArgInCLI( '-c' ) || hasArgInCLI( '--config' ),
+			() => undefined,
+		],
+		[
+			() => suffix && hasProjectFile( `jest-${ suffix }.config.js` ),
+			() => fromProjectRoot( `jest-${ suffix }.config.js` ),
+		],
+		[ () => hasJestConfig(), () => undefined ],
+		[ () => true, () => fromConfigRoot( 'jest-e2e.config.js' ) ],
+	] )();
+
 const hasJestConfig = () =>
-	hasArgInCLI( '-c' ) ||
-	hasArgInCLI( '--config' ) ||
 	hasProjectFile( 'jest.config.js' ) ||
 	hasProjectFile( 'jest.config.json' ) ||
 	hasPackageProp( 'jest' );
@@ -103,6 +131,7 @@ const getWebpackArgs = () => {
 module.exports = {
 	getWebpackArgs,
 	hasBabelConfig,
+	getJestOverrideConfigFile,
 	hasJestConfig,
 	hasPrettierConfig,
 };

--- a/packages/scripts/utils/index.js
+++ b/packages/scripts/utils/index.js
@@ -13,6 +13,7 @@ const {
 const {
 	getWebpackArgs,
 	hasBabelConfig,
+	getJestOverrideConfigFile,
 	hasJestConfig,
 	hasPrettierConfig,
 } = require( './config' );
@@ -36,6 +37,7 @@ module.exports = {
 	hasBabelConfig,
 	hasArgInCLI,
 	hasFileArgInCLI,
+	getJestOverrideConfigFile,
 	hasJestConfig,
 	hasPackageProp,
 	hasPrettierConfig,

--- a/packages/scripts/utils/test/index.js
+++ b/packages/scripts/utils/test/index.js
@@ -6,17 +6,31 @@ import crossSpawn from 'cross-spawn';
 /**
  * Internal dependencies
  */
-import { hasArgInCLI, hasProjectFile, spawnScript } from '../';
-import { getPackagePath as getPackagePathMock } from '../package';
+import {
+	hasArgInCLI,
+	hasProjectFile,
+	getJestOverrideConfigFile,
+	spawnScript,
+} from '../';
+import {
+	getPackagePath as getPackagePathMock,
+	hasPackageProp as hasPackagePropMock,
+} from '../package';
 import {
 	exit as exitMock,
 	getArgsFromCLI as getArgsFromCLIMock,
 } from '../process';
+import {
+	hasProjectFile as hasProjectFileMock,
+	fromProjectRoot as fromProjectRootMock,
+	fromConfigRoot as fromConfigRootMock,
+} from '../file';
 
 jest.mock( '../package', () => {
 	const module = jest.requireActual( '../package' );
 
 	jest.spyOn( module, 'getPackagePath' );
+	jest.spyOn( module, 'hasPackageProp' );
 
 	return module;
 } );
@@ -25,6 +39,15 @@ jest.mock( '../process', () => {
 
 	jest.spyOn( module, 'exit' );
 	jest.spyOn( module, 'getArgsFromCLI' );
+
+	return module;
+} );
+jest.mock( '../file', () => {
+	const module = jest.requireActual( '../file' );
+
+	jest.spyOn( module, 'hasProjectFile' );
+	jest.spyOn( module, 'fromProjectRoot' );
+	jest.spyOn( module, 'fromConfigRoot' );
 
 	return module;
 } );
@@ -73,6 +96,80 @@ describe( 'utils', () => {
 			getPackagePathMock.mockReturnValueOnce( __dirname );
 
 			expect( hasProjectFile( 'index.js' ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'getJestOverrideConfigFile', () => {
+		beforeEach( () => {
+			getArgsFromCLIMock.mockReturnValue( [] );
+			hasPackagePropMock.mockReturnValue( false );
+			hasProjectFileMock.mockReturnValue( false );
+			fromProjectRootMock.mockImplementation( ( path ) => '/p/' + path );
+			fromConfigRootMock.mockImplementation( ( path ) => '/c/' + path );
+		} );
+
+		afterEach( () => {
+			getArgsFromCLIMock.mockReset();
+			hasPackagePropMock.mockReset();
+			hasProjectFileMock.mockReset();
+			fromProjectRootMock.mockReset();
+			fromConfigRootMock.mockReset();
+		} );
+
+		it( 'should return undefined if --config flag is present', () => {
+			getArgsFromCLIMock.mockReturnValue( [ '--config=test' ] );
+
+			expect( getJestOverrideConfigFile( 'e2e' ) ).toBe( undefined );
+		} );
+
+		it( 'should return undefined if -c flag is present', () => {
+			getArgsFromCLIMock.mockReturnValue( [ '-c=test' ] );
+
+			expect( getJestOverrideConfigFile( 'e2e' ) ).toBe( undefined );
+		} );
+
+		it( 'should return variant project configuration if present', () => {
+			hasProjectFileMock.mockImplementation(
+				( file ) => file === 'jest-e2e.config.js'
+			);
+
+			expect( getJestOverrideConfigFile( 'e2e' ) ).toBe(
+				'/p/jest-e2e.config.js'
+			);
+		} );
+
+		it( 'should return undefined if jest.config.js available', () => {
+			hasProjectFileMock.mockImplementation(
+				( file ) => file === 'jest.config.js'
+			);
+
+			expect( getJestOverrideConfigFile( 'e2e' ) ).toBe( undefined );
+		} );
+
+		it( 'should return undefined if jest.config.json available', () => {
+			hasProjectFileMock.mockImplementation(
+				( file ) => file === 'jest.config.json'
+			);
+
+			expect( getJestOverrideConfigFile( 'e2e' ) ).toBe( undefined );
+		} );
+
+		it( 'should return undefined if jest package directive specified', () => {
+			hasPackagePropMock.mockImplementation(
+				( prop ) => prop === 'jest'
+			);
+
+			expect( getJestOverrideConfigFile( 'e2e' ) ).toBe( undefined );
+		} );
+
+		it( 'should return default configuration if nothing available', () => {
+			expect( getJestOverrideConfigFile( 'e2e' ) ).toBe(
+				'/c/jest-e2e.config.js'
+			);
+
+			expect( getJestOverrideConfigFile( 'unit' ) ).toBe(
+				'/c/jest-unit.config.js'
+			);
 		} );
 	} );
 


### PR DESCRIPTION
Previously: https://github.com/WordPress/gutenberg/pull/12437#discussion_r426178935

This pull request seeks to enhance `wp-scripts` to support disambiguation of configurations by test command. Currently, if a project has a `jest.config.js` or `jest` configuration, it will take effect for both `test-e2e` and `test-unit` commands. There is no way to force one or the other to use the default, and there's no easy way to provide a custom configuration for one or the other environment specifically (except via explicit `--config` flag).

With these changes, a developer can now have a `jest-unit.config.js` or `jest-e2e.config.js` (or `.json`) files to target configurations as applying to the specific applicable test command.

The prioritization is a bit complex, but the idea is:

- Always prefer `--config` (`-c`) if provided.
- Else, if a command-specific configuration is present (`jest-unit.config.js`, `jest-e2e.config.js`), use it.
- Else, if `jest.config.js` or the `package.json` `jest` directive is present, use it.
- Else, use the default configuration appropriate for the test command.

**Testing Instructions:**

It's not especially easy to test except by having an environment which uses `wp-scripts`, then using [`npm link`](https://docs.npmjs.com/cli/link.html) in the `packages/script` directory of this branch. I've tested it in local changes of the [Dones project](https://github.com/aduth/dones) where I originally encountered issues. I confirmed that `jest-e2e.config.js` is recognized, and also that omitting an e2e-specific configuration and providing only `jest-unit.config.js` allows the default end-to-end configuration to be used.

(**In Progress:** Not yet implemented, but I suppose it would be good to include some unit tests for the new `getJestOverrideConfigFile` utility)