### PR TITLE
Fix check-latest-npm.js failure on Windows.

### DIFF
--- a/bin/check-latest-npm.js
+++ b/bin/check-latest-npm.js
@@ -81,7 +81,8 @@ If you are certain of your changes and desire to commit anyways, you should eith
  */
 async function getLocalNPMVersion() {
 	return new Promise( async ( resolve ) => {
-		const childProcess = spawn( 'npm', [ '-v' ] );
+		const command = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+		const childProcess = spawn( command, [ '-v' ] );
 
 		let output = '';
 		for await ( const chunk of childProcess.stdout ) {

--- a/bin/check-latest-npm.js
+++ b/bin/check-latest-npm.js
@@ -81,6 +81,8 @@ If you are certain of your changes and desire to commit anyways, you should eith
  */
 async function getLocalNPMVersion() {
 	return new Promise( async ( resolve ) => {
+		// 'npm' doesn't work correctly on Windows.
+		// https://github.com/WordPress/gutenberg/issues/22484
 		const command = process.platform === 'win32' ? 'npm.cmd' : 'npm';
 		const childProcess = spawn( command, [ '-v' ] );
 


### PR DESCRIPTION
* Closes #22484

## Description

Fix `check-latest-npm.js` fails on Windows. (spawn npm ENOENT error.)

## How has this been tested?

Manually tested on Windows 10.

## Screenshots <!-- if applicable -->

N/A

## Types of changes

Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [N/A] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [N/A] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [N/A] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
