### PR TITLE
Start database service before running tasks

### DIFF
--- a/packages/env/lib/commands/clean.js
+++ b/packages/env/lib/commands/clean.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+const dockerCompose = require( 'docker-compose' );
+
+/**
  * Internal dependencies
  */
 const initConfig = require( '../init-config' );
@@ -21,6 +26,13 @@ module.exports = async function clean( { environment, spinner, debug } ) {
 	spinner.text = `Cleaning ${ description }.`;
 
 	const tasks = [];
+
+	// Start the database first to avoid race conditions where all tasks create
+	// different docker networks with the same name.
+	await dockerCompose.upOne( 'mysql', {
+		config: config.dockerComposeConfigPath,
+		log: config.debug,
+	} );
 
 	if ( environment === 'all' || environment === 'development' ) {
 		tasks.push(


### PR DESCRIPTION
## Description
There's a bug which happens when you run `wp-env stop` followed by `wp-env clean all`. The database clean commands both try to start the docker service at the same time, which results in a race condition which creates two different docker networks with the same name. This becomes apparent when running `wp-env start` afterwards, which fails with the following error:

```sh
$ npx wp-env start
✖ Error while running docker-compose command.
2 matches found based on name: network 31911d623e75f345e9ed328b9f48cff6_default is ambiguous
```

The fix is to start the database service before running any tasks so that tasks use the existing running service and don't create duplicate networks.

Here's what the output looked like before:

```sh
$ npx wp-env stop

$ npx wp-env clean all

$ npx wp-env start

✖ Error while running docker-compose command.
2 matches found based on name: network 31911d623e75f345e9ed328b9f48cff6_default is ambiguous

$ docker network ls

NETWORK ID          NAME                                       DRIVER              SCOPE
687d33805fdb        31911d623e75f345e9ed328b9f48cff6_default   bridge              local
7206872c8d8e        31911d623e75f345e9ed328b9f48cff6_default   bridge              local
```

As you can see, there are two networks with the same name but different IDs.

After this fix, the output after running the same wp-env commands looks like:

```sh
$ docker network ls

NETWORK ID          NAME                                       DRIVER              SCOPE
8cd7de9bb3cf        31911d623e75f345e9ed328b9f48cff6_default   bridge              local
``` 

Thanks for catching this bug @Addison-Stavlo! I don't think I had seen it before because the docker services are normally still running when I run `wp-env clean all`. I don't normally stop wp-env first :)

## How has this been tested?
Locally in wp-env

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
