### PR TITLE
Refactor block navigation block contents

### DIFF
--- a/packages/block-editor/src/components/block-navigation/block-contents.js
+++ b/packages/block-editor/src/components/block-navigation/block-contents.js
@@ -1,185 +1,14 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
-import {
-	__experimentalGetBlockLabel as getBlockLabel,
-	getBlockType,
-} from '@wordpress/blocks';
-import { Button, Fill, Slot, VisuallyHidden } from '@wordpress/components';
-import { useInstanceId } from '@wordpress/compose';
-import {
-	Children,
-	cloneElement,
-	forwardRef,
-	useContext,
-} from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { forwardRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import BlockIcon from '../block-icon';
-import { BlockListBlockContext } from '../block-list/block';
 import { useBlockNavigationContext } from './context';
-
-const getBlockPositionDescription = ( position, siblingCount, level ) =>
-	sprintf(
-		/* translators: 1: The numerical position of the block. 2: The total number of blocks. 3. The level of nesting for the block. */
-		__( 'Block %1$d of %2$d, Level %3$d' ),
-		position,
-		siblingCount,
-		level
-	);
-
-const BlockNavigationBlockSelectButton = forwardRef( function(
-	{
-		block,
-		isSelected,
-		onClick,
-		position,
-		siblingCount,
-		level,
-		tabIndex,
-		onFocus,
-	},
-	ref
-) {
-	const { name, attributes } = block;
-
-	const blockType = getBlockType( name );
-	const blockDisplayName = getBlockLabel( blockType, attributes );
-
-	const instanceId = useInstanceId( BlockNavigationBlockSelectButton );
-	const descriptionId = `block-navigation-block-select-button__${ instanceId }`;
-	const blockPositionDescription = getBlockPositionDescription(
-		position,
-		siblingCount,
-		level
-	);
-
-	return (
-		<>
-			<Button
-				className={ classnames(
-					'block-editor-block-navigation-block-select-button',
-					'block-editor-block-navigation-block-contents'
-				) }
-				onClick={ onClick }
-				aria-describedby={ descriptionId }
-				ref={ ref }
-				tabIndex={ tabIndex }
-				onFocus={ onFocus }
-			>
-				<BlockIcon icon={ blockType.icon } showColors />
-				{ blockDisplayName }
-				{ isSelected && (
-					<VisuallyHidden>
-						{ __( '(selected block)' ) }
-					</VisuallyHidden>
-				) }
-			</Button>
-			<div
-				className="block-editor-block-navigation-block-contents__description"
-				id={ descriptionId }
-			>
-				{ blockPositionDescription }
-			</div>
-		</>
-	);
-} );
-
-const BlockNavigationBlockSlot = forwardRef( function( props, ref ) {
-	const instanceId = useInstanceId( BlockNavigationBlockSlot );
-	const { clientId } = props.block;
-
-	return (
-		<Slot name={ getSlotName( clientId ) }>
-			{ ( fills ) => {
-				if ( ! fills.length ) {
-					return (
-						<BlockNavigationBlockSelectButton
-							ref={ ref }
-							{ ...props }
-						/>
-					);
-				}
-
-				const {
-					block,
-					isSelected,
-					position,
-					siblingCount,
-					level,
-					tabIndex,
-					onFocus,
-				} = props;
-
-				const { name } = block;
-				const blockType = getBlockType( name );
-
-				const descriptionId = `block-navigation-block-slot__${ instanceId }`;
-				const blockPositionDescription = getBlockPositionDescription(
-					position,
-					siblingCount,
-					level
-				);
-
-				const forwardedFillProps = {
-					// Ensure that the component in the slot can receive
-					// keyboard navigation.
-					tabIndex,
-					onFocus,
-					ref,
-					// Give the element rendered in the slot a description
-					// that describes its position.
-					'aria-describedby': descriptionId,
-				};
-
-				return (
-					<>
-						<div
-							className={ classnames(
-								'block-editor-block-navigation-block-slot',
-								'block-editor-block-navigation-block-contents'
-							) }
-						>
-							<BlockIcon icon={ blockType.icon } showColors />
-							{ Children.map( fills, ( fill ) =>
-								cloneElement( fill, {
-									...fill.props,
-									...forwardedFillProps,
-								} )
-							) }
-							{ isSelected && (
-								<VisuallyHidden>
-									{ __( '(selected block)' ) }
-								</VisuallyHidden>
-							) }
-							<div
-								className="block-editor-block-navigation-block-contents__description"
-								id={ descriptionId }
-							>
-								{ blockPositionDescription }
-							</div>
-						</div>
-					</>
-				);
-			} }
-		</Slot>
-	);
-} );
-
-const getSlotName = ( clientId ) => `BlockNavigationBlock-${ clientId }`;
-
-export const BlockNavigationBlockFill = ( props ) => {
-	const { clientId } = useContext( BlockListBlockContext );
-	return <Fill { ...props } name={ getSlotName( clientId ) } />;
-};
+import BlockNavigationBlockSlot from './block-slot';
+import BlockNavigationBlockSelectButton from './block-select-button';
 
 const BlockNavigationBlockContents = forwardRef(
 	(
@@ -193,6 +22,7 @@ const BlockNavigationBlockContents = forwardRef(
 		return withBlockNavigationSlots ? (
 			<BlockNavigationBlockSlot
 				ref={ ref }
+				className="block-editor-block-navigation-block-contents"
 				block={ block }
 				onClick={ onClick }
 				isSelected={ isSelected }
@@ -204,6 +34,7 @@ const BlockNavigationBlockContents = forwardRef(
 		) : (
 			<BlockNavigationBlockSelectButton
 				ref={ ref }
+				className="block-editor-block-navigation-block-contents"
 				block={ block }
 				onClick={ onClick }
 				isSelected={ isSelected }

--- a/packages/block-editor/src/components/block-navigation/block-contents.js
+++ b/packages/block-editor/src/components/block-navigation/block-contents.js
@@ -121,7 +121,7 @@ const BlockNavigationBlockSlot = forwardRef( ( props, ref ) => {
 					>
 						{ Children.map( fills, ( fill ) =>
 							cloneElement( fill, {
-								...{ props },
+								...props,
 								...fill.props,
 							} )
 						) }

--- a/packages/block-editor/src/components/block-navigation/block-contents.js
+++ b/packages/block-editor/src/components/block-navigation/block-contents.js
@@ -194,6 +194,7 @@ const BlockNavigationBlockContents = forwardRef(
 			<BlockNavigationBlockSlot
 				ref={ ref }
 				block={ block }
+				onClick={ onClick }
 				isSelected={ isSelected }
 				position={ position }
 				siblingCount={ siblingCount }

--- a/packages/block-editor/src/components/block-navigation/block-select-button.js
+++ b/packages/block-editor/src/components/block-navigation/block-select-button.js
@@ -69,7 +69,7 @@ const BlockNavigationBlockSelectButton = forwardRef( function(
 				) }
 			</Button>
 			<div
-				className="block-editor-block-navigation-block-contents__description"
+				className="block-editor-block-navigation-block-select-button__description"
 				id={ descriptionId }
 			>
 				{ blockPositionDescription }

--- a/packages/block-editor/src/components/block-navigation/block-select-button.js
+++ b/packages/block-editor/src/components/block-navigation/block-select-button.js
@@ -1,0 +1,79 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalGetBlockLabel as getBlockLabel,
+	getBlockType,
+} from '@wordpress/blocks';
+import { Button, VisuallyHidden } from '@wordpress/components';
+import { useInstanceId } from '@wordpress/compose';
+import { forwardRef } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import BlockIcon from '../block-icon';
+import { getBlockPositionDescription } from './utils';
+
+const BlockNavigationBlockSelectButton = forwardRef( function(
+	{
+		className,
+		block,
+		isSelected,
+		onClick,
+		position,
+		siblingCount,
+		level,
+		tabIndex,
+		onFocus,
+	},
+	ref
+) {
+	const { name, attributes } = block;
+
+	const blockType = getBlockType( name );
+	const blockDisplayName = getBlockLabel( blockType, attributes );
+	const instanceId = useInstanceId( BlockNavigationBlockSelectButton );
+	const descriptionId = `block-navigation-block-select-button__${ instanceId }`;
+	const blockPositionDescription = getBlockPositionDescription(
+		position,
+		siblingCount,
+		level
+	);
+
+	return (
+		<>
+			<Button
+				className={ classnames(
+					'block-editor-block-navigation-block-select-button',
+					className
+				) }
+				onClick={ onClick }
+				aria-describedby={ descriptionId }
+				ref={ ref }
+				tabIndex={ tabIndex }
+				onFocus={ onFocus }
+			>
+				<BlockIcon icon={ blockType.icon } showColors />
+				{ blockDisplayName }
+				{ isSelected && (
+					<VisuallyHidden>
+						{ __( '(selected block)' ) }
+					</VisuallyHidden>
+				) }
+			</Button>
+			<div
+				className="block-editor-block-navigation-block-contents__description"
+				id={ descriptionId }
+			>
+				{ blockPositionDescription }
+			</div>
+		</>
+	);
+} );

--- a/packages/block-editor/src/components/block-navigation/block-select-button.js
+++ b/packages/block-editor/src/components/block-navigation/block-select-button.js
@@ -21,7 +21,7 @@ import { __ } from '@wordpress/i18n';
 import BlockIcon from '../block-icon';
 import { getBlockPositionDescription } from './utils';
 
-const BlockNavigationBlockSelectButton = forwardRef( function(
+function BlockNavigationBlockSelectButton(
 	{
 		className,
 		block,
@@ -76,4 +76,6 @@ const BlockNavigationBlockSelectButton = forwardRef( function(
 			</div>
 		</>
 	);
-} );
+}
+
+export default forwardRef( BlockNavigationBlockSelectButton );

--- a/packages/block-editor/src/components/block-navigation/block-slot.js
+++ b/packages/block-editor/src/components/block-navigation/block-slot.js
@@ -1,0 +1,114 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { getBlockType } from '@wordpress/blocks';
+import { Fill, Slot, VisuallyHidden } from '@wordpress/components';
+import { useInstanceId } from '@wordpress/compose';
+import {
+	Children,
+	cloneElement,
+	forwardRef,
+	useContext,
+} from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import BlockIcon from '../block-icon';
+import { BlockListBlockContext } from '../block-list/block';
+import BlockNavigationBlockSelectButton from './block-select-button';
+import { getBlockPositionDescription } from './utils';
+
+const getSlotName = ( clientId ) => `BlockNavigationBlock-${ clientId }`;
+
+const BlockNavigationBlockSlot = forwardRef( function( props, ref ) {
+	const instanceId = useInstanceId( BlockNavigationBlockSlot );
+	const { clientId } = props.block;
+
+	return (
+		<Slot name={ getSlotName( clientId ) }>
+			{ ( fills ) => {
+				if ( ! fills.length ) {
+					return (
+						<BlockNavigationBlockSelectButton
+							ref={ ref }
+							{ ...props }
+						/>
+					);
+				}
+
+				const {
+					className,
+					block,
+					isSelected,
+					position,
+					siblingCount,
+					level,
+					tabIndex,
+					onFocus,
+				} = props;
+
+				const { name } = block;
+				const blockType = getBlockType( name );
+				const descriptionId = `block-navigation-block-slot__${ instanceId }`;
+				const blockPositionDescription = getBlockPositionDescription(
+					position,
+					siblingCount,
+					level
+				);
+
+				const forwardedFillProps = {
+					// Ensure that the component in the slot can receive
+					// keyboard navigation.
+					tabIndex,
+					onFocus,
+					ref,
+					// Give the element rendered in the slot a description
+					// that describes its position.
+					'aria-describedby': descriptionId,
+				};
+
+				return (
+					<>
+						<div
+							className={ classnames(
+								'block-editor-block-navigation-block-slot',
+								className
+							) }
+						>
+							<BlockIcon icon={ blockType.icon } showColors />
+							{ Children.map( fills, ( fill ) =>
+								cloneElement( fill, {
+									...fill.props,
+									...forwardedFillProps,
+								} )
+							) }
+							{ isSelected && (
+								<VisuallyHidden>
+									{ __( '(selected block)' ) }
+								</VisuallyHidden>
+							) }
+							<div
+								className="block-editor-block-navigation-block-contents__description"
+								id={ descriptionId }
+							>
+								{ blockPositionDescription }
+							</div>
+						</div>
+					</>
+				);
+			} }
+		</Slot>
+	);
+} );
+
+export const BlockNavigationBlockFill = ( props ) => {
+	const { clientId } = useContext( BlockListBlockContext );
+	return <Fill { ...props } name={ getSlotName( clientId ) } />;
+};

--- a/packages/block-editor/src/components/block-navigation/block-slot.js
+++ b/packages/block-editor/src/components/block-navigation/block-slot.js
@@ -27,7 +27,7 @@ import { getBlockPositionDescription } from './utils';
 
 const getSlotName = ( clientId ) => `BlockNavigationBlock-${ clientId }`;
 
-export default forwardRef( function BlockNavigationBlockSlot( props, ref ) {
+function BlockNavigationBlockSlot( props, ref ) {
 	const instanceId = useInstanceId( BlockNavigationBlockSlot );
 	const { clientId } = props.block;
 
@@ -106,7 +106,9 @@ export default forwardRef( function BlockNavigationBlockSlot( props, ref ) {
 			} }
 		</Slot>
 	);
-} );
+}
+
+export default forwardRef( BlockNavigationBlockSlot );
 
 export const BlockNavigationBlockFill = ( props ) => {
 	const { clientId } = useContext( BlockListBlockContext );

--- a/packages/block-editor/src/components/block-navigation/block-slot.js
+++ b/packages/block-editor/src/components/block-navigation/block-slot.js
@@ -95,7 +95,7 @@ const BlockNavigationBlockSlot = forwardRef( function( props, ref ) {
 								</VisuallyHidden>
 							) }
 							<div
-								className="block-editor-block-navigation-block-contents__description"
+								className="block-editor-block-navigation-block-slot__description"
 								id={ descriptionId }
 							>
 								{ blockPositionDescription }

--- a/packages/block-editor/src/components/block-navigation/block-slot.js
+++ b/packages/block-editor/src/components/block-navigation/block-slot.js
@@ -27,7 +27,7 @@ import { getBlockPositionDescription } from './utils';
 
 const getSlotName = ( clientId ) => `BlockNavigationBlock-${ clientId }`;
 
-const BlockNavigationBlockSlot = forwardRef( function( props, ref ) {
+export default forwardRef( function BlockNavigationBlockSlot( props, ref ) {
 	const instanceId = useInstanceId( BlockNavigationBlockSlot );
 	const { clientId } = props.block;
 

--- a/packages/block-editor/src/components/block-navigation/editor.js
+++ b/packages/block-editor/src/components/block-navigation/editor.js
@@ -7,7 +7,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { RichText } from '../';
-import { BlockNavigationBlockFill } from './block-contents';
+import { BlockNavigationBlockFill } from './block-slot';
 
 export default function BlockNavigationEditor( { value, onChange } ) {
 	return (

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -79,7 +79,8 @@ $tree-item-height: 36px;
 	}
 }
 
-.block-editor-block-navigation-block-contents__description,
+.block-editor-block-navigation-block-slot__description,
+.block-editor-block-navigation-block-select-button__description,
 .block-editor-block-navigation-appender__description {
 	display: none;
 }

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -25,7 +25,7 @@ $tree-item-height: 36px;
 	// Use position relative for row animation.
 	position: relative;
 
-	.block-editor-block-navigation-block-content-wrapper {
+	.block-editor-block-navigation-block-contents {
 		display: flex;
 		align-items: center;
 		width: calc(100% - 0.8em);
@@ -36,14 +36,10 @@ $tree-item-height: 36px;
 		border-radius: 2px;
 	}
 
-	&.is-visible .block-editor-block-navigation-block-content-wrapper {
+	&.is-visible .block-editor-block-navigation-block-contents {
 		opacity: 1;
 		@include edit-post__fade-in-animation;
 	}
-
-	// .block-editor-block-navigation__list-item {
-	// 	position: relative;
-	// }
 
 	.block-editor-block-icon {
 		margin-right: 6px;
@@ -81,22 +77,9 @@ $tree-item-height: 36px;
 		margin-left: 0.8em;
 		width: calc(100% - 0.8em);
 	}
-
-	& > li:last-child {
-		position: relative;
-		&::after {
-			position: absolute;
-			content: "";
-			background: $white;
-			top: ($tree-item-height + $tree-border-width ) / 2;
-			bottom: 0;
-			left: -$tree-border-width;
-			width: $tree-border-width;
-		}
-	}
 }
 
-.block-editor-block-navigation-block-content-wrapper__description,
+.block-editor-block-navigation-block-contents__description,
 .block-editor-block-navigation-appender__description {
 	display: none;
 }

--- a/packages/block-editor/src/components/block-navigation/utils.js
+++ b/packages/block-editor/src/components/block-navigation/utils.js
@@ -1,0 +1,13 @@
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+
+export const getBlockPositionDescription = ( position, siblingCount, level ) =>
+	sprintf(
+		/* translators: 1: The numerical position of the block. 2: The total number of blocks. 3. The level of nesting for the block. */
+		__( 'Block %1$d of %2$d, Level %3$d' ),
+		position,
+		siblingCount,
+		level
+	);

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -17,7 +17,7 @@ export { default as BlockEdit, useBlockEditContext } from './block-edit';
 export { default as BlockFormatControls } from './block-format-controls';
 export { default as BlockIcon } from './block-icon';
 export { default as BlockNavigationDropdown } from './block-navigation/dropdown';
-export { BlockNavigationBlockFill as __experimentalBlockNavigationBlockFill } from './block-navigation/block-contents';
+export { BlockNavigationBlockFill as __experimentalBlockNavigationBlockFill } from './block-navigation/block-slot';
 export { default as __experimentalBlockNavigationEditor } from './block-navigation/editor';
 export { default as __experimentalBlockNavigationTree } from './block-navigation/tree';
 export { default as __experimentalBlockVariationPicker } from './block-variation-picker';


### PR DESCRIPTION
## Description
This is a partial step towards fixing #22488.

Refactors some of the Block Navigator internals:

Previously the slot in the block navigator was using a `BlockContentWrapper` component to achieve the same layout as the button that's used to select blocks. However there were some issues with this code re-use, some attributes were being applied to the wrong elements, notably the props passed by `TreeGridCell` to manage keyboard navigation and the `id` used to set the `aria-description`. These should be passed onto the fill. I don't think there's a good way to achieve code reuse so I've removed `BlockContentWrapper` and now the slot component and the button component define their own content.

The PR also moves some of the components into their own files

## How has this been tested?
The block navigator should look and behave like it does in `master`.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Refactor/Code quality.
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
