### PR TITLE
ClassName doesn't need to exist for block style preview

### DIFF
--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -65,10 +65,8 @@ export class BlockSwitcher extends Component {
 			return null;
 		}
 
-		const hoveredBlock = hoveredClassName ? blocks[ 0 ] : null;
-		const hoveredBlockType = hoveredClassName
-			? getBlockType( hoveredBlock.name )
-			: null;
+		const hoveredBlock = blocks[ 0 ];
+		const hoveredBlockType = getBlockType( hoveredBlock.name );
 
 		const itemsByName = mapKeys( inserterItems, ( { name } ) => name );
 		const possibleBlockTransformations = orderBy(


### PR DESCRIPTION
## Description

Fixes #22375 

When rendering the dropdown in `BlockSwitcher`, `hoveredClassName` doesn't always exist, since classNames for default styles were removed in #22266. But when `BlockStyles` are hovered, `hoveredClassName` is set to either an actual classname or an empty string. As an empty string is sufficient for `BlockPreview` to work, its rendering doesn't need to be conditional on a classname existing.


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Tested in the browsers, checked that editor doesn't crash when block styles are hovered, and block style previews are displaying correctly.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
