### PR TITLE
Block Library: Register all block with "block.json" on the server'

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -20,6 +20,10 @@ function gutenberg_reregister_core_block_types() {
 		'audio',
 		'button',
 		'buttons',
+		'classic',
+		'code',
+		'column',
+		'columns',
 		'file',
 		'gallery',
 		'group',
@@ -44,6 +48,7 @@ function gutenberg_reregister_core_block_types() {
 		'text-columns',
 		'verse',
 		'video',
+		'widget-area',
 	);
 
 	$block_names = array(
@@ -67,16 +72,16 @@ function gutenberg_reregister_core_block_types() {
 		$block_names = array_merge(
 			$block_names,
 			array(
-				'post-title.php'          => 'core/post-title',
-				'post-content.php'        => 'core/post-content',
 				'post-author.php'         => 'core/post-author',
 				'post-comments.php'       => 'core/post-comments',
 				'post-comments-count.php' => 'core/post-comments-count',
 				'post-comments-form.php'  => 'core/post-comments-form',
+				'post-content.php'        => 'core/post-content',
 				'post-date.php'           => 'core/post-date',
 				'post-excerpt.php'        => 'core/post-excerpt',
 				'post-featured-image.php' => 'core/post-featured-image',
 				'post-tags.php'           => 'core/post-tags',
+				'post-title.php'          => 'core/post-title',
 				'query.php'               => 'core/query',
 				'query-loop.php'          => 'core/query-loop',
 				'query-pagination.php'    => 'core/query-pagination',

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -16,6 +16,36 @@ function gutenberg_reregister_core_block_types() {
 		return;
 	}
 
+	$block_folders = array(
+		'audio',
+		'button',
+		'buttons',
+		'file',
+		'gallery',
+		'group',
+		'heading',
+		'html',
+		'image',
+		'list',
+		'media-text',
+		'missing',
+		'more',
+		'navigation-link',
+		'nextpage',
+		'paragraph',
+		'preformatted',
+		'pullquote',
+		'quote',
+		'separator',
+		'social-links',
+		'spacer',
+		'subhead',
+		'table',
+		'text-columns',
+		'verse',
+		'video',
+	);
+
 	$block_names = array(
 		'archives.php'        => 'core/archives',
 		'block.php'           => 'core/block',
@@ -27,8 +57,8 @@ function gutenberg_reregister_core_block_types() {
 		'legacy-widget.php'   => 'core/legacy-widget',
 		'navigation.php'      => 'core/navigation',
 		'rss.php'             => 'core/rss',
-		'shortcode.php'       => 'core/shortcode',
 		'search.php'          => 'core/search',
+		'shortcode.php'       => 'core/shortcode',
 		'social-link.php'     => 'core/social-link',
 		'tag-cloud.php'       => 'core/tag-cloud',
 	);
@@ -47,16 +77,37 @@ function gutenberg_reregister_core_block_types() {
 				'post-excerpt.php'        => 'core/post-excerpt',
 				'post-featured-image.php' => 'core/post-featured-image',
 				'post-tags.php'           => 'core/post-tags',
-				'site-title.php'          => 'core/site-title',
-				'template-part.php'       => 'core/template-part',
 				'query.php'               => 'core/query',
 				'query-loop.php'          => 'core/query-loop',
 				'query-pagination.php'    => 'core/query-pagination',
+				'site-title.php'          => 'core/site-title',
+				'template-part.php'       => 'core/template-part',
 			)
 		);
 	}
 
 	$registry = WP_Block_Type_Registry::get_instance();
+
+	foreach ( $block_folders as $folder_name ) {
+		$block_json_file = $blocks_dir . '/' . $folder_name . '/block.json';
+		if ( ! file_exists( $block_json_file ) ) {
+			return;
+		}
+
+		// Ideally, all paths to block metadata files should be listed in
+		// WordPress core. In this place we should rather use filter
+		// to replace paths with overrides defined by the plugin.
+		$metadata = json_decode( file_get_contents( $block_json_file ), true );
+		if ( ! is_array( $metadata ) || ! $metadata['name'] ) {
+			return false;
+		}
+
+		if ( $registry->is_registered( $metadata['name'] ) ) {
+			$registry->unregister( $metadata['name'] );
+		}
+
+		register_block_type_from_metadata( $block_json_file );
+	}
 
 	foreach ( $block_names as $file => $block_names ) {
 		if ( ! file_exists( $blocks_dir . $file ) ) {

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -14,7 +14,8 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 	 *
 	 * @since 7.9.0
 	 *
-	 * @param string $path Path to the folder where the `block.json` file is located.
+	 * @param string $file_or_folder Path to the JSON file with metadata definition for
+	 *     the block or path to the folder where the `block.json` file is located.
 	 * @param array  $args {
 	 *     Optional. Array of block type arguments. Any arguments may be defined, however the
 	 *     ones described below are supported by default. Default empty array.
@@ -23,8 +24,10 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 	 * }
 	 * @return WP_Block_Type|false The registered block type on success, or false on failure.
 	 */
-	function register_block_type_from_metadata( $path, $args = array() ) {
-		$file = trailingslashit( $path ) . 'block.json';
+	function register_block_type_from_metadata( $file_or_folder, $args = array() ) {
+		$file = ( substr( $file_or_folder, -10 ) !== 'block.json' ) ?
+			trailingslashit( $file_or_folder ) . 'block.json' :
+			$file_or_folder;
 		if ( ! file_exists( $file ) ) {
 			return false;
 		}


### PR DESCRIPTION
## Description
This PR registers on the server all core blocks that have `block.json` defined when they don't contain PHP files that would take care of it. This way soon we should be able to get a few benefits like:
1. Ability to expose all registered blocks and their definitions with a new REST API endpoint as proposed in #21065 by @spacedmonkey.
2. Using the server-side preloaded REST API call to the endpoint mentioned in (1) we should be able to finally remove the temporary workaround used here:
  https://github.com/WordPress/wordpress-develop/blob/437ac63d7652b08095dc7f77b6ba4ef52db44dbb/src/wp-admin/edit-form-blocks.php#L111-L115
3. A way to process all core blocks on the server using their definitions.

## How has this been tested?

I checked in the source code that included blocks are listed in the `wp.blocks.unstable__bootstrapServerSideBlockDefinitions` call:

![Screen Shot 2020-05-20 at 16 04 47](https://user-images.githubusercontent.com/699132/82456139-1e380500-9ab4-11ea-9c16-323d84eb89cb.png)


## Types of changes
 New feature (non-breaking change which adds functionality).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [N/A] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
