### PR TITLE
Block: don't move initial focus within the block

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
@@ -1,13 +1,8 @@
 /**
- * External dependencies
- */
-import { first, last } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useEffect } from '@wordpress/element';
-import { focus, isTextField, placeCaretAtHorizontalEdge } from '@wordpress/dom';
+import { placeCaretAtHorizontalEdge } from '@wordpress/dom';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -79,21 +74,10 @@ export function useFocusFirstElement( ref, clientId ) {
 			return;
 		}
 
-		// Find all tabbables within node.
-		const textInputs = focus.tabbable.find( ref.current ).filter(
-			( node ) =>
-				isTextField( node ) &&
-				// Exclude inner blocks and block appenders
-				isInsideRootBlock( ref.current, node ) &&
-				! node.closest( '.block-list-appender' )
-		);
-
 		// If reversed (e.g. merge via backspace), use the last in the set of
 		// tabbables.
 		const isReverse = -1 === initialPosition;
-		const target =
-			( isReverse ? last : first )( textInputs ) || ref.current;
 
-		placeCaretAtHorizontalEdge( target, isReverse );
+		placeCaretAtHorizontalEdge( ref.current, isReverse );
 	}, [ initialPosition ] );
 }


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Currently, when a block is selected (e.g. inserted) and the block doesn't already have focus, focus is moved to the first or last tabbable element within the block. This is a remnant from when the basic blocks always had an outer wrapper. Now with light blocks, most basic blocks only have a single focusable element which is usually also content editable. In these cases, focus no longer has to move. For more complex blocks with multiple tabbable elements, it doesn't really make sense for initial focus to move within the block. It can just stay on the wrapper element and the user can tab forward to navigate inside.

For some more complex blocks this can be even disorientating. Imagine an image block with a caption. When you insert it, by the currently logic, focus would be moved to the caption, instead of being left on the block wrapper node. It's much clearer for more complex to leave focus on the block node which visually also indicates what you've inserted.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
