### PR TITLE
Image block: use hooks

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -119,24 +119,22 @@ export function ImageEdit( {
 	noticeOperations,
 	onReplace,
 } ) {
-	const selected = useSelect(
+	const { image, maxWidth, isRTL, imageSizes, mediaUpload } = useSelect(
 		( select ) => {
 			const { getMedia } = select( 'core' );
 			const { getSettings } = select( 'core/block-editor' );
-			const { mediaUpload, imageSizes, isRTL, maxWidth } = getSettings();
-			const image = id && isSelected ? getMedia( id ) : null;
-
 			return {
-				image,
-				maxWidth,
-				isRTL,
-				imageSizes,
-				mediaUpload,
+				...pick( getSettings(), [
+					'mediaUpload',
+					'imageSizes',
+					'isRTL',
+					'maxWidth',
+				] ),
+				image: id && isSelected ? getMedia( id ) : null,
 			};
 		},
 		[ id, isSelected ]
 	);
-	const { image, maxWidth, isRTL, imageSizes, mediaUpload } = selected;
 	const { toggleSelection } = useDispatch( 'core/block-editor' );
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const [ captionFocused, setCaptionFocused ] = useState( false );

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -119,20 +119,23 @@ export function ImageEdit( {
 	noticeOperations,
 	onReplace,
 } ) {
-	const selected = useSelect( ( select ) => {
-		const { getMedia } = select( 'core' );
-		const { getSettings } = select( 'core/block-editor' );
-		const { mediaUpload, imageSizes, isRTL, maxWidth } = getSettings();
-		const image = id && isSelected ? getMedia( id ) : null;
+	const selected = useSelect(
+		( select ) => {
+			const { getMedia } = select( 'core' );
+			const { getSettings } = select( 'core/block-editor' );
+			const { mediaUpload, imageSizes, isRTL, maxWidth } = getSettings();
+			const image = id && isSelected ? getMedia( id ) : null;
 
-		return {
-			image,
-			maxWidth,
-			isRTL,
-			imageSizes,
-			mediaUpload,
-		};
-	} );
+			return {
+				image,
+				maxWidth,
+				isRTL,
+				imageSizes,
+				mediaUpload,
+			};
+		},
+		[ id, isSelected ]
+	);
 	const { image, maxWidth, isRTL, imageSizes, mediaUpload } = selected;
 	const { toggleSelection } = useDispatch( 'core/block-editor' );
 	const isLargeViewport = useViewportMatch( 'medium' );

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -296,6 +296,7 @@ export function ImageEdit( {
 
 	const isTemp = isTemporaryImage( id, url );
 
+	// Upload a temporary image on mount.
 	useEffect( () => {
 		if ( ! isTemp ) {
 			return;
@@ -314,6 +315,14 @@ export function ImageEdit( {
 					noticeOperations.createErrorNotice( message );
 				},
 			} );
+		}
+	}, [] );
+
+	// If an image is temporary, revoke the Blob url when it is uploaded (and is
+	// no longer temporary).
+	useEffect( () => {
+		if ( ! isTemp ) {
+			return;
 		}
 
 		return () => {

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { get, filter, map, last, omit, pick } from 'lodash';
+import { get, filter, map, last, omit, pick, includes } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -140,6 +140,7 @@ export function ImageEdit( {
 	const { toggleSelection } = useDispatch( 'core/block-editor' );
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const [ captionFocused, setCaptionFocused ] = useState( false );
+	const isWideAligned = includes( [ 'wide', 'full' ], align );
 
 	function onResizeStart() {
 		toggleSelection( false );
@@ -259,10 +260,9 @@ export function ImageEdit( {
 	}
 
 	function updateAlignment( nextAlign ) {
-		const extraUpdatedAttributes =
-			[ 'wide', 'full' ].indexOf( nextAlign ) !== -1
-				? { width: undefined, height: undefined }
-				: {};
+		const extraUpdatedAttributes = isWideAligned
+			? { width: undefined, height: undefined }
+			: {};
 		setAttributes( {
 			...extraUpdatedAttributes,
 			align: nextAlign,
@@ -414,9 +414,7 @@ export function ImageEdit( {
 		[ `size-${ sizeSlug }` ]: sizeSlug,
 	} );
 
-	const isResizable =
-		[ 'wide', 'full' ].indexOf( align ) === -1 && isLargeViewport;
-
+	const isResizable = ! isWideAligned && isLargeViewport;
 	const imageSizeOptions = getImageSizeOptions();
 
 	const getInspectorControls = ( imageWidth, imageHeight ) => (

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -44,6 +44,7 @@ import { createBlock } from '@wordpress/blocks';
  */
 import { createUpgradedEmbedBlock } from '../embed/util';
 import ImageSize from './image-size';
+
 /**
  * Module constants
  */
@@ -173,7 +174,7 @@ export function ImageEdit( {
 		}
 
 		// If a caption text was meanwhile written by the user,
-		// make sure the text is not overwritten by empty captions
+		// make sure the text is not overwritten by empty captions.
 		if ( caption && ! get( mediaAttributes, [ 'caption' ] ) ) {
 			mediaAttributes = omit( mediaAttributes, [ 'caption' ] );
 		}
@@ -187,7 +188,8 @@ export function ImageEdit( {
 				sizeSlug: DEFAULT_SIZE_SLUG,
 			};
 		} else {
-			// Keep the same url when selecting the same file, so "Image Size" option is not changed.
+			// Keep the same url when selecting the same file, so "Image Size"
+			// option is not changed.
 			additionalAttributes = { url };
 		}
 
@@ -232,7 +234,8 @@ export function ImageEdit( {
 	}
 
 	function onSetTitle( value ) {
-		// This is the HTML title attribute, separate from the media object title
+		// This is the HTML title attribute, separate from the media object
+		// title.
 		setAttributes( { title: value } );
 	}
 
@@ -460,7 +463,7 @@ export function ImageEdit( {
 		</>
 	);
 
-	// Disable reason: Each block can be selected by clicking on it
+	// Disable reason: Each block can be selected by clicking on it.
 	/* eslint-disable jsx-a11y/click-events-have-key-events */
 	return (
 		<>


### PR DESCRIPTION
## Description

This PR rewrites the image block with hooks. I'm doing this so we can also rewrite the `ImageSize` component to a hook which would allow us to simplify the markup.

Best viewed without whitespace changes: https://github.com/WordPress/gutenberg/pull/22499/files?diff=split&w=1

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
