### PR TITLE
Blocks: Short-circuit validation for identical markup

### DIFF
--- a/packages/blocks/src/api/test/validation.js
+++ b/packages/blocks/src/api/test/validation.js
@@ -458,6 +458,15 @@ describe( 'validation', () => {
 	} );
 
 	describe( 'isEquivalentHTML()', () => {
+		it( 'should return true for identical markup', () => {
+			const isEquivalent = isEquivalentHTML(
+				'<div>Hello <span class="b">World!</span></div>',
+				'<div>Hello <span class="b">World!</span></div>'
+			);
+
+			expect( isEquivalent ).toBe( true );
+		} );
+
 		it( 'should return false for effectively inequivalent html', () => {
 			const isEquivalent = isEquivalentHTML(
 				'<div>Hello <span class="b">World!</span></div>',

--- a/packages/blocks/src/api/validation/index.js
+++ b/packages/blocks/src/api/validation/index.js
@@ -575,6 +575,11 @@ export function isClosedByToken( currentToken, nextToken ) {
  * @return {boolean} Whether HTML strings are equivalent.
  */
 export function isEquivalentHTML( actual, expected, logger = createLogger() ) {
+	// Short-circuit if markup is identical.
+	if ( actual === expected ) {
+		return true;
+	}
+
 	// Tokenize input content and reserialized save content
 	const [ actualTokens, expectedTokens ] = [
 		actual,


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/issues/21703#issuecomment-631504286

This pull request seeks to optimize block validation (specifically `isEquivalentHTML`) to short-circuit as `true` when given two markup strings which are identical. This bypasses the regular the tokenization / equivalence comparison which is relevant for two markup strings which are "equivalent" but not identical.

**Performance Results:**

I was not able to detect a meaningful difference using the `npm run test-performance` command. It's unclear if this is due to lack of precision of the output, if the test isn't set up in such a way to stress test this behavior, or if the result is not impactful in the grand scheme of the running application.

Using the [Chrome Performance Profiler](https://developers.google.com/web/tools/chrome-devtools/rendering-tools), I was able to find a pretty dramatic difference of the function itself.

In development mode, as an average of 4 runs, in a post containing 271 blocks (11052 words):

&nbsp;|Self Time|Total Time
---|---|---
Before|3.675ms|74.375ms
After|0.725ms|0.725ms

The Total Time being the same as Self Time in "After" is expected, since in a typical reload, all block markup should be able to leverage this shortcut and bypass all internal function calls. The difference in Total Time is most meaningful here.

**Testing Instructions:**

Ensure unit tests pass:

```
npm run test-unit packages/blocks/src/api/test/validation.js
```