### PR TITLE
API Fetch: Support preloading in `fetchAllMiddleware`.

### DIFF
--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -191,8 +191,8 @@ function gutenberg_edit_site_init( $hook ) {
 	$preload_paths = array(
 		'/',
 		'/wp/v2/types?context=edit',
-		'/wp/v2/taxonomies?per_page=-1&context=edit',
-		'/wp/v2/pages?per_page=-1&context=edit',
+		'/wp/v2/taxonomies?per_page=100&context=edit',
+		'/wp/v2/pages?per_page=100&context=edit',
 		'/wp/v2/themes?status=active',
 		sprintf( '/wp/v2/templates/%s?context=edit', $current_template_id ),
 		array( '/wp/v2/media', 'OPTIONS' ),

--- a/packages/api-fetch/src/middlewares/fetch-all-middleware.js
+++ b/packages/api-fetch/src/middlewares/fetch-all-middleware.js
@@ -3,6 +3,11 @@
  */
 import { addQueryArgs } from '@wordpress/url';
 
+/**
+ * Internal dependencies
+ */
+import apiFetch from '..';
+
 // Apply query arguments to both URL and Path, whichever is present.
 const modifyQuery = ( { path, url, ...options }, queryArgs ) => ( {
 	...options,
@@ -53,7 +58,7 @@ const fetchAllMiddleware = async ( options, next ) => {
 	}
 
 	// Retrieve requested page of results.
-	const response = await next( {
+	const response = await apiFetch( {
 		...modifyQuery( options, {
 			per_page: 100,
 		} ),
@@ -78,7 +83,7 @@ const fetchAllMiddleware = async ( options, next ) => {
 	// Iteratively fetch all remaining pages until no "next" header is found.
 	let mergedResults = [].concat( results );
 	while ( nextPage ) {
-		const nextResponse = await next( {
+		const nextResponse = await apiFetch( {
 			...options,
 			// Ensure the URL for the next page is used instead of any provided path.
 			path: undefined,

--- a/packages/api-fetch/src/middlewares/test/fetch-all-middleware.js
+++ b/packages/api-fetch/src/middlewares/test/fetch-all-middleware.js
@@ -1,9 +1,6 @@
-/**
- * Internal dependencies
- */
-import fetchAllMiddleware from '../fetch-all-middleware';
-
 describe( 'Fetch All Middleware', () => {
+	beforeEach( jest.resetModules );
+
 	it( 'should defer with the same options to the next middleware', async () => {
 		expect.hasAssertions();
 		const originalOptions = { path: '/posts' };
@@ -12,14 +9,17 @@ describe( 'Fetch All Middleware', () => {
 			return Promise.resolve( 'ok' );
 		};
 
-		await fetchAllMiddleware( originalOptions, next );
+		await require( '../fetch-all-middleware' ).default(
+			originalOptions,
+			next
+		);
 	} );
 
 	it( 'should paginate the request', async () => {
 		expect.hasAssertions();
 		const originalOptions = { url: '/posts?per_page=-1' };
 		let counter = 1;
-		const next = ( options ) => {
+		jest.doMock( '../../index.js', () => ( options ) => {
 			if ( counter === 1 ) {
 				expect( options.url ).toBe( '/posts?per_page=100' );
 			} else {
@@ -42,9 +42,11 @@ describe( 'Fetch All Middleware', () => {
 			counter++;
 
 			return response;
-		};
-
-		const result = await fetchAllMiddleware( originalOptions, next );
+		} );
+		const result = await require( '../fetch-all-middleware' ).default(
+			originalOptions,
+			() => {}
+		);
 
 		expect( result ).toEqual( [ 'item', 'item' ] );
 	} );


### PR DESCRIPTION
## Description

It was noted by @TimothyBJacobs that our use of `per_page=-1` in preloading was not working as intended because a value of `-1` there is a client-side affordance provided by `fetchAllMiddleware`.

This PR makes API fetch's `fetchAllMiddleware` requests go through the whole stack of middleware so that the server-inlined preloading middleware has a chance to resolve them.

It also changes our preloading usage of `per_page=-1` to `per_page=100`. This is the initial request size `fetchAllMiddleware` uses, so it will achieve what we were always intending.

## How to test this?

Verify nothing related to loading has changed.

## Checklist:

- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->