### PR TITLE
[Fix] update-api-docs.js: execa on file path with spaces in it

### DIFF
--- a/bin/api-docs/update-api-docs.js
+++ b/bin/api-docs/update-api-docs.js
@@ -205,14 +205,14 @@ glob.stream( [
 		for ( const [ token, path ] of tokens ) {
 			try {
 				await execa(
-					join(
+					`"${ join(
 						__dirname,
 						'..',
 						'..',
 						'node_modules',
 						'.bin',
 						'docgen'
-					),
+					) }"`,
 					[
 						relative( ROOT_DIR, resolve( dirname( file ), path ) ),
 						`--output ${ output }`,


### PR DESCRIPTION
## Description
This PR aims to close #22512. I've written a descriptive issue, so please refer to the issue in question.

## How has this been tested?
1. Set up Gutenberg on a WordPress installation with spaces in its file path, e.g. `/Users/<username>/Sites/Word Press`.
2. Ran `node ./bin/api-docs/update-api-docs.js`.
3. The script executed without an error. 

## Types of changes
This PR just quotes the file path to the `docgen` script in the `execa` call. Again, more description in #22512.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
