### PR TITLE
Fix dark menus in canvas, not in top toolbar

### DIFF
--- a/packages/block-editor/src/components/block-alignment-matrix-toolbar/index.js
+++ b/packages/block-editor/src/components/block-alignment-matrix-toolbar/index.js
@@ -24,12 +24,13 @@ export function BlockAlignmentMatrixToolbar( props ) {
 	const icon = <AlignmentMatrixControl.Icon value={ value } />;
 	const className = 'block-editor-block-alignment-matrix-toolbar';
 	const popoverClassName = `${ className }__popover`;
+	const isAlternate = true;
 
 	return (
 		<Dropdown
 			position="bottom right"
 			className={ className }
-			popoverProps={ { className: popoverClassName } }
+			popoverProps={ { className: popoverClassName, isAlternate } }
 			renderToggle={ ( { onToggle, isOpen } ) => {
 				const openOnArrowDown = ( event ) => {
 					if ( ! isOpen && event.keyCode === DOWN ) {

--- a/packages/block-editor/src/components/block-alignment-toolbar/index.js
+++ b/packages/block-editor/src/components/block-alignment-toolbar/index.js
@@ -45,6 +45,10 @@ const DEFAULT_CONTROLS = [ 'left', 'center', 'right', 'wide', 'full' ];
 const DEFAULT_CONTROL = 'center';
 const WIDE_CONTROLS = [ 'wide', 'full' ];
 
+const POPOVER_PROPS = {
+	isAlternate: true,
+};
+
 export function BlockAlignmentToolbar( {
 	value,
 	onChange,
@@ -68,6 +72,7 @@ export function BlockAlignmentToolbar( {
 
 	return (
 		<ToolbarGroup
+			popoverProps={ POPOVER_PROPS }
 			isCollapsed={ isCollapsed }
 			icon={
 				activeAlignmentControl

--- a/packages/block-editor/src/components/block-alignment-toolbar/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/block-alignment-toolbar/test/__snapshots__/index.js.snap
@@ -60,5 +60,10 @@ exports[`BlockAlignmentToolbar should match snapshot 1`] = `
   }
   isCollapsed={true}
   label="Change alignment"
+  popoverProps={
+    Object {
+      "isAlternate": true,
+    }
+  }
 />
 `;

--- a/packages/block-editor/src/components/block-vertical-alignment-toolbar/index.js
+++ b/packages/block-editor/src/components/block-vertical-alignment-toolbar/index.js
@@ -33,6 +33,10 @@ const BLOCK_ALIGNMENTS_CONTROLS = {
 const DEFAULT_CONTROLS = [ 'top', 'center', 'bottom' ];
 const DEFAULT_CONTROL = 'top';
 
+const POPOVER_PROPS = {
+	isAlternate: true,
+};
+
 export function BlockVerticalAlignmentToolbar( {
 	value,
 	onChange,
@@ -49,6 +53,7 @@ export function BlockVerticalAlignmentToolbar( {
 
 	return (
 		<ToolbarGroup
+			popoverProps={ POPOVER_PROPS }
 			isCollapsed={ isCollapsed }
 			icon={
 				activeAlignment

--- a/packages/block-editor/src/components/block-vertical-alignment-toolbar/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/block-vertical-alignment-toolbar/test/__snapshots__/index.js.snap
@@ -60,5 +60,10 @@ exports[`BlockVerticalAlignmentToolbar should match snapshot 1`] = `
   }
   isCollapsed={true}
   label="Change vertical alignment"
+  popoverProps={
+    Object {
+      "isAlternate": true,
+    }
+  }
 />
 `;

--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -105,8 +105,13 @@ const MediaReplaceFlow = ( {
 		}
 	};
 
+	const POPOVER_PROPS = {
+		isAlternate: true,
+	};
+
 	return (
 		<Dropdown
+			popoverProps={ POPOVER_PROPS }
 			contentClassName="block-editor-media-replace-flow__options"
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<ToolbarGroup className="media-replace-flow">

--- a/packages/components/src/dropdown/index.js
+++ b/packages/components/src/dropdown/index.js
@@ -103,7 +103,6 @@ class Dropdown extends Component {
 						expandOnMobile={ expandOnMobile }
 						headerTitle={ headerTitle }
 						focusOnMount={ focusOnMount }
-						isAlternate
 						{ ...popoverProps }
 						className={ classnames(
 							'components-dropdown__content',


### PR DESCRIPTION
Fixes small oversight in https://github.com/WordPress/gutenberg/pull/22351#issuecomment-630830889

The block editor uses elevation sparingly. Popovers by default have a shadow and ligther border because they, and modal dialogs, are elevated. But popovers in the canvas are not, and scroll under the top toolbar with the block. For those cases, we have the "alternate" display which uses block toolbar material to indicate the popover is part of that.

This PR fixes the typo that made all of them block toolbars, and fixes a couple of other cases where the old menus were used:

<img width="453" alt="Screenshot 2020-05-21 at 10 34 38" src="https://user-images.githubusercontent.com/1204802/82543088-56daeb80-9b53-11ea-8806-ab177a195dc6.png">

<img width="323" alt="Screenshot 2020-05-21 at 10 39 29" src="https://user-images.githubusercontent.com/1204802/82543091-580c1880-9b53-11ea-9ef1-aa71b5cc5f2e.png">

<img width="562" alt="Screenshot 2020-05-21 at 10 44 25" src="https://user-images.githubusercontent.com/1204802/82543095-593d4580-9b53-11ea-94f9-2fb31c87d4dc.png">

<img width="408" alt="Screenshot 2020-05-21 at 10 46 17" src="https://user-images.githubusercontent.com/1204802/82543102-5b070900-9b53-11ea-9432-f6f3e65f42cd.png">

<img width="418" alt="Screenshot 2020-05-21 at 11 04 57" src="https://user-images.githubusercontent.com/1204802/82543111-5cd0cc80-9b53-11ea-8bcf-cc264bcf632f.png">
