### PR TITLE
Disable ellipsis menu in the post editor

### DIFF
--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -77,10 +77,7 @@ function HeaderToolbar( { onToggleInserter, isInserterOpen } ) {
 			<EditorHistoryUndo />
 			<EditorHistoryRedo />
 			<TableOfContents hasOutlineItemsDisabled={ isTextModeEnabled } />
-			<BlockNavigationDropdown
-				isDisabled={ isTextModeEnabled }
-				__experimentalWithEllipsisMenu
-			/>
+			<BlockNavigationDropdown isDisabled={ isTextModeEnabled } />
 			{ displayBlockToolbar && (
 				<div className="edit-post-header-toolbar__block-toolbar">
 					<BlockToolbar hideDragHandle />


### PR DESCRIPTION
## Description
This PR disables the experimental block navigation ellipsis menu in the post editor.

## How has this been tested?
1. Go to the post editor
1. Open the block navigation in the header bar
1. Confirm the ellipsis menu is missing from all items.

## Types of changes
Bug fix (non-breaking change which fixes an issue)
