### PR TITLE
Block API: Extend `register_block_type_from_metadata` to handle assets

### DIFF
--- a/docs/rfc/block-registration.md
+++ b/docs/rfc/block-registration.md
@@ -295,7 +295,7 @@ Plugins and Themes can also register [custom block style](/docs/designers-develo
 	"example": {
 		"attributes": {
 			"message": "This is a notice!"
-		},
+		}
 	}
 }
  ```

--- a/docs/rfc/block-registration.md
+++ b/docs/rfc/block-registration.md
@@ -90,10 +90,10 @@ To register a new block type, start by creating a `block.json` file. This file:
 			"message": "This is a notice!"
 		},
 	},
-	"editorScript": "file://build/index.js",
-	"script": "file://build/script.js",
-	"editorStyle": "file://build/index.css",
-	"style": "file://build/style.css"
+	"editorScript": "file:./build/index.js",
+	"script": "file:./build/script.js",
+	"editorStyle": "file:./build/index.css",
+	"style": "file:./build/style.css"
 }
 ```
 
@@ -312,7 +312,7 @@ Plugins and Themes can also register [custom block style](/docs/designers-develo
 * Property: `editorScript`
 
 ```json
-{ "editorScript": "file://build/index.js" }
+{ "editorScript": "file:./build/index.js" }
 ```
 
 Block type editor script definition. It will only be enqueued in the context of the editor.
@@ -325,7 +325,7 @@ Block type editor script definition. It will only be enqueued in the context of 
 * Property: `script`
 
 ```json
-{ "script": "file://build/script.js" }
+{ "script": "file:./build/script.js" }
 ```
 
 Block type frontend script definition. It will be enqueued both in the editor and when viewing the content on the front of the site.
@@ -338,7 +338,7 @@ Block type frontend script definition. It will be enqueued both in the editor an
 * Property: `editorStyle`
 
 ```json
-{ "editorStyle": "file://build/index.css" }
+{ "editorStyle": "file:./build/index.css" }
 ```
 
 Block type editor style definition. It will only be enqueued in the context of the editor.
@@ -351,7 +351,7 @@ Block type editor style definition. It will only be enqueued in the context of t
 * Property: `style`
 
 ```json
-{ "style": "file://build/style.css" }
+{ "style": "file:./build/style.css" }
 ```
 
 Block type frontend style definition. It will be enqueued both in the editor and when viewing the content on the front of the site.
@@ -387,15 +387,17 @@ In the case of [dynamic blocks](/docs/designers-developers/developers/tutorials/
 
 ### `WPDefinedAsset`
 
-The `WPDefinedAsset` type is a subtype of string, where the value must represent a relative path to a JavaScript or CSS file prefixed with `file://`. An alternative would be a script or style handle name referencing a registered asset using WordPress helpers.
+The `WPDefinedAsset` type is a subtype of string, where the value represents a path to a JavaScript or CSS file relative to where `block.json` file is located. The path provided must be prefixed with `file:`. This approach is based on how npm handles [local paths](https://docs.npmjs.com/files/package.json#local-paths) for packages.
+
+An alternative would be a script or style handle name referencing a registered asset using WordPress helpers.
 
 **Example:**
 
 In `block.json`:
 ```json
 {
-	"editorScript": "file://build/index.js",
-	"editorStyle": "my-editor-style"
+	"editorScript": "file:./build/index.js",
+	"editorStyle": "my-editor-style-handle"
 }
 ```
 
@@ -422,7 +424,7 @@ build/
 
 In `block.json`:
 ```json
-{ "editorScript": "file://build/index.js" }
+{ "editorScript": "file:./build/index.js" }
 ```
 
 In `build/index.asset.php`:

--- a/docs/rfc/block-registration.md
+++ b/docs/rfc/block-registration.md
@@ -6,7 +6,7 @@ This RFC is intended to serve both as a specification and as documentation for t
 
 Behind any block type registration is some abstract concept of a unit of content. This content type can be described without consideration of any particular technology. In much the same way, we should be able to describe the core constructs of a block type in a way which can be interpreted in any runtime.
 
-In more practical terms, an implementation should fulfill requirements that...
+In more practical terms, an implementation should fulfill requirements that:
 
 * A block type registration should be declarative and context-agnostic. Any runtime (PHP, JS, or other) should be able to interpret the basics of a block type (see "Block API" in the sections below) and should be able to fetch or retrieve the definitions of the context-specific implementation details. The following things should be made possible:
   * Fetching the available block types through REST APIs.
@@ -16,7 +16,7 @@ In more practical terms, an implementation should fulfill requirements that...
 
 It can statically analyze the files of any plugin to retrieve blocks and their properties.
 * It should not require a build tool compilation step (e.g. Babel, Webpack) to author code which would be referenced in a block type definition.
-* There should allow the potential to dynamically load ("lazy-load") block types, or parts of block type definitions. It practical terms, it means that the editor should be able to be loaded without enqueuing all the assets (scripts and styles) of all block types. What it needs is the basic metadata (`title`, `description`, `category`, `icon`, etc...) to start with. It should be fine to defer loading all other code (`edit`, `save`, `transforms`, and other JavaScript implementations) until it is explicitly used (inserted into the post content).
+* There should allow the potential to dynamically load ("lazy-load") block types, or parts of block type definitions. It practical terms, it means that the editor should be able to be loaded without enqueuing all the assets (scripts and styles) of all block types. What it needs is the basic metadata (`title`, `description`, `category`, `icon`, etc…) to start with. It should be fine to defer loading all other code (`edit`, `save`, `transforms`, and other JavaScript implementations) until it is explicitly used (inserted into the post content).
 
 ## References
 
@@ -67,7 +67,7 @@ To register a new block type, start by creating a `block.json` file. This file:
 	"category": "text",
 	"parent": [ "core/group" ],
 	"icon": "star",
-	"description": "Shows warning, error or success notices  ...",
+	"description": "Shows warning, error or success notices…",
 	"keywords": [ "alert", "message" ],
 	"textdomain": "my-plugin",
 	"attributes": {

--- a/docs/rfc/block-registration.md
+++ b/docs/rfc/block-registration.md
@@ -90,10 +90,10 @@ To register a new block type, start by creating a `block.json` file. This file:
 			"message": "This is a notice!"
 		},
 	},
-	"editorScript": "build/editor.js",
-	"script": "build/main.js",
-	"editorStyle": "build/editor.css",
-	"style": "build/style.css"
+	"editorScript": "file://build/index.js",
+	"script": "file://build/script.js",
+	"editorStyle": "file://build/index.css",
+	"style": "file://build/style.css"
 }
 ```
 
@@ -312,7 +312,7 @@ Plugins and Themes can also register [custom block style](/docs/designers-develo
 * Property: `editorScript`
 
 ```json
-{ "editorScript": "build/editor.js" }
+{ "editorScript": "file://build/index.js" }
 ```
 
 Block type editor script definition. It will only be enqueued in the context of the editor.
@@ -325,7 +325,7 @@ Block type editor script definition. It will only be enqueued in the context of 
 * Property: `script`
 
 ```json
-{ "script": "build/main.js" }
+{ "script": "file://build/script.js" }
 ```
 
 Block type frontend script definition. It will be enqueued both in the editor and when viewing the content on the front of the site.
@@ -338,7 +338,7 @@ Block type frontend script definition. It will be enqueued both in the editor an
 * Property: `editorStyle`
 
 ```json
-{ "editorStyle": "build/editor.css" }
+{ "editorStyle": "file://build/index.css" }
 ```
 
 Block type editor style definition. It will only be enqueued in the context of the editor.
@@ -351,7 +351,7 @@ Block type editor style definition. It will only be enqueued in the context of t
 * Property: `style`
 
 ```json
-{ "style": "build/style.css" }
+{ "style": "file://build/style.css" }
 ```
 
 Block type frontend style definition. It will be enqueued both in the editor and when viewing the content on the front of the site.
@@ -387,18 +387,21 @@ In the case of [dynamic blocks](/docs/designers-developers/developers/tutorials/
 
 ### `WPDefinedAsset`
 
-The `WPDefinedAsset` type is a subtype of string, where the value must represent a relative path to a JavaScript or CSS file.
+The `WPDefinedAsset` type is a subtype of string, where the value must represent a relative path to a JavaScript or CSS file prefixed with `file://`. An alternative would be a script or style handle name referencing a registered asset using WordPress helpers.
 
 **Example:**
 
 In `block.json`:
 ```json
-{ "editorScript": "build/editor.js" }
+{
+	"editorScript": "file://build/index.js",
+	"editorStyle": "my-editor-style"
+}
 ```
 
 #### WordPress context
 
-In the context of WordPress, when a block is registered with PHP, it will automatically register all scripts and styles that are found in the `block.json` file.
+In the context of WordPress, when a block is registered with PHP, it will automatically register all scripts and styles that are found in the `block.json` file and use file paths rather than asset handles.
 
 That's why, the `WPDefinedAsset` type has to offer a way to mirror also the shape of params necessary to register scripts and styles using [`wp_register_script`](https://developer.wordpress.org/reference/functions/wp_register_script/) and [`wp_register_style`](https://developer.wordpress.org/reference/functions/wp_register_style/), and then assign these as handles associated with your block using the `script`, `style`, `editor_script`, and `editor_style` block type registration settings.
 
@@ -419,7 +422,7 @@ build/
 
 In `block.json`:
 ```json
-{ "editorScript": "build/index.js" }
+{ "editorScript": "file://build/index.js" }
 ```
 
 In `build/index.asset.php`:
@@ -480,7 +483,7 @@ Implementation should follow the existing [get_plugin_data](https://codex.wordpr
 There is also a new API method proposed `register_block_type_from_metadata` that aims to simplify the block type registration on the server from metadata stored in the `block.json` file. This function is going to handle also all necessary work to make internationalization work seamlessly for metadata defined.
 
 This function takes two params:
-- `$path` (`string`) – path to the folder where the `block.json` file is located.
+- `$path` (`string`) – path to the folder where the `block.json` file is located or full path to the metadata file if named differently.
 - `$args` (`array`) –  an optional array of block type arguments. Default value: `[]`. Any arguments may be defined. However, the one described below is supported by default:
   - `$render_callback` (`callable`) – callback used to render blocks of this block type.
 

--- a/docs/rfc/block-registration.md
+++ b/docs/rfc/block-registration.md
@@ -387,7 +387,7 @@ In the case of [dynamic blocks](/docs/designers-developers/developers/tutorials/
 
 ### `WPDefinedAsset`
 
-The `WPDefinedAsset` type is a subtype of string, where the value must represent an absolute or relative path to a JavaScript or CSS file.
+The `WPDefinedAsset` type is a subtype of string, where the value must represent a relative path to a JavaScript or CSS file.
 
 **Example:**
 

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -63,9 +63,13 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 	 * @param array  $metadata Block metadata.
 	 * @param string $field_name Field name to pick from metadata.
 	 *
-	 * @return string Script handle provided directly or created through script's registration.
+	 * @return string|boolean Script handle provided directly or created through
+	 *     script's registration, or false on failure.
 	 */
-	function gutenberg_get_script_handle( $metadata, $field_name ) {
+	function register_block_script_handle( $metadata, $field_name ) {
+		if ( empty( $metadata[ $field_name ] ) ) {
+			return false;
+		}
 		$script_handle = $metadata[ $field_name ];
 		$script_path   = gutenberg_remove_block_asset_path_prefix( $metadata[ $field_name ] );
 		if ( $script_handle === $script_path ) {
@@ -88,13 +92,13 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 			return false;
 		}
 		$script_asset = require( $script_asset_path );
-		wp_register_script(
+		$result       = wp_register_script(
 			$script_handle,
 			plugins_url( $script_path, $metadata['file'] ),
 			$script_asset['dependencies'],
 			$script_asset['version']
 		);
-		return $script_handle;
+		return $result ? $script_handle : false;
 	}
 
 	/**
@@ -107,9 +111,13 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 	 * @param array  $metadata Block metadata.
 	 * @param string $field_name Field name to pick from metadata.
 	 *
-	 * @return string Style handle provided directly or created through style's registration.
+	 * @return string|boolean Style handle provided directly or created through
+	 *     style's registration, or false on failure.
 	 */
-	function gutenberg_get_style_handle( $metadata, $field_name ) {
+	function register_block_style_handle( $metadata, $field_name ) {
+		if ( empty( $metadata[ $field_name ] ) ) {
+			return false;
+		}
 		$style_handle = $metadata[ $field_name ];
 		$style_path   = gutenberg_remove_block_asset_path_prefix( $metadata[ $field_name ] );
 		if ( $style_handle === $style_path ) {
@@ -118,13 +126,13 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 
 		$style_handle = gutenberg_generate_block_asset_handle( $metadata['name'], $field_name );
 		$block_dir    = dirname( $metadata['file'] );
-		wp_register_style(
+		$result       = wp_register_style(
 			$style_handle,
 			plugins_url( $style_path, $metadata['file'] ),
 			array(),
 			filemtime( realpath( "$block_dir/$style_path" ) )
 		);
-		return $style_handle;
+		return $result ? $style_handle : false;
 	}
 
 	/**
@@ -178,28 +186,28 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 		}
 
 		if ( ! empty( $metadata['editorScript'] ) ) {
-			$settings['editor_script'] = gutenberg_get_script_handle(
+			$settings['editor_script'] = register_block_script_handle(
 				$metadata,
 				'editorScript'
 			);
 		}
 
 		if ( ! empty( $metadata['script'] ) ) {
-			$settings['script'] = gutenberg_get_script_handle(
+			$settings['script'] = register_block_script_handle(
 				$metadata,
 				'script'
 			);
 		}
 
 		if ( ! empty( $metadata['editorStyle'] ) ) {
-			$settings['editor_style'] = gutenberg_get_style_handle(
+			$settings['editor_style'] = register_block_style_handle(
 				$metadata,
 				'editorStyle'
 			);
 		}
 
 		if ( ! empty( $metadata['style'] ) ) {
-			$settings['style'] = gutenberg_get_style_handle(
+			$settings['style'] = register_block_style_handle(
 				$metadata,
 				'style'
 			);

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -37,6 +37,7 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 			return false;
 		}
 
+		$settings          = array();
 		$property_mappings = array(
 			'title'           => 'title',
 			'category'        => 'category',
@@ -50,7 +51,6 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 			// Alias recommended in documentation to distinguish from assets.
 			'styleVariations' => 'styles',
 		);
-		$settings          = array();
 
 		foreach ( $property_mappings as $key => $mapped_key ) {
 			if ( isset( $metadata[ $key ] ) ) {
@@ -58,7 +58,7 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 			}
 		}
 
-		$block_name        = $metadata['name'];
+		$block_name          = $metadata['name'];
 		$block_dir           = dirname( $metadata_file );
 		$asset_handle_prefix = str_replace( '/', '-', $block_name );
 
@@ -69,9 +69,10 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 				$block_dir . '/' . substr_replace( $editor_script, '.asset.php', -3 )
 			);
 			if ( ! file_exists( $editor_script_asset_path ) ) {
-				throw new Error(
-					"The asset file for the \"editorScript\" defined in \"$block_name\" block definition is missing."
-				);
+				/* translators: %s: Block name. */
+				$message = sprintf( __( 'The asset file for the "editorScript" defined in "%s" block definition is missing.' ), $block_name );
+				_doing_it_wrong( __METHOD__, $message, '5.5.0' );
+				return false;
 			}
 			$editor_script_asset  = require( $editor_script_asset_path );
 			wp_register_script(
@@ -90,9 +91,10 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 				$block_dir . '/' . substr_replace( $script, '.asset.php', -3 )
 			);
 			if ( ! file_exists( $script_asset_path ) ) {
-				throw new Error(
-					"The asset file for the \"script\" defined in \"$block_name\" block definition is missing."
-				);
+				/* translators: %s: Block name. */
+				$message = sprintf( __( 'The asset file for the "script" defined in "%s" block definition is missing.' ), $block_name );
+				_doing_it_wrong( __METHOD__, $message, '5.5.0' );
+				return false;
 			}
 			$script_asset  = require( $script_asset_path );
 			wp_register_script(

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -25,8 +25,9 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 	 * @return WP_Block_Type|false The registered block type on success, or false on failure.
 	 */
 	function register_block_type_from_metadata( $file_or_folder, $args = array() ) {
-		$metadata_file = ( substr( $file_or_folder, -10 ) !== 'block.json' ) ?
-			trailingslashit( $file_or_folder ) . 'block.json' :
+		$filename      = 'block.json';
+		$metadata_file = ( substr( $file_or_folder, -strlen( $filename ) ) !== $filename ) ?
+			trailingslashit( $file_or_folder ) . $filename :
 			$file_or_folder;
 		if ( ! file_exists( $metadata_file ) ) {
 			return false;
@@ -39,15 +40,15 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 
 		$settings          = array();
 		$property_mappings = array(
-			'title'           => 'title',
-			'category'        => 'category',
-			'parent'          => 'parent',
-			'icon'            => 'icon',
-			'description'     => 'description',
-			'keywords'        => 'keywords',
-			'attributes'      => 'attributes',
-			'supports'        => 'supports',
-			'styles'          => 'styles',
+			'title'       => 'title',
+			'category'    => 'category',
+			'parent'      => 'parent',
+			'icon'        => 'icon',
+			'description' => 'description',
+			'keywords'    => 'keywords',
+			'attributes'  => 'attributes',
+			'supports'    => 'supports',
+			'styles'      => 'styles',
 		);
 
 		foreach ( $property_mappings as $key => $mapped_key ) {

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -37,8 +37,29 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 			return false;
 		}
 
+		$property_mappings = array(
+			'title'           => 'title',
+			'category'        => 'category',
+			'parent'          => 'parent',
+			'icon'            => 'icon',
+			'description'     => 'description',
+			'keywords'        => 'keywords',
+			'attributes'      => 'attributes',
+			'supports'        => 'supports',
+			'styles'          => 'styles',
+			// Alias recommended in documentation to distinguish from assets.
+			'styleVariations' => 'styles',
+		);
+		$settings          = array();
+
+		foreach ( $property_mappings as $key => $mapped_key ) {
+			if ( isset( $metadata[ $key ] ) ) {
+				$settings[ $mapped_key ] = $metadata[ $key ];
+			}
+		}
+
+		$block_name        = $metadata['name'];
 		$block_dir           = dirname( $metadata_file );
-		$block_name          = $metadata['name'];
 		$asset_handle_prefix = str_replace( '/', '-', $block_name );
 
 		if ( isset( $metadata['editorScript'] ) ) {
@@ -59,8 +80,7 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 				$editor_script_asset['dependencies'],
 				$editor_script_asset['version']
 			);
-			unset( $metadata['editorScript'] );
-			$metadata['editor_script'] = $editor_script_handle;
+			$settings['editor_script'] = $editor_script_handle;
 		}
 
 		if ( isset( $metadata['script'] ) ) {
@@ -81,7 +101,7 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 				$script_asset['dependencies'],
 				$script_asset['version']
 			);
-			$metadata['script'] = $script_handle;
+			$settings['script'] = $script_handle;
 		}
 
 		if ( isset( $metadata['editorStyle'] ) ) {
@@ -93,8 +113,7 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 				array(),
 				filemtime( realpath( "$block_dir/$editor_style" ) )
 			);
-			unset( $metadata['editorStyle'] );
-			$metadata['editor_style'] = $editor_style_handle;
+			$settings['editor_style'] = $editor_style_handle;
 		}
 
 		if ( isset( $metadata['style'] ) ) {
@@ -106,13 +125,13 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 				array(),
 				filemtime( realpath( "$block_dir/$style" ) )
 			);
-			$metadata['style'] = $style_handle;
+			$settings['style'] = $style_handle;
 		}
 
 		return register_block_type(
 			$block_name,
 			array_merge(
-				$metadata,
+				$settings,
 				$args
 			)
 		);

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -33,7 +33,7 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 		}
 
 		$metadata = json_decode( file_get_contents( $metadata_file ), true );
-		if ( ! is_array( $metadata ) || ! $metadata['name'] ) {
+		if ( ! is_array( $metadata ) || empty( $metadata['name'] ) ) {
 			return false;
 		}
 

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -18,7 +18,7 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 	 *
 	 * @return string Path without the prefix or the original value.
 	 */
-	function gutenberg_remove_block_asset_path_prefix( $asset_handle_or_path ) {
+	function remove_block_asset_path_prefix( $asset_handle_or_path ) {
 		$path_prefix = 'file:';
 		if ( strpos( $asset_handle_or_path, $path_prefix ) !== 0 ) {
 			return $asset_handle_or_path;
@@ -40,7 +40,7 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 	 *
 	 * @return string Generated asset name for the block's field.
 	 */
-	function gutenberg_generate_block_asset_handle( $block_name, $field_name ) {
+	function generate_block_asset_handle( $block_name, $field_name ) {
 		$field_mappings = array(
 			'editorScript' => 'editor-script',
 			'script'       => 'script',
@@ -71,12 +71,12 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 			return false;
 		}
 		$script_handle = $metadata[ $field_name ];
-		$script_path   = gutenberg_remove_block_asset_path_prefix( $metadata[ $field_name ] );
+		$script_path   = remove_block_asset_path_prefix( $metadata[ $field_name ] );
 		if ( $script_handle === $script_path ) {
 			return $script_handle;
 		}
 
-		$script_handle     = gutenberg_generate_block_asset_handle( $metadata['name'], $field_name );
+		$script_handle     = generate_block_asset_handle( $metadata['name'], $field_name );
 		$script_asset_path = realpath(
 			dirname( $metadata['file'] ) . '/' .
 			substr_replace( $script_path, '.asset.php', - strlen( '.js' ) )
@@ -88,7 +88,7 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 				$field_name,
 				$metadata['name']
 			);
-			_doing_it_wrong( __METHOD__, $message, '5.5.0' );
+			_doing_it_wrong( __FUNCTION__, $message, '5.5.0' );
 			return false;
 		}
 		$script_asset = require( $script_asset_path );
@@ -119,12 +119,12 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 			return false;
 		}
 		$style_handle = $metadata[ $field_name ];
-		$style_path   = gutenberg_remove_block_asset_path_prefix( $metadata[ $field_name ] );
+		$style_path   = remove_block_asset_path_prefix( $metadata[ $field_name ] );
 		if ( $style_handle === $style_path ) {
 			return $style_handle;
 		}
 
-		$style_handle = gutenberg_generate_block_asset_handle( $metadata['name'], $field_name );
+		$style_handle = generate_block_asset_handle( $metadata['name'], $field_name );
 		$block_dir    = dirname( $metadata['file'] );
 		$result       = wp_register_style(
 			$style_handle,

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -48,8 +48,6 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 			'attributes'      => 'attributes',
 			'supports'        => 'supports',
 			'styles'          => 'styles',
-			// Alias recommended in documentation to distinguish from assets.
-			'styleVariations' => 'styles',
 		);
 
 		foreach ( $property_mappings as $key => $mapped_key ) {

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -69,12 +69,15 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 				$block_dir . '/' . substr_replace( $editor_script, '.asset.php', -3 )
 			);
 			if ( ! file_exists( $editor_script_asset_path ) ) {
-				/* translators: %s: Block name. */
-				$message = sprintf( __( 'The asset file for the "editorScript" defined in "%s" block definition is missing.' ), $block_name );
+				$message = sprintf(
+					/* translators: %s: Block name. */
+					__( 'The asset file for the "editorScript" defined in "%s" block definition is missing.', 'default' ),
+					$block_name
+				);
 				_doing_it_wrong( __METHOD__, $message, '5.5.0' );
 				return false;
 			}
-			$editor_script_asset  = require( $editor_script_asset_path );
+			$editor_script_asset = require( $editor_script_asset_path );
 			wp_register_script(
 				$editor_script_handle,
 				plugins_url( $editor_script, $metadata_file ),
@@ -91,12 +94,15 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 				$block_dir . '/' . substr_replace( $script, '.asset.php', -3 )
 			);
 			if ( ! file_exists( $script_asset_path ) ) {
-				/* translators: %s: Block name. */
-				$message = sprintf( __( 'The asset file for the "script" defined in "%s" block definition is missing.' ), $block_name );
+				$message = sprintf(
+					/* translators: %s: Block name. */
+					__( 'The asset file for the "script" defined in "%s" block definition is missing.', 'default' ),
+					$block_name
+				);
 				_doing_it_wrong( __METHOD__, $message, '5.5.0' );
 				return false;
 			}
-			$script_asset  = require( $script_asset_path );
+			$script_asset = require( $script_asset_path );
 			wp_register_script(
 				$script_handle,
 				plugins_url( $script, $metadata_file ),

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -63,10 +63,12 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 		$asset_handle_prefix = str_replace( '/', '-', $block_name );
 
 		if ( isset( $metadata['editorScript'] ) ) {
-			$editor_script            = $metadata['editorScript'];
+			$settings['editor_script'] = $metadata['editorScript'];
+		} elseif ( isset( $metadata['editorScriptPath'] ) ) {
+			$editor_script_path       = $metadata['editorScriptPath'];
 			$editor_script_handle     = "$asset_handle_prefix-editor-script";
 			$editor_script_asset_path = realpath(
-				$block_dir . '/' . substr_replace( $editor_script, '.asset.php', -3 )
+				$block_dir . '/' . substr_replace( $editor_script_path, '.asset.php', -3 )
 			);
 			if ( ! file_exists( $editor_script_asset_path ) ) {
 				$message = sprintf(
@@ -80,7 +82,7 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 			$editor_script_asset = require( $editor_script_asset_path );
 			wp_register_script(
 				$editor_script_handle,
-				plugins_url( $editor_script, $metadata_file ),
+				plugins_url( $editor_script_path, $metadata_file ),
 				$editor_script_asset['dependencies'],
 				$editor_script_asset['version']
 			);
@@ -88,10 +90,12 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 		}
 
 		if ( isset( $metadata['script'] ) ) {
-			$script            = $metadata['script'];
+			$settings['script'] = $metadata['script'];
+		} elseif ( isset( $metadata['scriptPath'] ) ) {
+			$script_path       = $metadata['scriptPath'];
 			$script_handle     = "$asset_handle_prefix-script";
 			$script_asset_path = realpath(
-				$block_dir . '/' . substr_replace( $script, '.asset.php', -3 )
+				$block_dir . '/' . substr_replace( $script_path, '.asset.php', -3 )
 			);
 			if ( ! file_exists( $script_asset_path ) ) {
 				$message = sprintf(
@@ -105,7 +109,7 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 			$script_asset = require( $script_asset_path );
 			wp_register_script(
 				$script_handle,
-				plugins_url( $script, $metadata_file ),
+				plugins_url( $script_path, $metadata_file ),
 				$script_asset['dependencies'],
 				$script_asset['version']
 			);
@@ -113,25 +117,29 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 		}
 
 		if ( isset( $metadata['editorStyle'] ) ) {
-			$editor_style        = $metadata['editorStyle'];
+			$settings['editor_style'] = $metadata['editorStyle'];
+		} elseif ( isset( $metadata['editorStylePath'] ) ) {
+			$editor_style_path   = $metadata['editorStylePath'];
 			$editor_style_handle = "$asset_handle_prefix-editor-style";
 			wp_register_style(
 				$editor_style_handle,
-				plugins_url( $editor_style, $metadata_file ),
+				plugins_url( $editor_style_path, $metadata_file ),
 				array(),
-				filemtime( realpath( "$block_dir/$editor_style" ) )
+				filemtime( realpath( "$block_dir/$editor_style_path" ) )
 			);
 			$settings['editor_style'] = $editor_style_handle;
 		}
 
 		if ( isset( $metadata['style'] ) ) {
-			$style        = $metadata['style'];
+			$settings['style'] = $metadata['style'];
+		} elseif ( isset( $metadata['stylePath'] ) ) {
+			$style_path   = $metadata['stylePath'];
 			$style_handle = "$asset_handle_prefix-style";
 			wp_register_style(
 				$style_handle,
-				plugins_url( $style, $metadata_file ),
+				plugins_url( $style_path, $metadata_file ),
 				array(),
-				filemtime( realpath( "$block_dir/$style" ) )
+				filemtime( realpath( "$block_dir/$style_path" ) )
 			);
 			$settings['style'] = $style_handle;
 		}

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -19,7 +19,7 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 	 * @return string Path without the prefix or the original value.
 	 */
 	function gutenberg_remove_block_asset_path_prefix( $asset_handle_or_path ) {
-		$path_prefix = 'file://';
+		$path_prefix = 'file:';
 		if ( strpos( $asset_handle_or_path, $path_prefix ) !== 0 ) {
 			return $asset_handle_or_path;
 		}

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -168,6 +168,7 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 			'attributes'  => 'attributes',
 			'supports'    => 'supports',
 			'styles'      => 'styles',
+			'example'     => 'example',
 		);
 
 		foreach ( $property_mappings as $key => $mapped_key ) {

--- a/phpunit/class-register-block-type-from-metadata-test.php
+++ b/phpunit/class-register-block-type-from-metadata-test.php
@@ -32,14 +32,47 @@ class Register_Block_Type_From_Metadata_Test extends WP_UnitTestCase {
 	 */
 	function test_block_registers_with_metadata_fixture() {
 		$result = register_block_type_from_metadata(
-			__DIR__ . '/fixtures',
-			array(
-				'foo' => 'bar',
-			)
+			__DIR__ . '/fixtures'
 		);
 
 		$this->assertInstanceOf( 'WP_Block_Type', $result );
-		$this->assertEquals( 'test/block-name', $result->name );
-		$this->assertEquals( 'bar', $result->foo );
+		$this->assertEquals( 'my-plugin/notice', $result->name );
+		$this->assertEquals( 'Notice', $result->title );
+		$this->assertEquals( 'common', $result->category );
+		$this->assertEquals( array( 'core/group' ), $result->parent );
+		$this->assertEquals( 'star', $result->icon );
+		$this->assertEquals( 'Shows warning, error or success notices…', $result->description );
+		$this->assertEquals( array( 'alert', 'message' ), $result->keywords );
+		$this->assertEquals(
+			array(
+				'message' => array(
+					'type'     => 'string',
+					'source'   => 'html',
+					'selector' => '.message',
+				),
+			),
+			$result->attributes
+		);
+		$this->assertEquals(
+			array(
+				'align'             => true,
+				'lightBlockWrapper' => true,
+			),
+			$result->supports
+		);
+		$this->assertEquals(
+			array(
+				array(
+					'name'      => 'default',
+					'label'     => 'Default',
+					'isDefault' => true,
+				),
+				array(
+					'name'  => 'other',
+					'label' => 'Other',
+				),
+			),
+			$result->styles
+		);
 	}
 }

--- a/phpunit/class-register-block-type-from-metadata-test.php
+++ b/phpunit/class-register-block-type-from-metadata-test.php
@@ -40,6 +40,50 @@ class Register_Block_Type_From_Metadata_Test extends WP_UnitTestCase {
 		);
 	}
 
+	function test_field_not_found_register_block_script_handle() {
+		$result = register_block_script_handle( array(), 'script' );
+
+		$this->assertFalse( $result );
+	}
+
+	function test_empty_value_register_block_script_handle() {
+		$metadata = array( 'script' => '' );
+		$result   = register_block_script_handle( $metadata, 'script' );
+
+		$this->assertFalse( $result );
+	}
+
+	function test_handle_passed_register_block_script_handle() {
+		$metadata = array(
+			'editorScript' => 'test-script-handle',
+		);
+		$result   = register_block_script_handle( $metadata, 'editorScript' );
+
+		$this->assertSame( 'test-script-handle', $result );
+	}
+
+	function test_field_not_found_register_block_style_handle() {
+		$result = register_block_script_handle( array(), 'style' );
+
+		$this->assertFalse( $result );
+	}
+
+	function test_empty_value_found_register_block_style_handle() {
+		$metadata = array( 'style' => '' );
+		$result   = register_block_script_handle( $metadata, 'style' );
+
+		$this->assertFalse( $result );
+	}
+
+	function test_handle_passed_register_block_style_handle() {
+		$metadata = array(
+			'style' => 'test-style-handle',
+		);
+		$result   = register_block_script_handle( $metadata, 'style' );
+
+		$this->assertSame( 'test-style-handle', $result );
+	}
+
 	/**
 	 * Tests that the function returns false when the `block.json` is not found
 	 * in the WordPress core.

--- a/phpunit/class-register-block-type-from-metadata-test.php
+++ b/phpunit/class-register-block-type-from-metadata-test.php
@@ -14,9 +14,9 @@ class Register_Block_Type_From_Metadata_Test extends WP_UnitTestCase {
 	}
 
 	function test_removes_block_asset_path_prefix() {
-		$result = gutenberg_remove_block_asset_path_prefix( 'file://block.js' );
+		$result = gutenberg_remove_block_asset_path_prefix( 'file:./block.js' );
 
-		$this->assertSame( 'block.js', $result );
+		$this->assertSame( './block.js', $result );
 	}
 
 	function test_generate_block_asset_handle() {

--- a/phpunit/class-register-block-type-from-metadata-test.php
+++ b/phpunit/class-register-block-type-from-metadata-test.php
@@ -14,9 +14,9 @@ class Register_Block_Type_From_Metadata_Test extends WP_UnitTestCase {
 	}
 
 	function test_removes_block_asset_path_prefix() {
-		$result = gutenberg_remove_block_asset_path_prefix( 'file://./block.js' );
+		$result = gutenberg_remove_block_asset_path_prefix( 'file://block.js' );
 
-		$this->assertSame( './block.js', $result );
+		$this->assertSame( 'block.js', $result );
 	}
 
 	function test_generate_block_asset_handle() {

--- a/phpunit/class-register-block-type-from-metadata-test.php
+++ b/phpunit/class-register-block-type-from-metadata-test.php
@@ -6,6 +6,40 @@
  */
 
 class Register_Block_Type_From_Metadata_Test extends WP_UnitTestCase {
+
+	function test_does_not_remove_block_asset_path_prefix() {
+		$result = gutenberg_remove_block_asset_path_prefix( 'script-handle' );
+
+		$this->assertSame( 'script-handle', $result );
+	}
+
+	function test_removes_block_asset_path_prefix() {
+		$result = gutenberg_remove_block_asset_path_prefix( 'file://./block.js' );
+
+		$this->assertSame( './block.js', $result );
+	}
+
+	function test_generate_block_asset_handle() {
+		$block_name = 'my-namespace/my-block';
+
+		$this->assertSame(
+			'my-namespace-my-block-editor-script',
+			gutenberg_generate_block_asset_handle( $block_name, 'editorScript' )
+		);
+		$this->assertSame(
+			'my-namespace-my-block-script',
+			gutenberg_generate_block_asset_handle( $block_name, 'script' )
+		);
+		$this->assertSame(
+			'my-namespace-my-block-editor-style',
+			gutenberg_generate_block_asset_handle( $block_name, 'editorStyle' )
+		);
+		$this->assertSame(
+			'my-namespace-my-block-style',
+			gutenberg_generate_block_asset_handle( $block_name, 'style' )
+		);
+	}
+
 	/**
 	 * Tests that the function returns false when the `block.json` is not found
 	 * in the WordPress core.
@@ -36,12 +70,12 @@ class Register_Block_Type_From_Metadata_Test extends WP_UnitTestCase {
 		);
 
 		$this->assertInstanceOf( 'WP_Block_Type', $result );
-		$this->assertEquals( 'my-plugin/notice', $result->name );
-		$this->assertEquals( 'Notice', $result->title );
-		$this->assertEquals( 'common', $result->category );
+		$this->assertSame( 'my-plugin/notice', $result->name );
+		$this->assertSame( 'Notice', $result->title );
+		$this->assertSame( 'common', $result->category );
 		$this->assertEquals( array( 'core/group' ), $result->parent );
-		$this->assertEquals( 'star', $result->icon );
-		$this->assertEquals( 'Shows warning, error or success notices…', $result->description );
+		$this->assertSame( 'star', $result->icon );
+		$this->assertSame( 'Shows warning, error or success notices…', $result->description );
 		$this->assertEquals( array( 'alert', 'message' ), $result->keywords );
 		$this->assertEquals(
 			array(
@@ -74,9 +108,9 @@ class Register_Block_Type_From_Metadata_Test extends WP_UnitTestCase {
 			),
 			$result->styles
 		);
-		$this->assertEquals( 'my-plugin-notice-editor-script', $result->editor_script );
-		$this->assertEquals( 'my-plugin-notice-script', $result->script );
-		$this->assertEquals( 'my-plugin-notice-editor-style', $result->editor_style );
-		$this->assertEquals( 'my-plugin-notice-style', $result->style );
+		$this->assertSame( 'my-plugin-notice-editor-script', $result->editor_script );
+		$this->assertSame( 'my-plugin-notice-script', $result->script );
+		$this->assertSame( 'my-plugin-notice-editor-style', $result->editor_style );
+		$this->assertSame( 'my-plugin-notice-style', $result->style );
 	}
 }

--- a/phpunit/class-register-block-type-from-metadata-test.php
+++ b/phpunit/class-register-block-type-from-metadata-test.php
@@ -8,35 +8,35 @@
 class Register_Block_Type_From_Metadata_Test extends WP_UnitTestCase {
 
 	function test_does_not_remove_block_asset_path_prefix() {
-		$result = gutenberg_remove_block_asset_path_prefix( 'script-handle' );
+		$result = remove_block_asset_path_prefix( 'script-handle' );
 
 		$this->assertSame( 'script-handle', $result );
 	}
 
 	function test_removes_block_asset_path_prefix() {
-		$result = gutenberg_remove_block_asset_path_prefix( 'file:./block.js' );
+		$result = remove_block_asset_path_prefix( 'file:./block.js' );
 
 		$this->assertSame( './block.js', $result );
 	}
 
 	function test_generate_block_asset_handle() {
-		$block_name = 'my-namespace/my-block';
+		$block_name = 'unit-tests/my-block';
 
 		$this->assertSame(
-			'my-namespace-my-block-editor-script',
-			gutenberg_generate_block_asset_handle( $block_name, 'editorScript' )
+			'unit-tests-my-block-editor-script',
+			generate_block_asset_handle( $block_name, 'editorScript' )
 		);
 		$this->assertSame(
-			'my-namespace-my-block-script',
-			gutenberg_generate_block_asset_handle( $block_name, 'script' )
+			'unit-tests-my-block-script',
+			generate_block_asset_handle( $block_name, 'script' )
 		);
 		$this->assertSame(
-			'my-namespace-my-block-editor-style',
-			gutenberg_generate_block_asset_handle( $block_name, 'editorStyle' )
+			'unit-tests-my-block-editor-style',
+			generate_block_asset_handle( $block_name, 'editorStyle' )
 		);
 		$this->assertSame(
-			'my-namespace-my-block-style',
-			gutenberg_generate_block_asset_handle( $block_name, 'style' )
+			'unit-tests-my-block-style',
+			generate_block_asset_handle( $block_name, 'style' )
 		);
 	}
 
@@ -53,6 +53,20 @@ class Register_Block_Type_From_Metadata_Test extends WP_UnitTestCase {
 		$this->assertFalse( $result );
 	}
 
+	/**
+	 * @expectedIncorrectUsage register_block_script_handle
+	 */
+	function test_missing_asset_file_register_block_script_handle() {
+		$metadata = array(
+			'file'   => __FILE__,
+			'name'   => 'unit-tests/test-block',
+			'script' => 'file:./fixtures/missing-asset.js',
+		);
+		$result   = register_block_script_handle( $metadata, 'script' );
+
+		$this->assertFalse( $result );
+	}
+
 	function test_handle_passed_register_block_script_handle() {
 		$metadata = array(
 			'editorScript' => 'test-script-handle',
@@ -62,15 +76,26 @@ class Register_Block_Type_From_Metadata_Test extends WP_UnitTestCase {
 		$this->assertSame( 'test-script-handle', $result );
 	}
 
+	function test_success_register_block_script_handle() {
+		$metadata = array(
+			'file'   => __FILE__,
+			'name'   => 'unit-tests/test-block',
+			'script' => 'file:./fixtures/block.js',
+		);
+		$result   = register_block_script_handle( $metadata, 'script' );
+
+		$this->assertSame( 'unit-tests-test-block-script', $result );
+	}
+
 	function test_field_not_found_register_block_style_handle() {
-		$result = register_block_script_handle( array(), 'style' );
+		$result = register_block_style_handle( array(), 'style' );
 
 		$this->assertFalse( $result );
 	}
 
 	function test_empty_value_found_register_block_style_handle() {
 		$metadata = array( 'style' => '' );
-		$result   = register_block_script_handle( $metadata, 'style' );
+		$result   = register_block_style_handle( $metadata, 'style' );
 
 		$this->assertFalse( $result );
 	}
@@ -79,9 +104,20 @@ class Register_Block_Type_From_Metadata_Test extends WP_UnitTestCase {
 		$metadata = array(
 			'style' => 'test-style-handle',
 		);
-		$result   = register_block_script_handle( $metadata, 'style' );
+		$result   = register_block_style_handle( $metadata, 'style' );
 
 		$this->assertSame( 'test-style-handle', $result );
+	}
+
+	function test_success_register_block_style_handle() {
+		$metadata = array(
+			'file'  => __FILE__,
+			'name'  => 'unit-tests/test-block',
+			'style' => 'file:./fixtures/block.css',
+		);
+		$result   = register_block_style_handle( $metadata, 'style' );
+
+		$this->assertSame( 'unit-tests-test-block-style', $result );
 	}
 
 	/**

--- a/phpunit/class-register-block-type-from-metadata-test.php
+++ b/phpunit/class-register-block-type-from-metadata-test.php
@@ -108,6 +108,14 @@ class Register_Block_Type_From_Metadata_Test extends WP_UnitTestCase {
 			),
 			$result->styles
 		);
+		$this->assertEquals(
+			array(
+				'attributes' => array(
+					'message' => 'This is a notice!',
+				),
+			),
+			$result->example
+		);
 		$this->assertSame( 'my-plugin-notice-editor-script', $result->editor_script );
 		$this->assertSame( 'my-plugin-notice-script', $result->script );
 		$this->assertSame( 'my-plugin-notice-editor-style', $result->editor_style );

--- a/phpunit/class-register-block-type-from-metadata-test.php
+++ b/phpunit/class-register-block-type-from-metadata-test.php
@@ -74,5 +74,9 @@ class Register_Block_Type_From_Metadata_Test extends WP_UnitTestCase {
 			),
 			$result->styles
 		);
+		$this->assertEquals( 'my-plugin-notice-editor-script', $result->editor_script );
+		$this->assertEquals( 'my-plugin-notice-script', $result->script );
+		$this->assertEquals( 'my-plugin-notice-editor-style', $result->editor_style );
+		$this->assertEquals( 'my-plugin-notice-style', $result->style );
 	}
 }

--- a/phpunit/class-wp-rest-block-types-controller-test.php
+++ b/phpunit/class-wp-rest-block-types-controller-test.php
@@ -193,7 +193,7 @@ class REST_WP_REST_Block_Types_Controller_Test extends WP_Test_REST_Post_Type_Co
 			'keywords'        => 'invalid_keywords',
 			'parent'          => 'invalid_parent',
 			'supports'        => 'invalid_supports',
-			'styleVariations' => 'invalid_styles',
+			'styles'          => 'invalid_styles',
 			'render_callback' => 'invalid_callback',
 		);
 		register_block_type( $block_type, $settings );

--- a/phpunit/class-wp-rest-block-types-controller-test.php
+++ b/phpunit/class-wp-rest-block-types-controller-test.php
@@ -205,7 +205,7 @@ class REST_WP_REST_Block_Types_Controller_Test extends WP_Test_REST_Post_Type_Co
 		$this->assertEqualSets( array( 'invalid_keywords' ), $data['keywords'] );
 		$this->assertEqualSets( array( 'invalid_parent' ), $data['parent'] );
 		$this->assertEqualSets( array(), $data['supports'] );
-		$this->assertEqualSets( array(), $data['styles'] );
+		$this->assertEqualSets( array( 'invalid_styles' ), $data['styles'] );
 		$this->assertEquals( false, $data['is_dynamic'] );
 	}
 

--- a/phpunit/fixtures/block.asset.php
+++ b/phpunit/fixtures/block.asset.php
@@ -1,0 +1,6 @@
+<?php
+
+return array(
+	'dependencies' => array(),
+	'version'      => 'test',
+);

--- a/phpunit/fixtures/block.css
+++ b/phpunit/fixtures/block.css
@@ -1,0 +1,1 @@
+/* Test CSS file */

--- a/phpunit/fixtures/block.js
+++ b/phpunit/fixtures/block.js
@@ -1,0 +1,1 @@
+/* Test JavaScript file. */

--- a/phpunit/fixtures/block.json
+++ b/phpunit/fixtures/block.json
@@ -34,6 +34,11 @@
 			"label": "Other"
 		}
 	],
+	"example": {
+		"attributes": {
+			"message": "This is a notice!"
+		}
+	},
 	"editorScript": "my-plugin-notice-editor-script",
 	"script": "my-plugin-notice-script",
 	"editorStyle": "my-plugin-notice-editor-style",

--- a/phpunit/fixtures/block.json
+++ b/phpunit/fixtures/block.json
@@ -1,4 +1,37 @@
 {
-	"name": "test/block-name",
-	"category": "widgets"
+	"name": "my-plugin/notice",
+	"title": "Notice",
+	"category": "common",
+	"parent": [
+		"core/group"
+	],
+	"icon": "star",
+	"description": "Shows warning, error or success notices…",
+	"keywords": [
+		"alert",
+		"message"
+	],
+	"textDomain": "my-plugin",
+	"attributes": {
+		"message": {
+			"type": "string",
+			"source": "html",
+			"selector": ".message"
+		}
+	},
+	"supports": {
+		"align": true,
+		"lightBlockWrapper": true
+	},
+	"styleVariations": [
+		{
+			"name": "default",
+			"label": "Default",
+			"isDefault": true
+		},
+		{
+			"name": "other",
+			"label": "Other"
+		}
+	]
 }

--- a/phpunit/fixtures/block.json
+++ b/phpunit/fixtures/block.json
@@ -33,5 +33,9 @@
 			"name": "other",
 			"label": "Other"
 		}
-	]
+	],
+	"editorScript": "my-plugin-notice-editor-script",
+	"script": "my-plugin-notice-script",
+	"editorStyle": "my-plugin-notice-editor-style",
+	"style": "my-plugin-notice-style"
 }

--- a/phpunit/fixtures/block.json
+++ b/phpunit/fixtures/block.json
@@ -23,7 +23,7 @@
 		"align": true,
 		"lightBlockWrapper": true
 	},
-	"styleVariations": [
+	"styles": [
 		{
 			"name": "default",
 			"label": "Default",


### PR DESCRIPTION
## Description

The changes in this PR follow the solution proposed in Block Registration RFC:

https://github.com/WordPress/gutenberg/blob/master/docs/rfc/block-registration.md#assets

> ## Assets
> 
> ### `WPDefinedAsset`
> 
> The `WPDefinedAsset` type is a subtype of string, where the value represents a path to a JavaScript or CSS file relative to where `block.json` file is located. The path provided must be prefixed with `file:`. This approach is based on how npm handles [local paths](https://docs.npmjs.com/files/package.json#local-paths) for packages.
>
> An alternative would be a script or style handle name referencing a registered asset using WordPress helpers.
> 
>  **Example:**
> 
>  In `block.json`:
>  ```json
>  {
>  	"editorScript": "file:./build/index.js",
>  	"editorStyle": "my-editor-style"
>  }
> ```
> 
> #### WordPress context
> 
> In the context of WordPress, when a block is registered with PHP, it will automatically register all scripts and styles that are found in the `block.json` file and use file paths rather than asset handles.
> 
> That's why, the `WPDefinedAsset` type has to offer a way to mirror also the shape of params necessary to register scripts and styles using [`wp_register_script`](https://developer.wordpress.org/reference/functions/wp_register_script/) and [`wp_register_style`](https://developer.wordpress.org/reference/functions/wp_register_style/), and then assign these as handles associated with your block using the `script`, `style`, `editor_script`, and `editor_style` block type registration settings.
> 
> It's possible to provide an object which takes the following shape:
> - `handle` (`string`) - the name of the script. If omitted, it will be auto-generated.
> - `dependencies` (`string[]`) - an array of registered script handles this script depends on. Default value: `[]`.
> - `version` (`string`|`false`|`null`) - string specifying the script version number, if it has one, which is added to the URL as a query string for cache busting purposes. If the version is set to `false`, a version number is automatically added equal to current installed WordPress version. If set to `null`, no version is added. Default value: `false`.
> 
> The definition is stored inside separate PHP file which ends with `.asset.php` and is located next to the JS/CSS file listed in `block.json`. WordPress will automatically detect this file through pattern matching. This option is the preferred one as it is expected it will become an option to auto-generate those asset files with `@wordpress/scripts` package.
> 
> **Example:**
> 
> ```
> build/
> ├─ index.js
> └─ index.asset.php
> ```
> 
> In `block.json`:
> ```json
> { "editorScript": "file:./build/index.js" }
> ```
> 
> In `build/index.asset.php`:
> ```php
> <?php
> return array(
> 	'dependencies' => array(
> 		'wp-blocks',
> 		'wp-element',
> 		'wp-i18n',
> 	),
> 	'version'      => '3be55b05081a63d8f9d0ecb466c42cfd',
> );
> ```

## Motivation

`npm init @wordpress/block` creates a lot of boilerplate code in PHP file to load a single block. This is a way to simplify it to a single function call in the init hook:

```php
function create_block_esnext_example_block_init() {
	register_block_type_from_metadata( __DIR__ );
}
add_action( 'init', 'create_block_esnext_example_block_init' );
```

**In the future, it should make it possible to use `block.json` as an entry point for blocks crafted to be included in Block Directory!**

## Testing

I personally did the following steps to test this PR. I executed Create Block to have a block to play with all the defaults:

```bash
npx wp-create-block esnext-example
```

I moved then this folder to `lib` folder to make it simple to include.

I added the following `block.json` file inside `lib/esnext-example`

```json
{
    "name": "create-block/esnext-example",
    "editorScript": "file:./build/index.js",
    "editorStyle": "file:./editor.css",
    "style": "file:./style.css"
}
```

I replaced `lib/esnext-example/esnext-example.php` with:

```php
<?php

function create_block_esnext_example_block_init() {
	register_block_type_from_metadata( __DIR__ );
}
add_action( 'init', 'create_block_esnext_example_block_init' );
```

And I made sure it's required in `lib/load.php`.

I made sure that I can insert this block and inspected source code to confirm it properly generates in the codebase the HTML tags for assets like:

```html
<link rel="stylesheet" id="create-block-esnext-example-style-css"  href="http://localhost:8888/wp-content/plugins/gutenberg/lib/esnext-example/style.css?ver=1590053988" media="all" />
<link rel="stylesheet" id="create-block-esnext-example-editor-style-css"  href="http://localhost:8888/wp-content/plugins/gutenberg/lib/esnext-example/editor.css?ver=1590053988" media="all" />
<script src="http://localhost:8888/wp-content/plugins/gutenberg/lib/esnext-example/build/index.js?ver=c2283d6c83cb6f4b35398b803ac62056"></script>
```

## Follow up tasks

- Improve the way version is generated for CSS files as noted by @aduth in https://github.com/WordPress/gutenberg/pull/22519#discussion_r428648141

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [N/A] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
