### PR TITLE
Open up theme.json processing 

### DIFF
--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -559,8 +559,6 @@ function gutenberg_experimental_global_styles_register_cpt() {
 	register_post_type( 'wp_global_styles', $args );
 }
 
-if ( gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' ) ) {
-	add_action( 'init', 'gutenberg_experimental_global_styles_register_cpt' );
-	add_filter( 'block_editor_settings', 'gutenberg_experimental_global_styles_settings' );
-	add_action( 'wp_enqueue_scripts', 'gutenberg_experimental_global_styles_enqueue_assets' );
-}
+add_action( 'init', 'gutenberg_experimental_global_styles_register_cpt' );
+add_filter( 'block_editor_settings', 'gutenberg_experimental_global_styles_settings' );
+add_action( 'wp_enqueue_scripts', 'gutenberg_experimental_global_styles_enqueue_assets' );

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -482,30 +482,13 @@ function gutenberg_experimental_global_styles_enqueue_assets() {
 }
 
 /**
- * Whether the loaded page is the site editor.
- *
- * @return boolean Whether the loaded page is the site editor.
- */
-function gutenberg_experimental_global_styles_is_site_editor() {
-	if ( ! function_exists( 'get_current_screen' ) ) {
-		return false;
-	}
-
-	$screen = get_current_screen();
-	return ! empty( $screen ) && gutenberg_is_edit_site_page( $screen->id );
-}
-
-/**
  * Adds the necessary data for the Global Styles client UI to the block settings.
  *
  * @param array $settings Existing block editor settings.
  * @return array New block editor settings
  */
 function gutenberg_experimental_global_styles_settings( $settings ) {
-	if (
-		! gutenberg_experimental_global_styles_has_theme_json_support() ||
-		! gutenberg_experimental_global_styles_is_site_editor()
-	) {
+	if ( ! gutenberg_experimental_global_styles_has_theme_json_support() ) {
 		return $settings;
 	}
 


### PR DESCRIPTION
This PR removes the previous conditions required for `experimental-theme.json` to be processed, open it up to the front-end as well as all block editors (post, site, widgets). Previously we checked whether 1) the FSE experiment was enabled and 2) the editor was the site editor.

### Testing Instructions

Test that it doesn't load if the theme doesn't provide an `experimental-theme.json` file:

- Make sure you don't have any of the Gutenberg experiments enabled.
- Install & activate one of the default themes.
- Go to the front-end & make sure there's no embedded stylesheet with id `#global-styles-inline-css`.
- Go to the post editor, and it the embedded stylesheets search for `--wp--preset`. The expected result is that you don't find any CSS Custom Property.

Test that it loads if the theme provides an `experimental-theme.json` file:

- Make sure you don't have any of the Gutenberg experiments enabled.
- Install & activate one of the default themes.
- Create a file named `experimental-theme.json` within the theme directory. Let it be empty.
- Go to the front-end & make sure there's an embedded stylesheet with id `#global-styles-inline-css`.
- Go to the post editor, and it the embedded stylesheets search for `--wp--preset`. The expected result is that the same CSS Custom Properties you can find in the front-end should be present.
