### PR TITLE
Fix in-canvas inserter padding regression.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -368,6 +368,7 @@
 		background: $dark-gray-primary;
 		border-radius: $radius-block-ui;
 		color: $white;
+		padding: 0;
 
 		// Special dimensions for this button.
 		min-width: 24px;


### PR DESCRIPTION
Regression of #22460.

Before:

<img width="835" alt="Screenshot 2020-05-21 at 13 49 55" src="https://user-images.githubusercontent.com/1204802/82556425-f7d4a100-9b69-11ea-9583-10dc45f18d5d.png">


After:

<img width="698" alt="Screenshot 2020-05-21 at 13 48 17" src="https://user-images.githubusercontent.com/1204802/82556388-e9868500-9b69-11ea-96da-5de16d0b6c4d.png">
