### PR TITLE
Keep the focus in the block navigation when user's last interaction was with the block navigation

### DIFF
--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -733,6 +733,18 @@ _Returns_
 
 -   `boolean`: Whether an ancestor of the block is in multi-selection set.
 
+<a name="isAutoFocusEnabled" href="#isAutoFocusEnabled">#</a> **isAutoFocusEnabled**
+
+Returns whether the automatic focus is enabled.
+
+_Parameters_
+
+-   _state_ `Object`: Editor state.
+
+_Returns_
+
+-   `boolean`: Is automatic focus enabled.
+
 <a name="isBlockHighlighted" href="#isBlockHighlighted">#</a> **isBlockHighlighted**
 
 Returns true if the current highlighted block matches the block clientId.
@@ -1254,6 +1266,14 @@ clientId should be selected.
 _Parameters_
 
 -   _clientId_ `string`: Block client ID.
+
+<a name="setAutoFocusEnabled" href="#setAutoFocusEnabled">#</a> **setAutoFocusEnabled**
+
+Generators that triggers an action used to enable or disable the automatic focus.
+
+_Parameters_
+
+-   _isAutoFocusEnabled_ `boolean`: Enable/Disable navigation mode.
 
 <a name="setHasControlledInnerBlocks" href="#setHasControlledInnerBlocks">#</a> **setHasControlledInnerBlocks**
 

--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -30,6 +30,7 @@ const BlockComponent = forwardRef(
 		const {
 			clientId,
 			rootClientId,
+			isAutoFocusEnabled,
 			isSelected,
 			isFirstMultiSelected,
 			isLastMultiSelected,
@@ -124,10 +125,20 @@ const BlockComponent = forwardRef(
 		};
 
 		useEffect( () => {
-			if ( ! isMultiSelecting && ! isNavigationMode && isSelected ) {
+			if (
+				! isMultiSelecting &&
+				! isNavigationMode &&
+				isSelected &&
+				isAutoFocusEnabled
+			) {
 				focusTabbable();
 			}
-		}, [ isSelected, isMultiSelecting, isNavigationMode ] );
+		}, [
+			isSelected,
+			isMultiSelecting,
+			isNavigationMode,
+			isAutoFocusEnabled,
+		] );
 
 		// Block Reordering animation
 		const animationStyle = useMovingAnimation(

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -64,6 +64,7 @@ function BlockListBlock( {
 	toggleSelection,
 	index,
 	enableAnimation,
+	isAutoFocusEnabled,
 	isNavigationMode,
 	isMultiSelecting,
 } ) {
@@ -159,6 +160,7 @@ function BlockListBlock( {
 	const value = {
 		clientId,
 		rootClientId,
+		isAutoFocusEnabled,
 		isSelected,
 		isFirstMultiSelected,
 		isLastMultiSelected,
@@ -218,6 +220,7 @@ const applyWithSelect = withSelect(
 		const {
 			isBlockSelected,
 			isAncestorMultiSelected,
+			isAutoFocusEnabled,
 			isBlockMultiSelected,
 			isFirstMultiSelectedBlock,
 			getLastMultiSelectedBlockClientId,
@@ -251,6 +254,7 @@ const applyWithSelect = withSelect(
 		// Do not add new properties here, use `useSelect` instead to avoid
 		// leaking new props to the public API (editor.BlockListBlock filter).
 		return {
+			isAutoFocusEnabled: isAutoFocusEnabled(),
 			isMultiSelected: isBlockMultiSelected( clientId ),
 			isPartOfMultiSelection:
 				isBlockMultiSelected( clientId ) ||

--- a/packages/block-editor/src/components/block-navigation/block-contents.js
+++ b/packages/block-editor/src/components/block-navigation/block-contents.js
@@ -21,7 +21,6 @@ const BlockNavigationBlockContents = forwardRef(
 
 		return withBlockNavigationSlots ? (
 			<BlockNavigationBlockSlot
-				ref={ ref }
 				className="block-editor-block-navigation-block-contents"
 				block={ block }
 				onClick={ onClick }
@@ -30,10 +29,10 @@ const BlockNavigationBlockContents = forwardRef(
 				siblingCount={ siblingCount }
 				level={ level }
 				{ ...props }
+				ref={ ref }
 			/>
 		) : (
 			<BlockNavigationBlockSelectButton
-				ref={ ref }
 				className="block-editor-block-navigation-block-contents"
 				block={ block }
 				onClick={ onClick }
@@ -42,6 +41,7 @@ const BlockNavigationBlockContents = forwardRef(
 				siblingCount={ siblingCount }
 				level={ level }
 				{ ...props }
+				ref={ ref }
 			/>
 		);
 	}

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -884,6 +884,18 @@ export function* setNavigationMode( isNavigationMode = true ) {
 }
 
 /**
+ * Generators that triggers an action used to enable or disable the automatic focus.
+ *
+ * @param {boolean} isAutoFocusEnabled Enable/Disable navigation mode.
+ */
+export function* setAutoFocusEnabled( isAutoFocusEnabled = true ) {
+	yield {
+		type: 'SET_AUTO_FOCUS_ENABLED',
+		isAutoFocusEnabled,
+	};
+}
+
+/**
  * Generator that triggers an action used to duplicate a list of blocks.
  *
  * @param {string[]} clientIds

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1520,6 +1520,22 @@ export function isNavigationMode( state = false, action ) {
 }
 
 /**
+ * Reducer returning whether the automatic focus should be enabled or not.
+ *
+ * @param {boolean} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {string} Updated state.
+ */
+export function isAutoFocusEnabled( state = true, action ) {
+	if ( action.type === 'SET_AUTO_FOCUS_ENABLED' ) {
+		return action.isAutoFocusEnabled;
+	}
+
+	return state;
+}
+
+/**
  * Reducer return an updated state representing the most recent block attribute
  * update. The state is structured as an object where the keys represent the
  * client IDs of blocks, the values a subset of attributes from the most recent
@@ -1621,6 +1637,7 @@ export default combineReducers( {
 	preferences,
 	lastBlockAttributesChange,
 	isNavigationMode,
+	isAutoFocusEnabled,
 	automaticChangeStatus,
 	highlightedBlock,
 } );

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1628,6 +1628,17 @@ export function isNavigationMode( state ) {
 }
 
 /**
+ * Returns whether the automatic focus is enabled.
+ *
+ * @param {Object} state Editor state.
+ *
+ * @return {boolean}     Is automatic focus enabled.
+ */
+export function isAutoFocusEnabled( state ) {
+	return state.isAutoFocusEnabled;
+}
+
+/**
  * Returns true if the last change was an automatic change, false otherwise.
  *
  * @param {Object} state Global application state.

--- a/packages/components/src/panel/index.js
+++ b/packages/components/src/panel/index.js
@@ -8,10 +8,10 @@ import classnames from 'classnames';
  */
 import PanelHeader from './header';
 
-function Panel( { header, className, children } ) {
+function Panel( { header, className, children, ...props } ) {
 	const classNames = classnames( className, 'components-panel' );
 	return (
-		<div className={ classNames }>
+		<div className={ classNames } { ...props }>
 			{ header && <PanelHeader label={ header } /> }
 			{ children }
 		</div>

--- a/packages/edit-navigation/src/components/menu-editor/block-editor-panel.js
+++ b/packages/edit-navigation/src/components/menu-editor/block-editor-panel.js
@@ -26,6 +26,7 @@ export default function BlockEditorPanel( {
 	onDeleteMenu,
 	menuId,
 	saveBlocks,
+	...props
 } ) {
 	const { isNavigationModeActive, hasSelectedBlock } = useSelect(
 		( select ) => {
@@ -48,7 +49,10 @@ export default function BlockEditorPanel( {
 	);
 
 	return (
-		<Panel className="edit-navigation-menu-editor__block-editor-panel">
+		<Panel
+			className="edit-navigation-menu-editor__block-editor-panel"
+			{ ...props }
+		>
 			<PanelBody title={ __( 'Navigation menu' ) }>
 				<div className="components-panel__header-actions">
 					<Button isPrimary onClick={ saveBlocks }>

--- a/packages/edit-navigation/src/components/menu-editor/index.js
+++ b/packages/edit-navigation/src/components/menu-editor/index.js
@@ -39,7 +39,7 @@ export default function MenuEditor( {
 					hasFixedToolbar: true,
 				} }
 			>
-				<EditorBody
+				<MenuEditorBody
 					menuId={ menuId }
 					onDeleteMenu={ onDeleteMenu }
 					blocks={ blocks }
@@ -50,7 +50,11 @@ export default function MenuEditor( {
 	);
 }
 
-const EditorBody = ( { menuId, onDeleteMenu, blocks, saveBlocks } ) => {
+/*
+ * This has to be a separate component because core/block-editor data is only available for descendants
+ * of BlockEditorProvider
+ */
+const MenuEditorBody = ( { menuId, onDeleteMenu, blocks, saveBlocks } ) => {
 	const { setAutoFocusEnabled } = useDispatch( 'core/block-editor' );
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const [ lastInteractedSection, setLastInteractedSection ] = useState(

--- a/packages/edit-navigation/src/components/menu-editor/navigation-structure-panel.js
+++ b/packages/edit-navigation/src/components/menu-editor/navigation-structure-panel.js
@@ -6,7 +6,11 @@ import { Panel, PanelBody } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
-export default function NavigationStructurePanel( { blocks, initialOpen } ) {
+export default function NavigationStructurePanel( {
+	blocks,
+	initialOpen,
+	...props
+} ) {
 	const selectedBlockClientIds = useSelect(
 		( select ) => select( 'core/block-editor' ).getSelectedBlockClientIds(),
 		[]
@@ -15,7 +19,10 @@ export default function NavigationStructurePanel( { blocks, initialOpen } ) {
 	const showNavigationStructure = !! blocks.length;
 
 	return (
-		<Panel className="edit-navigation-menu-editor__navigation-structure-panel">
+		<Panel
+			className="edit-navigation-menu-editor__navigation-structure-panel"
+			{ ...props }
+		>
 			<PanelBody
 				title={ __( 'Navigation structure' ) }
 				initialOpen={ initialOpen }


### PR DESCRIPTION
## Description

PR https://github.com/WordPress/gutenberg/pull/22427 introduced an experimental ellipsis menu to the block navigation on the experimental nav management screen. Unfortunately, duplicating a block using that menu transfers the focus back to the editor area. To provide the best possible experience for users using mostly their keyboards, we should do the following:

* When the block is duplicated using the ellipsis menu in block navigation, we should `.focus()` the new item in the block navigation.
* When the block is duplicated using the editor area menu, we should `.focus()` the new block in the editor area.

I've been thinking about possible ways of approaching this issue and concluded that the editor must know whether or not it is allowed to grab the focus. This PR introduces the new editor state variable called `isAutoFocusEnabled`. The editor will only `focus()` on the new block if `isAutoFocusEnabled === true`. 

## How has this been tested?
1. Go to the experimental navigation page
1. Add a few menu items
1. Duplicate a menu item using the controls in the editor area, confirm the new block in the editor area gained focus.
1. Duplicate a menu item using the controls in the block navigation area, confirm the new block navigation item gained focus.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
