### PR TITLE
Fix presets in themes that use the default color & gradient palettes

### DIFF
--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -37,6 +37,7 @@
 // to assure colors take effect over another base class color, mainly to let
 // the colors override the added specificity by link states such as :hover.
 
+:root .editor-styles-wrapper,
 :root {
 	// Background colors.
 


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/22482