### PR TITLE
Fix dirty state e2e test intermittent failuire

### DIFF
--- a/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
@@ -248,11 +248,7 @@ describe( 'Multi-entity editor states', () => {
 		it( 'should only dirty the parent entity when editing the parent', async () => {
 			// Clear selection so that the block is not added to the template part.
 			await clickBreadcrumbItem( 'Document' );
-
-			// Add paragraph block to the end of the document.
-			await page.click( '.block-editor-button-block-appender' );
-			await page.waitForSelector( '.block-editor-inserter__menu' );
-			await page.click( 'button.editor-block-list-item-paragraph' );
+			await insertBlock( 'Paragraph' );
 
 			// Add changes to the main parent entity.
 			await page.keyboard.type( 'Test.' );


### PR DESCRIPTION
## Description
Try using `insertBlock` directly now that we clear the selection state correctly.

## How has this been tested?
e2e tests should pass

## Types of changes
e2e test fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
