### PR TITLE
Customizer: Mobile & toolbar; Block toolbar widgets mobile

### DIFF
--- a/packages/edit-widgets/src/components/customizer-edit-widgets-initializer/index.js
+++ b/packages/edit-widgets/src/components/customizer-edit-widgets-initializer/index.js
@@ -2,32 +2,41 @@
  * WordPress dependencies
  */
 import { navigateRegions } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
 import { useSimulatedMediaQuery } from '@wordpress/block-editor';
-import { useViewportMatch } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
+import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import './sync-customizer';
+import Header from '../header';
 import WidgetAreasBlockEditorProvider from '../widget-areas-block-editor-provider';
 import WidgetAreasBlockEditorContent from '../widget-areas-block-editor-content';
 
 function CustomizerEditWidgetsInitializer( { settings } ) {
 	useSimulatedMediaQuery( 'resizable-editor-section', 360 );
+	const blockEditorSettings = useMemo(
+		() => ( {
+			...settings,
+			hasFixedToolbar: true,
+		} ),
+		[ settings ]
+	);
 	return (
-		<useViewportMatch.__experimentalWidthProvider value={ 360 }>
-			<WidgetAreasBlockEditorProvider blockEditorSettings={ settings }>
-				<div
-					className="edit-widgets-customizer-edit-widgets-initializer__content"
-					role="region"
-					aria-label={ __( 'Widgets screen content' ) }
-					tabIndex="-1"
-				>
-					<WidgetAreasBlockEditorContent />
-				</div>
-			</WidgetAreasBlockEditorProvider>
-		</useViewportMatch.__experimentalWidthProvider>
+		<WidgetAreasBlockEditorProvider
+			blockEditorSettings={ blockEditorSettings }
+		>
+			<div
+				className="edit-widgets-customizer-edit-widgets-initializer__content"
+				role="region"
+				aria-label={ __( 'Widgets screen content' ) }
+				tabIndex="-1"
+			>
+				<Header isCustomizer />
+				<WidgetAreasBlockEditorContent />
+			</div>
+		</WidgetAreasBlockEditorProvider>
 	);
 }
 

--- a/packages/edit-widgets/src/components/customizer-edit-widgets-initializer/index.js
+++ b/packages/edit-widgets/src/components/customizer-edit-widgets-initializer/index.js
@@ -3,6 +3,8 @@
  */
 import { navigateRegions } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useSimulatedMediaQuery } from '@wordpress/block-editor';
+import { useViewportMatch } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -12,17 +14,20 @@ import WidgetAreasBlockEditorProvider from '../widget-areas-block-editor-provide
 import WidgetAreasBlockEditorContent from '../widget-areas-block-editor-content';
 
 function CustomizerEditWidgetsInitializer( { settings } ) {
+	useSimulatedMediaQuery( 'resizable-editor-section', 360 );
 	return (
-		<WidgetAreasBlockEditorProvider blockEditorSettings={ settings }>
-			<div
-				className="edit-widgets-customizer-edit-widgets-initializer__content"
-				role="region"
-				aria-label={ __( 'Widgets screen content' ) }
-				tabIndex="-1"
-			>
-				<WidgetAreasBlockEditorContent />
-			</div>
-		</WidgetAreasBlockEditorProvider>
+		<useViewportMatch.__experimentalWidthProvider value={ 360 }>
+			<WidgetAreasBlockEditorProvider blockEditorSettings={ settings }>
+				<div
+					className="edit-widgets-customizer-edit-widgets-initializer__content"
+					role="region"
+					aria-label={ __( 'Widgets screen content' ) }
+					tabIndex="-1"
+				>
+					<WidgetAreasBlockEditorContent />
+				</div>
+			</WidgetAreasBlockEditorProvider>
+		</useViewportMatch.__experimentalWidthProvider>
 	);
 }
 

--- a/packages/edit-widgets/src/components/customizer-edit-widgets-initializer/style.scss
+++ b/packages/edit-widgets/src/components/customizer-edit-widgets-initializer/style.scss
@@ -1,14 +1,13 @@
 .edit-widgets-customizer-edit-widgets-initializer__content {
-	background: #f1f1f1;
-	margin: 0;
-	min-height: 100%;
-	padding: 30px 0;
-
-	.block-editor-block-list__layout {
-		padding: 0 0 0 18px;
+	.edit-widgets-header {
+		margin-top: -16px;
+		border-top: 1px solid $light-gray-500;
 	}
 
-	.block-editor-block-list__empty-block-inserter {
-		left: -18px;
+	.edit-widgets-header,
+	.edit-widgets-header__block-toolbar {
+		margin-right: -12px;
+		margin-left: -12px;
+		background: #fff;
 	}
 }

--- a/packages/edit-widgets/src/components/header/index.js
+++ b/packages/edit-widgets/src/components/header/index.js
@@ -3,8 +3,13 @@
  */
 import { __ } from '@wordpress/i18n';
 import { NavigableMenu } from '@wordpress/components';
-import { BlockNavigationDropdown, Inserter } from '@wordpress/block-editor';
+import {
+	BlockNavigationDropdown,
+	BlockToolbar,
+	Inserter,
+} from '@wordpress/block-editor';
 import { PinnedItems } from '@wordpress/interface';
+import { useViewportMatch } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -15,27 +20,39 @@ import RedoButton from './undo-redo/redo';
 
 const inserterToggleProps = { isPrimary: true };
 
-function Header() {
+function Header( { isCustomizer } ) {
+	const isLargeViewport = useViewportMatch( 'medium' );
 	return (
-		<div className="edit-widgets-header">
-			<NavigableMenu>
-				<Inserter
-					position="bottom right"
-					showInserterHelpPanel
-					toggleProps={ inserterToggleProps }
-				/>
-				<UndoButton />
-				<RedoButton />
-				<BlockNavigationDropdown />
-			</NavigableMenu>
-			<h1 className="edit-widgets-header__title">
-				{ __( 'Block Areas' ) } { __( '(experimental)' ) }
-			</h1>
-			<div className="edit-widgets-header__actions">
-				<SaveButton />
-				<PinnedItems.Slot scope="core/edit-widgets" />
+		<>
+			<div className="edit-widgets-header">
+				<NavigableMenu>
+					<Inserter
+						position="bottom right"
+						showInserterHelpPanel
+						toggleProps={ inserterToggleProps }
+					/>
+					<UndoButton />
+					<RedoButton />
+					<BlockNavigationDropdown />
+				</NavigableMenu>
+				{ ! isCustomizer && (
+					<>
+						<h1 className="edit-widgets-header__title">
+							{ __( 'Block Areas' ) } { __( '(experimental)' ) }
+						</h1>
+						<div className="edit-widgets-header__actions">
+							<SaveButton />
+							<PinnedItems.Slot scope="core/edit-widgets" />
+						</div>
+					</>
+				) }
 			</div>
-		</div>
+			{ ( ! isLargeViewport || isCustomizer ) && (
+				<div className="edit-widgets-header__block-toolbar">
+					<BlockToolbar hideDragHandle />
+				</div>
+			) }
+		</>
 	);
 }
 

--- a/packages/edit-widgets/src/components/header/style.scss
+++ b/packages/edit-widgets/src/components/header/style.scss
@@ -15,3 +15,8 @@
 .edit-widgets-header__actions {
 	display: flex;
 }
+
+.edit-widgets-header__block-toolbar {
+	border-bottom: 1px solid $light-gray-500;
+	border-top: 1px solid $light-gray-500;
+}


### PR DESCRIPTION
## Description
Supersedes: https://github.com/WordPress/gutenberg/pull/17960
This PR implements three features very interconnected. I'm creating a single PR because with multiple PR's we would have constant conflicts between them.

The features implemented are:

- Forces the mobile view on the customizer using the mechanism we have to stimulate the mobile view.

- Add a toolbar with the global inserter, undo/redo, and navigator to the customizer blocks that missed this part of the UI.

- Make the block toolbar fixed on top in the widgets screen when viewed on mobile. Currently the widget screen when viewed on mobile does not show the block toolbar at all. On customizer we always show the toolbar on top as we are forcing a mobile view.


Before:
![image](https://user-images.githubusercontent.com/11271197/82598265-47cf5a00-9ba2-11ea-8b21-f1d63011b27e.png)



After:
![image](https://user-images.githubusercontent.com/11271197/82597431-dc38bd00-9ba0-11ea-93e9-473a005577ec.png)


## How has this been tested?
I added a media and text block on the customizer and verified by default it appears stacked instead of side by side (simulated mobile view). 

I verified the block toolbar and the toolbar with inserter, undo/redo, and block navigator appears on top of the customizer.

I opened the widgets screen I resized the window to a mobile view. I verified the block toolbar appeared on top, previously it did not appear anywhere.