### PR TITLE
Add focus mode to site editor

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -6,6 +6,7 @@ import {
 	useContext,
 	useState,
 	useMemo,
+	useEffect,
 	useCallback,
 } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
@@ -69,17 +70,27 @@ function Editor( { settings: _settings } ) {
 		setSettings,
 	] );
 
-	const { isFullscreenActive } = useSelect( ( select ) => {
-		return {
-			isFullscreenActive: select( 'core/edit-site' ).isFeatureActive(
-				'fullscreenMode'
-			),
-		};
-	}, [] );
+	const { isFullscreenActive, focusMode, deviceType } = useSelect(
+		( select ) => {
+			const {
+				isFeatureActive,
+				__experimentalGetPreviewDeviceType,
+			} = select( 'core/edit-site' );
+			return {
+				isFullscreenActive: isFeatureActive( 'fullscreenMode' ),
+				focusMode: isFeatureActive( 'focusMode' ),
+				deviceType: __experimentalGetPreviewDeviceType(),
+			};
+		},
+		[]
+	);
 
-	const deviceType = useSelect( ( select ) => {
-		return select( 'core/edit-site' ).__experimentalGetPreviewDeviceType();
-	}, [] );
+	useEffect( () => {
+		setSettings( {
+			...settings,
+			focusMode,
+		} );
+	}, [ focusMode ] );
 
 	const inlineStyles = useResizeCanvas( deviceType );
 

--- a/packages/edit-site/src/components/header/more-menu/index.js
+++ b/packages/edit-site/src/components/header/more-menu/index.js
@@ -29,18 +29,18 @@ const MoreMenu = () => (
 		{ () => (
 			<MenuGroup label={ _x( 'View', 'noun' ) }>
 				<FeatureToggle
-					feature="fullscreenMode"
-					label={ __( 'Fullscreen mode' ) }
-					info={ __( 'Work without distraction' ) }
-					messageActivated={ __( 'Fullscreen mode activated' ) }
-					messageDeactivated={ __( 'Fullscreen mode deactivated' ) }
-				/>
-				<FeatureToggle
 					feature="focusMode"
 					label={ __( 'Spotlight mode' ) }
 					info={ __( 'Focus on one block at a time' ) }
 					messageActivated={ __( 'Spotlight mode activated' ) }
 					messageDeactivated={ __( 'Spotlight mode deactivated' ) }
+				/>
+				<FeatureToggle
+					feature="fullscreenMode"
+					label={ __( 'Fullscreen mode' ) }
+					info={ __( 'Work without distraction' ) }
+					messageActivated={ __( 'Fullscreen mode activated' ) }
+					messageDeactivated={ __( 'Fullscreen mode deactivated' ) }
 				/>
 			</MenuGroup>
 		) }

--- a/packages/edit-site/src/components/header/more-menu/index.js
+++ b/packages/edit-site/src/components/header/more-menu/index.js
@@ -35,6 +35,13 @@ const MoreMenu = () => (
 					messageActivated={ __( 'Fullscreen mode activated' ) }
 					messageDeactivated={ __( 'Fullscreen mode deactivated' ) }
 				/>
+				<FeatureToggle
+					feature="focusMode"
+					label={ __( 'Spotlight mode' ) }
+					info={ __( 'Focus on one block at a time' ) }
+					messageActivated={ __( 'Spotlight mode activated' ) }
+					messageDeactivated={ __( 'Spotlight mode deactivated' ) }
+				/>
 			</MenuGroup>
 		) }
 	</DropdownMenu>


### PR DESCRIPTION
## Description
Adds focus mode feature toggle to site editor and passes it to block editor settings. Really not a big fan of having useEffect to get the value into settings, but I'm not sure there's a cleaner way at the time being. (Highlights the need for a more robust site editor store!)

## How has this been tested?
Locally in edit site. it's mostly copy/pasted from the post editor.

## Screenshots <!-- if applicable -->
<img width="1612" alt="Screen Shot 2020-05-21 at 1 10 42 PM" src="https://user-images.githubusercontent.com/6265975/82601498-80504300-9b64-11ea-887a-129994a6aeea.png">

## Types of changes
new feature

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
