### PR TITLE
Block Editor: useMovingAnimation: Avoid initial transform animation

### DIFF
--- a/packages/block-editor/src/components/use-moving-animation/index.js
+++ b/packages/block-editor/src/components/use-moving-animation/index.js
@@ -77,9 +77,13 @@ function useMovingAnimation(
 		}
 	}, [ triggeredAnimation ] );
 	useLayoutEffect( () => {
+		if ( ! previous ) {
+			return;
+		}
+
 		scrollContainer.current = getScrollContainer( ref.current );
 		if ( prefersReducedMotion ) {
-			if ( adjustScrolling && scrollContainer.current && previous ) {
+			if ( adjustScrolling && scrollContainer.current ) {
 				// if the animation is disabled and the scroll needs to be adjusted,
 				// just move directly to the final scroll position
 				ref.current.style.transform = 'none';
@@ -95,14 +99,13 @@ function useMovingAnimation(
 		ref.current.style.transform = 'none';
 		const destination = getAbsolutePosition( ref.current );
 		const newTransform = {
-			x: previous ? previous.left - destination.left : 0,
-			y: previous ? previous.top - destination.top : 0,
-			scrollTop:
-				previous && scrollContainer.current
-					? scrollContainer.current.scrollTop -
-					  previous.top +
-					  destination.top
-					: 0,
+			x: previous.left - destination.left,
+			y: previous.top - destination.top,
+			scrollTop: scrollContainer.current
+				? scrollContainer.current.scrollTop -
+				  previous.top +
+				  destination.top
+				: 0,
 		};
 		ref.current.style.transform =
 			newTransform.x === 0 && newTransform.y === 0


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/21231#issuecomment-631657664

This pull request seeks to try to optimize the implementation of `useMovingAnimation` to avoid logic associated with initial animation. In some unrelated performance auditing, it was observed that in larger posts, a significant amount of time is spent during load in this hook's `useLayoutEffect`, specifically in computing the scroll container (`getScrollContainer`). It's quite likely this is due to the fact that `getScrollContainer` does a combination of (a) possibly steps through the entire DOM ancestry of the block and (b) accesses positional properties which may trigger reflow (`scrollTop`, [see related](https://gist.github.com/paulirish/5d52fb081b3570c81e3a)).

The logic here is complex and I'm not intimately familiar with it, but the intent with these changes is to try to avoid animation / transform logic which can occur in the initial rendering of the component (the initial rendering of the editor). From what I can tell, the hook uses `previous` to determine a relative transform based on an earlier render. Much of the logic appears in the effect appears to act as a noop when the previous value is not assigned. Thus, the intent here is to try to bypass the effect altogether if previous is unavailable, to avoid computing the scroll container and assigning transform/animation properties.

The result is ~15% reduction in "Average time to load" via `npm run test-performance` (10.1s to 8.7s).

This is intended to be a minimal improvement, but ideally I'd wish this hook could still do a lot less until the point at which animations are relevant. I believe it's challenging in large part because the animation start and end rely on changes before / after a DOM update, which are difficult to achieve without storing references to those values. For example, `getAbsolutePosition` may be a costly operation as well, but is called on every render.

**Testing Instructions:**

Verify there are no regressions in block animation.

There was a note by @youknowriad that this could affect first render (animation of newly inserted blocks?) at https://github.com/WordPress/gutenberg/pull/21231#issuecomment-631978154, but I'm not really observing any differences, or feel strongly if this would be considered a regression.