### PR TITLE
FSE: Add focus mode and top toolbar modes

### DIFF
--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -25,19 +25,31 @@ import Sidebar from '../sidebar';
 
 export default function BlockEditor() {
 	const { settings: _settings, setSettings } = useEditorContext();
-	const canUserCreateMedia = useSelect( ( select ) => {
-		const _canUserCreateMedia = select( 'core' ).canUser(
-			'create',
-			'media'
-		);
-		return _canUserCreateMedia || _canUserCreateMedia !== false;
-	}, [] );
+	const { canUserCreateMedia, focusMode, hasFixedToolbar } = useSelect(
+		( select ) => {
+			const { isFeatureActive } = select( 'core/edit-site' );
+			const _canUserCreateMedia = select( 'core' ).canUser(
+				'create',
+				'media'
+			);
+			return {
+				canUserCreateMedia:
+					_canUserCreateMedia || _canUserCreateMedia !== false,
+				focusMode: isFeatureActive( 'focusMode' ),
+				hasFixedToolbar: isFeatureActive( 'fixedToolbar' ),
+			};
+		},
+		[]
+	);
+
 	const settings = useMemo( () => {
 		if ( ! canUserCreateMedia ) {
 			return _settings;
 		}
 		return {
 			..._settings,
+			focusMode,
+			hasFixedToolbar,
 			mediaUpload( { onError, ...rest } ) {
 				uploadMedia( {
 					wpAllowedMimeTypes: _settings.allowedMimeTypes,
@@ -46,11 +58,13 @@ export default function BlockEditor() {
 				} );
 			},
 		};
-	}, [ canUserCreateMedia, _settings ] );
+	}, [ canUserCreateMedia, _settings, focusMode, hasFixedToolbar ] );
+
 	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
 		'postType',
 		settings.templateType
 	);
+
 	const setActiveTemplateId = useCallback(
 		( newTemplateId ) =>
 			setSettings( ( prevSettings ) => ( {
@@ -60,6 +74,7 @@ export default function BlockEditor() {
 			} ) ),
 		[]
 	);
+
 	return (
 		<BlockEditorProvider
 			settings={ settings }

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -70,27 +70,30 @@ function Editor( { settings: _settings } ) {
 		setSettings,
 	] );
 
-	const { isFullscreenActive, focusMode, deviceType } = useSelect(
-		( select ) => {
-			const {
-				isFeatureActive,
-				__experimentalGetPreviewDeviceType,
-			} = select( 'core/edit-site' );
-			return {
-				isFullscreenActive: isFeatureActive( 'fullscreenMode' ),
-				focusMode: isFeatureActive( 'focusMode' ),
-				deviceType: __experimentalGetPreviewDeviceType(),
-			};
-		},
-		[]
-	);
+	const {
+		isFullscreenActive,
+		focusMode,
+		deviceType,
+		hasFixedToolbar,
+	} = useSelect( ( select ) => {
+		const { isFeatureActive, __experimentalGetPreviewDeviceType } = select(
+			'core/edit-site'
+		);
+		return {
+			hasFixedToolbar: isFeatureActive( 'fixedToolbar' ),
+			isFullscreenActive: isFeatureActive( 'fullscreenMode' ),
+			focusMode: isFeatureActive( 'focusMode' ),
+			deviceType: __experimentalGetPreviewDeviceType(),
+		};
+	}, [] );
 
 	useEffect( () => {
 		setSettings( {
 			...settings,
 			focusMode,
+			hasFixedToolbar,
 		} );
-	}, [ focusMode ] );
+	}, [ focusMode, hasFixedToolbar ] );
 
 	const inlineStyles = useResizeCanvas( deviceType );
 

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -6,7 +6,6 @@ import {
 	useContext,
 	useState,
 	useMemo,
-	useEffect,
 	useCallback,
 } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
@@ -70,30 +69,15 @@ function Editor( { settings: _settings } ) {
 		setSettings,
 	] );
 
-	const {
-		isFullscreenActive,
-		focusMode,
-		deviceType,
-		hasFixedToolbar,
-	} = useSelect( ( select ) => {
+	const { isFullscreenActive, deviceType } = useSelect( ( select ) => {
 		const { isFeatureActive, __experimentalGetPreviewDeviceType } = select(
 			'core/edit-site'
 		);
 		return {
-			hasFixedToolbar: isFeatureActive( 'fixedToolbar' ),
 			isFullscreenActive: isFeatureActive( 'fullscreenMode' ),
-			focusMode: isFeatureActive( 'focusMode' ),
 			deviceType: __experimentalGetPreviewDeviceType(),
 		};
 	}, [] );
-
-	useEffect( () => {
-		setSettings( {
-			...settings,
-			focusMode,
-			hasFixedToolbar,
-		} );
-	}, [ focusMode, hasFixedToolbar ] );
 
 	const inlineStyles = useResizeCanvas( deviceType );
 

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -6,6 +6,7 @@ import {
 	useContext,
 	useState,
 	useMemo,
+	useEffect,
 	useCallback,
 } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
@@ -69,17 +70,27 @@ function Editor( { settings: _settings } ) {
 		setSettings,
 	] );
 
-	const { isFullscreenActive } = useSelect( ( select ) => {
-		return {
-			isFullscreenActive: select( 'core/edit-site' ).isFeatureActive(
-				'fullscreenMode'
-			),
-		};
-	}, [] );
+	const { isFullscreenActive, focusMode, deviceType } = useSelect(
+		( select ) => {
+			const {
+				isFeatureActive,
+				__experimentalGetPreviewDeviceType,
+			} = select( 'core/edit-site' );
+			return {
+				isFullscreenActive: isFeatureActive( 'fullscreenMode' ),
+				focusMode: isFeatureActive( 'focusMode' ),
+				deviceType: __experimentalGetPreviewDeviceType(),
+			};
+		},
+		[]
+	);
 
-	const deviceType = useSelect( ( select ) => {
-		return select( 'core/edit-site' ).__experimentalGetPreviewDeviceType();
-	}, [] );
+	useEffect( () => {
+		setSettings( {
+			...settings,
+			focusMode,
+		} );
+	}, [ focusMode ] );
 
 	const inlineStyles = useResizeCanvas( deviceType );
 

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -1,11 +1,13 @@
 /**
  * WordPress dependencies
  */
+import { useViewportMatch } from '@wordpress/compose';
 import { useCallback } from '@wordpress/element';
 import { addQueryArgs } from '@wordpress/url';
 import {
 	BlockNavigationDropdown,
 	ToolSelector,
+	BlockToolbar,
 	__experimentalPreviewOptions as PreviewOptions,
 } from '@wordpress/block-editor';
 import {
@@ -99,13 +101,25 @@ export default function Header( {
 		} catch ( err ) {}
 	}, [] );
 
-	const deviceType = useSelect( ( select ) => {
-		return select( 'core/edit-site' ).__experimentalGetPreviewDeviceType();
-	}, [] );
+	const { deviceType, hasFixedToolbar } = useSelect(
+		( select ) => ( {
+			deviceType: select(
+				'core/edit-site'
+			).__experimentalGetPreviewDeviceType(),
+			hasFixedToolbar: select( 'core/edit-site' ).isFeatureActive(
+				'fixedToolbar'
+			),
+		} ),
+		[]
+	);
 
 	const {
 		__experimentalSetPreviewDeviceType: setPreviewDeviceType,
 	} = useDispatch( 'core/edit-site' );
+
+	const isLargeViewport = useViewportMatch( 'medium' );
+	const displayBlockToolbar =
+		! isLargeViewport || deviceType !== 'Desktop' || hasFixedToolbar;
 
 	return (
 		<div className="edit-site-header">
@@ -127,6 +141,11 @@ export default function Header( {
 				<UndoButton />
 				<RedoButton />
 				<BlockNavigationDropdown />
+				{ displayBlockToolbar && (
+					<div className="edit-site-header-toolbar__block-toolbar">
+						<BlockToolbar hideDragHandle />
+					</div>
+				) }
 				<div className="edit-site-header__toolbar-switchers">
 					<PageSwitcher
 						showOnFront={ settings.showOnFront }

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -101,17 +101,15 @@ export default function Header( {
 		} catch ( err ) {}
 	}, [] );
 
-	const { deviceType, hasFixedToolbar } = useSelect(
-		( select ) => ( {
-			deviceType: select(
-				'core/edit-site'
-			).__experimentalGetPreviewDeviceType(),
-			hasFixedToolbar: select( 'core/edit-site' ).isFeatureActive(
-				'fixedToolbar'
-			),
-		} ),
-		[]
-	);
+	const { deviceType, hasFixedToolbar } = useSelect( ( select ) => {
+		const { __experimentalGetPreviewDeviceType, isFeatureActive } = select(
+			'core/edit-site'
+		);
+		return {
+			deviceType: __experimentalGetPreviewDeviceType(),
+			hasFixedToolbar: isFeatureActive( 'fixedToolbar' ),
+		};
+	}, [] );
 
 	const {
 		__experimentalSetPreviewDeviceType: setPreviewDeviceType,

--- a/packages/edit-site/src/components/header/more-menu/index.js
+++ b/packages/edit-site/src/components/header/more-menu/index.js
@@ -29,6 +29,15 @@ const MoreMenu = () => (
 		{ () => (
 			<MenuGroup label={ _x( 'View', 'noun' ) }>
 				<FeatureToggle
+					feature="fixedToolbar"
+					label={ __( 'Top toolbar' ) }
+					info={ __(
+						'Access all block and document tools in a single place'
+					) }
+					messageActivated={ __( 'Top toolbar activated' ) }
+					messageDeactivated={ __( 'Top toolbar deactivated' ) }
+				/>
+				<FeatureToggle
 					feature="fullscreenMode"
 					label={ __( 'Fullscreen mode' ) }
 					info={ __( 'Work without distraction' ) }

--- a/packages/edit-site/src/components/header/more-menu/index.js
+++ b/packages/edit-site/src/components/header/more-menu/index.js
@@ -38,18 +38,18 @@ const MoreMenu = () => (
 					messageDeactivated={ __( 'Top toolbar deactivated' ) }
 				/>
 				<FeatureToggle
-					feature="fullscreenMode"
-					label={ __( 'Fullscreen mode' ) }
-					info={ __( 'Work without distraction' ) }
-					messageActivated={ __( 'Fullscreen mode activated' ) }
-					messageDeactivated={ __( 'Fullscreen mode deactivated' ) }
-				/>
-				<FeatureToggle
 					feature="focusMode"
 					label={ __( 'Spotlight mode' ) }
 					info={ __( 'Focus on one block at a time' ) }
 					messageActivated={ __( 'Spotlight mode activated' ) }
 					messageDeactivated={ __( 'Spotlight mode deactivated' ) }
+				/>
+				<FeatureToggle
+					feature="fullscreenMode"
+					label={ __( 'Fullscreen mode' ) }
+					info={ __( 'Work without distraction' ) }
+					messageActivated={ __( 'Fullscreen mode activated' ) }
+					messageDeactivated={ __( 'Fullscreen mode deactivated' ) }
 				/>
 			</MenuGroup>
 		) }

--- a/packages/edit-site/src/components/header/more-menu/index.js
+++ b/packages/edit-site/src/components/header/more-menu/index.js
@@ -35,6 +35,13 @@ const MoreMenu = () => (
 					messageActivated={ __( 'Fullscreen mode activated' ) }
 					messageDeactivated={ __( 'Fullscreen mode deactivated' ) }
 				/>
+				<FeatureToggle
+					feature="focusMode"
+					label={ __( 'Spotlight mode' ) }
+					info={ __( 'Focus on one block at a time' ) }
+					messageActivated={ __( 'Spotlight mode activated' ) }
+					messageDeactivated={ __( 'Spotlight mode deactivated' ) }
+				/>
 			</MenuGroup>
 		) }
 	</DropdownMenu>

--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -10,6 +10,7 @@
 	display: flex;
 	flex-grow: 1;
 	padding-left: $grid-unit-10;
+	align-items: center;
 
 	& > * {
 		margin-left: 5px;
@@ -44,6 +45,63 @@
 
 		.components-icon-button {
 			padding: 8px 4px;
+		}
+	}
+}
+
+// Block toolbar when fixed to the top of the screen.
+.edit-site-header-toolbar__block-toolbar {
+	// Stack toolbar below Editor Bar.
+	position: absolute;
+	top: $header-height + $border-width;
+	left: 0;
+	right: 0;
+	background: $white;
+	border-bottom: $border-width solid $light-gray-500;
+
+	&:empty {
+		display: none;
+	}
+
+	.block-editor-block-toolbar .components-toolbar-group,
+	.block-editor-block-toolbar .components-toolbar {
+		border-top: none;
+		border-bottom: none;
+	}
+
+	.is-sidebar-opened & {
+		display: none;
+	}
+
+	@include break-medium {
+		.is-sidebar-opened & {
+			display: block;
+			right: $sidebar-width;
+		}
+	}
+
+	// Move toolbar into top Editor Bar.
+	@include break-wide {
+		padding-left: $grid-unit-10;
+		position: static;
+		left: auto;
+		right: auto;
+		background: none;
+		border-bottom: none;
+
+		.is-sidebar-opened & {
+			right: auto;
+		}
+
+		.block-editor-block-toolbar {
+			border-left: $border-width solid $light-gray-500;
+		}
+
+		.block-editor-block-toolbar .components-toolbar-group,
+		.block-editor-block-toolbar .components-toolbar {
+			$top-toolbar-padding: ( $header-height - $grid-unit-60 ) / 2;
+			height: $header-height;
+			padding: $top-toolbar-padding 0;
 		}
 	}
 }


### PR DESCRIPTION
## Description
Adds top toolbar feature toggle to the site editor. Mostly copied from edit-post. (related: #22535)

While adding this, I noticed that there are a lot of small margin & style differences between edit-site and edit-post. For example, the inserter button isn't a proper square. Additionally, we are missing most of the mobile styles already coded in edit-post. I think we need to share more code between the two since the requirements for both toolbars are nearly identical. Should that kind of refactor go into the `interface` package?

## How has this been tested?
Locally in edit site

## Screenshots <!-- if applicable -->
<img width="1440" alt="Screen Shot 2020-05-25 at 12 37 01 PM" src="https://user-images.githubusercontent.com/6265975/82839853-9b34f700-9e85-11ea-9fba-4432f8008c26.png">
<img width="1440" alt="Screen Shot 2020-05-25 at 12 37 12 PM" src="https://user-images.githubusercontent.com/6265975/82839861-9d975100-9e85-11ea-9d05-00c7ed507b0a.png">


## Types of changes
new feature

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
