### PR TITLE
Add usePrevious hook to @wordpress/compose package

### DIFF
--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -171,11 +171,11 @@ Based on <https://usehooks.com/usePrevious/>.
 
 _Parameters_
 
--   _value_ `any`: The value to track.
+-   _value_ `T`: The value to track.
 
 _Returns_
 
--   `any`: The value from the previous render.
+-   `T`: The value from the previous render.
 
 <a name="useReducedMotion" href="#useReducedMotion">#</a> **useReducedMotion**
 

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -164,6 +164,19 @@ _Returns_
 
 -   `boolean`: return value of the media query.
 
+<a name="usePrevious" href="#usePrevious">#</a> **usePrevious**
+
+Use something's value from the previous render.
+Based on <https://usehooks.com/usePrevious/>.
+
+_Parameters_
+
+-   _value_ `any`: The value to track.
+
+_Returns_
+
+-   `any`: The value from the previous render.
+
 <a name="useReducedMotion" href="#useReducedMotion">#</a> **useReducedMotion**
 
 Hook returning whether the user has a preference for reduced motion.

--- a/packages/compose/src/hooks/use-previous/README.md
+++ b/packages/compose/src/hooks/use-previous/README.md
@@ -1,0 +1,36 @@
+# usePrevious
+
+Sometimes you need to get the value something had on the previous render. `usePrevious` tracks the value you pass to it using a ref, and returns the previous render's value.
+
+## Usage
+
+```jsx
+/**
+ * WordPress dependencies
+ */
+import { usePrevious } from '@wordpress/compose';
+import { useEffect, useState } from '@wordpress/element';
+
+function MyCustomElement() {
+	const [ myNumber, setMyNumber ] = useState( 5 );
+	const [ lastChange, setLastChange ] = useState( 'none' );
+	const prevNumber = usePrevious( myNumber );
+
+	useEffect( () => {
+		// On the first render, prevNumber will be undefined.
+		if ( prevNumber !== undefined ) {
+			if ( myNumber > prevNumber ) {
+				setLastChange( 'up' );
+			} else if ( myNumber < prevNumber ) {
+				setLastChange( 'down' );
+			}
+		}
+	}, [ myNumber ] );
+
+	return (
+		<p>
+			My number is { myNumber }. Last change: { lastChange }
+		</p>
+	);
+}
+```

--- a/packages/compose/src/hooks/use-previous/index.js
+++ b/packages/compose/src/hooks/use-previous/index.js
@@ -1,0 +1,24 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useRef } from '@wordpress/element';
+
+/**
+ * Use something's value from the previous render.
+ * Based on https://usehooks.com/usePrevious/.
+ *
+ * @param {any} value The value to track.
+ *
+ * @return {any} The value from the previous render.
+ */
+export default function usePrevious( value ) {
+	const ref = useRef();
+
+	// Store current value in ref.
+	useEffect( () => {
+		ref.current = value;
+	}, [ value ] ); // Re-run when value changes.
+
+	// Return previous value (happens before update in useEffect above).
+	return ref.current;
+}

--- a/packages/compose/src/hooks/use-previous/index.js
+++ b/packages/compose/src/hooks/use-previous/index.js
@@ -7,9 +7,11 @@ import { useEffect, useRef } from '@wordpress/element';
  * Use something's value from the previous render.
  * Based on https://usehooks.com/usePrevious/.
  *
- * @param {any} value The value to track.
+ * @template T
  *
- * @return {any} The value from the previous render.
+ * @param {T} value The value to track.
+ *
+ * @return {T} The value from the previous render.
  */
 export default function usePrevious( value ) {
 	const ref = useRef();

--- a/packages/compose/src/index.js
+++ b/packages/compose/src/index.js
@@ -18,6 +18,7 @@ export { default as __experimentalUseDragging } from './hooks/use-dragging';
 export { default as useInstanceId } from './hooks/use-instance-id';
 export { default as useKeyboardShortcut } from './hooks/use-keyboard-shortcut';
 export { default as useMediaQuery } from './hooks/use-media-query';
+export { default as usePrevious } from './hooks/use-previous';
 export { default as useReducedMotion } from './hooks/use-reduced-motion';
 export { default as useViewportMatch } from './hooks/use-viewport-match';
 export { default as useResizeObserver } from './hooks/use-resize-observer';


### PR DESCRIPTION
## Description
Something that React (and by extension, `@wordpress/element`) lacks is a direct equivalent to the `prevProps` value passed to the `componentDidUpdate` lifecycle method. Of course, with the way you implement stuff using hooks, you don't need to get the previous values of props nearly as much anymore.

But in some cases, you still do; I needed to in #21181. Fortunately, this is really quite simple to implement using a custom hook, in this case aptly named `usePrevious`. You pass in a value, and it returns the value from the previous render.

I thought it would be a good idea to make this hook easily available through the `@wordpress/compose` package so other people can use it. I expect it will be quite handy when converting existing class components to function components.

The implementation is copy-pasted from https://usehooks.com/usePrevious/; all code on that site is available under the Unlicense, which essentially commits something to the public domain. So there's no licensing issue, assuming something like this could even be considered copyright-able in the first place.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
