### PR TITLE
Edit Site: Implement post switcher and integrate with "navigate to link".

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10235,6 +10235,7 @@
 			"version": "file:packages/edit-site",
 			"requires": {
 				"@babel/runtime": "^7.9.2",
+				"@wordpress/api-fetch": "file:packages/api-fetch",
 				"@wordpress/block-editor": "file:packages/block-editor",
 				"@wordpress/block-library": "file:packages/block-library",
 				"@wordpress/blocks": "file:packages/blocks",
@@ -10245,6 +10246,7 @@
 				"@wordpress/editor": "file:packages/editor",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/hooks": "file:packages/hooks",
+				"@wordpress/html-entities": "file:packages/html-entities",
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/icons": "file:packages/icons",
 				"@wordpress/interface": "file:packages/interface",

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -22,7 +22,6 @@ import {
 	Fragment,
 	useEffect,
 	createElement,
-	useMemo,
 } from '@wordpress/element';
 import {
 	safeDecodeURI,
@@ -143,6 +142,7 @@ const makeCancelable = ( promise ) => {
  * @property {WPLinkControlValue=}                  value                  Current link value.
  * @property {WPLinkControlOnChangeProp=}           onChange               Value change handler, called with the updated value if
  *                                                                         the user selects a new link or updates settings.
+ * @property {boolean=}                             noDirectEntry          Whether to disable direct entries or not.
  * @property {boolean=}                             showSuggestions        Whether to present suggestions when typing the URL.
  * @property {boolean=}                             showInitialSuggestions Whether to present initial suggestions immediately.
  * @property {WPLinkControlCreateSuggestionProp=}   createSuggestion       Handler to manage creation of link value from suggestion.
@@ -159,6 +159,7 @@ function LinkControl( {
 	value,
 	settings,
 	onChange = noop,
+	noDirectEntry = false,
 	showSuggestions = true,
 	showInitialSuggestions,
 	forceIsEditingLink,
@@ -250,32 +251,34 @@ function LinkControl( {
 		setInputValue( val );
 	};
 
-	const handleDirectEntry = ( val ) => {
-		let type = 'URL';
+	const handleDirectEntry = noDirectEntry
+		? () => Promise.resolve( [] )
+		: ( val ) => {
+				let type = 'URL';
 
-		const protocol = getProtocol( val ) || '';
+				const protocol = getProtocol( val ) || '';
 
-		if ( protocol.includes( 'mailto' ) ) {
-			type = 'mailto';
-		}
+				if ( protocol.includes( 'mailto' ) ) {
+					type = 'mailto';
+				}
 
-		if ( protocol.includes( 'tel' ) ) {
-			type = 'tel';
-		}
+				if ( protocol.includes( 'tel' ) ) {
+					type = 'tel';
+				}
 
-		if ( startsWith( val, '#' ) ) {
-			type = 'internal';
-		}
+				if ( startsWith( val, '#' ) ) {
+					type = 'internal';
+				}
 
-		return Promise.resolve( [
-			{
-				id: val,
-				title: val,
-				url: type === 'URL' ? prependHTTP( val ) : val,
-				type,
-			},
-		] );
-	};
+				return Promise.resolve( [
+					{
+						id: val,
+						title: val,
+						url: type === 'URL' ? prependHTTP( val ) : val,
+						type,
+					},
+				] );
+		  };
 
 	const handleEntitySearch = async ( val, args ) => {
 		let results = await Promise.all( [
@@ -408,7 +411,11 @@ function LinkControl( {
 
 	const handleSelectSuggestion = ( suggestion, _value = {} ) => {
 		setIsEditingLink( false );
-		onChange( { ..._value, ...suggestion } );
+		const __value = { ..._value };
+		// Some direct entries don't have types or IDs, and we still need to clear the previous ones.
+		delete __value.type;
+		delete __value.id;
+		onChange( { ...__value, ...suggestion } );
 	};
 
 	// Render Components
@@ -530,10 +537,6 @@ function LinkControl( {
 		);
 	};
 
-	const viewerSlotFillProps = useMemo(
-		() => ( { url: value && value.url } ),
-		[ value && value.url ]
-	);
 	return (
 		<div
 			tabIndex={ -1 }
@@ -553,7 +556,10 @@ function LinkControl( {
 					onSelect={ async ( suggestion ) => {
 						if ( CREATE_TYPE === suggestion.type ) {
 							await handleOnCreate( inputValue );
-						} else {
+						} else if (
+							! noDirectEntry ||
+							Object.keys( suggestion ).length > 1
+						) {
 							handleSelectSuggestion( suggestion, value );
 							stopEditing();
 						}
@@ -600,7 +606,7 @@ function LinkControl( {
 						>
 							{ __( 'Edit' ) }
 						</Button>
-						<ViewerSlot fillProps={ viewerSlotFillProps } />
+						<ViewerSlot fillProps={ value } />
 					</div>
 				</Fragment>
 			) }

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -156,6 +156,7 @@ const makeCancelable = ( promise ) => {
  * @param {WPLinkControlProps} props Component props.
  */
 function LinkControl( {
+	searchInputPlaceholder,
 	value,
 	settings,
 	onChange = noop,
@@ -551,6 +552,7 @@ function LinkControl( {
 
 			{ ( isEditingLink || ! value ) && ! isResolvingLink && (
 				<LinkControlSearchInput
+					placeholder={ searchInputPlaceholder }
 					value={ inputValue }
 					onChange={ onInputChange }
 					onSelect={ async ( suggestion ) => {

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -12,6 +12,7 @@ import { keyboardReturn } from '@wordpress/icons';
 import { URLInput } from '../';
 
 const LinkControlSearchInput = ( {
+	placeholder,
 	value,
 	onChange,
 	onSelect,
@@ -50,7 +51,7 @@ const LinkControlSearchInput = ( {
 					className="block-editor-link-control__search-input"
 					value={ value }
 					onChange={ selectItemHandler }
-					placeholder={ __( 'Search or type url' ) }
+					placeholder={ placeholder ?? __( 'Search or type url' ) }
 					__experimentalRenderSuggestions={ renderSuggestions }
 					__experimentalFetchLinkSuggestions={ fetchSuggestions }
 					__experimentalHandleURLSuggestions={ true }

--- a/packages/core-data/src/entity-provider.js
+++ b/packages/core-data/src/entity-provider.js
@@ -171,6 +171,7 @@ export function useEntityBlockEditor(
 			const parsedContent = parse( content );
 			return parsedContent.length ? parsedContent : [];
 		}
+		return [];
 	}, [ content ] );
 	const [ blocks = initialBlocks, onInput ] = useEntityProp(
 		kind,

--- a/packages/core-data/src/entity-provider.js
+++ b/packages/core-data/src/entity-provider.js
@@ -5,6 +5,7 @@ import {
 	createContext,
 	useContext,
 	useCallback,
+	useEffect,
 	useMemo,
 } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -156,20 +157,21 @@ export function useEntityBlockEditor(
 	);
 
 	const { editEntityRecord } = useDispatch( 'core' );
-	const initialBlocks = useMemo( () => {
+	useEffect( () => {
 		if ( initialEdits ) {
 			editEntityRecord( kind, type, id, initialEdits, {
 				undoIgnore: true,
 			} );
 		}
-
+	}, [ id ] );
+	const initialBlocks = useMemo( () => {
 		// Guard against other instances that might have
 		// set content to a function already.
-		if ( typeof content !== 'function' ) {
+		if ( content && typeof content !== 'function' ) {
 			const parsedContent = parse( content );
 			return parsedContent.length ? parsedContent : [];
 		}
-	}, [ id ] ); // Reset when the provided entity record changes.
+	}, [ content ] );
 	const [ blocks = initialBlocks, onInput ] = useEntityProp(
 		kind,
 		type,

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -25,6 +25,7 @@
 	],
 	"dependencies": {
 		"@babel/runtime": "^7.9.2",
+		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/block-editor": "file:../block-editor",
 		"@wordpress/block-library": "file:../block-library",
 		"@wordpress/blocks": "file:../blocks",
@@ -35,6 +36,7 @@
 		"@wordpress/editor": "file:../editor",
 		"@wordpress/element": "file:../element",
 		"@wordpress/hooks": "file:../hooks",
+		"@wordpress/html-entities": "file:../html-entities",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/interface": "file:../interface",

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -64,12 +64,12 @@ export default function BlockEditor() {
 		'postType',
 		settings.templateType
 	);
-
-	const setActiveTemplateId = useCallback(
-		( newTemplateId ) =>
+	const setActivePageAndTemplateId = useCallback(
+		( { page, templateId } ) =>
 			setSettings( ( prevSettings ) => ( {
 				...prevSettings,
-				templateId: newTemplateId,
+				page,
+				templateId,
 				templateType: 'wp_template',
 			} ) ),
 		[]
@@ -89,11 +89,13 @@ export default function BlockEditor() {
 					( fillProps ) => (
 						<NavigateToLink
 							{ ...fillProps }
-							activeId={ settings.templateId }
-							onActiveIdChange={ setActiveTemplateId }
+							activePage={ settings.page }
+							onActivePageAndTemplateIdChange={
+								setActivePageAndTemplateId
+							}
 						/>
 					),
-					[ settings.templateId, setActiveTemplateId ]
+					[ settings.page, setActivePageAndTemplateId ]
 				) }
 			</__experimentalLinkControl.ViewerFill>
 			<Sidebar.InspectorFill>

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -96,6 +96,7 @@ export default function Header( {
 					...prevSettings,
 					page: newPage,
 					templateId: newTemplateId,
+					templateType: 'wp_template',
 				} ) );
 			}
 		} catch ( err ) {}

--- a/packages/edit-site/src/components/page-switcher/index.js
+++ b/packages/edit-site/src/components/page-switcher/index.js
@@ -9,6 +9,7 @@ import {
 	MenuItemsChoice,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { __experimentalLinkControl as LinkControl } from '@wordpress/block-editor';
 
 function getPathFromLink( link ) {
 	const path = getPath( link );
@@ -65,21 +66,29 @@ export default function PageSwitcher( {
 		},
 		[ showOnFront ]
 	);
+
 	const onPageSelect = ( newPath ) => {
 		const { value: path, context } = [ ...pages, ...categories ].find(
 			( choice ) => choice.value === newPath
 		);
 		onActivePageChange( { path, context } );
 	};
+	const onPostSelect = ( post ) =>
+		onActivePageChange( {
+			path: getPathFromLink( post.url ),
+			context: { postType: post.type, postId: post.id },
+		} );
 	return (
 		<DropdownMenu
 			icon={ null }
 			label={ __( 'Switch Page' ) }
 			toggleProps={ {
-				children: [ ...pages, ...categories, ...posts ].find(
-					( choice ) => choice.value === activePage.path
-				)?.label,
+				children:
+					[ ...pages, ...categories, ...posts ].find(
+						( choice ) => choice.value === activePage.path
+					)?.label || activePage.path,
 			} }
+			menuProps={ { className: 'edit-site-page-switcher__menu' } }
 		>
 			{ () => (
 				<>
@@ -102,6 +111,12 @@ export default function PageSwitcher( {
 							choices={ posts }
 							value={ activePage.path }
 							onSelect={ onPageSelect }
+						/>
+						<LinkControl
+							onChange={ onPostSelect }
+							settings={ {} }
+							noDirectEntry
+							showInitialSuggestions
 						/>
 					</MenuGroup>
 				</>

--- a/packages/edit-site/src/components/page-switcher/index.js
+++ b/packages/edit-site/src/components/page-switcher/index.js
@@ -113,6 +113,7 @@ export default function PageSwitcher( {
 							onSelect={ onPageSelect }
 						/>
 						<LinkControl
+							searchInputPlaceholder={ __( 'Search for Post' ) }
 							onChange={ onPostSelect }
 							settings={ {} }
 							noDirectEntry

--- a/packages/edit-site/src/components/page-switcher/style.scss
+++ b/packages/edit-site/src/components/page-switcher/style.scss
@@ -1,0 +1,20 @@
+.edit-site-page-switcher__menu {
+	.block-editor-link-control {
+		width: 100%;
+	}
+
+	.block-editor-link-control .block-editor-link-control__search-input.block-editor-link-control__search-input input[type="text"] {
+		margin-left: 0;
+		margin-right: 0;
+		width: 100%;
+	}
+
+	.block-editor-link-control__search-actions {
+		right: 3px;
+	}
+
+	.block-editor-link-control__settings {
+		padding-left: 0;
+		padding-right: 0;
+	}
+}

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -1,6 +1,10 @@
 /**
  * WordPress dependencies
  */
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
+import { decodeEntities } from '@wordpress/html-entities';
+import { __ } from '@wordpress/i18n';
 import '@wordpress/notices';
 import {
 	registerCoreBlocks,
@@ -16,6 +20,23 @@ import './hooks';
 import './store';
 import Editor from './components/editor';
 
+const fetchLinkSuggestions = ( search, { perPage = 20 } = {} ) =>
+	apiFetch( {
+		path: addQueryArgs( '/wp/v2/search', {
+			per_page: perPage,
+			search,
+			type: 'post',
+			subtype: 'post',
+		} ),
+	} ).then( ( posts ) =>
+		posts.map( ( post ) => ( {
+			url: post.url,
+			type: post.subtype || post.type,
+			id: post.id,
+			title: decodeEntities( post.title ) || __( '(no title)' ),
+		} ) )
+	);
+
 /**
  * Initializes the site editor screen.
  *
@@ -27,6 +48,7 @@ export function initialize( id, settings ) {
 	if ( process.env.GUTENBERG_PHASE === 2 ) {
 		__experimentalRegisterExperimentalCoreBlocks( settings );
 	}
+	settings.__experimentalFetchLinkSuggestions = fetchLinkSuggestions;
 	render( <Editor settings={ settings } />, document.getElementById( id ) );
 }
 

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -5,6 +5,7 @@
 @import "./components/header/fullscreen-mode-close/style.scss";
 @import "./components/header/more-menu/style.scss";
 @import "./components/notices/style.scss";
+@import "./components/page-switcher/style.scss";
 @import "./components/sidebar/style.scss";
 @import "./components/template-switcher/style.scss";
 @import "./components/editor/style.scss";

--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -34,6 +34,8 @@ export const link = {
 	className: null,
 	attributes: {
 		url: 'href',
+		type: 'data-type',
+		id: 'data-id',
 		target: 'target',
 	},
 	__unstablePasteRule( value, { html, plainText } ) {

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -80,6 +80,8 @@ function InlineLinkUI( {
 
 	const linkValue = {
 		url: activeAttributes.url,
+		type: activeAttributes.type,
+		id: activeAttributes.id,
 		opensInNewTab: activeAttributes.target === '_blank',
 		...nextLinkValue,
 	};
@@ -115,6 +117,8 @@ function InlineLinkUI( {
 		const newUrl = prependHTTP( nextValue.url );
 		const format = createLinkFormat( {
 			url: newUrl,
+			type: nextValue.type,
+			id: nextValue.type ?? String( nextValue.id ),
 			opensInNewWindow: nextValue.opensInNewTab,
 		} );
 

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -118,7 +118,10 @@ function InlineLinkUI( {
 		const format = createLinkFormat( {
 			url: newUrl,
 			type: nextValue.type,
-			id: nextValue.type ?? String( nextValue.id ),
+			id:
+				nextValue.id !== undefined && nextValue.id !== null
+					? String( nextValue.id )
+					: undefined,
 			opensInNewWindow: nextValue.opensInNewTab,
 		} );
 

--- a/packages/format-library/src/link/utils.js
+++ b/packages/format-library/src/link/utils.js
@@ -99,10 +99,11 @@ export function createLinkFormat( { url, type, id, opensInNewWindow } ) {
 		type: 'core/link',
 		attributes: {
 			url,
-			type,
-			id,
 		},
 	};
+
+	if ( type ) format.attributes.type = type;
+	if ( id ) format.attributes.type = id;
 
 	if ( opensInNewWindow ) {
 		format.attributes.target = '_blank';

--- a/packages/format-library/src/link/utils.js
+++ b/packages/format-library/src/link/utils.js
@@ -87,16 +87,20 @@ export function isValidHref( href ) {
  *
  * @param {Object}  options
  * @param {string}  options.url              The href of the link.
+ * @param {string}  options.type             The type of the link.
+ * @param {string}  options.id               The ID of the link.
  * @param {boolean} options.opensInNewWindow Whether this link will open in a new window.
  * @param {Object}  options.text             The text that is being hyperlinked.
  *
  * @return {Object} The final format object.
  */
-export function createLinkFormat( { url, opensInNewWindow } ) {
+export function createLinkFormat( { url, type, id, opensInNewWindow } ) {
 	const format = {
 		type: 'core/link',
 		attributes: {
 			url,
+			type,
+			id,
 		},
 	};
 


### PR DESCRIPTION
## Description

This PR adds a post picker to the page switcher in the site editor that allows you to load a specific post and its template. For this, a minor modification was made to `LinkControl` to allow disabling direct/custom entries as these wouldn't make sense in this context unless we decide to support creating new posts here in the future.

This PR also integrates this new functionality with the "navigate to link" functionality by adding support for link types and IDs to the inline link format.

This PR also fixes a small issue that these new features surfaced in the site editor when `useEntityBlockEditor` tries to parse initial content for an entity that is still loading.

## How has this been tested?

It was verified that navigating to a post either from the page switcher or from an inline link, as shown in the GIF below, works as expected.

## Screenshots

![gif](https://user-images.githubusercontent.com/19157096/82620785-3bd99d00-9b8e-11ea-8225-477b137c647a.gif)

## Types of Changes

*New Feature*: The site editor now has a post picker in the page switcher that is integrated with the "navigate to link" functionality.
*New Feature*: `LinkControl` now supports a prop for disabling direct/custom entries.
*New Feature*: The inline link format now tracks link types and IDs.
*Bug Fix:* `useEntityBlockEditor` now works as expected with entities that are not loaded yet.

## Checklist:

- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->