### PR TITLE
Mousetrap: update to latest stable version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10005,8 +10005,15 @@
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"clipboard": "^2.0.1",
 				"lodash": "^4.17.15",
-				"mousetrap": "^1.6.2",
+				"mousetrap": "^1.6.5",
 				"react-resize-aware": "^3.0.0"
+			},
+			"dependencies": {
+				"mousetrap": {
+					"version": "1.6.5",
+					"resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.5.tgz",
+					"integrity": "sha512-QNo4kEepaIBwiT8CDhP98umTetp+JNfQYBWvC1pc6/OAibuXtRcxZ58Qz8skvEHYvURne/7R8T5VoOI7rDsEUA=="
+				}
 			}
 		},
 		"@wordpress/core-data": {
@@ -31289,11 +31296,6 @@
 					}
 				}
 			}
-		},
-		"mousetrap": {
-			"version": "1.6.2",
-			"resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.2.tgz",
-			"integrity": "sha512-jDjhi7wlHwdO6q6DS7YRmSHcuI+RVxadBkLt3KHrhd3C2b+w5pKefg3oj5beTcHZyVFA9Aksf+yEE1y5jxUjVA=="
 		},
 		"move-concurrently": {
 			"version": "1.0.1",

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -28,7 +28,7 @@
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"clipboard": "^2.0.1",
 		"lodash": "^4.17.15",
-		"mousetrap": "^1.6.2",
+		"mousetrap": "^1.6.5",
 		"react-resize-aware": "^3.0.0"
 	},
 	"publishConfig": {


### PR DESCRIPTION
## Description

This PR upgrades the `Mousetrap` dependency on `@wordpress/compose` to the latest stable version, `1.6.5`:
https://github.com/ccampbell/mousetrap/releases

Those changes, while not directly impacting Gutenberg, include fixes that are useful for third-party applications that may rely on `Mousetrap` as well.

Related PR here in Gutenberg: #16227 

## How has this been tested?

1. Check overall behaviour of the plugin.

## Types of changes
- dependency update
