### PR TITLE
[Mobile] Link to existing content - RN UI implementation - (iOS only for now)

### DIFF
--- a/packages/components/src/mobile/bottom-sheet/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet/index.native.js
@@ -34,6 +34,7 @@ import PickerCell from './picker-cell';
 import SwitchCell from './switch-cell';
 import RangeCell from './range-cell';
 import ColorCell from './color-cell';
+import LinkCell from './link-cell';
 import KeyboardAvoidingView from './keyboard-avoiding-view';
 import { BottomSheetProvider } from './bottom-sheet-context';
 
@@ -424,5 +425,6 @@ ThemedBottomSheet.PickerCell = PickerCell;
 ThemedBottomSheet.SwitchCell = SwitchCell;
 ThemedBottomSheet.RangeCell = RangeCell;
 ThemedBottomSheet.ColorCell = ColorCell;
+ThemedBottomSheet.LinkCell = LinkCell;
 
 export default ThemedBottomSheet;

--- a/packages/components/src/mobile/bottom-sheet/link-cell/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet/link-cell/index.native.js
@@ -1,0 +1,41 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Platform } from '@wordpress/element';
+import { link } from '@wordpress/icons';
+import { withPreferredColorScheme } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import Cell from '../cell';
+import LinkPickerResults from './link-picker-results';
+
+function LinkCell( { value, onChangeValue, onSubmit, onLinkPicked } ) {
+	return (
+		<>
+			<Cell
+				icon={ link }
+				label={ __( 'URL' ) }
+				value={ value }
+				placeholder={ __( 'Add URL' ) }
+				autoCapitalize="none"
+				autoCorrect={ false }
+				keyboardType="url"
+				onChangeValue={ onChangeValue }
+				onSubmit={ onSubmit }
+				/* eslint-disable-next-line jsx-a11y/no-autofocus */
+				autoFocus={ Platform.OS === 'ios' }
+			/>
+			{ !! value && (
+				<LinkPickerResults
+					query={ value }
+					onLinkPicked={ onLinkPicked }
+				/>
+			) }
+		</>
+	);
+}
+
+export default withPreferredColorScheme( LinkCell );

--- a/packages/components/src/mobile/bottom-sheet/link-cell/link-picker-results.native.js
+++ b/packages/components/src/mobile/bottom-sheet/link-cell/link-picker-results.native.js
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import { FlatList } from 'react-native';
+import { requestLinks } from 'react-native-gutenberg-bridge';
+
+/**
+ * WordPress dependencies
+ */
+import { useState, useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import Cell from '../cell';
+
+export default function LinkPickerResults( { query, onLinkPicked } ) {
+	const [ links, setLinks ] = useState( [] );
+
+	useEffect( () => {
+		requestLinks( query, ( newLinks ) => {
+			setLinks( newLinks );
+		} );
+	}, [ query ] );
+
+	return (
+		<FlatList
+			data={ links }
+			keyboardShouldPersistTaps="always"
+			style={ { maxHeight: 250 } }
+			renderItem={ ( { item: { url, title } } ) => (
+				<Cell
+					label={ title }
+					onPress={ () => onLinkPicked( { url, title } ) }
+				/>
+			) }
+			keyExtractor={ ( { url } ) => url }
+		/>
+	);
+}

--- a/packages/format-library/src/link/modal.native.js
+++ b/packages/format-library/src/link/modal.native.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import { Platform } from 'react-native';
 
 /**
  * WordPress dependencies
@@ -19,7 +18,7 @@ import {
 	getTextContent,
 	slice,
 } from '@wordpress/rich-text';
-import { external, link, textColor } from '@wordpress/icons';
+import { external, textColor } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -40,6 +39,7 @@ class ModalLinkUI extends Component {
 		);
 		this.removeLink = this.removeLink.bind( this );
 		this.onDismiss = this.onDismiss.bind( this );
+		this.onLinkPicked = this.onLinkPicked.bind( this );
 
 		this.state = {
 			inputValue: '',
@@ -71,6 +71,10 @@ class ModalLinkUI extends Component {
 
 	onChangeText( text ) {
 		this.setState( { text } );
+	}
+
+	onLinkPicked( { url: inputValue, title: text } ) {
+		this.setState( { inputValue, text } );
 	}
 
 	onChangeOpensInNewWindow( opensInNewWindow ) {
@@ -158,22 +162,11 @@ class ModalLinkUI extends Component {
 				onClose={ this.onDismiss }
 				hideHeader
 			>
-				{
-					/* eslint-disable jsx-a11y/no-autofocus */
-					<BottomSheet.Cell
-						icon={ link }
-						label={ __( 'URL' ) }
-						value={ this.state.inputValue }
-						placeholder={ __( 'Add URL' ) }
-						autoCapitalize="none"
-						autoCorrect={ false }
-						keyboardType="url"
-						onChangeValue={ this.onChangeInputValue }
-						onSubmit={ this.onDismiss }
-						autoFocus={ Platform.OS === 'ios' }
-					/>
-					/* eslint-enable jsx-a11y/no-autofocus */
-				}
+				<BottomSheet.LinkCell
+					value={ this.state.inputValue }
+					onChangeValue={ this.onChangeInputValue }
+					onLinkPicked={ this.onLinkPicked }
+				/>
 				<BottomSheet.Cell
 					icon={ textColor }
 					label={ __( 'Link text' ) }


### PR DESCRIPTION
## Description
This PR adds an existing content picker and refactors the link editing modal to utilize it. This is part of the work to address this issue: https://github.com/wordpress-mobile/gutenberg-mobile/issues/2194.

This version uses a React Native implementation for the search / picker UI.

## How has this been tested?
This has been tested by editing and creating new links within a paragraph block, and selecting the picker from the URL field in the bottomsheet modal.

## Screenshots <!-- if applicable -->
tbd

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
