### PR TITLE
Storybook: Use a consistent port number

### DIFF
--- a/package.json
+++ b/package.json
@@ -241,7 +241,7 @@
 		"prestorybook:build": "npm run build:packages",
 		"storybook:build": "build-storybook -c ./storybook -o ./playground/dist",
 		"prestorybook:dev": "npm run build:packages",
-		"storybook:dev": "concurrently \"npm run dev:packages\" \"start-storybook -c ./storybook\"",
+		"storybook:dev": "concurrently \"npm run dev:packages\" \"start-storybook -c ./storybook -p 50240\"",
 		"design-system:build": "echo \"Please use storybook:build instead.\"",
 		"design-system:dev": "echo \"Please use storybook:dev instead.\"",
 		"playground:build": "npm run storybook:build",


### PR DESCRIPTION
This update modifies the storybook:dev script to ensure that the Storybook
dev environment uses a consistent port number (50240 - chosen at random).

This helps streamline the Storybook dev workflow, especially if someone
needs to switch branches and re-launch the dev environment multiple times
per day.

Storybook's CLI configs can be found here:
https://storybook.js.org/docs/configurations/cli-options/

## How has this been tested?

Tested locally in storybook

* Run `npm run storybook:dev`
* Ensure that it opens at `http://localhost:50240/?path=/story/*`
