### PR TITLE
Link Control: Fix search result focus state border

### DIFF
--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -135,6 +135,11 @@ $block-editor-link-control-number-of-actions: 1;
 		background-color: $light-gray-300;
 	}
 
+	// The added specificity is needed to override.
+	&:focus:not(:disabled) {
+		box-shadow: 0 0 0 $border-width-focus $theme-color inset;
+	}
+
 	&.is-selected {
 		background: $light-gray-200;
 


### PR DESCRIPTION
Currently, the `:focus` state for the search results when adding a link show's a border that is cut off:

<img width="377" alt="Screen Shot 2020-05-22 at 10 58 22 AM" src="https://user-images.githubusercontent.com/191598/82681574-fbc0fb80-9c1b-11ea-8091-44edc77a35ca.png">

To fix this, I overrode the default `:focus` styling for the button component to use an `inset` box-shadow:

 
<img width="380" alt="Screen Shot 2020-05-22 at 10 58 09 AM" src="https://user-images.githubusercontent.com/191598/82681625-0ed3cb80-9c1c-11ea-8206-b3ddc5dbabc6.png">
