### PR TITLE
Env: ensure correct port setting on related wp-config params

### DIFF
--- a/packages/env/lib/wordpress.js
+++ b/packages/env/lib/wordpress.js
@@ -91,10 +91,10 @@ async function configureWordPress( environment, config ) {
 	);
 
 	// Set wp-config.php values.
-	for ( const [ key, value ] of Object.entries( config.config ) ) {
+	for ( let [ key, value ] of Object.entries( config.config ) ) {
 		// Ensure correct port setting from config when configure WP urls.
-		if (key === 'WP_SITEURL' || key === 'WP_HOME') {
-			const url = new URL(value);
+		if ( key === 'WP_SITEURL' || key === 'WP_HOME' ) {
+			const url = new URL( value );
 			url.port = port;
 			value = url.toString();
 		}

--- a/packages/env/lib/wordpress.js
+++ b/packages/env/lib/wordpress.js
@@ -94,7 +94,7 @@ async function configureWordPress( environment, config ) {
 	for ( const [ key, value ] of Object.entries( config.config ) ) {
 		if (key === 'WP_SITEURL' || key === 'WP_HOME') {
 			const url = new URL(value);
-            url.port = port;
+			url.port = port;
 			value = url.toString();
 		}
 		const command = [ 'wp', 'config', 'set', key, value ];

--- a/packages/env/lib/wordpress.js
+++ b/packages/env/lib/wordpress.js
@@ -92,6 +92,11 @@ async function configureWordPress( environment, config ) {
 
 	// Set wp-config.php values.
 	for ( const [ key, value ] of Object.entries( config.config ) ) {
+		if (key === 'WP_SITEURL' || key === 'WP_HOME') {
+			const url = new URL(value);
+            url.port = port;
+			value = url.toString();
+		}
 		const command = [ 'wp', 'config', 'set', key, value ];
 		if ( typeof value !== 'string' ) {
 			command.push( '--raw' );

--- a/packages/env/lib/wordpress.js
+++ b/packages/env/lib/wordpress.js
@@ -92,6 +92,7 @@ async function configureWordPress( environment, config ) {
 
 	// Set wp-config.php values.
 	for ( const [ key, value ] of Object.entries( config.config ) ) {
+		// Ensure correct port setting from config when configure WP urls.
 		if (key === 'WP_SITEURL' || key === 'WP_HOME') {
 			const url = new URL(value);
 			url.port = port;


### PR DESCRIPTION
## Description

Hi, I like the usage of wp-env for setting up a development environment for WordPress.
I recogniced when I configure WP_HOME and/or WP_SITEURL as property in the config prop of .wp-env.json or .wp-env.override.json the setting is not correctly propagated to the resulting wp-config.php.

That is because the port property setting in .wp-env.json or .wp-env.override.json is independend from WP_HOME and WP_SITEURL configuration but needs to be merged in the resulting parameters injected in wp-config.php.

I added a code block in env/lib/wordpress.js which modifies the value given to the docker-compose command so that the correct port setting is ensured.

## How has this been tested?
All existing tests pass. Beside this it is an open question for me right now. Maybe I have not yet fully understood how the testing environment is used testing the wp-env stuff. There are no tests for setting wp-config.php config items right now as far as I can see. If you have any advice I would appreciate it.

I just tested by running the setup scripts and checking the resulting dev environment.

Example of test setup:
.wp-env.json:
```
{
  "port": 8888,
  "testsPort": 8889,
  "config": {
    "WP_DEBUG": true,
    "SCRIPT_DEBUG": true,
  }
}
```
.wp-env.overide.json:
```
{
  "config": {
    "WP_HOME": "http://test-on-internal-network.com/",
    "WP_SITEURL": "http://test-on-internal-network.com/",
    "WP_DEBUG": true,
    "SCRIPT_DEBUG": true,
  }
}
```

Expected for WordPress in wp-config.php
```
  ...
  define( 'WP_SITEURL', 'http://test-on-internal-network.com:8888/' );
  define( 'WP_HOME', 'http://test-on-internal-network.com:8888/' );
  ...
```

Expected for tests-WordPress in wp-config.php
```
  ...
  define( 'WP_SITEURL', 'http://test-on-internal-network.com:8889/' );
  define( 'WP_HOME', 'http://test-on-internal-network.com:8889/' );
  ...
```

but originally for both got
```
  ...
  define( 'WP_SITEURL', 'http://test-on-internal-network.com/' );
  define( 'WP_HOME', 'http://test-on-internal-network.com/' );
  ...
```

## Types of changes

Bug fix

## Checklist:
- [x] My code is tested (by hand).
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
