### PR TITLE
Block Library: Remove redundant condition from setting default grouping

### DIFF
--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -165,10 +165,7 @@ export const registerCoreBlocks = () => {
 		setFreeformContentHandlerName( classic.name );
 	}
 	setUnregisteredTypeHandlerName( missing.name );
-
-	if ( group ) {
-		setGroupingBlockName( group.name );
-	}
+	setGroupingBlockName( group.name );
 };
 
 /**


### PR DESCRIPTION
Previously: https://github.com/WordPress/gutenberg/pull/15774#discussion_r297209525

This pull request seeks to remove a redundant condition which checks for truthiness of the `group` imported variable before assigning it as the default grouping handler block. There is no case in which the resolved `import` assigning the `group` variable could ever be falsey. As such, the condition should be removed, as it will always match.

**Testing Instructions:**

Repeat testing instructions from #15774