### PR TITLE
Project Management Automation: Reorganize folder structure

### DIFF
--- a/packages/project-management-automation/README.md
+++ b/packages/project-management-automation/README.md
@@ -2,9 +2,9 @@
 
 This is a [GitHub Action](https://help.github.com/en/categories/automating-your-workflow-with-github-actions) which contains various automation to assist with managing the Gutenberg GitHub repository:
 
-- `first-time-contributor`: Adds the 'First Time Contributor' label to PRs merged on behalf of contributors that have not previously made a contribution, and prompts the user to link their GitHub account to their WordPress.org profile if neccessary for props credit.
-- `add-milestone`: Assigns the correct milestone to PRs once merged.
-- `assign-fixed-issues`: Assigns any issues 'fixed' by a newly opened PR to the author of that PR.
+- [First Time Contributor](./lib/tasks/first-time-contributor): Adds the "First Time Contributor" label to pull requests merged on behalf of contributors that have not previously made a contribution, and prompts the user to link their GitHub account to their WordPress.org profile if necessary for release notes credit.
+- [Add Milestone](./lib/tasks/add-milestone): Assigns the plugin release milestone to a pull request once it is merged.
+- [Assign Fixed Issues](./lib/tasks/assign-fixed-issues): Adds assignee for issues which are marked to be "Fixed" by a pull request, and adds the "In Progress" label.
 
 # Installation and usage
 

--- a/packages/project-management-automation/README.md
+++ b/packages/project-management-automation/README.md
@@ -2,9 +2,9 @@
 
 This is a [GitHub Action](https://help.github.com/en/categories/automating-your-workflow-with-github-actions) which contains various automation to assist with managing the Gutenberg GitHub repository:
 
-- [First Time Contributor](./lib/tasks/first-time-contributor): Adds the "First Time Contributor" label to pull requests merged on behalf of contributors that have not previously made a contribution, and prompts the user to link their GitHub account to their WordPress.org profile if necessary for release notes credit.
-- [Add Milestone](./lib/tasks/add-milestone): Assigns the plugin release milestone to a pull request once it is merged.
-- [Assign Fixed Issues](./lib/tasks/assign-fixed-issues): Adds assignee for issues which are marked to be "Fixed" by a pull request, and adds the "In Progress" label.
+- [First Time Contributor](https://github.com/WordPress/gutenberg/tree/master/packages/project-management-automation/lib/tasks/first-time-contributor): Adds the "First Time Contributor" label to pull requests merged on behalf of contributors that have not previously made a contribution, and prompts the user to link their GitHub account to their WordPress.org profile if necessary for release notes credit.
+- [Add Milestone](https://github.com/WordPress/gutenberg/tree/master/packages/project-management-automation/lib/tasks/add-milestone): Assigns the plugin release milestone to a pull request once it is merged.
+- [Assign Fixed Issues](https://github.com/WordPress/gutenberg/tree/master/packages/project-management-automation/lib/tasks/assign-fixed-issues): Adds assignee for issues which are marked to be "Fixed" by a pull request, and adds the "In Progress" label.
 
 # Installation and usage
 

--- a/packages/project-management-automation/lib/index.js
+++ b/packages/project-management-automation/lib/index.js
@@ -7,9 +7,9 @@ const { context, GitHub } = require( '@actions/github' );
 /**
  * Internal dependencies
  */
-const assignFixedIssues = require( './assign-fixed-issues' );
-const firstTimeContributor = require( './first-time-contributor' );
-const addMilestone = require( './add-milestone' );
+const assignFixedIssues = require( './tasks/assign-fixed-issues' );
+const firstTimeContributor = require( './tasks/first-time-contributor' );
+const addMilestone = require( './tasks/add-milestone' );
 const debug = require( './debug' );
 const ifNotFork = require( './if-not-fork' );
 

--- a/packages/project-management-automation/lib/tasks/add-milestone/README.md
+++ b/packages/project-management-automation/lib/tasks/add-milestone/README.md
@@ -1,0 +1,12 @@
+Add Milestone
+===
+
+Assigns the plugin release milestone to a pull request once it is merged.
+
+Creates the milestone if it does not yet exist.
+
+## Rationale
+
+If a pull request is merged, it can be difficult to know which upcoming or past plugin version that change would be included within. This is useful for debugging if a change should be expected to be available for testing, and to know if a change should be anticipated to be released within an upcoming release of the plugin.
+
+It is also used in automation associated with [release changelogs](https://github.com/WordPress/gutenberg/blob/master/docs/contributors/release.md#writing-the-release-post-and-changelog), which aggregate pull requests based on the assigned milestone.

--- a/packages/project-management-automation/lib/tasks/add-milestone/index.js
+++ b/packages/project-management-automation/lib/tasks/add-milestone/index.js
@@ -1,8 +1,8 @@
 /**
  * Internal dependencies
  */
-const debug = require( './debug' );
-const getAssociatedPullRequest = require( './get-associated-pull-request' );
+const debug = require( '../../debug' );
+const getAssociatedPullRequest = require( '../../get-associated-pull-request' );
 
 /** @typedef {import('@octokit/rest').HookError} HookError */
 /** @typedef {import('@actions/github').GitHub} GitHub */

--- a/packages/project-management-automation/lib/tasks/add-milestone/test/index.js
+++ b/packages/project-management-automation/lib/tasks/add-milestone/test/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import addMilestone from '../add-milestone';
+import addMilestone from '../';
 
 describe( 'addMilestone', () => {
 	it( 'does nothing if base is not master', async () => {

--- a/packages/project-management-automation/lib/tasks/assign-fixed-issues/README.md
+++ b/packages/project-management-automation/lib/tasks/assign-fixed-issues/README.md
@@ -1,0 +1,10 @@
+Assign Fixed Issues
+===
+
+Adds assignee for issues which are marked to be "Fixed" by a pull request, and adds the "In Progress" label.
+
+## Rationale
+
+For users who would be affected by an issue (including the issue's creator), it is useful to receive progress updates once efforts have begun to address the issue.
+
+[Issue assignment](https://help.github.com/en/github/managing-your-work-on-github/assigning-issues-and-pull-requests-to-other-github-users) is a useful GitHub feature for developers, as it can avoid a scenario where multiple developers spend effort toward resolving the same issue due to the fact that progress was not clearly communicated.

--- a/packages/project-management-automation/lib/tasks/assign-fixed-issues/index.js
+++ b/packages/project-management-automation/lib/tasks/assign-fixed-issues/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-const debug = require( './debug' );
+const debug = require( '../../debug' );
 
 /** @typedef {import('@actions/github').GitHub} GitHub */
 /** @typedef {import('@octokit/webhooks').WebhookPayloadPullRequest} WebhookPayloadPullRequest */

--- a/packages/project-management-automation/lib/tasks/assign-fixed-issues/test/index.js
+++ b/packages/project-management-automation/lib/tasks/assign-fixed-issues/test/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import assignFixedIssues from '../assign-fixed-issues';
+import assignFixedIssues from '../';
 
 describe( 'assignFixedIssues', () => {
 	it( 'does nothing if there are no fixed issues', async () => {

--- a/packages/project-management-automation/lib/tasks/first-time-contributor/README.md
+++ b/packages/project-management-automation/lib/tasks/first-time-contributor/README.md
@@ -1,0 +1,12 @@
+First Time Contributor
+===
+
+Adds the "First Time Contributor" label to pull requests merged on behalf of contributors that have not previously made a contribution, and prompts the user to link their GitHub account to their WordPress.org profile if necessary for release notes credit.
+
+## Rationale
+
+A person's first contribution to the project is an exciting moment worth celebrating.
+
+Rate of new contributorship can be a potential metric of a project's open-source health.
+
+Compiling credits for release notes of a WordPress release [requires that a person's WordPress.org profile can be associated with a GitHub account](https://make.wordpress.org/core/2020/03/19/associating-github-accounts-with-wordpress-org-profiles/). This is not an obvious requirement for new contributors, and it should be brought to their attention at the earliest opportunity in their contributing journey.

--- a/packages/project-management-automation/lib/tasks/first-time-contributor/index.js
+++ b/packages/project-management-automation/lib/tasks/first-time-contributor/index.js
@@ -1,13 +1,13 @@
 /**
  * Internal dependencies
  */
-const debug = require( './debug' );
-const getAssociatedPullRequest = require( './get-associated-pull-request' );
-const hasWordPressProfile = require( './has-wordpress-profile' );
+const debug = require( '../../debug' );
+const getAssociatedPullRequest = require( '../../get-associated-pull-request' );
+const hasWordPressProfile = require( '../../has-wordpress-profile' );
 
 /** @typedef {import('@actions/github').GitHub} GitHub */
 /** @typedef {import('@octokit/webhooks').WebhookPayloadPush} WebhookPayloadPush */
-/** @typedef {import('./get-associated-pull-request').WebhookPayloadPushCommit} WebhookPayloadPushCommit */
+/** @typedef {import('../../get-associated-pull-request').WebhookPayloadPushCommit} WebhookPayloadPushCommit */
 
 /**
  * Returns the message text to be used for the comment prompting contributor to

--- a/packages/project-management-automation/lib/tasks/first-time-contributor/test/index.js
+++ b/packages/project-management-automation/lib/tasks/first-time-contributor/test/index.js
@@ -1,10 +1,10 @@
 /**
  * Internal dependencies
  */
-import firstTimeContributor from '../first-time-contributor';
-import hasWordPressProfile from '../has-wordpress-profile';
+import firstTimeContributor from '../';
+import hasWordPressProfile from '../../../has-wordpress-profile';
 
-jest.mock( '../has-wordpress-profile', () => jest.fn() );
+jest.mock( '../../../has-wordpress-profile', () => jest.fn() );
 
 describe( 'firstTimeContributor', () => {
 	beforeEach( () => {


### PR DESCRIPTION
This pull request seeks to reorganize some files within the `@wordpress/project-management-automation` package. The file structure of this package has not scaled very well, and currently its `lib/` directory stands as an unorganized assortment of files of various responsibilities (both utilities and tasks). The changes here seek to introduce a new `lib/tasks` folder to contain the implementations of individual tasks. A secondary goal of these changes is to accommodate a `README.md` file per task, for the purpose of expanding upon the purpose of a task (task description, rationale, history, related links, etc). I've included new rationale descriptions for each of the current tasks.

**Testing Instructions:**

Ensure unit tests pass:

```
npm run test-unit packages/project-management-automation
```