### PR TITLE
Try: removing the multi-block type check to make __experimentalConvert more useful

### DIFF
--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -285,23 +285,6 @@ export const isContainerGroupBlock = ( name ) =>
 	name === getGroupingBlockName();
 
 /**
- * Determines whether the provided Blocks are of the same type
- * (eg: all `core/paragraph`).
- *
- * @param  {Array}  blocksArray the Block definitions
- *
- * @return {boolean} whether or not the given Blocks pass the criteria
- */
-export const isBlockSelectionOfSameType = ( blocksArray = [] ) => {
-	if ( ! blocksArray.length ) {
-		return false;
-	}
-	const sourceName = blocksArray[ 0 ].name;
-
-	return every( blocksArray, [ 'name', sourceName ] );
-};
-
-/**
  * Returns an array of block types that the set of blocks received as argument
  * can be transformed into.
  *

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -407,17 +407,6 @@ export function switchToBlockType( blocks, name ) {
 	const firstBlock = blocksArray[ 0 ];
 	const sourceName = firstBlock.name;
 
-	// Unless it's a Grouping Block then for multi block selections
-	// check that all Blocks are of the same type otherwise
-	// we can't run a conversion
-	if (
-		! isContainerGroupBlock( name ) &&
-		isMultiBlock &&
-		! isBlockSelectionOfSameType( blocksArray )
-	) {
-		return null;
-	}
-
 	// Find the right transformation by giving priority to the "to"
 	// transformation.
 	const transformationsFrom = getBlockTransforms( 'from', name );

--- a/packages/blocks/src/api/test/factory.js
+++ b/packages/blocks/src/api/test/factory.js
@@ -16,7 +16,6 @@ import {
 	findTransform,
 	isWildcardBlockTransform,
 	isContainerGroupBlock,
-	isBlockSelectionOfSameType,
 } from '../factory';
 import {
 	getBlockType,
@@ -1826,49 +1825,6 @@ describe( 'block factory', () => {
 		it( 'should return false when passed block name does not match the registered "Grouping" Block', () => {
 			setGroupingBlockName( 'registered-grouping-block' );
 			expect( isContainerGroupBlock( 'core/group' ) ).toBe( false );
-		} );
-	} );
-
-	describe( 'isBlockSelectionOfSameType', () => {
-		it( 'should return false when all blocks do not match the name of the first block', () => {
-			const blocks = [
-				{
-					name: 'core/test-block',
-				},
-				{
-					name: 'core/test-block',
-				},
-				{
-					name: 'core/test-block',
-				},
-				{
-					name: 'core/another-block',
-				},
-				{
-					name: 'core/test-block',
-				},
-			];
-
-			expect( isBlockSelectionOfSameType( blocks ) ).toBe( false );
-		} );
-
-		it( 'should return true when all blocks match the name of the first block', () => {
-			const blocks = [
-				{
-					name: 'core/test-block',
-				},
-				{
-					name: 'core/test-block',
-				},
-				{
-					name: 'core/test-block',
-				},
-				{
-					name: 'core/test-block',
-				},
-			];
-
-			expect( isBlockSelectionOfSameType( blocks ) ).toBe( true );
 		} );
 	} );
 } );

--- a/packages/blocks/src/api/test/factory.js
+++ b/packages/blocks/src/api/test/factory.js
@@ -1558,6 +1558,182 @@ describe( 'block factory', () => {
 			);
 		} );
 
+		it( 'should call "__experimentalConvert" with mixed block types and wildcard', () => {
+			const convertSpy = jest.fn( ( blocks ) => {
+				const groupInnerBlocks = blocks.map(
+					( { name, attributes, innerBlocks } ) => {
+						return createBlock( name, attributes, innerBlocks );
+					}
+				);
+
+				return createBlock(
+					'core/test-group-block',
+					{},
+					groupInnerBlocks
+				);
+			} );
+			const transformSpy = jest.fn();
+
+			registerBlockType( 'core/test-group-block', {
+				attributes: {
+					value: {
+						type: 'string',
+					},
+				},
+				transforms: {
+					from: [
+						{
+							type: 'block',
+							blocks: [ '*' ],
+							isMultiBlock: true,
+							__experimentalConvert: convertSpy,
+							transform: transformSpy,
+						},
+					],
+				},
+				save: noop,
+				category: 'text',
+				title: 'Test Group Block',
+			} );
+
+			registerBlockType( 'core/text-block', defaultBlockSettings );
+			registerBlockType( 'core/image-block', defaultBlockSettings );
+
+			const numOfBlocksToGroup = 4;
+			const blocks = times( numOfBlocksToGroup, ( index ) => {
+				return createBlock(
+					index % 2 ? 'core/text-block' : 'core/image-block',
+					{
+						value: `block-value-${ index + 1 }`,
+					} );
+			} );
+
+			const transformedBlocks = switchToBlockType(
+				blocks,
+				'core/test-group-block'
+			);
+
+			expect( transformedBlocks ).toHaveLength( 1 );
+			expect( convertSpy.mock.calls ).toHaveLength( 1 );
+			expect( transformSpy.mock.calls ).toHaveLength( 0 );
+		} );
+
+		it( 'should call "__experimentalConvert" with same block types', () => {
+			const convertSpy = jest.fn( ( blocks ) => {
+				const groupInnerBlocks = blocks.map(
+					( { name, attributes, innerBlocks } ) => {
+						return createBlock( name, attributes, innerBlocks );
+					}
+				);
+
+				return createBlock(
+					'core/test-group-block',
+					{},
+					groupInnerBlocks
+				);
+			} );
+			const transformSpy = jest.fn();
+
+			registerBlockType( 'core/test-group-block', {
+				attributes: {
+					value: {
+						type: 'string',
+					},
+				},
+				transforms: {
+					from: [
+						{
+							type: 'block',
+							blocks: [ 'core/text-block' ],
+							isMultiBlock: true,
+							__experimentalConvert: convertSpy,
+							transform: transformSpy,
+						},
+					],
+				},
+				save: noop,
+				category: 'text',
+				title: 'Test Group Block',
+			} );
+
+			registerBlockType( 'core/text-block', defaultBlockSettings );
+			registerBlockType( 'core/image-block', defaultBlockSettings );
+
+			const numOfBlocksToGroup = 4;
+			const blocks = times( numOfBlocksToGroup, ( index ) => {
+				return createBlock( 'core/text-block', {
+					value: `block-value-${ index + 1 }`,
+					} );
+			} );
+
+			const transformedBlocks = switchToBlockType(
+				blocks,
+				'core/test-group-block'
+			);
+
+			expect( transformedBlocks ).toHaveLength( 1 );
+			expect( convertSpy.mock.calls ).toHaveLength( 1 );
+			expect( transformSpy.mock.calls ).toHaveLength( 0 );
+		} );
+
+		it( 'should not call "__experimentalConvert" with non-matching block types', () => {
+			const convertSpy = jest.fn( ( blocks ) => {
+				const groupInnerBlocks = blocks.map(
+					( { name, attributes, innerBlocks } ) => {
+						return createBlock( name, attributes, innerBlocks );
+					}
+				);
+
+				return createBlock(
+					'core/test-group-block',
+					{},
+					groupInnerBlocks
+				);
+			} );
+			const transformSpy = jest.fn();
+
+			registerBlockType( 'core/test-group-block', {
+				attributes: {
+					value: {
+						type: 'string',
+					},
+				},
+				transforms: {
+					from: [
+						{
+							type: 'block',
+							blocks: [ 'core/image-block' ],
+							isMultiBlock: true,
+							__experimentalConvert: convertSpy,
+							transform: transformSpy,
+						},
+					],
+				},
+				save: noop,
+				category: 'text',
+				title: 'Test Group Block',
+			} );
+
+			registerBlockType( 'core/text-block', defaultBlockSettings );
+			registerBlockType( 'core/image-block', defaultBlockSettings );
+
+			const numOfBlocksToGroup = 4;
+			const blocks = times( numOfBlocksToGroup, ( index ) => {
+				return createBlock( 'core/text-block', {
+					value: `block-value-${ index + 1 }`,
+				} );
+			} );
+
+			const transformedBlocks = switchToBlockType(
+				blocks,
+				'core/test-group-block'
+			);
+
+			expect( transformedBlocks ).toEqual( null );
+			expect( convertSpy.mock.calls ).toHaveLength( 0 );
+			expect( transformSpy.mock.calls ).toHaveLength( 0 );
+		} );
+
 		it( 'should prefer "__experimentalConvert" method over "transform" method when running a transformation', () => {
 			const convertSpy = jest.fn( ( blocks ) => {
 				const groupInnerBlocks = blocks.map(

--- a/packages/blocks/src/api/test/factory.js
+++ b/packages/blocks/src/api/test/factory.js
@@ -1605,7 +1605,8 @@ describe( 'block factory', () => {
 					index % 2 ? 'core/text-block' : 'core/image-block',
 					{
 						value: `block-value-${ index + 1 }`,
-					} );
+					}
+				);
 			} );
 
 			const transformedBlocks = switchToBlockType(
@@ -1663,7 +1664,7 @@ describe( 'block factory', () => {
 			const blocks = times( numOfBlocksToGroup, ( index ) => {
 				return createBlock( 'core/text-block', {
 					value: `block-value-${ index + 1 }`,
-					} );
+				} );
 			} );
 
 			const transformedBlocks = switchToBlockType(


### PR DESCRIPTION
## Problem:

During block registration if we specify the following transform for a block other than "core/group" and make a selection of mixed block types say: (one paragraph, one image, and one heading) instead of (three paragraphs), we still have the option in the inserter to transform the selection to the block, however we will run into a JS error before the `__experimentalConvert` fires, due to the explicit check in https://github.com/WordPress/gutenberg/blob/281464af0991aeebd0b0bbf95f4015e84bf8df06/packages/blocks/src/api/factory.js#L413-L416

or TL;DR no other block other than group can transform mixed block selections.

```jsx
transforms: {
  from: [ {
    type: 'block',
    isMultiBlock: true,
    blocks: [ '*' ],
    __experimentalConvert( blocks ) {
```

As for **_why_** the check is here, it looks like we explicitly guard for this, but @getdave and others don't recall why this is the case. That being the case, we'll try removing this limitation but keep an eye out for any Group block regressions during testing.

### Example Block Use Case:

https://github.com/Automattic/wp-calypso/pull/42548

![premium content](https://user-images.githubusercontent.com/1270189/82715401-d6e27d80-9c47-11ea-9941-ffb2e91e38a4.gif)

## Testing Instructions

- Verify that `npm run test-unit -- --testPathPattern packages/blocks/src/api/test/factory.js` is green, and new test cases make sense
- Manually test for potential Group block regressions

## TODO

- [x] Code cleanup around isBlockSelectionOfSameType and any other unneeded usages
- [x] Any needed e2e or unit test updates
