### PR TITLE
Image: remove div wrapper

### DIFF
--- a/packages/block-library/src/image/image-size.js
+++ b/packages/block-library/src/image/image-size.js
@@ -1,25 +1,26 @@
 /**
  * WordPress dependencies
  */
-import { useRef, useState, useEffect } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { calculatePreferedImageSize } from './utils';
 
-export default function ImageSize( { src, dirtynessTrigger, children } ) {
-	const ref = useRef();
+export default function useImageSize( ref, src, dependencies ) {
 	const [ state, setState ] = useState( {
 		imageWidth: null,
 		imageHeight: null,
-		containerWidth: null,
-		containerHeight: null,
 		imageWidthWithinContainer: null,
 		imageHeightWithinContainer: null,
 	} );
 
 	useEffect( () => {
+		if ( ! src ) {
+			return;
+		}
+
 		const { defaultView } = ref.current.ownerDocument;
 		const image = new defaultView.Image();
 
@@ -32,8 +33,6 @@ export default function ImageSize( { src, dirtynessTrigger, children } ) {
 			setState( {
 				imageWidth: image.width,
 				imageHeight: image.height,
-				containerWidth: ref.current.clientWidth,
-				containerHeight: ref.current.clientHeight,
 				imageWidthWithinContainer: width,
 				imageHeightWithinContainer: height,
 			} );
@@ -47,7 +46,7 @@ export default function ImageSize( { src, dirtynessTrigger, children } ) {
 			defaultView.removeEventListener( 'resize', calculateSize );
 			image.removeEventListener( 'load', calculateSize );
 		};
-	}, [ src, dirtynessTrigger ] );
+	}, [ src, ...dependencies ] );
 
-	return <div ref={ ref }>{ children( state ) }</div>;
+	return state;
 }


### PR DESCRIPTION
## Description

Removes and extra wrapper div in the image block used for calculating the image size. We can simply use another container element.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
