### PR TITLE
Block Navigator: Use default block appender

### DIFF
--- a/packages/block-editor/src/components/block-navigation/appender.js
+++ b/packages/block-editor/src/components/block-navigation/appender.js
@@ -41,7 +41,7 @@ export default function BlockNavigationAppender( {
 				className="block-editor-block-navigation-appender__cell"
 				colSpan="3"
 			>
-				{ ( props ) => (
+				{ ( { ref, tabIndex, onFocus } ) => (
 					<div className="block-editor-block-navigation-appender__container">
 						<DescenderLines
 							level={ level }
@@ -52,7 +52,7 @@ export default function BlockNavigationAppender( {
 							rootClientId={ parentBlockClientId }
 							__experimentalSelectBlockOnInsert={ false }
 							aria-describedby={ descriptionId }
-							{ ...props }
+							toggleProps={ { ref, tabIndex, onFocus } }
 						/>
 						<div
 							className="block-editor-block-navigation-appender__description"

--- a/packages/block-editor/src/components/block-navigation/appender.js
+++ b/packages/block-editor/src/components/block-navigation/appender.js
@@ -9,8 +9,8 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import BlockNavigationLeaf from './leaf';
-import ButtonBlockAppender from '../button-block-appender';
 import DescenderLines from './descender-lines';
+import Inserter from '../inserter';
 
 export default function BlockNavigationAppender( {
 	parentBlockClientId,
@@ -48,7 +48,7 @@ export default function BlockNavigationAppender( {
 							isLastRow={ position === rowCount }
 							terminatedLevels={ terminatedLevels }
 						/>
-						<ButtonBlockAppender
+						<Inserter
 							rootClientId={ parentBlockClientId }
 							__experimentalSelectBlockOnInsert={ false }
 							aria-describedby={ descriptionId }

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -77,13 +77,16 @@ $tree-item-height: 36px;
 		height: $button-size;
 	}
 
-	.block-editor-button-block-appender {
-		outline: none;
-		background: none;
-		padding: $grid-unit-10;
-		padding: 6px;
-		margin-left: 0.8em;
-		width: calc(100% - 0.8em);
+	.block-editor-inserter__toggle {
+		background: $dark-gray-primary;
+		color: $white;
+		height: $grid-unit-30;
+		margin: 6px 6px 6px 0.8em;
+		min-width: $grid-unit-30;
+
+		&:active {
+			color: $white;
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #22170.

Changes the Block Navigator to use the default block appender instead of the button block appender.

| Before | After |
| - | - |
| <img width="292" alt="Screen Shot 2020-05-25 at 15 52 31" src="https://user-images.githubusercontent.com/612155/82782477-c88e9e80-9e9f-11ea-946e-5a56844418e9.png"> | <img width="291" alt="Screen Shot 2020-05-25 at 15 51 54" src="https://user-images.githubusercontent.com/612155/82782485-ca586200-9e9f-11ea-9a23-86af902bc7d2.png"> |

To test:

1. Go to _Gutenberg_ → _Experiments_ and enable the _Navigation_ experiment.
2. Go to _Navigation_.
3. Observe the new appender icons.