### PR TITLE
Navigation Screen: Fetch all menus for display in <select> menu

### DIFF
--- a/packages/edit-navigation/src/components/menus-editor/index.js
+++ b/packages/edit-navigation/src/components/menus-editor/index.js
@@ -21,9 +21,10 @@ import MenuEditor from '../menu-editor';
 export default function MenusEditor( { blockEditorSettings } ) {
 	const { menus, hasLoadedMenus } = useSelect( ( select ) => {
 		const { getMenus, hasFinishedResolution } = select( 'core' );
+		const query = { per_page: -1 };
 		return {
-			menus: getMenus(),
-			hasLoadedMenus: hasFinishedResolution( 'getMenus' ),
+			menus: getMenus( query ),
+			hasLoadedMenus: hasFinishedResolution( 'getMenus', [ query ] ),
 		};
 	}, [] );
 


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/22404.

Use an unbounded query (`per_page=-1`) when fetching menus for display in the Navigation Screen.

Note that [`fetchAllMiddleware()`](https://github.com/WordPress/gutenberg/blob/master/packages/api-fetch/src/middlewares/fetch-all-middleware.js) will translate this `per_page=-1` query into several `per_page=100` requests.

To test:

1. `for i in {1..20}; do npx wp-env run cli wp menu create "test-menu-$i"; done`
2. Go to _Gutenberg_ → _Experiments_ and enable the _Navigation_ experiment.
3. Go to _Navigation_.
4. Observe that more than 10 menus display in the _Select navigation to edit_ dropdown.