### PR TITLE
Remove opinionated label color from CustomSelectControl component

### DIFF
--- a/packages/components/src/custom-select-control/style.scss
+++ b/packages/components/src/custom-select-control/style.scss
@@ -1,5 +1,4 @@
 .components-custom-select-control {
-	color: $dark-gray-500;
 	position: relative;
 }
 


### PR DESCRIPTION
<img width="290" alt="Capture d’écran 2020-05-25 à 11 34 50 AM" src="https://user-images.githubusercontent.com/272444/82806596-0aa6e880-9e7e-11ea-80b0-80f0d8b7f719.png">

If you try to load the inspector outside of WP without style reset, you get the screenshot above:

 - specific color for the custom select control label
 - Borders and focus styles not consistent across inputs/selects...

This is a long term battle but ideally our components are reusable without external resets... This tiny PR solves the color issue for the CustomSelectControl. It shouldn't impact anything on Gutenberg.