### PR TITLE
Fix usePrevious hook JSDoc types

### DIFF
--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -175,7 +175,7 @@ _Parameters_
 
 _Returns_
 
--   `T`: The value from the previous render.
+-   `(T|undefined)`: The value from the previous render.
 
 <a name="useReducedMotion" href="#useReducedMotion">#</a> **useReducedMotion**
 

--- a/packages/compose/src/hooks/use-previous/index.js
+++ b/packages/compose/src/hooks/use-previous/index.js
@@ -11,7 +11,7 @@ import { useEffect, useRef } from '@wordpress/element';
  *
  * @param {T} value The value to track.
  *
- * @return {T} The value from the previous render.
+ * @return {T|undefined} The value from the previous render.
  */
 export default function usePrevious( value ) {
 	const ref = useRef();

--- a/packages/compose/src/hooks/use-previous/index.js
+++ b/packages/compose/src/hooks/use-previous/index.js
@@ -14,7 +14,12 @@ import { useEffect, useRef } from '@wordpress/element';
  * @return {T|undefined} The value from the previous render.
  */
 export default function usePrevious( value ) {
-	const ref = useRef();
+	// Disable reason: without an explicit type detail, the type of ref will be
+	// inferred based on the initial useRef argument, which is undefined.
+	// https://github.com/WordPress/gutenberg/pull/22597#issuecomment-633588366
+	/* eslint-disable jsdoc/no-undefined-types */
+	const ref = useRef( /** @type {T|undefined} */ undefined );
+	/* eslint-enable jsdoc/no-undefined-types */
 
 	// Store current value in ref.
 	useEffect( () => {


### PR DESCRIPTION
## Description
The newly-added `usePrevious` hook had a slight mistake in its return type. On the first render, it will return `undefined`, but this was not accounted for in the JSDoc type declarations. This PR fixes that.