### PR TITLE
Adds suggestions for categories and formats to LinkControl

### DIFF
--- a/lib/class-wp-rest-category-search-handler.php
+++ b/lib/class-wp-rest-category-search-handler.php
@@ -37,20 +37,22 @@ class WP_REST_Category_Search_Handler extends WP_REST_Search_Handler {
 	 */
 	public function search_items( WP_REST_Request $request ) {
 
-		$categories = get_categories( array( 'get' => 'all' ) );
-
 		if ( ! empty( $request['search'] ) ) {
 			$category_search = $request['search'];
 		}
 
 		$category_search = apply_filters( 'rest_category_search_query', $category_search, $request );
 
-		$found_ids = [];
+		$categories = get_categories(
+			array(
+				'get'        => 'all',
+				'name__like' => $category_search,
+			)
+		);
+
+		$found_ids = array();
 		foreach ( $categories as $category ) {
-			$name_match = stripos( $category->name, $category_search ) !== false;
-			if ( $name_match ) {
-				$found_ids[] = $category->term_id;
-			}
+			$found_ids[] = $category->term_id;
 		}
 
 		return array(
@@ -98,7 +100,7 @@ class WP_REST_Category_Search_Handler extends WP_REST_Search_Handler {
 	 * @return array Links for the given item.
 	 */
 	public function prepare_item_links( $id ) {
-		return [];
+		return array();
 	}
 
 }

--- a/lib/class-wp-rest-category-search-handler.php
+++ b/lib/class-wp-rest-category-search-handler.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * REST API: WP_REST_Category_Search_Handler class
+ *
+ * @package WordPress
+ * @subpackage REST_API
+ * @since 5.5.0
+ */
+
+/**
+ * Core class representing a search handler for categories in the REST API.
+ *
+ * @since 5.5.0
+ *
+ * @see WP_REST_Search_Handler
+ */
+class WP_REST_Category_Search_Handler extends WP_REST_Search_Handler {
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 5.0.0
+	 */
+	public function __construct() {
+		$this->type = 'category';
+	}
+
+	/**
+	 * Searches the object type content for a given search request.
+	 *
+	 * @since 5.0.0
+	 *
+	 * @param WP_REST_Request $request Full REST request.
+	 * @return array Associative array containing an `WP_REST_Search_Handler::RESULT_IDS` containing
+	 *               an array of found IDs and `WP_REST_Search_Handler::RESULT_TOTAL` containing the
+	 *               total count for the matching search results.
+	 */
+	public function search_items( WP_REST_Request $request ) {
+
+		$categories = get_categories( array( 'get' => 'all' ) );
+
+		if ( ! empty( $request['search'] ) ) {
+			$category_search = $request['search'];
+		}
+
+		$category_search = apply_filters( 'rest_category_search_query', $category_search, $request );
+
+		$found_ids = [];
+		foreach ( $categories as $category ) {
+			$name_match = stripos( $category->name, $category_search ) !== false;
+			if ( $name_match ) {
+				$found_ids[] = $category->term_id;
+			}
+		}
+
+		return array(
+			self::RESULT_IDS   => $found_ids,
+			self::RESULT_TOTAL => count( $found_ids ),
+		);
+	}
+
+	/**
+	 * Prepares the search result for a given ID.
+	 *
+	 * @since 5.0.0
+	 *
+	 * @param int   $id     Item ID.
+	 * @param array $fields Fields to include for the item.
+	 * @return array Associative array containing all fields for the item.
+	 */
+	public function prepare_item( $id, array $fields ) {
+		$category = get_category( $id );
+
+		$data = array();
+
+		if ( in_array( WP_REST_Search_Controller::PROP_ID, $fields, true ) ) {
+			$data[ WP_REST_Search_Controller::PROP_ID ] = (int) $id;
+		}
+		if ( in_array( WP_REST_Search_Controller::PROP_TITLE, $fields, true ) ) {
+			$data[ WP_REST_Search_Controller::PROP_TITLE ] = $category->name;
+		}
+		if ( in_array( WP_REST_Search_Controller::PROP_URL, $fields, true ) ) {
+			$data[ WP_REST_Search_Controller::PROP_URL ] = get_category_link( $id );
+		}
+		if ( in_array( WP_REST_Search_Controller::PROP_TYPE, $fields, true ) ) {
+			$data[ WP_REST_Search_Controller::PROP_TYPE ] = $this->type;
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Prepares links for the search result of a given ID.
+	 *
+	 * @since 5.0.0
+	 *
+	 * @param int $id Item ID.
+	 * @return array Links for the given item.
+	 */
+	public function prepare_item_links( $id ) {
+		return [];
+	}
+
+}

--- a/lib/class-wp-rest-post-format-search-handler.php
+++ b/lib/class-wp-rest-post-format-search-handler.php
@@ -46,13 +46,16 @@ class WP_REST_Post_Format_Search_Handler extends WP_REST_Search_Handler {
 
 		$format_search = apply_filters( 'rest_post_format_search_query', $format_search, $request );
 
-		$found_ids = [];
+		$found_ids = array();
 		foreach ( $format_fake_ids as $format_fake_id => $format_slug ) {
 			$format_title       = $formats[ $format_slug ];
 			$format_slug_match  = stripos( $format_slug, $format_search ) !== false;
 			$format_title_match = stripos( $format_title, $format_search ) !== false;
 			if ( $format_slug_match || $format_title_match ) {
-				$found_ids[] = $format_fake_id;
+				$format_index_url = get_post_format_link( $format_fake_ids[ $format_fake_id ] );
+				if ( $format_index_url ) {
+					$found_ids[] = $format_fake_id;
+				}
 			}
 		}
 
@@ -72,9 +75,10 @@ class WP_REST_Post_Format_Search_Handler extends WP_REST_Search_Handler {
 	 * @return array Associative array containing all fields for the item.
 	 */
 	public function prepare_item( $id, array $fields ) {
-		$formats         = get_post_format_strings();
-		$format_fake_ids = array_keys( $formats );
-		$format          = $formats[ $format_fake_ids[ $id ] ];
+		$formats          = get_post_format_strings();
+		$format_fake_ids  = array_keys( $formats );
+		$format           = $formats[ $format_fake_ids[ $id ] ];
+		$format_index_url = get_post_format_link( $format_fake_ids[ $id ] );
 
 		$data = array();
 
@@ -87,7 +91,7 @@ class WP_REST_Post_Format_Search_Handler extends WP_REST_Search_Handler {
 		}
 
 		if ( in_array( WP_REST_Search_Controller::PROP_URL, $fields, true ) ) {
-			$data[ WP_REST_Search_Controller::PROP_URL ] = get_post_format_link( $format_fake_ids[ $id ] );
+			$data[ WP_REST_Search_Controller::PROP_URL ] = $format_index_url;
 		}
 
 		if ( in_array( WP_REST_Search_Controller::PROP_TYPE, $fields, true ) ) {
@@ -97,8 +101,16 @@ class WP_REST_Post_Format_Search_Handler extends WP_REST_Search_Handler {
 		return $data;
 	}
 
+	/**
+	 * Prepares links for the search result of a given ID.
+	 *
+	 * @since 5.0.0
+	 *
+	 * @param int $id Item ID.
+	 * @return array Links for the given item.
+	 */
 	public function prepare_item_links( $id ) {
-		return [];
+		return array();
 	}
 
 }

--- a/lib/class-wp-rest-post-format-search-handler.php
+++ b/lib/class-wp-rest-post-format-search-handler.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * REST API: WP_REST_Post_Format_Search_Handler class
+ *
+ * @package WordPress
+ * @subpackage REST_API
+ * @since 5.5.0
+ */
+
+/**
+ * Core class representing a search handler for post formats in the REST API.
+ *
+ * @since 5.5.0
+ *
+ * @see WP_REST_Search_Handler
+ */
+class WP_REST_Post_Format_Search_Handler extends WP_REST_Search_Handler {
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 5.0.0
+	 */
+	public function __construct() {
+		$this->type = 'post-format';
+	}
+
+	/**
+	 * Searches the object type content for a given search request.
+	 *
+	 * @since 5.0.0
+	 *
+	 * @param WP_REST_Request $request Full REST request.
+	 * @return array Associative array containing an `WP_REST_Search_Handler::RESULT_IDS` containing
+	 *               an array of found IDs and `WP_REST_Search_Handler::RESULT_TOTAL` containing the
+	 *               total count for the matching search results.
+	 */
+	public function search_items( WP_REST_Request $request ) {
+
+		$formats         = get_post_format_strings();
+		$format_fake_ids = array_keys( $formats );
+
+		if ( ! empty( $request['search'] ) ) {
+			$format_search = $request['search'];
+		}
+
+		$format_search = apply_filters( 'rest_post_format_search_query', $format_search, $request );
+
+		$found_ids = [];
+		foreach ( $format_fake_ids as $format_fake_id => $format_slug ) {
+			$format_title       = $formats[ $format_slug ];
+			$format_slug_match  = stripos( $format_slug, $format_search ) !== false;
+			$format_title_match = stripos( $format_title, $format_search ) !== false;
+			if ( $format_slug_match || $format_title_match ) {
+				$found_ids[] = $format_fake_id;
+			}
+		}
+
+		return array(
+			self::RESULT_IDS   => $found_ids,
+			self::RESULT_TOTAL => count( $found_ids ),
+		);
+	}
+
+	/**
+	 * Prepares the search result for a given ID.
+	 *
+	 * @since 5.0.0
+	 *
+	 * @param int   $id     Item ID.
+	 * @param array $fields Fields to include for the item.
+	 * @return array Associative array containing all fields for the item.
+	 */
+	public function prepare_item( $id, array $fields ) {
+		$formats         = get_post_format_strings();
+		$format_fake_ids = array_keys( $formats );
+		$format          = $formats[ $format_fake_ids[ $id ] ];
+
+		$data = array();
+
+		if ( in_array( WP_REST_Search_Controller::PROP_ID, $fields, true ) ) {
+			$data[ WP_REST_Search_Controller::PROP_ID ] = $id;
+		}
+
+		if ( in_array( WP_REST_Search_Controller::PROP_TITLE, $fields, true ) ) {
+			$data[ WP_REST_Search_Controller::PROP_TITLE ] = $format;
+		}
+
+		if ( in_array( WP_REST_Search_Controller::PROP_URL, $fields, true ) ) {
+			$data[ WP_REST_Search_Controller::PROP_URL ] = get_post_format_link( $format_fake_ids[ $id ] );
+		}
+
+		if ( in_array( WP_REST_Search_Controller::PROP_TYPE, $fields, true ) ) {
+			$data[ WP_REST_Search_Controller::PROP_TYPE ] = $this->type;
+		}
+
+		return $data;
+	}
+
+	public function prepare_item_links( $id ) {
+		return [];
+	}
+
+}

--- a/lib/class-wp-rest-post-format-search-handler.php
+++ b/lib/class-wp-rest-post-format-search-handler.php
@@ -31,25 +31,28 @@ class WP_REST_Post_Format_Search_Handler extends WP_REST_Search_Handler {
 		$format_strings = get_post_format_strings();
 		$format_slugs   = array_keys( $format_strings );
 
-		$query = '';
+		$query_args = array();
+
 		if ( ! empty( $request['search'] ) ) {
-			$query = $request['search'];
+			$query_args['search'] = $request['search'];
 		}
 
 		/**
-		 * Filters the post format search query.
+		 * Filters the query arguments for a search request.
 		 *
-		 * @param string          $query   Search query.
-		 * @param WP_REST_Request $request The request used.
+		 * Enables adding extra arguments or setting defaults for a post format search request.
+		 *
+		 * @param array           $query_args Key value array of query var to query value.
+		 * @param WP_REST_Request $request    The request used.
 		 */
-		$query = apply_filters( 'rest_post_format_search_query', $query, $request );
+		$query_args = apply_filters( 'rest_post_format_search_query', $query_args, $request );
 
 		$found_ids = array();
 		foreach ( $format_slugs as $index => $format_slug ) {
-			if ( ! empty( $query ) ) {
+			if ( ! empty( $query_args['search'] ) ) {
 				$format_string       = get_post_format_string( $format_slug );
-				$format_slug_match   = stripos( $format_slug, $query ) !== false;
-				$format_string_match = stripos( $format_string, $query ) !== false;
+				$format_slug_match   = stripos( $format_slug, $query_args['search'] ) !== false;
+				$format_string_match = stripos( $format_string, $query_args['search'] ) !== false;
 				if ( ! $format_slug_match && ! $format_string_match ) {
 					continue;
 				}

--- a/lib/class-wp-rest-post-format-search-handler.php
+++ b/lib/class-wp-rest-post-format-search-handler.php
@@ -110,7 +110,7 @@ class WP_REST_Post_Format_Search_Handler extends WP_REST_Search_Handler {
 	 * @param string $id Item ID.
 	 * @return array Links for the given item.
 	 */
-	public function prepare_item_links( $id ) {
+	public function prepare_item_links( $id ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		return array();
 	}
 

--- a/lib/class-wp-rest-post-format-search-handler.php
+++ b/lib/class-wp-rest-post-format-search-handler.php
@@ -2,15 +2,11 @@
 /**
  * REST API: WP_REST_Post_Format_Search_Handler class
  *
- * @package WordPress
- * @subpackage REST_API
- * @since 5.5.0
+ * @package Gutenberg
  */
 
 /**
  * Core class representing a search handler for post formats in the REST API.
- *
- * @since 5.5.0
  *
  * @see WP_REST_Search_Handler
  */
@@ -18,8 +14,6 @@ class WP_REST_Post_Format_Search_Handler extends WP_REST_Search_Handler {
 
 	/**
 	 * Constructor.
-	 *
-	 * @since 5.0.0
 	 */
 	public function __construct() {
 		$this->type = 'post-format';
@@ -27,8 +21,6 @@ class WP_REST_Post_Format_Search_Handler extends WP_REST_Search_Handler {
 
 	/**
 	 * Searches the object type content for a given search request.
-	 *
-	 * @since 5.0.0
 	 *
 	 * @param WP_REST_Request $request Full REST request.
 	 * @return array Associative array containing an `WP_REST_Search_Handler::RESULT_IDS` containing
@@ -68,8 +60,6 @@ class WP_REST_Post_Format_Search_Handler extends WP_REST_Search_Handler {
 	/**
 	 * Prepares the search result for a given ID.
 	 *
-	 * @since 5.0.0
-	 *
 	 * @param int   $id     Item ID.
 	 * @param array $fields Fields to include for the item.
 	 * @return array Associative array containing all fields for the item.
@@ -102,14 +92,11 @@ class WP_REST_Post_Format_Search_Handler extends WP_REST_Search_Handler {
 	}
 
 	/**
-	 * Prepares links for the search result of a given ID.
+	 * Prepares links for the search result.
 	 *
-	 * @since 5.0.0
-	 *
-	 * @param int $id Item ID.
 	 * @return array Links for the given item.
 	 */
-	public function prepare_item_links( $id ) {
+	public function prepare_item_links() {
 		return array();
 	}
 

--- a/lib/class-wp-rest-term-search-handler.php
+++ b/lib/class-wp-rest-term-search-handler.php
@@ -28,7 +28,7 @@ class WP_REST_Term_Search_Handler extends WP_REST_Search_Handler {
 		$this->subtypes = array_values(
 			get_taxonomies(
 				array(
-					'public'   => true,
+					'public' => true,
 				),
 				'names'
 			)

--- a/lib/class-wp-rest-term-search-handler.php
+++ b/lib/class-wp-rest-term-search-handler.php
@@ -2,15 +2,11 @@
 /**
  * REST API: WP_REST_Terms_Search_Handler class
  *
- * @package WordPress
- * @subpackage REST_API
- * @since 5.5.0
+ * @package Gutenberg
  */
 
 /**
  * Core class representing a search handler for term in the REST API.
- *
- * @since 5.5.0
  *
  * @see WP_REST_Search_Handler
  */
@@ -18,8 +14,6 @@ class WP_REST_Term_Search_Handler extends WP_REST_Search_Handler {
 
 	/**
 	 * Constructor.
-	 *
-	 * @since 5.0.0
 	 */
 	public function __construct() {
 		$this->type = 'term';
@@ -37,8 +31,6 @@ class WP_REST_Term_Search_Handler extends WP_REST_Search_Handler {
 
 	/**
 	 * Searches the object type content for a given search request.
-	 *
-	 * @since 5.0.0
 	 *
 	 * @param WP_REST_Request $request Full REST request.
 	 * @return array Associative array containing an `WP_REST_Search_Handler::RESULT_IDS` containing
@@ -71,8 +63,6 @@ class WP_REST_Term_Search_Handler extends WP_REST_Search_Handler {
 		 *
 		 * Enables adding extra arguments or setting defaults for a term search request.
 		 *
-		 * @since 5.1.0
-		 *
 		 * @param array           $query_args Key value array of query var to query value.
 		 * @param WP_REST_Request $request    The request used.
 		 */
@@ -95,8 +85,6 @@ class WP_REST_Term_Search_Handler extends WP_REST_Search_Handler {
 
 	/**
 	 * Prepares the search result for a given ID.
-	 *
-	 * @since 5.0.0
 	 *
 	 * @param int   $id     Item ID.
 	 * @param array $fields Fields to include for the item.
@@ -126,8 +114,6 @@ class WP_REST_Term_Search_Handler extends WP_REST_Search_Handler {
 	/**
 	 * Prepares links for the search result of a given ID.
 	 *
-	 * @since 5.0.0
-	 *
 	 * @param int $id Item ID.
 	 * @return array Links for the given item.
 	 */
@@ -154,9 +140,7 @@ class WP_REST_Term_Search_Handler extends WP_REST_Search_Handler {
 	/**
 	 * Attempts to detect the route to access a single item.
 	 *
-	 * @since 5.0.0
-	 *
-	 * @param WP_Post $post Term object.
+	 * @param WP_Term $term Term object.
 	 * @return string REST route relative to the REST base URI, or empty string if unknown.
 	 */
 	protected function detect_rest_item_route( $term ) {

--- a/lib/class-wp-rest-term-search-handler.php
+++ b/lib/class-wp-rest-term-search-handler.php
@@ -55,7 +55,7 @@ class WP_REST_Term_Search_Handler extends WP_REST_Search_Handler {
 		);
 
 		if ( ! empty( $request['search'] ) ) {
-			$query_args['name__like'] = $request['search'];
+			$query_args['search'] = $request['search'];
 		}
 
 		/**

--- a/lib/class-wp-rest-term-search-handler.php
+++ b/lib/class-wp-rest-term-search-handler.php
@@ -68,14 +68,17 @@ class WP_REST_Term_Search_Handler extends WP_REST_Search_Handler {
 		 */
 		$query_args = apply_filters( 'rest_term_search_query', $query_args, $request );
 
-		$query = new WP_Term_Query();
-
+		$query     = new WP_Term_Query();
 		$found_ids = $query->query( $query_args );
 
 		unset( $query_args['offset'], $query_args['number'] );
-		$query_args['fields'] = 'count';
 
-		$total = (int) $query->query( $query_args );
+		$total = wp_count_terms( $query_args );
+
+		// wp_count_terms() can return a falsey value when the term has no children.
+		if ( ! $total ) {
+			$total = 0;
+		}
 
 		return array(
 			self::RESULT_IDS   => $found_ids,

--- a/lib/class-wp-rest-term-search-handler.php
+++ b/lib/class-wp-rest-term-search-handler.php
@@ -125,7 +125,7 @@ class WP_REST_Term_Search_Handler extends WP_REST_Search_Handler {
 
 		$links = array();
 
-		$item_route = $this->detect_rest_item_route( $term );
+		$item_route = rest_get_route_for_term( $term );
 		if ( $item_route ) {
 			$links['self'] = array(
 				'href'       => rest_url( $item_route ),
@@ -139,27 +139,4 @@ class WP_REST_Term_Search_Handler extends WP_REST_Search_Handler {
 
 		return $links;
 	}
-
-	/**
-	 * Attempts to detect the route to access a single item.
-	 *
-	 * @param WP_Term $term Term object.
-	 * @return string|null REST route relative to the REST base URI, or null if unknown.
-	 */
-	protected function detect_rest_item_route( $term ) {
-		$taxonomy = get_taxonomy( $term->taxonomy );
-		if ( ! $taxonomy ) {
-			return null;
-		}
-
-		// It's currently impossible to detect the REST URL from a custom controller.
-		if ( ! empty( $taxonomy->rest_controller_class ) && 'WP_REST_Terms_Controller' !== $taxonomy->rest_controller_class ) {
-			return null;
-		}
-
-		$rest_base = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxonomy->name;
-
-		return sprintf( 'wp/v2/%s/%d', $rest_base, $term->term_id );
-	}
-
 }

--- a/lib/class-wp-rest-term-search-handler.php
+++ b/lib/class-wp-rest-term-search-handler.php
@@ -51,7 +51,6 @@ class WP_REST_Term_Search_Handler extends WP_REST_Search_Handler {
 			'hide_empty' => false,
 			'offset'     => ( $page - 1 ) * $per_page,
 			'number'     => $per_page,
-			'fields'     => 'ids',
 		);
 
 		if ( ! empty( $request['search'] ) ) {
@@ -68,8 +67,9 @@ class WP_REST_Term_Search_Handler extends WP_REST_Search_Handler {
 		 */
 		$query_args = apply_filters( 'rest_term_search_query', $query_args, $request );
 
-		$query     = new WP_Term_Query();
-		$found_ids = $query->query( $query_args );
+		$query       = new WP_Term_Query();
+		$found_terms = $query->query( $query_args );
+		$found_ids   = wp_list_pluck( $found_terms, 'term_id' );
 
 		unset( $query_args['offset'], $query_args['number'] );
 

--- a/lib/class-wp-rest-term-search-handler.php
+++ b/lib/class-wp-rest-term-search-handler.php
@@ -18,11 +18,11 @@ class WP_REST_Term_Search_Handler extends WP_REST_Search_Handler {
 	public function __construct() {
 		$this->type = 'term';
 
-		// Support all public post types except attachments.
 		$this->subtypes = array_values(
 			get_taxonomies(
 				array(
-					'public' => true,
+					'public'       => true,
+					'show_in_rest' => true,
 				),
 				'names'
 			)

--- a/lib/class-wp-rest-term-search-handler.php
+++ b/lib/class-wp-rest-term-search-handler.php
@@ -46,7 +46,7 @@ class WP_REST_Term_Search_Handler extends WP_REST_Search_Handler {
 	 *               total count for the matching search results.
 	 */
 	public function search_items( WP_REST_Request $request ) {
-
+		$term_search = '';
 		if ( ! empty( $request['search'] ) ) {
 			$term_search = $request['search'];
 		}

--- a/lib/class-wp-rest-term-search-handler.php
+++ b/lib/class-wp-rest-term-search-handler.php
@@ -62,6 +62,7 @@ class WP_REST_Term_Search_Handler extends WP_REST_Search_Handler {
 			array(
 				'taxonomy'   => $taxonomies,
 				'name__like' => $term_search,
+				'hide_empty' => false,
 			)
 		);
 

--- a/lib/class-wp-rest-term-search-handler.php
+++ b/lib/class-wp-rest-term-search-handler.php
@@ -123,7 +123,7 @@ class WP_REST_Term_Search_Handler extends WP_REST_Search_Handler {
 		$links = array();
 
 		$item_route = $this->detect_rest_item_route( $term );
-		if ( ! empty( $item_route ) ) {
+		if ( $item_route ) {
 			$links['self'] = array(
 				'href'       => rest_url( $item_route ),
 				'embeddable' => true,
@@ -141,23 +141,22 @@ class WP_REST_Term_Search_Handler extends WP_REST_Search_Handler {
 	 * Attempts to detect the route to access a single item.
 	 *
 	 * @param WP_Term $term Term object.
-	 * @return string REST route relative to the REST base URI, or empty string if unknown.
+	 * @return string|null REST route relative to the REST base URI, or null if unknown.
 	 */
 	protected function detect_rest_item_route( $term ) {
 		$taxonomy = get_taxonomy( $term->taxonomy );
 		if ( ! $taxonomy ) {
-			return '';
+			return null;
 		}
 
 		// It's currently impossible to detect the REST URL from a custom controller.
 		if ( ! empty( $taxonomy->rest_controller_class ) && 'WP_REST_Terms_Controller' !== $taxonomy->rest_controller_class ) {
-			return '';
+			return null;
 		}
 
-		$namespace = 'wp/v2';
 		$rest_base = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxonomy->name;
 
-		return sprintf( '%s/%s/%d', $namespace, $rest_base, $term->term_id );
+		return sprintf( 'wp/v2/%s/%d', $rest_base, $term->term_id );
 	}
 
 }

--- a/lib/load.php
+++ b/lib/load.php
@@ -64,8 +64,8 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	if ( ! class_exists( 'WP_REST_Post_Format_Search_Handler' ) ) {
 		require_once dirname( __FILE__ ) . '/class-wp-rest-post-format-search-handler.php';
 	}
-	if ( ! class_exists( 'WP_REST_Category_Search_Handler' ) ) {
-		require_once dirname( __FILE__ ) . '/class-wp-rest-category-search-handler.php';
+	if ( ! class_exists( 'WP_REST_Term_Search_Handler' ) ) {
+		require_once dirname( __FILE__ ) . '/class-wp-rest-term-search-handler.php';
 	}
 	/**
 	* End: Include for phase 2

--- a/lib/load.php
+++ b/lib/load.php
@@ -61,6 +61,12 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	if ( ! class_exists( 'WP_REST_Plugins_Controller' ) ) {
 		require_once dirname( __FILE__ ) . '/class-wp-rest-plugins-controller.php';
 	}
+	if ( ! class_exists( 'WP_REST_Post_Format_Search_Handler' ) ) {
+		require_once dirname( __FILE__ ) . '/class-wp-rest-post-format-search-handler.php';
+	}
+	if ( ! class_exists( 'WP_REST_Category_Search_Handler' ) ) {
+		require_once dirname( __FILE__ ) . '/class-wp-rest-category-search-handler.php';
+	}
 	/**
 	* End: Include for phase 2
 	*/

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -345,14 +345,14 @@ function gutenberg_post_format_search_handler( $search_handlers ) {
 add_filter( 'wp_rest_search_handlers', 'gutenberg_post_format_search_handler', 10, 5 );
 
 /**
- * Registers the category search handler.
+ * Registers the terms search handler.
  *
  * @param string $search_handlers Title list of current handlers.
  *
  * @return array Title updated list of handlers.
  */
-function gutenberg_category_search_handler( $search_handlers ) {
-	$search_handlers[] = new WP_REST_Category_Search_Handler();
+function gutenberg_term_search_handler( $search_handlers ) {
+	$search_handlers[] = new WP_REST_Term_Search_Handler();
 	return $search_handlers;
 }
-add_filter( 'wp_rest_search_handlers', 'gutenberg_category_search_handler', 10, 5 );
+add_filter( 'wp_rest_search_handlers', 'gutenberg_term_search_handler', 10, 5 );

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -330,3 +330,15 @@ function gutenberg_register_image_editor() {
 	}
 }
 add_filter( 'rest_api_init', 'gutenberg_register_image_editor' );
+function gutenberg_post_format_search_handler( $search_handlers ) {
+	$search_handlers[] = new WP_REST_Post_Format_Search_Handler();
+	return $search_handlers;
+}
+
+add_filter( 'wp_rest_search_handlers', 'gutenberg_post_format_search_handler', 10, 5 );
+
+function gutenberg_category_search_handler( $search_handlers ) {
+	$search_handlers[] = new WP_REST_Category_Search_Handler();
+	return $search_handlers;
+}
+add_filter( 'wp_rest_search_handlers', 'gutenberg_category_search_handler', 10, 5 );

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -330,13 +330,27 @@ function gutenberg_register_image_editor() {
 	}
 }
 add_filter( 'rest_api_init', 'gutenberg_register_image_editor' );
+
+/**
+ * Registers the post format search handler.
+ *
+ * @param string $search_handlers     Title list of current handlers.
+ *
+ * @return array Title updated list of handlers.
+ */
 function gutenberg_post_format_search_handler( $search_handlers ) {
 	$search_handlers[] = new WP_REST_Post_Format_Search_Handler();
 	return $search_handlers;
 }
-
 add_filter( 'wp_rest_search_handlers', 'gutenberg_post_format_search_handler', 10, 5 );
 
+/**
+ * Registers the category search handler.
+ *
+ * @param string $search_handlers Title list of current handlers.
+ *
+ * @return array Title updated list of handlers.
+ */
 function gutenberg_category_search_handler( $search_handlers ) {
 	$search_handlers[] = new WP_REST_Category_Search_Handler();
 	return $search_handlers;

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -339,7 +339,10 @@ add_filter( 'rest_api_init', 'gutenberg_register_image_editor' );
  * @return array Title updated list of handlers.
  */
 function gutenberg_post_format_search_handler( $search_handlers ) {
-	$search_handlers[] = new WP_REST_Post_Format_Search_Handler();
+	if ( current_theme_supports( 'post-formats' ) ) {
+		$search_handlers[] = new WP_REST_Post_Format_Search_Handler();
+	}
+
 	return $search_handlers;
 }
 add_filter( 'wp_rest_search_handlers', 'gutenberg_post_format_search_handler', 10, 5 );

--- a/packages/edit-navigation/src/index.js
+++ b/packages/edit-navigation/src/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { map, set, flatten } from 'lodash';
+import { map, set, flatten, partialRight } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -39,11 +39,18 @@ function disableInsertingNonNavigationBlocks( settings, name ) {
  * It seems like there is no suitable package to import this from. Ideally it would be either part of core-data.
  * Until we refactor it, just copying the code is the simplest solution.
  *
- * @param {Object} search
- * @param {number} perPage
+ * @param {string} search
+ * @param {Object} [searchArguments]
+ * @param {number} [searchArguments.perPage=20]
+ * @param {Object} [editorSettings]
+ * @param {boolean} [editorSettings.disablePostFormats=false]
  * @return {Promise<Object[]>} List of suggestions
  */
-function fetchLinkSuggestions( search, { perPage = 20 } = {} ) {
+const fetchLinkSuggestions = (
+	search,
+	{ perPage = 20 } = {},
+	{ disablePostFormats = false } = {}
+) => {
 	const posts = apiFetch( {
 		path: addQueryArgs( '/wp/v2/search', {
 			search,
@@ -60,23 +67,28 @@ function fetchLinkSuggestions( search, { perPage = 20 } = {} ) {
 		} ),
 	} );
 
-	const formats = apiFetch( {
-		path: addQueryArgs( '/wp/v2/search', {
-			search,
-			per_page: perPage,
-			type: 'post-format',
-		} ),
-	} );
+	let formats;
+	if ( disablePostFormats ) {
+		formats = Promise.resolve( [] );
+	} else {
+		formats = apiFetch( {
+			path: addQueryArgs( '/wp/v2/search', {
+				search,
+				per_page: perPage,
+				type: 'post-format',
+			} ),
+		} );
+	}
 
 	return Promise.all( [ posts, terms, formats ] ).then( ( results ) => {
-		return map( flatten( results ), ( result ) => ( {
+		return map( flatten( results ).slice( 0, perPage ), ( result ) => ( {
 			id: result.id,
 			url: result.url,
 			title: decodeEntities( result.title ) || __( '(no title)' ),
 			type: result.subtype || result.type,
 		} ) );
 	} );
-}
+};
 
 export function initialize( id, settings ) {
 	if ( ! settings.blockNavMenus ) {
@@ -93,7 +105,10 @@ export function initialize( id, settings ) {
 		__experimentalRegisterExperimentalCoreBlocks( settings );
 	}
 
-	settings.__experimentalFetchLinkSuggestions = fetchLinkSuggestions;
+	settings.__experimentalFetchLinkSuggestions = partialRight(
+		fetchLinkSuggestions,
+		settings
+	);
 
 	render(
 		<Layout blockEditorSettings={ settings } />,

--- a/packages/edit-navigation/src/index.js
+++ b/packages/edit-navigation/src/index.js
@@ -44,7 +44,7 @@ function disableInsertingNonNavigationBlocks( settings, name ) {
  * @return {Promise<Object[]>} List of suggestions
  */
 async function fetchLinkSuggestions( search, { perPage = 20 } = {} ) {
-	const posts = await apiFetch( {
+	const posts = apiFetch( {
 		path: addQueryArgs( '/wp/v2/search', {
 			search,
 			per_page: perPage,
@@ -52,15 +52,15 @@ async function fetchLinkSuggestions( search, { perPage = 20 } = {} ) {
 		} ),
 	} );
 
-	const categories = await apiFetch( {
+	const terms = apiFetch( {
 		path: addQueryArgs( '/wp/v2/search', {
 			search,
 			per_page: perPage,
-			type: 'category',
+			type: 'term',
 		} ),
 	} );
 
-	const formats = await apiFetch( {
+	const formats = apiFetch( {
 		path: addQueryArgs( '/wp/v2/search', {
 			search,
 			per_page: perPage,
@@ -68,7 +68,7 @@ async function fetchLinkSuggestions( search, { perPage = 20 } = {} ) {
 		} ),
 	} );
 
-	return Promise.all( [ posts, categories, formats ] ).then( ( results ) => {
+	return Promise.all( [ posts, terms, formats ] ).then( ( results ) => {
 		return map( flatten( results ), ( post ) => ( {
 			id: post.id,
 			url: post.url,

--- a/packages/edit-navigation/src/index.js
+++ b/packages/edit-navigation/src/index.js
@@ -43,7 +43,7 @@ function disableInsertingNonNavigationBlocks( settings, name ) {
  * @param {number} perPage
  * @return {Promise<Object[]>} List of suggestions
  */
-async function fetchLinkSuggestions( search, { perPage = 20 } = {} ) {
+function fetchLinkSuggestions( search, { perPage = 20 } = {} ) {
 	const posts = apiFetch( {
 		path: addQueryArgs( '/wp/v2/search', {
 			search,
@@ -69,11 +69,11 @@ async function fetchLinkSuggestions( search, { perPage = 20 } = {} ) {
 	} );
 
 	return Promise.all( [ posts, terms, formats ] ).then( ( results ) => {
-		return map( flatten( results ), ( post ) => ( {
-			id: post.id,
-			url: post.url,
-			title: decodeEntities( post.title ) || __( '(no title)' ),
-			type: post.subtype || post.type,
+		return map( flatten( results ), ( result ) => ( {
+			id: result.id,
+			url: result.url,
+			title: decodeEntities( result.title ) || __( '(no title)' ),
+			type: result.subtype || result.type,
 		} ) );
 	} );
 }

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { map, pick, defaultTo, concat } from 'lodash';
+import { map, pick, defaultTo, flatten } from 'lodash';
 import memize from 'memize';
 
 /**
@@ -66,14 +66,14 @@ const fetchLinkSuggestions = async ( search, { perPage = 20 } = {} ) => {
 		} ),
 	} );
 
-	const results = concat( posts, categories, formats );
-
-	return map( results, ( post ) => ( {
-		id: post.id,
-		url: post.url,
-		title: decodeEntities( post.title ) || __( '(no title)' ),
-		type: post.subtype || post.type,
-	} ) );
+	return Promise.all( [ posts, categories, formats ] ).then( ( results ) => {
+		return map( flatten( results ), ( post ) => ( {
+			id: post.id,
+			url: post.url,
+			title: decodeEntities( post.title ) || __( '(no title)' ),
+			type: post.subtype || post.type,
+		} ) );
+	} );
 };
 
 class EditorProvider extends Component {

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { map, pick, defaultTo } from 'lodash';
+import { map, pick, defaultTo, concat } from 'lodash';
 import memize from 'memize';
 
 /**
@@ -50,7 +50,25 @@ const fetchLinkSuggestions = async ( search, { perPage = 20 } = {} ) => {
 		} ),
 	} );
 
-	return map( posts, ( post ) => ( {
+	const categories = await apiFetch( {
+		path: addQueryArgs( '/wp/v2/search', {
+			search,
+			per_page: perPage,
+			type: 'category',
+		} ),
+	} );
+
+	const formats = await apiFetch( {
+		path: addQueryArgs( '/wp/v2/search', {
+			search,
+			per_page: perPage,
+			type: 'post-format',
+		} ),
+	} );
+
+	const results = concat( posts, categories, formats );
+
+	return map( results, ( post ) => ( {
 		id: post.id,
 		url: post.url,
 		title: decodeEntities( post.title ) || __( '(no title)' ),

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -42,7 +42,7 @@ import ConvertToGroupButtons from '../convert-to-group-buttons';
  * @return {Promise<Object[]>} List of suggestions
  */
 const fetchLinkSuggestions = async ( search, { perPage = 20 } = {} ) => {
-	const posts = await apiFetch( {
+	const posts = apiFetch( {
 		path: addQueryArgs( '/wp/v2/search', {
 			search,
 			per_page: perPage,
@@ -50,15 +50,15 @@ const fetchLinkSuggestions = async ( search, { perPage = 20 } = {} ) => {
 		} ),
 	} );
 
-	const categories = await apiFetch( {
+	const terms = apiFetch( {
 		path: addQueryArgs( '/wp/v2/search', {
 			search,
 			per_page: perPage,
-			type: 'category',
+			type: 'term',
 		} ),
 	} );
 
-	const formats = await apiFetch( {
+	const formats = apiFetch( {
 		path: addQueryArgs( '/wp/v2/search', {
 			search,
 			per_page: perPage,
@@ -66,7 +66,7 @@ const fetchLinkSuggestions = async ( search, { perPage = 20 } = {} ) => {
 		} ),
 	} );
 
-	return Promise.all( [ posts, categories, formats ] ).then( ( results ) => {
+	return Promise.all( [ posts, terms, formats ] ).then( ( results ) => {
 		return map( flatten( results ), ( post ) => ( {
 			id: post.id,
 			url: post.url,

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -41,7 +41,7 @@ import ConvertToGroupButtons from '../convert-to-group-buttons';
  * @param {number} perPage
  * @return {Promise<Object[]>} List of suggestions
  */
-const fetchLinkSuggestions = async ( search, { perPage = 20 } = {} ) => {
+const fetchLinkSuggestions = ( search, { perPage = 20 } = {} ) => {
 	const posts = apiFetch( {
 		path: addQueryArgs( '/wp/v2/search', {
 			search,
@@ -67,11 +67,11 @@ const fetchLinkSuggestions = async ( search, { perPage = 20 } = {} ) => {
 	} );
 
 	return Promise.all( [ posts, terms, formats ] ).then( ( results ) => {
-		return map( flatten( results ), ( post ) => ( {
-			id: post.id,
-			url: post.url,
-			title: decodeEntities( post.title ) || __( '(no title)' ),
-			type: post.subtype || post.type,
+		return map( flatten( results ), ( result ) => ( {
+			id: result.id,
+			url: result.url,
+			title: decodeEntities( result.title ) || __( '(no title)' ),
+			type: result.subtype || result.type,
 		} ) );
 	} );
 };

--- a/phpunit/class-wp-rest-post-format-search-handler-test.php
+++ b/phpunit/class-wp-rest-post-format-search-handler-test.php
@@ -25,6 +25,8 @@ class WP_REST_Post_Format_Search_Handler_Test extends WP_Test_REST_Controller_Te
 	 * @param WP_UnitTest_Factory $factory Helper that lets us create fake data.
 	 */
 	public static function wpSetUpBeforeClass( $factory ) {
+		add_theme_support( 'post-formats' );
+
 		self::$my_post_id = $factory->post->create(
 			array(
 				'post_title' => 'Test post',
@@ -39,6 +41,8 @@ class WP_REST_Post_Format_Search_Handler_Test extends WP_Test_REST_Controller_Te
 	 */
 	public static function wpTearDownAfterClass() {
 		wp_delete_post( self::$my_post_id );
+
+		remove_theme_support( 'post-formats' );
 	}
 
 	/**

--- a/phpunit/class-wp-rest-post-format-search-handler-test.php
+++ b/phpunit/class-wp-rest-post-format-search-handler-test.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * WP_REST_Post_Format_Search_Handler tests
+ *
+ * @package Gutenberg
+ */
+
+/**
+ * Tests for WP_REST_Post_Format_Search_Handler_Test.
+ *
+ * @group restapi
+ */
+class WP_REST_Post_Format_Search_Handler_Test extends WP_Test_REST_Controller_Testcase {
+
+	/**
+	 * Term associated with a post format.
+	 *
+	 * @var array
+	 */
+	private static $my_post_format_term = array();
+
+	/**
+	 * Create fake data before our tests run.
+	 *
+	 * @param WP_UnitTest_Factory $factory Helper that lets us create fake data.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$my_post_format_term = $factory->term->create(
+			array(
+				'taxonomy' => 'post_format',
+				'name'     => 'Aside',
+				'slug'     => 'post-format-aside',
+			)
+		);
+	}
+
+	/**
+	 * Delete our fake data after our tests run.
+	 */
+	public static function wpTearDownAfterClass() {
+		wp_delete_term( self::$my_post_format_term, true );
+	}
+
+	/**
+	 * Search through terms of any type.
+	 */
+	public function test_get_items_search_type_post_format() {
+		$response = $this->do_request_with_params(
+			array(
+				'per_page' => 100,
+				'type'     => 'post-format',
+			)
+		);
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEqualSets(
+			array(
+				'Aside',
+			),
+			wp_list_pluck( $response->get_data(), 'title' )
+		);
+	}
+
+	/**
+	 * Search through all that matches a 'Aside' search.
+	 */
+	public function test_get_items_search_for_test_post_format() {
+		$response = $this->do_request_with_params(
+			array(
+				'per_page' => 100,
+				'search'   => 'Aside',
+				'type'     => 'post-format',
+			)
+		);
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEqualSets(
+			array(
+				'Aside',
+			),
+			wp_list_pluck( $response->get_data(), 'title' )
+		);
+	}
+
+	public function test_register_routes() {
+		$this->markTestSkipped( 'Covered by Search controller tests.' );
+	}
+
+	public function test_context_param() {
+		$this->markTestSkipped( 'Covered by Search controller tests.' );
+	}
+
+	public function test_get_items() {
+		$this->markTestSkipped( 'Covered by Search controller tests.' );
+	}
+
+	public function test_get_item() {
+		$this->markTestSkipped( 'Covered by Search controller tests.' );
+	}
+
+	public function test_create_item() {
+		$this->markTestSkipped( 'Covered by Search controller tests.' );
+	}
+
+	public function test_update_item() {
+		$this->markTestSkipped( 'Covered by Search controller tests.' );
+	}
+
+	public function test_delete_item() {
+		$this->markTestSkipped( 'Covered by Search controller tests.' );
+	}
+
+	public function test_prepare_item() {
+		$this->markTestSkipped( 'Covered by Search controller tests.' );
+	}
+
+	public function test_get_item_schema() {
+		$this->markTestSkipped( 'Covered by Search controller tests.' );
+	}
+
+	/**
+	 * Perform a REST request to our search endpoint with given parameters.
+	 */
+	private function do_request_with_params( $params = array(), $method = 'GET' ) {
+		$request = $this->get_request( $params, $method );
+
+		return rest_get_server()->dispatch( $request );
+	}
+
+	/**
+	 * Get a REST request object for given parameters.
+	 */
+	private function get_request( $params = array(), $method = 'GET' ) {
+		$request = new WP_REST_Request( $method, '/wp/v2/search' );
+
+		foreach ( $params as $param => $value ) {
+			$request->set_param( $param, $value );
+		}
+
+		return $request;
+	}
+}

--- a/phpunit/class-wp-rest-term-search-handler-test.php
+++ b/phpunit/class-wp-rest-term-search-handler-test.php
@@ -2,8 +2,7 @@
 /**
  * WP_REST_Term_Search_Handler tests
  *
- * @package WordPress
- * @subpackage REST_API
+ * @package Gutenberg
  */
 
 /**
@@ -77,7 +76,7 @@ class WP_REST_Term_Search_Handler_Test extends WP_Test_REST_Controller_Testcase 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEqualSets(
 			array(
-				0 => 1, // that is the default category
+				0 => 1, // That is the default category.
 				self::$my_category,
 				self::$my_tag,
 			),
@@ -100,7 +99,7 @@ class WP_REST_Term_Search_Handler_Test extends WP_Test_REST_Controller_Testcase 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEqualSets(
 			array(
-				0 => 1, // that is the default category
+				0 => 1, // That is the default category.
 				self::$my_category,
 			),
 			wp_list_pluck( $response->get_data(), 'id' )
@@ -136,7 +135,7 @@ class WP_REST_Term_Search_Handler_Test extends WP_Test_REST_Controller_Testcase 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEqualSets(
 			array(
-				0 => 1, // this is the default category
+				0 => 1, // This is the default category.
 				self::$my_category,
 				self::$my_tag,
 			),

--- a/phpunit/class-wp-rest-term-search-handler-test.php
+++ b/phpunit/class-wp-rest-term-search-handler-test.php
@@ -185,6 +185,21 @@ class WP_REST_Term_Search_Handler_Test extends WP_Test_REST_Controller_Testcase 
 		);
 	}
 
+	/**
+	 * Searching for a term that doesn't exist should return an empty result.
+	 */
+	public function test_get_items_search_for_missing_term() {
+		$response = $this->do_request_with_params(
+			array(
+				'per_page' => 100,
+				'search'   => 'Doesn\'t exist',
+				'type'     => 'term',
+			)
+		);
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEmpty( $response->get_data() );
+	}
 
 	public function test_register_routes() {
 		$this->markTestSkipped( 'Covered by Search controller tests.' );

--- a/phpunit/class-wp-rest-term-search-handler-test.php
+++ b/phpunit/class-wp-rest-term-search-handler-test.php
@@ -1,0 +1,246 @@
+<?php
+/**
+ * WP_REST_Term_Search_Handler tests
+ *
+ * @package WordPress
+ * @subpackage REST_API
+ */
+
+/**
+ * Tests for WP_REST_Term_Search_Handler_Test.
+ *
+ * @group restapi
+ */
+class WP_REST_Term_Search_Handler_Test extends WP_Test_REST_Controller_Testcase {
+
+	/**
+	 * Categories.
+	 *
+	 * @var array
+	 */
+	private static $my_category = array();
+
+	/**
+	 * Tags.
+	 *
+	 * @var array
+	 */
+	private static $my_tag = array();
+
+	/**
+	 * Create fake data before our tests run.
+	 *
+	 * @param WP_UnitTest_Factory $factory Helper that lets us create fake data.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$my_category = $factory->term->create(
+			array(
+				'taxonomy' => 'category',
+				'name'     => 'Test Category',
+			)
+		);
+
+		self::$my_tag = $factory->term->create(
+			array(
+				'taxonomy' => 'post_tag',
+				'name'     => 'Test Tag',
+			)
+		);
+
+	}
+
+	/**
+	 * Delete our fake data after our tests run.
+	 */
+	public static function wpTearDownAfterClass() {
+		$term_ids = array(
+			self::$my_category,
+			self::$my_tag,
+		);
+
+		foreach ( $term_ids as $term_id ) {
+			wp_delete_term( $term_id, true );
+		}
+	}
+
+
+	/**
+	 * Search through terms of any type.
+	 */
+	public function test_get_items_search_type_term() {
+		$response = $this->do_request_with_params(
+			array(
+				'per_page' => 100,
+				'type'     => 'term',
+			)
+		);
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEqualSets(
+			array(
+				self::$my_category,
+				self::$my_tag,
+			),
+			wp_list_pluck( $response->get_data(), 'id' )
+		);
+	}
+
+	/**
+	 * Search through terms of subtype 'category'.
+	 */
+	public function test_get_items_search_type_term_subtype_category() {
+		$response = $this->do_request_with_params(
+			array(
+				'per_page' => 100,
+				'type'     => 'term',
+				'subtype'  => 'category',
+			)
+		);
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEqualSets(
+			array(
+				self::$my_category,
+			),
+			wp_list_pluck( $response->get_data(), 'id' )
+		);
+	}
+
+	/**
+	 * Search through posts of an invalid post type.
+	 */
+	public function test_get_items_search_term_subtype_invalid() {
+		$response = $this->do_request_with_params(
+			array(
+				'per_page' => 100,
+				'type'     => 'term',
+				'subtype'  => 'invalid',
+			)
+		);
+
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
+	}
+
+	/**
+	 * Search through posts and pages.
+	 */
+	public function test_get_items_search_categories_and_tags() {
+		$response = $this->do_request_with_params(
+			array(
+				'per_page' => 100,
+				'type'     => 'term',
+				'subtype'  => 'category,post_tag',
+			)
+		);
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEqualSets(
+			array(
+				self::$my_category,
+				self::$my_tag,
+			),
+			wp_list_pluck( $response->get_data(), 'id' )
+		);
+	}
+
+	/**
+	 * Search through all that matches a 'Test Category' search.
+	 */
+	public function test_get_items_search_for_testcategory() {
+		$response = $this->do_request_with_params(
+			array(
+				'per_page' => 100,
+				'search'   => 'Test Category',
+				'type'     => 'term',
+			)
+		);
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEqualSets(
+			array(
+				self::$my_category,
+			),
+			wp_list_pluck( $response->get_data(), 'id' )
+		);
+	}
+
+	/**
+	 * Search through all that matches a 'Test Tag' search.
+	 */
+	public function test_get_items_search_for_testtag() {
+		$response = $this->do_request_with_params(
+			array(
+				'per_page' => 100,
+				'search'   => 'Test Tag',
+				'type'     => 'term',
+			)
+		);
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEqualSets(
+			array(
+				self::$my_tag,
+			),
+			wp_list_pluck( $response->get_data(), 'id' )
+		);
+	}
+
+
+	public function test_register_routes() {
+		$this->markTestSkipped( 'Covered by Search controller tests.' );
+	}
+
+	public function test_context_param() {
+		$this->markTestSkipped( 'Covered by Search controller tests.' );
+	}
+
+	public function test_get_items() {
+		$this->markTestSkipped( 'Covered by Search controller tests.' );
+	}
+
+	public function test_get_item() {
+		$this->markTestSkipped( 'Covered by Search controller tests.' );
+	}
+
+	public function test_create_item() {
+		$this->markTestSkipped( 'Covered by Search controller tests.' );
+	}
+
+	public function test_update_item() {
+		$this->markTestSkipped( 'Covered by Search controller tests.' );
+	}
+
+	public function test_delete_item() {
+		$this->markTestSkipped( 'Covered by Search controller tests.' );
+	}
+
+	public function test_prepare_item() {
+		$this->markTestSkipped( 'Covered by Search controller tests.' );
+	}
+
+	public function test_get_item_schema() {
+		$this->markTestSkipped( 'Covered by Search controller tests.' );
+	}
+
+	/**
+	 * Perform a REST request to our search endpoint with given parameters.
+	 */
+	private function do_request_with_params( $params = array(), $method = 'GET' ) {
+		$request = $this->get_request( $params, $method );
+
+		return rest_get_server()->dispatch( $request );
+	}
+
+	/**
+	 * Get a REST request object for given parameters.
+	 */
+	private function get_request( $params = array(), $method = 'GET' ) {
+		$request = new WP_REST_Request( $method, '/wp/v2/search' );
+
+		foreach ( $params as $param => $value ) {
+			$request->set_param( $param, $value );
+		}
+
+		return $request;
+	}
+
+
+}

--- a/phpunit/class-wp-rest-term-search-handler-test.php
+++ b/phpunit/class-wp-rest-term-search-handler-test.php
@@ -77,6 +77,7 @@ class WP_REST_Term_Search_Handler_Test extends WP_Test_REST_Controller_Testcase 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEqualSets(
 			array(
+				0 => 1, // that is the default category
 				self::$my_category,
 				self::$my_tag,
 			),
@@ -99,6 +100,7 @@ class WP_REST_Term_Search_Handler_Test extends WP_Test_REST_Controller_Testcase 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEqualSets(
 			array(
+				0 => 1, // that is the default category
 				self::$my_category,
 			),
 			wp_list_pluck( $response->get_data(), 'id' )
@@ -134,6 +136,7 @@ class WP_REST_Term_Search_Handler_Test extends WP_Test_REST_Controller_Testcase 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEqualSets(
 			array(
+				0 => 1, // this is the default category
 				self::$my_category,
 				self::$my_tag,
 			),


### PR DESCRIPTION
## Description
Closes #20924 and closes #20165 

## How has this been tested?
Tested locally by:

0. Make sure you are:
a) having some categories setup
b) on a theme that supports post formats (twentyfourteen)
c) some posts saved as a post formats other than standard
1. Add a new post
2. Add a navigation block in that post
3. Add a new navigation link
4. Search for something that is included in a category's or a post format's name
5. Observe the category and/or post format is included in suggestions

## Types of changes
- adds a format search handler
- adds a category search handler
- hooks the new handlers in the search endpoint
- updates LinkControl's fetchLinkSuggestions to handle formats and categories as well

**PS**
I don't know if this is the best way to implement this feature. However, because we need the link to the format index page, I can't see a better way to get it than from an API call. We could output formats in the bulk data which is rendered on load, but categories could be too many for this option. 

cc @getdave - this updates indirectly `LinkControl` to show more types of suggestions. Suggestions welcome! :) 