### PR TITLE
[RNMobile] Fix displaying blocks with HTML anchor

### DIFF
--- a/packages/block-editor/src/components/index.native.js
+++ b/packages/block-editor/src/components/index.native.js
@@ -11,6 +11,7 @@ export * from './gradients';
 export * from './font-sizes';
 export { default as AlignmentToolbar } from './alignment-toolbar';
 export { default as InnerBlocks } from './inner-blocks';
+export { default as InspectorAdvancedControls } from './inspector-advanced-controls';
 export { default as InspectorControls } from './inspector-controls';
 export { default as __experimentalLineHeightControl } from './line-height-control';
 export { default as PlainText } from './plain-text';

--- a/packages/block-editor/src/components/inspector-advanced-controls/index.native.js
+++ b/packages/block-editor/src/components/inspector-advanced-controls/index.native.js
@@ -1,0 +1,1 @@
+export default () => null;

--- a/packages/block-editor/src/components/inspector-advanced-controls/index.native.js
+++ b/packages/block-editor/src/components/inspector-advanced-controls/index.native.js
@@ -1,1 +1,0 @@
-export default () => null;

--- a/packages/block-editor/src/hooks/index.native.js
+++ b/packages/block-editor/src/hooks/index.native.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 export { AlignmentHookSettingsProvider } from './align';
-
+import './anchor';
 import './custom-class-name';
 import './generated-class-name';
 import './style';


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Fixes: https://github.com/wordpress-mobile/gutenberg-mobile/issues/2000
Gutenberg Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2311

Enabled hooks injecting anchor to block on mobile side and used `null` for the UI that lets you edit the HTML anchor on the web.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Add a `Heading` block
1. Switch to HTML mode
1. Add an `id` to the HTML tag of heading block
1. Switch back to Visual mode
1. Block should be displayed without errors
1. Repeat same with `Group` block

## Screenshots <!-- if applicable -->

Visual | HTML
-- | -- 
<img width="300" src="https://user-images.githubusercontent.com/1845482/82830709-c2f08300-9eb6-11ea-8baf-a4b58690d539.png">|<img width="300" src="https://user-images.githubusercontent.com/1845482/82830700-be2bcf00-9eb6-11ea-82b6-87850df66cc8.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
