### PR TITLE
Fix missing parentheses in usePrevious hook

### DIFF
--- a/packages/compose/src/hooks/use-previous/index.js
+++ b/packages/compose/src/hooks/use-previous/index.js
@@ -18,7 +18,7 @@ export default function usePrevious( value ) {
 	// inferred based on the initial useRef argument, which is undefined.
 	// https://github.com/WordPress/gutenberg/pull/22597#issuecomment-633588366
 	/* eslint-disable jsdoc/no-undefined-types */
-	const ref = useRef( /** @type {T|undefined} */ undefined );
+	const ref = useRef( /** @type {T|undefined} */ ( undefined ) );
 	/* eslint-enable jsdoc/no-undefined-types */
 
 	// Store current value in ref.


### PR DESCRIPTION
Thanks, @aduth.

> FYI the parentheses in the example of [#22597 (comment)](https://github.com/WordPress/gutenberg/pull/22597#issuecomment-633588366) are significant:
> 
> ![image](https://user-images.githubusercontent.com/1779930/82834678-cfadb080-9e8f-11ea-9b75-719b139afcdc.png)
> 
> ![image](https://user-images.githubusercontent.com/1779930/82834656-c02e6780-9e8f-11ea-94c3-52fe4cd9c511.png)