### PR TITLE
Framework: Upgrade to wp-prettier@2.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6573,6 +6573,12 @@
 						"json5": "^1.0.1"
 					}
 				},
+				"prettier": {
+					"version": "1.19.1",
+					"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+					"integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+					"dev": true
+				},
 				"regenerator-runtime": {
 					"version": "0.13.3",
 					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
@@ -8322,6 +8328,12 @@
 						"emojis-list": "^2.0.0",
 						"json5": "^1.0.1"
 					}
+				},
+				"prettier": {
+					"version": "1.19.1",
+					"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+					"integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+					"dev": true
 				},
 				"regenerator-runtime": {
 					"version": "0.13.3",
@@ -10384,7 +10396,7 @@
 				"eslint-plugin-react": "^7.19.0",
 				"eslint-plugin-react-hooks": "^3.0.0",
 				"globals": "^12.0.0",
-				"prettier": "npm:wp-prettier@1.19.1",
+				"prettier": "npm:wp-prettier@2.0.5-beta-3",
 				"requireindex": "^1.2.0"
 			}
 		},
@@ -10682,7 +10694,7 @@
 				"node-sass": "^4.13.1",
 				"npm-package-json-lint": "^5.0.0",
 				"postcss-loader": "^3.0.0",
-				"prettier": "npm:wp-prettier@1.19.1",
+				"prettier": "npm:wp-prettier@2.0.5-beta-3",
 				"puppeteer": "npm:puppeteer-core@3.0.0",
 				"read-pkg-up": "^1.0.1",
 				"resolve-bin": "^0.4.0",
@@ -34608,9 +34620,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "npm:wp-prettier@1.19.1",
-			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-1.19.1.tgz",
-			"integrity": "sha512-mqAC2r1NDmRjG+z3KCJ/i61tycKlmADIjxnDhQab+KBxSAGbF/W7/zwB2guy/ypIeKrrftNsIYkNZZQKf3vJcg==",
+			"version": "npm:wp-prettier@2.0.5-beta-3",
+			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.0.5-beta-3.tgz",
+			"integrity": "sha512-vddwsa/ENdQazA2moI8ZWdJ0j2dL31jlJ10RqHSdZ41NO/kgziCtZnm3aSVhx3s+MQYf1xmSpOxppE4rn3kAGg==",
 			"dev": true
 		},
 		"prettier-linter-helpers": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10396,7 +10396,7 @@
 				"eslint-plugin-react": "^7.19.0",
 				"eslint-plugin-react-hooks": "^3.0.0",
 				"globals": "^12.0.0",
-				"prettier": "npm:wp-prettier@2.0.5-beta-4",
+				"prettier": "npm:wp-prettier@2.0.5",
 				"requireindex": "^1.2.0"
 			}
 		},
@@ -10694,7 +10694,7 @@
 				"node-sass": "^4.13.1",
 				"npm-package-json-lint": "^5.0.0",
 				"postcss-loader": "^3.0.0",
-				"prettier": "npm:wp-prettier@2.0.5-beta-4",
+				"prettier": "npm:wp-prettier@2.0.5",
 				"puppeteer": "npm:puppeteer-core@3.0.0",
 				"read-pkg-up": "^1.0.1",
 				"resolve-bin": "^0.4.0",
@@ -34620,9 +34620,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "npm:wp-prettier@2.0.5-beta-4",
-			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.0.5-beta-4.tgz",
-			"integrity": "sha512-qt5wk1kq38bJ95LdSu7UYtZBQK2JhOjJyAOQ9Gm+P7k7nyV+M3VO20XSX3fAJg3URpCxuSCTHyKWde+MfXp2fA==",
+			"version": "npm:wp-prettier@2.0.5",
+			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.0.5.tgz",
+			"integrity": "sha512-5GCgdeevIXwR3cW4Qj5XWC5MO1iSCz8+IPn0mMw6awAt/PBiey8yyO7MhePRsaMqghJAhg6Q3QLYWSnUHWkG6A==",
 			"dev": true
 		},
 		"prettier-linter-helpers": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10396,7 +10396,7 @@
 				"eslint-plugin-react": "^7.19.0",
 				"eslint-plugin-react-hooks": "^3.0.0",
 				"globals": "^12.0.0",
-				"prettier": "npm:wp-prettier@2.0.5-beta-3",
+				"prettier": "npm:wp-prettier@2.0.5-beta-4",
 				"requireindex": "^1.2.0"
 			}
 		},
@@ -10694,7 +10694,7 @@
 				"node-sass": "^4.13.1",
 				"npm-package-json-lint": "^5.0.0",
 				"postcss-loader": "^3.0.0",
-				"prettier": "npm:wp-prettier@2.0.5-beta-3",
+				"prettier": "npm:wp-prettier@2.0.5-beta-4",
 				"puppeteer": "npm:puppeteer-core@3.0.0",
 				"read-pkg-up": "^1.0.1",
 				"resolve-bin": "^0.4.0",
@@ -34620,9 +34620,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "npm:wp-prettier@2.0.5-beta-3",
-			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.0.5-beta-3.tgz",
-			"integrity": "sha512-vddwsa/ENdQazA2moI8ZWdJ0j2dL31jlJ10RqHSdZ41NO/kgziCtZnm3aSVhx3s+MQYf1xmSpOxppE4rn3kAGg==",
+			"version": "npm:wp-prettier@2.0.5-beta-4",
+			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.0.5-beta-4.tgz",
+			"integrity": "sha512-qt5wk1kq38bJ95LdSu7UYtZBQK2JhOjJyAOQ9Gm+P7k7nyV+M3VO20XSX3fAJg3URpCxuSCTHyKWde+MfXp2fA==",
 			"dev": true
 		},
 		"prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
 		"node-watch": "0.6.0",
 		"postcss": "7.0.13",
 		"postcss-loader": "3.0.0",
-		"prettier": "npm:wp-prettier@2.0.5-beta-3",
+		"prettier": "npm:wp-prettier@2.0.5-beta-4",
 		"progress": "2.0.3",
 		"puppeteer": "npm:puppeteer-core@3.0.0",
 		"react": "16.9.0",

--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
 		"node-watch": "0.6.0",
 		"postcss": "7.0.13",
 		"postcss-loader": "3.0.0",
-		"prettier": "npm:wp-prettier@2.0.5-beta-4",
+		"prettier": "npm:wp-prettier@2.0.5",
 		"progress": "2.0.3",
 		"puppeteer": "npm:puppeteer-core@3.0.0",
 		"react": "16.9.0",

--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
 		"node-watch": "0.6.0",
 		"postcss": "7.0.13",
 		"postcss-loader": "3.0.0",
-		"prettier": "npm:wp-prettier@1.19.1",
+		"prettier": "npm:wp-prettier@2.0.5-beta-3",
 		"progress": "2.0.3",
 		"puppeteer": "npm:puppeteer-core@3.0.0",
 		"react": "16.9.0",

--- a/packages/api-fetch/src/index.js
+++ b/packages/api-fetch/src/index.js
@@ -147,9 +147,7 @@ function apiFetch( options ) {
 					.then( ( data ) => data.text() )
 					.then( ( text ) => {
 						apiFetch.nonceMiddleware.nonce = text;
-						apiFetch( options )
-							.then( resolve )
-							.catch( reject );
+						apiFetch( options ).then( resolve ).catch( reject );
 					} )
 					.catch( reject );
 			} );

--- a/packages/block-directory/src/components/downloadable-block-info/index.js
+++ b/packages/block-directory/src/components/downloadable-block-info/index.js
@@ -35,8 +35,10 @@ function DownloadableBlockInfo( {
 					className="block-directory-downloadable-block-info__icon"
 					icon={ update }
 				/>
-				{ // translators: %s: Humanized date of last update e.g: "2 months ago".
-				sprintf( __( 'Updated %s' ), humanizedUpdated ) }
+				{
+					// translators: %s: Humanized date of last update e.g: "2 months ago".
+					sprintf( __( 'Updated %s' ), humanizedUpdated )
+				}
 			</div>
 		</Fragment>
 	);

--- a/packages/block-editor/src/components/block-list/block-invalid-warning.js
+++ b/packages/block-editor/src/components/block-list/block-invalid-warning.js
@@ -62,8 +62,10 @@ export class BlockInvalidWarning extends Component {
 							isSecondary={ hasHTMLBlock }
 							isPrimary={ ! hasHTMLBlock }
 						>
-							{ // translators: Button to fix block content
-							_x( 'Resolve', 'imperative verb' ) }
+							{
+								// translators: Button to fix block content
+								_x( 'Resolve', 'imperative verb' )
+							}
 						</Button>,
 						hasHTMLBlock && (
 							<Button

--- a/packages/block-editor/src/components/block-switcher/test/index.js
+++ b/packages/block-editor/src/components/block-switcher/test/index.js
@@ -181,12 +181,10 @@ describe( 'BlockSwitcher', () => {
 
 			test( 'should simulate a keydown event, which should call onToggle and open transform toggle.', () => {
 				const toggleClosed = shallow(
-					getDropdown()
-						.props()
-						.renderToggle( {
-							onToggle: onToggleStub,
-							isOpen: false,
-						} )
+					getDropdown().props().renderToggle( {
+						onToggle: onToggleStub,
+						isOpen: false,
+					} )
 				);
 				const iconButtonClosed = toggleClosed.find( 'ToolbarButton' );
 
@@ -197,12 +195,10 @@ describe( 'BlockSwitcher', () => {
 
 			test( 'should simulate a click event, which should call onToggle.', () => {
 				const toggleOpen = shallow(
-					getDropdown()
-						.props()
-						.renderToggle( {
-							onToggle: onToggleStub,
-							isOpen: true,
-						} )
+					getDropdown().props().renderToggle( {
+						onToggle: onToggleStub,
+						isOpen: true,
+					} )
 				);
 				const iconButtonOpen = toggleOpen.find( 'ToolbarButton' );
 

--- a/packages/block-editor/src/components/contrast-checker/test/index.js
+++ b/packages/block-editor/src/components/contrast-checker/test/index.js
@@ -64,12 +64,7 @@ describe( 'ContrastChecker', () => {
 		expect( speak ).toHaveBeenCalledWith(
 			'This color combination may be hard for people to read.'
 		);
-		expect(
-			wrapper
-				.find( Notice )
-				.children()
-				.text()
-		).toBe(
+		expect( wrapper.find( Notice ).children().text() ).toBe(
 			'This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.'
 		);
 	} );
@@ -120,12 +115,7 @@ describe( 'ContrastChecker', () => {
 		expect( speak ).toHaveBeenCalledWith(
 			'This color combination may be hard for people to read.'
 		);
-		expect(
-			wrapper
-				.find( Notice )
-				.children()
-				.text()
-		).toBe(
+		expect( wrapper.find( Notice ).children().text() ).toBe(
 			'This color combination may be hard for people to read. Try using a darker background color and/or a brighter text color.'
 		);
 	} );
@@ -142,12 +132,7 @@ describe( 'ContrastChecker', () => {
 		expect( speak ).toHaveBeenCalledWith(
 			'This color combination may be hard for people to read.'
 		);
-		expect(
-			wrapperSmallText
-				.find( Notice )
-				.children()
-				.text()
-		).toBe(
+		expect( wrapperSmallText.find( Notice ).children().text() ).toBe(
 			'This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.'
 		);
 
@@ -174,12 +159,7 @@ describe( 'ContrastChecker', () => {
 		expect( speak ).toHaveBeenCalledWith(
 			'This color combination may be hard for people to read.'
 		);
-		expect(
-			wrapperSmallFontSize
-				.find( Notice )
-				.children()
-				.text()
-		).toBe(
+		expect( wrapperSmallFontSize.find( Notice ).children().text() ).toBe(
 			'This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.'
 		);
 
@@ -219,12 +199,7 @@ describe( 'ContrastChecker', () => {
 		expect( speak ).toHaveBeenCalledWith(
 			'This color combination may be hard for people to read.'
 		);
-		expect(
-			wrapperNoLargeText
-				.find( Notice )
-				.children()
-				.text()
-		).toBe(
+		expect( wrapperNoLargeText.find( Notice ).children().text() ).toBe(
 			'This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.'
 		);
 	} );
@@ -253,12 +228,7 @@ describe( 'ContrastChecker', () => {
 		expect( speak ).toHaveBeenCalledWith(
 			'This color combination may be hard for people to read.'
 		);
-		expect(
-			wrapper
-				.find( Notice )
-				.children()
-				.text()
-		).toBe(
+		expect( wrapper.find( Notice ).children().text() ).toBe(
 			'This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.'
 		);
 	} );

--- a/packages/block-editor/src/components/gradient-picker/index.js
+++ b/packages/block-editor/src/components/gradient-picker/index.js
@@ -33,7 +33,7 @@ function GradientPickerWithGradients( props ) {
 	);
 }
 
-export default function( props ) {
+export default function ( props ) {
 	const ComponentToUse =
 		props.gradients !== undefined &&
 		props.disableCustomGradients !== undefined

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -274,8 +274,9 @@ function getBlocksWithDefaultStylesApplied( blocks, blockEditorSettings ) {
 			...block,
 			attributes: {
 				...attributes,
-				className: `${ className ||
-					'' } is-style-${ blockStyle }`.trim(),
+				className: `${
+					className || ''
+				} is-style-${ blockStyle }`.trim(),
 			},
 		};
 	} );

--- a/packages/block-editor/src/utils/transform-styles/ast/parse.js
+++ b/packages/block-editor/src/utils/transform-styles/ast/parse.js
@@ -7,7 +7,7 @@
 // https://github.com/visionmedia/css-parse/pull/49#issuecomment-30088027
 const commentre = /\/\*[^*]*\*+([^/*][^*]*\*+)*\//g;
 
-export default function( css, options ) {
+export default function ( css, options ) {
 	options = options || {};
 
 	/**
@@ -37,7 +37,7 @@ export default function( css, options ) {
 
 	function position() {
 		const start = { line: lineno, column };
-		return function( node ) {
+		return function ( node ) {
 			node.position = new Position( start );
 			whitespace();
 			return node;
@@ -224,11 +224,11 @@ export default function( css, options ) {
 		// FIXME: Remove all comments from selectors http://ostermiller.org/findcomment.html
 		return trim( m[ 0 ] )
 			.replace( /\/\*([^*]|[\r\n]|(\*+([^*/]|[\r\n])))*\*\/+/g, '' )
-			.replace( /"(?:\\"|[^"])*"|'(?:\\'|[^'])*'/g, function( matched ) {
+			.replace( /"(?:\\"|[^"])*"|'(?:\\'|[^'])*'/g, function ( matched ) {
 				return matched.replace( /,/g, '\u200C' );
 			} )
 			.split( /\s*(?![^(]*\)),\s*/ )
-			.map( function( s ) {
+			.map( function ( s ) {
 				return s.replace( /\u200C/g, ',' );
 			} );
 	}
@@ -600,7 +600,7 @@ export default function( css, options ) {
 
 	function _compileAtrule( name ) {
 		const re = new RegExp( '^@' + name + '\\s*([^;]+);' );
-		return function() {
+		return function () {
 			const pos = position();
 			const m = match( re );
 			if ( ! m ) {
@@ -678,7 +678,7 @@ function addParent( obj, parent ) {
 	for ( const k in obj ) {
 		const value = obj[ k ];
 		if ( Array.isArray( value ) ) {
-			value.forEach( function( v ) {
+			value.forEach( function ( v ) {
 				addParent( v, childParent );
 			} );
 		} else if ( value && typeof value === 'object' ) {

--- a/packages/block-editor/src/utils/transform-styles/ast/stringify/compiler.js
+++ b/packages/block-editor/src/utils/transform-styles/ast/stringify/compiler.js
@@ -19,7 +19,7 @@ function Compiler( opts ) {
  * Emit `str`
  */
 
-Compiler.prototype.emit = function( str ) {
+Compiler.prototype.emit = function ( str ) {
 	return str;
 };
 
@@ -27,7 +27,7 @@ Compiler.prototype.emit = function( str ) {
  * Visit `node`.
  */
 
-Compiler.prototype.visit = function( node ) {
+Compiler.prototype.visit = function ( node ) {
 	return this[ node.type ]( node );
 };
 
@@ -35,7 +35,7 @@ Compiler.prototype.visit = function( node ) {
  * Map visit over array of `nodes`, optionally using a `delim`
  */
 
-Compiler.prototype.mapVisit = function( nodes, delim ) {
+Compiler.prototype.mapVisit = function ( nodes, delim ) {
 	let buf = '';
 	delim = delim || '';
 

--- a/packages/block-editor/src/utils/transform-styles/ast/stringify/compress.js
+++ b/packages/block-editor/src/utils/transform-styles/ast/stringify/compress.js
@@ -35,7 +35,7 @@ inherits( Compiler, Base );
  * Compile `node`.
  */
 
-Compiler.prototype.compile = function( node ) {
+Compiler.prototype.compile = function ( node ) {
 	return node.stylesheet.rules.map( this.visit, this ).join( '' );
 };
 
@@ -43,7 +43,7 @@ Compiler.prototype.compile = function( node ) {
  * Visit comment node.
  */
 
-Compiler.prototype.comment = function( node ) {
+Compiler.prototype.comment = function ( node ) {
 	return this.emit( '', node.position );
 };
 
@@ -51,7 +51,7 @@ Compiler.prototype.comment = function( node ) {
  * Visit import node.
  */
 
-Compiler.prototype.import = function( node ) {
+Compiler.prototype.import = function ( node ) {
 	return this.emit( '@import ' + node.import + ';', node.position );
 };
 
@@ -59,7 +59,7 @@ Compiler.prototype.import = function( node ) {
  * Visit media node.
  */
 
-Compiler.prototype.media = function( node ) {
+Compiler.prototype.media = function ( node ) {
 	return (
 		this.emit( '@media ' + node.media, node.position ) +
 		this.emit( '{' ) +
@@ -72,7 +72,7 @@ Compiler.prototype.media = function( node ) {
  * Visit document node.
  */
 
-Compiler.prototype.document = function( node ) {
+Compiler.prototype.document = function ( node ) {
 	const doc = '@' + ( node.vendor || '' ) + 'document ' + node.document;
 
 	return (
@@ -87,7 +87,7 @@ Compiler.prototype.document = function( node ) {
  * Visit charset node.
  */
 
-Compiler.prototype.charset = function( node ) {
+Compiler.prototype.charset = function ( node ) {
 	return this.emit( '@charset ' + node.charset + ';', node.position );
 };
 
@@ -95,7 +95,7 @@ Compiler.prototype.charset = function( node ) {
  * Visit namespace node.
  */
 
-Compiler.prototype.namespace = function( node ) {
+Compiler.prototype.namespace = function ( node ) {
 	return this.emit( '@namespace ' + node.namespace + ';', node.position );
 };
 
@@ -103,7 +103,7 @@ Compiler.prototype.namespace = function( node ) {
  * Visit supports node.
  */
 
-Compiler.prototype.supports = function( node ) {
+Compiler.prototype.supports = function ( node ) {
 	return (
 		this.emit( '@supports ' + node.supports, node.position ) +
 		this.emit( '{' ) +
@@ -116,7 +116,7 @@ Compiler.prototype.supports = function( node ) {
  * Visit keyframes node.
  */
 
-Compiler.prototype.keyframes = function( node ) {
+Compiler.prototype.keyframes = function ( node ) {
 	return (
 		this.emit(
 			'@' + ( node.vendor || '' ) + 'keyframes ' + node.name,
@@ -132,7 +132,7 @@ Compiler.prototype.keyframes = function( node ) {
  * Visit keyframe node.
  */
 
-Compiler.prototype.keyframe = function( node ) {
+Compiler.prototype.keyframe = function ( node ) {
 	const decls = node.declarations;
 
 	return (
@@ -147,7 +147,7 @@ Compiler.prototype.keyframe = function( node ) {
  * Visit page node.
  */
 
-Compiler.prototype.page = function( node ) {
+Compiler.prototype.page = function ( node ) {
 	const sel = node.selectors.length ? node.selectors.join( ', ' ) : '';
 
 	return (
@@ -162,7 +162,7 @@ Compiler.prototype.page = function( node ) {
  * Visit font-face node.
  */
 
-Compiler.prototype[ 'font-face' ] = function( node ) {
+Compiler.prototype[ 'font-face' ] = function ( node ) {
 	return (
 		this.emit( '@font-face', node.position ) +
 		this.emit( '{' ) +
@@ -175,7 +175,7 @@ Compiler.prototype[ 'font-face' ] = function( node ) {
  * Visit host node.
  */
 
-Compiler.prototype.host = function( node ) {
+Compiler.prototype.host = function ( node ) {
 	return (
 		this.emit( '@host', node.position ) +
 		this.emit( '{' ) +
@@ -188,7 +188,7 @@ Compiler.prototype.host = function( node ) {
  * Visit custom-media node.
  */
 
-Compiler.prototype[ 'custom-media' ] = function( node ) {
+Compiler.prototype[ 'custom-media' ] = function ( node ) {
 	return this.emit(
 		'@custom-media ' + node.name + ' ' + node.media + ';',
 		node.position
@@ -199,7 +199,7 @@ Compiler.prototype[ 'custom-media' ] = function( node ) {
  * Visit rule node.
  */
 
-Compiler.prototype.rule = function( node ) {
+Compiler.prototype.rule = function ( node ) {
 	const decls = node.declarations;
 	if ( ! decls.length ) {
 		return '';
@@ -217,7 +217,7 @@ Compiler.prototype.rule = function( node ) {
  * Visit declaration node.
  */
 
-Compiler.prototype.declaration = function( node ) {
+Compiler.prototype.declaration = function ( node ) {
 	return (
 		this.emit( node.property + ':' + node.value, node.position ) +
 		this.emit( ';' )

--- a/packages/block-editor/src/utils/transform-styles/ast/stringify/identity.js
+++ b/packages/block-editor/src/utils/transform-styles/ast/stringify/identity.js
@@ -39,7 +39,7 @@ inherits( Compiler, Base );
  * Compile `node`.
  */
 
-Compiler.prototype.compile = function( node ) {
+Compiler.prototype.compile = function ( node ) {
 	return this.stylesheet( node );
 };
 
@@ -47,7 +47,7 @@ Compiler.prototype.compile = function( node ) {
  * Visit stylesheet node.
  */
 
-Compiler.prototype.stylesheet = function( node ) {
+Compiler.prototype.stylesheet = function ( node ) {
 	return this.mapVisit( node.stylesheet.rules, '\n\n' );
 };
 
@@ -55,7 +55,7 @@ Compiler.prototype.stylesheet = function( node ) {
  * Visit comment node.
  */
 
-Compiler.prototype.comment = function( node ) {
+Compiler.prototype.comment = function ( node ) {
 	return this.emit(
 		this.indent() + '/*' + node.comment + '*/',
 		node.position
@@ -66,7 +66,7 @@ Compiler.prototype.comment = function( node ) {
  * Visit import node.
  */
 
-Compiler.prototype.import = function( node ) {
+Compiler.prototype.import = function ( node ) {
 	return this.emit( '@import ' + node.import + ';', node.position );
 };
 
@@ -74,7 +74,7 @@ Compiler.prototype.import = function( node ) {
  * Visit media node.
  */
 
-Compiler.prototype.media = function( node ) {
+Compiler.prototype.media = function ( node ) {
 	return (
 		this.emit( '@media ' + node.media, node.position ) +
 		this.emit( ' {\n' + this.indent( 1 ) ) +
@@ -87,7 +87,7 @@ Compiler.prototype.media = function( node ) {
  * Visit document node.
  */
 
-Compiler.prototype.document = function( node ) {
+Compiler.prototype.document = function ( node ) {
 	const doc = '@' + ( node.vendor || '' ) + 'document ' + node.document;
 
 	return (
@@ -102,7 +102,7 @@ Compiler.prototype.document = function( node ) {
  * Visit charset node.
  */
 
-Compiler.prototype.charset = function( node ) {
+Compiler.prototype.charset = function ( node ) {
 	return this.emit( '@charset ' + node.charset + ';', node.position );
 };
 
@@ -110,7 +110,7 @@ Compiler.prototype.charset = function( node ) {
  * Visit namespace node.
  */
 
-Compiler.prototype.namespace = function( node ) {
+Compiler.prototype.namespace = function ( node ) {
 	return this.emit( '@namespace ' + node.namespace + ';', node.position );
 };
 
@@ -118,7 +118,7 @@ Compiler.prototype.namespace = function( node ) {
  * Visit supports node.
  */
 
-Compiler.prototype.supports = function( node ) {
+Compiler.prototype.supports = function ( node ) {
 	return (
 		this.emit( '@supports ' + node.supports, node.position ) +
 		this.emit( ' {\n' + this.indent( 1 ) ) +
@@ -131,7 +131,7 @@ Compiler.prototype.supports = function( node ) {
  * Visit keyframes node.
  */
 
-Compiler.prototype.keyframes = function( node ) {
+Compiler.prototype.keyframes = function ( node ) {
 	return (
 		this.emit(
 			'@' + ( node.vendor || '' ) + 'keyframes ' + node.name,
@@ -147,7 +147,7 @@ Compiler.prototype.keyframes = function( node ) {
  * Visit keyframe node.
  */
 
-Compiler.prototype.keyframe = function( node ) {
+Compiler.prototype.keyframe = function ( node ) {
 	const decls = node.declarations;
 
 	return (
@@ -163,7 +163,7 @@ Compiler.prototype.keyframe = function( node ) {
  * Visit page node.
  */
 
-Compiler.prototype.page = function( node ) {
+Compiler.prototype.page = function ( node ) {
 	const sel = node.selectors.length ? node.selectors.join( ', ' ) + ' ' : '';
 
 	return (
@@ -180,7 +180,7 @@ Compiler.prototype.page = function( node ) {
  * Visit font-face node.
  */
 
-Compiler.prototype[ 'font-face' ] = function( node ) {
+Compiler.prototype[ 'font-face' ] = function ( node ) {
 	return (
 		this.emit( '@font-face ', node.position ) +
 		this.emit( '{\n' ) +
@@ -195,7 +195,7 @@ Compiler.prototype[ 'font-face' ] = function( node ) {
  * Visit host node.
  */
 
-Compiler.prototype.host = function( node ) {
+Compiler.prototype.host = function ( node ) {
 	return (
 		this.emit( '@host', node.position ) +
 		this.emit( ' {\n' + this.indent( 1 ) ) +
@@ -208,7 +208,7 @@ Compiler.prototype.host = function( node ) {
  * Visit custom-media node.
  */
 
-Compiler.prototype[ 'custom-media' ] = function( node ) {
+Compiler.prototype[ 'custom-media' ] = function ( node ) {
 	return this.emit(
 		'@custom-media ' + node.name + ' ' + node.media + ';',
 		node.position
@@ -219,7 +219,7 @@ Compiler.prototype[ 'custom-media' ] = function( node ) {
  * Visit rule node.
  */
 
-Compiler.prototype.rule = function( node ) {
+Compiler.prototype.rule = function ( node ) {
 	const indent = this.indent();
 	const decls = node.declarations;
 	if ( ! decls.length ) {
@@ -229,7 +229,7 @@ Compiler.prototype.rule = function( node ) {
 	return (
 		this.emit(
 			node.selectors
-				.map( function( s ) {
+				.map( function ( s ) {
 					return indent + s;
 				} )
 				.join( ',\n' ),
@@ -247,7 +247,7 @@ Compiler.prototype.rule = function( node ) {
  * Visit declaration node.
  */
 
-Compiler.prototype.declaration = function( node ) {
+Compiler.prototype.declaration = function ( node ) {
 	return (
 		this.emit( this.indent() ) +
 		this.emit( node.property + ': ' + node.value, node.position ) +
@@ -259,7 +259,7 @@ Compiler.prototype.declaration = function( node ) {
  * Increase, decrease or return current indentation.
  */
 
-Compiler.prototype.indent = function( level ) {
+Compiler.prototype.indent = function ( level ) {
 	this.level = this.level || 1;
 
 	if ( null !== level ) {

--- a/packages/block-editor/src/utils/transform-styles/ast/stringify/index.js
+++ b/packages/block-editor/src/utils/transform-styles/ast/stringify/index.js
@@ -20,7 +20,7 @@ import Identity from './identity';
  * @return {string}
  */
 
-export default function( node, options ) {
+export default function ( node, options ) {
 	options = options || {};
 
 	const compiler = options.compress

--- a/packages/block-editor/src/utils/transform-styles/traverse.js
+++ b/packages/block-editor/src/utils/transform-styles/traverse.js
@@ -12,7 +12,7 @@ function traverseCSS( css, callback ) {
 	try {
 		const parsed = parse( css );
 
-		const updated = traverse.map( parsed, function( node ) {
+		const updated = traverse.map( parsed, function ( node ) {
 			if ( ! node ) {
 				return node;
 			}

--- a/packages/block-library/src/cover/deprecated.js
+++ b/packages/block-library/src/cover/deprecated.js
@@ -209,8 +209,9 @@ const deprecated = [
 				style.backgroundColor = customOverlayColor;
 			}
 			if ( focalPoint && ! hasParallax ) {
-				style.backgroundPosition = `${ focalPoint.x *
-					100 }% ${ focalPoint.y * 100 }%`;
+				style.backgroundPosition = `${ focalPoint.x * 100 }% ${
+					focalPoint.y * 100
+				}%`;
 			}
 			if ( customGradient && ! url ) {
 				style.background = customGradient;
@@ -302,8 +303,9 @@ const deprecated = [
 				style.backgroundColor = customOverlayColor;
 			}
 			if ( focalPoint && ! hasParallax ) {
-				style.backgroundPosition = `${ focalPoint.x *
-					100 }% ${ focalPoint.y * 100 }%`;
+				style.backgroundPosition = `${ focalPoint.x * 100 }% ${
+					focalPoint.y * 100
+				}%`;
 			}
 
 			const classes = classnames(

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -287,8 +287,9 @@ function CoverEdit( {
 	}
 
 	if ( focalPoint ) {
-		style.backgroundPosition = `${ focalPoint.x * 100 }% ${ focalPoint.y *
-			100 }%`;
+		style.backgroundPosition = `${ focalPoint.x * 100 }% ${
+			focalPoint.y * 100
+		}%`;
 	}
 
 	const hasBackground = !! ( url || overlayColor.color || gradientValue );

--- a/packages/block-library/src/embed/settings.js
+++ b/packages/block-library/src/embed/settings.js
@@ -136,7 +136,9 @@ export function getEmbedBlockSettings( {
 			return (
 				<figure className={ embedClassName }>
 					<div className="wp-block-embed__wrapper">
-						{ `\n${ url }\n` /* URL needs to be on its own line. */ }
+						{
+							`\n${ url }\n` /* URL needs to be on its own line. */
+						}
 					</div>
 					{ ! RichText.isEmpty( caption ) && (
 						<RichText.Content
@@ -165,7 +167,9 @@ export function getEmbedBlockSettings( {
 
 					return (
 						<figure className={ embedClassName }>
-							{ `\n${ url }\n` /* URL needs to be on its own line. */ }
+							{
+								`\n${ url }\n` /* URL needs to be on its own line. */
+							}
 							{ ! RichText.isEmpty( caption ) && (
 								<RichText.Content
 									tagName="figcaption"

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -21,10 +21,7 @@ function usePostContentExcerpt( wordCount ) {
 		excerptElement.innerHTML = rawPostContent;
 		const excerpt =
 			excerptElement.textContent || excerptElement.innerText || '';
-		return excerpt
-			.trim()
-			.split( ' ', wordCount )
-			.join( ' ' );
+		return excerpt.trim().split( ' ', wordCount ).join( ' ' );
 	}, [ rawPostContent, wordCount ] );
 }
 

--- a/packages/components/src/alignment-matrix-control/styles/alignment-matrix-control-icon-styles.js
+++ b/packages/components/src/alignment-matrix-control/styles/alignment-matrix-control-icon-styles.js
@@ -41,16 +41,16 @@ export const Root = styled.div`
 	height: 100%;
 	width: 100%;
 
-	${rootBase};
-	${rootSize};
-	${rootPointerEvents};
+	${ rootBase };
+	${ rootSize };
+	${ rootPointerEvents };
 `;
 
 const pointActive = ( { isActive } ) => {
 	const boxShadow = isActive ? `0 0 0 1px currentColor` : null;
 
 	return css`
-		box-shadow: ${boxShadow};
+		box-shadow: ${ boxShadow };
 		color: currentColor;
 
 		*:hover > & {
@@ -62,8 +62,8 @@ const pointActive = ( { isActive } ) => {
 export const Point = styled.span`
 	height: 2px;
 	width: 2px;
-	${pointBase};
-	${pointActive};
+	${ pointBase };
+	${ pointActive };
 `;
 
 export const Cell = CellBase;

--- a/packages/components/src/alignment-matrix-control/styles/alignment-matrix-control-styles.js
+++ b/packages/components/src/alignment-matrix-control/styles/alignment-matrix-control-styles.js
@@ -21,19 +21,19 @@ export const rootBase = () => {
 
 const rootSize = ( { size = 92 } ) => {
 	return css`
-		grid-template-rows: repeat( 3, calc( ${size}px / 3 ) );
-		width: ${size}px;
+		grid-template-rows: repeat( 3, calc( ${ size }px / 3 ) );
+		width: ${ size }px;
 	`;
 };
 
 export const Root = styled.div`
-	${rootBase};
+	${ rootBase };
 
 	border: 1px solid transparent;
 	cursor: pointer;
 	grid-template-columns: auto;
 
-	${rootSize};
+	${ rootSize };
 `;
 
 export const Row = styled.div`
@@ -50,11 +50,11 @@ const pointActive = ( { isActive } ) => {
 		: color( 'blue.medium.focus' );
 
 	return css`
-		box-shadow: ${boxShadow};
-		color: ${pointColor};
+		box-shadow: ${ boxShadow };
+		color: ${ pointColor };
 
 		*:hover > & {
-			color: ${pointColorHover};
+			color: ${ pointColorHover };
 		}
 	`;
 };
@@ -67,15 +67,15 @@ export const pointBase = ( props ) => {
 		margin: auto;
 		transition: all 120ms linear;
 
-		${reduceMotion( 'transition' )}
-		${pointActive( props )}
+		${ reduceMotion( 'transition' ) }
+		${ pointActive( props ) }
 	`;
 };
 
 export const Point = styled.span`
 	height: 6px;
 	width: 6px;
-	${pointBase}
+	${ pointBase }
 `;
 
 export const Cell = styled.span`

--- a/packages/components/src/button/test/index.js
+++ b/packages/components/src/button/test/index.js
@@ -104,12 +104,9 @@ describe( 'Button', () => {
 				/>
 			);
 			expect( iconButton.find( 'Icon' ).dive() ).not.toBeNull();
-			expect(
-				iconButton
-					.find( '.test' )
-					.shallow()
-					.text()
-			).toBe( 'Test' );
+			expect( iconButton.find( '.test' ).shallow().text() ).toBe(
+				'Test'
+			);
 		} );
 
 		it( 'should add an aria-label when the label property is used, with Tooltip wrapper', () => {

--- a/packages/components/src/card/stories/media.js
+++ b/packages/components/src/card/stories/media.js
@@ -122,11 +122,11 @@ const HorizontallyAlignedCard = styled( Card )`
 		flex-direction: row-reverse;
 	}
 
-	${StyledCardBody} {
+	${ StyledCardBody } {
 		flex: 1;
 	}
 
-	${StyledCardMedia} {
+	${ StyledCardMedia } {
 		&.is-left {
 			border-radius: 3px 0 0 3px;
 		}

--- a/packages/components/src/card/styles/card-styles.js
+++ b/packages/components/src/card/styles/card-styles.js
@@ -22,12 +22,12 @@ export const styleProps = {
 const { borderColor, borderRadius, backgroundShady } = styleProps;
 
 export const CardUI = styled.div`
-	background: ${color( 'white' )};
+	background: ${ color( 'white' ) };
 	box-sizing: border-box;
-	border-radius: ${borderRadius};
-	border: 1px solid ${borderColor};
+	border-radius: ${ borderRadius };
+	border: 1px solid ${ borderColor };
 
-	${handleBorderless};
+	${ handleBorderless };
 
 	&.is-elevated {
 		box-shadow: 0px 1px 3px 0px rgba( 0, 0, 0, 0.2 ),
@@ -37,18 +37,18 @@ export const CardUI = styled.div`
 `;
 
 export const HeaderUI = styled.div`
-	border-bottom: 1px solid ${borderColor};
-	border-top-left-radius: ${borderRadius};
-	border-top-right-radius: ${borderRadius};
+	border-bottom: 1px solid ${ borderColor };
+	border-top-left-radius: ${ borderRadius };
+	border-top-right-radius: ${ borderRadius };
 	box-sizing: border-box;
 
 	&:last-child {
 		border-bottom: none;
 	}
 
-	${headerFooterSizes};
-	${handleBorderless};
-	${handleShady};
+	${ headerFooterSizes };
+	${ handleBorderless };
+	${ handleShady };
 `;
 
 export const MediaUI = styled.div`
@@ -64,41 +64,41 @@ export const MediaUI = styled.div`
 	}
 
 	&:first-of-type {
-		border-top-left-radius: ${borderRadius};
-		border-top-right-radius: ${borderRadius};
+		border-top-left-radius: ${ borderRadius };
+		border-top-right-radius: ${ borderRadius };
 	}
 
 	&:last-of-type {
-		border-bottom-left-radius: ${borderRadius};
-		border-bottom-right-radius: ${borderRadius};
+		border-bottom-left-radius: ${ borderRadius };
+		border-bottom-right-radius: ${ borderRadius };
 	}
 `;
 
 export const BodyUI = styled.div`
 	box-sizing: border-box;
 
-	${bodySize};
-	${handleShady};
+	${ bodySize };
+	${ handleShady };
 `;
 
 export const FooterUI = styled.div`
-	border-top: 1px solid ${borderColor};
-	border-bottom-left-radius: ${borderRadius};
-	border-bottom-right-radius: ${borderRadius};
+	border-top: 1px solid ${ borderColor };
+	border-bottom-left-radius: ${ borderRadius };
+	border-bottom-right-radius: ${ borderRadius };
 	box-sizing: border-box;
 
 	&:first-of-type {
 		border-top: none;
 	}
 
-	${headerFooterSizes};
-	${handleBorderless};
-	${handleShady};
+	${ headerFooterSizes };
+	${ handleBorderless };
+	${ handleShady };
 `;
 
 export const DividerUI = styled( HorizontalRule )`
 	all: unset;
-	border-top: 1px solid ${borderColor};
+	border-top: 1px solid ${ borderColor };
 	box-sizing: border-box;
 	display: block;
 	height: 0;

--- a/packages/components/src/disabled/test/index.js
+++ b/packages/components/src/disabled/test/index.js
@@ -47,7 +47,7 @@ describe( 'Disabled', () => {
 
 	beforeAll( () => {
 		MutationObserver = window.MutationObserver;
-		window.MutationObserver = function() {};
+		window.MutationObserver = function () {};
 		window.MutationObserver.prototype = {
 			observe() {},
 			disconnect() {},

--- a/packages/components/src/draggable/index.js
+++ b/packages/components/src/draggable/index.js
@@ -47,18 +47,16 @@ class Draggable extends Component {
 	 * @param  {Object} event The non-custom DragEvent.
 	 */
 	onDragOver( event ) {
-		this.cloneWrapper.style.top = `${ parseInt(
-			this.cloneWrapper.style.top,
-			10
-		) +
+		this.cloneWrapper.style.top = `${
+			parseInt( this.cloneWrapper.style.top, 10 ) +
 			event.clientY -
-			this.cursorTop }px`;
-		this.cloneWrapper.style.left = `${ parseInt(
-			this.cloneWrapper.style.left,
-			10
-		) +
+			this.cursorTop
+		}px`;
+		this.cloneWrapper.style.left = `${
+			parseInt( this.cloneWrapper.style.left, 10 ) +
 			event.clientX -
-			this.cursorLeft }px`;
+			this.cursorLeft
+		}px`;
 
 		// Update cursor coordinates.
 		this.cursorLeft = event.clientX;
@@ -108,8 +106,9 @@ class Draggable extends Component {
 		clone.id = `clone-${ elementId }`;
 		this.cloneWrapper = document.createElement( 'div' );
 		this.cloneWrapper.classList.add( cloneWrapperClass );
-		this.cloneWrapper.style.width = `${ elementRect.width +
-			clonePadding * 2 }px`;
+		this.cloneWrapper.style.width = `${
+			elementRect.width + clonePadding * 2
+		}px`;
 
 		if ( elementRect.height > cloneHeightTransformationBreakpoint ) {
 			// Scale down clone if original element is larger than 700px.
@@ -120,10 +119,12 @@ class Draggable extends Component {
 			this.cloneWrapper.style.left = `${ event.clientX }px`;
 		} else {
 			// Position clone right over the original element (20px padding).
-			this.cloneWrapper.style.top = `${ elementTopOffset -
-				clonePadding }px`;
-			this.cloneWrapper.style.left = `${ elementLeftOffset -
-				clonePadding }px`;
+			this.cloneWrapper.style.top = `${
+				elementTopOffset - clonePadding
+			}px`;
+			this.cloneWrapper.style.left = `${
+				elementLeftOffset - clonePadding
+			}px`;
 		}
 
 		// Hack: Remove iFrames as it's causing the embeds drag clone to freeze

--- a/packages/components/src/dropdown-menu/test/index.js
+++ b/packages/components/src/dropdown-menu/test/index.js
@@ -91,10 +91,7 @@ describe( 'DropdownMenu', () => {
 
 			expect( wrapper.find( NavigableMenu ) ).toHaveLength( 1 );
 
-			wrapper
-				.find( MenuItem )
-				.props()
-				.onClick();
+			wrapper.find( MenuItem ).props().onClick();
 			wrapper.update();
 
 			expect( wrapper.find( NavigableMenu ) ).toHaveLength( 0 );

--- a/packages/components/src/external-link/index.js
+++ b/packages/components/src/external-link/index.js
@@ -36,8 +36,10 @@ export function ExternalLink(
 		>
 			{ children }
 			<VisuallyHidden as="span">
-				{ /* translators: accessibility text */
-				__( '(opens in a new tab)' ) }
+				{
+					/* translators: accessibility text */
+					__( '(opens in a new tab)' )
+				}
 			</VisuallyHidden>
 			<Icon
 				icon={ external }

--- a/packages/components/src/focal-point-picker/index.js
+++ b/packages/components/src/focal-point-picker/index.js
@@ -111,7 +111,7 @@ export class FocalPointPicker extends Component {
 					( pickerDimensions.height - bounds.top * 2 )
 				).toFixed( 2 ),
 			};
-			this.setState( { percentages }, function() {
+			this.setState( { percentages }, function () {
 				onChange( {
 					x: this.state.percentages.x,
 					y: this.state.percentages.y,
@@ -135,7 +135,7 @@ export class FocalPointPicker extends Component {
 		percentages[ axis ] = ( cleanValue ? cleanValue / 100 : 0 ).toFixed(
 			2
 		);
-		this.setState( { percentages }, function() {
+		this.setState( { percentages }, function () {
 			onChange( {
 				x: this.state.percentages.x,
 				y: this.state.percentages.y,

--- a/packages/components/src/guide/test/page-control.js
+++ b/packages/components/src/guide/test/page-control.js
@@ -37,10 +37,7 @@ describe( 'PageControl', () => {
 				setCurrentPage={ setCurrentPage }
 			/>
 		);
-		wrapper
-			.find( Button )
-			.at( 1 )
-			.simulate( 'click' );
+		wrapper.find( Button ).at( 1 ).simulate( 'click' );
 		expect( setCurrentPage ).toHaveBeenCalledWith( 1 );
 	} );
 } );

--- a/packages/components/src/input-control/styles/input-control-styles.js
+++ b/packages/components/src/input-control/styles/input-control-styles.js
@@ -28,8 +28,8 @@ export const Root = styled.div`
 	position: relative;
 	border-radius: 2px;
 
-	${rootFloatLabelStyles};
-	${rootFocusedStyles};
+	${ rootFloatLabelStyles };
+	${ rootFocusedStyles };
 `;
 
 const containerDisabledStyle = ( { disabled } ) => {
@@ -47,7 +47,7 @@ export const Container = styled.div`
 	display: flex;
 	position: relative;
 
-	${containerDisabledStyle};
+	${ containerDisabledStyle };
 `;
 
 const disabledStyles = ( { disabled } ) => {
@@ -70,10 +70,10 @@ const fontSizeStyles = ( { size } ) => {
 	if ( ! fontSize ) return '';
 
 	return css`
-		font-size: ${fontSizeMobile};
+		font-size: ${ fontSizeMobile };
 
 		@media ( min-width: 600px ) {
-			font-size: ${fontSize};
+			font-size: ${ fontSize };
 		}
 	`;
 };
@@ -108,7 +108,7 @@ const placeholderStyles = ( { isFilled, isFloating, isFloatingLabel } ) => {
 
 	return css`
 		&::placeholder {
-			opacity: ${opacity};
+			opacity: ${ opacity };
 		}
 
 		&::-webkit-input-placeholder {
@@ -123,7 +123,7 @@ const dragStyles = ( { isDragging, dragCursor } ) => {
 
 	if ( isDragging ) {
 		defaultArrowStyles = css`
-			cursor: ${dragCursor};
+			cursor: ${ dragCursor };
 			user-select: none;
 
 			&::-webkit-outer-spin-button,
@@ -137,14 +137,14 @@ const dragStyles = ( { isDragging, dragCursor } ) => {
 	if ( isDragging && dragCursor ) {
 		activeDragCursorStyles = css`
 			&:active {
-				cursor: ${dragCursor};
+				cursor: ${ dragCursor };
 			}
 		`;
 	}
 
 	return css`
-		${defaultArrowStyles};
-		${activeDragCursorStyles};
+		${ defaultArrowStyles };
+		${ activeDragCursorStyles };
 	`;
 };
 
@@ -157,19 +157,19 @@ export const Input = styled.input`
 		box-sizing: border-box;
 		border: none;
 		box-shadow: none !important;
-		color: ${color( 'black' )};
+		color: ${ color( 'black' ) };
 		display: block;
 		outline: none;
 		padding-left: 8px;
 		padding-right: 8px;
 		width: 100%;
 
-		${dragStyles};
-		${disabledStyles};
-		${fontSizeStyles};
-		${sizeStyles};
+		${ dragStyles };
+		${ disabledStyles };
+		${ fontSizeStyles };
+		${ sizeStyles };
 
-		${placeholderStyles};
+		${ placeholderStyles };
 	}
 `;
 
@@ -256,17 +256,17 @@ const BaseLabel = styled( Text )`
 		padding: 0;
 		pointer-events: none;
 		top: 50%;
-		transition: transform ${FLOATING_LABEL_TRANSITION_SPEED} linear,
-			max-width ${FLOATING_LABEL_TRANSITION_SPEED} linear;
+		transition: transform ${ FLOATING_LABEL_TRANSITION_SPEED } linear,
+			max-width ${ FLOATING_LABEL_TRANSITION_SPEED } linear;
 		z-index: 1;
 
-		${laberColor};
-		${labelFontSize};
-		${labelPosition};
-		${labelTruncation};
-		${reduceMotion( 'transition' )};
+		${ laberColor };
+		${ labelFontSize };
+		${ labelPosition };
+		${ labelTruncation };
+		${ reduceMotion( 'transition' ) };
 
-		${rtl( { left: 0 } )}
+		${ rtl( { left: 0 } ) }
 	}
 `;
 
@@ -304,9 +304,9 @@ export const Fieldset = styled.fieldset`
 		position: absolute;
 		right: 0;
 
-		${fieldsetFocusedStyles};
-		${fieldsetTopStyles};
-		${rtl( { paddingLeft: 2 } )}
+		${ fieldsetFocusedStyles };
+		${ fieldsetTopStyles };
+		${ rtl( { paddingLeft: 2 } ) }
 	}
 `;
 
@@ -333,19 +333,19 @@ export const Legend = styled.legend`
 		line-height: 11px;
 		margin: 0;
 		padding: 0;
-		transition: max-width ${FLOATING_LABEL_TRANSITION_SPEED} linear;
+		transition: max-width ${ FLOATING_LABEL_TRANSITION_SPEED } linear;
 		visibility: hidden;
 		width: auto;
 
-		${legendSize};
-		${reduceMotion( 'transition' )};
+		${ legendSize };
+		${ reduceMotion( 'transition' ) };
 	}
 `;
 
 const BaseLegendText = styled( Text )`
 	box-sizing: border-box;
 	display: inline-block;
-	${rtl( { paddingLeft: 4, paddingRight: 5 } )}
+	${ rtl( { paddingLeft: 4, paddingRight: 5 } ) }
 `;
 
 export const LegendText = ( props ) => (

--- a/packages/components/src/number-control/styles/number-control-styles.js
+++ b/packages/components/src/number-control/styles/number-control-styles.js
@@ -21,5 +21,5 @@ const htmlArrowStyles = ( { hideHTMLArrows } ) => {
 };
 
 export const Input = styled( InputControl )`
-	${htmlArrowStyles};
+	${ htmlArrowStyles };
 `;

--- a/packages/components/src/panel/test/body.js
+++ b/packages/components/src/panel/test/body.js
@@ -27,12 +27,7 @@ describe( 'PanelBody', () => {
 				panelBody.instance().toggle
 			);
 			expect( button.childAt( 0 ).name() ).toBe( 'span' );
-			expect(
-				button
-					.childAt( 0 )
-					.childAt( 0 )
-					.name()
-			).toBe( 'Icon' );
+			expect( button.childAt( 0 ).childAt( 0 ).name() ).toBe( 'Icon' );
 			expect( button.childAt( 1 ).text() ).toBe( 'Some Text' );
 		} );
 

--- a/packages/components/src/panel/test/header.js
+++ b/packages/components/src/panel/test/header.js
@@ -17,10 +17,7 @@ describe( 'PanelHeader', () => {
 			);
 			expect( panelHeader.type() ).toBe( 'div' );
 			expect(
-				panelHeader
-					.find( 'div' )
-					.shallow()
-					.children()
+				panelHeader.find( 'div' ).shallow().children()
 			).toHaveLength( 0 );
 		} );
 
@@ -35,10 +32,7 @@ describe( 'PanelHeader', () => {
 			const panelHeader = shallow( <PanelHeader children="Some Text" /> );
 			expect( panelHeader.text() ).toBe( 'Some Text' );
 			expect(
-				panelHeader
-					.find( 'div' )
-					.shallow()
-					.children()
+				panelHeader.find( 'div' ).shallow().children()
 			).toHaveLength( 1 );
 		} );
 
@@ -47,10 +41,7 @@ describe( 'PanelHeader', () => {
 				<PanelHeader label="Some Label" children="Some Text" />
 			);
 			expect(
-				panelHeader
-					.find( 'div' )
-					.shallow()
-					.children()
+				panelHeader.find( 'div' ).shallow().children()
 			).toHaveLength( 2 );
 		} );
 	} );

--- a/packages/components/src/panel/test/index.js
+++ b/packages/components/src/panel/test/index.js
@@ -14,24 +14,18 @@ describe( 'Panel', () => {
 			const panel = shallow( <Panel /> );
 			expect( panel.hasClass( 'components-panel' ) ).toBe( true );
 			expect( panel.type() ).toBe( 'div' );
-			expect(
-				panel
-					.find( 'div' )
-					.shallow()
-					.children()
-			).toHaveLength( 0 );
+			expect( panel.find( 'div' ).shallow().children() ).toHaveLength(
+				0
+			);
 		} );
 
 		it( 'should render a PanelHeader component when provided text in the header prop', () => {
 			const panel = shallow( <Panel header="Header Label" /> );
 			const panelHeader = panel.find( 'PanelHeader' );
 			expect( panelHeader.prop( 'label' ) ).toBe( 'Header Label' );
-			expect(
-				panel
-					.find( 'div' )
-					.shallow()
-					.children()
-			).toHaveLength( 1 );
+			expect( panel.find( 'div' ).shallow().children() ).toHaveLength(
+				1
+			);
 		} );
 
 		it( 'should render an additional className', () => {
@@ -42,24 +36,18 @@ describe( 'Panel', () => {
 		it( 'should add additional child elements to be rendered in the panel', () => {
 			const panel = shallow( <Panel children="The Panel" /> );
 			expect( panel.text() ).toBe( 'The Panel' );
-			expect(
-				panel
-					.find( 'div' )
-					.shallow()
-					.children()
-			).toHaveLength( 1 );
+			expect( panel.find( 'div' ).shallow().children() ).toHaveLength(
+				1
+			);
 		} );
 
 		it( 'should render both children and header when provided as props', () => {
 			const panel = shallow(
 				<Panel children="The Panel" header="The Header" />
 			);
-			expect(
-				panel
-					.find( 'div' )
-					.shallow()
-					.children()
-			).toHaveLength( 2 );
+			expect( panel.find( 'div' ).shallow().children() ).toHaveLength(
+				2
+			);
 		} );
 	} );
 } );

--- a/packages/components/src/range-control/styles/range-control-styles.js
+++ b/packages/components/src/range-control/styles/range-control-styles.js
@@ -29,28 +29,28 @@ const wrapperMargin = ( { marks } ) =>
 
 export const Wrapper = styled.span`
 	box-sizing: border-box;
-	color: ${color( 'blue.medium.focus' )};
+	color: ${ color( 'blue.medium.focus' ) };
 	display: block;
 	padding-top: 15px;
 	position: relative;
 	width: 100%;
 
-	${rangeHeight};
-	${wrapperMargin};
+	${ rangeHeight };
+	${ wrapperMargin };
 
-	${rtl( { marginLeft: 10 } )}
+	${ rtl( { marginLeft: 10 } ) }
 `;
 
 export const BeforeIconWrapper = styled.span`
 	margin-top: 3px;
 
-	${rtl( { marginRight: 6 } )}
+	${ rtl( { marginRight: 6 } ) }
 `;
 
 export const AfterIconWrapper = styled.span`
 	margin-top: 3px;
 
-	${rtl( { marginLeft: 16 } )}
+	${ rtl( { marginLeft: 16 } ) }
 `;
 
 const disabledRailBackgroundColor = ( { disabled } ) => {
@@ -61,7 +61,7 @@ const disabledRailBackgroundColor = ( { disabled } ) => {
 };
 
 export const Rail = styled.span`
-	background-color: ${color( 'lightGray.600' )};
+	background-color: ${ color( 'lightGray.600' ) };
 	box-sizing: border-box;
 	left: 0;
 	pointer-events: none;
@@ -72,7 +72,7 @@ export const Rail = styled.span`
 	margin-top: 14px;
 	top: 0;
 
-	${disabledRailBackgroundColor};
+	${ disabledRailBackgroundColor };
 `;
 
 const disabledBackgroundColor = ( { disabled } ) => {
@@ -93,7 +93,7 @@ export const Track = styled.span`
 	margin-top: 14px;
 	top: 0;
 
-	${disabledBackgroundColor};
+	${ disabledBackgroundColor };
 `;
 
 export const MarksWrapper = styled.span`
@@ -118,8 +118,8 @@ export const Mark = styled.span`
 	top: -4px;
 	width: 1px;
 
-	${markFill};
-	${disabledBackgroundColor};
+	${ markFill };
+	${ disabledBackgroundColor };
 `;
 
 const markLabelFill = ( { isFilled } ) => {
@@ -130,7 +130,7 @@ const markLabelFill = ( { isFilled } ) => {
 
 export const MarkLabel = styled.span`
 	box-sizing: border-box;
-	color: ${color( 'lightGray.600' )};
+	color: ${ color( 'lightGray.600' ) };
 	left: 0;
 	font-size: 11px;
 	position: absolute;
@@ -138,7 +138,7 @@ export const MarkLabel = styled.span`
 	transform: translateX( -50% );
 	white-space: nowrap;
 
-	${markLabelFill};
+	${ markLabelFill };
 `;
 
 export const ThumbWrapper = styled.span`
@@ -155,7 +155,7 @@ export const ThumbWrapper = styled.span`
 	user-select: none;
 	width: 20px;
 
-	${rtl( { marginLeft: -10 } )}
+	${ rtl( { marginLeft: -10 } ) }
 `;
 
 const thumbFocus = ( { isFocused } ) => {
@@ -177,7 +177,7 @@ export const Thumb = styled.span`
 	align-items: center;
 	background-color: white;
 	border-radius: 50%;
-	border: 1px solid ${color( 'darkGray.200' )};
+	border: 1px solid ${ color( 'darkGray.200' ) };
 	box-sizing: border-box;
 	height: 100%;
 	outline: 0;
@@ -186,7 +186,7 @@ export const Thumb = styled.span`
 	user-select: none;
 	width: 100%;
 
-	${thumbFocus};
+	${ thumbFocus };
 `;
 
 export const InputRange = styled.input`
@@ -239,7 +239,7 @@ const tooltipPosition = ( { position } ) => {
 };
 
 export const Tooltip = styled.span`
-	background: ${color( 'darkGray.800' )};
+	background: ${ color( 'darkGray.800' ) };
 	border-radius: 3px;
 	box-sizing: border-box;
 	color: white;
@@ -255,7 +255,7 @@ export const Tooltip = styled.span`
 	user-select: none;
 
 	&::after {
-		border: 6px solid ${color( 'darkGray.800' )};
+		border: 6px solid ${ color( 'darkGray.800' ) };
 		border-left-color: transparent;
 		border-right-color: transparent;
 		bottom: -6px;
@@ -269,13 +269,13 @@ export const Tooltip = styled.span`
 		width: 0;
 	}
 
-	${tooltipShow};
-	${tooltipPosition};
-	${reduceMotion( 'transition' )};
-	${rtl(
+	${ tooltipShow };
+	${ tooltipPosition };
+	${ reduceMotion( 'transition' ) };
+	${ rtl(
 		{ transform: 'translateX(-50%)' },
 		{ transform: 'translateX(50%)' }
-	)}
+	) }
 `;
 
 export const InputNumber = styled.input`
@@ -286,10 +286,10 @@ export const InputNumber = styled.input`
 	max-width: 120px;
 
 	input[type='number']& {
-		${rangeHeight};
+		${ rangeHeight };
 	}
 
-	${rtl( { marginLeft: 16 } )}
+	${ rtl( { marginLeft: 16 } ) }
 `;
 
 export const ActionRightWrapper = styled.span`
@@ -300,8 +300,8 @@ export const ActionRightWrapper = styled.span`
 	button,
 	button.is-small {
 		margin-left: 0;
-		${rangeHeight};
+		${ rangeHeight };
 	}
 
-	${rtl( { marginLeft: 8 } )}
+	${ rtl( { marginLeft: 8 } ) }
 `;

--- a/packages/components/src/text/styles/text-mixins.js
+++ b/packages/components/src/text/styles/text-mixins.js
@@ -85,44 +85,44 @@ const variant = ( variantName = 'body' ) => {
 	switch ( variantName ) {
 		case 'title.large':
 			return css`
-				${title}
-				${titleLarge}
+				${ title }
+				${ titleLarge }
 			`;
 		case 'title.medium':
 			return css`
-				${title}
-				${titleMedium}
+				${ title }
+				${ titleMedium }
 			`;
 		case 'title.small':
 			return css`
-				${title}
-				${titleSmall}
+				${ title }
+				${ titleSmall }
 			`;
 
 		case 'subtitle':
 			return css`
-				${subtitle}
-				${subtitleLarge}
+				${ subtitle }
+				${ subtitleLarge }
 			`;
 		case 'subtitle.small':
 			return css`
-				${subtitle}
-				${subtitleSmall}
+				${ subtitle }
+				${ subtitleSmall }
 			`;
 
 		case 'body':
 			return css`
-				${body}
+				${ body }
 			`;
 		case 'body.large':
 			return css`
-				${body}
-				${bodyLarge}
+				${ body }
+				${ bodyLarge }
 			`;
 		case 'body.small':
 			return css`
-				${body}
-				${bodySmall}
+				${ body }
+				${ bodySmall }
 			`;
 
 		case 'button':
@@ -145,6 +145,6 @@ const variant = ( variantName = 'body' ) => {
  * @param {TextProps} props
  */
 export const text = ( props ) => css`
-	${fontFamily}
-	${variant( props.variant )}
+	${ fontFamily }
+	${ variant( props.variant ) }
 `;

--- a/packages/components/src/tooltip/test/index.js
+++ b/packages/components/src/tooltip/test/index.js
@@ -54,12 +54,7 @@ describe( 'Tooltip', () => {
 			expect( button.childAt( 1 ).name() ).toBe( 'Popover' );
 			expect( popover.prop( 'focusOnMount' ) ).toBe( false );
 			expect( popover.prop( 'position' ) ).toBe( 'bottom right' );
-			expect(
-				popover
-					.children()
-					.first()
-					.text()
-			).toBe( 'Help text' );
+			expect( popover.children().first().text() ).toBe( 'Help text' );
 		} );
 
 		it( 'should show popover on focus', () => {

--- a/packages/components/src/unit-control/styles/unit-control-styles.js
+++ b/packages/components/src/unit-control/styles/unit-control-styles.js
@@ -18,7 +18,7 @@ const paddingStyles = ( { disableUnits } ) => {
 	const value = disableUnits ? 3 : 24;
 
 	return css`
-		${rtl( { paddingRight: value } )()};
+		${ rtl( { paddingRight: value } )() };
 	`;
 };
 
@@ -45,8 +45,8 @@ export const ValueInput = styled( NumberControl )`
 			display: block;
 			width: 100%;
 
-			${arrowStyles};
-			${paddingStyles};
+			${ arrowStyles };
+			${ paddingStyles };
 		}
 	}
 `;
@@ -106,23 +106,23 @@ export const UnitLabel = styled.div`
 	&&& {
 		pointer-events: none;
 
-		${baseUnitLabelStyles};
-		${unitLabelPaddingStyles};
+		${ baseUnitLabelStyles };
+		${ unitLabelPaddingStyles };
 	}
 `;
 
 export const UnitSelect = styled.select`
 	&&& {
-		${baseUnitLabelStyles};
+		${ baseUnitLabelStyles };
 		cursor: pointer;
 		border: 1px solid transparent;
 
 		&:hover {
-			background-color: ${color( 'lightGray.300' )};
+			background-color: ${ color( 'lightGray.300' ) };
 		}
 
 		&:focus {
-			border-color: ${color( 'ui.borderFocus' )};
+			border-color: ${ color( 'ui.borderFocus' ) };
 			outline: 2px solid transparent;
 			outline-offset: 0;
 		}

--- a/packages/core-data/src/utils/test/if-not-resolved.js
+++ b/packages/core-data/src/utils/test/if-not-resolved.js
@@ -31,7 +31,9 @@ describe( 'ifNotResolved', () => {
 				selectorName === 'hasStartedResolution' ? false : undefined,
 		} ) );
 
-		const originalResolver = jest.fn().mockImplementation( function*() {} );
+		const originalResolver = jest
+			.fn()
+			.mockImplementation( function* () {} );
 
 		const resolver = ifNotResolved( originalResolver, 'originalResolver' );
 
@@ -52,7 +54,9 @@ describe( 'ifNotResolved', () => {
 				selectorName === 'hasStartedResolution' ? true : undefined,
 		} ) );
 
-		const originalResolver = jest.fn().mockImplementation( function*() {} );
+		const originalResolver = jest
+			.fn()
+			.mockImplementation( function* () {} );
 
 		const resolver = ifNotResolved( originalResolver, 'originalResolver' );
 

--- a/packages/data/src/namespace-store/test/index.js
+++ b/packages/data/src/namespace-store/test/index.js
@@ -14,7 +14,7 @@ describe( 'controls', () => {
 	describe( 'should call registry-aware controls', () => {
 		it( 'registers multiple selectors to the public API', () => {
 			const action1 = jest.fn( () => ( { type: 'NOTHING' } ) );
-			const action2 = function*() {
+			const action2 = function* () {
 				yield { type: 'DISPATCH', store: 'store1', action: 'action1' };
 			};
 			registry.registerStore( 'store1', {

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -170,7 +170,7 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 			if ( typeof attribute !== 'function' ) {
 				return attribute;
 			}
-			return function() {
+			return function () {
 				return registry[ key ].apply( null, arguments );
 			};
 		} );

--- a/packages/docgen/src/test/fixtures/default-function-anonymous/code.js
+++ b/packages/docgen/src/test/fixtures/default-function-anonymous/code.js
@@ -1,4 +1,4 @@
 /**
  * Function declaration example.
  */
-export default function() {}
+export default function () {}

--- a/packages/docgen/src/test/fixtures/default-undocumented-nocomments/code.js
+++ b/packages/docgen/src/test/fixtures/default-undocumented-nocomments/code.js
@@ -1,3 +1,3 @@
-const myDeclaration = function() {};
+const myDeclaration = function () {};
 
 export default myDeclaration;

--- a/packages/docgen/src/test/fixtures/default-undocumented-oneliner/code.js
+++ b/packages/docgen/src/test/fixtures/default-undocumented-oneliner/code.js
@@ -1,2 +1,2 @@
 // This comment should be ignored
-export default function() {}
+export default function () {}

--- a/packages/docgen/src/test/fixtures/named-default-exported/module-code.js
+++ b/packages/docgen/src/test/fixtures/named-default-exported/module-code.js
@@ -1,4 +1,4 @@
 /**
  * Module declaration.
  */
-export default function() {}
+export default function () {}

--- a/packages/docgen/src/test/fixtures/named-default/module-code.js
+++ b/packages/docgen/src/test/fixtures/named-default/module-code.js
@@ -1,4 +1,4 @@
 /**
  * Module declaration.
  */
-export default function() {}
+export default function () {}

--- a/packages/dom/src/test/utils/create-element.js
+++ b/packages/dom/src/test/utils/create-element.js
@@ -10,7 +10,7 @@ export default function createElement( type ) {
 	const element = document.createElement( type );
 
 	const ifNotHidden = ( value, elseValue ) =>
-		function() {
+		function () {
 			let isHidden = false;
 			let node = this;
 			do {

--- a/packages/edit-post/src/components/manage-blocks-modal/show-all.js
+++ b/packages/edit-post/src/components/manage-blocks-modal/show-all.js
@@ -15,8 +15,10 @@ export default function BlockManagerShowAll( { checked, onChange } ) {
 				htmlFor={ id }
 				className="edit-post-manage-blocks-modal__show-all-label"
 			>
-				{ /* translators: Checkbox toggle label */
-				__( 'Show section' ) }
+				{
+					/* translators: Checkbox toggle label */
+					__( 'Show section' )
+				}
 			</label>
 			<FormToggle
 				id={ id }

--- a/packages/edit-post/src/components/options-modal/options/test/enable-custom-fields.js
+++ b/packages/edit-post/src/components/options-modal/options/test/enable-custom-fields.js
@@ -34,7 +34,7 @@ describe( 'EnableCustomFieldsOption', () => {
 
 	it( 'renders an unchecked checkbox and a confirmation message when toggled off', () => {
 		const renderer = new TestRenderer.create(
-			( <EnableCustomFieldsOption areCustomFieldsEnabled /> )
+			<EnableCustomFieldsOption areCustomFieldsEnabled />
 		);
 		act( () => {
 			renderer.root.findByType( BaseOption ).props.onChange( false );
@@ -44,7 +44,7 @@ describe( 'EnableCustomFieldsOption', () => {
 
 	it( 'renders a checked checkbox and a confirmation message when toggled on', () => {
 		const renderer = new TestRenderer.create(
-			( <EnableCustomFieldsOption areCustomFieldsEnabled={ false } /> )
+			<EnableCustomFieldsOption areCustomFieldsEnabled={ false } />
 		);
 		act( () => {
 			renderer.root.findByType( BaseOption ).props.onChange( true );
@@ -63,7 +63,7 @@ describe( 'CustomFieldsConfirmation', () => {
 			} ) );
 
 		const renderer = new TestRenderer.create(
-			( <CustomFieldsConfirmation /> )
+			<CustomFieldsConfirmation />
 		);
 		act( () => {
 			renderer.root.findByType( Button ).props.onClick();

--- a/packages/edit-site/src/components/template-switcher/theme-preview.js
+++ b/packages/edit-site/src/components/template-switcher/theme-preview.js
@@ -20,8 +20,10 @@ function ThemePreview( {
 				{ 'v' + version }
 			</span>
 			<div className="edit-site-template-switcher__theme-preview-byline">
-				{ // translators: %s: theme author name.
-				sprintf( __( 'By %s' ), [ authorName ] ) }
+				{
+					// translators: %s: theme author name.
+					sprintf( __( 'By %s' ), [ authorName ] )
+				}
 			</div>
 			<img
 				className="edit-site-template-switcher__theme-preview-screenshot"

--- a/packages/editor/src/components/document-outline/item.js
+++ b/packages/editor/src/components/document-outline/item.js
@@ -34,13 +34,15 @@ const TableOfContentsItem = ( {
 				className="document-outline__emdash"
 				aria-hidden="true"
 			></span>
-			{ // path is an array of nodes that are ancestors of the heading starting in the top level node.
-			// This mapping renders each ancestor to make it easier for the user to know where the headings are nested.
-			path.map( ( { clientId }, index ) => (
-				<strong key={ index } className="document-outline__level">
-					<BlockTitle clientId={ clientId } />
-				</strong>
-			) ) }
+			{
+				// path is an array of nodes that are ancestors of the heading starting in the top level node.
+				// This mapping renders each ancestor to make it easier for the user to know where the headings are nested.
+				path.map( ( { clientId }, index ) => (
+					<strong key={ index } className="document-outline__level">
+						<BlockTitle clientId={ clientId } />
+					</strong>
+				) )
+			}
 			<strong className="document-outline__level">{ level }</strong>
 			<span className="document-outline__item-content">{ children }</span>
 		</a>

--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -208,8 +208,10 @@ export class PostPreviewButton extends Component {
 					? this.props.textContent
 					: _x( 'Preview', 'imperative verb' ) }
 				<VisuallyHidden as="span">
-					{ /* translators: accessibility text */
-					__( '(opens in a new tab)' ) }
+					{
+						/* translators: accessibility text */
+						__( '(opens in a new tab)' )
+					}
 				</VisuallyHidden>
 			</Button>
 		);

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -722,7 +722,7 @@ export function updateEditorSettings( settings ) {
  */
 
 const getBlockEditorAction = ( name ) =>
-	function*( ...args ) {
+	function* ( ...args ) {
 		deprecated( "`wp.data.dispatch( 'core/editor' )." + name + '`', {
 			alternative:
 				"`wp.data.dispatch( 'core/block-editor' )." + name + '`',

--- a/packages/env/lib/config.js
+++ b/packages/env/lib/config.js
@@ -413,8 +413,5 @@ async function getHomeDirectory() {
  * @return {string} An MD5 hash string.
  */
 function md5( data ) {
-	return crypto
-		.createHash( 'md5' )
-		.update( data )
-		.digest( 'hex' );
+	return crypto.createHash( 'md5' ).update( data ).digest( 'hex' );
 }

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+- The bundled `wp-prettier` dependency has been upgraded from `1.19.1` to `2.0.5`. Refer to the [Prettier 2.0 "2020" blog post](https://prettier.io/blog/2020/03/21/2.0.0.html) for full details about the major changes included in Prettier 2.0.
+
 ### Bug Fixes
 
 - `@wordpress/dependency-group` will now correctly identify issues associated with CommonJS (`require`) module imports.

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -35,7 +35,7 @@
 		"eslint-plugin-react": "^7.19.0",
 		"eslint-plugin-react-hooks": "^3.0.0",
 		"globals": "^12.0.0",
-		"prettier": "npm:wp-prettier@1.19.1",
+		"prettier": "npm:wp-prettier@2.0.5-beta-3",
 		"requireindex": "^1.2.0"
 	},
 	"peerDependencies": {

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -35,7 +35,7 @@
 		"eslint-plugin-react": "^7.19.0",
 		"eslint-plugin-react-hooks": "^3.0.0",
 		"globals": "^12.0.0",
-		"prettier": "npm:wp-prettier@2.0.5-beta-3",
+		"prettier": "npm:wp-prettier@2.0.5-beta-4",
 		"requireindex": "^1.2.0"
 	},
 	"peerDependencies": {

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -35,7 +35,7 @@
 		"eslint-plugin-react": "^7.19.0",
 		"eslint-plugin-react-hooks": "^3.0.0",
 		"globals": "^12.0.0",
-		"prettier": "npm:wp-prettier@2.0.5-beta-4",
+		"prettier": "npm:wp-prettier@2.0.5",
 		"requireindex": "^1.2.0"
 	},
 	"peerDependencies": {

--- a/packages/eslint-plugin/rules/dependency-group.js
+++ b/packages/eslint-plugin/rules/dependency-group.js
@@ -183,8 +183,8 @@ module.exports = /** @type {import('eslint').Rule.RuleModule} */ ( {
 					let source;
 					switch ( child.type ) {
 						case 'ImportDeclaration':
-							source =
-								/** @type {string} */ ( child.source.value );
+							source = /** @type {string} */ ( child.source
+								.value );
 							candidates.push( [ child, source ] );
 							break;
 
@@ -196,8 +196,8 @@ module.exports = /** @type {import('eslint').Rule.RuleModule} */ ( {
 									init.type !== 'CallExpression' ||
 									/** @type {import('estree').CallExpression} */ ( init )
 										.callee.type !== 'Identifier' ||
-									/** @type {import('estree').Identifier} */ ( init
-										.callee ).name !== 'require'
+									/** @type {import('estree').Identifier} */ ( init.callee )
+										.name !== 'require'
 								) {
 									return;
 								}

--- a/packages/format-library/src/link/test/modal.native.js
+++ b/packages/format-library/src/link/test/modal.native.js
@@ -46,10 +46,7 @@ describe( 'LinksUI', () => {
 		// When
 
 		// Simulate user typing on the URL Cell.
-		const bottomSheet = wrapper
-			.dive()
-			.find( 'BottomSheet' )
-			.first();
+		const bottomSheet = wrapper.dive().find( 'BottomSheet' ).first();
 		const cell = bottomSheet
 			.dive()
 			.find( 'WithPreferredColorScheme(BottomSheetCell)' )

--- a/packages/hooks/src/test/index.test.js
+++ b/packages/hooks/src/test/index.test.js
@@ -716,7 +716,7 @@ test( 'Test `this` context via composition', () => {
 
 	testObject.hooks = createHooks();
 
-	const theCallback = function() {
+	const theCallback = function () {
 		expect( this.test ).toBe( 'test this' );
 	};
 	addAction( 'test.action', 'my_callback', theCallback.bind( testObject ) );

--- a/packages/media-utils/src/components/media-upload/index.js
+++ b/packages/media-utils/src/components/media-upload/index.js
@@ -370,10 +370,7 @@ class MediaUpload extends Component {
 	onSelect() {
 		const { onSelect, multiple = false } = this.props;
 		// Get media attachment details from the frame state
-		const attachment = this.frame
-			.state()
-			.get( 'selection' )
-			.toJSON();
+		const attachment = this.frame.state().get( 'selection' ).toJSON();
 		onSelect( multiple ? attachment : attachment[ 0 ] );
 	}
 

--- a/packages/project-management-automation/lib/tasks/first-time-contributor/index.js
+++ b/packages/project-management-automation/lib/tasks/first-time-contributor/index.js
@@ -47,8 +47,8 @@ async function firstTimeContributor( payload, octokit ) {
 		return;
 	}
 
-	const commit =
-		/** @type {WebhookPayloadPushCommit} */ ( payload.commits[ 0 ] );
+	const commit = /** @type {WebhookPayloadPushCommit} */ ( payload
+		.commits[ 0 ] );
 	const pullRequest = getAssociatedPullRequest( commit );
 	if ( ! pullRequest ) {
 		debug(

--- a/packages/redux-routine/src/test/is-generator.js
+++ b/packages/redux-routine/src/test/is-generator.js
@@ -23,13 +23,13 @@ describe( 'isGenerator', () => {
 	} );
 
 	it( 'should return false if an async generator', () => {
-		const value = ( async function*() {} )();
+		const value = ( async function* () {} )();
 
 		expect( isGenerator( value ) ).toBe( false );
 	} );
 
 	it( 'should return true if a generator', () => {
-		const value = ( function*() {} )();
+		const value = ( function* () {} )();
 
 		expect( isGenerator( value ) ).toBe( true );
 	} );

--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -837,29 +837,34 @@ export class RichText extends Component {
 							onFocus={ () => {} }
 						/>
 						<BlockFormatControls>
-							{ // eslint-disable-next-line no-undef
-							__DEV__ && isMentionsSupported( capabilities ) && (
-								<Toolbar>
-									<ToolbarButton
-										title={ __( 'Insert mention' ) }
-										icon={ <Icon icon={ atSymbol } /> }
-										onClick={ () => {
-											addMention()
-												.then( ( mentionUserId ) => {
-													let stringToInsert = `@${ mentionUserId }`;
-													if ( this.isIOS ) {
-														stringToInsert += ' ';
-													}
-													this.insertString(
-														record,
-														stringToInsert
-													);
-												} )
-												.catch( () => {} );
-										} }
-									/>
-								</Toolbar>
-							) }
+							{
+								// eslint-disable-next-line no-undef
+								__DEV__ && isMentionsSupported( capabilities ) && (
+									<Toolbar>
+										<ToolbarButton
+											title={ __( 'Insert mention' ) }
+											icon={ <Icon icon={ atSymbol } /> }
+											onClick={ () => {
+												addMention()
+													.then(
+														( mentionUserId ) => {
+															let stringToInsert = `@${ mentionUserId }`;
+															if ( this.isIOS ) {
+																stringToInsert +=
+																	' ';
+															}
+															this.insertString(
+																record,
+																stringToInsert
+															);
+														}
+													)
+													.catch( () => {} );
+											} }
+										/>
+									</Toolbar>
+								)
+							}
 						</BlockFormatControls>
 					</>
 				) }

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,16 +2,17 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+- The default babel configuration has changed to only support stage-4 proposals. This affects the `build` and `start` commands that use the bundled babel configuration; if a project provides its own, this change doesn't affect it. [#22083](https://github.com/WordPress/gutenberg/pull/22083)
+- The bundled `wp-prettier` dependency has been upgraded from `1.19.1` to `2.0.5`. Refer to the [Prettier 2.0 "2020" blog post](https://prettier.io/blog/2020/03/21/2.0.0.html) for full details about the major changes included in Prettier 2.0.
+
 ### New Feature
 
 - New `--webpack-no-externals` flag added to `build` and `start` scripts. It disables scripts' assets generation, and omits the list of default externals ([#22310](https://github.com/WordPress/gutenberg/pull/22310)).
 - New `--webpack-bundle-analyzer` flag added to `build` and `start` scripts. It enables visualization for the size of webpack output files with an interactive zoomable treemap ([#22310](https://github.com/WordPress/gutenberg/pull/22310)).
 - New `--webpack--devtool` flag added to `start` script. It controls how source maps are generated. See options at https://webpack.js.org/configuration/devtool/#devtool ([#22310](https://github.com/WordPress/gutenberg/pull/22310)).
 - The `test-e2e` and `test-unit` scripts will now disambiguate custom configurations, preferring a `jest-e2e.config.js`, `jest-e2e.config.json`, `jest-unit.config.js`, or `jest-unit.config.json` Jest configuration file if present, falling back to `jest.config.js` or `jest.config.json`. This allows for configurations which should only apply to one or the other test variant.
-
-### Breaking Changes
-
-- The default babel configuration has changed to only support stage-4 proposals. This affects the `build` and `start` commands that use the bundled babel configuration; if a project provides its own, this change doesn't affect it. [#22083](https://github.com/WordPress/gutenberg/pull/22083)
 
 ## 9.1.0 (2020-05-14)
 

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -65,7 +65,7 @@
 		"node-sass": "^4.13.1",
 		"npm-package-json-lint": "^5.0.0",
 		"postcss-loader": "^3.0.0",
-		"prettier": "npm:wp-prettier@2.0.5-beta-3",
+		"prettier": "npm:wp-prettier@2.0.5-beta-4",
 		"puppeteer": "npm:puppeteer-core@3.0.0",
 		"read-pkg-up": "^1.0.1",
 		"resolve-bin": "^0.4.0",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -65,7 +65,7 @@
 		"node-sass": "^4.13.1",
 		"npm-package-json-lint": "^5.0.0",
 		"postcss-loader": "^3.0.0",
-		"prettier": "npm:wp-prettier@2.0.5-beta-4",
+		"prettier": "npm:wp-prettier@2.0.5",
 		"puppeteer": "npm:puppeteer-core@3.0.0",
 		"read-pkg-up": "^1.0.1",
 		"resolve-bin": "^0.4.0",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -65,7 +65,7 @@
 		"node-sass": "^4.13.1",
 		"npm-package-json-lint": "^5.0.0",
 		"postcss-loader": "^3.0.0",
-		"prettier": "npm:wp-prettier@1.19.1",
+		"prettier": "npm:wp-prettier@2.0.5-beta-3",
 		"puppeteer": "npm:puppeteer-core@3.0.0",
 		"read-pkg-up": "^1.0.1",
 		"resolve-bin": "^0.4.0",

--- a/packages/shortcode/src/index.js
+++ b/packages/shortcode/src/index.js
@@ -90,7 +90,7 @@ export function next( tag, text, index = 0 ) {
  * @return {string} Text with shortcodes replaced.
  */
 export function replace( tag, text, callback ) {
-	return text.replace( regexp( tag ), function(
+	return text.replace( regexp( tag ), function (
 		match,
 		left,
 		$3,
@@ -266,7 +266,7 @@ export function fromMatch( match ) {
  * @return {WPShortcode} Shortcode instance.
  */
 const shortcode = extend(
-	function( options ) {
+	function ( options ) {
 		extend(
 			this,
 			pick( options || {}, 'tag', 'attrs', 'type', 'content' )


### PR DESCRIPTION
This pull request seeks to attempt to upgrade to the 2.x major version of Prettier (still `wp-prettier` fork).

See changelog: https://prettier.io/blog/2020/03/21/2.0.0.html

~**Status:** It's considered in progress due to a few potential errors in the formatted output, and related need to wait for a new stable release of `wp-prettier`.~ **Edit:** Fixed, see https://github.com/WordPress/gutenberg/pull/22610#issuecomment-634552341.

**Status (2020-05-27):** Awaiting stable published release of `wp-prettier@2.0.5`.

Notable changes:

- [As noted in the release notes](https://prettier.io/blog/2020/03/21/2.0.0.html#always-add-a-space-after-the-function-keyword-3903httpsgithubcomprettierprettierpull3903-by-j-f1httpsgithubcomj-f1-josephfrazierhttpsgithubcomjosephfrazier-sosukesuzukihttpsgithubcomsosukesuzuki-thorn0httpsgithubcomthorn0-7516httpsgithubcomprettierprettierpull7516-by-bakkothttpsgithubcombakkot), the default behavior is changed to add a space after the `function` keyword. This contributes to a majority of the included modifications.
- ~There are a few changes which seem to be unexpected, where a space is omitted or put on the wrong side of a parenthesis.~ **Edit:** Fixed, see https://github.com/WordPress/gutenberg/pull/22610#issuecomment-634552341.

<details><summary>Click to expand outdated issues explanation</summary>
Examples:

https://github.com/WordPress/gutenberg/blob/2cc80de37432d0d377b670ae4ab9f6fd08f8df3b/packages/blocks/src/api/factory.js#L353

https://github.com/WordPress/gutenberg/blob/2cc80de37432d0d377b670ae4ab9f6fd08f8df3b/packages/block-editor/src/components/colors/use-colors.js#L220

https://github.com/WordPress/gutenberg/blob/2cc80de37432d0d377b670ae4ab9f6fd08f8df3b/packages/block-library/src/gallery/tiles.native.js#L59

https://github.com/WordPress/gutenberg/blob/2cc80de37432d0d377b670ae4ab9f6fd08f8df3b/packages/block-library/src/index.native.js#L125

I note the issue at the upstream https://github.com/Automattic/wp-prettier/issues/19, which is intended to be fixed by the https://github.com/Automattic/wp-prettier/pull/20 , currently only available in a beta release. It's not entirely clear if this addresses both of the issues seen in the examples above, where template strings are one problem, but also a problem in some parenthesis usage (cc @sirreal, @scinos, @griffbrad).
</details>