### PR TITLE
Env: Add support for interactive run commands (like bash)

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Feature
 
+-   Add support for running interactive commands. Examples: `wp-env run cli wp shell` and `wp-env run cli bash`.
 -   View php and WordPress log output with the new `wp-env logs` command.
 -   Clean up your local environment with the new `wp-env destroy` command.
 -   Expose Docker service for running phpunit commands.

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -215,13 +215,20 @@ Positionals:
 ```sh
 wp-env run <container> [command..]
 
-Runs an arbitrary command in one of the underlying Docker containers, for
-example it's useful for running wp cli commands.
-
+Run an arbitrary command in one of the underlying Docker containers. For
+example, it can be useful for running wp cli commands. You can also use it to
+open shell sessions like bash and the WordPress shell in the WordPress instance.
+For example, `wp-env run cli bash` will open bash in the development WordPress
+instance.
 
 Positionals:
   container  The container to run the command on.            [string] [required]
   command    The command to run.                           [array] [default: []]
+
+Options:
+  --help     Show help                                                 [boolean]
+  --version  Show version number                                       [boolean]
+  --debug    Enable debug output.                     [boolean] [default: false]
 ```
 
 For example:
@@ -234,6 +241,18 @@ ID      user_login      display_name    user_email      user_registered roles
 1       admin   admin   wordpress@example.com   2020-03-05 10:45:14     administrator
 
 ✔ Ran `wp user list` in 'cli'. (in 2s 374ms)
+```
+
+```sh
+wp-env run tests-cli wp shell
+ℹ Starting 'wp shell' on the tests-cli container. Exit the WordPress shell with ctrl-c.
+
+Starting 31911d623e75f345e9ed328b9f48cff6_mysql_1 ... done
+Starting 31911d623e75f345e9ed328b9f48cff6_tests-wordpress_1 ... done
+wp> echo( 'hello world!' );
+hello world!
+wp> ^C
+✔ Ran `wp shell` in 'tests-cli'. (in 16s 400ms)
 ```
 
 ### `wp-env destroy`

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -215,7 +215,7 @@ Positionals:
 ```sh
 wp-env run <container> [command..]
 
-Run an arbitrary command in one of the underlying Docker containers. For
+Runs an arbitrary command in one of the underlying Docker containers. For
 example, it can be useful for running wp cli commands. You can also use it to
 open shell sessions like bash and the WordPress shell in the WordPress instance.
 For example, `wp-env run cli bash` will open bash in the development WordPress

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -140,7 +140,7 @@ module.exports = function cli() {
 	);
 	yargs.command(
 		'run <container> [command..]',
-		"Runs an arbitrary command in one of the underlying Docker containers, for example it's useful for running wp cli commands.",
+		'Run an arbitrary command in one of the underlying Docker containers. For example, it can be useful for running wp cli commands. You can also use it to open shell sessions like bash and the WordPress shell in the WordPress instance. For example, `wp-env run cli bash` will open bash in the development WordPress instance.',
 		( args ) => {
 			args.positional( 'container', {
 				type: 'string',
@@ -156,6 +156,14 @@ module.exports = function cli() {
 	yargs.example(
 		'$0 run cli wp user list',
 		'Runs `wp user list` wp-cli command which lists WordPress users.'
+	);
+	yargs.example(
+		'$0 run cli wp shell',
+		'Open the interactive WordPress shell for the development instance.'
+	);
+	yargs.example(
+		'$0 run tests-cli bash',
+		'Open a bash session in the WordPress tests instance.'
 	);
 	yargs.command(
 		'destroy',

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -140,7 +140,7 @@ module.exports = function cli() {
 	);
 	yargs.command(
 		'run <container> [command..]',
-		'Run an arbitrary command in one of the underlying Docker containers. For example, it can be useful for running wp cli commands. You can also use it to open shell sessions like bash and the WordPress shell in the WordPress instance. For example, `wp-env run cli bash` will open bash in the development WordPress instance.',
+		'Runs an arbitrary command in one of the underlying Docker containers. For example, it can be useful for running wp cli commands. You can also use it to open shell sessions like bash and the WordPress shell in the WordPress instance. For example, `wp-env run cli bash` will open bash in the development WordPress instance.',
 		( args ) => {
 			args.positional( 'container', {
 				type: 'string',

--- a/packages/env/lib/commands/run.js
+++ b/packages/env/lib/commands/run.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-const dockerCompose = require( 'docker-compose' );
+const { spawn } = require( 'child_process' );
 
 /**
  * Internal dependencies
@@ -9,45 +9,94 @@ const dockerCompose = require( 'docker-compose' );
 const initConfig = require( '../init-config' );
 
 /**
+ * @typedef {import('../config').Config} Config
+ */
+
+/**
  * Runs an arbitrary command on the given Docker container.
  *
- * @param {Object}  options
- * @param {Object}  options.container The Docker container to run the command on.
- * @param {Object}  options.command   The command to run.
- * @param {Object}  options.spinner   A CLI spinner which indicates progress.
- * @param {boolean} options.debug     True if debug mode is enabled.
+ * @param {Object}   options
+ * @param {string}   options.container The Docker container to run the command on.
+ * @param {string[]} options.command   The command to run.
+ * @param {Object}   options.spinner   A CLI spinner which indicates progress.
+ * @param {boolean}  options.debug     True if debug mode is enabled.
  */
 module.exports = async function run( { container, command, spinner, debug } ) {
 	const config = await initConfig( { spinner, debug } );
 
+	spinner.info( typeof container );
 	command = command.join( ' ' );
 
-	spinner.text = `Running \`${ command }\` in '${ container }'.`;
+	// Shows a contextual tip for the given command.
+	showCommandTips( command, container, spinner );
 
-	const result = await dockerCompose.run( container, command, {
-		config: config.dockerComposeConfigPath,
-		commandOptions: [ '--rm' ],
-		log: config.debug,
+	await spawnCommandDirectly( {
+		container,
+		command,
+		spinner,
+		config,
 	} );
-
-	if ( result.out ) {
-		// eslint-disable-next-line no-console
-		console.log(
-			process.stdout.isTTY ? `\n\n${ result.out }\n\n` : result.out
-		);
-	} else if ( result.err ) {
-		// eslint-disable-next-line no-console
-		console.error(
-			process.stdout.isTTY ? `\n\n${ result.err }\n\n` : result.err
-		);
-		// Some tools (like composer) may send messages to stderr. Those messages
-		// do not always mean that we need to abort the process. For example,
-		// composer will say "Nothing to install or update" on stderr when your
-		// local composer packages are up to date.
-		if ( result.exitCode !== 0 ) {
-			throw result.err;
-		}
-	}
 
 	spinner.text = `Ran \`${ command }\` in '${ container }'.`;
 };
+
+/**
+ * Runs an arbitrary command on the given Docker container.
+ *
+ * @param {Object} options
+ * @param {string} options.container The Docker container to run the command on.
+ * @param {string} options.command   The command to run.
+ * @param {Config} options.config    The wp-env configuration.
+ * @param {Object} options.spinner   A CLI spinner which indicates progress.
+ */
+function spawnCommandDirectly( { container, command, config, spinner } ) {
+	const composeCommand = [
+		'-f',
+		config.dockerComposeConfigPath,
+		'run',
+		'--rm',
+		container,
+		...command.split( ' ' ), // The command will fail if passed as a complete string.
+	];
+
+	return new Promise( ( resolve, reject ) => {
+		// Note: since the npm docker-compose package uses the -T option, we
+		// cannot use it to spawn an interactive command. Thus, we run docker-
+		// compose on the CLI directly.
+		const childProc = spawn(
+			'docker-compose',
+			composeCommand,
+			{
+				stdio: 'inherit',
+				shell: true,
+			},
+			spinner
+		);
+		childProc.on( 'error', reject );
+		childProc.on( 'exit', ( code ) => {
+			if ( code === 0 ) {
+				resolve();
+			} else {
+				reject( `Command failed with exit code ${ code }` );
+			}
+		} );
+	} );
+}
+
+function showCommandTips( command, container, spinner ) {
+	if ( ! command.length ) {
+		return;
+	}
+
+	const tip = `Starting '${ command }' on the ${ container } container. ${ ( () => {
+		switch ( command ) {
+			case 'bash':
+				return 'Exit bash with ctrl-d.';
+			case 'wp shell':
+				return 'Exit the WordPress shell with ctrl-c.';
+			default:
+				return '';
+		}
+	} )() }\n`;
+	spinner.info( tip );
+}

--- a/packages/env/lib/commands/run.js
+++ b/packages/env/lib/commands/run.js
@@ -83,6 +83,15 @@ function spawnCommandDirectly( { container, command, config, spinner } ) {
 	} );
 }
 
+/**
+ * This shows a contextual tip for the command being run. Certain commands (like
+ * bash) may have weird behavior (exit with ctrl-d instead of ctrl-c or ctrl-z),
+ * so we want the user to have that information without having to ask someone.
+ *
+ * @param {string} command   The command for which to show a tip.
+ * @param {string} container The container the command will be run on.
+ * @param {Object} spinner   A spinner object to show progress.
+ */
 function showCommandTips( command, container, spinner ) {
 	if ( ! command.length ) {
 		return;

--- a/packages/env/lib/commands/run.js
+++ b/packages/env/lib/commands/run.js
@@ -24,7 +24,6 @@ const initConfig = require( '../init-config' );
 module.exports = async function run( { container, command, spinner, debug } ) {
 	const config = await initConfig( { spinner, debug } );
 
-	spinner.info( typeof container );
 	command = command.join( ' ' );
 
 	// Shows a contextual tip for the given command.
@@ -74,7 +73,9 @@ function spawnCommandDirectly( { container, command, config, spinner } ) {
 		);
 		childProc.on( 'error', reject );
 		childProc.on( 'exit', ( code ) => {
-			if ( code === 0 ) {
+			// Code 130 is set if the user tries to exit with ctrl-c before using
+			// ctrl-d (so it is not an error which should fail the script.)
+			if ( code === 0 || code === 130 ) {
 				resolve();
 			} else {
 				reject( `Command failed with exit code ${ code }` );


### PR DESCRIPTION
## Description
Resolves #21301. The run command now supports more interactive commands like bash or wp-cli shell without any extra options. One benefit of this approach is that since stdio is inherited from the calling terminal, information should be logged to the terminal immediately without waiting for the process to finish. This means some long running commands (like test-php) give more immediate feedback.

## Alternatives I tried
I would have preferred using the docker-compose npm package we already use, but it does not appear to support running interactive commands. It passes the `-T` option to both `run` and `exec`, which [_disables_ TTY allocation](https://docs.docker.com/compose/reference/exec/). I tried passing `--interactive` and `-i` and `-it` as commandOptions and as composeOptions, but none of those seemed to override that behavior.

As a result, I had to spawn `docker-compose` on the CLI directly. Thankfully, this seems to add support for interactive shells like bash & wp shell without really changing the behavior of the current run command. So basically, we don't need to add any extra options.

The only thing I couldn't figure out is how to get of the docker logging information. I tried setting the log level, but it didn't get the messages about starting the services to go away.

## How has this been tested?
locally in wp-env with gutenberg. wp-env should continue working in CI as well.

## Screenshots <!-- if applicable -->
![2020-05-26 11 24 15](https://user-images.githubusercontent.com/6265975/82936522-8fa80580-9f43-11ea-8ae0-3fed9ce3d1a0.gif)


## Types of changes
new feature

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
