### PR TITLE
Try adding 'Template Parts' as a tab on the inserter.

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -41,6 +41,7 @@ function InserterMenu( {
 		getBlockIndex,
 		getBlockSelectionEnd,
 		getBlockOrder,
+		hasTemplateParts,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -57,6 +58,8 @@ function InserterMenu( {
 				}
 			}
 			return {
+				hasTemplateParts: getSettings()
+					.__experimentalEnableFullSiteEditing,
 				hasPatterns: !! getSettings().__experimentalBlockPatterns
 					?.length,
 				destinationRootClientId: destRootClientId,
@@ -172,6 +175,27 @@ function InserterMenu( {
 		</div>
 	);
 
+	const tabsToUse = [
+		{
+			name: 'blocks',
+			/* translators: Blocks tab title in the block inserter. */
+			title: __( 'Blocks' ),
+		},
+	];
+	if ( showPatterns ) {
+		tabsToUse.push( {
+			name: 'patterns',
+			/* translators: Patterns tab title in the block inserter. */
+			title: __( 'Patterns' ),
+		} );
+	}
+	if ( hasTemplateParts ) {
+		tabsToUse.push( {
+			name: 'template parts',
+			/* translators: Template Parts tab title in the block inserter. */
+			title: __( 'Template Parts' ),
+		} );
+	}
 	// Disable reason (no-autofocus): The inserter menu is a modal display, not one which
 	// is always visible, and one which already incurs this behavior of autoFocus via
 	// Popover's focusOnMount.
@@ -186,26 +210,10 @@ function InserterMenu( {
 		>
 			<div className="block-editor-inserter__main-area">
 				<InserterSearchForm onChange={ setFilterValue } />
-				{ showPatterns && (
+				{ tabsToUse.length > 1 && (
 					<TabPanel
 						className="block-editor-inserter__tabs"
-						tabs={ [
-							{
-								name: 'blocks',
-								/* translators: Blocks tab title in the block inserter. */
-								title: __( 'Blocks' ),
-							},
-							{
-								name: 'patterns',
-								/* translators: Patterns tab title in the block inserter. */
-								title: __( 'Patterns' ),
-							},
-							{
-								name: 'template parts',
-								/* translators: Template Parts tab title in the block inserter. */
-								title: __( 'Template Parts' ),
-							},
-						] }
+						tabs={ tabsToUse }
 					>
 						{ ( tab ) => {
 							if ( tab.name === 'blocks' ) {
@@ -215,7 +223,7 @@ function InserterMenu( {
 						} }
 					</TabPanel>
 				) }
-				{ ! showPatterns && blocksTab }
+				{ tabsToUse.length === 1 && blocksTab }
 			</div>
 			{ showInserterHelpPanel && hoveredItem && (
 				<div className="block-editor-inserter__preview-container">

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -21,6 +21,7 @@ import InserterSearchForm from './search-form';
 import InserterPreviewPanel from './preview-panel';
 import InserterBlockList from './block-list';
 import BlockPatterns from './block-patterns';
+import TemplateParts from './template-parts';
 
 const stopKeyPropagation = ( event ) => event.stopPropagation();
 
@@ -175,6 +176,12 @@ function InserterMenu( {
 		</div>
 	);
 
+	const templatePartsTab = (
+		<div className="block-editor-inserter__scrollable">
+			<TemplateParts />
+		</div>
+	);
+
 	const tabsToUse = [
 		{
 			name: 'blocks',
@@ -218,6 +225,8 @@ function InserterMenu( {
 						{ ( tab ) => {
 							if ( tab.name === 'blocks' ) {
 								return blocksTab;
+							} else if ( tab.name === 'template parts' ) {
+								return templatePartsTab;
 							}
 							return patternsTab;
 						} }

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -200,6 +200,11 @@ function InserterMenu( {
 								/* translators: Patterns tab title in the block inserter. */
 								title: __( 'Patterns' ),
 							},
+							{
+								name: 'template parts',
+								/* translators: Template Parts tab title in the block inserter. */
+								title: __( 'Template Parts' ),
+							},
 						] }
 					>
 						{ ( tab ) => {

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -178,7 +178,10 @@ function InserterMenu( {
 
 	const templatePartsTab = (
 		<div className="block-editor-inserter__scrollable">
-			<TemplateParts />
+			<TemplateParts
+				onInsert={ onInsertBlocks }
+				filterValue={ filterValue }
+			/>
 		</div>
 	);
 

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -247,7 +247,8 @@ $block-inserter-tabs-height: 44px;
 	flex-shrink: 0;
 }
 
-.block-editor-inserter__patterns-item {
+.block-editor-inserter__patterns-item,
+.block-editor-inserter__template-part-item {
 	border-radius: $radius-block-ui;
 	cursor: pointer;
 	margin-top: $grid-unit-20;
@@ -271,7 +272,8 @@ $block-inserter-tabs-height: 44px;
 	}
 }
 
-.block-editor-inserter__patterns-item-title {
+.block-editor-inserter__patterns-item-title,
+.block-editor-inserter__template-part-item-title {
 	padding: $grid-unit-05;
 	font-size: 12px;
 	text-align: center;

--- a/packages/block-editor/src/components/inserter/template-parts.js
+++ b/packages/block-editor/src/components/inserter/template-parts.js
@@ -63,17 +63,7 @@ function TemplatePartItem( { templatePart, onInsert } ) {
 	);
 }
 
-export default function TemplateParts( { onInsert } ) {
-	const templateParts = useSelect( ( select ) => {
-		return select( 'core' ).getEntityRecords(
-			'postType',
-			'wp_template_part',
-			{
-				status: [ 'publish', 'auto-draft' ],
-			}
-		);
-	}, [] );
-
+function TemplatePartsByTheme( { templateParts, onInsert } ) {
 	// Group by Theme.
 	const templatePartsByTheme = useMemo( () => {
 		return Object.values( groupBy( templateParts, 'meta.theme' ) );
@@ -97,5 +87,38 @@ export default function TemplateParts( { onInsert } ) {
 					</InserterPanel>
 				) ) }
 		</>
+	);
+}
+
+function TemplatePartSearchResults( { templateParts, onInsert, filterValue } ) {
+	return <h1>I am the search results...</h1>;
+}
+
+export default function TemplateParts( { onInsert, filterValue } ) {
+	const templateParts = useSelect( ( select ) => {
+		return select( 'core' ).getEntityRecords(
+			'postType',
+			'wp_template_part',
+			{
+				status: [ 'publish', 'auto-draft' ],
+			}
+		);
+	}, [] );
+
+	if ( filterValue ) {
+		return (
+			<TemplatePartSearchResults
+				templateParts={ templateParts }
+				onInsert={ onInsert }
+				filterValue={ filterValue }
+			/>
+		);
+	}
+
+	return (
+		<TemplatePartsByTheme
+			templateParts={ templateParts }
+			onInsert={ onInsert }
+		/>
 	);
 }

--- a/packages/block-editor/src/components/inserter/template-parts.js
+++ b/packages/block-editor/src/components/inserter/template-parts.js
@@ -1,7 +1,52 @@
-export default function TemplateParts() {
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { parse } from '@wordpress/blocks';
+import { useMemo } from '@wordpress/element';
+/**
+ * Internal dependencies
+ */
+import BlockPreview from '../block-preview';
+
+function TemplatePartItem( { templatePart } ) {
+	const blocks = useMemo( () => parse( templatePart.content.raw ), [
+		templatePart.content.raw,
+	] );
+
 	return (
 		<div>
-			<h1>TPs!!!</h1>
+			<BlockPreview blocks={ blocks } />
+			<div>{ templatePart.slug }</div>
+		</div>
+	);
+}
+
+export default function TemplateParts() {
+	const templateParts = useSelect( ( select ) => {
+		return select( 'core' ).getEntityRecords(
+			'postType',
+			'wp_template_part',
+			{
+				status: [ 'publish', 'auto-draft' ],
+			}
+		);
+	}, [] );
+
+	if ( ! Array.isArray( templateParts ) ) {
+		return null;
+	}
+
+	return (
+		<div>
+			{ templateParts.map( ( templatePart ) => {
+				return (
+					<TemplatePartItem
+						key={ templatePart.id }
+						templatePart={ templatePart }
+					/>
+				);
+			} ) }
 		</div>
 	);
 }

--- a/packages/block-editor/src/components/inserter/template-parts.js
+++ b/packages/block-editor/src/components/inserter/template-parts.js
@@ -1,13 +1,8 @@
 /**
- * External dependencies
- */
-import { map } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { parse, cloneBlock } from '@wordpress/blocks';
+import { parse, createBlock } from '@wordpress/blocks';
 import { useMemo } from '@wordpress/element';
 import { ENTER, SPACE } from '@wordpress/keycodes';
 /**
@@ -18,20 +13,15 @@ import InserterPanel from './panel';
 
 function TemplatePartItem( { templatePart, onInsert } ) {
 	const { id, slug, theme } = templatePart;
-	const blocks = useMemo( () => parse( templatePart.content.raw ), [
-		templatePart.content.raw,
-	] );
+	const content = templatePart.content.raw || '';
+	const blocks = useMemo( () => parse( content ), [ content ] );
+	const templatePartBlock = createBlock( 'core/template-part', {
+		postId: id,
+		slug,
+		theme,
+	} );
 
-	const blocksToInsert = useMemo(
-		() =>
-			parse(
-				`<!-- wp:template-part {"postId":${ id },"slug":"${ slug }","theme":"${ theme }"} /-->`
-			),
-		[ id, slug, theme ]
-	);
-
-	const onClick = () =>
-		onInsert( map( blocksToInsert, ( block ) => cloneBlock( block ) ) );
+	const onClick = () => onInsert( templatePartBlock );
 
 	return (
 		<div

--- a/packages/block-editor/src/components/inserter/template-parts.js
+++ b/packages/block-editor/src/components/inserter/template-parts.js
@@ -1,0 +1,7 @@
+export default function TemplateParts() {
+	return (
+		<div>
+			<h1>TPs!!!</h1>
+		</div>
+	);
+}

--- a/packages/block-editor/src/components/inserter/template-parts.js
+++ b/packages/block-editor/src/components/inserter/template-parts.js
@@ -1,28 +1,55 @@
 /**
+ * External dependencies
+ */
+import { map } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { parse } from '@wordpress/blocks';
+import { parse, cloneBlock } from '@wordpress/blocks';
 import { useMemo } from '@wordpress/element';
+import { ENTER, SPACE } from '@wordpress/keycodes';
 /**
  * Internal dependencies
  */
 import BlockPreview from '../block-preview';
 
-function TemplatePartItem( { templatePart } ) {
+function TemplatePartItem( { templatePart, onInsert } ) {
+	const { id, slug, theme } = templatePart;
 	const blocks = useMemo( () => parse( templatePart.content.raw ), [
 		templatePart.content.raw,
 	] );
 
+	const blocksToInsert = useMemo(
+		() =>
+			parse(
+				`<!-- wp:template-part {"postId":${ id },"slug":"${ slug }","theme":"${ theme }"} /-->`
+			),
+		[ id, slug, theme ]
+	);
+
+	const onClick = () =>
+		onInsert( map( blocksToInsert, ( block ) => cloneBlock( block ) ) );
+
 	return (
-		<div>
+		<div
+			role="button"
+			onClick={ onClick }
+			onKeyDown={ ( event ) => {
+				if ( ENTER === event.keyCode || SPACE === event.keyCode ) {
+					onClick();
+				}
+			} }
+			tabIndex={ 0 }
+		>
 			<BlockPreview blocks={ blocks } />
 			<div>{ templatePart.slug }</div>
 		</div>
 	);
 }
 
-export default function TemplateParts() {
+export default function TemplateParts( { onInsert } ) {
 	const templateParts = useSelect( ( select ) => {
 		return select( 'core' ).getEntityRecords(
 			'postType',
@@ -41,6 +68,7 @@ export default function TemplateParts() {
 						<TemplatePartItem
 							key={ templatePart.id }
 							templatePart={ templatePart }
+							onInsert={ onInsert }
 						/>
 					);
 				} ) }

--- a/packages/block-editor/src/components/inserter/template-parts.js
+++ b/packages/block-editor/src/components/inserter/template-parts.js
@@ -1,10 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { parse, createBlock } from '@wordpress/blocks';
-import { useMemo } from '@wordpress/element';
+import { useMemo, useCallback } from '@wordpress/element';
 import { ENTER, SPACE } from '@wordpress/keycodes';
+import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
@@ -20,13 +21,26 @@ function TemplatePartItem( { templatePart, onInsert } ) {
 	const { id, slug, theme } = templatePart;
 	const content = templatePart.content.raw || '';
 	const blocks = useMemo( () => parse( content ), [ content ] );
-	const templatePartBlock = createBlock( 'core/template-part', {
-		postId: id,
-		slug,
-		theme,
-	} );
+	const { createSuccessNotice } = useDispatch( 'core/notices' );
 
-	const onClick = () => onInsert( templatePartBlock );
+	const onClick = useCallback( () => {
+		const templatePartBlock = createBlock( 'core/template-part', {
+			postId: id,
+			slug,
+			theme,
+		} );
+		onInsert( templatePartBlock );
+		createSuccessNotice(
+			sprintf(
+				/* translators: %s: template part title. */
+				__( 'Template Part "%s" inserted.' ),
+				slug
+			),
+			{
+				type: 'snackbar',
+			}
+		);
+	}, [ id, slug, theme ] );
 
 	return (
 		<div

--- a/packages/block-editor/src/components/inserter/template-parts.js
+++ b/packages/block-editor/src/components/inserter/template-parts.js
@@ -26,6 +26,8 @@ function TemplatePartPlaceholder() {
 
 function TemplatePartItem( { templatePart, onInsert } ) {
 	const { id, slug, theme } = templatePart;
+	// The 'raw' property is not defined for a brief period in the save cycle.
+	// The fallback prevents an error in the parse function while saving.
 	const content = templatePart.content.raw || '';
 	const blocks = useMemo( () => parse( content ), [ content ] );
 	const { createSuccessNotice } = useDispatch( 'core/notices' );
@@ -74,7 +76,6 @@ function TemplatePartsByTheme( { templateParts, onInsert } ) {
 	const templatePartsByTheme = useMemo( () => {
 		return Object.values( groupBy( templateParts, 'meta.theme' ) );
 	}, [ templateParts ] );
-
 	const currentShownTPs = useAsyncList( templateParts );
 
 	return (
@@ -108,13 +109,13 @@ function TemplatePartSearchResults( { templateParts, onInsert, filterValue } ) {
 	const filteredTPs = useMemo( () => {
 		// Filter based on value.
 		const lowerFilterValue = filterValue.toLowerCase();
-		const thing = templateParts.filter(
+		const searchResults = templateParts.filter(
 			( { slug, meta: { theme } } ) =>
 				slug.toLowerCase().includes( lowerFilterValue ) ||
 				theme.toLowerCase().includes( lowerFilterValue )
 		);
 		// Order based on value location.
-		thing.sort( ( a, b ) => {
+		searchResults.sort( ( a, b ) => {
 			// First prioritize index found in slug.
 			const indexInSlugA = a.slug
 				.toLowerCase()
@@ -135,7 +136,7 @@ function TemplatePartSearchResults( { templateParts, onInsert, filterValue } ) {
 				b.meta.theme.toLowerCase().indexOf( lowerFilterValue )
 			);
 		} );
-		return thing;
+		return searchResults;
 	}, [ filterValue, templateParts ] );
 
 	const currentShownTPs = useAsyncList( filteredTPs );

--- a/packages/block-editor/src/components/inserter/template-parts.js
+++ b/packages/block-editor/src/components/inserter/template-parts.js
@@ -14,6 +14,7 @@ import { ENTER, SPACE } from '@wordpress/keycodes';
  * Internal dependencies
  */
 import BlockPreview from '../block-preview';
+import InserterPanel from './panel';
 
 function TemplatePartItem( { templatePart, onInsert } ) {
 	const { id, slug, theme } = templatePart;
@@ -34,6 +35,7 @@ function TemplatePartItem( { templatePart, onInsert } ) {
 
 	return (
 		<div
+			className="block-editor-inserter__template-part-item"
 			role="button"
 			onClick={ onClick }
 			onKeyDown={ ( event ) => {
@@ -42,9 +44,12 @@ function TemplatePartItem( { templatePart, onInsert } ) {
 				}
 			} }
 			tabIndex={ 0 }
+			aria-label={ templatePart.slug }
 		>
 			<BlockPreview blocks={ blocks } />
-			<div>{ templatePart.slug }</div>
+			<div className="block-editor-inserter__template-part-item-title">
+				{ templatePart.slug }
+			</div>
 		</div>
 	);
 }
@@ -61,7 +66,7 @@ export default function TemplateParts( { onInsert } ) {
 	}, [] );
 
 	return (
-		<div>
+		<InserterPanel>
 			{ templateParts &&
 				templateParts.map( ( templatePart ) => {
 					return (
@@ -72,6 +77,6 @@ export default function TemplateParts( { onInsert } ) {
 						/>
 					);
 				} ) }
-		</div>
+		</InserterPanel>
 	);
 }

--- a/packages/block-editor/src/components/inserter/template-parts.js
+++ b/packages/block-editor/src/components/inserter/template-parts.js
@@ -33,20 +33,17 @@ export default function TemplateParts() {
 		);
 	}, [] );
 
-	if ( ! Array.isArray( templateParts ) ) {
-		return null;
-	}
-
 	return (
 		<div>
-			{ templateParts.map( ( templatePart ) => {
-				return (
-					<TemplatePartItem
-						key={ templatePart.id }
-						templatePart={ templatePart }
-					/>
-				);
-			} ) }
+			{ templateParts &&
+				templateParts.map( ( templatePart ) => {
+					return (
+						<TemplatePartItem
+							key={ templatePart.id }
+							templatePart={ templatePart }
+						/>
+					);
+				} ) }
 		</div>
 	);
 }

--- a/packages/block-editor/src/components/inserter/template-parts.js
+++ b/packages/block-editor/src/components/inserter/template-parts.js
@@ -91,7 +91,55 @@ function TemplatePartsByTheme( { templateParts, onInsert } ) {
 }
 
 function TemplatePartSearchResults( { templateParts, onInsert, filterValue } ) {
-	return <h1>I am the search results...</h1>;
+	const filteredTPs = useMemo( () => {
+		// Filter based on value.
+		const lowerFilterValue = filterValue.toLowerCase();
+		const thing = templateParts.filter(
+			( { slug, meta: { theme } } ) =>
+				slug.toLowerCase().includes( lowerFilterValue ) ||
+				theme.toLowerCase().includes( lowerFilterValue )
+		);
+		// Order based on value location.
+		thing.sort( ( a, b ) => {
+			// First prioritize index found in slug.
+			const indexInSlugA = a.slug
+				.toLowerCase()
+				.indexOf( lowerFilterValue );
+			const indexInSlugB = b.slug
+				.toLowerCase()
+				.indexOf( lowerFilterValue );
+			if ( indexInSlugA !== -1 && indexInSlugB !== -1 ) {
+				return indexInSlugA - indexInSlugB;
+			} else if ( indexInSlugA !== -1 ) {
+				return -1;
+			} else if ( indexInSlugB !== -1 ) {
+				return 1;
+			}
+			// Second prioritize index found in theme.
+			return (
+				a.meta.theme.toLowerCase().indexOf( lowerFilterValue ) -
+				b.meta.theme.toLowerCase().indexOf( lowerFilterValue )
+			);
+		} );
+		return thing;
+	}, [ filterValue, templateParts ] );
+
+	return (
+		<>
+			{ filteredTPs.map( ( templatePart ) => (
+				<InserterPanel
+					key={ templatePart.id }
+					title={ templatePart.meta.theme }
+				>
+					<TemplatePartItem
+						key={ templatePart.id }
+						templatePart={ templatePart }
+						onInsert={ onInsert }
+					/>
+				</InserterPanel>
+			) ) }
+		</>
+	);
 }
 
 export default function TemplateParts( { onInsert, filterValue } ) {

--- a/packages/block-editor/src/components/inserter/template-parts.js
+++ b/packages/block-editor/src/components/inserter/template-parts.js
@@ -11,6 +11,11 @@ import { ENTER, SPACE } from '@wordpress/keycodes';
 import BlockPreview from '../block-preview';
 import InserterPanel from './panel';
 
+/**
+ * External dependencies
+ */
+import { groupBy } from 'lodash';
+
 function TemplatePartItem( { templatePart, onInsert } ) {
 	const { id, slug, theme } = templatePart;
 	const content = templatePart.content.raw || '';
@@ -55,18 +60,28 @@ export default function TemplateParts( { onInsert } ) {
 		);
 	}, [] );
 
+	// Group by Theme.
+	const templatePartsByTheme = useMemo( () => {
+		return Object.values( groupBy( templateParts, 'meta.theme' ) );
+	}, [ templateParts ] );
+
 	return (
-		<InserterPanel>
-			{ templateParts &&
-				templateParts.map( ( templatePart ) => {
-					return (
-						<TemplatePartItem
-							key={ templatePart.id }
-							templatePart={ templatePart }
-							onInsert={ onInsert }
-						/>
-					);
-				} ) }
-		</InserterPanel>
+		<>
+			{ templatePartsByTheme.length &&
+				templatePartsByTheme.map( ( templatePartList ) => (
+					<InserterPanel
+						key={ templatePartList[ 0 ].meta.theme }
+						title={ templatePartList[ 0 ].meta.theme }
+					>
+						{ templatePartList.map( ( templatePart ) => (
+							<TemplatePartItem
+								key={ templatePart.id }
+								templatePart={ templatePart }
+								onInsert={ onInsert }
+							/>
+						) ) }
+					</InserterPanel>
+				) ) }
+		</>
 	);
 }


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This is an exploration at inserting template parts via a tab on the inserter.  Some designs for this have been suggested, although I am not sure if there is a consensus about whether or not we would want to preview/add Template Parts in this manner.  Either way, this gives us a decent idea about how that might look and behave.

More Info:
* A 'Template Parts' tab is added to the inserter when the full site editing experiment is active.
* By default the Template Parts are grouped by their 'theme' property.
* Searching via the input field will filter/sort the list by prioritizing matching the slug first, and then the theme.
* Clicking (or ENTER/SPACE) a Template Part inserts the template part into the editor and shows a notification.

## Screenshots <!-- if applicable -->

![template-part-inserting](https://user-images.githubusercontent.com/28742426/82969267-3ec4fb00-9f9d-11ea-8fbf-58518b588f03.gif)

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Tested on local docker environment.  Tested in the Site Editor as well as in the Post editor (w/ and w/o the FSE experiment enabled).

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
