### PR TITLE
Move between nesting levels with arrow keys in navigate mode.

### DIFF
--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -398,13 +398,13 @@ export default function WritingFlow( { children } ) {
 				focusedBlockUid = selectionAfterEndClientId;
 			} else if ( navigateOut ) {
 				focusedBlockUid =
-					getBlockRootClientId( selectedBlockClientId ) ||
+					getBlockRootClientId( selectedBlockClientId ) ??
 					selectedBlockClientId;
 			} else if ( navigateIn ) {
 				focusedBlockUid =
 					getClientIdsOfDescendants( [
 						selectedBlockClientId,
-					] )[ 0 ] || selectedBlockClientId;
+					] )[ 0 ] ?? selectedBlockClientId;
 			}
 
 			if ( navigateDown || navigateUp || navigateOut || navigateIn ) {

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -871,7 +871,7 @@ export function* setNavigationMode( isNavigationMode = true ) {
 	if ( isNavigationMode ) {
 		speak(
 			__(
-				'You are currently in navigation mode. Navigate blocks using the Tab key. To exit navigation mode and edit the selected block, press Enter.'
+				'You are currently in navigation mode. Navigate blocks using the Tab key and Arrow keys. Use Left and Right Arrow keys to move between nesting levels. To exit navigation mode and edit the selected block, press Enter.'
 			)
 		);
 	} else {

--- a/packages/e2e-tests/specs/editor/various/writing-flow.test.js
+++ b/packages/e2e-tests/specs/editor/various/writing-flow.test.js
@@ -15,6 +15,38 @@ const getActiveBlockName = async () =>
 		() => wp.data.select( 'core/block-editor' ).getSelectedBlock().name
 	);
 
+const addParagraphsAndColumnsDemo = async () => {
+	// Add demo content
+	await clickBlockAppender();
+	await page.keyboard.type( 'First paragraph' );
+	await page.keyboard.press( 'Enter' );
+	await page.keyboard.type( '/columns' );
+	await page.keyboard.press( 'Enter' );
+	await page.click( ':focus [aria-label="Two columns; equal split"]' );
+	await page.click( ':focus .block-editor-button-block-appender' );
+	await page.waitForSelector( ':focus.block-editor-inserter__search-input' );
+	await page.keyboard.type( 'Paragraph' );
+	await pressKeyTimes( 'Tab', 3 ); // Tab to paragraph result.
+	await page.keyboard.press( 'Enter' ); // Insert paragraph.
+	await page.keyboard.type( '1st col' ); // If this text is too long, it may wrap to a new line and cause test failure. That's why we're using "1st" instead of "First" here.
+
+	// TODO: ArrowDown should traverse into the second column. In slower
+	// CPUs, it can sometimes remain in the first column paragraph. This
+	// is a temporary solution.
+	await page.focus( '.wp-block[data-type="core/column"]:nth-child(2)' );
+	await page.click( ':focus .block-editor-button-block-appender' );
+	await page.waitForSelector( ':focus.block-editor-inserter__search-input' );
+	await page.keyboard.type( 'Paragraph' );
+	await pressKeyTimes( 'Tab', 3 ); // Tab to paragraph result.
+	await page.keyboard.press( 'Enter' ); // Insert paragraph.
+	await page.keyboard.type( '2nd col' ); // If this text is too long, it may wrap to a new line and cause test failure. That's why we're using "2nd" instead of "Second" here.
+
+	// Arrow down from last of layouts exits nested context to default
+	// appender of root level.
+	await page.keyboard.press( 'ArrowDown' );
+	await page.keyboard.type( 'Second paragraph' );
+};
+
 describe( 'Writing Flow', () => {
 	beforeEach( async () => {
 		await createNewPost();
@@ -32,38 +64,7 @@ describe( 'Writing Flow', () => {
 		let activeElementText, activeBlockName;
 
 		// Add demo content
-		await clickBlockAppender();
-		await page.keyboard.type( 'First paragraph' );
-		await page.keyboard.press( 'Enter' );
-		await page.keyboard.type( '/columns' );
-		await page.keyboard.press( 'Enter' );
-		await page.click( ':focus [aria-label="Two columns; equal split"]' );
-		await page.click( ':focus .block-editor-button-block-appender' );
-		await page.waitForSelector(
-			':focus.block-editor-inserter__search-input'
-		);
-		await page.keyboard.type( 'Paragraph' );
-		await pressKeyTimes( 'Tab', 3 ); // Tab to paragraph result.
-		await page.keyboard.press( 'Enter' ); // Insert paragraph.
-		await page.keyboard.type( '1st col' ); // If this text is too long, it may wrap to a new line and cause test failure. That's why we're using "1st" instead of "First" here.
-
-		// TODO: ArrowDown should traverse into the second column. In slower
-		// CPUs, it can sometimes remain in the first column paragraph. This
-		// is a temporary solution.
-		await page.focus( '.wp-block[data-type="core/column"]:nth-child(2)' );
-		await page.click( ':focus .block-editor-button-block-appender' );
-		await page.waitForSelector(
-			':focus.block-editor-inserter__search-input'
-		);
-		await page.keyboard.type( 'Paragraph' );
-		await pressKeyTimes( 'Tab', 3 ); // Tab to paragraph result.
-		await page.keyboard.press( 'Enter' ); // Insert paragraph.
-		await page.keyboard.type( '2nd col' ); // If this text is too long, it may wrap to a new line and cause test failure. That's why we're using "2nd" instead of "Second" here.
-
-		// Arrow down from last of layouts exits nested context to default
-		// appender of root level.
-		await page.keyboard.press( 'ArrowDown' );
-		await page.keyboard.type( 'Second paragraph' );
+		await addParagraphsAndColumnsDemo();
 
 		// Arrow up into nested context focuses last text input
 		await page.keyboard.press( 'ArrowUp' );
@@ -98,6 +99,43 @@ describe( 'Writing Flow', () => {
 		expect( activeElementText ).toBe( 'First paragraph' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'Should navigate between inner and root blocks in navigation mode', async () => {
+		// In navigation mode the active element is the block name button, so we can't easily check the block content.
+		let activeBlockName;
+
+		// Add demo content
+		await addParagraphsAndColumnsDemo();
+
+		// Switch to navigation mode
+		await page.keyboard.press( 'Escape' );
+		// Arrow up to Columns block
+		await page.keyboard.press( 'ArrowUp' );
+		activeBlockName = await getActiveBlockName();
+		expect( activeBlockName ).toBe( 'core/columns' );
+		// Arrow right into Column block
+		await page.keyboard.press( 'ArrowRight' );
+		activeBlockName = await getActiveBlockName();
+		expect( activeBlockName ).toBe( 'core/column' );
+		// Arrow down to reach second Column block
+		await page.keyboard.press( 'ArrowDown' );
+		// Arrow right again into Paragraph block
+		await page.keyboard.press( 'ArrowRight' );
+		activeBlockName = await getActiveBlockName();
+		expect( activeBlockName ).toBe( 'core/paragraph' );
+		// Arrow left back to Column block
+		await page.keyboard.press( 'ArrowLeft' );
+		activeBlockName = await getActiveBlockName();
+		expect( activeBlockName ).toBe( 'core/column' );
+		// Arrow left back to Columns block
+		await page.keyboard.press( 'ArrowLeft' );
+		activeBlockName = await getActiveBlockName();
+		expect( activeBlockName ).toBe( 'core/columns' );
+		// Arrow up to first paragraph
+		await page.keyboard.press( 'ArrowUp' );
+		activeBlockName = await getActiveBlockName();
+		expect( activeBlockName ).toBe( 'core/paragraph' );
 	} );
 
 	it( 'should navigate around inline boundaries', async () => {


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Split out from #22453 to simplify review process.

Fixes #20732.

Add the ability to navigate between nesting levels with the arrow keys when in navigate mode. Left Arrow goes up one level (if not already at root level), Right Arrow goes down one level (if focus is on a block containing inner blocks).

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Tested navigating around a post with multiple nested blocks with keyboard only:

1. In a post containing columns, cover, navigation or other blocks with inner blocks;
2. With a block selected, press Esc to go into navigation mode;
3. Use Up and Down Arrow keys to navigate within the same level;
4. Use Right Arrow to go into a nested level (e.g. into a columns block);
5. Use Left Arrow to go out of a nesting level (e.g. out of a columns block).

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
 New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
