### PR TITLE
Remove unused isDraggable prop from BlockList

### DIFF
--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -27,7 +27,6 @@ function BlockList(
 	{
 		className,
 		rootClientId,
-		isDraggable,
 		renderAppender,
 		__experimentalTagName = 'div',
 		__experimentalAppenderTagName,
@@ -96,9 +95,8 @@ function BlockList(
 						<BlockListBlock
 							rootClientId={ rootClientId }
 							clientId={ clientId }
-							isDraggable={ isDraggable }
 							isMultiSelecting={ isMultiSelecting }
-							// This prop is explicitely computed and passed down
+							// This prop is explicitly computed and passed down
 							// to avoid being impacted by the async mode
 							// otherwise there might be a small delay to trigger the animation.
 							index={ index }


### PR DESCRIPTION
## Description
I noticed the `isDraggable` prop is passed to `BlockListBlock`, but isn't used by that component.

A search of the codebase shows that there's a similar prop in `BlockDraggable`, but it's unrelated to this.

Given the prop does nothing, it looks like it can be safely removed.

Also fixes a nearby typo.

## How has this been tested?
- Manual testing of drag/drop with blocks.
- Searched codebase for usages of this variable.
- Checked value of `isDraggable` in debugger (always seems to be `undefined`).

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->


## Types of changes
Non-breaking code quality change.
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
