### PR TITLE
Remove <BlockNavigationEditor /> from navigation-link/edit.js

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -29,7 +29,6 @@ import {
 	RichText,
 	__experimentalLinkControl as LinkControl,
 	__experimentalBlock as Block,
-	__experimentalBlockNavigationEditor as BlockNavigationEditor,
 } from '@wordpress/block-editor';
 import { isURL, prependHTTP } from '@wordpress/url';
 import { Fragment, useState, useEffect, useRef } from '@wordpress/element';
@@ -199,12 +198,6 @@ function NavigationLinkEdit( {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<BlockNavigationEditor
-				value={ label }
-				onChange={ ( labelValue ) =>
-					setAttributes( { label: labelValue } )
-				}
-			/>
 			<Block.li
 				className={ classnames( {
 					'is-editing': isSelected || isParentOfSelectedBlock,


### PR DESCRIPTION
## Description
This PR effectively reverts the part of https://github.com/WordPress/gutenberg/pull/22210 where it makes the navigator item editable.

Having all items editable by default introduces conceptual issues with block selection - see https://github.com/WordPress/gutenberg/issues/22089#issuecomment-632170542 for more details.

## How has this been tested?
1. Enable the navigation experiment in Gutenberg > Experiments
1. Go to Gutenberg > Navigation (beta)
1. Click on any menu item in the block navigation
1. Confirm it's not editable in the navigation

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
