### PR TITLE
Rename EllipsisMenu to BlockNavigationBlockSettings

### DIFF
--- a/packages/block-editor/src/components/block-navigation/block.js
+++ b/packages/block-editor/src/components/block-navigation/block.js
@@ -48,10 +48,10 @@ export default function BlockNavigationBlock( {
 		{ 'is-visible': hasVisibleMovers }
 	);
 	const {
-		__experimentalWithEllipsisMenu: withEllipsisMenu,
-		__experimentalWithEllipsisMenuMinLevel: ellipsisMenuMinLevel,
+		__experimentalWithBlockNavigationBlockSettings: withBlockNavigationBlockSettings,
+		__experimentalWithBlockNavigationBlockSettingsMinLevel: BlockNavigationBlockSettingsMinLevel,
 	} = useBlockNavigationContext();
-	const ellipsisMenuClassName = classnames(
+	const BlockNavigationBlockSettingsClassName = classnames(
 		'block-editor-block-navigation-block__menu-cell',
 		{ 'is-visible': hasVisibleMovers }
 	);
@@ -116,17 +116,20 @@ export default function BlockNavigationBlock( {
 				</>
 			) }
 
-			{ withEllipsisMenu && level >= ellipsisMenuMinLevel && (
-				<TreeGridCell className={ ellipsisMenuClassName }>
-					{ ( props ) => (
-						<BlockSettingsDropdown
-							clientIds={ [ clientId ] }
-							icon={ moreVertical }
-							{ ...props }
-						/>
-					) }
-				</TreeGridCell>
-			) }
+			{ withBlockNavigationBlockSettings &&
+				level >= BlockNavigationBlockSettingsMinLevel && (
+					<TreeGridCell
+						className={ BlockNavigationBlockSettingsClassName }
+					>
+						{ ( props ) => (
+							<BlockSettingsDropdown
+								clientIds={ [ clientId ] }
+								icon={ moreVertical }
+								{ ...props }
+							/>
+						) }
+					</TreeGridCell>
+				) }
 		</BlockNavigationLeaf>
 	);
 }

--- a/packages/block-editor/src/components/block-navigation/block.js
+++ b/packages/block-editor/src/components/block-navigation/block.js
@@ -49,9 +49,9 @@ export default function BlockNavigationBlock( {
 	);
 	const {
 		__experimentalWithBlockNavigationBlockSettings: withBlockNavigationBlockSettings,
-		__experimentalWithBlockNavigationBlockSettingsMinLevel: BlockNavigationBlockSettingsMinLevel,
+		__experimentalWithBlockNavigationBlockSettingsMinLevel: blockNavigationBlockSettingsMinLevel,
 	} = useBlockNavigationContext();
-	const BlockNavigationBlockSettingsClassName = classnames(
+	const blockNavigationBlockSettingsClassName = classnames(
 		'block-editor-block-navigation-block__menu-cell',
 		{ 'is-visible': hasVisibleMovers }
 	);
@@ -117,9 +117,9 @@ export default function BlockNavigationBlock( {
 			) }
 
 			{ withBlockNavigationBlockSettings &&
-				level >= BlockNavigationBlockSettingsMinLevel && (
+				level >= blockNavigationBlockSettingsMinLevel && (
 					<TreeGridCell
-						className={ BlockNavigationBlockSettingsClassName }
+						className={ blockNavigationBlockSettingsClassName }
 					>
 						{ ( props ) => (
 							<BlockSettingsDropdown

--- a/packages/block-editor/src/components/block-navigation/context.js
+++ b/packages/block-editor/src/components/block-navigation/context.js
@@ -5,8 +5,8 @@ import { createContext, useContext } from '@wordpress/element';
 
 export const BlockNavigationContext = createContext( {
 	__experimentalWithBlockNavigationSlots: false,
-	__experimentalWithEllipsisMenu: false,
-	__experimentalWithEllipsisMenuMinLevel: 0,
+	__experimentalWithBlockNavigationBlockSettings: false,
+	__experimentalWithBlockNavigationBlockSettingsMinLevel: 0,
 } );
 
 export const useBlockNavigationContext = () =>

--- a/packages/block-editor/src/components/block-navigation/dropdown.js
+++ b/packages/block-editor/src/components/block-navigation/dropdown.js
@@ -56,7 +56,7 @@ function BlockNavigationDropdownToggle( { isEnabled, onToggle, isOpen } ) {
 function BlockNavigationDropdown( {
 	isDisabled,
 	__experimentalWithBlockNavigationSlots,
-	__experimentalWithEllipsisMenu,
+	__experimentalWithBlockNavigationBlockSettings,
 } ) {
 	const hasBlocks = useSelect(
 		( select ) => !! select( 'core/block-editor' ).getBlockCount(),
@@ -80,8 +80,8 @@ function BlockNavigationDropdown( {
 					__experimentalWithBlockNavigationSlots={
 						__experimentalWithBlockNavigationSlots
 					}
-					__experimentalWithEllipsisMenu={
-						__experimentalWithEllipsisMenu
+					__experimentalWithBlockNavigationBlockSettings={
+						__experimentalWithBlockNavigationBlockSettings
 					}
 				/>
 			) }

--- a/packages/block-editor/src/components/block-navigation/index.js
+++ b/packages/block-editor/src/components/block-navigation/index.js
@@ -21,8 +21,8 @@ function BlockNavigation( {
 	selectedBlockClientId,
 	selectBlock,
 	__experimentalWithBlockNavigationSlots,
-	__experimentalWithEllipsisMenu,
-	__experimentalWithEllipsisMenuMinLevel,
+	__experimentalWithBlockNavigationBlockSettings,
+	__experimentalWithBlockNavigationBlockSettingsMinLevel,
 } ) {
 	if ( ! rootBlocks || rootBlocks.length === 0 ) {
 		return null;
@@ -43,11 +43,11 @@ function BlockNavigation( {
 					blocks={ [ rootBlock ] }
 					selectedBlockClientId={ selectedBlockClientId }
 					selectBlock={ selectBlock }
-					__experimentalWithEllipsisMenu={
-						__experimentalWithEllipsisMenu
+					__experimentalWithBlockNavigationBlockSettings={
+						__experimentalWithBlockNavigationBlockSettings
 					}
-					__experimentalWithEllipsisMenuMinLevel={
-						__experimentalWithEllipsisMenuMinLevel
+					__experimentalWithBlockNavigationBlockSettingsMinLevel={
+						__experimentalWithBlockNavigationBlockSettingsMinLevel
 					}
 					__experimentalWithBlockNavigationSlots={
 						__experimentalWithBlockNavigationSlots
@@ -60,11 +60,11 @@ function BlockNavigation( {
 					blocks={ rootBlocks }
 					selectedBlockClientId={ selectedBlockClientId }
 					selectBlock={ selectBlock }
-					__experimentalWithEllipsisMenu={
-						__experimentalWithEllipsisMenu
+					__experimentalWithBlockNavigationBlockSettings={
+						__experimentalWithBlockNavigationBlockSettings
 					}
-					__experimentalWithEllipsisMenuMinLevel={
-						__experimentalWithEllipsisMenuMinLevel
+					__experimentalWithBlockNavigationBlockSettingsMinLevel={
+						__experimentalWithBlockNavigationBlockSettingsMinLevel
 					}
 					__experimentalWithBlockNavigationSlots={
 						__experimentalWithBlockNavigationSlots

--- a/packages/block-editor/src/components/block-navigation/tree.js
+++ b/packages/block-editor/src/components/block-navigation/tree.js
@@ -21,23 +21,24 @@ import { BlockNavigationContext } from './context';
  */
 export default function BlockNavigationTree( {
 	__experimentalWithBlockNavigationSlots,
-	__experimentalWithEllipsisMenu,
-	__experimentalWithEllipsisMenuMinLevel,
+	__experimentalWithBlockNavigationBlockSettings,
+	__experimentalWithBlockNavigationBlockSettingsMinLevel,
 	...props
 } ) {
 	const contextValue = useMemo(
 		() => ( {
 			__experimentalWithBlockNavigationSlots,
-			__experimentalWithEllipsisMenu,
-			__experimentalWithEllipsisMenuMinLevel:
-				typeof __experimentalWithEllipsisMenuMinLevel === 'number'
-					? __experimentalWithEllipsisMenuMinLevel
+			__experimentalWithBlockNavigationBlockSettings,
+			__experimentalWithBlockNavigationBlockSettingsMinLevel:
+				typeof __experimentalWithBlockNavigationBlockSettingsMinLevel ===
+				'number'
+					? __experimentalWithBlockNavigationBlockSettingsMinLevel
 					: 0,
 		} ),
 		[
 			__experimentalWithBlockNavigationSlots,
-			__experimentalWithEllipsisMenu,
-			__experimentalWithEllipsisMenuMinLevel,
+			__experimentalWithBlockNavigationBlockSettings,
+			__experimentalWithBlockNavigationBlockSettingsMinLevel,
 		]
 	);
 

--- a/packages/edit-navigation/src/components/menu-editor/navigation-structure-panel.js
+++ b/packages/edit-navigation/src/components/menu-editor/navigation-structure-panel.js
@@ -26,8 +26,10 @@ export default function NavigationStructurePanel( { blocks, initialOpen } ) {
 						selectedBlockClientId={ selectedBlockClientIds[ 0 ] }
 						selectBlock={ selectBlock }
 						__experimentalWithBlockNavigationSlots
-						__experimentalWithEllipsisMenu
-						__experimentalWithEllipsisMenuMinLevel={ 2 }
+						__experimentalWithBlockNavigationBlockSettings
+						__experimentalWithBlockNavigationBlockSettingsMinLevel={
+							2
+						}
 						showNestedBlocks
 						showAppender
 						showBlockMovers


### PR DESCRIPTION
## Description
This PR renames EllipsisMenu to BlockNavigationBlockSettings as a follow up on the naming brainstorm here: https://github.com/WordPress/gutenberg/pull/22427/files#r428525553

## How has this been tested?

This PR doesn't add any features, we only need to make sure it does not break anything.

1. Enable the navigation experiment in Gutenberg > Experiments
1. Go to Gutenberg > Navigation (beta)
1. Select some items using the navigator, use block movers, use the ellipsis menu
1. Go to Post Editor > block navigation, confirm it works

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
