### PR TITLE
fix: unset max-width for reusable blocks

### DIFF
--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -106,7 +106,8 @@ body.block-editor-page {
 		max-width: 1100px;
 	}
 
-	&[data-align="full"] {
+	&[data-align="full"],
+	&.is-reusable {
 		max-width: none;
 	}
 }


### PR DESCRIPTION
## Description

This PR addresses the issue described in #8288.

See: https://github.com/WordPress/gutenberg/issues/8288#issuecomment-633669390

There are also [other](https://github.com/WordPress/gutenberg/issues/8288#issuecomment-440124315) interesting [ideas](https://github.com/WordPress/gutenberg/issues/8288#issuecomment-633835828) as to how we can improve this fix in the future, which can be addressed in a future PR.

If you all think this css should be more closely coupled with the reusable block (say in `packages/block-library/src/block/editor.scss`, for example) let me know and I'll move it there.

## How has this been tested?

Unable to get `wp-env` running on my linux machine, so this was not tested here. But I did test this in another installation by applying a similar change to the css.

## Screenshots <!-- if applicable -->

(from the issue thread)...

![example](https://user-images.githubusercontent.com/612155/82771978-1647de80-9e81-11ea-9caf-e2b757bd36f6.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->