### PR TITLE
Block Registration: Document innerBlocks for example property

### DIFF
--- a/docs/designers-developers/developers/block-api/README.md
+++ b/docs/designers-developers/developers/block-api/README.md
@@ -4,7 +4,7 @@ Blocks are the fundamental element of the editor. They are the primary way in wh
 
 The following sections will walk you through the existing block APIs:
 
-- [Block registration](/docs/designers-developers/developers/block-api/block-registration.md).
+- [Block registration](/docs/designers-developers/developers/block-api/block-registration.md)
 - [Edit and Save](/docs/designers-developers/developers/block-api/block-edit-save.md)
 - [Attributes](/docs/designers-developers/developers/block-api/block-attributes.md)
 - [Deprecated blocks](/docs/designers-developers/developers/block-api/block-deprecation.md)

--- a/docs/designers-developers/developers/block-api/block-registration.md
+++ b/docs/designers-developers/developers/block-api/block-registration.md
@@ -188,6 +188,25 @@ example: {
 
 If `example` is not defined, the preview will not be shown. So even if no-attributes are defined, setting a empty example object `example: {}` will trigger the preview to show.
 
+It's also possible to extend the block preview with inner blocks via `innerBlocks`. For example:
+
+```js
+example: {
+    attributes: {
+        cover: 'https://example.com/image.jpg',
+    },
+    innerBlocks: {
+        name: 'core/paragraph',
+        attributes: {
+            /* translators: example text. */
+            content: __(
+                'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent et eros eu felis.'
+            ),
+        },
+    },
+},
+```
+
 #### variations (optional)
 
 - **Type:** `Object[]`


### PR DESCRIPTION
## Description
This adds documentation for the `innerBlocks` support in the `example` property when registering a block.