### PR TITLE
Add block transform to transform preformatted block into code block

### DIFF
--- a/packages/block-library/src/preformatted/transforms.js
+++ b/packages/block-library/src/preformatted/transforms.js
@@ -35,6 +35,11 @@ const transforms = {
 			transform: ( attributes ) =>
 				createBlock( 'core/paragraph', attributes ),
 		},
+		{
+			type: 'block',
+			blocks: [ 'core/code' ],
+			transform: ( attributes ) => createBlock( 'core/code', attributes ),
+		},
 	],
 };
 

--- a/packages/e2e-tests/fixtures/block-transforms.js
+++ b/packages/e2e-tests/fixtures/block-transforms.js
@@ -274,7 +274,7 @@ export const EXPECTED_TRANSFORMS = {
 	},
 	core__preformatted: {
 		originalBlock: 'Preformatted',
-		availableTransforms: [ 'Group', 'Paragraph' ],
+		availableTransforms: [ 'Group', 'Paragraph', 'Code' ],
 	},
 	core__pullquote: {
 		originalBlock: 'Pullquote',


### PR DESCRIPTION
## Description
This provides a block transform to transform Preformatted into Code.

## How has this been tested?
Add a preformatted block, insert some content, convert to code block, ensure that the content is still there. Bonus: Convert back to preformatted and code is still there.

## Screenshots 
![Kapture 2020-05-26 at 18 17 23](https://user-images.githubusercontent.com/617637/82925137-a10e0380-9f7d-11ea-93f8-fa10c6ea9837.gif)

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
