### PR TITLE
Cover: Fix height reset on unit change

### DIFF
--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -115,6 +115,7 @@ function CoverHeightInput( {
 		<BaseControl label={ __( 'Minimum height of cover' ) } id={ inputId }>
 			<UnitControl
 				id={ inputId }
+				isResetValueOnUnitChange
 				min={ min }
 				onBlur={ handleOnBlur }
 				onChange={ handleOnChange }


### PR DESCRIPTION
## Description

![Screen Capture on 2020-05-26 at 14-47-13](https://user-images.githubusercontent.com/2322354/82939009-a872e400-9f60-11ea-85cf-25518b6e2086.gif)

This update fixes the height control in the **Cover** block, specifically when it comes to switching units. 

When a unit is changed, the value needs to reset to a (preferred) default value associated with that unit. This avoids having situations where switching `500px` to `vh` results in `500vh`, which is SUPER tall

This bug was discovered during this PR review by @youknowriad 
https://github.com/WordPress/gutenberg/pull/21492#discussion_r430209393

It's a regression that occurred when the underlying `UnitControl` components [were updated](https://github.com/WordPress/gutenberg/pulls?q=is%3Apr+unitcontrol+is%3Aclosed).

## How has this been tested?

This fix was tested in Gutenberg development locally.

* Run `npm run dev`
* Add a Cover block
* Set the height to `500` (it should be at `px` by default)
* Change the unit to `vh`
* Value should change to `50`
* Change unit to `em`
* Value should change to `20`

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
