### PR TITLE
Update docs to reference wp-env destroy

### DIFF
--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -157,16 +157,14 @@ $ wp-env start
 
 ### 6. Nuke everything and start again 🔥
 
-When all else fails, you can try forcibly removing all of the underlying Docker containers and volumes, the underlying WordPress directory, and starting again from scratch.
+When all else fails, you can use `wp-env destroy` to forcibly remove all of the underlying Docker containers and volumes. This will allow you to start from scratch.
 
 To nuke everything:
 
 **⚠️ WARNING: This will permanently delete any posts, pages, media, etc. in the local WordPress installation.**
 
 ```sh
-$ docker rm -f $(docker ps -aq)
-$ docker volume rm -f $(docker volume ls -q)
-$ rm -rf "../$(basename $(pwd))-wordpress"
+$ wp-env destroy
 $ wp-env start
 ```
 


### PR DESCRIPTION
## Description
Some docs were out of date, mentioning that you have to destroy docker container manually. This can now be done with `wp-env destroy`. 

## How has this been tested?
N/A

## Screenshots <!-- if applicable -->

## Types of changes
Documentation

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
