### PR TITLE
Replace function expressions with named function or arrow expression

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,4 @@
-module.exports = function( api ) {
+module.exports = ( api ) => {
 	api.cache( true );
 
 	return {

--- a/bin/packages/get-babel-config.js
+++ b/bin/packages/get-babel-config.js
@@ -1,4 +1,4 @@
-module.exports = function( environment = '', file ) {
+module.exports = ( environment = '', file ) => {
 	/*
 	 * Specific options to be passed using the caller config option:
 	 * https://babeljs.io/docs/en/options#caller

--- a/packages/annotations/src/store/selectors.js
+++ b/packages/annotations/src/store/selectors.js
@@ -32,12 +32,12 @@ export const __experimentalGetAnnotationsForBlock = createSelector(
 	( state, blockClientId ) => [ get( state, blockClientId, EMPTY_ARRAY ) ]
 );
 
-export const __experimentalGetAllAnnotationsForBlock = function(
+export function __experimentalGetAllAnnotationsForBlock(
 	state,
 	blockClientId
 ) {
 	return get( state, blockClientId, EMPTY_ARRAY );
-};
+}
 
 /**
  * Returns the annotations that apply to the given RichText instance.

--- a/packages/api-fetch/src/index.js
+++ b/packages/api-fetch/src/index.js
@@ -132,7 +132,7 @@ function apiFetch( options ) {
 		return step( workingOptions, next );
 	};
 
-	return new Promise( function( resolve, reject ) {
+	return new Promise( ( resolve, reject ) => {
 		createRunStep( 0 )( options )
 			.then( resolve )
 			.catch( ( error ) => {

--- a/packages/api-fetch/src/middlewares/preloading.js
+++ b/packages/api-fetch/src/middlewares/preloading.js
@@ -23,17 +23,11 @@ export function getStablePath( path ) {
 			// [ 'b=1', 'c=2', 'a=5' ]
 			.split( '&' )
 			// [ [ 'b, '1' ], [ 'c', '2' ], [ 'a', '5' ] ]
-			.map( function( entry ) {
-				return entry.split( '=' );
-			} )
+			.map( ( entry ) => entry.split( '=' ) )
 			// [ [ 'a', '5' ], [ 'b, '1' ], [ 'c', '2' ] ]
-			.sort( function( a, b ) {
-				return a[ 0 ].localeCompare( b[ 0 ] );
-			} )
+			.sort( ( a, b ) => a[ 0 ].localeCompare( b[ 0 ] ) )
 			// [ 'a=5', 'b=1', 'c=2' ]
-			.map( function( pair ) {
-				return pair.join( '=' );
-			} )
+			.map( ( pair ) => pair.join( '=' ) )
 			// 'a=5&b=1&c=2'
 			.join( '&' )
 	);

--- a/packages/autop/src/index.js
+++ b/packages/autop/src/index.js
@@ -354,18 +354,19 @@ export function removep( html ) {
 
 	// Protect script and style tags.
 	if ( html.indexOf( '<script' ) !== -1 || html.indexOf( '<style' ) !== -1 ) {
-		html = html.replace( /<(script|style)[^>]*>[\s\S]*?<\/\1>/g, function(
-			match
-		) {
-			preserve.push( match );
-			return '<wp-preserve>';
-		} );
+		html = html.replace(
+			/<(script|style)[^>]*>[\s\S]*?<\/\1>/g,
+			( match ) => {
+				preserve.push( match );
+				return '<wp-preserve>';
+			}
+		);
 	}
 
 	// Protect pre tags.
 	if ( html.indexOf( '<pre' ) !== -1 ) {
 		preserveLinebreaks = true;
-		html = html.replace( /<pre[^>]*>[\s\S]+?<\/pre>/g, function( a ) {
+		html = html.replace( /<pre[^>]*>[\s\S]+?<\/pre>/g, ( a ) => {
 			a = a.replace( /<br ?\/?>(\r\n|\n)?/g, '<wp-line-break>' );
 			a = a.replace( /<\/?p( [^>]*)?>(\r\n|\n)?/g, '<wp-line-break>' );
 			return a.replace( /\r?\n/g, '<wp-line-break>' );
@@ -375,7 +376,7 @@ export function removep( html ) {
 	// Remove line breaks but keep <br> tags inside image captions.
 	if ( html.indexOf( '[caption' ) !== -1 ) {
 		preserveBr = true;
-		html = html.replace( /\[caption[\s\S]+?\[\/caption\]/g, function( a ) {
+		html = html.replace( /\[caption[\s\S]+?\[\/caption\]/g, ( a ) => {
 			return a
 				.replace( /<br([^>]*)>/g, '<wp-temp-br$1>' )
 				.replace( /[\r\n\t]+/, '' );
@@ -406,7 +407,7 @@ export function removep( html ) {
 	html = html.replace( /\n[\s\u00a0]+\n/g, '\n\n' );
 
 	// Replace <br> tags with line breaks.
-	html = html.replace( /(\s*)<br ?\/?>\s*/gi, function( _, space ) {
+	html = html.replace( /(\s*)<br ?\/?>\s*/gi, ( _, space ) => {
 		if ( space && space.indexOf( '\n' ) !== -1 ) {
 			return '\n\n';
 		}
@@ -451,7 +452,7 @@ export function removep( html ) {
 
 	// Remove line breaks in <object> tags.
 	if ( html.indexOf( '<object' ) !== -1 ) {
-		html = html.replace( /<object[\s\S]+?<\/object>/g, function( a ) {
+		html = html.replace( /<object[\s\S]+?<\/object>/g, ( a ) => {
 			return a.replace( /[\r\n]+/g, '' );
 		} );
 	}
@@ -476,7 +477,7 @@ export function removep( html ) {
 
 	// Restore preserved tags.
 	if ( preserve.length ) {
-		html = html.replace( /<wp-preserve>/g, function() {
+		html = html.replace( /<wp-preserve>/g, () => {
 			return /** @type {string} */ ( preserve.shift() );
 		} );
 	}

--- a/packages/babel-plugin-import-jsx-pragma/index.js
+++ b/packages/babel-plugin-import-jsx-pragma/index.js
@@ -29,7 +29,7 @@ const DEFAULT_OPTIONS = {
  *
  * @return {Object} Babel transform plugin.
  */
-module.exports = function( babel ) {
+module.exports = ( babel ) => {
 	const { types: t } = babel;
 
 	function getOptions( state ) {

--- a/packages/babel-plugin-makepot/src/index.js
+++ b/packages/babel-plugin-makepot/src/index.js
@@ -193,7 +193,7 @@ function isSameTranslation( a, b ) {
 	);
 }
 
-module.exports = function() {
+module.exports = () => {
 	const strings = {};
 	let nplurals = 2,
 		baseData;

--- a/packages/babel-preset-default/index.js
+++ b/packages/babel-preset-default/index.js
@@ -1,4 +1,4 @@
-module.exports = function( api ) {
+module.exports = ( api ) => {
 	let wpBuildOpts = {};
 	const isWPBuild = ( name ) =>
 		[ 'WP_BUILD_MAIN', 'WP_BUILD_MODULE' ].some(

--- a/packages/block-editor/src/components/block-breadcrumb/index.js
+++ b/packages/block-editor/src/components/block-breadcrumb/index.js
@@ -15,7 +15,7 @@ import BlockTitle from '../block-title';
  *
  * @return {WPElement} Block Breadcrumb.
  */
-const BlockBreadcrumb = function() {
+function BlockBreadcrumb() {
 	const { selectBlock, clearSelectedBlock } = useDispatch(
 		'core/block-editor'
 	);
@@ -85,6 +85,6 @@ const BlockBreadcrumb = function() {
 		</ul>
 		/* eslint-enable jsx-a11y/no-redundant-roles */
 	);
-};
+}
 
 export default BlockBreadcrumb;

--- a/packages/block-editor/src/components/gradient-picker/control.js
+++ b/packages/block-editor/src/components/gradient-picker/control.js
@@ -16,7 +16,7 @@ import { useSelect } from '@wordpress/data';
  */
 import GradientPicker from './';
 
-export default function( {
+export default function GradientPickerControl( {
 	className,
 	value,
 	onChange,

--- a/packages/block-editor/src/components/url-popover/image-url-input-ui.js
+++ b/packages/block-editor/src/components/url-popover/image-url-input-ui.js
@@ -100,7 +100,7 @@ const ImageURLInputUI = ( {
 
 		if ( currentRel !== undefined && ! isEmpty( newRel ) ) {
 			if ( ! isEmpty( newRel ) ) {
-				each( NEW_TAB_REL, function( relVal ) {
+				each( NEW_TAB_REL, ( relVal ) => {
 					const regExp = new RegExp( '\\b' + relVal + '\\b', 'gi' );
 					newRel = newRel.replace( regExp, '' );
 				} );

--- a/packages/block-editor/src/utils/transform-styles/transforms/url-rewrite.js
+++ b/packages/block-editor/src/utils/transform-styles/transforms/url-rewrite.js
@@ -67,20 +67,17 @@ function getResourcePath( str, baseURL ) {
  * @return {Promise}         the Promise
  */
 function processURL( baseURL ) {
-	return function( meta ) {
-		const URL = getResourcePath( meta.value, baseURL );
-		return {
-			...meta,
-			newUrl:
-				'url(' +
-				meta.before +
-				meta.quote +
-				URL +
-				meta.quote +
-				meta.after +
-				')',
-		};
-	};
+	return ( meta ) => ( {
+		...meta,
+		newUrl:
+			'url(' +
+			meta.before +
+			meta.quote +
+			getResourcePath( meta.value, baseURL ) +
+			meta.quote +
+			meta.after +
+			')',
+	} );
 }
 
 /**

--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -147,7 +147,7 @@ export default class ClassicEdit extends Component {
 		} );
 
 		// Show the second, third, etc. toolbars when the `kitchensink` button is removed by a plugin.
-		editor.on( 'init', function() {
+		editor.on( 'init', () => {
 			if (
 				editor.settings.toolbar1 &&
 				editor.settings.toolbar1.indexOf( 'kitchensink' ) === -1

--- a/packages/block-library/src/image/utils.js
+++ b/packages/block-library/src/image/utils.js
@@ -22,7 +22,7 @@ export function removeNewTabRel( currentRel ) {
 
 	if ( currentRel !== undefined && ! isEmpty( newRel ) ) {
 		if ( ! isEmpty( newRel ) ) {
-			each( NEW_TAB_REL, function( relVal ) {
+			each( NEW_TAB_REL, ( relVal ) => {
 				const regExp = new RegExp( '\\b' + relVal + '\\b', 'gi' );
 				newRel = newRel.replace( regExp, '' );
 			} );

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -22,7 +22,7 @@ const TEMPLATE = [
 	[ 'core/social-link', { service: 'youtube' } ],
 ];
 
-export const SocialLinksEdit = function() {
+export function SocialLinksEdit() {
 	return (
 		<InnerBlocks
 			allowedBlocks={ ALLOWED_BLOCKS }
@@ -33,6 +33,6 @@ export const SocialLinksEdit = function() {
 			__experimentalAppenderTagName="li"
 		/>
 	);
-};
+}
 
 export default SocialLinksEdit;

--- a/packages/blocks/src/api/raw-handling/blockquote-normaliser.js
+++ b/packages/blocks/src/api/raw-handling/blockquote-normaliser.js
@@ -3,7 +3,7 @@
  */
 import normaliseBlocks from './normalise-blocks';
 
-export default function( node ) {
+export default function blockquoteNormaliser( node ) {
 	if ( node.nodeName !== 'BLOCKQUOTE' ) {
 		return;
 	}

--- a/packages/blocks/src/api/raw-handling/br-remover.js
+++ b/packages/blocks/src/api/raw-handling/br-remover.js
@@ -8,7 +8,7 @@ import { getSibling } from './utils';
  *
  * @param {Element} node Node to check.
  */
-export default function( node ) {
+export default function brRemover( node ) {
 	if ( node.nodeName !== 'BR' ) {
 		return;
 	}

--- a/packages/blocks/src/api/raw-handling/comment-remover.js
+++ b/packages/blocks/src/api/raw-handling/comment-remover.js
@@ -14,7 +14,7 @@ const { COMMENT_NODE } = window.Node;
  * @param {Node} node The node to be processed.
  * @return {void}
  */
-export default function( node ) {
+export default function commentRemover( node ) {
 	if ( node.nodeType === COMMENT_NODE ) {
 		remove( node );
 	}

--- a/packages/blocks/src/api/raw-handling/empty-paragraph-remover.js
+++ b/packages/blocks/src/api/raw-handling/empty-paragraph-remover.js
@@ -3,7 +3,7 @@
  *
  * @param {Element} node Node to check.
  */
-export default function( node ) {
+export default function emptyParagraphRemover( node ) {
 	if ( node.nodeName !== 'P' ) {
 		return;
 	}

--- a/packages/blocks/src/api/raw-handling/figure-content-reducer.js
+++ b/packages/blocks/src/api/raw-handling/figure-content-reducer.js
@@ -64,7 +64,7 @@ function wrapFigureContent( element, beforeElement = element ) {
  *
  * @return {void}
  */
-export default function( node, doc, schema ) {
+export default function figureContentReducer( node, doc, schema ) {
 	if ( ! isFigureContent( node, schema ) ) {
 		return;
 	}

--- a/packages/blocks/src/api/raw-handling/google-docs-uid-remover.js
+++ b/packages/blocks/src/api/raw-handling/google-docs-uid-remover.js
@@ -3,7 +3,7 @@
  */
 import { unwrap } from '@wordpress/dom';
 
-export default function( node ) {
+export default function googleDocsUIdRemover( node ) {
 	if ( ! node.id || node.id.indexOf( 'docs-internal-guid-' ) !== 0 ) {
 		return;
 	}

--- a/packages/blocks/src/api/raw-handling/head-remover.js
+++ b/packages/blocks/src/api/raw-handling/head-remover.js
@@ -1,4 +1,4 @@
-export default function( node ) {
+export default function headRemover( node ) {
 	if (
 		node.nodeName !== 'SCRIPT' &&
 		node.nodeName !== 'NOSCRIPT' &&

--- a/packages/blocks/src/api/raw-handling/html-formatting-remover.js
+++ b/packages/blocks/src/api/raw-handling/html-formatting-remover.js
@@ -20,7 +20,7 @@ function isFormattingSpace( character ) {
  * @param {Node} node The node to be processed.
  * @return {void}
  */
-export default function( node ) {
+export default function htmlFormattingRemover( node ) {
 	if ( node.nodeType !== node.TEXT_NODE ) {
 		return;
 	}

--- a/packages/blocks/src/api/raw-handling/iframe-remover.js
+++ b/packages/blocks/src/api/raw-handling/iframe-remover.js
@@ -5,7 +5,7 @@
  *
  * @return {void}
  */
-export default function( node ) {
+export default function iframeRemover( node ) {
 	if ( node.nodeName === 'IFRAME' ) {
 		const text = node.ownerDocument.createTextNode( node.src );
 		node.parentNode.replaceChild( text, node );

--- a/packages/blocks/src/api/raw-handling/image-corrector.js
+++ b/packages/blocks/src/api/raw-handling/image-corrector.js
@@ -8,7 +8,7 @@ import { createBlobURL } from '@wordpress/blob';
  */
 const { atob, File } = window;
 
-export default function( node ) {
+export default function imageCorrector( node ) {
 	if ( node.nodeName !== 'IMG' ) {
 		return;
 	}

--- a/packages/blocks/src/api/raw-handling/image-corrector.native.js
+++ b/packages/blocks/src/api/raw-handling/image-corrector.native.js
@@ -5,7 +5,7 @@
  *
  * @return {void}
  */
-export default function( node ) {
+export default function imageCorrector( node ) {
 	if ( node.nodeName !== 'IMG' ) {
 		return;
 	}

--- a/packages/blocks/src/api/raw-handling/is-inline-content.js
+++ b/packages/blocks/src/api/raw-handling/is-inline-content.js
@@ -53,7 +53,7 @@ function isDoubleBR( node ) {
 	);
 }
 
-export default function( HTML, contextTag ) {
+export default function isInlineContent( HTML, contextTag ) {
 	const doc = document.implementation.createHTMLDocument( '' );
 
 	doc.body.innerHTML = HTML;

--- a/packages/blocks/src/api/raw-handling/list-reducer.js
+++ b/packages/blocks/src/api/raw-handling/list-reducer.js
@@ -13,7 +13,7 @@ function shallowTextContent( element ) {
 		.join( '' );
 }
 
-export default function( node ) {
+export default function listReducer( node ) {
 	if ( ! isList( node ) ) {
 		return;
 	}

--- a/packages/blocks/src/api/raw-handling/markdown-converter.js
+++ b/packages/blocks/src/api/raw-handling/markdown-converter.js
@@ -38,6 +38,6 @@ function slackMarkdownVariantCorrector( text ) {
  *
  * @return {string} HTML.
  */
-export default function( text ) {
+export default function markdownConverter( text ) {
 	return converter.makeHtml( slackMarkdownVariantCorrector( text ) );
 }

--- a/packages/blocks/src/api/raw-handling/ms-list-converter.js
+++ b/packages/blocks/src/api/raw-handling/ms-list-converter.js
@@ -7,7 +7,7 @@ function isList( node ) {
 	return node.nodeName === 'OL' || node.nodeName === 'UL';
 }
 
-export default function( node, doc ) {
+export default function msListConverter( node, doc ) {
 	if ( node.nodeName !== 'P' ) {
 		return;
 	}

--- a/packages/blocks/src/api/raw-handling/normalise-blocks.js
+++ b/packages/blocks/src/api/raw-handling/normalise-blocks.js
@@ -9,7 +9,7 @@ import { isPhrasingContent } from './phrasing-content';
  */
 const { ELEMENT_NODE, TEXT_NODE } = window.Node;
 
-export default function( HTML ) {
+export default function normaliseBlocks( HTML ) {
 	const decuDoc = document.implementation.createHTMLDocument( '' );
 	const accuDoc = document.implementation.createHTMLDocument( '' );
 

--- a/packages/blocks/src/api/raw-handling/phrasing-content-reducer.js
+++ b/packages/blocks/src/api/raw-handling/phrasing-content-reducer.js
@@ -8,7 +8,7 @@ import { includes } from 'lodash';
  */
 import { wrap, replaceTag } from '@wordpress/dom';
 
-export default function( node, doc ) {
+export default function phrasingContentReducer( node, doc ) {
 	// In jsdom-jscore, 'node.style' can be null.
 	// TODO: Explore fixing this by patching jsdom-jscore.
 	if ( node.nodeName === 'SPAN' && node.style ) {

--- a/packages/blocks/src/api/raw-handling/special-comment-converter.js
+++ b/packages/blocks/src/api/raw-handling/special-comment-converter.js
@@ -24,7 +24,7 @@ const { COMMENT_NODE } = window.Node;
  * @param {Document} doc  The document of the node.
  * @return {void}
  */
-export default function( node, doc ) {
+export default function specialCommentConverter( node, doc ) {
 	if ( node.nodeType !== COMMENT_NODE ) {
 		return;
 	}

--- a/packages/components/src/form-token-field/test/index.js
+++ b/packages/components/src/form-token-field/test/index.js
@@ -31,7 +31,7 @@ const charCodes = {
 	comma: 44,
 };
 
-describe( 'FormTokenField', function() {
+describe( 'FormTokenField', () => {
 	let wrapper, wrapperElement, textInputElement, textInputComponent;
 
 	function setText( text ) {
@@ -95,7 +95,7 @@ describe( 'FormTokenField', function() {
 		return selectedSuggestions[ 0 ] || null;
 	}
 
-	beforeEach( function() {
+	beforeEach( () => {
 		wrapper = TestUtils.renderIntoDocument( <TokenFieldWrapper /> );
 		/* eslint-disable react/no-find-dom-node */
 		wrapperElement = () => ReactDOM.findDOMNode( wrapper );
@@ -110,15 +110,15 @@ describe( 'FormTokenField', function() {
 		TestUtils.Simulate.focus( textInputElement() );
 	} );
 
-	describe( 'displaying tokens', function() {
-		it( 'should render default tokens', function() {
+	describe( 'displaying tokens', () => {
+		it( 'should render default tokens', () => {
 			wrapper.setState( {
 				isExpanded: true,
 			} );
 			expect( wrapper.state.tokens ).toEqual( [ 'foo', 'bar' ] );
 		} );
 
-		it( 'should display tokens with escaped special characters properly', function() {
+		it( 'should display tokens with escaped special characters properly', () => {
 			wrapper.setState( {
 				tokens: fixtures.specialTokens.textEscaped,
 				isExpanded: true,
@@ -128,7 +128,7 @@ describe( 'FormTokenField', function() {
 			);
 		} );
 
-		it( 'should display tokens with special characters properly', function() {
+		it( 'should display tokens with special characters properly', () => {
 			// This test is not as realistic as the previous one: if a WP site
 			// contains tag names with special characters, the API will always
 			// return the tag names already escaped.  However, this is still
@@ -145,8 +145,8 @@ describe( 'FormTokenField', function() {
 		} );
 	} );
 
-	describe( 'suggestions', function() {
-		it( 'should not render suggestions unless we type at least two characters', function() {
+	describe( 'suggestions', () => {
+		it( 'should not render suggestions unless we type at least two characters', () => {
 			wrapper.setState( {
 				isExpanded: true,
 			} );
@@ -157,14 +157,14 @@ describe( 'FormTokenField', function() {
 			);
 		} );
 
-		it( 'should remove already added tags from suggestions', function() {
+		it( 'should remove already added tags from suggestions', () => {
 			wrapper.setState( {
 				tokens: Object.freeze( [ 'of', 'and' ] ),
 			} );
 			expect( getSuggestionsText() ).not.toEqual( getTokensHTML() );
 		} );
 
-		it( 'suggestions that begin with match are boosted', function() {
+		it( 'suggestions that begin with match are boosted', () => {
 			wrapper.setState( {
 				isExpanded: true,
 			} );
@@ -174,7 +174,7 @@ describe( 'FormTokenField', function() {
 			);
 		} );
 
-		it( 'should match against the unescaped values of suggestions with special characters', function() {
+		it( 'should match against the unescaped values of suggestions with special characters', () => {
 			wrapper.setState( {
 				tokenSuggestions: fixtures.specialSuggestions.textUnescaped,
 				isExpanded: true,
@@ -185,7 +185,7 @@ describe( 'FormTokenField', function() {
 			);
 		} );
 
-		it( 'should match against the unescaped values of suggestions with special characters (including spaces)', function() {
+		it( 'should match against the unescaped values of suggestions with special characters (including spaces)', () => {
 			wrapper.setState( {
 				tokenSuggestions: fixtures.specialSuggestions.textUnescaped,
 				isExpanded: true,
@@ -196,7 +196,7 @@ describe( 'FormTokenField', function() {
 			);
 		} );
 
-		it( 'should not match against the escaped values of suggestions with special characters', function() {
+		it( 'should not match against the escaped values of suggestions with special characters', () => {
 			setText( 'amp' );
 			wrapper.setState( {
 				tokenSuggestions: fixtures.specialSuggestions.textUnescaped,
@@ -207,7 +207,7 @@ describe( 'FormTokenField', function() {
 			);
 		} );
 
-		it( 'should match suggestions even with trailing spaces', function() {
+		it( 'should match suggestions even with trailing spaces', () => {
 			wrapper.setState( {
 				isExpanded: true,
 			} );
@@ -217,7 +217,7 @@ describe( 'FormTokenField', function() {
 			);
 		} );
 
-		it( 'should manage the selected suggestion based on both keyboard and mouse events', function() {
+		it( 'should manage the selected suggestion based on both keyboard and mouse events', () => {
 			wrapper.setState( {
 				isExpanded: true,
 			} );
@@ -254,7 +254,7 @@ describe( 'FormTokenField', function() {
 			expect( getTokensHTML() ).toEqual( [ 'foo', 'bar', 'with' ] );
 		} );
 
-		it( 'should re-render when suggestions prop has changed', function() {
+		it( 'should re-render when suggestions prop has changed', () => {
 			wrapper.setState( {
 				tokenSuggestions: [],
 				isExpanded: true,
@@ -277,19 +277,19 @@ describe( 'FormTokenField', function() {
 		} );
 	} );
 
-	describe( 'adding tokens', function() {
-		it( 'should not allow adding blank tokens with Tab', function() {
+	describe( 'adding tokens', () => {
+		it( 'should not allow adding blank tokens with Tab', () => {
 			sendKeyDown( keyCodes.tab );
 			expect( wrapper.state.tokens ).toEqual( [ 'foo', 'bar' ] );
 		} );
 
-		it( 'should not allow adding whitespace tokens with Tab', function() {
+		it( 'should not allow adding whitespace tokens with Tab', () => {
 			setText( '   ' );
 			sendKeyDown( keyCodes.tab );
 			expect( wrapper.state.tokens ).toEqual( [ 'foo', 'bar' ] );
 		} );
 
-		it( 'should add a token when Enter pressed', function() {
+		it( 'should add a token when Enter pressed', () => {
 			setText( 'baz' );
 			sendKeyDown( keyCodes.enter );
 			expect( wrapper.state.tokens ).toEqual( [ 'foo', 'bar', 'baz' ] );
@@ -297,38 +297,38 @@ describe( 'FormTokenField', function() {
 			expect( textNode.props.value ).toBe( '' );
 		} );
 
-		it( 'should not allow adding blank tokens with Enter', function() {
+		it( 'should not allow adding blank tokens with Enter', () => {
 			sendKeyDown( keyCodes.enter );
 			expect( wrapper.state.tokens ).toEqual( [ 'foo', 'bar' ] );
 		} );
 
-		it( 'should not allow adding whitespace tokens with Enter', function() {
+		it( 'should not allow adding whitespace tokens with Enter', () => {
 			setText( '   ' );
 			sendKeyDown( keyCodes.enter );
 			expect( wrapper.state.tokens ).toEqual( [ 'foo', 'bar' ] );
 		} );
 
-		it( 'should not allow adding whitespace tokens with comma', function() {
+		it( 'should not allow adding whitespace tokens with comma', () => {
 			setText( '   ' );
 			sendKeyPress( charCodes.comma );
 			expect( wrapper.state.tokens ).toEqual( [ 'foo', 'bar' ] );
 		} );
 
-		it( 'should add a token when comma pressed', function() {
+		it( 'should add a token when comma pressed', () => {
 			setText( 'baz' );
 			sendKeyPress( charCodes.comma );
 			expect( wrapper.state.tokens ).toEqual( [ 'foo', 'bar', 'baz' ] );
 		} );
 
-		it( 'should trim token values when adding', function() {
+		it( 'should trim token values when adding', () => {
 			setText( '  baz  ' );
 			sendKeyDown( keyCodes.enter );
 			expect( wrapper.state.tokens ).toEqual( [ 'foo', 'bar', 'baz' ] );
 		} );
 	} );
 
-	describe( 'removing tokens', function() {
-		it( 'should remove tokens when X icon clicked', function() {
+	describe( 'removing tokens', () => {
+		it( 'should remove tokens when X icon clicked', () => {
 			const forClickNode = wrapperElement().querySelector(
 				'.components-form-token-field__remove-token'
 			).firstChild;

--- a/packages/components/src/higher-order/with-focus-return/index.js
+++ b/packages/components/src/higher-order/with-focus-return/index.js
@@ -49,7 +49,7 @@ function withFocusReturn( options ) {
 
 	const { onFocusReturn = stubTrue } = options;
 
-	return function( WrappedComponent ) {
+	return ( WrappedComponent ) => {
 		class FocusReturn extends Component {
 			constructor() {
 				super( ...arguments );

--- a/packages/compose/src/hooks/use-preferred-color-scheme/index.android.js
+++ b/packages/compose/src/hooks/use-preferred-color-scheme/index.android.js
@@ -15,7 +15,7 @@ import { useState, useEffect } from '@wordpress/element';
  *
  * @return {string} return current color scheme.
  */
-const usePreferredColorScheme = function() {
+function usePreferredColorScheme() {
 	const [ currentColorScheme, setCurrentColorScheme ] = useState(
 		isInitialColorSchemeDark ? 'dark' : 'light'
 	);
@@ -28,6 +28,6 @@ const usePreferredColorScheme = function() {
 		} );
 	} );
 	return currentColorScheme;
-};
+}
 
 export default usePreferredColorScheme;

--- a/packages/core-data/src/utils/with-weak-map-cache.js
+++ b/packages/core-data/src/utils/with-weak-map-cache.js
@@ -15,7 +15,7 @@ import { isObjectLike } from 'lodash';
 function withWeakMapCache( fn ) {
 	const cache = new WeakMap();
 
-	return function( key ) {
+	return ( key ) => {
 		let value;
 		if ( cache.has( key ) ) {
 			value = cache.get( key );

--- a/packages/create-block/lib/index.js
+++ b/packages/create-block/lib/index.js
@@ -94,7 +94,7 @@ program
 			}
 		}
 	)
-	.on( '--help', function() {
+	.on( '--help', () => {
 		log.info( '' );
 		log.info( 'Examples:' );
 		log.info( `  $ ${ commandName }` );

--- a/packages/create-block/lib/init-wp-scripts.js
+++ b/packages/create-block/lib/init-wp-scripts.js
@@ -11,13 +11,7 @@ const writePkg = require( 'write-pkg' );
  */
 const { info } = require( './log' );
 
-module.exports = async function( {
-	author,
-	description,
-	license,
-	slug,
-	version,
-} ) {
+module.exports = async ( { author, description, license, slug, version } ) => {
 	const cwd = join( process.cwd(), slug );
 
 	info( '' );

--- a/packages/create-block/lib/scaffold.js
+++ b/packages/create-block/lib/scaffold.js
@@ -14,7 +14,7 @@ const initWPScripts = require( './init-wp-scripts' );
 const { code, info, success } = require( './log' );
 const { hasWPScriptsEnabled } = require( './templates' );
 
-module.exports = async function(
+module.exports = async (
 	blockTemplate,
 	{
 		namespace,
@@ -28,7 +28,7 @@ module.exports = async function(
 		licenseURI,
 		version,
 	}
-) {
+) => {
 	slug = slug.toLowerCase();
 	namespace = namespace.toLowerCase();
 

--- a/packages/data/src/namespace-store/index.js
+++ b/packages/data/src/namespace-store/index.js
@@ -82,7 +82,7 @@ export default function createNamespace( key, options, registry ) {
 	// not on every dispatch.
 	const subscribe =
 		store &&
-		function( listener ) {
+		( ( listener ) => {
 			let lastState = store.__unstableOriginalGetState();
 			store.subscribe( () => {
 				const state = store.__unstableOriginalGetState();
@@ -93,7 +93,7 @@ export default function createNamespace( key, options, registry ) {
 					listener();
 				}
 			} );
-		};
+		} );
 
 	// This can be simplified to just { subscribe, getSelectors, getActions }
 	// Once we remove the use function.

--- a/packages/data/src/plugins/controls/index.js
+++ b/packages/data/src/plugins/controls/index.js
@@ -3,9 +3,9 @@
  */
 import deprecated from '@wordpress/deprecated';
 
-export default function( registry ) {
+export default ( registry ) => {
 	deprecated( 'wp.data.plugins.controls', {
 		hint: 'The controls plugins is now baked-in.',
 	} );
 	return registry;
-}
+};

--- a/packages/data/src/plugins/persistence/index.js
+++ b/packages/data/src/plugins/persistence/index.js
@@ -121,7 +121,7 @@ export function createPersistenceInterface( options ) {
  *
  * @return {WPDataPlugin} Data plugin.
  */
-const persistencePlugin = function( registry, pluginOptions ) {
+function persistencePlugin( registry, pluginOptions ) {
 	const persistence = createPersistenceInterface( pluginOptions );
 
 	/**
@@ -220,7 +220,7 @@ const persistencePlugin = function( registry, pluginOptions ) {
 			return store;
 		},
 	};
-};
+}
 
 /**
  * Deprecated: Remove this function and the code in WordPress Core that calls

--- a/packages/docgen/src/get-dependency-path.js
+++ b/packages/docgen/src/get-dependency-path.js
@@ -1,3 +1,1 @@
-module.exports = function( token ) {
-	return token.source.value;
-};
+module.exports = ( token ) => token.source.value;

--- a/packages/docgen/src/get-export-entries.js
+++ b/packages/docgen/src/get-export-entries.js
@@ -19,7 +19,7 @@ const { get } = require( 'lodash' );
  *    lineEnd: 3,
  * } ]
  */
-module.exports = function( token ) {
+module.exports = ( token ) => {
 	if ( token.type === 'ExportDefaultDeclaration' ) {
 		const getLocalName = ( t ) => {
 			let name;

--- a/packages/docgen/src/get-intermediate-representation.js
+++ b/packages/docgen/src/get-intermediate-representation.js
@@ -129,12 +129,12 @@ const getJSDoc = ( token, entry, ast, parseDependency ) => {
  *
  * @return {Object} Intermediate Representation in JSON.
  */
-module.exports = function(
+module.exports = (
 	path,
 	token,
 	ast = { body: [] },
 	parseDependency = () => {}
-) {
+) => {
 	const exportEntries = getExportEntries( token );
 	const ir = [];
 	exportEntries.forEach( ( entry ) => {

--- a/packages/docgen/src/get-jsdoc-from-token.js
+++ b/packages/docgen/src/get-jsdoc-from-token.js
@@ -17,7 +17,7 @@ const getTypeAsString = require( './get-type-as-string' );
  * @param {Object} token Espree token.
  * @return {Object} Object representing the JSDoc comment.
  */
-module.exports = function( token ) {
+module.exports = ( token ) => {
 	let jsdoc;
 	const comments = getLeadingComments( token );
 	if ( comments && /^\*\r?\n/.test( comments ) ) {

--- a/packages/docgen/src/get-leading-comments.js
+++ b/packages/docgen/src/get-leading-comments.js
@@ -11,7 +11,7 @@ const { last } = require( 'lodash' );
  *
  * @return {?string} Leading comment or undefined if there is none.
  */
-module.exports = function( declaration ) {
+module.exports = ( declaration ) => {
 	let comments;
 	if ( declaration.leadingComments ) {
 		comments = last( declaration.leadingComments ).value;

--- a/packages/docgen/src/get-type-as-string.js
+++ b/packages/docgen/src/get-type-as-string.js
@@ -1,11 +1,11 @@
-const maybeAddDefault = function( value, defaultValue ) {
+const maybeAddDefault = ( value, defaultValue ) => {
 	if ( defaultValue ) {
 		return `value=${ defaultValue }`;
 	}
 	return value;
 };
 
-const getType = function( param, defaultValue ) {
+const getType = ( param, defaultValue ) => {
 	if ( ! defaultValue ) {
 		defaultValue = param.default;
 	}
@@ -42,6 +42,4 @@ const getType = function( param, defaultValue ) {
 	return maybeAddDefault( param.name, defaultValue );
 };
 
-module.exports = function( param ) {
-	return getType( param );
-};
+module.exports = ( param ) => getType( param );

--- a/packages/docgen/src/index.js
+++ b/packages/docgen/src/index.js
@@ -87,7 +87,7 @@ const runCustomFormatter = (
 // To keep track of file being processed.
 const currentFileStack = [];
 
-module.exports = function( sourceFile, options ) {
+module.exports = ( sourceFile, options ) => {
 	// Input: process CLI args, prepare files, etc
 	const processDir = process.cwd();
 	if ( sourceFile === undefined ) {

--- a/packages/docgen/src/markdown/embed.js
+++ b/packages/docgen/src/markdown/embed.js
@@ -20,7 +20,7 @@ const getHeadingIndex = ( ast, index ) => {
  * @param {Object} newContentAst The new contents to be embedded in remark AST format.
  * @return {boolean} Whether the contents were embedded or not.
  */
-const embed = function( token, targetAst, newContentAst ) {
+const embed = ( token, targetAst, newContentAst ) => {
 	let headingIndex = -1;
 
 	const START_TOKEN = `<!-- START TOKEN(${ token }) -->`;

--- a/packages/docgen/src/markdown/formatter.js
+++ b/packages/docgen/src/markdown/formatter.js
@@ -65,13 +65,13 @@ const getTypeOutput = ( type ) => {
 	return type ? `\`${ type }\`` : '(unknown type)';
 };
 
-module.exports = function(
+module.exports = (
 	rootDir,
 	docPath,
 	symbols,
 	headingTitle,
 	headingStartIndex
-) {
+) => {
 	const docs = [];
 	let headingIndex = headingStartIndex || 1;
 	if ( headingTitle ) {

--- a/packages/docgen/src/markdown/index.js
+++ b/packages/docgen/src/markdown/index.js
@@ -36,13 +36,7 @@ const appendOrEmbedContents = ( { options, newContents } ) => {
 	};
 };
 
-module.exports = function(
-	options,
-	processDir,
-	doc,
-	filteredIR,
-	headingTitle
-) {
+module.exports = ( options, processDir, doc, filteredIR, headingTitle ) => {
 	if ( options.toSection || options.toToken ) {
 		const currentReadmeFile = fs.readFileSync( options.output, 'utf8' );
 		const newContents = unified()
@@ -51,7 +45,7 @@ module.exports = function(
 		remark()
 			.use( { settings: { commonmark: true } } )
 			.use( appendOrEmbedContents, { options, newContents } )
-			.process( currentReadmeFile, function( err, file ) {
+			.process( currentReadmeFile, ( err, file ) => {
 				if ( err ) {
 					throw err;
 				}

--- a/packages/docgen/src/test/get-export-entries.js
+++ b/packages/docgen/src/test/get-export-entries.js
@@ -9,7 +9,7 @@ const path = require( 'path' );
  */
 const getExportEntries = require( '../get-export-entries' );
 
-describe( 'Export entries', function() {
+describe( 'Export entries', () => {
 	it( 'default class (anonymous)', () => {
 		const token = fs.readFileSync(
 			path.join(
@@ -29,7 +29,7 @@ describe( 'Export entries', function() {
 		} );
 	} );
 
-	it( 'default class (named)', function() {
+	it( 'default class (named)', () => {
 		const token = fs.readFileSync(
 			path.join(
 				__dirname,
@@ -48,7 +48,7 @@ describe( 'Export entries', function() {
 		} );
 	} );
 
-	it( 'default function (anonymous)', function() {
+	it( 'default function (anonymous)', () => {
 		const token = fs.readFileSync(
 			path.join(
 				__dirname,
@@ -67,7 +67,7 @@ describe( 'Export entries', function() {
 		} );
 	} );
 
-	it( 'default function (named)', function() {
+	it( 'default function (named)', () => {
 		const token = fs.readFileSync(
 			path.join(
 				__dirname,
@@ -86,7 +86,7 @@ describe( 'Export entries', function() {
 		} );
 	} );
 
-	it( 'default identifier', function() {
+	it( 'default identifier', () => {
 		const token = fs.readFileSync(
 			path.join(
 				__dirname,
@@ -105,7 +105,7 @@ describe( 'Export entries', function() {
 		} );
 	} );
 
-	it( 'default import (named)', function() {
+	it( 'default import (named)', () => {
 		const token = fs.readFileSync(
 			path.join(
 				__dirname,
@@ -124,7 +124,7 @@ describe( 'Export entries', function() {
 		} );
 	} );
 
-	it( 'default import (default)', function() {
+	it( 'default import (default)', () => {
 		const token = fs.readFileSync(
 			path.join(
 				__dirname,
@@ -143,7 +143,7 @@ describe( 'Export entries', function() {
 		} );
 	} );
 
-	it( 'default named export', function() {
+	it( 'default named export', () => {
 		const tokens = fs.readFileSync(
 			path.join(
 				__dirname,
@@ -171,7 +171,7 @@ describe( 'Export entries', function() {
 		} );
 	} );
 
-	it( 'default variable', function() {
+	it( 'default variable', () => {
 		const token = fs.readFileSync(
 			path.join( __dirname, './fixtures/default-variable/exports.json' ),
 			'utf-8'
@@ -187,7 +187,7 @@ describe( 'Export entries', function() {
 		} );
 	} );
 
-	it( 'named class', function() {
+	it( 'named class', () => {
 		const token = fs.readFileSync(
 			path.join( __dirname, './fixtures/named-class/exports.json' ),
 			'utf-8'
@@ -203,7 +203,7 @@ describe( 'Export entries', function() {
 		} );
 	} );
 
-	it( 'named default', function() {
+	it( 'named default', () => {
 		const token = fs.readFileSync(
 			path.join( __dirname, './fixtures/named-default/exports.json' ),
 			'utf-8'
@@ -219,7 +219,7 @@ describe( 'Export entries', function() {
 		} );
 	} );
 
-	it( 'named default (exported)', function() {
+	it( 'named default (exported)', () => {
 		const token = fs.readFileSync(
 			path.join(
 				__dirname,
@@ -238,7 +238,7 @@ describe( 'Export entries', function() {
 		} );
 	} );
 
-	it( 'named function', function() {
+	it( 'named function', () => {
 		const token = fs.readFileSync(
 			path.join( __dirname, './fixtures/named-function/exports.json' ),
 			'utf-8'
@@ -254,7 +254,7 @@ describe( 'Export entries', function() {
 		} );
 	} );
 
-	it( 'named identifier', function() {
+	it( 'named identifier', () => {
 		const token = fs.readFileSync(
 			path.join( __dirname, './fixtures/named-identifier/exports.json' ),
 			'utf-8'
@@ -286,7 +286,7 @@ describe( 'Export entries', function() {
 		} );
 	} );
 
-	it( 'named identifiers', function() {
+	it( 'named identifiers', () => {
 		const token = fs.readFileSync(
 			path.join( __dirname, './fixtures/named-identifiers/exports.json' ),
 			'utf-8'
@@ -352,7 +352,7 @@ describe( 'Export entries', function() {
 		} );
 	} );
 
-	it( 'named import namespace', function() {
+	it( 'named import namespace', () => {
 		const token = fs.readFileSync(
 			path.join(
 				__dirname,
@@ -371,7 +371,7 @@ describe( 'Export entries', function() {
 		} );
 	} );
 
-	it( 'named variable', function() {
+	it( 'named variable', () => {
 		const token = fs.readFileSync(
 			path.join( __dirname, './fixtures/named-variable/exports.json' ),
 			'utf-8'
@@ -387,7 +387,7 @@ describe( 'Export entries', function() {
 		} );
 	} );
 
-	it( 'named variables', function() {
+	it( 'named variables', () => {
 		const token = fs.readFileSync(
 			path.join( __dirname, './fixtures/named-variables/exports.json' ),
 			'utf-8'
@@ -410,7 +410,7 @@ describe( 'Export entries', function() {
 		} );
 	} );
 
-	it( 'namespace (*)', function() {
+	it( 'namespace (*)', () => {
 		const token = fs.readFileSync(
 			path.join( __dirname, './fixtures/namespace/exports.json' ),
 			'utf-8'

--- a/packages/docgen/src/test/get-intermediate-representation.js
+++ b/packages/docgen/src/test/get-intermediate-representation.js
@@ -9,8 +9,8 @@ const path = require( 'path' );
  */
 const getIntermediateRepresentation = require( '../get-intermediate-representation' );
 
-describe( 'Intermediate Representation', function() {
-	it( 'undocumented', function() {
+describe( 'Intermediate Representation', () => {
+	it( 'undocumented', () => {
 		const token = fs.readFileSync(
 			path.join(
 				__dirname,
@@ -81,8 +81,8 @@ describe( 'Intermediate Representation', function() {
 		} );
 	} );
 
-	describe( 'JSDoc in export statement', function() {
-		it( 'default export', function() {
+	describe( 'JSDoc in export statement', () => {
+		it( 'default export', () => {
 			const tokenClassAnonymous = fs.readFileSync(
 				path.join(
 					__dirname,
@@ -182,7 +182,7 @@ describe( 'Intermediate Representation', function() {
 				lineEnd: 4,
 			} );
 		} );
-		it( 'named export', function() {
+		it( 'named export', () => {
 			const tokenClass = fs.readFileSync(
 				path.join( __dirname, './fixtures/named-class/exports.json' ),
 				'utf-8'
@@ -271,8 +271,8 @@ describe( 'Intermediate Representation', function() {
 		} );
 	} );
 
-	describe( 'JSDoc in same file', function() {
-		it( 'default export', function() {
+	describe( 'JSDoc in same file', () => {
+		it( 'default export', () => {
 			const token = fs.readFileSync(
 				path.join(
 					__dirname,
@@ -344,7 +344,7 @@ describe( 'Intermediate Representation', function() {
 			} );
 		} );
 
-		it( 'named export', function() {
+		it( 'named export', () => {
 			const token = fs.readFileSync(
 				path.join(
 					__dirname,
@@ -491,8 +491,8 @@ describe( 'Intermediate Representation', function() {
 		} );
 	} );
 
-	describe( 'JSDoc in module dependency', function() {
-		it( 'named export', function() {
+	describe( 'JSDoc in module dependency', () => {
+		it( 'named export', () => {
 			const tokenImportNamed = fs.readFileSync(
 				path.join(
 					__dirname,
@@ -543,7 +543,7 @@ describe( 'Intermediate Representation', function() {
 			} );
 		} );
 
-		it( 'named default export', function() {
+		it( 'named default export', () => {
 			const tokenDefault = fs.readFileSync(
 				path.join( __dirname, './fixtures/named-default/exports.json' ),
 				'utf-8'
@@ -597,7 +597,7 @@ describe( 'Intermediate Representation', function() {
 			} );
 		} );
 
-		it( 'namespace export', function() {
+		it( 'namespace export', () => {
 			const token = fs.readFileSync(
 				path.join( __dirname, './fixtures/namespace/exports.json' ),
 				'utf-8'
@@ -684,8 +684,8 @@ describe( 'Intermediate Representation', function() {
 		} );
 	} );
 
-	describe( 'JSDoc in module dependency through import', function() {
-		it( 'default export', function() {
+	describe( 'JSDoc in module dependency through import', () => {
+		it( 'default export', () => {
 			const tokenDefault = fs.readFileSync(
 				path.join(
 					__dirname,
@@ -766,7 +766,7 @@ describe( 'Intermediate Representation', function() {
 			} );
 		} );
 
-		it( 'named export', function() {
+		it( 'named export', () => {
 			const tokenImportNamespace = fs.readFileSync(
 				path.join(
 					__dirname,

--- a/packages/edit-post/src/components/editor-initialization/index.js
+++ b/packages/edit-post/src/components/editor-initialization/index.js
@@ -13,7 +13,7 @@ import {
  * @param {number} postId  The id of the post.
  * @return {null} This is a data component so does not render any ui.
  */
-export default function( { postId } ) {
+export default function EditorInitialization( { postId } ) {
 	useBlockSelectionListener( postId );
 	useUpdatePostLinkListener( postId );
 	return null;

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -118,7 +118,7 @@ export function initializeEditor(
 
 	const isIphone = window.navigator.userAgent.indexOf( 'iPhone' ) !== -1;
 	if ( isIphone ) {
-		window.addEventListener( 'scroll', function( event ) {
+		window.addEventListener( 'scroll', ( event ) => {
 			const editorScrollContainer = document.getElementsByClassName(
 				'interface-interface-skeleton__body'
 			)[ 0 ];

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -607,64 +607,63 @@ export function isEditedPostEmpty( state ) {
  * @return {boolean} Whether the post can be autosaved.
  */
 export const isEditedPostAutosaveable = createRegistrySelector(
-	( select ) =>
-		function( state ) {
-			// A post must contain a title, an excerpt, or non-empty content to be valid for autosaving.
-			if ( ! isEditedPostSaveable( state ) ) {
-				return false;
-			}
-
-			// A post is not autosavable when there is a post autosave lock.
-			if ( isPostAutosavingLocked( state ) ) {
-				return false;
-			}
-
-			const postType = getCurrentPostType( state );
-			const postId = getCurrentPostId( state );
-			const hasFetchedAutosave = select( 'core' ).hasFetchedAutosaves(
-				postType,
-				postId
-			);
-			const currentUserId = get( select( 'core' ).getCurrentUser(), [
-				'id',
-			] );
-
-			// Disable reason - this line causes the side-effect of fetching the autosave
-			// via a resolver, moving below the return would result in the autosave never
-			// being fetched.
-			// eslint-disable-next-line @wordpress/no-unused-vars-before-return
-			const autosave = select( 'core' ).getAutosave(
-				postType,
-				postId,
-				currentUserId
-			);
-
-			// If any existing autosaves have not yet been fetched, this function is
-			// unable to determine if the post is autosaveable, so return false.
-			if ( ! hasFetchedAutosave ) {
-				return false;
-			}
-
-			// If we don't already have an autosave, the post is autosaveable.
-			if ( ! autosave ) {
-				return true;
-			}
-
-			// To avoid an expensive content serialization, use the content dirtiness
-			// flag in place of content field comparison against the known autosave.
-			// This is not strictly accurate, and relies on a tolerance toward autosave
-			// request failures for unnecessary saves.
-			if ( hasChangedContent( state ) ) {
-				return true;
-			}
-
-			// If the title or excerpt has changed, the post is autosaveable.
-			return [ 'title', 'excerpt' ].some(
-				( field ) =>
-					getPostRawValue( autosave[ field ] ) !==
-					getEditedPostAttribute( state, field )
-			);
+	( select ) => ( state ) => {
+		// A post must contain a title, an excerpt, or non-empty content to be valid for autosaving.
+		if ( ! isEditedPostSaveable( state ) ) {
+			return false;
 		}
+
+		// A post is not autosavable when there is a post autosave lock.
+		if ( isPostAutosavingLocked( state ) ) {
+			return false;
+		}
+
+		const postType = getCurrentPostType( state );
+		const postId = getCurrentPostId( state );
+		const hasFetchedAutosave = select( 'core' ).hasFetchedAutosaves(
+			postType,
+			postId
+		);
+		const currentUserId = get( select( 'core' ).getCurrentUser(), [
+			'id',
+		] );
+
+		// Disable reason - this line causes the side-effect of fetching the autosave
+		// via a resolver, moving below the return would result in the autosave never
+		// being fetched.
+		// eslint-disable-next-line @wordpress/no-unused-vars-before-return
+		const autosave = select( 'core' ).getAutosave(
+			postType,
+			postId,
+			currentUserId
+		);
+
+		// If any existing autosaves have not yet been fetched, this function is
+		// unable to determine if the post is autosaveable, so return false.
+		if ( ! hasFetchedAutosave ) {
+			return false;
+		}
+
+		// If we don't already have an autosave, the post is autosaveable.
+		if ( ! autosave ) {
+			return true;
+		}
+
+		// To avoid an expensive content serialization, use the content dirtiness
+		// flag in place of content field comparison against the known autosave.
+		// This is not strictly accurate, and relies on a tolerance toward autosave
+		// request failures for unnecessary saves.
+		if ( hasChangedContent( state ) ) {
+			return true;
+		}
+
+		// If the title or excerpt has changed, the post is autosaveable.
+		return [ 'title', 'excerpt' ].some(
+			( field ) =>
+				getPostRawValue( autosave[ field ] ) !==
+				getEditedPostAttribute( state, field )
+		);
+	}
 );
 
 /**

--- a/packages/editor/src/store/selectors.native.js
+++ b/packages/editor/src/store/selectors.native.js
@@ -34,25 +34,24 @@ export function isPostTitleSelected( state ) {
  * @return {boolean} Whether the post can be autosaved.
  */
 export const isEditedPostAutosaveable = createRegistrySelector(
-	() =>
-		function( state ) {
-			// A post must contain a title, an excerpt, or non-empty content to be valid for autosaving.
-			if ( ! isEditedPostSaveable( state ) ) {
-				return false;
-			}
-
-			// To avoid an expensive content serialization, use the content dirtiness
-			// flag in place of content field comparison against the known autosave.
-			// This is not strictly accurate, and relies on a tolerance toward autosave
-			// request failures for unnecessary saves.
-			if ( hasChangedContent( state ) ) {
-				return true;
-			}
-
-			if ( isEditedPostDirty( state ) ) {
-				return true;
-			}
-
+	() => ( state ) => {
+		// A post must contain a title, an excerpt, or non-empty content to be valid for autosaving.
+		if ( ! isEditedPostSaveable( state ) ) {
 			return false;
 		}
+
+		// To avoid an expensive content serialization, use the content dirtiness
+		// flag in place of content field comparison against the known autosave.
+		// This is not strictly accurate, and relies on a tolerance toward autosave
+		// request failures for unnecessary saves.
+		if ( hasChangedContent( state ) ) {
+			return true;
+		}
+
+		if ( isEditedPostDirty( state ) ) {
+			return true;
+		}
+
+		return false;
+	}
 );

--- a/packages/editor/src/utils/media-upload/index.js
+++ b/packages/editor/src/utils/media-upload/index.js
@@ -21,7 +21,7 @@ import { uploadMedia } from '@wordpress/media-utils';
  * @param   {Function} $0.onError           Function called when an error happens.
  * @param   {Function} $0.onFileChange      Function called each time a file or a temporary representation of the file is available.
  */
-export default function( {
+export default function mediaUpload( {
 	additionalData = {},
 	allowedTypes,
 	filesList,

--- a/packages/editor/src/utils/media-upload/index.native.js
+++ b/packages/editor/src/utils/media-upload/index.native.js
@@ -1,1 +1,1 @@
-export default function() {}
+export default function mediaUpload() {}

--- a/packages/list-reusable-blocks/src/utils/file.js
+++ b/packages/list-reusable-blocks/src/utils/file.js
@@ -33,7 +33,7 @@ export function download( fileName, content, contentType ) {
 export function readTextFile( file ) {
 	const reader = new window.FileReader();
 	return new Promise( ( resolve ) => {
-		reader.onload = function() {
+		reader.onload = () => {
 			resolve( reader.result );
 		};
 		reader.readAsText( file );

--- a/packages/postcss-themes/index.js
+++ b/packages/postcss-themes/index.js
@@ -3,8 +3,8 @@
  */
 const postcss = require( 'postcss' );
 
-module.exports = postcss.plugin( 'postcss-themes', function( options ) {
-	return function( root ) {
+module.exports = postcss.plugin( 'postcss-themes', ( options ) => {
+	return ( root ) => {
 		root.walkRules( ( rule ) => {
 			const themeDecls = {};
 			let hasThemeDecls = false;

--- a/packages/redux-routine/src/test/is-action.js
+++ b/packages/redux-routine/src/test/is-action.js
@@ -3,7 +3,7 @@
  */
 import { isAction, isActionOfType } from '../is-action';
 
-const nonActions = [ null, [], 42, 'foo', function() {}, { foo: 'bar' } ];
+const nonActions = [ null, [], 42, 'foo', () => {}, { foo: 'bar' } ];
 const validAction = { type: 'winner' };
 
 describe( 'isAction()', () => {

--- a/packages/server-side-render/src/test/index.js
+++ b/packages/server-side-render/src/test/index.js
@@ -3,8 +3,8 @@
  */
 import { rendererPath } from '../server-side-render';
 
-describe( 'rendererPath', function() {
-	test( 'should return an base path for empty input', function() {
+describe( 'rendererPath', () => {
+	test( 'should return an base path for empty input', () => {
 		expect( rendererPath( 'core/test-block', null ) ).toBe(
 			'/wp/v2/block-renderer/core/test-block?context=edit'
 		);
@@ -13,7 +13,7 @@ describe( 'rendererPath', function() {
 		);
 	} );
 
-	test( 'should format basic url params ', function() {
+	test( 'should format basic url params ', () => {
 		expect(
 			rendererPath( 'core/test-block', {
 				stringArg: 'test',
@@ -26,7 +26,7 @@ describe( 'rendererPath', function() {
 		);
 	} );
 
-	test( 'should format object params ', function() {
+	test( 'should format object params ', () => {
 		expect(
 			rendererPath( 'core/test-block', {
 				objectArg: {
@@ -39,7 +39,7 @@ describe( 'rendererPath', function() {
 		);
 	} );
 
-	test( 'should format an array of objects', function() {
+	test( 'should format an array of objects', () => {
 		expect(
 			rendererPath( 'core/test-block', {
 				children: [
@@ -60,7 +60,7 @@ describe( 'rendererPath', function() {
 		);
 	} );
 
-	test( 'should include urlQueryArgs', function() {
+	test( 'should include urlQueryArgs', () => {
 		expect(
 			rendererPath(
 				'core/test-block',

--- a/packages/warning/test/babel-plugin.js
+++ b/packages/warning/test/babel-plugin.js
@@ -20,7 +20,7 @@ function compare( input, output, options = {} ) {
 	expect( code ).toEqual( output );
 }
 
-describe( 'babel-plugin', function() {
+describe( 'babel-plugin', () => {
 	it( 'should replace warning calls with import declaration', () => {
 		compare(
 			join(

--- a/packages/wordcount/src/stripConnectors.js
+++ b/packages/wordcount/src/stripConnectors.js
@@ -6,7 +6,7 @@
  *
  * @return {string} The manipulated text.
  */
-export default function( settings, text ) {
+export default function stripConnectors( settings, text ) {
 	if ( settings.connectorRegExp ) {
 		return text.replace( settings.connectorRegExp, ' ' );
 	}

--- a/packages/wordcount/src/stripHTMLComments.js
+++ b/packages/wordcount/src/stripHTMLComments.js
@@ -6,7 +6,7 @@
  *
  * @return {string} The manipulated text.
  */
-export default function( settings, text ) {
+export default function stripHTMLComments( settings, text ) {
 	if ( settings.HTMLcommentRegExp ) {
 		return text.replace( settings.HTMLcommentRegExp, '' );
 	}

--- a/packages/wordcount/src/stripHTMLEntities.js
+++ b/packages/wordcount/src/stripHTMLEntities.js
@@ -6,7 +6,7 @@
  *
  * @return {string} The manipulated text.
  */
-export default function( settings, text ) {
+export default function stripHTMLEntities( settings, text ) {
 	if ( settings.HTMLEntityRegExp ) {
 		return text.replace( settings.HTMLEntityRegExp, '' );
 	}

--- a/packages/wordcount/src/stripRemovables.js
+++ b/packages/wordcount/src/stripRemovables.js
@@ -6,7 +6,7 @@
  *
  * @return {string} The manipulated text.
  */
-export default function( settings, text ) {
+export default function stripRemovables( settings, text ) {
 	if ( settings.removeRegExp ) {
 		return text.replace( settings.removeRegExp, '' );
 	}

--- a/packages/wordcount/src/stripShortcodes.js
+++ b/packages/wordcount/src/stripShortcodes.js
@@ -6,7 +6,7 @@
  *
  * @return {string} The manipulated text.
  */
-export default function( settings, text ) {
+export default function stripShortcodes( settings, text ) {
 	if ( settings.shortcodesRegExp ) {
 		return text.replace( settings.shortcodesRegExp, '\n' );
 	}

--- a/packages/wordcount/src/stripSpaces.js
+++ b/packages/wordcount/src/stripSpaces.js
@@ -6,7 +6,7 @@
  *
  * @return {string} The manipulated text.
  */
-export default function( settings, text ) {
+export default function stripSpaces( settings, text ) {
 	if ( settings.spaceRegExp ) {
 		return text.replace( settings.spaceRegExp, ' ' );
 	}

--- a/packages/wordcount/src/stripTags.js
+++ b/packages/wordcount/src/stripTags.js
@@ -6,7 +6,7 @@
  *
  * @return {string} The manipulated text.
  */
-export default function( settings, text ) {
+export default function stripTags( settings, text ) {
 	if ( settings.HTMLRegExp ) {
 		return text.replace( settings.HTMLRegExp, '\n' );
 	}

--- a/packages/wordcount/src/transposeAstralsToCountableChar.js
+++ b/packages/wordcount/src/transposeAstralsToCountableChar.js
@@ -6,7 +6,7 @@
  *
  * @return {string} The manipulated text.
  */
-export default function( settings, text ) {
+export default function transposeAstralsToCountableChar( settings, text ) {
 	if ( settings.astralRegExp ) {
 		return text.replace( settings.astralRegExp, 'a' );
 	}

--- a/packages/wordcount/src/transposeHTMLEntitiesToCountableChars.js
+++ b/packages/wordcount/src/transposeHTMLEntitiesToCountableChars.js
@@ -6,7 +6,10 @@
  *
  * @return {string} The manipulated text.
  */
-export default function( settings, text ) {
+export default function transposeHTMLEntitiesToCountableChars(
+	settings,
+	text
+) {
 	if ( settings.HTMLEntityRegExp ) {
 		return text.replace( settings.HTMLEntityRegExp, 'a' );
 	}

--- a/test/native/babel.config.js
+++ b/test/native/babel.config.js
@@ -1,4 +1,4 @@
-module.exports = function( api ) {
+module.exports = ( api ) => {
 	api.cache( true );
 	return {
 		presets: [ 'module:metro-react-native-babel-preset' ],


### PR DESCRIPTION
Related (facilitates): #22610

This pull request seeks to replace the majority of [function expressions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/function) throughout the codebase, with an equivalent (named) [function declaration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function) or [arrow function expression](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions).

This serves a few purposes:

- Code consistency
- Reduce changes involved with the Prettier upgrade in #22610 
- Encourage named functions where appropriate, since it helps dramatically in error stack traces, debugger call stacks, and performance audits to quickly identify a function by name (vs. "(anonymous)").

**Implementation Notes:**

While the changes are numerous, I expected them to be straight-forward. It was complicated by the fact that arrow functions have a few distinct differences from function expressions, which are used intentionally in some cases (availability of [`arguments`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments) and difference in [`this` binding](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this)). I've made a best effort to verify against regressions to intentional references to `arguments` and `this` which could be affected by these changes, and have avoided a few areas of mixed usage altogether (e.g. `block-editor/src/utils/transform-styles/ast`).

**Testing Instructions:**

Ensure all tests and end-to-end tests pass:

```
npm test
```

```
npm run test-e2e
```

Perform spot testing to identify potential regressions. Particular attention should be paid to affected code.