### PR TITLE
Env: fix ssh-auth nodegit + better snap pack detection

### DIFF
--- a/packages/env/lib/config.js
+++ b/packages/env/lib/config.js
@@ -212,7 +212,7 @@ module.exports = {
 		}
 
 		const workDirectoryPath = path.resolve(
-			getHomeDirectory(),
+			await getHomeDirectory(),
 			md5( configPath )
 		);
 
@@ -386,7 +386,7 @@ function getNumberFromEnvVariable( varName ) {
  *
  * @return {string} The absolute path to the `wp-env` home directory.
  */
-function getHomeDirectory() {
+async function getHomeDirectory() {
 	// Allow user to override download location.
 	if ( process.env.WP_ENV_HOME ) {
 		return path.resolve( process.env.WP_ENV_HOME );
@@ -400,7 +400,9 @@ function getHomeDirectory() {
 	 */
 	return path.resolve(
 		os.homedir(),
-		os.platform() === 'linux' ? 'wp-env' : '.wp-env'
+		!! ( await fs.stat( '/snap' ).catch( () => false ) )
+			? 'wp-env'
+			: '.wp-env'
 	);
 }
 

--- a/packages/env/lib/config.js
+++ b/packages/env/lib/config.js
@@ -384,7 +384,7 @@ function getNumberFromEnvVariable( varName ) {
  * By default, '~/.wp-env/'. On Linux, '~/wp-env/'. Can be overriden with the
  * WP_ENV_HOME environment variable.
  *
- * @return {string} The absolute path to the `wp-env` home directory.
+ * @return {Promise<string>} The absolute path to the `wp-env` home directory.
  */
 async function getHomeDirectory() {
 	// Allow user to override download location.

--- a/packages/env/lib/download-source.js
+++ b/packages/env/lib/download-source.js
@@ -70,6 +70,14 @@ async function downloadGitSource( source, { onProgress, spinner, debug } ) {
 							( progress.totalObjects() * 2 )
 					);
 				},
+				certificateCheck: () => 0,
+				credentials: ( url, userName ) => {
+					try {
+						return NodeGit.Cred.sshKeyFromAgent( userName );
+					} catch {
+						return NodeGit.Cred.defaultNew();
+					}
+				},
 			},
 		},
 	};

--- a/packages/env/test/config.js
+++ b/packages/env/test/config.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-const { readFile } = require( 'fs' ).promises;
+const { readFile, stat } = require( 'fs' ).promises;
 const os = require( 'os' );
 
 /**
@@ -14,6 +14,7 @@ const detectDirectoryType = require( '../lib/detect-directory-type' );
 jest.mock( 'fs', () => ( {
 	promises: {
 		readFile: jest.fn(),
+		stat: jest.fn().mockReturnValue( Promise.resolve( false ) ),
 	},
 } ) );
 
@@ -512,20 +513,17 @@ describe( 'readConfig', () => {
 		os.platform = oldOsPlatform;
 	} );
 
-	it( 'should use a non-private folder on Linux', async () => {
+	it( 'should use a non-private folder with Snap-installed Docker', async () => {
 		readFile.mockImplementation( () =>
 			Promise.resolve( JSON.stringify( {} ) )
 		);
-		const oldOsPlatform = os.platform;
-		os.platform = () => 'linux';
+		stat.mockReturnValue( Promise.resolve( true ) );
 
 		expect.assertions( 2 );
 
 		const config = await readConfig( '.wp-env.json' );
 		expect( config.workDirectoryPath.includes( '.wp-env' ) ).toBe( false );
 		expect( config.workDirectoryPath.includes( 'wp-env' ) ).toBe( true );
-
-		os.platform = oldOsPlatform;
 	} );
 } );
 


### PR DESCRIPTION
## Description

This PR stems from a discussion I had today with @epiqueras. The changes accomplish 2 things:

1. Fixes an issue that prevented WordPress from being cloned sucessfully if ssh-agent based git auth is enabled.
2. Improves the detection of [Snap](https://snapcraft.io/) on Linux systems to allow those who install Docker from source to still use `~/.wp-env` by default.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

I tested (1) with and without ssh-agent auth enabled.

I tested (2) with a clear home directory and ran `wp-env start` from scratch.

## Screenshots <!-- if applicable -->

N/A

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->