### PR TITLE
Move selection to end of link after insertion.

### DIFF
--- a/packages/format-library/src/link/index.native.js
+++ b/packages/format-library/src/link/index.native.js
@@ -59,12 +59,13 @@ export const link = {
 				const text = getTextContent( slice( value ) );
 
 				if ( text && isURL( text ) ) {
-					onChange(
-						applyFormat( value, {
-							type: name,
-							attributes: { url: text },
-						} )
-					);
+					const newValue = applyFormat( value, {
+						type: name,
+						attributes: { url: text },
+					} );
+					newValue.start = newValue.end;
+					newValue.activeFormats = [];
+					onChange( { ...newValue, needsSelectionUpdate: true } );
 				} else {
 					this.setState( { addingLink: true } );
 					this.getURLFromClipboard();

--- a/packages/format-library/src/link/modal.native.js
+++ b/packages/format-library/src/link/modal.native.js
@@ -87,7 +87,7 @@ class ModalLinkUI extends Component {
 			opensInNewWindow,
 			text: linkText,
 		} );
-
+		let newAttributes;
 		if ( isCollapsed( value ) && ! isActive ) {
 			// insert link
 			const toInsert = applyFormat(
@@ -96,8 +96,7 @@ class ModalLinkUI extends Component {
 				0,
 				linkText.length
 			);
-			const newAttributes = insert( value, toInsert );
-			onChange( { ...newAttributes, needsSelectionUpdate: true } );
+			newAttributes = insert( value, toInsert );
 		} else if ( text !== getTextContent( slice( value ) ) ) {
 			// edit text in selected link
 			const toInsert = applyFormat(
@@ -106,18 +105,15 @@ class ModalLinkUI extends Component {
 				0,
 				text.length
 			);
-			const newAttributes = insert(
-				value,
-				toInsert,
-				value.start,
-				value.end
-			);
-			onChange( { ...newAttributes, needsSelectionUpdate: true } );
+			newAttributes = insert( value, toInsert, value.start, value.end );
 		} else {
 			// transform selected text into link
-			const newAttributes = applyFormat( value, format );
-			onChange( { ...newAttributes, needsSelectionUpdate: true } );
+			newAttributes = applyFormat( value, format );
 		}
+		//move selection to end of link
+		newAttributes.start = newAttributes.end;
+		newAttributes.activeFormats = [];
+		onChange( { ...newAttributes, needsSelectionUpdate: true } );
 
 		if ( ! isValidHref( url ) ) {
 			speak(


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This PR updates the caret position to be at the end of the link, after insertion or change. This follows the same approach that was implemented on the web here: https://github.com/WordPress/gutenberg/pull/17126

It also fixes the issue described here: https://github.com/wordpress-mobile/gutenberg-mobile/issues/2319

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

This can be tested using the PR on GB-Mobile here: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2323

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Bugfix and enhancement.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
