### PR TITLE
Navigation: Allow Search block to be added alongside links

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -472,3 +472,111 @@ add_filter( 'pre_render_block', 'gutenberg_render_block_with_assigned_block_cont
  * @see WP_Block::render
  */
 remove_action( 'enqueue_block_assets', 'wp_enqueue_registered_block_scripts_and_styles' );
+
+/**
+ * Shim that hooks into `wp_update_nav_menu_item` and makes it so that nav menu
+ * items support a 'content' field. This field contains HTML and is used by nav
+ * menu items with `type` set to `'html'`.
+ *
+ * Specifically, this shim makes it so that:
+ *
+ * 1) The `wp_update_nav_menu_item()` function supports setting
+ * `'menu-item-content'` on a menu item. When merged to Core, this functionality
+ * should exist in `wp_update_nav_menu_item()`.
+ *
+ * 2) The `customize_save` ajax action supports setting `'content'` on a nav
+ * menu item. When merged to Core, this functionality should exist in
+ * `WP_Customize_Manager::save()`.
+ *
+ * This shim can be removed when the Gutenberg plugin requires a WordPress
+ * version that has the ticket below.
+ *
+ * @see <TICKET>
+ *
+ * @param int   $menu_id         ID of the updated menu.
+ * @param int   $menu_item_db_id ID of the new menu item.
+ * @param array $args            An array of arguments used to update/add the menu item.
+ */
+function gutenberg_update_nav_menu_item_content( $menu_id, $menu_item_db_id, $args ) {
+	global $wp_customize;
+
+	// Support setting content in customize_save admin-ajax.php requests by
+	// grabbing the unsanitized $_POST values.
+	if ( isset( $wp_customize ) ) {
+		$values = $wp_customize->unsanitized_post_values();
+		if ( isset( $values[ "nav_menu_item[$menu_item_db_id]" ]['content'] ) ) {
+			if ( is_string( $values[ "nav_menu_item[$menu_item_db_id]" ]['content'] ) ) {
+				$args['menu-item-content'] = $values[ "nav_menu_item[$menu_item_db_id]" ]['content'];
+			} elseif ( isset( $values[ "nav_menu_item[$menu_item_db_id]" ]['content']['raw'] ) ) {
+				$args['menu-item-content'] = $values[ "nav_menu_item[$menu_item_db_id]" ]['content']['raw'];
+			}
+		}
+	}
+
+	$defaults = array(
+		'menu-item-content' => '',
+	);
+
+	$args = wp_parse_args( $args, $defaults );
+
+	update_post_meta( $menu_item_db_id, '_menu_item_content', $args['menu-item-content'] );
+}
+add_action( 'wp_update_nav_menu_item', 'gutenberg_update_nav_menu_item_content', 10, 3 );
+
+/**
+ * Shim that hooks into `wp_setup_nav_menu_items` and makes it so that nav menu
+ * items have a 'content' field. This field contains HTML and is used by nav
+ * menu items with `type` set to `'html'`.
+ *
+ * Specifically, this shim makes it so that the `wp_setup_nav_menu_item()`
+ * function sets `content` on the returned menu item. When merged to Core, this
+ * functionality should exist in `wp_setup_nav_menu_item()`.
+ *
+ * This shim can be removed when the Gutenberg plugin requires a WordPress
+ * version that has the ticket below.
+ *
+ * @see <TICKET>
+ *
+ * @param object $menu_item The menu item object.
+ */
+function gutenberg_setup_html_nav_menu_item( $menu_item ) {
+	if ( 'html' === $menu_item->type ) {
+		$menu_item->type_label = __( 'HTML', 'gutenberg' );
+		$menu_item->content    = ! isset( $menu_item->content ) ? get_post_meta( $menu_item->db_id, '_menu_item_content', true ) : $menu_item->content;
+	}
+
+	return $menu_item;
+}
+add_filter( 'wp_setup_nav_menu_item', 'gutenberg_setup_html_nav_menu_item' );
+
+/**
+ * Shim that hooks into `walker_nav_menu_start_el` and makes it so that the
+ * default walker which renders a menu will correctly render the HTML associated
+ * with any navigation menu item that has `type` set to `'html`'.
+ *
+ * Specifically, this shim makes it so that `Walker_Nav_Menu::start_el()`
+ * renders the `content` of a nav menu item when its `type` is `'html'`. When
+ * merged to Core, this functionality should exist in
+ * `Walker_Nav_Menu::start_el()`.
+ *
+ * This shim can be removed when the Gutenberg plugin requires a WordPress
+ * version that has the ticket below.
+ *
+ * @see <TICKET>
+ *
+ * @param string   $item_output The menu item's starting HTML output.
+ * @param WP_Post  $item        Menu item data object.
+ * @param int      $depth       Depth of menu item. Used for padding.
+ * @param stdClass $args        An object of wp_nav_menu() arguments.
+ */
+function gutenberg_output_html_nav_menu_item( $item_output, $item, $depth, $args ) {
+	if ( 'html' === $item->type ) {
+		$item_output = $args->before;
+		/** This filter is documented in wp-includes/post-template.php */
+		$item_output .= apply_filters( 'the_content', $item->content );
+		$item_output .= $args->after;
+	}
+
+	return $item_output;
+}
+add_filter( 'walker_nav_menu_start_el', 'gutenberg_output_html_nav_menu_item', 10, 4 );

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -491,7 +491,7 @@ remove_action( 'enqueue_block_assets', 'wp_enqueue_registered_block_scripts_and_
  * This shim can be removed when the Gutenberg plugin requires a WordPress
  * version that has the ticket below.
  *
- * @see <TICKET>
+ * @see https://core.trac.wordpress.org/ticket/50544
  *
  * @param int   $menu_id         ID of the updated menu.
  * @param int   $menu_item_db_id ID of the new menu item.
@@ -535,7 +535,7 @@ add_action( 'wp_update_nav_menu_item', 'gutenberg_update_nav_menu_item_content',
  * This shim can be removed when the Gutenberg plugin requires a WordPress
  * version that has the ticket below.
  *
- * @see <TICKET>
+ * @see https://core.trac.wordpress.org/ticket/50544
  *
  * @param object $menu_item The menu item object.
  */
@@ -562,7 +562,7 @@ add_filter( 'wp_setup_nav_menu_item', 'gutenberg_setup_html_nav_menu_item' );
  * This shim can be removed when the Gutenberg plugin requires a WordPress
  * version that has the ticket below.
  *
- * @see <TICKET>
+ * @see https://core.trac.wordpress.org/ticket/50544
  *
  * @param string   $item_output The menu item's starting HTML output.
  * @param WP_Post  $item        Menu item data object.

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -519,7 +519,7 @@ function gutenberg_update_nav_menu_item_content( $menu_id, $menu_item_db_id, $ar
 
 	$args = wp_parse_args( $args, $defaults );
 
-	update_post_meta( $menu_item_db_id, '_menu_item_content', $args['menu-item-content'] );
+	update_post_meta( $menu_item_db_id, '_menu_item_content', wp_slash( $args['menu-item-content'] ) );
 }
 add_action( 'wp_update_nav_menu_item', 'gutenberg_update_nav_menu_item_content', 10, 3 );
 

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -193,7 +193,10 @@ function Navigation( {
 					>
 						<InnerBlocks
 							ref={ ref }
-							allowedBlocks={ [ 'core/navigation-link' ] }
+							allowedBlocks={ [
+								'core/navigation-link',
+								'core/search',
+							] }
 							renderAppender={
 								( isImmediateParentOfSelectedBlock &&
 									! selectedBlockHasDescendants ) ||

--- a/packages/e2e-tests/specs/experiments/navigation.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation.test.js
@@ -421,10 +421,16 @@ describe( 'Navigation', () => {
 
 		await showBlockToolbar();
 
-		// Add another Link block.
+		// Add another block.
 		// Using 'click' here checks for regressions of https://github.com/WordPress/gutenberg/issues/18329,
 		// an issue where the block appender requires two clicks.
 		await page.click( '.wp-block-navigation .block-list-appender' );
+
+		// Select a Link block.
+		const [ linkButton ] = await page.$x(
+			"//*[contains(@class, 'block-editor-inserter__quick-inserter')]//*[text()='Link']"
+		);
+		await linkButton.click();
 
 		// After adding a new block, search input should be shown immediately.
 		// Verify that Escape would close the popover.

--- a/packages/edit-navigation/src/store/resolvers.js
+++ b/packages/edit-navigation/src/store/resolvers.js
@@ -6,7 +6,7 @@ import { groupBy, sortBy } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { createBlock } from '@wordpress/blocks';
+import { parse, createBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -99,7 +99,7 @@ function createNavigationBlock( menuItems ) {
 					itemsByParentID[ item.id ]
 				);
 			}
-			const linkBlock = convertMenuItemToLinkBlock(
+			const linkBlock = convertMenuItemToBlock(
 				item,
 				menuItemInnerBlocks
 			);
@@ -115,7 +115,19 @@ function createNavigationBlock( menuItems ) {
 	return [ navigationBlock, menuItemIdToClientId ];
 }
 
-function convertMenuItemToLinkBlock( menuItem, innerBlocks = [] ) {
+function convertMenuItemToBlock( menuItem, innerBlocks = [] ) {
+	if ( menuItem.type === 'html' ) {
+		const parsedBlocks = parse( menuItem.content.raw );
+
+		if ( parsedBlocks.length !== 1 ) {
+			return createBlock( 'core/freeform', {
+				originalContent: menuItem.content.raw,
+			} );
+		}
+
+		return parsedBlocks[ 0 ];
+	}
+
 	const attributes = {
 		label: menuItem.title.rendered,
 		url: menuItem.url,

--- a/packages/edit-navigation/src/store/resolvers.js
+++ b/packages/edit-navigation/src/store/resolvers.js
@@ -99,12 +99,9 @@ function createNavigationBlock( menuItems ) {
 					itemsByParentID[ item.id ]
 				);
 			}
-			const linkBlock = convertMenuItemToBlock(
-				item,
-				menuItemInnerBlocks
-			);
-			menuItemIdToClientId[ item.id ] = linkBlock.clientId;
-			innerBlocks.push( linkBlock );
+			const block = convertMenuItemToBlock( item, menuItemInnerBlocks );
+			menuItemIdToClientId[ item.id ] = block.clientId;
+			innerBlocks.push( block );
 		}
 		return innerBlocks;
 	};

--- a/packages/edit-navigation/src/store/resolvers.js
+++ b/packages/edit-navigation/src/store/resolvers.js
@@ -106,7 +106,7 @@ function createNavigationBlock( menuItems ) {
 		return innerBlocks;
 	};
 
-	// menuItemsToTreeOfLinkBlocks takes an array of top-level menu items and recursively creates all their innerBlocks
+	// menuItemsToTreeOfBlocks takes an array of top-level menu items and recursively creates all their innerBlocks
 	const innerBlocks = menuItemsToTreeOfBlocks( itemsByParentID[ 0 ] || [] );
 	const navigationBlock = createBlock( 'core/navigation', {}, innerBlocks );
 	return [ navigationBlock, menuItemIdToClientId ];


### PR DESCRIPTION
This is a quick proof of concept for how I was thinking we could support saving non-`core/navigation-link` blocks in the Navigation Screen. I've demonstrated the approach by allowing Search to be added.

Being able to add different kinds of blocks to a site's existing menu is the primary reason we're building out a block-based Navigation Screen as it will allow more WordPress users to access blocks.

I'm focused only on a technical proof of concept here. See https://github.com/WordPress/gutenberg/issues/22096 for discussion on the UX of adding different types of blocks to Navigation.

### Implementation notes

- The `nav_menu_item` CPT now supports `$menu_item->type = 'html'`. This accompanies the existing allowed types: `taxonomy`, `post_type`, `post_type_archive` and `custom`. When `type` is `html` it signifies that the menu item will render custom HTML, stored in a new `$menu_item->content` field, in place of the `<a>` link. The custom HTML may contain block markup.

- `$menu_item->content` is stored in post meta. I wanted to use `post_content` but this is already taken by `$menu_item->description`. I thought about using `post_content` only if `$menu_item→type === 'html'` but decided against it as this may break third party code that reads `$menu_item->post_content` to access an item's description.

- The experimental `/menu-items` REST API endpoint supports `type=html` and a new `content` property as above. The content property is split into `content.raw` and `content.rendered` so that it closely matches the `/posts` endpoint. `content.raw` may only be accessed when `context=edit`.

- The approach requires minimal changes to Core that are easy for the Gutenberg plugin to shim.

  - `wp_setup_nav_menu_item` and `wp_update_nav_menu_item` must be be updated to save and populate the new `$menu_item->content` field.

  - `Walker_Nav_Menu::start_el` must be updated to display `$menu_item->content` instead of the `<a>`, `$args→link_before`, and `$args->link_after`.

- I made no effort to make these new changes display nicely in `nav-menus.php`. I don't think it's important that we do this as these changes would likely land in Core alongside a `nav-menus.php` replacement.

- Non-`core/navigation-link` blocks do not display in Navigation blocks that are added to a post or to a FSE template. This is because `core/navigation` overrides the link's `render_callback`. #21075 will address this.

### Outstanding questions

- The resultant markup on the frontend looks like this:

   ```html
   <ul id="primary-menu" class="menu nav-menu" aria-expanded="false">
	   <li id="menu-item-118" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-118">
		   <a href="#">A menu item</a>
	   </li>
	   <li id="menu-item-128" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-128">
		   <a href="#">A menu item with children</a>
		   <ul class="sub-menu">
			   <li id="menu-item-161" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-161">
				   <a href="#">A child menu item</a>
			   </li>
		   </ul>
	   </li>
	   <li id="menu-item-193" class="menu-item menu-item-type-html menu-item-object- menu-item-193">
		   <form class="wp-block-search" role="search" method="get" action="http://localhost:8888/">
			   <label for="wp-block-search__input-1" class="wp-block-search__label">Search</label>
			   <input type="search" id="wp-block-search__input-1" class="wp-block-search__input" name="s" value="" placeholder="" required="">
			   <button type="submit" class="wp-block-search__button">Search</button>
		   </form>
	   </li>
   </ul>
   ```

  I suspect a great many themes will not work nicely with something other than an `<a>` element inside the `<li>`. How do we ease this transition? 

  We definitely will want to add a filter which allows developers to disable `html` menu items. In addition to this, we could explore making `html` menu items opt-in using `add_theme_support()`.

- When `$menu_item->type === 'html'`, `$menu_item->title` and `$menu_item->url` will both be set to `''`. This will break any third party code that blindly expects a non-empty value. I don't think this would be very common, but it's worth thinking through.

- I had to remove `parent` from `core/navigation-link` so that the Inserter appears when adding to a Navigation block. This means that the Navigation Link block appears in the Inserter when adding a block to a post or page, though. How do we make it so that Navigation Link can only be added to a Navigation block?

### Tasks

#### Before merge

- [x] Find and implement a solution to https://github.com/WordPress/gutenberg/pull/22656#discussion_r432230413.
- [x] Add tests to the new REST API endpoint fields.
- [x] Add inline documentation.

#### After merge

- Merge https://github.com/WordPress/gutenberg/pull/21075 so that the Search block works when added to a Navigation block in posts, pages and FSE.
- Adjust default Search styles per https://github.com/WordPress/gutenberg/pull/22656#pullrequestreview-420622082.
- Add support for more block types e.g. Social Icons, Paragraph, Image, Spacer, Divider.
- Ensure that the Navigation block as rendered in posts, pages and FSE has near-identical markup to what is rendered by `wp_nav_menu()`.