### PR TITLE
Fix gallery block initial creation via media library

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -347,7 +347,7 @@ class GalleryEdit extends Component {
 
 		const mediaPlaceholder = (
 			<MediaPlaceholder
-				addToGallery={ true }
+				addToGallery={ hasImages }
 				isAppender={ hasImages }
 				className={ className }
 				disableMediaButtons={ hasImages && ! isSelected }

--- a/packages/e2e-tests/specs/editor/blocks/gallery.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/gallery.test.js
@@ -69,6 +69,8 @@ describe( 'Gallery', () => {
 		expect( mediaLibraryButtonText ).toBe( 'Create a new gallery' );
 
 		// Unfortunately the Media Library has invalid HTML.
+		// Axe tests fail with the following error:
+		// `List element has direct children with a role that is not allowed: checkbox.`
 		await expect( page ).not.toPassAxeTests();
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/blocks/gallery.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/gallery.test.js
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+import { v4 as uuid } from 'uuid';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	insertBlock,
+	getEditedPostContent,
+	createNewPost,
+	clickButton,
+} from '@wordpress/e2e-test-utils';
+
+async function upload( selector ) {
+	await page.waitForSelector( selector );
+	const inputElement = await page.$( selector );
+	const testImagePath = path.join(
+		__dirname,
+		'..',
+		'..',
+		'..',
+		'assets',
+		'10x10_e2e_test_image_z9T8jK.png'
+	);
+	const filename = uuid();
+	const tmpFileName = path.join( os.tmpdir(), filename + '.png' );
+	fs.copyFileSync( testImagePath, tmpFileName );
+	await inputElement.uploadFile( tmpFileName );
+	await page.waitForSelector(
+		`.wp-block-gallery img[src$="${ filename }.png"]`
+	);
+	return filename;
+}
+
+describe( 'Gallery', () => {
+	beforeEach( async () => {
+		await createNewPost();
+	} );
+
+	it( 'can be created using uploaded images', async () => {
+		await insertBlock( 'Gallery' );
+		const filename = await upload( '.wp-block-gallery input[type="file"]' );
+
+		const regex = new RegExp(
+			`<!-- wp:gallery {"ids":\\[\\d+\\]} -->\\s*<figure class="wp-block-gallery columns-1 is-cropped"><ul class="blocks-gallery-grid"><li class="blocks-gallery-item"><figure><img src="[^"]+\\/${ filename }\\.png" alt="" data-id="\\d+" data-link=".+" class="wp-image-\\d+"\\/><\\/figure><\\/li><\\/ul><\\/figure>\\s*<!-- \\/wp:gallery -->`
+		);
+		expect( await getEditedPostContent() ).toMatch( regex );
+	} );
+
+	it( 'when initially added the media library shows the Create Gallery view', async () => {
+		await insertBlock( 'Gallery' );
+		await clickButton( 'Media Library' );
+		await page.waitForSelector( '.media-frame' );
+		const mediaLibraryHeaderText = await page.$eval(
+			'.media-frame-title h1',
+			( element ) => element.textContent
+		);
+		const mediaLibraryButtonText = await page.$eval(
+			'.media-toolbar-primary button',
+			( element ) => element.textContent
+		);
+
+		expect( mediaLibraryHeaderText ).toBe( 'Create Gallery' );
+		expect( mediaLibraryButtonText ).toBe( 'Create a new gallery' );
+	} );
+} );

--- a/packages/e2e-tests/specs/editor/blocks/gallery.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/gallery.test.js
@@ -67,5 +67,8 @@ describe( 'Gallery', () => {
 
 		expect( mediaLibraryHeaderText ).toBe( 'Create Gallery' );
 		expect( mediaLibraryButtonText ).toBe( 'Create a new gallery' );
+
+		// Unfortunately the Media Library has invalid HTML.
+		await expect( page ).not.toPassAxeTests();
 	} );
 } );


### PR DESCRIPTION
## Description
Fixes #22338

When creating a gallery, the media library was hard coded to be in the Add To Gallery view.

This PR semi-reverts a one-line change from #19134 which seems to have caused the issue. 

If there's a way to solve this without causing a regression of the bugs #19134 solves that would be great. Input welcome.

## How has this been tested?
Added e2e tests

1. Add a Gallery Block
2. Click the Media Library button in the placeholder
3. Notice that the Create Gallery view is shown instead of the Add to Gallery view.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
