### PR TITLE
Update block fixture README to use shorter friendlier version of command

### DIFF
--- a/packages/e2e-tests/fixtures/blocks/README.md
+++ b/packages/e2e-tests/fixtures/blocks/README.md
@@ -68,7 +68,7 @@ the attributes are serialized correctly.
 
 The process for updating fixtures for existing tests is similar to that for creating them:
 
-First delete files (2) through (4), then run the command to regenerate the files:
+Run the command to regenerate the files:
 ```sh
 npm run fixtures:regenerate test/integration/full-content/full-content.test.js
 ```

--- a/packages/e2e-tests/fixtures/blocks/README.md
+++ b/packages/e2e-tests/fixtures/blocks/README.md
@@ -55,7 +55,7 @@ Next, to generate files (2) through (4) run the following command from the root 
 project:
 
 ```sh
-GENERATE_MISSING_FIXTURES=y npm run test-unit test/integration/full-content/full-content.test.js
+npm run fixtures:regenerate test/integration/full-content/full-content.test.js
 ```
 
 When using this command, please be sure to manually verify that the
@@ -70,7 +70,7 @@ The process for updating fixtures for existing tests is similar to that for crea
 
 First delete files (2) through (4), then run the command to regenerate the files:
 ```sh
-GENERATE_MISSING_FIXTURES=y npm run test-unit test/integration/full-content/full-content.test.js
+npm run fixtures:regenerate test/integration/full-content/full-content.test.js
 ```
 
 After regenerating fixtures, check the diff (using git/github) to check that the changes were expected


### PR DESCRIPTION
## Description
Uses the suggestion on https://github.com/WordPress/gutenberg/pull/22654#discussion_r430914281 to update the test command in the full content fixture README.