### PR TITLE
Update package-lock.json so that CI tests pass

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42296,9 +42296,9 @@
 			"dev": true
 		},
 		"unbzip2-stream": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.2.tgz",
-			"integrity": "sha512-pZMVAofMrrHX6Ik39hCk470kulCbmZ2SWfQLPmTWqfJV/oUm0gn1CblvHdUu4+54Je6Jq34x8kY6XjTy6dMkOg==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+			"integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
 			"dev": true,
 			"requires": {
 				"buffer": "^5.2.1",


### PR DESCRIPTION
## Description
Continuous Integration tests seem to be failing due to a package-lock.json change.

This PR commits the updates to the package-lock.json to master.