### PR TITLE
Inline font-sizes to fix themes that don't enqueue the preset classes

### DIFF
--- a/packages/block-editor/src/hooks/font-size.js
+++ b/packages/block-editor/src/hooks/font-size.js
@@ -90,6 +90,12 @@ function addEditProps( settings ) {
 	return settings;
 }
 
+function useFontizes() {
+	return useSelect(
+		( select ) => select( 'core/block-editor' ).getSettings().fontSizes
+	);
+}
+
 /**
  * Inspector control panel containing the font size related configuration
  *
@@ -103,10 +109,7 @@ export function FontSizeEdit( props ) {
 		setAttributes,
 	} = props;
 	const isDisabled = useIsFontSizeDisabled( props );
-
-	const { fontSizes } = useSelect( ( select ) =>
-		select( 'core/block-editor' ).getSettings()
-	);
+	const fontSizes = useFontizes();
 
 	if ( isDisabled ) {
 		return null;
@@ -144,9 +147,7 @@ export function FontSizeEdit( props ) {
  * @return {boolean} Whether setting is disabled.
  */
 export function useIsFontSizeDisabled( { name: blockName } = {} ) {
-	const { fontSizes } = useSelect( ( select ) =>
-		select( 'core/block-editor' ).getSettings()
-	);
+	const fontSizes = useFontizes();
 	const hasFontSizes = fontSizes.length;
 
 	return (
@@ -163,15 +164,12 @@ export function useIsFontSizeDisabled( { name: blockName } = {} ) {
  */
 const withFontSizeInlineStyles = createHigherOrderComponent(
 	( BlockListBlock ) => ( props ) => {
+		const fontSizes = useFontizes();
 		const {
 			name: blockName,
 			attributes: { fontSize, style },
 			wrapperProps,
 		} = props;
-
-		const { fontSizes } = useSelect( ( select ) =>
-			select( 'core/block-editor' ).getSettings()
-		);
 
 		// Return early if the block doesn't allow modify the font-size,
 		// already has a inline font-size,

--- a/packages/block-editor/src/hooks/font-size.js
+++ b/packages/block-editor/src/hooks/font-size.js
@@ -157,7 +157,8 @@ export function useIsFontSizeDisabled( { name: blockName } = {} ) {
 
 /**
  * Add inline styles for font sizes.
- * Ideally, this is not needed and themes load the font-size classes on the editor.
+ * Ideally, this is not needed and themes load the font-size classes on the
+ * editor.
  *
  * @param  {Function} BlockListBlock Original component
  * @return {Function}                Wrapped component
@@ -171,31 +172,30 @@ const withFontSizeInlineStyles = createHigherOrderComponent(
 			wrapperProps,
 		} = props;
 
-		// Return early if the block doesn't allow modify the font-size,
-		// already has a inline font-size,
-		// or doesn't have a class to extract font-size from.
+		// Only add inline styles if the block supports font sizes, doesn't
+		// already have an inline font size, and does have a class to extract
+		// the font size from.
 		if (
-			! hasBlockSupport( blockName, FONT_SIZE_SUPPORT_KEY ) ||
-			style?.typography?.fontSize ||
-			! fontSize
+			hasBlockSupport( blockName, FONT_SIZE_SUPPORT_KEY ) &&
+			fontSize &&
+			! style?.typography?.fontSize
 		) {
-			return <BlockListBlock { ...props } />;
+			const fontSizeValue = getFontSize(
+				fontSizes,
+				fontSize,
+				style?.typography?.fontSize
+			).size;
+
+			props.wrapperProps = {
+				...wrapperProps,
+				style: {
+					fontSize: fontSizeValue,
+					...wrapperProps?.style,
+				},
+			};
 		}
 
-		const fontSizeValue = getFontSize(
-			fontSizes,
-			fontSize,
-			style?.typography?.fontSize
-		).size;
-		const newWrapperProps = {
-			...wrapperProps,
-			style: {
-				fontSize: fontSizeValue,
-				...wrapperProps?.style,
-			},
-		};
-
-		return <BlockListBlock { ...props } wrapperProps={ newWrapperProps } />;
+		return <BlockListBlock { ...props } />;
 	},
 	'withFontSizeInlineStyles'
 );


### PR DESCRIPTION
Depends on https://github.com/WordPress/gutenberg/pull/22356

**I've set `fix/themes-not-loading-palette` as the base to easy review. This should be changed before merging the PR.**

This PR follows suit on what is proposed at https://github.com/WordPress/gutenberg/pull/22356

It adds the font-size attribute as an inline style for the editor, regardless of the font value being a preset or a custom value. This is to fix themes that don't enqueue the preset classes. See [context](https://github.com/WordPress/gutenberg/pull/22356#issuecomment-632220379).

### How to test

- Apply this PR.
- Open the editor and create two paragraphs:
  - Apply a given preset class to one of them. Check that the p node has the proper font-size value as an inline style.
  - Apply a custom font size to another. Check that the p node still has the custom font-size value as an inline style.