### PR TITLE
Require at least php 5.6

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -4,6 +4,8 @@
  * Plugin URI: https://github.com/WordPress/gutenberg
  * Description: Printing since 1440. This is the development plugin for the new block editor in core.
  * Version: 8.2.0-rc.1
+ * Requires at least: 5.3
+ * Requires PHP: 5.6
  * Author: Gutenberg Team
  * Text Domain: gutenberg
  *

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://github.com/WordPress/gutenberg
  * Description: Printing since 1440. This is the development plugin for the new block editor in core.
  * Version: 8.2.0-rc.1
- * Requires at least: 5.3
+ * Requires WP: 5.3
  * Requires PHP: 5.6
  * Author: Gutenberg Team
  * Text Domain: gutenberg

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://github.com/WordPress/gutenberg
  * Description: Printing since 1440. This is the development plugin for the new block editor in core.
  * Version: 8.2.0-rc.1
- * Requires WP: 5.3
+ * Requires at least: 5.3
  * Requires PHP: 5.6
  * Author: Gutenberg Team
  * Text Domain: gutenberg

--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,7 @@
 Contributors: matveb, joen, karmatosed
 Requires at least: 5.3.0
 Tested up to: 5.4
+Requires PHP: 5.6
 Stable tag: V.V.V
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
## Description
Require at least php 5.6 in readme and plugin header.
WordPress 5.3 requires at least this version.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
