### PR TITLE
Replace three experimental flags (ellipsis menu w/ min level, navigator slots) with just __experimentalFeatures

### DIFF
--- a/packages/block-editor/src/components/block-navigation/block-contents.js
+++ b/packages/block-editor/src/components/block-navigation/block-contents.js
@@ -16,7 +16,7 @@ const BlockNavigationBlockContents = forwardRef(
 		ref
 	) => {
 		const {
-			__experimentalWithBlockNavigationSlots: withBlockNavigationSlots,
+			__experimentalFeatures: withBlockNavigationSlots,
 		} = useBlockNavigationContext();
 
 		return withBlockNavigationSlots ? (

--- a/packages/block-editor/src/components/block-navigation/block.js
+++ b/packages/block-editor/src/components/block-navigation/block.js
@@ -48,8 +48,7 @@ export default function BlockNavigationBlock( {
 		{ 'is-visible': hasVisibleMovers }
 	);
 	const {
-		__experimentalWithBlockNavigationBlockSettings: withBlockNavigationBlockSettings,
-		__experimentalWithBlockNavigationBlockSettingsMinLevel: blockNavigationBlockSettingsMinLevel,
+		__experimentalFeatures: withBlockNavigationBlockSettings,
 	} = useBlockNavigationContext();
 	const blockNavigationBlockSettingsClassName = classnames(
 		'block-editor-block-navigation-block__menu-cell',
@@ -116,20 +115,19 @@ export default function BlockNavigationBlock( {
 				</>
 			) }
 
-			{ withBlockNavigationBlockSettings &&
-				level >= blockNavigationBlockSettingsMinLevel && (
-					<TreeGridCell
-						className={ blockNavigationBlockSettingsClassName }
-					>
-						{ ( props ) => (
-							<BlockSettingsDropdown
-								clientIds={ [ clientId ] }
-								icon={ moreVertical }
-								{ ...props }
-							/>
-						) }
-					</TreeGridCell>
-				) }
+			{ withBlockNavigationBlockSettings && level > 1 && (
+				<TreeGridCell
+					className={ blockNavigationBlockSettingsClassName }
+				>
+					{ ( props ) => (
+						<BlockSettingsDropdown
+							clientIds={ [ clientId ] }
+							icon={ moreVertical }
+							{ ...props }
+						/>
+					) }
+				</TreeGridCell>
+			) }
 		</BlockNavigationLeaf>
 	);
 }

--- a/packages/block-editor/src/components/block-navigation/context.js
+++ b/packages/block-editor/src/components/block-navigation/context.js
@@ -4,9 +4,7 @@
 import { createContext, useContext } from '@wordpress/element';
 
 export const BlockNavigationContext = createContext( {
-	__experimentalWithBlockNavigationSlots: false,
-	__experimentalWithBlockNavigationBlockSettings: false,
-	__experimentalWithBlockNavigationBlockSettingsMinLevel: 0,
+	__experimentalFeatures: false,
 } );
 
 export const useBlockNavigationContext = () =>

--- a/packages/block-editor/src/components/block-navigation/dropdown.js
+++ b/packages/block-editor/src/components/block-navigation/dropdown.js
@@ -55,8 +55,7 @@ function BlockNavigationDropdownToggle( { isEnabled, onToggle, isOpen } ) {
 
 function BlockNavigationDropdown( {
 	isDisabled,
-	__experimentalWithBlockNavigationSlots,
-	__experimentalWithBlockNavigationBlockSettings,
+	__experimentalFeatures,
 } ) {
 	const hasBlocks = useSelect(
 		( select ) => !! select( 'core/block-editor' ).getBlockCount(),
@@ -77,11 +76,8 @@ function BlockNavigationDropdown( {
 			renderContent={ ( { onClose } ) => (
 				<BlockNavigation
 					onSelect={ onClose }
-					__experimentalWithBlockNavigationSlots={
-						__experimentalWithBlockNavigationSlots
-					}
-					__experimentalWithBlockNavigationBlockSettings={
-						__experimentalWithBlockNavigationBlockSettings
+					__experimentalFeatures={
+						__experimentalFeatures
 					}
 				/>
 			) }

--- a/packages/block-editor/src/components/block-navigation/dropdown.js
+++ b/packages/block-editor/src/components/block-navigation/dropdown.js
@@ -53,10 +53,7 @@ function BlockNavigationDropdownToggle( { isEnabled, onToggle, isOpen } ) {
 	);
 }
 
-function BlockNavigationDropdown( {
-	isDisabled,
-	__experimentalFeatures,
-} ) {
+function BlockNavigationDropdown( { isDisabled, __experimentalFeatures } ) {
 	const hasBlocks = useSelect(
 		( select ) => !! select( 'core/block-editor' ).getBlockCount(),
 		[]
@@ -76,9 +73,7 @@ function BlockNavigationDropdown( {
 			renderContent={ ( { onClose } ) => (
 				<BlockNavigation
 					onSelect={ onClose }
-					__experimentalFeatures={
-						__experimentalFeatures
-					}
+					__experimentalFeatures={ __experimentalFeatures }
 				/>
 			) }
 		/>

--- a/packages/block-editor/src/components/block-navigation/index.js
+++ b/packages/block-editor/src/components/block-navigation/index.js
@@ -20,9 +20,7 @@ function BlockNavigation( {
 	rootBlocks,
 	selectedBlockClientId,
 	selectBlock,
-	__experimentalWithBlockNavigationSlots,
-	__experimentalWithBlockNavigationBlockSettings,
-	__experimentalWithBlockNavigationBlockSettingsMinLevel,
+	__experimentalFeatures,
 } ) {
 	if ( ! rootBlocks || rootBlocks.length === 0 ) {
 		return null;
@@ -43,15 +41,7 @@ function BlockNavigation( {
 					blocks={ [ rootBlock ] }
 					selectedBlockClientId={ selectedBlockClientId }
 					selectBlock={ selectBlock }
-					__experimentalWithBlockNavigationBlockSettings={
-						__experimentalWithBlockNavigationBlockSettings
-					}
-					__experimentalWithBlockNavigationBlockSettingsMinLevel={
-						__experimentalWithBlockNavigationBlockSettingsMinLevel
-					}
-					__experimentalWithBlockNavigationSlots={
-						__experimentalWithBlockNavigationSlots
-					}
+					__experimentalFeatures={ __experimentalFeatures }
 					showNestedBlocks
 				/>
 			) }
@@ -60,15 +50,7 @@ function BlockNavigation( {
 					blocks={ rootBlocks }
 					selectedBlockClientId={ selectedBlockClientId }
 					selectBlock={ selectBlock }
-					__experimentalWithBlockNavigationBlockSettings={
-						__experimentalWithBlockNavigationBlockSettings
-					}
-					__experimentalWithBlockNavigationBlockSettingsMinLevel={
-						__experimentalWithBlockNavigationBlockSettingsMinLevel
-					}
-					__experimentalWithBlockNavigationSlots={
-						__experimentalWithBlockNavigationSlots
-					}
+					__experimentalFeatures={ __experimentalFeatures }
 				/>
 			) }
 		</div>

--- a/packages/block-editor/src/components/block-navigation/tree.js
+++ b/packages/block-editor/src/components/block-navigation/tree.js
@@ -20,26 +20,14 @@ import { BlockNavigationContext } from './context';
  * @param {Object} props
  */
 export default function BlockNavigationTree( {
-	__experimentalWithBlockNavigationSlots,
-	__experimentalWithBlockNavigationBlockSettings,
-	__experimentalWithBlockNavigationBlockSettingsMinLevel,
+	__experimentalFeatures,
 	...props
 } ) {
 	const contextValue = useMemo(
 		() => ( {
-			__experimentalWithBlockNavigationSlots,
-			__experimentalWithBlockNavigationBlockSettings,
-			__experimentalWithBlockNavigationBlockSettingsMinLevel:
-				typeof __experimentalWithBlockNavigationBlockSettingsMinLevel ===
-				'number'
-					? __experimentalWithBlockNavigationBlockSettingsMinLevel
-					: 0,
+			__experimentalFeatures,
 		} ),
-		[
-			__experimentalWithBlockNavigationSlots,
-			__experimentalWithBlockNavigationBlockSettings,
-			__experimentalWithBlockNavigationBlockSettingsMinLevel,
-		]
+		[ __experimentalFeatures ]
 	);
 
 	return (

--- a/packages/block-library/src/navigation/block-navigation-list.js
+++ b/packages/block-library/src/navigation/block-navigation-list.js
@@ -6,7 +6,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 
 export default function BlockNavigationList( {
 	clientId,
-	__experimentalWithBlockNavigationSlots,
+	__experimentalFeatures,
 } ) {
 	const { block, selectedBlockClientId } = useSelect(
 		( select ) => {
@@ -29,9 +29,7 @@ export default function BlockNavigationList( {
 			blocks={ [ block ] }
 			selectedBlockClientId={ selectedBlockClientId }
 			selectBlock={ selectBlock }
-			__experimentalWithBlockNavigationSlots={
-				__experimentalWithBlockNavigationSlots
-			}
+			__experimentalFeatures={ __experimentalFeatures }
 			showNestedBlocks
 			showAppender
 			showBlockMovers

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -85,8 +85,7 @@ function Navigation( {
 	);
 
 	const { navigatorToolbarButton, navigatorModal } = useBlockNavigator(
-		clientId,
-		true
+		clientId
 	);
 
 	// Builds navigation links from default Pages.
@@ -233,10 +232,7 @@ function Navigation( {
 			{ navigatorModal }
 			<InspectorControls>
 				<PanelBody title={ __( 'Navigation Structure' ) }>
-					<BlockNavigationList
-						clientId={ clientId }
-						__experimentalWithBlockNavigationSlots
-					/>
+					<BlockNavigationList clientId={ clientId } />
 				</PanelBody>
 				<PanelBody title={ __( 'Text settings' ) }>
 					<FontSizePicker

--- a/packages/block-library/src/navigation/use-block-navigator.js
+++ b/packages/block-library/src/navigation/use-block-navigator.js
@@ -21,10 +21,7 @@ const NavigatorIcon = (
 	</SVG>
 );
 
-export default function useBlockNavigator(
-	clientId,
-	__experimentalWithBlockNavigationSlots
-) {
+export default function useBlockNavigator( clientId, __experimentalFeatures ) {
 	const [ isNavigationListOpen, setIsNavigationListOpen ] = useState( false );
 
 	const navigatorToolbarButton = (
@@ -46,9 +43,7 @@ export default function useBlockNavigator(
 		>
 			<BlockNavigationList
 				clientId={ clientId }
-				__experimentalWithBlockNavigationSlots={
-					__experimentalWithBlockNavigationSlots
-				}
+				__experimentalFeatures={ __experimentalFeatures }
 			/>
 		</Modal>
 	);

--- a/packages/edit-navigation/src/components/menu-editor/navigation-structure-panel.js
+++ b/packages/edit-navigation/src/components/menu-editor/navigation-structure-panel.js
@@ -25,11 +25,7 @@ export default function NavigationStructurePanel( { blocks, initialOpen } ) {
 						blocks={ blocks }
 						selectedBlockClientId={ selectedBlockClientIds[ 0 ] }
 						selectBlock={ selectBlock }
-						__experimentalWithBlockNavigationSlots
-						__experimentalWithBlockNavigationBlockSettings
-						__experimentalWithBlockNavigationBlockSettingsMinLevel={
-							2
-						}
+						__experimentalFeatures
 						showNestedBlocks
 						showAppender
 						showBlockMovers


### PR DESCRIPTION
## Description
This PR replaces three long-named experimental flags we use in the block navigation with just one. One is all we really need - we're either in the experiment or not. It's also pretty reusable for anything else we decide to add in future iterations.

## How has this been tested?
**Make sure the ellipsis menu is missing in all navigators in the post editor:**

1. Navigation block inspector:
<img width="284" alt="Zrzut ekranu 2020-05-27 o 12 44 58" src="https://user-images.githubusercontent.com/205419/83010009-e54de200-a017-11ea-9c2c-494fc05d6106.png">

1. Global block navigation:
<img width="540" alt="Zrzut ekranu 2020-05-27 o 12 37 15" src="https://user-images.githubusercontent.com/205419/83009857-afa8f900-a017-11ea-810d-4c94b47b4727.png">

1. Navigation block toolbar button "Open block navigator":
<img width="1078" alt="Zrzut ekranu 2020-05-27 o 12 40 28" src="https://user-images.githubusercontent.com/205419/83009863-b172bc80-a017-11ea-9a1a-22fe9407a90f.png">

1. Make sure the ellipsis menu is still present on the experimental navigation screen:
<img width="297" alt="Zrzut ekranu 2020-05-27 o 12 37 05" src="https://user-images.githubusercontent.com/205419/83009879-b9326100-a017-11ea-89e7-683117b0afcd.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
