### PR TITLE
Increase font-size selector specificity

### DIFF
--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -238,34 +238,31 @@
 
 // Font sizes.
 // The reason we add the editor class wrapper here is
-// to avoid enqueing the classes twice: here and in ./editor.scss
-.editor-styles-wrapper .has-small-font-size,
-.has-small-font-size {
-	font-size: 13px;
-}
+// to avoid enqueuing the classes twice: here and in ./editor.scss
+:root,
+:root .editor-styles-wrapper {
 
-.editor-styles-wrapper .has-regular-font-size,
-.editor-styles-wrapper .has-normal-font-size,
-.has-regular-font-size, // Not used now, kept because of backward compatibility.
-.has-normal-font-size {
-	font-size: 16px;
-}
+	.has-small-font-size {
+		font-size: 13px;
+	}
 
-.editor-styles-wrapper .has-medium-font-size,
-.has-medium-font-size {
-	font-size: 20px;
-}
+	.has-regular-font-size, // Not used now, kept because of backward compatibility.
+	.has-normal-font-size {
+		font-size: 16px;
+	}
 
-.editor-styles-wrapper .has-large-font-size,
-.has-large-font-size {
-	font-size: 36px;
-}
+	.has-medium-font-size {
+		font-size: 20px;
+	}
 
-.editor-styles-wrapper .has-larger-font-size,
-.editor-styles-wrapper .has-huge-font-size,
-.has-larger-font-size, // Not used now, kept because of backward compatibility.
-.has-huge-font-size {
-	font-size: 42px;
+	.has-large-font-size {
+		font-size: 36px;
+	}
+
+	.has-larger-font-size, // Not used now, kept because of backward compatibility.
+	.has-huge-font-size {
+		font-size: 42px;
+	}
 }
 
 // Text alignments.


### PR DESCRIPTION
This PR is a follow-up to [this conversation](https://github.com/WordPress/gutenberg/pull/22526/files#r428797090).

While adding the editor styles wrapper to the preset colors we discussed why we used the `:root` pseudo-class there while we didn't for font-sizes. It looks like the `:root` for colors was added to cover for hover/focus statuses ([PR](https://github.com/WordPress/gutenberg/pull/15167), [conversation](https://github.com/WordPress/gutenberg/issues/12986#issuecomment-486099766)).

The question is: is there a similar need for font-sizes? Is this PR useful?

cc @kjellr @jasmussen 