### PR TITLE
Allow block-specific settings controls

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu-controls/index.js
+++ b/packages/block-editor/src/components/block-settings-menu-controls/index.js
@@ -58,8 +58,10 @@ export const BlockSettingsMenuControls = ( {
 	...fillProps
 } ) => {
 	const context = useContext( BlockListBlockContext );
-	if ( ! forAllBlocks && context?.clientId ) {
-		fillProps.name = getSlotName( context.clientId );
+	if ( ! forAllBlocks ) {
+		// Let's use non-existent ID in case the context is missing
+		const clientId = context?.clientId || 'non-such-id';
+		fillProps.name = getSlotName( clientId );
 	}
 
 	return <Fill { ...fillProps } />;

--- a/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
+++ b/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
@@ -92,7 +92,7 @@ const PluginBlockSettingsMenuItem = ( {
 	small,
 	role,
 } ) => (
-	<BlockSettingsMenuControls>
+	<BlockSettingsMenuControls forAllBlocks>
 		{ ( { selectedBlocks, onClose } ) => {
 			if ( ! shouldRenderItem( selectedBlocks, allowedBlocks ) ) {
 				return null;

--- a/packages/editor/src/components/convert-to-group-buttons/index.js
+++ b/packages/editor/src/components/convert-to-group-buttons/index.js
@@ -19,7 +19,7 @@ export function ConvertToGroupButton( {
 	}
 
 	return (
-		<BlockSettingsMenuControls>
+		<BlockSettingsMenuControls forAllBlocks>
 			{ ( { onClose } ) => (
 				<>
 					{ isGroupable && (

--- a/packages/editor/src/components/reusable-blocks-buttons/reusable-block-convert-button.js
+++ b/packages/editor/src/components/reusable-blocks-buttons/reusable-block-convert-button.js
@@ -24,7 +24,7 @@ export function ReusableBlockConvertButton( {
 	}
 
 	return (
-		<BlockSettingsMenuControls>
+		<BlockSettingsMenuControls forAllBlocks>
 			{ ( { onClose } ) => (
 				<>
 					{ ! isReusable && (

--- a/packages/editor/src/components/reusable-blocks-buttons/reusable-block-delete-button.js
+++ b/packages/editor/src/components/reusable-blocks-buttons/reusable-block-delete-button.js
@@ -18,7 +18,7 @@ export function ReusableBlockDeleteButton( {
 	}
 
 	return (
-		<BlockSettingsMenuControls>
+		<BlockSettingsMenuControls forAllBlocks>
 			{ ( { onClose } ) => (
 				<MenuItem
 					disabled={ isDisabled }


### PR DESCRIPTION
## Description + Test plan
**The problem**
Let's imagine I'd like to add an additional `MenuItem` to block settings menu in a `core/navigation-link` block. I add the following snippet of code to the `edit.js`:

```js
	<BlockSettingsMenuControls>
		{ () => <MenuItem> My test menu item <MenuItem> }
	</BlockSettingsMenuControls>
```

Nice! This should do the trick. Let's test with a navigation link selected:

<img width="666" alt="Zrzut ekranu 2020-05-27 o 13 54 33" src="https://user-images.githubusercontent.com/205419/83016016-9b69f980-a021-11ea-86db-9d35ff63b7c6.png">

So far so good, maybe we can call it a day? Let's add one more link to be extra sure:

<img width="651" alt="Zrzut ekranu 2020-05-27 o 13 55 59" src="https://user-images.githubusercontent.com/205419/83016189-d8ce8700-a021-11ea-8d29-848eb92c5050.png">

Uh oh, not good! Let's se what happens when the parent navigation block is selected:

<img width="645" alt="Zrzut ekranu 2020-05-27 o 13 55 39" src="https://user-images.githubusercontent.com/205419/83016125-c18f9980-a021-11ea-93a4-39258111ccd1.png">

Wow - that's unexpected.

**Proposed solution**

This behavior occurs because `BlockSettingsMenuControls.Slot` doesn't have any restrictions on block id - it just accepts all the fills from the entire component tree. This plays nicely with MenuItems that are supposed to be in every BlockSettingsMenu such as "duplicate" or "convert", but doesn't support specifying additional controls by the block itself.

This PR introduces a separation between the two - the `BlockSettingsMenuControls` fill now has two modes: block-specific (default) and global. Unless `forAllBlocks` property is set to true, the fill will have an instance-specific name and will not be used by any `BlockSettingsMenu` related to another block (or multi-block selection).

Note that making block-specific mode the default feels more natural, but it also breaks BC - any third party code relying on the default global behavior will no longer work. I'd really like to get a second opinion about this decision before merging.

With this PR applied, adding the snippet of code mentioned above results in a more intuitive outcome:

<img width="680" alt="Zrzut ekranu 2020-05-27 o 14 02 25" src="https://user-images.githubusercontent.com/205419/83016719-b852fc80-a022-11ea-9243-16b9235c32d6.png">
<img width="665" alt="Zrzut ekranu 2020-05-27 o 14 02 31" src="https://user-images.githubusercontent.com/205419/83016726-bb4ded00-a022-11ea-91fe-bf1e206845f1.png">
<img width="827" alt="Zrzut ekranu 2020-05-27 o 14 03 10" src="https://user-images.githubusercontent.com/205419/83016784-d15bad80-a022-11ea-807c-f57258fd2bf9.png">

If this approach gets positive feedback, I'd like to add some tests before merging this PR.

## Types of changes
Breaking change (fix or feature that would cause existing functionality to not work as expected)
