### PR TITLE
Add support for context-specific BlockSettingsMenuControls

### DIFF
--- a/packages/block-editor/src/components/block-navigation/block.js
+++ b/packages/block-editor/src/components/block-navigation/block.js
@@ -125,6 +125,7 @@ export default function BlockNavigationBlock( {
 							<BlockSettingsDropdown
 								clientIds={ [ clientId ] }
 								icon={ moreVertical }
+								contexts={ [ 'default', 'navigator' ] }
 								{ ...props }
 							/>
 						) }

--- a/packages/block-editor/src/components/block-settings-menu-controls/index.js
+++ b/packages/block-editor/src/components/block-settings-menu-controls/index.js
@@ -17,8 +17,13 @@ import { BlockListBlockContext } from '../block-list/block';
 
 const { Fill, Slot } = createSlotFill( 'BlockSettingsMenuControls' );
 
-const getSlotName = ( clientId ) => `BlockSettings-${ clientId }`;
-const BlockSettingsMenuControlsSlots = ( { fillProps, clientIds = null } ) => {
+const getSlotName = ( context, clientId = null ) =>
+	`BlockSettings-${ context }-${ clientId ? clientId : '' }`;
+const BlockSettingsMenuControlsSlots = ( {
+	fillProps,
+	context = 'default',
+	clientIds = null,
+} ) => {
 	const { selectedBlocks } = useSelect( ( select ) => {
 		const { getBlocksByClientId, getSelectedBlockClientIds } = select(
 			'core/block-editor'
@@ -36,11 +41,14 @@ const BlockSettingsMenuControlsSlots = ( { fillProps, clientIds = null } ) => {
 	const slotProps = { ...fillProps, selectedBlocks };
 	return (
 		<>
-			<BlockSettingsMenuControlsSlot { ...slotProps } />
+			<BlockSettingsMenuControlsSlot
+				{ ...slotProps }
+				name={ getSlotName( context ) }
+			/>
 			{ clientIds.length === 1 && (
 				<BlockSettingsMenuControlsSlot
 					{ ...slotProps }
-					name={ getSlotName( clientIds[ 0 ] ) }
+					name={ getSlotName( context, clientIds[ 0 ] ) }
 				/>
 			) }
 		</>
@@ -55,16 +63,16 @@ const BlockSettingsMenuControlsSlot = ( props ) => (
 
 export const BlockSettingsMenuControls = ( {
 	forAllBlocks = false,
+	context = 'default',
 	...fillProps
 } ) => {
-	const context = useContext( BlockListBlockContext );
+	const blockContext = useContext( BlockListBlockContext );
+	let clientId;
 	if ( ! forAllBlocks ) {
-		// Let's use non-existent ID in case the context is missing
-		const clientId = context?.clientId || 'non-such-id';
-		fillProps.name = getSlotName( clientId );
+		// Let's use non-existent ID in case the block context is missing
+		clientId = blockContext?.clientId || 'non-such-id';
 	}
-
-	return <Fill { ...fillProps } />;
+	return <Fill { ...fillProps } name={ getSlotName( context, clientId ) } />;
 };
 
 BlockSettingsMenuControls.Slot = BlockSettingsMenuControlsSlots;

--- a/packages/block-editor/src/components/block-settings-menu-controls/index.js
+++ b/packages/block-editor/src/components/block-settings-menu-controls/index.js
@@ -58,8 +58,10 @@ export const BlockSettingsMenuControls = ( {
 	...fillProps
 } ) => {
 	const context = useContext( BlockListBlockContext );
-	if ( ! forAllBlocks && context?.clientId ) {
-		fillProps.name = getSlotName( context.clientId );
+	if ( ! forAllBlocks ) {
+		// Let's use non-existent ID in case the context is missing
+		const clientId = context?.clientId || 'non-such-id';
+		fillProps.name = getSlotName( clientId );
 	}
 
 	return <Fill { ...fillProps } />;

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -34,7 +34,11 @@ const POPOVER_PROPS = {
 	isAlternate: true,
 };
 
-export function BlockSettingsDropdown( { clientIds, ...props } ) {
+export function BlockSettingsDropdown( {
+	clientIds,
+	contexts = [ 'default' ],
+	...props
+} ) {
 	const blockClientIds = castArray( clientIds );
 	const count = blockClientIds.length;
 	const firstBlockClientId = blockClientIds[ 0 ];
@@ -145,10 +149,14 @@ export function BlockSettingsDropdown( { clientIds, ...props } ) {
 									/>
 								) }
 							</MenuGroup>
-							<BlockSettingsMenuControls.Slot
-								fillProps={ { onClose } }
-								clientIds={ clientIds }
-							/>
+							{ contexts.map( ( context ) => (
+								<BlockSettingsMenuControls.Slot
+									key={ context }
+									fillProps={ { onClose } }
+									clientIds={ clientIds }
+									context={ context }
+								/>
+							) ) }
 							<MenuGroup>
 								{ ! isLocked && (
 									<MenuItem

--- a/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
+++ b/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
@@ -92,7 +92,7 @@ const PluginBlockSettingsMenuItem = ( {
 	small,
 	role,
 } ) => (
-	<BlockSettingsMenuControls>
+	<BlockSettingsMenuControls forAllBlocks>
 		{ ( { selectedBlocks, onClose } ) => {
 			if ( ! shouldRenderItem( selectedBlocks, allowedBlocks ) ) {
 				return null;

--- a/packages/editor/src/components/convert-to-group-buttons/index.js
+++ b/packages/editor/src/components/convert-to-group-buttons/index.js
@@ -19,7 +19,7 @@ export function ConvertToGroupButton( {
 	}
 
 	return (
-		<BlockSettingsMenuControls>
+		<BlockSettingsMenuControls forAllBlocks>
 			{ ( { onClose } ) => (
 				<>
 					{ isGroupable && (

--- a/packages/editor/src/components/reusable-blocks-buttons/reusable-block-convert-button.js
+++ b/packages/editor/src/components/reusable-blocks-buttons/reusable-block-convert-button.js
@@ -24,7 +24,7 @@ export function ReusableBlockConvertButton( {
 	}
 
 	return (
-		<BlockSettingsMenuControls>
+		<BlockSettingsMenuControls forAllBlocks>
 			{ ( { onClose } ) => (
 				<>
 					{ ! isReusable && (

--- a/packages/editor/src/components/reusable-blocks-buttons/reusable-block-delete-button.js
+++ b/packages/editor/src/components/reusable-blocks-buttons/reusable-block-delete-button.js
@@ -18,7 +18,7 @@ export function ReusableBlockDeleteButton( {
 	}
 
 	return (
-		<BlockSettingsMenuControls>
+		<BlockSettingsMenuControls forAllBlocks>
 			{ ( { onClose } ) => (
 				<MenuItem
 					disabled={ isDisabled }


### PR DESCRIPTION
## Description
TBD once the parent branch (https://github.com/WordPress/gutenberg/pull/22672) is merged

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
