### PR TITLE
[RNMobile] Remove Keyboard.dismiss when deleting block

### DIFF
--- a/packages/block-editor/src/components/block-mobile-toolbar/index.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/index.native.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Keyboard, View } from 'react-native';
+import { View } from 'react-native';
 
 /**
  * WordPress dependencies
@@ -76,11 +76,7 @@ export default compose(
 		const { removeBlock } = dispatch( 'core/block-editor' );
 		return {
 			onDelete:
-				onDelete ||
-				( () => {
-					Keyboard.dismiss();
-					removeBlock( clientId, rootClientId );
-				} ),
+				onDelete || ( () => removeBlock( clientId, rootClientId ) ),
 		};
 	} )
 )( BlockMobileToolbar );


### PR DESCRIPTION
## Description

Remove the line with `Keyboard.dismiss()` which could be the cause of crash on Android when _newly_ added block such as: `Media&Text`, `Contact Info`

It can fix: https://github.com/wordpress-mobile/WordPress-Android/issues/10491

Ref to gutenberg mobile: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2327

## How has this been tested?

1. Open mobile app
2. Open new draft post
3. Add `Media&Text`, `ContactInfo` or any block
4. Remove `Media&Text` block
5. The app cannot crash

## Screenshots <!-- if applicable -->

before | after
--- | ---
![crash_and](https://user-images.githubusercontent.com/22746080/83036247-a9784400-a03a-11ea-9673-10a9754e55a3.gif) | ![fix](https://user-images.githubusercontent.com/22746080/83036251-abda9e00-a03a-11ea-8f60-82ae8b27f246.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
