### PR TITLE
Update repository-management.md with proposed guidelines

### DIFF
--- a/docs/contributors/repository-management.md
+++ b/docs/contributors/repository-management.md
@@ -77,7 +77,7 @@ For labeling and naming pull requests, here are guidelines to follow that make c
 - When working on experimental screens and features, apply the `[Type] Experimental` label instead of `Feature`, `Enhancement`, etc.
 - When working on new features to technical packages (scripts, create-block, adding  react hooks, etc), apply the `[Type] New API`  label instead of `Feature`, `Enhancement`, etc.
 - When fixing a bug or making an enhancement to an internal tool used in the project, apply the `[Type] Build Tooling` instead of `Bugs`, `Enhancement`, etc
-- In PR titles, instead of describing the code change done to fix an issue, consider referring to the actual bug being fixed instead. For example: instead of saying "Check for nullable object in component", it would be preferable to say "Fix editor breakage when clicking the copy block button". 
+- In pull request titles, instead of describing the code change done to fix an issue, consider referring to the actual bug being fixed instead. For example: instead of saying "Check for nullable object in component", it would be preferable to say "Fix editor breakage when clicking the copy block button". 
 
 Along with this process, there are a few important points to mention:
 

--- a/docs/contributors/repository-management.md
+++ b/docs/contributors/repository-management.md
@@ -70,6 +70,14 @@ Gutenberg follows a feature branch pull request workflow for all code and docume
 2. Make your changes, testing thoroughly.
 3. Commit your changes when you’re happy with them, and push the branch.
 4. Open your pull request.
+5. Label and name your pull request appropriately (see below).
+
+For labeling and naming pull requests, here are guidelines to follow that make compiling the changelog more efficient and organized:
+
+- When working on experimental screens and features, apply the `[Type] Experimental` label instead of `Feature`, `Enhancement`, etc.
+- When working on new features to technical packages (scripts, create-block, adding  react hooks, etc), apply the `[Type] New API`  label instead of `Feature`, `Enhancement`, etc.
+- When fixing a bug or making an enhancement to an internal tool used in the project, apply the `[Type] Build Tooling` instead of `Bugs`, `Enhancement`, etc
+- In PR titles, instead of describing the code change done to fix an issue, consider referring to the actual bug being fixed instead. For example: instead of saying "Check for nullable object in component", it would be preferable to say "Fix editor breakage when clicking the copy block button". 
 
 Along with this process, there are a few important points to mention:
 
@@ -97,7 +105,9 @@ If you are not yet comfortable leaving a full review, try commenting on a PR. Qu
 
 ### Design Review
 
-If your pull request impacts the design, you should ask for a design review. To request a design review add the [Needs Design Feedback](https://github.com/WordPress/gutenberg/labels/Needs%20Design%20Feedback) label to your PR. As a guide, changes that should be reviewed:
+If your pull request impacts the design/UI, you need to label appropriately to alert design. To request a design review, add the [Needs Design Feedback](https://github.com/WordPress/gutenberg/labels/Needs%20Design%20Feedback) label to your PR. If there are any PRs that require an update to the design/UI, please use the [Figma Library Update](https://github.com/WordPress/gutenberg/labels/Figma%20Library%20Update) label.
+
+As a guide, changes that should be reviewed:
 
 - A change based on a previous design, to confirm the design is still valid with the change.
 - Anything that changes something visually.

--- a/docs/contributors/repository-management.md
+++ b/docs/contributors/repository-management.md
@@ -70,9 +70,9 @@ Gutenberg follows a feature branch pull request workflow for all code and docume
 2. Make your changes, testing thoroughly.
 3. Commit your changes when you’re happy with them, and push the branch.
 4. Open your pull request.
-5. Label and name your pull request appropriately (see below).
+5. If you are a regular contributor with proper access, label and name your pull request appropriately (see below).
 
-For labeling and naming pull requests, here are guidelines to follow that make compiling the changelog more efficient and organized:
+For labeling and naming pull requests, here are guidelines to consider that make compiling the changelog more efficient and organized. These guidelines are particularly relevant for regular contributors. Don't let getting the following right be a blocker for sharing your work - mistakes are expected and easy to fix!
 
 - When working on experimental screens and features, apply the `[Type] Experimental` label instead of `Feature`, `Enhancement`, etc.
 - When working on new features to technical packages (scripts, create-block, adding  react hooks, etc), apply the `[Type] New API`  label instead of `Feature`, `Enhancement`, etc.


### PR DESCRIPTION
In light of today's core editor chat, this change aims to incorporate proposed guidelines from @youknowriad to make creating the changelog easier: 

https://make.wordpress.org/core/2020/05/27/editor-chat-summary-27th-may-2020/

The wording is slightly refined and made more explicit. I also included additional updates wanted from design.