### PR TITLE
Update PULL_REQUEST_TEMPLATE.md to include PR documentation nudge

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->
+
 ## Description
 <!-- Please describe what you have changed or added -->
 


### PR DESCRIPTION
Updating this template in light of proposed changes to pull request documentation to create more consistency and awareness around best practices: https://github.com/WordPress/gutenberg/pull/22679#pullrequestreview-419496666

This "nudge" matches the approach here (first line): https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/dom/CHANGELOG.md

Props to @aduth for the idea to update this!