### PR TITLE
Env: update copy-dir dependency to version 1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10351,7 +10351,7 @@
 			"dev": true,
 			"requires": {
 				"chalk": "^4.0.0",
-				"copy-dir": "^1.2.0",
+				"copy-dir": "^1.3.0",
 				"docker-compose": "^0.22.2",
 				"extract-zip": "^1.6.7",
 				"got": "^10.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15701,9 +15701,9 @@
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
 		},
 		"copy-dir": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/copy-dir/-/copy-dir-1.2.0.tgz",
-			"integrity": "sha512-UeaUFUIHqGV4brjQ9bY2mHll/hoxyCak2emgmYG72LkGKABHBdBDKFw0H5nTKt5OzVBkBhkxCwnniJBAE7EGEw==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/copy-dir/-/copy-dir-1.3.0.tgz",
+			"integrity": "sha512-Q4+qBFnN4bwGwvtXXzbp4P/4iNk0MaiGAzvQ8OiMtlLjkIKjmNN689uVzShSM0908q7GoFHXIPx4zi75ocoaHw==",
 			"dev": true
 		},
 		"copy-to-clipboard": {

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -33,7 +33,7 @@
 	},
 	"dependencies": {
 		"chalk": "^4.0.0",
-		"copy-dir": "^1.2.0",
+		"copy-dir": "^1.3.0",
 		"docker-compose": "^0.22.2",
 		"extract-zip": "^1.6.7",
 		"got": "^10.7.0",


### PR DESCRIPTION
## Description
I updated the dependency for the node-module copy-dir to version 1.3.0.

When restarting the environment via ```npm run wp-env start``` I ran into the problem that wp-env tried to copy ```wp-config.php``` to the new started container but had no write access. (Because ```wp-config.php``` is owned by www-data).

The code in ```wordpress.js``` uses copy-dir to perform the copy task and provides a filter to skip several files including ```wp-config.php```.

Unfortunately there is a bug in copy-dir 1.2.0 which is triggered by using the filter because the signature of the filter function is passed on incorrectly. This problem was fixed yesterday (See [bugfix commit](https://github.com/pillys/copy-dir/commit/dbda8b6c1a30f15c59545bdb4b1b8f30be02b9a3) ) and version 1.3.0 is released.

I am working on a linux system, maybe the write access problems only occur in this context, I am not quite shure about.



## How has this been tested?
Tested by running the setup stuff with new dependency installed (several times :-) ) and checking the resulting installation.

## Types of changes
bug fix (using bug fix version of dep)

## Checklist:
- [x] My code is tested (by hand).
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
