### PR TITLE
Add context properties to block types REST endpoint

### DIFF
--- a/docs/designers-developers/developers/backward-compatibility/deprecations.md
+++ b/docs/designers-developers/developers/backward-compatibility/deprecations.md
@@ -2,10 +2,14 @@
 
 For features included in the Gutenberg plugin, the deprecation policy is intended to support backward compatibility for two minor plugin releases, when possible. Features and code included in a stable release of WordPress are not included in this deprecation timeline, and are instead subject to the [versioning policies of the WordPress project](https://make.wordpress.org/core/handbook/about/release-cycle/version-numbering/). The current deprecations are listed below and are grouped by _the version at which they will be removed completely_. If your plugin depends on these behaviors, you must update to the recommended alternative before the noted version.
 
+## 8.6.0
+
+- Block API integration with [Block Context](https://github.com/WordPress/gutenberg/blob/master/docs/designers-developers/developers/block-api/block-context.md) was updated. When registering a block use `usesContext` and `providesContext` pair in JavaScript files and `uses_context` and `provides_context` pair in PHP files instead of previous pair `context` and `providesContext`.
+
 ## 8.3.0
 
 - The PHP function `gutenberg_get_post_from_context` has been removed. Use [Block Context](https://github.com/WordPress/gutenberg/blob/master/docs/designers-developers/developers/block-api/block-context.md) instead.
-- The old Block Pattern APIs `register_pattern`/`unregister_pattern` have been removed. Use the [new functions](https://github.com/WordPress/gutenberg/blob/master/docs/designers-developers/developers/block-api/block-patterns.md#register_block_pattern) instead. 
+- The old Block Pattern APIs `register_pattern`/`unregister_pattern` have been removed. Use the [new functions](https://github.com/WordPress/gutenberg/blob/master/docs/designers-developers/developers/block-api/block-patterns.md#register_block_pattern) instead.
 
 ## 5.5.0
 

--- a/docs/designers-developers/developers/block-api/block-context.md
+++ b/docs/designers-developers/developers/block-api/block-context.md
@@ -34,14 +34,14 @@ As seen in the above example, it is recommended that you include a namespace as 
 
 ### Consuming Block Context
 
-A block can inherit a context value from an ancestor provider by assigning a `context` property in its registered settings. This should be assigned as an array of the context names the block seeks to inherit.
+A block can inherit a context value from an ancestor provider by assigning a `usesContext` property in its registered settings. This should be assigned as an array of the context names the block seeks to inherit.
 
 `record-title/block.json`
 
 ```json
 {
 	"name": "my-plugin/record-title",
-	"context": [ "my-plugin/recordId" ]
+	"usesContext": [ "my-plugin/recordId" ]
 }
 ```
 

--- a/docs/rfc/block-registration.md
+++ b/docs/rfc/block-registration.md
@@ -356,6 +356,36 @@ Block type editor style definition. It will only be enqueued in the context of t
 
 Block type frontend style definition. It will be enqueued both in the editor and when viewing the content on the front of the site.
 
+### Provides Context
+
+* Type: `object`
+* Optional
+* Localized: No
+* Property: `providesContext`
+
+Context provided for available access by descendants of blocks of this type, in the form of an object which maps a context name to one of the block's own attribute.
+
+See [the block context documentation](/docs/designers-developers/developers/block-api/block-context.md) for more details.
+
+```json
+{ "providesContext": { "my-plugin/recordId": "recordId" } }
+```
+
+### Context
+
+* Type: `string[]`
+* Optional
+* Localized: No
+* Property: `context`
+
+Array of the names of context values to inherit from an ancestor provider.
+
+See [the block context documentation](/docs/designers-developers/developers/block-api/block-context.md) for more details.
+
+```json
+{ "context": [ "my-plugin/recordId" ] }
+```
+
 ## Backward compatibility
 
 The following properties are going to be supported for backward compatibility reasons on the client-side only. Some of them might be replaced with alternative APIs in the future:

--- a/docs/rfc/block-registration.md
+++ b/docs/rfc/block-registration.md
@@ -362,6 +362,7 @@ Block type frontend style definition. It will be enqueued both in the editor and
 * Optional
 * Localized: No
 * Property: `providesContext`
+* Default: `{}`
 
 Context provided for available access by descendants of blocks of this type, in the form of an object which maps a context name to one of the block's own attribute.
 
@@ -377,6 +378,7 @@ See [the block context documentation](/docs/designers-developers/developers/bloc
 * Optional
 * Localized: No
 * Property: `context`
+* Default: `[]`
 
 Array of the names of context values to inherit from an ancestor provider.
 

--- a/docs/rfc/block-registration.md
+++ b/docs/rfc/block-registration.md
@@ -90,6 +90,12 @@ To register a new block type, start by creating a `block.json` file. This file:
 			"message": "This is a notice!"
 		},
 	},
+	"providesContext": {
+		"my-plugin/message": "message"
+	},
+	"context": [
+		"groupId"
+	],
 	"editorScript": "file:./build/index.js",
 	"script": "file:./build/script.js",
 	"editorStyle": "file:./build/index.css",

--- a/docs/rfc/block-registration.md
+++ b/docs/rfc/block-registration.md
@@ -77,6 +77,12 @@ To register a new block type, start by creating a `block.json` file. This file:
 			"selector": ".message"
 		}
 	},
+	"providesContext": {
+		"my-plugin/message": "message"
+	},
+	"usesContext": [
+		"groupId"
+	],
 	"supports": {
 		"align": true,
 		"lightBlockWrapper": true
@@ -90,12 +96,6 @@ To register a new block type, start by creating a `block.json` file. This file:
 			"message": "This is a notice!"
 		},
 	},
-	"providesContext": {
-		"my-plugin/message": "message"
-	},
-	"context": [
-		"groupId"
-	],
 	"editorScript": "file:./build/index.js",
 	"script": "file:./build/script.js",
 	"editorStyle": "file:./build/index.css",
@@ -258,6 +258,46 @@ Attributes provide the structured data needs of a block. They can exist in diffe
 
 See the [the attributes documentation](/docs/designers-developers/developers/block-api/block-attributes.md) for more details.
 
+### Provides Context
+
+* Type: `object`
+* Optional
+* Localized: No
+* Property: `providesContext`
+* Default: `{}`
+
+Context provided for available access by descendants of blocks of this type, in the form of an object which maps a context name to one of the block's own attribute.
+
+See [the block context documentation](/docs/designers-developers/developers/block-api/block-context.md) for more details.
+
+```json
+{
+	"providesContext": {
+		"my-plugin/recordId": "recordId"
+	}
+}
+```
+
+### Context
+
+* Type: `string[]`
+* Optional
+* Localized: No
+* Property: `usesContext`
+* Default: `[]`
+
+Array of the names of context values to inherit from an ancestor provider.
+
+See [the block context documentation](/docs/designers-developers/developers/block-api/block-context.md) for more details.
+
+```json
+{
+	"usesContext": [
+		"message"
+	]
+}
+```
+
 ### Supports
 
  *   Type: `object`
@@ -361,38 +401,6 @@ Block type editor style definition. It will only be enqueued in the context of t
 ```
 
 Block type frontend style definition. It will be enqueued both in the editor and when viewing the content on the front of the site.
-
-### Provides Context
-
-* Type: `object`
-* Optional
-* Localized: No
-* Property: `providesContext`
-* Default: `{}`
-
-Context provided for available access by descendants of blocks of this type, in the form of an object which maps a context name to one of the block's own attribute.
-
-See [the block context documentation](/docs/designers-developers/developers/block-api/block-context.md) for more details.
-
-```json
-{ "providesContext": { "my-plugin/recordId": "recordId" } }
-```
-
-### Context
-
-* Type: `string[]`
-* Optional
-* Localized: No
-* Property: `context`
-* Default: `[]`
-
-Array of the names of context values to inherit from an ancestor provider.
-
-See [the block context documentation](/docs/designers-developers/developers/block-api/block-context.md) for more details.
-
-```json
-{ "context": [ "my-plugin/recordId" ] }
-```
 
 ## Backward compatibility
 

--- a/lib/class-wp-block.php
+++ b/lib/class-wp-block.php
@@ -107,8 +107,8 @@ class WP_Block {
 
 		$this->available_context = $available_context;
 
-		if ( ! empty( $this->block_type->context ) ) {
-			foreach ( $this->block_type->context as $context_name ) {
+		if ( ! empty( $this->block_type->uses_context ) ) {
+			foreach ( $this->block_type->uses_context as $context_name ) {
 				if ( array_key_exists( $context_name, $this->available_context ) ) {
 					$this->context[ $context_name ] = $this->available_context[ $context_name ];
 				}
@@ -118,15 +118,13 @@ class WP_Block {
 		if ( ! empty( $block['innerBlocks'] ) ) {
 			$child_context = $this->available_context;
 
-			/* phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase */
-			if ( ! empty( $this->block_type->providesContext ) ) {
-				foreach ( $this->block_type->providesContext as $context_name => $attribute_name ) {
+			if ( ! empty( $this->block_type->provides_context ) ) {
+				foreach ( $this->block_type->provides_context as $context_name => $attribute_name ) {
 					if ( array_key_exists( $attribute_name, $this->attributes ) ) {
 						$child_context[ $context_name ] = $this->attributes[ $attribute_name ];
 					}
 				}
 			}
-			/* phpcs:enable */
 
 			$this->inner_blocks = new WP_Block_List( $block['innerBlocks'], $child_context, $registry );
 		}

--- a/lib/class-wp-block.php
+++ b/lib/class-wp-block.php
@@ -124,7 +124,6 @@ class WP_Block {
 			$this->block_type->provides_context = $this->block_type->providesContext;
 		}
 
-
 		$this->available_context = $available_context;
 
 		if ( ! empty( $this->block_type->uses_context ) ) {

--- a/lib/class-wp-block.php
+++ b/lib/class-wp-block.php
@@ -108,19 +108,19 @@ class WP_Block {
 		if ( ! empty( $this->block_type->context ) ) {
 			$message = sprintf(
 				/* translators: 1: Block name. */
-				__( 'Block type "context" option is deprecated. Please use "uses_context" instead in "%s" block.', 'gutenberg' ),
+				__( 'The "context" parameter provided in block type "%s" is deprecated. Please use "uses_context" instead.', 'gutenberg' ),
 				$this->name
 			);
-			_doing_it_wrong( __CLASS__, $message, '8.4.0' );
+			_doing_it_wrong( __CLASS__, $message, '8.6.0' );
 			$this->block_type->uses_context = $this->block_type->context;
 		}
 		if ( ! empty( $this->block_type->providesContext ) ) {
 			$message = sprintf(
 				/* translators: 1: Block name. */
-				__( 'Block type "providesContext" option is deprecated. Please use "provides_context" instead in "%s" block.', 'gutenberg' ),
+				__( 'The "providesContext" parameter provided in block type "%s" is deprecated. Please use "provides_context".', 'gutenberg' ),
 				$this->name
 			);
-			_doing_it_wrong( __CLASS__, $message, '8.4.0' );
+			_doing_it_wrong( __CLASS__, $message, '8.6.0' );
 			$this->block_type->provides_context = $this->block_type->providesContext;
 		}
 

--- a/lib/class-wp-block.php
+++ b/lib/class-wp-block.php
@@ -105,6 +105,26 @@ class WP_Block {
 
 		$this->block_type = $registry->get_registered( $this->name );
 
+		if ( ! empty( $this->block_type->context ) ) {
+			$message = sprintf(
+				/* translators: 1: Block name. */
+				__( 'Block type "context" option is deprecated. Please use "uses_context" instead in "%s" block.', 'gutenberg' ),
+				$this->name
+			);
+			_doing_it_wrong( __CLASS__, $message, '8.4.0' );
+			$this->block_type->uses_context = $this->block_type->context;
+		}
+		if ( ! empty( $this->block_type->providesContext ) ) {
+			$message = sprintf(
+				/* translators: 1: Block name. */
+				__( 'Block type "providesContext" option is deprecated. Please use "provides_context" instead in "%s" block.', 'gutenberg' ),
+				$this->name
+			);
+			_doing_it_wrong( __CLASS__, $message, '8.4.0' );
+			$this->block_type->provides_context = $this->block_type->providesContext;
+		}
+
+
 		$this->available_context = $available_context;
 
 		if ( ! empty( $this->block_type->uses_context ) ) {

--- a/lib/class-wp-rest-block-types-controller.php
+++ b/lib/class-wp-rest-block-types-controller.php
@@ -239,30 +239,30 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 
 		$schema       = $this->get_item_schema();
 		$extra_fields = array(
-			'name',
-			'title',
-			'description',
-			'icon',
-			'category',
-			'keywords',
-			'parent',
-			'supports',
-			'styles',
-			'textdomain',
-			'example',
-			'editor_script',
-			'script',
-			'editor_style',
-			'style',
-			'provides_context',
-			'use_context',
+			'name'             => 'name',
+			'title'            => 'title',
+			'description'      => 'description',
+			'icon'             => 'icon',
+			'category'         => 'category',
+			'keywords'         => 'keywords',
+			'parent'           => 'parent',
+			'supports'         => 'supports',
+			'styles'           => 'styles',
+			'textdomain'       => 'textdomain',
+			'example'          => 'example',
+			'editor_script'    => 'editor_script',
+			'script'           => 'script',
+			'editor_style'     => 'editor_style',
+			'style'            => 'style',
+			'provides_context' => 'providesContext',
+			'use_context'      => 'context',
 		);
-		foreach ( $extra_fields as $extra_field ) {
+		foreach ( $extra_fields as $key => $extra_field ) {
 			if ( rest_is_field_included( $key, $fields ) ) {
 				if ( isset( $block_type->$extra_field ) ) {
 					$field = $block_type->$extra_field;
-				} elseif ( array_key_exists( 'default', $schema['properties'][ $extra_field ] ) ) {
-					$field = $schema['properties'][ $extra_field ]['default'];
+				} elseif ( array_key_exists( 'default', $schema['properties'][ $key ] ) ) {
+					$field = $schema['properties'][ $key ]['default'];
 				} else {
 					$field = '';
 				}
@@ -439,14 +439,14 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 					'context'              => array( 'embed', 'view', 'edit' ),
 					'readonly'             => true,
 				),
-				'textdomain'    => array(
+				'textdomain'       => array(
 					'description' => __( 'Public text domain.', 'gutenberg' ),
 					'type'        => array( 'string', 'null' ),
 					'default'     => null,
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'parent'        => array(
+				'parent'           => array(
 					'description' => __( 'Parent blocks.', 'gutenberg' ),
 					'type'        => array( 'array', 'null' ),
 					'items'       => array(
@@ -466,7 +466,7 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'example'       => array(
+				'example'          => array(
 					'description'          => __( 'Block example.', 'gutenberg' ),
 					'type'                 => array( 'object', 'null' ),
 					'default'              => null,
@@ -474,6 +474,8 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 					'additionalProperties' => array(
 						'type' => 'object',
 					),
+					'context'              => array( 'embed', 'view', 'edit' ),
+					'readonly'             => true,
 				),
 				'provides_context' => array(
 					'description'          => __( 'Context provided by blocks of this type.', 'gutenberg' ),
@@ -486,7 +488,7 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 					'context'              => array( 'embed', 'view', 'edit' ),
 					'readonly'             => true,
 				),
-				'use_context'       => array(
+				'use_context'      => array(
 					'description' => __( 'Context values inherited by blocks of this type.', 'gutenberg' ),
 					'type'        => 'array',
 					'default'     => array(),

--- a/lib/class-wp-rest-block-types-controller.php
+++ b/lib/class-wp-rest-block-types-controller.php
@@ -255,7 +255,7 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 			'editor_style'     => 'editor_style',
 			'style'            => 'style',
 			'provides_context' => 'providesContext',
-			'use_context'      => 'context',
+			'uses_context'     => 'context',
 		);
 		foreach ( $extra_fields as $key => $extra_field ) {
 			if ( rest_is_field_included( $key, $fields ) ) {
@@ -488,7 +488,7 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 					'context'              => array( 'embed', 'view', 'edit' ),
 					'readonly'             => true,
 				),
-				'use_context'      => array(
+				'uses_context'     => array(
 					'description' => __( 'Context values inherited by blocks of this type.', 'gutenberg' ),
 					'type'        => 'array',
 					'default'     => array(),

--- a/lib/class-wp-rest-block-types-controller.php
+++ b/lib/class-wp-rest-block-types-controller.php
@@ -239,28 +239,30 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 
 		$schema       = $this->get_item_schema();
 		$extra_fields = array(
-			'name'          => 'name',
-			'title'         => 'title',
-			'description'   => 'description',
-			'icon'          => 'icon',
-			'category'      => 'category',
-			'keywords'      => 'keywords',
-			'parent'        => 'parent',
-			'supports'      => 'supports',
-			'styles'        => 'styles',
-			'textdomain'    => 'textdomain',
-			'example'       => 'example',
-			'editor_script' => 'editor_script',
-			'script'        => 'script',
-			'editor_style'  => 'editor_style',
-			'style'         => 'style',
+			'name',
+			'title',
+			'description',
+			'icon',
+			'category',
+			'keywords',
+			'parent',
+			'supports',
+			'styles',
+			'textdomain',
+			'example',
+			'editor_script',
+			'script',
+			'editor_style',
+			'style',
+			'provides_context',
+			'use_context',
 		);
-		foreach ( $extra_fields as $key => $extra_field ) {
+		foreach ( $extra_fields as $extra_field ) {
 			if ( rest_is_field_included( $key, $fields ) ) {
 				if ( isset( $block_type->$extra_field ) ) {
 					$field = $block_type->$extra_field;
-				} elseif ( array_key_exists( 'default', $schema['properties'][ $key ] ) ) {
-					$field = $schema['properties'][ $key ]['default'];
+				} elseif ( array_key_exists( 'default', $schema['properties'][ $extra_field ] ) ) {
+					$field = $schema['properties'][ $extra_field ]['default'];
 				} else {
 					$field = '';
 				}
@@ -337,35 +339,35 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 			'title'      => 'block-type',
 			'type'       => 'object',
 			'properties' => array(
-				'title'         => array(
+				'title'            => array(
 					'description' => __( 'Title of block type.', 'gutenberg' ),
 					'type'        => 'string',
 					'default'     => '',
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'name'          => array(
+				'name'             => array(
 					'description' => __( 'Unique name identifying the block type.', 'gutenberg' ),
 					'type'        => 'string',
 					'default'     => '',
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'description'   => array(
+				'description'      => array(
 					'description' => __( 'Description of block type.', 'gutenberg' ),
 					'type'        => 'string',
 					'default'     => '',
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'icon'          => array(
+				'icon'             => array(
 					'description' => __( 'Icon of block type.', 'gutenberg' ),
 					'type'        => array( 'string', 'null' ),
 					'default'     => null,
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'attributes'    => array(
+				'attributes'       => array(
 					'description'          => __( 'Block attributes.', 'gutenberg' ),
 					'type'                 => array( 'object', 'null' ),
 					'properties'           => array(),
@@ -376,7 +378,7 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 					'context'              => array( 'embed', 'view', 'edit' ),
 					'readonly'             => true,
 				),
-				'supports'      => array(
+				'supports'         => array(
 					'description' => __( 'Block supports.', 'gutenberg' ),
 					'type'        => 'object',
 					'default'     => array(),
@@ -384,49 +386,49 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'category'      => array(
+				'category'         => array(
 					'description' => __( 'Block category.', 'gutenberg' ),
 					'type'        => array( 'string', null ),
 					'default'     => null,
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'is_dynamic'    => array(
+				'is_dynamic'       => array(
 					'description' => __( 'Is the block dynamically rendered.', 'gutenberg' ),
 					'type'        => 'boolean',
 					'default'     => false,
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'editor_script' => array(
+				'editor_script'    => array(
 					'description' => __( 'Editor script handle.', 'gutenberg' ),
 					'type'        => array( 'string', null ),
 					'default'     => null,
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'script'        => array(
+				'script'           => array(
 					'description' => __( 'Public facing script handle.', 'gutenberg' ),
 					'type'        => array( 'string', null ),
 					'default'     => null,
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'editor_style'  => array(
+				'editor_style'     => array(
 					'description' => __( 'Editor style handle.', 'gutenberg' ),
 					'type'        => array( 'string', null ),
 					'default'     => null,
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'style'         => array(
+				'style'            => array(
 					'description' => __( 'Public facing style handle.', 'gutenberg' ),
 					'type'        => array( 'string', null ),
 					'default'     => null,
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'styles'        => array(
+				'styles'           => array(
 					'description'          => __( 'Block style variations.', 'gutenberg' ),
 					'type'                 => 'array',
 					'properties'           => array(),
@@ -454,7 +456,7 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'keywords'      => array(
+				'keywords'         => array(
 					'description' => __( 'Block keywords.', 'gutenberg' ),
 					'type'        => 'array',
 					'items'       => array(
@@ -472,8 +474,27 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 					'additionalProperties' => array(
 						'type' => 'object',
 					),
+				),
+				'provides_context' => array(
+					'description'          => __( 'Context provided by blocks of this type.', 'gutenberg' ),
+					'type'                 => 'object',
+					'properties'           => array(),
+					'additionalProperties' => array(
+						'type' => 'string',
+					),
+					'default'              => array(),
 					'context'              => array( 'embed', 'view', 'edit' ),
 					'readonly'             => true,
+				),
+				'use_context'       => array(
+					'description' => __( 'Context values inherited by blocks of this type.', 'gutenberg' ),
+					'type'        => 'array',
+					'default'     => array(),
+					'items'       => array(
+						'type' => 'string',
+					),
+					'context'     => array( 'embed', 'view', 'edit' ),
+					'readonly'    => true,
 				),
 			),
 		);

--- a/lib/class-wp-rest-block-types-controller.php
+++ b/lib/class-wp-rest-block-types-controller.php
@@ -246,6 +246,8 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 			'category'         => 'category',
 			'keywords'         => 'keywords',
 			'parent'           => 'parent',
+			'provides_context' => 'provides_context',
+			'uses_context'     => 'uses_context',
 			'supports'         => 'supports',
 			'styles'           => 'styles',
 			'textdomain'       => 'textdomain',
@@ -254,8 +256,6 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 			'script'           => 'script',
 			'editor_style'     => 'editor_style',
 			'style'            => 'style',
-			'provides_context' => 'providesContext',
-			'uses_context'     => 'context',
 		);
 		foreach ( $extra_fields as $key => $extra_field ) {
 			if ( rest_is_field_included( $key, $fields ) ) {
@@ -378,6 +378,27 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 					'context'              => array( 'embed', 'view', 'edit' ),
 					'readonly'             => true,
 				),
+				'provides_context' => array(
+					'description'          => __( 'Context provided by blocks of this type.', 'gutenberg' ),
+					'type'                 => 'object',
+					'properties'           => array(),
+					'additionalProperties' => array(
+						'type' => 'string',
+					),
+					'default'              => array(),
+					'context'              => array( 'embed', 'view', 'edit' ),
+					'readonly'             => true,
+				),
+				'uses_context'     => array(
+					'description' => __( 'Context values inherited by blocks of this type.', 'gutenberg' ),
+					'type'        => 'array',
+					'default'     => array(),
+					'items'       => array(
+						'type' => 'string',
+					),
+					'context'     => array( 'embed', 'view', 'edit' ),
+					'readonly'    => true,
+				),
 				'supports'         => array(
 					'description' => __( 'Block supports.', 'gutenberg' ),
 					'type'        => 'object',
@@ -476,27 +497,6 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 					),
 					'context'              => array( 'embed', 'view', 'edit' ),
 					'readonly'             => true,
-				),
-				'provides_context' => array(
-					'description'          => __( 'Context provided by blocks of this type.', 'gutenberg' ),
-					'type'                 => 'object',
-					'properties'           => array(),
-					'additionalProperties' => array(
-						'type' => 'string',
-					),
-					'default'              => array(),
-					'context'              => array( 'embed', 'view', 'edit' ),
-					'readonly'             => true,
-				),
-				'uses_context'     => array(
-					'description' => __( 'Context values inherited by blocks of this type.', 'gutenberg' ),
-					'type'        => 'array',
-					'default'     => array(),
-					'items'       => array(
-						'type' => 'string',
-					),
-					'context'     => array( 'embed', 'view', 'edit' ),
-					'readonly'    => true,
 				),
 			),
 		);

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -177,7 +177,7 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 			'providesContext' => 'provides_context',
 			'usesContext'     => 'uses_context',
 			// Deprecated: remove with Gutenberg 8.6 release.
-			'context'         => 'uses_context',
+			'context'         => 'context',
 			'supports'        => 'supports',
 			'styles'          => 'styles',
 			'example'         => 'example',

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -167,17 +167,18 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 
 		$settings          = array();
 		$property_mappings = array(
-			'title'       => 'title',
-			'category'    => 'category',
-			'context'     => 'context',
-			'parent'      => 'parent',
-			'icon'        => 'icon',
-			'description' => 'description',
-			'keywords'    => 'keywords',
-			'attributes'  => 'attributes',
-			'supports'    => 'supports',
-			'styles'      => 'styles',
-			'example'     => 'example',
+			'title'           => 'title',
+			'category'        => 'category',
+			'parent'          => 'parent',
+			'icon'            => 'icon',
+			'description'     => 'description',
+			'keywords'        => 'keywords',
+			'attributes'      => 'attributes',
+			'providesContext' => 'provides_context',
+			'usesContext'     => 'uses_context',
+			'supports'        => 'supports',
+			'styles'          => 'styles',
+			'example'         => 'example',
 		);
 
 		foreach ( $property_mappings as $key => $mapped_key ) {

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -176,6 +176,8 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 			'attributes'      => 'attributes',
 			'providesContext' => 'provides_context',
 			'usesContext'     => 'uses_context',
+			// Deprecated: remove with Gutenberg 8.6 release.
+			'context'         => 'uses_context',
 			'supports'        => 'supports',
 			'styles'          => 'styles',
 			'example'         => 'example',

--- a/packages/block-editor/src/components/block-edit/edit.js
+++ b/packages/block-editor/src/components/block-edit/edit.js
@@ -38,8 +38,8 @@ export const Edit = ( props ) => {
 	// Assign context values using the block type's declared context needs.
 	const context = useMemo(
 		() =>
-			blockType && blockType.context
-				? pick( blockContext, blockType.context )
+			blockType && blockType.usesContext
+				? pick( blockContext, blockType.usesContext )
 				: DEFAULT_BLOCK_CONTEXT,
 		[ blockType, blockContext ]
 	);

--- a/packages/block-editor/src/components/block-edit/edit.js
+++ b/packages/block-editor/src/components/block-edit/edit.js
@@ -41,6 +41,7 @@ export const Edit = ( props ) => {
 		if ( blockType && blockType.context ) {
 			deprecated( 'Block type "context" option', {
 				alternative: '"usesContext"',
+				version: '8.6.0',
 				hint: `Block "${ name }".`,
 				link:
 					'https://developer.wordpress.org/block-editor/developers/block-api/block-context/',

--- a/packages/block-editor/src/components/block-edit/edit.js
+++ b/packages/block-editor/src/components/block-edit/edit.js
@@ -13,6 +13,7 @@ import {
 	hasBlockSupport,
 	getBlockType,
 } from '@wordpress/blocks';
+import deprecated from '@wordpress/deprecated';
 import { useContext, useMemo } from '@wordpress/element';
 
 /**
@@ -36,13 +37,21 @@ export const Edit = ( props ) => {
 	const blockContext = useContext( BlockContext );
 
 	// Assign context values using the block type's declared context needs.
-	const context = useMemo(
-		() =>
-			blockType && blockType.usesContext
-				? pick( blockContext, blockType.usesContext )
-				: DEFAULT_BLOCK_CONTEXT,
-		[ blockType, blockContext ]
-	);
+	const context = useMemo( () => {
+		if ( blockType && blockType.context ) {
+			deprecated( 'Block type "context" option', {
+				alternative: '"usesContext"',
+				hint: `Block "${ name }".`,
+				link:
+					'https://developer.wordpress.org/block-editor/developers/block-api/block-context/',
+			} );
+			return pick( blockContext, blockType.context );
+		}
+
+		return blockType && blockType.usesContext
+			? pick( blockContext, blockType.usesContext )
+			: DEFAULT_BLOCK_CONTEXT;
+	}, [ blockType, blockContext ] );
 
 	if ( ! blockType ) {
 		return null;

--- a/packages/block-editor/src/components/block-edit/test/edit.js
+++ b/packages/block-editor/src/components/block-edit/test/edit.js
@@ -86,7 +86,7 @@ describe( 'Edit', () => {
 		registerBlockType( 'core/test-block', {
 			category: 'text',
 			title: 'block title',
-			context: [ 'value' ],
+			usesContext: [ 'value' ],
 			edit,
 			save: noop,
 		} );
@@ -106,7 +106,7 @@ describe( 'Edit', () => {
 			registerBlockType( 'core/test-block', {
 				category: 'text',
 				title: 'block title',
-				context: [ 'value' ],
+				usesContext: [ 'value' ],
 				supports: {
 					lightBlockWrapper: true,
 				},

--- a/packages/block-library/src/post-author/block.json
+++ b/packages/block-library/src/post-author/block.json
@@ -32,7 +32,7 @@
 			"type": "string"
 		}
 	},
-	"context": [
+	"usesContext": [
 		"postType",
 		"postId"
 	],

--- a/packages/block-library/src/post-comments-count/block.json
+++ b/packages/block-library/src/post-comments-count/block.json
@@ -1,7 +1,7 @@
 {
 	"name": "core/post-comments-count",
 	"category": "design",
-	"context": [
+	"usesContext": [
 		"postId"
 	],
 	"supports": {

--- a/packages/block-library/src/post-comments-form/block.json
+++ b/packages/block-library/src/post-comments-form/block.json
@@ -1,7 +1,7 @@
 {
 	"name": "core/post-comments-form",
 	"category": "design",
-	"context": [
+	"usesContext": [
 		"postId"
 	],
 	"supports": {

--- a/packages/block-library/src/post-comments/block.json
+++ b/packages/block-library/src/post-comments/block.json
@@ -1,5 +1,7 @@
 {
 	"name": "core/post-comments",
 	"category": "design",
-	"context": [ "postId" ]
+	"usesContext": [
+		"postId"
+	]
 }

--- a/packages/block-library/src/post-content/block.json
+++ b/packages/block-library/src/post-content/block.json
@@ -1,7 +1,7 @@
 {
 	"name": "core/post-content",
 	"category": "design",
-	"context": [
+	"usesContext": [
 		"postId",
 		"postType"
 	],

--- a/packages/block-library/src/post-date/block.json
+++ b/packages/block-library/src/post-date/block.json
@@ -6,7 +6,7 @@
 			"type": "string"
 		}
 	},
-	"context": [
+	"usesContext": [
 		"postId"
 	],
 	"supports": {

--- a/packages/block-library/src/post-excerpt/block.json
+++ b/packages/block-library/src/post-excerpt/block.json
@@ -14,7 +14,7 @@
 			"default": true
 		}
 	},
-	"context": [
+	"usesContext": [
 		"postId"
 	],
 	"supports": {

--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -1,7 +1,7 @@
 {
 	"name": "core/post-featured-image",
 	"category": "design",
-	"context": [
+	"usesContext": [
 		"postId"
 	],
 	"supports": {

--- a/packages/block-library/src/post-tags/block.json
+++ b/packages/block-library/src/post-tags/block.json
@@ -1,7 +1,7 @@
 {
 	"name": "core/post-tags",
 	"category": "design",
-	"context": [
+	"usesContext": [
 		"postId"
 	],
 	"supports": {

--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -1,7 +1,7 @@
 {
 	"name": "core/post-title",
 	"category": "design",
-	"context": [
+	"usesContext": [
 		"postId",
 		"postType"
 	],

--- a/packages/block-library/src/query-loop/block.json
+++ b/packages/block-library/src/query-loop/block.json
@@ -1,7 +1,7 @@
 {
 	"name": "core/query-loop",
 	"category": "design",
-	"context": [
+	"usesContext": [
 		"queryId",
 		"query",
 		"queryContext"

--- a/packages/block-library/src/query-pagination/block.json
+++ b/packages/block-library/src/query-pagination/block.json
@@ -1,7 +1,7 @@
 {
 	"name": "core/query-pagination",
 	"category": "design",
-	"context": [
+	"usesContext": [
 		"queryId",
 		"query",
 		"queryContext"

--- a/packages/e2e-tests/plugins/block-context.php
+++ b/packages/e2e-tests/plugins/block-context.php
@@ -32,13 +32,13 @@ function gutenberg_test_register_context_blocks() {
 	register_block_type(
 		'gutenberg/test-context-provider',
 		array(
-			'attributes'      => array(
+			'attributes'       => array(
 				'recordId' => array(
 					'type'    => 'number',
 					'default' => 0,
 				),
 			),
-			'providesContext' => array(
+			'provides_context' => array(
 				'gutenberg/recordId' => 'recordId',
 			),
 		)
@@ -47,7 +47,7 @@ function gutenberg_test_register_context_blocks() {
 	register_block_type(
 		'gutenberg/test-context-consumer',
 		array(
-			'context'         => array(
+			'uses_context'    => array(
 				'gutenberg/recordId',
 				'postId',
 				'postType',

--- a/packages/e2e-tests/plugins/block-context/index.js
+++ b/packages/e2e-tests/plugins/block-context/index.js
@@ -49,7 +49,7 @@
 		// TODO: While redundant with server-side registration, it's required
 		// to assign this value since it is not picked in the implementation of
 		// `get_block_editor_server_block_settings`.
-		context: [ 'gutenberg/recordId' ],
+		usesContext: [ 'gutenberg/recordId' ],
 
 		category: 'text',
 

--- a/phpunit/class-block-context-test.php
+++ b/phpunit/class-block-context-test.php
@@ -72,7 +72,7 @@ class Block_Context_Test extends WP_UnitTestCase {
 		$this->register_block_type(
 			'gutenberg/test-context-provider',
 			array(
-				'attributes'      => array(
+				'attributes'       => array(
 					'contextWithAssigned'   => array(
 						'type' => 'number',
 					),
@@ -87,7 +87,7 @@ class Block_Context_Test extends WP_UnitTestCase {
 						'type' => 'number',
 					),
 				),
-				'providesContext' => array(
+				'provides_context' => array(
 					'gutenberg/contextWithAssigned'   => 'contextWithAssigned',
 					'gutenberg/contextWithDefault'    => 'contextWithDefault',
 					'gutenberg/contextWithoutDefault' => 'contextWithoutDefault',
@@ -99,7 +99,7 @@ class Block_Context_Test extends WP_UnitTestCase {
 		$this->register_block_type(
 			'gutenberg/test-context-consumer',
 			array(
-				'context'         => array(
+				'uses_context'    => array(
 					'gutenberg/contextWithDefault',
 					'gutenberg/contextWithAssigned',
 					'gutenberg/contextWithoutDefault',
@@ -141,7 +141,7 @@ class Block_Context_Test extends WP_UnitTestCase {
 		$this->register_block_type(
 			'gutenberg/test-context-consumer',
 			array(
-				'context'         => array( 'postId', 'postType' ),
+				'uses_context'    => array( 'postId', 'postType' ),
 				'render_callback' => function( $attributes, $content, $block ) use ( &$provided_context ) {
 					$provided_context[] = $block->context;
 
@@ -172,7 +172,7 @@ class Block_Context_Test extends WP_UnitTestCase {
 		$this->register_block_type(
 			'gutenberg/test-context-consumer',
 			array(
-				'context'         => array( 'example' ),
+				'uses_context'    => array( 'example' ),
 				'render_callback' => function( $attributes, $content, $block ) use ( &$provided_context ) {
 					$provided_context[] = $block->context;
 

--- a/phpunit/class-register-block-type-from-metadata-test.php
+++ b/phpunit/class-register-block-type-from-metadata-test.php
@@ -153,10 +153,10 @@ class Register_Block_Type_From_Metadata_Test extends WP_UnitTestCase {
 		$this->assertSame( 'my-plugin/notice', $result->name );
 		$this->assertSame( 'Notice', $result->title );
 		$this->assertSame( 'common', $result->category );
-		$this->assertEquals( array( 'core/group' ), $result->parent );
+		$this->assertEqualSets( array( 'core/group' ), $result->parent );
 		$this->assertSame( 'star', $result->icon );
 		$this->assertSame( 'Shows warning, error or success notices…', $result->description );
-		$this->assertEquals( array( 'alert', 'message' ), $result->keywords );
+		$this->assertEqualSets( array( 'alert', 'message' ), $result->keywords );
 		$this->assertEquals(
 			array(
 				'message' => array(
@@ -167,6 +167,13 @@ class Register_Block_Type_From_Metadata_Test extends WP_UnitTestCase {
 			),
 			$result->attributes
 		);
+		$this->assertEquals(
+			array(
+				'my-plugin/message' => 'message',
+			),
+			$result->provides_context
+		);
+		$this->assertEqualSets( array( 'groupId' ), $result->uses_context );
 		$this->assertEquals(
 			array(
 				'align'             => true,

--- a/phpunit/class-wp-block-test.php
+++ b/phpunit/class-wp-block-test.php
@@ -133,7 +133,7 @@ class WP_Block_Test extends WP_UnitTestCase {
 		$this->registry->register(
 			'core/example',
 			array(
-				'context' => array( 'requested' ),
+				'uses_context' => array( 'requested' ),
 			)
 		);
 
@@ -164,12 +164,12 @@ class WP_Block_Test extends WP_UnitTestCase {
 		$this->registry->register(
 			'core/outer',
 			array(
-				'attributes'      => array(
+				'attributes'       => array(
 					'recordId' => array(
 						'type' => 'number',
 					),
 				),
-				'providesContext' => array(
+				'provides_context' => array(
 					'core/recordId' => 'recordId',
 				),
 			)
@@ -177,7 +177,7 @@ class WP_Block_Test extends WP_UnitTestCase {
 		$this->registry->register(
 			'core/inner',
 			array(
-				'context' => array( 'core/recordId' ),
+				'uses_context' => array( 'core/recordId' ),
 			)
 		);
 
@@ -197,15 +197,15 @@ class WP_Block_Test extends WP_UnitTestCase {
 		$this->registry->register(
 			'core/example',
 			array(
-				'attributes'      => array(
+				'attributes'       => array(
 					'value' => array(
 						'type' => array( 'string', 'null' ),
 					),
 				),
-				'providesContext' => array(
+				'provides_context' => array(
 					'core/value' => 'value',
 				),
-				'context'         => array( 'core/value' ),
+				'uses_context'     => array( 'core/value' ),
 			)
 		);
 

--- a/phpunit/class-wp-rest-block-types-controller-test.php
+++ b/phpunit/class-wp-rest-block-types-controller-test.php
@@ -236,7 +236,7 @@ class REST_WP_REST_Block_Types_Controller_Test extends WP_Test_REST_Post_Type_Co
 		$this->assertArrayHasKey( 'style', $properties );
 		$this->assertArrayHasKey( 'parent', $properties );
 		$this->assertArrayHasKey( 'example', $properties );
-		$this->assertArrayHasKey( 'use_context', $properties );
+		$this->assertArrayHasKey( 'uses_context', $properties );
 		$this->assertArrayHasKey( 'provides_context', $properties );
 	}
 
@@ -351,7 +351,7 @@ class REST_WP_REST_Block_Types_Controller_Test extends WP_Test_REST_Post_Type_Co
 			'textdomain'       => 'textdomain',
 			'example'          => 'example',
 			'provides_context' => 'providesContext',
-			'use_context'      => 'context',
+			'uses_context'     => 'context',
 		);
 
 		foreach ( $extra_fields as $key => $extra_field ) {

--- a/phpunit/class-wp-rest-block-types-controller-test.php
+++ b/phpunit/class-wp-rest-block-types-controller-test.php
@@ -347,10 +347,11 @@ class REST_WP_REST_Block_Types_Controller_Test extends WP_Test_REST_Post_Type_Co
 			'description'      => 'description',
 			'keywords'         => 'keywords',
 			'parent'           => 'parent',
-			'styles'           => 'styleVariations',
-			'text_domain'      => 'textDomain',
-			'context'          => 'context',
+			'styles'           => 'styles',
+			'textdomain'       => 'textdomain',
+			'example'          => 'example',
 			'provides_context' => 'providesContext',
+			'use_context'      => 'context',
 		);
 
 		foreach ( $extra_fields as $key => $extra_field ) {

--- a/phpunit/class-wp-rest-block-types-controller-test.php
+++ b/phpunit/class-wp-rest-block-types-controller-test.php
@@ -218,7 +218,7 @@ class REST_WP_REST_Block_Types_Controller_Test extends WP_Test_REST_Post_Type_Co
 		$response   = rest_get_server()->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertCount( 17, $properties );
+		$this->assertCount( 19, $properties );
 		$this->assertArrayHasKey( 'title', $properties );
 		$this->assertArrayHasKey( 'icon', $properties );
 		$this->assertArrayHasKey( 'description', $properties );
@@ -236,6 +236,8 @@ class REST_WP_REST_Block_Types_Controller_Test extends WP_Test_REST_Post_Type_Co
 		$this->assertArrayHasKey( 'style', $properties );
 		$this->assertArrayHasKey( 'parent', $properties );
 		$this->assertArrayHasKey( 'example', $properties );
+		$this->assertArrayHasKey( 'use_context', $properties );
+		$this->assertArrayHasKey( 'provides_context', $properties );
 	}
 
 	/**
@@ -333,21 +335,22 @@ class REST_WP_REST_Block_Types_Controller_Test extends WP_Test_REST_Post_Type_Co
 		$this->assertEquals( $data['is_dynamic'], $block_type->is_dynamic() );
 
 		$extra_fields = array(
-			'name'          => 'name',
-			'category'      => 'category',
-			'editor_script' => 'editor_script',
-			'script'        => 'script',
-			'editor_style'  => 'editor_style',
-			'style'         => 'style',
-			'supports'      => 'supports',
-			'title'         => 'title',
-			'icon'          => 'icon',
-			'description'   => 'description',
-			'keywords'      => 'keywords',
-			'parent'        => 'parent',
-			'styles'        => 'styles',
-			'textdomain'    => 'textdomain',
-			'example'       => 'example',
+			'name'             => 'name',
+			'category'         => 'category',
+			'editor_script'    => 'editor_script',
+			'script'           => 'script',
+			'editor_style'     => 'editor_style',
+			'style'            => 'style',
+			'supports'         => 'supports',
+			'title'            => 'title',
+			'icon'             => 'icon',
+			'description'      => 'description',
+			'keywords'         => 'keywords',
+			'parent'           => 'parent',
+			'styles'           => 'styleVariations',
+			'text_domain'      => 'textDomain',
+			'context'          => 'context',
+			'provides_context' => 'providesContext',
 		);
 
 		foreach ( $extra_fields as $key => $extra_field ) {

--- a/phpunit/class-wp-rest-block-types-controller-test.php
+++ b/phpunit/class-wp-rest-block-types-controller-test.php
@@ -341,17 +341,17 @@ class REST_WP_REST_Block_Types_Controller_Test extends WP_Test_REST_Post_Type_Co
 			'script'           => 'script',
 			'editor_style'     => 'editor_style',
 			'style'            => 'style',
-			'supports'         => 'supports',
 			'title'            => 'title',
 			'icon'             => 'icon',
 			'description'      => 'description',
 			'keywords'         => 'keywords',
 			'parent'           => 'parent',
+			'provides_context' => 'provides_context',
+			'uses_context'     => 'uses_context',
+			'supports'         => 'supports',
 			'styles'           => 'styles',
 			'textdomain'       => 'textdomain',
 			'example'          => 'example',
-			'provides_context' => 'providesContext',
-			'uses_context'     => 'context',
 		);
 
 		foreach ( $extra_fields as $key => $extra_field ) {

--- a/phpunit/fixtures/block.json
+++ b/phpunit/fixtures/block.json
@@ -5,6 +5,12 @@
 	"parent": [
 		"core/group"
 	],
+	"providesContext": {
+		"my-plugin/message": "message"
+	},
+	"usesContext": [
+		"groupId"
+	],
 	"icon": "star",
 	"description": "Shows warning, error or success notices…",
 	"keywords": [


### PR DESCRIPTION
This pull request seeks to add [block context](https://github.com/WordPress/gutenberg/blob/master/docs/designers-developers/developers/block-api/block-context.md) properties to the block types REST controller originally implemented in #21065. Block context documentation was created as part of #21925, but not incorporated into the existing Block Type RFC document. It has been included here alongside the necessary revisions to include the properties in the REST controller.

**Status:** The implementation should work well enough, though it may warrant being considered blocked by one or both of:

- A decision at https://github.com/WordPress/gutenberg/pull/22519#discussion_r431461183 in regards to registering block types using snake-cased `provides_context`, rather than camel-cased `providesContext`.
- A solution to provide `provides_context` as an empty _object_ `{}`, rather than incorrect array `[]`, related to the comment at https://github.com/WordPress/gutenberg/pull/21065/files#r431468417.

**Testing Instructions:**

Ensure tests pass:

```
./packages/env/bin/wp-env run composer 'composer install'
npm run test-unit-php
```

Test scenario from #21467 is helpful as well:

> Given that this pull request only ports the Post Title experimental full-site editing block, testing can be a bit cumbersome at the moment, especially if you've not yet defined templates for full-site editing mode.
> 
> My recommendation for testing is as follows:
> 
> 1. Navigate to Gutenberg > Experiments
> 2. Enable "Full Site Editing" and click "Save Changes"
> 3. Navigate to Posts > Add New
> 4. Insert a Post Title block
> 5. Observe that the block inherits the title of the post and updates if you change the title
> 6. Preview the post in a separate tab
>    - Note: If you don't have templates on your site, you may see a message "No template found". This is expected, and can be disregarded for now.
> 7. Navigate to Gutenberg > Experiments
> 8. Disable "Full Site Editing" and click "Save Changes"
> 9. In your separate preview tab, refresh the page.
> 10. Observe that the Post Title block displays the title of the current post