### PR TITLE
Fix image centering in gutenberg 8.2.0

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -259,7 +259,7 @@ export function ImageEdit( {
 	}
 
 	function updateAlignment( nextAlign ) {
-		const extraUpdatedAttributes = isWideAligned
+		const extraUpdatedAttributes = [ 'wide', 'full' ].includes( nextAlign )
 			? { width: undefined, height: undefined }
 			: {};
 		setAttributes( {

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -24,10 +24,13 @@ figure.wp-block-image:not(.wp-block) {
 }
 
 // This is necessary for the editor resize handles to accurately work on a non-floated, non-resized, small image.
-.wp-block-image .components-resizable-box__container img {
-	display: block;
-	width: inherit;
-	height: inherit;
+.wp-block-image .components-resizable-box__container {
+	display: inline-block;
+	img {
+		display: block;
+		width: inherit;
+		height: inherit;
+	}
 }
 
 .block-editor-block-list__block[data-type="core/image"] .block-editor-block-toolbar .block-editor-url-input__button-modal {


### PR DESCRIPTION
closes #22694 

## Description
Currently in 8.2.0, image centering is broken, I originally found it testing for wordpress.com and can confirm it also happens in gutenberg's docker testing environment
Before:
![May-28-2020 16-04-11](https://user-images.githubusercontent.com/22446385/83104927-148a4f00-a0fd-11ea-8579-bbe6ddef5a56.gif)

https://github.com/Automattic/wp-calypso/issues/42637


## How has this been tested?
* Installed latest version to the local docker test environment
* Test the other image centering modes
* Tested with resized images
![May-28-2020 18-57-21](https://user-images.githubusercontent.com/22446385/83121129-427b8d80-a115-11ea-9deb-d5ac940f51da.gif)


### Technical Details

It looks like the missing piece was that the `.components-resizable-box__container` element no longer had `display: inline-block;` set on it after this change https://github.com/WordPress/gutenberg/pull/22360/files#diff-d1d037caeeea85a91038b28fa70cd435L28


### Note 

There is currently an issue with resizing the image and then setting it to "Wide width", if you do this, the image is not set to full screen like it should be
