### PR TITLE
REST API: Update default values for fields in the block type schema

### DIFF
--- a/docs/rfc/block-registration.md
+++ b/docs/rfc/block-registration.md
@@ -69,7 +69,7 @@ To register a new block type, start by creating a `block.json` file. This file:
 	"icon": "star",
 	"description": "Shows warning, error or success notices  ...",
 	"keywords": [ "alert", "message" ],
-	"textDomain": "my-plugin",
+	"textdomain": "my-plugin",
 	"attributes": {
 		"message": {
 			"type": "string",
@@ -81,10 +81,15 @@ To register a new block type, start by creating a `block.json` file. This file:
 		"align": true,
 		"lightBlockWrapper": true
 	},
-	"styleVariations": [
+	"styles": [
 		{ "name": "default", "label": "Default", "isDefault": true },
 		{ "name": "other", "label": "Other" }
 	],
+	"example": {
+		"attributes": {
+			"message": "This is a notice!"
+		},
+	},
 	"editorScript": "build/editor.js",
 	"script": "build/main.js",
 	"editorStyle": "build/editor.css",
@@ -210,10 +215,10 @@ Sometimes a block could have aliases that help users discover it while searching
 * Type: `string`
 * Optional
 * Localized: No
-* Property: `textDomain`
+* Property: `textdomain`
 
 ```json
-{ "textDomain": "my-plugin" }
+{ "textdomain": "my-plugin" }
 ```
 
 The [gettext](https://www.gnu.org/software/gettext/) text domain of the plugin/block. More information can be found in the [Text Domain](https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#text-domains) section of the [How to Internationalize your Plugin](https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/) page.
@@ -264,11 +269,10 @@ See the [the attributes documentation](/docs/designers-developers/developers/blo
 * Optional
 * Localized: Yes (`label` only)
 * Property: `styles`
-* Alias: `styleVariations`
 
 ```json
 {
-	"styleVariations": [
+	"styles": [
 		{ "name": "default", "label": "Default", "isDefault": true },
 		{ "name": "other", "label": "Other" }
 	]
@@ -278,6 +282,27 @@ See the [the attributes documentation](/docs/designers-developers/developers/blo
 Block styles can be used to provide alternative styles to block. It works by adding a class name to the block's wrapper. Using CSS, a theme developer can target the class name for the style variation if it is selected.
 
 Plugins and Themes can also register [custom block style](/docs/designers-developers/developers/filters/block-filters.md#block-style-variations) for existing blocks.
+
+### Example
+
+ *   Type: `object`
+ *   Optional
+ *   Localized: No
+ *   Property: `example`
+
+ ```json
+{
+	"example": {
+		"attributes": {
+			"message": "This is a notice!"
+		},
+	}
+}
+ ```
+
+ It provides structured example data for the block. This data is used to construct a preview for the block to be shown in the Inspector Help Panel when the user mouses over the block.
+
+ See the [the example documentation](/docs/designers-developers/developers/block-api/block-registration.md#example-optional) for more details.
 
 ### Editor Script
 
@@ -414,7 +439,7 @@ return array(
 
 Localized properties are automatically wrapped in `_x` function calls on the backend and the frontend of WordPress. These translations are added as an inline script to the `wp-block-library` script handle in WordPress core or to the plugin's script handle when it defines metadata definition.
 
-WordPress string discovery automatically translates these strings using the `textDomain` property specified in the `block.json` file.
+WordPress string discovery automatically translates these strings using the `textdomain` property specified in the `block.json` file.
 
 **Example:**
 
@@ -423,7 +448,7 @@ WordPress string discovery automatically translates these strings using the `tex
 	"title": "My block",
 	"description": "My block is fantastic",
 	"keywords": [ "fantastic" ],
-	"textDomain": "my-plugin"
+	"textdomain": "my-plugin"
 }
 ```
 

--- a/lib/class-wp-rest-block-types-controller.php
+++ b/lib/class-wp-rest-block-types-controller.php
@@ -469,6 +469,9 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 					'type'        => array( 'object', 'null' ),
 					'default'     => null,
 					'properties'  => array(),
+					'additionalProperties' => array(
+						'type' => 'object',
+					),
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),

--- a/lib/class-wp-rest-block-types-controller.php
+++ b/lib/class-wp-rest-block-types-controller.php
@@ -465,15 +465,15 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 					'readonly'    => true,
 				),
 				'example'       => array(
-					'description' => __( 'Block example.', 'gutenberg' ),
-					'type'        => array( 'object', 'null' ),
-					'default'     => null,
-					'properties'  => array(),
+					'description'          => __( 'Block example.', 'gutenberg' ),
+					'type'                 => array( 'object', 'null' ),
+					'default'              => null,
+					'properties'           => array(),
 					'additionalProperties' => array(
 						'type' => 'object',
 					),
-					'context'     => array( 'embed', 'view', 'edit' ),
-					'readonly'    => true,
+					'context'              => array( 'embed', 'view', 'edit' ),
+					'readonly'             => true,
 				),
 			),
 		);

--- a/lib/class-wp-rest-block-types-controller.php
+++ b/lib/class-wp-rest-block-types-controller.php
@@ -249,7 +249,7 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 			'supports'      => 'supports',
 			'styles'        => 'styles',
 			'textdomain'    => 'textdomain',
-			'example'       => 'styles',
+			'example'       => 'example',
 			'editor_script' => 'editor_script',
 			'script'        => 'script',
 			'editor_style'  => 'editor_style',

--- a/lib/class-wp-rest-block-types-controller.php
+++ b/lib/class-wp-rest-block-types-controller.php
@@ -240,25 +240,26 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 		$schema       = $this->get_item_schema();
 		$extra_fields = array(
 			'name'          => 'name',
+			'title'         => 'title',
+			'description'   => 'description',
+			'icon'          => 'icon',
 			'category'      => 'category',
+			'keywords'      => 'keywords',
+			'parent'        => 'parent',
+			'supports'      => 'supports',
+			'styles'        => 'styles',
+			'textdomain'    => 'textdomain',
+			'example'       => 'styles',
 			'editor_script' => 'editor_script',
 			'script'        => 'script',
 			'editor_style'  => 'editor_style',
 			'style'         => 'style',
-			'supports'      => 'supports',
-			'title'         => 'title',
-			'icon'          => 'icon',
-			'description'   => 'description',
-			'keywords'      => 'keywords',
-			'parent'        => 'parent',
-			'styles'        => 'styleVariations',
-			'text_domain'   => 'textDomain',
 		);
 		foreach ( $extra_fields as $key => $extra_field ) {
 			if ( rest_is_field_included( $key, $fields ) ) {
 				if ( isset( $block_type->$extra_field ) ) {
 					$field = $block_type->$extra_field;
-				} elseif ( isset( $schema['properties'][ $key ]['default'] ) ) {
+				} elseif ( array_key_exists( 'default', $schema['properties'][ $key ] ) ) {
 					$field = $schema['properties'][ $key ]['default'];
 				} else {
 					$field = '';
@@ -366,9 +367,9 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 				),
 				'attributes'    => array(
 					'description'          => __( 'Block attributes.', 'gutenberg' ),
-					'type'                 => 'object',
+					'type'                 => array( 'object', 'null' ),
 					'properties'           => array(),
-					'default'              => array(),
+					'default'              => null,
 					'additionalProperties' => array(
 						'type' => 'object',
 					),
@@ -427,7 +428,7 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 				),
 				'styles'        => array(
 					'description'          => __( 'Block style variations.', 'gutenberg' ),
-					'type'                 => 'object',
+					'type'                 => 'array',
 					'properties'           => array(),
 					'additionalProperties' => array(
 						'type' => 'object',
@@ -436,16 +437,16 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 					'context'              => array( 'embed', 'view', 'edit' ),
 					'readonly'             => true,
 				),
-				'text_domain'   => array(
+				'textdomain'    => array(
 					'description' => __( 'Public text domain.', 'gutenberg' ),
-					'type'        => 'string',
-					'default'     => '',
+					'type'        => array( 'string', 'null' ),
+					'default'     => null,
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'parent'        => array(
 					'description' => __( 'Parent blocks.', 'gutenberg' ),
-					'type'        => 'array',
+					'type'        => array( 'array', 'null' ),
 					'items'       => array(
 						'type' => 'string',
 					),
@@ -460,6 +461,14 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 						'type' => 'string',
 					),
 					'default'     => array(),
+					'context'     => array( 'embed', 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'example'       => array(
+					'description' => __( 'Block example.', 'gutenberg' ),
+					'type'        => array( 'object', 'null' ),
+					'default'     => null,
+					'properties'  => array(),
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),

--- a/lib/class-wp-rest-block-types-controller.php
+++ b/lib/class-wp-rest-block-types-controller.php
@@ -444,12 +444,12 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 					'readonly'    => true,
 				),
 				'parent'        => array(
-					'description' => __( 'Parent blocks, defaults to empty it no parents', 'gutenberg' ),
+					'description' => __( 'Parent blocks.', 'gutenberg' ),
 					'type'        => 'array',
 					'items'       => array(
 						'type' => 'string',
 					),
-					'default'     => array(),
+					'default'     => null,
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),

--- a/phpunit/class-wp-rest-block-types-controller-test.php
+++ b/phpunit/class-wp-rest-block-types-controller-test.php
@@ -224,7 +224,7 @@ class REST_WP_REST_Block_Types_Controller_Test extends WP_Test_REST_Post_Type_Co
 		$this->assertArrayHasKey( 'description', $properties );
 		$this->assertArrayHasKey( 'keywords', $properties );
 		$this->assertArrayHasKey( 'styles', $properties );
-		$this->assertArrayHasKey( 'text_domain', $properties );
+		$this->assertArrayHasKey( 'textdomain', $properties );
 		$this->assertArrayHasKey( 'name', $properties );
 		$this->assertArrayHasKey( 'attributes', $properties );
 		$this->assertArrayHasKey( 'supports', $properties );

--- a/phpunit/class-wp-rest-block-types-controller-test.php
+++ b/phpunit/class-wp-rest-block-types-controller-test.php
@@ -145,7 +145,7 @@ class REST_WP_REST_Block_Types_Controller_Test extends WP_Test_REST_Post_Type_Co
 			'style_handle' => 'myguten-style',
 		);
 		$settings     = array(
-			'styleVariations' => array(
+			'styles' => array(
 				array(
 					'name'         => 'blue-quote',
 					'label'        => 'Blue Quote',
@@ -218,7 +218,7 @@ class REST_WP_REST_Block_Types_Controller_Test extends WP_Test_REST_Post_Type_Co
 		$response   = rest_get_server()->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertCount( 16, $properties );
+		$this->assertCount( 17, $properties );
 		$this->assertArrayHasKey( 'title', $properties );
 		$this->assertArrayHasKey( 'icon', $properties );
 		$this->assertArrayHasKey( 'description', $properties );
@@ -235,6 +235,7 @@ class REST_WP_REST_Block_Types_Controller_Test extends WP_Test_REST_Post_Type_Co
 		$this->assertArrayHasKey( 'editor_style', $properties );
 		$this->assertArrayHasKey( 'style', $properties );
 		$this->assertArrayHasKey( 'parent', $properties );
+		$this->assertArrayHasKey( 'example', $properties );
 	}
 
 	/**
@@ -344,8 +345,9 @@ class REST_WP_REST_Block_Types_Controller_Test extends WP_Test_REST_Post_Type_Co
 			'description'   => 'description',
 			'keywords'      => 'keywords',
 			'parent'        => 'parent',
-			'styles'        => 'styleVariations',
-			'text_domain'   => 'textDomain',
+			'styles'        => 'styles',
+			'textdomain'    => 'textdomain',
+			'example'       => 'example',
 		);
 
 		foreach ( $extra_fields as $key => $extra_field ) {


### PR DESCRIPTION
## Description

This change aligns with the state of the corresponding change proposed to WordPress core to `WP_Block_Type` class: https://core.trac.wordpress.org/ticket/48529.

More details about this optional field:
https://developer.wordpress.org/block-editor/developers/block-api/block-registration/#parent-optional

Related code that uses this field that confirms that using an empty array would lead to unexpected results:

https://github.com/WordPress/gutenberg/blob/1530b55a06fa3c8c367af1b8dc025adc84ee36cc/packages/block-editor/src/store/selectors.js#L1168-L1173

https://github.com/WordPress/gutenberg/blob/1530b55a06fa3c8c367af1b8dc025adc84ee36cc/packages/block-editor/src/store/selectors.js#L1122-L1136

