### PR TITLE
[ Navigation Screen ] Enables the new navigation screen to set up menus that auto add new pages

### DIFF
--- a/lib/class-wp-rest-menus-controller.php
+++ b/lib/class-wp-rest-menus-controller.php
@@ -514,7 +514,7 @@ class WP_REST_Menus_Controller extends WP_REST_Terms_Controller {
 			$nav_menu_option['auto_add'] = array();
 		}
 
-		$auto_add = (bool) $request['auto_add'];
+		$auto_add = $request['auto_add'];
 
 		if ( $auto_add ) {
 			if ( ! in_array( $menu_id, $nav_menu_option['auto_add'], true ) ) {

--- a/lib/class-wp-rest-menus-controller.php
+++ b/lib/class-wp-rest-menus-controller.php
@@ -453,7 +453,7 @@ class WP_REST_Menus_Controller extends WP_REST_Terms_Controller {
 	 * replicates the behavior of `wp_nav_menu_update_menu_items`
 	 * in `src/wp-admin/includes/nav-menu.php`.
 	 *
-	 * @param int             $menu_id The menu id to update the location form.
+	 * @param int             $term The menu id to update the location form.
 	 * @param WP_REST_Request $request The request object with menu and locations data.
 	 *
 	 * @return true|WP_Error WP_Error on an error assigning any of the locations, otherwise null.

--- a/lib/class-wp-rest-menus-controller.php
+++ b/lib/class-wp-rest-menus-controller.php
@@ -489,10 +489,9 @@ class WP_REST_Menus_Controller extends WP_REST_Terms_Controller {
 	 */
 	function get_menu_auto_add( $menu_id ) {
 		$nav_menu_option = (array) get_option( 'nav_menu_options', array( 'auto_add' => array() ) );
-		if ( ! in_array( $menu_id, $nav_menu_option['auto_add'], true ) ) {
-			return false;
-		}
-		return true;
+		$check = in_array( $menu_id, $nav_menu_option['auto_add'], true );
+		
+		return $check;
 	}
 
 	/**

--- a/lib/class-wp-rest-menus-controller.php
+++ b/lib/class-wp-rest-menus-controller.php
@@ -489,8 +489,8 @@ class WP_REST_Menus_Controller extends WP_REST_Terms_Controller {
 	 */
 	function get_menu_auto_add( $menu_id ) {
 		$nav_menu_option = (array) get_option( 'nav_menu_options', array( 'auto_add' => array() ) );
-		$check = in_array( $menu_id, $nav_menu_option['auto_add'], true );
-		
+		$check           = in_array( $menu_id, $nav_menu_option['auto_add'], true );
+
 		return $check;
 	}
 

--- a/lib/class-wp-rest-menus-controller.php
+++ b/lib/class-wp-rest-menus-controller.php
@@ -321,7 +321,7 @@ class WP_REST_Menus_Controller extends WP_REST_Terms_Controller {
 			return $locations_update;
 		}
 
-		$this->handle_auto_add( $term->id, $request );
+		$this->handle_auto_add( $term->term_id, $request );
 
 		$fields_update = $this->update_additional_fields_for_object( $term, $request );
 

--- a/lib/class-wp-rest-menus-controller.php
+++ b/lib/class-wp-rest-menus-controller.php
@@ -160,7 +160,7 @@ class WP_REST_Menus_Controller extends WP_REST_Terms_Controller {
 	 *
 	 * @param WP_REST_Request $request The request object with post and locations data.
 	 *
-	 * @return bool|WP_Error Whether the current user can assign the provided terms.
+	 * @return true|WP_Error Whether the current user can assign the provided terms.
 	 */
 	protected function check_set_auto_add_permission( $request ) {
 		if ( ! isset( $request['auto_add'] ) ) {

--- a/lib/class-wp-rest-menus-controller.php
+++ b/lib/class-wp-rest-menus-controller.php
@@ -515,12 +515,12 @@ class WP_REST_Menus_Controller extends WP_REST_Terms_Controller {
 
 		$auto_add = $request['auto_add'];
 
-		$i = array_search( $menu_id, $nav_menu_options['auto_add'], true );
+		$i = array_search( $menu_id, $nav_menu_option['auto_add'], true );
 
 		if ( $auto_add && false === $i ) {
 			$nav_menu_option['auto_add'][] = $menu_id;
 		} elseif ( ! $auto_add && false !== $i ) {
-			array_splice( $nav_menu_options['auto_add'], $i, 1 );
+			array_splice( $nav_menu_option['auto_add'], $i, 1 );
 		}
 
 		$update = update_option( 'nav_menu_options', $nav_menu_option );

--- a/lib/class-wp-rest-menus-controller.php
+++ b/lib/class-wp-rest-menus-controller.php
@@ -501,8 +501,7 @@ class WP_REST_Menus_Controller extends WP_REST_Terms_Controller {
 	 * @param int             $menu_id The menu id to update the location form.
 	 * @param WP_REST_Request $request The request object with menu and locations data.
 	 *
-	 * @return Boolean|Null   Return the value of auto_add or null if the auto_add
-	 *                        is not present in the request.
+	 * @return bool True if the auto update was successfully updated.
 	 */
 	function handle_auto_add( $menu_id, $request ) {
 		if ( ! isset( $request['auto_add'] ) ) {

--- a/lib/class-wp-rest-menus-controller.php
+++ b/lib/class-wp-rest-menus-controller.php
@@ -515,15 +515,12 @@ class WP_REST_Menus_Controller extends WP_REST_Terms_Controller {
 
 		$auto_add = $request['auto_add'];
 
-		if ( $auto_add ) {
-			if ( ! in_array( $menu_id, $nav_menu_option['auto_add'], true ) ) {
-				$nav_menu_option['auto_add'][] = $menu_id;
-			}
-		} else {
-			$key = array_search( $menu_id, $nav_menu_option['auto_add'], true );
-			if ( false !== $key ) {
-				unset( $nav_menu_option['auto_add'][ $key ] );
-			}
+		$i = array_search( $menu_id, $nav_menu_options['auto_add'], true );
+
+		if ( $auto_add && false === $i ) {
+			$nav_menu_option['auto_add'][] = $menu_id;
+		} elseif ( ! $auto_add && false !== $i ) {
+			array_splice( $nav_menu_options['auto_add'], $i, 1 );
 		}
 
 		$update = update_option( 'nav_menu_options', $nav_menu_option );

--- a/lib/class-wp-rest-menus-controller.php
+++ b/lib/class-wp-rest-menus-controller.php
@@ -485,7 +485,7 @@ class WP_REST_Menus_Controller extends WP_REST_Terms_Controller {
 	 *
 	 * @param int $menu_id The menu id to update the location form.
 	 *
-	 * @return Boolean The value of auto_add.
+	 * @return bool The value of auto_add.
 	 */
 	function get_menu_auto_add( $menu_id ) {
 		$nav_menu_option = (array) get_option( 'nav_menu_options', array( 'auto_add' => array() ) );

--- a/lib/class-wp-rest-menus-controller.php
+++ b/lib/class-wp-rest-menus-controller.php
@@ -592,7 +592,7 @@ class WP_REST_Menus_Controller extends WP_REST_Terms_Controller {
 
 		$schema['properties']['auto_add'] = array(
 			'description' => __( 'Whether to automatically add top level pages to this menu.', 'gutenberg' ),
-			'context'     => array( 'edit', 'embed' ),
+			'context'     => array( 'view', 'edit' ),
 			'type'        => 'boolean',
 		);
 

--- a/lib/class-wp-rest-menus-controller.php
+++ b/lib/class-wp-rest-menus-controller.php
@@ -447,9 +447,9 @@ class WP_REST_Menus_Controller extends WP_REST_Terms_Controller {
 	/**
 	 * Returns the value of a menu's auto_add
 	 *
-	 * @param int             $menu_id The menu id to update the location form.
+	 * @param int $menu_id The menu id to update the location form.
 	 *
-	 * @return Boolean        The value of auto_add.
+	 * @return Boolean The value of auto_add.
 	 */
 	function get_menu_auto_add( $menu_id ) {
 		$nav_menu_option = (array) get_option( 'nav_menu_options' );
@@ -464,7 +464,7 @@ class WP_REST_Menus_Controller extends WP_REST_Terms_Controller {
 	 * replicates the behavior of `wp_nav_menu_update_menu_items`
 	 * in `src/wp-admin/includes/nav-menu.php`.
 	 *
-	 * @param int             $term The menu id to update the location form.
+	 * @param int             $menu_id The menu id to update the location form.
 	 * @param WP_REST_Request $request The request object with menu and locations data.
 	 *
 	 * @return Boolean|Null   Return the value of auto_add or null if the auto_add

--- a/packages/edit-navigation/src/components/navigation-editor/block-editor-area.js
+++ b/packages/edit-navigation/src/components/navigation-editor/block-editor-area.js
@@ -13,9 +13,10 @@ import {
 	ObserveTyping,
 	WritingFlow,
 } from '@wordpress/block-editor';
-import { useEffect } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 import {
 	Button,
+	CheckboxControl,
 	Card,
 	CardHeader,
 	CardBody,
@@ -56,6 +57,16 @@ export default function BlockEditorArea( {
 		},
 		[]
 	);
+	const { saveMenu } = useDispatch( 'core' );
+	const menu = useSelect( ( select ) => select( 'core' ).getMenu( menuId ), [
+		menuId,
+	] );
+
+	const [ autoAddPages, setAutoAddPages ] = useState( menu.auto_add );
+
+	useEffect( () => {
+		setAutoAddPages( menu.auto_add );
+	}, [ menuId ] );
 
 	// Select the navigation block when it becomes available
 	const { selectBlock } = useDispatch( 'core/block-editor' );
@@ -96,6 +107,22 @@ export default function BlockEditorArea( {
 				</WritingFlow>
 			</CardBody>
 			<CardFooter>
+				<CheckboxControl
+					label={ __(
+						'Automatically add new top-level pages to this menu'
+					) }
+					help={ __(
+						'New menu items will automatically appear in this menu as new top level pages are added to your site'
+					) }
+					onChange={ async () => {
+						setAutoAddPages( ! autoAddPages );
+						saveMenu( {
+							...menu,
+							auto_add: ! autoAddPages,
+						} );
+					} }
+					checked={ autoAddPages }
+				/>
 				<DeleteMenuButton menuId={ menuId } onDelete={ onDeleteMenu } />
 			</CardFooter>
 		</Card>

--- a/packages/edit-navigation/src/components/navigation-editor/block-editor-area.js
+++ b/packages/edit-navigation/src/components/navigation-editor/block-editor-area.js
@@ -13,14 +13,14 @@ import {
 	ObserveTyping,
 	WritingFlow,
 } from '@wordpress/block-editor';
-import { useState, useEffect } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import {
 	Button,
-	CheckboxControl,
 	Card,
 	CardHeader,
 	CardBody,
 	CardFooter,
+	CheckboxControl,
 	Popover,
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -57,15 +57,18 @@ export default function BlockEditorArea( {
 		},
 		[]
 	);
+
 	const { saveMenu } = useDispatch( 'core' );
 	const menu = useSelect( ( select ) => select( 'core' ).getMenu( menuId ), [
 		menuId,
 	] );
 
-	const [ autoAddPages, setAutoAddPages ] = useState( menu.auto_add );
+	const [ autoAddPages, setAutoAddPages ] = useState( false );
 
 	useEffect( () => {
-		setAutoAddPages( menu.auto_add );
+		if ( menu ) {
+			setAutoAddPages( menu.auto_add );
+		}
 	}, [ menuId ] );
 
 	// Select the navigation block when it becomes available

--- a/packages/edit-navigation/src/components/navigation-editor/index.js
+++ b/packages/edit-navigation/src/components/navigation-editor/index.js
@@ -72,7 +72,7 @@ function NavigationPostEditor( { post, blockEditorSettings, onDeleteMenu } ) {
 			/>
 			<BlockEditorArea
 				saveBlocks={ save }
-				menuId={ post.menuId }
+				menuId={ post.meta.menuId }
 				onDeleteMenu={ onDeleteMenu }
 			/>
 		</BlockEditorProvider>

--- a/phpunit/class-rest-nav-menus-controller-test.php
+++ b/phpunit/class-rest-nav-menus-controller-test.php
@@ -53,7 +53,7 @@ class REST_Nav_Menus_Controller_Test extends WP_Test_REST_Controller_Testcase {
 				'role' => 'administrator',
 			)
 		);
-		self::$editor_id      = $factory->user->create(
+		self::$editor_id     = $factory->user->create(
 			array(
 				'role' => 'editor',
 			)
@@ -343,7 +343,7 @@ class REST_Nav_Menus_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	 *
 	 */
 	public function test_create_item_with_auto_add_permission_incorrect() {
-		wp_set_current_user( self::$editor_id  );
+		wp_set_current_user( self::$editor_id );
 		$request = new WP_REST_Request( 'POST', '/__experimental/menus' );
 		$request->set_param( 'name', 'My Awesome Term' );
 		$request->set_param( 'slug', 'so-awesome' );

--- a/phpunit/class-rest-nav-menus-controller-test.php
+++ b/phpunit/class-rest-nav-menus-controller-test.php
@@ -216,6 +216,7 @@ class REST_Nav_Menus_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request = new WP_REST_Request( 'POST', '/__experimental/menus/' . $this->menu_id );
 		$request->set_param( 'name', 'New Name' );
 		$request->set_param( 'description', 'New Description' );
+		$request->set_param( 'auto_add', true );
 		$request->set_param(
 			'meta',
 			array(
@@ -227,6 +228,7 @@ class REST_Nav_Menus_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$data = $response->get_data();
 		$this->assertEquals( 'New Name', $data['name'] );
 		$this->assertEquals( 'New Description', $data['description'] );
+		$this->assertEquals( true, $data['auto_add'] );
 		$this->assertEquals( 'new-name', $data['slug'] );
 		$this->assertEquals( 'just meta', $data['meta']['test_single_menu'] );
 		$this->assertFalse( isset( $data['meta']['test_cat_meta'] ) );
@@ -286,7 +288,7 @@ class REST_Nav_Menus_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$response   = rest_get_server()->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertEquals( 6, count( $properties ) );
+		$this->assertEquals( 7, count( $properties ) );
 		$this->assertArrayHasKey( 'id', $properties );
 		$this->assertArrayHasKey( 'description', $properties );
 		$this->assertArrayHasKey( 'meta', $properties );

--- a/phpunit/class-rest-nav-menus-controller-test.php
+++ b/phpunit/class-rest-nav-menus-controller-test.php
@@ -332,6 +332,20 @@ class REST_Nav_Menus_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	/**
 	 *
 	 */
+	public function test_create_item_with_auto_add_permission_incorrect() {
+		wp_set_current_user( self::$subscriber_id );
+		$request = new WP_REST_Request( 'POST', '/__experimental/menus' );
+		$request->set_param( 'name', 'My Awesome Term' );
+		$request->set_param( 'slug', 'so-awesome' );
+		$request->set_param( 'auto_add', true );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertEquals( rest_authorization_required_code(), $response->get_status() );
+		$this->assertErrorResponse( 'rest_cannot_set_auto_add', $response, rest_authorization_required_code() );
+	}
+
+	/**
+	 *
+	 */
 	public function test_create_item_with_location_permission_no_location() {
 		wp_set_current_user( self::$admin_id );
 		$request = new WP_REST_Request( 'POST', '/__experimental/menus' );

--- a/phpunit/class-rest-nav-menus-controller-test.php
+++ b/phpunit/class-rest-nav-menus-controller-test.php
@@ -25,6 +25,11 @@ class REST_Nav_Menus_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	/**
 	 * @var int
 	 */
+	protected static $editor_id;
+
+	/**
+	 * @var int
+	 */
 	protected static $subscriber_id;
 
 	/**
@@ -46,6 +51,11 @@ class REST_Nav_Menus_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		self::$admin_id      = $factory->user->create(
 			array(
 				'role' => 'administrator',
+			)
+		);
+		self::$editor_id      = $factory->user->create(
+			array(
+				'role' => 'editor',
 			)
 		);
 		self::$subscriber_id = $factory->user->create(
@@ -319,7 +329,7 @@ class REST_Nav_Menus_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	 *
 	 */
 	public function test_create_item_with_location_permission_incorrect() {
-		wp_set_current_user( self::$subscriber_id );
+		wp_set_current_user( self::$editor_id );
 		$request = new WP_REST_Request( 'POST', '/__experimental/menus' );
 		$request->set_param( 'name', 'My Awesome Term' );
 		$request->set_param( 'slug', 'so-awesome' );
@@ -333,7 +343,7 @@ class REST_Nav_Menus_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	 *
 	 */
 	public function test_create_item_with_auto_add_permission_incorrect() {
-		wp_set_current_user( self::$subscriber_id );
+		wp_set_current_user( self::$editor_id  );
 		$request = new WP_REST_Request( 'POST', '/__experimental/menus' );
 		$request->set_param( 'name', 'My Awesome Term' );
 		$request->set_param( 'slug', 'so-awesome' );


### PR DESCRIPTION
Closes #21311

## Description
This PR adds a new `auto_add` property to the `__experimental/menus` REST endpoint. This property is the same as the one in the current `wp_nav_menu_update_menu_items`.

It also adds a checkbox to each menu that sets `auto_add`

## How has this been tested?
Tested locally by:
1. Enable the navigation screen experiment
2. Select a menu
3. Check the "Automatically add new top-level pages to this menu" option
4. Go to the old `nav-menus.php`
5. Check that the option is set

## Screenshots <!-- if applicable -->
![auto-add](https://user-images.githubusercontent.com/107534/83128683-6e324f80-a0e4-11ea-96c4-a528b170cdc6.gif)

## Types of changes
Non breaking changes, adds `auto_add` to the schema of Menu and a checkbox with state to the `BlockEditorPanel` component.

cc @TimothyBJacobs @spacedmonkey 