### PR TITLE
Support disabled prop in ToggleControl, QueryControls

### DIFF
--- a/packages/components/src/query-controls/index.js
+++ b/packages/components/src/query-controls/index.js
@@ -24,6 +24,7 @@ export default function QueryControls( {
 	onNumberOfItemsChange,
 	onOrderChange,
 	onOrderByChange,
+	disabled,
 } ) {
 	return [
 		onOrderChange && onOrderByChange && (
@@ -60,6 +61,7 @@ export default function QueryControls( {
 						onOrderByChange( newOrderBy );
 					}
 				} }
+				disabled={ disabled }
 			/>
 		),
 		onCategoryChange && (
@@ -75,6 +77,7 @@ export default function QueryControls( {
 				suggestions={ Object.keys( categorySuggestions ) }
 				onChange={ onCategoryChange }
 				maxSuggestions={ MAX_CATEGORIES_SUGGESTIONS }
+				disabled={ disabled }
 			/>
 		),
 
@@ -87,6 +90,7 @@ export default function QueryControls( {
 				min={ minItems }
 				max={ maxItems }
 				required
+				disabled={ disabled }
 			/>
 		),
 	];

--- a/packages/components/src/toggle-control/index.js
+++ b/packages/components/src/toggle-control/index.js
@@ -30,7 +30,14 @@ class ToggleControl extends Component {
 	}
 
 	render() {
-		const { label, checked, help, instanceId, className } = this.props;
+		const {
+			label,
+			checked,
+			help,
+			instanceId,
+			className,
+			disabled,
+		} = this.props;
 		const id = `inspector-toggle-control-${ instanceId }`;
 
 		let describedBy, helpLabel;
@@ -45,6 +52,9 @@ class ToggleControl extends Component {
 				help={ helpLabel }
 				className={ classnames(
 					'components-toggle-control',
+					{
+						'is-disabled': disabled,
+					},
 					className
 				) }
 			>
@@ -53,6 +63,7 @@ class ToggleControl extends Component {
 					checked={ checked }
 					onChange={ this.onChange }
 					aria-describedby={ describedBy }
+					disabled={ disabled }
 				/>
 				<label
 					htmlFor={ id }

--- a/packages/components/src/toggle-control/stories/index.js
+++ b/packages/components/src/toggle-control/stories/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { text } from '@storybook/addon-knobs';
+import { text, boolean } from '@storybook/addon-knobs';
 
 /**
  * WordPress dependencies
@@ -18,6 +18,7 @@ export default { title: 'Components/ToggleControl', component: ToggleControl };
 const ToggleControlWithState = ( {
 	helpTextChecked,
 	helpTextUnchecked,
+	forceChecked,
 	...props
 } ) => {
 	const [ hasFixedBackground, setHasFixedBackground ] = useState( true );
@@ -25,7 +26,9 @@ const ToggleControlWithState = ( {
 		<ToggleControl
 			{ ...props }
 			help={ hasFixedBackground ? helpTextChecked : helpTextUnchecked }
-			checked={ hasFixedBackground }
+			checked={
+				forceChecked === undefined ? hasFixedBackground : forceChecked
+			}
 			onChange={ setHasFixedBackground }
 		/>
 	);
@@ -53,6 +56,19 @@ export const withHelpText = () => {
 			label={ label }
 			helpTextChecked={ helpTextChecked }
 			helpTextUnchecked={ helpTextUnchecked }
+		/>
+	);
+};
+
+export const disabled = () => {
+	const label = text( 'Label', 'Does this have a fixed background?' );
+	const forceChecked = boolean( 'Checked', true );
+
+	return (
+		<ToggleControlWithState
+			disabled
+			forceChecked={ forceChecked }
+			label={ label }
 		/>
 	);
 };

--- a/packages/components/src/toggle-control/style.scss
+++ b/packages/components/src/toggle-control/style.scss
@@ -1,14 +1,26 @@
-.components-toggle-control .components-base-control__field {
-	display: flex;
-	margin-bottom: $grid-unit-05 * 3;
-	line-height: initial;
-	align-items: center;
-
-	.components-form-toggle {
-		margin-right: $grid-unit-20;
+.components-toggle-control {
+	&.is-disabled {
+		.components-form-toggle__thumb,
+		.components-form-toggle .components-form-toggle__track {
+			background: $light-gray-500;
+			border-color: $light-gray-900;
+		}
+		svg {
+			color: $light-gray-900;
+		}
 	}
+	.components-base-control__field {
+		display: flex;
+		margin-bottom: $grid-unit-05 * 3;
+		line-height: initial;
+		align-items: center;
 
-	.components-toggle-control__label {
-		display: block;
+		.components-form-toggle {
+			margin-right: $grid-unit-20;
+		}
+
+		.components-toggle-control__label {
+			display: block;
+		}
 	}
 }


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Added support for `disabled` prop in `QueryControls`, `ToggleControl` components.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Added a Storybook story for `ToggleControl`. Tested locally.

## Screenshots <!-- if applicable -->

![image](https://user-images.githubusercontent.com/7383192/83133391-16471900-a0e3-11ea-9d1e-4ec133e81634.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
