### PR TITLE
Icons: Fix package references

### DIFF
--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -25,8 +25,8 @@
 	"types": "build-types",
 	"dependencies": {
 		"@babel/runtime": "^7.9.2",
-		"@wordpress/element": "../element",
-		"@wordpress/primitives": "../primitives"
+		"@wordpress/element": "file:../element",
+		"@wordpress/primitives": "file:../primitives"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/icons/tsconfig.json
+++ b/packages/icons/tsconfig.json
@@ -5,5 +5,5 @@
 		"declarationDir": "build-types"
 	},
 	"include": [ "src/**/*" ],
-	"references": [ { "path": "../primitives" } ]
+	"references": [ { "path": "../element" }, { "path": "../primitives" } ]
 }


### PR DESCRIPTION
## Description

The icons package was using `../` monorepo dependencies. These should be prefixed by `file:` as other packages do.

Add the `file:` prefix to monorepo dependencies.
Add missing `element` reference in the icons `tsconfig`.

Noticed by @jameskoster 

## How has this been tested?
The build continues to work as expected.