### PR TITLE
Fix plus.

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/style.scss
+++ b/packages/block-editor/src/components/block-list-appender/style.scss
@@ -11,6 +11,7 @@
 
 	// Animate appearance.
 	.block-list-appender__toggle {
+		padding: 0;
 		opacity: 1;
 		transform: scale(1);
 		transition: all 0.1s ease;

--- a/packages/block-editor/src/components/button-block-appender/index.js
+++ b/packages/block-editor/src/components/button-block-appender/index.js
@@ -9,7 +9,7 @@ import classnames from 'classnames';
 import { Button, Tooltip, VisuallyHidden } from '@wordpress/components';
 import { forwardRef } from '@wordpress/element';
 import { _x, sprintf } from '@wordpress/i18n';
-import { Icon, create } from '@wordpress/icons';
+import { Icon, plus } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -71,7 +71,7 @@ function ButtonBlockAppender(
 						{ ! hasSingleBlockType && (
 							<VisuallyHidden as="span">{ label }</VisuallyHidden>
 						) }
-						<Icon icon={ create } />
+						<Icon icon={ plus } />
 						{ hasSingleBlockType && (
 							<span className="block-editor-button-block-appender__label">
 								{ label }{ ' ' }


### PR DESCRIPTION
The plus in Buttons, Social Links, and Navigation regressed:

<img width="257" alt="Screenshot 2020-05-28 at 13 21 06" src="https://user-images.githubusercontent.com/1204802/83136131-41cc0280-a0e7-11ea-947a-183b8d7c0a42.png">

<img width="137" alt="Screenshot 2020-05-28 at 12 47 06" src="https://user-images.githubusercontent.com/1204802/83136141-442e5c80-a0e7-11ea-818a-416afde35d1e.png">

This fixes that:

<img width="320" alt="Screenshot 2020-05-28 at 13 29 53" src="https://user-images.githubusercontent.com/1204802/83136177-54463c00-a0e7-11ea-8a73-0948b80917f7.png">

However there's one niggle. We use the same component for the appender in buttons/sociallinks/navigation, as we do for the big generic appender in columns. The latter we intentionally changed to use the smaller plus button, the icon called `create`. This PR actually regesses that, so both of those use the same icon:

<img width="992" alt="Screenshot 2020-05-28 at 13 28 38" src="https://user-images.githubusercontent.com/1204802/83136266-793aaf00-a0e7-11ea-98d1-3eb37c14aee9.png">

I couldn't immediately figure out how to serve one or the other depending on whether it was the big white background version, or the small black version. Input appreciated. 