### PR TITLE
Add support for page=1 and perPage=-1 to getMergedItemIds

### DIFF
--- a/packages/core-data/src/queried-data/reducer.js
+++ b/packages/core-data/src/queried-data/reducer.js
@@ -33,6 +33,9 @@ import getQueryParts from './get-query-parts';
  */
 export function getMergedItemIds( itemIds, nextItemIds, page, perPage ) {
 	const receivedAllIds = page === 1 && perPage === -1;
+	if ( receivedAllIds ) {
+		return nextItemIds;
+	}
 	const nextItemIdsStartIndex = ( page - 1 ) * perPage;
 
 	// If later page has already been received, default to the larger known
@@ -47,9 +50,8 @@ export function getMergedItemIds( itemIds, nextItemIds, page, perPage ) {
 
 	for ( let i = 0; i < size; i++ ) {
 		const isInNextItemsRange =
-			receivedAllIds ||
-			( i >= nextItemIdsStartIndex &&
-				i < nextItemIdsStartIndex + nextItemIds.length );
+			i >= nextItemIdsStartIndex &&
+			i < nextItemIdsStartIndex + nextItemIds.length;
 
 		mergedItemIds[ i ] = isInNextItemsRange
 			? nextItemIds[ i - nextItemIdsStartIndex ]

--- a/packages/core-data/src/queried-data/reducer.js
+++ b/packages/core-data/src/queried-data/reducer.js
@@ -34,7 +34,7 @@ import getQueryParts from './get-query-parts';
 export function getMergedItemIds( itemIds, nextItemIds, page, perPage ) {
 	const receivedAllIds = page === 1 && perPage === -1;
 	if ( receivedAllIds ) {
-		return nextItemIds;
+		return [ ...nextItemIds ];
 	}
 	const nextItemIdsStartIndex = ( page - 1 ) * perPage;
 

--- a/packages/core-data/src/queried-data/reducer.js
+++ b/packages/core-data/src/queried-data/reducer.js
@@ -34,7 +34,7 @@ import getQueryParts from './get-query-parts';
 export function getMergedItemIds( itemIds, nextItemIds, page, perPage ) {
 	const receivedAllIds = page === 1 && perPage === -1;
 	if ( receivedAllIds ) {
-		return [ ...nextItemIds ];
+		return nextItemIds;
 	}
 	const nextItemIdsStartIndex = ( page - 1 ) * perPage;
 
@@ -49,6 +49,7 @@ export function getMergedItemIds( itemIds, nextItemIds, page, perPage ) {
 	const mergedItemIds = new Array( size );
 
 	for ( let i = 0; i < size; i++ ) {
+		// Preserve existing item ID except for subset of range of next items.
 		const isInNextItemsRange =
 			i >= nextItemIdsStartIndex &&
 			i < nextItemIdsStartIndex + nextItemIds.length;

--- a/packages/core-data/src/queried-data/reducer.js
+++ b/packages/core-data/src/queried-data/reducer.js
@@ -32,6 +32,7 @@ import getQueryParts from './get-query-parts';
  * @return {number[]} Merged array of item IDs.
  */
 export function getMergedItemIds( itemIds, nextItemIds, page, perPage ) {
+	const receivedAllIds = page === 1 && perPage === -1;
 	const nextItemIdsStartIndex = ( page - 1 ) * perPage;
 
 	// If later page has already been received, default to the larger known
@@ -45,10 +46,10 @@ export function getMergedItemIds( itemIds, nextItemIds, page, perPage ) {
 	const mergedItemIds = new Array( size );
 
 	for ( let i = 0; i < size; i++ ) {
-		// Preserve existing item ID except for subset of range of next items.
 		const isInNextItemsRange =
-			i >= nextItemIdsStartIndex &&
-			i < nextItemIdsStartIndex + nextItemIds.length;
+			receivedAllIds ||
+			( i >= nextItemIdsStartIndex &&
+				i < nextItemIdsStartIndex + nextItemIds.length );
 
 		mergedItemIds[ i ] = isInNextItemsRange
 			? nextItemIds[ i - nextItemIdsStartIndex ]

--- a/packages/core-data/src/queried-data/test/reducer.js
+++ b/packages/core-data/src/queried-data/test/reducer.js
@@ -54,7 +54,7 @@ describe( 'getMergedItemIds', () => {
 		const original = deepFreeze( [ 1, 2, 3 ] );
 		const result = getMergedItemIds( original, [ 1, 3 ], 1, -1 );
 
-		expect( result ).toEqual( [ 1, 3, undefined ] );
+		expect( result ).toEqual( [ 1, 3 ] );
 	} );
 
 	it( 'should replace with nextItemIds if it represents all ids (page=1 and perPage=-1)', () => {

--- a/packages/core-data/src/queried-data/test/reducer.js
+++ b/packages/core-data/src/queried-data/test/reducer.js
@@ -49,6 +49,13 @@ describe( 'getMergedItemIds', () => {
 
 		expect( result ).toEqual( [ 1, 2, 3, 4, 5, 6, 7 ] );
 	} );
+
+	it( 'should return less items if nextItemIds represent all ids (page=1 and perPage=-1)', () => {
+		const original = deepFreeze( [ 1, 2, 3 ] );
+		const result = getMergedItemIds( original, [ 1, 3 ], 1, -1 );
+
+		expect( result ).toEqual( [ 1, 3, undefined ] );
+	} );
 } );
 
 describe( 'reducer', () => {

--- a/packages/core-data/src/queried-data/test/reducer.js
+++ b/packages/core-data/src/queried-data/test/reducer.js
@@ -50,11 +50,18 @@ describe( 'getMergedItemIds', () => {
 		expect( result ).toEqual( [ 1, 2, 3, 4, 5, 6, 7 ] );
 	} );
 
-	it( 'should return less items if nextItemIds represent all ids (page=1 and perPage=-1)', () => {
+	it( 'should replace missing ids with undefined if nextItemIds is a subset of itemIds and represents all ids (page=1 and perPage=-1)', () => {
 		const original = deepFreeze( [ 1, 2, 3 ] );
 		const result = getMergedItemIds( original, [ 1, 3 ], 1, -1 );
 
 		expect( result ).toEqual( [ 1, 3, undefined ] );
+	} );
+
+	it( 'should replace with nextItemIds if it represents all ids (page=1 and perPage=-1)', () => {
+		const original = deepFreeze( [ 1, 2, 3 ] );
+		const result = getMergedItemIds( original, [ 1, 3, 4 ], 1, -1 );
+
+		expect( result ).toEqual( [ 1, 3, 4 ] );
 	} );
 } );
 

--- a/packages/core-data/src/queried-data/test/reducer.js
+++ b/packages/core-data/src/queried-data/test/reducer.js
@@ -52,16 +52,14 @@ describe( 'getMergedItemIds', () => {
 
 	it( 'should return a copy of nextItemIds if it represents all ids (single id removed) (page=1 and perPage=-1)', () => {
 		const original = deepFreeze( [ 1, 2, 3 ] );
-		const nextItemIds = [ 1, 3 ];
-		const result = getMergedItemIds( original, nextItemIds, 1, -1 );
+		const result = getMergedItemIds( original, [ 1, 3 ], 1, -1 );
 
 		expect( result ).toEqual( [ 1, 3 ] );
 	} );
 
 	it( 'should return a copy of nextItemIds if it represents all ids (single id removed and another one added) (page=1 and perPage=-1)', () => {
 		const original = deepFreeze( [ 1, 2, 3 ] );
-		const nextItemIds = [ 1, 3, 4 ];
-		const result = getMergedItemIds( original, nextItemIds, 1, -1 );
+		const result = getMergedItemIds( original, [ 1, 3, 4 ], 1, -1 );
 
 		expect( result ).toEqual( [ 1, 3, 4 ] );
 	} );

--- a/packages/core-data/src/queried-data/test/reducer.js
+++ b/packages/core-data/src/queried-data/test/reducer.js
@@ -50,14 +50,14 @@ describe( 'getMergedItemIds', () => {
 		expect( result ).toEqual( [ 1, 2, 3, 4, 5, 6, 7 ] );
 	} );
 
-	it( 'should replace missing ids with undefined if nextItemIds is a subset of itemIds and represents all ids (page=1 and perPage=-1)', () => {
+	it( 'should return nextItemIds if it represents all ids (single id removed) (page=1 and perPage=-1)', () => {
 		const original = deepFreeze( [ 1, 2, 3 ] );
 		const result = getMergedItemIds( original, [ 1, 3 ], 1, -1 );
 
 		expect( result ).toEqual( [ 1, 3 ] );
 	} );
 
-	it( 'should replace with nextItemIds if it represents all ids (page=1 and perPage=-1)', () => {
+	it( 'should return nextItemIds if it represents all ids (single id removed and another one added) (page=1 and perPage=-1)', () => {
 		const original = deepFreeze( [ 1, 2, 3 ] );
 		const result = getMergedItemIds( original, [ 1, 3, 4 ], 1, -1 );
 

--- a/packages/core-data/src/queried-data/test/reducer.js
+++ b/packages/core-data/src/queried-data/test/reducer.js
@@ -56,7 +56,6 @@ describe( 'getMergedItemIds', () => {
 		const result = getMergedItemIds( original, nextItemIds, 1, -1 );
 
 		expect( result ).toEqual( [ 1, 3 ] );
-		expect( result ).not.toBe( nextItemIds );
 	} );
 
 	it( 'should return a copy of nextItemIds if it represents all ids (single id removed and another one added) (page=1 and perPage=-1)', () => {
@@ -65,7 +64,6 @@ describe( 'getMergedItemIds', () => {
 		const result = getMergedItemIds( original, nextItemIds, 1, -1 );
 
 		expect( result ).toEqual( [ 1, 3, 4 ] );
-		expect( result ).not.toBe( nextItemIds );
 	} );
 } );
 

--- a/packages/core-data/src/queried-data/test/reducer.js
+++ b/packages/core-data/src/queried-data/test/reducer.js
@@ -50,18 +50,22 @@ describe( 'getMergedItemIds', () => {
 		expect( result ).toEqual( [ 1, 2, 3, 4, 5, 6, 7 ] );
 	} );
 
-	it( 'should return nextItemIds if it represents all ids (single id removed) (page=1 and perPage=-1)', () => {
+	it( 'should return a copy of nextItemIds if it represents all ids (single id removed) (page=1 and perPage=-1)', () => {
 		const original = deepFreeze( [ 1, 2, 3 ] );
-		const result = getMergedItemIds( original, [ 1, 3 ], 1, -1 );
+		const nextItemIds = [ 1, 3 ];
+		const result = getMergedItemIds( original, nextItemIds, 1, -1 );
 
 		expect( result ).toEqual( [ 1, 3 ] );
+		expect( result ).not.toBe( nextItemIds );
 	} );
 
-	it( 'should return nextItemIds if it represents all ids (single id removed and another one added) (page=1 and perPage=-1)', () => {
+	it( 'should return a copy of nextItemIds if it represents all ids (single id removed and another one added) (page=1 and perPage=-1)', () => {
 		const original = deepFreeze( [ 1, 2, 3 ] );
-		const result = getMergedItemIds( original, [ 1, 3, 4 ], 1, -1 );
+		const nextItemIds = [ 1, 3, 4 ];
+		const result = getMergedItemIds( original, nextItemIds, 1, -1 );
 
 		expect( result ).toEqual( [ 1, 3, 4 ] );
+		expect( result ).not.toBe( nextItemIds );
 	} );
 } );
 


### PR DESCRIPTION
## Description

`getMergedItemIds()` does not handle a scenario where `perPage = -1` (nextItemIds are all ids from all pages). This results in the following issue:

```
# getMergedItemIds( [1, 2, 3], [ 1, 3 ], 1, -1 );
[1, 3, 3]
```

A practical consequence of this is that dispatching `receiveEntityRecords` with data similar to these:

```js
{
    kind: "root",
    name: "menuItem",
    type: "RECEIVE_ITEMS",
    items: [ /*... less items than currently in the state ...*/ ],
    menus: 2,
    per_page: -1
}
```

Updates the state in such a way that `entities.data.menuItem.queriedData.queries["menus=2"]` contains duplicate entries like `[1, 2, 3, 2, 3]`. This in turn causes a `select()` call to return duplicate results.

## How has this been tested?
Confirm all unit and e2e tests pass

## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [ ] My code is tested (Tested with #22603 but Travis is still running).
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: htpts://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
