### PR TITLE
[RNMobile] Correct concatenation in Button block merge function

### DIFF
--- a/packages/block-library/src/button/edit.native.js
+++ b/packages/block-library/src/button/edit.native.js
@@ -477,7 +477,7 @@ class ButtonEdit extends Component {
 						placeholderTextColor={
 							styles.placeholderTextColor.color
 						}
-						identifier="content"
+						identifier="text"
 						tagName="p"
 						minWidth={ minWidth }
 						maxWidth={ maxWidth }

--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -39,6 +39,6 @@ export const settings = {
 	deprecated,
 	merge: ( a, { text = '' } ) => ( {
 		...a,
-		text: a.text + text,
+		text: ( a.text || '' ) + text,
 	} ),
 };


### PR DESCRIPTION
## Description

Fixes crash in mobile `Buttons` block:
`Once removing the text from second Button on build app getting undefined in the previous button / on develop there is crash`

More details in [comment](https://github.com/wordpress-mobile/gutenberg-mobile/pull/2321#issuecomment-635276561).

Ref to gutenberg mobile: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2332

## How has this been tested?

1. Open mobile app
2. Add `Buttons` block
3. Press inserter
4. Remove `Button` using `backspace` on mobile keyboard
5. Expect `Button` is removed and the previous one is selected
6. Expect `Button` is empty
7. Expect no crash

## Screenshots <!-- if applicable -->

before | after
--- | ---
![bug_two](https://user-images.githubusercontent.com/22746080/83149041-f1aa6b80-a0f9-11ea-9741-fc05899c9796.gif) | ![ok](https://user-images.githubusercontent.com/22746080/83149419-54036c00-a0fa-11ea-8047-54f286d00e5f.gif)


## Types of changes

Correct the concatenation in `merge` function in `button/index.js` and added a fallback for `a.text` which can be `undefined` what currently is resulting in `undefined + '' = 'undefined'`

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
