### PR TITLE
[RNMobile] Fix footer appender in buttons block

### DIFF
--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -50,7 +50,10 @@ const getStyles = (
 export class BlockList extends Component {
 	constructor() {
 		super( ...arguments );
-
+		this.extraData = {
+			parentWidth: this.props.parentWidth,
+			renderFooterAppender: this.props.renderFooterAppender,
+		};
 		this.renderItem = this.renderItem.bind( this );
 		this.renderBlockListFooter = this.renderBlockListFooter.bind( this );
 		this.onCaretVerticalPositionChange = this.onCaretVerticalPositionChange.bind(
@@ -65,6 +68,7 @@ export class BlockList extends Component {
 			this
 		);
 		this.renderEmptyList = this.renderEmptyList.bind( this );
+		this.getExtraData = this.getExtraData.bind( this );
 	}
 
 	addBlockToEndOfPost( newBlock ) {
@@ -102,6 +106,20 @@ export class BlockList extends Component {
 		);
 	}
 
+	getExtraData() {
+		if (
+			this.extraData.parentWidth !== this.props.parentWidth ||
+			this.extraData.renderFooterAppender !==
+				this.props.renderFooterAppender
+		) {
+			this.extraData = {
+				parentWidth: this.props.parentWidth,
+				renderFooterAppender: this.props.renderFooterAppender,
+			};
+		}
+		return this.extraData;
+	}
+
 	render() {
 		const { isRootList } = this.props;
 		// Use of Context to propagate the main scroll ref to its children e.g InnerBlocks
@@ -134,7 +152,6 @@ export class BlockList extends Component {
 			isFloatingToolbarVisible,
 			isStackedHorizontally,
 			horizontalAlignment,
-			parentWidth,
 		} = this.props;
 		const { parentScrollRef } = extraProps;
 
@@ -180,7 +197,7 @@ export class BlockList extends Component {
 						! isRootList && styles.overflowVisible,
 					] }
 					horizontal={ horizontal }
-					extraData={ parentWidth }
+					extraData={ this.getExtraData() }
 					scrollEnabled={ isRootList }
 					contentContainerStyle={
 						horizontal && styles.horizontalContentContainer

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -107,14 +107,14 @@ export class BlockList extends Component {
 	}
 
 	getExtraData() {
+		const { parentWidth, renderFooterAppender } = this.props;
 		if (
-			this.extraData.parentWidth !== this.props.parentWidth ||
-			this.extraData.renderFooterAppender !==
-				this.props.renderFooterAppender
+			this.extraData.parentWidth !== parentWidth ||
+			this.extraData.renderFooterAppender !== renderFooterAppender
 		) {
 			this.extraData = {
-				parentWidth: this.props.parentWidth,
-				renderFooterAppender: this.props.renderFooterAppender,
+				parentWidth,
+				renderFooterAppender,
 			};
 		}
 		return this.extraData;

--- a/packages/block-library/src/button/editor.native.scss
+++ b/packages/block-library/src/button/editor.native.scss
@@ -48,3 +48,8 @@
 	font-size: 16px;
 	display: none;
 }
+
+.linkSettingsPanel {
+	padding-left: 0;
+	padding-right: 0;
+}

--- a/packages/block-library/src/buttons/edit.native.js
+++ b/packages/block-library/src/buttons/edit.native.js
@@ -12,7 +12,7 @@ import {
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose, useResizeObserver } from '@wordpress/compose';
 import { createBlock } from '@wordpress/blocks';
-import { useState, useEffect } from '@wordpress/element';
+import { useState, useEffect, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -45,16 +45,14 @@ function ButtonsEdit( {
 		}
 	}, [ sizes ] );
 
-	function renderFooterAppender() {
-		return (
-			<View style={ styles.appenderContainer }>
-				<InnerBlocks.ButtonBlockAppender
-					isFloating={ true }
-					onAddBlock={ onAddNextButton }
-				/>
-			</View>
-		);
-	}
+	const renderFooterAppender = useRef( () => (
+		<View style={ styles.appenderContainer }>
+			<InnerBlocks.ButtonBlockAppender
+				isFloating={ true }
+				onAddBlock={ onAddNextButton }
+			/>
+		</View>
+	) );
 
 	// Inside buttons block alignment options are not supported.
 	const alignmentHooksSetting = {
@@ -68,7 +66,7 @@ function ButtonsEdit( {
 				allowedBlocks={ ALLOWED_BLOCKS }
 				template={ BUTTONS_TEMPLATE }
 				renderFooterAppender={
-					shouldRenderFooterAppender && renderFooterAppender
+					shouldRenderFooterAppender && renderFooterAppender.current
 				}
 				__experimentalMoverDirection="horizontal"
 				horizontalAlignment={ align }


### PR DESCRIPTION
## Description
gutenberg-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2331

In this PR i fixed the issue with the appender in Buttons block. Since the FooterComponent od flatList is a pure component the list didn't re-render when props of block-list have changed. I added a `renderFooterAppender` function to the extra data and saved the extraData to a class property to not pass a new reference on every render. I also had to add `useRef` in the `buttons/edit.native.js` to not create the function on every render which was forcing to re-render of the whole list.

See https://github.com/wordpress-mobile/gutenberg-mobile/pull/2321#issuecomment-635276561

In addition, I fixed one small issue with padding in the link settings of the button block.

## How has this been tested?
- Add buttons block
- Unselect the buttons block
- The appender should not be visible

## Screenshots
![appenderbuttons](https://user-images.githubusercontent.com/16336501/83154807-db53de00-a100-11ea-87ef-e3c4ffa91a15.gif)

## Types of changes
Fix of buttons appender

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
