### PR TITLE
Define end-to-end test experimental features utility as lifecycle helper

### DIFF
--- a/packages/e2e-tests/experimental-features.js
+++ b/packages/e2e-tests/experimental-features.js
@@ -27,19 +27,13 @@ async function setExperimentalFeaturesState( features, enable ) {
 }
 
 /**
- * Enables experimental features from the plugin settings section.
+ * Establishes test lifecycle to enable experimental feature for the duration of
+ * the grouped test block.
  *
- * @param {Array} features Array of {string} selectors of settings to enable. Assumes they can be enabled with one click.
+ * @param {Array} features Array of {string} selectors of settings to enable.
+ *                         Assumes they can be enabled with one click.
  */
-export async function enableExperimentalFeatures( features ) {
-	await setExperimentalFeaturesState( features, true );
-}
-
-/**
- * Disables experimental features from the plugin settings section.
- *
- * @param {Array} features Array of {string} selectors of settings to disable. Assumes they can be disabled with one click.
- */
-export async function disableExperimentalFeatures( features ) {
-	await setExperimentalFeaturesState( features, false );
+export function useExperimentalFeatures( features ) {
+	beforeAll( () => setExperimentalFeaturesState( features, true ) );
+	afterAll( () => setExperimentalFeaturesState( features, false ) );
 }

--- a/packages/e2e-tests/specs/experiments/block-directory-add.test.js
+++ b/packages/e2e-tests/specs/experiments/block-directory-add.test.js
@@ -11,7 +11,7 @@ import {
 /**
  * Internal dependencies
  */
-import { enableExperimentalFeatures } from '../../experimental-features';
+import { useExperimentalFeatures } from '../../experimental-features';
 
 // Urls to mock
 const SEARCH_URLS = [
@@ -119,8 +119,9 @@ const matchUrl = ( reqUrl, urls ) => {
 };
 
 describe( 'adding blocks from block directory', () => {
+	useExperimentalFeatures( [ '#gutenberg-block-directory' ] );
+
 	beforeEach( async () => {
-		await enableExperimentalFeatures( [ '#gutenberg-block-directory' ] );
 		await createNewPost();
 	} );
 

--- a/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
@@ -12,10 +12,7 @@ import { addQueryArgs } from '@wordpress/url';
 /**
  * Internal dependencies
  */
-import {
-	enableExperimentalFeatures,
-	disableExperimentalFeatures,
-} from '../../experimental-features';
+import { useExperimentalFeatures } from '../../experimental-features';
 import { trashExistingPosts } from '../../config/setup-test-framework';
 
 const visitSiteEditor = async () => {
@@ -172,24 +169,18 @@ const removeErrorMocks = () => {
 };
 
 describe( 'Multi-entity editor states', () => {
-	// Setup & Teardown.
-	const requiredExperiments = [
-		'#gutenberg-full-site-editing',
-		'#gutenberg-full-site-editing-demo',
-	];
-
 	const templatePartName = 'Test Template Part Name Edit';
 	const templateName = 'Test Template Name Edit';
 	const nestedTPName = 'Test Nested Template Part Name Edit';
 
+	useExperimentalFeatures( [
+		'#gutenberg-full-site-editing',
+		'#gutenberg-full-site-editing-demo',
+	] );
+
 	beforeAll( async () => {
-		await enableExperimentalFeatures( requiredExperiments );
 		await trashExistingPosts( 'wp_template' );
 		await trashExistingPosts( 'wp_template_part' );
-	} );
-
-	afterAll( async () => {
-		await disableExperimentalFeatures( requiredExperiments );
 	} );
 
 	it( 'should not display any dirty entities when loading the site editor', async () => {

--- a/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
@@ -12,10 +12,7 @@ import { addQueryArgs } from '@wordpress/url';
 /**
  * Internal dependencies
  */
-import {
-	enableExperimentalFeatures,
-	disableExperimentalFeatures,
-} from '../../experimental-features';
+import { useExperimentalFeatures } from '../../experimental-features';
 import { trashExistingPosts } from '../../config/setup-test-framework';
 
 describe( 'Multi-entity save flow', () => {
@@ -53,18 +50,15 @@ describe( 'Multi-entity save flow', () => {
 			expect( element ).toBeNull();
 		}
 	};
-	// Setup & Teardown.
-	const requiredExperiments = [
+
+	useExperimentalFeatures( [
 		'#gutenberg-full-site-editing',
 		'#gutenberg-full-site-editing-demo',
-	];
+	] );
+
 	beforeAll( async () => {
-		await enableExperimentalFeatures( requiredExperiments );
 		await trashExistingPosts( 'wp_template' );
 		await trashExistingPosts( 'wp_template_part' );
-	} );
-	afterAll( async () => {
-		await disableExperimentalFeatures( requiredExperiments );
 	} );
 
 	describe( 'Post Editor', () => {

--- a/packages/e2e-tests/specs/experiments/template-part.test.js
+++ b/packages/e2e-tests/specs/experiments/template-part.test.js
@@ -12,28 +12,22 @@ import { addQueryArgs } from '@wordpress/url';
 /**
  * Internal dependencies
  */
-import {
-	enableExperimentalFeatures,
-	disableExperimentalFeatures,
-} from '../../experimental-features';
+import { useExperimentalFeatures } from '../../experimental-features';
 import { trashExistingPosts } from '../../config/setup-test-framework';
 
 describe( 'Template Part', () => {
+	useExperimentalFeatures( [
+		'#gutenberg-full-site-editing',
+		'#gutenberg-full-site-editing-demo',
+	] );
+
 	beforeAll( async () => {
-		await enableExperimentalFeatures( [
-			'#gutenberg-full-site-editing',
-			'#gutenberg-full-site-editing-demo',
-		] );
 		await trashExistingPosts( 'wp_template' );
 		await trashExistingPosts( 'wp_template_part' );
 	} );
 	afterAll( async () => {
 		await trashExistingPosts( 'wp_template' );
 		await trashExistingPosts( 'wp_template_part' );
-		await disableExperimentalFeatures( [
-			'#gutenberg-full-site-editing',
-			'#gutenberg-full-site-editing-demo',
-		] );
 	} );
 
 	describe( 'Template part block', () => {


### PR DESCRIPTION
Related Slack conversation ([link requires registration](https://make.wordpress.org/chat/)): https://wordpress.slack.com/archives/C02QB2JS7/p1590677131416000

This pull request seeks to resolve intermittent failures of end-to-end tests, where the block directory end-to-end test suite does not currently tear down to reset experimental features to the initial state, causing subsequent tests run in the same container to unexpectedly run with the block directory experiment enabled. This causes builds to fail due to a related issue with ARIA attributes not being applied:

Example: https://travis-ci.com/github/WordPress/gutenberg/jobs/340966385

```
    Expected page to pass Axe accessibility tests.
    Violations found:
    Rule: "aria-required-attr" (Required ARIA attributes must be provided)
    Help: https://dequeuniversity.com/rules/axe/3.5/aria-required-attr?application=axe-puppeteer
    Affected Nodes:
      .block-directory-downloadable-block-header__title
        Fix ANY of the following:
        - Required ARIA attribute not present: aria-level
```

**Implementation Notes:**

The implementation here addresses this by encapsulating the entire lifecycle requirements of enabling experimental features into a single utility, thus avoiding the potential to overlook the need to provide a `afterEach` tear-down.

The idea here is to promote a pattern that in cases where something should be "activated" before and "deactivated" after a test is run, we should prefer to create a single utility which manages the full lifecycle of the behavior in a test. In this way, it behaves a lot like a [React Hook](https://reactjs.org/docs/hooks-intro.html).

Before:

```js
const requiredExperiments = [
	'#gutenberg-full-site-editing',
	'#gutenberg-full-site-editing-demo',
];

beforeAll( async () => {
	await enableExperimentalFeatures( requiredExperiments );
} );

// And _hopefully_:
// afterAll( async () => {
//	await disableExperimentalFeatures( requiredExperiments );
// } );
```

After:

```js
useExperimentalFeatures( [
	'#gutenberg-full-site-editing',
	'#gutenberg-full-site-editing-demo',
] );
```

**Testing Instructions:**

Ensure end-to-end tests pass:

```
npm run test-e2e packages/e2e-tests/specs/experiments/block-directory-add.test.js
```