### PR TITLE
Use semantic element for block directory download heading

### DIFF
--- a/packages/block-directory/src/components/downloadable-block-header/index.js
+++ b/packages/block-directory/src/components/downloadable-block-header/index.js
@@ -37,12 +37,9 @@ export function DownloadableBlockHeader( {
 			) }
 
 			<div className="block-directory-downloadable-block-header__column">
-				<span
-					role="heading"
-					className="block-directory-downloadable-block-header__title"
-				>
+				<h2 className="block-directory-downloadable-block-header__title">
 					{ title }
-				</span>
+				</h2>
 				<BlockRatings rating={ rating } ratingCount={ ratingCount } />
 			</div>
 			<Button

--- a/packages/block-directory/src/components/downloadable-block-header/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-header/style.scss
@@ -18,13 +18,12 @@
 		display: flex;
 		flex-direction: column;
 		flex-grow: 1;
-
-		.block-directory-downloadable-block-header__title {
-			font-weight: 600;
-			margin-left: 12px;
-		}
-		.block-directory-block-ratings {
-			margin-left: 12px;
-		}
+		padding-left: $grid-unit-15;
 	}
+}
+
+.block-directory-downloadable-block-header__title {
+	margin: 0;
+	font-size: $default-font-size;
+	color: currentColor;
 }


### PR DESCRIPTION
Related Slack conversation ([link requires registration](https://make.wordpress.org/chat/)): https://wordpress.slack.com/archives/C02QB2JS7/p1590677131416000

This pull request seeks to improve the markup and styling associated with the block directory `DownloadableBlockHeader` component.

While AXE tests are not anticipated to apply for block directory tests currently, due to an unrelated issue (#22712), they are, and the markup fails with a legitimate error about the markup being generated: "Required ARIA attribute not present: aria-level" ([see related documentation](https://dequeuniversity.com/rules/axe/3.5/aria-required-attr?application=axe-puppeteer)).
 
Technically, `aria-level` can be considered optional (["If no level is present, a value of 2 is the default"](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/heading_role)), though the AXE tests are configured to require an explicit value, likely to prevent implicit values from oversights of not considering to add the attribute. It's not clear if the original implementation omitting `aria-level` was an oversight or intentional (#17431).

Ultimately though, it's not clear why the `role` is used here in the first place, vs. the more semantic heading elements. It may have been used merely as a convenience for styling, though it's not a very compelling reason, and the styling appears to seek to inherit some default heading styles anyways.

For this reason, the component has been changed to render `<h2>`, which should be semantically equivalent to how it was rendered previously.

Styling has been updated for a few reasons:

- The [CSS naming guidelines](https://github.com/WordPress/gutenberg/blob/master/docs/contributors/coding-guidelines.md#css) are intentionally crafted so as to avoid the need of SASS "nesting" in most cases. It has been updated here where it appears to be unnecessary.
- Establish container padding by `padding` on the container, rather than multiple `margin` on its children.
- Use standard (but equivalent) grid size values in place of ad hoc pixel values.
- Avoid redundant `font-weight` heading styles, now inherited automatically as `h2` element.
- Otherwise, preserve previous styling by a combination of `margin` and `color` overrides to the heading.

**Open Question:**

Depending if it was intentional to omit `aria-level` and fall back to the default `2`, it would be good to clarify if `h2` is the best fit here.

**Testing Instructions:**

Verify that the presentation of the downloadable block header is identical in this branch compared to `master`:

1. (Prerequisite) Enable Block Directory Search experiment from Gutenberg > Experiments screen
2. Navigate to Posts > Add New
3. Toggle block inserter
4. Search "Listicle"
5. Observe heading "List Item" in presented block directory search result