### PR TITLE
E2E Tests: Configure Axe to ignore media modal markup

### DIFF
--- a/packages/e2e-tests/config/setup-test-framework.js
+++ b/packages/e2e-tests/config/setup-test-framework.js
@@ -246,6 +246,7 @@ async function runAxeTestsForBlockEditor() {
 			// Ignores elements created by TinyMCE.
 			'.mce-container',
 			// Ignores elements within the media modal.
+			// Related: https://core.trac.wordpress.org/ticket/50273
 			'.media-modal',
 			// These properties were not included in the 1.1 spec
 			// through error, they should be allowed on role="row":

--- a/packages/e2e-tests/config/setup-test-framework.js
+++ b/packages/e2e-tests/config/setup-test-framework.js
@@ -248,6 +248,7 @@ async function runAxeTestsForBlockEditor() {
 			// Ignores elements within the media modal.
 			// Related: https://core.trac.wordpress.org/ticket/50273
 			'.media-modal',
+			'.media-modal .attachment',
 			// These properties were not included in the 1.1 spec
 			// through error, they should be allowed on role="row":
 			// https://github.com/w3c/aria/issues/558

--- a/packages/e2e-tests/config/setup-test-framework.js
+++ b/packages/e2e-tests/config/setup-test-framework.js
@@ -245,6 +245,8 @@ async function runAxeTestsForBlockEditor() {
 			'.edit-post-layout__metaboxes',
 			// Ignores elements created by TinyMCE.
 			'.mce-container',
+			// Ignores elements within the media modal.
+			'.media-modal',
 			// These properties were not included in the 1.1 spec
 			// through error, they should be allowed on role="row":
 			// https://github.com/w3c/aria/issues/558

--- a/packages/e2e-tests/specs/editor/blocks/gallery.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/gallery.test.js
@@ -67,10 +67,5 @@ describe( 'Gallery', () => {
 
 		expect( mediaLibraryHeaderText ).toBe( 'Create Gallery' );
 		expect( mediaLibraryButtonText ).toBe( 'Create a new gallery' );
-
-		// Unfortunately the Media Library has invalid HTML.
-		// Axe tests fail with the following error:
-		// `List element has direct children with a role that is not allowed: checkbox.`
-		await expect( page ).not.toPassAxeTests();
 	} );
 } );


### PR DESCRIPTION
Previously: #22659

This pull request seeks to resolve a failure in the end-to-end tests.

Example: https://travis-ci.com/github/WordPress/gutenberg/jobs/341126161

```
    Expected page to pass Axe accessibility tests.
    Violations found:
    Rule: "list" (<ul> and <ol> must only directly contain <li>, <script> or <template> elements)
    Help: https://dequeuniversity.com/rules/axe/3.5/list?application=axe-puppeteer
    Affected Nodes:
      #__attachments-view-91
        Fix ALL of the following:
          - List element has direct children with a role that is not allowed: checkbox.
      222 | 	}
      223 | 
    > 224 | 	await expect( page ).toPassAxeTests( {
          | 	                     ^
      225 | 		// Temporary disabled rules to enable initial integration.
      226 | 		// See: https://github.com/WordPress/gutenberg/pull/15018.
      227 | 		disabledRules: [
      at runAxeTestsForBlockEditor (config/setup-test-framework.js:224:23)
          at runMicrotasks (<anonymous>)
      at Object.<anonymous> (config/setup-test-framework.js:298:2)
```

The issue appears to stem from the fact that the core media library markup has accessibility errors. There was an attempt to address this in #22659 via the assertion (removed here) `await expect( page ).not.toPassAxeTests();`. It's assumed that while this assertion alone could pass, since the `afterEach` `await expect( page ).toPassAxeTests()` would still be run, the test would fail.

**Testing Instructions:**

Ensure end-to-end tests pass:

```
npm run test-e2e packages/e2e-tests/specs/editor/blocks/gallery.test.js
```