### PR TITLE
Add data-handle to all script tags in the admin.

### DIFF
--- a/lib/block-directory.php
+++ b/lib/block-directory.php
@@ -18,4 +18,22 @@ if (
 		wp_enqueue_style( 'wp-block-directory' );
 	}
 	add_action( 'enqueue_block_editor_assets', 'gutenberg_enqueue_block_editor_assets_block_directory' );
+
+	/**
+	 * Add data attribute of handle to all script tags output in the wp-admin.
+	 *
+	 * @param string $tag    The `<script>` tag for the enqueued script.
+	 * @param string $handle The script's registered handle.
+	 *
+	 * @return string  Filter script tag.
+	 */
+	function gutenberg_change_script_tag( $tag, $handle ) {
+		if ( ! is_admin() ) {
+			return $tag;
+		}
+		$tag = str_replace( '<script ', sprintf( '<script data-handle="%s" ', $handle ), $tag );
+
+		return $tag;
+	}
+	add_filter( 'script_loader_tag', 'gutenberg_change_script_tag', 10, 2 );
 }

--- a/lib/block-directory.php
+++ b/lib/block-directory.php
@@ -31,7 +31,7 @@ if (
 		if ( ! is_admin() ) {
 			return $tag;
 		}
-		$tag = str_replace( '<script ', sprintf( '<script data-handle="%s" ', esc_attr ( $handle ) ), $tag );
+		$tag = str_replace( '<script ', sprintf( '<script data-handle="%s" ', esc_attr( $handle ) ), $tag );
 
 		return $tag;
 	}

--- a/lib/block-directory.php
+++ b/lib/block-directory.php
@@ -31,7 +31,7 @@ if (
 		if ( ! is_admin() ) {
 			return $tag;
 		}
-		$tag = str_replace( '<script ', sprintf( '<script data-handle="%s" ', $handle ), $tag );
+		$tag = str_replace( '<script ', sprintf( '<script data-handle="%s" ', esc_attr ( $handle ) ), $tag );
 
 		return $tag;
 	}


### PR DESCRIPTION
## Description
Add all handle as attribute on all script tags. 
Only do this in the admin and if block directory is enabled.

Related: #22703

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
