### PR TITLE
Disable inconsistent gallery end-to-end test

### DIFF
--- a/packages/e2e-tests/config/setup-test-framework.js
+++ b/packages/e2e-tests/config/setup-test-framework.js
@@ -245,10 +245,6 @@ async function runAxeTestsForBlockEditor() {
 			'.edit-post-layout__metaboxes',
 			// Ignores elements created by TinyMCE.
 			'.mce-container',
-			// Ignores elements within the media modal.
-			// Related: https://core.trac.wordpress.org/ticket/50273
-			'.media-modal',
-			'.media-modal .attachment',
 			// These properties were not included in the 1.1 spec
 			// through error, they should be allowed on role="row":
 			// https://github.com/w3c/aria/issues/558

--- a/packages/e2e-tests/specs/editor/blocks/gallery.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/gallery.test.js
@@ -52,7 +52,18 @@ describe( 'Gallery', () => {
 		expect( await getEditedPostContent() ).toMatch( regex );
 	} );
 
-	it( 'when initially added the media library shows the Create Gallery view', async () => {
+	// Disable reason:
+	// This test would be good to enable, but the media modal contains an
+	// invalid role, which is causing Axe tests to fail:
+	// https://core.trac.wordpress.org/ticket/50273
+	//
+	// Attempts to add an Axe exception for the media modal haven't proved
+	// successful:
+	// https://github.com/WordPress/gutenberg/pull/22719
+	//
+	// This test could be re-enabled once the trac ticket is solved.
+	// eslint-disable-next-line jest/no-disabled-tests
+	it.skip( 'when initially added the media library shows the Create Gallery view', async () => {
 		await insertBlock( 'Gallery' );
 		await clickButton( 'Media Library' );
 		await page.waitForSelector( '.media-frame' );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This test was introduced in #22659, but has only inconsistently passed due to an invalid role in the media modal causing Axe tests to fail.

A previous attempt to add exceptions for the media modal doesn't seem to have been successful - https://github.com/WordPress/gutenberg/pull/22719.

This PR skips the test until the underlying issue has been solved - https://core.trac.wordpress.org/ticket/50273.