### PR TITLE
Create Block: Integrate CSS import in JS with esnext template

### DIFF
--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+- Update `esnext` (default) template to integrate with CSS import support added to `@wordpress/scripts`.
+
 ## 0.13.0 (2020-05-28)
 
 ### Internal
@@ -16,7 +20,7 @@
 
 ### Enhancements
 
-- Update `esnext` template to scaffold 3 JavaScript source files to illustrate how ES modules help to better organize code.
+- Update `esnext` (default) template to scaffold 3 JavaScript source files to illustrate how ES modules help to better organize code ([#21750](https://github.com/WordPress/gutenberg/pull/21750)).
 
 ## 0.10.0 (2020-04-01)
 

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
-- Update `esnext` (default) template to integrate with CSS import support added to `@wordpress/scripts`.
+- Update `esnext` (default) template to integrate with CSS import in JavaScript support added to `@wordpress/scripts` ([#22727](https://github.com/WordPress/gutenberg/pull/22727/files)).
 
 ## 0.13.0 (2020-05-28)
 

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
-- Update `esnext` (default) template to integrate with CSS import in JavaScript support added to `@wordpress/scripts` ([#22727](https://github.com/WordPress/gutenberg/pull/22727/files)).
+- Update `esnext` (default) template to leverage CSS import in JavaScript support added to `@wordpress/scripts` ([#22727](https://github.com/WordPress/gutenberg/pull/22727/files)).
 
 ## 0.13.0 (2020-05-28)
 

--- a/packages/create-block/lib/templates/esnext/$slug.php.mustache
+++ b/packages/create-block/lib/templates/esnext/$slug.php.mustache
@@ -43,7 +43,7 @@ function {{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init() {
 		$script_asset['version']
 	);
 
-	$editor_css = 'editor.css';
+	$editor_css = 'build/index.css';
 	wp_register_style(
 		'{{namespace}}-{{slug}}-block-editor',
 		plugins_url( $editor_css, __FILE__ ),
@@ -51,7 +51,7 @@ function {{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init() {
 		filemtime( "$dir/$editor_css" )
 	);
 
-	$style_css = 'style.css';
+	$style_css = 'build/style.css';
 	wp_register_style(
 		'{{namespace}}-{{slug}}-block',
 		plugins_url( $style_css, __FILE__ ),

--- a/packages/create-block/lib/templates/esnext/src/edit.js.mustache
+++ b/packages/create-block/lib/templates/esnext/src/edit.js.mustache
@@ -6,6 +6,11 @@
 import { __ } from '@wordpress/i18n';
 
 /**
+ * Internal dependencies
+ */
+import './editor.scss';
+
+/**
  * The edit function describes the structure of your block in the context of the
  * editor. This represents what the editor will render when the block is used.
  *

--- a/packages/create-block/lib/templates/esnext/src/editor.scss.mustache
+++ b/packages/create-block/lib/templates/esnext/src/editor.scss.mustache
@@ -5,5 +5,5 @@
  */
 
 .wp-block-{{namespace}}-{{slug}} {
-	border: 1px dotted #f00;
+	border: 1px dotted red;
 }

--- a/packages/create-block/lib/templates/esnext/src/index.js.mustache
+++ b/packages/create-block/lib/templates/esnext/src/index.js.mustache
@@ -15,6 +15,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import './style.scss';
 import Edit from './edit';
 import save from './save';
 

--- a/packages/create-block/lib/templates/esnext/src/style.scss.mustache
+++ b/packages/create-block/lib/templates/esnext/src/style.scss.mustache
@@ -6,7 +6,7 @@
  */
 
 .wp-block-{{namespace}}-{{slug}} {
-	background-color: #000;
-	color: #fff;
+	background-color: theme(button);
+	color: white;
 	padding: 2px;
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Now that CSS import in JS has been added to `@wordpress/scripts` and build scripts, it's time to integrate it into the default template used by `@wordpress/create-block`. This PR handles it by updating `esnext` (default) template. Two existing files were moved to `src` folder and referenced in JavaScript files.

I also used `theme(button)` in one of the files to ensure that PostCSS preset is properly integrated. The generated output looks something along those lines:

![Screen Shot 2020-05-29 at 07 47 37](https://user-images.githubusercontent.com/699132/83225761-bd2dc280-a180-11ea-9ecf-1cc2267bb38b.png)


## How has this been tested?
`npx wp-create-block`

I confirmed that CSS files were created in `build` folder and properly loaded in the block editor.