### PR TITLE
Scripts: Add support for postcss.config.js

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -7,6 +7,9 @@
 - The default babel configuration has changed to only support stage-4 proposals. This affects the `build` and `start` commands that use the bundled babel configuration; if a project provides its own, this change doesn't affect it. [#22083](https://github.com/WordPress/gutenberg/pull/22083)
 - The bundled `wp-prettier` dependency has been upgraded from `1.19.1` to `2.0.5`. Refer to the [Prettier 2.0 "2020" blog post](https://prettier.io/blog/2020/03/21/2.0.0.html) for full details about the major changes included in Prettier 2.0.
 
+### New Feature
+- The PostCSS loader now gives preference to a `postcss.config.js` configuration file if present.
+
 ## 10.0.0 (2020-05-28)
 
 ### New Feature

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -16,7 +16,7 @@ const postcssPlugins = require( '@wordpress/postcss-plugins-preset' );
 /**
  * Internal dependencies
  */
-const { hasBabelConfig } = require( '../utils' );
+const { hasBabelConfig, hasPostCssConfig } = require( '../utils' );
 
 const isProduction = process.env.NODE_ENV === 'production';
 const mode = isProduction ? 'production' : 'development';
@@ -103,8 +103,12 @@ const config = {
 					{
 						loader: require.resolve( 'postcss-loader' ),
 						options: {
-							ident: 'postcss',
-							plugins: postcssPlugins,
+							// Provide a fallback configuration if there's not
+							// one explicitly available in the project.
+							...( ! hasPostCssConfig() && {
+								ident: 'postcss',
+								plugins: postcssPlugins,
+							} ),
 						},
 					},
 					{

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -16,7 +16,7 @@ const postcssPlugins = require( '@wordpress/postcss-plugins-preset' );
 /**
  * Internal dependencies
  */
-const { hasBabelConfig, hasPostCssConfig } = require( '../utils' );
+const { hasBabelConfig, hasPostCSSConfig } = require( '../utils' );
 
 const isProduction = process.env.NODE_ENV === 'production';
 const mode = isProduction ? 'production' : 'development';
@@ -105,7 +105,7 @@ const config = {
 						options: {
 							// Provide a fallback configuration if there's not
 							// one explicitly available in the project.
-							...( ! hasPostCssConfig() && {
+							...( ! hasPostCSSConfig() && {
 								ident: 'postcss',
 								plugins: postcssPlugins,
 							} ),

--- a/packages/scripts/utils/config.js
+++ b/packages/scripts/utils/config.js
@@ -57,6 +57,7 @@ const hasJestConfig = () =>
 	hasProjectFile( 'jest.config.json' ) ||
 	hasPackageProp( 'jest' );
 
+// See https://prettier.io/docs/en/configuration.html.
 const hasPrettierConfig = () =>
 	hasProjectFile( '.prettierrc.js' ) ||
 	hasProjectFile( '.prettierrc.json' ) ||
@@ -72,7 +73,8 @@ const hasWebpackConfig = () =>
 	hasProjectFile( 'webpack.config.js' ) ||
 	hasProjectFile( 'webpack.config.babel.js' );
 
-const hasPostCssConfig = () =>
+// See https://github.com/michael-ciniawsky/postcss-load-config#usage (used by postcss-loader).
+const hasPostCSSConfig = () =>
 	hasProjectFile( 'postcss.config.js' ) ||
 	hasProjectFile( '.postcssrc' ) ||
 	hasProjectFile( '.postcssrc.json' ) ||
@@ -141,5 +143,5 @@ module.exports = {
 	getJestOverrideConfigFile,
 	hasJestConfig,
 	hasPrettierConfig,
-	hasPostCssConfig,
+	hasPostCSSConfig,
 };

--- a/packages/scripts/utils/config.js
+++ b/packages/scripts/utils/config.js
@@ -72,6 +72,8 @@ const hasWebpackConfig = () =>
 	hasProjectFile( 'webpack.config.js' ) ||
 	hasProjectFile( 'webpack.config.babel.js' );
 
+const hasPostCssConfig = () => hasProjectFile( 'postcss.config.js' );
+
 /**
  * Converts CLI arguments to the format which webpack understands.
  *
@@ -132,4 +134,5 @@ module.exports = {
 	getJestOverrideConfigFile,
 	hasJestConfig,
 	hasPrettierConfig,
+	hasPostCssConfig,
 };

--- a/packages/scripts/utils/config.js
+++ b/packages/scripts/utils/config.js
@@ -72,7 +72,14 @@ const hasWebpackConfig = () =>
 	hasProjectFile( 'webpack.config.js' ) ||
 	hasProjectFile( 'webpack.config.babel.js' );
 
-const hasPostCssConfig = () => hasProjectFile( 'postcss.config.js' );
+const hasPostCssConfig = () =>
+	hasProjectFile( 'postcss.config.js' ) ||
+	hasProjectFile( '.postcssrc' ) ||
+	hasProjectFile( '.postcssrc.json' ) ||
+	hasProjectFile( '.postcssrc.yaml' ) ||
+	hasProjectFile( '.postcssrc.yml' ) ||
+	hasProjectFile( '.postcssrc.js' ) ||
+	hasPackageProp( 'postcss' );
 
 /**
  * Converts CLI arguments to the format which webpack understands.

--- a/packages/scripts/utils/index.js
+++ b/packages/scripts/utils/index.js
@@ -16,7 +16,7 @@ const {
 	getJestOverrideConfigFile,
 	hasJestConfig,
 	hasPrettierConfig,
-	hasPostCssConfig,
+	hasPostCSSConfig,
 } = require( './config' );
 const {
 	buildWordPress,
@@ -42,7 +42,7 @@ module.exports = {
 	hasJestConfig,
 	hasPackageProp,
 	hasPrettierConfig,
-	hasPostCssConfig,
+	hasPostCSSConfig,
 	hasProjectFile,
 	downloadWordPressZip,
 	mergeYAMLConfigs,

--- a/packages/scripts/utils/index.js
+++ b/packages/scripts/utils/index.js
@@ -16,6 +16,7 @@ const {
 	getJestOverrideConfigFile,
 	hasJestConfig,
 	hasPrettierConfig,
+	hasPostCssConfig,
 } = require( './config' );
 const {
 	buildWordPress,
@@ -41,6 +42,7 @@ module.exports = {
 	hasJestConfig,
 	hasPackageProp,
 	hasPrettierConfig,
+	hasPostCssConfig,
 	hasProjectFile,
 	downloadWordPressZip,
 	mergeYAMLConfigs,


### PR DESCRIPTION
## Description

Fixes #22732.

This implements the Babel config behaviour for PostCSS and its `postcss.config.js`.

## How has this been tested?
* Copy the example config from #22732
* `npm i -D postcss-import postcss-mixins postcss-nested postcss-preset-env postcss-hexrgba css-mqpacker cssnano`
* Run the build command
* Verify that the CSS files are built as expected

## Screenshots <!-- if applicable -->

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
