### PR TITLE
[RNMobile] Correct color selection in color settings

### DIFF
--- a/packages/components/src/color-palette/index.native.js
+++ b/packages/components/src/color-palette/index.native.js
@@ -12,7 +12,7 @@ import { map, uniq } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { useState, useEffect, createRef } from '@wordpress/element';
+import { useRef, useEffect, createRef } from '@wordpress/element';
 import { usePreferredColorSchemeStyle } from '@wordpress/compose';
 /**
  * Internal dependencies
@@ -42,8 +42,8 @@ function ColorPalette( {
 
 	const isGradientSegment = currentSegment === colorsUtils.segments[ 1 ];
 
-	const [ scale ] = useState( new Animated.Value( 1 ) );
-	const [ opacity ] = useState( new Animated.Value( 1 ) );
+	const scale = useRef( new Animated.Value( 1 ) ).current;
+	const opacity = useRef( new Animated.Value( 1 ) ).current;
 
 	const defaultColors = uniq( map( defaultSettings.colors, 'color' ) );
 	const defaultGradientColors = uniq(
@@ -75,13 +75,17 @@ function ColorPalette( {
 	}
 
 	function performAnimation( color ) {
-		opacity.setValue( isSelected( color ) ? 1 : 0 );
-		scale.setValue( 1 );
+		if ( ! isSelected( color ) ) {
+			opacity.setValue( 0 );
+		}
 
 		Animated.parallel( [
 			timingAnimation( scale, 2 ),
 			timingAnimation( opacity, 1 ),
-		] ).start();
+		] ).start( () => {
+			opacity.setValue( 1 );
+			scale.setValue( 1 );
+		} );
 	}
 
 	const scaleInterpolation = scale.interpolate( {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

Fixing the bug where color selection disappears when switching between solid/gradient segments.

Ref to gutenberg mobile: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2335

## How has this been tested?

1. Open mobile app
2. Add `Button` block
3. Open `Button` settings
4. Go to background color
5. Select any solid color
6. Press gradient segment
7. Press solid segment
8. Expect selection is visible (check mark on white background)


## Screenshots <!-- if applicable -->

before | after 
---  | ---
![-1](https://user-images.githubusercontent.com/22746080/83243683-91213a00-a19e-11ea-8fad-c3282c631c96.gif) | ![+1](https://user-images.githubusercontent.com/22746080/83243750-a0a08300-a19e-11ea-81fd-1f969146a674.gif)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [X] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
