### PR TITLE
Set default selection to the root navigation block

### DIFF
--- a/packages/edit-navigation/src/components/menu-editor/block-editor-panel.js
+++ b/packages/edit-navigation/src/components/menu-editor/block-editor-panel.js
@@ -13,8 +13,9 @@ import {
 	ObserveTyping,
 	WritingFlow,
 } from '@wordpress/block-editor';
+import { useEffect } from '@wordpress/element';
 import { Button, Panel, PanelBody, Popover } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -27,17 +28,19 @@ export default function BlockEditorPanel( {
 	menuId,
 	saveBlocks,
 } ) {
-	const { isNavigationModeActive, hasSelectedBlock } = useSelect(
+	const { rootBlock, isNavigationModeActive, hasSelectedBlock } = useSelect(
 		( select ) => {
 			const {
 				isNavigationMode,
 				getBlockSelectionStart,
 				getBlock,
+				getBlocks,
 			} = select( 'core/block-editor' );
 
 			const selectionStartClientId = getBlockSelectionStart();
 
 			return {
+				rootBlock: getBlocks()[ 0 ],
 				isNavigationModeActive: isNavigationMode(),
 				hasSelectedBlock:
 					!! selectionStartClientId &&
@@ -46,6 +49,14 @@ export default function BlockEditorPanel( {
 		},
 		[]
 	);
+
+	// Select the navigation block when it becomes available
+	const { selectBlock } = useDispatch( 'core/block-editor' );
+	useEffect( () => {
+		if ( rootBlock?.clientId ) {
+			selectBlock( rootBlock.clientId );
+		}
+	}, [ rootBlock?.clientId ] );
 
 	return (
 		<Panel className="edit-navigation-menu-editor__block-editor-panel">

--- a/packages/edit-navigation/src/components/menu-editor/block-editor-panel.js
+++ b/packages/edit-navigation/src/components/menu-editor/block-editor-panel.js
@@ -28,7 +28,7 @@ export default function BlockEditorPanel( {
 	menuId,
 	saveBlocks,
 } ) {
-	const { rootBlock, isNavigationModeActive, hasSelectedBlock } = useSelect(
+	const { rootBlockId, isNavigationModeActive, hasSelectedBlock } = useSelect(
 		( select ) => {
 			const {
 				isNavigationMode,
@@ -40,7 +40,7 @@ export default function BlockEditorPanel( {
 			const selectionStartClientId = getBlockSelectionStart();
 
 			return {
-				rootBlock: getBlocks()[ 0 ],
+				rootBlockId: getBlocks()[ 0 ]?.clientId,
 				isNavigationModeActive: isNavigationMode(),
 				hasSelectedBlock:
 					!! selectionStartClientId &&
@@ -53,10 +53,10 @@ export default function BlockEditorPanel( {
 	// Select the navigation block when it becomes available
 	const { selectBlock } = useDispatch( 'core/block-editor' );
 	useEffect( () => {
-		if ( rootBlock?.clientId ) {
-			selectBlock( rootBlock.clientId );
+		if ( rootBlockId ) {
+			selectBlock( rootBlockId );
 		}
-	}, [ rootBlock?.clientId ] );
+	}, [ rootBlockId ] );
 
 	return (
 		<Panel className="edit-navigation-menu-editor__block-editor-panel">


### PR DESCRIPTION
## Description

Solves #22468 by setting default selection to the root navigation block.

<img width="1323" alt="Zrzut ekranu 2020-05-29 o 11 19 46" src="https://user-images.githubusercontent.com/205419/83243781-abf3ae80-a19e-11ea-9670-727644f5e618.png">

_(any ideas how to get rid of the blue border without calling `document.body.focus()` or separating the concepts of selection and focus in the block-editor package?)_

## How has this been tested?
1. Enable the experimental navigation management screen
1. Go to http://localhost:8888/wp-admin/admin.php?page=gutenberg-navigation
1. Confirm the navigation block is selected

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
