### PR TITLE
Navigation screen: retain block IDs on save

### DIFF
--- a/packages/edit-navigation/src/components/menu-editor/use-navigation-blocks.js
+++ b/packages/edit-navigation/src/components/menu-editor/use-navigation-blocks.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { groupBy, sortBy } from 'lodash';
+import { keyBy, groupBy, sortBy } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -35,9 +35,18 @@ export default function useNavigationBlocks( menuId ) {
 	useEffect( () => {
 		if ( menuItems ) {
 			const [
-				navigationBlock,
+				innerBlocks,
 				clientIdToMenuItemMapping,
-			] = menuItemsToNavigationBlock( menuItems );
+			] = menuItemsToLinkBlocks(
+				menuItems,
+				innerBlocks,
+				clientIdToMenuItemMapping
+			);
+
+			const navigationBlock =
+				blocks[ 0 ] ||
+				createBlock( 'core/navigation', {}, innerBlocks );
+
 			setBlocks( [ navigationBlock ] );
 			menuItemsRef.current = clientIdToMenuItemMapping;
 		}
@@ -115,7 +124,16 @@ async function createDraftMenuItem() {
 	} );
 }
 
-const menuItemsToNavigationBlock = ( menuItems ) => {
+const menuItemsToLinkBlocks = (
+	menuItems,
+	prevLinkBlocks = [],
+	prevClientIdToMenuItemMapping = {}
+) => {
+	const blocksByMenuId = mapBlocksByMenuId(
+		prevLinkBlocks,
+		prevClientIdToMenuItemMapping
+	);
+
 	const itemsByParentID = groupBy( menuItems, 'parent' );
 	const clientIdToMenuItemMapping = {};
 	const menuItemsToTreeOfLinkBlocks = ( items ) => {
@@ -132,7 +150,11 @@ const menuItemsToNavigationBlock = ( menuItems ) => {
 					itemsByParentID[ item.id ]
 				);
 			}
-			const linkBlock = menuItemToLinkBlock( item, menuItemInnerBlocks );
+			const linkBlock = menuItemToLinkBlock(
+				item,
+				menuItemInnerBlocks,
+				blocksByMenuId[ item.id ]
+			);
 			clientIdToMenuItemMapping[ linkBlock.clientId ] = item;
 			innerBlocks.push( linkBlock );
 		}
@@ -140,25 +162,46 @@ const menuItemsToNavigationBlock = ( menuItems ) => {
 	};
 
 	// menuItemsToTreeOfLinkBlocks takes an array of top-level menu items and recursively creates all their innerBlocks
-	const innerBlocks = menuItemsToTreeOfLinkBlocks(
+	const linkBlocks = menuItemsToTreeOfLinkBlocks(
 		itemsByParentID[ 0 ] || []
 	);
-	const navigationBlock = createBlock( 'core/navigation', {}, innerBlocks );
-	return [ navigationBlock, clientIdToMenuItemMapping ];
+	return [ linkBlocks, clientIdToMenuItemMapping ];
 };
 
-function menuItemToLinkBlock( menuItem, innerBlocks = [] ) {
-	return createBlock(
-		'core/navigation-link',
-		{
-			label: menuItem.title.rendered,
-			url: menuItem.url,
-		},
-		innerBlocks
-	);
+function menuItemToLinkBlock(
+	menuItem,
+	innerBlocks = [],
+	existingBlock = null
+) {
+	const attributes = {
+		label: menuItem.title.rendered,
+		url: menuItem.url,
+	};
+
+	if ( existingBlock ) {
+		return {
+			...existingBlock,
+			attributes,
+			innerBlocks,
+		};
+	}
+	return createBlock( 'core/navigation-link', attributes, innerBlocks );
 }
 
+const mapBlocksByMenuId = ( blocks, menuItemsByClientId ) => {
+	const blocksByClientId = keyBy( flattenBlocks( blocks ), 'clientId' );
+	const blocksByMenuId = {};
+	for ( const clientId in menuItemsByClientId ) {
+		const menuItem = menuItemsByClientId[ clientId ];
+		blocksByMenuId[ menuItem.id ] = blocksByClientId[ clientId ];
+	}
+	return blocksByMenuId;
+};
+
 const getAllClientIds = ( blocks ) =>
+	flattenBlocks( blocks ).map( ( { clientId } ) => clientId );
+
+const flattenBlocks = ( blocks ) =>
 	blocks.flatMap( ( item ) =>
-		[ item.clientId ].concat( getAllClientIds( item.innerBlocks || [] ) )
+		[ item ].concat( flattenBlocks( item.innerBlocks || [] ) )
 	);

--- a/packages/edit-navigation/src/components/menu-editor/use-navigation-blocks.js
+++ b/packages/edit-navigation/src/components/menu-editor/use-navigation-blocks.js
@@ -47,7 +47,7 @@ export default function useNavigationBlocks( menuId ) {
 		] = menuItemsToLinkBlocks(
 			menuItems,
 			blocks[ 0 ]?.innerBlocks,
-			clientIdToMenuItemMapping
+			menuItemsRef.current
 		);
 
 		const navigationBlock = blocks[ 0 ]


### PR DESCRIPTION
## Description

Solves #21594

At the moment, the navigation screen will recreate all the blocks on every save, which means new `clientId`s, which means selection loss and a bit of a flicker. With this PR, saving changes retains all the existing `clientId`s which improves the user experience.

## How has this been tested?
1. Enable the navigation experiment in Gutenberg > Experiments
1. Go to Gutenberg > Navigation (beta)
1. Add a few menu items, update a few other, delete a few existing ones
1. Select a sub-menu
1. Hit the save button
1. Confirm your selection was retained and there was no flickering to be seen

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
