### PR TITLE
Try: Scripts: Add Sass file processing only when dependencies are installed

### DIFF
--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -62,14 +62,12 @@
 		"markdownlint-cli": "^0.21.0",
 		"mini-css-extract-plugin": "^0.9.0",
 		"minimist": "^1.2.0",
-		"node-sass": "^4.13.1",
 		"npm-package-json-lint": "^5.0.0",
 		"postcss-loader": "^3.0.0",
 		"prettier": "npm:wp-prettier@2.0.5",
 		"puppeteer": "npm:puppeteer-core@3.0.0",
 		"read-pkg-up": "^1.0.1",
 		"resolve-bin": "^0.4.0",
-		"sass-loader": "^8.0.2",
 		"source-map-loader": "^0.2.4",
 		"sprintf-js": "^1.1.1",
 		"stylelint": "^9.10.1",
@@ -80,6 +78,10 @@
 		"webpack-bundle-analyzer": "^3.6.1",
 		"webpack-cli": "^3.3.11",
 		"webpack-livereload-plugin": "^2.3.0"
+	},
+	"peerDependencies": {
+		"node-sass": "^4.13.1",
+		"sass-loader": "^8.0.2"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
## Description
This PR explores the possibility of avoiding the need of installing Sass dependencies if a project doesn't use .sass/scss files. It's related to #22733 and #22729.

Not running the Sass loader on a simple CSS file saves only <100ms so it's probably more about the hassle of installing the node-sass dependency which could be solved by switching to Dart SASS.

I'm fine with closing this as wontfix but wanted to have it documented at least.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
