### PR TITLE
[RNMobile] Fix: Add default value to format when start and end are undefined

### DIFF
--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -178,7 +178,7 @@ export class RichText extends Component {
 	}
 
 	onFormatChange( record ) {
-		const { start, end, activeFormats = [] } = record;
+		const { start = 0, end = 0, activeFormats = [] } = record;
 		const changeHandlers = pickBy( this.props, ( v, key ) =>
 			key.startsWith( 'format_on_change_functions_' )
 		);
@@ -837,34 +837,29 @@ export class RichText extends Component {
 							onFocus={ () => {} }
 						/>
 						<BlockFormatControls>
-							{
-								// eslint-disable-next-line no-undef
-								__DEV__ && isMentionsSupported( capabilities ) && (
-									<Toolbar>
-										<ToolbarButton
-											title={ __( 'Insert mention' ) }
-											icon={ <Icon icon={ atSymbol } /> }
-											onClick={ () => {
-												addMention()
-													.then(
-														( mentionUserId ) => {
-															let stringToInsert = `@${ mentionUserId }`;
-															if ( this.isIOS ) {
-																stringToInsert +=
-																	' ';
-															}
-															this.insertString(
-																record,
-																stringToInsert
-															);
-														}
-													)
-													.catch( () => {} );
-											} }
-										/>
-									</Toolbar>
-								)
-							}
+							{ // eslint-disable-next-line no-undef
+							__DEV__ && isMentionsSupported( capabilities ) && (
+								<Toolbar>
+									<ToolbarButton
+										title={ __( 'Insert mention' ) }
+										icon={ <Icon icon={ atSymbol } /> }
+										onClick={ () => {
+											addMention()
+												.then( ( mentionUserId ) => {
+													let stringToInsert = `@${ mentionUserId }`;
+													if ( this.isIOS ) {
+														stringToInsert += ' ';
+													}
+													this.insertString(
+														record,
+														stringToInsert
+													);
+												} )
+												.catch( () => {} );
+										} }
+									/>
+								</Toolbar>
+							) }
 						</BlockFormatControls>
 					</>
 				) }

--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -837,29 +837,34 @@ export class RichText extends Component {
 							onFocus={ () => {} }
 						/>
 						<BlockFormatControls>
-							{ // eslint-disable-next-line no-undef
-							__DEV__ && isMentionsSupported( capabilities ) && (
-								<Toolbar>
-									<ToolbarButton
-										title={ __( 'Insert mention' ) }
-										icon={ <Icon icon={ atSymbol } /> }
-										onClick={ () => {
-											addMention()
-												.then( ( mentionUserId ) => {
-													let stringToInsert = `@${ mentionUserId }`;
-													if ( this.isIOS ) {
-														stringToInsert += ' ';
-													}
-													this.insertString(
-														record,
-														stringToInsert
-													);
-												} )
-												.catch( () => {} );
-										} }
-									/>
-								</Toolbar>
-							) }
+							{
+								// eslint-disable-next-line no-undef
+								__DEV__ && isMentionsSupported( capabilities ) && (
+									<Toolbar>
+										<ToolbarButton
+											title={ __( 'Insert mention' ) }
+											icon={ <Icon icon={ atSymbol } /> }
+											onClick={ () => {
+												addMention()
+													.then(
+														( mentionUserId ) => {
+															let stringToInsert = `@${ mentionUserId }`;
+															if ( this.isIOS ) {
+																stringToInsert +=
+																	' ';
+															}
+															this.insertString(
+																record,
+																stringToInsert
+															);
+														}
+													)
+													.catch( () => {} );
+											} }
+										/>
+									</Toolbar>
+								)
+							}
 						</BlockFormatControls>
 					</>
 				) }


### PR DESCRIPTION
This PR fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/2334

gutenberg-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2336

In this PR i added a default value to the `onFormatChange` because at the first render they are `undefined` which is the cause of not applied formatting. The rest of changes are autogenerated by prettier/linter.

I still investigate this issue - https://github.com/wordpress-mobile/gutenberg-mobile/issues/2154 but since they are related. However, i think it should be done in separate PR.

## How has this been tested?
- Create a new image/video block with an image/video so the caption can be selected
- Select the caption
- Activate the bold, italic, or strikethrough formatting buttons
- Format button's state should change
- Begin typing text
- The correct format should be applied

## Screenshots <!-- if applicable -->
![selection](https://user-images.githubusercontent.com/16336501/83257801-6393bb00-a1b5-11ea-826d-a2e9b2ebb312.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
