### PR TITLE
Make global styles shape consistent with local styles shape.

### DIFF
--- a/docs/designers-developers/developers/themes/theme-json.md
+++ b/docs/designers-developers/developers/themes/theme-json.md
@@ -191,32 +191,46 @@ This is being implemented, so it's not currently available.
   },
   core/paragraph: {
     styles: {
-        line-height: <value>,
-        font-size: <value>,
-        color: <value>,
+      typography: { 
+        lineHeight: <value>,
+        fontSize: <value>
+      },
+      color: {
+        text: <value>
+      }
     }
   },
   /* core/heading/h1, core/heading/h2, etc */
   core/heading/h*: {
     styles: {
-        line-height: <value>,
-        font-size: <value>,
-        color: <value>,
+      typography: { 
+        lineHeight: <value>,
+        fontSize: <value>
+      },
+      color: {
+        text: <value>
+      }
     }
   },
   core/columns: {
     styles: {
-        color: <value>,
+      color: {
+        text: <value>
+      }
     }
   },
   core/group: {
     styles: {
-        color: <value>,
+      color: {
+        text: <value>
+      }
     }
   },
   core/media-text: {
     styles: {
-        color: <value>,
+      color: {
+        text: <value>
+      }
     }
   },
 }

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -315,6 +315,35 @@ function gutenberg_experimental_global_styles_get_block_data() {
 }
 
 /**
+ * Given an array contain the styles shape returns the css for this styles.
+ * A similar function exists on the client at /packages/block-editor/src/hooks/style.js.
+ *
+ * @param array $styles  Array containing the styles shape from global styles.
+ *
+ * @return array Containing a set of css rules.
+ */
+function gutenberg_experimental_global_styles_flatten_styles_tree( $styles ) {
+	$mappings = array(
+		'line-height'      => array( 'typography', 'lineHeight' ),
+		'font-size'        => array( 'typography', 'fontSize' ),
+		'background'       => array( 'color', 'gradient' ),
+		'background-color' => array( 'color', 'background' ),
+		'color'            => array( 'color', 'text' ),
+	);
+
+	$result = array();
+
+	foreach ( $mappings as $key => $path ) {
+		$value = gutenberg_experimental_get( $styles, $path );
+		if ( null !== $value ) {
+			$result[ $key ] = $value;
+		}
+	}
+	return $result;
+
+}
+
+/**
  * Takes a tree adhering to the theme.json schema and generates
  * the corresponding stylesheet.
  *
@@ -352,7 +381,10 @@ function gutenberg_experimental_global_styles_resolver( $tree ) {
 		$stylesheet .= gutenberg_experimental_global_styles_resolver_styles(
 			$block_data[ $block_name ]['selector'],
 			$block_data[ $block_name ]['supports'],
-			array_merge( $tree[ $block_name ]['styles'], $css_variables )
+			array_merge(
+				gutenberg_experimental_global_styles_flatten_styles_tree( $tree[ $block_name ]['styles'] ),
+				$css_variables
+			)
 		);
 	}
 	return $stylesheet;

--- a/lib/load.php
+++ b/lib/load.php
@@ -79,6 +79,7 @@ if ( ! class_exists( 'WP_Block_List' ) ) {
 }
 
 require dirname( __FILE__ ) . '/compat.php';
+require dirname( __FILE__ ) . '/utils.php';
 
 require dirname( __FILE__ ) . '/blocks.php';
 require dirname( __FILE__ ) . '/templates.php';

--- a/lib/utils.php
+++ b/lib/utils.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * General utilities.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * This function allows to easily access a part from a php array.
+ * It is equivalent to want lodash get provides for JavaScript and is useful to have something similar
+ * in php so functions that do the same thing on the client and sever can have identical code.
+ *
+ * @param array $array  An array from where we want to retrieve some information from.
+ * @param array $path   An array containing the path we want to retrieve.
+ *
+ * @return array Containing a set of css rules.
+ */
+function gutenberg_experimental_get( $array, $path ) {
+	$path_length = count( $path );
+	for ( $i = 0; $i < $path_length; ++$i ) {
+		if ( empty( $array[ $path[ $i ] ] ) ) {
+			return null;
+		}
+		$array = $array[ $path[ $i ] ];
+	}
+	return $array;
+}


### PR DESCRIPTION
Currently, for the shape of the local style we are using something like this:
```
		"style": {
			"color": {
				"text": "#00e"
			},
			"typography": {
				"lineHeight": 20,
				"fontSize": 12
			}
		}
```

While for global styles we were using the shape:
```
		"styles": {
			"color": "#00e",
			"line-height": 20,
			"font-size": 12
		}
```

We should use the same shape and this PR updates the global styles shape to be similar to what we had for local styles.

There is still one inconsistency for local styles we call "style" and for global styles, we call "styles". Should we update global styles to use "style"?


Besides this update we also perform smaller updates required to have a link color end to end implementation:
	- We add a setting __experimentalGlobalStyles containing the full global styles required to show the defaults including user-set global styles.
	- We unconditional include the default styles even if the theme does not has theme.json support. I guess even if the theme does not contain theme.json we may want to allow users to change the link color, and even change it globally and for that, we need a default even if for themes that don't have theme.json.


## How has this been tested?
I added this after global to /lib/experimental-default-theme.json:
```
	"core/paragraph": {
		"styles": {
			"color": {
				"text": "#00e"
			},
			"typography": {
				"lineHeight": 20,
				"fontSize": 12
			}
		}
	}
```
I verified the following styles were output:
```
p {
	line-height: 20;
	font-size: 12;
	color: #00e;
}
```

