### PR TITLE
Clean up block padding rules for group block children

### DIFF
--- a/packages/block-library/src/group/editor.scss
+++ b/packages/block-library/src/group/editor.scss
@@ -16,13 +16,6 @@
 
 	// Full Width Blocks
 	// specificity required to only target immediate child Blocks of a Group
-	> .wp-block-group__inner-container > .wp-block {
-		padding-left: 0;
-		padding-right: 0;
-	}
-
-	// Full Width Blocks
-	// specificity required to only target immediate child Blocks of a Group
 	> .wp-block-group__inner-container > [data-align="full"] {
 		margin-left: auto;
 		margin-right: auto;

--- a/packages/block-library/src/group/editor.scss
+++ b/packages/block-library/src/group/editor.scss
@@ -16,16 +16,16 @@
 
 	// Full Width Blocks
 	// specificity required to only target immediate child Blocks of a Group
+	> .wp-block-group__inner-container > .wp-block {
+		padding-left: 0;
+		padding-right: 0;
+	}
+
+	// Full Width Blocks
+	// specificity required to only target immediate child Blocks of a Group
 	> .wp-block-group__inner-container > [data-align="full"] {
 		margin-left: auto;
 		margin-right: auto;
-		padding-left: $block-padding*2;
-		padding-right: $block-padding*2;
-
-		@include break-small() {
-			padding-left: $block-padding*4 + $block-spacing/2; // 58px
-			padding-right: $block-padding*4 + $block-spacing/2; // 58px
-		}
 	}
 
 	// Full Width Blocks with a background (ie: has padding)
@@ -46,7 +46,19 @@
 /**
  * Group: Full Width Alignment
  */
-[data-align="full"] .wp-block[data-type="core/group"] {
+[data-align="full"] .wp-block-group {
+
+	// Non-full Width Blocks
+	// specificity required to only target immediate child Blocks of Group
+	> .wp-block-group__inner-container > .wp-block {
+		padding-left: $block-padding;
+		padding-right: $block-padding;
+
+		@include break-small() {
+			padding-left: 0;
+			padding-right: 0;
+		}
+	}
 
 	// Full Width Blocks
 	// specificity required to only target immediate child Blocks of Group


### PR DESCRIPTION
Fixes #22742. 

This PR recalibrates all the Group block children CSS so that inner blocks behave as expected at all alignments. 

Before: 

- Desktop, normal-width Groups: Full-width children appeared with too much left/right padding.
- Desktop, wide-width Groups: Full-width children appeared with too much left/right padding.
- Desktop, full-width Groups: Wide-width children appeared too wide, and full-width children appeared with too much left/right padding.
- Mobile, normal-width Groups: Full-width children appeared with too much left/right padding.
- Mobile, wide-width Groups: Full-width children appeared with too much left/right padding.
Mobile, full-width Groups: Normal and wide-width children appeared too wide, and full-width children appeared with too much left/right padding.

## Screenshots
Before (Desktop)|After (Desktop)
---|---
![gutenberg test_wp-admin_post php_post=1 action=edit (3)](https://user-images.githubusercontent.com/1202812/83262719-7396a500-a18b-11ea-906d-37812db3c4bc.png)|![gutenberg test_wp-admin_post php_post=1 action=edit](https://user-images.githubusercontent.com/1202812/83262728-75606880-a18b-11ea-960e-0796fbf0ba53.png)


Before (Mobile)|After (Mobile)
---|---
![gutenberg test_wp-admin_post php_post=1 action=edit (2)](https://user-images.githubusercontent.com/1202812/83262794-890bcf00-a18b-11ea-9575-c7c5c0b2ce57.png)|![gutenberg test_wp-admin_post php_post=1 action=edit (1)](https://user-images.githubusercontent.com/1202812/83262800-8a3cfc00-a18b-11ea-877e-fed48a3535aa.png)
