### PR TITLE
Enqueue assets for rendered blocks only

### DIFF
--- a/lib/class-wp-block.php
+++ b/lib/class-wp-block.php
@@ -206,6 +206,14 @@ class WP_Block {
 			$post          = $global_post;
 		}
 
+		if ( ! empty( $this->block_type->script ) ) {
+			wp_enqueue_script( $this->block_type->script );
+		}
+
+		if ( ! empty( $this->block_type->style ) ) {
+			wp_enqueue_style( $this->block_type->style );
+		}
+
 		/** This filter is documented in src/wp-includes/blocks.php */
 		return apply_filters( 'render_block', $block_content, $this->parsed_block );
 	}

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -291,3 +291,12 @@ function gutenberg_render_block_with_assigned_block_context( $pre_render, $parse
 	return $block->render();
 }
 add_filter( 'pre_render_block', 'gutenberg_render_block_with_assigned_block_context', 9, 2 );
+
+/**
+ * Avoid enqueueing block assets of all registered blocks for all posts, instead
+ * deferring to block render mechanics to enqueue scripts, thereby ensuring only
+ * blocks of the content have their assets enqueued.
+ *
+ * @see WP_Block::render
+ */
+remove_action( 'enqueue_block_assets', 'wp_enqueue_registered_block_scripts_and_styles' );

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -297,6 +297,11 @@ add_filter( 'pre_render_block', 'gutenberg_render_block_with_assigned_block_cont
  * deferring to block render mechanics to enqueue scripts, thereby ensuring only
  * blocks of the content have their assets enqueued.
  *
+ * This can be removed once minimum support for the plugin is outside the range
+ * of the version associated with closure of the following ticket.
+ *
+ * @see https://core.trac.wordpress.org/ticket/50328
+ *
  * @see WP_Block::render
  */
 remove_action( 'enqueue_block_assets', 'wp_enqueue_registered_block_scripts_and_styles' );


### PR DESCRIPTION
Closes #21838
Closes #5445

This pull request seeks to explore optimizing block asset enqueueing. Currently, all scripts and styles for all blocks will be rendered in every front-end page. This is hugely wasteful, since in reality only the scripts and styles associated with blocks relevant for that page should be enqueued.

The changes proposed here seek to achieve this behavior by bypassing the default script asset enqueueing associated with the `enqueue_block_assets` action, instead deferring enqueueing to occur at the time that a block is rendering.

This leverages the `script` and `style` properties of a `register_block_type` settings to determine the assets relevant for the block type. The optimization will not take place if a plugin uses `enqueue_block_assets`, which will run for every page load.

While the changes here are quite minimal, it may require more effort in (a) how this impacts existing core code and (b) how this can take effect for core blocks.

1. With these changes, [`wp_enqueue_registered_block_scripts_and_styles`](https://github.com/WordPress/wordpress-develop/blob/64a2e8d55eba5b91bc7fff382676bd5873feaa38/src/wp-includes/script-loader.php#L2486-L2521) will now only be called by default in the core editor screen. Therefore, its purpose should be considered as changing to the more generic behavior of "enqueue all assets for all blocks", and existing logic for evaluating the current screen can be removed.
   - [See example patch](https://gist.github.com/aduth/f9b4b9683f6cdd37092d7a99773bcd2f)
   - Related: It may also be worth reevaluating whether it makes sense that a block's `script` asset is enqueued in the editor. It works this way today, though arguably it may be causing some conflict or confusion for a block's "front-end" JavaScript to load in the editor.
2. The assets associated with core block's are always enqueued ([source](https://github.com/WordPress/wordpress-develop/blob/64a2e8d55eba5b91bc7fff382676bd5873feaa38/src/wp-includes/script-loader.php#L2452-L2484)). Thus, they won't be able to take advantage of the optimizations here. At a minimum, the core blocks should be updated to reference the script and style asset handles themselves, rather than creating an ad hoc enqueuing implementation. This should serve as a simplifying refactoring, and ensure consistent behavior of assets enqueuing for all blocks.
   - A separate effort should seek to try to split the core blocks' script and style assets to per-block assets. In the meantime, there's not much benefit to these optimizations for core blocks.

Also note a few subtleties of the differences in behavior:

- Enqueuing during the rendering of a block is likely to occur later in the page lifecycle (`the_content`) than it would have previously (`wp_enqueue_scripts`). While this should still work, it's quite likely that if an asset was registered as intending to enqueue during the page header, the actual enqueue could occur later.
   - Technically this could be remedied, if the parsing of blocks from content of the current post occurs earlier in the page lifecycle, closer to the `wp_enqueue_scripts` as it had been implemented previously.
- The enqueueing will occur as a side effect of `render_block`. Thus, it could potentially impact usage which is expecting pure behavior of `render_block` to generate markup. It's not clear what these conflicting circumstances may be, or whether there's some better indication to know the rendering context of a block (i.e. preparing for front-end display).

**Testing Instructions:**

As noted above, core blocks are currently not able to take advantage of this optimization due to the fact that their assets will always be enqueued via [`wp_common_block_scripts_and_styles`](https://developer.wordpress.org/reference/functions/wp_common_block_scripts_and_styles/).

However, it's possible to verify the behavior by implementing a custom block.

Example code:

```php
<?php

/**
 * Plugin Name: My Block Plugin
 */

function my_block_plugin_register_block() {
	wp_register_script( 'my-block-plugin-block-js', null );
	wp_add_inline_script( 'my-block-plugin-block-js', 'console.log( "loaded" );' );
	wp_register_script( 'my-block-plugin-block-editor-js', null, array( 'wp-blocks' ) );
	wp_add_inline_script(
		'my-block-plugin-block-editor-js',
		'wp.blocks.registerBlockType( "my-block-plugin/block", { edit() { return "edit my-block-plugin/block"; } } );'
	);
	register_block_type( 'my-block-plugin/block', [
		'title'           => 'My Block',
		'script'          => 'my-block-plugin-block-js',
		'editor_script'   => 'my-block-plugin-block-editor-js',
		'render_callback' => function() {
			return 'render my-block-plugin/block';
		},
	] );
}
add_action( 'init', 'my_block_plugin_register_block' );
```

With the above, you should only see logging for "loaded" in the front-end if the block is included in the contents of the post being viewed. This is contrasted with `master`, where the message will be logged on every front-end page of the site.