### PR TITLE
Customizer complementary area should not include the block areas

### DIFF
--- a/packages/edit-widgets/src/components/customizer-edit-widgets-initializer/index.js
+++ b/packages/edit-widgets/src/components/customizer-edit-widgets-initializer/index.js
@@ -2,17 +2,20 @@
  * WordPress dependencies
  */
 import { navigateRegions } from '@wordpress/components';
-import { useSimulatedMediaQuery } from '@wordpress/block-editor';
+import {
+	useSimulatedMediaQuery,
+	BlockInspector,
+} from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { useMemo } from '@wordpress/element';
 import { ComplementaryArea } from '@wordpress/interface';
+import { cog } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import './sync-customizer';
 import Header from '../header';
-import Sidebar from '../sidebar';
 import WidgetAreasBlockEditorProvider from '../widget-areas-block-editor-provider';
 import WidgetAreasBlockEditorContent from '../widget-areas-block-editor-content';
 
@@ -37,8 +40,16 @@ function CustomizerEditWidgetsInitializer( { settings } ) {
 			>
 				<Header isCustomizer />
 				<WidgetAreasBlockEditorContent />
-				<ComplementaryArea.Slot scope="core/edit-widgets" />
-				<Sidebar />
+				<ComplementaryArea.Slot scope="core/edit-widgets-customizer" />
+				<ComplementaryArea
+					className="edit-widgets-sidebar"
+					scope="core/edit-widgets-customizer"
+					identifier="edit-widgets-customizer/block-inspector"
+					icon={ cog }
+					title={ __( 'Block Inspector' ) }
+				>
+					<BlockInspector />
+				</ComplementaryArea>
 			</div>
 		</WidgetAreasBlockEditorProvider>
 	);

--- a/packages/edit-widgets/src/components/header/index.js
+++ b/packages/edit-widgets/src/components/header/index.js
@@ -42,7 +42,13 @@ function Header( { isCustomizer } ) {
 				) }
 				<div className="edit-widgets-header__actions">
 					{ ! isCustomizer && <SaveButton /> }
-					<PinnedItems.Slot scope="core/edit-widgets" />
+					<PinnedItems.Slot
+						scope={
+							isCustomizer
+								? 'core/edit-widgets-customizer'
+								: 'core/edit-widgets'
+						}
+					/>
 				</div>
 			</div>
 			{ ( ! isLargeViewport || isCustomizer ) && (


### PR DESCRIPTION
By mistake https://github.com/WordPress/gutenberg/pull/22467 also includes the block areas sidebar o the customizer.
The sidebar is not usable at all on the customizer and this PR fixes the issue by removing it from the customizer.
