### PR TITLE
fix z-index issues #22416

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -25,7 +25,7 @@ $z-layers: (
 	".block-library-gallery-item__inline-menu": 20,
 	".block-editor-url-input__suggestions": 30,
 	".edit-post-layout__footer": 30,
-	".interface-interface-skeleton__header": 30,
+	".interface-interface-skeleton__header": 32,
 	".edit-site-header": 62,
 	".edit-widgets-header": 30,
 	".block-library-button__inline-link .block-editor-url-input__suggestions": 6, // URL suggestions for button block above sibling inserter
@@ -86,7 +86,7 @@ $z-layers: (
 
 	// Show notices below expanded editor bar
 	// .edit-post-header { z-index: 30 }
-	".components-notice-list": 29,
+	".components-notice-list": 32,
 
 	// Above the block list and the header.
 	".block-editor-block-list__block-popover": 31,


### PR DESCRIPTION
## Description
This commit fixes the issue described in #22416 

## How has this been tested?
Manually on the browser 

## Screenshots <!-- if applicable -->
**This commit fixes the following 2 issues**
1- The block toolbar is appearing on top of the notice 

![Screen Shot 2020-05-29 at 6 30 33 PM](https://user-images.githubusercontent.com/39377174/83289097-6950c700-a1dc-11ea-9fd0-12d1f45280d8.png)

2- on scrolling enough, the block toolbar also appears on top of the top bar

![Screen Shot 2020-05-29 at 1 02 41 PM](https://user-images.githubusercontent.com/39377174/83289100-6d7ce480-a1dc-11ea-9575-a73211a756cc.png)


## Types of changes
Changed the **z-index** value for both the notice and the top bar 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
