### PR TITLE
Image block: avoid edit (history/undo) during image upload

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -300,9 +300,20 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
 	// Do not add new properties here, use `useDispatch` instead to avoid
 	// leaking new props to the public API (editor.BlockListBlock filter).
 	return {
-		setAttributes( newAttributes ) {
+		setAttributes( newAttributes, options = {} ) {
 			const { clientId } = ownProps;
-			updateBlockAttributes( clientId, newAttributes );
+
+			if ( options.silent ) {
+				const attributes = window.wp.data
+					.select( 'core/block-editor' )
+					.getBlockAttributes( clientId );
+
+				for ( const name in newAttributes ) {
+					attributes[ name ] = newAttributes[ name ];
+				}
+			} else {
+				updateBlockAttributes( clientId, newAttributes );
+			}
 		},
 		onInsertBlocks( blocks, index ) {
 			const { rootClientId } = ownProps;

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -12,7 +12,6 @@ import {
 	ExternalLink,
 	PanelBody,
 	ResizableBox,
-	Spinner,
 	TextareaControl,
 	TextControl,
 	ToolbarGroup,
@@ -94,11 +93,6 @@ function getFilename( url ) {
 	}
 }
 
-export function useForceUpdate() {
-	const [ , setState ] = useState();
-	return () => setState( ( value ) => ! value );
-}
-
 export function ImageEdit( {
 	attributes: {
 		url = '',
@@ -124,7 +118,6 @@ export function ImageEdit( {
 	noticeOperations,
 	onReplace,
 } ) {
-	const forceUpdate = useForceUpdate();
 	const ref = useRef();
 	const { image, maxWidth, isRTL, imageSizes, mediaUpload } = useSelect(
 		( select ) => {
@@ -228,10 +221,6 @@ export function ImageEdit( {
 			},
 			options
 		);
-
-		if ( onSelectImage.count > 1 ) {
-			forceUpdate();
-		}
 	}
 
 	onSelectImage.count = 0;
@@ -436,7 +425,6 @@ export function ImageEdit( {
 	}
 
 	const classes = classnames( className, {
-		'is-transient': isBlobURL( url ),
 		'is-resized': !! width || !! height,
 		'is-focused': isSelected,
 		[ `size-${ sizeSlug }` ]: sizeSlug,
@@ -528,7 +516,6 @@ export function ImageEdit( {
 				onClick={ onImageClick }
 				onError={ () => onImageError() }
 			/>
-			{ isBlobURL( url ) && <Spinner /> }
 		</>
 		/* eslint-enable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events */
 	);

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -5,21 +5,8 @@ figure.wp-block-image:not(.wp-block) {
 .wp-block-image {
 	position: relative;
 
-	&.is-transient img {
-		opacity: 0.3;
-	}
-
 	figcaption img {
 		display: inline;
-	}
-
-	// Shown while image is being uploaded
-	.components-spinner {
-		position: absolute;
-		top: 50%;
-		left: 50%;
-		margin-top: -9px;
-		margin-left: -9px;
 	}
 }
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

Partly fixes #8119.

This tries fixed a long standing issue with the image block: undo after upload loads the temporary URL, which is no longer available. The problem is that the attributes are set twice and seen as two steps in the history.

My proposed solution is to set the attributes once, and then "silently" mutate the state when the upload is complete. The only **rule** for a block to silently set attributes is that **there should be no difference in data or appearance**. This is the case for image upload, because the temporary image should be the exact same as the image after upload.

The only conflict to this rule with the current UI is that we have some loading UI that is displayed while image is uploading to the server. I think we should get rid of this.

* It feels much smoother to the user if it seems like the image is instantly uploaded.
* There's no need for the user to know what happens in the background. The image is there, and they can continue writing.
* We should only communicate with the user when the upload fails for some reason.
* Google Docs does this too, and image upload feels instant.

**Timeline of image upload**

* User selects an image, and a temporary image URL is set. To the user, image insertion feels instant without loading indicators etc.
* Upload completes and the attributes object is silently mutated, meaning that no re-render will happen by itself. A re-render is not necessary because a silent attribute change should only be done if there's no real data and visual change.
* At some later point, the component might render again and the new attributes will be used.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
