### PR TITLE
Rnmobile: merge 1.29.0 release to master

### DIFF
--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -53,6 +53,7 @@ export class BlockList extends Component {
 		this.extraData = {
 			parentWidth: this.props.parentWidth,
 			renderFooterAppender: this.props.renderFooterAppender,
+			onDeleteBlock: this.props.onDeleteBlock,
 		};
 		this.renderItem = this.renderItem.bind( this );
 		this.renderBlockListFooter = this.renderBlockListFooter.bind( this );
@@ -107,14 +108,16 @@ export class BlockList extends Component {
 	}
 
 	getExtraData() {
-		const { parentWidth, renderFooterAppender } = this.props;
+		const { parentWidth, renderFooterAppender, onDeleteBlock } = this.props;
 		if (
 			this.extraData.parentWidth !== parentWidth ||
-			this.extraData.renderFooterAppender !== renderFooterAppender
+			this.extraData.renderFooterAppender !== renderFooterAppender ||
+			this.extraData.onDeleteBlock !== onDeleteBlock
 		) {
 			this.extraData = {
 				parentWidth,
 				renderFooterAppender,
+				onDeleteBlock,
 			};
 		}
 		return this.extraData;

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -50,7 +50,10 @@ const getStyles = (
 export class BlockList extends Component {
 	constructor() {
 		super( ...arguments );
-
+		this.extraData = {
+			parentWidth: this.props.parentWidth,
+			renderFooterAppender: this.props.renderFooterAppender,
+		};
 		this.renderItem = this.renderItem.bind( this );
 		this.renderBlockListFooter = this.renderBlockListFooter.bind( this );
 		this.onCaretVerticalPositionChange = this.onCaretVerticalPositionChange.bind(
@@ -65,6 +68,7 @@ export class BlockList extends Component {
 			this
 		);
 		this.renderEmptyList = this.renderEmptyList.bind( this );
+		this.getExtraData = this.getExtraData.bind( this );
 	}
 
 	addBlockToEndOfPost( newBlock ) {
@@ -102,6 +106,20 @@ export class BlockList extends Component {
 		);
 	}
 
+	getExtraData() {
+		const { parentWidth, renderFooterAppender } = this.props;
+		if (
+			this.extraData.parentWidth !== parentWidth ||
+			this.extraData.renderFooterAppender !== renderFooterAppender
+		) {
+			this.extraData = {
+				parentWidth,
+				renderFooterAppender,
+			};
+		}
+		return this.extraData;
+	}
+
 	render() {
 		const { isRootList } = this.props;
 		// Use of Context to propagate the main scroll ref to its children e.g InnerBlocks
@@ -134,7 +152,6 @@ export class BlockList extends Component {
 			isFloatingToolbarVisible,
 			isStackedHorizontally,
 			horizontalAlignment,
-			parentWidth,
 		} = this.props;
 		const { parentScrollRef } = extraProps;
 
@@ -180,7 +197,7 @@ export class BlockList extends Component {
 						! isRootList && styles.overflowVisible,
 					] }
 					horizontal={ horizontal }
-					extraData={ parentWidth }
+					extraData={ this.getExtraData() }
 					scrollEnabled={ isRootList }
 					contentContainerStyle={
 						horizontal && styles.horizontalContentContainer

--- a/packages/block-editor/src/components/block-mobile-toolbar/index.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/index.native.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Keyboard, View } from 'react-native';
+import { View } from 'react-native';
 
 /**
  * WordPress dependencies
@@ -76,11 +76,7 @@ export default compose(
 		const { removeBlock } = dispatch( 'core/block-editor' );
 		return {
 			onDelete:
-				onDelete ||
-				( () => {
-					Keyboard.dismiss();
-					removeBlock( clientId, rootClientId );
-				} ),
+				onDelete || ( () => removeBlock( clientId, rootClientId ) ),
 		};
 	} )
 )( BlockMobileToolbar );

--- a/packages/block-library/src/button/edit.native.js
+++ b/packages/block-library/src/button/edit.native.js
@@ -477,7 +477,7 @@ class ButtonEdit extends Component {
 						placeholderTextColor={
 							styles.placeholderTextColor.color
 						}
-						identifier="content"
+						identifier="text"
 						tagName="p"
 						minWidth={ minWidth }
 						maxWidth={ maxWidth }

--- a/packages/block-library/src/button/editor.native.scss
+++ b/packages/block-library/src/button/editor.native.scss
@@ -48,3 +48,8 @@
 	font-size: 16px;
 	display: none;
 }
+
+.linkSettingsPanel {
+	padding-left: 0;
+	padding-right: 0;
+}

--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -39,6 +39,6 @@ export const settings = {
 	deprecated,
 	merge: ( a, { text = '' } ) => ( {
 		...a,
-		text: a.text + text,
+		text: ( a.text || '' ) + text,
 	} ),
 };

--- a/packages/block-library/src/buttons/edit.native.js
+++ b/packages/block-library/src/buttons/edit.native.js
@@ -12,7 +12,7 @@ import {
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose, useResizeObserver } from '@wordpress/compose';
 import { createBlock } from '@wordpress/blocks';
-import { useState, useEffect } from '@wordpress/element';
+import { useState, useEffect, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -45,16 +45,14 @@ function ButtonsEdit( {
 		}
 	}, [ sizes ] );
 
-	function renderFooterAppender() {
-		return (
-			<View style={ styles.appenderContainer }>
-				<InnerBlocks.ButtonBlockAppender
-					isFloating={ true }
-					onAddBlock={ onAddNextButton }
-				/>
-			</View>
-		);
-	}
+	const renderFooterAppender = useRef( () => (
+		<View style={ styles.appenderContainer }>
+			<InnerBlocks.ButtonBlockAppender
+				isFloating={ true }
+				onAddBlock={ onAddNextButton }
+			/>
+		</View>
+	) );
 
 	// Inside buttons block alignment options are not supported.
 	const alignmentHooksSetting = {
@@ -68,7 +66,7 @@ function ButtonsEdit( {
 				allowedBlocks={ ALLOWED_BLOCKS }
 				template={ BUTTONS_TEMPLATE }
 				renderFooterAppender={
-					shouldRenderFooterAppender && renderFooterAppender
+					shouldRenderFooterAppender && renderFooterAppender.current
 				}
 				__experimentalMoverDirection="horizontal"
 				horizontalAlignment={ align }

--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { Platform } from 'react-native';
+
+/**
  * WordPress dependencies
  */
 import {
@@ -129,6 +134,8 @@ const registerBlock = ( block ) => {
 // eslint-disable-next-line no-undef
 const devOnly = ( block ) => ( !! __DEV__ ? block : null );
 
+const iOSOnly = ( block ) => ( Platform.OS === 'ios' ? block : null );
+
 // Hide the Classic block
 addFilter(
 	'blocks.registerBlockType',
@@ -185,7 +192,7 @@ export const registerCoreBlocks = () => {
 		latestPosts,
 		verse,
 		cover,
-		pullquote,
+		iOSOnly( pullquote ),
 	].forEach( registerBlock );
 
 	setDefaultBlockName( paragraph.name );

--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -134,7 +134,7 @@ const registerBlock = ( block ) => {
 // eslint-disable-next-line no-undef
 const devOnly = ( block ) => ( !! __DEV__ ? block : null );
 
-const iOSOnly = ( block ) => ( Platform.OS === 'ios' ? block : null );
+const iOSOnly = ( block ) => ( Platform.OS === 'ios' ? block : devOnly( block ) );
 
 // Hide the Classic block
 addFilter(

--- a/packages/components/src/color-palette/index.native.js
+++ b/packages/components/src/color-palette/index.native.js
@@ -12,7 +12,7 @@ import { map, uniq } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { useState, useEffect, createRef } from '@wordpress/element';
+import { useRef, useEffect, createRef } from '@wordpress/element';
 import { usePreferredColorSchemeStyle } from '@wordpress/compose';
 /**
  * Internal dependencies
@@ -42,8 +42,8 @@ function ColorPalette( {
 
 	const isGradientSegment = currentSegment === colorsUtils.segments[ 1 ];
 
-	const [ scale ] = useState( new Animated.Value( 1 ) );
-	const [ opacity ] = useState( new Animated.Value( 1 ) );
+	const scale = useRef( new Animated.Value( 1 ) ).current;
+	const opacity = useRef( new Animated.Value( 1 ) ).current;
 
 	const defaultColors = uniq( map( defaultSettings.colors, 'color' ) );
 	const defaultGradientColors = uniq(
@@ -75,13 +75,17 @@ function ColorPalette( {
 	}
 
 	function performAnimation( color ) {
-		opacity.setValue( isSelected( color ) ? 1 : 0 );
-		scale.setValue( 1 );
+		if ( ! isSelected( color ) ) {
+			opacity.setValue( 0 );
+		}
 
 		Animated.parallel( [
 			timingAnimation( scale, 2 ),
 			timingAnimation( opacity, 1 ),
-		] ).start();
+		] ).start( () => {
+			opacity.setValue( 1 );
+			scale.setValue( 1 );
+		} );
 	}
 
 	const scaleInterpolation = scale.interpolate( {

--- a/packages/format-library/src/link/index.native.js
+++ b/packages/format-library/src/link/index.native.js
@@ -59,12 +59,13 @@ export const link = {
 				const text = getTextContent( slice( value ) );
 
 				if ( text && isURL( text ) ) {
-					onChange(
-						applyFormat( value, {
-							type: name,
-							attributes: { url: text },
-						} )
-					);
+					const newValue = applyFormat( value, {
+						type: name,
+						attributes: { url: text },
+					} );
+					newValue.start = newValue.end;
+					newValue.activeFormats = [];
+					onChange( { ...newValue, needsSelectionUpdate: true } );
 				} else {
 					this.setState( { addingLink: true } );
 					this.getURLFromClipboard();

--- a/packages/format-library/src/link/modal.native.js
+++ b/packages/format-library/src/link/modal.native.js
@@ -87,7 +87,7 @@ class ModalLinkUI extends Component {
 			opensInNewWindow,
 			text: linkText,
 		} );
-
+		let newAttributes;
 		if ( isCollapsed( value ) && ! isActive ) {
 			// insert link
 			const toInsert = applyFormat(
@@ -96,8 +96,7 @@ class ModalLinkUI extends Component {
 				0,
 				linkText.length
 			);
-			const newAttributes = insert( value, toInsert );
-			onChange( { ...newAttributes, needsSelectionUpdate: true } );
+			newAttributes = insert( value, toInsert );
 		} else if ( text !== getTextContent( slice( value ) ) ) {
 			// edit text in selected link
 			const toInsert = applyFormat(
@@ -106,18 +105,15 @@ class ModalLinkUI extends Component {
 				0,
 				text.length
 			);
-			const newAttributes = insert(
-				value,
-				toInsert,
-				value.start,
-				value.end
-			);
-			onChange( { ...newAttributes, needsSelectionUpdate: true } );
+			newAttributes = insert( value, toInsert, value.start, value.end );
 		} else {
 			// transform selected text into link
-			const newAttributes = applyFormat( value, format );
-			onChange( { ...newAttributes, needsSelectionUpdate: true } );
+			newAttributes = applyFormat( value, format );
 		}
+		//move selection to end of link
+		newAttributes.start = newAttributes.end;
+		newAttributes.activeFormats = [];
+		onChange( { ...newAttributes, needsSelectionUpdate: true } );
 
 		if ( ! isValidHref( url ) ) {
 			speak(

--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -178,7 +178,7 @@ export class RichText extends Component {
 	}
 
 	onFormatChange( record ) {
-		const { start, end, activeFormats = [] } = record;
+		const { start = 0, end = 0, activeFormats = [] } = record;
 		const changeHandlers = pickBy( this.props, ( v, key ) =>
 			key.startsWith( 'format_on_change_functions_' )
 		);


### PR DESCRIPTION
Merging the 1.29.0 release to master.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [X] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
