### PR TITLE
Size check action: Fix pattern warning

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2-beta
+    - uses: actions/checkout@v2
       with:
         fetch-depth: 1
     - uses: preactjs/compressed-size-action@v1

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -9,8 +9,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        fetch-depth: 1
     - uses: preactjs/compressed-size-action@v1
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -14,4 +14,3 @@ jobs:
     - uses: preactjs/compressed-size-action@v1
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        pattern: "{build/**/*.js,build/**/*.css}"


### PR DESCRIPTION
## Description

Remove the `pattern` input from size check step.

The action has been displaying a warning, the input is invalid:

```
##[warning]Unexpected input 'pattern', valid inputs are ['repo-token', 'build-script', 'compression', 'show-total', 'collapse-unchanged', 'omit-unchanged']
```

<img width="1190" alt="Screen Shot 2020-05-31 at 10 42 48" src="https://user-images.githubusercontent.com/841763/83348308-a4154500-a32b-11ea-9719-c364b145c08c.png">

Action yaml showing valid inputs [here](https://github.com/preactjs/compressed-size-action/blob/d85e1f35d37b4df8a5f29c2f06209d70a0578702/action.yml).

This also updates the `checkout` step from `v2-beta` to `v2` (stable).

## How has this been tested?

Check the action on this PR.

## Screenshots <!-- if applicable -->

## Types of changes

Internal.
