### PR TITLE
Block Directory: Fix "no result" ui flash

### DIFF
--- a/packages/block-directory/src/components/downloadable-blocks-panel/index.js
+++ b/packages/block-directory/src/components/downloadable-blocks-panel/index.js
@@ -94,7 +94,7 @@ export default compose( [
 		const downloadableItems = hasPermission
 			? getDownloadableBlocks( filterValue )
 			: [];
-		const isLoading = isRequestingDownloadableBlocks();
+		const isLoading = isRequestingDownloadableBlocks( filterValue );
 
 		return {
 			downloadableItems,

--- a/packages/block-directory/src/store/reducer.js
+++ b/packages/block-directory/src/store/reducer.js
@@ -14,7 +14,7 @@ import { combineReducers } from '@wordpress/data';
 export const downloadableBlocks = (
 	state = {
 		results: {},
-		pendingBlockRequests: 0,
+		pendingSearchRequests: 0,
 	},
 	action
 ) => {
@@ -22,7 +22,7 @@ export const downloadableBlocks = (
 		case 'FETCH_DOWNLOADABLE_BLOCKS':
 			return {
 				...state,
-				pendingBlockRequests: state.pendingBlockRequests + 1,
+				pendingSearchRequests: state.pendingSearchRequests + 1,
 			};
 		case 'RECEIVE_DOWNLOADABLE_BLOCKS':
 			return {
@@ -31,7 +31,7 @@ export const downloadableBlocks = (
 					...state.results,
 					[ action.filterValue ]: action.downloadableBlocks,
 				},
-				pendingBlockRequests: state.pendingBlockRequests - 1,
+				pendingSearchRequests: state.pendingSearchRequests - 1,
 			};
 	}
 	return state;

--- a/packages/block-directory/src/store/reducer.js
+++ b/packages/block-directory/src/store/reducer.js
@@ -11,27 +11,22 @@ import { combineReducers } from '@wordpress/data';
  *
  * @return {Object} Updated state.
  */
-export const downloadableBlocks = (
-	state = {
-		results: {},
-		pendingSearchRequests: 0,
-	},
-	action
-) => {
+export const downloadableBlocks = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case 'FETCH_DOWNLOADABLE_BLOCKS':
 			return {
 				...state,
-				pendingSearchRequests: state.pendingSearchRequests + 1,
+				[ action.filterValue ]: {
+					isRequesting: true,
+				},
 			};
 		case 'RECEIVE_DOWNLOADABLE_BLOCKS':
 			return {
 				...state,
-				results: {
-					...state.results,
-					[ action.filterValue ]: action.downloadableBlocks,
+				[ action.filterValue ]: {
+					results: action.downloadableBlocks,
+					isRequesting: false,
 				},
-				pendingSearchRequests: state.pendingSearchRequests - 1,
 			};
 	}
 	return state;

--- a/packages/block-directory/src/store/reducer.js
+++ b/packages/block-directory/src/store/reducer.js
@@ -14,7 +14,7 @@ import { combineReducers } from '@wordpress/data';
 export const downloadableBlocks = (
 	state = {
 		results: {},
-		isRequestingDownloadableBlocks: true,
+		pendingBlockRequests: 0,
 	},
 	action
 ) => {
@@ -22,7 +22,7 @@ export const downloadableBlocks = (
 		case 'FETCH_DOWNLOADABLE_BLOCKS':
 			return {
 				...state,
-				isRequestingDownloadableBlocks: true,
+				pendingBlockRequests: state.pendingBlockRequests + 1,
 			};
 		case 'RECEIVE_DOWNLOADABLE_BLOCKS':
 			return {
@@ -31,7 +31,7 @@ export const downloadableBlocks = (
 					...state.results,
 					[ action.filterValue ]: action.downloadableBlocks,
 				},
-				isRequestingDownloadableBlocks: false,
+				pendingBlockRequests: state.pendingBlockRequests - 1,
 			};
 	}
 	return state;

--- a/packages/block-directory/src/store/selectors.js
+++ b/packages/block-directory/src/store/selectors.js
@@ -16,7 +16,7 @@ import hasBlockType from './utils/has-block-type';
  * @return {Array} Downloadable blocks
  */
 export function isRequestingDownloadableBlocks( state ) {
-	return state.downloadableBlocks.isRequestingDownloadableBlocks;
+	return state.downloadableBlocks.pendingBlockRequests > 0;
 }
 
 /**

--- a/packages/block-directory/src/store/selectors.js
+++ b/packages/block-directory/src/store/selectors.js
@@ -12,11 +12,19 @@ import hasBlockType from './utils/has-block-type';
  * Returns true if application is requesting for downloadable blocks.
  *
  * @param {Object} state Global application state.
+ * @param {string} filterValue Search string.
+ *
  *
  * @return {Array} Downloadable blocks
  */
-export function isRequestingDownloadableBlocks( state ) {
-	return state.downloadableBlocks.pendingSearchRequests > 0;
+export function isRequestingDownloadableBlocks( state, filterValue ) {
+	if (
+		! state.downloadableBlocks[ filterValue ] ||
+		! state.downloadableBlocks[ filterValue ].isRequesting
+	) {
+		return false;
+	}
+	return state.downloadableBlocks[ filterValue ].isRequesting;
 }
 
 /**
@@ -28,10 +36,13 @@ export function isRequestingDownloadableBlocks( state ) {
  * @return {Array} Downloadable blocks
  */
 export function getDownloadableBlocks( state, filterValue ) {
-	if ( ! state.downloadableBlocks.results[ filterValue ] ) {
+	if (
+		! state.downloadableBlocks[ filterValue ] ||
+		! state.downloadableBlocks[ filterValue ].results
+	) {
 		return [];
 	}
-	return state.downloadableBlocks.results[ filterValue ];
+	return state.downloadableBlocks[ filterValue ].results;
 }
 
 /**

--- a/packages/block-directory/src/store/selectors.js
+++ b/packages/block-directory/src/store/selectors.js
@@ -16,7 +16,7 @@ import hasBlockType from './utils/has-block-type';
  * @return {Array} Downloadable blocks
  */
 export function isRequestingDownloadableBlocks( state ) {
-	return state.downloadableBlocks.pendingBlockRequests > 0;
+	return state.downloadableBlocks.pendingSearchRequests > 0;
 }
 
 /**

--- a/packages/block-directory/src/store/test/reducer.js
+++ b/packages/block-directory/src/store/test/reducer.js
@@ -18,14 +18,14 @@ describe( 'state', () => {
 	describe( 'downloadableBlocks()', () => {
 		it( 'should update state to reflect active search', () => {
 			const initialState = {};
-			const blockName = 'Awesome Block';
+			const filterValue = 'Awesome Block';
 
 			const state = downloadableBlocks( initialState, {
 				type: 'FETCH_DOWNLOADABLE_BLOCKS',
-				filterValue: blockName,
+				filterValue,
 			} );
 
-			expect( state[ blockName ].isRequesting ).toEqual( true );
+			expect( state[ filterValue ].isRequesting ).toEqual( true );
 		} );
 
 		it( 'should update state to reflect search results have returned', () => {

--- a/packages/block-directory/src/store/test/reducer.js
+++ b/packages/block-directory/src/store/test/reducer.js
@@ -58,36 +58,6 @@ describe( 'state', () => {
 			expect( state ).toHaveProperty( query );
 			expect( state[ query ].results ).toHaveLength( 1 );
 		} );
-
-		it( 'should set query to reflect its pending status', () => {
-			const filterValue = 'Awesome Block';
-
-			// Simulate a second call.
-			const stateAfterRequest = downloadableBlocks(
-				{},
-				{
-					type: 'FETCH_DOWNLOADABLE_BLOCKS',
-					filterValue,
-				}
-			);
-
-			expect( stateAfterRequest[ filterValue ].isRequesting ).toEqual(
-				true
-			);
-
-			const stateAfterResponse = downloadableBlocks(
-				{},
-				{
-					type: 'RECEIVE_DOWNLOADABLE_BLOCKS',
-					filterValue,
-					downloadableBlocks: [],
-				}
-			);
-
-			expect( stateAfterResponse[ filterValue ].isRequesting ).toEqual(
-				false
-			);
-		} );
 	} );
 
 	describe( 'blockManagement()', () => {

--- a/packages/block-directory/src/store/test/reducer.js
+++ b/packages/block-directory/src/store/test/reducer.js
@@ -18,25 +18,29 @@ describe( 'state', () => {
 	describe( 'downloadableBlocks()', () => {
 		it( 'should update state to reflect active search', () => {
 			const initialState = deepFreeze( {
-				isRequestingDownloadableBlocks: false,
+				pendingBlockRequests: 0,
 			} );
 			const state = downloadableBlocks( initialState, {
 				type: 'FETCH_DOWNLOADABLE_BLOCKS',
 				filterValue: 'test',
 			} );
 
-			expect( state.isRequestingDownloadableBlocks ).toEqual( true );
+			expect( state.pendingBlockRequests ).toEqual( 1 );
 		} );
 
 		it( 'should update state to reflect search results have returned', () => {
 			const query = downloadableBlock.title;
-			const state = downloadableBlocks( undefined, {
+			const initialState = deepFreeze( {
+				pendingBlockRequests: 1,
+			} );
+
+			const state = downloadableBlocks( initialState, {
 				type: 'RECEIVE_DOWNLOADABLE_BLOCKS',
 				filterValue: query,
 				downloadableBlocks: [ downloadableBlock ],
 			} );
 
-			expect( state.isRequestingDownloadableBlocks ).toEqual( false );
+			expect( state.pendingBlockRequests ).toEqual( 0 );
 		} );
 
 		it( "should set user's search term and save results", () => {

--- a/packages/block-directory/src/store/test/reducer.js
+++ b/packages/block-directory/src/store/test/reducer.js
@@ -17,7 +17,7 @@ import { blockTypeInstalled, downloadableBlock } from './fixtures';
 describe( 'state', () => {
 	describe( 'downloadableBlocks()', () => {
 		it( 'should update state to reflect active search', () => {
-			const initialState = {};
+			const initialState = deepFreeze( {} );
 			const filterValue = 'Awesome Block';
 
 			const state = downloadableBlocks( initialState, {
@@ -30,11 +30,11 @@ describe( 'state', () => {
 
 		it( 'should update state to reflect search results have returned', () => {
 			const query = downloadableBlock.title;
-			const initialState = {
+			const initialState = deepFreeze( {
 				[ query ]: {
 					isRequesting: true,
 				},
-			};
+			} );
 
 			const state = downloadableBlocks( initialState, {
 				type: 'RECEIVE_DOWNLOADABLE_BLOCKS',
@@ -47,14 +47,12 @@ describe( 'state', () => {
 
 		it( "should set user's search term and save results", () => {
 			const query = downloadableBlock.title;
-			const state = downloadableBlocks(
-				{},
-				{
-					type: 'RECEIVE_DOWNLOADABLE_BLOCKS',
-					filterValue: query,
-					downloadableBlocks: [ downloadableBlock ],
-				}
-			);
+			const initialState = deepFreeze( {} );
+			const state = downloadableBlocks( initialState, {
+				type: 'RECEIVE_DOWNLOADABLE_BLOCKS',
+				filterValue: query,
+				downloadableBlocks: [ downloadableBlock ],
+			} );
 			expect( state ).toHaveProperty( query );
 			expect( state[ query ].results ).toHaveLength( 1 );
 		} );

--- a/packages/block-directory/src/store/test/reducer.js
+++ b/packages/block-directory/src/store/test/reducer.js
@@ -18,20 +18,19 @@ describe( 'state', () => {
 	describe( 'downloadableBlocks()', () => {
 		it( 'should update state to reflect active search', () => {
 			const initialState = deepFreeze( {
-				pendingBlockRequests: 0,
+				pendingSearchRequests: 0,
 			} );
 			const state = downloadableBlocks( initialState, {
 				type: 'FETCH_DOWNLOADABLE_BLOCKS',
-				filterValue: 'test',
 			} );
 
-			expect( state.pendingBlockRequests ).toEqual( 1 );
+			expect( state.pendingSearchRequests ).toEqual( 1 );
 		} );
 
 		it( 'should update state to reflect search results have returned', () => {
 			const query = downloadableBlock.title;
 			const initialState = deepFreeze( {
-				pendingBlockRequests: 1,
+				pendingSearchRequests: 1,
 			} );
 
 			const state = downloadableBlocks( initialState, {
@@ -40,7 +39,7 @@ describe( 'state', () => {
 				downloadableBlocks: [ downloadableBlock ],
 			} );
 
-			expect( state.pendingBlockRequests ).toEqual( 0 );
+			expect( state.pendingSearchRequests ).toEqual( 0 );
 		} );
 
 		it( "should set user's search term and save results", () => {
@@ -61,6 +60,44 @@ describe( 'state', () => {
 			} );
 
 			expect( Object.keys( updatedState.results ) ).toHaveLength( 2 );
+		} );
+
+		it( 'should increment block requests', () => {
+			const initialState = {
+				pendingSearchRequests: 0,
+			};
+
+			// Simulate the first call.
+			const state = downloadableBlocks( initialState, {
+				type: 'FETCH_DOWNLOADABLE_BLOCKS',
+			} );
+
+			// Simulate a second call.
+			const finalState = downloadableBlocks( state, {
+				type: 'FETCH_DOWNLOADABLE_BLOCKS',
+			} );
+
+			expect( finalState.pendingSearchRequests ).toEqual( 2 );
+		} );
+		it( 'should decrement block requests', () => {
+			const initialState = {
+				pendingSearchRequests: 2,
+			};
+
+			// Simulate the first call response
+			const state = downloadableBlocks( initialState, {
+				type: 'RECEIVE_DOWNLOADABLE_BLOCKS',
+				filterValue: 'Test',
+				downloadableBlocks: [],
+			} );
+
+			const finalState = downloadableBlocks( state, {
+				type: 'RECEIVE_DOWNLOADABLE_BLOCKS',
+				filterValue: 'Test 1',
+				downloadableBlocks: [],
+			} );
+
+			expect( finalState.pendingSearchRequests ).toEqual( 0 );
 		} );
 	} );
 

--- a/packages/block-directory/src/store/test/reducer.js
+++ b/packages/block-directory/src/store/test/reducer.js
@@ -78,7 +78,8 @@ describe( 'state', () => {
 			} );
 
 			expect( finalState.pendingSearchRequests ).toEqual( 2 );
-		} );
+        } );
+        
 		it( 'should decrement block requests', () => {
 			const initialState = {
 				pendingSearchRequests: 2,

--- a/packages/block-directory/src/store/test/selectors.js
+++ b/packages/block-directory/src/store/test/selectors.js
@@ -102,6 +102,76 @@ describe( 'selectors', () => {
 		} );
 	} );
 
+	describe( 'getNewBlockTypes', () => {
+		it( 'should retrieve the block types that are installed and in the post content', () => {
+			getNewBlockTypes.registry = {
+				select: jest.fn( () => ( { getBlocks: () => blockList } ) ),
+			};
+			const state = {
+				blockManagement: {
+					installedBlockTypes: [
+						blockTypeInstalled,
+						blockTypeUnused,
+					],
+				},
+			};
+			const blockTypes = getNewBlockTypes( state );
+			expect( blockTypes ).toHaveLength( 1 );
+			expect( blockTypes[ 0 ] ).toEqual( blockTypeInstalled );
+		} );
+
+		it( 'should return an empty array if no blocks are used', () => {
+			getNewBlockTypes.registry = {
+				select: jest.fn( () => ( { getBlocks: () => [] } ) ),
+			};
+			const state = {
+				blockManagement: {
+					installedBlockTypes: [
+						blockTypeInstalled,
+						blockTypeUnused,
+					],
+				},
+			};
+			const blockTypes = getNewBlockTypes( state );
+			expect( blockTypes ).toHaveLength( 0 );
+		} );
+	} );
+
+	describe( 'getUnusedBlockTypes', () => {
+		it( 'should retrieve the block types that are installed but not used', () => {
+			getUnusedBlockTypes.registry = {
+				select: jest.fn( () => ( { getBlocks: () => blockList } ) ),
+			};
+			const state = {
+				blockManagement: {
+					installedBlockTypes: [
+						blockTypeInstalled,
+						blockTypeUnused,
+					],
+				},
+			};
+			const blockTypes = getUnusedBlockTypes( state );
+			expect( blockTypes ).toHaveLength( 1 );
+			expect( blockTypes[ 0 ] ).toEqual( blockTypeUnused );
+		} );
+
+		it( 'should return all block types if no blocks are used', () => {
+			getUnusedBlockTypes.registry = {
+				select: jest.fn( () => ( { getBlocks: () => [] } ) ),
+			};
+			const state = {
+				blockManagement: {
+					installedBlockTypes: [
+						blockTypeInstalled,
+						blockTypeUnused,
+					],
+				},
+			};
+			const blockTypes = getUnusedBlockTypes( state );
+			expect( blockTypes ).toHaveLength( 2 );
+		} );
+	} );
+
 	describe( 'getErrorNoticeForBlock', () => {
 		const state = {
 			errorNotices: {

--- a/packages/block-directory/src/store/test/selectors.js
+++ b/packages/block-directory/src/store/test/selectors.js
@@ -15,6 +15,7 @@ import {
 	getNewBlockTypes,
 	getUnusedBlockTypes,
 	isInstalling,
+	isRequestingDownloadableBlocks,
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -31,73 +32,27 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( 'getNewBlockTypes', () => {
-		it( 'should retrieve the block types that are installed and in the post content', () => {
-			getNewBlockTypes.registry = {
-				select: jest.fn( () => ( { getBlocks: () => blockList } ) ),
-			};
+	describe( 'isRequestingDownloadableBlocks', () => {
+		it( 'should return false if there are no calls pending', () => {
 			const state = {
-				blockManagement: {
-					installedBlockTypes: [
-						blockTypeInstalled,
-						blockTypeUnused,
-					],
+				downloadableBlocks: {
+					pendingBlockRequests: 0,
 				},
 			};
-			const blockTypes = getNewBlockTypes( state );
-			expect( blockTypes ).toHaveLength( 1 );
-			expect( blockTypes[ 0 ] ).toEqual( blockTypeInstalled );
+			const isRequesting = isRequestingDownloadableBlocks( state );
+
+			expect( isRequesting ).toEqual( false );
 		} );
 
-		it( 'should return an empty array if no blocks are used', () => {
-			getNewBlockTypes.registry = {
-				select: jest.fn( () => ( { getBlocks: () => [] } ) ),
-			};
+		it( 'should return true if at least one call is pending', () => {
 			const state = {
-				blockManagement: {
-					installedBlockTypes: [
-						blockTypeInstalled,
-						blockTypeUnused,
-					],
+				downloadableBlocks: {
+					pendingBlockRequests: 1,
 				},
 			};
-			const blockTypes = getNewBlockTypes( state );
-			expect( blockTypes ).toHaveLength( 0 );
-		} );
-	} );
+			const isRequesting = isRequestingDownloadableBlocks( state );
 
-	describe( 'getUnusedBlockTypes', () => {
-		it( 'should retrieve the block types that are installed but not used', () => {
-			getUnusedBlockTypes.registry = {
-				select: jest.fn( () => ( { getBlocks: () => blockList } ) ),
-			};
-			const state = {
-				blockManagement: {
-					installedBlockTypes: [
-						blockTypeInstalled,
-						blockTypeUnused,
-					],
-				},
-			};
-			const blockTypes = getUnusedBlockTypes( state );
-			expect( blockTypes ).toHaveLength( 1 );
-			expect( blockTypes[ 0 ] ).toEqual( blockTypeUnused );
-		} );
-
-		it( 'should return all block types if no blocks are used', () => {
-			getUnusedBlockTypes.registry = {
-				select: jest.fn( () => ( { getBlocks: () => [] } ) ),
-			};
-			const state = {
-				blockManagement: {
-					installedBlockTypes: [
-						blockTypeInstalled,
-						blockTypeUnused,
-					],
-				},
-			};
-			const blockTypes = getUnusedBlockTypes( state );
-			expect( blockTypes ).toHaveLength( 2 );
+			expect( isRequesting ).toEqual( true );
 		} );
 	} );
 
@@ -143,7 +98,6 @@ describe( 'selectors', () => {
 	describe( 'getDownloadableBlocks', () => {
 		const state = {
 			downloadableBlocks: {
-				isRequestingDownloadableBlocks: false,
 				results: {
 					boxer: [ downloadableBlock ],
 				},

--- a/packages/block-directory/src/store/test/selectors.js
+++ b/packages/block-directory/src/store/test/selectors.js
@@ -33,7 +33,7 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'isRequestingDownloadableBlocks', () => {
-		it( 'should return false if there are no calls pending', () => {
+		it( 'should return false if no requests have been made for the block', () => {
 			const filterValue = 'Awesome Block';
 
 			const state = {
@@ -47,13 +47,34 @@ describe( 'selectors', () => {
 			expect( isRequesting ).toEqual( false );
 		} );
 
-		it( 'should return true if at least one call is pending', () => {
+		it( 'should return false if there are no pending requests for the block', () => {
+			const filterValue = 'Awesome Block';
+
+			const state = {
+				downloadableBlocks: {
+					[ filterValue ]: {
+						isRequesting: false,
+					},
+				},
+			};
+			const isRequesting = isRequestingDownloadableBlocks(
+				state,
+				filterValue
+			);
+
+			expect( isRequesting ).toEqual( false );
+		} );
+
+		it( 'should return true if the block has a pending request', () => {
 			const filterValue = 'Awesome Block';
 
 			const state = {
 				downloadableBlocks: {
 					[ filterValue ]: {
 						isRequesting: true,
+					},
+					'previous-search-keyword': {
+						isRequesting: false,
 					},
 				},
 			};

--- a/packages/block-directory/src/store/test/selectors.js
+++ b/packages/block-directory/src/store/test/selectors.js
@@ -34,23 +34,33 @@ describe( 'selectors', () => {
 
 	describe( 'isRequestingDownloadableBlocks', () => {
 		it( 'should return false if there are no calls pending', () => {
+			const filterValue = 'Awesome Block';
+
 			const state = {
-				downloadableBlocks: {
-					pendingSearchRequests: 0,
-				},
+				downloadableBlocks: {},
 			};
-			const isRequesting = isRequestingDownloadableBlocks( state );
+			const isRequesting = isRequestingDownloadableBlocks(
+				state,
+				filterValue
+			);
 
 			expect( isRequesting ).toEqual( false );
 		} );
 
 		it( 'should return true if at least one call is pending', () => {
+			const filterValue = 'Awesome Block';
+
 			const state = {
 				downloadableBlocks: {
-					pendingSearchRequests: 1,
+					[ filterValue ]: {
+						isRequesting: true,
+					},
 				},
 			};
-			const isRequesting = isRequestingDownloadableBlocks( state );
+			const isRequesting = isRequestingDownloadableBlocks(
+				state,
+				filterValue
+			);
 
 			expect( isRequesting ).toEqual( true );
 		} );
@@ -98,8 +108,8 @@ describe( 'selectors', () => {
 	describe( 'getDownloadableBlocks', () => {
 		const state = {
 			downloadableBlocks: {
-				results: {
-					boxer: [ downloadableBlock ],
+				boxer: {
+					results: [ downloadableBlock ],
 				},
 			},
 		};

--- a/packages/block-directory/src/store/test/selectors.js
+++ b/packages/block-directory/src/store/test/selectors.js
@@ -87,21 +87,6 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( 'getErrorNotices', () => {
-		const state = {
-			errorNotices: {
-				'block/has-error': 'Error notice',
-			},
-		};
-
-		it( 'should retrieve all error notices', () => {
-			const errorNotices = getErrorNotices( state );
-			expect( errorNotices ).toEqual( {
-				'block/has-error': 'Error notice',
-			} );
-		} );
-	} );
-
 	describe( 'getNewBlockTypes', () => {
 		it( 'should retrieve the block types that are installed and in the post content', () => {
 			getNewBlockTypes.registry = {
@@ -169,6 +154,21 @@ describe( 'selectors', () => {
 			};
 			const blockTypes = getUnusedBlockTypes( state );
 			expect( blockTypes ).toHaveLength( 2 );
+		} );
+	} );
+
+	describe( 'getErrorNotices', () => {
+		const state = {
+			errorNotices: {
+				'block/has-error': 'Error notice',
+			},
+		};
+
+		it( 'should retrieve all error notices', () => {
+			const errorNotices = getErrorNotices( state );
+			expect( errorNotices ).toEqual( {
+				'block/has-error': 'Error notice',
+			} );
 		} );
 	} );
 

--- a/packages/block-directory/src/store/test/selectors.js
+++ b/packages/block-directory/src/store/test/selectors.js
@@ -36,7 +36,7 @@ describe( 'selectors', () => {
 		it( 'should return false if there are no calls pending', () => {
 			const state = {
 				downloadableBlocks: {
-					pendingBlockRequests: 0,
+					pendingSearchRequests: 0,
 				},
 			};
 			const isRequesting = isRequestingDownloadableBlocks( state );
@@ -47,7 +47,7 @@ describe( 'selectors', () => {
 		it( 'should return true if at least one call is pending', () => {
 			const state = {
 				downloadableBlocks: {
-					pendingBlockRequests: 1,
+					pendingSearchRequests: 1,
 				},
 			};
 			const isRequesting = isRequestingDownloadableBlocks( state );


### PR DESCRIPTION
## Description
When searching for block directory blocks, we flash "No blocks found in your library" and then 
switch it out with a result from the block directory.

Ideally, the user should never see "No blocks found in your library" while there is still a request pending.

## How has this been tested?
Typing slowly (to avoid debouncing), one letter at a time,
- Search for "github" (or any block).
- Notice the "no results" flash before it shows the results.

Watch the gif below ⬇️ . 
 
## Screenshots
![The issue](https://d.pr/i/mvx0nX.gif)

## Types of changes
The problem arises because we are queuing API requests while the user is typing. We try to reduce the number of request by debouncing but it's still common to queue up multiple requests. 

**Before:**
- When we request, we set the property `isRequestingDownloadableBlocks` to `true`.
- When the request finishes, we set the property `isRequestingDownloadableBlocks` to `false`.

If the user has 2 requests pending at once, `isRequestingDownloadableBlocks` is set to `false` once the first request resolves even though the latest request is still in transit. 

**After**
- Use a counter named `pendingSearchRequests` instead of a boolean value to track requests.
- Update the selector to return true if there is `> 0` requests pending.


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
