### PR TITLE
Env: Update Source type to WPSource

### DIFF
--- a/packages/env/lib/config.js
+++ b/packages/env/lib/config.js
@@ -38,7 +38,7 @@ const HOME_PATH_PREFIX = `~${ path.sep }`;
  * @property {number}      port                    The port on which to start the development WordPress environment.
  * @property {number}      testsPort               The port on which to start the testing WordPress environment.
  * @property {Object}      config                  Mapping of wp-config.php constants to their desired values.
- * @property {Object.<string, Source>} mappings    Mapping of WordPress directories to local directories which should be mounted.
+ * @property {Object.<string, WPSource>} mappings    Mapping of WordPress directories to local directories which should be mounted.
  * @property {boolean}     debug                   True if debug mode is enabled.
  */
 


### PR DESCRIPTION
## Description

Fix undefined `Source` type lint/type error

The following PRs were fine in isolation, but when merged resulted in
the introduction of an undefined `Source` type in the `env` package:

https://github.com/WordPress/gutenberg/pull/22256
https://github.com/WordPress/gutenberg/pull/20522

Rename `Source` introduced in #22256 to `WPSource` according to changes
in #20522.

This is causing a lint error in master and new PRs.

## How has this been tested?

No more lint error.

