### PR TITLE
Scripts: Split webpack loader rules for CSS and Sass files

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -10,6 +10,10 @@
 ### New Feature
 - The PostCSS loader now gives preference to a `postcss.config.js` configuration file if present.
 
+### Bug fix
+
+- Update webpack configuration to not run the Sass loader on CSS files. It's now limited to .scss and .sass files.
+
 ## 10.0.0 (2020-05-28)
 
 ### New Feature

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -21,6 +21,29 @@ const { hasBabelConfig, hasPostCSSConfig } = require( '../utils' );
 const isProduction = process.env.NODE_ENV === 'production';
 const mode = isProduction ? 'production' : 'development';
 
+const cssLoaders = [
+	{
+		loader: MiniCSSExtractPlugin.loader,
+	},
+	{
+		loader: require.resolve( 'css-loader' ),
+		options: {
+			sourceMap: ! isProduction,
+		},
+	},
+	{
+		loader: require.resolve( 'postcss-loader' ),
+		options: {
+			// Provide a fallback configuration if there's not
+			// one explicitly available in the project.
+			...( ! hasPostCSSConfig() && {
+				ident: 'postcss',
+				plugins: postcssPlugins,
+			} ),
+		},
+	},
+];
+
 const config = {
 	mode,
 	entry: {
@@ -88,29 +111,15 @@ const config = {
 				use: [ '@svgr/webpack', 'url-loader' ],
 			},
 			{
-				test: /\.(sc|sa|c)ss$/,
+				test: /\.css$/,
+				exclude: /node_modules/,
+				use: cssLoaders,
+			},
+			{
+				test: /\.(sc|sa)ss$/,
 				exclude: /node_modules/,
 				use: [
-					{
-						loader: MiniCSSExtractPlugin.loader,
-					},
-					{
-						loader: require.resolve( 'css-loader' ),
-						options: {
-							sourceMap: ! isProduction,
-						},
-					},
-					{
-						loader: require.resolve( 'postcss-loader' ),
-						options: {
-							// Provide a fallback configuration if there's not
-							// one explicitly available in the project.
-							...( ! hasPostCSSConfig() && {
-								ident: 'postcss',
-								plugins: postcssPlugins,
-							} ),
-						},
-					},
+					...cssLoaders,
 					{
 						loader: require.resolve( 'sass-loader' ),
 						options: {


### PR DESCRIPTION
## Description

Fixes #22733.

Updates the webpack configuration to not run the Sass loader on CSS files. It's now limited to .scss and .sass files.


## How has this been tested?

`wp-scripts build` with and without a custom PostCSS config with .css and .scss files.


## Screenshots <!-- if applicable -->

## Types of changes
Bug fix 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
