### PR TITLE
Make the panels not collapsible on the experimental navigation screen

### DIFF
--- a/packages/components/src/panel/README.md
+++ b/packages/components/src/panel/README.md
@@ -127,6 +127,14 @@ An icon to be shown next to the `PanelBody` title.
 -   Type: `String`
 -   Required: No
 
+###### collapsible
+
+If collapsible is true, then the collapse arrow is not be rendered and the `PanelBody` cannot be collapsed.
+
+-   Type: `boolean`
+-   Required: No
+-   Default: true
+
 ###### onToggle
 
 A function that is called when the user clicks on the `PanelBody` title after the open state is changed.

--- a/packages/components/src/panel/body.js
+++ b/packages/components/src/panel/body.js
@@ -44,41 +44,53 @@ export class PanelBody extends Component {
 			opened,
 			className,
 			icon,
+			collapsible = true,
 			forwardedRef,
 		} = this.props;
-		const isOpened = opened === undefined ? this.state.opened : opened;
+		const isOpened =
+			! collapsible || opened === undefined ? this.state.opened : opened;
 		const classes = classnames( 'components-panel__body', className, {
 			'is-opened': isOpened,
+			'is-collapsible': collapsible,
 		} );
 
 		return (
 			<div className={ classes } ref={ forwardedRef }>
 				{ !! title && (
 					<h2 className="components-panel__body-title">
-						<Button
-							className="components-panel__body-toggle"
-							onClick={ this.toggle }
-							aria-expanded={ isOpened }
-						>
-							{ /*
+						{ collapsible ? (
+							<Button
+								className="components-panel__body-toggle"
+								onClick={ this.toggle }
+								aria-expanded={ isOpened }
+							>
+								{ /*
 								Firefox + NVDA don't announce aria-expanded because the browser
 								repaints the whole element, so this wrapping span hides that.
 							*/ }
-							<span aria-hidden="true">
-								<Icon
-									className="components-panel__arrow"
-									icon={ isOpened ? chevronUp : chevronDown }
-								/>
-							</span>
-							{ title }
-							{ icon && (
-								<Icon
-									icon={ icon }
-									className="components-panel__icon"
-									size={ 20 }
-								/>
-							) }
-						</Button>
+
+								<span aria-hidden="true">
+									<Icon
+										className="components-panel__arrow"
+										icon={
+											isOpened ? chevronUp : chevronDown
+										}
+									/>
+								</span>
+								{ title }
+								{ icon && (
+									<Icon
+										icon={ icon }
+										className="components-panel__icon"
+										size={ 20 }
+									/>
+								) }
+							</Button>
+						) : (
+							<div className="components-panel__body-title-text">
+								{ title }
+							</div>
+						) }
 					</h2>
 				) }
 				{ isOpened && children }

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -68,12 +68,13 @@
 }
 
 // Hover States
-.components-panel__body > .components-panel__body-title:hover {
+.components-panel__body.is-collapsible > .components-panel__body-title:hover {
 	// Override the default button hover style
 	background: $light-gray-200;
 	border: none;
 }
 
+.components-panel__body-title-text,
 .components-panel__body-toggle.components-button {
 	position: relative;
 	padding: 15px;

--- a/packages/edit-navigation/src/components/menu-editor/block-editor-panel.js
+++ b/packages/edit-navigation/src/components/menu-editor/block-editor-panel.js
@@ -60,7 +60,7 @@ export default function BlockEditorPanel( {
 
 	return (
 		<Panel className="edit-navigation-menu-editor__block-editor-panel">
-			<PanelBody title={ __( 'Navigation menu' ) }>
+			<PanelBody title={ __( 'Navigation menu' ) } collapsible={ false }>
 				<div className="components-panel__header-actions">
 					<Button isPrimary onClick={ saveBlocks }>
 						{ __( 'Save navigation' ) }

--- a/packages/edit-navigation/src/components/menu-editor/navigation-structure-panel.js
+++ b/packages/edit-navigation/src/components/menu-editor/navigation-structure-panel.js
@@ -19,6 +19,7 @@ export default function NavigationStructurePanel( { blocks, initialOpen } ) {
 			<PanelBody
 				title={ __( 'Navigation structure' ) }
 				initialOpen={ initialOpen }
+				collapsible={ false }
 			>
 				{ showNavigationStructure && (
 					<__experimentalBlockNavigationTree


### PR DESCRIPTION
## Description

This PR makes the panels on the experimental navigation screen non-collapsible.

_"A picture is worth a thousand words"_ 

Before:

<img width="1390" alt="Zrzut ekranu 2020-06-1 o 12 33 44" src="https://user-images.githubusercontent.com/205419/83400973-25d8a180-a404-11ea-9bdb-f8c32a34d6af.png">

After:

<img width="1412" alt="Zrzut ekranu 2020-06-1 o 12 34 07" src="https://user-images.githubusercontent.com/205419/83400998-3426bd80-a404-11ea-85f0-54a45e0fb7ae.png">

## How has this been tested?
1. Enable the navigation experiment in Gutenberg > Experiments
1. Go to Gutenberg > Navigation (beta)
1. Confirm the panels are not collapsible

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
