### PR TITLE
Align navigator icon and buttons to top

### DIFF
--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -42,6 +42,7 @@ $tree-item-height: 36px;
 	}
 
 	.block-editor-block-icon {
+		align-self: flex-start;
 		margin-right: 6px;
 	}
 
@@ -57,6 +58,7 @@ $tree-item-height: 36px;
 	.block-editor-block-navigation-block__mover-cell {
 		width: $button-size;
 		opacity: 0;
+		vertical-align: top;
 		@include reduce-motion("transition");
 
 		&.is-visible {


### PR DESCRIPTION
## Description
This tiny PR improves the top alignment like this:

Before (vertical center):

<img width="280" alt="Zrzut ekranu 2020-06-1 o 13 18 09" src="https://user-images.githubusercontent.com/205419/83404138-59b6c580-a40a-11ea-9a00-90cc977bff97.png">

After (vertical top):

<img width="257" alt="Zrzut ekranu 2020-06-1 o 13 16 59" src="https://user-images.githubusercontent.com/205419/83404123-515e8a80-a40a-11ea-8dc6-8a97192c9f3e.png">
