### PR TITLE
Disable the navigator toolbar button on the experimental navigation screen

### DIFF
--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -19,7 +19,12 @@ import {
 } from '@wordpress/block-editor';
 
 import { createBlock } from '@wordpress/blocks';
-import { useDispatch, withSelect, withDispatch } from '@wordpress/data';
+import {
+	useSelect,
+	useDispatch,
+	withSelect,
+	withDispatch,
+} from '@wordpress/data';
 import {
 	Button,
 	PanelBody,
@@ -82,6 +87,11 @@ function Navigation( {
 			},
 		},
 		[ fontSize.size ]
+	);
+	const isNavigationManagementScreen = useSelect(
+		( select ) =>
+			select( 'core/block-editor' ).getSettings()
+				.__experimentalNavigationManagementEditor
 	);
 
 	const { navigatorToolbarButton, navigatorModal } = useBlockNavigator(
@@ -220,7 +230,9 @@ function Navigation( {
 						},
 					] }
 				/>
-				<ToolbarGroup>{ navigatorToolbarButton }</ToolbarGroup>
+				{ ! isNavigationManagementScreen && (
+					<ToolbarGroup>{ navigatorToolbarButton }</ToolbarGroup>
+				) }
 
 				<BlockColorsStyleSelector
 					TextColor={ TextColor }

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -91,7 +91,7 @@ function Navigation( {
 	const isNavigationManagementScreen = useSelect(
 		( select ) =>
 			select( 'core/block-editor' ).getSettings()
-				.__experimentalNavigationManagementEditor
+				.__experimentalNavigationScreen
 	);
 
 	const { navigatorToolbarButton, navigatorModal } = useBlockNavigator(

--- a/packages/edit-navigation/src/index.js
+++ b/packages/edit-navigation/src/index.js
@@ -57,7 +57,7 @@ export function initialize( id, settings ) {
 		__experimentalRegisterExperimentalCoreBlocks( settings );
 	}
 	settings.__experimentalFetchLinkSuggestions = fetchLinkSuggestions;
-	settings.__experimentalNavigationManagementEditor = true;
+	settings.__experimentalNavigationScreen = true;
 	render(
 		<Layout blockEditorSettings={ settings } />,
 		document.getElementById( id )

--- a/packages/edit-navigation/src/index.js
+++ b/packages/edit-navigation/src/index.js
@@ -57,6 +57,7 @@ export function initialize( id, settings ) {
 		__experimentalRegisterExperimentalCoreBlocks( settings );
 	}
 	settings.__experimentalFetchLinkSuggestions = fetchLinkSuggestions;
+	settings.__experimentalNavigationManagementEditor = true;
 	render(
 		<Layout blockEditorSettings={ settings } />,
 		document.getElementById( id )


### PR DESCRIPTION
Advances #21310

## Description
The navigation block's toolbar has a button to bring up the block navigator modal. It makes a lot of sense in the post editor, but less so on the experimental navigation screen the navigator is always visible. This PR hides it on the experimental navigation screen using `blockEditorSettings` - any alternative ideas are highly appreciated!

## How has this been tested?
1. Enable the navigation experiment in Gutenberg > Experiments
1. Go to Gutenberg > Navigation (beta)
1. Add at least one menu item and save the menu
1. Select the navigation block and confirm the "Open block navigator" button is not there:

<img width="773" alt="Zrzut ekranu 2020-06-1 o 13 40 10" src="https://user-images.githubusercontent.com/205419/83406319-af8d6c80-a40e-11ea-83ab-d67cd88aa8b5.png">

1. Go to post editor, create a navigation block, confirm the "Open block navigator" button is still there:

<img width="661" alt="Zrzut ekranu 2020-06-1 o 13 40 39" src="https://user-images.githubusercontent.com/205419/83406340-bcaa5b80-a40e-11ea-8fb4-dcc6fd4723e5.png">

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
