### PR TITLE
CopyHandler: Fix unintended Copy override when copying from input or textarea elements

### DIFF
--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -3,7 +3,10 @@
  */
 import { useCallback, useRef } from '@wordpress/element';
 import { serialize, pasteHandler } from '@wordpress/blocks';
-import { documentHasSelection, documentHasTextSelection } from '@wordpress/dom';
+import {
+	documentHasSelection,
+	documentHasUncollapsedSelection,
+} from '@wordpress/dom';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 
@@ -93,7 +96,7 @@ function CopyHandler( { children } ) {
 			// Otherwise, any focus on an input field is considered.
 			const hasSelection =
 				event.type === 'copy' || event.type === 'cut'
-					? documentHasTextSelection()
+					? documentHasUncollapsedSelection()
 					: documentHasSelection();
 
 			// Let native copy behaviour take over in input fields.

--- a/packages/dom/CHANGELOG.md
+++ b/packages/dom/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Feature
+
+- Add `documentHasUncollapsedSelection` to inquire about ranges of selected text in the document, including the separately managed selections inside <input> and <textarea> elements.
+
 ## 2.10.0 (2020-05-28)
 
 ### New Feature

--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -33,11 +33,25 @@ _Returns_
 
 <a name="documentHasTextSelection" href="#documentHasTextSelection">#</a> **documentHasTextSelection**
 
-Check whether the current document has selected text.
+Check whether the current document has selected text. This applies to ranges
+of text in the document, and not selection inside <input> and <textarea>
+elements.
+
+See: <https://developer.mozilla.org/en-US/docs/Web/API/Window/getSelection#Related_objects>.
 
 _Returns_
 
 -   `boolean`: True if there is selection, false if not.
+
+<a name="documentHasUncollapsedSelection" href="#documentHasUncollapsedSelection">#</a> **documentHasUncollapsedSelection**
+
+Check whether the current document has any sort of selection. This includes
+ranges of text across elements and any selection inside <input> and
+<textarea> elements.
+
+_Returns_
+
+-   `boolean`: Whether there is any sort of "selection" in the document.
 
 <a name="focus" href="#focus">#</a> **focus**
 

--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -484,7 +484,11 @@ export function isNumberInput( element ) {
 }
 
 /**
- * Check whether the current document has selected text.
+ * Check whether the current document has selected text. This applies to ranges
+ * of text in the document, and not selection inside <input> and <textarea>
+ * elements.
+ *
+ * See: https://developer.mozilla.org/en-US/docs/Web/API/Window/getSelection#Related_objects.
  *
  * @return {boolean} True if there is selection, false if not.
  */
@@ -492,6 +496,54 @@ export function documentHasTextSelection() {
 	const selection = window.getSelection();
 	const range = selection.rangeCount ? selection.getRangeAt( 0 ) : null;
 	return range && ! range.collapsed;
+}
+
+/**
+ * Check whether the given element, assumed an input field or textarea,
+ * contains a (uncollapsed) selection of text.
+ *
+ * Note: this is perhaps an abuse of the term "selection", since these elements
+ * manage selection differently and aren't covered by Selection#collapsed.
+ *
+ * See: https://developer.mozilla.org/en-US/docs/Web/API/Window/getSelection#Related_objects.
+ *
+ * @param {HTMLElement} element The HTML element.
+ *
+ * @return {boolean} Whether the input/textareaa element has some "selection".
+ */
+function inputFieldHasUncollapsedSelection( element ) {
+	if ( ! isTextField( element ) && ! isNumberInput( element ) ) {
+		return false;
+	}
+	try {
+		const { selectionStart, selectionEnd } = element;
+
+		return selectionStart !== null && selectionStart !== selectionEnd;
+	} catch ( error ) {
+		// Safari throws an exception when trying to get `selectionStart`
+		// on non-text <input> elements (which, understandably, don't
+		// have the text selection API). We catch this via a try/catch
+		// block, as opposed to a more explicit check of the element's
+		// input types, because of Safari's non-standard behavior. This
+		// also means we don't have to worry about the list of input
+		// types that support `selectionStart` changing as the HTML spec
+		// evolves over time.
+		return false;
+	}
+}
+
+/**
+ * Check whether the current document has any sort of selection. This includes
+ * ranges of text across elements and any selection inside <input> and
+ * <textarea> elements.
+ *
+ * @return {boolean} Whether there is any sort of "selection" in the document.
+ */
+export function documentHasUncollapsedSelection() {
+	return (
+		documentHasTextSelection() ||
+		inputFieldHasUncollapsedSelection( document.activeElement )
+	);
 }
 
 /**

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/copy-cut-paste-whole-blocks.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/copy-cut-paste-whole-blocks.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Multi-block selection should copy and paste individual blocks 1`] = `
+exports[`Copy/cut/paste of whole blocks should copy and paste individual blocks 1`] = `
 "<!-- wp:paragraph -->
 <p>Here is a unique string so we can test copying.</p>
 <!-- /wp:paragraph -->
@@ -10,7 +10,7 @@ exports[`Multi-block selection should copy and paste individual blocks 1`] = `
 <!-- /wp:paragraph -->"
 `;
 
-exports[`Multi-block selection should copy and paste individual blocks 2`] = `
+exports[`Copy/cut/paste of whole blocks should copy and paste individual blocks 2`] = `
 "<!-- wp:paragraph -->
 <p>Here is a unique string so we can test copying.</p>
 <!-- /wp:paragraph -->
@@ -24,13 +24,13 @@ exports[`Multi-block selection should copy and paste individual blocks 2`] = `
 <!-- /wp:paragraph -->"
 `;
 
-exports[`Multi-block selection should cut and paste individual blocks 1`] = `
+exports[`Copy/cut/paste of whole blocks should cut and paste individual blocks 1`] = `
 "<!-- wp:paragraph -->
 <p>2</p>
 <!-- /wp:paragraph -->"
 `;
 
-exports[`Multi-block selection should cut and paste individual blocks 2`] = `
+exports[`Copy/cut/paste of whole blocks should cut and paste individual blocks 2`] = `
 "<!-- wp:paragraph -->
 <p>2</p>
 <!-- /wp:paragraph -->
@@ -40,7 +40,23 @@ exports[`Multi-block selection should cut and paste individual blocks 2`] = `
 <!-- /wp:paragraph -->"
 `;
 
-exports[`Multi-block selection should respect inline copy when text is selected 1`] = `
+exports[`Copy/cut/paste of whole blocks should respect inline copy in places like input fields and textareas 1`] = `
+"<!-- wp:shortcode -->
+[my-shortcode]
+<!-- /wp:shortcode -->"
+`;
+
+exports[`Copy/cut/paste of whole blocks should respect inline copy in places like input fields and textareas 2`] = `
+"<!-- wp:shortcode -->
+[my-shortcode]
+<!-- /wp:shortcode -->
+
+<!-- wp:paragraph -->
+<p>Pasted: e]</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Copy/cut/paste of whole blocks should respect inline copy when text is selected 1`] = `
 "<!-- wp:paragraph -->
 <p>First block</p>
 <!-- /wp:paragraph -->
@@ -50,7 +66,7 @@ exports[`Multi-block selection should respect inline copy when text is selected 
 <!-- /wp:paragraph -->"
 `;
 
-exports[`Multi-block selection should respect inline copy when text is selected 2`] = `
+exports[`Copy/cut/paste of whole blocks should respect inline copy when text is selected 2`] = `
 "<!-- wp:paragraph -->
 <p>First block</p>
 <!-- /wp:paragraph -->

--- a/packages/e2e-tests/specs/editor/various/copy-cut-paste-whole-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/copy-cut-paste-whole-blocks.test.js
@@ -6,9 +6,10 @@ import {
 	createNewPost,
 	pressKeyWithModifier,
 	getEditedPostContent,
+	insertBlock,
 } from '@wordpress/e2e-test-utils';
 
-describe( 'Multi-block selection', () => {
+describe( 'Copy/cut/paste of whole blocks', () => {
 	beforeEach( async () => {
 		await createNewPost();
 	} );
@@ -60,6 +61,23 @@ describe( 'Multi-block selection', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 
 		await page.keyboard.press( 'Enter' );
+		await pressKeyWithModifier( 'primary', 'v' );
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should respect inline copy in places like input fields and textareas', async () => {
+		await insertBlock( 'Shortcode' );
+		await page.keyboard.type( '[my-shortcode]' );
+		await pressKeyWithModifier( 'shift', 'ArrowLeft' );
+		await pressKeyWithModifier( 'shift', 'ArrowLeft' );
+
+		await pressKeyWithModifier( 'primary', 'c' );
+		await page.keyboard.press( 'ArrowRight' );
+		await page.keyboard.press( 'ArrowRight' );
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		await insertBlock( 'Paragraph' );
+		await page.keyboard.type( 'Pasted: ' );
 		await pressKeyWithModifier( 'primary', 'v' );
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );


### PR DESCRIPTION
## Description

Fixes #22775.

#22186 introduced the ability to automatically copy the current block as a whole by pressing <kbd>CTRL-C</kbd> or <kbd>CTRL-X</kbd> as long as there was no active selection of text. The way to detect this failed to account for the fact that any text selected inside `<input>` and `<textarea>` elements is not handled by `getSelection()`. See [getSelection#Related objects](https://developer.mozilla.org/en-US/docs/Web/API/Window/getSelection#Related_objects) on MDN.

Affects blocks such as Embed, Custom HTML, Shortcode.

## How has this been tested?

See #22775 for original report and steps.

In addition, for any of the aforementioned affected blocks:
  * Try copying selected content inside `input` or `textarea` elements using <kbd>CTRL-C</kbd>. The selection should be copied. 
  * Deselect the block while leaving the caret inside the element, then press <kbd>CTRL-C</kbd>. Since there is no actual (= uncollapsed) selection, the whole block should be copied.
  * Select the block by focusing on something other than the `input` or `textarea` element, then press <kbd>CTRL-C</kbd>. The whole block should be copied.

## Types of changes
Bug fix.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
