### PR TITLE
Fix JSDoc for __experimentalAddAnnotation()

### DIFF
--- a/packages/annotations/src/store/actions.js
+++ b/packages/annotations/src/store/actions.js
@@ -4,6 +4,13 @@
 import { v4 as uuid } from 'uuid';
 
 /**
+ * @typedef WPAnnotationRange
+ *
+ * @property {number} start The offset where the annotation should start.
+ * @property {number} end   The offset where the annotation should end.
+ */
+
+/**
  * Adds an annotation to a block.
  *
  * The `block` attribute refers to a block ID that needs to be annotated.
@@ -13,15 +20,13 @@ import { v4 as uuid } from 'uuid';
  *
  * The `range` property is only relevant if the selector is 'range'.
  *
- * @param {Object} annotation                    The annotation to add.
- * @param {string} annotation.blockClientId      The blockClientId to add the annotation to.
- * @param {string} annotation.richTextIdentifier Identifier for the RichText instance the annotation applies to.
- * @param {Object} annotation.range              The range at which to apply this annotation.
- * @param {number} annotation.range.start        The offset where the annotation should start.
- * @param {number} annotation.range.end          The offset where the annotation should end.
- * @param {string} annotation.[selector="range"] The way to apply this annotation.
- * @param {string} annotation.[source="default"] The source that added the annotation.
- * @param {string} annotation.[id]               The ID the annotation should have. Generates a UUID by default.
+ * @param {Object}            annotation                    The annotation to add.
+ * @param {string}            annotation.blockClientId      The blockClientId to add the annotation to.
+ * @param {string}            annotation.richTextIdentifier Identifier for the RichText instance the annotation applies to.
+ * @param {WPAnnotationRange} annotation.range              The range at which to apply this annotation.
+ * @param {string}            [annotation.selector="range"] The way to apply this annotation.
+ * @param {string}            [annotation.source="default"] The source that added the annotation.
+ * @param {string}            [annotation.id]               The ID the annotation should have. Generates a UUID by default.
  *
  * @return {Object} Action object.
  */


### PR DESCRIPTION
## Description
Fixes the JSDoc formatting of `__experimentalAddAnnotation()` to fix the new linting errors which will be introduced by an update to `eslint-plugin-jsdoc`, see #22771.

```
[1] /home/travis/build/WordPress/gutenberg/packages/annotations/src/store/actions.js
[1]    6:1  error  Missing JSDoc @param "annotation.selector" declaration  jsdoc/require-param
[1]    6:1  error  Missing JSDoc @param "annotation.source" declaration    jsdoc/require-param
[1]    6:1  error  Missing JSDoc @param "annotation.id" declaration        jsdoc/require-param
[1]   16:0  error  Missing @param "annotation.selector"                    jsdoc/check-param-names
[1]   16:0  error  Missing @param "annotation.source"                      jsdoc/check-param-names
[1]   16:0  error  Missing @param "annotation.id"                          jsdoc/check-param-names
```

I also got the `@param "annotation.range.start" does not exist on annotation eslint(jsdoc/check-param-names)` error after fixing the above. That's why `WPAnnotationRange` exists now.

## How has this been tested?
`npm run lint-js packages/annotations/src/store/actions.js`

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
