### PR TITLE
Visual improvements to the block navigator

### DIFF
--- a/packages/block-editor/src/components/block-navigation/block.js
+++ b/packages/block-editor/src/components/block-navigation/block.js
@@ -6,7 +6,11 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { __experimentalTreeGridCell as TreeGridCell } from '@wordpress/components';
+import {
+	__experimentalTreeGridCell as TreeGridCell,
+	__experimentalTreeGridItem as TreeGridItem,
+} from '@wordpress/components';
+
 import { moreVertical } from '@wordpress/icons';
 import { useState } from '@wordpress/element';
 
@@ -96,27 +100,32 @@ export default function BlockNavigationBlock( {
 			</TreeGridCell>
 			{ hasRenderedMovers && (
 				<>
-					<TreeGridCell className={ moverCellClassName }>
-						{ ( { ref, tabIndex, onFocus } ) => (
-							<BlockMoverUpButton
-								__experimentalOrientation="vertical"
-								clientIds={ [ clientId ] }
-								ref={ ref }
-								tabIndex={ tabIndex }
-								onFocus={ onFocus }
-							/>
-						) }
-					</TreeGridCell>
-					<TreeGridCell className={ moverCellClassName }>
-						{ ( { ref, tabIndex, onFocus } ) => (
-							<BlockMoverDownButton
-								__experimentalOrientation="vertical"
-								clientIds={ [ clientId ] }
-								ref={ ref }
-								tabIndex={ tabIndex }
-								onFocus={ onFocus }
-							/>
-						) }
+					<TreeGridCell
+						className={ moverCellClassName }
+						withoutGridItem
+					>
+						<TreeGridItem>
+							{ ( { ref, tabIndex, onFocus } ) => (
+								<BlockMoverUpButton
+									__experimentalOrientation="vertical"
+									clientIds={ [ clientId ] }
+									ref={ ref }
+									tabIndex={ tabIndex }
+									onFocus={ onFocus }
+								/>
+							) }
+						</TreeGridItem>
+						<TreeGridItem>
+							{ ( { ref, tabIndex, onFocus } ) => (
+								<BlockMoverDownButton
+									__experimentalOrientation="vertical"
+									clientIds={ [ clientId ] }
+									ref={ ref }
+									tabIndex={ tabIndex }
+									onFocus={ onFocus }
+								/>
+							) }
+						</TreeGridItem>
 					</TreeGridCell>
 				</>
 			) }

--- a/packages/block-editor/src/components/block-navigation/block.js
+++ b/packages/block-editor/src/components/block-navigation/block.js
@@ -71,7 +71,7 @@ export default function BlockNavigationBlock( {
 		>
 			<TreeGridCell
 				className="block-editor-block-navigation-block__contents-cell"
-				colSpan={ hasRenderedMovers ? undefined : 3 }
+				colSpan={ hasRenderedMovers ? undefined : 2 }
 			>
 				{ ( { ref, tabIndex, onFocus } ) => (
 					<div className="block-editor-block-navigation-block__contents-container">
@@ -121,7 +121,7 @@ export default function BlockNavigationBlock( {
 				</>
 			) }
 
-			{ withBlockNavigationBlockSettings && level > 1 && (
+			{ withBlockNavigationBlockSettings && (
 				<TreeGridCell
 					className={ blockNavigationBlockSettingsClassName }
 				>

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -24,20 +24,6 @@ $tree-item-height: 36px;
 .block-editor-block-navigation-leaf {
 	// Use position relative for row animation.
 	position: relative;
-	transition: background 0.1s ease-out;
-	@include reduce-motion("transition");
-
-	// Highlight the entire row on hover
-	&:hover {
-		background: $light-gray-300;
-	}
-
-	// Do not highlight rows when inside of the popover
-	.block-editor-block-navigation__popover & {
-		&:hover {
-			background: transparent;
-		}
-	}
 
 	.block-editor-block-navigation-block-contents {
 		display: flex;

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -34,6 +34,11 @@ $tree-item-height: 36px;
 		text-align: left;
 		color: $dark-gray-600;
 		border-radius: 2px;
+
+		.components-modal__content & {
+			padding-left: 0;
+			padding-right: 0;
+		}
 	}
 
 	&.is-visible .block-editor-block-navigation-block-contents {
@@ -139,7 +144,7 @@ $tree-item-height: 36px;
 			position: absolute;
 			top: -1px;
 			bottom: -2px;
-			right: 0;
+			right: 1px;
 			border-right: 2px solid $light-gray-900;
 		}
 
@@ -153,12 +158,16 @@ $tree-item-height: 36px;
 			height: $grid-unit-20;
 		}
 
+		&.has-item.is-last-row::after {
+			top: 100%;
+		}
+
 		// Draw a horizontal line using border-bottom.
 		&.has-item::after {
 			content: "";
 			display: block;
 			position: absolute;
-			top: $grid-unit-20;
+			top: calc(50% - 1px);
 			left: 100%;
 			width: 5px;
 			border-bottom: 2px solid $light-gray-900;

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -222,7 +222,7 @@ $tree-item-height: 36px;
 
 		// Make the last vertical line half-height.
 		&.has-item.is-last-row {
-			height: 22px;
+			height: 26px;
 		}
 
 		// Draw a horizontal line using border-bottom.
@@ -230,7 +230,7 @@ $tree-item-height: 36px;
 			content: "";
 			display: block;
 			position: absolute;
-			top: 22px;
+			top: 26px;
 			left: 100%;
 			width: 5px;
 			border-bottom: 2px solid $light-gray-900;

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -31,6 +31,8 @@ $tree-item-height: 36px;
 		width: calc(100% - 0.8em);
 		height: auto;
 		padding: $grid-unit-15 6px;
+		margin-top: auto;
+		margin-bottom: auto;
 		text-align: left;
 		color: $dark-gray-600;
 		border-radius: 2px;
@@ -84,6 +86,10 @@ $tree-item-height: 36px;
 			min-width: 24px;
 			padding: 0;
 		}
+	}
+
+	.block-editor-block-navigation-block__menu-cell {
+		padding-top: $grid-unit-10;
 	}
 
 	.block-editor-block-navigation-block__mover-cell-alignment-wrapper {
@@ -159,7 +165,7 @@ $tree-item-height: 36px;
 		background: $dark-gray-primary;
 		color: $white;
 		height: $grid-unit-30;
-		margin: 6px 6px 6px 0.8em;
+		margin: 6px 6px 6px 1px;
 		min-width: $grid-unit-30;
 
 		&:active {
@@ -181,6 +187,10 @@ $tree-item-height: 36px;
 		display: flex;
 	}
 
+	.block-editor-block-navigation-block__contents-container {
+		min-height: 56px;
+	}
+
 	.block-editor-block-navigator-descender-line {
 		position: relative;
 		flex-shrink: 0;
@@ -199,7 +209,7 @@ $tree-item-height: 36px;
 			content: "";
 			display: block;
 			position: absolute;
-			top: -1px;
+			top: 1px;
 			bottom: -2px;
 			right: -1px;
 			border-right: 2px solid $light-gray-900;

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -24,13 +24,27 @@ $tree-item-height: 36px;
 .block-editor-block-navigation-leaf {
 	// Use position relative for row animation.
 	position: relative;
+	transition: background 0.1s ease-out;
+	@include reduce-motion("transition");
+
+	// Highlight the entire row on hover
+	&:hover {
+		background: $light-gray-300;
+	}
+
+	// Do not highlight rows when inside of the popover
+	.block-editor-block-navigation__popover & {
+		&:hover {
+			background: transparent;
+		}
+	}
 
 	.block-editor-block-navigation-block-contents {
 		display: flex;
 		align-items: center;
 		width: calc(100% - 0.8em);
 		height: auto;
-		padding: 6px;
+		padding: $grid-unit-15 6px;
 		text-align: left;
 		color: $dark-gray-600;
 		border-radius: 2px;

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -201,7 +201,7 @@ $tree-item-height: 36px;
 			position: absolute;
 			top: -1px;
 			bottom: -2px;
-			right: 1px;
+			right: -1px;
 			border-right: 2px solid $light-gray-900;
 		}
 

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -212,11 +212,7 @@ $tree-item-height: 36px;
 
 		// Make the last vertical line half-height.
 		&.has-item.is-last-row {
-			height: $grid-unit-20;
-		}
-
-		&.has-item.is-last-row::after {
-			top: 100%;
+			height: 22px;
 		}
 
 		// Draw a horizontal line using border-bottom.
@@ -224,10 +220,20 @@ $tree-item-height: 36px;
 			content: "";
 			display: block;
 			position: absolute;
-			top: calc(50% - 1px);
+			top: 22px;
 			left: 100%;
 			width: 5px;
 			border-bottom: 2px solid $light-gray-900;
+		}
+	}
+}
+
+// Position the horizontal line in the middle of appender's height
+.block-editor-block-navigation-appender__cell .block-editor-block-navigator-descender-line {
+	&.has-item.is-last-row {
+		height: $grid-unit-20;
+		&::after {
+			top: 100%;
 		}
 	}
 }

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -54,6 +54,13 @@ $tree-item-height: 36px;
 		border-radius: $border-width;
 	}
 
+	.block-editor-block-navigation-block__mover-cell-alignment-wrapper {
+		display: flex;
+		height: 100%;
+		flex-direction: column;
+		align-items: center;
+	}
+
 	.block-editor-block-navigation-block__menu-cell,
 	.block-editor-block-navigation-block__mover-cell {
 		width: $button-size;
@@ -76,7 +83,7 @@ $tree-item-height: 36px;
 
 	.block-editor-block-mover-button {
 		width: $button-size;
-		height: $button-size;
+		height: 16px;
 	}
 
 	.block-editor-inserter__toggle {

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -54,11 +54,11 @@ $tree-item-height: 36px;
 		border-radius: $border-width;
 	}
 
-	.block-editor-block-navigation-block__mover-cell-alignment-wrapper {
-		display: flex;
-		height: 100%;
-		flex-direction: column;
-		align-items: center;
+	.block-editor-block-navigation-block__menu-cell,
+	.block-editor-block-navigation-block__mover-cell,
+	.block-editor-block-navigation-block__contents-cell {
+		padding-top: 0;
+		padding-bottom: 0;
 	}
 
 	.block-editor-block-navigation-block__menu-cell,
@@ -81,9 +81,16 @@ $tree-item-height: 36px;
 		}
 	}
 
+	.block-editor-block-navigation-block__mover-cell-alignment-wrapper {
+		display: flex;
+		height: 100%;
+		flex-direction: column;
+		align-items: center;
+	}
+
 	.block-editor-block-mover-button {
 		width: $button-size;
-		height: 16px;
+		height: 24px;
 	}
 
 	.block-editor-inserter__toggle {

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -93,9 +93,66 @@ $tree-item-height: 36px;
 		align-items: center;
 	}
 
+	// Keep the tap target large but the focus target small
 	.block-editor-block-mover-button {
+		position: relative;
 		width: $button-size;
 		height: $button-size-small;
+
+		// Position the icon
+		svg {
+			position: relative;
+			height: $button-size-small;
+		}
+
+		&.is-up-button {
+			align-items: flex-end;
+			svg {
+				bottom: -4px;
+			}
+		}
+
+		&.is-down-button {
+			align-items: flex-start;
+			svg {
+				top: -4px;
+			}
+		}
+
+		// Don't show the focus inherited by the Button component.
+		&:focus:enabled {
+			box-shadow: none;
+			outline: none;
+		}
+
+		// Focus style.
+		&:focus {
+			box-shadow: none;
+			outline: none;
+		}
+
+		&:focus::before {
+			@include block-toolbar-button-style__focus();
+		}
+
+		// Focus and toggle pseudo elements.
+		&::before {
+			content: "";
+			position: absolute;
+			display: block;
+			border-radius: $radius-block-ui;
+			height: 16px;
+			min-width: 100%;
+
+			// Position the focus rectangle.
+			left: 0;
+			right: 0;
+
+			// Animate in.
+			animation: components-button__appear-animation 0.1s ease;
+			animation-fill-mode: forwards;
+			@include reduce-motion("animation");
+		}
 	}
 
 	.block-editor-inserter__toggle {

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -104,7 +104,7 @@ $tree-item-height: 36px;
 
 	.block-editor-block-mover-button {
 		width: $button-size;
-		height: 24px;
+		height: $button-size-small;
 	}
 
 	.block-editor-inserter__toggle {

--- a/packages/block-library/src/navigation-link/index.js
+++ b/packages/block-library/src/navigation-link/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { mapMarker as icon } from '@wordpress/icons';
+import { page as icon } from '@wordpress/icons';
 
 /**
  * Internal dependencies

--- a/packages/block-library/src/navigation-link/index.js
+++ b/packages/block-library/src/navigation-link/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { page as icon } from '@wordpress/icons';
+import { mapMarker as icon } from '@wordpress/icons';
 
 /**
  * Internal dependencies

--- a/packages/block-library/src/navigation/block-navigation-list.js
+++ b/packages/block-library/src/navigation/block-navigation-list.js
@@ -26,7 +26,7 @@ export default function BlockNavigationList( {
 
 	return (
 		<__experimentalBlockNavigationTree
-			blocks={ [ block ] }
+			blocks={ block.innerBlocks }
 			selectedBlockClientId={ selectedBlockClientId }
 			selectBlock={ selectBlock }
 			__experimentalFeatures={ __experimentalFeatures }

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -105,6 +105,7 @@ export {
 	default as __experimentalTreeGrid,
 	TreeGridRow as __experimentalTreeGridRow,
 	TreeGridCell as __experimentalTreeGridCell,
+	TreeGridItem as __experimentalTreeGridItem,
 } from './tree-grid';
 export { default as TreeSelect } from './tree-select';
 export { default as __experimentalUnitControl } from './unit-control';

--- a/packages/components/src/tree-grid/cell.js
+++ b/packages/components/src/tree-grid/cell.js
@@ -1,12 +1,20 @@
 /**
  * Internal dependencies
  */
-import RovingTabIndexItem from './roving-tab-index-item';
+import TreeGridItem from './item';
 
-export default function TreeGridCell( { children, ...props } ) {
+export default function TreeGridCell( {
+	children,
+	withoutGridItem = false,
+	...props
+} ) {
 	return (
 		<td { ...props } role="gridcell">
-			<RovingTabIndexItem>{ children }</RovingTabIndexItem>
+			{ withoutGridItem ? (
+				children
+			) : (
+				<TreeGridItem>{ children }</TreeGridItem>
+			) }
 		</td>
 	);
 }

--- a/packages/components/src/tree-grid/index.js
+++ b/packages/components/src/tree-grid/index.js
@@ -160,3 +160,4 @@ export default function TreeGrid( { children, ...props } ) {
 
 export { default as TreeGridRow } from './row';
 export { default as TreeGridCell } from './cell';
+export { default as TreeGridItem } from './item';

--- a/packages/components/src/tree-grid/item.js
+++ b/packages/components/src/tree-grid/item.js
@@ -1,0 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import RovingTabIndexItem from './roving-tab-index-item';
+
+export default function TreeGridItem( { children, ...props } ) {
+	return <RovingTabIndexItem { ...props }>{ children }</RovingTabIndexItem>;
+}

--- a/packages/edit-navigation/src/components/menu-editor/index.js
+++ b/packages/edit-navigation/src/components/menu-editor/index.js
@@ -57,7 +57,7 @@ export default function MenuEditor( {
 				<BlockEditorKeyboardShortcuts />
 				<MenuEditorShortcuts saveBlocks={ saveMenuItems } />
 				<NavigationStructureArea
-					blocks={ blocks }
+					blocks={ blocks[ 0 ]?.innerBlocks || [] }
 					initialOpen={ isLargeViewport }
 				/>
 				<BlockEditorArea

--- a/packages/edit-navigation/src/components/menu-editor/style.scss
+++ b/packages/edit-navigation/src/components/menu-editor/style.scss
@@ -51,12 +51,11 @@
 
 .block-editor-block-navigation-leaf {
 	> :first-child {
-		padding-left: $grid-unit-20;
+		padding-left: 0;
 	}
-	> :last-child {
-		padding-right: $grid-unit-20;
+	> :first-child button {
+		padding-left: 0;
 	}
-
 }
 
 .edit-navigation-menu-editor__navigation-structure-panel {

--- a/packages/edit-navigation/src/components/menu-editor/style.scss
+++ b/packages/edit-navigation/src/components/menu-editor/style.scss
@@ -50,9 +50,6 @@
 }
 
 .block-editor-block-navigation-leaf {
-	transition: background 0.1s ease-out;
-	@include reduce-motion("transition");
-
 	> :first-child {
 		padding-left: $grid-unit-20;
 	}
@@ -60,14 +57,6 @@
 		padding-right: $grid-unit-20;
 	}
 
-	&:hover {
-		background: $light-gray-300;
-	}
-
-	.block-editor-block-navigation-block-contents {
-		padding-top: $grid-unit-15;
-		padding-bottom: $grid-unit-15;
-	}
 }
 
 .edit-navigation-menu-editor__navigation-structure-panel {

--- a/packages/edit-navigation/src/components/menu-editor/style.scss
+++ b/packages/edit-navigation/src/components/menu-editor/style.scss
@@ -49,13 +49,40 @@
 	}
 }
 
-.edit-navigation-menu-editor__navigation-structure-card,
+.block-editor-block-navigation-leaf {
+	transition: background 0.1s ease-out;
+	@include reduce-motion("transition");
+
+	> :first-child {
+		padding-left: $grid-unit-20;
+	}
+	> :last-child {
+		padding-right: $grid-unit-20;
+	}
+
+	&:hover {
+		background: $light-gray-300;
+	}
+
+	.block-editor-block-navigation-block-contents {
+		padding-top: $grid-unit-15;
+		padding-bottom: $grid-unit-15;
+	}
+}
+
 .edit-navigation-menu-editor__navigation-structure-panel {
 	// IE11 requires the column to be explicitly declared.
 	grid-column: 1;
 
 	// Make panels collapsible in IE. The IE analogue of align-items: self-start;.
 	-ms-grid-row-align: start;
+
+	.components-card__header {
+		font-weight: bold;
+		border-bottom: 0;
+		padding-top: $grid-unit-30 !important;
+		padding-bottom: $grid-unit-30 !important;
+	}
 }
 
 .edit-navigation-menu-editor__navigation-structure-header {


### PR DESCRIPTION
## Description

This PR is an initial take on the design changes proposed in  https://github.com/WordPress/gutenberg/issues/22497

<img width="1095" alt="Zrzut ekranu 2020-06-1 o 16 08 13" src="https://user-images.githubusercontent.com/205419/83417242-1bc59b80-a422-11ea-808b-645e2b933115.png">

## What's missing

- [x] Inserter (@noisysocks works on it in #22170)
- [ ] Collapsing (requires more discussion - e.g. how collapse action would be different from select and edit?
- [ ] Custom icons for different types of menu items