### PR TITLE
Encode the heading block as block variations of h1-h6 elements

### DIFF
--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -64,4 +64,80 @@ export const settings = {
 	},
 	edit,
 	save,
+	variations: [
+		{
+			name: 'h1',
+			title: 'h1',
+			attributes: {
+				level: 1,
+				placeholder: 'I am level 1',
+			},
+			// scope: [],
+			// supports: {
+			// 	__experimentalSelector: 'h1',
+			// },
+		},
+		{
+			name: 'h2',
+			title: 'h2',
+			// isDefault: true,
+			attributes: {
+				level: 2,
+				placeholder: 'I am level 2',
+			},
+			// scope: [],
+			// supports: {
+			// 	__experimentalSelector: 'h2',
+			// },
+		},
+		{
+			name: 'h3',
+			title: 'h3',
+			isDefault: true,
+			attributes: {
+				level: 3,
+				placeholder: 'I am level 3',
+			},
+			// scope: [],
+			// supports: {
+			// 	__experimentalSelector: 'h3',
+			// },
+		},
+		{
+			name: 'h4',
+			title: 'h4',
+			attributes: {
+				level: 4,
+				placeholder: 'I am level 4',
+			},
+			// scope: [],
+			// supports: {
+			// 	__experimentalSelector: 'h4',
+			// },
+		},
+		{
+			name: 'h5',
+			title: 'h5',
+			attributes: {
+				level: 5,
+				placeholder: 'I am level 5',
+			},
+			// scope: [],
+			// supports: {
+			// 	__experimentalSelector: 'h5',
+			// },
+		},
+		{
+			name: 'h6',
+			title: 'h6',
+			attributes: {
+				level: 6,
+				placeholder: 'I am level 6',
+			},
+			// scope: [],
+			// supports: {
+			// 	__experimentalSelector: 'h6',
+			// },
+		},
+	],
 };


### PR DESCRIPTION
Related

- https://github.com/WordPress/gutenberg/pull/22518#discussion_r429911471
- https://github.com/WordPress/gutenberg/pull/22698#issuecomment-635352451

Some blocks represent many HTML elements. Examples of this are the core/heading block (h1-h6) and the core/list block (ol, ul). The Block Style System needs to bind a block to a CSS selector. However, for these blocks, the selector they use depends on some other attribute values.

This PR explores whether the selector can be expressed as a field within a block variation in these cases.