### PR TITLE
i18n: Standardize isRTL practices

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -470,7 +470,6 @@ _Properties_
 -   _hasPermissionsToManageWidgets_ `boolean`: Whether or not the user is able to manage widgets.
 -   _focusMode_ `boolean`: Whether the focus mode is enabled or not
 -   _styles_ `Array`: Editor Styles
--   _isRTL_ `boolean`: Whether the editor is in RTL mode
 -   _bodyPlaceholder_ `string`: Empty post placeholder
 -   _titlePlaceholder_ `string`: Empty title placeholder
 -   _codeEditingEnabled_ `boolean`: Whether or not the user can switch to the code editor

--- a/packages/block-editor/src/components/alignment-toolbar/index.js
+++ b/packages/block-editor/src/components/alignment-toolbar/index.js
@@ -6,7 +6,7 @@ import { find } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
 import { ToolbarGroup } from '@wordpress/components';
 import { alignLeft, alignRight, alignCenter } from '@wordpress/icons';
 
@@ -40,7 +40,6 @@ export function AlignmentToolbar( props ) {
 		alignmentControls = DEFAULT_ALIGNMENT_CONTROLS,
 		label = __( 'Change text alignment' ),
 		isCollapsed = true,
-		isRTL,
 	} = props;
 
 	function applyOrUnset( align ) {
@@ -54,7 +53,7 @@ export function AlignmentToolbar( props ) {
 
 	function setIcon() {
 		if ( activeAlignment ) return activeAlignment.icon;
-		return isRTL ? alignRight : alignLeft;
+		return isRTL() ? alignRight : alignLeft;
 	}
 
 	return (

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -232,7 +232,7 @@ const applyWithSelect = withSelect(
 		} = select( 'core/block-editor' );
 		const block = __unstableGetBlockWithoutInnerBlocks( clientId );
 		const isSelected = isBlockSelected( clientId );
-		const { focusMode, isRTL } = getSettings();
+		const { focusMode } = getSettings();
 		const templateLock = getTemplateLock( rootClientId );
 		const checkDeep = true;
 
@@ -270,7 +270,6 @@ const applyWithSelect = withSelect(
 			isLocked: !! templateLock,
 			isFocusMode: focusMode && isLargeViewport,
 			isNavigationMode: isNavigationMode(),
-			isRTL,
 
 			// Users of the editor.BlockListBlock filter used to be able to
 			// access the block prop.

--- a/packages/block-editor/src/components/block-list/breadcrumb.native.js
+++ b/packages/block-editor/src/components/block-list/breadcrumb.native.js
@@ -24,7 +24,6 @@ const BlockBreadcrumb = ( {
 	blockIcon,
 	rootClientId,
 	rootBlockIcon,
-	isRTL,
 } ) => {
 	return (
 		<View
@@ -51,10 +50,7 @@ const BlockBreadcrumb = ( {
 							fill={ styles.icon.color }
 						/>,
 						<View key="subdirectory-icon" style={ styles.arrow }>
-							<SubdirectorSVG
-								fill={ styles.arrow.color }
-								isRTL={ isRTL }
-							/>
+							<SubdirectorSVG fill={ styles.arrow.color } />
 						</View>,
 					] }
 				<Icon
@@ -77,7 +73,7 @@ const BlockBreadcrumb = ( {
 
 export default compose( [
 	withSelect( ( select, { clientId } ) => {
-		const { getBlockRootClientId, getBlockName, getSettings } = select(
+		const { getBlockRootClientId, getBlockName } = select(
 			'core/block-editor'
 		);
 
@@ -102,7 +98,6 @@ export default compose( [
 			blockIcon,
 			rootClientId,
 			rootBlockIcon,
-			isRTL: getSettings().isRTL,
 		};
 	} ),
 ] )( BlockBreadcrumb );

--- a/packages/block-editor/src/components/block-list/subdirectory-icon.js
+++ b/packages/block-editor/src/components/block-list/subdirectory-icon.js
@@ -1,19 +1,20 @@
 /**
  * WordPress dependencies
  */
+import { isRTL } from '@wordpress/i18n';
 import { SVG, Path } from '@wordpress/components';
 
-const Subdirectory = ( { isRTL, ...extraProps } ) => (
+const Subdirectory = ( props ) => (
 	<SVG
 		xmlns="http://www.w3.org/2000/svg"
 		width={ 14 }
 		height={ 14 }
 		viewBox="0 0 20 20"
-		{ ...extraProps }
+		{ ...props }
 	>
 		<Path
 			d="M19 15l-6 6-1.42-1.42L15.17 16H4V4h2v10h9.17l-3.59-3.58L13 9l6 6z"
-			transform={ isRTL ? 'scale(-1,1) translate(-20,0)' : undefined }
+			transform={ isRTL() ? 'scale(-1,1) translate(-20,0)' : undefined }
 		/>
 	</SVG>
 );

--- a/packages/block-editor/src/components/block-mover/button.js
+++ b/packages/block-editor/src/components/block-mover/button.js
@@ -12,7 +12,7 @@ import { Button } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { forwardRef } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, isRTL as getRTL } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -21,7 +21,8 @@ import { leftArrow, rightArrow } from './icons';
 import { chevronUp, chevronDown } from '@wordpress/icons';
 import { getBlockMoverDescription } from './mover-description';
 
-const getArrowIcon = ( direction, orientation, isRTL ) => {
+const getArrowIcon = ( direction, orientation ) => {
+	const isRTL = getRTL();
 	if ( direction === 'up' ) {
 		if ( orientation === 'horizontal' ) {
 			return isRTL ? rightArrow : leftArrow;
@@ -36,7 +37,8 @@ const getArrowIcon = ( direction, orientation, isRTL ) => {
 	return null;
 };
 
-const getMovementDirectionLabel = ( moveDirection, orientation, isRTL ) => {
+const getMovementDirectionLabel = ( moveDirection, orientation ) => {
+	const isRTL = getRTL();
 	if ( moveDirection === 'up' ) {
 		if ( orientation === 'horizontal' ) {
 			return isRTL ? __( 'Move right' ) : __( 'Move left' );
@@ -71,7 +73,6 @@ const BlockMoverButton = forwardRef(
 			isFirst,
 			isLast,
 			firstIndex,
-			isRTL,
 			moverOrientation,
 		} = useSelect(
 			( select ) => {
@@ -80,7 +81,6 @@ const BlockMoverButton = forwardRef(
 					getBlockRootClientId,
 					getBlockOrder,
 					getBlock,
-					getSettings,
 					getBlockListSettings,
 				} = select( 'core/block-editor' );
 				const normalizedClientIds = castArray( clientIds );
@@ -108,7 +108,6 @@ const BlockMoverButton = forwardRef(
 					firstIndex: firstBlockIndex,
 					isFirst: isFirstBlock,
 					isLast: isLastBlock,
-					isRTL: getSettings().isRTL,
 					moverOrientation:
 						orientation || __experimentalMoverDirection,
 				};
@@ -139,11 +138,10 @@ const BlockMoverButton = forwardRef(
 						'block-editor-block-mover-button',
 						`is-${ direction }-button`
 					) }
-					icon={ getArrowIcon( direction, moverOrientation, isRTL ) }
+					icon={ getArrowIcon( direction, moverOrientation ) }
 					label={ getMovementDirectionLabel(
 						direction,
-						moverOrientation,
-						isRTL
+						moverOrientation
 					) }
 					aria-describedby={ descriptionId }
 					{ ...props }
@@ -161,8 +159,7 @@ const BlockMoverButton = forwardRef(
 						isFirst,
 						isLast,
 						direction === 'up' ? -1 : 1,
-						moverOrientation,
-						isRTL
+						moverOrientation
 					) }
 				</span>
 			</>

--- a/packages/block-editor/src/components/floating-toolbar/index.native.js
+++ b/packages/block-editor/src/components/floating-toolbar/index.native.js
@@ -30,7 +30,6 @@ const FloatingToolbar = ( {
 	parentId,
 	showFloatingToolbar,
 	onNavigateUp,
-	isRTL,
 } ) => {
 	// sustain old selection for proper Breacdrumb rendering when exit animation is ongoing
 	const [ previousSelection, setPreviousSelection ] = useState( {} );
@@ -87,7 +86,7 @@ const FloatingToolbar = ( {
 								! showPrevious &&
 								( () => onNavigateUp( parentId ) )
 							}
-							icon={ <NavigateUpSVG isRTL={ isRTL } /> }
+							icon={ <NavigateUpSVG /> }
 						/>
 						<View style={ styles.pipe } />
 					</Toolbar>
@@ -105,7 +104,6 @@ export default compose( [
 			getBlockHierarchyRootClientId,
 			getBlockRootClientId,
 			getBlockCount,
-			getSettings,
 		} = select( 'core/block-editor' );
 
 		const selectedClientId = getSelectedBlockClientId();
@@ -118,7 +116,6 @@ export default compose( [
 			selectedClientId,
 			showFloatingToolbar: !! getBlockCount( rootBlockId ),
 			parentId: getBlockRootClientId( selectedClientId ),
-			isRTL: getSettings().isRTL,
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/packages/block-editor/src/components/floating-toolbar/nav-up-icon.js
+++ b/packages/block-editor/src/components/floating-toolbar/nav-up-icon.js
@@ -1,9 +1,10 @@
 /**
  * WordPress dependencies
  */
+import { isRTL } from '@wordpress/i18n';
 import { SVG, Path } from '@wordpress/components';
 
-const NavigateUp = ( { isRTL } ) => (
+const NavigateUp = () => (
 	<SVG
 		width="24"
 		height="24"
@@ -16,7 +17,7 @@ const NavigateUp = ( { isRTL } ) => (
 			fillRule="evenodd"
 			clipRule="evenodd"
 			d="M17,11  z L15.58,12.42 L12,8.83 L12,18 L22,18 L22,20 L10,20 L10,8.83 L6.42,12.42 L5,11 L11,5 L17,11"
-			transform={ isRTL ? 'scale(-1,1) translate(-24,0)' : undefined }
+			transform={ isRTL() ? 'scale(-1,1) translate(-24,0)' : undefined }
 		/>
 	</SVG>
 );

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -24,7 +24,6 @@ export const PREFERENCES_DEFAULTS = {
  * @property {boolean} hasPermissionsToManageWidgets Whether or not the user is able to manage widgets.
  * @property {boolean} focusMode Whether the focus mode is enabled or not
  * @property {Array} styles Editor Styles
- * @property {boolean} isRTL Whether the editor is in RTL mode
  * @property {string} bodyPlaceholder Empty post placeholder
  * @property {string} titlePlaceholder Empty title placeholder
  * @property {boolean} codeEditingEnabled Whether or not the user can switch to the code editor

--- a/packages/block-editor/tsconfig.json
+++ b/packages/block-editor/tsconfig.json
@@ -5,7 +5,8 @@
 		"declarationDir": "build-types"
 	},
 	"references": [
-		{ "path": "../element" }
+		{ "path": "../element" },
+		{ "path": "../i18n" }
 	],
 	// NOTE: This package is being progressively typed. You are encouraged to
 	// expand this array with files which can be type-checked. At some point in

--- a/packages/block-library/src/gallery/gallery-image.native.js
+++ b/packages/block-library/src/gallery/gallery-image.native.js
@@ -3,6 +3,7 @@
  */
 import {
 	Image,
+	I18nManager,
 	StyleSheet,
 	View,
 	ScrollView,
@@ -180,7 +181,6 @@ class GalleryImage extends Component {
 			'aria-label': ariaLabel,
 			isCropped,
 			getStylesFromColorScheme,
-			isRTL,
 		} = this.props;
 
 		const { isUploadInProgress, captionSelected } = this.state;
@@ -246,7 +246,9 @@ class GalleryImage extends Component {
 										<Button
 											style={ buttonStyle }
 											icon={
-												isRTL ? arrowRight : arrowLeft
+												I18nManager.isRTL
+													? arrowRight
+													: arrowLeft
 											}
 											iconSize={ ICON_SIZE_ARROW }
 											onClick={
@@ -264,7 +266,9 @@ class GalleryImage extends Component {
 										<Button
 											style={ buttonStyle }
 											icon={
-												isRTL ? arrowLeft : arrowRight
+												I18nManager.isRTL
+													? arrowLeft
+													: arrowRight
 											}
 											iconSize={ ICON_SIZE_ARROW }
 											onClick={

--- a/packages/block-library/src/gallery/gallery.native.js
+++ b/packages/block-library/src/gallery/gallery.native.js
@@ -19,7 +19,6 @@ import Tiles from './tiles';
 import { __, sprintf } from '@wordpress/i18n';
 import { BlockCaption } from '@wordpress/block-editor';
 import { useState, useEffect } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
 
 const TILE_SPACING = 15;
 
@@ -30,10 +29,6 @@ const MAX_DISPLAYED_COLUMNS_NARROW = 2;
 export const Gallery = ( props ) => {
 	const [ isCaptionSelected, setIsCaptionSelected ] = useState( false );
 	useEffect( mediaUploadSync, [] );
-
-	const isRTL = useSelect( ( select ) => {
-		return !! select( 'core/block-editor' ).getSettings().isRTL;
-	}, [] );
 
 	const {
 		clientId,
@@ -121,7 +116,6 @@ export const Gallery = ( props ) => {
 							}
 							caption={ img.caption }
 							aria-label={ ariaLabel }
-							isRTL={ isRTL }
 						/>
 					);
 				} ) }

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -34,7 +34,7 @@ import {
 	__experimentalImageURLInputUI as ImageURLInputUI,
 } from '@wordpress/block-editor';
 import { useEffect, useState, useRef } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, isRTL, sprintf } from '@wordpress/i18n';
 import { getPath } from '@wordpress/url';
 import { image as icon } from '@wordpress/icons';
 import { createBlock } from '@wordpress/blocks';
@@ -120,7 +120,7 @@ export function ImageEdit( {
 	onReplace,
 } ) {
 	const ref = useRef();
-	const { image, maxWidth, isRTL, imageSizes, mediaUpload } = useSelect(
+	const { image, maxWidth, imageSizes, mediaUpload } = useSelect(
 		( select ) => {
 			const { getMedia } = select( 'core' );
 			const { getSettings } = select( 'core/block-editor' );
@@ -128,7 +128,6 @@ export function ImageEdit( {
 				...pick( getSettings(), [
 					'mediaUpload',
 					'imageSizes',
-					'isRTL',
 					'maxWidth',
 				] ),
 				image: id && isSelected ? getMedia( id ) : null,
@@ -542,7 +541,7 @@ export function ImageEdit( {
 			// When the image is centered, show both handles.
 			showRightHandle = true;
 			showLeftHandle = true;
-		} else if ( isRTL ) {
+		} else if ( isRTL() ) {
 			// In RTL mode the image is on the right by default.
 			// Show the right handle and hide the left handle only when it is
 			// aligned left. Otherwise always show the left handle.

--- a/packages/block-library/src/list/edit.js
+++ b/packages/block-library/src/list/edit.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
+import { __, _x, isRTL as getRTL } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
 import {
 	RichText,
@@ -29,7 +29,6 @@ import {
 	formatOutdent,
 	formatOutdentRTL,
 } from '@wordpress/icons';
-import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -47,9 +46,7 @@ export default function ListEdit( {
 	const { ordered, values, type, reversed, start } = attributes;
 	const tagName = ordered ? 'ol' : 'ul';
 
-	const isRTL = useSelect( ( select ) => {
-		return !! select( 'core/block-editor' ).getSettings().isRTL;
-	}, [] );
+	const isRTL = getRTL();
 
 	const controls = ( { value, onChange, onFocus } ) => (
 		<>

--- a/packages/block-library/src/media-text/edit.native.js
+++ b/packages/block-library/src/media-text/edit.native.js
@@ -7,7 +7,7 @@ import { View } from 'react-native';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, isRTL as getRTL } from '@wordpress/i18n';
 import {
 	BlockControls,
 	BlockVerticalAlignmentToolbar,
@@ -184,7 +184,6 @@ class MediaTextEdit extends Component {
 			backgroundColor,
 			setAttributes,
 			isSelected,
-			isRTL,
 			wrapperProps,
 		} = this.props;
 		const {
@@ -195,6 +194,7 @@ class MediaTextEdit extends Component {
 		} = attributes;
 		const { containerWidth } = this.state;
 
+		const isRTL = getRTL();
 		const isMobile = containerWidth < BREAKPOINTS.mobile;
 		const shouldStack = isStackedOnMobile && isMobile;
 		const temporaryMediaWidth = shouldStack
@@ -302,7 +302,6 @@ export default compose(
 			getSelectedBlockClientId,
 			getBlockRootClientId,
 			getBlockParents,
-			getSettings,
 		} = select( 'core/block-editor' );
 
 		const parents = getBlockParents( clientId, true );
@@ -318,7 +317,6 @@ export default compose(
 			isSelected: selectedBlockClientId === clientId,
 			isParentSelected,
 			isAncestorSelected,
-			isRTL: getSettings().isRTL,
 		};
 	} )
 )( MediaTextEdit );

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
+import { __, _x, isRTL } from '@wordpress/i18n';
 import { PanelBody, ToggleControl, ToolbarGroup } from '@wordpress/components';
 import {
 	AlignmentToolbar,
@@ -32,12 +32,8 @@ const name = 'core/paragraph';
 const PARAGRAPH_DROP_CAP_SELECTOR = 'p.has-drop-cap';
 
 function ParagraphRTLToolbar( { direction, setDirection } ) {
-	const isRTL = useSelect( ( select ) => {
-		return !! select( 'core/block-editor' ).getSettings().isRTL;
-	}, [] );
-
 	return (
-		isRTL && (
+		isRTL() && (
 			<ToolbarGroup
 				controls={ [
 					{

--- a/packages/block-library/src/paragraph/edit.native.js
+++ b/packages/block-library/src/paragraph/edit.native.js
@@ -8,7 +8,6 @@ import {
 	BlockControls,
 	RichText,
 } from '@wordpress/block-editor';
-import { useSelect } from '@wordpress/data';
 
 const name = 'core/paragraph';
 
@@ -20,10 +19,6 @@ function ParagraphBlock( {
 	mergedStyle,
 	style,
 } ) {
-	const isRTL = useSelect( ( select ) => {
-		return !! select( 'core/block-editor' ).getSettings().isRTL;
-	}, [] );
-
 	const { align, content, placeholder } = attributes;
 
 	const styles = {
@@ -36,7 +31,6 @@ function ParagraphBlock( {
 			<BlockControls>
 				<AlignmentToolbar
 					value={ align }
-					isRTL={ isRTL }
 					onChange={ ( nextAlign ) => {
 						setAttributes( { align: nextAlign } );
 					} }

--- a/packages/components/src/alignment-matrix-control/index.js
+++ b/packages/components/src/alignment-matrix-control/index.js
@@ -12,7 +12,7 @@ import {
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
 import { useInstanceId } from '@wordpress/compose';
 import { useState, useEffect } from '@wordpress/element';
 
@@ -21,7 +21,6 @@ import { useState, useEffect } from '@wordpress/element';
  */
 import Cell from './cell';
 import { Root, Row } from './styles/alignment-matrix-control-styles';
-import { useRTL } from '../utils/rtl';
 import AlignmentMatrixControlIcon from './icon';
 import { GRID, getItemId } from './utils';
 
@@ -45,14 +44,13 @@ export default function AlignmentMatrixControl( {
 	...props
 } ) {
 	const [ immutableDefaultValue ] = useState( value ?? defaultValue );
-	const isRTL = useRTL();
 	const baseId = useBaseId( id );
 	const initialCurrentId = getItemId( baseId, immutableDefaultValue );
 
 	const composite = useCompositeState( {
 		baseId,
 		currentId: initialCurrentId,
-		rtl: isRTL,
+		rtl: isRTL(),
 	} );
 
 	const handleOnChange = ( nextValue ) => {

--- a/packages/components/src/date-time/date.js
+++ b/packages/components/src/date-time/date.js
@@ -10,12 +10,12 @@ import DayPickerSingleDateController from 'react-dates/lib/components/DayPickerS
  * WordPress dependencies
  */
 import { Component, createRef } from '@wordpress/element';
+import { isRTL } from '@wordpress/i18n';
 
 /**
  * Module Constants
  */
 const TIMEZONELESS_FORMAT = 'YYYY-MM-DDTHH:mm:ss';
-const isRTL = () => document.documentElement.dir === 'rtl';
 
 class DatePicker extends Component {
 	constructor() {

--- a/packages/components/src/popover/utils.js
+++ b/packages/components/src/popover/utils.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { getScrollContainer } from '@wordpress/dom';
+import { isRTL as getRTL } from '@wordpress/i18n';
 
 /**
  * Module constants
@@ -33,7 +34,7 @@ export function computePopoverXAxisPosition(
 	boundaryElement
 ) {
 	const { width } = contentSize;
-	const isRTL = document.documentElement.dir === 'rtl';
+	const isRTL = getRTL();
 
 	// Correct xAxis for RTL support
 	if ( xAxis === 'left' && isRTL ) {

--- a/packages/components/src/range-control/index.js
+++ b/packages/components/src/range-control/index.js
@@ -7,7 +7,7 @@ import { clamp, isFinite, noop } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
 import { useRef, useState, forwardRef } from '@wordpress/element';
 import { compose, withInstanceId } from '@wordpress/compose';
 
@@ -37,7 +37,6 @@ import {
 	Wrapper,
 } from './styles/range-control-styles';
 import InputField from './input-field';
-import { useRTL } from '../utils/rtl';
 
 const BaseRangeControl = forwardRef(
 	(
@@ -71,8 +70,6 @@ const BaseRangeControl = forwardRef(
 		},
 		ref
 	) => {
-		const isRTL = useRTL();
-
 		const sliderValue =
 			valueProp !== undefined ? valueProp : initialPosition;
 
@@ -184,7 +181,7 @@ const BaseRangeControl = forwardRef(
 		} );
 
 		const offsetStyle = {
-			[ isRTL ? 'right' : 'left' ]: fillValueOffset,
+			[ isRTL() ? 'right' : 'left' ]: fillValueOffset,
 		};
 
 		return (
@@ -194,10 +191,7 @@ const BaseRangeControl = forwardRef(
 				id={ id }
 				help={ help }
 			>
-				<Root
-					className="components-range-control__root"
-					isRTL={ isRTL }
-				>
+				<Root className="components-range-control__root">
 					{ beforeIcon && (
 						<BeforeIconWrapper>
 							<Icon icon={ beforeIcon } />

--- a/packages/components/src/range-control/rail.js
+++ b/packages/components/src/range-control/rail.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { isRTL } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import RangeMark from './mark';
@@ -58,8 +63,6 @@ function Marks( {
 }
 
 function useMarks( { marks, min = 0, max = 100, step = 1, value = 0 } ) {
-	const isRTL = document.documentElement.dir === 'rtl';
-
 	if ( ! marks ) {
 		return [];
 	}
@@ -81,7 +84,7 @@ function useMarks( { marks, min = 0, max = 100, step = 1, value = 0 } ) {
 		const offset = `${ ( markValue / markCount ) * 100 }%`;
 
 		const offsetStyle = {
-			[ isRTL ? 'right' : 'left' ]: offset,
+			[ isRTL() ? 'right' : 'left' ]: offset,
 		};
 
 		return {

--- a/packages/components/src/utils/rtl.js
+++ b/packages/components/src/utils/rtl.js
@@ -4,28 +4,15 @@
 import { css } from '@emotion/core';
 import { mapKeys } from 'lodash';
 
+/**
+ * WordPress dependencies
+ */
+import { isRTL as getRTL } from '@wordpress/i18n';
+
 const LOWER_LEFT_REGEXP = new RegExp( /-left/g );
 const LOWER_RIGHT_REGEXP = new RegExp( /-right/g );
 const UPPER_LEFT_REGEXP = new RegExp( /Left/g );
 const UPPER_RIGHT_REGEXP = new RegExp( /Right/g );
-
-/**
- * Checks to see whether the document is set to rtl.
- *
- * @return {boolean} Whether document is RTL.
- */
-export function getRTL() {
-	return !! ( document && document.documentElement.dir === 'rtl' );
-}
-
-/**
- * Simple hook to retrieve RTL direction value
- *
- * @return {boolean} Whether document is RTL.
- */
-export function useRTL() {
-	return getRTL();
-}
 
 /**
  * Flips a CSS property from left <-> right.

--- a/packages/components/src/utils/style-mixins.js
+++ b/packages/components/src/utils/style-mixins.js
@@ -1,3 +1,3 @@
 export { color, rgba } from './colors';
 export { reduceMotion } from './reduce-motion';
-export { rtl, getRTL, useRTL } from './rtl';
+export { rtl } from './rtl';

--- a/packages/edit-post/src/components/header/header-toolbar/index.native.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.native.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useRef } from 'react';
-import { ScrollView, View } from 'react-native';
+import { I18nManager, ScrollView, View } from 'react-native';
 
 /**
  * WordPress dependencies
@@ -33,7 +33,6 @@ function HeaderToolbar( {
 	showKeyboardHideButton,
 	getStylesFromColorScheme,
 	onHideKeyboard,
-	isRTL,
 } ) {
 	const scrollViewRef = useRef( null );
 	const scrollToStart = () => {
@@ -65,7 +64,7 @@ function HeaderToolbar( {
 			/>,
 		];
 
-		return isRTL ? buttons.reverse() : buttons;
+		return I18nManager.isRTL ? buttons.reverse() : buttons;
 	};
 
 	return (
@@ -114,7 +113,6 @@ export default compose( [
 			select( 'core/editor' ).getEditorSettings().richEditingEnabled,
 		isTextModeEnabled:
 			select( 'core/edit-post' ).getEditorMode() === 'text',
-		isRTL: select( 'core/block-editor' ).getSettings().isRTL,
 	} ) ),
 	withDispatch( ( dispatch ) => {
 		const { clearSelectedBlock } = dispatch( 'core/block-editor' );

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -139,7 +139,6 @@ class EditorProvider extends Component {
 				'hasPermissionsToManageWidgets',
 				'imageSizes',
 				'imageDimensions',
-				'isRTL',
 				'maxWidth',
 				'onUpdateDefaultBlockStyles',
 				'styles',


### PR DESCRIPTION
#20298 added an `isRTL` function to `@wordpress/i18n`. Use it throughout Gutenberg.

## Description
<!-- Please describe what you have changed or added -->

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
