### PR TITLE
Trigger additional widget setup actions

### DIFF
--- a/lib/widgets.php
+++ b/lib/widgets.php
@@ -44,6 +44,12 @@ add_action( 'admin_print_styles', 'gutenberg_block_editor_admin_print_styles' );
  */
 function gutenberg_block_editor_admin_print_scripts() {
 	if ( gutenberg_is_block_editor() ) {
+		/** This action is documented in wp-admin/includes/ajax-actions.php */
+		do_action( 'load-widgets.php' ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+		/** This action is documented in wp-admin/includes/ajax-actions.php */
+		do_action( 'widgets.php' ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+		/** This action is documented in wp-admin/widgets.php */
+		do_action( 'sidebar_admin_setup' );
 		// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 		do_action( 'admin_print_scripts-widgets.php' );
 	}


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/22765.
Some widgets don't enqueue their scripts using "admin_print_scripts-widgets.php" action and use other actions like "sidebar_admin_setup".
This makes these widgets not work as expected on the legacy widgets block.
This PR improves the "emulation" of the widgets screen for these cases.


## How has this been tested?
I installed these two plugins https://wordpress.org/plugins/simple-image-widget/, http://wordpress.org/plugins/image-widget/.
I created a new post I added the legacy widgets block.
I selected each of the widgets and verified both of them work as expected. On master they do not work.
