### PR TITLE
BlockEditor: fix readme syntax

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/README.md
+++ b/packages/block-editor/src/components/media-placeholder/README.md
@@ -12,7 +12,7 @@ import { MediaPlaceholder } from '@wordpress/block-editor';
 
 ...
 
-	edit: ( { attributes, setAttributes } ) {
+	edit: ( { attributes, setAttributes } ) => {
 		const mediaPlaceholder = <MediaPlaceholder
 			onSelect = {
 				( el ) => {


### PR DESCRIPTION
## Description
As written this is a syntax error; the PR fixes it.

## How has this been tested?
N/A

## Types of changes
Docs

## Checklist:
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->