### PR TITLE
E2E Tests: Specify icon for block context test blocks

### DIFF
--- a/packages/e2e-tests/plugins/block-context/index.js
+++ b/packages/e2e-tests/plugins/block-context/index.js
@@ -1,10 +1,12 @@
-( function() {
+( function () {
 	const { createElement: el, Fragment } = wp.element;
 	const { registerBlockType } = wp.blocks;
 	const { InnerBlocks } = wp.blockEditor;
 
 	registerBlockType( 'gutenberg/test-context-provider', {
 		title: 'Test Context Provider',
+
+		icon: 'list-view',
 
 		// TODO: While redundant with server-side registration, it's required
 		// to assign this value since it is not picked in the implementation of
@@ -41,6 +43,8 @@
 
 	registerBlockType( 'gutenberg/test-context-consumer', {
 		title: 'Test Context Consumer',
+
+		icon: 'list-view',
 
 		// TODO: While redundant with server-side registration, it's required
 		// to assign this value since it is not picked in the implementation of


### PR DESCRIPTION
Related: #22810

This pull request is intended to serve as a temporary fix for the issue described at #22810.

Specifically, it ensures that a block icon is provided for the block context blocks so that the default empty string value does not take effect, where in WordPress trunk environments it will be flagged as invalid. `icon` should be considered as optional, so technically this change should not be required, but is intended to serve as a temporary fix to allow builds to fail until a more permanent resolution can be implemented for #22810.

The icon chosen is arbitrary.

**Testing Instructions:**

Ensure end-to-end tests pass:

```
npm run test-e2e packages/e2e-tests/specs/editor/plugins/block-context.test.js
```

**Follow-up Tasks:**

Once a permanent resolution is addressed for #22810, these changes should ideally be reverted, as apparently they serve as indirect verification of the default block registrations. Alternatively, a test dedicated to verifying these behaviors should be implemented.