### PR TITLE
Sibling Inserter: Try reduced animation time and line indicator

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -339,7 +339,8 @@
 	justify-content: center;
 
 	// Clicks on the inserter are redirected to the nearest tabbable element.
-	cursor: text;
+	//cursor: text;
+	cursor: default;
 
 	// Hide the inserter above the selected block.
 	&.is-inserter-hidden .block-editor-inserter__toggle {
@@ -369,6 +370,7 @@
 		border-radius: $radius-block-ui;
 		color: $white;
 		padding: 0;
+		outline: 10px solid $white;
 
 		// Special dimensions for this button.
 		min-width: 24px;
@@ -385,7 +387,7 @@
 .block-editor-block-list__block-popover-inserter {
 	.block-editor-inserter__toggle.components-button {
 		// Fade it in after a delay.
-		animation: block-editor-inserter__toggle__fade-in-animation-delayed 1.2s ease;
+		animation: block-editor-inserter__toggle__fade-in-animation-delayed 0.6s ease;
 		animation-fill-mode: forwards;
 		@include reduce-motion("animation");
 	}
@@ -558,6 +560,11 @@
 		box-shadow: none;
 		overflow-y: visible;
 		margin-left: 0;
+
+		border-top: 2px solid $light-gray-secondary;
+		animation: block-editor-inserter__toggle__fade-in-animation-delayed 0.6s ease;
+		animation-fill-mode: forwards;
+		@include reduce-motion("animation");
 	}
 }
 


### PR DESCRIPTION
From: #22801

## Description
This is a test for a concept introduced in https://github.com/WordPress/gutenberg/issues/22801#issuecomment-637065608 to make the sibling inserter more discoverable.

I've spun this up quickly to show a proof of concept so folks can try it out and discuss.

* The animation for display of the sibling inserter has been reduced by half.
* A line has been added to indicate where the new block would be inserted.
* There has been no change to the target area, but the line helps with orientation.
* The cursor is no longer a text caret when hovering over the target area, but instead the default cursor. I expect there is some history to this setup, but I'm including this change anyway.
* If your editor does not have a white background this will not look good, but for the sake of trying this out I think it's okay for now.

## Screenshots <!-- if applicable -->

![2020-06-01 16 15 05](https://user-images.githubusercontent.com/1464705/83463524-1ddc2a00-a423-11ea-912a-1cbb25100eef.gif)

## How has this been tested?
Not tested.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
