### PR TITLE
Custom select control: don't announce external value changes

### DIFF
--- a/packages/components/src/custom-select-control/index.js
+++ b/packages/components/src/custom-select-control/index.js
@@ -22,6 +22,12 @@ const stateReducer = (
 	{ selectedItem },
 	{ type, changes, props: { items } }
 ) => {
+	const selectedItemIndex = items.findIndex(
+		( item ) => item.key === selectedItem.key
+	);
+	if ( changes.highlightedIndex < 0 ) {
+		changes.highlightedIndex = selectedItemIndex;
+	}
 	switch ( type ) {
 		case useSelect.stateChangeTypes.ToggleButtonKeyDownArrowDown:
 			// If we already have a selected item, try to select the next one,
@@ -31,7 +37,7 @@ const stateReducer = (
 					items[
 						selectedItem
 							? Math.min(
-									items.indexOf( selectedItem ) + 1,
+									selectedItemIndex + 1,
 									items.length - 1
 							  )
 							: 0
@@ -44,7 +50,7 @@ const stateReducer = (
 				selectedItem:
 					items[
 						selectedItem
-							? Math.max( items.indexOf( selectedItem ) - 1, 0 )
+							? Math.max( selectedItemIndex - 1, 0 )
 							: items.length - 1
 					],
 			};
@@ -60,6 +66,7 @@ export default function CustomSelectControl( {
 	onChange: onSelectedItemChange,
 	value,
 } ) {
+	const valueIndex = items.findIndex( ( item ) => item === value );
 	const {
 		getLabelProps,
 		getToggleButtonProps,
@@ -68,13 +75,12 @@ export default function CustomSelectControl( {
 		isOpen,
 		highlightedIndex,
 	} = useSelect( {
-		initialSelectedItem: items[ 0 ],
+		initialSelectedItem: items[ valueIndex ],
 		items,
 		itemToString,
 		onSelectedItemChange,
 		stateReducer,
 	} );
-
 	const menuProps = getMenuProps( {
 		className: 'components-custom-select-control__menu',
 		'aria-hidden': ! isOpen,
@@ -83,13 +89,11 @@ export default function CustomSelectControl( {
 	// fully ARIA compliant.
 	if (
 		menuProps[ 'aria-activedescendant' ] &&
-		menuProps[ 'aria-activedescendant' ].slice(
-			0,
-			'downshift-null'.length
-		) === 'downshift-null'
+		menuProps[ 'aria-hidden' ] === true
 	) {
 		delete menuProps[ 'aria-activedescendant' ];
 	}
+
 	return (
 		<div
 			className={ classnames(
@@ -129,7 +133,7 @@ export default function CustomSelectControl( {
 			<ul { ...menuProps }>
 				{ isOpen &&
 					items.map( ( item, index ) => (
-						// eslint-disable-next-line react/jsx-key
+						// eslint-disable-next-line react/jsx-key, jsx-a11y/role-supports-aria-props
 						<li
 							{ ...getItemProps( {
 								item,
@@ -145,6 +149,7 @@ export default function CustomSelectControl( {
 								),
 								style: item.style,
 							} ) }
+							aria-selected={ index === valueIndex }
 						>
 							{ item === value && (
 								<Icon

--- a/packages/components/src/custom-select-control/index.js
+++ b/packages/components/src/custom-select-control/index.js
@@ -66,7 +66,7 @@ export default function CustomSelectControl( {
 	onChange: onSelectedItemChange,
 	value,
 } ) {
-	const valueIndex = items.findIndex( ( item ) => item === value );
+	const valueIndex = items.findIndex( ( item ) => item.key === value.key );
 	const {
 		getLabelProps,
 		getToggleButtonProps,
@@ -151,7 +151,7 @@ export default function CustomSelectControl( {
 							} ) }
 							aria-selected={ index === valueIndex }
 						>
-							{ item === value && (
+							{ item.key === value.key && (
 								<Icon
 									icon={ check }
 									className="components-custom-select-control__item-icon"

--- a/packages/components/src/custom-select-control/index.js
+++ b/packages/components/src/custom-select-control/index.js
@@ -66,7 +66,7 @@ export default function CustomSelectControl( {
 	onChange: onSelectedItemChange,
 	value,
 } ) {
-	const valueIndex = items.findIndex( ( item ) => item.key === value.key );
+	const valueIndex = items.findIndex( ( item ) => item.key === value?.key );
 	const {
 		getLabelProps,
 		getToggleButtonProps,
@@ -75,7 +75,7 @@ export default function CustomSelectControl( {
 		isOpen,
 		highlightedIndex,
 	} = useSelect( {
-		initialSelectedItem: items[ valueIndex ],
+		initialSelectedItem: items[ valueIndex >= 0 ? valueIndex : 0 ],
 		items,
 		itemToString,
 		onSelectedItemChange,
@@ -93,6 +93,7 @@ export default function CustomSelectControl( {
 	) {
 		delete menuProps[ 'aria-activedescendant' ];
 	}
+	const selectedItem = value ? value : items[ 0 ];
 
 	return (
 		<div
@@ -124,7 +125,7 @@ export default function CustomSelectControl( {
 					isSmall: true,
 				} ) }
 			>
-				{ itemToString( value ) }
+				{ itemToString( selectedItem ) }
 				<Icon
 					icon={ chevronDown }
 					className="components-custom-select-control__button-icon"
@@ -148,10 +149,10 @@ export default function CustomSelectControl( {
 									}
 								),
 								style: item.style,
+								'aria-selected': index === valueIndex,
 							} ) }
-							aria-selected={ index === valueIndex }
 						>
-							{ item.key === value.key && (
+							{ item.key === selectedItem.key && (
 								<Icon
 									icon={ check }
 									className="components-custom-select-control__item-icon"

--- a/packages/components/src/custom-select-control/index.js
+++ b/packages/components/src/custom-select-control/index.js
@@ -74,6 +74,7 @@ export default function CustomSelectControl( {
 		getItemProps,
 		isOpen,
 		highlightedIndex,
+		selectedItem,
 	} = useSelect( {
 		initialSelectedItem: items[ valueIndex >= 0 ? valueIndex : 0 ],
 		items,
@@ -93,7 +94,7 @@ export default function CustomSelectControl( {
 	) {
 		delete menuProps[ 'aria-activedescendant' ];
 	}
-	const selectedItem = value ? value : items[ 0 ];
+	const selectedItemValue = value ? value : selectedItem;
 
 	return (
 		<div
@@ -125,7 +126,7 @@ export default function CustomSelectControl( {
 					isSmall: true,
 				} ) }
 			>
-				{ itemToString( selectedItem ) }
+				{ itemToString( selectedItemValue ) }
 				<Icon
 					icon={ chevronDown }
 					className="components-custom-select-control__button-icon"
@@ -152,7 +153,7 @@ export default function CustomSelectControl( {
 								'aria-selected': index === valueIndex,
 							} ) }
 						>
-							{ item.key === selectedItem.key && (
+							{ item.key === selectedItemValue.key && (
 								<Icon
 									icon={ check }
 									className="components-custom-select-control__item-icon"

--- a/packages/components/src/custom-select-control/index.js
+++ b/packages/components/src/custom-select-control/index.js
@@ -58,7 +58,7 @@ export default function CustomSelectControl( {
 	label,
 	options: items,
 	onChange: onSelectedItemChange,
-	value: _selectedItem,
+	value,
 } ) {
 	const {
 		getLabelProps,
@@ -67,13 +67,11 @@ export default function CustomSelectControl( {
 		getItemProps,
 		isOpen,
 		highlightedIndex,
-		selectedItem,
 	} = useSelect( {
 		initialSelectedItem: items[ 0 ],
 		items,
 		itemToString,
 		onSelectedItemChange,
-		selectedItem: _selectedItem,
 		stateReducer,
 	} );
 
@@ -122,7 +120,7 @@ export default function CustomSelectControl( {
 					isSmall: true,
 				} ) }
 			>
-				{ itemToString( selectedItem ) }
+				{ itemToString( value ) }
 				<Icon
 					icon={ chevronDown }
 					className="components-custom-select-control__button-icon"
@@ -148,7 +146,7 @@ export default function CustomSelectControl( {
 								style: item.style,
 							} ) }
 						>
-							{ item === selectedItem && (
+							{ item === value && (
 								<Icon
 									icon={ check }
 									className="components-custom-select-control__item-icon"

--- a/packages/components/src/custom-select-control/index.js
+++ b/packages/components/src/custom-select-control/index.js
@@ -23,7 +23,7 @@ const stateReducer = (
 	{ type, changes, props: { items } }
 ) => {
 	const selectedItemIndex = items.findIndex(
-		( item ) => item.key === selectedItem.key
+		( item ) => item.key === selectedItem?.key
 	);
 	if ( changes.highlightedIndex < 0 ) {
 		changes.highlightedIndex = selectedItemIndex;

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -1,14 +1,10 @@
 /**
- * External dependencies
- */
-import memoize from 'memize';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { useInstanceId } from '@wordpress/compose';
 import { textColor } from '@wordpress/icons';
+import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -31,7 +27,10 @@ function getSelectValueFromFontSize( fontSizes, value ) {
 	return DEFAULT_FONT_SIZE;
 }
 
-const getSelectOptions = memoize( ( optionsArray, disableCustomFontSizes ) => {
+function getSelectOptions( optionsArray, disableCustomFontSizes ) {
+	if ( disableCustomFontSizes && ! optionsArray.length ) {
+		return null;
+	}
 	optionsArray = [
 		{ slug: DEFAULT_FONT_SIZE, name: __( 'Default' ) },
 		...optionsArray,
@@ -44,7 +43,7 @@ const getSelectOptions = memoize( ( optionsArray, disableCustomFontSizes ) => {
 		name: option.name,
 		style: { fontSize: option.size },
 	} ) );
-} );
+}
 
 export default function FontSizePicker( {
 	fallbackFontSize,
@@ -56,11 +55,14 @@ export default function FontSizePicker( {
 } ) {
 	const instanceId = useInstanceId( FontSizePicker );
 
-	if ( disableCustomFontSizes && ! fontSizes.length ) {
+	const options = useMemo(
+		() => getSelectOptions( fontSizes, disableCustomFontSizes ),
+		[ fontSizes, disableCustomFontSizes ]
+	);
+
+	if ( ! options ) {
 		return null;
 	}
-
-	const options = getSelectOptions( fontSizes, disableCustomFontSizes );
 
 	const selectedFontSizeSlug = getSelectValueFromFontSize( fontSizes, value );
 

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import memoize from 'memize';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -26,7 +31,7 @@ function getSelectValueFromFontSize( fontSizes, value ) {
 	return DEFAULT_FONT_SIZE;
 }
 
-function getSelectOptions( optionsArray, disableCustomFontSizes ) {
+const getSelectOptions = memoize( ( optionsArray, disableCustomFontSizes ) => {
 	optionsArray = [
 		{ slug: DEFAULT_FONT_SIZE, name: __( 'Default' ) },
 		...optionsArray,
@@ -39,7 +44,7 @@ function getSelectOptions( optionsArray, disableCustomFontSizes ) {
 		name: option.name,
 		style: { fontSize: option.size },
 	} ) );
-}
+} );
 
 export default function FontSizePicker( {
 	fallbackFontSize,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

While testing #22453 I found that announcements of switch between Navigation and Edit modes are not being read out by VoiceOver on Paragraph and Heading blocks. They're  working as expected on other block types.

The issue is with the `useSelect` hook in `CustomSelectControl` being passed the current value of the control. `useSelect` generates an `aria-live` announcement every time the value changes, or every time `CustomSelectControl` re-renders. Because the switch between modes causes the sidebar to re-render, that announcement is triggered for `FontSizePicker`, and  it overrides the mode switch announcement. 

My change here is to bypass `useSelect` and use the current value prop directly for populating the toggle button and styling the selected item. This changes nothing in the visual functionality, and has the extra benefit of stopping change announcements for the Preset size field whenever the Custom font size field or the Reset buttons are used. (Currently, changing the size in the Custom field with the up and down arrows causes "Custom has been selected" to be announced at every change, which can become quite annoying.)

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Tested across browsers; especially with Safari + VoiceOver on mac OS, and Firefox + NVDA on Windows.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
 Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
