### PR TITLE
Update wording: Images size => Image size in the gallery block view

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -405,7 +405,7 @@ class GalleryEdit extends Component {
 						/>
 						{ shouldShowSizeOptions && (
 							<SelectControl
-								label={ __( 'Images size' ) }
+								label={ __( 'Image size' ) }
 								value={ sizeSlug }
 								options={ imageSizeOptions }
 								onChange={ this.updateImagesSize }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/2043

Related Gutenberg-mobile PR 
https://github.com/wordpress-mobile/gutenberg-mobile/pull/2342
 
## Description
Updates the label to be more as expected. 

## How has this been tested?
On react native side. Remove `shouldShowSizeOptions` on line https://github.com/WordPress/gutenberg/pull/22826/files#diff-34f83402fe8954f15f8d404d01c9e4c9R406 

So that the Image size options show up on the Gutenberg demo side. 

Before: 
<img width="429" alt="Screen Shot 2020-06-02 at 4 39 34 PM" src="https://user-images.githubusercontent.com/115071/83533299-afb16900-a4ef-11ea-8e40-d6d080dcba48.png">


After:
<img width="432" alt="Screen Shot 2020-06-02 at 4 32 17 PM" src="https://user-images.githubusercontent.com/115071/83533177-842e7e80-a4ef-11ea-8c58-1b6b8ffb72e5.png">

## Types of changes
Fixes a minor typo

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
