### PR TITLE
Use Card instead of Panel for the block editor

### DIFF
--- a/packages/edit-navigation/src/components/menu-editor/block-editor-area.js
+++ b/packages/edit-navigation/src/components/menu-editor/block-editor-area.js
@@ -66,17 +66,13 @@ export default function BlockEditorArea( {
 	}, [ rootBlockId ] );
 
 	return (
-		<Card className="edit-navigation-menu-editor__block-editor-panel">
+		<Card className="edit-navigation-menu-editor__block-editor-area">
 			<CardHeader>
-				<div className="edit-navigation-menu-editor__block-editor-panel-header-text">
+				<div className="edit-navigation-menu-editor__block-editor-area-header-text">
 					{ __( 'Navigation menu' ) }
 				</div>
 
-				<Button
-					className="edit-navigation-menu-editor__block-editor-panel-action"
-					isPrimary
-					onClick={ saveBlocks }
-				>
+				<Button isPrimary onClick={ saveBlocks }>
 					{ __( 'Save navigation' ) }
 				</Button>
 			</CardHeader>
@@ -101,11 +97,7 @@ export default function BlockEditorArea( {
 			</CardBody>
 			<CardFooter>
 				<DeleteMenuButton menuId={ menuId } onDelete={ onDeleteMenu } />
-				<Button
-					className="edit-navigation-menu-editor__block-editor-panel-action"
-					isPrimary
-					onClick={ saveBlocks }
-				>
+				<Button isPrimary onClick={ saveBlocks }>
 					{ __( 'Save navigation' ) }
 				</Button>
 			</CardFooter>

--- a/packages/edit-navigation/src/components/menu-editor/block-editor-area.js
+++ b/packages/edit-navigation/src/components/menu-editor/block-editor-area.js
@@ -19,6 +19,7 @@ import {
 	Card,
 	CardHeader,
 	CardBody,
+	CardFooter,
 	Popover,
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -66,16 +67,11 @@ export default function BlockEditorArea( {
 
 	return (
 		<Card className="edit-navigation-menu-editor__block-editor-panel">
-			<CardHeader className="edit-navigation-menu-editor__block-editor-panel-header">
+			<CardHeader>
 				<div className="edit-navigation-menu-editor__block-editor-panel-header-text">
 					{ __( 'Navigation menu' ) }
 				</div>
 
-				<DeleteMenuButton
-					className="edit-navigation-menu-editor__block-editor-panel-action"
-					menuId={ menuId }
-					onDelete={ onDeleteMenu }
-				/>
 				<Button
 					className="edit-navigation-menu-editor__block-editor-panel-action"
 					isPrimary
@@ -103,6 +99,16 @@ export default function BlockEditorArea( {
 					</ObserveTyping>
 				</WritingFlow>
 			</CardBody>
+			<CardFooter>
+				<DeleteMenuButton menuId={ menuId } onDelete={ onDeleteMenu } />
+				<Button
+					className="edit-navigation-menu-editor__block-editor-panel-action"
+					isPrimary
+					onClick={ saveBlocks }
+				>
+					{ __( 'Save navigation' ) }
+				</Button>
+			</CardFooter>
 		</Card>
 	);
 }

--- a/packages/edit-navigation/src/components/menu-editor/block-editor-area.js
+++ b/packages/edit-navigation/src/components/menu-editor/block-editor-area.js
@@ -97,9 +97,6 @@ export default function BlockEditorArea( {
 			</CardBody>
 			<CardFooter>
 				<DeleteMenuButton menuId={ menuId } onDelete={ onDeleteMenu } />
-				<Button isPrimary onClick={ saveBlocks }>
-					{ __( 'Save navigation' ) }
-				</Button>
 			</CardFooter>
 		</Card>
 	);

--- a/packages/edit-navigation/src/components/menu-editor/block-editor-area.js
+++ b/packages/edit-navigation/src/components/menu-editor/block-editor-area.js
@@ -67,14 +67,24 @@ export default function BlockEditorArea( {
 	return (
 		<Card className="edit-navigation-menu-editor__block-editor-panel">
 			<CardHeader className="edit-navigation-menu-editor__block-editor-panel-header">
-				{ __( 'Navigation menu' ) }
+				<div className="edit-navigation-menu-editor__block-editor-panel-header-text">
+					{ __( 'Navigation menu' ) }
+				</div>
+
+				<DeleteMenuButton
+					className="edit-navigation-menu-editor__block-editor-panel-action"
+					menuId={ menuId }
+					onDelete={ onDeleteMenu }
+				/>
+				<Button
+					className="edit-navigation-menu-editor__block-editor-panel-action"
+					isPrimary
+					onClick={ saveBlocks }
+				>
+					{ __( 'Save navigation' ) }
+				</Button>
 			</CardHeader>
 			<CardBody>
-				<div className="components-panel__header-actions">
-					<Button isPrimary onClick={ saveBlocks }>
-						{ __( 'Save navigation' ) }
-					</Button>
-				</div>
 				<NavigableToolbar
 					className={ classnames(
 						'edit-navigation-menu-editor__block-editor-toolbar',
@@ -92,12 +102,6 @@ export default function BlockEditorArea( {
 						<BlockList />
 					</ObserveTyping>
 				</WritingFlow>
-				<div className="components-panel__footer-actions">
-					<DeleteMenuButton
-						menuId={ menuId }
-						onDelete={ onDeleteMenu }
-					/>
-				</div>
 			</CardBody>
 		</Card>
 	);

--- a/packages/edit-navigation/src/components/menu-editor/block-editor-area.js
+++ b/packages/edit-navigation/src/components/menu-editor/block-editor-area.js
@@ -29,7 +29,7 @@ import { __ } from '@wordpress/i18n';
  */
 import DeleteMenuButton from '../delete-menu-button';
 
-export default function BlockEditorPanel( {
+export default function BlockEditorArea( {
 	onDeleteMenu,
 	menuId,
 	saveBlocks,

--- a/packages/edit-navigation/src/components/menu-editor/block-editor-panel.js
+++ b/packages/edit-navigation/src/components/menu-editor/block-editor-panel.js
@@ -14,7 +14,13 @@ import {
 	WritingFlow,
 } from '@wordpress/block-editor';
 import { useEffect } from '@wordpress/element';
-import { Button, Panel, PanelBody, Popover } from '@wordpress/components';
+import {
+	Button,
+	Card,
+	CardHeader,
+	CardBody,
+	Popover,
+} from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
@@ -59,8 +65,11 @@ export default function BlockEditorPanel( {
 	}, [ rootBlockId ] );
 
 	return (
-		<Panel className="edit-navigation-menu-editor__block-editor-panel">
-			<PanelBody title={ __( 'Navigation menu' ) }>
+		<Card className="edit-navigation-menu-editor__block-editor-panel">
+			<CardHeader className="edit-navigation-menu-editor__block-editor-panel-header">
+				{ __( 'Navigation menu' ) }
+			</CardHeader>
+			<CardBody>
 				<div className="components-panel__header-actions">
 					<Button isPrimary onClick={ saveBlocks }>
 						{ __( 'Save navigation' ) }
@@ -89,7 +98,7 @@ export default function BlockEditorPanel( {
 						onDelete={ onDeleteMenu }
 					/>
 				</div>
-			</PanelBody>
-		</Panel>
+			</CardBody>
+		</Card>
 	);
 }

--- a/packages/edit-navigation/src/components/menu-editor/index.js
+++ b/packages/edit-navigation/src/components/menu-editor/index.js
@@ -14,7 +14,7 @@ import { useMemo } from '@wordpress/element';
 import useMenuItems from './use-menu-items';
 import useNavigationBlocks from './use-navigation-blocks';
 import MenuEditorShortcuts from './shortcuts';
-import BlockEditorPanel from './block-editor-panel';
+import BlockEditorArea from './block-editor-area';
 import NavigationStructureArea from './navigation-structure-area';
 
 export default function MenuEditor( {
@@ -60,8 +60,8 @@ export default function MenuEditor( {
 					blocks={ blocks }
 					initialOpen={ isLargeViewport }
 				/>
-				<BlockEditorPanel
-					saveBlocks={ saveMenuItems }
+				<BlockEditorArea
+					saveBlocks={ eventuallySaveMenuItems }
 					menuId={ menuId }
 					onDeleteMenu={ onDeleteMenu }
 				/>

--- a/packages/edit-navigation/src/components/menu-editor/style.scss
+++ b/packages/edit-navigation/src/components/menu-editor/style.scss
@@ -72,21 +72,18 @@
 	// Make panels collapsible in IE. The IE analogue of align-items: self-start;.
 	-ms-grid-row-align: start;
 
-	.edit-navigation-menu-editor__block-editor-panel-header {
+	.components-card__footer,
+	.components-card__header {
 		display: flex;
 		align-items: center;
-		flex-wrap: wrap;
+		justify-content: space-between;
 	}
 
 	.edit-navigation-menu-editor__block-editor-panel-header-text {
 		flex-grow: 1;
 		font-weight: bold;
-		flex-basis: 100%;
-		@include break-medium {
-			flex-basis: auto;
-		}
 	}
-	.edit-navigation-menu-editor__block-editor-panel-action {
+	.edit-navigation-menu-editor__action {
 		margin-left: $grid-unit-20;
 	}
 }

--- a/packages/edit-navigation/src/components/menu-editor/style.scss
+++ b/packages/edit-navigation/src/components/menu-editor/style.scss
@@ -62,15 +62,12 @@
 	font-weight: bold;
 }
 
-.edit-navigation-menu-editor__block-editor-panel {
+.edit-navigation-menu-editor__block-editor-area {
 	@include break-medium {
 		// IE11 requires the column to be explicitly declared.
 		// Only shift this into the second column on desktop.
 		grid-column: 2;
 	}
-
-	// Make panels collapsible in IE. The IE analogue of align-items: self-start;.
-	-ms-grid-row-align: start;
 
 	.components-card__footer,
 	.components-card__header {
@@ -79,12 +76,9 @@
 		justify-content: space-between;
 	}
 
-	.edit-navigation-menu-editor__block-editor-panel-header-text {
+	.edit-navigation-menu-editor__block-editor-area-header-text {
 		flex-grow: 1;
 		font-weight: bold;
-	}
-	.edit-navigation-menu-editor__action {
-		margin-left: $grid-unit-20;
 	}
 }
 

--- a/packages/edit-navigation/src/components/menu-editor/style.scss
+++ b/packages/edit-navigation/src/components/menu-editor/style.scss
@@ -71,15 +71,16 @@
 
 	// Make panels collapsible in IE. The IE analogue of align-items: self-start;.
 	-ms-grid-row-align: start;
+
+	.edit-navigation-menu-editor__block-editor-panel-header {
+		font-weight: bold;
+	}
 }
 
 .components-panel__header-actions {
-	margin-top: $grid-unit-20;
-	padding-bottom: $grid-unit-20;
 	margin-bottom: $grid-unit-60;
 	width: 100%;
 	text-align: right;
-	border-bottom: 1px solid $light-gray-300;
 }
 
 .components-panel__footer-actions {

--- a/packages/edit-navigation/src/components/menu-editor/style.scss
+++ b/packages/edit-navigation/src/components/menu-editor/style.scss
@@ -73,7 +73,21 @@
 	-ms-grid-row-align: start;
 
 	.edit-navigation-menu-editor__block-editor-panel-header {
+		display: flex;
+		align-items: center;
+		flex-wrap: wrap;
+	}
+
+	.edit-navigation-menu-editor__block-editor-panel-header-text {
+		flex-grow: 1;
 		font-weight: bold;
+		flex-basis: 100%;
+		@include break-medium {
+			flex-basis: auto;
+		}
+	}
+	.edit-navigation-menu-editor__block-editor-panel-action {
+		margin-left: $grid-unit-20;
 	}
 }
 


### PR DESCRIPTION
## Description
There is no reason to make the BlockEditorPanel collapsible, so let's use Card instead of Panel there. A follow-up PR will make the other panel only collapsible on mobile devices.

**Before:**
<img width="898" alt="Zrzut ekranu 2020-06-2 o 14 59 09" src="https://user-images.githubusercontent.com/205419/83522915-a3beaa80-a4e1-11ea-866c-4d2e86b66a3b.png">

**After:**
<img width="900" alt="Zrzut ekranu 2020-06-2 o 14 58 56" src="https://user-images.githubusercontent.com/205419/83522924-a4efd780-a4e1-11ea-8a13-2acb567d8d2b.png">

## Types of changes
Non-breaking changes

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
