### PR TITLE
[Navigation block] Edit the link using a modal instead of Popover

### DIFF
--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -94,8 +94,8 @@ function Navigation( {
 			return null;
 		}
 
-		return pages.map( ( { title, type, link: url, id } ) =>
-			createBlock( 'core/navigation-link', {
+		return pages.map( ( { title, type, link: url, id } ) => {
+			return createBlock( 'core/navigation-link', {
 				type,
 				id,
 				url,
@@ -103,8 +103,8 @@ function Navigation( {
 					? __( '(no title)' )
 					: escape( title.rendered ),
 				opensInNewTab: false,
-			} )
-		);
+			} );
+		} );
 	}, [ pages ] );
 
 	//

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -94,8 +94,8 @@ function Navigation( {
 			return null;
 		}
 
-		return pages.map( ( { title, type, link: url, id } ) => {
-			return createBlock( 'core/navigation-link', {
+		return pages.map( ( { title, type, link: url, id } ) =>
+			createBlock( 'core/navigation-link', {
 				type,
 				id,
 				url,
@@ -103,8 +103,8 @@ function Navigation( {
 					? __( '(no title)' )
 					: escape( title.rendered ),
 				opensInNewTab: false,
-			} );
-		} );
+			} )
+		);
 	}, [ pages ] );
 
 	//


### PR DESCRIPTION
## Description

This PR implements a rough prototype of what link editing in a modal could look like.

Try it for yourself! Personally, I think the modal experience feels off. Tweaking the LinkControl may be pre-requisite for this PR.

<img width="847" alt="Zrzut ekranu 2020-06-2 o 16 09 59" src="https://user-images.githubusercontent.com/205419/83530070-85f64300-a4eb-11ea-91f3-de42619b1502.png">

## How has this been tested?

1. Add a navigation block
1. Add a menu item, confirm the edit widget was displayed in a Popover
1. Click the edit button in the toolbar, confirm the edit widget was displayed in a Modal

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
