### PR TITLE
Fix skipped shortcode transforms in raw handling

### DIFF
--- a/packages/blocks/src/api/raw-handling/shortcode-converter.js
+++ b/packages/blocks/src/api/raw-handling/shortcode-converter.js
@@ -106,7 +106,7 @@ function segmentHTMLToShortcodeBlock(
 		return [
 			...segmentHTMLToShortcodeBlock( beforeHTML ),
 			block,
-			...segmentHTMLToShortcodeBlock( HTML.substr( lastIndex ) ),
+			...segmentHTMLToShortcodeBlock( afterHTML ),
 		];
 	}
 

--- a/packages/blocks/src/api/raw-handling/shortcode-converter.js
+++ b/packages/blocks/src/api/raw-handling/shortcode-converter.js
@@ -104,7 +104,7 @@ function segmentHTMLToShortcodeBlock(
 		);
 
 		return [
-			beforeHTML,
+			...segmentHTMLToShortcodeBlock( beforeHTML ),
 			block,
 			...segmentHTMLToShortcodeBlock( HTML.substr( lastIndex ) ),
 		];

--- a/test/integration/shortcode-converter.test.js
+++ b/test/integration/shortcode-converter.test.js
@@ -257,7 +257,9 @@ describe( 'segmentHTMLToShortcodeBlock', () => {
 
 		expect( transformed[ 0 ] ).toBe( '<p>' );
 
-		let firstExpectedBlock = createBlock( 'test/gallery', { ids: [ 4, 5, 6 ] } );
+		let firstExpectedBlock = createBlock( 'test/gallery', {
+			ids: [ 4, 5, 6 ],
+		} );
 		// clientId will always be random.
 		firstExpectedBlock.clientId = transformed[ 1 ].clientId;
 		expect( transformed[ 1 ] ).toEqual( firstExpectedBlock );
@@ -287,7 +289,9 @@ describe( 'segmentHTMLToShortcodeBlock', () => {
 
 		expect( reverseTransformed[ 2 ] ).toBe( '</p>\n<p>' );
 
-		secondExpectedBlock = createBlock( 'test/gallery', { ids: [ 4, 5, 6 ] } );
+		secondExpectedBlock = createBlock( 'test/gallery', {
+			ids: [ 4, 5, 6 ],
+		} );
 		// clientId will always be random.
 		secondExpectedBlock.clientId = reverseTransformed[ 3 ].clientId;
 		expect( reverseTransformed[ 3 ] ).toEqual( secondExpectedBlock );

--- a/test/integration/shortcode-converter.test.js
+++ b/test/integration/shortcode-converter.test.js
@@ -248,4 +248,51 @@ describe( 'segmentHTMLToShortcodeBlock', () => {
 		expect( transformed[ 3 ] ).toHaveProperty( 'name', 'test/gallery' );
 		expect( transformed[ 4 ] ).toBe( '</p>' );
 	} );
+
+	it( 'should convert regardless of shortcode order', () => {
+		const original = `<p>[my-gallery ids="4,5,6"]</p>
+<p>[my-broccoli id="42"]</p>`;
+
+		const transformed = segmentHTMLToShortcodeBlock( original, 0 );
+
+		expect( transformed[ 0 ] ).toBe( '<p>' );
+
+		let firstExpectedBlock = createBlock( 'test/gallery', { ids: [ 4, 5, 6 ] } );
+		// clientId will always be random.
+		firstExpectedBlock.clientId = transformed[ 1 ].clientId;
+		expect( transformed[ 1 ] ).toEqual( firstExpectedBlock );
+
+		expect( transformed[ 2 ] ).toBe( '</p>\n<p>' );
+
+		let secondExpectedBlock = createBlock( 'test/broccoli', { id: 42 } );
+		// clientId will always be random.
+		secondExpectedBlock.clientId = transformed[ 3 ].clientId;
+		expect( transformed[ 3 ] ).toEqual( secondExpectedBlock );
+
+		expect( transformed[ 4 ] ).toBe( '</p>' );
+		expect( transformed ).toHaveLength( 5 );
+
+		// Flip the order of the shortcodes.
+		const reversed = `<p>[my-broccoli id="42"]</p>
+<p>[my-gallery ids="4,5,6"]</p>`;
+
+		const reverseTransformed = segmentHTMLToShortcodeBlock( reversed, 0 );
+
+		expect( reverseTransformed[ 0 ] ).toBe( '<p>' );
+
+		firstExpectedBlock = createBlock( 'test/broccoli', { id: 42 } );
+		// clientId will always be random.
+		firstExpectedBlock.clientId = reverseTransformed[ 1 ].clientId;
+		expect( reverseTransformed[ 1 ] ).toEqual( firstExpectedBlock );
+
+		expect( reverseTransformed[ 2 ] ).toBe( '</p>\n<p>' );
+
+		secondExpectedBlock = createBlock( 'test/gallery', { ids: [ 4, 5, 6 ] } );
+		// clientId will always be random.
+		secondExpectedBlock.clientId = reverseTransformed[ 3 ].clientId;
+		expect( reverseTransformed[ 3 ] ).toEqual( secondExpectedBlock );
+
+		expect( reverseTransformed[ 4 ] ).toBe( '</p>' );
+		expect( reverseTransformed ).toHaveLength( 5 );
+	} );
 } );


### PR DESCRIPTION
Fixes #22837 

## Description
Changes the shortcode converter in `rawHandler()` to allow non-linear shortcode replacement while segmenting an HTML string. This prevents the priority or registration order of a transform from affecting how shortcodes are parsed out of HTML and into blocks.

I'd appreciate feedback on whether this might have unintended consequences or if there was a reason it was not done before.

## How has this been tested?
~~I've tested locally with the example outlined in #22837, but someone more familiar with the codebase should definitely take a look.~~

Integration test case has been included.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
