### PR TITLE
Site Title Block: Add alignment and tag level support

### DIFF
--- a/packages/block-library/src/site-title/block.json
+++ b/packages/block-library/src/site-title/block.json
@@ -5,6 +5,9 @@
 		"level": {
 			"type": "number",
 			"default": 1
+		},
+		"align": {
+			"type": "string"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/site-title/edit.js
+++ b/packages/block-library/src/site-title/edit.js
@@ -1,18 +1,24 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { useEntityProp } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 import {
-	PlainText,
+	RichText,
 	AlignmentToolbar,
 	BlockControls,
 	__experimentalBlock as Block,
 } from '@wordpress/block-editor';
 
 export default function SiteTitleEdit( { attributes, setAttributes } ) {
-	const { align } = attributes;
+	const { level, align } = attributes;
 	const [ title, setTitle ] = useEntityProp( 'root', 'site', 'title' );
+	const tagName = 0 === level ? 'p' : 'h' + level;
 
 	return (
 		<>
@@ -25,12 +31,15 @@ export default function SiteTitleEdit( { attributes, setAttributes } ) {
 				/>
 			</BlockControls>
 
-			<PlainText
-				__experimentalVersion={ 2 }
-				tagName={ Block.h1 }
+			<RichText
+				tagName={ Block[ tagName ] }
 				placeholder={ __( 'Site Title' ) }
 				value={ title }
 				onChange={ setTitle }
+				className={ classnames( {
+					[ `has-text-align-${ align }` ]: align,
+				} ) }
+				allowedFormats={ [] }
 				disableLineBreaks
 			/>
 		</>

--- a/packages/block-library/src/site-title/edit.js
+++ b/packages/block-library/src/site-title/edit.js
@@ -5,19 +5,34 @@ import { useEntityProp } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 import {
 	PlainText,
+	AlignmentToolbar,
+	BlockControls,
 	__experimentalBlock as Block,
 } from '@wordpress/block-editor';
 
-export default function SiteTitleEdit() {
+export default function SiteTitleEdit( { attributes, setAttributes } ) {
+	const { align } = attributes;
 	const [ title, setTitle ] = useEntityProp( 'root', 'site', 'title' );
+
 	return (
-		<PlainText
-			__experimentalVersion={ 2 }
-			tagName={ Block.h1 }
-			placeholder={ __( 'Site Title' ) }
-			value={ title }
-			onChange={ setTitle }
-			disableLineBreaks
-		/>
+		<>
+			<BlockControls>
+				<AlignmentToolbar
+					value={ align }
+					onChange={ ( nextAlign ) => {
+						setAttributes( { align: nextAlign } );
+					} }
+				/>
+			</BlockControls>
+
+			<PlainText
+				__experimentalVersion={ 2 }
+				tagName={ Block.h1 }
+				placeholder={ __( 'Site Title' ) }
+				value={ title }
+				onChange={ setTitle }
+				disableLineBreaks
+			/>
+		</>
 	);
 }

--- a/packages/block-library/src/site-title/index.php
+++ b/packages/block-library/src/site-title/index.php
@@ -13,8 +13,8 @@
  * @return string The render.
  */
 function render_block_core_site_title( $attributes ) {
-	$tag_name = 'h1';
-	$align_class_name  = empty( $attributes['align'] ) ? '' : ' ' . "has-text-align-{$attributes['align']}";
+	$tag_name         = 'h1';
+	$align_class_name = empty( $attributes['align'] ) ? '' : ' ' . "has-text-align-{$attributes['align']}";
 
 	if ( isset( $attributes['level'] ) ) {
 		$tag_name = 0 === $attributes['level'] ? 'p' : 'h' . $attributes['level'];

--- a/packages/block-library/src/site-title/index.php
+++ b/packages/block-library/src/site-title/index.php
@@ -14,10 +14,15 @@
  */
 function render_block_core_site_title( $attributes ) {
 	$tag_name = 'h1';
+	$class = '';
+
 	if ( isset( $attributes['level'] ) ) {
 		$tag_name = 0 === $attributes['level'] ? 'p' : 'h' . $attributes['level'];
 	}
-	return sprintf( '<%1$s>%2$s</%1$s>', $tag_name, get_bloginfo( 'name' ) );
+	if ( isset( $attributes['align'] ) ) {
+		$class = ' class="has-text-align-' . $attributes['align'] . '"';
+	}
+	return sprintf( '<%1$s%2$s>%3$s</%1$s>', $tag_name, $class, get_bloginfo( 'name' ) );
 }
 
 /**

--- a/packages/block-library/src/site-title/index.php
+++ b/packages/block-library/src/site-title/index.php
@@ -14,15 +14,18 @@
  */
 function render_block_core_site_title( $attributes ) {
 	$tag_name = 'h1';
-	$class = '';
+	$align_class_name  = empty( $attributes['align'] ) ? '' : ' ' . "has-text-align-{$attributes['align']}";
 
 	if ( isset( $attributes['level'] ) ) {
 		$tag_name = 0 === $attributes['level'] ? 'p' : 'h' . $attributes['level'];
 	}
-	if ( isset( $attributes['align'] ) ) {
-		$class = ' class="has-text-align-' . $attributes['align'] . '"';
-	}
-	return sprintf( '<%1$s%2$s>%3$s</%1$s>', $tag_name, $class, get_bloginfo( 'name' ) );
+
+	return sprintf(
+		'<%1$s class="%2$s">%3$s</%1$s>',
+		$tag_name,
+		'wp-block-site-title' . esc_attr( $align_class_name ),
+		get_bloginfo( 'name' )
+	);
 }
 
 /**


### PR DESCRIPTION
Part of #21087

## Description
Adds text alignment support to the Site Title block. This also adds support for changing the heading level or using a paragraph as the tagName, but does not expose this in the UI.

## How has this been tested?
* Enable the site editor experiments.
* Open the site editor and insert a site title block if one does not exist.
* Confirm that adjusting the alignment of the site title block works in the editor and front end.

## Screenshots <!-- if applicable -->
![2020-06-02 15 09 46](https://user-images.githubusercontent.com/1464705/83574856-272ccb80-a4e3-11ea-91fd-94a762bb323c.gif)

## Types of changes
New feature.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
