### PR TITLE
Edit Site: Refactor business logic into store.

### DIFF
--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -142,6 +142,7 @@ function gutenberg_edit_site_init( $hook ) {
 	if ( false !== $font_sizes ) {
 		$settings['fontSizes'] = $font_sizes;
 	}
+	$settings['styles'] = gutenberg_get_editor_styles();
 
 	$template_ids      = array();
 	$template_part_ids = array();
@@ -161,17 +162,18 @@ function gutenberg_edit_site_init( $hook ) {
 
 	$current_template_id = $template_ids['front-page'];
 
-	$settings['templateId']      = $current_template_id;
-	$settings['homeTemplateId']  = $current_template_id;
-	$settings['templateType']    = 'wp_template';
-	$settings['templateIds']     = array_values( $template_ids );
-	$settings['templatePartIds'] = array_values( $template_part_ids );
-	$settings['styles']          = gutenberg_get_editor_styles();
+	$settings['editSiteInitialState'] = array();
 
-	$settings['showOnFront'] = get_option( 'show_on_front' );
-	$settings['page']        = array(
+	$settings['editSiteInitialState']['homeTemplateId']  = $current_template_id;
+	$settings['editSiteInitialState']['templateId']      = $current_template_id;
+	$settings['editSiteInitialState']['templateType']    = 'wp_template';
+	$settings['editSiteInitialState']['templateIds']     = array_values( $template_ids );
+	$settings['editSiteInitialState']['templatePartIds'] = array_values( $template_part_ids );
+
+	$settings['editSiteInitialState']['showOnFront'] = get_option( 'show_on_front' );
+	$settings['editSiteInitialState']['page']        = array(
 		'path'    => '/',
-		'context' => 'page' === $settings['showOnFront'] ? array(
+		'context' => 'page' === $settings['editSiteInitialState']['showOnFront'] ? array(
 			'postType' => 'page',
 			'postId'   => get_option( 'page_on_front' ),
 		) : array(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -10263,6 +10263,7 @@
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/core-data": "file:packages/core-data",
 				"@wordpress/data": "file:packages/data",
+				"@wordpress/data-controls": "file:packages/data-controls",
 				"@wordpress/editor": "file:packages/editor",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/hooks": "file:packages/hooks",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10278,7 +10278,8 @@
 				"@wordpress/url": "file:packages/url",
 				"file-saver": "^2.0.2",
 				"jszip": "^3.2.2",
-				"lodash": "^4.17.15"
+				"lodash": "^4.17.15",
+				"rememo": "^3.0.0"
 			}
 		},
 		"@wordpress/edit-widgets": {

--- a/packages/block-editor/src/components/provider/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/use-block-sync.js
@@ -106,6 +106,8 @@ export default function useBlockSync( {
 	// have been made. This lets us inform the data source of changes. This
 	// is an effect so that the subscriber can run synchronously without
 	// waiting for React renders for changes.
+	const onInputRef = useRef( onInput );
+	const onChangeRef = useRef( onChange );
 	useEffect( () => {
 		const {
 			getSelectionStart,
@@ -118,7 +120,17 @@ export default function useBlockSync( {
 		let isPersistent = isLastBlockChangePersistent();
 		let previousAreBlocksDifferent = false;
 
+		onInputRef.current = onInput;
+		onChangeRef.current = onChange;
 		const unsubscribe = registry.subscribe( () => {
+			// Sometimes, subscriptions might trigger with stale callbacks
+			// before they are cleaned up. Avoid running them.
+			if (
+				onInputRef.current !== onInput ||
+				onChangeRef.current !== onChange
+			)
+				return;
+
 			// Sometimes, when changing block lists, lingering subscriptions
 			// might trigger before they are cleaned up. If the block for which
 			// the subscription runs is no longer in the store, this would clear

--- a/packages/data/src/plugins/persistence/index.js
+++ b/packages/data/src/plugins/persistence/index.js
@@ -181,7 +181,7 @@ function persistencePlugin( registry, pluginOptions ) {
 			// Load from persistence to use as initial state.
 			const persistedState = persistence.get()[ reducerKey ];
 			if ( persistedState !== undefined ) {
-				let initialState = options.reducer( undefined, {
+				let initialState = options.reducer( options.initialState, {
 					type: '@@WP/PERSISTENCE_RESTORE',
 				} );
 

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -33,6 +33,7 @@
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/core-data": "file:../core-data",
 		"@wordpress/data": "file:../data",
+		"@wordpress/data-controls": "file:../data-controls",
 		"@wordpress/editor": "file:../editor",
 		"@wordpress/element": "file:../element",
 		"@wordpress/hooks": "file:../hooks",

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -48,7 +48,8 @@
 		"@wordpress/url": "file:../url",
 		"file-saver": "^2.0.2",
 		"jszip": "^3.2.2",
-		"lodash": "^4.17.15"
+		"lodash": "^4.17.15",
+		"rememo": "^3.0.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -1,14 +1,8 @@
 /**
  * WordPress dependencies
  */
-import {
-	createContext,
-	useContext,
-	useState,
-	useMemo,
-	useCallback,
-} from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
+import { useState, useMemo, useCallback } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	SlotFillProvider,
 	DropZoneProvider,
@@ -45,52 +39,56 @@ import { SidebarComplementaryAreaFills } from '../sidebar';
 import BlockEditor from '../block-editor';
 import KeyboardShortcuts from '../keyboard-shortcuts';
 
-const Context = createContext();
-export function useEditorContext() {
-	return useContext( Context );
-}
-
 const interfaceLabels = {
 	leftSidebar: __( 'Block Library' ),
 };
 
-function Editor( { settings: _settings } ) {
+function Editor() {
 	const [ isInserterOpen, setIsInserterOpen ] = useState( false );
 	const isMobile = useViewportMatch( 'medium', '<' );
-	const [ settings, setSettings ] = useState( _settings );
-	const template = useSelect(
-		( select ) =>
-			select( 'core' ).getEntityRecord(
-				'postType',
-				settings.templateType,
-				settings.templateType === 'wp_template'
-					? settings.templateId
-					: settings.templatePartId
-			),
-		[ settings.templateType, settings.templateId, settings.templatePartId ]
-	);
 
-	const context = useMemo( () => ( { settings, setSettings } ), [
+	const {
+		isFullscreenActive,
+		deviceType,
+		sidebarIsOpened,
 		settings,
-		setSettings,
-	] );
-
-	const { isFullscreenActive, deviceType, sidebarIsOpened } = useSelect(
-		( select ) => {
-			const {
-				isFeatureActive,
-				__experimentalGetPreviewDeviceType,
-			} = select( 'core/edit-site' );
-			return {
-				isFullscreenActive: isFeatureActive( 'fullscreenMode' ),
-				deviceType: __experimentalGetPreviewDeviceType(),
-				sidebarIsOpened: !! select(
-					'core/interface'
-				).getActiveComplementaryArea( 'core/edit-site' ),
-			};
-		},
-		[]
-	);
+		templateId,
+		templatePartId,
+		templateType,
+		page,
+		template,
+	} = useSelect( ( select ) => {
+		const {
+			isFeatureActive,
+			__experimentalGetPreviewDeviceType,
+			getSettings,
+			getTemplateId,
+			getTemplatePartId,
+			getTemplateType,
+			getPage,
+		} = select( 'core/edit-site' );
+		const _templateId = getTemplateId();
+		const _templatePartId = getTemplatePartId();
+		const _templateType = getTemplateType();
+		return {
+			isFullscreenActive: isFeatureActive( 'fullscreenMode' ),
+			deviceType: __experimentalGetPreviewDeviceType(),
+			sidebarIsOpened: !! select(
+				'core/interface'
+			).getActiveComplementaryArea( 'core/edit-site' ),
+			settings: getSettings(),
+			templateId: _templateId,
+			templatePartId: _templatePartId,
+			templateType: _templateType,
+			page: getPage(),
+			template: select( 'core' ).getEntityRecord(
+				'postType',
+				_templateType,
+				_templateType === 'wp_template' ? _templateId : _templatePartId
+			),
+		};
+	}, [] );
+	const { setPage } = useDispatch( 'core/edit-site' );
 
 	const inlineStyles = useResizeCanvas( deviceType );
 
@@ -112,27 +110,24 @@ function Editor( { settings: _settings } ) {
 	// and Query Pagination blocks.
 	const blockContext = useMemo(
 		() => ( {
-			...settings.page.context,
-			query: settings.page.context.query || { categoryIds: [] },
+			...page.context,
+			query: page.context.query || { categoryIds: [] },
 			queryContext: [
-				settings.page.context.queryContext || { page: 1 },
+				page.context.queryContext || { page: 1 },
 				( newQueryContext ) =>
-					setSettings( ( prevSettings ) => ( {
-						...prevSettings,
-						page: {
-							...prevSettings.page,
-							context: {
-								...prevSettings.page.context,
-								queryContext: {
-									...prevSettings.page.context.queryContext,
-									...newQueryContext,
-								},
+					setPage( {
+						...page,
+						context: {
+							...page.context,
+							queryContext: {
+								...page.context.queryContext,
+								...newQueryContext,
 							},
 						},
-					} ) ),
+					} ),
 			],
 		} ),
-		[ settings.page.context ]
+		[ page.context ]
 	);
 	return template ? (
 		<>
@@ -143,117 +138,115 @@ function Editor( { settings: _settings } ) {
 					<EntityProvider kind="root" type="site">
 						<EntityProvider
 							kind="postType"
-							type={ settings.templateType }
+							type={ templateType }
 							id={
-								settings.templateType === 'wp_template'
-									? settings.templateId
-									: settings.templatePartId
+								templateType === 'wp_template'
+									? templateId
+									: templatePartId
 							}
 						>
 							<BlockContextProvider value={ blockContext }>
-								<Context.Provider value={ context }>
-									<FocusReturnProvider>
-										<KeyboardShortcuts.Register />
-										<SidebarComplementaryAreaFills />
-										<InterfaceSkeleton
-											labels={ interfaceLabels }
-											leftSidebar={
-												isInserterOpen && (
-													<div className="edit-site-editor__inserter-panel">
-														<div className="edit-site-editor__inserter-panel-header">
-															<Button
-																icon={ close }
-																onClick={ () =>
+								<FocusReturnProvider>
+									<KeyboardShortcuts.Register />
+									<SidebarComplementaryAreaFills />
+									<InterfaceSkeleton
+										labels={ interfaceLabels }
+										leftSidebar={
+											isInserterOpen && (
+												<div className="edit-site-editor__inserter-panel">
+													<div className="edit-site-editor__inserter-panel-header">
+														<Button
+															icon={ close }
+															onClick={ () =>
+																setIsInserterOpen(
+																	false
+																)
+															}
+														/>
+													</div>
+													<div className="edit-site-editor__inserter-panel-content">
+														<Library
+															showInserterHelpPanel
+															onSelect={ () => {
+																if (
+																	isMobile
+																) {
 																	setIsInserterOpen(
 																		false
-																	)
+																	);
 																}
-															/>
-														</div>
-														<div className="edit-site-editor__inserter-panel-content">
-															<Library
-																showInserterHelpPanel
-																onSelect={ () => {
-																	if (
-																		isMobile
-																	) {
-																		setIsInserterOpen(
-																			false
-																		);
-																	}
-																} }
-															/>
-														</div>
+															} }
+														/>
 													</div>
-												)
-											}
-											sidebar={
-												sidebarIsOpened && (
-													<ComplementaryArea.Slot scope="core/edit-site" />
-												)
-											}
-											header={
-												<Header
-													openEntitiesSavedStates={
-														openEntitiesSavedStates
+												</div>
+											)
+										}
+										sidebar={
+											sidebarIsOpened && (
+												<ComplementaryArea.Slot scope="core/edit-site" />
+											)
+										}
+										header={
+											<Header
+												openEntitiesSavedStates={
+													openEntitiesSavedStates
+												}
+												isInserterOpen={
+													isInserterOpen
+												}
+												onToggleInserter={ () =>
+													setIsInserterOpen(
+														! isInserterOpen
+													)
+												}
+											/>
+										}
+										content={
+											<BlockSelectionClearer
+												className="edit-site-visual-editor"
+												style={ inlineStyles }
+											>
+												<Notices />
+												<Popover.Slot name="block-toolbar" />
+												<BlockEditor />
+												<KeyboardShortcuts />
+											</BlockSelectionClearer>
+										}
+										actions={
+											<>
+												<EntitiesSavedStates
+													isOpen={
+														isEntitiesSavedStatesOpen
 													}
-													isInserterOpen={
-														isInserterOpen
-													}
-													onToggleInserter={ () =>
-														setIsInserterOpen(
-															! isInserterOpen
-														)
+													close={
+														closeEntitiesSavedStates
 													}
 												/>
-											}
-											content={
-												<BlockSelectionClearer
-													className="edit-site-visual-editor"
-													style={ inlineStyles }
-												>
-													<Notices />
-													<Popover.Slot name="block-toolbar" />
-													<BlockEditor />
-													<KeyboardShortcuts />
-												</BlockSelectionClearer>
-											}
-											actions={
-												<>
-													<EntitiesSavedStates
-														isOpen={
-															isEntitiesSavedStatesOpen
-														}
-														close={
-															closeEntitiesSavedStates
-														}
-													/>
-													{ ! isEntitiesSavedStatesOpen && (
-														<div className="edit-site-editor__toggle-save-panel">
-															<Button
-																isSecondary
-																className="edit-site-editor__toggle-save-panel-button"
-																onClick={
-																	openEntitiesSavedStates
-																}
-																aria-expanded={
-																	false
-																}
-															>
-																{ __(
-																	'Open save panel'
-																) }
-															</Button>
-														</div>
-													) }
-												</>
-											}
-											footer={ <BlockBreadcrumb /> }
-										/>
-										<Popover.Slot />
-										<PluginArea />
-									</FocusReturnProvider>
-								</Context.Provider>
+												{ ! isEntitiesSavedStatesOpen && (
+													<div className="edit-site-editor__toggle-save-panel">
+														<Button
+															isSecondary
+															className="edit-site-editor__toggle-save-panel-button"
+															onClick={
+																openEntitiesSavedStates
+															}
+															aria-expanded={
+																false
+															}
+														>
+															{ __(
+																'Open save panel'
+															) }
+														</Button>
+													</div>
+												) }
+											</>
+										}
+										footer={ <BlockBreadcrumb /> }
+									/>
+									<Popover.Slot />
+									<PluginArea />
+								</FocusReturnProvider>
 							</BlockContextProvider>
 						</EntityProvider>
 					</EntityProvider>

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -124,8 +124,8 @@ export default function Header( {
 						isTemplatePart={ templateType === 'wp_template_part' }
 						onActiveIdChange={ setTemplate }
 						onActiveTemplatePartIdChange={ setTemplatePart }
-						onAddTemplateId={ addTemplate }
-						onRemoveTemplateId={ removeTemplate }
+						onAddTemplate={ addTemplate }
+						onRemoveTemplate={ removeTemplate }
 					/>
 				</div>
 			</div>

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -2,19 +2,13 @@
  * WordPress dependencies
  */
 import { useViewportMatch } from '@wordpress/compose';
-import { useCallback } from '@wordpress/element';
-import { addQueryArgs } from '@wordpress/url';
 import {
 	BlockNavigationDropdown,
 	ToolSelector,
 	BlockToolbar,
 	__experimentalPreviewOptions as PreviewOptions,
 } from '@wordpress/block-editor';
-import {
-	__experimentalResolveSelect as resolveSelect,
-	useSelect,
-	useDispatch,
-} from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	PinnedItems,
 	__experimentalMainDashboardButton as MainDashboardButton,
@@ -26,7 +20,6 @@ import { Button } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { useEditorContext } from '../editor';
 import MoreMenu from './more-menu';
 import PageSwitcher from '../page-switcher';
 import TemplateSwitcher from '../template-switcher';
@@ -35,98 +28,53 @@ import UndoButton from './undo-redo/undo';
 import RedoButton from './undo-redo/redo';
 import FullscreenModeClose from './fullscreen-mode-close';
 
-/**
- * Browser dependencies
- */
-const { fetch } = window;
-
 export default function Header( {
 	openEntitiesSavedStates,
 	isInserterOpen,
 	onToggleInserter,
 } ) {
-	const { settings, setSettings } = useEditorContext();
-	const setActiveTemplateId = useCallback(
-		( newTemplateId ) =>
-			setSettings( ( prevSettings ) => ( {
-				...prevSettings,
-				templateId: newTemplateId,
-				templateType: 'wp_template',
-			} ) ),
-		[]
-	);
-	const setActiveTemplatePartId = useCallback(
-		( newTemplatePartId ) =>
-			setSettings( ( prevSettings ) => ( {
-				...prevSettings,
-				templatePartId: newTemplatePartId,
-				templateType: 'wp_template_part',
-			} ) ),
-		[]
-	);
-	const setActivePage = useCallback( async ( newPage ) => {
-		try {
-			const { success, data } = await fetch(
-				addQueryArgs( newPage.path, { '_wp-find-template': true } )
-			).then( ( res ) => res.json() );
-			if ( success ) {
-				let newTemplateId = data.ID;
-				if ( newTemplateId === null ) {
-					newTemplateId = (
-						await resolveSelect( 'core' ).getEntityRecords(
-							'postType',
-							'wp_template',
-							{
-								resolved: true,
-								slug: data.post_name,
-							}
-						)
-					 )[ 0 ].id;
-				}
-				setSettings( ( prevSettings ) => ( {
-					...prevSettings,
-					page: newPage,
-					templateId: newTemplateId,
-					templateType: 'wp_template',
-				} ) );
-			}
-		} catch ( err ) {}
-	}, [] );
-	const addTemplateId = useCallback(
-		( newTemplateId ) =>
-			setSettings( ( prevSettings ) => ( {
-				...prevSettings,
-				templateId: newTemplateId,
-				templateType: 'wp_template',
-				templateIds: [ ...prevSettings.templateIds, newTemplateId ],
-			} ) ),
-		[]
-	);
-	const removeTemplateId = useCallback(
-		( oldTemplateId ) => {
-			setSettings( ( prevSettings ) => ( {
-				...prevSettings,
-				templateIds: prevSettings.templateIds.filter(
-					( templateId ) => templateId !== oldTemplateId
-				),
-			} ) );
-			setActivePage( settings.page );
-		},
-		[ settings.page ]
-	);
-
-	const { deviceType, hasFixedToolbar } = useSelect( ( select ) => {
-		const { __experimentalGetPreviewDeviceType, isFeatureActive } = select(
-			'core/edit-site'
-		);
+	const {
+		deviceType,
+		hasFixedToolbar,
+		homeTemplateId,
+		templateId,
+		templatePartId,
+		templateType,
+		templatePartIds,
+		page,
+		showOnFront,
+	} = useSelect( ( select ) => {
+		const {
+			__experimentalGetPreviewDeviceType,
+			isFeatureActive,
+			getHomeTemplateId,
+			getTemplateId,
+			getTemplatePartId,
+			getTemplateType,
+			getTemplatePartIds,
+			getPage,
+			getShowOnFront,
+		} = select( 'core/edit-site' );
 		return {
 			deviceType: __experimentalGetPreviewDeviceType(),
 			hasFixedToolbar: isFeatureActive( 'fixedToolbar' ),
+			homeTemplateId: getHomeTemplateId(),
+			templateId: getTemplateId(),
+			templatePartId: getTemplatePartId(),
+			templateType: getTemplateType(),
+			templatePartIds: getTemplatePartIds(),
+			page: getPage(),
+			showOnFront: getShowOnFront(),
 		};
 	}, [] );
 
 	const {
 		__experimentalSetPreviewDeviceType: setPreviewDeviceType,
+		setTemplate,
+		addTemplate,
+		removeTemplate,
+		setTemplatePart,
+		setPage,
 	} = useDispatch( 'core/edit-site' );
 
 	const isLargeViewport = useViewportMatch( 'medium' );
@@ -160,26 +108,24 @@ export default function Header( {
 				) }
 				<div className="edit-site-header__toolbar-switchers">
 					<PageSwitcher
-						showOnFront={ settings.showOnFront }
-						activePage={ settings.page }
-						onActivePageChange={ setActivePage }
+						showOnFront={ showOnFront }
+						activePage={ page }
+						onActivePageChange={ setPage }
 					/>
 					<div className="edit-site-header__toolbar-switchers-separator">
 						/
 					</div>
 					<TemplateSwitcher
-						templatePartIds={ settings.templatePartIds }
-						page={ settings.page }
-						activeId={ settings.templateId }
-						activeTemplatePartId={ settings.templatePartId }
-						homeId={ settings.homeTemplateId }
-						isTemplatePart={
-							settings.templateType === 'wp_template_part'
-						}
-						onActiveIdChange={ setActiveTemplateId }
-						onActiveTemplatePartIdChange={ setActiveTemplatePartId }
-						onAddTemplateId={ addTemplateId }
-						onRemoveTemplateId={ removeTemplateId }
+						templatePartIds={ templatePartIds }
+						page={ page }
+						activeId={ templateId }
+						activeTemplatePartId={ templatePartId }
+						homeId={ homeTemplateId }
+						isTemplatePart={ templateType === 'wp_template_part' }
+						onActiveIdChange={ setTemplate }
+						onActiveTemplatePartIdChange={ setTemplatePart }
+						onAddTemplateId={ addTemplate }
+						onRemoveTemplateId={ removeTemplate }
 					/>
 				</div>
 			</div>

--- a/packages/edit-site/src/components/page-switcher/index.js
+++ b/packages/edit-site/src/components/page-switcher/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { getPath, getQueryString } from '@wordpress/url';
+import { getPathAndQueryString } from '@wordpress/url';
 import { useSelect } from '@wordpress/data';
 import {
 	Tooltip,
@@ -13,14 +13,6 @@ import { Icon, home } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { __experimentalLinkControl as LinkControl } from '@wordpress/block-editor';
 
-function getPathFromLink( link ) {
-	const path = getPath( link );
-	const queryString = getQueryString( link );
-	let value = '/';
-	if ( path ) value += path;
-	if ( queryString ) value += `?${ queryString }`;
-	return value;
-}
 export default function PageSwitcher( {
 	showOnFront,
 	activePage,
@@ -32,7 +24,7 @@ export default function PageSwitcher( {
 			const pageGroups = {
 				pages: getEntityRecords( 'postType', 'page' )?.map(
 					( _page ) => {
-						const path = getPathFromLink( _page.link );
+						const path = getPathAndQueryString( _page.link );
 						return {
 							label:
 								path === '/' ? (
@@ -59,7 +51,7 @@ export default function PageSwitcher( {
 				),
 				categories: getEntityRecords( 'taxonomy', 'category' )?.map(
 					( category ) => {
-						const path = getPathFromLink( category.link );
+						const path = getPathAndQueryString( category.link );
 						return {
 							label: category.name,
 							type: 'category',
@@ -109,7 +101,7 @@ export default function PageSwitcher( {
 		onActivePageChange( {
 			type: 'post',
 			slug: post.slug,
-			path: getPathFromLink( post.url ),
+			path: getPathAndQueryString( post.url ),
 			context: { postType: post.type, postId: post.id },
 		} );
 	return (

--- a/packages/edit-site/src/components/save-button/index.js
+++ b/packages/edit-site/src/components/save-button/index.js
@@ -12,31 +12,8 @@ import { useSelect } from '@wordpress/data';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-/**
- * Internal dependencies
- */
-import { useEditorContext } from '../editor';
-
 export default function SaveButton( { openEntitiesSavedStates } ) {
-	const { settings } = useEditorContext();
-	const [ , setStatus ] = useEntityProp(
-		'postType',
-		settings.templateType,
-		'status'
-	);
-	const [ , setTitle ] = useEntityProp(
-		'postType',
-		settings.templateType,
-		'title'
-	);
-	const [ slug ] = useEntityProp( 'postType', settings.templateType, 'slug' );
-	// Publish template if not done yet.
-	useEffect( () => {
-		setStatus( 'publish' );
-		setTitle( slug );
-	}, [ slug ] );
-
-	const { isDirty, isSaving } = useSelect( ( select ) => {
+	const { isDirty, isSaving, templateType } = useSelect( ( select ) => {
 		const {
 			__experimentalGetDirtyEntityRecords,
 			isSavingEntityRecord,
@@ -47,10 +24,21 @@ export default function SaveButton( { openEntitiesSavedStates } ) {
 			isSaving: some( dirtyEntityRecords, ( record ) =>
 				isSavingEntityRecord( record.kind, record.name, record.key )
 			),
+			templateType: select( 'core/edit-site' ).getTemplateType(),
 		};
 	} );
-	const disabled = ! isDirty || isSaving;
 
+	const [ , setStatus ] = useEntityProp( 'postType', templateType, 'status' );
+	const [ , setTitle ] = useEntityProp( 'postType', templateType, 'title' );
+	const [ slug ] = useEntityProp( 'postType', templateType, 'slug' );
+
+	// Publish template if not done yet.
+	useEffect( () => {
+		setStatus( 'publish' );
+		setTitle( slug );
+	}, [ slug ] );
+
+	const disabled = ! isDirty || isSaving;
 	return (
 		<>
 			<Button

--- a/packages/edit-site/src/components/template-switcher/index.js
+++ b/packages/edit-site/src/components/template-switcher/index.js
@@ -2,9 +2,8 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
-import apiFetch from '@wordpress/api-fetch';
 import {
 	Tooltip,
 	DropdownMenu,
@@ -55,8 +54,8 @@ export default function TemplateSwitcher( {
 	isTemplatePart,
 	onActiveIdChange,
 	onActiveTemplatePartIdChange,
-	onAddTemplateId,
-	onRemoveTemplateId,
+	onAddTemplate,
+	onRemoveTemplate,
 } ) {
 	const [ hoveredTemplate, setHoveredTemplate ] = useState();
 	const [ themePreviewVisible, setThemePreviewVisible ] = useState( false );
@@ -117,29 +116,20 @@ export default function TemplateSwitcher( {
 		[ activeId, templatePartIds, homeId ]
 	);
 
-	const { saveEntityRecord } = useDispatch( 'core' );
-
 	const overwriteSlug =
 		TEMPLATE_OVERRIDES[ page.type ] &&
 		page.slug &&
 		TEMPLATE_OVERRIDES[ page.type ]( page.slug );
-	const overwriteTemplate = async () => {
-		const newTemplate = await saveEntityRecord( 'postType', 'wp_template', {
+	const overwriteTemplate = () =>
+		onAddTemplate( {
 			slug: overwriteSlug,
 			title: overwriteSlug,
 			status: 'publish',
 			content: template.content.raw,
 		} );
-		onAddTemplateId( newTemplate.id );
+	const revertToParent = async () => {
+		onRemoveTemplate( template.value );
 	};
-	const unoverwriteTemplate = async () => {
-		await apiFetch( {
-			path: `/wp/v2/templates/${ template.value }`,
-			method: 'DELETE',
-		} );
-		onRemoveTemplateId( template.value );
-	};
-
 	return (
 		<>
 			<DropdownMenu
@@ -180,7 +170,7 @@ export default function TemplateSwitcher( {
 							{ overwriteSlug === template.slug && (
 								<MenuItem
 									icon={ undo }
-									onClick={ unoverwriteTemplate }
+									onClick={ revertToParent }
 								>
 									{ __( 'Revert to Parent' ) }
 								</MenuItem>

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -16,7 +16,7 @@ import { render } from '@wordpress/element';
  */
 import './plugins';
 import './hooks';
-import './store';
+import registerEditSiteStore from './store';
 import Editor from './components/editor';
 
 const fetchLinkSuggestions = ( search, { perPage = 20 } = {} ) =>
@@ -52,12 +52,19 @@ const fetchLinkSuggestions = ( search, { perPage = 20 } = {} ) =>
  * @param {Object} settings Editor settings.
  */
 export function initialize( id, settings ) {
+	settings.__experimentalFetchLinkSuggestions = fetchLinkSuggestions;
+
+	const initialState = settings.editSiteInitialState;
+	delete settings.editSiteInitialState;
+	initialState.settings = settings;
+	registerEditSiteStore( initialState );
+
 	registerCoreBlocks();
 	if ( process.env.GUTENBERG_PHASE === 2 ) {
 		__experimentalRegisterExperimentalCoreBlocks( settings );
 	}
-	settings.__experimentalFetchLinkSuggestions = fetchLinkSuggestions;
-	render( <Editor settings={ settings } />, document.getElementById( id ) );
+
+	render( <Editor />, document.getElementById( id ) );
 }
 
 export { default as __experimentalFullscreenModeClose } from './components/header/fullscreen-mode-close';

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import { findTemplate } from './controls';
+
+/**
  * Returns an action object used to toggle a feature flag.
  *
  * @param {string} feature Feature name.
@@ -23,5 +28,81 @@ export function __experimentalSetPreviewDeviceType( deviceType ) {
 	return {
 		type: 'SET_PREVIEW_DEVICE_TYPE',
 		deviceType,
+	};
+}
+
+/**
+ * Returns an action object used to set a template.
+ *
+ * @param {number} templateId The template ID.
+ *
+ * @return {Object} Action object.
+ */
+export function setTemplate( templateId ) {
+	return {
+		type: 'SET_TEMPLATE',
+		templateId,
+	};
+}
+
+/**
+ * Returns an action object used to add a template.
+ *
+ * @param {number} templateId The template ID.
+ *
+ * @return {Object} Action object.
+ */
+export function addTemplate( templateId ) {
+	return {
+		type: 'ADD_TEMPLATE',
+		templateId,
+	};
+}
+
+/**
+ * Returns an action object used to remove a template.
+ *
+ * @param {number} templateId The template ID.
+ *
+ * @return {Object} Action object.
+ */
+export function removeTemplate( templateId ) {
+	return {
+		type: 'REMOVE_TEMPLATE',
+		templateId,
+	};
+}
+
+/**
+ * Returns an action object used to set a template part.
+ *
+ * @param {number} templatePartId The template part ID.
+ *
+ * @return {Object} Action object.
+ */
+export function setTemplatePart( templatePartId ) {
+	return {
+		type: 'SET_TEMPLATE_PART',
+		templatePartId,
+	};
+}
+
+/**
+ * Resolves the template for a page and sets them.
+ *
+ * @param {Object} page         The page object.
+ * @param {string} page.type    The page type.
+ * @param {string} page.slug    The page slug.
+ * @param {string} page.path    The page path.
+ * @param {Object} page.context The page context.
+ *
+ * @return {Object} Action object.
+ */
+export function* setPage( page ) {
+	const templateId = yield findTemplate( page.path );
+	return {
+		type: 'SET_PAGE',
+		page,
+		templateId,
 	};
 }

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { select, dispatch, apiFetch } from '@wordpress/data-controls';
+
+/**
  * Internal dependencies
  */
 import { findTemplate } from './controls';
@@ -48,14 +53,21 @@ export function setTemplate( templateId ) {
 /**
  * Returns an action object used to add a template.
  *
- * @param {number} templateId The template ID.
+ * @param {Object} template The template.
  *
  * @return {Object} Action object.
  */
-export function addTemplate( templateId ) {
+export function* addTemplate( template ) {
+	const newTemplate = yield dispatch(
+		'core',
+		'saveEntityRecord',
+		'postType',
+		'wp_template',
+		template
+	);
 	return {
 		type: 'ADD_TEMPLATE',
-		templateId,
+		templateId: newTemplate.id,
 	};
 }
 
@@ -66,7 +78,16 @@ export function addTemplate( templateId ) {
  *
  * @return {Object} Action object.
  */
-export function removeTemplate( templateId ) {
+export function* removeTemplate( templateId ) {
+	yield apiFetch( {
+		path: `/wp/v2/templates/${ templateId }`,
+		method: 'DELETE',
+	} );
+	yield dispatch(
+		'core/edit-site',
+		'setPage',
+		yield select( 'core/edit-site', 'getPage' )
+	);
 	return {
 		type: 'REMOVE_TEMPLATE',
 		templateId,

--- a/packages/edit-site/src/store/controls.js
+++ b/packages/edit-site/src/store/controls.js
@@ -3,11 +3,36 @@
  */
 import { createRegistryControl } from '@wordpress/data';
 
+/**
+ * Internal dependencies
+ */
+import { findTemplate as findTemplateUtil } from '../utils';
+
+/**
+ * Find the template for a given page path.
+ *
+ * @param {string} path The page path.
+ *
+ * @return {number} The found template ID.
+ */
+export function findTemplate( path ) {
+	return {
+		type: 'FIND_TEMPLATE',
+		path,
+	};
+}
+
 const controls = {
 	SELECT: createRegistryControl(
 		( registry ) => ( { storeName, selectorName, args } ) => {
 			return registry.select( storeName )[ selectorName ]( ...args );
 		}
+	),
+	FIND_TEMPLATE: createRegistryControl( ( registry ) => ( { path } ) =>
+		findTemplateUtil(
+			path,
+			registry.__experimentalResolveSelect( 'core' ).getEntityRecords
+		)
 	),
 };
 

--- a/packages/edit-site/src/store/controls.js
+++ b/packages/edit-site/src/store/controls.js
@@ -23,11 +23,6 @@ export function findTemplate( path ) {
 }
 
 const controls = {
-	SELECT: createRegistryControl(
-		( registry ) => ( { storeName, selectorName, args } ) => {
-			return registry.select( storeName )[ selectorName ]( ...args );
-		}
-	),
 	FIND_TEMPLATE: createRegistryControl( ( registry ) => ( { path } ) =>
 		findTemplateUtil(
 			path,

--- a/packages/edit-site/src/store/index.js
+++ b/packages/edit-site/src/store/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { registerStore } from '@wordpress/data';
+import { controls as dataControls } from '@wordpress/data-controls';
 
 /**
  * Internal dependencies
@@ -17,7 +18,7 @@ export default function registerEditSiteStore( initialState ) {
 		reducer,
 		actions,
 		selectors,
-		controls,
+		controls: { ...dataControls, ...controls },
 		persist: [ 'preferences' ],
 		initialState,
 	} );

--- a/packages/edit-site/src/store/index.js
+++ b/packages/edit-site/src/store/index.js
@@ -12,12 +12,13 @@ import * as selectors from './selectors';
 import controls from './controls';
 import { STORE_KEY } from './constants';
 
-const store = registerStore( STORE_KEY, {
-	reducer,
-	actions,
-	selectors,
-	controls,
-	persist: [ 'preferences' ],
-} );
-
-export default store;
+export default function registerEditSiteStore( initialState ) {
+	return registerStore( STORE_KEY, {
+		reducer,
+		actions,
+		selectors,
+		controls,
+		persist: [ 'preferences' ],
+		initialState,
+	} );
+}

--- a/packages/edit-site/src/store/reducer.js
+++ b/packages/edit-site/src/store/reducer.js
@@ -65,7 +65,162 @@ export function deviceType( state = 'Desktop', action ) {
 	return state;
 }
 
+/**
+ * Reducer returning the settings.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+export function settings( state = {}, action ) {
+	switch ( action.type ) {
+		case 'UPDATE_SETTINGS':
+			return {
+				...state,
+				...action.settings,
+			};
+	}
+
+	return state;
+}
+
+/**
+ * Reducer returning the home template ID.
+ *
+ * @param {Object} state Current state.
+ *
+ * @return {Object} Updated state.
+ */
+export function homeTemplateId( state ) {
+	return state;
+}
+
+/**
+ * Reducer returning the template ID.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+export function templateId( state, action ) {
+	switch ( action.type ) {
+		case 'SET_TEMPLATE':
+		case 'ADD_TEMPLATE':
+		case 'SET_PAGE':
+			return action.templateId;
+	}
+
+	return state;
+}
+
+/**
+ * Reducer returning the template part ID.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+export function templatePartId( state, action ) {
+	switch ( action.type ) {
+		case 'SET_TEMPLATE_PART':
+			return action.templatePartId;
+	}
+
+	return state;
+}
+
+/**
+ * Reducer returning the template type.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+export function templateType( state, action ) {
+	switch ( action.type ) {
+		case 'SET_TEMPLATE':
+		case 'ADD_TEMPLATE':
+		case 'SET_PAGE':
+			return 'wp_template';
+		case 'SET_TEMPLATE_PART':
+			return 'wp_template_part';
+	}
+
+	return state;
+}
+
+/**
+ * Reducer returning the list of template IDs.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+export function templateIds( state = [], action ) {
+	switch ( action.type ) {
+		case 'ADD_TEMPLATE':
+			return [ ...state, action.templateId ];
+		case 'REMOVE_TEMPLATE':
+			return state.filter( ( id ) => id !== action.templateId );
+	}
+
+	return state;
+}
+
+/**
+ * Reducer returning the list of template part IDs.
+ *
+ * @param {Object} state Current state.
+ *
+ * @return {Object} Updated state.
+ */
+export function templatePartIds( state = [] ) {
+	return state;
+}
+
+/**
+ * Reducer returning the page being edited.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+export function page( state = {}, action ) {
+	switch ( action.type ) {
+		case 'SET_PAGE':
+			return action.page;
+	}
+
+	return state;
+}
+
+/**
+ * Reducer returning the site's `show_on_front` setting.
+ *
+ * @param {Object} state Current state.
+ *
+ * @return {Object} Updated state.
+ */
+export function showOnFront( state ) {
+	return state;
+}
+
 export default combineReducers( {
 	preferences,
 	deviceType,
+	settings,
+	homeTemplateId,
+	templateId,
+	templatePartId,
+	templateType,
+	templateIds,
+	templatePartIds,
+	page,
+	showOnFront,
 } );

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -2,6 +2,13 @@
  * External dependencies
  */
 import { get } from 'lodash';
+import createSelector from 'rememo';
+
+/**
+ * WordPress dependencies
+ */
+import { createRegistrySelector } from '@wordpress/data';
+import { uploadMedia } from '@wordpress/media-utils';
 
 /**
  * Returns whether the given feature is enabled or not.
@@ -24,4 +31,138 @@ export function isFeatureActive( state, feature ) {
  */
 export function __experimentalGetPreviewDeviceType( state ) {
 	return state.deviceType;
+}
+
+/**
+ * Returns whether the current user can create media or not.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {Object} Whether the current user can create media or not.
+ */
+export const getCanUserCreateMedia = createRegistrySelector( ( select ) => () =>
+	select( 'core' ).canUser( 'create', 'media' )
+);
+
+/**
+ * Returns the settings, taking into account active features and permissions.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {Object} Settings.
+ */
+export const getSettings = createSelector(
+	( state ) => {
+		const canUserCreateMedia = getCanUserCreateMedia( state );
+		if ( ! canUserCreateMedia ) {
+			return state.settings;
+		}
+
+		return {
+			...state.settings,
+			focusMode: isFeatureActive( state, 'focusMode' ),
+			hasFixedToolbar: isFeatureActive( state, 'fixedToolbar' ),
+			mediaUpload( { onError, ...rest } ) {
+				uploadMedia( {
+					wpAllowedMimeTypes: state.settings.allowedMimeTypes,
+					onError: ( { message } ) => onError( message ),
+					...rest,
+				} );
+			},
+		};
+	},
+	( state ) => [
+		getCanUserCreateMedia( state ),
+		state.settings,
+		isFeatureActive( state, 'focusMode' ),
+		isFeatureActive( state, 'fixedToolbar' ),
+	]
+);
+
+/**
+ * Returns the current home template ID.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {number} Home template ID.
+ */
+export function getHomeTemplateId( state ) {
+	return state.homeTemplateId;
+}
+
+/**
+ * Returns the current template ID.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {number} Template ID.
+ */
+export function getTemplateId( state ) {
+	return state.templateId;
+}
+
+/**
+ * Returns the current template part ID.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {number} Template part ID.
+ */
+export function getTemplatePartId( state ) {
+	return state.templatePartId;
+}
+
+/**
+ * Returns the current template type.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {string} Template type.
+ */
+export function getTemplateType( state ) {
+	return state.templateType;
+}
+
+/**
+ * Returns the current template IDs.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {number[]} Template IDs.
+ */
+export function getTemplateIds( state ) {
+	return state.templateIds;
+}
+
+/**
+ * Returns the current template part IDs.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {number[]} Template part IDs.
+ */
+export function getTemplatePartIds( state ) {
+	return state.templatePartIds;
+}
+
+/**
+ * Returns the current page object.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {Object} Page.
+ */
+export function getPage( state ) {
+	return state.page;
+}
+
+/**
+ * Returns the site's current `show_on_front` setting.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {Object} The setting.
+ */
+export function getShowOnFront( state ) {
+	return state.showOnFront;
 }

--- a/packages/edit-site/src/store/test/actions.js
+++ b/packages/edit-site/src/store/test/actions.js
@@ -32,21 +32,58 @@ describe( 'actions', () => {
 	} );
 
 	describe( 'addTemplate', () => {
-		it( 'should return the ADD_TEMPLATE action', () => {
-			const templateId = 1;
-			expect( addTemplate( templateId ) ).toEqual( {
-				type: 'ADD_TEMPLATE',
-				templateId,
+		it( 'should yield the DISPATCH control to create the template and return the ADD_TEMPLATE action', () => {
+			const template = { slug: 'index' };
+			const newTemplate = { id: 1 };
+
+			const it = addTemplate( template );
+			expect( it.next().value ).toEqual( {
+				type: 'DISPATCH',
+				storeKey: 'core',
+				actionName: 'saveEntityRecord',
+				args: [ 'postType', 'wp_template', template ],
+			} );
+			expect( it.next( newTemplate ) ).toEqual( {
+				value: {
+					type: 'ADD_TEMPLATE',
+					templateId: newTemplate.id,
+				},
+				done: true,
 			} );
 		} );
 	} );
 
 	describe( 'removeTemplate', () => {
-		it( 'should return the REMOVE_TEMPLATE action', () => {
+		it( 'should yield the API_FETCH control, yield the SELECT control to set the page by yielding the DISPATCH control for the SET_PAGE action, and return the REMOVE_TEMPLATE action', () => {
 			const templateId = 1;
-			expect( removeTemplate( templateId ) ).toEqual( {
-				type: 'REMOVE_TEMPLATE',
-				templateId,
+			const page = { path: '/' };
+
+			const it = removeTemplate( templateId );
+			expect( it.next().value ).toEqual( {
+				type: 'API_FETCH',
+				request: {
+					path: `/wp/v2/templates/${ templateId }`,
+					method: 'DELETE',
+				},
+			} );
+			expect( it.next().value ).toEqual( {
+				type: 'SELECT',
+				storeKey: 'core/edit-site',
+				selectorName: 'getPage',
+				args: [],
+			} );
+			expect( it.next( page ).value ).toEqual( {
+				type: 'DISPATCH',
+				storeKey: 'core/edit-site',
+				actionName: 'setPage',
+				args: [ page ],
+			} );
+			expect( it.next() ).toEqual( {
+				value: {
+					type: 'REMOVE_TEMPLATE',
+					templateId,
+				},
+				done: true,
 			} );
 		} );
 	} );

--- a/packages/edit-site/src/store/test/actions.js
+++ b/packages/edit-site/src/store/test/actions.js
@@ -1,7 +1,14 @@
 /**
  * Internal dependencies
  */
-import { toggleFeature } from '../actions';
+import {
+	toggleFeature,
+	setTemplate,
+	addTemplate,
+	removeTemplate,
+	setTemplatePart,
+	setPage,
+} from '../actions';
 
 describe( 'actions', () => {
 	describe( 'toggleFeature', () => {
@@ -10,6 +17,67 @@ describe( 'actions', () => {
 			expect( toggleFeature( feature ) ).toEqual( {
 				type: 'TOGGLE_FEATURE',
 				feature,
+			} );
+		} );
+	} );
+
+	describe( 'setTemplate', () => {
+		it( 'should return the SET_TEMPLATE action', () => {
+			const templateId = 1;
+			expect( setTemplate( templateId ) ).toEqual( {
+				type: 'SET_TEMPLATE',
+				templateId,
+			} );
+		} );
+	} );
+
+	describe( 'addTemplate', () => {
+		it( 'should return the ADD_TEMPLATE action', () => {
+			const templateId = 1;
+			expect( addTemplate( templateId ) ).toEqual( {
+				type: 'ADD_TEMPLATE',
+				templateId,
+			} );
+		} );
+	} );
+
+	describe( 'removeTemplate', () => {
+		it( 'should return the REMOVE_TEMPLATE action', () => {
+			const templateId = 1;
+			expect( removeTemplate( templateId ) ).toEqual( {
+				type: 'REMOVE_TEMPLATE',
+				templateId,
+			} );
+		} );
+	} );
+
+	describe( 'setTemplatePart', () => {
+		it( 'should return the SET_TEMPLATE_PART action', () => {
+			const templatePartId = 1;
+			expect( setTemplatePart( templatePartId ) ).toEqual( {
+				type: 'SET_TEMPLATE_PART',
+				templatePartId,
+			} );
+		} );
+	} );
+
+	describe( 'setPage', () => {
+		it( 'should yield the FIND_TEMPLATE control and return the SET_TEMPLATE_PART action', () => {
+			const page = { path: '/' };
+			const templateId = 1;
+
+			const it = setPage( page );
+			expect( it.next().value ).toEqual( {
+				type: 'FIND_TEMPLATE',
+				path: page.path,
+			} );
+			expect( it.next( templateId ) ).toEqual( {
+				value: {
+					type: 'SET_PAGE',
+					page,
+					templateId,
+				},
+				done: true,
 			} );
 		} );
 	} );

--- a/packages/edit-site/src/store/test/controls.js
+++ b/packages/edit-site/src/store/test/controls.js
@@ -1,0 +1,44 @@
+/**
+ * Internal dependencies
+ */
+import controls, { findTemplate } from '../controls';
+import { findTemplate as findTemplateUtil } from '../../utils';
+
+jest.mock( '../../utils', () => {
+	return {
+		__esModule: true,
+		findTemplate: jest.fn( () => 1 ),
+	};
+} );
+
+describe( 'controls', () => {
+	describe( 'findTemplate', () => {
+		it( 'should return the FIND_TEMPLATE control descriptor', () => {
+			expect( findTemplate( '/' ) ).toEqual( {
+				type: 'FIND_TEMPLATE',
+				path: '/',
+			} );
+		} );
+	} );
+
+	describe( 'controls.FIND_TEMPLATE', () => {
+		it( 'should be a registry control that calls the `findTemplate` util with the provided path and the `getEntityRecords` resolve selector', () => {
+			const getEntityRecords = {};
+			const registry = {
+				__experimentalResolveSelect: jest.fn( () => ( {
+					getEntityRecords,
+				} ) ),
+			};
+			expect( controls.FIND_TEMPLATE( registry )( { path: '/' } ) ).toBe(
+				1
+			);
+			expect( registry.__experimentalResolveSelect ).toHaveBeenCalledWith(
+				'core'
+			);
+			expect( findTemplateUtil ).toHaveBeenCalledWith(
+				'/',
+				getEntityRecords
+			);
+		} );
+	} );
+} );

--- a/packages/edit-site/src/store/test/reducer.js
+++ b/packages/edit-site/src/store/test/reducer.js
@@ -6,7 +6,18 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import { preferences } from '../reducer';
+import {
+	preferences,
+	settings,
+	homeTemplateId,
+	templateId,
+	templatePartId,
+	templateType,
+	templateIds,
+	templatePartIds,
+	page,
+	showOnFront,
+} from '../reducer';
 import { PREFERENCES_DEFAULTS } from '../defaults';
 
 describe( 'state', () => {
@@ -27,6 +38,225 @@ describe( 'state', () => {
 			);
 
 			expect( state.features ).toEqual( { chicken: false } );
+		} );
+	} );
+
+	describe( 'settings()', () => {
+		it( 'should apply default state', () => {
+			expect( settings( undefined, {} ) ).toEqual( {} );
+		} );
+
+		it( 'should default to returning the same state', () => {
+			const state = {};
+			expect( settings( state, {} ) ).toBe( state );
+		} );
+
+		it( 'should update settings with a shallow merge', () => {
+			expect(
+				settings(
+					deepFreeze( {
+						setting: { key: 'value' },
+						otherSetting: 'value',
+					} ),
+					{
+						type: 'UPDATE_SETTINGS',
+						settings: { setting: { newKey: 'newValue' } },
+					}
+				)
+			).toEqual( {
+				setting: { newKey: 'newValue' },
+				otherSetting: 'value',
+			} );
+		} );
+	} );
+
+	describe( 'homeTemplateId()', () => {
+		it( 'should apply default state', () => {
+			expect( homeTemplateId( undefined, {} ) ).toEqual( undefined );
+		} );
+
+		it( 'should default to returning the same state', () => {
+			const state = {};
+			expect( homeTemplateId( state, {} ) ).toBe( state );
+		} );
+	} );
+
+	describe( 'templateId()', () => {
+		it( 'should apply default state', () => {
+			expect( templateId( undefined, {} ) ).toEqual( undefined );
+		} );
+
+		it( 'should default to returning the same state', () => {
+			const state = {};
+			expect( templateId( state, {} ) ).toBe( state );
+		} );
+
+		it( 'should update when a template is set', () => {
+			expect(
+				templateId( 1, {
+					type: 'SET_TEMPLATE',
+					templateId: 2,
+				} )
+			).toEqual( 2 );
+		} );
+
+		it( 'should update when a template is added', () => {
+			expect(
+				templateId( 1, {
+					type: 'ADD_TEMPLATE',
+					templateId: 2,
+				} )
+			).toEqual( 2 );
+		} );
+
+		it( 'should update when a page is set', () => {
+			expect(
+				templateId( 1, {
+					type: 'SET_PAGE',
+					templateId: 2,
+				} )
+			).toEqual( 2 );
+		} );
+	} );
+
+	describe( 'templatePartId()', () => {
+		it( 'should apply default state', () => {
+			expect( templatePartId( undefined, {} ) ).toEqual( undefined );
+		} );
+
+		it( 'should default to returning the same state', () => {
+			const state = {};
+			expect( templatePartId( state, {} ) ).toBe( state );
+		} );
+
+		it( 'should update when a template part is set', () => {
+			expect(
+				templatePartId( 1, {
+					type: 'SET_TEMPLATE_PART',
+					templatePartId: 2,
+				} )
+			).toEqual( 2 );
+		} );
+	} );
+
+	describe( 'templateType()', () => {
+		it( 'should apply default state', () => {
+			expect( templateType( undefined, {} ) ).toEqual( undefined );
+		} );
+
+		it( 'should default to returning the same state', () => {
+			const state = {};
+			expect( templateType( state, {} ) ).toBe( state );
+		} );
+
+		it( 'should update when a template is set', () => {
+			expect(
+				templateType( undefined, {
+					type: 'SET_TEMPLATE',
+				} )
+			).toEqual( 'wp_template' );
+		} );
+
+		it( 'should update when a template is added', () => {
+			expect(
+				templateType( undefined, {
+					type: 'ADD_TEMPLATE',
+				} )
+			).toEqual( 'wp_template' );
+		} );
+
+		it( 'should update when a page is set', () => {
+			expect(
+				templateType( undefined, {
+					type: 'SET_PAGE',
+				} )
+			).toEqual( 'wp_template' );
+		} );
+
+		it( 'should update when a template part is set', () => {
+			expect(
+				templateType( undefined, {
+					type: 'SET_TEMPLATE_PART',
+				} )
+			).toEqual( 'wp_template_part' );
+		} );
+	} );
+
+	describe( 'templateIds()', () => {
+		it( 'should apply default state', () => {
+			expect( templateIds( undefined, {} ) ).toEqual( [] );
+		} );
+
+		it( 'should default to returning the same state', () => {
+			const state = {};
+			expect( templateIds( state, {} ) ).toBe( state );
+		} );
+
+		it( 'should add template IDs', () => {
+			expect(
+				templateIds( deepFreeze( [ 1 ] ), {
+					type: 'ADD_TEMPLATE',
+					templateId: 2,
+				} )
+			).toEqual( [ 1, 2 ] );
+		} );
+
+		it( 'should remove template IDs', () => {
+			expect(
+				templateIds( deepFreeze( [ 1, 2 ] ), {
+					type: 'REMOVE_TEMPLATE',
+					templateId: 2,
+				} )
+			).toEqual( [ 1 ] );
+			expect(
+				templateIds( deepFreeze( [ 1, 2 ] ), {
+					type: 'REMOVE_TEMPLATE',
+					templateId: 1,
+				} )
+			).toEqual( [ 2 ] );
+		} );
+	} );
+
+	describe( 'templatePartIds()', () => {
+		it( 'should apply default state', () => {
+			expect( templatePartIds( undefined, {} ) ).toEqual( [] );
+		} );
+
+		it( 'should default to returning the same state', () => {
+			const state = {};
+			expect( templatePartIds( state, {} ) ).toBe( state );
+		} );
+	} );
+
+	describe( 'page()', () => {
+		it( 'should apply default state', () => {
+			expect( page( undefined, {} ) ).toEqual( {} );
+		} );
+
+		it( 'should default to returning the same state', () => {
+			const state = {};
+			expect( page( state, {} ) ).toBe( state );
+		} );
+
+		it( 'should set the page', () => {
+			const newPage = {};
+			expect(
+				page( undefined, {
+					type: 'SET_PAGE',
+					page: newPage,
+				} )
+			).toBe( newPage );
+		} );
+	} );
+
+	describe( 'showOnFront()', () => {
+		it( 'should apply default state', () => {
+			expect( showOnFront( undefined, {} ) ).toEqual( undefined );
+		} );
+
+		it( 'should default to returning the same state', () => {
+			const state = {};
+			expect( showOnFront( state, {} ) ).toBe( state );
 		} );
 	} );
 } );

--- a/packages/edit-site/src/store/test/selectors.js
+++ b/packages/edit-site/src/store/test/selectors.js
@@ -1,9 +1,26 @@
 /**
  * Internal dependencies
  */
-import { isFeatureActive } from '../selectors';
+import {
+	isFeatureActive,
+	getCanUserCreateMedia,
+	getSettings,
+	getHomeTemplateId,
+	getTemplateId,
+	getTemplatePartId,
+	getTemplateType,
+	getTemplateIds,
+	getTemplatePartIds,
+	getPage,
+	getShowOnFront,
+} from '../selectors';
 
 describe( 'selectors', () => {
+	const canUser = jest.fn( () => true );
+	getCanUserCreateMedia.registry = {
+		select: jest.fn( () => ( { canUser } ) ),
+	};
+
 	describe( 'isFeatureActive', () => {
 		it( 'is tolerant to an undefined features preference', () => {
 			// See: https://github.com/WordPress/gutenberg/issues/14580
@@ -46,6 +63,99 @@ describe( 'selectors', () => {
 			};
 
 			expect( isFeatureActive( state, 'chicken' ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'getCanUserCreateMedia', () => {
+		it( "selects `canUser( 'create', 'media' )` from the core store", () => {
+			expect( getCanUserCreateMedia() ).toBe( true );
+			expect(
+				getCanUserCreateMedia.registry.select
+			).toHaveBeenCalledWith( 'core' );
+			expect( canUser ).toHaveBeenCalledWith( 'create', 'media' );
+		} );
+	} );
+
+	describe( 'getSettings', () => {
+		it( "returns the settings when the user can't create media", () => {
+			canUser.mockReturnValueOnce( false );
+			canUser.mockReturnValueOnce( false );
+			const state = { settings: {}, preferences: {} };
+			expect( getSettings( state ) ).toBe( state.settings );
+		} );
+
+		it( 'returns the extended settings when the user can create media', () => {
+			const state = {
+				settings: { key: 'value' },
+				preferences: {
+					features: {
+						focusMode: true,
+						fixedToolbar: true,
+					},
+				},
+			};
+			expect( getSettings( state ) ).toEqual( {
+				key: 'value',
+				focusMode: true,
+				hasFixedToolbar: true,
+				mediaUpload: expect.any( Function ),
+			} );
+		} );
+	} );
+
+	describe( 'getHomeTemplateId', () => {
+		it( 'returns the home template ID', () => {
+			const state = { homeTemplateId: {} };
+			expect( getHomeTemplateId( state ) ).toBe( state.homeTemplateId );
+		} );
+	} );
+
+	describe( 'getTemplateId', () => {
+		it( 'returns the template ID', () => {
+			const state = { templateId: {} };
+			expect( getTemplateId( state ) ).toBe( state.templateId );
+		} );
+	} );
+
+	describe( 'getTemplatePartId', () => {
+		it( 'returns the template part ID', () => {
+			const state = { templatePartId: {} };
+			expect( getTemplatePartId( state ) ).toBe( state.templatePartId );
+		} );
+	} );
+
+	describe( 'getTemplateType', () => {
+		it( 'returns the template type', () => {
+			const state = { templateType: {} };
+			expect( getTemplateType( state ) ).toBe( state.templateType );
+		} );
+	} );
+
+	describe( 'getTemplateIds', () => {
+		it( 'returns the template IDs', () => {
+			const state = { templateIds: {} };
+			expect( getTemplateIds( state ) ).toBe( state.templateIds );
+		} );
+	} );
+
+	describe( 'getTemplatePartIds', () => {
+		it( 'returns the template part IDs', () => {
+			const state = { templatePartIds: {} };
+			expect( getTemplatePartIds( state ) ).toBe( state.templatePartIds );
+		} );
+	} );
+
+	describe( 'getPage', () => {
+		it( 'returns the page object', () => {
+			const state = { page: {} };
+			expect( getPage( state ) ).toBe( state.page );
+		} );
+	} );
+
+	describe( 'getShowOnFront', () => {
+		it( 'returns the `show_on_front` setting', () => {
+			const state = { showOnFront: {} };
+			expect( getShowOnFront( state ) ).toBe( state.showOnFront );
 		} );
 	} );
 } );

--- a/packages/edit-site/src/utils/find-template.js
+++ b/packages/edit-site/src/utils/find-template.js
@@ -1,0 +1,35 @@
+/**
+ * WordPress dependencies
+ */
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Browser dependencies
+ */
+const { fetch } = window;
+
+/**
+ * Find the template for a given page path.
+ *
+ * @param {string}   path The page path.
+ * @param {Function} getEntityRecords The promise-returning `getEntityRecords` selector to use.
+ *
+ * @return {number} The found template ID.
+ */
+export default async function findTemplate( path, getEntityRecords ) {
+	const { data } = await fetch(
+		addQueryArgs( path, { '_wp-find-template': true } )
+	).then( ( res ) => res.json() );
+
+	let newTemplateId = data.ID;
+	if ( newTemplateId === null ) {
+		newTemplateId = (
+			await getEntityRecords( 'postType', 'wp_template', {
+				resolved: true,
+				slug: data.post_name,
+			} )
+		 )[ 0 ].id;
+	}
+
+	return newTemplateId;
+}

--- a/packages/edit-site/src/utils/index.js
+++ b/packages/edit-site/src/utils/index.js
@@ -1,0 +1,1 @@
+export { default as findTemplate } from './find-template';

--- a/packages/edit-site/src/utils/test/find-template.js
+++ b/packages/edit-site/src/utils/test/find-template.js
@@ -1,0 +1,49 @@
+describe( 'findTemplate()', () => {
+	let fetch;
+	beforeAll( () => ( fetch = window.fetch ) );
+	afterAll( () => ( window.fetch = fetch ) );
+
+	afterEach( jest.resetModules );
+
+	const createMockFetch = ( response ) =>
+		( window.fetch = jest.fn( () =>
+			Promise.resolve( {
+				json() {
+					return Promise.resolve( response );
+				},
+			} )
+		) );
+
+	it( 'Should call fetch with the provided path and resolve the returned ID.', async () => {
+		const mockFetch = createMockFetch( { data: { ID: 1 } } );
+		expect(
+			await require( '../find-template' ).default( '/path?query=true' )
+		).toBe( 1 );
+		expect( mockFetch ).toHaveBeenCalledWith(
+			'/path?query=true&_wp-find-template=true'
+		);
+	} );
+
+	it( 'Should resolve the ID from the returned post name if not found.', async () => {
+		createMockFetch( {
+			data: { ID: null, post_name: 'post-name' },
+		} );
+		const getEntityRecords = jest.fn( () =>
+			Promise.resolve( [ { id: 2 } ] )
+		);
+		expect(
+			await require( '../find-template' ).default(
+				'/path?query=true',
+				getEntityRecords
+			)
+		).toBe( 2 );
+		expect( getEntityRecords ).toHaveBeenCalledWith(
+			'postType',
+			'wp_template',
+			{
+				resolved: true,
+				slug: 'post-name',
+			}
+		);
+	} );
+} );

--- a/packages/format-library/src/link/utils.js
+++ b/packages/format-library/src/link/utils.js
@@ -103,7 +103,7 @@ export function createLinkFormat( { url, type, id, opensInNewWindow } ) {
 	};
 
 	if ( type ) format.attributes.type = type;
-	if ( id ) format.attributes.type = id;
+	if ( id ) format.attributes.id = id;
 
 	if ( opensInNewWindow ) {
 		format.attributes.target = '_blank';

--- a/packages/url/CHANGELOG.md
+++ b/packages/url/CHANGELOG.md
@@ -2,36 +2,40 @@
 
 ## Unreleased
 
+### New Feature
+
+-   Added `getPathAndQueryString`.
+
 ## 2.14.0 (2020-04-30)
 
 ### Bug fix
 
-- `addQueryArgs` arguments are optional ([#21926](https://github.com/WordPress/gutenberg/pull/21926))
+-   `addQueryArgs` arguments are optional ([#21926](https://github.com/WordPress/gutenberg/pull/21926))
 
 ## 2.13.0 (2020-04-15)
 
 ### New feature
 
-- Include TypeScript type declarations ([#18942](https://github.com/WordPress/gutenberg/pull/18942))
+-   Include TypeScript type declarations ([#18942](https://github.com/WordPress/gutenberg/pull/18942))
 
 # 2.12.0 (2020-04-01)
 
 ### Bug Fixes
 
-- `getQueryString` now correctly considers hash fragments when considering whether to return a query string. Previously, `getQueryString( 'https://example.com/#?foo' )` would wrongly return `'foo'` as its result. A hash fragment is always the last segment of a URL, and the querystring must always precede it ([see reference specification](https://url.spec.whatwg.org/#absolute-url-with-fragment-string)).
+-   `getQueryString` now correctly considers hash fragments when considering whether to return a query string. Previously, `getQueryString( 'https://example.com/#?foo' )` would wrongly return `'foo'` as its result. A hash fragment is always the last segment of a URL, and the querystring must always precede it ([see reference specification](https://url.spec.whatwg.org/#absolute-url-with-fragment-string)).
 
 ## 2.11.0 (2020-02-10)
 
 ### Bug Fixes
 
-- `isURL` now correctly returns `true` for many other forms of a valid URL, as it now conforms to the [URL Living Standard](https://url.spec.whatwg.org/) definition of a [valid URL string](https://url.spec.whatwg.org/#valid-url-string).
+-   `isURL` now correctly returns `true` for many other forms of a valid URL, as it now conforms to the [URL Living Standard](https://url.spec.whatwg.org/) definition of a [valid URL string](https://url.spec.whatwg.org/#valid-url-string).
 
 ## 2.3.3 (2019-01-03)
 
 ### Bug Fixes
 
-- `addQueryArgs` will return only the querystring fragment if the passed `url` is undefined. Previously, an uncaught error would be thrown.
-- `addQueryArgs` will not append (or remove) a `?` if there are no query arguments to be added. Previously, `?` would be wrongly appended even if there was no querystring generated.
+-   `addQueryArgs` will return only the querystring fragment if the passed `url` is undefined. Previously, an uncaught error would be thrown.
+-   `addQueryArgs` will not append (or remove) a `?` if there are no query arguments to be added. Previously, `?` would be wrongly appended even if there was no querystring generated.
 
 ## 2.3.2 (2018-12-12)
 
@@ -39,46 +43,46 @@
 
 ### Bug fixes
 
-- The `isValidProtocol` function now correctly considers the protocol of the URL as only incoporating characters up to and including the colon (':').
-- `getFragment` is now greedier and matches fragments from the first occurence of the '#' symbol instead of the last.
+-   The `isValidProtocol` function now correctly considers the protocol of the URL as only incoporating characters up to and including the colon (':').
+-   `getFragment` is now greedier and matches fragments from the first occurence of the '#' symbol instead of the last.
 
 ## 2.3.0 (2018-11-12)
 
 ### New Features
 
-- Added `getProtocol`.
-- Added `isValidProtocol`.
-- Added `getAuthority`
-- Added `isValidAuthority`.
-- Added `getPath`.
-- Added `isValidPath`.
-- Added `getQueryString`.
-- Added `isValidQueryString`.
-- Added `getFragment`.
-- Added `isValidFragment`.
+-   Added `getProtocol`.
+-   Added `isValidProtocol`.
+-   Added `getAuthority`
+-   Added `isValidAuthority`.
+-   Added `getPath`.
+-   Added `isValidPath`.
+-   Added `getQueryString`.
+-   Added `isValidQueryString`.
+-   Added `getFragment`.
+-   Added `isValidFragment`.
 
 ## 2.2.0 (2018-10-29)
 
 ### New Features
 
-- Added `getQueryArg`.
-- Added `hasQueryArg`.
-- Added `removeQueryArgs`.
+-   Added `getQueryArg`.
+-   Added `hasQueryArg`.
+-   Added `removeQueryArgs`.
 
 ## 2.1.0 (2018-10-16)
 
 ### New Feature
 
-- Added `safeDecodeURI`.
+-   Added `safeDecodeURI`.
 
 ## 2.0.1 (2018-09-30)
 
 ### Bug Fix
 
-- Fix typo in the `qs` dependency definition in the `package.json`
+-   Fix typo in the `qs` dependency definition in the `package.json`
 
 ## 2.0.0 (2018-09-05)
 
 ### Breaking Change
 
-- Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)). If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.
+-   Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)). If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.

--- a/packages/url/README.md
+++ b/packages/url/README.md
@@ -133,6 +133,25 @@ _Returns_
 
 -   `(string|void)`: The path part of the URL.
 
+<a name="getPathAndQueryString" href="#getPathAndQueryString">#</a> **getPathAndQueryString**
+
+Returns the path part and query string part of the URL.
+
+_Usage_
+
+```js
+const pathAndQueryString1 = getPathAndQueryString( 'http://localhost:8080/this/is/a/test?query=true' ); // '/this/is/a/test?query=true'
+const pathAndQueryString2 = getPathAndQueryString( 'https://wordpress.org/help/faq/' ); // '/help/faq'
+```
+
+_Parameters_
+
+-   _url_ `string`: The full URL.
+
+_Returns_
+
+-   `string`: The path part and query string part of the URL.
+
 <a name="getProtocol" href="#getProtocol">#</a> **getProtocol**
 
 Returns the protocol part of the URL.

--- a/packages/url/src/get-path-and-query-string.js
+++ b/packages/url/src/get-path-and-query-string.js
@@ -1,0 +1,26 @@
+/**
+ * Internal dependencies
+ */
+import { getPath, getQueryString } from '.';
+
+/**
+ * Returns the path part and query string part of the URL.
+ *
+ * @param {string} url The full URL.
+ *
+ * @example
+ * ```js
+ * const pathAndQueryString1 = getPathAndQueryString( 'http://localhost:8080/this/is/a/test?query=true' ); // '/this/is/a/test?query=true'
+ * const pathAndQueryString2 = getPathAndQueryString( 'https://wordpress.org/help/faq/' ); // '/help/faq'
+ * ```
+ *
+ * @return {string} The path part and query string part of the URL.
+ */
+export function getPathAndQueryString( url ) {
+	const path = getPath( url );
+	const queryString = getQueryString( url );
+	let value = '/';
+	if ( path ) value += path;
+	if ( queryString ) value += `?${ queryString }`;
+	return value;
+}

--- a/packages/url/src/index.js
+++ b/packages/url/src/index.js
@@ -8,6 +8,7 @@ export { getPath } from './get-path';
 export { isValidPath } from './is-valid-path';
 export { getQueryString } from './get-query-string';
 export { isValidQueryString } from './is-valid-query-string';
+export { getPathAndQueryString } from './get-path-and-query-string';
 export { getFragment } from './get-fragment';
 export { isValidFragment } from './is-valid-fragment';
 export { addQueryArgs } from './add-query-args';

--- a/packages/url/src/test/index.test.js
+++ b/packages/url/src/test/index.test.js
@@ -347,6 +347,43 @@ describe( 'isValidQueryString', () => {
 	} );
 } );
 
+describe( 'getPathAndQueryString', () => {
+	beforeAll( jest.resetModules );
+	afterAll( jest.resetModules );
+	it( 'combines the results of `getPath` and `getQueryString`', () => {
+		jest.doMock( '../get-path.js', () => ( {
+			getPath( { path } = {} ) {
+				return path;
+			},
+		} ) );
+		jest.doMock( '../get-query-string.js', () => ( {
+			getQueryString( { queryString } = {} ) {
+				return queryString;
+			},
+		} ) );
+		const {
+			getPathAndQueryString,
+		} = require( '../get-path-and-query-string' );
+		expect(
+			getPathAndQueryString( {
+				path: 'path',
+				queryString: 'queryString',
+			} )
+		).toBe( '/path?queryString' );
+		expect(
+			getPathAndQueryString( {
+				queryString: 'queryString',
+			} )
+		).toBe( '/?queryString' );
+		expect(
+			getPathAndQueryString( {
+				path: 'path',
+			} )
+		).toBe( '/path' );
+		expect( getPathAndQueryString() ).toBe( '/' );
+	} );
+} );
+
 describe( 'getFragment', () => {
 	it( 'returns the fragment of a URL', () => {
 		expect(


### PR DESCRIPTION
## Description

This PR refactors all of the `edit-site` business logic and editor state into the store.

It also moves a local utility, `getPathAndQueryString`, into the `@wordpress/url` package.

## How has this been tested?

Tests were written for all the new functions, and it was verified that nothing changed in the site editor.

## Types of Changes

*New Feature:* `@wordpress/url` now has a `getPathAndQueryString` utility.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->