### PR TITLE
Support a more flexible useItems API for the autocompleters API

### DIFF
--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -171,7 +171,7 @@ const getAutoCompleterUI = ( autocompleter ) => {
 								}
 								const keyedOptions = optionsData.map(
 									( optionData, optionIndex ) => ( {
-										key: `${ autocompleter.idx }-${ optionIndex }`,
+										key: `${ autocompleter.name }-${ optionIndex }`,
 										value: optionData,
 										label: autocompleter.getOptionLabel(
 											optionData
@@ -442,12 +442,8 @@ export class Autocomplete extends Component {
 				const textAfterSelection = getTextContent(
 					slice( record, undefined, getTextContent( record ).length )
 				);
-				const allCompleters = map( completers, ( completer, idx ) => ( {
-					...completer,
-					idx,
-				} ) );
 				const autocompleter = find(
-					allCompleters,
+					completers,
 					( { triggerPrefix, allowContext } ) => {
 						const index = text.lastIndexOf( triggerPrefix );
 

--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -10,7 +10,7 @@ import { escapeRegExp, find, map, debounce, deburr } from 'lodash';
 import {
 	Component,
 	renderToString,
-	useEffect,
+	useLayoutEffect,
 	useState,
 } from '@wordpress/element';
 import { ENTER, ESCAPE, UP, DOWN, LEFT, RIGHT } from '@wordpress/keycodes';
@@ -157,7 +157,7 @@ const getAutoCompleterUI = ( autocompleter ) => {
 				 * `activePromise` in the state would result in it actually being in `this.state`
 				 * before the promise resolves and we check to see if this is the active promise or not.
 				 */
-				useEffect( () => {
+				useLayoutEffect( () => {
 					const { options, isDebounced } = autocompleter;
 					const loadOptions = debounce(
 						() => {
@@ -229,7 +229,7 @@ const getAutoCompleterUI = ( autocompleter ) => {
 		onReset,
 	} ) {
 		const [ items ] = useItems( filterValue );
-		useEffect( () => {
+		useLayoutEffect( () => {
 			onChangeOptions( items );
 		}, [ items ] );
 

--- a/packages/e2e-tests/specs/editor/blocks/group.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/group.test.js
@@ -23,6 +23,9 @@ describe( 'Group', () => {
 	it( 'can be created using the slash inserter', async () => {
 		await clickBlockAppender();
 		await page.keyboard.type( '/group' );
+		await page.waitForXPath(
+			`//*[contains(@class, "components-autocomplete__result") and contains(@class, "is-selected") and contains(text(), 'Group')]`
+		);
 		await page.keyboard.press( 'Enter' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();

--- a/packages/e2e-tests/specs/editor/blocks/html.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/html.test.js
@@ -16,6 +16,9 @@ describe( 'HTML block', () => {
 		// Create a Custom HTML block with the slash shortcut.
 		await clickBlockAppender();
 		await page.keyboard.type( '/html' );
+		await page.waitForXPath(
+			`//*[contains(@class, "components-autocomplete__result") and contains(@class, "is-selected") and contains(text(), 'Custom HTML')]`
+		);
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '<p>Pythagorean theorem: ' );
 		await page.keyboard.press( 'Enter' );

--- a/packages/e2e-tests/specs/editor/blocks/spacer.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/spacer.test.js
@@ -17,6 +17,9 @@ describe( 'Spacer', () => {
 		// Create a spacer with the slash block shortcut.
 		await clickBlockAppender();
 		await page.keyboard.type( '/spacer' );
+		await page.waitForXPath(
+			`//*[contains(@class, "components-autocomplete__result") and contains(@class, "is-selected") and contains(text(), 'Spacer')]`
+		);
 		await page.keyboard.press( 'Enter' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
@@ -26,6 +29,9 @@ describe( 'Spacer', () => {
 		// Create a spacer with the slash block shortcut.
 		await clickBlockAppender();
 		await page.keyboard.type( '/spacer' );
+		await page.waitForXPath(
+			`//*[contains(@class, "components-autocomplete__result") and contains(@class, "is-selected") and contains(text(), 'Spacer')]`
+		);
 		await page.keyboard.press( 'Enter' );
 
 		const resizableHandle = await page.$(

--- a/packages/e2e-tests/specs/editor/various/embedding.test.js
+++ b/packages/e2e-tests/specs/editor/various/embedding.test.js
@@ -151,6 +151,17 @@ const MOCK_RESPONSES = [
 	},
 ];
 
+async function insertEmbed( URL ) {
+	await clickBlockAppender();
+	await page.keyboard.type( '/embed' );
+	await page.waitForXPath(
+		`//*[contains(@class, "components-autocomplete__result") and contains(@class, "is-selected") and contains(text(), 'Embed')]`
+	);
+	await page.keyboard.press( 'Enter' );
+	await page.keyboard.type( URL );
+	await page.keyboard.press( 'Enter' );
+}
+
 describe( 'Embedding content', () => {
 	beforeEach( async () => {
 		await setUpResponseMocking( MOCK_RESPONSES );
@@ -159,87 +170,49 @@ describe( 'Embedding content', () => {
 
 	it( 'should render embeds in the correct state', async () => {
 		// Valid embed. Should render valid figure element.
-		await clickBlockAppender();
-		await page.keyboard.type( '/embed' );
-		await page.keyboard.press( 'Enter' );
-		await page.keyboard.type( 'https://twitter.com/notnownikki' );
-		await page.keyboard.press( 'Enter' );
+		await insertEmbed( 'https://twitter.com/notnownikki' );
 		await page.waitForSelector( 'figure.wp-block-embed-twitter' );
 
 		// Valid provider; invalid content. Should render failed, edit state.
-		await clickBlockAppender();
-		await page.keyboard.type( '/embed' );
-		await page.keyboard.press( 'Enter' );
-		await page.keyboard.type(
-			'https://twitter.com/wooyaygutenberg123454312'
-		);
-		await page.keyboard.press( 'Enter' );
+		await insertEmbed( 'https://twitter.com/wooyaygutenberg123454312' );
 		await page.waitForSelector(
 			'input[value="https://twitter.com/wooyaygutenberg123454312"]'
 		);
 
 		// WordPress invalid content. Should render failed, edit state.
-		await clickBlockAppender();
-		await page.keyboard.type( '/embed' );
-		await page.keyboard.press( 'Enter' );
-		await page.keyboard.type( 'https://wordpress.org/gutenberg/handbook/' );
-		await page.keyboard.press( 'Enter' );
+		await insertEmbed( 'https://wordpress.org/gutenberg/handbook/' );
 		await page.waitForSelector(
 			'input[value="https://wordpress.org/gutenberg/handbook/"]'
 		);
 
 		// Provider whose oembed API has gone wrong. Should render failed, edit
 		// state.
-		await clickBlockAppender();
-		await page.keyboard.type( '/embed' );
-		await page.keyboard.press( 'Enter' );
-		await page.keyboard.type( 'https://twitter.com/thatbunty' );
-		await page.keyboard.press( 'Enter' );
+		await insertEmbed( 'https://twitter.com/thatbunty' );
 		await page.waitForSelector(
 			'input[value="https://twitter.com/thatbunty"]'
 		);
 
 		// WordPress content that can be embedded. Should render valid figure
 		// element.
-		await clickBlockAppender();
-		await page.keyboard.type( '/embed' );
-		await page.keyboard.press( 'Enter' );
-		await page.keyboard.type(
+		await insertEmbed(
 			'https://wordpress.org/gutenberg/handbook/block-api/attributes/'
 		);
-		await page.keyboard.press( 'Enter' );
 		await page.waitForSelector( 'figure.wp-block-embed-wordpress' );
 
 		// Video content. Should render valid figure element, and include the
 		// aspect ratio class.
-		await clickBlockAppender();
-		await page.keyboard.type( '/embed' );
-		await page.keyboard.press( 'Enter' );
-		await page.keyboard.type(
-			'https://www.youtube.com/watch?v=lXMskKTw3Bc'
-		);
-		await page.keyboard.press( 'Enter' );
+		await insertEmbed( 'https://www.youtube.com/watch?v=lXMskKTw3Bc' );
 		await page.waitForSelector(
 			'figure.wp-block-embed-youtube.wp-embed-aspect-16-9'
 		);
 
 		// Photo content. Should render valid figure element.
-		await clickBlockAppender();
-		await page.keyboard.type( '/embed' );
-		await page.keyboard.press( 'Enter' );
-		await page.keyboard.type( 'https://cloudup.com/cQFlxqtY4ob' );
-		await page.keyboard.press( 'Enter' );
+		await insertEmbed( 'https://cloudup.com/cQFlxqtY4ob' );
 	} );
 
 	it( 'should allow the user to convert unembeddable URLs to a paragraph with a link in it', async () => {
 		// URL that can't be embedded.
-		await clickBlockAppender();
-		await page.keyboard.type( '/embed' );
-		await page.keyboard.press( 'Enter' );
-		await page.keyboard.type(
-			'https://twitter.com/wooyaygutenberg123454312'
-		);
-		await page.keyboard.press( 'Enter' );
+		await insertEmbed( 'https://twitter.com/wooyaygutenberg123454312' );
 
 		// Wait for the request to fail and present an error. Since placeholder
 		// has styles applied which depend on resize observer, wait for the
@@ -254,25 +227,14 @@ describe( 'Embedding content', () => {
 	} );
 
 	it( 'should retry embeds that could not be embedded with trailing slashes, without the trailing slashes', async () => {
-		await clickBlockAppender();
-		await page.keyboard.type( '/embed' );
-		await page.keyboard.press( 'Enter' );
-		// This URL can't be embedded, but without the trailing slash, it can.
-		await page.keyboard.type( 'https://twitter.com/notnownikki/' );
-		await page.keyboard.press( 'Enter' );
+		await insertEmbed( 'https://twitter.com/notnownikki/' );
 		// The twitter block should appear correctly.
 		await page.waitForSelector( 'figure.wp-block-embed-twitter' );
 	} );
 
 	it( 'should allow the user to try embedding a failed URL again', async () => {
 		// URL that can't be embedded.
-		await clickBlockAppender();
-		await page.keyboard.type( '/embed' );
-		await page.keyboard.press( 'Enter' );
-		await page.keyboard.type(
-			'https://twitter.com/wooyaygutenberg123454312'
-		);
-		await page.keyboard.press( 'Enter' );
+		await insertEmbed( 'https://twitter.com/wooyaygutenberg123454312' );
 
 		// Wait for the request to fail and present an error. Since placeholder
 		// has styles applied which depend on resize observer, wait for the
@@ -313,11 +275,7 @@ describe( 'Embedding content', () => {
 
 		// Start a new post, embed the previous post.
 		await createNewPost();
-		await clickBlockAppender();
-		await page.keyboard.type( '/embed' );
-		await page.keyboard.press( 'Enter' );
-		await page.keyboard.type( postUrl );
-		await page.keyboard.press( 'Enter' );
+		await insertEmbed( postUrl );
 
 		// Check the block has become a WordPress block.
 		await page.waitForSelector( '.wp-block-embed-wordpress' );

--- a/packages/e2e-tests/specs/editor/various/writing-flow.test.js
+++ b/packages/e2e-tests/specs/editor/various/writing-flow.test.js
@@ -21,6 +21,9 @@ const addParagraphsAndColumnsDemo = async () => {
 	await page.keyboard.type( 'First paragraph' );
 	await page.keyboard.press( 'Enter' );
 	await page.keyboard.type( '/columns' );
+	await page.waitForXPath(
+		`//*[contains(@class, "components-autocomplete__result") and contains(@class, "is-selected") and contains(text(), 'Columns')]`
+	);
 	await page.keyboard.press( 'Enter' );
 	await page.click( ':focus [aria-label="Two columns; equal split"]' );
 	await page.click( ':focus .block-editor-button-block-appender' );


### PR DESCRIPTION
Right now, the autocompleters API is a bit limitted and relies only on global functions to fetch the options. It also doesn't allow us to reuse logic easily: for instance the Inserter use hooks to fetch the available items to insert but these hooks can't be  reused inside the autocompleter itself which make it very hard to support things like: block variations, block patterns... without duplicating a lot of logic.

This  PR updates the `Autocomplete` component to rely on a `useItems` hook in the autocompleter definition. If the hook has not been provided, a default one relying on the existing autocompeters API is used.

That component is a bit complex, so potential regressions are not excluded.

As a follow-up I'll be updating the block autocompleter to support patterns and block variations.

**Testing instructions**

 - Make sure the user and block autocompleters work as expected.