### PR TITLE
LinkControl: avoid showing "Recently updated" when there are no recently updated Pages from the API

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -299,6 +299,11 @@ function LinkControl( {
 				? results[ 0 ].concat( results[ 1 ] )
 				: results[ 0 ];
 
+		// If displaying initial suggestions just return plain results.
+		if ( args.isInitialSuggestions ) {
+			return results;
+		}
+
 		// Here we append a faux suggestion to represent a "CREATE" option. This
 		// is detected in the rendering of the search results and handled as a
 		// special case. This is currently necessary because the suggestions

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -630,6 +630,8 @@ describe( 'Default search suggestions', () => {
 
 		await eventLoopTick();
 
+		const searchInput = getURLInput();
+
 		const searchResultElements = getSearchResults();
 
 		const searchResultLabel = container.querySelector(
@@ -639,6 +641,8 @@ describe( 'Default search suggestions', () => {
 		expect( searchResultLabel ).toBeFalsy();
 
 		expect( searchResultElements ).toHaveLength( 0 );
+
+		expect( searchInput.getAttribute( 'aria-expanded' ) ).toBe( 'false' );
 	} );
 } );
 

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -616,6 +616,30 @@ describe( 'Default search suggestions', () => {
 
 		expect( searchResultElements ).toHaveLength( 3 );
 	} );
+
+	it( 'should not display initial suggestions when there are no recently updated pages/posts', async () => {
+		const noResults = [];
+		// Force API returning empty results for recently updated Pages.
+		mockFetchSearchSuggestions.mockImplementation( () =>
+			Promise.resolve( noResults )
+		);
+
+		act( () => {
+			render( <LinkControl showInitialSuggestions />, container );
+		} );
+
+		await eventLoopTick();
+
+		const searchResultElements = getSearchResults();
+
+		const searchResultLabel = container.querySelector(
+			'.block-editor-link-control__search-results-label'
+		);
+
+		expect( searchResultLabel ).toBeFalsy();
+
+		expect( searchResultElements ).toHaveLength( 0 );
+	} );
 } );
 
 describe( 'Creating Entities (eg: Posts, Pages)', () => {

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -276,6 +276,8 @@ describe( 'Searching for a link', () => {
 			fauxEntitySuggestions.length
 		);
 
+		expect( searchInput.getAttribute( 'aria-expanded' ) ).toBe( 'true' );
+
 		// Sanity check that a search suggestion shows up corresponding to the data
 		expect( firstSearchResultItemHTML ).toEqual(
 			expect.stringContaining( firstFauxSuggestion.title )
@@ -565,6 +567,8 @@ describe( 'Default search suggestions', () => {
 
 		// it should match any url that's like ?p= and also include a URL option
 		expect( searchResultElements ).toHaveLength( 5 );
+
+		expect( searchInput.getAttribute( 'aria-expanded' ) ).toBe( 'true' );
 
 		expect( mockFetchSearchSuggestions ).toHaveBeenCalledTimes( 1 );
 	} );

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -152,7 +152,6 @@ class URLInput extends Component {
 		this.isUpdatingSuggestions = true;
 
 		this.setState( {
-			showSuggestions: true,
 			selectedSuggestion: null,
 			loading: true,
 		} );
@@ -173,6 +172,7 @@ class URLInput extends Component {
 				this.setState( {
 					suggestions,
 					loading: false,
+					showSuggestions: !! suggestions.length,
 				} );
 
 				if ( !! suggestions.length ) {


### PR DESCRIPTION
## Description
This PR fixes an error in the `<LinkControl>` component whereby the "Recently updated" label would still be displayed even if there were no recently updated Pages returned by the API request.

Now if the site in question has no published Pages, the "Recently updated" label is never shown and no results are shown. 

This bug was uncovered by changes to e2e tests in https://github.com/WordPress/gutenberg/pull/18869#issuecomment-636931681 which caused the bug to trigger an Axe warning in the tests. 

## How has this been tested?

This change manually tested (see instructions below) and is covered by new unit tests.

## Testing Instructions

#### On Master

* Delete all existing `Pages` from your website.
* Create a new Post.
* Add a Navigation block.
* Click the "Create empty" option to create a blank navigation.
* See Link UI (`LinkControl`) is displayed.
* See "Recently updated" label below search input is displayed but no results are shown.

#### On this PR's branch

* Delete all existing `Pages` from your website.
* Create a new Post.
* Add a Navigation block.
* Click the "Create empty" option to create a blank navigation.
* See Link UI (`LinkControl`) is displayed.
* See that the "Recently updated" label below search input is **_NOT_** displayed.
* Check that `aria-expanded` attribute on search input is set to `false` (also covered by tests).

## Screenshots <!-- if applicable -->

#### Broken state example 

The following shows the broken state. This is fixed by this PR.
![Screen Shot 2020-06-03 at 13 44 31](https://user-images.githubusercontent.com/444434/83638051-797ff200-a5a0-11ea-90f2-baf138119693.png)

#### After fix in this PR

![Screen Shot 2020-06-03 at 13 53 06](https://user-images.githubusercontent.com/444434/83638783-9832b880-a5a1-11ea-973d-b7007e5d6b61.png)


## Types of changes
Bug fix (non-breaking change which fixes an issue)
## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
