### PR TITLE
Date: Update `moment-timezone` package to support string timezones

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11301,7 +11301,17 @@
 			"requires": {
 				"@babel/runtime": "^7.9.2",
 				"moment": "^2.22.1",
-				"moment-timezone": "^0.5.16"
+				"moment-timezone": "^0.5.31"
+			},
+			"dependencies": {
+				"moment-timezone": {
+					"version": "0.5.31",
+					"resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.31.tgz",
+					"integrity": "sha512-+GgHNg8xRhMXfEbv81iDtrVeTcWt0kWmTEY1XQK14dICTXnWJnT0dxdlPspwqF3keKMVPXwayEsk1DI0AA/jdA==",
+					"requires": {
+						"moment": ">= 2.9.0"
+					}
+				}
 			}
 		},
 		"@wordpress/dependency-extraction-webpack-plugin": {
@@ -40481,14 +40491,6 @@
 			"version": "2.22.1",
 			"resolved": "https://registry.npmjs.org/moment/-/moment-2.22.1.tgz",
 			"integrity": "sha512-shJkRTSebXvsVqk56I+lkb2latjBs8I+pc2TzWc545y2iFnSjm7Wg0QMh+ZWcdSLQyGEau5jI8ocnmkyTgr9YQ=="
-		},
-		"moment-timezone": {
-			"version": "0.5.16",
-			"resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.16.tgz",
-			"integrity": "sha512-4d1l92plNNqnMkqI/7boWNVXJvwGL2WyByl1Hxp3h/ao3HZiAqaoQY+6KBkYdiN5QtNDpndq+58ozl8W4GVoNw==",
-			"requires": {
-				"moment": ">= 2.9.0"
-			}
 		},
 		"moo": {
 			"version": "0.4.3",

--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -24,7 +24,7 @@
 	"dependencies": {
 		"@babel/runtime": "^7.9.2",
 		"moment": "^2.22.1",
-		"moment-timezone": "^0.5.16"
+		"moment-timezone": "^0.5.31"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
## Description
Fixes #22193. Sites with string timezones throw errors because the timezone is not recognized by moment. This issue isn't present in core, because the moment-timezone used in core is a higher version, which correctly loads all the timezones.

I moved the required version all the way to current, `0.5.31`.

@gziolo This undoes the optimization from https://github.com/WordPress/gutenberg/pull/12356, bringing the built date size back up to ~200K… but it seems we do need these timezones defined after all (see https://github.com/WordPress/gutenberg/issues/22193#issuecomment-630341746)

## How has this been tested?
The unit tests still pass, this was only an issue in the browser. Change your site to use a string timezone by picking a city from the site options dropdown. Load the editor, add a Latest Posts block, and toggle on the date display. On master, you'll get a series of console errors about the date. Switch to this branch, install & build, they should be fixed.

Alternately, check the timezones moment supports with `moment.tz.names()`. On master, only `WP` is shown.

## Types of changes
Bug fix (non-breaking change which fixes an issue) 
