### PR TITLE
Remove aria-label from iframe resizers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10115,7 +10115,7 @@
 				"clipboard": "^2.0.1",
 				"lodash": "^4.17.15",
 				"mousetrap": "^1.6.5",
-				"react-resize-aware": "^3.0.0"
+				"react-resize-aware": "^3.0.1"
 			},
 			"dependencies": {
 				"mousetrap": {
@@ -36945,9 +36945,9 @@
 			"dev": true
 		},
 		"react-resize-aware": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/react-resize-aware/-/react-resize-aware-3.0.0.tgz",
-			"integrity": "sha512-UyLk1KNbFHDye9AFLyr7HBGmzkRDGz2mYp6LDS+LCxM6DXGpviwS5Q4JRzXWdw0tk+n46UE/Kotku/cb8HCh0Q=="
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/react-resize-aware/-/react-resize-aware-3.0.1.tgz",
+			"integrity": "sha512-HdPzwdcAv+BMFQEgyacFB40G4IxNMO7tSqaMjbnAouot8LXi5/Rx3/Fv+LU2cQekqiivE1LF4sGnwQ7SnoHrpg=="
 		},
 		"react-select": {
 			"version": "3.0.8",

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -29,7 +29,7 @@
 		"clipboard": "^2.0.1",
 		"lodash": "^4.17.15",
 		"mousetrap": "^1.6.5",
-		"react-resize-aware": "^3.0.0"
+		"react-resize-aware": "^3.0.1"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
closes #22864
 
This pull request seeks to upgrade `react-resize-aware` from `3.0.0` to `3.0.1` in order to account for the change proposed and merged at https://github.com/FezVrasta/react-resize-aware/pull/42 . This change will remove the incorrect `aria-label` from resizer iframes of the `useResizeObserver` hook exported from `@wordpress/compose`. You can find more information at https://github.com/FezVrasta/react-resize-aware/pull/42 or in #22864 or at the earlier Slack discussion at https://wordpress.slack.com/archives/C02RP4X03/p1584717155024800 ([link requires registration](https://make.wordpress.org/chat/)).

**Testing Instructions:**

Verify the `aria-label` is not applied to resizer iframes.

1. (Prerequisite) Ensure to `npm install` before `npm run build` to ensure the dependency is up to date
2. Navigate to Posts > Add New
3. Open the global block inserter
4. Change to the Patterns tab
5. Right click and "Inspect Element" a pattern preview
6. Verify the `src="about:blank"` iframe descendent does not include `aria-label`

![iframe resizer screenshot](https://user-images.githubusercontent.com/1779930/83678703-2613a100-a5ac-11ea-95ef-1e473c3a57dc.png)
