### PR TITLE
Post Title Block: Add alignment and heading level support

### DIFF
--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -24,7 +24,7 @@
 			"core/post-title/h4": "h4",
 			"core/post-title/h5": "h5",
 			"core/post-title/h6": "h6",
-			"core/post-title/p": "p",
+			"core/post-title/p": "p"
 		}
 	}
 }

--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -5,6 +5,15 @@
 		"postId",
 		"postType"
 	],
+	"attributes": {
+		"align": {
+			"type": "string"
+		},
+		"level": {
+			"type": "number",
+			"default": 2
+		}
+	},
 	"supports": {
 		"html": false
 	}

--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -15,6 +15,16 @@
 		}
 	},
 	"supports": {
-		"html": false
+		"html": false,
+		"lightBlockWrapper": true,
+		"__experimentalSelector": {
+			"core/post-title/h1": "h1",
+			"core/post-title/h2": "h2",
+			"core/post-title/h3": "h3",
+			"core/post-title/h4": "h4",
+			"core/post-title/h5": "h5",
+			"core/post-title/h6": "h6",
+			"core/post-title/p": "p",
+		}
 	}
 }

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -1,10 +1,32 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
+import {
+	AlignmentToolbar,
+	BlockControls,
+	__experimentalBlock as Block,
+} from '@wordpress/block-editor';
+import { ToolbarGroup } from '@wordpress/components';
 
-export default function PostTitleEdit( { context } ) {
+/**
+ * Internal dependencies
+ */
+import HeadingLevelDropdown from '../heading/heading-level-dropdown';
+
+export default function PostTitleEdit( {
+	attributes,
+	setAttributes,
+	context,
+} ) {
+	const { level, align } = attributes;
 	const { postType, postId } = context;
+	const tagName = 0 === level ? 'p' : 'h' + level;
 
 	const post = useSelect(
 		( select ) =>
@@ -20,5 +42,32 @@ export default function PostTitleEdit( { context } ) {
 		return null;
 	}
 
-	return <h2>{ post.title }</h2>;
+	return (
+		<>
+			<BlockControls>
+				<ToolbarGroup>
+					<HeadingLevelDropdown
+						selectedLevel={ level }
+						onChange={ ( newLevel ) =>
+							setAttributes( { level: newLevel } )
+						}
+					/>
+				</ToolbarGroup>
+				<AlignmentToolbar
+					value={ align }
+					onChange={ ( nextAlign ) => {
+						setAttributes( { align: nextAlign } );
+					} }
+				/>
+			</BlockControls>
+			<Block
+				tagName={ tagName }
+				className={ classnames( {
+					[ `has-text-align-${ align }` ]: align,
+				} ) }
+			>
+				{ post.title }
+			</Block>
+		</>
+	);
 }

--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -19,8 +19,8 @@ function render_block_core_post_title( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$tag_name = 'h2';
-	$align_class_name  = empty( $attributes['align'] ) ? '' : ' ' . "has-text-align-{$attributes['align']}";
+	$tag_name         = 'h2';
+	$align_class_name = empty( $attributes['align'] ) ? '' : ' ' . "has-text-align-{$attributes['align']}";
 
 	if ( isset( $attributes['level'] ) ) {
 		$tag_name = 0 === $attributes['level'] ? 'p' : 'h' . $attributes['level'];

--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -19,7 +19,17 @@ function render_block_core_post_title( $attributes, $content, $block ) {
 		return '';
 	}
 
-	return '<h1>' . get_the_title( $block->context['postId'] ) . '</h1>';
+	$tag_name = 'h2';
+	$class = '';
+
+	if ( isset( $attributes['level'] ) ) {
+		$tag_name = 0 === $attributes['level'] ? 'p' : 'h' . $attributes['level'];
+	}
+	if ( isset( $attributes['align'] ) ) {
+		$class = ' class="has-text-align-' . $attributes['align'] . '"';
+	}
+
+	return sprintf( '<%1$s%2$s>%3$s</%1$s>', $tag_name, $class, get_the_title( $block->context['postId'] ) );
 }
 
 /**

--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -20,16 +20,18 @@ function render_block_core_post_title( $attributes, $content, $block ) {
 	}
 
 	$tag_name = 'h2';
-	$class = '';
+	$align_class_name  = empty( $attributes['align'] ) ? '' : ' ' . "has-text-align-{$attributes['align']}";
 
 	if ( isset( $attributes['level'] ) ) {
 		$tag_name = 0 === $attributes['level'] ? 'p' : 'h' . $attributes['level'];
 	}
-	if ( isset( $attributes['align'] ) ) {
-		$class = ' class="has-text-align-' . $attributes['align'] . '"';
-	}
 
-	return sprintf( '<%1$s%2$s>%3$s</%1$s>', $tag_name, $class, get_the_title( $block->context['postId'] ) );
+	return sprintf(
+		'<%1$s class="%2$s">%3$s</%1$s>',
+		$tag_name,
+		'wp-block-post-title' . esc_attr( $align_class_name ),
+		get_the_title( $block->context['postId'] )
+	);
 }
 
 /**

--- a/packages/e2e-tests/fixtures/blocks/core__post-title.json
+++ b/packages/e2e-tests/fixtures/blocks/core__post-title.json
@@ -3,7 +3,9 @@
         "clientId": "_clientId_0",
         "name": "core/post-title",
         "isValid": true,
-        "attributes": {},
+        "attributes": {
+            "level": 2
+        },
         "innerBlocks": [],
         "originalContent": ""
     }


### PR DESCRIPTION
Part of #21087

## Description
Adds text alignment and heading level support to the Post Title block. One question is how to handle the shared code for the `HeadingLevelDropdown` component. I expect this needs to be extracted from the heading block so it can be shared appropriately.

## How has this been tested?
* Enable the site editor experiments.
* Open the site editor and insert a  query block.
* Confirm that adjusting the alignment of the post title block works in the editor and front end.
* Confirm that adjusting the heading level of the post title block works in the editor and front end.

## Screenshots <!-- if applicable -->
![2020-06-03 14 32 04](https://user-images.githubusercontent.com/1464705/83691480-1776bb00-a5a7-11ea-913e-428e17157a0b.gif)


## Types of changes
New feature.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
