### PR TITLE
Update the block directory state to store the installing status per block id.

### DIFF
--- a/packages/block-directory/src/components/downloadable-block-header/index.js
+++ b/packages/block-directory/src/components/downloadable-block-header/index.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
-import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -11,7 +10,7 @@ import { withSelect } from '@wordpress/data';
 import BlockRatings from '../block-ratings';
 import DownloadableBlockIcon from '../downloadable-block-icon';
 
-export function DownloadableBlockHeader( {
+function DownloadableBlockHeader( {
 	icon,
 	title,
 	rating,
@@ -46,8 +45,4 @@ export function DownloadableBlockHeader( {
 	);
 }
 
-export default withSelect( ( select ) => {
-	return {
-		isLoading: select( 'core/block-directory' ).isInstalling(),
-	};
-} )( DownloadableBlockHeader );
+export default DownloadableBlockHeader;

--- a/packages/block-directory/src/components/downloadable-block-header/test/index.js
+++ b/packages/block-directory/src/components/downloadable-block-header/test/index.js
@@ -11,7 +11,7 @@ import { Button } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { DownloadableBlockHeader } from '../index';
+import DownloadableBlockHeader from '../index';
 import { pluginWithIcon } from './fixtures';
 
 const getContainer = (

--- a/packages/block-directory/src/components/downloadable-block-list-item/index.js
+++ b/packages/block-directory/src/components/downloadable-block-list-item/index.js
@@ -11,7 +11,7 @@ import DownloadableBlockHeader from '../downloadable-block-header';
 import DownloadableBlockInfo from '../downloadable-block-info';
 import DownloadableBlockNotice from '../downloadable-block-notice';
 
-function DownloadableBlockListItem( { item, onClick, isLoading } ) {
+export function DownloadableBlockListItem( { item, onClick, isLoading } ) {
 	const {
 		icon,
 		title,

--- a/packages/block-directory/src/components/downloadable-block-list-item/index.js
+++ b/packages/block-directory/src/components/downloadable-block-list-item/index.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { withSelect } from '@wordpress/data';
+
+/**
  * Internal dependencies
  */
 import DownloadableBlockAuthorInfo from '../downloadable-block-author-info';
@@ -6,7 +11,7 @@ import DownloadableBlockHeader from '../downloadable-block-header';
 import DownloadableBlockInfo from '../downloadable-block-info';
 import DownloadableBlockNotice from '../downloadable-block-notice';
 
-function DownloadableBlockListItem( { item, onClick } ) {
+function DownloadableBlockListItem( { item, onClick, isLoading } ) {
 	const {
 		icon,
 		title,
@@ -30,6 +35,7 @@ function DownloadableBlockListItem( { item, onClick } ) {
 						title={ title }
 						rating={ rating }
 						ratingCount={ ratingCount }
+						isLoading={ isLoading }
 					/>
 				</header>
 				<section className="block-directory-downloadable-block-list-item__body">
@@ -55,4 +61,8 @@ function DownloadableBlockListItem( { item, onClick } ) {
 	);
 }
 
-export default DownloadableBlockListItem;
+export default withSelect( ( select, { item } ) => {
+	return {
+		isLoading: select( 'core/block-directory' ).isInstalling( item.id ),
+	};
+} )( DownloadableBlockListItem );

--- a/packages/block-directory/src/components/downloadable-block-list-item/index.js
+++ b/packages/block-directory/src/components/downloadable-block-list-item/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { withSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -11,7 +11,12 @@ import DownloadableBlockHeader from '../downloadable-block-header';
 import DownloadableBlockInfo from '../downloadable-block-info';
 import DownloadableBlockNotice from '../downloadable-block-notice';
 
-export function DownloadableBlockListItem( { item, onClick, isLoading } ) {
+export default function DownloadableBlockListItem( { item, onClick } ) {
+	const isLoading = useSelect(
+		( select ) => select( 'core/block-directory' ).isInstalling( item.id ),
+		[ item ]
+	);
+
 	const {
 		icon,
 		title,
@@ -60,9 +65,3 @@ export function DownloadableBlockListItem( { item, onClick, isLoading } ) {
 		</li>
 	);
 }
-
-export default withSelect( ( select, { item } ) => {
-	return {
-		isLoading: select( 'core/block-directory' ).isInstalling( item.id ),
-	};
-} )( DownloadableBlockListItem );

--- a/packages/block-directory/src/components/downloadable-block-list-item/test/__snapshots__/index.js.snap
+++ b/packages/block-directory/src/components/downloadable-block-list-item/test/__snapshots__/index.js.snap
@@ -10,7 +10,7 @@ exports[`DownloadableBlockListItem should render a block item 1`] = `
     <header
       className="block-directory-downloadable-block-list-item__header"
     >
-      <WithSelect(DownloadableBlockHeader)
+      <DownloadableBlockHeader
         icon="block-default"
         onClick={[MockFunction]}
         rating={5}

--- a/packages/block-directory/src/components/downloadable-block-list-item/test/index.js
+++ b/packages/block-directory/src/components/downloadable-block-list-item/test/index.js
@@ -6,9 +6,15 @@ import { shallow } from 'enzyme';
 /**
  * Internal dependencies
  */
-import { DownloadableBlockListItem } from '../index';
+import DownloadableBlockListItem from '../index';
 import DownloadableBlockHeader from '../../downloadable-block-header';
 import { item } from './fixtures';
+
+jest.mock( '@wordpress/data/src/components/use-select', () => {
+	// This allows us to tweak the returned value on each test
+	const mock = jest.fn();
+	return mock;
+} );
 
 describe( 'DownloadableBlockListItem', () => {
 	it( 'should render a block item', () => {

--- a/packages/block-directory/src/components/downloadable-block-list-item/test/index.js
+++ b/packages/block-directory/src/components/downloadable-block-list-item/test/index.js
@@ -6,7 +6,7 @@ import { shallow } from 'enzyme';
 /**
  * Internal dependencies
  */
-import DownloadableBlockListItem from '../index';
+import { DownloadableBlockListItem } from '../index';
 import DownloadableBlockHeader from '../../downloadable-block-header';
 import { item } from './fixtures';
 

--- a/packages/block-directory/src/components/downloadable-blocks-list/test/__snapshots__/index.js.snap
+++ b/packages/block-directory/src/components/downloadable-blocks-list/test/__snapshots__/index.js.snap
@@ -5,7 +5,7 @@ exports[`DownloadableBlocksList List rendering should render plugins items into 
   className="block-directory-downloadable-blocks-list"
   role="list"
 >
-  <WithSelect(DownloadableBlockListItem)
+  <DownloadableBlockListItem
     item={
       Object {
         "active_installs": 0,
@@ -29,7 +29,7 @@ exports[`DownloadableBlocksList List rendering should render plugins items into 
     key="boxer-block"
     onClick={[Function]}
   />
-  <WithSelect(DownloadableBlockListItem)
+  <DownloadableBlockListItem
     item={
       Object {
         "active_installs": 0,

--- a/packages/block-directory/src/components/downloadable-blocks-list/test/__snapshots__/index.js.snap
+++ b/packages/block-directory/src/components/downloadable-blocks-list/test/__snapshots__/index.js.snap
@@ -5,7 +5,7 @@ exports[`DownloadableBlocksList List rendering should render plugins items into 
   className="block-directory-downloadable-blocks-list"
   role="list"
 >
-  <DownloadableBlockListItem
+  <WithSelect(DownloadableBlockListItem)
     item={
       Object {
         "active_installs": 0,
@@ -29,7 +29,7 @@ exports[`DownloadableBlocksList List rendering should render plugins items into 
     key="boxer-block"
     onClick={[Function]}
   />
-  <DownloadableBlockListItem
+  <WithSelect(DownloadableBlockListItem)
     item={
       Object {
         "active_installs": 0,

--- a/packages/block-directory/src/store/actions.js
+++ b/packages/block-directory/src/store/actions.js
@@ -65,7 +65,7 @@ export function* installBlockType( block ) {
 		if ( ! Array.isArray( assets ) || ! assets.length ) {
 			throw new Error( __( 'Block has no assets.' ) );
 		}
-		yield setIsInstalling( true );
+		yield setIsInstalling( block.id, true );
 		const response = yield apiFetch( {
 			path: '__experimental/block-directory/install',
 			data: {
@@ -87,7 +87,7 @@ export function* installBlockType( block ) {
 	} catch ( error ) {
 		yield setErrorNotice( id, error.message || __( 'An error occurred.' ) );
 	}
-	yield setIsInstalling( false );
+	yield setIsInstalling( block.id, false );
 	return success;
 }
 
@@ -108,13 +108,15 @@ export function addInstalledBlockType( item ) {
 /**
  * Returns an action object used to indicate install in progress
  *
+ * @param {string} blockId
  * @param {boolean} isInstalling
  *
  * @return {Object} Action object.
  */
-export function setIsInstalling( isInstalling ) {
+export function setIsInstalling( blockId, isInstalling ) {
 	return {
 		type: 'SET_INSTALLING_BLOCK',
+		blockId,
 		isInstalling,
 	};
 }

--- a/packages/block-directory/src/store/reducer.js
+++ b/packages/block-directory/src/store/reducer.js
@@ -48,7 +48,7 @@ export const downloadableBlocks = (
 export const blockManagement = (
 	state = {
 		installedBlockTypes: [],
-		isInstalling: false,
+		isInstalling: {},
 	},
 	action
 ) => {
@@ -71,7 +71,10 @@ export const blockManagement = (
 		case 'SET_INSTALLING_BLOCK':
 			return {
 				...state,
-				isInstalling: action.isInstalling,
+				isInstalling: {
+					...state.isInstalling,
+					[ action.blockId ]: action.isInstalling,
+				},
 			};
 	}
 	return state;

--- a/packages/block-directory/src/store/selectors.js
+++ b/packages/block-directory/src/store/selectors.js
@@ -50,11 +50,15 @@ export function getInstalledBlockTypes( state ) {
  * Returns true if application is calling install endpoint.
  *
  * @param {Object} state Global application state.
+ * @param {string} blockId Id of the block.
  *
  * @return {boolean} Whether its currently installing
  */
-export function isInstalling( state ) {
-	return state.blockManagement.isInstalling;
+export function isInstalling( state, blockId ) {
+	if ( ! state.blockManagement.isInstalling[ blockId ] ) {
+		return false;
+	}
+	return state.blockManagement.isInstalling[ blockId ];
 }
 
 /**

--- a/packages/block-directory/src/store/selectors.js
+++ b/packages/block-directory/src/store/selectors.js
@@ -55,10 +55,7 @@ export function getInstalledBlockTypes( state ) {
  * @return {boolean} Whether its currently installing
  */
 export function isInstalling( state, blockId ) {
-	if ( ! state.blockManagement.isInstalling[ blockId ] ) {
-		return false;
-	}
-	return state.blockManagement.isInstalling[ blockId ];
+	return state.blockManagement.isInstalling[ blockId ] || false;
 }
 
 /**

--- a/packages/block-directory/src/store/test/actions.js
+++ b/packages/block-directory/src/store/test/actions.js
@@ -22,6 +22,7 @@ describe( 'actions', () => {
 
 			expect( generator.next().value ).toEqual( {
 				type: 'SET_INSTALLING_BLOCK',
+				blockId: item.id,
 				isInstalling: true,
 			} );
 
@@ -48,6 +49,7 @@ describe( 'actions', () => {
 
 			expect( generator.next( [ item ] ).value ).toEqual( {
 				type: 'SET_INSTALLING_BLOCK',
+				blockId: item.id,
 				isInstalling: false,
 			} );
 
@@ -73,6 +75,7 @@ describe( 'actions', () => {
 
 			expect( generator.next().value ).toEqual( {
 				type: 'SET_INSTALLING_BLOCK',
+				blockId: item.id,
 				isInstalling: false,
 			} );
 
@@ -93,6 +96,7 @@ describe( 'actions', () => {
 
 			expect( generator.next().value ).toEqual( {
 				type: 'SET_INSTALLING_BLOCK',
+				blockId: item.id,
 				isInstalling: true,
 			} );
 
@@ -112,6 +116,7 @@ describe( 'actions', () => {
 
 			expect( generator.next().value ).toEqual( {
 				type: 'SET_INSTALLING_BLOCK',
+				blockId: item.id,
 				isInstalling: false,
 			} );
 

--- a/packages/block-directory/src/store/test/selectors.js
+++ b/packages/block-directory/src/store/test/selectors.js
@@ -7,6 +7,7 @@ import {
 	getErrorNotices,
 	getErrorNoticeForBlock,
 	getInstalledBlockTypes,
+	isInstalling,
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -80,6 +81,29 @@ describe( 'selectors', () => {
 		it( 'should get an empty array if no matching query is found', () => {
 			const blocks = getDownloadableBlocks( state, 'not-found' );
 			expect( blocks ).toEqual( [] );
+		} );
+	} );
+
+	describe( 'isInstalling', () => {
+		const BLOCK_1_ID = 'box-block-id';
+		const BLOCK_2_ID = 'image-slider-id';
+
+		const state = {
+			blockManagement: {
+				isInstalling: {
+					[ BLOCK_1_ID ]: true,
+					[ BLOCK_2_ID ]: false,
+				},
+			},
+		};
+
+		it( 'it should reflect that the block is installing', () => {
+			expect( isInstalling( state, BLOCK_1_ID ) ).toBeTruthy();
+		} );
+
+		it( 'it should reflect that the block is not installing', () => {
+			expect( isInstalling( state, 'not-in-state' ) ).toBeFalsy();
+			expect( isInstalling( state, BLOCK_2_ID ) ).toBeFalsy();
 		} );
 	} );
 } );


### PR DESCRIPTION
## Description
When installing a block from the block directory the `isInstalling` state is shared across all the results. This means that if I install 1 block, all the buttons display the loading state.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
