### PR TITLE
Rename the navigation mode BlockBreadcrumb component to BlockSelectionButton

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -8,7 +8,7 @@ $z-layers: (
 	".block-editor-block-list__block {core/image aligned wide or fullwide}": 20,
 	".block-library-classic__toolbar": 10,
 	".block-editor-block-list__layout .reusable-block-indicator": 1,
-	".block-editor-block-list__breadcrumb": 22,
+	".block-editor-block-list__block-selection-button": 22,
 	".components-form-toggle__input": 1,
 	".components-panel__header.edit-post-sidebar__panel-tabs": -1,
 	".edit-post-sidebar .components-panel": -2,

--- a/packages/block-editor/src/components/block-list/block-popover.js
+++ b/packages/block-editor/src/components/block-list/block-popover.js
@@ -17,7 +17,7 @@ import { useViewportMatch } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import BlockBreadcrumb from './breadcrumb';
+import BlockSelectionButton from './block-selection-button';
 import BlockContextualToolbar from './block-contextual-toolbar';
 import Inserter from '../inserter';
 import { BlockNodes } from './root-container';
@@ -201,7 +201,7 @@ function BlockPopover( {
 				/>
 			) }
 			{ shouldShowBreadcrumb && (
-				<BlockBreadcrumb
+				<BlockSelectionButton
 					clientId={ clientId }
 					rootClientId={ rootClientId }
 					moverDirection={ moverDirection }

--- a/packages/block-editor/src/components/block-list/block-selection-button.js
+++ b/packages/block-editor/src/components/block-list/block-selection-button.js
@@ -16,7 +16,7 @@ import {
 import BlockTitle from '../block-title';
 
 /**
- * Block breadcrumb component, displaying the label of the block. If the block
+ * Block selection button component, displaying the label of the block. If the block
  * descends from a root block, a button is displayed enabling the user to select
  * the root block.
  *
@@ -25,7 +25,7 @@ import BlockTitle from '../block-title';
  *
  * @return {WPComponent} The component to be rendered.
  */
-function BlockBreadcrumb( {
+function BlockSelectionButton( {
 	clientId,
 	rootClientId,
 	moverDirection,
@@ -74,7 +74,10 @@ function BlockBreadcrumb( {
 	);
 
 	return (
-		<div className="block-editor-block-list__breadcrumb" { ...props }>
+		<div
+			className="block-editor-block-list__block-selection-button"
+			{ ...props }
+		>
 			<Button
 				ref={ ref }
 				onClick={ () => setNavigationMode( false ) }
@@ -87,4 +90,4 @@ function BlockBreadcrumb( {
 	);
 }
 
-export default BlockBreadcrumb;
+export default BlockSelectionButton;

--- a/packages/block-editor/src/components/block-list/block-selection-button.native.js
+++ b/packages/block-editor/src/components/block-list/block-selection-button.native.js
@@ -17,9 +17,9 @@ import { View, Text, TouchableOpacity } from 'react-native';
 import BlockTitle from '../block-title';
 import SubdirectorSVG from './subdirectory-icon';
 
-import styles from './breadcrumb.scss';
+import styles from './block-selection-button.scss';
 
-const BlockBreadcrumb = ( {
+const BlockSelectionButton = ( {
 	clientId,
 	blockIcon,
 	rootClientId,
@@ -29,7 +29,7 @@ const BlockBreadcrumb = ( {
 	return (
 		<View
 			style={ [
-				styles.breadcrumbContainer,
+				styles.selectionButtonContainer,
 				rootClientId && styles.densedPaddingLeft,
 			] }
 		>
@@ -66,7 +66,7 @@ const BlockBreadcrumb = ( {
 					maxFontSizeMultiplier={ 1.25 }
 					ellipsizeMode="tail"
 					numberOfLines={ 1 }
-					style={ styles.breadcrumbTitle }
+					style={ styles.selectionButtonTitle }
 				>
 					<BlockTitle clientId={ clientId } />
 				</Text>
@@ -105,4 +105,4 @@ export default compose( [
 			isRTL: getSettings().isRTL,
 		};
 	} ),
-] )( BlockBreadcrumb );
+] )( BlockSelectionButton );

--- a/packages/block-editor/src/components/block-list/block-selection-button.native.scss
+++ b/packages/block-editor/src/components/block-list/block-selection-button.native.scss
@@ -1,4 +1,4 @@
-.breadcrumbContainer {
+.selectionButtonContainer {
 	flex-direction: row;
 	align-items: center;
 	justify-content: flex-start;
@@ -7,7 +7,7 @@
 	flex-shrink: 1;
 }
 
-.breadcrumbTitle {
+.selectionButtonTitle {
 	color: $white;
 	margin-left: 4;
 	flex-shrink: 1;

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -496,9 +496,9 @@
  * Block Label for Navigation/Selection Mode
  */
 
-.block-editor-block-list__breadcrumb {
+.block-editor-block-list__block-selection-button {
 	display: block;
-	z-index: z-index(".block-editor-block-list__breadcrumb");
+	z-index: z-index(".block-editor-block-list__block-selection-button");
 
 	// The button here has a special style to appear as a toolbar.
 	.components-button {
@@ -581,14 +581,14 @@
 		}
 
 		// Position the block toolbar.
-		.block-editor-block-list__breadcrumb,
+		.block-editor-block-list__block-selection-button,
 		.block-editor-block-contextual-toolbar {
 			margin-bottom: $grid-unit-15;
 			margin-left: - $block-toolbar-height;
 		}
 
 		.block-editor-block-contextual-toolbar[data-align="full"],
-		.block-editor-block-list__breadcrumb[data-align="full"] {
+		.block-editor-block-list__block-selection-button[data-align="full"] {
 			margin-left: 0;
 		}
 	}

--- a/packages/block-editor/src/components/floating-toolbar/index.native.js
+++ b/packages/block-editor/src/components/floating-toolbar/index.native.js
@@ -17,7 +17,7 @@ import { __ } from '@wordpress/i18n';
  */
 import styles from './styles.scss';
 import NavigateUpSVG from './nav-up-icon';
-import Breadcrumb from '../block-list/breadcrumb.native';
+import BlockSelectionButton from '../block-list/block-selection-button.native';
 
 const EASE_IN_DURATION = 250;
 const EASE_OUT_DURATION = 80;
@@ -32,7 +32,7 @@ const FloatingToolbar = ( {
 	onNavigateUp,
 	isRTL,
 } ) => {
-	// sustain old selection for proper Breacdrumb rendering when exit animation is ongoing
+	// Sustain old selection for proper block selection button rendering when exit animation is ongoing.
 	const [ previousSelection, setPreviousSelection ] = useState( {} );
 
 	useEffect( () => {
@@ -70,7 +70,7 @@ const FloatingToolbar = ( {
 	} = previousSelection;
 
 	const showPrevious = previousSelectedClientId && ! showFloatingToolbar;
-	const breadcrumbClientId = showPrevious
+	const blockSelectionButtonClientId = showPrevious
 		? previousSelectedClientId
 		: selectedClientId;
 	const showNavUpButton =
@@ -92,7 +92,9 @@ const FloatingToolbar = ( {
 						<View style={ styles.pipe } />
 					</Toolbar>
 				) }
-				<Breadcrumb clientId={ breadcrumbClientId } />
+				<BlockSelectionButton
+					clientId={ blockSelectionButtonClientId }
+				/>
 			</Animated.View>
 		)
 	);


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
There seem to be two separate `BlockBreadcrumb` components within the `block-editor` package at the moment, which is confusing for communication between contributors.

1. `BlockBreadcrumb` is a component that's exported from the package and is used in the footer of the editor:
https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/block-breadcrumb/index.js

2. `BlockBreadcrumb` is used internally only and is the button that's displayed in navigation mode as a way to navigate between blocks:
https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/block-list/breadcrumb.js

The second one isn't traditionally what would be considered a breadcrumb, so I've renamed it `BlockSelectionButton`. As this component isn't exported, this isn't a breaking change.

This PR will need some mobile testing, as there was also a `.native` component called BlockBreadcrumb.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Enter navigation mode using the `esc` key or the Tools options.
2. Ensure keyboard navigation and mouse selection of blocks continues to work correctly.


## Types of changes
Non breaking code quality task.
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
