### PR TITLE
Fix Block Navigation Settings Menu keyboard navigation in Navigation Menus page

### DIFF
--- a/packages/block-editor/src/components/block-navigation/block.js
+++ b/packages/block-editor/src/components/block-navigation/block.js
@@ -73,7 +73,7 @@ export default function BlockNavigationBlock( {
 				className="block-editor-block-navigation-block__contents-cell"
 				colSpan={ hasRenderedMovers ? undefined : 3 }
 			>
-				{ ( props ) => (
+				{ ( { ref, tabIndex, onFocus } ) => (
 					<div className="block-editor-block-navigation-block__contents-container">
 						<DescenderLines
 							level={ level }
@@ -87,7 +87,9 @@ export default function BlockNavigationBlock( {
 							position={ position }
 							siblingCount={ siblingCount }
 							level={ level }
-							{ ...props }
+							ref={ ref }
+							tabIndex={ tabIndex }
+							onFocus={ onFocus }
 						/>
 					</div>
 				) }
@@ -95,20 +97,24 @@ export default function BlockNavigationBlock( {
 			{ hasRenderedMovers && (
 				<>
 					<TreeGridCell className={ moverCellClassName }>
-						{ ( props ) => (
+						{ ( { ref, tabIndex, onFocus } ) => (
 							<BlockMoverUpButton
 								__experimentalOrientation="vertical"
 								clientIds={ [ clientId ] }
-								{ ...props }
+								ref={ ref }
+								tabIndex={ tabIndex }
+								onFocus={ onFocus }
 							/>
 						) }
 					</TreeGridCell>
 					<TreeGridCell className={ moverCellClassName }>
-						{ ( props ) => (
+						{ ( { ref, tabIndex, onFocus } ) => (
 							<BlockMoverDownButton
 								__experimentalOrientation="vertical"
 								clientIds={ [ clientId ] }
-								{ ...props }
+								ref={ ref }
+								tabIndex={ tabIndex }
+								onFocus={ onFocus }
 							/>
 						) }
 					</TreeGridCell>
@@ -119,11 +125,11 @@ export default function BlockNavigationBlock( {
 				<TreeGridCell
 					className={ blockNavigationBlockSettingsClassName }
 				>
-					{ ( props ) => (
+					{ ( { ref, tabIndex, onFocus } ) => (
 						<BlockSettingsDropdown
 							clientIds={ [ clientId ] }
 							icon={ moreVertical }
-							{ ...props }
+							toggleProps={ { ref, tabIndex, onFocus } }
 						/>
 					) }
 				</TreeGridCell>

--- a/packages/block-editor/src/components/block-navigation/block.js
+++ b/packages/block-editor/src/components/block-navigation/block.js
@@ -129,7 +129,12 @@ export default function BlockNavigationBlock( {
 						<BlockSettingsDropdown
 							clientIds={ [ clientId ] }
 							icon={ moreVertical }
-							toggleProps={ { ref, tabIndex, onFocus } }
+							toggleProps={ {
+								ref,
+								tabIndex,
+								onFocus,
+							} }
+							disableOpenOnArrowDown
 						/>
 					) }
 				</TreeGridCell>

--- a/packages/components/src/dropdown-menu/README.md
+++ b/packages/components/src/dropdown-menu/README.md
@@ -201,3 +201,11 @@ Use this object to modify props available for the `NavigableMenu` component that
 
 -   Type: `Object`
 -   Required: No
+
+#### disableOpenOnArrowDown
+
+In some contexts, the arrow down key used to open the dropdown menu might need to be disabled—for example when that key is used to perform another action.
+
+-   Type: `Object`
+-   Required: No
+-   Default: `false`

--- a/packages/components/src/dropdown-menu/index.js
+++ b/packages/components/src/dropdown-menu/index.js
@@ -42,6 +42,7 @@ function DropdownMenu( {
 	popoverProps,
 	toggleProps,
 	menuProps,
+	disableOpenOnArrowDown = false,
 	// The following props exist for backward compatibility.
 	menuLabel,
 	position,
@@ -87,6 +88,10 @@ function DropdownMenu( {
 			popoverProps={ mergedPopoverProps }
 			renderToggle={ ( { isOpen, onToggle } ) => {
 				const openOnArrowDown = ( event ) => {
+					if ( disableOpenOnArrowDown ) {
+						return;
+					}
+
 					if ( ! isOpen && event.keyCode === DOWN ) {
 						event.preventDefault();
 						event.stopPropagation();


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Some keyboard accessibility issues had crept into the Block Navigation in its form on the Navigation Screen.

This PR fixes an issue with the Block Navigation's Block Settings menu. Roving tab index and arrow key navigation should now work again with this component.

It also makes the relationship between `TreeGridCell` and the various components used in the `BlockNavigation` clearer by explicitly declaring the forwarded props individually rather than by spreading them as `...props`.

## How has this been tested?
1. Visit the Navigation Menu screen and build a menu
2. Tab into the Block Navigation panel and use arrow keys to move around it
3. Expect that arrow keys should behave as though navigating within a grid
4. Focus the Block Settings Menu toggle button in the Block Navigation
5. Press the down arrow.
6. Expect that the menu did not open and focus was moved to the settings menu on the next row.
7. Press Shift + Tab
8. Expect that focus left the Block Navigation Menu
9. Press Tab
10. Expect that focus moved back to the element that was last focused within Block Navigation.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
