### PR TITLE
Edit Site: Remove templateIds state

### DIFF
--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -145,27 +145,11 @@ function gutenberg_edit_site_init( $hook ) {
 	}
 	$settings['styles'] = gutenberg_get_editor_styles();
 
-	$template_part_ids = array();
-	foreach ( get_template_types() as $template_type ) {
-		// Skip 'embed' for now because it is not a regular template type.
-		// Skip 'index' because it's a fallback that we handle differently.
-		if ( in_array( $template_type, array( 'embed', 'index' ), true ) ) {
-			continue;
-		}
-
-		$current_template = gutenberg_find_template_post_and_parts( $template_type );
-		if ( isset( $current_template ) ) {
-			$template_part_ids = $template_part_ids + $current_template['template_part_ids'];
-		}
-	}
-
 	$settings['editSiteInitialState'] = array();
 
-	$settings['editSiteInitialState']['templateType']    = 'wp_template';
-	$settings['editSiteInitialState']['templatePartIds'] = array_values( $template_part_ids );
-
-	$settings['editSiteInitialState']['showOnFront'] = get_option( 'show_on_front' );
-	$settings['editSiteInitialState']['page']        = array(
+	$settings['editSiteInitialState']['templateType'] = 'wp_template';
+	$settings['editSiteInitialState']['showOnFront']  = get_option( 'show_on_front' );
+	$settings['editSiteInitialState']['page']         = array(
 		'path'    => '/',
 		'context' => 'page' === $settings['editSiteInitialState']['showOnFront'] ? array(
 			'postType' => 'page',

--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -145,7 +145,6 @@ function gutenberg_edit_site_init( $hook ) {
 	}
 	$settings['styles'] = gutenberg_get_editor_styles();
 
-	$template_ids      = array();
 	$template_part_ids = array();
 	foreach ( get_template_types() as $template_type ) {
 		// Skip 'embed' for now because it is not a regular template type.
@@ -156,8 +155,7 @@ function gutenberg_edit_site_init( $hook ) {
 
 		$current_template = gutenberg_find_template_post_and_parts( $template_type );
 		if ( isset( $current_template ) ) {
-			$template_ids[ $template_type ] = $current_template['template_post']->ID;
-			$template_part_ids              = $template_part_ids + $current_template['template_part_ids'];
+			$template_part_ids = $template_part_ids + $current_template['template_part_ids'];
 		}
 	}
 

--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -147,9 +147,8 @@ function gutenberg_edit_site_init( $hook ) {
 
 	$settings['editSiteInitialState'] = array();
 
-	$settings['editSiteInitialState']['templateType'] = 'wp_template';
-	$settings['editSiteInitialState']['showOnFront']  = get_option( 'show_on_front' );
-	$settings['editSiteInitialState']['page']         = array(
+	$settings['editSiteInitialState']['showOnFront'] = get_option( 'show_on_front' );
+	$settings['editSiteInitialState']['page']        = array(
 		'path'    => '/',
 		'context' => 'page' === $settings['editSiteInitialState']['showOnFront'] ? array(
 			'postType' => 'page',

--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -164,7 +164,6 @@ function gutenberg_edit_site_init( $hook ) {
 	$settings['editSiteInitialState'] = array();
 
 	$settings['editSiteInitialState']['templateType']    = 'wp_template';
-	$settings['editSiteInitialState']['templateIds']     = array_values( $template_ids );
 	$settings['editSiteInitialState']['templatePartIds'] = array_values( $template_part_ids );
 
 	$settings['editSiteInitialState']['showOnFront'] = get_option( 'show_on_front' );

--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -147,8 +147,9 @@ function gutenberg_edit_site_init( $hook ) {
 
 	$settings['editSiteInitialState'] = array();
 
-	$settings['editSiteInitialState']['showOnFront'] = get_option( 'show_on_front' );
-	$settings['editSiteInitialState']['page']        = array(
+	$settings['editSiteInitialState']['templateType'] = 'wp_template';
+	$settings['editSiteInitialState']['showOnFront']  = get_option( 'show_on_front' );
+	$settings['editSiteInitialState']['page']         = array(
 		'path'    => '/',
 		'context' => 'page' === $settings['editSiteInitialState']['showOnFront'] ? array(
 			'postType' => 'page',

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -431,7 +431,7 @@ function gutenberg_template_loader_filter_block_editor_settings( $settings ) {
 	}
 
 	// If this is the Site Editor, auto-drafts for template parts have already been generated
-	// through `gutenberg_find_template_post_and_parts` in `gutenberg_edit_site_init`.
+	// through `gutenberg_find_template_post_and_parts`, when called via the REST API.
 	if ( isset( $settings['editSiteInitialState'] ) ) {
 		return $settings;
 	}

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -431,7 +431,7 @@ function gutenberg_template_loader_filter_block_editor_settings( $settings ) {
 	}
 
 	// If this is the Site Editor, auto-drafts for template parts have already been generated
-	// through `gutenberg_find_template_post_and_parts`, when called through `filter_rest_wp_template_part_query`.
+	// through `filter_rest_wp_template_part_query`, when called via the REST API.
 	if ( isset( $settings['editSiteInitialState'] ) ) {
 		return $settings;
 	}

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -431,7 +431,7 @@ function gutenberg_template_loader_filter_block_editor_settings( $settings ) {
 	}
 
 	// If this is the Site Editor, auto-drafts for template parts have already been generated
-	// through `gutenberg_find_template_post_and_parts`, when called via the REST API.
+	// through `gutenberg_find_template_post_and_parts`, when called through `filter_rest_wp_template_part_query`.
 	if ( isset( $settings['editSiteInitialState'] ) ) {
 		return $settings;
 	}

--- a/packages/e2e-tests/specs/experiments/template-part.test.js
+++ b/packages/e2e-tests/specs/experiments/template-part.test.js
@@ -41,12 +41,10 @@ describe( 'Template Part', () => {
 		);
 
 		it( 'Should load customizations when in a template even if only the slug and theme attributes are set.', async () => {
-			const templateDropdownSelector =
-				'.components-dropdown-menu__toggle[aria-label="Switch Template"]';
-
 			// Switch to editing the header template part.
-			await page.waitForSelector( templateDropdownSelector );
-			await page.click( templateDropdownSelector );
+			await page.click(
+				'.components-dropdown-menu__toggle[aria-label="Switch Template"]'
+			);
 			const switchToHeaderTemplatePartButton = await page.waitForXPath(
 				'//button[contains(text(), "header")]'
 			);
@@ -64,7 +62,9 @@ describe( 'Template Part', () => {
 			);
 
 			// Switch back to the front page template.
-			await page.click( templateDropdownSelector );
+			await page.click(
+				'.components-dropdown-menu__toggle[aria-label="Switch Template"]'
+			);
 			const [ switchToFrontPageTemplateButton ] = await page.$x(
 				'//button[contains(text(), "front-page")]'
 			);

--- a/packages/e2e-tests/specs/experiments/template-part.test.js
+++ b/packages/e2e-tests/specs/experiments/template-part.test.js
@@ -41,10 +41,12 @@ describe( 'Template Part', () => {
 		);
 
 		it( 'Should load customizations when in a template even if only the slug and theme attributes are set.', async () => {
+			const templateDropdownSelector =
+				'.components-dropdown-menu__toggle[aria-label="Switch Template"]';
+
 			// Switch to editing the header template part.
-			await page.click(
-				'.components-dropdown-menu__toggle[aria-label="Switch Template"]'
-			);
+			await page.waitForSelector( templateDropdownSelector );
+			await page.click( templateDropdownSelector );
 			const switchToHeaderTemplatePartButton = await page.waitForXPath(
 				'//button[contains(text(), "header")]'
 			);
@@ -62,9 +64,7 @@ describe( 'Template Part', () => {
 			);
 
 			// Switch back to the front page template.
-			await page.click(
-				'.components-dropdown-menu__toggle[aria-label="Switch Template"]'
-			);
+			await page.click( templateDropdownSelector );
 			const [ switchToFrontPageTemplateButton ] = await page.$x(
 				'//button[contains(text(), "front-page")]'
 			);

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -83,15 +83,11 @@ export function* removeTemplate( templateId ) {
 		path: `/wp/v2/templates/${ templateId }`,
 		method: 'DELETE',
 	} );
-	yield dispatch(
+	return dispatch(
 		'core/edit-site',
 		'setPage',
 		yield select( 'core/edit-site', 'getPage' )
 	);
-	return {
-		type: 'REMOVE_TEMPLATE',
-		templateId,
-	};
 }
 
 /**

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -66,7 +66,7 @@ export function* addTemplate( template ) {
 		template
 	);
 	return {
-		type: 'ADD_TEMPLATE',
+		type: 'SET_TEMPLATE',
 		templateId: newTemplate.id,
 	};
 }

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -51,11 +51,11 @@ export function setTemplate( templateId ) {
 }
 
 /**
- * Returns an action object used to add a template.
+ * Adds a new template, and sets it as the current template.
  *
  * @param {Object} template The template.
  *
- * @return {Object} Action object.
+ * @return {Object} Action object used to set the current template.
  */
 export function* addTemplate( template ) {
 	const newTemplate = yield dispatch(
@@ -72,11 +72,11 @@ export function* addTemplate( template ) {
 }
 
 /**
- * Returns an action object used to remove a template.
+ * Removes a template, and updates the current page and template.
  *
  * @param {number} templateId The template ID.
  *
- * @return {Object} Action object.
+ * @return {Object} Action object used to set the current page and template.
  */
 export function* removeTemplate( templateId ) {
 	yield apiFetch( {

--- a/packages/edit-site/src/store/reducer.js
+++ b/packages/edit-site/src/store/reducer.js
@@ -107,7 +107,6 @@ export function homeTemplateId( state ) {
 export function templateId( state, action ) {
 	switch ( action.type ) {
 		case 'SET_TEMPLATE':
-		case 'ADD_TEMPLATE':
 		case 'SET_PAGE':
 			return action.templateId;
 	}
@@ -143,7 +142,6 @@ export function templatePartId( state, action ) {
 export function templateType( state, action ) {
 	switch ( action.type ) {
 		case 'SET_TEMPLATE':
-		case 'ADD_TEMPLATE':
 		case 'SET_PAGE':
 			return 'wp_template';
 		case 'SET_TEMPLATE_PART':

--- a/packages/edit-site/src/store/reducer.js
+++ b/packages/edit-site/src/store/reducer.js
@@ -154,25 +154,6 @@ export function templateType( state, action ) {
 }
 
 /**
- * Reducer returning the list of template IDs.
- *
- * @param {Object} state  Current state.
- * @param {Object} action Dispatched action.
- *
- * @return {Object} Updated state.
- */
-export function templateIds( state = [], action ) {
-	switch ( action.type ) {
-		case 'ADD_TEMPLATE':
-			return [ ...state, action.templateId ];
-		case 'REMOVE_TEMPLATE':
-			return state.filter( ( id ) => id !== action.templateId );
-	}
-
-	return state;
-}
-
-/**
  * Reducer returning the list of template part IDs.
  *
  * @param {Object} state Current state.
@@ -219,7 +200,6 @@ export default combineReducers( {
 	templateId,
 	templatePartId,
 	templateType,
-	templateIds,
 	templatePartIds,
 	page,
 	showOnFront,

--- a/packages/edit-site/src/store/reducer.js
+++ b/packages/edit-site/src/store/reducer.js
@@ -152,17 +152,6 @@ export function templateType( state, action ) {
 }
 
 /**
- * Reducer returning the list of template part IDs.
- *
- * @param {Object} state Current state.
- *
- * @return {Object} Updated state.
- */
-export function templatePartIds( state = [] ) {
-	return state;
-}
-
-/**
  * Reducer returning the page being edited.
  *
  * @param {Object} state  Current state.
@@ -198,7 +187,6 @@ export default combineReducers( {
 	templateId,
 	templatePartId,
 	templateType,
-	templatePartIds,
 	page,
 	showOnFront,
 } );

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -124,17 +124,6 @@ export function getTemplateType( state ) {
 }
 
 /**
- * Returns the current template IDs.
- *
- * @param {Object} state Global application state.
- *
- * @return {number[]} Template IDs.
- */
-export function getTemplateIds( state ) {
-	return state.templateIds;
-}
-
-/**
  * Returns the current template part IDs.
  *
  * @param {Object} state Global application state.

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -124,17 +124,6 @@ export function getTemplateType( state ) {
 }
 
 /**
- * Returns the current template part IDs.
- *
- * @param {Object} state Global application state.
- *
- * @return {number[]} Template part IDs.
- */
-export function getTemplatePartIds( state ) {
-	return state.templatePartIds;
-}
-
-/**
  * Returns the current page object.
  *
  * @param {Object} state Global application state.

--- a/packages/edit-site/src/store/test/actions.js
+++ b/packages/edit-site/src/store/test/actions.js
@@ -54,7 +54,7 @@ describe( 'actions', () => {
 	} );
 
 	describe( 'removeTemplate', () => {
-		it( 'should yield the API_FETCH control, yield the SELECT control to set the page by yielding the DISPATCH control for the SET_PAGE action, and return the REMOVE_TEMPLATE action', () => {
+		it( 'should yield the API_FETCH control and yield the SELECT control to set the page by yielding the DISPATCH control for the SET_PAGE action', () => {
 			const templateId = 1;
 			const page = { path: '/' };
 
@@ -73,15 +73,11 @@ describe( 'actions', () => {
 				args: [],
 			} );
 			expect( it.next( page ).value ).toEqual( {
-				type: 'DISPATCH',
-				storeKey: 'core/edit-site',
-				actionName: 'setPage',
-				args: [ page ],
-			} );
-			expect( it.next() ).toEqual( {
 				value: {
-					type: 'REMOVE_TEMPLATE',
-					templateId,
+					type: 'DISPATCH',
+					storeKey: 'core/edit-site',
+					actionName: 'setPage',
+					args: [ page ],
 				},
 				done: true,
 			} );

--- a/packages/edit-site/src/store/test/actions.js
+++ b/packages/edit-site/src/store/test/actions.js
@@ -32,7 +32,7 @@ describe( 'actions', () => {
 	} );
 
 	describe( 'addTemplate', () => {
-		it( 'should yield the DISPATCH control to create the template and return the ADD_TEMPLATE action', () => {
+		it( 'should yield the DISPATCH control to create the template and return the SET_TEMPLATE action', () => {
 			const template = { slug: 'index' };
 			const newTemplate = { id: 1 };
 
@@ -45,7 +45,7 @@ describe( 'actions', () => {
 			} );
 			expect( it.next( newTemplate ) ).toEqual( {
 				value: {
-					type: 'ADD_TEMPLATE',
+					type: 'SET_TEMPLATE',
 					templateId: newTemplate.id,
 				},
 				done: true,

--- a/packages/edit-site/src/store/test/actions.js
+++ b/packages/edit-site/src/store/test/actions.js
@@ -73,13 +73,10 @@ describe( 'actions', () => {
 				args: [],
 			} );
 			expect( it.next( page ).value ).toEqual( {
-				value: {
-					type: 'DISPATCH',
-					storeKey: 'core/edit-site',
-					actionName: 'setPage',
-					args: [ page ],
-				},
-				done: true,
+				type: 'DISPATCH',
+				storeKey: 'core/edit-site',
+				actionName: 'setPage',
+				args: [ page ],
 			} );
 		} );
 	} );

--- a/packages/edit-site/src/store/test/actions.js
+++ b/packages/edit-site/src/store/test/actions.js
@@ -73,10 +73,13 @@ describe( 'actions', () => {
 				args: [],
 			} );
 			expect( it.next( page ).value ).toEqual( {
-				type: 'DISPATCH',
-				storeKey: 'core/edit-site',
-				actionName: 'setPage',
-				args: [ page ],
+				value: {
+					type: 'DISPATCH',
+					storeKey: 'core/edit-site',
+					actionName: 'setPage',
+					args: [ page ],
+				},
+				done: true,
 			} );
 		} );
 	} );

--- a/packages/edit-site/src/store/test/actions.js
+++ b/packages/edit-site/src/store/test/actions.js
@@ -72,6 +72,7 @@ describe( 'actions', () => {
 				selectorName: 'getPage',
 				args: [],
 			} );
+			// @FIXME: Test for done: true.
 			expect( it.next( page ).value ).toEqual( {
 				type: 'DISPATCH',
 				storeKey: 'core/edit-site',

--- a/packages/edit-site/src/store/test/reducer.js
+++ b/packages/edit-site/src/store/test/reducer.js
@@ -13,7 +13,6 @@ import {
 	templateId,
 	templatePartId,
 	templateType,
-	templateIds,
 	templatePartIds,
 	page,
 	showOnFront,
@@ -179,41 +178,6 @@ describe( 'state', () => {
 					type: 'SET_TEMPLATE_PART',
 				} )
 			).toEqual( 'wp_template_part' );
-		} );
-	} );
-
-	describe( 'templateIds()', () => {
-		it( 'should apply default state', () => {
-			expect( templateIds( undefined, {} ) ).toEqual( [] );
-		} );
-
-		it( 'should default to returning the same state', () => {
-			const state = {};
-			expect( templateIds( state, {} ) ).toBe( state );
-		} );
-
-		it( 'should add template IDs', () => {
-			expect(
-				templateIds( deepFreeze( [ 1 ] ), {
-					type: 'ADD_TEMPLATE',
-					templateId: 2,
-				} )
-			).toEqual( [ 1, 2 ] );
-		} );
-
-		it( 'should remove template IDs', () => {
-			expect(
-				templateIds( deepFreeze( [ 1, 2 ] ), {
-					type: 'REMOVE_TEMPLATE',
-					templateId: 2,
-				} )
-			).toEqual( [ 1 ] );
-			expect(
-				templateIds( deepFreeze( [ 1, 2 ] ), {
-					type: 'REMOVE_TEMPLATE',
-					templateId: 1,
-				} )
-			).toEqual( [ 2 ] );
 		} );
 	} );
 

--- a/packages/edit-site/src/store/test/reducer.js
+++ b/packages/edit-site/src/store/test/reducer.js
@@ -99,15 +99,6 @@ describe( 'state', () => {
 			).toEqual( 2 );
 		} );
 
-		it( 'should update when a template is added', () => {
-			expect(
-				templateId( 1, {
-					type: 'ADD_TEMPLATE',
-					templateId: 2,
-				} )
-			).toEqual( 2 );
-		} );
-
 		it( 'should update when a page is set', () => {
 			expect(
 				templateId( 1, {
@@ -152,14 +143,6 @@ describe( 'state', () => {
 			expect(
 				templateType( undefined, {
 					type: 'SET_TEMPLATE',
-				} )
-			).toEqual( 'wp_template' );
-		} );
-
-		it( 'should update when a template is added', () => {
-			expect(
-				templateType( undefined, {
-					type: 'ADD_TEMPLATE',
 				} )
 			).toEqual( 'wp_template' );
 		} );

--- a/packages/edit-site/src/store/test/reducer.js
+++ b/packages/edit-site/src/store/test/reducer.js
@@ -13,7 +13,6 @@ import {
 	templateId,
 	templatePartId,
 	templateType,
-	templatePartIds,
 	page,
 	showOnFront,
 } from '../reducer';
@@ -161,17 +160,6 @@ describe( 'state', () => {
 					type: 'SET_TEMPLATE_PART',
 				} )
 			).toEqual( 'wp_template_part' );
-		} );
-	} );
-
-	describe( 'templatePartIds()', () => {
-		it( 'should apply default state', () => {
-			expect( templatePartIds( undefined, {} ) ).toEqual( [] );
-		} );
-
-		it( 'should default to returning the same state', () => {
-			const state = {};
-			expect( templatePartIds( state, {} ) ).toBe( state );
 		} );
 	} );
 

--- a/packages/edit-site/src/store/test/selectors.js
+++ b/packages/edit-site/src/store/test/selectors.js
@@ -9,7 +9,6 @@ import {
 	getTemplateId,
 	getTemplatePartId,
 	getTemplateType,
-	getTemplateIds,
 	getTemplatePartIds,
 	getPage,
 	getShowOnFront,
@@ -128,13 +127,6 @@ describe( 'selectors', () => {
 		it( 'returns the template type', () => {
 			const state = { templateType: {} };
 			expect( getTemplateType( state ) ).toBe( state.templateType );
-		} );
-	} );
-
-	describe( 'getTemplateIds', () => {
-		it( 'returns the template IDs', () => {
-			const state = { templateIds: {} };
-			expect( getTemplateIds( state ) ).toBe( state.templateIds );
 		} );
 	} );
 

--- a/packages/edit-site/src/store/test/selectors.js
+++ b/packages/edit-site/src/store/test/selectors.js
@@ -9,7 +9,6 @@ import {
 	getTemplateId,
 	getTemplatePartId,
 	getTemplateType,
-	getTemplatePartIds,
 	getPage,
 	getShowOnFront,
 } from '../selectors';
@@ -127,13 +126,6 @@ describe( 'selectors', () => {
 		it( 'returns the template type', () => {
 			const state = { templateType: {} };
 			expect( getTemplateType( state ) ).toBe( state.templateType );
-		} );
-	} );
-
-	describe( 'getTemplatePartIds', () => {
-		it( 'returns the template part IDs', () => {
-			const state = { templatePartIds: {} };
-			expect( getTemplatePartIds( state ) ).toBe( state.templatePartIds );
 		} );
 	} );
 


### PR DESCRIPTION
## Description
Remove some now-obsolete state.

## How has this been tested?
Verify that site editing still works :slightly_smiling_face: 

## Types of changes
Janitorial.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
