### PR TITLE
Refactor FormFileUpload to use React hooks

### DIFF
--- a/packages/components/src/form-file-upload/index.js
+++ b/packages/components/src/form-file-upload/index.js
@@ -1,59 +1,46 @@
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import Button from '../button';
 
-class FormFileUpload extends Component {
-	constructor() {
-		super( ...arguments );
-		this.openFileDialog = this.openFileDialog.bind( this );
-		this.bindInput = this.bindInput.bind( this );
-	}
+function FormFileUpload( {
+	accept,
+	children,
+	multiple = false,
+	onChange,
+	render,
+	...props
+} ) {
+	const ref = useRef();
+	const openFileDialog = () => {
+		ref.current.click();
+	};
 
-	openFileDialog() {
-		this.input.click();
-	}
-
-	bindInput( ref ) {
-		this.input = ref;
-	}
-
-	render() {
-		const {
-			accept,
-			children,
-			multiple = false,
-			onChange,
-			render,
-			...props
-		} = this.props;
-
-		const ui = render ? (
-			render( { openFileDialog: this.openFileDialog } )
-		) : (
-			<Button onClick={ this.openFileDialog } { ...props }>
-				{ children }
-			</Button>
-		);
-		return (
-			<div className="components-form-file-upload">
-				{ ui }
-				<input
-					type="file"
-					ref={ this.bindInput }
-					multiple={ multiple }
-					style={ { display: 'none' } }
-					accept={ accept }
-					onChange={ onChange }
-				/>
-			</div>
-		);
-	}
+	const ui = render ? (
+		render( { openFileDialog } )
+	) : (
+		<Button onClick={ openFileDialog } { ...props }>
+			{ children }
+		</Button>
+	);
+	return (
+		<div className="components-form-file-upload">
+			{ ui }
+			<input
+				type="file"
+				ref={ ref }
+				multiple={ multiple }
+				style={ { display: 'none' } }
+				accept={ accept }
+				onChange={ onChange }
+			/>
+		</div>
+	);
 }
 
 export default FormFileUpload;


### PR DESCRIPTION
Related #22890 

Refactored FormFileUpload to use hooks.

**Testing instructions**

 - Make sure that uploading images using the Image block "upload" button works as expected.