### PR TITLE
Make font size picker reset button visible

### DIFF
--- a/packages/components/src/font-size-picker/style.scss
+++ b/packages/components/src/font-size-picker/style.scss
@@ -2,7 +2,6 @@
 	max-width: $sidebar-width - ( 2 * $panel-padding );
 	display: flex;
 	flex-wrap: wrap;
-	justify-content: flex-start;
 	align-items: center;
 	margin-bottom: $grid-unit-30;
 

--- a/packages/components/src/font-size-picker/style.scss
+++ b/packages/components/src/font-size-picker/style.scss
@@ -1,6 +1,8 @@
 .components-font-size-picker__controls {
 	max-width: $sidebar-width - ( 2 * $panel-padding );
 	display: flex;
+	flex-wrap: wrap;
+	justify-content: flex-start;
 	align-items: center;
 	margin-bottom: $grid-unit-30;
 

--- a/packages/components/src/font-size-picker/style.scss
+++ b/packages/components/src/font-size-picker/style.scss
@@ -33,7 +33,6 @@
 	// Allow the font-size picker dropdown to grow in width.
 	.components-font-size-picker__select {
 		margin-right: $grid-unit-10;
-		flex-grow: 1;
 	}
 
 	.components-color-palette__clear {


### PR DESCRIPTION
## Description
The font size picker reset button isn't visible in many translated WP versions. Fixes #21327

Thanks to: @RickorDD 

**Without translation (Current and After)**:
![Bildschirmfoto 2020-06-04 um 16 27 57](https://user-images.githubusercontent.com/695201/83770713-b243c800-a681-11ea-9c6a-b79bd7091e43.png)

**Current (German)**:
![Bildschirmfoto 2020-06-04 um 16 22 10](https://user-images.githubusercontent.com/695201/83770800-d1425a00-a681-11ea-9f7a-6080c31ba9f5.png)

**Current (Spanish)**:
![Bildschirmfoto 2020-06-04 um 16 43 08](https://user-images.githubusercontent.com/695201/83771450-97258800-a682-11ea-8c4c-159b5f9b924b.png)

**After (German)**:
![Bildschirmfoto 2020-06-04 um 16 21 35](https://user-images.githubusercontent.com/695201/83770839-da332b80-a681-11ea-915f-dd71e4a65be3.png)

**After (Spanish):**
![Bildschirmfoto 2020-06-04 um 16 42 27](https://user-images.githubusercontent.com/695201/83771639-c6d49000-a682-11ea-8351-da5e7ba82db5.png)