### PR TITLE
Refactor DatePicker to use React hooks

### DIFF
--- a/packages/components/src/date-time/date.js
+++ b/packages/components/src/date-time/date.js
@@ -9,7 +9,7 @@ import DayPickerSingleDateController from 'react-dates/lib/components/DayPickerS
 /**
  * WordPress dependencies
  */
-import { Component, createRef } from '@wordpress/element';
+import { createRef } from '@wordpress/element';
 
 /**
  * Module Constants
@@ -17,14 +17,8 @@ import { Component, createRef } from '@wordpress/element';
 const TIMEZONELESS_FORMAT = 'YYYY-MM-DDTHH:mm:ss';
 const isRTL = () => document.documentElement.dir === 'rtl';
 
-class DatePicker extends Component {
-	constructor() {
-		super( ...arguments );
-
-		this.onChangeMoment = this.onChangeMoment.bind( this );
-		this.nodeRef = createRef();
-		this.keepFocusInside = this.keepFocusInside.bind( this );
-	}
+function DatePicker( { currentDate, isInvalidDate, onChange } ) {
+	const nodeRef = createRef();
 
 	/*
 	 * Todo: We should remove this function ASAP.
@@ -32,17 +26,17 @@ class DatePicker extends Component {
 	 * This focus loss closes the date picker popover.
 	 * Ideally we should add an upstream commit on react-dates to fix this issue.
 	 */
-	keepFocusInside() {
-		if ( ! this.nodeRef.current ) {
+	const keepFocusInside = () => {
+		if ( ! nodeRef.current ) {
 			return;
 		}
 		// If focus was lost.
 		if (
 			! document.activeElement ||
-			! this.nodeRef.current.contains( document.activeElement )
+			! nodeRef.current.contains( document.activeElement )
 		) {
 			// Retrieve the focus region div.
-			const focusRegion = this.nodeRef.current.querySelector(
+			const focusRegion = nodeRef.current.querySelector(
 				'.DayPicker_focusRegion'
 			);
 			if ( ! focusRegion ) {
@@ -51,11 +45,9 @@ class DatePicker extends Component {
 			// Keep the focus on focus region.
 			focusRegion.focus();
 		}
-	}
+	};
 
-	onChangeMoment( newDate ) {
-		const { currentDate, onChange } = this.props;
-
+	const onChangeMoment = ( newDate ) => {
 		// If currentDate is null, use now as momentTime to designate hours, minutes, seconds.
 		const momentDate = currentDate ? moment( currentDate ) : moment();
 		const momentTime = {
@@ -65,54 +57,49 @@ class DatePicker extends Component {
 		};
 
 		onChange( newDate.set( momentTime ).format( TIMEZONELESS_FORMAT ) );
-	}
+	};
 
 	/**
 	 * Create a Moment object from a date string. With no currentDate supplied, default to a Moment
 	 * object representing now. If a null value is passed, return a null value.
 	 *
-	 * @param {?string} currentDate Date representing the currently selected date or null to signify no selection.
 	 * @return {?moment.Moment} Moment object for selected date or null.
 	 */
-	getMomentDate( currentDate ) {
+	const getMomentDate = () => {
 		if ( null === currentDate ) {
 			return null;
 		}
 		return currentDate ? moment( currentDate ) : moment();
-	}
+	};
 
-	render() {
-		const { currentDate, isInvalidDate } = this.props;
+	const momentDate = getMomentDate();
 
-		const momentDate = this.getMomentDate( currentDate );
-
-		return (
-			<div className="components-datetime__date" ref={ this.nodeRef }>
-				<DayPickerSingleDateController
-					date={ momentDate }
-					daySize={ 30 }
-					focused
-					hideKeyboardShortcutsPanel
-					// This is a hack to force the calendar to update on month or year change
-					// https://github.com/airbnb/react-dates/issues/240#issuecomment-361776665
-					key={ `datepicker-controller-${
-						momentDate ? momentDate.format( 'MM-YYYY' ) : 'null'
-					}` }
-					noBorder
-					numberOfMonths={ 1 }
-					onDateChange={ this.onChangeMoment }
-					transitionDuration={ 0 }
-					weekDayFormat="ddd"
-					isRTL={ isRTL() }
-					isOutsideRange={ ( date ) => {
-						return isInvalidDate && isInvalidDate( date.toDate() );
-					} }
-					onPrevMonthClick={ this.keepFocusInside }
-					onNextMonthClick={ this.keepFocusInside }
-				/>
-			</div>
-		);
-	}
+	return (
+		<div className="components-datetime__date" ref={ nodeRef }>
+			<DayPickerSingleDateController
+				date={ momentDate }
+				daySize={ 30 }
+				focused
+				hideKeyboardShortcutsPanel
+				// This is a hack to force the calendar to update on month or year change
+				// https://github.com/airbnb/react-dates/issues/240#issuecomment-361776665
+				key={ `datepicker-controller-${
+					momentDate ? momentDate.format( 'MM-YYYY' ) : 'null'
+				}` }
+				noBorder
+				numberOfMonths={ 1 }
+				onDateChange={ onChangeMoment }
+				transitionDuration={ 0 }
+				weekDayFormat="ddd"
+				isRTL={ isRTL() }
+				isOutsideRange={ ( date ) => {
+					return isInvalidDate && isInvalidDate( date.toDate() );
+				} }
+				onPrevMonthClick={ keepFocusInside }
+				onNextMonthClick={ keepFocusInside }
+			/>
+		</div>
+	);
 }
 
 export default DatePicker;

--- a/packages/components/src/date-time/date.js
+++ b/packages/components/src/date-time/date.js
@@ -9,7 +9,7 @@ import DayPickerSingleDateController from 'react-dates/lib/components/DayPickerS
 /**
  * WordPress dependencies
  */
-import { createRef } from '@wordpress/element';
+import { useRef } from '@wordpress/element';
 
 /**
  * Module Constants
@@ -18,7 +18,7 @@ const TIMEZONELESS_FORMAT = 'YYYY-MM-DDTHH:mm:ss';
 const isRTL = () => document.documentElement.dir === 'rtl';
 
 function DatePicker( { currentDate, isInvalidDate, onChange } ) {
-	const nodeRef = createRef();
+	const nodeRef = useRef();
 
 	/*
 	 * Todo: We should remove this function ASAP.

--- a/packages/components/src/date-time/date.js
+++ b/packages/components/src/date-time/date.js
@@ -26,7 +26,7 @@ function DatePicker( { currentDate, isInvalidDate, onChange } ) {
 	 * This focus loss closes the date picker popover.
 	 * Ideally we should add an upstream commit on react-dates to fix this issue.
 	 */
-	const keepFocusInside = () => {
+	function keepFocusInside() {
 		if ( ! nodeRef.current ) {
 			return;
 		}
@@ -45,9 +45,9 @@ function DatePicker( { currentDate, isInvalidDate, onChange } ) {
 			// Keep the focus on focus region.
 			focusRegion.focus();
 		}
-	};
+	}
 
-	const onChangeMoment = ( newDate ) => {
+	function onChangeMoment( newDate ) {
 		// If currentDate is null, use now as momentTime to designate hours, minutes, seconds.
 		const momentDate = currentDate ? moment( currentDate ) : moment();
 		const momentTime = {
@@ -57,7 +57,7 @@ function DatePicker( { currentDate, isInvalidDate, onChange } ) {
 		};
 
 		onChange( newDate.set( momentTime ).format( TIMEZONELESS_FORMAT ) );
-	};
+	}
 
 	/**
 	 * Create a Moment object from a date string. With no currentDate supplied, default to a Moment
@@ -65,12 +65,12 @@ function DatePicker( { currentDate, isInvalidDate, onChange } ) {
 	 *
 	 * @return {?moment.Moment} Moment object for selected date or null.
 	 */
-	const getMomentDate = () => {
+	function getMomentDate() {
 		if ( null === currentDate ) {
 			return null;
 		}
 		return currentDate ? moment( currentDate ) : moment();
-	};
+	}
 
 	const momentDate = getMomentDate();
 


### PR DESCRIPTION
## Description
Related to #22890

## How has this been tested?
1. Edit page or post
2. Click on post schedule date
3. Change date

## Types of changes
Refactor to use React hooks.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
