### PR TITLE
Add heading to the block inserter tips (#22863)

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -8,7 +8,7 @@ import { includes } from 'lodash';
  */
 import { useState } from '@wordpress/element';
 import { LEFT, RIGHT, UP, DOWN, BACKSPACE, ENTER } from '@wordpress/keycodes';
-import { TabPanel } from '@wordpress/components';
+import { TabPanel, VisuallyHidden } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 
@@ -92,6 +92,11 @@ function InserterMenu( {
 			</div>
 			{ showInserterHelpPanel && (
 				<div className="block-editor-inserter__tips">
+					<VisuallyHidden>
+						<h2 className="block-editor-inserter__tips-title">
+							{ __( 'Tips for using the block editor:' ) }
+						</h2>
+					</VisuallyHidden>
 					<Tips />
 				</div>
 			) }

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -92,10 +92,8 @@ function InserterMenu( {
 			</div>
 			{ showInserterHelpPanel && (
 				<div className="block-editor-inserter__tips">
-					<VisuallyHidden>
-						<h2 className="block-editor-inserter__tips-title">
-							{ __( 'Tips for using the block editor:' ) }
-						</h2>
+					<VisuallyHidden as="h2">
+						{ __( 'A tip for using the block editor' ) }
 					</VisuallyHidden>
 					<Tips />
 				</div>


### PR DESCRIPTION
closes ~#22683~ #22863

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Adds a heading for the tips in the block inserter as discussed in #22683 

## How has this been tested?
- Open the block inserter
- Heading is not visible (only for alternate devices like screenreader)

## Screenshots
![grafik](https://user-images.githubusercontent.com/5585580/83774908-9db5fe80-a686-11ea-8787-0a2c58b226f2.png)

## Types of changes
- Bug fix only
- Adds a new element with the class `block-editor-inserter__tips-title` allthough no need for styling because it's wrapped in a `VisuallyHidden` component.
- Adds a Text of `Tips for using the block editor:` which needs translation

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
