### PR TITLE
Refactor AudioEdit block to use React hooks

### DIFF
--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -46,10 +46,9 @@ function AudioEdit( {
 	// }
 	const { id, autoplay, caption, loop, preload, src } = attributes;
 
-	const audioUpload = useSelect( ( select ) => {
+	const mediaUpload = useSelect( ( select ) => {
 		const { getSettings } = select( 'core/block-editor' );
-		const { mediaUpload } = getSettings();
-		return { mediaUpload };
+		return getSettings().mediaUpload;
 	} );
 
 	useEffect( () => {
@@ -57,7 +56,7 @@ function AudioEdit( {
 			const file = getBlobByURL( src );
 
 			if ( file ) {
-				audioUpload( {
+				mediaUpload( {
 					filesList: [ file ],
 					onFileChange: ( [ { id: mediaId, url } ] ) => {
 						setAttributes( { id: mediaId, src: url } );

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -65,13 +65,13 @@ function AudioEdit( {
 		}
 	}, [] );
 
-	const toggleAttribute = ( attribute ) => {
+	function toggleAttribute( attribute ) {
 		return ( newValue ) => {
 			setAttributes( { [ attribute ]: newValue } );
 		};
-	};
+	}
 
-	const onSelectURL = ( newSrc ) => {
+	function onSelectURL( newSrc ) {
 		// Set the block's src from the edit component's state, and switch off
 		// the editing UI.
 		if ( newSrc !== src ) {
@@ -85,23 +85,23 @@ function AudioEdit( {
 			}
 			setAttributes( { src: newSrc, id: undefined } );
 		}
-	};
+	}
 
-	const onUploadError = ( message ) => {
+	function onUploadError( message ) {
 		noticeOperations.removeAllNotices();
 		noticeOperations.createErrorNotice( message );
-	};
+	}
 
-	const getAutoplayHelp = ( checked ) => {
+	function getAutoplayHelp( checked ) {
 		return checked
 			? __(
 					'Note: Autoplaying audio may cause usability issues for some visitors.'
 			  )
 			: null;
-	};
+	}
 
 	// const { setAttributes, isSelected, noticeUI } = this.props;
-	const onSelectAudio = ( media ) => {
+	function onSelectAudio( media ) {
 		if ( ! media || ! media.url ) {
 			// in this case there was an error and we should continue in the editing state
 			// previous attributes should be removed because they may be temporary blob urls
@@ -111,7 +111,7 @@ function AudioEdit( {
 		// sets the block's attribute and updates the edit component from the
 		// selected media, then switches off the editing UI
 		setAttributes( { src: media.url, id: media.id } );
-	};
+	}
 	if ( ! src ) {
 		return (
 			<Block.div>

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -19,7 +19,7 @@ import {
 	RichText,
 	__experimentalBlock as Block,
 } from '@wordpress/block-editor';
-import { Component } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { withSelect } from '@wordpress/data';
 import { audio as icon } from '@wordpress/icons';
@@ -31,23 +31,24 @@ import { createUpgradedEmbedBlock } from '../embed/util';
 
 const ALLOWED_MEDIA_TYPES = [ 'audio' ];
 
-class AudioEdit extends Component {
-	constructor() {
-		super( ...arguments );
-		this.toggleAttribute = this.toggleAttribute.bind( this );
-		this.onSelectURL = this.onSelectURL.bind( this );
-		this.onUploadError = this.onUploadError.bind( this );
-	}
+function AudioEdit( {
+	attributes,
+	mediaUpload,
+	noticeOperations,
+	setAttributes,
+	onReplace,
+	isSelected,
+	noticeUI,
+} ) {
+	// constructor() {
+	// 	super( ...arguments );
+	// 	this.toggleAttribute = this.toggleAttribute.bind( this );
+	// 	this.onSelectURL = this.onSelectURL.bind( this );
+	// 	this.onUploadError = this.onUploadError.bind( this );
+	// }
+	const { id, autoplay, caption, loop, preload, src } = attributes;
 
-	componentDidMount() {
-		const {
-			attributes,
-			mediaUpload,
-			noticeOperations,
-			setAttributes,
-		} = this.props;
-		const { id, src = '' } = attributes;
-
+	useEffect( () => {
 		if ( ! id && isBlobURL( src ) ) {
 			const file = getBlobByURL( src );
 
@@ -65,18 +66,15 @@ class AudioEdit extends Component {
 				} );
 			}
 		}
-	}
+	}, [] );
 
-	toggleAttribute( attribute ) {
+	const toggleAttribute = ( attribute ) => {
 		return ( newValue ) => {
-			this.props.setAttributes( { [ attribute ]: newValue } );
+			setAttributes( { [ attribute ]: newValue } );
 		};
-	}
+	};
 
-	onSelectURL( newSrc ) {
-		const { attributes, setAttributes } = this.props;
-		const { src } = attributes;
-
+	const onSelectURL = ( newSrc ) => {
 		// Set the block's src from the edit component's state, and switch off
 		// the editing UI.
 		if ( newSrc !== src ) {
@@ -85,132 +83,121 @@ class AudioEdit extends Component {
 				attributes: { url: newSrc },
 			} );
 			if ( undefined !== embedBlock ) {
-				this.props.onReplace( embedBlock );
+				onReplace( embedBlock );
 				return;
 			}
 			setAttributes( { src: newSrc, id: undefined } );
 		}
-	}
+	};
 
-	onUploadError( message ) {
-		const { noticeOperations } = this.props;
+	const onUploadError = ( message ) => {
 		noticeOperations.removeAllNotices();
 		noticeOperations.createErrorNotice( message );
-	}
+	};
 
-	getAutoplayHelp( checked ) {
+	const getAutoplayHelp = ( checked ) => {
 		return checked
 			? __(
 					'Note: Autoplaying audio may cause usability issues for some visitors.'
 			  )
 			: null;
-	}
+	};
 
-	render() {
-		const {
-			id,
-			autoplay,
-			caption,
-			loop,
-			preload,
-			src,
-		} = this.props.attributes;
-		const { setAttributes, isSelected, noticeUI } = this.props;
-		const onSelectAudio = ( media ) => {
-			if ( ! media || ! media.url ) {
-				// in this case there was an error and we should continue in the editing state
-				// previous attributes should be removed because they may be temporary blob urls
-				setAttributes( { src: undefined, id: undefined } );
-				return;
-			}
-			// sets the block's attribute and updates the edit component from the
-			// selected media, then switches off the editing UI
-			setAttributes( { src: media.url, id: media.id } );
-		};
-		if ( ! src ) {
-			return (
-				<Block.div>
-					<MediaPlaceholder
-						icon={ <BlockIcon icon={ icon } /> }
-						onSelect={ onSelectAudio }
-						onSelectURL={ this.onSelectURL }
-						accept="audio/*"
-						allowedTypes={ ALLOWED_MEDIA_TYPES }
-						value={ this.props.attributes }
-						notices={ noticeUI }
-						onError={ this.onUploadError }
-					/>
-				</Block.div>
-			);
+	// const { setAttributes, isSelected, noticeUI } = this.props;
+	const onSelectAudio = ( media ) => {
+		if ( ! media || ! media.url ) {
+			// in this case there was an error and we should continue in the editing state
+			// previous attributes should be removed because they may be temporary blob urls
+			setAttributes( { src: undefined, id: undefined } );
+			return;
 		}
-
+		// sets the block's attribute and updates the edit component from the
+		// selected media, then switches off the editing UI
+		setAttributes( { src: media.url, id: media.id } );
+	};
+	if ( ! src ) {
 		return (
-			<>
-				<BlockControls>
-					<MediaReplaceFlow
-						mediaId={ id }
-						mediaURL={ src }
-						allowedTypes={ ALLOWED_MEDIA_TYPES }
-						accept="audio/*"
-						onSelect={ onSelectAudio }
-						onSelectURL={ this.onSelectURL }
-						onError={ this.onUploadError }
-					/>
-				</BlockControls>
-				<InspectorControls>
-					<PanelBody title={ __( 'Audio settings' ) }>
-						<ToggleControl
-							label={ __( 'Autoplay' ) }
-							onChange={ this.toggleAttribute( 'autoplay' ) }
-							checked={ autoplay }
-							help={ this.getAutoplayHelp }
-						/>
-						<ToggleControl
-							label={ __( 'Loop' ) }
-							onChange={ this.toggleAttribute( 'loop' ) }
-							checked={ loop }
-						/>
-						<SelectControl
-							label={ __( 'Preload' ) }
-							value={ preload || '' }
-							// `undefined` is required for the preload attribute to be unset.
-							onChange={ ( value ) =>
-								setAttributes( {
-									preload: value || undefined,
-								} )
-							}
-							options={ [
-								{ value: '', label: __( 'Browser default' ) },
-								{ value: 'auto', label: __( 'Auto' ) },
-								{ value: 'metadata', label: __( 'Metadata' ) },
-								{ value: 'none', label: __( 'None' ) },
-							] }
-						/>
-					</PanelBody>
-				</InspectorControls>
-				<Block.figure>
-					{ /*
-						Disable the audio tag so the user clicking on it won't play the
-						file or change the position slider when the controls are enabled.
-					*/ }
-					<Disabled>
-						<audio controls="controls" src={ src } />
-					</Disabled>
-					{ ( ! RichText.isEmpty( caption ) || isSelected ) && (
-						<RichText
-							tagName="figcaption"
-							placeholder={ __( 'Write caption…' ) }
-							value={ caption }
-							onChange={ ( value ) =>
-								setAttributes( { caption: value } )
-							}
-							inlineToolbar
-						/>
-					) }
-				</Block.figure>
-			</>
+			<Block.div>
+				<MediaPlaceholder
+					icon={ <BlockIcon icon={ icon } /> }
+					onSelect={ onSelectAudio }
+					onSelectURL={ onSelectURL }
+					accept="audio/*"
+					allowedTypes={ ALLOWED_MEDIA_TYPES }
+					value={ attributes }
+					notices={ noticeUI }
+					onError={ onUploadError }
+				/>
+			</Block.div>
 		);
 	}
+
+	return (
+		<>
+			<BlockControls>
+				<MediaReplaceFlow
+					mediaId={ id }
+					mediaURL={ src }
+					allowedTypes={ ALLOWED_MEDIA_TYPES }
+					accept="audio/*"
+					onSelect={ onSelectAudio }
+					onSelectURL={ onSelectURL }
+					onError={ onUploadError }
+				/>
+			</BlockControls>
+			<InspectorControls>
+				<PanelBody title={ __( 'Audio settings' ) }>
+					<ToggleControl
+						label={ __( 'Autoplay' ) }
+						onChange={ toggleAttribute( 'autoplay' ) }
+						checked={ autoplay }
+						help={ getAutoplayHelp }
+					/>
+					<ToggleControl
+						label={ __( 'Loop' ) }
+						onChange={ toggleAttribute( 'loop' ) }
+						checked={ loop }
+					/>
+					<SelectControl
+						label={ __( 'Preload' ) }
+						value={ preload || '' }
+						// `undefined` is required for the preload attribute to be unset.
+						onChange={ ( value ) =>
+							setAttributes( {
+								preload: value || undefined,
+							} )
+						}
+						options={ [
+							{ value: '', label: __( 'Browser default' ) },
+							{ value: 'auto', label: __( 'Auto' ) },
+							{ value: 'metadata', label: __( 'Metadata' ) },
+							{ value: 'none', label: __( 'None' ) },
+						] }
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<Block.figure>
+				{ /*
+					Disable the audio tag so the user clicking on it won't play the
+					file or change the position slider when the controls are enabled.
+				*/ }
+				<Disabled>
+					<audio controls="controls" src={ src } />
+				</Disabled>
+				{ ( ! RichText.isEmpty( caption ) || isSelected ) && (
+					<RichText
+						tagName="figcaption"
+						placeholder={ __( 'Write caption…' ) }
+						value={ caption }
+						onChange={ ( value ) =>
+							setAttributes( { caption: value } )
+						}
+						inlineToolbar
+					/>
+				) }
+			</Block.figure>
+		</>
+	);
 }
 export default compose( [
 	withSelect( ( select ) => {

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -38,12 +38,6 @@ function AudioEdit( {
 	isSelected,
 	noticeUI,
 } ) {
-	// constructor() {
-	// 	super( ...arguments );
-	// 	this.toggleAttribute = this.toggleAttribute.bind( this );
-	// 	this.onSelectURL = this.onSelectURL.bind( this );
-	// 	this.onUploadError = this.onUploadError.bind( this );
-	// }
 	const { id, autoplay, caption, loop, preload, src } = attributes;
 
 	const mediaUpload = useSelect( ( select ) => {

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { getBlobByURL, isBlobURL } from '@wordpress/blob';
-import { compose } from '@wordpress/compose';
 import {
 	Disabled,
 	PanelBody,
@@ -21,7 +20,7 @@ import {
 } from '@wordpress/block-editor';
 import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { withSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { audio as icon } from '@wordpress/icons';
 
 /**
@@ -33,7 +32,6 @@ const ALLOWED_MEDIA_TYPES = [ 'audio' ];
 
 function AudioEdit( {
 	attributes,
-	mediaUpload,
 	noticeOperations,
 	setAttributes,
 	onReplace,
@@ -48,12 +46,18 @@ function AudioEdit( {
 	// }
 	const { id, autoplay, caption, loop, preload, src } = attributes;
 
+	const audioUpload = useSelect( ( select ) => {
+		const { getSettings } = select( 'core/block-editor' );
+		const { mediaUpload } = getSettings();
+		return { mediaUpload };
+	} );
+
 	useEffect( () => {
 		if ( ! id && isBlobURL( src ) ) {
 			const file = getBlobByURL( src );
 
 			if ( file ) {
-				mediaUpload( {
+				audioUpload( {
 					filesList: [ file ],
 					onFileChange: ( [ { id: mediaId, url } ] ) => {
 						setAttributes( { id: mediaId, src: url } );
@@ -199,11 +203,4 @@ function AudioEdit( {
 		</>
 	);
 }
-export default compose( [
-	withSelect( ( select ) => {
-		const { getSettings } = select( 'core/block-editor' );
-		const { mediaUpload } = getSettings();
-		return { mediaUpload };
-	} ),
-	withNotices,
-] )( AudioEdit );
+export default withNotices( AudioEdit );

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -43,7 +43,7 @@ function AudioEdit( {
 	const mediaUpload = useSelect( ( select ) => {
 		const { getSettings } = select( 'core/block-editor' );
 		return getSettings().mediaUpload;
-	} );
+	}, [] );
 
 	useEffect( () => {
 		if ( ! id && isBlobURL( src ) ) {


### PR DESCRIPTION
## Description
Related to #22890

## How has this been tested?
1. Edit page or post
2. Add Audio block
3. Upload .mp3 file
4. Change options


## Types of changes
Refactor Component to use React hooks. 
Refactor withSelect to useSelect hook.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
