### PR TITLE
Add heading to the block inserter groups #22859

### DIFF
--- a/packages/block-editor/src/components/inserter/panel.js
+++ b/packages/block-editor/src/components/inserter/panel.js
@@ -7,9 +7,9 @@ function InserterPanel( { title, icon, children } ) {
 	return (
 		<>
 			<div className="block-editor-inserter__panel-header">
-				<span className="block-editor-inserter__panel-title">
+				<h2 className="block-editor-inserter__panel-title">
 					{ title }
-				</span>
+				</h2>
 				<Icon icon={ icon } />
 			</div>
 			<div className="block-editor-inserter__panel-content">

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -139,7 +139,7 @@ $block-inserter-tabs-height: 44px;
 	text-transform: uppercase;
 	font-size: 11px;
 	font-weight: 500;
-	margin-right: $grid-unit-10;
+	margin: 0 $grid-unit-10 0 0;
 }
 
 .block-editor-inserter__block-list {


### PR DESCRIPTION
closes #22859 

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Changes the headings of block groups from `span`s to `h2` to provide a semantic structuring.
Also changes the margin so styling is the same as with `spans` before and overwrites default `h2` stylings.
Related to #22859 

## How has this been tested?
- Open the block inserter - headings should look exactly as before the commit (same margin, font-size etc).
- [ ] Should be tested with a screenreader?

## Screenshots <!-- if applicable -->
![grafik](https://user-images.githubusercontent.com/5585580/83779224-f63bca80-a68b-11ea-9b5f-fc11b2b9f637.png)


## Types of changes
Bug fix, css-class is the same as before and styling is the same.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
