### PR TITLE
Remove ifBlockEditSelected internal higher-order component

### DIFF
--- a/packages/block-editor/src/components/block-controls/index.js
+++ b/packages/block-editor/src/components/block-controls/index.js
@@ -16,7 +16,7 @@ import {
 /**
  * Internal dependencies
  */
-import { ifBlockEditSelected } from '../block-edit/context';
+import { useBlockEditContext } from '../block-edit/context';
 
 const { Fill, Slot } = createSlotFill( 'BlockControls' );
 
@@ -26,6 +26,11 @@ function BlockControlsSlot( props ) {
 }
 
 function BlockControlsFill( { controls, children } ) {
+	const { isSelected } = useBlockEditContext();
+	if ( ! isSelected ) {
+		return null;
+	}
+
 	return (
 		<Fill>
 			{ ( fillProps ) => {
@@ -44,7 +49,7 @@ function BlockControlsFill( { controls, children } ) {
 	);
 }
 
-const BlockControls = ifBlockEditSelected( BlockControlsFill );
+const BlockControls = BlockControlsFill;
 
 BlockControls.Slot = BlockControlsSlot;
 

--- a/packages/block-editor/src/components/block-controls/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/block-controls/test/__snapshots__/index.js.snap
@@ -15,7 +15,7 @@ exports[`BlockControls should render a dynamic toolbar of controls 1`] = `
   <WithFilters(Edit)
     isSelected={true}
   >
-    <IfBlockEditSelected(BlockControlsFill)
+    <BlockControlsFill
       controls={
         Array [
           Object {
@@ -60,7 +60,7 @@ exports[`BlockControls should render a dynamic toolbar of controls 1`] = `
       <p>
         Child
       </p>
-    </IfBlockEditSelected(BlockControlsFill)>
+    </BlockControlsFill>
   </WithFilters(Edit)>
 </ContextProvider>
 `;

--- a/packages/block-editor/src/components/block-edit/context.js
+++ b/packages/block-editor/src/components/block-edit/context.js
@@ -52,24 +52,3 @@ export const withBlockEditContext = ( mapContextToProps ) =>
 			</Consumer>
 		);
 	}, 'withBlockEditContext' );
-
-/**
- * A Higher Order Component used to render conditionally the wrapped
- * component only when the BlockEdit has selected state set.
- *
- * @param {WPComponent} OriginalComponent Component to wrap.
- *
- * @return {WPComponent} Component which renders only when the BlockEdit is selected.
- */
-export const ifBlockEditSelected = createHigherOrderComponent(
-	( OriginalComponent ) => {
-		return ( props ) => (
-			<Consumer>
-				{ ( { isSelected } ) =>
-					isSelected && <OriginalComponent { ...props } />
-				}
-			</Consumer>
-		);
-	},
-	'ifBlockEditSelected'
-);

--- a/packages/block-editor/src/components/block-format-controls/index.js
+++ b/packages/block-editor/src/components/block-format-controls/index.js
@@ -15,7 +15,7 @@ import {
 /**
  * Internal dependencies
  */
-import { ifBlockEditSelected } from '../block-edit/context';
+import { useBlockEditContext } from '../block-edit/context';
 
 const { Fill, Slot } = createSlotFill( 'BlockFormatControls' );
 
@@ -25,6 +25,11 @@ function BlockFormatControlsSlot( props ) {
 }
 
 function BlockFormatControlsFill( props ) {
+	const { isSelected } = useBlockEditContext();
+	if ( ! isSelected ) {
+		return null;
+	}
+
 	return (
 		<Fill>
 			{ ( fillProps ) => {
@@ -39,7 +44,7 @@ function BlockFormatControlsFill( props ) {
 	);
 }
 
-const BlockFormatControls = ifBlockEditSelected( BlockFormatControlsFill );
+const BlockFormatControls = BlockFormatControlsFill;
 
 BlockFormatControls.Slot = BlockFormatControlsSlot;
 

--- a/packages/block-editor/src/components/inspector-advanced-controls/index.js
+++ b/packages/block-editor/src/components/inspector-advanced-controls/index.js
@@ -6,12 +6,15 @@ import { createSlotFill } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { ifBlockEditSelected } from '../block-edit/context';
+import { useBlockEditContext } from '../block-edit/context';
 
 const name = 'InspectorAdvancedControls';
 const { Fill, Slot } = createSlotFill( name );
 
-const InspectorAdvancedControls = ifBlockEditSelected( Fill );
+function InspectorAdvancedControls() {
+	const { isSelected } = useBlockEditContext();
+	return isSelected ? <Fill /> : null;
+}
 
 InspectorAdvancedControls.slotName = name;
 InspectorAdvancedControls.Slot = Slot;

--- a/packages/block-editor/src/components/inspector-advanced-controls/index.js
+++ b/packages/block-editor/src/components/inspector-advanced-controls/index.js
@@ -11,9 +11,9 @@ import { useBlockEditContext } from '../block-edit/context';
 const name = 'InspectorAdvancedControls';
 const { Fill, Slot } = createSlotFill( name );
 
-function InspectorAdvancedControls() {
+function InspectorAdvancedControls( { children } ) {
 	const { isSelected } = useBlockEditContext();
-	return isSelected ? <Fill /> : null;
+	return isSelected ? <Fill>{ children }</Fill> : null;
 }
 
 InspectorAdvancedControls.slotName = name;

--- a/packages/block-editor/src/components/inspector-controls/index.js
+++ b/packages/block-editor/src/components/inspector-controls/index.js
@@ -10,9 +10,9 @@ import { useBlockEditContext } from '../block-edit/context';
 
 const { Fill, Slot } = createSlotFill( 'InspectorControls' );
 
-function InspectorControls() {
+function InspectorControls( { children } ) {
 	const { isSelected } = useBlockEditContext();
-	return isSelected ? <Fill /> : null;
+	return isSelected ? <Fill>{ children }</Fill> : null;
 }
 
 InspectorControls.Slot = Slot;

--- a/packages/block-editor/src/components/inspector-controls/index.js
+++ b/packages/block-editor/src/components/inspector-controls/index.js
@@ -6,11 +6,14 @@ import { createSlotFill } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { ifBlockEditSelected } from '../block-edit/context';
+import { useBlockEditContext } from '../block-edit/context';
 
 const { Fill, Slot } = createSlotFill( 'InspectorControls' );
 
-const InspectorControls = ifBlockEditSelected( Fill );
+function InspectorControls() {
+	const { isSelected } = useBlockEditContext();
+	return isSelected ? <Fill /> : null;
+}
 
 InspectorControls.Slot = Slot;
 

--- a/packages/block-editor/src/components/inspector-controls/index.native.js
+++ b/packages/block-editor/src/components/inspector-controls/index.native.js
@@ -10,12 +10,17 @@ import { createSlotFill, BottomSheetConsumer } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { ifBlockEditSelected } from '../block-edit/context';
+import { useBlockEditContext } from '../block-edit/context';
 import { BlockSettingsButton } from '../block-settings';
 
 const { Fill, Slot } = createSlotFill( 'InspectorControls' );
 
 const FillWithSettingsButton = ( { children, ...props } ) => {
+	const { isSelected } = useBlockEditContext();
+	if ( ! isSelected ) {
+		return null;
+	}
+
 	return (
 		<>
 			<Fill { ...props }>
@@ -30,7 +35,7 @@ const FillWithSettingsButton = ( { children, ...props } ) => {
 	);
 };
 
-const InspectorControls = ifBlockEditSelected( FillWithSettingsButton );
+const InspectorControls = FillWithSettingsButton;
 
 InspectorControls.Slot = Slot;
 

--- a/packages/block-library/src/more/test/__snapshots__/edit.js.snap
+++ b/packages/block-library/src/more/test/__snapshots__/edit.js.snap
@@ -2,7 +2,7 @@
 
 exports[`core/more/edit should match snapshot when noTeaser is false 1`] = `
 <React.Fragment>
-  <IfBlockEditSelected(InspectorControlsFill)>
+  <InspectorControls>
     <ForwardRef(PanelBody)>
       <WithInstanceId(ToggleControl)
         checked={false}
@@ -11,7 +11,7 @@ exports[`core/more/edit should match snapshot when noTeaser is false 1`] = `
         onChange={[Function]}
       />
     </ForwardRef(PanelBody)>
-  </IfBlockEditSelected(InspectorControlsFill)>
+  </InspectorControls>
   <div
     className="wp-block-more"
   >
@@ -32,7 +32,7 @@ exports[`core/more/edit should match snapshot when noTeaser is false 1`] = `
 
 exports[`core/more/edit should match snapshot when noTeaser is true 1`] = `
 <React.Fragment>
-  <IfBlockEditSelected(InspectorControlsFill)>
+  <InspectorControls>
     <ForwardRef(PanelBody)>
       <WithInstanceId(ToggleControl)
         checked={true}
@@ -41,7 +41,7 @@ exports[`core/more/edit should match snapshot when noTeaser is true 1`] = `
         onChange={[Function]}
       />
     </ForwardRef(PanelBody)>
-  </IfBlockEditSelected(InspectorControlsFill)>
+  </InspectorControls>
   <div
     className="wp-block-more"
   >


### PR DESCRIPTION
This pull request seeks to remove the `ifBlockEditSelected` internal helper of the `@wordpress/block-editor` package. The motivation here is (a) to flatten the common block React element hierarchy and (b) to favor hooks-based implementations over higher-order components. `ifBlockEditSelected` was a useful and expressive helper at the time it was originally implemented, due to the cumbersome nature of using React Context `<Consumer>` elements. With `useContext`, it's much simpler now to get direct access to the context object properties relevant for this behavior. For some affected components, it's arguably still more verbose than the previous implementation, but it seems like a reasonable compromise. A flattened element hierarchy _may_ bring some improved performance and debugging benefit.

**Testing Instructions:**

Verify no regressions in the behavior of affected components. For example, block toolbar and inspector controls should only appear for the selected block.