### PR TITLE
Use React hooks for TabPanel component

### DIFF
--- a/packages/components/src/tab-panel/index.js
+++ b/packages/components/src/tab-panel/index.js
@@ -29,7 +29,7 @@ const TabButton = ( { tabId, onClick, children, selected, ...rest } ) => (
 	</Button>
 );
 
-const TabPanel = ( {
+export default function TabPanel( {
 	className,
 	children,
 	tabs,
@@ -37,8 +37,8 @@ const TabPanel = ( {
 	orientation = 'horizontal',
 	activeClass = 'is-active',
 	onSelect = noop,
-} ) => {
-	const instanceId = useInstanceId( TabPanel );
+} ) {
+	const instanceId = useInstanceId( TabPanel, 'tab-panel' );
 	const [ selected, setSelected ] = useState(
 		initialTabName || ( tabs.length > 0 ? tabs[ 0 ].name : null )
 	);
@@ -53,7 +53,7 @@ const TabPanel = ( {
 	};
 
 	const selectedTab = find( tabs, { name: selected } );
-	const selectedId = instanceId + '-' + selectedTab.name;
+	const selectedId = `${ instanceId }-${ selectedTab.name }`;
 
 	return (
 		<div className={ className }>
@@ -72,8 +72,8 @@ const TabPanel = ( {
 								[ activeClass ]: tab.name === selected,
 							}
 						) }
-						tabId={ instanceId + '-' + tab.name }
-						aria-controls={ instanceId + '-' + tab.name + '-view' }
+						tabId={ `${ instanceId }-${ tab.name }` }
+						aria-controls={ `${ instanceId }-${ tab.name }-view` }
 						selected={ tab.name === selected }
 						key={ tab.name }
 						onClick={ partial( handleClick, tab.name ) }
@@ -86,7 +86,7 @@ const TabPanel = ( {
 				<div
 					aria-labelledby={ selectedId }
 					role="tabpanel"
-					id={ selectedId + '-view' }
+					id={ `${ selectedId }-view` }
 					className="components-tab-panel__tab-content"
 				>
 					{ children( selectedTab ) }
@@ -94,6 +94,4 @@ const TabPanel = ( {
 			) }
 		</div>
 	);
-};
-
-export default TabPanel;
+}

--- a/packages/components/src/tab-panel/index.js
+++ b/packages/components/src/tab-panel/index.js
@@ -8,7 +8,7 @@ import { partial, noop, find } from 'lodash';
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
-import { withInstanceId } from '@wordpress/compose';
+import { useInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -32,13 +32,13 @@ const TabButton = ( { tabId, onClick, children, selected, ...rest } ) => (
 const TabPanel = ( {
 	className,
 	children,
-	instanceId,
 	tabs,
 	initialTabName,
 	orientation = 'horizontal',
 	activeClass = 'is-active',
 	onSelect = noop,
 } ) => {
+	const instanceId = useInstanceId( TabPanel );
 	const [ selected, setSelected ] = useState(
 		initialTabName || ( tabs.length > 0 ? tabs[ 0 ].name : null )
 	);
@@ -96,4 +96,4 @@ const TabPanel = ( {
 	);
 };
 
-export default withInstanceId( TabPanel );
+export default TabPanel;

--- a/packages/components/src/tab-panel/index.js
+++ b/packages/components/src/tab-panel/index.js
@@ -7,7 +7,7 @@ import { partial, noop, find } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { withInstanceId } from '@wordpress/compose';
 
 /**
@@ -29,87 +29,71 @@ const TabButton = ( { tabId, onClick, children, selected, ...rest } ) => (
 	</Button>
 );
 
-class TabPanel extends Component {
-	constructor() {
-		super( ...arguments );
-		const { tabs, initialTabName } = this.props;
+const TabPanel = ( {
+	className,
+	children,
+	instanceId,
+	tabs,
+	initialTabName,
+	orientation = 'horizontal',
+	activeClass = 'is-active',
+	onSelect = noop,
+} ) => {
+	const [ selected, setSelected ] = useState(
+		initialTabName || ( tabs.length > 0 ? tabs[ 0 ].name : null )
+	);
 
-		this.handleClick = this.handleClick.bind( this );
-		this.onNavigate = this.onNavigate.bind( this );
-
-		this.state = {
-			selected:
-				initialTabName || ( tabs.length > 0 ? tabs[ 0 ].name : null ),
-		};
-	}
-
-	handleClick( tabKey ) {
-		const { onSelect = noop } = this.props;
-		this.setState( {
-			selected: tabKey,
-		} );
+	const handleClick = ( tabKey ) => {
+		setSelected( tabKey );
 		onSelect( tabKey );
-	}
+	};
 
-	onNavigate( childIndex, child ) {
+	const onNavigate = ( childIndex, child ) => {
 		child.click();
-	}
+	};
 
-	render() {
-		const { selected } = this.state;
-		const {
-			activeClass = 'is-active',
-			className,
-			instanceId,
-			orientation = 'horizontal',
-			tabs,
-		} = this.props;
+	const selectedTab = find( tabs, { name: selected } );
+	const selectedId = instanceId + '-' + selectedTab.name;
 
-		const selectedTab = find( tabs, { name: selected } );
-		const selectedId = instanceId + '-' + selectedTab.name;
-
-		return (
-			<div className={ className }>
-				<NavigableMenu
-					role="tablist"
-					orientation={ orientation }
-					onNavigate={ this.onNavigate }
-					className="components-tab-panel__tabs"
-				>
-					{ tabs.map( ( tab ) => (
-						<TabButton
-							className={ classnames(
-								'components-tab-panel__tabs-item',
-								tab.className,
-								{
-									[ activeClass ]: tab.name === selected,
-								}
-							) }
-							tabId={ instanceId + '-' + tab.name }
-							aria-controls={
-								instanceId + '-' + tab.name + '-view'
+	return (
+		<div className={ className }>
+			<NavigableMenu
+				role="tablist"
+				orientation={ orientation }
+				onNavigate={ onNavigate }
+				className="components-tab-panel__tabs"
+			>
+				{ tabs.map( ( tab ) => (
+					<TabButton
+						className={ classnames(
+							'components-tab-panel__tabs-item',
+							tab.className,
+							{
+								[ activeClass ]: tab.name === selected,
 							}
-							selected={ tab.name === selected }
-							key={ tab.name }
-							onClick={ partial( this.handleClick, tab.name ) }
-						>
-							{ tab.title }
-						</TabButton>
-					) ) }
-				</NavigableMenu>
-				{ selectedTab && (
-					<div
-						aria-labelledby={ selectedId }
-						role="tabpanel"
-						id={ selectedId + '-view' }
-						className="components-tab-panel__tab-content"
+						) }
+						tabId={ instanceId + '-' + tab.name }
+						aria-controls={ instanceId + '-' + tab.name + '-view' }
+						selected={ tab.name === selected }
+						key={ tab.name }
+						onClick={ partial( handleClick, tab.name ) }
 					>
-						{ this.props.children( selectedTab ) }
-					</div>
-				) }
-			</div>
-		);
-	}
-}
+						{ tab.title }
+					</TabButton>
+				) ) }
+			</NavigableMenu>
+			{ selectedTab && (
+				<div
+					aria-labelledby={ selectedId }
+					role="tabpanel"
+					id={ selectedId + '-view' }
+					className="components-tab-panel__tab-content"
+				>
+					{ children( selectedTab ) }
+				</div>
+			) }
+		</div>
+	);
+};
 
 export default withInstanceId( TabPanel );


### PR DESCRIPTION
## Description
Related to #22890

## How has this been tested?
The TabPanel component is used in two places:
- View switcher for Blocks and Patterns.
- Experimental Navigation's page navigation.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
