### PR TITLE
Refactor BlockCompare block to use React hooks

### DIFF
--- a/packages/block-editor/src/components/block-compare/index.js
+++ b/packages/block-editor/src/components/block-compare/index.js
@@ -11,7 +11,6 @@ import { diffChars } from 'diff/lib/diff/character';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component } from '@wordpress/element';
 import { getSaveContent, getSaveElement } from '@wordpress/blocks';
 
 /**
@@ -19,8 +18,14 @@ import { getSaveContent, getSaveElement } from '@wordpress/blocks';
  */
 import BlockView from './block-view';
 
-class BlockCompare extends Component {
-	getDifference( originalContent, newContent ) {
+function BlockCompare( {
+	block,
+	onKeep,
+	onConvert,
+	convertor,
+	convertButtonText,
+} ) {
+	const getDifference = ( originalContent, newContent ) => {
 		const difference = diffChars( originalContent, newContent );
 
 		return difference.map( ( item, pos ) => {
@@ -35,18 +40,18 @@ class BlockCompare extends Component {
 				</span>
 			);
 		} );
-	}
+	};
 
-	getOriginalContent( block ) {
+	const getOriginalContent = () => {
 		return {
 			rawContent: block.originalContent,
 			renderedContent: getSaveElement( block.name, block.attributes ),
 		};
-	}
+	};
 
-	getConvertedContent( block ) {
+	const getConvertedContent = ( convertedBlock ) => {
 		// The convertor may return an array of items or a single item
-		const newBlocks = castArray( block );
+		const newBlocks = castArray( convertedBlock );
 
 		// Get converted block details
 		const newContent = newBlocks.map( ( item ) =>
@@ -60,45 +65,36 @@ class BlockCompare extends Component {
 			rawContent: newContent.join( '' ),
 			renderedContent,
 		};
-	}
+	};
 
-	render() {
-		const {
-			block,
-			onKeep,
-			onConvert,
-			convertor,
-			convertButtonText,
-		} = this.props;
-		const original = this.getOriginalContent( block );
-		const converted = this.getConvertedContent( convertor( block ) );
-		const difference = this.getDifference(
-			original.rawContent,
-			converted.rawContent
-		);
+	const original = getOriginalContent();
+	const converted = getConvertedContent( convertor( block ) );
+	const difference = getDifference(
+		original.rawContent,
+		converted.rawContent
+	);
 
-		return (
-			<div className="block-editor-block-compare__wrapper">
-				<BlockView
-					title={ __( 'Current' ) }
-					className="block-editor-block-compare__current"
-					action={ onKeep }
-					actionText={ __( 'Convert to HTML' ) }
-					rawContent={ original.rawContent }
-					renderedContent={ original.renderedContent }
-				/>
+	return (
+		<div className="block-editor-block-compare__wrapper">
+			<BlockView
+				title={ __( 'Current' ) }
+				className="block-editor-block-compare__current"
+				action={ onKeep }
+				actionText={ __( 'Convert to HTML' ) }
+				rawContent={ original.rawContent }
+				renderedContent={ original.renderedContent }
+			/>
 
-				<BlockView
-					title={ __( 'After Conversion' ) }
-					className="block-editor-block-compare__converted"
-					action={ onConvert }
-					actionText={ convertButtonText }
-					rawContent={ difference }
-					renderedContent={ converted.renderedContent }
-				/>
-			</div>
-		);
-	}
+			<BlockView
+				title={ __( 'After Conversion' ) }
+				className="block-editor-block-compare__converted"
+				action={ onConvert }
+				actionText={ convertButtonText }
+				rawContent={ difference }
+				renderedContent={ converted.renderedContent }
+			/>
+		</div>
+	);
 }
 
 export default BlockCompare;

--- a/packages/block-editor/src/components/block-compare/index.js
+++ b/packages/block-editor/src/components/block-compare/index.js
@@ -42,13 +42,6 @@ function BlockCompare( {
 		} );
 	};
 
-	const getOriginalContent = () => {
-		return {
-			rawContent: block.originalContent,
-			renderedContent: getSaveElement( block.name, block.attributes ),
-		};
-	};
-
 	const getConvertedContent = ( convertedBlock ) => {
 		// The convertor may return an array of items or a single item
 		const newBlocks = castArray( convertedBlock );
@@ -67,7 +60,10 @@ function BlockCompare( {
 		};
 	};
 
-	const original = getOriginalContent();
+	const original = {
+		rawContent: block.originalContent,
+		renderedContent: getSaveElement( block.name, block.attributes ),
+	};
 	const converted = getConvertedContent( convertor( block ) );
 	const difference = getDifference(
 		original.rawContent,

--- a/packages/block-editor/src/components/block-compare/index.js
+++ b/packages/block-editor/src/components/block-compare/index.js
@@ -25,7 +25,7 @@ function BlockCompare( {
 	convertor,
 	convertButtonText,
 } ) {
-	const getDifference = ( originalContent, newContent ) => {
+	function getDifference( originalContent, newContent ) {
 		const difference = diffChars( originalContent, newContent );
 
 		return difference.map( ( item, pos ) => {
@@ -40,9 +40,9 @@ function BlockCompare( {
 				</span>
 			);
 		} );
-	};
+	}
 
-	const getConvertedContent = ( convertedBlock ) => {
+	function getConvertedContent( convertedBlock ) {
 		// The convertor may return an array of items or a single item
 		const newBlocks = castArray( convertedBlock );
 
@@ -58,7 +58,7 @@ function BlockCompare( {
 			rawContent: newContent.join( '' ),
 			renderedContent,
 		};
-	};
+	}
 
 	const original = {
 		rawContent: block.originalContent,


### PR DESCRIPTION
## Description
Related #22890

## How has this been tested?
1. Edit page or post
2. Go to editor code
3. Code wrong block
4. Save content
5. Refresh page
6. Message "This block contains unexpected or invalid content." will appear
7. Click on "Resolve" button

## Types of changes
Refactor BlockCompare to use React hooks.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
