### PR TITLE
BlockTitle: refactor withSelect to useSelect

### DIFF
--- a/docs/contributors/coding-guidelines.md
+++ b/docs/contributors/coding-guidelines.md
@@ -452,11 +452,11 @@ Documenting a function component should be treated the same as any other functio
  * @example
  *
  * ```jsx
- * <BlockTitle name="my-plugin/my-block" />
+ * <BlockTitle clientId="afd1cb17-2c08-4e7a-91be-007ba7ddc3a1" />
  * ```
  *
- * @param {Object}  props      Component props.
- * @param {?string} props.name Block name.
+ * @param {Object} props
+ * @param {string} props.clientId Client ID of block.
  *
  * @return {?string} Block title.
  */

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -186,7 +186,23 @@ _Related_
 
 <a name="BlockTitle" href="#BlockTitle">#</a> **BlockTitle**
 
-Undocumented declaration.
+Renders the block's configured title as a string, or empty if the title
+cannot be determined.
+
+_Usage_
+
+```jsx
+<BlockTitle clientId="afd1cb17-2c08-4e7a-91be-007ba7ddc3a1" />
+```
+
+_Parameters_
+
+-   _props_ `Object`: 
+-   _props.clientId_ `?string`: Block Client ID.
+
+_Returns_
+
+-   `?string`: Block title.
 
 <a name="BlockToolbar" href="#BlockToolbar">#</a> **BlockToolbar**
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -198,7 +198,7 @@ _Usage_
 _Parameters_
 
 -   _props_ `Object`: 
--   _props.clientId_ `?string`: Block Client ID.
+-   _props.clientId_ `string`: Client ID of block.
 
 _Returns_
 

--- a/packages/block-editor/src/components/block-title/index.js
+++ b/packages/block-editor/src/components/block-title/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { withSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { getBlockType } from '@wordpress/blocks';
 
 /**
@@ -15,11 +15,19 @@ import { getBlockType } from '@wordpress/blocks';
  * ```
  *
  * @param {Object}  props
- * @param {?string} props.name Block name.
+ * @param {?string} props.clientId Block Client ID.
  *
  * @return {?string} Block title.
  */
-export function BlockTitle( { name } ) {
+export function BlockTitle( { clientId } ) {
+	const name = useSelect(
+		( select ) => {
+			const { getBlockName } = select( 'core/block-editor' );
+			return getBlockName( clientId );
+		},
+		[ clientId ]
+	);
+
 	if ( ! name ) {
 		return null;
 	}
@@ -32,11 +40,4 @@ export function BlockTitle( { name } ) {
 	return blockType.title;
 }
 
-export default withSelect( ( select, ownProps ) => {
-	const { getBlockName } = select( 'core/block-editor' );
-	const { clientId } = ownProps;
-
-	return {
-		name: getBlockName( clientId ),
-	};
-} )( BlockTitle );
+export default BlockTitle;

--- a/packages/block-editor/src/components/block-title/index.js
+++ b/packages/block-editor/src/components/block-title/index.js
@@ -19,7 +19,7 @@ import { getBlockType } from '@wordpress/blocks';
  *
  * @return {?string} Block title.
  */
-function BlockTitle( { clientId } ) {
+export default function BlockTitle( { clientId } ) {
 	const name = useSelect(
 		( select ) => {
 			if ( ! clientId ) {
@@ -42,5 +42,3 @@ function BlockTitle( { clientId } ) {
 
 	return blockType.title;
 }
-
-export default BlockTitle;

--- a/packages/block-editor/src/components/block-title/index.js
+++ b/packages/block-editor/src/components/block-title/index.js
@@ -14,14 +14,17 @@ import { getBlockType } from '@wordpress/blocks';
  * <BlockTitle clientId="afd1cb17-2c08-4e7a-91be-007ba7ddc3a1" />
  * ```
  *
- * @param {Object}  props
- * @param {?string} props.clientId Block Client ID.
+ * @param {Object} props
+ * @param {string} props.clientId Client ID of block.
  *
  * @return {?string} Block title.
  */
-export function BlockTitle( { clientId } ) {
+function BlockTitle( { clientId } ) {
 	const name = useSelect(
 		( select ) => {
+			if ( ! clientId ) {
+				return null;
+			}
 			const { getBlockName } = select( 'core/block-editor' );
 			return getBlockName( clientId );
 		},

--- a/packages/block-editor/src/components/block-title/test/index.js
+++ b/packages/block-editor/src/components/block-title/test/index.js
@@ -4,9 +4,14 @@
 import { shallow } from 'enzyme';
 
 /**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
  * Internal dependencies
  */
-import { BlockTitle } from '../';
+import BlockTitle from '../';
 
 jest.mock( '@wordpress/blocks', () => {
 	return {
@@ -22,6 +27,12 @@ jest.mock( '@wordpress/blocks', () => {
 	};
 } );
 
+jest.mock( '@wordpress/data/src/components/use-select', () => {
+	// This allows us to tweak the returned value on each test
+	const mock = jest.fn();
+	return mock;
+} );
+
 describe( 'BlockTitle', () => {
 	it( 'renders nothing if name is falsey', () => {
 		const wrapper = shallow( <BlockTitle /> );
@@ -30,13 +41,19 @@ describe( 'BlockTitle', () => {
 	} );
 
 	it( 'renders nothing if block type does not exist', () => {
-		const wrapper = shallow( <BlockTitle name="name-not-exists" /> );
+		useSelect.mockImplementation( () => 'name-not-exists' );
+		const wrapper = shallow(
+			<BlockTitle clientId="afd1cb17-2c08-4e7a-91be-007ba7ddc3a1" />
+		);
 
 		expect( wrapper.type() ).toBe( null );
 	} );
 
 	it( 'renders title if block type exists', () => {
-		const wrapper = shallow( <BlockTitle name="name-exists" /> );
+		useSelect.mockImplementation( () => 'name-exists' );
+		const wrapper = shallow(
+			<BlockTitle clientId="afd1cb17-2c08-4e7a-91be-007ba7ddc3a1" />
+		);
 
 		expect( wrapper.text() ).toBe( 'Block Title' );
 	} );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

Related to #22890

## How has this been tested?

select block and check footer breadcrumbs.


## Types of changes

Refactaring.

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
