### PR TITLE
Env: Remove unused options.hasTests param from JSDoc

### DIFF
--- a/packages/env/lib/config.js
+++ b/packages/env/lib/config.js
@@ -265,7 +265,6 @@ module.exports = {
  *
  * @param {?string} sourceString The source string. See README.md for documentation on valid source string patterns.
  * @param {Object} options
- * @param {boolean} options.hasTests Whether or not a `testsPath` is required. Only the 'core' source needs this.
  * @param {string} options.workDirectoryPath Path to the work directory located in ~/.wp-env.
  *
  * @return {?WPSource} A source object.


### PR DESCRIPTION
## Description
See #22907.

Fixes `267:0  warning  @param "options.hasTests" does not exist on options  jsdoc/check-param-names`

Introduced in https://github.com/WordPress/gutenberg/commit/82c301a0a1fa76056dad79aae6c8485491986ad3 but never used.

## How has this been tested?
`npm run lint-js packages/env/lib/config.js`