### PR TITLE
Format library: Remove unused options.text param from JSDoc for createLinkFormat()

### DIFF
--- a/packages/format-library/src/link/utils.js
+++ b/packages/format-library/src/link/utils.js
@@ -90,7 +90,6 @@ export function isValidHref( href ) {
  * @param {string}  options.type             The type of the link.
  * @param {string}  options.id               The ID of the link.
  * @param {boolean} options.opensInNewWindow Whether this link will open in a new window.
- * @param {Object}  options.text             The text that is being hyperlinked.
  *
  * @return {Object} The final format object.
  */


### PR DESCRIPTION
## Description
See #22907.

Fixes `  88:0  warning  @param "options.text" does not exist on options  jsdoc/check-param-names`

This param was removed in https://github.com/WordPress/gutenberg/commit/c84784ff5037b4f859f2d30ac5487cca2f95dacf.

## How has this been tested?
`npm run lint-js packages/format-library/src/link/utils.js`