### PR TITLE
Block Directory: Uninstall unused block types

### DIFF
--- a/packages/block-directory/src/components/auto-block-uninstaller/index.js
+++ b/packages/block-directory/src/components/auto-block-uninstaller/index.js
@@ -5,57 +5,16 @@ import { unregisterBlockType } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 
-/**
- * Check if a block list contains a specific block type. Recursively searches
- * through `innerBlocks` if they exist.
- *
- * @param {Object} blockType A block object to search for.
- * @param {Object[]} blocks  The list of blocks to look through.
- *
- * @return {boolean} Whether the blockType is found.
- */
-function hasBlockType( blockType, blocks = [] ) {
-	if ( ! blocks.length ) {
-		return false;
-	}
-	if ( blocks.some( ( { name } ) => name === blockType.name ) ) {
-		return true;
-	}
-	for ( let i = 0; i < blocks.length; i++ ) {
-		if ( hasBlockType( blockType, blocks[ i ].innerBlocks ) ) {
-			return true;
-		}
-	}
-
-	return false;
-}
-
 export default function AutoBlockUninstaller() {
 	const { uninstallBlockType } = useDispatch( 'core/block-directory' );
-	const usedBlocks = useSelect( ( select ) =>
-		select( 'core/block-editor' ).getBlocks()
-	);
 
 	const shouldRemoveBlockTypes = useSelect( ( select ) => {
 		const { isAutosavingPost, isSavingPost } = select( 'core/editor' );
 		return isSavingPost() && ! isAutosavingPost();
 	} );
 
-	const unusedBlockTypes = useSelect(
-		( select ) => {
-			const { getInstalledBlockTypes } = select( 'core/block-directory' );
-			const installedBlocks = getInstalledBlockTypes();
-
-			const blockList = [];
-			installedBlocks.forEach( ( blockType ) => {
-				if ( ! hasBlockType( blockType, usedBlocks ) ) {
-					blockList.push( blockType );
-				}
-			} );
-
-			return blockList;
-		},
-		[ usedBlocks ]
+	const unusedBlockTypes = useSelect( ( select ) =>
+		select( 'core/block-directory' ).getUnusedBlockTypes()
 	);
 
 	useEffect( () => {

--- a/packages/block-directory/src/components/auto-block-uninstaller/index.js
+++ b/packages/block-directory/src/components/auto-block-uninstaller/index.js
@@ -37,11 +37,8 @@ export default function AutoBlockUninstaller() {
 	);
 
 	const shouldRemoveBlockTypes = useSelect( ( select ) => {
-		select( 'core/block-editor' ).getBlocks();
-		const { isCurrentPostPublished, isSavingPost } = select(
-			'core/editor'
-		);
-		return ! isCurrentPostPublished() && isSavingPost();
+		const { isAutosavingPost, isSavingPost } = select( 'core/editor' );
+		return isSavingPost() && ! isAutosavingPost();
 	} );
 
 	const unusedBlockTypes = useSelect(

--- a/packages/block-directory/src/components/auto-block-uninstaller/index.js
+++ b/packages/block-directory/src/components/auto-block-uninstaller/index.js
@@ -1,0 +1,74 @@
+/**
+ * WordPress dependencies
+ */
+import { unregisterBlockType } from '@wordpress/blocks';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+
+/**
+ * Check if a block list contains a specific block type. Recursively searches
+ * through `innerBlocks` if they exist.
+ *
+ * @param {Object} blockType A block object to search for.
+ * @param {Object[]} blocks  The list of blocks to look through.
+ *
+ * @return {boolean} Whether the blockType is found.
+ */
+function hasBlockType( blockType, blocks = [] ) {
+	if ( ! blocks.length ) {
+		return false;
+	}
+	if ( blocks.some( ( { name } ) => name === blockType.name ) ) {
+		return true;
+	}
+	for ( let i = 0; i < blocks.length; i++ ) {
+		if ( hasBlockType( blockType, blocks[ i ].innerBlocks ) ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+export default function AutoBlockUninstaller() {
+	const { uninstallBlockType } = useDispatch( 'core/block-directory' );
+	const usedBlocks = useSelect( ( select ) =>
+		select( 'core/block-editor' ).getBlocks()
+	);
+
+	const shouldRemoveBlockTypes = useSelect( ( select ) => {
+		select( 'core/block-editor' ).getBlocks();
+		const { isCurrentPostPublished, isSavingPost } = select(
+			'core/editor'
+		);
+		return ! isCurrentPostPublished() && isSavingPost();
+	} );
+
+	const unusedBlockTypes = useSelect(
+		( select ) => {
+			const { getInstalledBlockTypes } = select( 'core/block-directory' );
+			const installedBlocks = getInstalledBlockTypes();
+
+			const blockList = [];
+			installedBlocks.forEach( ( blockType ) => {
+				if ( ! hasBlockType( blockType, usedBlocks ) ) {
+					blockList.push( blockType );
+				}
+			} );
+
+			return blockList;
+		},
+		[ usedBlocks ]
+	);
+
+	useEffect( () => {
+		if ( shouldRemoveBlockTypes && unusedBlockTypes.length ) {
+			unusedBlockTypes.forEach( ( blockType ) => {
+				uninstallBlockType( blockType );
+				unregisterBlockType( blockType.name );
+			} );
+		}
+	}, [ shouldRemoveBlockTypes ] );
+
+	return null;
+}

--- a/packages/block-directory/src/plugins/index.js
+++ b/packages/block-directory/src/plugins/index.js
@@ -6,6 +6,7 @@ import { registerPlugin } from '@wordpress/plugins';
 /**
  * Internal dependencies
  */
+import AutoBlockUninstaller from '../components/auto-block-uninstaller';
 import InserterMenuDownloadableBlocksPanel from './inserter-menu-downloadable-blocks-panel';
 import InstalledBlocksPrePublishPanel from './installed-blocks-pre-publish-panel';
 
@@ -13,6 +14,7 @@ registerPlugin( 'block-directory', {
 	render() {
 		return (
 			<>
+				<AutoBlockUninstaller />
 				<InserterMenuDownloadableBlocksPanel />
 				<InstalledBlocksPrePublishPanel />
 			</>

--- a/packages/block-directory/src/plugins/installed-blocks-pre-publish-panel/index.js
+++ b/packages/block-directory/src/plugins/installed-blocks-pre-publish-panel/index.js
@@ -12,7 +12,7 @@ import CompactList from '../../components/compact-list';
 
 export default function InstalledBlocksPrePublishPanel() {
 	const newBlockTypes = useSelect( ( select ) =>
-		select( 'core/block-directory' ).getInstalledBlockTypes()
+		select( 'core/block-directory' ).getNewBlockTypes()
 	);
 
 	if ( ! newBlockTypes.length ) {

--- a/packages/block-directory/src/store/actions.js
+++ b/packages/block-directory/src/store/actions.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { apiFetch, select } from '@wordpress/data-controls';
+import { apiFetch, dispatch, select } from '@wordpress/data-controls';
 
 /**
  * Internal dependencies
@@ -92,6 +92,34 @@ export function* installBlockType( block ) {
 }
 
 /**
+ * Action triggered to uninstall a block plugin.
+ *
+ * @param {Object} block The blockType object.
+ */
+export function* uninstallBlockType( block ) {
+	const { id } = block;
+	try {
+		const response = yield apiFetch( {
+			path: '__experimental/block-directory/uninstall',
+			data: {
+				slug: id,
+			},
+			method: 'DELETE',
+		} );
+		if ( response !== true ) {
+			throw new Error( __( 'Unable to uninstall this block.' ) );
+		}
+		yield removeInstalledBlockType( block );
+	} catch ( error ) {
+		yield dispatch(
+			'core/notices',
+			'createErrorNotice',
+			error.message || __( 'An error occurred.' )
+		);
+	}
+}
+
+/**
  * Returns an action object used to add a newly installed block type.
  *
  * @param {Object} item The block item with the block id and name.
@@ -101,6 +129,20 @@ export function* installBlockType( block ) {
 export function addInstalledBlockType( item ) {
 	return {
 		type: 'ADD_INSTALLED_BLOCK_TYPE',
+		item,
+	};
+}
+
+/**
+ * Returns an action object used to remove a newly installed block type.
+ *
+ * @param {string} item The block item with the block id and name.
+ *
+ * @return {Object} Action object.
+ */
+export function removeInstalledBlockType( item ) {
+	return {
+		type: 'REMOVE_INSTALLED_BLOCK_TYPE',
 		item,
 	};
 }

--- a/packages/block-directory/src/store/selectors.js
+++ b/packages/block-directory/src/store/selectors.js
@@ -66,12 +66,12 @@ export function getInstalledBlockTypes( state ) {
  */
 export const getNewBlockTypes = createRegistrySelector(
 	( select ) => ( state ) => {
-		const usedBlockTypes = select( 'core/block-editor' ).getBlocks();
+		const usedBlockTree = select( 'core/block-editor' ).getBlocks();
 		const installedBlockTypes = getInstalledBlockTypes( state );
 
 		const newBlockTypes = [];
 		installedBlockTypes.forEach( ( blockType ) => {
-			if ( hasBlockType( blockType, usedBlockTypes ) ) {
+			if ( hasBlockType( blockType, usedBlockTree ) ) {
 				newBlockTypes.push( blockType );
 			}
 		} );
@@ -90,12 +90,12 @@ export const getNewBlockTypes = createRegistrySelector(
  */
 export const getUnusedBlockTypes = createRegistrySelector(
 	( select ) => ( state ) => {
-		const usedBlockTypes = select( 'core/block-editor' ).getBlocks();
+		const usedBlockTree = select( 'core/block-editor' ).getBlocks();
 		const installedBlockTypes = getInstalledBlockTypes( state );
 
 		const newBlockTypes = [];
 		installedBlockTypes.forEach( ( blockType ) => {
-			if ( ! hasBlockType( blockType, usedBlockTypes ) ) {
+			if ( ! hasBlockType( blockType, usedBlockTree ) ) {
 				newBlockTypes.push( blockType );
 			}
 		} );

--- a/packages/block-directory/src/store/selectors.js
+++ b/packages/block-directory/src/store/selectors.js
@@ -1,4 +1,14 @@
 /**
+ * WordPress dependencies
+ */
+import { createRegistrySelector } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import hasBlockType from './utils/has-block-type';
+
+/**
  * Returns true if application is requesting for downloadable blocks.
  *
  * @param {Object} state Global application state.
@@ -45,6 +55,54 @@ export function hasInstallBlocksPermission( state ) {
 export function getInstalledBlockTypes( state ) {
 	return state.blockManagement.installedBlockTypes;
 }
+
+/**
+ * Returns block types that have been installed on the server and used in the
+ * current post.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {Array} Block type items.
+ */
+export const getNewBlockTypes = createRegistrySelector(
+	( select ) => ( state ) => {
+		const usedBlockTypes = select( 'core/block-editor' ).getBlocks();
+		const installedBlockTypes = getInstalledBlockTypes( state );
+
+		const newBlockTypes = [];
+		installedBlockTypes.forEach( ( blockType ) => {
+			if ( hasBlockType( blockType, usedBlockTypes ) ) {
+				newBlockTypes.push( blockType );
+			}
+		} );
+
+		return newBlockTypes;
+	}
+);
+
+/**
+ * Returns the block types that have been installed on the server but are not
+ * used in the current post.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {Array} Block type items.
+ */
+export const getUnusedBlockTypes = createRegistrySelector(
+	( select ) => ( state ) => {
+		const usedBlockTypes = select( 'core/block-editor' ).getBlocks();
+		const installedBlockTypes = getInstalledBlockTypes( state );
+
+		const newBlockTypes = [];
+		installedBlockTypes.forEach( ( blockType ) => {
+			if ( ! hasBlockType( blockType, usedBlockTypes ) ) {
+				newBlockTypes.push( blockType );
+			}
+		} );
+
+		return newBlockTypes;
+	}
+);
 
 /**
  * Returns true if application is calling install endpoint.

--- a/packages/block-directory/src/store/test/actions.js
+++ b/packages/block-directory/src/store/test/actions.js
@@ -135,7 +135,7 @@ describe( 'actions', () => {
 				type: 'API_FETCH',
 			} );
 
-			expect( generator.next( { success: true } ).value ).toEqual( {
+			expect( generator.next( true ).value ).toEqual( {
 				type: 'REMOVE_INSTALLED_BLOCK_TYPE',
 				item,
 			} );

--- a/packages/block-directory/src/store/test/actions.js
+++ b/packages/block-directory/src/store/test/actions.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { installBlockType } from '../actions';
+import { installBlockType, uninstallBlockType } from '../actions';
 
 describe( 'actions', () => {
 	const item = {
@@ -122,6 +122,50 @@ describe( 'actions', () => {
 
 			expect( generator.next() ).toEqual( {
 				value: false,
+				done: true,
+			} );
+		} );
+	} );
+
+	describe( 'uninstallBlockType', () => {
+		it( 'should uninstall a block successfully', () => {
+			const generator = uninstallBlockType( item );
+
+			expect( generator.next().value ).toMatchObject( {
+				type: 'API_FETCH',
+			} );
+
+			expect( generator.next( { success: true } ).value ).toEqual( {
+				type: 'REMOVE_INSTALLED_BLOCK_TYPE',
+				item,
+			} );
+
+			expect( generator.next() ).toEqual( {
+				value: undefined,
+				done: true,
+			} );
+		} );
+
+		it( "should set a global notice if the plugin can't uninstall", () => {
+			const generator = uninstallBlockType( item );
+
+			expect( generator.next().value ).toMatchObject( {
+				type: 'API_FETCH',
+			} );
+
+			const apiError = {
+				code: 'could_not_remove_plugin',
+				message: 'Could not fully remove the plugin .',
+				data: null,
+			};
+			expect( generator.next( apiError ).value ).toMatchObject( {
+				type: 'DISPATCH',
+				actionName: 'createErrorNotice',
+				storeKey: 'core/notices',
+			} );
+
+			expect( generator.next() ).toEqual( {
+				value: undefined,
 				done: true,
 			} );
 		} );

--- a/packages/block-directory/src/store/test/fixtures/index.js
+++ b/packages/block-directory/src/store/test/fixtures/index.js
@@ -18,7 +18,33 @@ export const downloadableBlock = {
 	humanizedUpdated: '3 months ago',
 };
 
-export const installedItem = {
+export const blockTypeInstalled = {
 	id: 'boxer-block',
 	name: 'boxer/boxer',
 };
+
+export const blockTypeUnused = {
+	id: 'example-block',
+	name: 'fake/unused',
+};
+
+export const blockList = [
+	{
+		clientId: 1,
+		name: 'core/paragraph',
+		attributes: {},
+		innerBlocks: [],
+	},
+	{
+		clientId: 2,
+		name: 'boxer/boxer',
+		attributes: {},
+		innerBlocks: [],
+	},
+	{
+		clientId: 3,
+		name: 'core/heading',
+		attributes: {},
+		innerBlocks: [],
+	},
+];

--- a/packages/block-directory/src/store/test/reducer.js
+++ b/packages/block-directory/src/store/test/reducer.js
@@ -12,7 +12,7 @@ import {
 	errorNotices,
 	hasPermission,
 } from '../reducer';
-import { installedItem, downloadableBlock } from './fixtures';
+import { blockTypeInstalled, downloadableBlock } from './fixtures';
 
 describe( 'state', () => {
 	describe( 'downloadableBlocks()', () => {
@@ -72,7 +72,7 @@ describe( 'state', () => {
 			const initialState = deepFreeze( { installedBlockTypes: [] } );
 			const state = blockManagement( initialState, {
 				type: 'ADD_INSTALLED_BLOCK_TYPE',
-				item: installedItem,
+				item: blockTypeInstalled,
 			} );
 
 			expect( state.installedBlockTypes ).toHaveLength( 1 );
@@ -80,11 +80,11 @@ describe( 'state', () => {
 
 		it( 'should remove item from the installedBlockTypesList', () => {
 			const initialState = deepFreeze( {
-				installedBlockTypes: [ installedItem ],
+				installedBlockTypes: [ blockTypeInstalled ],
 			} );
 			const state = blockManagement( initialState, {
 				type: 'REMOVE_INSTALLED_BLOCK_TYPE',
-				item: installedItem,
+				item: blockTypeInstalled,
 			} );
 
 			expect( state.installedBlockTypes ).toHaveLength( 0 );

--- a/packages/block-directory/src/store/test/selectors.js
+++ b/packages/block-directory/src/store/test/selectors.js
@@ -1,12 +1,19 @@
 /**
  * Internal dependencies
  */
-import { downloadableBlock } from './fixtures';
+import {
+	blockList,
+	blockTypeInstalled,
+	blockTypeUnused,
+	downloadableBlock,
+} from './fixtures';
 import {
 	getDownloadableBlocks,
 	getErrorNotices,
 	getErrorNoticeForBlock,
 	getInstalledBlockTypes,
+	getNewBlockTypes,
+	getUnusedBlockTypes,
 	isInstalling,
 } from '../selectors';
 
@@ -21,6 +28,76 @@ describe( 'selectors', () => {
 			};
 			const installedBlockTypes = getInstalledBlockTypes( state );
 			expect( installedBlockTypes ).toEqual( blockTypes );
+		} );
+	} );
+
+	describe( 'getNewBlockTypes', () => {
+		it( 'should retrieve the block types that are installed and in the post content', () => {
+			getNewBlockTypes.registry = {
+				select: jest.fn( () => ( { getBlocks: () => blockList } ) ),
+			};
+			const state = {
+				blockManagement: {
+					installedBlockTypes: [
+						blockTypeInstalled,
+						blockTypeUnused,
+					],
+				},
+			};
+			const blockTypes = getNewBlockTypes( state );
+			expect( blockTypes ).toHaveLength( 1 );
+			expect( blockTypes[ 0 ] ).toEqual( blockTypeInstalled );
+		} );
+
+		it( 'should return an empty array if no blocks are used', () => {
+			getNewBlockTypes.registry = {
+				select: jest.fn( () => ( { getBlocks: () => [] } ) ),
+			};
+			const state = {
+				blockManagement: {
+					installedBlockTypes: [
+						blockTypeInstalled,
+						blockTypeUnused,
+					],
+				},
+			};
+			const blockTypes = getNewBlockTypes( state );
+			expect( blockTypes ).toHaveLength( 0 );
+		} );
+	} );
+
+	describe( 'getUnusedBlockTypes', () => {
+		it( 'should retrieve the block types that are installed but not used', () => {
+			getUnusedBlockTypes.registry = {
+				select: jest.fn( () => ( { getBlocks: () => blockList } ) ),
+			};
+			const state = {
+				blockManagement: {
+					installedBlockTypes: [
+						blockTypeInstalled,
+						blockTypeUnused,
+					],
+				},
+			};
+			const blockTypes = getUnusedBlockTypes( state );
+			expect( blockTypes ).toHaveLength( 1 );
+			expect( blockTypes[ 0 ] ).toEqual( blockTypeUnused );
+		} );
+
+		it( 'should return all block types if no blocks are used', () => {
+			getUnusedBlockTypes.registry = {
+				select: jest.fn( () => ( { getBlocks: () => [] } ) ),
+			};
+			const state = {
+				blockManagement: {
+					installedBlockTypes: [
+						blockTypeInstalled,
+						blockTypeUnused,
+					],
+				},
+			};
+			const blockTypes = getUnusedBlockTypes( state );
+			expect( blockTypes ).toHaveLength( 2 );
 		} );
 	} );
 

--- a/packages/block-directory/src/store/utils/has-block-type.js
+++ b/packages/block-directory/src/store/utils/has-block-type.js
@@ -1,0 +1,24 @@
+/**
+ * Check if a block list contains a specific block type. Recursively searches
+ * through `innerBlocks` if they exist.
+ *
+ * @param {Object} blockType A block object to search for.
+ * @param {Object[]} blocks  The list of blocks to look through.
+ *
+ * @return {boolean} Whether the blockType is found.
+ */
+export default function hasBlockType( blockType, blocks = [] ) {
+	if ( ! blocks.length ) {
+		return false;
+	}
+	if ( blocks.some( ( { name } ) => name === blockType.name ) ) {
+		return true;
+	}
+	for ( let i = 0; i < blocks.length; i++ ) {
+		if ( hasBlockType( blockType, blocks[ i ].innerBlocks ) ) {
+			return true;
+		}
+	}
+
+	return false;
+}

--- a/packages/block-directory/src/store/utils/test/has-block-type.js
+++ b/packages/block-directory/src/store/utils/test/has-block-type.js
@@ -1,0 +1,42 @@
+/**
+ * Internal dependencies
+ */
+import {
+	blockList,
+	blockTypeInstalled,
+	blockTypeUnused,
+} from '../../test/fixtures';
+import hasBlockType from '../has-block-type';
+
+describe( 'hasBlockType', () => {
+	it( 'should find the block', () => {
+		const found = hasBlockType( blockTypeInstalled, blockList );
+		expect( found ).toBe( true );
+	} );
+
+	it( 'should not find the unused block', () => {
+		const found = hasBlockType( blockTypeUnused, blockList );
+		expect( found ).toBe( false );
+	} );
+
+	it( 'should find the block in innerBlocks', () => {
+		const innerBlockList = [
+			...blockList,
+			{
+				clientId: 4,
+				name: 'core/cover',
+				attributes: {},
+				innerBlocks: [
+					{
+						clientId: 5,
+						name: blockTypeUnused.name,
+						attributes: {},
+						innerBlocks: [],
+					},
+				],
+			},
+		];
+		const found = hasBlockType( blockTypeUnused, innerBlockList );
+		expect( found ).toBe( true );
+	} );
+} );


### PR DESCRIPTION
## Description
This pulls the rest of #22452 out, which uninstalls any block plugins that were installed from the block directory but not used in this post. See conversation in #22307 for more robust ideas, but this gets the work started with a basic implementation.

The new `AutoBlockUninstaller` component looks through the list of installed blocks (saved in state, `getInstalledBlockTypes`) and filters out any that are not used in the current post. On save, if the post is not published, it loops through this unused block list, and removes those plugins & unregisters the blocks.

The uninstall action is run on every save (except autosaves). The original intent was to be run only on publish, but I think this works better — if you save a draft without using Block A, it gets uninstalled. If you want to use that block after all, you can reinstall it. This approach also avoids leaving plugins in a half-installed state, where abandoned drafts are keeping some plugins installed-but-invisible.

Unfortunately someone can still use the plugin in another post concurrently with this one, otherwise the whole persistence issue would be solved 😆

## How has this been tested?
Install a few blocks from the block directory, and use some in your post. Before saving, open the plugins list in a new tab (or list via wp-cli). All those plugins are installed. Save your post, it should save correctly, no errors. Reload the plugins list, the blocks that weren't used should be removed.

If there was an error uninstalling, it will display a notice in the editor.

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->

