### PR TITLE
Add isDestructive style to Button

### DIFF
--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -20,7 +20,7 @@ $light-gray-placeholder: rgba($white, 0.65);
 
 // Alert colors.
 $alert-yellow: #f0b849;
-$alert-red: #d94f4f;
+$alert-red: #cc1818;
 $alert-green: #4ab866;
 
 

--- a/packages/components/src/button/stories/index.js
+++ b/packages/components/src/button/stories/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { text, number } from '@storybook/addon-knobs';
+import { text, number, boolean } from '@storybook/addon-knobs';
 
 /**
  * WordPress dependencies
@@ -43,6 +43,18 @@ export const tertiary = () => {
 	const label = text( 'Label', 'Tertiary Button' );
 
 	return <Button isTertiary>{ label }</Button>;
+};
+
+export const isDestructive = () => {
+	const label = text( 'Label', 'Destructive Button' );
+	const isSmall = boolean( 'isSmall', false );
+	const disabled = boolean( 'disabled', false );
+
+	return (
+		<Button isDestructive isSmall={ isSmall } disabled={ disabled }>
+			{ label }
+		</Button>
+	);
 };
 
 export const small = () => {

--- a/packages/components/src/button/stories/index.js
+++ b/packages/components/src/button/stories/index.js
@@ -105,6 +105,16 @@ export const disabledLink = () => {
 	);
 };
 
+export const destructiveLink = () => {
+	const label = text( 'Label', 'Destructive Link' );
+
+	return (
+		<Button isDestructive isLink>
+			{ label }
+		</Button>
+	);
+};
+
 export const icon = () => {
 	const usedIcon = text( 'Icon', 'ellipsis' );
 	const label = text( 'Label', 'More' );

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -194,25 +194,31 @@
 		}
 	}
 
+	// Link buttons that are red to indicate destructive behavior.
+	&.is-link.is-destructive {
+	  color: #b52727;
+	}
+
 	/**
 	 * Buttons that indicate destructive actions.
 	 */
 
 	&.is-destructive {
-		color: darken($alert-red, 15%);
+		color: $alert-red;
+		box-shadow: inset 0 0 0 $border-width $alert-red;
 
 		&.is-secondary {
-			box-shadow: inset 0 0 0 $border-width darken($alert-red, 15%);
+		  	box-shadow: inset 0 0 0 $border-width darken($alert-red, 15%);
 		}
 
 		&:hover:not(:disabled),
 		&:active:not(:disabled) {
 			color: darken($alert-red, 20%);
-			box-shadow: inset 0 0 0 $border-width darken($alert-red, 20%);
+		  	box-shadow: inset 0 0 0 $border-width darken($alert-red, 20%);
 		}
 
 		&:focus:not(:disabled) {
-			box-shadow: inset 0 0 0 1px $white, 0 0 0 $border-width-focus darken($alert-red, 20%);
+		  	color: $blue-medium-900;
 		}
 	}
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -160,46 +160,6 @@
 	}
 
 	/**
-	 * Link buttons.
-	 */
-
-	&.is-link {
-		margin: 0;
-		padding: 0;
-		box-shadow: none;
-		border: 0;
-		border-radius: 0;
-		background: none;
-		outline: none;
-		text-align: left;
-		/* Mimics the default link style in common.css */
-		color: #0073aa;
-		text-decoration: underline;
-		transition-property: border, background, color;
-		transition-duration: 0.05s;
-		transition-timing-function: ease-in-out;
-		@include reduce-motion("transition");
-		height: auto;
-
-		&:hover:not(:disabled),
-		&:active:not(:disabled) {
-			color: #00a0d2;
-		}
-
-		&:focus {
-			color: #124964;
-			box-shadow:
-				0 0 0 $border-width #5b9dd9,
-				0 0 $border-width-focus $border-width rgba(30, 140, 190, 0.8);
-		}
-	}
-
-	// Link buttons that are red to indicate destructive behavior.
-	&.is-link.is-destructive {
-		color: $alert-red;
-	}
-
-	/**
 	 * Destructive buttons.
 	 */
 
@@ -230,6 +190,57 @@
 			background: lighten($light-gray-tertiary, 5%);
 			transform: none;
 			box-shadow: inset 0 0 0 $border-width $dark-gray-200;
+		}
+	}
+
+	/**
+	 * Link buttons.
+	 */
+
+	&.is-link {
+		margin: 0;
+		padding: 0;
+		box-shadow: none;
+		border: 0;
+		border-radius: 0;
+		background: none;
+		outline: none;
+		text-align: left;
+		/* Mimics the default link style in common.css */
+		color: #0073aa;
+		text-decoration: underline;
+		transition-property: border, background, color;
+		transition-duration: 0.05s;
+		transition-timing-function: ease-in-out;
+		@include reduce-motion("transition");
+		height: auto;
+
+		&:hover:not(:disabled),
+		&:active:not(:disabled) {
+			color: #00a0d2;
+			box-shadow: none;
+		}
+
+		&:focus {
+			color: #124964;
+			box-shadow:
+				0 0 0 $border-width #5b9dd9,
+				0 0 $border-width-focus $border-width rgba(30, 140, 190, 0.8);
+		}
+
+		// Link buttons that are red to indicate destructive behavior.
+		&.is-destructive {
+			color: $alert-red;
+
+			&:active:not(:disabled),
+			&:hover:not(:disabled) {
+				color: darken($alert-red, 20%);
+				background: none;
+			}
+
+			&:focus:not(:disabled) {
+				color: $blue-medium-900;
+			}
 		}
 	}
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -196,29 +196,40 @@
 
 	// Link buttons that are red to indicate destructive behavior.
 	&.is-link.is-destructive {
-	  color: #b52727;
+		color: $alert-red;
 	}
 
 	/**
-	 * Buttons that indicate destructive actions.
+	 * Destructive buttons.
 	 */
 
 	&.is-destructive {
 		color: $alert-red;
 		box-shadow: inset 0 0 0 $border-width $alert-red;
 
-		&.is-secondary {
-		  	box-shadow: inset 0 0 0 $border-width darken($alert-red, 15%);
-		}
-
-		&:hover:not(:disabled),
-		&:active:not(:disabled) {
+		&:hover:not(:disabled) {
 			color: darken($alert-red, 20%);
-		  	box-shadow: inset 0 0 0 $border-width darken($alert-red, 20%);
+			box-shadow: inset 0 0 0 $border-width darken($alert-red, 20%);
 		}
 
 		&:focus:not(:disabled) {
-		  	color: $blue-medium-900;
+			color: $blue-medium-900;
+			box-shadow: 0 0 0 $border-width-focus $blue-dark-900;
+		}
+
+		&:active:not(:disabled) {
+			background: $light-gray-tertiary;
+			color: color($theme-color shade(10%));
+			box-shadow: inset 0 0 0 $border-width $dark-gray-200;
+		}
+
+		&:disabled,
+		&[aria-disabled="true"],
+		&[aria-disabled="true"]:hover {
+			color: lighten($medium-gray-text, 5%);
+			background: lighten($light-gray-tertiary, 5%);
+			transform: none;
+			box-shadow: inset 0 0 0 $border-width $dark-gray-200;
 		}
 	}
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -173,11 +173,11 @@
 		}
 
 		&:focus:not(:disabled) {
-			color: $theme-color;
+			color: var(--wp-admin-theme-color);
 		}
 
 		&:active:not(:disabled) {
-			background: $light-gray-tertiary;
+			background: $light-gray-600;
 		}
 	}
 
@@ -227,7 +227,7 @@
 			}
 
 			&:focus:not(:disabled) {
-				color: $blue-medium-900;
+				color: var(--wp-admin-theme-color);
 			}
 		}
 	}

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -173,23 +173,11 @@
 		}
 
 		&:focus:not(:disabled) {
-			color: $blue-medium-900;
-			box-shadow: 0 0 0 $border-width-focus $blue-dark-900;
+			color: $theme-color;
 		}
 
 		&:active:not(:disabled) {
 			background: $light-gray-tertiary;
-			color: color($theme-color shade(10%));
-			box-shadow: inset 0 0 0 $border-width $dark-gray-200;
-		}
-
-		&:disabled,
-		&[aria-disabled="true"],
-		&[aria-disabled="true"]:hover {
-			color: lighten($medium-gray-text, 5%);
-			background: lighten($light-gray-tertiary, 5%);
-			transform: none;
-			box-shadow: inset 0 0 0 $border-width $dark-gray-200;
 		}
 	}
 


### PR DESCRIPTION
## Description

Fixes #18674.

Add style for button component with the isDestructive props. I follow the figma design find on the issue #18674 

## How has this been tested?
This is just adding style, not removing any. A did test by looking a the new style on my local instalation 

## Screenshots 
isDestructive : 
<img width="83" alt="isDestructive" src="https://user-images.githubusercontent.com/1626370/83807750-db7d4c00-a6b3-11ea-843a-b64c874c1fc5.png">

isDestructive hover : 
<img width="74" alt="isDestructive-hover" src="https://user-images.githubusercontent.com/1626370/83807758-dcae7900-a6b3-11ea-95a9-a99989e09710.png">

isDestructive focus : 
<img width="82" alt="isDestructive-focus" src="https://user-images.githubusercontent.com/1626370/83807756-dcae7900-a6b3-11ea-877a-30ca62fc58c8.png">

isDestructive active : 
<img width="78" alt="isDestructive-active" src="https://user-images.githubusercontent.com/1626370/83807753-dc15e280-a6b3-11ea-8089-a66022eb1920.png">

isDestructive disabled : 
<img width="82" alt="isDestructive-disabled" src="https://user-images.githubusercontent.com/1626370/83807755-dc15e280-a6b3-11ea-8eba-ba068e35c8b4.png">


## Types of changes
Add CSS Style

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
