### PR TITLE
Edit Site: Add theme exporter.

### DIFF
--- a/lib/edit-site-export.php
+++ b/lib/edit-site-export.php
@@ -9,7 +9,7 @@
  * Output a ZIP file with an export of the current templates
  * and template parts from the site editor, and close the connection.
  */
-function edit_site_export() {
+function gutenberg_edit_site_export() {
 	// Create ZIP file and directories.
 	$filename = tempnam( get_temp_dir(), 'edit-site-export' );
 	$zip      = new ZipArchive();
@@ -50,11 +50,11 @@ add_action(
 	'rest_api_init',
 	function () {
 		register_rest_route(
-			'edit-site/v1',
+			'__experimental/edit-site/v1',
 			'/export',
 			array(
 				'methods'             => 'GET',
-				'callback'            => 'edit_site_export',
+				'callback'            => 'gutenberg_edit_site_export',
 				'permission_callback' => function () {
 					return current_user_can( 'edit_theme_options' );
 				},

--- a/lib/edit-site-export.php
+++ b/lib/edit-site-export.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * REST endpoint for exporting the contents of the Edit Site Page editor.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Output a ZIP file with an export of the current templates
+ * and template parts from the site editor, and close the connection.
+ */
+function edit_site_export() {
+	// Create ZIP file and directories.
+	$filename = tempnam( get_temp_dir(), 'edit-site-export' );
+	$zip      = new ZipArchive();
+	$zip->open( $filename, ZipArchive::OVERWRITE );
+	$zip->addEmptyDir( 'theme' );
+	$zip->addEmptyDir( 'theme/block-templates' );
+	$zip->addEmptyDir( 'theme/block-template-parts' );
+
+	// Load files into ZIP file.
+	foreach ( get_template_types() as $template_type ) {
+		// Skip 'embed' for now because it is not a regular template type.
+		// Skip 'index' because it's a fallback that we handle differently.
+		if ( in_array( $template_type, array( 'embed', 'index' ), true ) ) {
+			continue;
+		}
+
+		$current_template = gutenberg_find_template_post_and_parts( $template_type );
+		if ( isset( $current_template ) ) {
+			$zip->addFromString( 'theme/block-templates/' . $current_template['template_post']->post_name . '.html', $current_template['template_post']->post_content );
+
+			foreach ( $current_template['template_part_ids'] as $template_part_id ) {
+				$template_part = get_post( $template_part_id );
+				$zip->addFromString( 'theme/block-template-parts/' . $template_part->post_name . '.html', $template_part->post_content );
+			}
+		}
+	}
+
+	// Send back the ZIP file.
+	$zip->close();
+	header( 'Content-Type: application/zip' );
+	header( 'Content-Disposition: attachment; filename=edit-site-export.zip' );
+	header( 'Content-Length: ' . filesize( $filename ) );
+	flush();
+	echo readfile( $filename );
+	die();
+}
+add_action(
+	'rest_api_init',
+	function () {
+		register_rest_route(
+			'edit-site/v1',
+			'/export',
+			array(
+				'methods'             => 'GET',
+				'callback'            => 'edit_site_export',
+				'permission_callback' => function () {
+					return current_user_can( 'edit_theme_options' );
+				},
+			)
+		);
+	}
+);

--- a/lib/load.php
+++ b/lib/load.php
@@ -100,5 +100,6 @@ require dirname( __FILE__ ) . '/navigation-page.php';
 require dirname( __FILE__ ) . '/experiments-page.php';
 require dirname( __FILE__ ) . '/customizer.php';
 require dirname( __FILE__ ) . '/edit-site-page.php';
+require dirname( __FILE__ ) . '/edit-site-export.php';
 require dirname( __FILE__ ) . '/editor-features.php';
 require dirname( __FILE__ ) . '/global-styles.php';

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -321,7 +321,7 @@ function gutenberg_find_template_post_and_parts( $template_type, $template_hiera
 
 	if ( $current_template_post ) {
 		$template_part_ids = array();
-		if ( is_admin() ) {
+		if ( is_admin() || defined( 'REST_REQUEST' ) ) {
 			foreach ( parse_blocks( $current_template_post->post_content ) as $block ) {
 				$template_part_ids = array_merge( $template_part_ids, create_auto_draft_for_template_part_block( $block ) );
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10649,6 +10649,7 @@
 				"@wordpress/plugins": "file:packages/plugins",
 				"@wordpress/primitives": "file:packages/primitives",
 				"@wordpress/url": "file:packages/url",
+				"downloadjs": "^1.4.7",
 				"file-saver": "^2.0.2",
 				"jszip": "^3.2.2",
 				"lodash": "^4.17.15",
@@ -17545,6 +17546,11 @@
 			"requires": {
 				"dotenv-defaults": "^1.0.2"
 			}
+		},
+		"downloadjs": {
+			"version": "1.4.7",
+			"resolved": "https://registry.npmjs.org/downloadjs/-/downloadjs-1.4.7.tgz",
+			"integrity": "sha1-9p+W+UDg0FU9rCkROYZaPNAQHjw="
 		},
 		"downshift": {
 			"version": "4.0.7",

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -47,6 +47,7 @@
 		"@wordpress/plugins": "file:../plugins",
 		"@wordpress/primitives": "file:../primitives",
 		"@wordpress/url": "file:../url",
+		"downloadjs": "^1.4.7",
 		"file-saver": "^2.0.2",
 		"jszip": "^3.2.2",
 		"lodash": "^4.17.15",

--- a/packages/edit-site/src/plugins/index.js
+++ b/packages/edit-site/src/plugins/index.js
@@ -1,10 +1,16 @@
 /**
+ * External dependencies
+ */
+import downloadjs from 'downloadjs';
+
+/**
  * WordPress dependencies
  */
 import { MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
 import { addQueryArgs } from '@wordpress/url';
+import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
@@ -16,6 +22,29 @@ registerPlugin( 'edit-site', {
 		return (
 			<>
 				<ToolsMoreMenuGroup>
+					<MenuItem
+						role="menuitem"
+						icon="download"
+						onClick={ () =>
+							apiFetch( {
+								path: '/edit-site/v1/export',
+								parse: false,
+							} )
+								.then( ( res ) => res.blob() )
+								.then( ( blob ) =>
+									downloadjs(
+										blob,
+										'edit-site-export.zip',
+										'application/zip'
+									)
+								)
+						}
+						info={ __(
+							'Download your templates and template parts.'
+						) }
+					>
+						{ __( 'Export' ) }
+					</MenuItem>
 					<MenuItem
 						role="menuitem"
 						href={ addQueryArgs( 'edit.php', {

--- a/packages/edit-site/src/plugins/index.js
+++ b/packages/edit-site/src/plugins/index.js
@@ -27,7 +27,7 @@ registerPlugin( 'edit-site', {
 						icon="download"
 						onClick={ () =>
 							apiFetch( {
-								path: '/edit-site/v1/export',
+								path: '/__experimental/edit-site/v1/export',
 								parse: false,
 							} )
 								.then( ( res ) => res.blob() )


### PR DESCRIPTION
Closes #19260 

## Description

This PR adds a theme exporter button to the site editor header's "More" dropdown.

It is like #21958 but implements the zip creation in the server to avoid loading a large zip management library in the client.

## How to test this?

Try exporting templates/parts with different modifications and verify that the exported files match what you have on the editor.

## Screenshots

<img width="308" alt="Screen Shot 2020-06-04 at 4 22 31 PM" src="https://user-images.githubusercontent.com/19157096/83820191-d18e2580-a680-11ea-9ee4-b330f5e62043.png">

## Types of Changes

*New Feature:* The site editor now has a theme exporter button for exporting customized templates and template parts in a theme zip file.

## Checklist:

- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->