### PR TITLE
Fix CustomSelectControl component dropdown arrow spacing

### DIFF
--- a/packages/components/src/custom-select-control/stories/index.js
+++ b/packages/components/src/custom-select-control/stories/index.js
@@ -8,7 +8,7 @@ export default {
 	component: CustomSelectControl,
 };
 
-const options = [
+const defaultOptions = [
 	{
 		key: 'small',
 		name: 'Small',
@@ -31,5 +31,28 @@ const options = [
 	},
 ];
 export const _default = () => (
-	<CustomSelectControl label="Font size" options={ options } />
+	<CustomSelectControl label="Font size" options={ defaultOptions } />
+);
+
+const longLabelOptions = [
+	{
+		key: 'reallylonglabel1',
+		name: 'Really long labels are good for stress testing',
+	},
+	{
+		key: 'reallylonglabel2',
+		name: 'But they can take a long time to type.',
+	},
+	{
+		key: 'reallylonglabel3',
+		name:
+			'That really is ok though because you should stress test your UIs.',
+	},
+];
+
+export const longLabels = () => (
+	<CustomSelectControl
+		label="Testing long labels"
+		options={ longLabelOptions }
+	/>
 );

--- a/packages/components/src/custom-select-control/style.scss
+++ b/packages/components/src/custom-select-control/style.scss
@@ -19,7 +19,7 @@
 	// For all button sizes allow sufficient space for the
 	// dropdown "arrow" icon to display.
 	&.components-custom-select-control__button {
-		padding-right: $icon_width;
+		padding-right: $icon-size;
 	}
 
 	&:focus:not(:disabled) {

--- a/packages/components/src/custom-select-control/style.scss
+++ b/packages/components/src/custom-select-control/style.scss
@@ -1,5 +1,3 @@
-$icon_width: 24px;
-
 .components-custom-select-control {
 	position: relative;
 }

--- a/packages/components/src/custom-select-control/style.scss
+++ b/packages/components/src/custom-select-control/style.scss
@@ -1,3 +1,5 @@
+$icon_width: 24px;
+
 .components-custom-select-control {
 	position: relative;
 }
@@ -15,6 +17,12 @@
 	min-width: 130px;
 	position: relative;
 	text-align: left;
+
+	// For all button sizes allow sufficient space for the
+	// dropdown "arrow" icon to display.
+	&.components-custom-select-control__button {
+		padding-right: $icon_width;
+	}
 
 	&:focus:not(:disabled) {
 		border-color: $theme-color;


### PR DESCRIPTION
This PR fixes an issue identified in https://github.com/WordPress/gutenberg/pull/18869#discussion_r435126329 whereby if the selected option in a  `CustomSelectControl` component is a particularly long string then if overlays the down arrow icon.

![Screen Shot 2020-06-05 at 08 08 18](https://user-images.githubusercontent.com/444434/83847917-f88e3b00-a704-11ea-8d32-b3506437590f.png)

This PR adds sufficient padding to the RHS of the control to ensure the icon has room to display (see fix below).

![Screen Shot 2020-06-05 at 08 12 47](https://user-images.githubusercontent.com/444434/83847975-0e036500-a705-11ea-8e67-9c7b12a8a923.png)


## How has this been tested?
* Added Storybook story.
* Visually verified issue fixed.

## Testing Instructions

#### On Master
* Go to [latest Storybook for `CustomSelectControl`.](https://wordpress.github.io/gutenberg/?path=/story/components-customselectcontrol--default).
* Select an option from the control dropdown.
* Using devtools amend the select option text to a really long string (see screencapture below for instructions on how to do this).
* See dropdown arrow is overlayed by the text.

![Screen Capture on 2020-06-05 at 08-22-16](https://user-images.githubusercontent.com/444434/83848510-e52f9f80-a705-11ea-90d7-7a815dd91dbf.gif)

#### On this PR

* Checkout PR and build Gutenberg `npm run dev`.
* Run local Storybook - `npm run storybook:dev`.
* Navigate to `CustomSelectControl` stories in Storybook. Chose the "Long labels" story.
* See that despite using really long option labels the arrow is _**not**_ overlayed by the option text.


## Types of changes
Bug fix (non-breaking change which fixes an issue).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
