### PR TITLE
Revert - add selectionStart and selectionEnd to transientEdits

### DIFF
--- a/packages/editor/src/components/provider/index.native.js
+++ b/packages/editor/src/components/provider/index.native.js
@@ -34,8 +34,6 @@ const postTypeEntities = [
 	...postTypeEntity,
 	transientEdits: {
 		blocks: true,
-		selectionStart: true,
-		selectionEnd: true,
 	},
 	mergedEdits: {
 		meta: true,

--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -6,7 +6,7 @@
 import RCTAztecView from 'react-native-aztec';
 import { View, Platform } from 'react-native';
 import { addMention } from 'react-native-gutenberg-bridge';
-import { get, pickBy, debounce } from 'lodash';
+import { get, pickBy } from 'lodash';
 import memize from 'memize';
 
 /**
@@ -88,7 +88,7 @@ export class RichText extends Component {
 		this.formatToValue = memize( this.formatToValue.bind( this ), {
 			maxSize: 1,
 		} );
-		this.debounceCreateUndoLevel = debounce( this.onCreateUndoLevel, 1000 );
+
 		// This prevents a bug in Aztec which triggers onSelectionChange twice on format change
 		this.onSelectionChange = this.onSelectionChange.bind( this );
 		this.onSelectionChangeFromAztec = this.onSelectionChangeFromAztec.bind(
@@ -276,7 +276,7 @@ export class RichText extends Component {
 		const contentWithoutRootTag = this.removeRootTagsProduceByAztec(
 			unescapeSpaces( event.nativeEvent.text )
 		);
-		this.debounceCreateUndoLevel();
+
 		const refresh = this.value !== contentWithoutRootTag;
 		this.value = contentWithoutRootTag;
 


### PR DESCRIPTION
This PR reverts changes that introduced a regression described here: https://github.com/wordpress-mobile/gutenberg-mobile/issues/2349

Guntenberg-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2353

## How has this been tested?
- Run WP-iOS app
- type something really fast and press publish
- the correct version should be published

## Types of changes
Revert changes that introduced a regression

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
