### PR TITLE
Add caption split at end to all caption blocks

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -385,6 +385,7 @@ function RichTextWrapper(
 			__unstableMarkAutomaticChange,
 			multiline,
 			splitValue,
+			onSplitAtEnd,
 		]
 	);
 

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -22,6 +22,7 @@ import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { audio as icon } from '@wordpress/icons';
+import { createBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -37,6 +38,7 @@ function AudioEdit( {
 	onReplace,
 	isSelected,
 	noticeUI,
+	insertBlocksAfter,
 } ) {
 	const { id, autoplay, caption, loop, preload, src } = attributes;
 
@@ -190,6 +192,9 @@ function AudioEdit( {
 							setAttributes( { caption: value } )
 						}
 						inlineToolbar
+						__unstableOnSplitAtEnd={ () =>
+							insertBlocksAfter( createBlock( 'core/paragraph' ) )
+						}
 					/>
 				) }
 			</Block.figure>

--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -175,6 +175,7 @@ export function getEmbedEditComponent(
 				cannotEmbed,
 				themeSupportsResponsive,
 				tryAgain,
+				insertBlocksAfter,
 			} = this.props;
 
 			if ( fetching ) {
@@ -241,6 +242,7 @@ export function getEmbedEditComponent(
 						isSelected={ isSelected }
 						icon={ icon }
 						label={ label }
+						insertBlocksAfter={ insertBlocksAfter }
 					/>
 				</>
 			);

--- a/packages/block-library/src/embed/embed-preview.js
+++ b/packages/block-library/src/embed/embed-preview.js
@@ -15,6 +15,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { Placeholder, SandBox } from '@wordpress/components';
 import { RichText, BlockIcon } from '@wordpress/block-editor';
 import { Component } from '@wordpress/element';
+import { createBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -62,6 +63,7 @@ class EmbedPreview extends Component {
 			className,
 			icon,
 			label,
+			insertBlocksAfter,
 		} = this.props;
 		const { scripts } = preview;
 		const { interactive } = this.state;
@@ -142,6 +144,9 @@ class EmbedPreview extends Component {
 						value={ caption }
 						onChange={ onCaptionChange }
 						inlineToolbar
+						__unstableOnSplitAtEnd={ () =>
+							insertBlocksAfter( createBlock( 'core/paragraph' ) )
+						}
 					/>
 				) }
 			</figure>

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -334,7 +334,13 @@ class GalleryEdit extends Component {
 	}
 
 	render() {
-		const { attributes, className, isSelected, noticeUI } = this.props;
+		const {
+			attributes,
+			className,
+			isSelected,
+			noticeUI,
+			insertBlocksAfter,
+		} = this.props;
 		const {
 			columns = defaultColumnsNumber( attributes ),
 			imageCrop,
@@ -425,6 +431,7 @@ class GalleryEdit extends Component {
 					onDeselectImage={ this.onDeselectImage }
 					onSetImageAttributes={ this.setImageAttributes }
 					onFocusGalleryCaption={ this.onFocusGalleryCaption }
+					insertBlocksAfter={ insertBlocksAfter }
 				/>
 			</>
 		);

--- a/packages/block-library/src/gallery/gallery.js
+++ b/packages/block-library/src/gallery/gallery.js
@@ -9,6 +9,7 @@ import classnames from 'classnames';
 import { RichText } from '@wordpress/block-editor';
 import { VisuallyHidden } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
+import { createBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -31,6 +32,7 @@ export const Gallery = ( props ) => {
 		onDeselectImage,
 		onSetImageAttributes,
 		onFocusGalleryCaption,
+		insertBlocksAfter,
 	} = props;
 
 	const {
@@ -97,6 +99,9 @@ export const Gallery = ( props ) => {
 				unstableOnFocus={ onFocusGalleryCaption }
 				onChange={ ( value ) => setAttributes( { caption: value } ) }
 				inlineToolbar
+				__unstableOnSplitAtEnd={ () =>
+					insertBlocksAfter( createBlock( 'core/paragraph' ) )
+				}
 			/>
 		</figure>
 	);

--- a/packages/block-library/src/pullquote/edit.js
+++ b/packages/block-library/src/pullquote/edit.js
@@ -16,6 +16,8 @@ import {
 	withColors,
 	PanelColorSettings,
 } from '@wordpress/block-editor';
+import { createBlock } from '@wordpress/blocks';
+
 /**
  * Internal dependencies
  */
@@ -103,6 +105,7 @@ class PullQuoteEdit extends Component {
 			setAttributes,
 			isSelected,
 			className,
+			insertBlocksAfter,
 		} = this.props;
 
 		const { value, citation } = attributes;
@@ -165,6 +168,11 @@ class PullQuoteEdit extends Component {
 								className="wp-block-pullquote__citation"
 								__unstableMobileNoFocusOnMount
 								textAlign="center"
+								__unstableOnSplitAtEnd={ () =>
+									insertBlocksAfter(
+										createBlock( 'core/paragraph' )
+									)
+								}
 							/>
 						) }
 					</BlockQuote>

--- a/packages/block-library/src/quote/edit.js
+++ b/packages/block-library/src/quote/edit.js
@@ -22,6 +22,7 @@ export default function QuoteEdit( {
 	mergeBlocks,
 	onReplace,
 	className,
+	insertBlocksAfter,
 } ) {
 	const { align, value, citation } = attributes;
 
@@ -89,6 +90,9 @@ export default function QuoteEdit( {
 						}
 						className="wp-block-quote__citation"
 						textAlign={ align }
+						__unstableOnSplitAtEnd={ () =>
+							insertBlocksAfter( createBlock( 'core/paragraph' ) )
+						}
 					/>
 				) }
 			</BlockQuotation>

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -39,6 +39,7 @@ import {
 	tableRowDelete,
 	table,
 } from '@wordpress/icons';
+import { createBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -538,6 +539,7 @@ export class TableEdit extends Component {
 			backgroundColor,
 			setBackgroundColor,
 			setAttributes,
+			insertBlocksAfter,
 		} = this.props;
 		const { initialRowCount, initialColumnCount } = this.state;
 		const { hasFixedLayout, caption, head, body, foot } = attributes;
@@ -663,6 +665,9 @@ export class TableEdit extends Component {
 						// Deselect the selected table cell when the caption is focused.
 						unstableOnFocus={ () =>
 							this.setState( { selectedCell: null } )
+						}
+						__unstableOnSplitAtEnd={ () =>
+							insertBlocksAfter( createBlock( 'core/paragraph' ) )
 						}
 					/>
 				</figure>

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -25,6 +25,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { compose, withInstanceId } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 import { video as icon } from '@wordpress/icons';
+import { createBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -121,6 +122,7 @@ class VideoEdit extends Component {
 			noticeUI,
 			attributes,
 			setAttributes,
+			insertBlocksAfter,
 		} = this.props;
 		const onSelectVideo = ( media ) => {
 			if ( ! media || ! media.url ) {
@@ -245,6 +247,11 @@ class VideoEdit extends Component {
 								setAttributes( { caption: value } )
 							}
 							inlineToolbar
+							__unstableOnSplitAtEnd={ () =>
+								insertBlocksAfter(
+									createBlock( 'core/paragraph' )
+								)
+							}
 						/>
 					) }
 				</Block.figure>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

This was recently added to the image block and should be added to all blocks that have a caption or similar. In the future, it might be nice to add a figure with caption component that can be reused so we don't need to duplicate the same config across multiple blocks.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
