### PR TITLE
Block: remove animation component so it is just a hook

### DIFF
--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -3,7 +3,6 @@
  */
 import classnames from 'classnames';
 import { first, last, omit } from 'lodash';
-import { animated } from 'react-spring/web.cjs';
 
 /**
  * WordPress dependencies
@@ -24,7 +23,10 @@ import { BlockListBlockContext } from './block';
 import ELEMENTS from './block-wrapper-elements';
 
 const BlockComponent = forwardRef(
-	( { children, tagName = 'div', __unstableIsHtml, ...props }, wrapper ) => {
+	(
+		{ children, tagName: TagName = 'div', __unstableIsHtml, ...props },
+		wrapper
+	) => {
 		const onSelectionStart = useContext( Context );
 		const setBlockNodes = useContext( SetBlockNodes );
 		const {
@@ -130,7 +132,7 @@ const BlockComponent = forwardRef(
 		}, [ isSelected, isMultiSelecting, isNavigationMode ] );
 
 		// Block Reordering animation
-		const animationStyle = useMovingAnimation(
+		useMovingAnimation(
 			wrapper,
 			isSelected || isPartOfMultiSelection,
 			isSelected || isFirstMultiSelected,
@@ -188,10 +190,9 @@ const BlockComponent = forwardRef(
 		const htmlSuffix =
 			mode === 'html' && ! __unstableIsHtml ? '-visual' : '';
 		const blockElementId = `block-${ clientId }${ htmlSuffix }`;
-		const Animated = animated[ tagName ];
 
 		const blockWrapper = (
-			<Animated
+			<TagName
 				// Overrideable props.
 				aria-label={ blockLabel }
 				role="group"
@@ -216,11 +217,10 @@ const BlockComponent = forwardRef(
 				style={ {
 					...( wrapperProps ? wrapperProps.style : {} ),
 					...( props.style || {} ),
-					...animationStyle,
 				} }
 			>
 				{ children }
-			</Animated>
+			</TagName>
 		);
 
 		// For aligned blocks, provide a wrapper element so the block can be

--- a/packages/block-editor/src/components/use-moving-animation/index.js
+++ b/packages/block-editor/src/components/use-moving-animation/index.js
@@ -125,7 +125,7 @@ function useMovingAnimation(
 		reset: triggeredAnimation !== finishedAnimation,
 		config: { mass: 5, tension: 2000, friction: 200 },
 		immediate: prefersReducedMotion,
-		onFrame: ( { x, y } ) => {
+		onFrame( { x, y } ) {
 			if (
 				adjustScrolling &&
 				scrollContainer.current &&

--- a/packages/block-editor/src/components/use-moving-animation/index.js
+++ b/packages/block-editor/src/components/use-moving-animation/index.js
@@ -137,11 +137,9 @@ function useMovingAnimation(
 
 			ref.current.style.transformOrigin = 'center';
 			ref.current.style.transform =
-				x === 0 && y === 0
-					? undefined
-					: `translate3d(${ x }px,${ y }px,0)`;
+				x === 0 && y === 0 ? null : `translate3d(${ x }px,${ y }px,0)`;
 			ref.current.style.zIndex =
-				! isSelected || ( x === 0 && y === 0 ) ? undefined : '1';
+				! isSelected || ( x === 0 && y === 0 ) ? null : '1';
 		},
 	} );
 }

--- a/packages/block-editor/src/components/use-moving-animation/index.js
+++ b/packages/block-editor/src/components/use-moving-animation/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useSpring, interpolate } from 'react-spring/web.cjs';
+import { useSpring } from 'react-spring/web.cjs';
 
 /**
  * WordPress dependencies
@@ -46,8 +46,6 @@ const getAbsolutePosition = ( element ) => {
  * @param {boolean} adjustScrolling          Adjust the scroll position to the current block.
  * @param {boolean} enableAnimation          Enable/Disable animation.
  * @param {*}       triggerAnimationOnChange Variable used to trigger the animation if it changes.
- *
- * @return {Object} Style object.
  */
 function useMovingAnimation(
 	ref,
@@ -115,7 +113,7 @@ function useMovingAnimation(
 		setTransform( newTransform );
 	}, [ triggerAnimationOnChange ] );
 
-	const animationProps = useSpring( {
+	useSpring( {
 		from: {
 			x: transform.x,
 			y: transform.y,
@@ -127,37 +125,25 @@ function useMovingAnimation(
 		reset: triggeredAnimation !== finishedAnimation,
 		config: { mass: 5, tension: 2000, friction: 200 },
 		immediate: prefersReducedMotion,
-		onFrame: ( props ) => {
+		onFrame: ( { x, y } ) => {
 			if (
 				adjustScrolling &&
 				scrollContainer.current &&
 				! prefersReducedMotion &&
-				props.y
+				y
 			) {
-				scrollContainer.current.scrollTop =
-					transform.scrollTop + props.y;
+				scrollContainer.current.scrollTop = transform.scrollTop + y;
 			}
+
+			ref.current.style.transformOrigin = 'center';
+			ref.current.style.transform =
+				x === 0 && y === 0
+					? undefined
+					: `translate3d(${ x }px,${ y }px,0)`;
+			ref.current.style.zIndex =
+				! isSelected || ( x === 0 && y === 0 ) ? undefined : '1';
 		},
 	} );
-
-	// Dismiss animations if disabled.
-	return prefersReducedMotion
-		? {}
-		: {
-				transformOrigin: 'center',
-				transform: interpolate(
-					[ animationProps.x, animationProps.y ],
-					( x, y ) =>
-						x === 0 && y === 0
-							? undefined
-							: `translate3d(${ x }px,${ y }px,0)`
-				),
-				zIndex: interpolate(
-					[ animationProps.x, animationProps.y ],
-					( x, y ) =>
-						! isSelected || ( x === 0 && y === 0 ) ? undefined : `1`
-				),
-		  };
 }
 
 export default useMovingAnimation;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

I'm pretty excited about this PR. :) This PR removes the `Animated` component from the block tree by applying styles to the ref on frame instead. This way, the whole animation is now reduced to a simple hook.

For background, see https://github.com/react-spring/react-spring/issues/1042.

Why is this exciting? This could potentially allow us to write a simple `useBlock( ref )` component to be used within blocks. Such a hook would be very flexible to use compared to a component or HoC.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
