### PR TITLE
Fix: Latest posts - display Author

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -449,7 +449,7 @@ class LatestPostsEdit extends Component {
 										__( '(no title)' )
 									) }
 								</a>
-								{ displayAuthor && (
+								{ displayAuthor && currentAuthor && (
 									<div className="wp-block-latest-posts__post-author">
 										{ sprintf(
 											/* translators: byline. %s: current author. */


### PR DESCRIPTION
## Description
If you activate the display author option in the latest posts block, save and reload the editor, the block fails. On the first rendering the author information is not fetched and the `currentAuthor` is `undefined`, so we need to add a check. 

## How has this been tested?
- Add a latest post block
- Activate the display author option
- Save and reload the editor
- Verify the block is not broken