### PR TITLE
Remove withBlockEditContext internal higher-order component

### DIFF
--- a/packages/block-editor/src/components/autocomplete/index.js
+++ b/packages/block-editor/src/components/autocomplete/index.js
@@ -7,15 +7,14 @@ import { clone } from 'lodash';
  * WordPress dependencies
  */
 import { applyFilters, hasFilter } from '@wordpress/hooks';
-import { compose } from '@wordpress/compose';
-import { Autocomplete as OriginalAutocomplete } from '@wordpress/components';
+import { Autocomplete } from '@wordpress/components';
 import { useMemo } from '@wordpress/element';
 import { getDefaultBlockName } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
-import { withBlockEditContext } from '../block-edit/context';
+import { useBlockEditContext } from '../block-edit/context';
 import blockAutocompleter from '../../autocompleters/block';
 
 /**
@@ -27,41 +26,45 @@ import blockAutocompleter from '../../autocompleters/block';
 const EMPTY_ARRAY = [];
 
 /**
- * Wrap the default Autocomplete component with one that
- * supports a filter hook for customizing its list of autocompleters.
+ * Wrap the default Autocomplete component with one that supports a filter hook
+ * for customizing its list of autocompleters.
  *
- * This function is exported for unit test.
- *
- * @param  {Function} Autocomplete Original component.
- * @return {Function}              Wrapped component
+ * @type {import('react').FC}
  */
-export function withFilteredAutocompleters( Autocomplete ) {
-	return ( props ) => {
-		let { completers = EMPTY_ARRAY, blockName } = props;
-		completers = useMemo( () => {
-			if ( blockName === getDefaultBlockName() ) {
-				return completers.concat( [ blockAutocompleter ] );
-			}
-			return completers;
-		}, [ completers, blockName ] );
+function BlockEditorAutocomplete( props ) {
+	const { name } = useBlockEditContext();
+
+	let { completers = EMPTY_ARRAY } = props;
+
+	completers = useMemo( () => {
+		let filteredCompleters = completers;
+
+		if ( name === getDefaultBlockName() ) {
+			filteredCompleters = filteredCompleters.concat( [
+				blockAutocompleter,
+			] );
+		}
 
 		if ( hasFilter( 'editor.Autocomplete.completers' ) ) {
-			completers = applyFilters(
+			// Provide copies so filters may directly modify them.
+			if ( filteredCompleters === completers ) {
+				filteredCompleters = filteredCompleters.map( clone );
+			}
+
+			filteredCompleters = applyFilters(
 				'editor.Autocomplete.completers',
-				// Provide copies so filters may directly modify them.
-				completers.map( clone ),
-				props.blockName
+				filteredCompleters,
+				name
 			);
 		}
 
-		return <Autocomplete { ...props } completers={ completers } />;
-	};
+		return filteredCompleters;
+	}, [ completers, name ] );
+
+	return <Autocomplete { ...props } completers={ completers } />;
 }
 
 /**
  * @see https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/autocomplete/README.md
  */
-export default compose( [
-	withBlockEditContext( ( { name } ) => ( { blockName: name } ) ),
-	withFilteredAutocompleters,
-] )( OriginalAutocomplete );
+export default BlockEditorAutocomplete;

--- a/packages/block-editor/src/components/block-alignment-toolbar/index.js
+++ b/packages/block-editor/src/components/block-alignment-toolbar/index.js
@@ -13,11 +13,6 @@ import {
 	stretchWide,
 } from '@wordpress/icons';
 
-/**
- * Internal dependencies
- */
-import { withBlockEditContext } from '../block-edit/context';
-
 const BLOCK_ALIGNMENTS_CONTROLS = {
 	left: {
 		icon: positionLeft,
@@ -88,11 +83,6 @@ export function BlockAlignmentToolbar( {
 }
 
 export default compose(
-	withBlockEditContext( ( { clientId } ) => {
-		return {
-			clientId,
-		};
-	} ),
 	withSelect( ( select ) => {
 		const { getSettings } = select( 'core/block-editor' );
 		const settings = getSettings();

--- a/packages/block-editor/src/components/block-edit/context.js
+++ b/packages/block-editor/src/components/block-edit/context.js
@@ -7,7 +7,6 @@ import { noop } from 'lodash';
  * WordPress dependencies
  */
 import { createContext, useContext } from '@wordpress/element';
-import { createHigherOrderComponent } from '@wordpress/compose';
 
 const Context = createContext( {
 	name: '',
@@ -16,7 +15,7 @@ const Context = createContext( {
 	setFocusedElement: noop,
 	clientId: null,
 } );
-const { Provider, Consumer } = Context;
+const { Provider } = Context;
 
 export { Provider as BlockEditContextProvider };
 
@@ -28,27 +27,3 @@ export { Provider as BlockEditContextProvider };
 export function useBlockEditContext() {
 	return useContext( Context );
 }
-
-/**
- * A Higher Order Component used to inject BlockEdit context to the
- * wrapped component.
- *
- * @param {Function} mapContextToProps Function called on every context change,
- *                                     expected to return object of props to
- *                                     merge with the component's own props.
- *
- * @return {WPComponent} Enhanced component with injected context as props.
- */
-export const withBlockEditContext = ( mapContextToProps ) =>
-	createHigherOrderComponent( ( OriginalComponent ) => {
-		return ( props ) => (
-			<Consumer>
-				{ ( context ) => (
-					<OriginalComponent
-						{ ...props }
-						{ ...mapContextToProps( context, props ) }
-					/>
-				) }
-			</Consumer>
-		);
-	}, 'withBlockEditContext' );

--- a/packages/block-editor/src/components/inner-blocks/with-client-id.js
+++ b/packages/block-editor/src/components/inner-blocks/with-client-id.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { pick } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { createHigherOrderComponent } from '@wordpress/compose';
@@ -11,13 +6,13 @@ import { createHigherOrderComponent } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import { withBlockEditContext } from '../block-edit/context';
+import { useBlockEditContext } from '../block-edit/context';
 
 const withClientId = createHigherOrderComponent(
-	( WrappedComponent ) =>
-		withBlockEditContext( ( context ) => pick( context, [ 'clientId' ] ) )(
-			WrappedComponent
-		),
+	( WrappedComponent ) => ( props ) => {
+		const { clientId } = useBlockEditContext();
+		return <WrappedComponent { ...props } clientId={ clientId } />;
+	},
 	'withClientId'
 );
 


### PR DESCRIPTION
Related: #22905

This pull request seeks to remove the `withBlockEditContext` internal helper of the `@wordpress/block-editor` package. The motivation here is (a) to flatten the common block React element hierarchy and (b) to favor hooks-based implementations over higher-order components. `withBlockEditContext` was a useful and expressive helper at the time it was originally implemented, due to the cumbersome nature of using React Context `<Consumer>` elements. With `useContext`, it's much simpler now to get direct access to the context object properties relevant for this behavior.

**Testing Instructions:**

Verify no regressions in the behavior of affected components. For example, block-based autocomplete and alignment toolbar.