### PR TITLE
Blocks: Add missing param docs for BlockContentProvider and registerBlockCollection()

### DIFF
--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -632,8 +632,10 @@ Registers a new block collection to group blocks in the same namespace in the in
 
 _Parameters_
 
--   _namespace_ `string`: The namespace to group blocks by in the inserter; corresponds to the block namespace
--   _settings_ `Object`: An object composed of a title to show in the inserter, and an icon to show in the inserter
+-   _namespace_ `string`: The namespace to group blocks by in the inserter; corresponds to the block namespace.
+-   _settings_ `Object`: The block collection settings.
+-   _settings.title_ `string`: The title to display in the block inserter.
+-   _settings.icon_ `Object`: The icon to display in the block inserter.
 
 <a name="registerBlockStyle" href="#registerBlockStyle">#</a> **registerBlockStyle**
 

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -635,7 +635,7 @@ _Parameters_
 -   _namespace_ `string`: The namespace to group blocks by in the inserter; corresponds to the block namespace.
 -   _settings_ `Object`: The block collection settings.
 -   _settings.title_ `string`: The title to display in the block inserter.
--   _settings.icon_ `Object`: The icon to display in the block inserter.
+-   _settings.icon_ `[Object]`: The icon to display in the block inserter.
 
 <a name="registerBlockStyle" href="#registerBlockStyle">#</a> **registerBlockStyle**
 

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -277,10 +277,10 @@ export function registerBlockType( name, settings ) {
 /**
  * Registers a new block collection to group blocks in the same namespace in the inserter.
  *
- * @param {string} namespace The namespace to group blocks by in the inserter; corresponds to the block namespace.
- * @param {Object} settings  The block collection settings.
- * @param {string} settings.title The title to display in the block inserter.
- * @param {Object} settings.icon  The icon to display in the block inserter.
+ * @param {string} namespace       The namespace to group blocks by in the inserter; corresponds to the block namespace.
+ * @param {Object} settings        The block collection settings.
+ * @param {string} settings.title  The title to display in the block inserter.
+ * @param {Object} [settings.icon] The icon to display in the block inserter.
  */
 export function registerBlockCollection( namespace, { title, icon } ) {
 	dispatch( 'core/blocks' ).addBlockCollection( namespace, title, icon );

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -277,9 +277,10 @@ export function registerBlockType( name, settings ) {
 /**
  * Registers a new block collection to group blocks in the same namespace in the inserter.
  *
- * @param {string} namespace The namespace to group blocks by in the inserter; corresponds to the block namespace
- * @param {Object} settings  An object composed of a title to show in the inserter, and an icon to show in the inserter
- *
+ * @param {string} namespace The namespace to group blocks by in the inserter; corresponds to the block namespace.
+ * @param {Object} settings  The block collection settings.
+ * @param {string} settings.title The title to display in the block inserter.
+ * @param {Object} settings.icon  The icon to display in the block inserter.
  */
 export function registerBlockCollection( namespace, { title, icon } ) {
 	dispatch( 'core/blocks' ).addBlockCollection( namespace, title, icon );

--- a/packages/blocks/src/block-content-provider/index.js
+++ b/packages/blocks/src/block-content-provider/index.js
@@ -26,6 +26,10 @@ const { Consumer, Provider } = createContext( () => {} );
  * </BlockContentProvider>
  * ```
  *
+ * @param {Object}    props             Component props.
+ * @param {WPElement} props.children    Block save result.
+ * @param {Array}     props.innerBlocks Block(s) to serialize.
+ *
  * @return {WPComponent} Element with BlockContent injected via context.
  */
 const BlockContentProvider = ( { children, innerBlocks } ) => {


### PR DESCRIPTION
## Description
See #22907.

Fixes the following JSDoc warnings:

```
packages/blocks/src/api/registration.js
  277:1  warning  Missing JSDoc @param "settings.title" declaration  jsdoc/require-param
  277:1  warning  Missing JSDoc @param "settings.icon" declaration   jsdoc/require-param
  281:0  warning  Missing @param "settings.title"                    jsdoc/check-param-names
  281:0  warning  Missing @param "settings.icon"                     jsdoc/check-param-names

packages/blocks/src/block-content-provider/index.js
  14:1  warning  Missing JSDoc @param "root0" declaration              jsdoc/require-param
  14:1  warning  Missing JSDoc @param "root0.children" declaration     jsdoc/require-param
  14:1  warning  Missing JSDoc @param "root0.innerBlocks" declaration  jsdoc/require-param
```

## How has this been tested?
`npm run lint-js packages/blocks/src`

## Types of changes
Bug fix