### PR TITLE
Edit Post: Add missing param docs for PluginBlockSettingsMenuItem and PluginPostStatusInfo.

### DIFF
--- a/packages/edit-post/README.md
+++ b/packages/edit-post/README.md
@@ -95,6 +95,8 @@ _Parameters_
 -   _props.icon_ `[WPBlockTypeIconRender]`: The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug string, or an SVG WP element.
 -   _props.label_ `string`: The menu item text.
 -   _props.onClick_ `Function`: Callback function to be executed when the user click the menu item.
+-   _props.small_ `[boolean]`: Whether to render the label or not.
+-   _props.role_ `[string]`: The ARIA role for the menu item.
 
 _Returns_
 
@@ -311,6 +313,7 @@ _Parameters_
 
 -   _props_ `Object`: Component properties.
 -   _props.className_ `[string]`: An optional class name added to the row.
+-   _props.children_ `WPElement`: Children to be rendered.
 
 _Returns_
 

--- a/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
+++ b/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
@@ -37,6 +37,8 @@ const shouldRenderItem = ( selectedBlocks, allowedBlocks ) =>
  * @param {WPBlockTypeIconRender} [props.icon] The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug string, or an SVG WP element.
  * @param {string} props.label The menu item text.
  * @param {Function} props.onClick Callback function to be executed when the user click the menu item.
+ * @param {boolean} [props.small] Whether to render the label or not.
+ * @param {string} [props.role] The ARIA role for the menu item.
  *
  * @example
  * <caption>ES5</caption>

--- a/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
+++ b/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
@@ -32,13 +32,13 @@ const shouldRenderItem = ( selectedBlocks, allowedBlocks ) =>
 /**
  * Renders a new item in the block settings menu.
  *
- * @param {Object} props Component props.
- * @param {Array} [props.allowedBlocks] An array containing a list of block names for which the item should be shown. If not present, it'll be rendered for any block. If multiple blocks are selected, it'll be shown if and only if all of them are in the whitelist.
- * @param {WPBlockTypeIconRender} [props.icon] The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug string, or an SVG WP element.
- * @param {string} props.label The menu item text.
- * @param {Function} props.onClick Callback function to be executed when the user click the menu item.
- * @param {boolean} [props.small] Whether to render the label or not.
- * @param {string} [props.role] The ARIA role for the menu item.
+ * @param {Object}                props                 Component props.
+ * @param {Array}                 [props.allowedBlocks] An array containing a list of block names for which the item should be shown. If not present, it'll be rendered for any block. If multiple blocks are selected, it'll be shown if and only if all of them are in the whitelist.
+ * @param {WPBlockTypeIconRender} [props.icon]          The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug string, or an SVG WP element.
+ * @param {string}                props.label           The menu item text.
+ * @param {Function}              props.onClick         Callback function to be executed when the user click the menu item.
+ * @param {boolean}               [props.small]         Whether to render the label or not.
+ * @param {string}                [props.role]          The ARIA role for the menu item.
  *
  * @example
  * <caption>ES5</caption>

--- a/packages/edit-post/src/components/sidebar/plugin-post-status-info/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-post-status-info/index.js
@@ -16,6 +16,7 @@ export const { Fill, Slot } = createSlotFill( 'PluginPostStatusInfo' );
  *
  * @param {Object} props Component properties.
  * @param {string} [props.className] An optional class name added to the row.
+ * @param {WPElement} props.children Children to be rendered.
  *
  * @example
  * <caption>ES5</caption>

--- a/packages/edit-post/src/components/sidebar/plugin-post-status-info/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-post-status-info/index.js
@@ -14,9 +14,9 @@ export const { Fill, Slot } = createSlotFill( 'PluginPostStatusInfo' );
  * It should be noted that this is named and implemented around the function it serves
  * and not its location, which may change in future iterations.
  *
- * @param {Object} props Component properties.
- * @param {string} [props.className] An optional class name added to the row.
- * @param {WPElement} props.children Children to be rendered.
+ * @param {Object}    props             Component properties.
+ * @param {string}    [props.className] An optional class name added to the row.
+ * @param {WPElement} props.children    Children to be rendered.
  *
  * @example
  * <caption>ES5</caption>


### PR DESCRIPTION
## Description
See #22907.

Fixes the following JSDoc warnings:

```
packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
  32:1  warning  Missing JSDoc @param "props.small" declaration  jsdoc/require-param
  32:1  warning  Missing JSDoc @param "props.role" declaration   jsdoc/require-param
  35:0  warning  Missing @param "props.small"                    jsdoc/check-param-names
  35:0  warning  Missing @param "props.role"                     jsdoc/check-param-names

packages/edit-post/src/components/sidebar/plugin-post-status-info/index.js
  12:1  warning  Missing JSDoc @param "props.children" declaration  jsdoc/require-param
  17:0  warning  Missing @param "props.children"                    jsdoc/check-param-names
```

## How has this been tested?
`npm run lint-js packages/edit-post/src`

## Types of changes
Bug fix