### PR TITLE
E2E Test Utils: Add missing param docs for createNewPost()

### DIFF
--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -107,6 +107,11 @@ Creates new post.
 _Parameters_
 
 -   _obj_ `Object`: Object to create new post, along with tips enabling option.
+-   _obj.postType_ `[string]`: Post type of the new post.
+-   _obj.title_ `[string]`: Title of the new post.
+-   _obj.content_ `[string]`: Content of the new post.
+-   _obj.excerpt_ `[string]`: Excerpt of the new post.
+-   _obj.showWelcomeGuide_ `[boolean]`: Whether to show the welcome guide.
 
 <a name="createURL" href="#createURL">#</a> **createURL**
 

--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -106,12 +106,12 @@ Creates new post.
 
 _Parameters_
 
--   _obj_ `Object`: Object to create new post, along with tips enabling option.
--   _obj.postType_ `[string]`: Post type of the new post.
--   _obj.title_ `[string]`: Title of the new post.
--   _obj.content_ `[string]`: Content of the new post.
--   _obj.excerpt_ `[string]`: Excerpt of the new post.
--   _obj.showWelcomeGuide_ `[boolean]`: Whether to show the welcome guide.
+-   _object_ `Object`: Object to create new post, along with tips enabling option.
+-   _object.postType_ `[string]`: Post type of the new post.
+-   _object.title_ `[string]`: Title of the new post.
+-   _object.content_ `[string]`: Content of the new post.
+-   _object.excerpt_ `[string]`: Excerpt of the new post.
+-   _object.showWelcomeGuide_ `[boolean]`: Whether to show the welcome guide.
 
 <a name="createURL" href="#createURL">#</a> **createURL**
 

--- a/packages/e2e-test-utils/src/create-new-post.js
+++ b/packages/e2e-test-utils/src/create-new-post.js
@@ -11,12 +11,12 @@ import { visitAdminPage } from './visit-admin-page';
 /**
  * Creates new post.
  *
- * @param {Object} obj Object to create new post, along with tips enabling option.
- * @param {string} [obj.postType] Post type of the new post.
- * @param {string} [obj.title] Title of the new post.
- * @param {string} [obj.content] Content of the new post.
- * @param {string} [obj.excerpt] Excerpt of the new post.
- * @param {boolean} [obj.showWelcomeGuide] Whether to show the welcome guide.
+ * @param {Object}  object                    Object to create new post, along with tips enabling option.
+ * @param {string}  [object.postType]         Post type of the new post.
+ * @param {string}  [object.title]            Title of the new post.
+ * @param {string}  [object.content]          Content of the new post.
+ * @param {string}  [object.excerpt]          Excerpt of the new post.
+ * @param {boolean} [object.showWelcomeGuide] Whether to show the welcome guide.
  */
 export async function createNewPost( {
 	postType,

--- a/packages/e2e-test-utils/src/create-new-post.js
+++ b/packages/e2e-test-utils/src/create-new-post.js
@@ -12,6 +12,11 @@ import { visitAdminPage } from './visit-admin-page';
  * Creates new post.
  *
  * @param {Object} obj Object to create new post, along with tips enabling option.
+ * @param {string} [obj.postType] Post type of the new post.
+ * @param {string} [obj.title] Title of the new post.
+ * @param {string} [obj.content] Content of the new post.
+ * @param {string} [obj.excerpt] Excerpt of the new post.
+ * @param {boolean} [obj.showWelcomeGuide] Whether to show the welcome guide.
  */
 export async function createNewPost( {
 	postType,


### PR DESCRIPTION
## Description
See #22907.

Fixes the following JSDoc warnings:

```
packages/e2e-test-utils/src/create-new-post.js
  11:1  warning  Missing JSDoc @param "obj.postType" declaration          jsdoc/require-param
  11:1  warning  Missing JSDoc @param "obj.title" declaration             jsdoc/require-param
  11:1  warning  Missing JSDoc @param "obj.content" declaration           jsdoc/require-param
  11:1  warning  Missing JSDoc @param "obj.excerpt" declaration           jsdoc/require-param
  11:1  warning  Missing JSDoc @param "obj.showWelcomeGuide" declaration  jsdoc/require-param
  14:0  warning  Missing @param "obj.postType"                            jsdoc/check-param-names
  14:0  warning  Missing @param "obj.title"                               jsdoc/check-param-names
  14:0  warning  Missing @param "obj.content"                             jsdoc/check-param-names
  14:0  warning  Missing @param "obj.excerpt"                             jsdoc/check-param-names
  14:0  warning  Missing @param "obj.showWelcomeGuide"                    jsdoc/check-param-names
```

## How has this been tested?
`npm run lint-js packages/e2e-test-utils/src`

## Types of changes
Bug fix