### PR TITLE
Editor: Display Site Icon (if one is set) in Gutenberg Fullscreen Mode

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -161,3 +161,16 @@ function gutenberg_rest_nonce() {
 	exit( wp_create_nonce( 'wp_rest' ) );
 }
 add_action( 'wp_ajax_gutenberg_rest_nonce', 'gutenberg_rest_nonce' );
+
+
+/**
+ * Exposes the site icon url to the Gutenberg editor through the WordPress REST API.
+ */
+function register_site_icon_url_setting() {
+	register_setting('general', 'site_icon_url', array(
+		'default' => get_site_icon_url(),
+		'show_in_rest' => true
+	));
+}
+
+add_action( 'rest_api_init', 'register_site_icon_url_setting' );

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -169,6 +169,9 @@ add_action( 'wp_ajax_gutenberg_rest_nonce', 'gutenberg_rest_nonce' );
  * endpoint when https://github.com/WordPress/gutenberg/pull/19967 is complete.
  *
  * @since 8.2.1
+ *
+ * @param WP_REST_Response $response Response data served by the WordPress REST index endpoint.
+ * @return WP_REST_Response
  */
 function register_site_icon_url( $response ) {
 	$data                  = $response->data;

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -164,17 +164,17 @@ add_action( 'wp_ajax_gutenberg_rest_nonce', 'gutenberg_rest_nonce' );
 
 
 /**
- * Exposes the site icon url to the Gutenberg editor through the WordPress REST API.
+ * Exposes the site icon url to the Gutenberg editor through the WordPress REST
+ * API. The site icon url should instead be fetched from the wp/v2/settings
+ * endpoint when https://github.com/WordPress/gutenberg/pull/19967 is complete.
+ *
+ * @since 8.2.1
  */
-function register_site_icon_url_setting() {
-	register_setting(
-		'general',
-		'site_icon_url',
-		array(
-			'default'      => get_site_icon_url(),
-			'show_in_rest' => true,
-		)
-	);
+function register_site_icon_url( $response ) {
+	$data                  = $response->data;
+	$data['site_icon_url'] = get_site_icon_url();
+	$response->set_data( $data );
+	return $response;
 }
 
-add_action( 'rest_api_init', 'register_site_icon_url_setting' );
+add_filter( 'rest_index', 'register_site_icon_url' );

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -167,10 +167,14 @@ add_action( 'wp_ajax_gutenberg_rest_nonce', 'gutenberg_rest_nonce' );
  * Exposes the site icon url to the Gutenberg editor through the WordPress REST API.
  */
 function register_site_icon_url_setting() {
-	register_setting('general', 'site_icon_url', array(
-		'default' => get_site_icon_url(),
-		'show_in_rest' => true
-	));
+	register_setting(
+		'general',
+		'site_icon_url',
+		array(
+			'default'      => get_site_icon_url(),
+			'show_in_rest' => true,
+		)
+	);
 }
 
 add_action( 'rest_api_init', 'register_site_icon_url_setting' );

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -572,6 +572,8 @@ add_filter( 'walker_nav_menu_start_el', 'gutenberg_output_html_nav_menu_item', 1
 /**
  * Amends the paths to preload when initializing edit post.
  *
+ * @see https://core.trac.wordpress.org/ticket/50606
+ *
  * @since 8.4.0
  *
  * @param  array $preload_paths Default path list that will be preloaded.

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -568,3 +568,18 @@ function gutenberg_output_html_nav_menu_item( $item_output, $item, $depth, $args
 	return $item_output;
 }
 add_filter( 'walker_nav_menu_start_el', 'gutenberg_output_html_nav_menu_item', 10, 4 );
+
+/**
+ * Amends the paths to preload when initializing edit post.
+ *
+ * @since 8.4.0
+ *
+ * @param  array $preload_paths Default path list that will be preloaded.
+ * @return array Modified path list to preload.
+ */
+function gutenberg_preload_edit_post( $preload_paths ) {
+	$additional_paths = array( '/?context=edit' );
+	return array_merge( $preload_paths, $additional_paths );
+}
+
+add_filter( 'block_editor_preload_paths', 'gutenberg_preload_edit_post' );

--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -165,7 +165,7 @@ function gutenberg_edit_site_init( $hook ) {
 	// Preload block editor paths.
 	// most of these are copied from edit-forms-blocks.php.
 	$preload_paths = array(
-		'/',
+		'/?context=edit',
 		'/wp/v2/types?context=edit',
 		'/wp/v2/taxonomies?per_page=100&context=edit',
 		'/wp/v2/pages?per_page=100&context=edit',

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -19,7 +19,7 @@ export const DEFAULT_ENTITY_KEY = 'id';
 export const defaultEntities = [
 	{
 		label: __( 'Base' ),
-		name: 'base',
+		name: '__unstableBase',
 		kind: 'root',
 		baseURL: '',
 	},

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -18,6 +18,12 @@ export const DEFAULT_ENTITY_KEY = 'id';
 
 export const defaultEntities = [
 	{
+		label: __( 'Base' ),
+		name: 'base',
+		kind: 'root',
+		baseURL: '',
+	},
+	{
 		label: __( 'Site' ),
 		name: 'site',
 		kind: 'root',

--- a/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
@@ -45,7 +45,7 @@ function FullscreenModeClose() {
 	if ( siteIconUrl ) {
 		buttonIcon = (
 			<img
-				alt="site-icon"
+				alt={ __( 'Site Icon' ) }
 				className="edit-post-fullscreen-mode-close_site-icon"
 				src={ siteIconUrl }
 			/>

--- a/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
@@ -60,6 +60,7 @@ function FullscreenModeClose() {
 				post_type: postType.slug,
 			} ) }
 			label={ get( postType, [ 'labels', 'view_items' ], __( 'Back' ) ) }
+			showTooltip
 		>
 			{ buttonIcon }
 		</Button>

--- a/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
@@ -19,13 +19,14 @@ function FullscreenModeClose() {
 			const { isFeatureActive } = select( 'core/edit-post' );
 			const { isResolving } = select( 'core/data' );
 			const { getEntityRecord, getPostType } = select( 'core' );
-			const siteData = getEntityRecord( 'root', 'base', undefined ) || {};
+			const siteData =
+				getEntityRecord( 'root', '__unstableBase', undefined ) || {};
 
 			return {
 				isActive: isFeatureActive( 'fullscreenMode' ),
 				isRequestingSiteIcon: isResolving( 'core', 'getEntityRecord', [
 					'root',
-					'base',
+					'__unstableBase',
 					undefined,
 				] ),
 				postType: getPostType( getCurrentPostType() ),

--- a/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
@@ -19,13 +19,13 @@ function FullscreenModeClose() {
 			const { isFeatureActive } = select( 'core/edit-post' );
 			const { isResolving } = select( 'core/data' );
 			const { getEntityRecord, getPostType } = select( 'core' );
-			const siteData = getEntityRecord( 'root', 'site', undefined ) || {};
+			const siteData = getEntityRecord( 'root', 'base', undefined ) || {};
 
 			return {
 				isActive: isFeatureActive( 'fullscreenMode' ),
 				isRequestingSiteIcon: isResolving( 'core', 'getEntityRecord', [
 					'root',
-					'site',
+					'base',
 					undefined,
 				] ),
 				postType: getPostType( getCurrentPostType() ),

--- a/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
@@ -7,33 +7,33 @@ import { get } from 'lodash';
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { useEntityProp } from '@wordpress/core-data';
 import { Button, Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { wordpress } from '@wordpress/icons';
 
 function FullscreenModeClose() {
-	const [ siteIconURL ] = useEntityProp( 'root', 'site', 'site_icon_url' );
+	const { isActive, isRequestingSiteIcon, postType, siteIconUrl } = useSelect(
+		( select ) => {
+			const { getCurrentPostType } = select( 'core/editor' );
+			const { isFeatureActive } = select( 'core/edit-post' );
+			const { isResolving } = select( 'core/data' );
+			const { getEntityRecord, getPostType } = select( 'core' );
+			const siteData = getEntityRecord( 'root', 'site', undefined ) || {};
 
-	const isRequestingSiteIcon = useSelect( ( select ) => {
-		return select( 'core/data' ).isResolving( 'core', 'getEntityRecord', [
-			'root',
-			'site',
-			undefined,
-		] );
-	}, [] );
-
-	const { isActive, postType } = useSelect( ( select ) => {
-		const { getCurrentPostType } = select( 'core/editor' );
-		const { isFeatureActive } = select( 'core/edit-post' );
-		const { getPostType } = select( 'core' );
-
-		return {
-			isActive: isFeatureActive( 'fullscreenMode' ),
-			postType: getPostType( getCurrentPostType() ),
-		};
-	}, [] );
+			return {
+				isActive: isFeatureActive( 'fullscreenMode' ),
+				isRequestingSiteIcon: isResolving( 'core', 'getEntityRecord', [
+					'root',
+					'site',
+					undefined,
+				] ),
+				postType: getPostType( getCurrentPostType() ),
+				siteIconUrl: siteData.site_icon_url,
+			};
+		},
+		[]
+	);
 
 	if ( ! isActive || ! postType ) {
 		return null;
@@ -41,12 +41,12 @@ function FullscreenModeClose() {
 
 	let buttonIcon = <Icon size="36px" icon={ wordpress } />;
 
-	if ( siteIconURL ) {
+	if ( siteIconUrl ) {
 		buttonIcon = (
 			<img
-				className="edit-post-fullscreen-mode-close_site-icon"
-				src={ siteIconURL }
 				alt="site-icon"
+				className="edit-post-fullscreen-mode-close_site-icon"
+				src={ siteIconUrl }
 			/>
 		);
 	} else if ( isRequestingSiteIcon ) {

--- a/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
@@ -7,12 +7,23 @@ import { get } from 'lodash';
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { Button } from '@wordpress/components';
+import { useEntityProp } from '@wordpress/core-data';
+import { Button, Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { wordpress } from '@wordpress/icons';
 
 function FullscreenModeClose() {
+	const [ siteIconURL ] = useEntityProp( 'root', 'site', 'site_icon_url' );
+
+	const isRequestingSiteIcon = useSelect( ( select ) => {
+		return select( 'core/data' ).isResolving( 'core', 'getEntityRecord', [
+			'root',
+			'site',
+			undefined,
+		] );
+	}, [] );
+
 	const { isActive, postType } = useSelect( ( select ) => {
 		const { getCurrentPostType } = select( 'core/editor' );
 		const { isFeatureActive } = select( 'core/edit-post' );
@@ -28,16 +39,30 @@ function FullscreenModeClose() {
 		return null;
 	}
 
+	let buttonIcon = <Icon size="36px" icon={ wordpress } />;
+
+	if ( siteIconURL ) {
+		buttonIcon = (
+			<img
+				className="edit-post-fullscreen-mode-close_site-icon"
+				src={ siteIconURL }
+				alt="site-icon"
+			/>
+		);
+	} else if ( isRequestingSiteIcon ) {
+		buttonIcon = null;
+	}
+
 	return (
 		<Button
-			className="edit-post-fullscreen-mode-close"
-			icon={ wordpress }
-			iconSize={ 36 }
+			className="edit-post-fullscreen-mode-close has-icon"
 			href={ addQueryArgs( 'edit.php', {
 				post_type: postType.slug,
 			} ) }
 			label={ get( postType, [ 'labels', 'view_items' ], __( 'Back' ) ) }
-		/>
+		>
+			{ buttonIcon }
+		</Button>
 	);
 }
 

--- a/packages/edit-post/src/components/header/fullscreen-mode-close/style.scss
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/style.scss
@@ -27,3 +27,8 @@
 		}
 	}
 }
+
+.edit-post-fullscreen-mode-close_site-icon {
+	width: 36px;
+}
+

--- a/packages/edit-post/src/components/header/fullscreen-mode-close/test/index.js
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/test/index.js
@@ -7,7 +7,6 @@ import { render } from '@testing-library/react';
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { useEntityProp } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -24,18 +23,17 @@ jest.mock( '@wordpress/core-data' );
 
 describe( 'FullscreenModeClose', () => {
 	describe( 'when in full screen mode', () => {
-		useSelect.mockImplementation( ( cb ) => {
-			return cb( () => ( {
-				isResolving: () => false,
-				isFeatureActive: () => true,
-				getCurrentPostType: () => {},
-				getPostType: () => true,
-			} ) );
-		} );
-
 		it( 'should display a user uploaded site icon if it exists', () => {
-			useEntityProp.mockImplementation( () => {
-				return [ 'https://fakeUrl.com' ];
+			useSelect.mockImplementation( ( cb ) => {
+				return cb( () => ( {
+					isResolving: () => false,
+					isFeatureActive: () => true,
+					getCurrentPostType: () => {},
+					getPostType: () => true,
+					getEntityRecord: () => ( {
+						site_icon_url: 'https://fakeUrl.com',
+					} ),
+				} ) );
 			} );
 
 			const { getByAltText } = render( <FullscreenModeClose /> );
@@ -45,8 +43,16 @@ describe( 'FullscreenModeClose', () => {
 		} );
 
 		it( 'should display a default site icon if no user uploaded site icon exists', () => {
-			useEntityProp.mockImplementation( () => {
-				return [ undefined ];
+			useSelect.mockImplementation( ( cb ) => {
+				return cb( () => ( {
+					isResolving: () => false,
+					isFeatureActive: () => true,
+					getCurrentPostType: () => {},
+					getPostType: () => true,
+					getEntityRecord: () => ( {
+						site_icon_url: '',
+					} ),
+				} ) );
 			} );
 
 			const { container, queryByAltText } = render(

--- a/packages/edit-post/src/components/header/fullscreen-mode-close/test/index.js
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/test/index.js
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { useEntityProp } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import FullscreenModeClose from '../';
+
+jest.mock( '@wordpress/data/src/components/use-select', () => {
+	// This allows us to tweak the returned value on each test
+	const mock = jest.fn();
+	return mock;
+} );
+
+jest.mock( '@wordpress/core-data' );
+
+describe( 'FullscreenModeClose', () => {
+	describe( 'when in full screen mode', () => {
+		useSelect.mockImplementation( ( cb ) => {
+			return cb( () => ( {
+				isResolving: () => false,
+				isFeatureActive: () => true,
+				getCurrentPostType: () => {},
+				getPostType: () => true,
+			} ) );
+		} );
+
+		it( 'should display a user uploaded site icon if it exists', () => {
+			useEntityProp.mockImplementation( () => {
+				return [ 'https://fakeUrl.com' ];
+			} );
+
+			const { getByAltText } = render( <FullscreenModeClose /> );
+			const siteIcon = getByAltText( 'site-icon' );
+
+			expect( siteIcon ).toBeTruthy();
+		} );
+
+		it( 'should display a default site icon if no user uploaded site icon exists', () => {
+			useEntityProp.mockImplementation( () => {
+				return [ undefined ];
+			} );
+
+			const { container, queryByAltText } = render(
+				<FullscreenModeClose />
+			);
+			const siteIcon = queryByAltText( 'site-icon' );
+			const defaultIcon = container.querySelector( 'svg' );
+
+			expect( siteIcon ).toBeFalsy();
+			expect( defaultIcon ).toBeTruthy();
+		} );
+	} );
+} );

--- a/packages/edit-post/src/components/header/fullscreen-mode-close/test/index.js
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/test/index.js
@@ -36,8 +36,10 @@ describe( 'FullscreenModeClose', () => {
 				} ) );
 			} );
 
-			const { getByAltText } = render( <FullscreenModeClose /> );
-			const siteIcon = getByAltText( 'site-icon' );
+			const { container } = render( <FullscreenModeClose /> );
+			const siteIcon = container.querySelector(
+				'.edit-post-fullscreen-mode-close_site-icon'
+			);
 
 			expect( siteIcon ).toBeTruthy();
 		} );
@@ -55,10 +57,10 @@ describe( 'FullscreenModeClose', () => {
 				} ) );
 			} );
 
-			const { container, queryByAltText } = render(
-				<FullscreenModeClose />
+			const { container } = render( <FullscreenModeClose /> );
+			const siteIcon = container.querySelector(
+				'.edit-post-fullscreen-mode-close_site-icon'
 			);
-			const siteIcon = queryByAltText( 'site-icon' );
 			const defaultIcon = container.querySelector( 'svg' );
 
 			expect( siteIcon ).toBeFalsy();

--- a/packages/edit-site/src/components/header/fullscreen-mode-close/index.js
+++ b/packages/edit-site/src/components/header/fullscreen-mode-close/index.js
@@ -9,7 +9,7 @@ import { wordpress } from '@wordpress/icons';
 
 function FullscreenModeClose( { icon } ) {
 	const [ siteIconURL ] = useEntityProp( 'root', 'site', 'site_icon_url' );
-	
+
 	const isRequestingSiteIcon = useSelect( ( select ) => {
 		return ! select( 'core/data' ).hasFinishedResolution(
 			'core',

--- a/packages/edit-site/src/components/header/fullscreen-mode-close/index.js
+++ b/packages/edit-site/src/components/header/fullscreen-mode-close/index.js
@@ -2,11 +2,22 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
+import { useEntityProp } from '@wordpress/core-data';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
 
 function FullscreenModeClose( { icon } ) {
+	const [ siteIconURL ] = useEntityProp( 'root', 'site', 'site_icon_url' );
+	
+	const isRequestingSiteIcon = useSelect( ( select ) => {
+		return ! select( 'core/data' ).hasFinishedResolution(
+			'core',
+			'getEntityRecord',
+			[ 'root', 'site', undefined ]
+		);
+	}, [] );
+
 	const isActive = useSelect( ( select ) => {
 		return select( 'core/edit-site' ).isFeatureActive( 'fullscreenMode' );
 	}, [] );
@@ -15,7 +26,8 @@ function FullscreenModeClose( { icon } ) {
 		return null;
 	}
 
-	const buttonIcon = icon || wordpress;
+	const shouldDisplaySiteIcon = siteIconURL || isRequestingSiteIcon;
+	const buttonIcon = shouldDisplaySiteIcon ? null : icon || wordpress;
 
 	return (
 		<Button
@@ -24,7 +36,16 @@ function FullscreenModeClose( { icon } ) {
 			iconSize={ 36 }
 			href="index.php"
 			label={ __( 'Back' ) }
-		/>
+		>
+			{ /* TODO: Properly style site icon */ }
+			{ siteIconURL && (
+				<img
+					src={ siteIconURL }
+					alt="site-icon"
+					style={ { width: '36px', height: 'auto' } }
+				/>
+			) }
+		</Button>
 	);
 }
 

--- a/packages/edit-site/src/components/header/fullscreen-mode-close/index.js
+++ b/packages/edit-site/src/components/header/fullscreen-mode-close/index.js
@@ -12,13 +12,14 @@ function FullscreenModeClose( { icon } ) {
 			const { isFeatureActive } = select( 'core/edit-site' );
 			const { getEntityRecord } = select( 'core' );
 			const { isResolving } = select( 'core/data' );
-			const siteData = getEntityRecord( 'root', 'base', undefined ) || {};
+			const siteData =
+				getEntityRecord( 'root', '__unstableBase', undefined ) || {};
 
 			return {
 				isActive: isFeatureActive( 'fullscreenMode' ),
 				isRequestingSiteIcon: isResolving( 'core', 'getEntityRecord', [
 					'root',
-					'base',
+					'__unstableBase',
 					undefined,
 				] ),
 				siteIconUrl: siteData.site_icon_url,

--- a/packages/edit-site/src/components/header/fullscreen-mode-close/index.js
+++ b/packages/edit-site/src/components/header/fullscreen-mode-close/index.js
@@ -44,7 +44,7 @@ function FullscreenModeClose( { icon } ) {
 
 	return (
 		<Button
-			className="edit-site-fullscreen-mode-close"
+			className="edit-site-fullscreen-mode-close has-icon"
 			href="index.php"
 			label={ __( 'Back' ) }
 		>

--- a/packages/edit-site/src/components/header/fullscreen-mode-close/index.js
+++ b/packages/edit-site/src/components/header/fullscreen-mode-close/index.js
@@ -3,7 +3,7 @@
  */
 import { useSelect } from '@wordpress/data';
 import { useEntityProp } from '@wordpress/core-data';
-import { Button } from '@wordpress/components';
+import { Button, Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
 
@@ -26,25 +26,29 @@ function FullscreenModeClose( { icon } ) {
 		return null;
 	}
 
-	const shouldDisplaySiteIcon = siteIconURL || isRequestingSiteIcon;
-	const buttonIcon = shouldDisplaySiteIcon ? null : icon || wordpress;
+	let buttonIcon = <Icon size="36px" icon={ wordpress } />;
+
+	if ( siteIconURL ) {
+		buttonIcon = (
+			<img
+				className="edit-site-fullscreen-mode-close_site-icon"
+				src={ siteIconURL }
+				alt="site-icon"
+			/>
+		);
+	} else if ( isRequestingSiteIcon ) {
+		buttonIcon = null;
+	} else if ( icon ) {
+		buttonIcon = <Icon size="36px" icon={ icon } />;
+	}
 
 	return (
 		<Button
 			className="edit-site-fullscreen-mode-close"
-			icon={ buttonIcon }
-			iconSize={ 36 }
 			href="index.php"
 			label={ __( 'Back' ) }
 		>
-			{ /* TODO: Properly style site icon */ }
-			{ siteIconURL && (
-				<img
-					src={ siteIconURL }
-					alt="site-icon"
-					style={ { width: '36px', height: 'auto' } }
-				/>
-			) }
+			{ buttonIcon }
 		</Button>
 	);
 }

--- a/packages/edit-site/src/components/header/fullscreen-mode-close/index.js
+++ b/packages/edit-site/src/components/header/fullscreen-mode-close/index.js
@@ -11,11 +11,11 @@ function FullscreenModeClose( { icon } ) {
 	const [ siteIconURL ] = useEntityProp( 'root', 'site', 'site_icon_url' );
 
 	const isRequestingSiteIcon = useSelect( ( select ) => {
-		return ! select( 'core/data' ).hasFinishedResolution(
-			'core',
-			'getEntityRecord',
-			[ 'root', 'site', undefined ]
-		);
+		return select( 'core/data' ).isResolving( 'core', 'getEntityRecord', [
+			'root',
+			'site',
+			undefined,
+		] );
 	}, [] );
 
 	const isActive = useSelect( ( select ) => {

--- a/packages/edit-site/src/components/header/fullscreen-mode-close/index.js
+++ b/packages/edit-site/src/components/header/fullscreen-mode-close/index.js
@@ -37,7 +37,7 @@ function FullscreenModeClose( { icon } ) {
 	if ( siteIconUrl ) {
 		buttonIcon = (
 			<img
-				alt="site-icon"
+				alt={ __( 'Site Icon' ) }
 				className="edit-site-fullscreen-mode-close_site-icon"
 				src={ siteIconUrl }
 			/>

--- a/packages/edit-site/src/components/header/fullscreen-mode-close/index.js
+++ b/packages/edit-site/src/components/header/fullscreen-mode-close/index.js
@@ -47,6 +47,7 @@ function FullscreenModeClose( { icon } ) {
 			className="edit-site-fullscreen-mode-close has-icon"
 			href="index.php"
 			label={ __( 'Back' ) }
+			showTooltip
 		>
 			{ buttonIcon }
 		</Button>

--- a/packages/edit-site/src/components/header/fullscreen-mode-close/index.js
+++ b/packages/edit-site/src/components/header/fullscreen-mode-close/index.js
@@ -12,13 +12,13 @@ function FullscreenModeClose( { icon } ) {
 			const { isFeatureActive } = select( 'core/edit-site' );
 			const { getEntityRecord } = select( 'core' );
 			const { isResolving } = select( 'core/data' );
-			const siteData = getEntityRecord( 'root', 'site', undefined ) || {};
+			const siteData = getEntityRecord( 'root', 'base', undefined ) || {};
 
 			return {
 				isActive: isFeatureActive( 'fullscreenMode' ),
 				isRequestingSiteIcon: isResolving( 'core', 'getEntityRecord', [
 					'root',
-					'site',
+					'base',
 					undefined,
 				] ),
 				siteIconUrl: siteData.site_icon_url,

--- a/packages/edit-site/src/components/header/fullscreen-mode-close/index.js
+++ b/packages/edit-site/src/components/header/fullscreen-mode-close/index.js
@@ -2,25 +2,30 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { useEntityProp } from '@wordpress/core-data';
 import { Button, Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
 
 function FullscreenModeClose( { icon } ) {
-	const [ siteIconURL ] = useEntityProp( 'root', 'site', 'site_icon_url' );
+	const { isActive, isRequestingSiteIcon, siteIconUrl } = useSelect(
+		( select ) => {
+			const { isFeatureActive } = select( 'core/edit-site' );
+			const { getEntityRecord } = select( 'core' );
+			const { isResolving } = select( 'core/data' );
+			const siteData = getEntityRecord( 'root', 'site', undefined ) || {};
 
-	const isRequestingSiteIcon = useSelect( ( select ) => {
-		return select( 'core/data' ).isResolving( 'core', 'getEntityRecord', [
-			'root',
-			'site',
-			undefined,
-		] );
-	}, [] );
-
-	const isActive = useSelect( ( select ) => {
-		return select( 'core/edit-site' ).isFeatureActive( 'fullscreenMode' );
-	}, [] );
+			return {
+				isActive: isFeatureActive( 'fullscreenMode' ),
+				isRequestingSiteIcon: isResolving( 'core', 'getEntityRecord', [
+					'root',
+					'site',
+					undefined,
+				] ),
+				siteIconUrl: siteData.site_icon_url,
+			};
+		},
+		[]
+	);
 
 	if ( ! isActive ) {
 		return null;
@@ -28,12 +33,12 @@ function FullscreenModeClose( { icon } ) {
 
 	let buttonIcon = <Icon size="36px" icon={ wordpress } />;
 
-	if ( siteIconURL ) {
+	if ( siteIconUrl ) {
 		buttonIcon = (
 			<img
-				className="edit-site-fullscreen-mode-close_site-icon"
-				src={ siteIconURL }
 				alt="site-icon"
+				className="edit-site-fullscreen-mode-close_site-icon"
+				src={ siteIconUrl }
 			/>
 		);
 	} else if ( isRequestingSiteIcon ) {

--- a/packages/edit-site/src/components/header/fullscreen-mode-close/style.scss
+++ b/packages/edit-site/src/components/header/fullscreen-mode-close/style.scss
@@ -1,4 +1,4 @@
-.edit-site-fullscreen-mode-close.has-icon {
+.edit-site-fullscreen-mode-close {
 	// Do not show the toolbar icon on small screens,
 	// when Fullscreen Mode is not an option in the "More" menu.
 	display: none;
@@ -8,22 +8,21 @@
 		align-items: center;
 		align-self: stretch;
 		border: none;
-		background: #23282e; // WP-admin gray.
 		color: $white;
 		border-radius: 0;
-		height: $header-height;
+		min-height: $header-height;
 		width: $header-height;
 
-		&:hover {
-			background: #32373d; // WP-admin light-gray.
-		}
-
-		&:active {
-			color: $white;
-		}
-
-		&:focus {
-			box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color), inset 0 0 0 3px $white;
+		&.has-icon {
+			&:hover {
+				background: #32373d; // WP-admin light-gray.
+			}
+			&:active {
+				color: $white;
+			}
+			&:focus {
+				box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color), inset 0 0 0 3px $white;
+			}
 		}
 	}
 }

--- a/packages/edit-site/src/components/header/fullscreen-mode-close/style.scss
+++ b/packages/edit-site/src/components/header/fullscreen-mode-close/style.scss
@@ -1,4 +1,4 @@
-.edit-site-fullscreen-mode-close {
+.edit-site-fullscreen-mode-close.has-icon {
 	// Do not show the toolbar icon on small screens,
 	// when Fullscreen Mode is not an option in the "More" menu.
 	display: none;
@@ -8,10 +8,11 @@
 		align-items: center;
 		align-self: stretch;
 		border: none;
+		background: #23282e; // WP-admin gray.
 		color: $white;
 		border-radius: 0;
-		min-height: $header-height;
-		width: $header-height;
+		height: $header-height;
+		min-width: $header-height;
 
 		&.has-icon {
 			&:hover {
@@ -25,4 +26,8 @@
 			}
 		}
 	}
+}
+
+.edit-site-fullscreen-mode-close_site-icon {
+	width: 36px;
 }

--- a/packages/edit-site/src/components/header/fullscreen-mode-close/test/index.js
+++ b/packages/edit-site/src/components/header/fullscreen-mode-close/test/index.js
@@ -7,7 +7,6 @@ import { render } from '@testing-library/react';
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { useEntityProp } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -24,16 +23,15 @@ jest.mock( '@wordpress/core-data' );
 
 describe( 'FullscreenModeClose', () => {
 	describe( 'when in full screen mode', () => {
-		useSelect.mockImplementation( ( cb ) => {
-			return cb( () => ( {
-				isResolving: () => false,
-				isFeatureActive: () => true,
-			} ) );
-		} );
-
 		it( 'should display a user uploaded site icon if it exists', () => {
-			useEntityProp.mockImplementation( () => {
-				return [ 'https://fakeUrl.com' ];
+			useSelect.mockImplementation( ( cb ) => {
+				return cb( () => ( {
+					isResolving: () => false,
+					isFeatureActive: () => true,
+					getEntityRecord: () => ( {
+						site_icon_url: 'https://fakeUrl.com',
+					} ),
+				} ) );
 			} );
 
 			const { getByAltText } = render( <FullscreenModeClose /> );
@@ -43,8 +41,14 @@ describe( 'FullscreenModeClose', () => {
 		} );
 
 		it( 'should display a default site icon if no user uploaded site icon exists', () => {
-			useEntityProp.mockImplementation( () => {
-				return [ undefined ];
+			useSelect.mockImplementation( ( cb ) => {
+				return cb( () => ( {
+					isResolving: () => false,
+					isFeatureActive: () => true,
+					getEntityRecord: () => ( {
+						site_icon_url: '',
+					} ),
+				} ) );
 			} );
 
 			const { container, queryByAltText } = render(

--- a/packages/edit-site/src/components/header/fullscreen-mode-close/test/index.js
+++ b/packages/edit-site/src/components/header/fullscreen-mode-close/test/index.js
@@ -34,8 +34,10 @@ describe( 'FullscreenModeClose', () => {
 				} ) );
 			} );
 
-			const { getByAltText } = render( <FullscreenModeClose /> );
-			const siteIcon = getByAltText( 'site-icon' );
+			const { container } = render( <FullscreenModeClose /> );
+			const siteIcon = container.querySelector(
+				'.edit-site-fullscreen-mode-close_site-icon'
+			);
 
 			expect( siteIcon ).toBeTruthy();
 		} );
@@ -51,10 +53,10 @@ describe( 'FullscreenModeClose', () => {
 				} ) );
 			} );
 
-			const { container, queryByAltText } = render(
-				<FullscreenModeClose />
+			const { container } = render( <FullscreenModeClose /> );
+			const siteIcon = container.querySelector(
+				'.edit-site-fullscreen-mode-close_site-icon'
 			);
-			const siteIcon = queryByAltText( 'site-icon' );
 			const defaultIcon = container.querySelector( 'svg' );
 
 			expect( siteIcon ).toBeFalsy();

--- a/packages/edit-site/src/components/header/fullscreen-mode-close/test/index.js
+++ b/packages/edit-site/src/components/header/fullscreen-mode-close/test/index.js
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { useEntityProp } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import FullscreenModeClose from '../';
+
+jest.mock( '@wordpress/data/src/components/use-select', () => {
+	// This allows us to tweak the returned value on each test
+	const mock = jest.fn();
+	return mock;
+} );
+
+jest.mock( '@wordpress/core-data' );
+
+describe( 'FullscreenModeClose', () => {
+	describe( 'when in full screen mode', () => {
+		useSelect.mockImplementation( ( cb ) => {
+			return cb( () => ( {
+				isResolving: () => false,
+				isFeatureActive: () => true,
+			} ) );
+		} );
+
+		it( 'should display a user uploaded site icon if it exists', () => {
+			useEntityProp.mockImplementation( () => {
+				return [ 'https://fakeUrl.com' ];
+			} );
+
+			const { getByAltText } = render( <FullscreenModeClose /> );
+			const siteIcon = getByAltText( 'site-icon' );
+
+			expect( siteIcon ).toBeTruthy();
+		} );
+
+		it( 'should display a default site icon if no user uploaded site icon exists', () => {
+			useEntityProp.mockImplementation( () => {
+				return [ undefined ];
+			} );
+
+			const { container, queryByAltText } = render(
+				<FullscreenModeClose />
+			);
+			const siteIcon = queryByAltText( 'site-icon' );
+			const defaultIcon = container.querySelector( 'svg' );
+
+			expect( siteIcon ).toBeFalsy();
+			expect( defaultIcon ).toBeTruthy();
+		} );
+	} );
+} );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
This PR addresses issue #20929  `Iterations on W icon in the editor header`. It renders the current site icon (if one is set) instead of the default WordPress icon in the site **and** post editor.

**Note**:
1. @noahtallen made a great callout. This PR only handles displaying a user uploaded site icon. We may need to update the site icon from the Gutenberg editor in the future as well. Although not addressed here, a strategy for updating site icons is worthwhile to consider while reviewing this PR.
2. Since information about site icons wasn't originally provided to the Gutenberg editor, we exposed the site icon url as a settings field. We use `register_setting` to extend the WordPress `wp/v2/settings` API. @ockham discussed the idea of including that as a field in Core WordPress itself. We are considering opening a new issue, and I'd love to hear more feedback about this.

## How has this been tested?
- Set up local instance of WordPress and Gutenberg by following instructions [here](https://github.com/WordPress/gutenberg/blob/master/docs/contributors/getting-started.md)
- Navigate to WordPress admin sidebar -> _Appearance_ -> _Customize_ -> _Site Identity_
- Upload a site icon
- Publish changes
- If already enabled, navigate to the site editor
  - Verify changes in full-screen mode
- If not already enabled, navigate to WordPress admin sidebar -> _Gutenberg_ -> _Experiments_
  - Enable `Full Site Editing`
  - Enable `Full Site Editing Demo Templates`
  - Navigate to the site editor and verify changes in full-screen mode


<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots
### With no uploaded site icon
<img width="1536" alt="Screen Shot 2020-06-05 at 1 07 29 PM" src="https://user-images.githubusercontent.com/5414230/83925247-8be26300-a73b-11ea-847c-de10ce479766.png">

### With site icon
<img width="1404" alt="Screen Shot 2020-06-08 at 6 24 13 PM" src="https://user-images.githubusercontent.com/5414230/84096006-a293ee80-a9b5-11ea-9110-82fefad81490.png">

### GIF
![Site Icon](https://user-images.githubusercontent.com/5414230/84096135-f999c380-a9b5-11ea-85da-2c288d68df9a.gif)

## Types of changes
- Expose site icon URL to Gutenberg editor
- Display site icon in full-screen mode

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
### Requirements
**With default WordPress icon**
- [ ] Icon button disappears on screens smaller than `782px`
- [ ] Clicking icon button redirects user to wp-admin home page
- [ ] Back button tooltip displays on hover after timed delay

**With custom site icon**
- [ ] Icon button disappears on screens smaller than `782px`
- [ ] Clicking icon button redirects user to wp-admin home page
- [ ] Back button tooltip displays on hover after timed delay
- [ ] Icon is displayed for Contributor, Author, Editor, and Admin roles.

### Browsers
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] IE11
