### PR TITLE
Edit Site: Fix template lookup

### DIFF
--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -155,7 +155,7 @@ function gutenberg_edit_site_init( $hook ) {
 
 		$current_template = gutenberg_find_template_post_and_parts( $template_type );
 		if ( isset( $current_template ) ) {
-			$template_ids[ $current_template['template_post']->post_name ] = $current_template['template_post']->ID;
+			$template_ids[ $template_type ] = $current_template['template_post']->ID;
 			$template_part_ids = $template_part_ids + $current_template['template_part_ids'];
 		}
 	}

--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -156,7 +156,7 @@ function gutenberg_edit_site_init( $hook ) {
 		$current_template = gutenberg_find_template_post_and_parts( $template_type );
 		if ( isset( $current_template ) ) {
 			$template_ids[ $template_type ] = $current_template['template_post']->ID;
-			$template_part_ids = $template_part_ids + $current_template['template_part_ids'];
+			$template_part_ids              = $template_part_ids + $current_template['template_part_ids'];
 		}
 	}
 

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -319,6 +319,29 @@ function gutenberg_find_template_post_and_parts( $template_type, $template_hiera
 		}
 	}
 
+	// If we haven't found any template post by here, it means that this theme doesn't even come with a fallback
+	// `index.html` block template. We create one so that people that are trying to access the editor are greeted
+	// with a blank page rather than an error.
+	if( ! $current_template_post && ( is_admin() || defined( 'REST_REQUEST' ) ) ) {
+		// 'index' is the ultimate fallback template. If even this template doesn't exist, we create an empty one for it.
+		$current_template_post = array(
+			//'post_content' => $file_contents,
+			'post_title'   => 'index',
+			'post_status'  => 'auto-draft',
+			'post_type'    => 'wp_template',
+			'post_name'    => 'index',
+		);
+		if ( is_admin() || defined( 'REST_REQUEST' ) ) {
+			$current_template_post = get_post(
+				wp_insert_post( $current_template_post )
+			);
+		} else {
+			$current_template_post = new WP_Post(
+				(object) $current_template_post
+			);
+		}
+	}
+
 	if ( $current_template_post ) {
 		$template_part_ids = array();
 		if ( is_admin() ) {

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -322,12 +322,12 @@ function gutenberg_find_template_post_and_parts( $template_type, $template_hiera
 	// If we haven't found any template post by here, it means that this theme doesn't even come with a fallback
 	// `index.html` block template. We create one so that people that are trying to access the editor are greeted
 	// with a blank page rather than an error.
-	if( ! $current_template_post && ( is_admin() || defined( 'REST_REQUEST' ) ) ) {
+	if ( ! $current_template_post && ( is_admin() || defined( 'REST_REQUEST' ) ) ) {
 		$current_template_post = array(
-			'post_title'   => 'index',
-			'post_status'  => 'auto-draft',
-			'post_type'    => 'wp_template',
-			'post_name'    => 'index',
+			'post_title'  => 'index',
+			'post_status' => 'auto-draft',
+			'post_type'   => 'wp_template',
+			'post_name'   => 'index',
 		);
 		$current_template_post = get_post(
 			wp_insert_post( $current_template_post )

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -323,7 +323,6 @@ function gutenberg_find_template_post_and_parts( $template_type, $template_hiera
 	// `index.html` block template. We create one so that people that are trying to access the editor are greeted
 	// with a blank page rather than an error.
 	if( ! $current_template_post && ( is_admin() || defined( 'REST_REQUEST' ) ) ) {
-		// 'index' is the ultimate fallback template. If even this template doesn't exist, we create an empty one for it.
 		$current_template_post = array(
 			'post_title'   => 'index',
 			'post_status'  => 'auto-draft',

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -330,15 +330,9 @@ function gutenberg_find_template_post_and_parts( $template_type, $template_hiera
 			'post_type'    => 'wp_template',
 			'post_name'    => 'index',
 		);
-		if ( is_admin() || defined( 'REST_REQUEST' ) ) {
-			$current_template_post = get_post(
-				wp_insert_post( $current_template_post )
-			);
-		} else {
-			$current_template_post = new WP_Post(
-				(object) $current_template_post
-			);
-		}
+		$current_template_post = get_post(
+			wp_insert_post( $current_template_post )
+		);
 	}
 
 	if ( $current_template_post ) {

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -325,7 +325,6 @@ function gutenberg_find_template_post_and_parts( $template_type, $template_hiera
 	if( ! $current_template_post && ( is_admin() || defined( 'REST_REQUEST' ) ) ) {
 		// 'index' is the ultimate fallback template. If even this template doesn't exist, we create an empty one for it.
 		$current_template_post = array(
-			//'post_content' => $file_contents,
 			'post_title'   => 'index',
 			'post_status'  => 'auto-draft',
 			'post_type'    => 'wp_template',


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This PR fixes two issues with template lookup:

### 1. Templates with `index.html` block template fallback

When using a theme that came with an `index.html` but not with a `front-page.html` block template, the site editor would show the following `Notice: Undefined index: front-page in /var/www/html/wp-content/plugins/gutenberg/lib/edit-site-page.php on line 162`.
 
The reason is that I was setting the wrong key here: https://github.com/WordPress/gutenberg/blob/710373b254fbcd15d524afdeb31da0d93c4defd4/lib/edit-site-page.php#L158

This would use the name of the template that was _found_, not the name of the key that was looked for. So if we're looking up `front-page`, but don't find any template, and [thus fall](https://github.com/WordPress/gutenberg/blob/710373b254fbcd15d524afdeb31da0d93c4defd4/lib/template-loader.php#L226) back to `index`, the template will be stored under the `index` key, rather than the front-end one. 

The fix for this is to use the template we were looking for as key (rather than the name of the template we actually found).

### 2. Templates without `index.html` block template fallback

When using a theme that doesn't come with any block templates at all, we need to provide a blank `index` template when the user first opens the site editor (see [discussion](https://github.com/WordPress/gutenberg/pull/22893#discussion_r435430149)).

## How has this been tested?
- There shouldn't be any `wp_template` CPTs (neither published nor `auto-draft`s) from previous Site Editor runs. (It's best to start with a fresh install, i.e. `npx wp-env clean all && npx wp-env start`. _Careful, this will wipe your WordPress install's data!_)
- Furthermore, the "Full Site Editing Demo Templates" checkbox in `/wp-admin/admin.php?page=gutenberg-experiments` _must not be ticked_. (Make sure the "Full Site Editing" checkbox is ticked -- since it also gets reset after a wipe.)
- Make sure you have linked your wp-env install to themes from the `theme-experiments` repo (see the [`wp-env` README](https://github.com/WordPress/gutenberg/blob/710373b254fbcd15d524afdeb31da0d93c4defd4/packages/env/README.md)).
- Activate the "Twenty Twenty Blocks" theme, and open the site editor. Verify that the template switcher shows the index template, and no errors or notices are printed. (Don't modify anything in order not to create an auto draft of that template.)
- Activate the "Twenty Twenty" theme, and open the site editor. Verify that the template switcher shows a _blank_ index template, and no errors or notices are printed. This is the template that was autogenerated, since the regular Twenty Twenty theme doesn't come with any block templates.

## Open question

Upon running 

```
npx wp-env run cli "wp post list --post_type=wp_template --post_status=auto-draft"
```

I see a sleuth of `index` template `auto-draft`s. I was hoping that only one would be created :confused: -- maybe my newly added logic is still buggy.

## Types of changes
Bug fix. Fixes #22800.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
