### PR TITLE
Remove "block" from "Hide Block Settings" and "Show Block Settings" labels

### DIFF
--- a/packages/edit-post/src/components/visual-editor/block-inspector-button.js
+++ b/packages/edit-post/src/components/visual-editor/block-inspector-button.js
@@ -43,8 +43,8 @@ export function BlockInspectorButton( {
 	};
 
 	const label = areAdvancedSettingsOpened
-		? __( 'Hide Settings' )
-		: __( 'Show Settings' );
+		? __( 'Hide More Settings' )
+		: __( 'Show More Settings' );
 
 	return (
 		<MenuItem

--- a/packages/edit-post/src/components/visual-editor/block-inspector-button.js
+++ b/packages/edit-post/src/components/visual-editor/block-inspector-button.js
@@ -43,8 +43,8 @@ export function BlockInspectorButton( {
 	};
 
 	const label = areAdvancedSettingsOpened
-		? __( 'Hide Block Settings' )
-		: __( 'Show Block Settings' );
+		? __( 'Hide Settings' )
+		: __( 'Show Settings' );
 
 	return (
 		<MenuItem


### PR DESCRIPTION
## Description
Update labels from "Hide Block Settings" and "Show Block Settings" to "Hide More Settings" and "Show More Settings".

Closes #22920.

## Types of changes
Just labels update, no change in functionality of the component.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
