### PR TITLE
Fix the modal height too small #22854

### DIFF
--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -36,7 +36,7 @@
 		left: 50%;
 		min-width: $modal-min-width;
 		max-width: calc(100% - #{ $grid-unit-20 } - #{ $grid-unit-20 });
-		max-height: calc(100% - #{ $header-height } - #{ $header-height });
+		max-height: 90%;
 		transform: translate(-50%, -50%);
 
 		// Animate the modal frame/contents appearing on the page.

--- a/packages/edit-post/src/components/manage-blocks-modal/style.scss
+++ b/packages/edit-post/src/components/manage-blocks-modal/style.scss
@@ -1,6 +1,6 @@
 .edit-post-manage-blocks-modal {
 	@include break-small() {
-		height: calc(100% - #{ $header-height } - #{ $header-height });
+		height: 90%;
 	}
 }
 


### PR DESCRIPTION
 Description
I read #22854 and I changed 2 lines.
I hope this fix will work well...

## How has this been tested?
1. Your window size sets 667 x 375 (iPhone6/7/8).
2. Create a new post or page.
3. Open the Keyboard shortcuts modal.

## Screenshots
<img width="687" alt="ss2020-06-06 8 34 39" src="https://user-images.githubusercontent.com/487207/83930048-b0d4e580-a7d0-11ea-8749-96ec83018b05.png">

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
