### PR TITLE
Fix Drag and Drop in Safari by upgrading Reakit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10393,7 +10393,7 @@
 				"react-dates": "^17.1.1",
 				"react-spring": "^8.0.20",
 				"react-use-gesture": "^7.0.15",
-				"reakit": "^1.0.2",
+				"reakit": "^1.0.4",
 				"rememo": "^3.0.0",
 				"tinycolor2": "^1.4.1",
 				"uuid": "^7.0.2"
@@ -14015,9 +14015,9 @@
 			}
 		},
 		"body-scroll-lock": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/body-scroll-lock/-/body-scroll-lock-3.0.2.tgz",
-			"integrity": "sha512-PtItUun94iIupKry8J/h6SfRCLWZnly77KbPsTSKALmxfR282L8R0Ujkv7bydSZvLxAJS4sBJ3y/E6X8gYkGrQ=="
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/body-scroll-lock/-/body-scroll-lock-3.0.3.tgz",
+			"integrity": "sha512-EUryImgD6Gv87HOjJB/yB2WIGECiZMhmcUK+DrqVRFDDa64xR+FsK0LgvLPnBxZDTxIl+W80/KJ8i6gp2IwOHQ=="
 		},
 		"boolbase": {
 			"version": "1.0.0",
@@ -37643,36 +37643,36 @@
 			}
 		},
 		"reakit": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/reakit/-/reakit-1.0.2.tgz",
-			"integrity": "sha512-l1yvXm9sjVGljsVxoPoSOWwsZWVMJZI7nWEgY+HqzPcsVH483F64oLamj21uCAbwpxfaEkQ/hS5g9RAbdfGEog==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/reakit/-/reakit-1.0.4.tgz",
+			"integrity": "sha512-v9tZoO40IBA7zX4SypyGco9z6+mDGcn/JsZfYRA+Qvmh2FjLX08m7FwhkQMgwccygHaZP+nEgVIsE6QUroCWrw==",
 			"requires": {
 				"@popperjs/core": "^2.4.0",
 				"body-scroll-lock": "^3.0.2",
-				"reakit-system": "^0.12.1",
-				"reakit-utils": "^0.12.0",
-				"reakit-warning": "^0.3.0"
+				"reakit-system": "^0.12.2",
+				"reakit-utils": "^0.12.1",
+				"reakit-warning": "^0.3.1"
 			}
 		},
 		"reakit-system": {
-			"version": "0.12.1",
-			"resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.12.1.tgz",
-			"integrity": "sha512-92NRBxCHslIkME4y2Z5jPAOESiBbkOF2g0LE2FiPSzZwdJ9/geWfhP50y/WFAO1WIFChVREATSXqng1xhWGwwg==",
+			"version": "0.12.2",
+			"resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.12.2.tgz",
+			"integrity": "sha512-+/tZ/atDbHhDOapcIxniNZd7z0cze1L9MJBEnvykqM/bdqUE59Eb/OQ6odPZwK35gcN1lNyZtw7DgnFrmsDi4w==",
 			"requires": {
-				"reakit-utils": "^0.12.0"
+				"reakit-utils": "^0.12.1"
 			}
 		},
 		"reakit-utils": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.12.0.tgz",
-			"integrity": "sha512-B0KUjRDu0GFDTi+FQApm4gynJGn18DuDdgCtcUytkN/AIJdKGaqHJ6FpeE1zMr1KAAUzZKrRqq/x93MrcQtvfQ=="
+			"version": "0.12.1",
+			"resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.12.1.tgz",
+			"integrity": "sha512-P66TYzmQFD5CqNWcRvbPb6B5nXRLfiWqwTJhVGDUeOJTSdlnjfsBuOIauojfuS+p4yeyFVsUFsFwuBM6uZ8F3A=="
 		},
 		"reakit-warning": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/reakit-warning/-/reakit-warning-0.3.0.tgz",
-			"integrity": "sha512-sJhgKQl6b4BZOo8jAXpneYFuAkx4wuftGl5KiIDAQZWg+e8YfB41QayjqM2eh0mQkG13hbc4pBOAyR5oFZxK0w==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/reakit-warning/-/reakit-warning-0.3.1.tgz",
+			"integrity": "sha512-kFGASQG1ogpyknF0vlfab2emptCuW4a2Ku0SOeNkD+WGkMytJMNqrklqqfuWFEPqpuWGkBduOLbmEEyVLgSLZg==",
 			"requires": {
-				"reakit-utils": "^0.12.0"
+				"reakit-utils": "^0.12.1"
 			}
 		},
 		"realpath-native": {

--- a/packages/block-library/src/heading/heading-level-dropdown.js
+++ b/packages/block-library/src/heading/heading-level-dropdown.js
@@ -93,15 +93,6 @@ export default function HeadingLevelDropdown( { selectedLevel, onChange } ) {
 								onClick() {
 									onChange( targetLevel );
 								},
-								// Temporary workaround for macOS Firefox/Safari issue
-								// where clicking buttons in the heading level toolbar
-								// doesn't work.
-								// TODO: Replace this with a more general solution.
-								// https://github.com/WordPress/gutenberg/pull/20246#pullrequestreview-417338057
-								onMouseDown( event ) {
-									event.preventDefault();
-									event.currentTarget.focus();
-								},
 							};
 						} ) }
 					/>

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -53,7 +53,7 @@
 		"react-dates": "^17.1.1",
 		"react-spring": "^8.0.20",
 		"react-use-gesture": "^7.0.15",
-		"reakit": "^1.0.2",
+		"reakit": "^1.0.4",
 		"rememo": "^3.0.0",
 		"tinycolor2": "^1.4.1",
 		"uuid": "^7.0.2"


### PR DESCRIPTION
This PR upgrades `reakit` and fixes #22730 so drag and drop works in Safari again.

<details><summary>Changelog</summary>

## [1.0.4](https://github.com/reakit/reakit/compare/reakit@1.0.3...reakit@1.0.4) (2020-06-06)


### Bug Fixes

* Fix `Tabbable` preventing drag events on mouse down on Safari ([#670](https://github.com/reakit/reakit/issues/670)) ([6830c5a](https://github.com/reakit/reakit/commit/6830c5a649c55c6e1a418490fff4a9b70a92b9d8))





## [1.0.3](https://github.com/reakit/reakit/compare/reakit@1.0.2...reakit@1.0.3) (2020-06-04)


### Bug Fixes

* Fix blur/focus events order on `Tabbable` on Safari and Firefox on MacOS ([#658](https://github.com/reakit/reakit/issues/658)) ([aad12ce](https://github.com/reakit/reakit/commit/aad12ced87dd3a94e4679a8e510a2e8d9fd3c1f8))


### Performance Improvements

* Improve `Composite` performance ([#660](https://github.com/reakit/reakit/issues/660)) ([f6656b6](https://github.com/reakit/reakit/commit/f6656b6b765bbec639754aa96a2f08b717413068))



</details>

**Before**

![Jun-06-2020 00-51-13](https://user-images.githubusercontent.com/3068563/83935583-405aa400-a791-11ea-82d2-ea46587715de.gif)

**After**

![Jun-06-2020 00-50-06](https://user-images.githubusercontent.com/3068563/83935578-39cc2c80-a791-11ea-9608-c285ef7c0b1c.gif)

Also, the workaround on the Heading level control dropdown is no longer necessary (cc @ZebulanStanphill):

<details>

![Jun-06-2020 00-52-49](https://user-images.githubusercontent.com/3068563/83935580-3d5fb380-a791-11ea-9731-ea3fcbaf257d.gif)

</details>

## How to test

- Check if drag and drop on the block toolbar works in Safari.
- Check if changing the heading level on the Heading block toolbar works in Safari.