### PR TITLE
Make ToolbarButton API consistent

### DIFF
--- a/packages/components/src/toolbar-button/index.js
+++ b/packages/components/src/toolbar-button/index.js
@@ -52,6 +52,7 @@ function ToolbarButton( {
 					disabled={ isDisabled }
 					data-experimental-toolbar-item
 					{ ...extraProps }
+					{ ...props }
 				>
 					{ children }
 				</Button>
@@ -65,6 +66,7 @@ function ToolbarButton( {
 	return (
 		<ToolbarItem
 			className={ classnames( 'components-toolbar-button', className ) }
+			{ ...extraProps }
 			{ ...props }
 		>
 			{ ( toolbarItemProps ) => (


### PR DESCRIPTION
Currently, `ToolbarButton` accepts different props depending on the context in which it's being rendered:

- If it's a descendant of `<Toolbar>`, it accepts `extraProps`, `title` and `isActive` props.

- If it's a descendant of `<Toolbar __experimentalAccessibilityLabel>`, it accepts additional `Button` props like `label` and `isPressed` (which are equivalent to `title` and `isActive`). This is so `ToolbarButton` has the same API as `Button`, which makes it easier to migrate from one to another.

The problem is that, depending on the situation, the same `ToolbarButton` component may be rendered within different `Toolbar` components, and, because of that, it'll unpredictably change its own API.

The following `ToolbarButton` would work only when within `<Toolbar __experimentalAccessibilityLabel>`:
```jsx
<ToolbarButton label="label" isPressed />
```

If it's rendered within `<Toolbar>`, both `label` and `isPressed` props would be ignored.

There's another PR (#22637) that proposes deprecating `title`, `isActive` and `extraProps` from `ToolbarButton`, but it turns out that getting rid of those props is not as simple as I'd anticipated, so I'm creating this simpler PR just to avoid future issues.

This PR updates the component so both cases have the same API: both will accept the `Button` props in addition to the `ToolbarButton` custom props.