### PR TITLE
Fix am / pm i18n's bug

### DIFF
--- a/packages/components/src/date-time/time.js
+++ b/packages/components/src/date-time/time.js
@@ -115,7 +115,7 @@ class TimePicker extends Component {
 			? date
 					.clone()
 					.hours(
-						am === 'AM' ? value % 12 : ( ( value % 12 ) + 12 ) % 24
+						am === __( 'AM' ) ? value % 12 : ( ( value % 12 ) + 12 ) % 24
 					)
 			: date.clone().hours( value );
 		this.changeDate( newDate );
@@ -184,7 +184,7 @@ class TimePicker extends Component {
 				return;
 			}
 			let newDate;
-			if ( value === 'PM' ) {
+			if ( value === __( 'PM' ) ) {
 				newDate = date
 					.clone()
 					.hours( ( ( parseInt( hours, 10 ) % 12 ) + 12 ) % 24 );
@@ -336,17 +336,17 @@ class TimePicker extends Component {
 						{ is12Hour && (
 							<ButtonGroup className="components-datetime__time-field components-datetime__time-field-am-pm">
 								<Button
-									isPrimary={ am === 'AM' }
-									isSecondary={ am !== 'AM' }
-									onClick={ this.updateAmPm( 'AM' ) }
+									isPrimary={ am === __( 'AM' ) }
+									isSecondary={ am !== __( 'AM' ) }
+									onClick={ this.updateAmPm( __( 'AM' ) ) }
 									className="components-datetime__time-am-button"
 								>
 									{ __( 'AM' ) }
 								</Button>
 								<Button
-									isPrimary={ am === 'PM' }
-									isSecondary={ am !== 'PM' }
-									onClick={ this.updateAmPm( 'PM' ) }
+									isPrimary={ am === __( 'PM' ) }
+									isSecondary={ am !== __('PM') }
+									onClick={ this.updateAmPm( __('PM') ) }
 									className="components-datetime__time-pm-button"
 								>
 									{ __( 'PM' ) }

--- a/packages/components/src/date-time/time.js
+++ b/packages/components/src/date-time/time.js
@@ -31,7 +31,7 @@ class TimePicker extends Component {
 			year: '',
 			hours: '',
 			minutes: '',
-			am: true,
+			am: '',
 			date: null,
 		};
 		this.changeDate = this.changeDate.bind( this );
@@ -89,7 +89,8 @@ class TimePicker extends Component {
 		const month = selected.format( 'MM' );
 		const year = selected.format( 'YYYY' );
 		const minutes = selected.format( 'mm' );
-		const am = selected.format( 'A' );
+		//const am = selected.format( 'A' );
+		const am = selected.format( 'A' ) === __( 'AM' ) ? 'AM' : 'PM';
 		const hours = selected.format( is12Hour ? 'hh' : 'HH' );
 		const date = currentTime ? moment( currentTime ) : moment();
 		this.setState( { day, month, year, minutes, hours, am, date } );
@@ -115,9 +116,7 @@ class TimePicker extends Component {
 			? date
 					.clone()
 					.hours(
-						am === __( 'AM' )
-							? value % 12
-							: ( ( value % 12 ) + 12 ) % 24
+						am === 'AM' ? value % 12 : ( ( value % 12 ) + 12 ) % 24
 					)
 			: date.clone().hours( value );
 		this.changeDate( newDate );
@@ -186,7 +185,7 @@ class TimePicker extends Component {
 				return;
 			}
 			let newDate;
-			if ( value === __( 'PM' ) ) {
+			if ( value === 'PM' ) {
 				newDate = date
 					.clone()
 					.hours( ( ( parseInt( hours, 10 ) % 12 ) + 12 ) % 24 );
@@ -338,17 +337,17 @@ class TimePicker extends Component {
 						{ is12Hour && (
 							<ButtonGroup className="components-datetime__time-field components-datetime__time-field-am-pm">
 								<Button
-									isPrimary={ am === __( 'AM' ) }
-									isSecondary={ am !== __( 'AM' ) }
-									onClick={ this.updateAmPm( __( 'AM' ) ) }
+									isPrimary={ am === 'AM' }
+									isSecondary={ am !== 'AM' }
+									onClick={ this.updateAmPm( 'AM' ) }
 									className="components-datetime__time-am-button"
 								>
 									{ __( 'AM' ) }
 								</Button>
 								<Button
-									isPrimary={ am === __( 'PM' ) }
-									isSecondary={ am !== __( 'PM' ) }
-									onClick={ this.updateAmPm( __( 'PM' ) ) }
+									isPrimary={ am === 'PM' }
+									isSecondary={ am !== 'PM' }
+									onClick={ this.updateAmPm( 'PM' ) }
 									className="components-datetime__time-pm-button"
 								>
 									{ __( 'PM' ) }

--- a/packages/components/src/date-time/time.js
+++ b/packages/components/src/date-time/time.js
@@ -89,7 +89,7 @@ class TimePicker extends Component {
 		const month = selected.format( 'MM' );
 		const year = selected.format( 'YYYY' );
 		const minutes = selected.format( 'mm' );
-		const am = selected.format( 'A' ) === __( 'AM' ) ? 'AM' : 'PM';
+		const am = selected.format( 'H' ) <= 11 ? 'AM' : 'PM';
 		const hours = selected.format( is12Hour ? 'hh' : 'HH' );
 		const date = currentTime ? moment( currentTime ) : moment();
 		this.setState( { day, month, year, minutes, hours, am, date } );

--- a/packages/components/src/date-time/time.js
+++ b/packages/components/src/date-time/time.js
@@ -89,7 +89,6 @@ class TimePicker extends Component {
 		const month = selected.format( 'MM' );
 		const year = selected.format( 'YYYY' );
 		const minutes = selected.format( 'mm' );
-		//const am = selected.format( 'A' );
 		const am = selected.format( 'A' ) === __( 'AM' ) ? 'AM' : 'PM';
 		const hours = selected.format( is12Hour ? 'hh' : 'HH' );
 		const date = currentTime ? moment( currentTime ) : moment();

--- a/packages/components/src/date-time/time.js
+++ b/packages/components/src/date-time/time.js
@@ -115,7 +115,9 @@ class TimePicker extends Component {
 			? date
 					.clone()
 					.hours(
-						am === __( 'AM' ) ? value % 12 : ( ( value % 12 ) + 12 ) % 24
+						am === __( 'AM' )
+							? value % 12
+							: ( ( value % 12 ) + 12 ) % 24
 					)
 			: date.clone().hours( value );
 		this.changeDate( newDate );
@@ -345,8 +347,8 @@ class TimePicker extends Component {
 								</Button>
 								<Button
 									isPrimary={ am === __( 'PM' ) }
-									isSecondary={ am !== __('PM') }
-									onClick={ this.updateAmPm( __('PM') ) }
+									isSecondary={ am !== __( 'PM' ) }
+									onClick={ this.updateAmPm( __( 'PM' ) ) }
 									className="components-datetime__time-pm-button"
 								>
 									{ __( 'PM' ) }


### PR DESCRIPTION
## Description
Fixes #22924
I changed the state `am` value to just string 'AM' and 'PM' for i18n.

## How has this been tested?
1. Make the setting of time to `g:i A`, and the language to Japanese.
2. Create a new post.
3. Document > Publish
4. You can change AM='午前', PM='午後' and that's current color.

## Screenshots
![Kapture 2020-06-06 at 16 12 23](https://user-images.githubusercontent.com/487207/83938865-3aa5a280-a813-11ea-8435-1d763a847945.gif)

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.