### PR TITLE
Interface: Add missing param docs for singleEnableItems() and multipleEnableItems()

### DIFF
--- a/packages/interface/src/store/reducer.js
+++ b/packages/interface/src/store/reducer.js
@@ -11,8 +11,12 @@ import { combineReducers } from '@wordpress/data';
 /**
  * Reducer to keep tract of the active area per scope.
  *
- * @param {boolean}  state   Previous state.
- * @param {Object}   action  Action Object.
+ * @param {boolean} state           Previous state.
+ * @param {Object}  action          Action object.
+ * @param {string}  action.type     Action type.
+ * @param {string}  action.itemType Type of item.
+ * @param {string}  action.scope    Item scope.
+ * @param {string}  action.item     Item name.
  *
  * @return {Object} Updated state.
  */
@@ -34,10 +38,15 @@ export function singleEnableItems(
 }
 
 /**
- * Reducer keeping track of the "pinned" items per scope
+ * Reducer keeping track of the "pinned" items per scope.
  *
- * @param {boolean}  state   Previous state.
- * @param {Object}   action  Action Object.
+ * @param {boolean} state           Previous state.
+ * @param {Object}  action          Action object.
+ * @param {string}  action.type     Action type.
+ * @param {string}  action.itemType Type of item.
+ * @param {string}  action.scope    Item scope.
+ * @param {string}  action.item     Item name.
+ * @param {boolean} action.isEnable Whether the item is pinned.
  *
  * @return {Object} Updated state.
  */


### PR DESCRIPTION
## Description
See #22907.

Fixes the following JSDoc warnings:

```
packages/interface/src/store/reducer.js
  11:1  warning  Missing JSDoc @param "action.type" declaration      jsdoc/require-param
  11:1  warning  Missing JSDoc @param "action.itemType" declaration  jsdoc/require-param
  11:1  warning  Missing JSDoc @param "action.scope" declaration     jsdoc/require-param
  11:1  warning  Missing JSDoc @param "action.item" declaration      jsdoc/require-param
  15:0  warning  Missing @param "action.type"                        jsdoc/check-param-names
  15:0  warning  Missing @param "action.itemType"                    jsdoc/check-param-names
  15:0  warning  Missing @param "action.scope"                       jsdoc/check-param-names
  15:0  warning  Missing @param "action.item"                        jsdoc/check-param-names
  36:1  warning  Missing JSDoc @param "action.type" declaration      jsdoc/require-param
  36:1  warning  Missing JSDoc @param "action.itemType" declaration  jsdoc/require-param
  36:1  warning  Missing JSDoc @param "action.scope" declaration     jsdoc/require-param
  36:1  warning  Missing JSDoc @param "action.item" declaration      jsdoc/require-param
  36:1  warning  Missing JSDoc @param "action.isEnable" declaration  jsdoc/require-param
  40:0  warning  Missing @param "action.type"                        jsdoc/check-param-names
  40:0  warning  Missing @param "action.itemType"                    jsdoc/check-param-names
  40:0  warning  Missing @param "action.scope"                       jsdoc/check-param-names
  40:0  warning  Missing @param "action.item"                        jsdoc/check-param-names
  40:0  warning  Missing @param "action.isEnable"                    jsdoc/check-param-names
```

## How has this been tested?
`npm run lint-js  packages/interface/src`

## Types of changes
Bug fix