### PR TITLE
Core Data: Add missing param doc for saveEntityRecord()

### DIFF
--- a/docs/designers-developers/developers/data/data-core.md
+++ b/docs/designers-developers/developers/data/data-core.md
@@ -634,6 +634,7 @@ _Parameters_
 -   _name_ `string`: Name of the received entity.
 -   _record_ `Object`: Record to be saved.
 -   _options_ `Object`: Saving options.
+-   _options.isAutosave_ `[boolean]`: Whether this is an autosave.
 
 <a name="undo" href="#undo">#</a> **undo**
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -217,6 +217,7 @@ _Parameters_
 -   _name_ `string`: Name of the received entity.
 -   _record_ `Object`: Record to be saved.
 -   _options_ `Object`: Saving options.
+-   _options.isAutosave_ `[boolean]`: Whether this is an autosave.
 
 <a name="undo" href="#undo">#</a> **undo**
 

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -249,10 +249,11 @@ export function __unstableCreateUndoLevel() {
 /**
  * Action triggered to save an entity record.
  *
- * @param {string} kind    Kind of the received entity.
- * @param {string} name    Name of the received entity.
- * @param {Object} record  Record to be saved.
- * @param {Object} options Saving options.
+ * @param {string}  kind                       Kind of the received entity.
+ * @param {string}  name                       Name of the received entity.
+ * @param {Object}  record                     Record to be saved.
+ * @param {Object}  options                    Saving options.
+ * @param {boolean} [options.isAutosave=false] Whether this is an autosave.
  */
 export function* saveEntityRecord(
 	kind,


### PR DESCRIPTION
## Description
See #22907.

Fixes the following JSDoc warnings:

```
packages/core-data/src/actions.js
  249:1  warning  Missing JSDoc @param "options.isAutosave" declaration  jsdoc/require-param
  255:0  warning  Missing @param "options.isAutosave"                    jsdoc/check-param-names
```

## How has this been tested?
`npm run lint-js  packages/core-data/src/`

## Types of changes
Bug fix