### PR TITLE
Components: ToolbarButton use forwardRef.

### DIFF
--- a/packages/block-editor/src/components/block-switcher/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/block-switcher/test/__snapshots__/index.js.snap
@@ -2,7 +2,7 @@
 
 exports[`BlockSwitcher should render disabled block switcher with multi block of different types when no transforms 1`] = `
 <ToolbarGroup>
-  <ToolbarButton
+  <ForwardRef(ToolbarButton)
     className="block-editor-block-switcher__no-switcher-icon"
     disabled={true}
     icon={

--- a/packages/block-editor/src/components/block-switcher/test/index.js
+++ b/packages/block-editor/src/components/block-switcher/test/index.js
@@ -8,6 +8,7 @@ import { shallow } from 'enzyme';
  */
 import { registerBlockType, unregisterBlockType } from '@wordpress/blocks';
 import { DOWN } from '@wordpress/keycodes';
+import { ToolbarButton } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -186,7 +187,7 @@ describe( 'BlockSwitcher', () => {
 						isOpen: false,
 					} )
 				);
-				const iconButtonClosed = toggleClosed.find( 'ToolbarButton' );
+				const iconButtonClosed = toggleClosed.find( ToolbarButton );
 
 				iconButtonClosed.simulate( 'keydown', mockKeyDown );
 
@@ -200,7 +201,7 @@ describe( 'BlockSwitcher', () => {
 						isOpen: true,
 					} )
 				);
-				const iconButtonOpen = toggleOpen.find( 'ToolbarButton' );
+				const iconButtonOpen = toggleOpen.find( ToolbarButton );
 
 				iconButtonOpen.simulate( 'keydown', mockKeyDown );
 

--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -6,7 +6,7 @@ import { uniqueId } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { useState, createRef, renderToString } from '@wordpress/element';
+import { useState, renderToString } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
 import {
@@ -44,7 +44,7 @@ const MediaReplaceFlow = ( {
 	const mediaUpload = useSelect( ( select ) => {
 		return select( 'core/block-editor' ).getSettings().mediaUpload;
 	}, [] );
-	const editMediaButtonRef = createRef();
+	const editMediaButtonRef = ToolbarButton.ref;
 	const errorNoticeID = uniqueId(
 		'block-editor/media-replace-flow/error-notice/'
 	);
@@ -111,7 +111,6 @@ const MediaReplaceFlow = ( {
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<ToolbarGroup className="media-replace-flow">
 					<ToolbarButton
-						ref={ editMediaButtonRef }
 						aria-expanded={ isOpen }
 						onClick={ onToggle }
 						onKeyDown={ openOnArrowDown }

--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -6,7 +6,7 @@ import { uniqueId } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { useState, renderToString, useRef } from '@wordpress/element';
+import { useState, createRef, renderToString } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
 import {
@@ -44,7 +44,7 @@ const MediaReplaceFlow = ( {
 	const mediaUpload = useSelect( ( select ) => {
 		return select( 'core/block-editor' ).getSettings().mediaUpload;
 	}, [] );
-	const editMediaButtonRef = useRef();
+	const editMediaButtonRef = createRef();
 	const errorNoticeID = uniqueId(
 		'block-editor/media-replace-flow/error-notice/'
 	);

--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -6,7 +6,7 @@ import { uniqueId } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { useState, renderToString } from '@wordpress/element';
+import { useState, renderToString, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
 import {
@@ -44,7 +44,7 @@ const MediaReplaceFlow = ( {
 	const mediaUpload = useSelect( ( select ) => {
 		return select( 'core/block-editor' ).getSettings().mediaUpload;
 	}, [] );
-	const editMediaButtonRef = ToolbarButton.ref;
+	const editMediaButtonRef = useRef();
 	const errorNoticeID = uniqueId(
 		'block-editor/media-replace-flow/error-notice/'
 	);
@@ -111,6 +111,7 @@ const MediaReplaceFlow = ( {
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<ToolbarGroup className="media-replace-flow">
 					<ToolbarButton
+						ref={ editMediaButtonRef }
 						aria-expanded={ isOpen }
 						onClick={ onToggle }
 						onKeyDown={ openOnArrowDown }

--- a/packages/components/src/toolbar-button/index.js
+++ b/packages/components/src/toolbar-button/index.js
@@ -2,12 +2,10 @@
  * External dependencies
  */
 import classnames from 'classnames';
-
 /**
  * WordPress dependencies
  */
-import { useContext, forwardRef } from '@wordpress/element';
-
+import { useContext, useRef } from '@wordpress/element';
 /**
  * Internal dependencies
  */
@@ -16,28 +14,27 @@ import ToolbarItem from '../toolbar-item';
 import ToolbarContext from '../toolbar-context';
 import ToolbarButtonContainer from './toolbar-button-container';
 
-function ToolbarButton(
-	{
-		containerClassName,
-		className,
-		extraProps,
-		children,
-		title,
-		isActive,
-		isDisabled,
-		...props
-	},
-	ref
-) {
-	const accessibleToolbarState = useContext( ToolbarContext );
+function ToolbarButton( {
+	containerClassName,
+	className,
+	extraProps,
+	children,
+	title,
+	isActive,
+	isDisabled,
+	...props
+} ) {
+	ToolbarButton.ref = useRef();
 
+	const accessibleToolbarState = useContext( ToolbarContext );
 	if ( ! accessibleToolbarState ) {
 		// This should be deprecated when <Toolbar __experimentalAccessibilityLabel="label">
 		// becomes stable.
+
 		return (
 			<ToolbarButtonContainer className={ containerClassName }>
 				<Button
-					ref={ ref }
+					ref={ ToolbarButton.ref }
 					icon={ props.icon }
 					label={ title }
 					shortcut={ props.shortcut }
@@ -75,6 +72,7 @@ function ToolbarButton(
 		>
 			{ ( toolbarItemProps ) => (
 				<Button
+					ref={ ToolbarButton.ref }
 					label={ title }
 					isPressed={ isActive }
 					disabled={ isDisabled }
@@ -87,4 +85,4 @@ function ToolbarButton(
 	);
 }
 
-export default forwardRef( ToolbarButton );
+export default ToolbarButton;

--- a/packages/components/src/toolbar-button/index.js
+++ b/packages/components/src/toolbar-button/index.js
@@ -28,10 +28,10 @@ function ToolbarButton(
 	ref
 ) {
 	const accessibleToolbarState = useContext( ToolbarContext );
+
 	if ( ! accessibleToolbarState ) {
 		// This should be deprecated when <Toolbar __experimentalAccessibilityLabel="label">
 		// becomes stable.
-
 		return (
 			<ToolbarButtonContainer className={ containerClassName }>
 				<Button

--- a/packages/components/src/toolbar-button/index.js
+++ b/packages/components/src/toolbar-button/index.js
@@ -5,7 +5,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useContext, useRef } from '@wordpress/element';
+import { useContext, forwardRef } from '@wordpress/element';
 /**
  * Internal dependencies
  */
@@ -14,18 +14,19 @@ import ToolbarItem from '../toolbar-item';
 import ToolbarContext from '../toolbar-context';
 import ToolbarButtonContainer from './toolbar-button-container';
 
-function ToolbarButton( {
-	containerClassName,
-	className,
-	extraProps,
-	children,
-	title,
-	isActive,
-	isDisabled,
-	...props
-} ) {
-	ToolbarButton.ref = useRef();
-
+function ToolbarButton(
+	{
+		containerClassName,
+		className,
+		extraProps,
+		children,
+		title,
+		isActive,
+		isDisabled,
+		...props
+	},
+	ref
+) {
 	const accessibleToolbarState = useContext( ToolbarContext );
 	if ( ! accessibleToolbarState ) {
 		// This should be deprecated when <Toolbar __experimentalAccessibilityLabel="label">
@@ -34,7 +35,7 @@ function ToolbarButton( {
 		return (
 			<ToolbarButtonContainer className={ containerClassName }>
 				<Button
-					ref={ ToolbarButton.ref }
+					ref={ ref }
 					icon={ props.icon }
 					label={ title }
 					shortcut={ props.shortcut }
@@ -69,10 +70,10 @@ function ToolbarButton( {
 			className={ classnames( 'components-toolbar-button', className ) }
 			{ ...extraProps }
 			{ ...props }
+			ref={ ref }
 		>
 			{ ( toolbarItemProps ) => (
 				<Button
-					ref={ ToolbarButton.ref }
 					label={ title }
 					isPressed={ isActive }
 					disabled={ isDisabled }
@@ -85,4 +86,4 @@ function ToolbarButton( {
 	);
 }
 
-export default ToolbarButton;
+export default forwardRef( ToolbarButton );

--- a/packages/components/src/toolbar-button/index.js
+++ b/packages/components/src/toolbar-button/index.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useContext } from '@wordpress/element';
+import { useContext, forwardRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -16,16 +16,19 @@ import ToolbarItem from '../toolbar-item';
 import ToolbarContext from '../toolbar-context';
 import ToolbarButtonContainer from './toolbar-button-container';
 
-function ToolbarButton( {
-	containerClassName,
-	className,
-	extraProps,
-	children,
-	title,
-	isActive,
-	isDisabled,
-	...props
-} ) {
+function ToolbarButton(
+	{
+		containerClassName,
+		className,
+		extraProps,
+		children,
+		title,
+		isActive,
+		isDisabled,
+		...props
+	},
+	ref
+) {
 	const accessibleToolbarState = useContext( ToolbarContext );
 
 	if ( ! accessibleToolbarState ) {
@@ -34,6 +37,7 @@ function ToolbarButton( {
 		return (
 			<ToolbarButtonContainer className={ containerClassName }>
 				<Button
+					ref={ ref }
 					icon={ props.icon }
 					label={ title }
 					shortcut={ props.shortcut }
@@ -83,4 +87,4 @@ function ToolbarButton( {
 	);
 }
 
-export default ToolbarButton;
+export default forwardRef( ToolbarButton );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

Fix error in `MediaReplaceFlow`.

```
Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?

Check the render method of `Dropdown`.
    in ToolbarButton (created by Dropdown)
    in div (created by ToolbarGroupContainer)
    in ToolbarGroupContainer (created by ToolbarGroup)
    in ToolbarGroup (created by Dropdown)
    in div (created by Dropdown)
    in Dropdown (created by MediaReplaceFlow)
    in MediaReplaceFlow (created by WithDispatch(MediaReplaceFlow))
 ...
```

Edit Custom media url, show error

```
TypeError: Cannot read property 'focus'
```

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Make sure MediaReplaceFlow. 

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
