### PR TITLE
Docs: Add code examples section

### DIFF
--- a/docs/contributors/document.md
+++ b/docs/contributors/document.md
@@ -65,7 +65,7 @@ This way they will be properly handled in all three aforementioned contexts.
 
 ### Code Examples
 
-The code example in markdown should be wrapped in three tick marks <code>```</code> and can additionally include a language specifier. See this [Github documentation around fenced code blocks](https://help.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks).
+The code example in markdown should be wrapped in three tick marks <code>```</code> and can additionally include a language specifier. See this [GitHub documentation around fenced code blocks](https://help.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks).
 
 A unique feature to the Gutenberg documentation is the `codetabs` toggle, this allows two versions of code to be shown at once. This is used for showing both `ESNext` and `ES5` code samples. For example, [on this block tutorial page](/docs/designers-developers/developers/tutorials/block-tutorial/block-controls-toolbar-and-sidebar.md).
 
@@ -82,7 +82,7 @@ Here is an example `codetabs` section:
 		```
 		{% end %}
 
-The preferred format for code examples is ESNext, which should also be the default viewed, when placed first in source it will show as the default.
+The preferred format for code examples is ESNext, which should also be the default viewed. The example placed first in source will be shown as the default.
 
 Note: not all code examples are required to include ES5 code. The guidance is to include `ES5` code for beginner tutorials, but the majority of code in Gutenberg packages and across the larger React and JavaScript ecosystem is in ESNext.
 

--- a/docs/contributors/document.md
+++ b/docs/contributors/document.md
@@ -63,6 +63,29 @@ To create links that work in all contexts, you should use absolute path links wi
 
 This way they will be properly handled in all three aforementioned contexts.
 
+### Code Examples
+
+The code example in markdown should be wrapped in three tick marks <code>```</code> and can additionally include a language specifier. See this [Github documentation around fenced code blocks](https://help.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks).
+
+A unique feature to the Gutenberg documentation is the `codetabs` toggle, this allows two versions of code to be shown at once. This is used for showing both `ESNext` and `ES5` code samples. For example, [on this block tutorial page](/docs/designers-developers/developers/tutorials/block-tutorial/block-controls-toolbar-and-sidebar.md).
+
+Here is an example `codetabs` section:
+
+		{% codetabs %}
+		{% ESNext %}
+		```js
+			// ESNext code here
+		```
+		{% ES5 %}
+		```js
+			// ES5 code here
+		```
+		{% endtab %}
+
+The preferred format for code examples is ESNext, which should also be the default viewed, when placed first in source it will show as the default.
+
+Note: not all code examples are required to include ES5 code. The guidance is to include `ES5` code for beginner tutorials, but the majority of code in Gutenberg packages and across the larger React and JavaScript ecosystem is in ESNext.
+
 ## Resources
 
 - [Copy Guidelines](/docs/contributors/copy-guide.md) for writing instructions, documentations, or other contributions to Gutenberg project.

--- a/docs/contributors/document.md
+++ b/docs/contributors/document.md
@@ -80,7 +80,7 @@ Here is an example `codetabs` section:
 		```js
 			// ES5 code here
 		```
-		{% endtab %}
+		{% end %}
 
 The preferred format for code examples is ESNext, which should also be the default viewed, when placed first in source it will show as the default.
 

--- a/docs/contributors/document.md
+++ b/docs/contributors/document.md
@@ -71,16 +71,16 @@ A unique feature to the Gutenberg documentation is the `codetabs` toggle, this a
 
 Here is an example `codetabs` section:
 
-		{% codetabs %}
-		{% ESNext %}
-		```js
-			// ESNext code here
-		```
-		{% ES5 %}
-		```js
-			// ES5 code here
-		```
-		{% end %}
+	{% codetabs %}
+	{% ESNext %}
+	```js
+		// ESNext code here
+	```
+	{% ES5 %}
+	```js
+		// ES5 code here
+	```
+	{% end %}
 
 The preferred format for code examples is ESNext, which should also be the default viewed. The example placed first in source will be shown as the default.
 


### PR DESCRIPTION
## Description

Adds a code example section to the Documentation contributors page that explains how to use the triple tick marks and code tabs.

This also clarifies the preference for ESNext as the default codetab, this was discussed in #17873 and in [core-editor chat](https://make.wordpress.org/core/2019/10/09/editor-chat-summary-wednesday-9-october-2019/)

## How has this been tested?

Confirm code markup doesn't get wonky, it's tricky to document code using the format used to document code. You can [view rendered on the branch here](https://github.com/WordPress/gutenberg/blob/add/docs-code-ex/docs/contributors/document.md).

It looks fine in Github but will it survive handbook conversion 🤞

## Types of changes

Documentation.
