### PR TITLE
Block Editor: Update createBlockCompleter for @param rules

### DIFF
--- a/packages/block-editor/src/autocompleters/block.js
+++ b/packages/block-editor/src/autocompleters/block.js
@@ -84,6 +84,10 @@ const fetchReusableBlocks = once( () => {
 /**
  * Creates a blocks repeater for replacing the current block with a selected block type.
  *
+ * @param {Object}       props                                   Component props.
+ * @param {string}       [props.getBlockInsertionParentClientId] Client ID of the parent.
+ * @param {string}       [props.getInserterItems]                Inserter items for parent.
+ * @param {string}       [props.getSelectedBlockName]            Name of selected block or null.
  * @return {WPCompleter} A blocks completer.
  */
 export function createBlockCompleter( {

--- a/packages/block-editor/src/autocompleters/block.js
+++ b/packages/block-editor/src/autocompleters/block.js
@@ -84,10 +84,11 @@ const fetchReusableBlocks = once( () => {
 /**
  * Creates a blocks repeater for replacing the current block with a selected block type.
  *
- * @param {Object}       props                                   Component props.
- * @param {string}       [props.getBlockInsertionParentClientId] Client ID of the parent.
- * @param {string}       [props.getInserterItems]                Inserter items for parent.
- * @param {string}       [props.getSelectedBlockName]            Name of selected block or null.
+ * @param {Object} props                                   Component props.
+ * @param {string} [props.getBlockInsertionParentClientId] Client ID of the parent.
+ * @param {string} [props.getInserterItems]                Inserter items for parent.
+ * @param {string} [props.getSelectedBlockName]            Name of selected block or null.
+ *
  * @return {WPCompleter} A blocks completer.
  */
 export function createBlockCompleter( {


### PR DESCRIPTION

## Description

Update JSDoc for `block-editor/src/autocompleters/block.js`

See #22907.

## How has this been tested?

Run: `npm run lint-js packages/block-editor/src/autocompleters`

```
npm run lint-js packages/block-editor/src/autocompleters

> gutenberg@8.2.1 lint-js C:\Users\mkaz\src\wp\gutenberg
> wp-scripts lint-js "packages/block-editor/src/autocompleters"

C:\Users\mkaz\src\wp\gutenberg\packages\block-editor\src\autocompleters\block.js
  84:1  warning  Missing JSDoc @param "root0" declaration                                  jsdoc/require-param
  84:1  warning  Missing JSDoc @param "root0.getBlockInsertionParentClientId" declaration  jsdoc/require-param
  84:1  warning  Missing JSDoc @param "root0.getInserterItems" declaration                 jsdoc/require-param
  84:1  warning  Missing JSDoc @param "root0.getSelectedBlockName" declaration             jsdoc/require-param
```

## Types of changes

JSDoc string.
