### PR TITLE
Create Block: Enhancements for the upcoming npm release

### DIFF
--- a/packages/create-block/lib/prompts.js
+++ b/packages/create-block/lib/prompts.js
@@ -70,7 +70,7 @@ const category = {
 	type: 'list',
 	name: 'category',
 	message: 'The category name to help users browse and discover your block:',
-	choices: [ 'text', 'embed', 'media', 'design', 'widgets' ],
+	choices: [ 'common', 'embed', 'formatting', 'layout', 'widgets' ],
 };
 
 const author = {

--- a/packages/create-block/lib/templates/esnext/src/edit.js.mustache
+++ b/packages/create-block/lib/templates/esnext/src/edit.js.mustache
@@ -6,7 +6,10 @@
 import { __ } from '@wordpress/i18n';
 
 /**
- * Internal dependencies
+ * Lets webpack process CSS, SASS or SCSS files referenced in JavaScript files.
+ * Those files can contain any CSS code that gets applied to the editor.
+ *
+ * @see https://www.npmjs.com/package/@wordpress/scripts#using-css
  */
 import './editor.scss';
 

--- a/packages/create-block/lib/templates/esnext/src/index.js.mustache
+++ b/packages/create-block/lib/templates/esnext/src/index.js.mustache
@@ -13,9 +13,17 @@ import { registerBlockType } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 
 /**
- * Internal dependencies
+ * Lets webpack process CSS, SASS or SCSS files referenced in JavaScript files.
+ * All files containing `style` keyword are bundled together. The code used
+ * gets applied both to the front of your site and to the editor.
+ *
+ * @see https://www.npmjs.com/package/@wordpress/scripts#using-css
  */
 import './style.scss';
+
+/**
+ * Internal dependencies
+ */
 import Edit from './edit';
 import save from './save';
 


### PR DESCRIPTION
## Description

This PR contains two tweaks that would be nice to land in the upcoming npm release related to the next Gutenberg plugin.

Related issue: #22848
It ensures that blocks will continue to work with WordPress 5.4.x.
We should be able to use the new set of categories once WordPress 5.5 is out.

Related PR: #22727
This PR also adds inline comments explaining how CSS imports in JS work.