### PR TITLE
Fix use of backticks

### DIFF
--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -263,7 +263,7 @@ Destroy the WordPress environment. Delete docker containers and remove local fil
 
 ### `wp-env logs [environment]`
 
-````sh
+```sh
 wp-env logs
 
 displays PHP and Docker logs for given WordPress environment.
@@ -400,4 +400,3 @@ You can tell `wp-env` to use a custom port number so that your instance does not
 ```
 
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>
-````


### PR DESCRIPTION
## Description
Fixes the [readme](https://github.com/WordPress/gutenberg/tree/master/packages/env) of the env package. [See preview for testing](https://github.com/WordPress/gutenberg/pull/22980/files?short_path=d8567df#diff-d8567df8f65168c8284d7f590af7a553).

Fixes #22977