### PR TITLE
Update/react native colours to variables

### DIFF
--- a/packages/block-editor/src/components/floating-toolbar/styles.native.scss
+++ b/packages/block-editor/src/components/floating-toolbar/styles.native.scss
@@ -38,6 +38,6 @@
 	margin-left: 2px;
 	height: 28px;
 	width: 1px;
-	background-color: #e9eff3;
+	background-color: $light-opacity-light-700;
 	opacity: 0.4;
 }

--- a/packages/block-library/src/image/styles.native.scss
+++ b/packages/block-library/src/image/styles.native.scss
@@ -13,7 +13,7 @@
 }
 
 .uploadFailedText {
-	color: #fff;
+	color: $white;
 	font-size: 14;
 	margin-top: 5;
 }
@@ -39,7 +39,7 @@
 }
 
 .iconRetry {
-	fill: #fff;
+	fill: $white;
 	width: 100%;
 	height: 100%;
 }
@@ -103,7 +103,7 @@
 }
 
 .iconCustomise {
-	fill: #fff;
+	fill: $white;
 	position: absolute;
 	top: 7px;
 	left: 7px;


### PR DESCRIPTION
## Description
This PR tries to fix https://github.com/wordpress-mobile/gutenberg-mobile/issues/1783
By updating the hard coded colours with sass variables.  

## How has this been tested?
TBD

## Screenshots <!-- if applicable -->

**Floating tool bar (Spacer bar colour):**
Before:
<img width="229" alt="Screen Shot 2020-06-05 at 3 20 11 PM" src="https://user-images.githubusercontent.com/115071/84012699-3f379b80-a978-11ea-9101-01248bd812a2.png">

After: notice that the spacer bar matches the colour of the arrow. 
<img width="277" alt="Screen Shot 2020-06-05 at 3 19 14 PM" src="https://user-images.githubusercontent.com/115071/84012703-4068c880-a978-11ea-8e05-886cd4d45b64.png">


## Types of changes
Updated of the code to use the currently supplied sass colour variables. 


## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
