### PR TITLE
Make Preview and Save Draft buttons use the same style

### DIFF
--- a/packages/block-editor/src/components/preview-options/index.js
+++ b/packages/block-editor/src/components/preview-options/index.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  */
 import { Button, Dropdown, MenuGroup, MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Icon, check, chevronDown } from '@wordpress/icons';
+import { check } from '@wordpress/icons';
 
 export default function PreviewOptions( {
 	children,
@@ -28,13 +28,13 @@ export default function PreviewOptions( {
 			position="bottom left"
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<Button
+					isTertiary
 					onClick={ onToggle }
 					className="block-editor-post-preview__button-toggle"
 					aria-expanded={ isOpen }
 					disabled={ ! isEnabled }
 				>
 					{ __( 'Preview' ) }
-					<Icon icon={ chevronDown } />
 				</Button>
 			) }
 			renderContent={ () => (

--- a/packages/block-editor/src/components/preview-options/style.scss
+++ b/packages/block-editor/src/components/preview-options/style.scss
@@ -4,20 +4,6 @@
 	padding: 0;
 }
 
-.block-editor-post-preview__button-toggle {
-	display: flex;
-	justify-content: space-between;
-	padding: 0 $grid-unit-10 0 $grid-unit-15;
-
-	&:focus:not(:disabled) {
-		box-shadow: inset 0 0 0 1px $white, 0 0 0 $border-width-focus $theme-color;
-	}
-
-	svg {
-		margin-left: $grid-unit-05;
-	}
-}
-
 .block-editor-post-preview__button-resize.block-editor-post-preview__button-resize {
 	padding-left: $button-size-small + $grid-unit-10 + $grid-unit-10;
 

--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -70,6 +70,22 @@
 	.editor-post-saved-state,
 	.components-button.editor-post-switch-to-draft,
 	.components-button.editor-post-preview,
+	.components-button.block-editor-post-preview__dropdown {
+		padding: 0 6px;
+		margin-right: $grid-unit-05;
+
+		@include break-small() {
+			margin-right: $grid-unit-15;
+		}
+	}
+
+	.components-button.editor-post-save-draft,
+	.components-button.editor-post-switch-to-draft,
+	.components-button.editor-post-preview,
+	.components-button.block-editor-post-preview__button-toggle {
+		color: $dark-gray-primary;
+	}
+
 	.components-button.block-editor-post-preview__dropdown,
 	.components-button.editor-post-publish-button,
 	.components-button.editor-post-publish-panel__toggle {

--- a/packages/editor/src/components/post-saved-state/index.js
+++ b/packages/editor/src/components/post-saved-state/index.js
@@ -117,7 +117,7 @@ export class PostSavedState extends Component {
 			return null;
 		}
 
-		const label = isPending ? __( 'Save as Pending' ) : __( 'Save Draft' );
+		const label = isPending ? __( 'Save as dending' ) : __( 'Save draft' );
 		if ( ! isLargeViewport ) {
 			return (
 				<Button


### PR DESCRIPTION
Props @ZebulanStanphill

This was not meant to be a separate PR, just an experiment that turned out to succeed.

This is an alternative to #21192. It does this:
![buttons new](https://user-images.githubusercontent.com/1204802/84012883-86be2780-a978-11ea-87ac-136edca84b00.gif)
