### PR TITLE
MediaReplaceFlow: improve error customization

### DIFF
--- a/packages/block-editor/src/components/media-replace-flow/README.md
+++ b/packages/block-editor/src/components/media-replace-flow/README.md
@@ -38,6 +38,10 @@ Comma delimited list of MIME types accepted for upload.
 - Type: `string`
 - Required: Yes
 
+### onFilesUpload
+
+Callback called before to start to upload the files. It receives an array with the files to upload before to the final process. 
+
 ### onSelect
 
 Callback used when media is replaced from the Media Library or when a new media is uploaded. It is called with one argument `media` which is an object with all the media details.

--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -16,6 +16,7 @@ import {
 	ToolbarGroup,
 	Button,
 	Dropdown,
+	withFilters,
 } from '@wordpress/components';
 import { withDispatch, useSelect } from '@wordpress/data';
 import { DOWN } from '@wordpress/keycodes';
@@ -194,4 +195,5 @@ export default compose( [
 			removeNotice,
 		};
 	} ),
+	withFilters( 'editor.MediaReplaceFlow' ),
 ] )( MediaReplaceFlow );

--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { uniqueId } from 'lodash';
+import { uniqueId, noop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -37,6 +37,7 @@ const MediaReplaceFlow = ( {
 	accept,
 	onSelect,
 	onSelectURL,
+	onFilesUpload = noop,
 	name = __( 'Replace' ),
 	createNotice,
 	removeNotice,
@@ -87,6 +88,7 @@ const MediaReplaceFlow = ( {
 
 	const uploadFiles = ( event ) => {
 		const files = event.target.files;
+		onFilesUpload( files );
 		const setMedia = ( [ media ] ) => {
 			selectMedia( media );
 		};


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This PR adds some changes in order to be able to handle errors when something fails in the media replacing flow. It adds a filter to the component which allows catching the notices (among all other customizations that a filter provides) and also adds an optional `onFilesUpload` property helpful when we want to know files to upload.

### How to use it
The following example shows how to change the status and description of all notices. 

```es6
const customizeReplaceButton = createHigherOrderComponent(
	MediaReplaceFlow => props => {
		return <MediaReplaceFlow
			{ ...props }
			createNotice={ ( status, content, options ) => {
				props.createNotice(
					'info',
					'Dont worry be Happy',
					options
				);
			} }
		/>;
	},
	'coverEditMediaPlaceholder'
);

addFilter( 'editor.MediaReplaceFlow', 'me/customize', customizeReplaceButton );
```

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

These changes shouldn't modify the MediaReplaceFlow API which means that everything should be ok when you upload a new media using the `Replace` button. It's available in many blocks, for instance `core/cover`.
So the first testing is replacing a media from this button.

<img width="496" alt="Screen Shot 2020-06-08 at 11 35 18 AM" src="https://user-images.githubusercontent.com/77539/84043040-33e66f00-a97c-11ea-8f07-a81de524c475.png">

Also, you could modify how the `Replace` button renders, binding a function to the filter hook. The example shown above is a good and valid example of how to do it. In the following, I've replaced the staus of the notice always to `info`, even when I try to upload an invalid file. Also, added an example of how to use `onFilesUpload` property:

```es6
const customizeReplaceButton = createHigherOrderComponent(
	MediaReplaceFlow => props => {
		return <MediaReplaceFlow
			{ ...props }
			createNotice={ ( status, content, options ) => {
				props.createNotice(
					'info',
					'Dont worry be Happy',
					options
				);
			} }
			onFilesUpload= { ( files ) => console.log( `Uploading ${ files.length } files...` ) } 
		/>;
	},
	'coverEditMediaPlaceholder'
);

addFilter( 'editor.MediaReplaceFlow', 'me/customize', customizeReplaceButton );
```



<img width="665" alt="Screen Shot 2020-06-08 at 11 42 42 AM" src="https://user-images.githubusercontent.com/77539/84043905-3dbca200-a97d-11ea-8287-67e18b285ac6.png">

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [ x My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->