### PR TITLE
[Navigation screen] Separate block navigator focus from the editor focus

### DIFF
--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -946,6 +946,7 @@ Generator that triggers an action used to duplicate a list of blocks.
 _Parameters_
 
 -   _clientIds_ `Array<string>`: 
+-   _updateSelection_ `boolean`: 
 
 <a name="enterFormattedText" href="#enterFormattedText">#</a> **enterFormattedText**
 

--- a/packages/block-editor/src/components/block-actions/index.js
+++ b/packages/block-editor/src/components/block-actions/index.js
@@ -113,4 +113,3 @@ export default function BlockActions( {
 		},
 	} );
 }
-

--- a/packages/block-editor/src/components/block-actions/index.js
+++ b/packages/block-editor/src/components/block-actions/index.js
@@ -113,3 +113,4 @@ export default function BlockActions( {
 		},
 	} );
 }
+

--- a/packages/block-editor/src/components/block-actions/index.js
+++ b/packages/block-editor/src/components/block-actions/index.js
@@ -14,7 +14,11 @@ import { hasBlockSupport, switchToBlockType } from '@wordpress/blocks';
  */
 import { useNotifyCopy } from '../copy-handler';
 
-export default function BlockActions( { clientIds, children } ) {
+export default function BlockActions( {
+	clientIds,
+	children,
+	__experimentalUpdateSelection: updateSelection,
+} ) {
 	const {
 		canInsertBlockType,
 		getBlockRootClientId,
@@ -59,10 +63,10 @@ export default function BlockActions( { clientIds, children } ) {
 		rootClientId,
 		blocks,
 		onDuplicate() {
-			return duplicateBlocks( clientIds );
+			return duplicateBlocks( clientIds, updateSelection );
 		},
 		onRemove() {
-			removeBlocks( clientIds );
+			return removeBlocks( clientIds, updateSelection );
 		},
 		onInsertBefore() {
 			insertBeforeBlock( first( castArray( clientIds ) ) );

--- a/packages/block-editor/src/components/block-navigation/block.js
+++ b/packages/block-editor/src/components/block-navigation/block.js
@@ -152,8 +152,7 @@ export default function BlockNavigationBlock( {
 								onFocus,
 							} }
 							disableOpenOnArrowDown
-							updateSelection={ false }
-							selectBlock={ selectBlock }
+							__experimentalSelectBlock={ selectBlock }
 						/>
 					) }
 				</TreeGridCell>

--- a/packages/block-editor/src/components/block-navigation/block.js
+++ b/packages/block-editor/src/components/block-navigation/block.js
@@ -159,15 +159,21 @@ export default function BlockNavigationBlock( {
 							disableOpenOnArrowDown
 							__experimentalSelectBlock={ onClick }
 						>
-							<MenuGroup>
-								<MenuItem
-									onClick={ () => {
-										selectEditorBlock( clientId );
-									} }
-								>
-									{ __( 'Go to block' ) }
-								</MenuItem>
-							</MenuGroup>
+							{ ( { onClose } ) => (
+								<MenuGroup>
+									<MenuItem
+										onClick={ async () => {
+											// If clientId is already selected, it won't be focused (see block-wrapper.js)
+											// This removes the selection first to ensure the focus will always switch.
+											await selectEditorBlock( null );
+											await selectEditorBlock( clientId );
+											onClose();
+										} }
+									>
+										{ __( 'Go to block' ) }
+									</MenuItem>
+								</MenuGroup>
+							) }
 						</BlockSettingsDropdown>
 					) }
 				</TreeGridCell>

--- a/packages/block-editor/src/components/block-navigation/block.js
+++ b/packages/block-editor/src/components/block-navigation/block.js
@@ -9,10 +9,13 @@ import classnames from 'classnames';
 import {
 	__experimentalTreeGridCell as TreeGridCell,
 	__experimentalTreeGridItem as TreeGridItem,
+	MenuGroup,
+	MenuItem,
 } from '@wordpress/components';
-
+import { __ } from '@wordpress/i18n';
 import { moreVertical } from '@wordpress/icons';
 import { useState, useRef, useEffect } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -30,7 +33,7 @@ import { useBlockNavigationContext } from './context';
 export default function BlockNavigationBlock( {
 	block,
 	isSelected,
-	selectBlock,
+	onClick,
 	position,
 	level,
 	rowCount,
@@ -41,6 +44,9 @@ export default function BlockNavigationBlock( {
 	const cellRef = useRef( null );
 	const [ isHovered, setIsHovered ] = useState( false );
 	const [ isFocused, setIsFocused ] = useState( false );
+	const { selectBlock: selectEditorBlock } = useDispatch(
+		'core/block-editor'
+	);
 	const { clientId } = block;
 
 	// Subtract 1 from rowCount, as it includes the block appender.
@@ -93,7 +99,7 @@ export default function BlockNavigationBlock( {
 						/>
 						<BlockNavigationBlockContents
 							block={ block }
-							onClick={ () => selectBlock( block.clientId ) }
+							onClick={ () => onClick( block.clientId ) }
 							isSelected={ isSelected }
 							position={ position }
 							siblingCount={ siblingCount }
@@ -151,8 +157,18 @@ export default function BlockNavigationBlock( {
 								onFocus,
 							} }
 							disableOpenOnArrowDown
-							__experimentalSelectBlock={ selectBlock }
-						/>
+							__experimentalSelectBlock={ onClick }
+						>
+							<MenuGroup>
+								<MenuItem
+									onClick={ () => {
+										selectEditorBlock( clientId );
+									} }
+								>
+									{ __( 'Go to block' ) }
+								</MenuItem>
+							</MenuGroup>
+						</BlockSettingsDropdown>
 					) }
 				</TreeGridCell>
 			) }

--- a/packages/block-editor/src/components/block-navigation/block.js
+++ b/packages/block-editor/src/components/block-navigation/block.js
@@ -59,17 +59,17 @@ export default function BlockNavigationBlock( {
 		{ 'is-visible': hasVisibleMovers }
 	);
 	const {
-		__experimentalFeatures: withBlockNavigationBlockSettings,
+		__experimentalFeatures: withExperimentalFeatures,
 	} = useBlockNavigationContext();
 	const blockNavigationBlockSettingsClassName = classnames(
 		'block-editor-block-navigation-block__menu-cell',
 		{ 'is-visible': hasVisibleMovers }
 	);
 	useEffect( () => {
-		if ( isSelected ) {
+		if ( withExperimentalFeatures && isSelected ) {
 			cellRef.current.focus();
 		}
-	}, [ isSelected ] );
+	}, [ withExperimentalFeatures, isSelected ] );
 
 	return (
 		<BlockNavigationLeaf
@@ -143,7 +143,7 @@ export default function BlockNavigationBlock( {
 				</>
 			) }
 
-			{ withBlockNavigationBlockSettings && (
+			{ withExperimentalFeatures && (
 				<TreeGridCell
 					className={ blockNavigationBlockSettingsClassName }
 				>

--- a/packages/block-editor/src/components/block-navigation/block.js
+++ b/packages/block-editor/src/components/block-navigation/block.js
@@ -47,7 +47,7 @@ export default function BlockNavigationBlock( {
 	const siblingCount = rowCount - 1;
 	const hasSiblings = siblingCount > 1;
 	const hasRenderedMovers = showBlockMovers && hasSiblings;
-	const hasVisibleMovers = isHovered || isSelected || isFocused;
+	const hasVisibleMovers = isHovered || isFocused;
 	const moverCellClassName = classnames(
 		'block-editor-block-navigation-block__mover-cell',
 		{ 'is-visible': hasVisibleMovers }

--- a/packages/block-editor/src/components/block-navigation/block.js
+++ b/packages/block-editor/src/components/block-navigation/block.js
@@ -29,7 +29,6 @@ import { useBlockNavigationContext } from './context';
 
 export default function BlockNavigationBlock( {
 	block,
-	onClick,
 	isSelected,
 	selectBlock,
 	position,
@@ -94,7 +93,7 @@ export default function BlockNavigationBlock( {
 						/>
 						<BlockNavigationBlockContents
 							block={ block }
-							onClick={ onClick }
+							onClick={ () => selectBlock( block.clientId ) }
 							isSelected={ isSelected }
 							position={ position }
 							siblingCount={ siblingCount }

--- a/packages/block-editor/src/components/block-navigation/block.js
+++ b/packages/block-editor/src/components/block-navigation/block.js
@@ -12,7 +12,7 @@ import {
 } from '@wordpress/components';
 
 import { moreVertical } from '@wordpress/icons';
-import { useState } from '@wordpress/element';
+import { useState, useRef, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -31,6 +31,7 @@ export default function BlockNavigationBlock( {
 	block,
 	onClick,
 	isSelected,
+	selectBlock,
 	position,
 	level,
 	rowCount,
@@ -38,6 +39,7 @@ export default function BlockNavigationBlock( {
 	terminatedLevels,
 	path,
 } ) {
+	const cellRef = useRef( null );
 	const [ isHovered, setIsHovered ] = useState( false );
 	const [ isFocused, setIsFocused ] = useState( false );
 	const { clientId } = block;
@@ -58,6 +60,11 @@ export default function BlockNavigationBlock( {
 		'block-editor-block-navigation-block__menu-cell',
 		{ 'is-visible': hasVisibleMovers }
 	);
+	useEffect( () => {
+		if ( isSelected ) {
+			cellRef.current.focus();
+		}
+	}, [ isSelected ] );
 
 	return (
 		<BlockNavigationLeaf
@@ -76,6 +83,7 @@ export default function BlockNavigationBlock( {
 			<TreeGridCell
 				className="block-editor-block-navigation-block__contents-cell"
 				colSpan={ hasRenderedMovers ? undefined : 2 }
+				ref={ cellRef }
 			>
 				{ ( { ref, tabIndex, onFocus } ) => (
 					<div className="block-editor-block-navigation-block__contents-container">
@@ -144,6 +152,8 @@ export default function BlockNavigationBlock( {
 								onFocus,
 							} }
 							disableOpenOnArrowDown
+							updateSelection={ false }
+							selectBlock={ selectBlock }
 						/>
 					) }
 				</TreeGridCell>

--- a/packages/block-editor/src/components/block-navigation/branch.js
+++ b/packages/block-editor/src/components/block-navigation/branch.js
@@ -60,6 +60,7 @@ export default function BlockNavigationBranch( props ) {
 						<BlockNavigationBlock
 							block={ block }
 							onClick={ () => selectBlock( clientId ) }
+							selectBlock={ selectBlock }
 							isSelected={ selectedBlockClientId === clientId }
 							level={ level }
 							position={ position }

--- a/packages/block-editor/src/components/block-navigation/branch.js
+++ b/packages/block-editor/src/components/block-navigation/branch.js
@@ -59,7 +59,7 @@ export default function BlockNavigationBranch( props ) {
 					<Fragment key={ clientId }>
 						<BlockNavigationBlock
 							block={ block }
-							selectBlock={ selectBlock }
+							onClick={ selectBlock }
 							isSelected={ selectedBlockClientId === clientId }
 							level={ level }
 							position={ position }

--- a/packages/block-editor/src/components/block-navigation/branch.js
+++ b/packages/block-editor/src/components/block-navigation/branch.js
@@ -59,7 +59,6 @@ export default function BlockNavigationBranch( props ) {
 					<Fragment key={ clientId }>
 						<BlockNavigationBlock
 							block={ block }
-							onClick={ () => selectBlock( clientId ) }
 							selectBlock={ selectBlock }
 							isSelected={ selectedBlockClientId === clientId }
 							level={ level }

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -56,14 +56,6 @@ $tree-item-height: 36px;
 		margin-right: 6px;
 	}
 
-	&.is-selected .block-editor-block-icon svg,
-	&.is-selected:focus .block-editor-block-icon svg {
-		color: $white;
-		background: $dark-gray-primary;
-		box-shadow: 0 0 0 $border-width $dark-gray-primary;
-		border-radius: $border-width;
-	}
-
 	.block-editor-block-navigation-block__menu-cell,
 	.block-editor-block-navigation-block__mover-cell,
 	.block-editor-block-navigation-block__contents-cell {

--- a/packages/block-editor/src/components/block-settings-menu/README.md
+++ b/packages/block-editor/src/components/block-settings-menu/README.md
@@ -1,0 +1,13 @@
+BlockSettingsMenu
+============
+
+This is a menu that allows the user to act on the block (duplicate, remove, etc).
+
+# BlockSettingsDropdown
+
+This is the dropdown itself, it covers the bulk of the logic of this component.
+
+## Props
+
+`__experimentalSelectBlock` - A callback. If passed, interacting with dropdown options (such as duplicate) will not update the 
+editor selection. Instead, every time a selection change should happen the callback will be called with a proper clientId.

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -35,7 +35,11 @@ const POPOVER_PROPS = {
 	isAlternate: true,
 };
 
-export function BlockSettingsDropdown( { clientIds, selectBlock, ...props } ) {
+export function BlockSettingsDropdown( {
+	clientIds,
+	__experimentalSelectBlock,
+	...props
+} ) {
 	const blockClientIds = castArray( clientIds );
 	const count = blockClientIds.length;
 	const firstBlockClientId = blockClientIds[ 0 ];
@@ -60,17 +64,20 @@ export function BlockSettingsDropdown( { clientIds, selectBlock, ...props } ) {
 
 	const [ hasCopied, setHasCopied ] = useState();
 	const updateSelection = useCallback(
-		async ( clientIdPromise ) => {
-			const clientId = await clientIdPromise;
-			if ( clientId ) {
-				selectBlock( clientId );
+		async ( clientIdsPromise ) => {
+			const ids = await clientIdsPromise;
+			if ( ids && ids[ 0 ] ) {
+				__experimentalSelectBlock( ids[ 0 ] );
 			}
 		},
-		[ selectBlock ]
+		[ __experimentalSelectBlock ]
 	);
 
 	return (
-		<BlockActions clientIds={ clientIds } updateSelection={ ! selectBlock }>
+		<BlockActions
+			clientIds={ clientIds }
+			__experimentalUpdateSelection={ ! __experimentalSelectBlock }
+		>
 			{ ( {
 				canDuplicate,
 				canInsertDefaultBlock,

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { castArray, flow } from 'lodash';
+import { castArray, flow, noop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -64,12 +64,14 @@ export function BlockSettingsDropdown( {
 
 	const [ hasCopied, setHasCopied ] = useState();
 	const updateSelection = useCallback(
-		async ( clientIdsPromise ) => {
-			const ids = await clientIdsPromise;
-			if ( ids && ids[ 0 ] ) {
-				__experimentalSelectBlock( ids[ 0 ] );
-			}
-		},
+		__experimentalSelectBlock
+			? async ( clientIdsPromise ) => {
+					const ids = await clientIdsPromise;
+					if ( ids && ids[ 0 ] ) {
+						__experimentalSelectBlock( ids[ 0 ] );
+					}
+			  }
+			: noop,
 		[ __experimentalSelectBlock ]
 	);
 

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -15,6 +15,8 @@ import {
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { moreHorizontal } from '@wordpress/icons';
+
+import { useState, useCallback } from '@wordpress/element';
 import { serialize } from '@wordpress/blocks';
 
 /**
@@ -33,7 +35,7 @@ const POPOVER_PROPS = {
 	isAlternate: true,
 };
 
-export function BlockSettingsDropdown( { clientIds, ...props } ) {
+export function BlockSettingsDropdown( { clientIds, selectBlock, ...props } ) {
 	const blockClientIds = castArray( clientIds );
 	const count = blockClientIds.length;
 	const firstBlockClientId = blockClientIds[ 0 ];
@@ -56,8 +58,19 @@ export function BlockSettingsDropdown( { clientIds, ...props } ) {
 		};
 	}, [] );
 
+	const [ hasCopied, setHasCopied ] = useState();
+	const updateSelection = useCallback(
+		async ( clientIdPromise ) => {
+			const clientId = await clientIdPromise;
+			if ( clientId ) {
+				selectBlock( clientId );
+			}
+		},
+		[ selectBlock ]
+	);
+
 	return (
-		<BlockActions clientIds={ clientIds }>
+		<BlockActions clientIds={ clientIds } updateSelection={ ! selectBlock }>
 			{ ( {
 				canDuplicate,
 				canInsertDefaultBlock,
@@ -103,7 +116,11 @@ export function BlockSettingsDropdown( { clientIds, ...props } ) {
 								</ClipboardButton>
 								{ canDuplicate && (
 									<MenuItem
-										onClick={ flow( onClose, onDuplicate ) }
+										onClick={ flow(
+											onClose,
+											onDuplicate,
+											updateSelection
+										) }
 										shortcut={ shortcuts.duplicate }
 									>
 										{ __( 'Duplicate' ) }
@@ -145,7 +162,11 @@ export function BlockSettingsDropdown( { clientIds, ...props } ) {
 							<MenuGroup>
 								{ ! isLocked && (
 									<MenuItem
-										onClick={ flow( onClose, onRemove ) }
+										onClick={ flow(
+											onClose,
+											onRemove,
+											updateSelection
+										) }
 										shortcut={ shortcuts.remove }
 									>
 										{ _n(

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -16,7 +16,7 @@ import {
 import { useSelect } from '@wordpress/data';
 import { moreHorizontal } from '@wordpress/icons';
 
-import { useCallback } from '@wordpress/element';
+import { Children, cloneElement, useCallback } from '@wordpress/element';
 import { serialize } from '@wordpress/blocks';
 
 /**
@@ -168,7 +168,11 @@ export function BlockSettingsDropdown( {
 								fillProps={ { onClose } }
 								clientIds={ clientIds }
 							/>
-							{ children }
+							{ typeof children === 'function'
+								? children( { onClose } )
+								: Children.map( ( child ) =>
+										cloneElement( child, { onClose } )
+								  ) }
 							<MenuGroup>
 								{ ! isLocked && (
 									<MenuItem

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -16,7 +16,7 @@ import {
 import { useSelect } from '@wordpress/data';
 import { moreHorizontal } from '@wordpress/icons';
 
-import { useState, useCallback } from '@wordpress/element';
+import { useCallback } from '@wordpress/element';
 import { serialize } from '@wordpress/blocks';
 
 /**
@@ -38,6 +38,7 @@ const POPOVER_PROPS = {
 export function BlockSettingsDropdown( {
 	clientIds,
 	__experimentalSelectBlock,
+	children,
 	...props
 } ) {
 	const blockClientIds = castArray( clientIds );
@@ -62,7 +63,6 @@ export function BlockSettingsDropdown( {
 		};
 	}, [] );
 
-	const [ hasCopied, setHasCopied ] = useState();
 	const updateSelection = useCallback(
 		__experimentalSelectBlock
 			? async ( clientIdsPromise ) => {
@@ -168,6 +168,7 @@ export function BlockSettingsDropdown( {
 								fillProps={ { onClose } }
 								clientIds={ clientIds }
 							/>
+							{ children }
 							<MenuGroup>
 								{ ! isLocked && (
 									<MenuItem

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -163,8 +163,8 @@ export function* selectPreviousBlock( clientId ) {
 
 	if ( previousBlockClientId ) {
 		yield selectBlock( previousBlockClientId, -1 );
+		return [ previousBlockClientId ];
 	}
-	return previousBlockClientId;
 }
 
 /**
@@ -182,6 +182,7 @@ export function* selectNextBlock( clientId ) {
 
 	if ( nextBlockClientId ) {
 		yield selectBlock( nextBlockClientId );
+		return [ nextBlockClientId ];
 	}
 }
 
@@ -614,7 +615,7 @@ export function* removeBlocks( clientIds, selectPrevious = true ) {
 	// To avoid a focus loss when removing the last block, assure there is
 	// always a default block if the last of the blocks have been removed.
 	const defaultBlockId = yield* ensureDefaultBlock();
-	return previousBlockId || defaultBlockId;
+	return [ previousBlockId || defaultBlockId ];
 }
 
 /**
@@ -945,7 +946,7 @@ export function* duplicateBlocks( clientIds, updateSelection = true ) {
 			last( clonedBlocks ).clientId
 		);
 	}
-	return last( clonedBlocks ).clientId;
+	return clonedBlocks.map( ( block ) => block.clientId );
 }
 
 /**

--- a/packages/block-editor/src/store/test/actions.js
+++ b/packages/block-editor/src/store/test/actions.js
@@ -799,6 +799,11 @@ describe( 'actions', () => {
 			expect( actions ).toEqual( [
 				select( 'core/block-editor', 'getBlockRootClientId', clientId ),
 				select( 'core/block-editor', 'getTemplateLock', undefined ),
+				select(
+					'core/block-editor',
+					'getPreviousBlockClientId',
+					'myclientid'
+				),
 				{
 					type: 'REMOVE_BLOCKS',
 					clientIds: [ clientId ],

--- a/packages/components/src/tree-grid/cell.js
+++ b/packages/components/src/tree-grid/cell.js
@@ -1,20 +1,25 @@
 /**
+ * WordPress dependencies
+ */
+import { forwardRef } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import TreeGridItem from './item';
 
-export default function TreeGridCell( {
+export default forwardRef( function TreeGridCell( {
 	children,
 	withoutGridItem = false,
 	...props
-} ) {
+}, ref ) {
 	return (
 		<td { ...props } role="gridcell">
 			{ withoutGridItem ? (
 				children
 			) : (
-				<TreeGridItem>{ children }</TreeGridItem>
+				<TreeGridItem ref={ ref }>{ children }</TreeGridItem>
 			) }
 		</td>
 	);
-}
+} );

--- a/packages/components/src/tree-grid/cell.js
+++ b/packages/components/src/tree-grid/cell.js
@@ -8,11 +8,10 @@ import { forwardRef } from '@wordpress/element';
  */
 import TreeGridItem from './item';
 
-export default forwardRef( function TreeGridCell( {
-	children,
-	withoutGridItem = false,
-	...props
-}, ref ) {
+export default forwardRef( function TreeGridCell(
+	{ children, withoutGridItem = false, ...props },
+	ref
+) {
 	return (
 		<td { ...props } role="gridcell">
 			{ withoutGridItem ? (

--- a/packages/components/src/tree-grid/item.js
+++ b/packages/components/src/tree-grid/item.js
@@ -1,8 +1,20 @@
 /**
+ * WordPress dependencies
+ */
+import { forwardRef } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import RovingTabIndexItem from './roving-tab-index-item';
 
-export default function TreeGridItem( { children, ...props } ) {
-	return <RovingTabIndexItem { ...props }>{ children }</RovingTabIndexItem>;
-}
+export default forwardRef( function TreeGridItem(
+	{ children, ...props },
+	ref
+) {
+	return (
+		<RovingTabIndexItem ref={ ref } { ...props }>
+			{ children }
+		</RovingTabIndexItem>
+	);
+} );

--- a/packages/components/src/tree-grid/roving-tab-index-item.js
+++ b/packages/components/src/tree-grid/roving-tab-index-item.js
@@ -1,19 +1,19 @@
 /**
  * WordPress dependencies
  */
-import { useRef } from '@wordpress/element';
+import { useRef, forwardRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { useRovingTabIndexContext } from './roving-tab-index-context';
 
-export default function RovingTabIndexItem( {
-	children,
-	as: Component,
-	...props
-} ) {
-	const ref = useRef();
+export default forwardRef( function RovingTabIndexItem(
+	{ children, as: Component, ...props },
+	forwardedRef
+) {
+	const localRef = useRef();
+	const ref = forwardedRef || localRef;
 	const {
 		lastFocusedElement,
 		setLastFocusedElement,
@@ -32,4 +32,4 @@ export default function RovingTabIndexItem( {
 	}
 
 	return <Component { ...allProps }>{ children }</Component>;
-}
+} );

--- a/packages/edit-navigation/src/components/menu-editor/navigation-structure-area.js
+++ b/packages/edit-navigation/src/components/menu-editor/navigation-structure-area.js
@@ -10,23 +10,21 @@ import {
 	Panel,
 	PanelBody,
 } from '@wordpress/components';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 export default function NavigationStructureArea( { blocks, initialOpen } ) {
+	const [ selectedBlockId, setSelectedBlockId ] = useState( null );
 	const isSmallScreen = useViewportMatch( 'medium', '<' );
-	const selectedBlockClientIds = useSelect(
-		( select ) => select( 'core/block-editor' ).getSelectedBlockClientIds(),
-		[]
-	);
-	const { selectBlock } = useDispatch( 'core/block-editor' );
 	const showNavigationStructure = !! blocks.length;
 
 	const content = showNavigationStructure && (
 		<__experimentalBlockNavigationTree
 			blocks={ blocks }
-			selectedBlockClientId={ selectedBlockClientIds[ 0 ] }
-			selectBlock={ selectBlock }
+			selectedBlockClientId={ selectedBlockId }
+			selectBlock={ ( id ) => {
+				setSelectedBlockId( id );
+			} }
 			__experimentalFeatures
 			showNestedBlocks
 			showAppender


### PR DESCRIPTION
## Description

Closes #22705

This PR is an attempt to separates the block navigator selection/focus from the editor area. Once applied, all actions performed in the navigator will only affect selection/focus within the navigator instead of trying to synchronize with the editor area:

![2020-06-08 16-05-56 2020-06-08 16_06_55](https://user-images.githubusercontent.com/205419/84039888-322fa200-a9a2-11ea-9a8d-27f4f9048f8d.gif)

CC @enriquesanchez and @karmatosed for sanity check

Editing the caption is not implemented yet.

Open questions:
* Does it feel like the right approach?
* The concept of selecting a navigator item, as in turning the icon dark once an item is clicked, does not seem to be useful anymore - should we get rid of it and switch to the caption edit mode on click?

## How has this been tested?
1. Enable the navigation experiment in Gutenberg > Experiments
1. Go to Gutenberg > Navigation (beta) and create a menu
1. Use the navigator using a keyboard, select/remove/duplicate some navigation items, confirm the behavior makes intuitive sense
1. Go to the post editor, create a navigation block, select/move some navigation items using the navigator, confirm the behavior did not change.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
