### PR TITLE
[Navigation screen] Only show appender for the currently selected block

### DIFF
--- a/packages/block-editor/src/components/block-navigation/branch.js
+++ b/packages/block-editor/src/components/block-navigation/branch.js
@@ -30,14 +30,15 @@ export default function BlockNavigationBranch( props ) {
 
 	const isTreeRoot = ! parentBlockClientId;
 	const filteredBlocks = compact( blocks );
-	// Add +1 to the rowCount to take the block appender into account.
-	const rowCount = showAppender
-		? filteredBlocks.length + 1
-		: filteredBlocks.length;
-	const hasAppender =
+	const itemHasAppender = ( parentClientId ) =>
 		showAppender &&
 		! isTreeRoot &&
-		selectedBlockClientId === parentBlockClientId;
+		selectedBlockClientId === parentClientId;
+	const hasAppender = itemHasAppender( parentBlockClientId );
+	// Add +1 to the rowCount to take the block appender into account.
+	const rowCount = hasAppender
+		? filteredBlocks.length + 1
+		: filteredBlocks.length;
 	const appenderPosition = rowCount;
 
 	return (
@@ -50,6 +51,9 @@ export default function BlockNavigationBranch( props ) {
 					? [ ...terminatedLevels, level ]
 					: terminatedLevels;
 				const updatedPath = [ ...path, position ];
+				const hasNestedBlocks =
+					showNestedBlocks && !! innerBlocks && !! innerBlocks.length;
+				const hasNestedAppender = itemHasAppender( clientId );
 
 				return (
 					<Fragment key={ clientId }>
@@ -64,18 +68,20 @@ export default function BlockNavigationBranch( props ) {
 							terminatedLevels={ terminatedLevels }
 							path={ updatedPath }
 						/>
-						<BlockNavigationBranch
-							blocks={ innerBlocks }
-							selectedBlockClientId={ selectedBlockClientId }
-							selectBlock={ selectBlock }
-							showAppender={ showAppender }
-							showBlockMovers={ showBlockMovers }
-							showNestedBlocks={ showNestedBlocks }
-							parentBlockClientId={ clientId }
-							level={ level + 1 }
-							terminatedLevels={ updatedTerminatedLevels }
-							path={ updatedPath }
-						/>
+						{ ( hasNestedBlocks || hasNestedAppender ) && (
+							<BlockNavigationBranch
+								blocks={ innerBlocks }
+								selectedBlockClientId={ selectedBlockClientId }
+								selectBlock={ selectBlock }
+								showAppender={ showAppender }
+								showBlockMovers={ showBlockMovers }
+								showNestedBlocks={ showNestedBlocks }
+								parentBlockClientId={ clientId }
+								level={ level + 1 }
+								terminatedLevels={ updatedTerminatedLevels }
+								path={ updatedPath }
+							/>
+						) }
 					</Fragment>
 				);
 			} ) }

--- a/packages/block-editor/src/components/block-navigation/branch.js
+++ b/packages/block-editor/src/components/block-navigation/branch.js
@@ -35,15 +35,15 @@ export default function BlockNavigationBranch( props ) {
 		? filteredBlocks.length + 1
 		: filteredBlocks.length;
 	const hasAppender =
-		showAppender && filteredBlocks.length > 0 && ! isTreeRoot;
+		showAppender &&
+		! isTreeRoot &&
+		selectedBlockClientId === parentBlockClientId;
 	const appenderPosition = rowCount;
 
 	return (
 		<>
 			{ map( filteredBlocks, ( block, index ) => {
 				const { clientId, innerBlocks } = block;
-				const hasNestedBlocks =
-					showNestedBlocks && !! innerBlocks && !! innerBlocks.length;
 				const position = index + 1;
 				const isLastRowAtLevel = rowCount === position;
 				const updatedTerminatedLevels = isLastRowAtLevel
@@ -64,20 +64,18 @@ export default function BlockNavigationBranch( props ) {
 							terminatedLevels={ terminatedLevels }
 							path={ updatedPath }
 						/>
-						{ hasNestedBlocks && (
-							<BlockNavigationBranch
-								blocks={ innerBlocks }
-								selectedBlockClientId={ selectedBlockClientId }
-								selectBlock={ selectBlock }
-								showAppender={ showAppender }
-								showBlockMovers={ showBlockMovers }
-								showNestedBlocks={ showNestedBlocks }
-								parentBlockClientId={ clientId }
-								level={ level + 1 }
-								terminatedLevels={ updatedTerminatedLevels }
-								path={ updatedPath }
-							/>
-						) }
+						<BlockNavigationBranch
+							blocks={ innerBlocks }
+							selectedBlockClientId={ selectedBlockClientId }
+							selectBlock={ selectBlock }
+							showAppender={ showAppender }
+							showBlockMovers={ showBlockMovers }
+							showNestedBlocks={ showNestedBlocks }
+							parentBlockClientId={ clientId }
+							level={ level + 1 }
+							terminatedLevels={ updatedTerminatedLevels }
+							path={ updatedPath }
+						/>
 					</Fragment>
 				);
 			} ) }


### PR DESCRIPTION
## Description
This PR updates the navigator to only display a single appender - one related to the currently selected block:

<img width="294" alt="Zrzut ekranu 2020-06-8 o 16 54 12" src="https://user-images.githubusercontent.com/205419/84045148-bedd5e80-a9a8-11ea-9493-774da86293b7.png">
<img width="296" alt="Zrzut ekranu 2020-06-8 o 16 54 19" src="https://user-images.githubusercontent.com/205419/84045153-c13fb880-a9a8-11ea-88fd-658bb2d5442c.png">

It also proposes the following way of handling the appender for single menu items - this way there is no need for a separate "add nested menu" action:

<img width="290" alt="Zrzut ekranu 2020-06-8 o 16 54 25" src="https://user-images.githubusercontent.com/205419/84045163-c1d84f00-a9a8-11ea-90da-ec72ab59eedb.png">

## How has this been tested?
1. Enable the navigation experiment in Gutenberg > Experiments
1. Go to Gutenberg > Navigation (beta)
1. Play with the navigator and confirm the experience feels natural
1. Confirm the navigator in the post editor keeps working the same way as before

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
