### PR TITLE
npm scripts: use wp-env instead of wp-scripts env command

### DIFF
--- a/package.json
+++ b/package.json
@@ -248,7 +248,7 @@
 		"design-system:dev": "echo \"Please use storybook:dev instead.\"",
 		"playground:build": "npm run storybook:build",
 		"playground:dev": "echo \"Please use storybook:dev instead.\"",
-		"env": "wp-scripts env",
+		"env": "packages/env/bin/wp-env",
 		"wp-env": "packages/env/bin/wp-env"
 	},
 	"husky": {


### PR DESCRIPTION
Updates the `env` npm script to use the `@wordpress/env` packages instead of `@wordpress/scripts` package (env command).