### PR TITLE
Remove child space in Tooltip.

### DIFF
--- a/packages/block-editor/src/components/button-block-appender/index.js
+++ b/packages/block-editor/src/components/button-block-appender/index.js
@@ -82,7 +82,7 @@ function ButtonBlockAppender(
 
 				if ( isToggleButton ) {
 					inserterButton = (
-						<Tooltip text={ label }> { inserterButton } </Tooltip>
+						<Tooltip text={ label }>{ inserterButton }</Tooltip>
 					);
 				}
 				return inserterButton;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

fix #22989 

ToolTip does not allow multiple children. And spaces are also treated as children, which causes an error. 

## How has this been tested?

Make sure there are no errors in console when you insert the Group Block.

( Need `process.env.NODE_ENV === 'development' ` )

## Types of changes

Bug fix

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
