### PR TITLE
Remove navigator from the navigation block inspector

### DIFF
--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -42,7 +42,6 @@ import { navigation as icon } from '@wordpress/icons';
  * Internal dependencies
  */
 import useBlockNavigator from './use-block-navigator';
-import BlockNavigationList from './block-navigation-list';
 import BlockColorsStyleSelector from './block-colors-selector';
 import * as navIcons from './icons';
 
@@ -243,9 +242,6 @@ function Navigation( {
 			</BlockControls>
 			{ navigatorModal }
 			<InspectorControls>
-				<PanelBody title={ __( 'Navigation Structure' ) }>
-					<BlockNavigationList clientId={ clientId } />
-				</PanelBody>
 				<PanelBody title={ __( 'Text settings' ) }>
 					<FontSizePicker
 						value={ fontSize.size }


### PR DESCRIPTION
## Description

As in the title. Solves https://github.com/WordPress/gutenberg/issues/20846.

**Before**
<img width="1245" alt="Zrzut ekranu 2020-06-9 o 13 09 16" src="https://user-images.githubusercontent.com/205419/84140822-7aa69880-aa52-11ea-832d-c74748985a76.png">


**After**
<img width="1243" alt="Zrzut ekranu 2020-06-9 o 13 08 18" src="https://user-images.githubusercontent.com/205419/84140818-79756b80-aa52-11ea-9145-dcf80396c080.png">

## How has this been tested?
1. Go to post editor
1. Create a navigation block with a few links'
1. Confirm the navigator is no longer available in the inspector

## Types of changes
Non-breaking changes

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
