### PR TITLE
Try: Don't show a clone when dragging.

### DIFF
--- a/packages/block-editor/src/components/block-draggable/draggable-chip.js
+++ b/packages/block-editor/src/components/block-draggable/draggable-chip.js
@@ -1,0 +1,70 @@
+/**
+ * External dependencies
+ */
+import { uniq, map } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { getBlockType } from '@wordpress/blocks';
+import { useSelect } from '@wordpress/data';
+import { Flex, FlexItem, FlexBlock } from '@wordpress/components';
+import { menu } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import BlockIcon from '../block-icon';
+
+export function BlockDraggableChip( { icon = menu, label } ) {
+	return (
+		<div className="block-editor-block-draggable-chip-wrapper">
+			<div className="block-editor-block-draggable-chip">
+				<Flex
+					justify="center"
+					className="block-editor-block-draggable-chip__content"
+				>
+					<FlexItem>
+						<BlockIcon icon={ icon } />
+					</FlexItem>
+					{ label && (
+						<FlexBlock>
+							<div className="block-editor-block-draggable-chip__label">
+								{ label }
+							</div>
+						</FlexBlock>
+					) }
+				</Flex>
+			</div>
+		</div>
+	);
+}
+
+/*
+ * Connects the <BaseBlockDraggableChip /> UI with data from @wordpress/data.
+ */
+function ConnectedBlockDraggableChip( { clientIds } ) {
+	const { blocks } = useSelect( ( select ) => {
+		const { getBlocksByClientId } = select( 'core/block-editor' );
+
+		return { blocks: getBlocksByClientId( clientIds ) };
+	} );
+
+	// When selection consists of blocks of multiple types, display an
+	// appropriate icon to communicate the non-uniformity.
+	const isSelectionOfSameType = uniq( map( blocks, 'name' ) ).length === 1;
+
+	let icon;
+	let label;
+
+	if ( isSelectionOfSameType ) {
+		const sourceBlockName = blocks[ 0 ].name;
+		const blockType = getBlockType( sourceBlockName );
+		icon = blockType.icon;
+		label = blockType.title;
+	}
+
+	return <BlockDraggableChip icon={ icon } label={ label } />;
+}
+
+export default ConnectedBlockDraggableChip;

--- a/packages/block-editor/src/components/block-draggable/draggable-chip.js
+++ b/packages/block-editor/src/components/block-draggable/draggable-chip.js
@@ -8,15 +8,15 @@ import { uniq, map } from 'lodash';
  */
 import { getBlockType } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
-import { Flex, FlexItem, FlexBlock } from '@wordpress/components';
-import { menu } from '@wordpress/icons';
+import { Flex, FlexItem } from '@wordpress/components';
+import { menu, handle } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import BlockIcon from '../block-icon';
 
-export function BlockDraggableChip( { icon = menu, label } ) {
+export function BlockDraggableChip( { icon = menu } ) {
 	return (
 		<div className="block-editor-block-draggable-chip-wrapper">
 			<div className="block-editor-block-draggable-chip">
@@ -25,15 +25,11 @@ export function BlockDraggableChip( { icon = menu, label } ) {
 					className="block-editor-block-draggable-chip__content"
 				>
 					<FlexItem>
+						<BlockIcon icon={ handle } />
+					</FlexItem>
+					<FlexItem>
 						<BlockIcon icon={ icon } />
 					</FlexItem>
-					{ label && (
-						<FlexBlock>
-							<div className="block-editor-block-draggable-chip__label">
-								{ label }
-							</div>
-						</FlexBlock>
-					) }
 				</Flex>
 			</div>
 		</div>

--- a/packages/block-editor/src/components/block-draggable/draggable-chip.js
+++ b/packages/block-editor/src/components/block-draggable/draggable-chip.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { uniq, map } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { getBlockType } from '@wordpress/blocks';
@@ -16,7 +11,25 @@ import { menu, handle } from '@wordpress/icons';
  */
 import BlockIcon from '../block-icon';
 
-export function BlockDraggableChip( { icon = menu } ) {
+export default function BlockDraggableChip( { clientIds } ) {
+	const icon = useSelect(
+		( select ) => {
+			const { getBlockName } = select( 'core/block-editor' );
+			const [ firstId ] = clientIds;
+			const blockName = getBlockName( firstId );
+			const isOfSameType = clientIds.every(
+				( id ) => getBlockName( id ) === blockName
+			);
+
+			if ( ! isOfSameType ) {
+				return menu;
+			}
+
+			return getBlockType( blockName ).icon;
+		},
+		[ clientIds ]
+	);
+
 	return (
 		<div className="block-editor-block-draggable-chip-wrapper">
 			<div className="block-editor-block-draggable-chip">
@@ -35,32 +48,3 @@ export function BlockDraggableChip( { icon = menu } ) {
 		</div>
 	);
 }
-
-/*
- * Connects the <BaseBlockDraggableChip /> UI with data from @wordpress/data.
- */
-function ConnectedBlockDraggableChip( { clientIds } ) {
-	const { blocks } = useSelect( ( select ) => {
-		const { getBlocksByClientId } = select( 'core/block-editor' );
-
-		return { blocks: getBlocksByClientId( clientIds ) };
-	} );
-
-	// When selection consists of blocks of multiple types, display an
-	// appropriate icon to communicate the non-uniformity.
-	const isSelectionOfSameType = uniq( map( blocks, 'name' ) ).length === 1;
-
-	let icon;
-	let label;
-
-	if ( isSelectionOfSameType ) {
-		const sourceBlockName = blocks[ 0 ].name;
-		const blockType = getBlockType( sourceBlockName );
-		icon = blockType.icon;
-		label = blockType.title;
-	}
-
-	return <BlockDraggableChip icon={ icon } label={ label } />;
-}
-
-export default ConnectedBlockDraggableChip;

--- a/packages/block-editor/src/components/block-draggable/index.js
+++ b/packages/block-editor/src/components/block-draggable/index.js
@@ -6,6 +6,11 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
 import { getScrollContainer } from '@wordpress/dom';
 
+/**
+ * Internal dependencies
+ */
+import BlockDraggableChip from './draggable-chip';
+
 const SCROLL_INACTIVE_DISTANCE_PX = 50;
 const SCROLL_INTERVAL_MS = 25;
 const PIXELS_PER_SECOND_PER_DISTANCE = 5;
@@ -153,6 +158,9 @@ const BlockDraggable = ( {
 					onDragEnd();
 				}
 			} }
+			__experimentalDragComponent={
+				<BlockDraggableChip clientIds={ clientIds } />
+			}
 		>
 			{ ( { onDraggableStart, onDraggableEnd } ) => {
 				return children( {

--- a/packages/block-editor/src/components/block-draggable/stories/index.js
+++ b/packages/block-editor/src/components/block-draggable/stories/index.js
@@ -1,0 +1,15 @@
+/**
+ * WordPress dependencies
+ */
+import { wordpress } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { BlockDraggableChip } from '../draggable-chip';
+
+export default { title: 'BlockEditor/BlockDraggable' };
+
+export const _default = () => {
+	return <BlockDraggableChip icon={ wordpress } label="WordPress" />;
+};

--- a/packages/block-editor/src/components/block-draggable/style.scss
+++ b/packages/block-editor/src/components/block-draggable/style.scss
@@ -23,12 +23,6 @@
 	&__content {
 		margin: auto;
 	}
-
-	&__label {
-		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif !important;
-		font-size: 13px !important;
-		font-weight: 500;
-	}
 }
 
 // This hides the block being dragged.

--- a/packages/block-editor/src/components/block-draggable/style.scss
+++ b/packages/block-editor/src/components/block-draggable/style.scss
@@ -34,11 +34,6 @@
 // This hides the block being dragged.
 // The effect is that the block being dragged appears to be "lifted".
 .is-dragging.is-selected {
-	opacity: 0.4 !important;
-
-	&::before,
-	&::after {
-		display: none !important;
-	}
+	display: none !important;
 }
 

--- a/packages/block-editor/src/components/block-draggable/style.scss
+++ b/packages/block-editor/src/components/block-draggable/style.scss
@@ -1,0 +1,44 @@
+.block-editor-block-draggable-chip-wrapper {
+	position: absolute;
+	top: -$block-toolbar-height - $grid-unit-15;
+}
+
+.block-editor-block-draggable-chip {
+	background-color: $dark-gray-primary;
+	border-radius: $radius-block-ui;
+	border: $border-width solid $dark-gray-primary;
+	box-shadow: $shadow-popover;
+	color: $white;
+	cursor: grabbing;
+	display: inline-flex;
+	height: $block-toolbar-height;
+	min-width: $button-size * 2;
+	padding: 0 $grid-unit-15;
+	user-select: none;
+
+	svg {
+		fill: currentColor;
+	}
+
+	&__content {
+		margin: auto;
+	}
+
+	&__label {
+		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif !important;
+		font-size: 13px !important;
+		font-weight: 500;
+	}
+}
+
+// This hides the block being dragged.
+// The effect is that the block being dragged appears to be "lifted".
+.is-dragging.is-selected {
+	opacity: 0.4 !important;
+
+	&::before,
+	&::after {
+		display: none !important;
+	}
+}
+

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -590,10 +590,13 @@
 		.components-button.has-icon.block-editor-block-mover-button.block-editor-block-mover-button {
 			min-width: $button-size;
 			width: $button-size;
-			cursor: grab;
 
-			&:active {
-				cursor: grabbing;
+			[draggable="true"] & {
+				cursor: grab;
+
+				&:active {
+					cursor: grabbing;
+				}
 			}
 		}
 

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -2,13 +2,14 @@
  * External dependencies
  */
 import classnames from 'classnames';
+
 /**
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
 import { useRef } from '@wordpress/element';
 import { useViewportMatch } from '@wordpress/compose';
-import { hasBlockSupport } from '@wordpress/blocks';
+import { getBlockType, hasBlockSupport } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -32,7 +33,6 @@ export default function BlockToolbar( { hideDragHandle } ) {
 		isVisual,
 		moverDirection,
 	} = useSelect( ( select ) => {
-		const { getBlockType } = select( 'core/blocks' );
 		const {
 			getBlockName,
 			getBlockMode,

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -103,23 +103,3 @@
 		display: block;
 	}
 }
-
-// Show a draggable handle when you're dragging using the toolbar component.
-.block-editor-block-toolbar__drag-clone::before {
-	content: "";
-	display: block;
-	position: absolute;
-	top: -$block-toolbar-height - $grid-unit-15;
-	width: $button-size * 2;
-	height: $block-toolbar-height;
-	border-radius: $radius-block-ui;
-	background-color: $dark-gray-primary;
-	border: $border-width solid $dark-gray-primary;
-	box-shadow: $shadow-popover;
-
-	// This should be reconsidered if successful.
-	background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZD0iTTcgMTYuNWgxMFYxNUg3djEuNXptMC05VjloMTBWNy41SDd6IiBmaWxsPSIjZmZmIi8+PC9zdmc+);
-	background-size: $icon-size;
-	background-repeat: no-repeat;
-	background-position: center center;
-}

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -115,6 +115,7 @@
 	border-radius: $radius-block-ui;
 	background-color: $dark-gray-primary;
 	border: $border-width solid $dark-gray-primary;
+	box-shadow: $shadow-popover;
 
 	// This should be reconsidered if successful.
 	background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZD0iTTcgMTYuNWgxMFYxNUg3djEuNXptMC05VjloMTBWNy41SDd6IiBmaWxsPSIjZmZmIi8+PC9zdmc+);

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -14,6 +14,7 @@
 @import "./components/block-breadcrumb/style.scss";
 @import "./components/block-card/style.scss";
 @import "./components/block-compare/style.scss";
+@import "./components/block-draggable/style.scss";
 @import "./components/block-mobile-toolbar/style.scss";
 @import "./components/block-mover/style.scss";
 @import "./components/block-navigation/style.scss";

--- a/packages/components/src/draggable/index.js
+++ b/packages/components/src/draggable/index.js
@@ -76,7 +76,6 @@ class Draggable extends Component {
 	/**
 	 * This method does a couple of things:
 	 *
-	 * - Clones the current element and spawns clone over original element.
 	 * - Adds a fake temporary drag image to avoid browser defaults.
 	 * - Sets transfer data.
 	 * - Adds dragover listener.
@@ -117,8 +116,6 @@ class Draggable extends Component {
 		const elementWrapper = element.parentNode;
 		const elementTopOffset = parseInt( elementRect.top, 10 );
 		const elementLeftOffset = parseInt( elementRect.left, 10 );
-		const clone = element.cloneNode( true );
-		clone.id = `clone-${ elementId }`;
 		this.cloneWrapper = document.createElement( 'div' );
 		this.cloneWrapper.classList.add( cloneWrapperClass );
 		if ( cloneClassname ) {
@@ -145,12 +142,6 @@ class Draggable extends Component {
 			}px`;
 		}
 
-		// Hack: Remove iFrames as it's causing the embeds drag clone to freeze
-		Array.from( clone.querySelectorAll( 'iframe' ) ).forEach( ( child ) =>
-			child.parentNode.removeChild( child )
-		);
-
-		this.cloneWrapper.appendChild( clone );
 		elementWrapper.appendChild( this.cloneWrapper );
 
 		// Mark the current cursor coordinates.

--- a/packages/components/src/draggable/index.js
+++ b/packages/components/src/draggable/index.js
@@ -11,7 +11,6 @@ import { withSafeTimeout } from '@wordpress/compose';
 
 const dragImageClass = 'components-draggable__invisible-drag-image';
 const cloneWrapperClass = 'components-draggable__clone';
-const cloneHeightTransformationBreakpoint = 700;
 const clonePadding = 0;
 
 class Draggable extends Component {
@@ -126,22 +125,11 @@ class Draggable extends Component {
 			elementRect.width + clonePadding * 2
 		}px`;
 
-		if ( elementRect.height > cloneHeightTransformationBreakpoint ) {
-			// Scale down clone if original element is larger than 700px.
-			this.cloneWrapper.style.transform = 'scale(0.5)';
-			this.cloneWrapper.style.transformOrigin = 'top left';
-			// Position clone near the cursor.
-			this.cloneWrapper.style.top = `${ event.clientY - 100 }px`;
-			this.cloneWrapper.style.left = `${ event.clientX }px`;
-		} else {
-			// Position clone right over the original element (20px padding).
-			this.cloneWrapper.style.top = `${
-				elementTopOffset - clonePadding
-			}px`;
-			this.cloneWrapper.style.left = `${
-				elementLeftOffset - clonePadding
-			}px`;
-		}
+		// Position clone right over the original element (20px padding).
+		this.cloneWrapper.style.top = `${ elementTopOffset - clonePadding }px`;
+		this.cloneWrapper.style.left = `${
+			elementLeftOffset - clonePadding
+		}px`;
 
 		/*
 		 * __experimentalDragComponent

--- a/packages/components/src/draggable/style.scss
+++ b/packages/components/src/draggable/style.scss
@@ -16,15 +16,10 @@ body.is-dragging-components-draggable {
 	background: transparent;
 	pointer-events: none;
 	z-index: z-index(".components-draggable__clone");
-	opacity: 0.7;
-
-	// Hide the actual clone. If this experiment is successful, we'll want to actually remove the clone entirely.
-	> * {
-		display: none;
-	}
 }
 
-// This is only for testing.
+// This hides the block being dragged.
+// The effect is that the block being dragged appears to be "lifted".
 .is-dragging.is-selected {
 	display: none !important;
 }

--- a/packages/components/src/draggable/style.scss
+++ b/packages/components/src/draggable/style.scss
@@ -23,3 +23,8 @@ body.is-dragging-components-draggable {
 		display: none;
 	}
 }
+
+// This is only for testing.
+.is-dragging.is-selected {
+	display: none !important;
+}

--- a/packages/components/src/draggable/style.scss
+++ b/packages/components/src/draggable/style.scss
@@ -17,9 +17,3 @@ body.is-dragging-components-draggable {
 	pointer-events: none;
 	z-index: z-index(".components-draggable__clone");
 }
-
-// This hides the block being dragged.
-// The effect is that the block being dragged appears to be "lifted".
-.is-dragging.is-selected {
-	display: none !important;
-}

--- a/packages/components/src/draggable/style.scss
+++ b/packages/components/src/draggable/style.scss
@@ -18,9 +18,8 @@ body.is-dragging-components-draggable {
 	z-index: z-index(".components-draggable__clone");
 	opacity: 0.7;
 
+	// Hide the actual clone. If this experiment is successful, we'll want to actually remove the clone entirely.
 	> * {
-		// This needs specificity as a theme is meant to define these by default.
-		margin-top: 0 !important;
-		margin-bottom: 0 !important;
+		display: none;
 	}
 }

--- a/packages/icons/src/index.js
+++ b/packages/icons/src/index.js
@@ -70,6 +70,7 @@ export { default as gallery } from './library/gallery';
 export { default as globe } from './library/globe';
 export { default as grid } from './library/grid';
 export { default as group } from './library/group';
+export { default as handle } from './library/handle';
 export { default as heading } from './library/heading';
 export { default as help } from './library/help';
 export { default as inbox } from './library/inbox';

--- a/packages/icons/src/library/handle.js
+++ b/packages/icons/src/library/handle.js
@@ -1,0 +1,12 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, SVG } from '@wordpress/primitives';
+
+const handle = (
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+		<Path d="M7 16.5h10V15H7v1.5zm0-9V9h10V7.5H7z" />
+	</SVG>
+);
+
+export default handle;

--- a/storybook/main.js
+++ b/storybook/main.js
@@ -1,5 +1,6 @@
 const stories = [
 	process.env.NODE_ENV !== 'test' && './stories/**/*.(js|mdx)',
+	'../packages/block-editor/src/**/stories/*.js',
 	'../packages/components/src/**/stories/*.js',
 	'../packages/icons/src/**/stories/*.js',
 ].filter( Boolean );


### PR DESCRIPTION
As of #22673, the mover control is now a permanent fixture next to the block switcher, and the entire unit is a draggable handle. One thing that effort helped surface, was that the fact that we make a clone of the block when dragging feels like it breaks with some physics — you duplicate the block when you're supposed to move it. This is because you don't actually move the block until you drop it.

This PR removes the clone, and hides the block being lifted, leaving only the draggable handle. Before:

![before](https://user-images.githubusercontent.com/1204802/84143309-a3309180-aa56-11ea-8180-f6de01e9ee48.gif)

After:

![Kapture 2020-06-22 at 15 44 57](https://user-images.githubusercontent.com/1204802/85295574-6cb83500-b4a0-11ea-8118-0a572d084ca3.gif)

The drag and drop experience feels slightly more precise as a result, and less muddy overall. 

_This description was edited as the PR changed while working on it. You can see the edit history if you like._