### PR TITLE
Fix link color style rule

### DIFF
--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -439,6 +439,16 @@ function gutenberg_experimental_global_styles_resolver( $tree ) {
 			)
 		);
 	}
+
+	if ( gutenberg_experimental_global_styles_has_theme_json_support() ) {
+		// To support all themes, we added in the block-library stylesheet
+		// a style rule such as .has-link-color a { color: var(--wp--style--color--link, #00e); }
+		// so that existing link colors themes used didn't break.
+		// We add this here to make it work for themes that opt-in to theme.json
+		// In the future, we may do this differently.
+		$stylesheet .= 'a { color: var(--wp--style--color--link, #00e); }';
+	}
+
 	return $stylesheet;
 }
 
@@ -454,15 +464,6 @@ function gutenberg_experimental_global_styles_resolver( $tree ) {
 function gutenberg_experimental_global_styles_resolver_styles( $block_selector, $block_supports, $block_styles ) {
 	$css_rule         = '';
 	$css_declarations = '';
-
-	if ( gutenberg_experimental_global_styles_has_theme_json_support() ) {
-		// To support all themes, we added in the block-library stylesheet
-		// a style rule such as .has-link-color a { color: var(--wp--style--color--link, #00e); }
-		// so that existing link colors themes used didn't break.
-		// We add this here to make it work for themes that opt-in to theme.json
-		// In the future, we may do this differently.
-		$css_rule = 'a { color: var(--wp--style--color--link, #00e); }';
-	}
 
 	foreach ( $block_styles as $property => $value ) {
 		// Only convert to CSS:


### PR DESCRIPTION
Using the theme.json, the style rule for link color is added once per block but should be added only once.

### How to test

Install and activate a theme that uses theme.json and verify that the embedded stylesheet with id `#global-styles-inline-css` has only one style declaration for:

```css
a { color: var(--wp--style--color--link, #00e); }
```

For example:

- Install and activate this ([demo theme](https://github.com/nosolosw/global-styles-theme)).
- Activate the FSE experiment (necessary for this demo theme as it only works with FSE).
- Go to the front end and inspect the embedded stylesheet.
