### PR TITLE
Try absorbing padding for cover

### DIFF
--- a/lib/experimental-default-theme.json
+++ b/lib/experimental-default-theme.json
@@ -122,44 +122,6 @@
 					"slug": "vivid-cyan-blue-to-vivid-purple",
 					"value": "linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)"
 				}
-			],
-			"padding": [
-				{
-					"slug": "unit",
-					"value": 8
-				},
-				{
-					"slug": "unit-05",
-					"value": "calc(0.5 * var(--wp--preset--padding--unit))"
-				},
-				{
-					"slug": "unit-10",
-					"value": "calc(1 * var(--wp--preset--padding--unit))"
-				},
-				{
-					"slug": "unit-15",
-					"value": "calc(1.5 * var(--wp--preset--padding--unit))"
-				},
-				{
-					"slug": "unit-20",
-					"value": "calc(2 * var(--wp--preset--padding--unit))"
-				},
-				{
-					"slug": "unit-30",
-					"value": "calc(3 * var(--wp--preset--padding--unit))"
-				},
-				{
-					"slug": "unit-40",
-					"value": "calc(4 * var(--wp--preset--padding--unit))"
-				},
-				{
-					"slug": "unit-50",
-					"value": "calc(5 * var(--wp--preset--padding--unit))"
-				},
-				{
-					"slug": "unit-60",
-					"value": "calc(6 * var(--wp--preset--padding--unit))"
-				}
 			]
 		},
 		"features": {
@@ -171,7 +133,7 @@
 	"core/cover": {
 		"styles": {
 			"spacing": {
-				"padding": "var(--wp--preset--padding--unit-20)"
+				"padding": 16
 			}
 		}
 	}

--- a/lib/experimental-default-theme.json
+++ b/lib/experimental-default-theme.json
@@ -122,6 +122,44 @@
 					"slug": "vivid-cyan-blue-to-vivid-purple",
 					"value": "linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)"
 				}
+			],
+			"padding": [
+				{
+					"slug": "unit",
+					"value": 8
+				},
+				{
+					"slug": "unit-05",
+					"value": "calc(0.5 * var(--wp--preset--padding--unit))"
+				},
+				{
+					"slug": "unit-10",
+					"value": "calc(1 * var(--wp--preset--padding--unit))"
+				},
+				{
+					"slug": "unit-15",
+					"value": "calc(1.5 * var(--wp--preset--padding--unit))"
+				},
+				{
+					"slug": "unit-20",
+					"value": "calc(2 * var(--wp--preset--padding--unit))"
+				},
+				{
+					"slug": "unit-30",
+					"value": "calc(3 * var(--wp--preset--padding--unit))"
+				},
+				{
+					"slug": "unit-40",
+					"value": "calc(4 * var(--wp--preset--padding--unit))"
+				},
+				{
+					"slug": "unit-50",
+					"value": "calc(5 * var(--wp--preset--padding--unit))"
+				},
+				{
+					"slug": "unit-60",
+					"value": "calc(6 * var(--wp--preset--padding--unit))"
+				}
 			]
 		},
 		"features": {

--- a/lib/experimental-default-theme.json
+++ b/lib/experimental-default-theme.json
@@ -167,5 +167,12 @@
 				"dropCap": false
 			}
 		}
+	},
+	"core/cover": {
+		"styles": {
+			"spacing": {
+				"padding": "var(--wp--preset--padding--unit-20)"
+			}
+		}
 	}
 }

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -281,6 +281,7 @@ function gutenberg_experimental_global_styles_get_supported_styles( $supports ) 
 		'background'       => array( '__experimentalColor', 'gradients' ),
 		'line-height'      => array( '__experimentalLineHeight' ),
 		'font-size'        => array( '__experimentalFontSize' ),
+		'padding'          => array( '__experimentalPadding' ),
 	);
 
 	$supported_features = array();
@@ -381,6 +382,7 @@ function gutenberg_experimental_global_styles_flatten_styles_tree( $styles ) {
 		'background-color'         => array( 'color', 'background' ),
 		'color'                    => array( 'color', 'text' ),
 		'--wp--style--color--link' => array( 'color', 'link' ),
+		'padding'                  => array( 'spacing', 'padding' ),
 	);
 
 	$result = array();

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -9,7 +9,6 @@
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	padding: $grid-unit-20;
 
 	&.has-parallax {
 		background-attachment: fixed;


### PR DESCRIPTION
Follow-up on https://github.com/WordPress/gutenberg/pull/21492

**Work In Progress**

This is an in-progress experiment to absorb style declarations that were previously included in the block's CSS via theme.json. By _managing the block's CSS_ we can consolidate the style needs of different origins (block defaults, theme, and user), ship less CSS to the browser (more performant), and adapt the CSS to the different contexts (editor, front) without any theme intervention.
