### PR TITLE
Light block: introduce useBlockWrapperProps

### DIFF
--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -43,7 +43,7 @@ import ELEMENTS from './block-wrapper-elements';
  *
  * @return {Object} Props to pass to the element to mark as a block.
  */
-export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
+export function useBlockWrapperProps( props = {}, { __unstableIsHtml } = {} ) {
 	const fallbackRef = useRef();
 	const ref = props.ref || fallbackRef;
 	const onSelectionStart = useContext( Context );
@@ -296,7 +296,10 @@ const BlockComponent = forwardRef(
 		ref
 	) => (
 		<TagName
-			{ ...useBlockProps( { ...props, ref }, { __unstableIsHtml } ) }
+			{ ...useBlockWrapperProps(
+				{ ...props, ref },
+				{ __unstableIsHtml }
+			) }
 		>
 			{ children }
 		</TagName>

--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -15,7 +15,7 @@ import {
 	forwardRef,
 } from '@wordpress/element';
 import { focus, isTextField, placeCaretAtHorizontalEdge } from '@wordpress/dom';
-import { ENTER } from '@wordpress/keycodes';
+import { ENTER, BACKSPACE, DELETE } from '@wordpress/keycodes';
 import { __, sprintf } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 
@@ -88,7 +88,9 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		},
 		[ isSelected ]
 	);
-	const { insertDefaultBlock } = useDispatch( 'core/block-editor' );
+	const { insertDefaultBlock, removeBlock } = useDispatch(
+		'core/block-editor'
+	);
 	const [ isHovered, setHovered ] = useState( false );
 
 	// Provide the selected node, or the first and last nodes of a multi-
@@ -182,7 +184,11 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		function onKeyDown( event ) {
 			const { keyCode, target } = event;
 
-			if ( keyCode !== ENTER ) {
+			if (
+				keyCode !== ENTER &&
+				keyCode !== BACKSPACE &&
+				keyCode !== DELETE
+			) {
 				return;
 			}
 
@@ -192,7 +198,11 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 
 			event.preventDefault();
 
-			insertDefaultBlock( {}, rootClientId, index + 1 );
+			if ( keyCode === ENTER ) {
+				insertDefaultBlock( {}, rootClientId, index + 1 );
+			} else {
+				removeBlock( clientId );
+			}
 		}
 
 		function onMouseLeave( { which, buttons } ) {
@@ -213,7 +223,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 			ref.current.removeEventListener( 'mouseleave', onMouseLeave );
 			ref.current.removeEventListener( 'keydown', onKeyDown );
 		};
-	}, [ isSelected, onSelectionStart, insertDefaultBlock ] );
+	}, [ isSelected, onSelectionStart, insertDefaultBlock, removeBlock ] );
 
 	useEffect( () => {
 		if ( ! isNavigationMode ) {

--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -292,16 +292,13 @@ const BlockComponent = forwardRef(
 	(
 		{ children, tagName: TagName = 'div', __unstableIsHtml, ...props },
 		ref
-	) => (
-		<TagName
-			{ ...useBlockWrapperProps(
-				{ ...props, ref },
-				{ __unstableIsHtml }
-			) }
-		>
-			{ children }
-		</TagName>
-	)
+	) => {
+		const blockWrapperProps = useBlockWrapperProps(
+			{ ...props, ref },
+			{ __unstableIsHtml }
+		);
+		return <TagName { ...blockWrapperProps }>{ children }</TagName>;
+	}
 );
 
 const ExtendedBlockComponent = ELEMENTS.reduce( ( acc, element ) => {

--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -15,7 +15,7 @@ import {
 	forwardRef,
 } from '@wordpress/element';
 import { focus, isTextField, placeCaretAtHorizontalEdge } from '@wordpress/dom';
-import { ENTER, BACKSPACE, DELETE } from '@wordpress/keycodes';
+import { ENTER } from '@wordpress/keycodes';
 import { __, sprintf } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 
@@ -28,175 +28,174 @@ import { Context, SetBlockNodes } from './root-container';
 import { BlockListBlockContext } from './block';
 import ELEMENTS from './block-wrapper-elements';
 
-const BlockComponent = forwardRef(
-	(
-		{ children, tagName: TagName = 'div', __unstableIsHtml, ...props },
-		wrapper
-	) => {
-		const onSelectionStart = useContext( Context );
-		const setBlockNodes = useContext( SetBlockNodes );
-		const {
-			clientId,
-			rootClientId,
-			isSelected,
-			isFirstMultiSelected,
-			isLastMultiSelected,
-			isPartOfMultiSelection,
-			enableAnimation,
-			index,
-			className,
-			name,
-			mode,
-			blockTitle,
-			wrapperProps,
-		} = useContext( BlockListBlockContext );
-		const {
-			initialPosition,
-			shouldFocusFirstElement,
-			isNavigationMode,
-		} = useSelect(
-			( select ) => {
-				const {
-					getSelectedBlocksInitialCaretPosition,
-					isMultiSelecting: _isMultiSelecting,
-					isNavigationMode: _isNavigationMode,
-				} = select( 'core/block-editor' );
+/**
+ * This hook is used to lighly mark an element as a block element. Call this
+ * hook and pass the returned props to the element to mark as a block. If you
+ * define a ref for the element, it is important to pass the ref to this hook,
+ * which the hooks in turn will pass to the component through the props it
+ * returns. Optionally, you can also pass any other props through this hook, and
+ * they will be merged and returned.
+ *
+ * @param {Object}  props   Optional. Props to pass to the element. Must contain
+ *                          the ref if one is defined.
+ * @param {Object}  options Options for internal use only.
+ * @param {boolean} options.__unstableIsHtml
+ *
+ * @return {Object} Props to pass to the element to mark as a block.
+ */
+export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
+	const fallbackRef = useRef();
+	const ref = props.ref || fallbackRef;
+	const onSelectionStart = useContext( Context );
+	const setBlockNodes = useContext( SetBlockNodes );
+	const {
+		clientId,
+		rootClientId,
+		isSelected,
+		isFirstMultiSelected,
+		isLastMultiSelected,
+		isPartOfMultiSelection,
+		enableAnimation,
+		index,
+		className,
+		name,
+		mode,
+		blockTitle,
+		wrapperProps = {},
+	} = useContext( BlockListBlockContext );
+	const {
+		initialPosition,
+		shouldFocusFirstElement,
+		isNavigationMode,
+	} = useSelect(
+		( select ) => {
+			const {
+				getSelectedBlocksInitialCaretPosition,
+				isMultiSelecting: _isMultiSelecting,
+				isNavigationMode: _isNavigationMode,
+			} = select( 'core/block-editor' );
 
-				return {
-					shouldFocusFirstElement:
-						isSelected &&
-						! _isMultiSelecting() &&
-						! _isNavigationMode(),
-					initialPosition: isSelected
-						? getSelectedBlocksInitialCaretPosition()
-						: undefined,
-					isNavigationMode: _isNavigationMode,
-				};
-			},
-			[ isSelected ]
-		);
-		const { insertDefaultBlock, removeBlock } = useDispatch(
-			'core/block-editor'
-		);
-		const fallbackRef = useRef();
-		wrapper = wrapper || fallbackRef;
+			return {
+				shouldFocusFirstElement:
+					isSelected &&
+					! _isMultiSelecting() &&
+					! _isNavigationMode(),
+				initialPosition: isSelected
+					? getSelectedBlocksInitialCaretPosition()
+					: undefined,
+				isNavigationMode: _isNavigationMode,
+			};
+		},
+		[ isSelected ]
+	);
+	const { insertDefaultBlock } = useDispatch( 'core/block-editor' );
+	const [ isHovered, setHovered ] = useState( false );
 
-		const [ isHovered, setHovered ] = useState( false );
+	// Provide the selected node, or the first and last nodes of a multi-
+	// selection, so it can be used to position the contextual block toolbar.
+	// We only provide what is necessary, and remove the nodes again when they
+	// are no longer selected.
+	useEffect( () => {
+		if ( isSelected || isFirstMultiSelected || isLastMultiSelected ) {
+			const node = ref.current;
+			setBlockNodes( ( nodes ) => ( {
+				...nodes,
+				[ clientId ]: node,
+			} ) );
+			return () => {
+				setBlockNodes( ( nodes ) => omit( nodes, clientId ) );
+			};
+		}
+	}, [ isSelected, isFirstMultiSelected, isLastMultiSelected ] );
 
-		// Provide the selected node, or the first and last nodes of a multi-
-		// selection, so it can be used to position the contextual block toolbar.
-		// We only provide what is necessary, and remove the nodes again when they
-		// are no longer selected.
-		useEffect( () => {
-			if ( isSelected || isFirstMultiSelected || isLastMultiSelected ) {
-				const node = wrapper.current;
-				setBlockNodes( ( nodes ) => ( {
-					...nodes,
-					[ clientId ]: node,
-				} ) );
-				return () => {
-					setBlockNodes( ( nodes ) => omit( nodes, clientId ) );
-				};
-			}
-		}, [ isSelected, isFirstMultiSelected, isLastMultiSelected ] );
+	// translators: %s: Type of block (i.e. Text, Image etc)
+	const blockLabel = sprintf( __( 'Block: %s' ), blockTitle );
 
-		// translators: %s: Type of block (i.e. Text, Image etc)
-		const blockLabel = sprintf( __( 'Block: %s' ), blockTitle );
+	// Handing the focus of the block on creation and update
 
-		// Handing the focus of the block on creation and update
+	/**
+	 * When a block becomes selected, transition focus to an inner tabbable.
+	 */
+	const focusTabbable = () => {
+		const { ownerDocument } = ref.current;
+
+		// Focus is captured by the wrapper node, so while focus transition
+		// should only consider tabbables within editable display, since it
+		// may be the wrapper itself or a side control which triggered the
+		// focus event, don't unnecessary transition to an inner tabbable.
+		if (
+			ownerDocument.activeElement &&
+			isInsideRootBlock( ref.current, ownerDocument.activeElement )
+		) {
+			return;
+		}
+
+		// Find all tabbables within node.
+		const textInputs = focus.tabbable
+			.find( ref.current )
+			.filter( isTextField )
+			// Exclude inner blocks and block appenders
+			.filter(
+				( node ) =>
+					isInsideRootBlock( ref.current, node ) &&
+					! node.closest( '.block-list-appender' )
+			);
+
+		// If reversed (e.g. merge via backspace), use the last in the set of
+		// tabbables.
+		const isReverse = -1 === initialPosition;
+		const target =
+			( isReverse ? last : first )( textInputs ) || ref.current;
+
+		placeCaretAtHorizontalEdge( target, isReverse );
+	};
+
+	useEffect( () => {
+		if ( shouldFocusFirstElement ) {
+			focusTabbable();
+		}
+	}, [ shouldFocusFirstElement ] );
+
+	// Block Reordering animation
+	useMovingAnimation(
+		ref,
+		isSelected || isPartOfMultiSelection,
+		isSelected || isFirstMultiSelected,
+		enableAnimation,
+		index
+	);
+
+	useEffect( () => {
+		if ( ! isSelected ) {
+			return;
+		}
 
 		/**
-		 * When a block becomes selected, transition focus to an inner tabbable.
-		 */
-		const focusTabbable = () => {
-			const { ownerDocument } = wrapper.current;
-
-			// Focus is captured by the wrapper node, so while focus transition
-			// should only consider tabbables within editable display, since it
-			// may be the wrapper itself or a side control which triggered the
-			// focus event, don't unnecessary transition to an inner tabbable.
-			if (
-				ownerDocument.activeElement &&
-				isInsideRootBlock(
-					wrapper.current,
-					ownerDocument.activeElement
-				)
-			) {
-				return;
-			}
-
-			// Find all tabbables within node.
-			const textInputs = focus.tabbable
-				.find( wrapper.current )
-				.filter( isTextField )
-				// Exclude inner blocks and block appenders
-				.filter(
-					( node ) =>
-						isInsideRootBlock( wrapper.current, node ) &&
-						! node.closest( '.block-list-appender' )
-				);
-
-			// If reversed (e.g. merge via backspace), use the last in the set of
-			// tabbables.
-			const isReverse = -1 === initialPosition;
-			const target =
-				( isReverse ? last : first )( textInputs ) || wrapper.current;
-
-			placeCaretAtHorizontalEdge( target, isReverse );
-		};
-
-		useEffect( () => {
-			if ( shouldFocusFirstElement ) {
-				focusTabbable();
-			}
-		}, [ shouldFocusFirstElement ] );
-
-		// Block Reordering animation
-		useMovingAnimation(
-			wrapper,
-			isSelected || isPartOfMultiSelection,
-			isSelected || isFirstMultiSelected,
-			enableAnimation,
-			index
-		);
-
-		/**
-		 * Interprets keydown event intent to remove or insert after block if key
-		 * event occurs on wrapper node. This can occur when the block has no text
-		 * fields of its own, particularly after initial insertion, to allow for
-		 * easy deletion and continuous writing flow to add additional content.
+		 * Interprets keydown event intent to remove or insert after block if
+		 * key event occurs on wrapper node. This can occur when the block has
+		 * no text fields of its own, particularly after initial insertion, to
+		 * allow for easy deletion and continuous writing flow to add additional
+		 * content.
 		 *
 		 * @param {KeyboardEvent} event Keydown event.
 		 */
-		const onKeyDown = ( event ) => {
+		function onKeyDown( event ) {
 			const { keyCode, target } = event;
 
-			if ( props.onKeyDown ) {
-				props.onKeyDown( event );
-			}
-
-			if (
-				keyCode !== ENTER &&
-				keyCode !== BACKSPACE &&
-				keyCode !== DELETE
-			) {
+			if ( keyCode !== ENTER ) {
 				return;
 			}
 
-			if ( target !== wrapper.current || isTextField( target ) ) {
+			if ( target !== ref.current || isTextField( target ) ) {
 				return;
 			}
 
 			event.preventDefault();
 
-			if ( keyCode === ENTER ) {
-				insertDefaultBlock( {}, rootClientId, index + 1 );
-			} else {
-				removeBlock( clientId );
-			}
-		};
+			insertDefaultBlock( {}, rootClientId, index + 1 );
+		}
 
-		const onMouseLeave = ( { which, buttons } ) => {
+		function onMouseLeave( { which, buttons } ) {
 			// The primary button must be pressed to initiate selection. Fall back
 			// to `which` if the standard `buttons` property is falsy. There are
 			// cases where Firefox might always set `buttons` to `0`.
@@ -205,11 +204,21 @@ const BlockComponent = forwardRef(
 			if ( ( buttons || which ) === 1 ) {
 				onSelectionStart( clientId );
 			}
-		};
+		}
 
-		const htmlSuffix =
-			mode === 'html' && ! __unstableIsHtml ? '-visual' : '';
-		const blockElementId = `block-${ clientId }${ htmlSuffix }`;
+		ref.current.addEventListener( 'keydown', onKeyDown );
+		ref.current.addEventListener( 'mouseleave', onMouseLeave );
+
+		return () => {
+			ref.current.removeEventListener( 'mouseleave', onMouseLeave );
+			ref.current.removeEventListener( 'keydown', onKeyDown );
+		};
+	}, [ isSelected, onSelectionStart, insertDefaultBlock ] );
+
+	useEffect( () => {
+		if ( ! isNavigationMode ) {
+			return;
+		}
 
 		function onMouseOver( event ) {
 			if ( event.defaultPrevented ) {
@@ -239,44 +248,49 @@ const BlockComponent = forwardRef(
 			setHovered( false );
 		}
 
-		return (
-			// eslint-disable-next-line jsx-a11y/mouse-events-have-key-events
-			<TagName
-				// Overrideable props.
-				aria-label={ blockLabel }
-				role="group"
-				{ ...omit( wrapperProps, [ 'data-align' ] ) }
-				{ ...props }
-				id={ blockElementId }
-				ref={ wrapper }
-				className={ classnames(
-					className,
-					props.className,
-					wrapperProps && wrapperProps.className,
-					{
-						'is-hovered': isHovered,
-					}
-				) }
-				data-block={ clientId }
-				data-type={ name }
-				data-title={ blockTitle }
-				// Only allow shortcuts when a blocks is selected.
-				onKeyDown={ isSelected ? onKeyDown : undefined }
-				// Only allow selection to be started from a selected block.
-				onMouseLeave={ isSelected ? onMouseLeave : undefined }
-				// No need to have these listeners for hover class in edit mode.
-				onMouseOver={ isNavigationMode ? onMouseOver : undefined }
-				onMouseOut={ isNavigationMode ? onMouseOut : undefined }
-				tabIndex="0"
-				style={ {
-					...( wrapperProps ? wrapperProps.style : {} ),
-					...( props.style || {} ),
-				} }
-			>
-				{ children }
-			</TagName>
-		);
-	}
+		ref.current.addEventListener( 'mouseover', onMouseOver );
+		ref.current.addEventListener( 'mouseout', onMouseOut );
+
+		return () => {
+			ref.current.removeEventListener( 'mouseover', onMouseOver );
+			ref.current.removeEventListener( 'mouseout', onMouseOut );
+		};
+	}, [ isNavigationMode, isHovered, setHovered ] );
+
+	const htmlSuffix = mode === 'html' && ! __unstableIsHtml ? '-visual' : '';
+
+	return {
+		...wrapperProps,
+		...props,
+		ref,
+		id: `block-${ clientId }${ htmlSuffix }`,
+		tabIndex: 0,
+		role: 'group',
+		'aria-label': blockLabel,
+		'data-block': clientId,
+		'data-type': name,
+		'data-title': blockTitle,
+		className: classnames(
+			className,
+			props.className,
+			wrapperProps.className,
+			{ 'is-hovered': isHovered }
+		),
+		style: { ...wrapperProps.style, ...props.style },
+	};
+}
+
+const BlockComponent = forwardRef(
+	(
+		{ children, tagName: TagName = 'div', __unstableIsHtml, ...props },
+		ref
+	) => (
+		<TagName
+			{ ...useBlockProps( { ...props, ref }, { __unstableIsHtml } ) }
+		>
+			{ children }
+		</TagName>
+	)
 );
 
 const ExtendedBlockComponent = ELEMENTS.reduce( ( acc, element ) => {

--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -133,15 +133,13 @@ export function useBlockWrapperProps( props = {}, { __unstableIsHtml } = {} ) {
 		}
 
 		// Find all tabbables within node.
-		const textInputs = focus.tabbable
-			.find( ref.current )
-			.filter( isTextField )
-			// Exclude inner blocks and block appenders
-			.filter(
-				( node ) =>
-					isInsideRootBlock( ref.current, node ) &&
-					! node.closest( '.block-list-appender' )
-			);
+		const textInputs = focus.tabbable.find( ref.current ).filter(
+			( node ) =>
+				isTextField( node ) &&
+				// Exclude inner blocks and block appenders
+				isInsideRootBlock( ref.current, node ) &&
+				! node.closest( '.block-list-appender' )
+		);
 
 		// If reversed (e.g. merge via backspace), use the last in the set of
 		// tabbables.

--- a/packages/block-editor/src/components/block-list/block-wrapper.native.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.native.js
@@ -3,7 +3,7 @@
  */
 import ELEMENTS from './block-wrapper-elements';
 
-export function useBlockProps( props = {} ) {
+export function useBlockWrapperProps( props = {} ) {
 	return props;
 }
 

--- a/packages/block-editor/src/components/block-list/block-wrapper.native.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.native.js
@@ -3,6 +3,10 @@
  */
 import ELEMENTS from './block-wrapper-elements';
 
+export function useBlockProps( props = {} ) {
+	return props;
+}
+
 const ExtendedBlockComponent = ELEMENTS.reduce( ( acc, element ) => {
 	acc[ element ] = element;
 	return acc;

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -210,7 +211,7 @@ function BlockListBlock( {
 		name,
 		mode,
 		blockTitle: blockType.title,
-		wrapperProps,
+		wrapperProps: omit( wrapperProps, [ 'data-align' ] ),
 	};
 	const memoizedValue = useMemo( () => value, Object.values( value ) );
 

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -70,7 +70,7 @@ export { default as BlockInspector } from './block-inspector';
 export { default as BlockList } from './block-list';
 export {
 	Block as __experimentalBlock,
-	useBlockProps as __experimentalUseBlockProps,
+	useBlockWrapperProps as __experimentalUseBlockWrapperProps,
 } from './block-list/block-wrapper';
 export { default as BlockMover } from './block-mover';
 export { default as BlockPreview } from './block-preview';

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -68,7 +68,10 @@ export { default as __experimentalPreviewOptions } from './preview-options';
 export { default as __experimentalUseResizeCanvas } from './use-resize-canvas';
 export { default as BlockInspector } from './block-inspector';
 export { default as BlockList } from './block-list';
-export { Block as __experimentalBlock } from './block-list/block-wrapper';
+export {
+	Block as __experimentalBlock,
+	useBlockProps as __experimentalUseBlockProps,
+} from './block-list/block-wrapper';
 export { default as BlockMover } from './block-mover';
 export { default as BlockPreview } from './block-preview';
 export { default as BlockSelectionClearer } from './block-selection-clearer';

--- a/packages/block-editor/src/components/index.native.js
+++ b/packages/block-editor/src/components/index.native.js
@@ -57,7 +57,7 @@ export { default as __unstableEditorStyles } from './editor-styles';
 export { default as Inserter } from './inserter';
 export {
 	Block as __experimentalBlock,
-	useBlockProps as __experimentalUseBlockProps,
+	useBlockWrapperProps as __experimentalUseBlockWrapperProps,
 } from './block-list/block-wrapper';
 export { default as FloatingToolbar } from './floating-toolbar';
 

--- a/packages/block-editor/src/components/index.native.js
+++ b/packages/block-editor/src/components/index.native.js
@@ -55,7 +55,10 @@ export { default as BlockStyles } from './block-styles';
 export { default as DefaultBlockAppender } from './default-block-appender';
 export { default as __unstableEditorStyles } from './editor-styles';
 export { default as Inserter } from './inserter';
-export { Block as __experimentalBlock } from './block-list/block-wrapper';
+export {
+	Block as __experimentalBlock,
+	useBlockProps as __experimentalUseBlockProps,
+} from './block-list/block-wrapper';
 export { default as FloatingToolbar } from './floating-toolbar';
 
 // State Related Components

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -128,6 +128,22 @@ function RichTextWrapper(
 		__unstableEmbedURLOnPaste,
 		__unstableDisableFormats: disableFormats,
 		disableLineBreaks,
+		unstableOnFocus,
+		__unstableAllowPrefixTransformations,
+		__unstableMultilineRootTag,
+		// Native props.
+		__unstableMobileNoFocusOnMount,
+		deleteEnter,
+		placeholderTextColor,
+		textAlign,
+		selectionColor,
+		tagsToEliminate,
+		rootTagsToEliminate,
+		disableEditingMenu,
+		fontSize,
+		fontFamily,
+		fontWeight,
+		fontStyle,
 		...props
 	},
 	forwardedRef
@@ -528,7 +544,6 @@ function RichTextWrapper(
 
 	const content = (
 		<RichText
-			{ ...props }
 			clientId={ clientId }
 			identifier={ identifier }
 			ref={ ref }
@@ -563,6 +578,11 @@ function RichTextWrapper(
 			disabled={ disabled }
 			start={ startAttr }
 			reversed={ reversed }
+			unstableOnFocus={ unstableOnFocus }
+			__unstableAllowPrefixTransformations={
+				__unstableAllowPrefixTransformations
+			}
+			__unstableMultilineRootTag={ __unstableMultilineRootTag }
 			// Native props.
 			onCaretVerticalPositionChange={ onCaretVerticalPositionChange }
 			blockIsSelected={
@@ -571,6 +591,18 @@ function RichTextWrapper(
 					: blockIsSelected
 			}
 			shouldBlurOnUnmount={ shouldBlurOnUnmount }
+			__unstableMobileNoFocusOnMount={ __unstableMobileNoFocusOnMount }
+			deleteEnter={ deleteEnter }
+			placeholderTextColor={ placeholderTextColor }
+			textAlign={ textAlign }
+			selectionColor={ selectionColor }
+			tagsToEliminate={ tagsToEliminate }
+			rootTagsToEliminate={ rootTagsToEliminate }
+			disableEditingMenu={ disableEditingMenu }
+			fontSize={ fontSize }
+			fontFamily={ fontFamily }
+			fontWeight={ fontWeight }
+			fontStyle={ fontStyle }
 		>
 			{ ( {
 				isSelected: nestedIsSelected,
@@ -599,6 +631,7 @@ function RichTextWrapper(
 						{ ( { listBoxId, activeId, onKeyDown } ) => (
 							<TagName
 								{ ...editableProps }
+								{ ...props }
 								aria-autocomplete={
 									listBoxId ? 'list' : undefined
 								}

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -16,7 +16,7 @@ import {
 	MediaPlaceholder,
 	MediaReplaceFlow,
 	RichText,
-	__experimentalBlock as Block,
+	__experimentalUseBlockProps as useBlockProps,
 } from '@wordpress/block-editor';
 import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -41,7 +41,7 @@ function AudioEdit( {
 	insertBlocksAfter,
 } ) {
 	const { id, autoplay, caption, loop, preload, src } = attributes;
-
+	const blockProps = useBlockProps();
 	const mediaUpload = useSelect( ( select ) => {
 		const { getSettings } = select( 'core/block-editor' );
 		return getSettings().mediaUpload;
@@ -116,7 +116,7 @@ function AudioEdit( {
 	}
 	if ( ! src ) {
 		return (
-			<Block.div>
+			<div { ...blockProps }>
 				<MediaPlaceholder
 					icon={ <BlockIcon icon={ icon } /> }
 					onSelect={ onSelectAudio }
@@ -127,7 +127,7 @@ function AudioEdit( {
 					notices={ noticeUI }
 					onError={ onUploadError }
 				/>
-			</Block.div>
+			</div>
 		);
 	}
 
@@ -175,7 +175,7 @@ function AudioEdit( {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<Block.figure>
+			<figure { ...blockProps }>
 				{ /*
 					Disable the audio tag so the user clicking on it won't play the
 					file or change the position slider when the controls are enabled.
@@ -197,7 +197,7 @@ function AudioEdit( {
 						}
 					/>
 				) }
-			</Block.figure>
+			</figure>
 		</>
 	);
 }

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -16,7 +16,7 @@ import {
 	MediaPlaceholder,
 	MediaReplaceFlow,
 	RichText,
-	__experimentalUseBlockProps as useBlockProps,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -41,7 +41,7 @@ function AudioEdit( {
 	insertBlocksAfter,
 } ) {
 	const { id, autoplay, caption, loop, preload, src } = attributes;
-	const blockProps = useBlockProps();
+	const blockProps = useBlockWrapperProps();
 	const mediaUpload = useSelect( ( select ) => {
 		const { getSettings } = select( 'core/block-editor' );
 		return getSettings().mediaUpload;

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -41,7 +41,7 @@ function AudioEdit( {
 	insertBlocksAfter,
 } ) {
 	const { id, autoplay, caption, loop, preload, src } = attributes;
-	const blockProps = useBlockWrapperProps();
+	const blockWrapperProps = useBlockWrapperProps();
 	const mediaUpload = useSelect( ( select ) => {
 		const { getSettings } = select( 'core/block-editor' );
 		return getSettings().mediaUpload;
@@ -116,7 +116,7 @@ function AudioEdit( {
 	}
 	if ( ! src ) {
 		return (
-			<div { ...blockProps }>
+			<div { ...blockWrapperProps }>
 				<MediaPlaceholder
 					icon={ <BlockIcon icon={ icon } /> }
 					onSelect={ onSelectAudio }
@@ -175,7 +175,7 @@ function AudioEdit( {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<figure { ...blockProps }>
+			<figure { ...blockWrapperProps }>
 				{ /*
 					Disable the audio tag so the user clicking on it won't play the
 					file or change the position slider when the controls are enabled.

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -197,11 +197,12 @@ function ButtonEdit( props ) {
 	);
 
 	const colorProps = getColorAndStyleProps( attributes, colors, true );
+	const blockWrapperProps = useBlockWrapperProps();
 
 	return (
 		<>
 			<ColorEdit { ...props } />
-			<div { ...useBlockWrapperProps() }>
+			<div { ...blockWrapperProps }>
 				<RichText
 					placeholder={ placeholder || __( 'Add text…' ) }
 					value={ text }

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -22,7 +22,7 @@ import {
 	BlockControls,
 	InspectorControls,
 	RichText,
-	__experimentalBlock as Block,
+	__experimentalUseBlockProps as useBlockProps,
 	__experimentalLinkControl as LinkControl,
 	__experimentalUseEditorFeature as useEditorFeature,
 } from '@wordpress/block-editor';
@@ -201,7 +201,7 @@ function ButtonEdit( props ) {
 	return (
 		<>
 			<ColorEdit { ...props } />
-			<Block.div>
+			<div { ...useBlockProps() }>
 				<RichText
 					placeholder={ placeholder || __( 'Add text…' ) }
 					value={ text }
@@ -231,7 +231,7 @@ function ButtonEdit( props ) {
 					onMerge={ mergeBlocks }
 					identifier="text"
 				/>
-			</Block.div>
+			</div>
 			<URLPicker
 				url={ url }
 				setAttributes={ setAttributes }

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -22,7 +22,7 @@ import {
 	BlockControls,
 	InspectorControls,
 	RichText,
-	__experimentalUseBlockProps as useBlockProps,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 	__experimentalLinkControl as LinkControl,
 	__experimentalUseEditorFeature as useEditorFeature,
 } from '@wordpress/block-editor';
@@ -201,7 +201,7 @@ function ButtonEdit( props ) {
 	return (
 		<>
 			<ColorEdit { ...props } />
-			<div { ...useBlockProps() }>
+			<div { ...useBlockWrapperProps() }>
 				<RichText
 					placeholder={ placeholder || __( 'Add text…' ) }
 					value={ text }

--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -21,8 +21,9 @@ const alignmentHooksSetting = {
 };
 
 function ButtonsEdit() {
+	const blockWrapperProps = useBlockWrapperProps();
 	return (
-		<div { ...useBlockWrapperProps() }>
+		<div { ...blockWrapperProps }>
 			<AlignmentHookSettingsProvider value={ alignmentHooksSetting }>
 				<InnerBlocks
 					allowedBlocks={ ALLOWED_BLOCKS }

--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -4,7 +4,7 @@
 import {
 	__experimentalAlignmentHookSettingsProvider as AlignmentHookSettingsProvider,
 	InnerBlocks,
-	__experimentalBlock as Block,
+	__experimentalUseBlockProps as useBlockProps,
 } from '@wordpress/block-editor';
 
 /**
@@ -22,7 +22,7 @@ const alignmentHooksSetting = {
 
 function ButtonsEdit() {
 	return (
-		<Block.div>
+		<div { ...useBlockProps() }>
 			<AlignmentHookSettingsProvider value={ alignmentHooksSetting }>
 				<InnerBlocks
 					allowedBlocks={ ALLOWED_BLOCKS }
@@ -30,7 +30,7 @@ function ButtonsEdit() {
 					orientation="horizontal"
 				/>
 			</AlignmentHookSettingsProvider>
-		</Block.div>
+		</div>
 	);
 }
 

--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -4,7 +4,7 @@
 import {
 	__experimentalAlignmentHookSettingsProvider as AlignmentHookSettingsProvider,
 	InnerBlocks,
-	__experimentalUseBlockProps as useBlockProps,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 } from '@wordpress/block-editor';
 
 /**
@@ -22,7 +22,7 @@ const alignmentHooksSetting = {
 
 function ButtonsEdit() {
 	return (
-		<div { ...useBlockProps() }>
+		<div { ...useBlockWrapperProps() }>
 			<AlignmentHookSettingsProvider value={ alignmentHooksSetting }>
 				<InnerBlocks
 					allowedBlocks={ ALLOWED_BLOCKS }

--- a/packages/block-library/src/code/edit.js
+++ b/packages/block-library/src/code/edit.js
@@ -12,8 +12,9 @@ import {
 } from '@wordpress/block-editor';
 
 export default function CodeEdit( { attributes, setAttributes } ) {
+	const blockWrapperProps = useBlockWrapperProps();
 	return (
-		<pre { ...useBlockWrapperProps() }>
+		<pre { ...blockWrapperProps }>
 			<PlainText
 				__experimentalVersion={ 2 }
 				tagName="code"

--- a/packages/block-library/src/code/edit.js
+++ b/packages/block-library/src/code/edit.js
@@ -8,12 +8,12 @@ import { __ } from '@wordpress/i18n';
  */
 import {
 	PlainText,
-	__experimentalUseBlockProps as useBlockProps,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 } from '@wordpress/block-editor';
 
 export default function CodeEdit( { attributes, setAttributes } ) {
 	return (
-		<pre { ...useBlockProps() }>
+		<pre { ...useBlockWrapperProps() }>
 			<PlainText
 				__experimentalVersion={ 2 }
 				tagName="code"

--- a/packages/block-library/src/code/edit.js
+++ b/packages/block-library/src/code/edit.js
@@ -8,12 +8,12 @@ import { __ } from '@wordpress/i18n';
  */
 import {
 	PlainText,
-	__experimentalBlock as Block,
+	__experimentalUseBlockProps as useBlockProps,
 } from '@wordpress/block-editor';
 
 export default function CodeEdit( { attributes, setAttributes } ) {
 	return (
-		<Block.pre>
+		<pre { ...useBlockProps() }>
 			<PlainText
 				__experimentalVersion={ 2 }
 				tagName="code"
@@ -22,6 +22,6 @@ export default function CodeEdit( { attributes, setAttributes } ) {
 				placeholder={ __( 'Write code…' ) }
 				aria-label={ __( 'Code' ) }
 			/>
-		</Block.pre>
+		</pre>
 	);
 }

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -31,7 +31,7 @@ import {
 	MediaReplaceFlow,
 	withColors,
 	ColorPalette,
-	__experimentalBlock as Block,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 	__experimentalUseGradient,
 	__experimentalPanelColorGradientSettings as PanelColorGradientSettings,
 	__experimentalUnitControl as UnitControl,
@@ -426,6 +426,8 @@ function CoverEdit( {
 		</>
 	);
 
+	const blockWrapperProps = useBlockWrapperProps();
+
 	if ( ! hasBackground ) {
 		const placeholderIcon = <BlockIcon icon={ icon } />;
 		const label = __( 'Cover' );
@@ -433,7 +435,13 @@ function CoverEdit( {
 		return (
 			<>
 				{ controls }
-				<Block.div className="is-placeholder">
+				<div
+					{ ...blockWrapperProps }
+					className={ classnames(
+						'is-placeholder',
+						blockWrapperProps.className
+					) }
+				>
 					<MediaPlaceholder
 						icon={ placeholderIcon }
 						labels={ {
@@ -460,7 +468,7 @@ function CoverEdit( {
 							/>
 						</div>
 					</MediaPlaceholder>
-				</Block.div>
+				</div>
 			</>
 		);
 	}
@@ -484,7 +492,12 @@ function CoverEdit( {
 	return (
 		<>
 			{ controls }
-			<Block.div className={ classes } data-url={ url } style={ style }>
+			<div
+				{ ...blockWrapperProps }
+				className={ classnames( classes, blockWrapperProps.className ) }
+				style={ { ...style, ...blockWrapperProps.style } }
+				data-url={ url }
+			>
 				<BoxControlVisualizer
 					values={ styleAttribute?.spacing?.padding }
 					showValues={ styleAttribute?.visualizers?.padding }
@@ -543,7 +556,7 @@ function CoverEdit( {
 					} }
 					template={ INNER_BLOCKS_TEMPLATE }
 				/>
-			</Block.div>
+			</div>
 		</>
 	);
 }

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -15,7 +15,7 @@ import {
 	BlockControls,
 	BlockIcon,
 	MediaPlaceholder,
-	__experimentalUseBlockProps as useBlockProps,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -272,12 +272,15 @@ export function ImageEdit( {
 		[ `size-${ sizeSlug }` ]: sizeSlug,
 	} );
 
-	const blockProps = useBlockProps( { ref, className: classes } );
+	const blockWrapperProps = useBlockWrapperProps( {
+		ref,
+		className: classes,
+	} );
 
 	return (
 		<>
 			{ controls }
-			<figure { ...blockProps }>
+			<figure { ...blockWrapperProps }>
 				{ url && (
 					<Image
 						attributes={ attributes }

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -271,10 +271,6 @@ export function ImageEdit( {
 		'is-focused': isSelected,
 		[ `size-${ sizeSlug }` ]: sizeSlug,
 	} );
-	const blockWrapperProps = useBlockWrapperProps( {
-		ref,
-		className: classes,
-	} );
 
 	const blockWrapperProps = useBlockWrapperProps( {
 		ref,

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -15,7 +15,7 @@ import {
 	BlockControls,
 	BlockIcon,
 	MediaPlaceholder,
-	__experimentalBlock as Block,
+	__experimentalUseBlockProps as useBlockProps,
 } from '@wordpress/block-editor';
 import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -272,10 +272,12 @@ export function ImageEdit( {
 		[ `size-${ sizeSlug }` ]: sizeSlug,
 	} );
 
+	const blockProps = useBlockProps( { ref, className: classes } );
+
 	return (
 		<>
 			{ controls }
-			<Block.figure ref={ ref } className={ classes }>
+			<figure { ...blockProps }>
 				{ url && (
 					<Image
 						attributes={ attributes }
@@ -290,7 +292,7 @@ export function ImageEdit( {
 					/>
 				) }
 				{ mediaPlaceholder }
-			</Block.figure>
+			</figure>
 		</>
 	);
 }

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -271,6 +271,10 @@ export function ImageEdit( {
 		'is-focused': isSelected,
 		[ `size-${ sizeSlug }` ]: sizeSlug,
 	} );
+	const blockWrapperProps = useBlockWrapperProps( {
+		ref,
+		className: classes,
+	} );
 
 	const blockWrapperProps = useBlockWrapperProps( {
 		ref,

--- a/packages/block-library/src/list/edit.js
+++ b/packages/block-library/src/list/edit.js
@@ -7,7 +7,7 @@ import {
 	RichText,
 	BlockControls,
 	RichTextShortcut,
-	__experimentalUseBlockProps as useBlockProps,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import { ToolbarGroup } from '@wordpress/components';
 import {
@@ -178,7 +178,7 @@ export default function ListEdit( {
 				start={ start }
 				reversed={ reversed }
 				type={ type }
-				{ ...useBlockProps() }
+				{ ...useBlockWrapperProps() }
 			>
 				{ controls }
 			</RichText>

--- a/packages/block-library/src/list/edit.js
+++ b/packages/block-library/src/list/edit.js
@@ -154,6 +154,8 @@ export default function ListEdit( {
 		</>
 	);
 
+	const blockWrapperProps = useBlockWrapperProps();
+
 	return (
 		<>
 			<RichText
@@ -178,7 +180,7 @@ export default function ListEdit( {
 				start={ start }
 				reversed={ reversed }
 				type={ type }
-				{ ...useBlockWrapperProps() }
+				{ ...blockWrapperProps }
 			>
 				{ controls }
 			</RichText>

--- a/packages/block-library/src/list/edit.js
+++ b/packages/block-library/src/list/edit.js
@@ -7,7 +7,7 @@ import {
 	RichText,
 	BlockControls,
 	RichTextShortcut,
-	__experimentalBlock as Block,
+	__experimentalUseBlockProps as useBlockProps,
 } from '@wordpress/block-editor';
 import { ToolbarGroup } from '@wordpress/components';
 import {
@@ -160,7 +160,7 @@ export default function ListEdit( {
 				identifier="values"
 				multiline="li"
 				__unstableMultilineRootTag={ tagName }
-				tagName={ Block[ tagName ] }
+				tagName={ tagName }
 				onChange={ ( nextValues ) =>
 					setAttributes( { values: nextValues } )
 				}
@@ -178,6 +178,7 @@ export default function ListEdit( {
 				start={ start }
 				reversed={ reversed }
 				type={ type }
+				{ ...useBlockProps() }
 			>
 				{ controls }
 			</RichText>

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -15,7 +15,7 @@ import {
 	BlockVerticalAlignmentToolbar,
 	InnerBlocks,
 	InspectorControls,
-	__experimentalBlock as Block,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 	__experimentalImageURLInputUI as ImageURLInputUI,
 	__experimentalImageSizeControl as ImageSizeControl,
 } from '@wordpress/block-editor';
@@ -280,6 +280,11 @@ function MediaTextEdit( { attributes, isSelected, setAttributes } ) {
 		</PanelBody>
 	);
 
+	const blockWrapperProps = useBlockWrapperProps( {
+		className: classNames,
+		style,
+	} );
+
 	return (
 		<>
 			<InspectorControls>{ mediaTextGeneralSettings }</InspectorControls>
@@ -305,7 +310,7 @@ function MediaTextEdit( { attributes, isSelected, setAttributes } ) {
 					</ToolbarGroup>
 				) }
 			</BlockControls>
-			<Block.div className={ classNames } style={ style }>
+			<div { ...blockWrapperProps }>
 				<MediaContainer
 					className="wp-block-media-text__media"
 					onSelectMedia={ onSelectMedia }
@@ -332,7 +337,7 @@ function MediaTextEdit( { attributes, isSelected, setAttributes } ) {
 					template={ TEMPLATE }
 					templateInsertUpdatesSelection={ false }
 				/>
-			</Block.div>
+			</div>
 		</>
 	);
 }

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -32,7 +32,7 @@ import {
 	InspectorControls,
 	RichText,
 	__experimentalLinkControl as LinkControl,
-	__experimentalBlock as Block,
+	__experimentalUseBlockProps as useBlockProps,
 } from '@wordpress/block-editor';
 import { isURL, prependHTTP } from '@wordpress/url';
 import {
@@ -295,27 +295,29 @@ function NavigationLinkEdit( {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<Block.li
-				className={ classnames( {
-					'is-editing':
-						( isSelected || isParentOfSelectedBlock ) &&
-						// Don't show the element as editing while dragging.
-						! isDraggingBlocks,
-					// Don't select the element while dragging.
-					'is-selected': isSelected && ! isDraggingBlocks,
-					'is-dragging-within': isDraggingWithin,
-					'has-link': !! url,
-					'has-child': hasDescendants,
-					'has-text-color': rgbTextColor,
-					[ `has-${ textColor }-color` ]: !! textColor,
-					'has-background': rgbBackgroundColor,
-					[ `has-${ backgroundColor }-background-color` ]: !! backgroundColor,
+			<li
+				{ ...useBlockProps( {
+					ref: listItemRef,
+					className: classnames( {
+						'is-editing':
+							( isSelected || isParentOfSelectedBlock ) &&
+							// Don't show the element as editing while dragging.
+							! isDraggingBlocks,
+						// Don't select the element while dragging.
+						'is-selected': isSelected && ! isDraggingBlocks,
+						'is-dragging-within': isDraggingWithin,
+						'has-link': !! url,
+						'has-child': hasDescendants,
+						'has-text-color': rgbTextColor,
+						[ `has-${ textColor }-color` ]: !! textColor,
+						'has-background': rgbBackgroundColor,
+						[ `has-${ backgroundColor }-background-color` ]: !! backgroundColor,
+					} ),
+					style: {
+						color: rgbTextColor,
+						backgroundColor: rgbBackgroundColor,
+					},
 				} ) }
-				style={ {
-					color: rgbTextColor,
-					backgroundColor: rgbBackgroundColor,
-				} }
-				ref={ listItemRef }
 			>
 				<div className="wp-block-navigation-link__content">
 					<RichText
@@ -443,7 +445,7 @@ function NavigationLinkEdit( {
 						),
 					} }
 				/>
-			</Block.li>
+			</li>
 		</Fragment>
 	);
 }

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -32,7 +32,7 @@ import {
 	InspectorControls,
 	RichText,
 	__experimentalLinkControl as LinkControl,
-	__experimentalUseBlockProps as useBlockProps,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import { isURL, prependHTTP } from '@wordpress/url';
 import {
@@ -296,7 +296,7 @@ function NavigationLinkEdit( {
 				</PanelBody>
 			</InspectorControls>
 			<li
-				{ ...useBlockProps( {
+				{ ...useBlockWrapperProps( {
 					ref: listItemRef,
 					className: classnames( {
 						'is-editing':

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -239,6 +239,29 @@ function NavigationLinkEdit( {
 		};
 	}
 
+	const blockWrapperProps = useBlockWrapperProps( {
+		ref: listItemRef,
+		className: classnames( {
+			'is-editing':
+				( isSelected || isParentOfSelectedBlock ) &&
+				// Don't show the element as editing while dragging.
+				! isDraggingBlocks,
+			// Don't select the element while dragging.
+			'is-selected': isSelected && ! isDraggingBlocks,
+			'is-dragging-within': isDraggingWithin,
+			'has-link': !! url,
+			'has-child': hasDescendants,
+			'has-text-color': rgbTextColor,
+			[ `has-${ textColor }-color` ]: !! textColor,
+			'has-background': rgbBackgroundColor,
+			[ `has-${ backgroundColor }-background-color` ]: !! backgroundColor,
+		} ),
+		style: {
+			color: rgbTextColor,
+			backgroundColor: rgbBackgroundColor,
+		},
+	} );
+
 	return (
 		<Fragment>
 			<BlockControls>
@@ -295,30 +318,7 @@ function NavigationLinkEdit( {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<li
-				{ ...useBlockWrapperProps( {
-					ref: listItemRef,
-					className: classnames( {
-						'is-editing':
-							( isSelected || isParentOfSelectedBlock ) &&
-							// Don't show the element as editing while dragging.
-							! isDraggingBlocks,
-						// Don't select the element while dragging.
-						'is-selected': isSelected && ! isDraggingBlocks,
-						'is-dragging-within': isDraggingWithin,
-						'has-link': !! url,
-						'has-child': hasDescendants,
-						'has-text-color': rgbTextColor,
-						[ `has-${ textColor }-color` ]: !! textColor,
-						'has-background': rgbBackgroundColor,
-						[ `has-${ backgroundColor }-background-color` ]: !! backgroundColor,
-					} ),
-					style: {
-						color: rgbTextColor,
-						backgroundColor: rgbBackgroundColor,
-					},
-				} ) }
-			>
+			<li { ...blockWrapperProps }>
 				<div className="wp-block-navigation-link__content">
 					<RichText
 						ref={ ref }

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -13,7 +13,7 @@ import {
 	InspectorControls,
 	BlockControls,
 	__experimentalUseColors,
-	__experimentalBlock as Block,
+	__experimentalUseBlockProps as useBlockProps,
 } from '@wordpress/block-editor';
 import { useDispatch, withSelect, withDispatch } from '@wordpress/data';
 import {
@@ -54,6 +54,8 @@ function Navigation( {
 	);
 
 	const { selectBlock } = useDispatch( 'core/block-editor' );
+
+	const blockProps = useBlockProps( { ref } );
 
 	const { TextColor, BackgroundColor, ColorPanel } = __experimentalUseColors(
 		[
@@ -97,7 +99,7 @@ function Navigation( {
 
 	if ( isPlaceholderShown ) {
 		return (
-			<Block.div>
+			<div { ...blockProps }>
 				<NavigationPlaceholder
 					ref={ ref }
 					onCreate={ ( blocks, selectNavigationBlock ) => {
@@ -108,7 +110,7 @@ function Navigation( {
 						}
 					} }
 				/>
-			</Block.div>
+			</div>
 		);
 	}
 
@@ -176,7 +178,13 @@ function Navigation( {
 			</InspectorControls>
 			<TextColor>
 				<BackgroundColor>
-					<Block.nav className={ blockClassNames }>
+					<nav
+						{ ...blockProps }
+						className={ classnames(
+							blockProps.className,
+							blockClassNames
+						) }
+					>
 						<InnerBlocks
 							ref={ ref }
 							allowedBlocks={ [
@@ -206,7 +214,7 @@ function Navigation( {
 							// inherit templateLock={ 'all' }.
 							templateLock={ false }
 						/>
-					</Block.nav>
+					</nav>
 				</BackgroundColor>
 			</TextColor>
 		</>

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -55,7 +55,7 @@ function Navigation( {
 
 	const { selectBlock } = useDispatch( 'core/block-editor' );
 
-	const blockProps = useBlockWrapperProps( { ref } );
+	const blockProps = useBlockWrapperProps();
 
 	const { TextColor, BackgroundColor, ColorPanel } = __experimentalUseColors(
 		[

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -13,7 +13,7 @@ import {
 	InspectorControls,
 	BlockControls,
 	__experimentalUseColors,
-	__experimentalUseBlockProps as useBlockProps,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import { useDispatch, withSelect, withDispatch } from '@wordpress/data';
 import {
@@ -55,7 +55,7 @@ function Navigation( {
 
 	const { selectBlock } = useDispatch( 'core/block-editor' );
 
-	const blockProps = useBlockProps( { ref } );
+	const blockProps = useBlockWrapperProps( { ref } );
 
 	const { TextColor, BackgroundColor, ColorPanel } = __experimentalUseColors(
 		[

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -117,6 +117,14 @@ function ParagraphBlock( {
 		minHeight: dropCapMinimumHeight,
 	};
 
+	const blockWrapperProps = useBlockWrapperProps( {
+		className: classnames( {
+			'has-drop-cap': dropCap,
+			[ `has-text-align-${ align }` ]: align,
+		} ),
+		style: styles,
+	} );
+
 	return (
 		<>
 			<BlockControls>
@@ -156,13 +164,7 @@ function ParagraphBlock( {
 			<RichText
 				identifier="content"
 				tagName="p"
-				{ ...useBlockWrapperProps( {
-					className: classnames( {
-						'has-drop-cap': dropCap,
-						[ `has-text-align-${ align }` ]: align,
-					} ),
-					style: styles,
-				} ) }
+				{ ...blockWrapperProps }
 				value={ content }
 				onChange={ ( newContent ) =>
 					setAttributes( { content: newContent } )

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -13,13 +13,13 @@ import {
 	BlockControls,
 	InspectorControls,
 	RichText,
-	__experimentalBlock as Block,
+	__experimentalUseBlockProps as useBlockProps,
 	getFontSize,
 	__experimentalUseEditorFeature as useEditorFeature,
 } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
-import { useEffect, useState, useRef } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { formatLtr } from '@wordpress/icons';
 
 function getComputedStyle( node, pseudo ) {
@@ -106,7 +106,6 @@ function ParagraphBlock( {
 		fontSize,
 		style,
 	} = attributes;
-	const ref = useRef();
 	const [ isDropCapEnabled, dropCapMinimumHeight ] = useDropCap(
 		dropCap,
 		fontSize,
@@ -155,14 +154,15 @@ function ParagraphBlock( {
 				) }
 			</InspectorControls>
 			<RichText
-				ref={ ref }
 				identifier="content"
-				tagName={ Block.p }
-				className={ classnames( {
-					'has-drop-cap': dropCap,
-					[ `has-text-align-${ align }` ]: align,
+				tagName="p"
+				{ ...useBlockProps( {
+					className: classnames( {
+						'has-drop-cap': dropCap,
+						[ `has-text-align-${ align }` ]: align,
+					} ),
+					style: styles,
 				} ) }
-				style={ styles }
 				value={ content }
 				onChange={ ( newContent ) =>
 					setAttributes( { content: newContent } )

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -13,7 +13,7 @@ import {
 	BlockControls,
 	InspectorControls,
 	RichText,
-	__experimentalUseBlockProps as useBlockProps,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 	getFontSize,
 	__experimentalUseEditorFeature as useEditorFeature,
 } from '@wordpress/block-editor';
@@ -156,7 +156,7 @@ function ParagraphBlock( {
 			<RichText
 				identifier="content"
 				tagName="p"
-				{ ...useBlockProps( {
+				{ ...useBlockWrapperProps( {
 					className: classnames( {
 						'has-drop-cap': dropCap,
 						[ `has-text-align-${ align }` ]: align,

--- a/packages/block-library/src/post-author/edit.js
+++ b/packages/block-library/src/post-author/edit.js
@@ -12,7 +12,7 @@ import {
 	BlockControls,
 	InspectorControls,
 	RichText,
-	__experimentalBlock as Block,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import { PanelBody, SelectControl, ToggleControl } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -54,6 +54,12 @@ function PostAuthorEdit( { isSelected, context, attributes, setAttributes } ) {
 			} );
 		} );
 	}
+
+	const blockWrapperProps = useBlockWrapperProps( {
+		className: classnames( {
+			[ `has-text-align-${ textAlign }` ]: textAlign,
+		} ),
+	} );
 
 	return (
 		<>
@@ -112,11 +118,7 @@ function PostAuthorEdit( { isSelected, context, attributes, setAttributes } ) {
 				/>
 			</BlockControls>
 
-			<Block.div
-				className={ classnames( {
-					[ `has-text-align-${ textAlign }` ]: textAlign,
-				} ) }
-			>
+			<div { ...blockWrapperProps }>
 				{ showAvatar && authorDetails && (
 					<div className="wp-block-post-author__avatar">
 						<img
@@ -151,7 +153,7 @@ function PostAuthorEdit( { isSelected, context, attributes, setAttributes } ) {
 						</p>
 					) }
 				</div>
-			</Block.div>
+			</div>
 		</>
 	);
 }

--- a/packages/block-library/src/post-comment-date/edit.js
+++ b/packages/block-library/src/post-comment-date/edit.js
@@ -5,7 +5,7 @@ import { useEntityProp } from '@wordpress/core-data';
 import { __experimentalGetSettings, dateI18n } from '@wordpress/date';
 import {
 	InspectorControls,
-	__experimentalBlock as Block,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import { PanelBody, CustomSelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -25,6 +25,7 @@ export default function Edit( { attributes, context, setAttributes } ) {
 		} )
 	);
 	const resolvedFormat = format || siteDateFormat || settings.formats.date;
+	const blockWrapperProps = useBlockWrapperProps( { className } );
 
 	return (
 		<>
@@ -46,11 +47,11 @@ export default function Edit( { attributes, context, setAttributes } ) {
 				</PanelBody>
 			</InspectorControls>
 
-			<Block.div className={ className }>
+			<div { ...blockWrapperProps }>
 				<time dateTime={ dateI18n( 'c', date ) }>
 					{ dateI18n( resolvedFormat, date ) }
 				</time>
-			</Block.div>
+			</div>
 		</>
 	);
 }

--- a/packages/block-library/src/post-comments-count/edit.js
+++ b/packages/block-library/src/post-comments-count/edit.js
@@ -10,7 +10,7 @@ import {
 	AlignmentToolbar,
 	BlockControls,
 	Warning,
-	__experimentalBlock as Block,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import { useState, useEffect } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
@@ -25,6 +25,12 @@ export default function PostCommentsCountEdit( {
 	const { textAlign } = attributes;
 	const { postId } = context;
 	const [ commentsCount, setCommentsCount ] = useState();
+	const blockWrapperProps = useBlockWrapperProps( {
+		className: classnames( {
+			[ `has-text-align-${ textAlign }` ]: textAlign,
+		} ),
+	} );
+
 	useEffect( () => {
 		if ( ! postId ) {
 			return;
@@ -53,11 +59,7 @@ export default function PostCommentsCountEdit( {
 					} }
 				/>
 			</BlockControls>
-			<Block.div
-				className={ classnames( {
-					[ `has-text-align-${ textAlign }` ]: textAlign,
-				} ) }
-			>
+			<div { ...blockWrapperProps }>
 				{ postId && commentsCount !== undefined ? (
 					commentsCount
 				) : (
@@ -65,7 +67,7 @@ export default function PostCommentsCountEdit( {
 						{ __( 'Post Comments Count block: post not found.' ) }
 					</Warning>
 				) }
-			</Block.div>
+			</div>
 		</>
 	);
 }

--- a/packages/block-library/src/post-comments-form/edit.js
+++ b/packages/block-library/src/post-comments-form/edit.js
@@ -10,7 +10,7 @@ import {
 	AlignmentToolbar,
 	BlockControls,
 	Warning,
-	__experimentalBlock as Block,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import { useEntityProp } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
@@ -28,6 +28,11 @@ export default function PostCommentsFormEdit( {
 		'comment_status',
 		postId
 	);
+	const blockWrapperProps = useBlockWrapperProps( {
+		className: classnames( {
+			[ `has-text-align-${ textAlign }` ]: textAlign,
+		} ),
+	} );
 
 	return (
 		<>
@@ -39,11 +44,7 @@ export default function PostCommentsFormEdit( {
 					} }
 				/>
 			</BlockControls>
-			<Block.div
-				className={ classnames( {
-					[ `has-text-align-${ textAlign }` ]: textAlign,
-				} ) }
-			>
+			<div { ...blockWrapperProps }>
 				{ ! commentStatus && (
 					<Warning>
 						{ __(
@@ -61,7 +62,7 @@ export default function PostCommentsFormEdit( {
 				) }
 
 				{ 'open' === commentStatus && __( 'Post Comments Form' ) }
-			</Block.div>
+			</div>
 		</>
 	);
 }

--- a/packages/block-library/src/post-comments/edit.js
+++ b/packages/block-library/src/post-comments/edit.js
@@ -11,7 +11,7 @@ import {
 	AlignmentToolbar,
 	BlockControls,
 	Warning,
-	__experimentalBlock as Block,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { RawHTML } from '@wordpress/element';
@@ -49,6 +49,11 @@ export default function PostCommentsEdit( {
 } ) {
 	const { postType, postId } = context;
 	const { textAlign } = attributes;
+	const blockWrapperProps = useBlockWrapperProps( {
+		className: classnames( {
+			[ `has-text-align-${ textAlign }` ]: textAlign,
+		} ),
+	} );
 
 	if ( ! postType || ! postId ) {
 		return (
@@ -67,13 +72,9 @@ export default function PostCommentsEdit( {
 				/>
 			</BlockControls>
 
-			<Block.div
-				className={ classnames( {
-					[ `has-text-align-${ textAlign }` ]: textAlign,
-				} ) }
-			>
+			<div { ...blockWrapperProps }>
 				<PostCommentsDisplay postId={ postId } />
-			</Block.div>
+			</div>
 		</>
 	);
 }

--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -13,7 +13,7 @@ import {
 	AlignmentToolbar,
 	BlockControls,
 	InspectorControls,
-	__experimentalBlock as Block,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import {
 	ToolbarGroup,
@@ -55,6 +55,11 @@ export default function PostDateEdit( { attributes, context, setAttributes } ) {
 		} )
 	);
 	const resolvedFormat = format || siteFormat || settings.formats.date;
+	const blockWrapperProps = useBlockWrapperProps( {
+		className: classnames( {
+			[ `has-text-align-${ textAlign }` ]: textAlign,
+		} ),
+	} );
 
 	return (
 		<>
@@ -99,11 +104,7 @@ export default function PostDateEdit( { attributes, context, setAttributes } ) {
 				</PanelBody>
 			</InspectorControls>
 
-			<Block.div
-				className={ classnames( {
-					[ `has-text-align-${ textAlign }` ]: textAlign,
-				} ) }
-			>
+			<div { ...blockWrapperProps }>
 				{ date && (
 					<time dateTime={ dateI18n( 'c', date ) }>
 						{ dateI18n( resolvedFormat, date ) }
@@ -122,7 +123,7 @@ export default function PostDateEdit( { attributes, context, setAttributes } ) {
 					</time>
 				) }
 				{ ! date && __( 'No Date' ) }
-			</Block.div>
+			</div>
 		</>
 	);
 }

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -14,7 +14,7 @@ import {
 	InspectorControls,
 	RichText,
 	Warning,
-	__experimentalBlock as Block,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import { PanelBody, RangeControl, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -57,6 +57,11 @@ function PostExcerptEditor( {
 		postId,
 		postType
 	);
+	const blockWrapperProps = useBlockWrapperProps( {
+		className: classnames( {
+			[ `has-text-align-${ textAlign }` ]: textAlign,
+		} ),
+	} );
 
 	return (
 		<>
@@ -92,11 +97,7 @@ function PostExcerptEditor( {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<Block.div
-				className={ classnames( {
-					[ `has-text-align-${ textAlign }` ]: textAlign,
-				} ) }
-			>
+			<div { ...blockWrapperProps }>
 				<RichText
 					className={
 						! showMoreOnNewLine &&
@@ -135,7 +136,7 @@ function PostExcerptEditor( {
 						}
 					/>
 				) }
-			</Block.div>
+			</div>
 		</>
 	);
 }

--- a/packages/block-library/src/post-hierarchical-terms/edit.js
+++ b/packages/block-library/src/post-hierarchical-terms/edit.js
@@ -11,7 +11,7 @@ import {
 	AlignmentToolbar,
 	BlockControls,
 	Warning,
-	__experimentalBlock as Block,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 	__experimentalBlockVariationPicker as BlockVariationPicker,
 } from '@wordpress/block-editor';
 import { Spinner } from '@wordpress/components';
@@ -81,20 +81,25 @@ export default function PostHierarchicalTermsEdit( {
 	const hasPost = postId && postType;
 	const hasHierarchicalTermLinks =
 		hierarchicalTermLinks && hierarchicalTermLinks.length > 0;
+	const blockWrapperProps = useBlockWrapperProps( {
+		className: classnames( {
+			[ `has-text-align-${ textAlign }` ]: textAlign,
+		} ),
+	} );
 
 	if ( ! hasPost ) {
 		return (
-			<Block.div>
+			<div { ...blockWrapperProps }>
 				<Warning>
 					{ __( 'Post Hierarchical Terms block: post not found.' ) }
 				</Warning>
-			</Block.div>
+			</div>
 		);
 	}
 
 	if ( ! term ) {
 		return (
-			<Block.div>
+			<div { ...blockWrapperProps }>
 				<BlockVariationPicker
 					icon={ blockType?.icon?.src }
 					label={ blockType?.title }
@@ -103,7 +108,7 @@ export default function PostHierarchicalTermsEdit( {
 					} }
 					variations={ variations }
 				/>
-			</Block.div>
+			</div>
 		);
 	}
 
@@ -117,11 +122,7 @@ export default function PostHierarchicalTermsEdit( {
 					} }
 				/>
 			</BlockControls>
-			<Block.div
-				className={ classnames( {
-					[ `has-text-align-${ textAlign }` ]: textAlign,
-				} ) }
-			>
+			<div { ...blockWrapperProps }>
 				{ isLoadingHierarchicalTermLinks && <Spinner /> }
 
 				{ hasHierarchicalTermLinks &&
@@ -137,7 +138,7 @@ export default function PostHierarchicalTermsEdit( {
 					// eslint-disable-next-line camelcase
 					( selectedTerm?.labels?.no_terms ||
 						__( 'Term items not found.' ) ) }
-			</Block.div>
+			</div>
 		</>
 	);
 }

--- a/packages/block-library/src/post-tags/edit.js
+++ b/packages/block-library/src/post-tags/edit.js
@@ -10,7 +10,7 @@ import { useEntityProp } from '@wordpress/core-data';
 import {
 	BlockControls,
 	Warning,
-	__experimentalBlock as Block,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 	AlignmentToolbar,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
@@ -77,6 +77,12 @@ export default function PostTagsEdit( { context, attributes, setAttributes } ) {
 		);
 	}
 
+	const blockWrapperProps = useBlockWrapperProps( {
+		className: classnames( {
+			[ `has-text-align-${ textAlign }` ]: textAlign,
+		} ),
+	} );
+
 	return (
 		<>
 			<BlockControls>
@@ -87,13 +93,7 @@ export default function PostTagsEdit( { context, attributes, setAttributes } ) {
 					} }
 				/>
 			</BlockControls>
-			<Block.div
-				className={ classnames( {
-					[ `has-text-align-${ textAlign }` ]: textAlign,
-				} ) }
-			>
-				{ display }
-			</Block.div>
+			<div { ...blockWrapperProps }>{ display }</div>
 		</>
 	);
 }

--- a/packages/block-library/src/query-loop/edit.js
+++ b/packages/block-library/src/query-loop/edit.js
@@ -7,7 +7,7 @@ import {
 	BlockContextProvider,
 	InnerBlocks,
 	BlockPreview,
-	__experimentalBlock as Block,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 } from '@wordpress/block-editor';
 
 /**
@@ -84,8 +84,10 @@ export default function QueryLoopEdit( {
 			} ) ),
 		[ posts ]
 	);
+	const blockWrapperProps = useBlockWrapperProps();
+
 	return (
-		<Block.div>
+		<div { ...blockWrapperProps }>
 			{ blockContexts &&
 				blockContexts.map( ( blockContext ) => (
 					<BlockContextProvider
@@ -106,6 +108,6 @@ export default function QueryLoopEdit( {
 						) }
 					</BlockContextProvider>
 				) ) }
-		</Block.div>
+		</div>
 	);
 }

--- a/packages/block-library/src/query/edit/index.js
+++ b/packages/block-library/src/query/edit/index.js
@@ -6,7 +6,7 @@ import { useEffect } from '@wordpress/element';
 import {
 	BlockControls,
 	InnerBlocks,
-	__experimentalBlock as Block,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 } from '@wordpress/block-editor';
 
 /**
@@ -22,6 +22,7 @@ export default function QueryEdit( {
 	setAttributes,
 } ) {
 	const instanceId = useInstanceId( QueryEdit );
+	const blockWrapperProps = useBlockWrapperProps();
 	// We need this for multi-query block pagination.
 	// Query parameters for each block are scoped to their ID.
 	useEffect( () => {
@@ -37,11 +38,11 @@ export default function QueryEdit( {
 			<BlockControls>
 				<QueryToolbar query={ query } setQuery={ updateQuery } />
 			</BlockControls>
-			<Block.div>
+			<div { ...blockWrapperProps }>
 				<QueryProvider>
 					<InnerBlocks template={ TEMPLATE } />
 				</QueryProvider>
-			</Block.div>
+			</div>
 		</>
 	);
 }

--- a/packages/block-library/src/quote/block.json
+++ b/packages/block-library/src/quote/block.json
@@ -20,6 +20,7 @@
 		}
 	},
 	"supports": {
-		"anchor": true
+		"anchor": true,
+		"lightBlockWrapper": true
 	}
 }

--- a/packages/block-library/src/quote/edit.js
+++ b/packages/block-library/src/quote/edit.js
@@ -26,6 +26,11 @@ export default function QuoteEdit( {
 	insertBlocksAfter,
 } ) {
 	const { align, value, citation } = attributes;
+	const blockWrapperProps = useBlockWrapperProps( {
+		className: classnames( className, {
+			[ `has-text-align-${ align }` ]: align,
+		} ),
+	} );
 
 	return (
 		<>
@@ -37,13 +42,7 @@ export default function QuoteEdit( {
 					} }
 				/>
 			</BlockControls>
-			<BlockQuotation
-				{ ...useBlockWrapperProps( {
-					className: classnames( className, {
-						[ `has-text-align-${ align }` ]: align,
-					} ),
-				} ) }
-			>
+			<BlockQuotation { ...blockWrapperProps }>
 				<RichText
 					identifier="value"
 					multiline

--- a/packages/block-library/src/quote/edit.js
+++ b/packages/block-library/src/quote/edit.js
@@ -11,6 +11,7 @@ import {
 	AlignmentToolbar,
 	BlockControls,
 	RichText,
+	__experimentalUseBlockProps as useBlockProps,
 } from '@wordpress/block-editor';
 import { BlockQuotation } from '@wordpress/components';
 import { createBlock } from '@wordpress/blocks';
@@ -37,8 +38,10 @@ export default function QuoteEdit( {
 				/>
 			</BlockControls>
 			<BlockQuotation
-				className={ classnames( className, {
-					[ `has-text-align-${ align }` ]: align,
+				{ ...useBlockProps( {
+					className: classnames( className, {
+						[ `has-text-align-${ align }` ]: align,
+					} ),
 				} ) }
 			>
 				<RichText

--- a/packages/block-library/src/quote/edit.js
+++ b/packages/block-library/src/quote/edit.js
@@ -11,7 +11,7 @@ import {
 	AlignmentToolbar,
 	BlockControls,
 	RichText,
-	__experimentalUseBlockProps as useBlockProps,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import { BlockQuotation } from '@wordpress/components';
 import { createBlock } from '@wordpress/blocks';
@@ -38,7 +38,7 @@ export default function QuoteEdit( {
 				/>
 			</BlockControls>
 			<BlockQuotation
-				{ ...useBlockProps( {
+				{ ...useBlockWrapperProps( {
 					className: classnames( className, {
 						[ `has-text-align-${ align }` ]: align,
 					} ),

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import {
-	__experimentalBlock as Block,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 	BlockControls,
 	InspectorControls,
 	RichText,
@@ -319,8 +319,12 @@ export default function SearchEdit( {
 		</>
 	);
 
+	const blockWrapperProps = useBlockWrapperProps( {
+		className: getBlockClassNames(),
+	} );
+
 	return (
-		<Block.div className={ getBlockClassNames() }>
+		<div { ...blockWrapperProps }>
 			{ controls }
 
 			{ showLabel && (
@@ -368,6 +372,6 @@ export default function SearchEdit( {
 				{ 'button-only' === buttonPosition && renderButton() }
 				{ 'no-button' === buttonPosition && renderTextField() }
 			</ResizableBox>
-		</Block.div>
+		</div>
 	);
 }

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -26,7 +26,7 @@ import {
 	InspectorControls,
 	MediaPlaceholder,
 	MediaReplaceFlow,
-	__experimentalBlock as Block,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
 
@@ -363,11 +363,17 @@ export default function LogoEdit( {
 
 	const key = !! logoUrl;
 
+	const blockWrapperProps = useBlockWrapperProps( {
+		ref,
+		className: classes,
+		key,
+	} );
+
 	return (
-		<Block.div ref={ ref } className={ classes } key={ key }>
+		<div { ...blockWrapperProps }>
 			{ controls }
 			{ logoUrl && logoImage }
 			{ ! logoUrl && mediaPlaceholder }
-		</Block.div>
+		</div>
 	);
 }

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -10,7 +10,7 @@ import {
 	InspectorControls,
 	URLPopover,
 	URLInput,
-	__experimentalUseBlockProps as useBlockProps,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import { Fragment, useState } from '@wordpress/element';
 import {
@@ -62,7 +62,7 @@ const SocialLinkEdit = ( { attributes, setAttributes, isSelected } ) => {
 					</PanelRow>
 				</PanelBody>
 			</InspectorControls>
-			<li { ...useBlockProps( { className: classes } ) }>
+			<li { ...useBlockWrapperProps( { className: classes } ) }>
 				<Button onClick={ () => setPopover( true ) }>
 					<IconComponent />
 					{ isSelected && showURLPopover && (

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -36,6 +36,7 @@ const SocialLinkEdit = ( { attributes, setAttributes, isSelected } ) => {
 
 	const IconComponent = getIconBySite( service );
 	const socialLinkName = getNameBySite( service );
+	const blockWrapperProps = useBlockWrapperProps( { className: classes } );
 
 	return (
 		<Fragment>
@@ -62,7 +63,7 @@ const SocialLinkEdit = ( { attributes, setAttributes, isSelected } ) => {
 					</PanelRow>
 				</PanelBody>
 			</InspectorControls>
-			<li { ...useBlockWrapperProps( { className: classes } ) }>
+			<li { ...blockWrapperProps }>
 				<Button onClick={ () => setPopover( true ) }>
 					<IconComponent />
 					{ isSelected && showURLPopover && (

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -10,7 +10,7 @@ import {
 	InspectorControls,
 	URLPopover,
 	URLInput,
-	__experimentalBlock as Block,
+	__experimentalUseBlockProps as useBlockProps,
 } from '@wordpress/block-editor';
 import { Fragment, useState } from '@wordpress/element';
 import {
@@ -62,7 +62,7 @@ const SocialLinkEdit = ( { attributes, setAttributes, isSelected } ) => {
 					</PanelRow>
 				</PanelBody>
 			</InspectorControls>
-			<Block.li className={ classes }>
+			<li { ...useBlockProps( { className: classes } ) }>
 				<Button onClick={ () => setPopover( true ) }>
 					<IconComponent />
 					{ isSelected && showURLPopover && (
@@ -93,7 +93,7 @@ const SocialLinkEdit = ( { attributes, setAttributes, isSelected } ) => {
 						</URLPopover>
 					) }
 				</Button>
-			</Block.li>
+			</li>
 		</Fragment>
 	);
 };

--- a/packages/e2e-tests/specs/editor/various/toolbar-roving-tabindex.test.js
+++ b/packages/e2e-tests/specs/editor/various/toolbar-roving-tabindex.test.js
@@ -65,17 +65,17 @@ describe( 'Toolbar roving tabindex', () => {
 	it( 'ensures heading block toolbar uses roving tabindex', async () => {
 		await insertBlock( 'Heading' );
 		await page.keyboard.type( 'Heading' );
-		await testBlockToolbarKeyboardNavigation( 'Write heading…' );
+		await testBlockToolbarKeyboardNavigation( 'Block: Heading' );
 		await wrapCurrentBlockWithGroup();
-		await testGroupKeyboardNavigation( 'Write heading…' );
+		await testGroupKeyboardNavigation( 'Block: Heading' );
 	} );
 
 	it( 'ensures list block toolbar uses roving tabindex', async () => {
 		await insertBlock( 'List' );
 		await page.keyboard.type( 'List' );
-		await testBlockToolbarKeyboardNavigation( 'Write list…' );
+		await testBlockToolbarKeyboardNavigation( 'Block: List' );
 		await wrapCurrentBlockWithGroup();
-		await testGroupKeyboardNavigation( 'Write list…' );
+		await testGroupKeyboardNavigation( 'Block: List' );
 	} );
 
 	it( 'ensures image block toolbar uses roving tabindex', async () => {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

This PR introduces `useBlockWrapperProps`, a hook used to lightly mark any element as a block.

To use, just pass the returned props to the element:

```jsx
<p attribute="value" { ...useBlockWrapperProps() } />
```

If the component defines a ref for the element, it must be passed through `useBlockWrapperProps`. If no ref is defined, `useBlockWrapperProps` will create one and pass it to the element.

```jsx
<p attribute="value" { ...useBlockWrapperProps( { ref } ) } />
```

You can pass any props to `useBlockWrapperProps` and they will be returned, but you don't _have_ to. In case of `style` and `className` props, `useBlockWrapperProps` will automatically merge them. If you don't pass them through `useBlockWrapperProps`, you have to merge them yourself.

Both are equally ok:

```jsx
<p { ...useBlockWrapperProps( { ref, className: 'something', attribute: value } ) } />
```

```jsx
const blockProps = useBlockWrapperProps( { ref } );
<p attribute="value" { ... blockProps } className={ classnames( blockProps.className, 'something' ) } />
```

A hook means that it can work for any component. No need to have a `<Block as />` component and `block()` HoC so that it works in different scenarios. Just one API. We don't need access to the element/component at all, we only need to define some props and have access to the ref.

I think it's really nice that this leaves the original element structure intact, since it doesn't need to be wrapped in another component.

I could imagine a similar API for `InnerBlocks`, which would avoid having things like the ugly `passedProps` etc.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
