### PR TITLE
Convert PostSavedState to functional component

### DIFF
--- a/packages/editor/src/components/post-saved-state/index.js
+++ b/packages/editor/src/components/post-saved-state/index.js
@@ -2,19 +2,17 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { get } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { Animate, Button } from '@wordpress/components';
-import { Component } from '@wordpress/element';
-import { withSelect, withDispatch } from '@wordpress/data';
-import { displayShortcut } from '@wordpress/keycodes';
-import { withSafeTimeout, compose } from '@wordpress/compose';
-import { withViewportMatch } from '@wordpress/viewport';
+import { usePrevious, useViewportMatch } from '@wordpress/compose';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import { Icon, check, cloud, cloudUpload } from '@wordpress/icons';
+import { displayShortcut } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -22,155 +20,146 @@ import { Icon, check, cloud, cloudUpload } from '@wordpress/icons';
 import PostSwitchToDraftButton from '../post-switch-to-draft-button';
 
 /**
- * Component showing whether the post is saved or not and displaying save links.
+ * Component showing whether the post is saved or not and providing save
+ * buttons.
  *
- * @param   {Object}    Props Component Props.
+ * @param {Object}   props               Component props.
+ * @param {?boolean} props.forceIsDirty  Whether to force the post to be marked
+ *                                       as dirty.
+ * @param {?boolean} props.forceIsSaving Whether to force the post to be marked
+ *                                       as being saved.
+ *
+ * @return {import('@wordpress/element').WPComponent} The component.
  */
-export class PostSavedState extends Component {
-	constructor() {
-		super( ...arguments );
-		this.state = {
-			forceSavedMessage: false,
-		};
-	}
+export default function PostSavedState( { forceIsDirty, forceIsSaving } ) {
+	const [ forceSavedMessage, setForceSavedMessage ] = useState( false );
 
-	componentDidUpdate( prevProps ) {
-		if ( prevProps.isSaving && ! this.props.isSaving ) {
-			this.setState( { forceSavedMessage: true } );
-			this.props.setTimeout( () => {
-				this.setState( { forceSavedMessage: false } );
+	const isLargeViewport = useViewportMatch( 'small' );
+
+	const {
+		isAutosaving,
+		isDirty,
+		isNew,
+		isPending,
+		isPublished,
+		isSaveable,
+		isSaving,
+		isScheduled,
+		post,
+	} = useSelect(
+		( select ) => {
+			const {
+				isEditedPostNew,
+				isCurrentPostPublished,
+				isCurrentPostScheduled,
+				isEditedPostDirty,
+				isSavingPost,
+				isEditedPostSaveable,
+				getCurrentPost,
+				isAutosavingPost,
+				getEditedPostAttribute,
+			} = select( 'core/editor' );
+
+			return {
+				isAutosaving: isAutosavingPost(),
+				isDirty: forceIsDirty || isEditedPostDirty(),
+				isNew: isEditedPostNew(),
+				isPending: 'pending' === getEditedPostAttribute( 'status' ),
+				isPublished: isCurrentPostPublished(),
+				isSaving: forceIsSaving || isSavingPost(),
+				isSaveable: isEditedPostSaveable(),
+				isScheduled: isCurrentPostScheduled(),
+				post: getCurrentPost(),
+			};
+		},
+		[ forceIsDirty, forceIsSaving ]
+	);
+
+	const { savePost } = useDispatch( 'core/editor' );
+
+	const wasSaving = usePrevious( isSaving );
+
+	useEffect( () => {
+		let timeoutId;
+
+		if ( wasSaving && ! isSaving ) {
+			setForceSavedMessage( true );
+			timeoutId = setTimeout( () => {
+				setForceSavedMessage( false );
 			}, 1000 );
 		}
+
+		return () => clearTimeout( timeoutId );
+	}, [ isSaving ] );
+
+	if ( isSaving ) {
+		// TODO: Classes generation should be common across all return
+		// paths of this function, including proper naming convention for
+		// the "Save Draft" button.
+		const classes = classnames( 'editor-post-saved-state', 'is-saving', {
+			'is-autosaving': isAutosaving,
+		} );
+
+		return (
+			<Animate type="loading">
+				{ ( { className: animateClassName } ) => (
+					<span className={ classnames( classes, animateClassName ) }>
+						<Icon icon={ cloud } />
+						{ isAutosaving ? __( 'Autosaving' ) : __( 'Saving' ) }
+					</span>
+				) }
+			</Animate>
+		);
 	}
 
-	render() {
-		const {
-			post,
-			isNew,
-			isScheduled,
-			isPublished,
-			isDirty,
-			isSaving,
-			isSaveable,
-			onSave,
-			isAutosaving,
-			isPending,
-			isLargeViewport,
-		} = this.props;
-		const { forceSavedMessage } = this.state;
-		if ( isSaving ) {
-			// TODO: Classes generation should be common across all return
-			// paths of this function, including proper naming convention for
-			// the "Save Draft" button.
-			const classes = classnames(
-				'editor-post-saved-state',
-				'is-saving',
-				{
-					'is-autosaving': isAutosaving,
-				}
-			);
+	if ( isPublished || isScheduled ) {
+		return <PostSwitchToDraftButton />;
+	}
 
-			return (
-				<Animate type="loading">
-					{ ( { className: animateClassName } ) => (
-						<span
-							className={ classnames(
-								classes,
-								animateClassName
-							) }
-						>
-							<Icon icon={ cloud } />
-							{ isAutosaving
-								? __( 'Autosaving' )
-								: __( 'Saving' ) }
-						</span>
-					) }
-				</Animate>
-			);
-		}
+	if ( ! isSaveable ) {
+		return null;
+	}
 
-		if ( isPublished || isScheduled ) {
-			return <PostSwitchToDraftButton />;
-		}
-
-		if ( ! isSaveable ) {
-			return null;
-		}
-
-		if ( forceSavedMessage || ( ! isNew && ! isDirty ) ) {
-			return (
-				<span className="editor-post-saved-state is-saved">
-					<Icon icon={ check } />
-					{ __( 'Saved' ) }
-				</span>
-			);
-		}
-
-		// Once the post has been submitted for review this button
-		// is not needed for the contributor role.
-		const hasPublishAction = get(
-			post,
-			[ '_links', 'wp:action-publish' ],
-			false
+	if ( forceSavedMessage || ( ! isNew && ! isDirty ) ) {
+		return (
+			<span className="editor-post-saved-state is-saved">
+				<Icon icon={ check } />
+				{ __( 'Saved' ) }
+			</span>
 		);
-		if ( ! hasPublishAction && isPending ) {
-			return null;
-		}
+	}
 
-		const label = isPending ? __( 'Save as pending' ) : __( 'Save draft' );
-		if ( ! isLargeViewport ) {
-			return (
-				<Button
-					className="editor-post-save-draft"
-					label={ label }
-					onClick={ () => onSave() }
-					shortcut={ displayShortcut.primary( 's' ) }
-					icon={ cloudUpload }
-				/>
-			);
-		}
+	// Once the post has been submitted for review this button
+	// is not needed for the contributor role.
+	const hasPublishAction =
+		post?.[ '_links' ]?.[ 'wp:action-publish' ] ?? false;
 
+	if ( ! hasPublishAction && isPending ) {
+		return null;
+	}
+
+	const label = isPending ? __( 'Save as pending' ) : __( 'Save draft' );
+
+	if ( ! isLargeViewport ) {
 		return (
 			<Button
 				className="editor-post-save-draft"
-				onClick={ () => onSave() }
+				label={ label }
+				onClick={ () => savePost() }
 				shortcut={ displayShortcut.primary( 's' ) }
-				isTertiary
-			>
-				{ label }
-			</Button>
+				icon={ cloudUpload }
+			/>
 		);
 	}
-}
 
-export default compose( [
-	withSelect( ( select, { forceIsDirty, forceIsSaving } ) => {
-		const {
-			isEditedPostNew,
-			isCurrentPostPublished,
-			isCurrentPostScheduled,
-			isEditedPostDirty,
-			isSavingPost,
-			isEditedPostSaveable,
-			getCurrentPost,
-			isAutosavingPost,
-			getEditedPostAttribute,
-		} = select( 'core/editor' );
-		return {
-			post: getCurrentPost(),
-			isNew: isEditedPostNew(),
-			isPublished: isCurrentPostPublished(),
-			isScheduled: isCurrentPostScheduled(),
-			isDirty: forceIsDirty || isEditedPostDirty(),
-			isSaving: forceIsSaving || isSavingPost(),
-			isSaveable: isEditedPostSaveable(),
-			isAutosaving: isAutosavingPost(),
-			isPending: 'pending' === getEditedPostAttribute( 'status' ),
-		};
-	} ),
-	withDispatch( ( dispatch ) => ( {
-		onSave: dispatch( 'core/editor' ).savePost,
-	} ) ),
-	withSafeTimeout,
-	withViewportMatch( { isLargeViewport: 'small' } ),
-] )( PostSavedState );
+	return (
+		<Button
+			className="editor-post-save-draft"
+			onClick={ () => savePost() }
+			shortcut={ displayShortcut.primary( 's' ) }
+			isTertiary
+		>
+			{ label }
+		</Button>
+	);
+}

--- a/packages/editor/src/components/post-saved-state/test/index.js
+++ b/packages/editor/src/components/post-saved-state/test/index.js
@@ -4,74 +4,104 @@
 import { mount, shallow } from 'enzyme';
 
 /**
+ * WordPress dependencies
+ */
+import { useViewportMatch } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
+
+/**
  * Internal dependencies
  */
-import { PostSavedState } from '../';
+import PostSavedState from '../';
+
+const mockSavePost = jest.fn();
+
+jest.mock( '@wordpress/data/src/components/use-dispatch', () => {
+	return {
+		useDispatch: () => ( { savePost: mockSavePost } ),
+	};
+} );
+
+jest.mock( '@wordpress/data/src/components/use-select', () => {
+	// This allows us to tweak the returned value on each test
+	const mock = jest.fn();
+	return mock;
+} );
+
+jest.mock( '@wordpress/compose/src/hooks/use-viewport-match', () => {
+	// This allows us to tweak the returned value on each test
+	const mock = jest.fn();
+	return mock;
+} );
 
 describe( 'PostSavedState', () => {
 	it( 'should display saving while save in progress, even if not saveable', () => {
-		const wrapper = mount(
-			<PostSavedState
-				isNew
-				isDirty={ false }
-				isSaving={ true }
-				isSaveable={ false }
-			/>
-		);
+		useSelect.mockImplementation( () => ( {
+			isDirty: false,
+			isNew: true,
+			isSaveable: false,
+			isSaving: true,
+		} ) );
+
+		const wrapper = mount( <PostSavedState /> );
 
 		expect( wrapper.text() ).toContain( 'Saving' );
 	} );
 
 	it( 'returns null if the post is not saveable', () => {
-		const wrapper = shallow(
-			<PostSavedState
-				isNew
-				isDirty={ false }
-				isSaving={ false }
-				isSaveable={ false }
-			/>
-		);
+		useSelect.mockImplementation( () => ( {
+			isDirty: false,
+			isNew: true,
+			isSaveable: false,
+			isSaving: false,
+		} ) );
+
+		const wrapper = shallow( <PostSavedState /> );
 
 		expect( wrapper.type() ).toBeNull();
 	} );
 
 	it( 'returns a switch to draft link if the post is published', () => {
-		const wrapper = shallow( <PostSavedState isPublished /> );
+		useSelect.mockImplementation( () => ( {
+			isPublished: true,
+		} ) );
+
+		const wrapper = shallow( <PostSavedState /> );
 
 		expect( wrapper ).toMatchSnapshot();
 	} );
 
 	it( 'should return Saved text if not new and not dirty', () => {
-		const wrapper = shallow(
-			<PostSavedState
-				isNew={ false }
-				isDirty={ false }
-				isSaving={ false }
-				isSaveable={ true }
-			/>
-		);
+		useSelect.mockImplementation( () => ( {
+			isDirty: false,
+			isNew: false,
+			isSaveable: true,
+			isSaving: false,
+		} ) );
+
+		const wrapper = shallow( <PostSavedState /> );
 
 		expect( wrapper.childAt( 0 ).name() ).toBe( 'Icon' );
 		expect( wrapper.childAt( 1 ).text() ).toBe( 'Saved' );
 	} );
 
 	it( 'should return Save button if edits to be saved', () => {
-		const saveSpy = jest.fn();
-		const wrapper = shallow(
-			<PostSavedState
-				isNew={ false }
-				isDirty={ true }
-				isSaving={ false }
-				isSaveable={ true }
-				isLargeViewport
-				onSave={ saveSpy }
-			/>
-		);
+		useSelect.mockImplementation( () => ( {
+			isDirty: true,
+			isNew: false,
+			isSaveable: true,
+			isSaving: false,
+		} ) );
+
+		// Simulate the viewport being considered large.
+		useViewportMatch.mockImplementation( () => true );
+
+		const wrapper = shallow( <PostSavedState /> );
 
 		expect( wrapper ).toMatchSnapshot();
 		wrapper.simulate( 'click', {} );
-		expect( saveSpy ).toHaveBeenCalled();
+		expect( mockSavePost ).toHaveBeenCalled();
 		// Regression: Verify the event object is not passed to prop callback.
-		expect( saveSpy.mock.calls[ 0 ] ).toEqual( [] );
+		expect( mockSavePost.mock.calls[ 0 ] ).toEqual( [] );
 	} );
 } );


### PR DESCRIPTION
## Description
As a first step towards [revising the save draft experience](https://github.com/WordPress/gutenberg/pull/21192#issuecomment-640775151), I need to convert PostSavedState to a functional component. This PR does just that.

Changes in this PR are best viewed with [whitespace changes hidden](https://github.com/WordPress/gutenberg/pull/23038/files?diff=split&w=1).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
