### PR TITLE
Speed up hover timing for inserter

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -384,7 +384,7 @@
 .block-editor-block-list__block-popover-inserter {
 	.block-editor-inserter__toggle.components-button {
 		// Fade it in after a delay.
-		animation: block-editor-inserter__toggle__fade-in-animation-delayed 1.2s ease;
+		animation: block-editor-inserter__toggle__fade-in-animation-delayed 0.075s 0.04s ease;
 		animation-fill-mode: forwards;
 		@include reduce-motion("animation");
 	}
@@ -392,9 +392,6 @@
 
 @keyframes block-editor-inserter__toggle__fade-in-animation-delayed {
 	0% {
-		opacity: 0;
-	}
-	80% {
 		opacity: 0;
 	}
 	100% {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

Inspired by conversation in #22813 and in response to #22801, I sped up the timing and dramatically reduced the delay of the hover animation on the inserter.

I'm going for a delay just long enough to allow you to move your cursor over several blocks without flashing the inserter, but fast enough where the inserter is still discoverable.

I am noticing a bug that I don't think is related to this PR and would appreciate someone else confirming it. When hovering around the inserter, sometimes it flashes extremely quickly. I think this has to do with the location of the mouse being misinterpreted by the inserter JS or something as if I mouse just right, the inserter appears in the wrong spot. Gif below:

![2020-06-09 15 41 13](https://user-images.githubusercontent.com/1123119/84204214-037bff00-aa68-11ea-92fa-3af5f5ec6703.gif)

## How has this been tested?
I tested this on FF (latest) on MacOS (latest).

## Screenshots <!-- if applicable -->
Screenshots just don't do this justice and gifs are a bit stuttery. It's probably better to test yourself to get a feel for it.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
