### PR TITLE
Try: Reduced inserter hover delay.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -384,7 +384,7 @@
 .block-editor-block-list__block-popover-inserter {
 	.block-editor-inserter__toggle.components-button {
 		// Fade it in after a delay.
-		animation: block-editor-inserter__toggle__fade-in-animation-delayed 1.2s ease;
+		animation: block-editor-inserter__toggle__fade-in-animation-delayed 0.3s ease;
 		animation-fill-mode: forwards;
 		@include reduce-motion("animation");
 	}


### PR DESCRIPTION
Alternative to #23043, props @MichaelArestad.

This one is faster, but still delayed.

![alternative](https://user-images.githubusercontent.com/1204802/84238605-96b24480-aafb-11ea-9872-7c0d8ca25216.gif)
