### PR TITLE
Make link color control opt-in

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -703,6 +703,21 @@ function gutenberg_extend_settings_custom_spacing( $settings ) {
 }
 add_filter( 'block_editor_settings', 'gutenberg_extend_settings_custom_spacing' );
 
+
+/**
+ * Extends block editor settings to determine whether to use custom spacing controls.
+ * Currently experimental.
+ *
+ * @param array $settings Default editor settings.
+ *
+ * @return array Filtered editor settings.
+ */
+function gutenberg_extend_settings_link_color( $settings ) {
+	$settings['__experimentalEnableLinkColor'] = get_theme_support( 'experimental-link-color' );
+	return $settings;
+}
+add_filter( 'block_editor_settings', 'gutenberg_extend_settings_link_color' );
+
 /*
  * Register default patterns if not registered in Core already.
  */

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -180,9 +180,10 @@ const getLinkColorFromAttributeValue = ( colors, value ) => {
  */
 export function ColorEdit( props ) {
 	const { name: blockName, attributes } = props;
-	const { colors, gradients } = useSelect( ( select ) => {
+	const { colors, gradients, __experimentalEnableLinkColor } = useSelect( ( select ) => {
 		return select( 'core/block-editor' ).getSettings();
 	}, [] );
+
 	// Shouldn't be needed but right now the ColorGradientsPanel
 	// can trigger both onChangeColor and onChangeBackground
 	// synchronously causing our two callbacks to override changes
@@ -310,7 +311,7 @@ export function ColorEdit( props ) {
 						? onChangeGradient
 						: undefined,
 				},
-				...( hasLinkColorSupport( blockName )
+				...( __experimentalEnableLinkColor && hasLinkColorSupport( blockName )
 					? [
 							{
 								label: __( 'Link Color' ),

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -180,9 +180,12 @@ const getLinkColorFromAttributeValue = ( colors, value ) => {
  */
 export function ColorEdit( props ) {
 	const { name: blockName, attributes } = props;
-	const { colors, gradients, __experimentalEnableLinkColor } = useSelect( ( select ) => {
-		return select( 'core/block-editor' ).getSettings();
-	}, [] );
+	const { colors, gradients, __experimentalEnableLinkColor } = useSelect(
+		( select ) => {
+			return select( 'core/block-editor' ).getSettings();
+		},
+		[]
+	);
 
 	// Shouldn't be needed but right now the ColorGradientsPanel
 	// can trigger both onChangeColor and onChangeBackground
@@ -311,7 +314,8 @@ export function ColorEdit( props ) {
 						? onChangeGradient
 						: undefined,
 				},
-				...( __experimentalEnableLinkColor && hasLinkColorSupport( blockName )
+				...( __experimentalEnableLinkColor &&
+				hasLinkColorSupport( blockName )
 					? [
 							{
 								label: __( 'Link Color' ),

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -118,6 +118,7 @@ class EditorProvider extends Component {
 				'__experimentalDisableCustomLineHeight',
 				'__experimentalEnableCustomSpacing',
 				'__experimentalEnableLegacyWidgetBlock',
+				'__experimentalEnableLinkColor',
 				'__experimentalEnableFullSiteEditing',
 				'__experimentalEnableFullSiteEditingDemo',
 				'__experimentalFeatures',


### PR DESCRIPTION
In landing https://github.com/WordPress/gutenberg/pull/22722 we missed that this control should be opt-in at the moment.