### PR TITLE
Edit Site: Fix Template Part Auto-draft creation

### DIFF
--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -134,67 +134,66 @@ function gutenberg_override_query_template( $template, $type, array $templates =
  * @return int[] A list of template parts IDs for the given block.
  */
 function create_auto_draft_for_template_part_block( $block ) {
-	if ( 'core/template-part' !== $block['blockName'] ) {
-		return array();
-	}
+	$template_part_ids = array();
 
-	if ( isset( $block['attrs']['postId'] ) ) {
-		// Template part is customized.
-		$template_part_id = $block['attrs']['postId'];
-	} else {
-		// A published post might already exist if this template part
-		// was customized elsewhere or if it's part of a customized
-		// template. We also check if an auto-draft was already created
-		// because preloading can make this run twice, so, different code
-		// paths can end up with different posts for the same template part.
-		// E.g. The server could send back post ID 1 to the client, preload,
-		// and create another auto-draft. So, if the client tries to resolve the
-		// post ID from the slug and theme, it won't match with what the server sent.
-		$template_part_query = new WP_Query(
-			array(
-				'post_type'      => 'wp_template_part',
-				'post_status'    => array( 'publish', 'auto-draft' ),
-				'name'           => $block['attrs']['slug'],
-				'meta_key'       => 'theme',
-				'meta_value'     => $block['attrs']['theme'],
-				'posts_per_page' => 1,
-				'no_found_rows'  => true,
-			)
-		);
-		$template_part_post  = $template_part_query->have_posts() ? $template_part_query->next_post() : null;
-		if ( $template_part_post ) {
-			$template_part_id = $template_part_post->ID;
+	if ( 'core/template-part' === $block['blockName'] ) {
+		if ( isset( $block['attrs']['postId'] ) ) {
+			// Template part is customized.
+			$template_part_id = $block['attrs']['postId'];
 		} else {
-			// Template part is not customized, get it from a file and make an auto-draft for it.
-			$template_part_file_path =
-			get_stylesheet_directory() . '/block-template-parts/' . $block['attrs']['slug'] . '.html';
-			if ( ! file_exists( $template_part_file_path ) ) {
-				if ( gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing-demo' ) ) {
-					$template_part_file_path =
-						dirname( __FILE__ ) . '/demo-block-template-parts/' . $block['attrs']['slug'] . '.html';
-					if ( ! file_exists( $template_part_file_path ) ) {
-						return;
-					}
-				} else {
-					return;
-				}
-			}
-			$template_part_id = wp_insert_post(
+			// A published post might already exist if this template part
+			// was customized elsewhere or if it's part of a customized
+			// template. We also check if an auto-draft was already created
+			// because preloading can make this run twice, so, different code
+			// paths can end up with different posts for the same template part.
+			// E.g. The server could send back post ID 1 to the client, preload,
+			// and create another auto-draft. So, if the client tries to resolve the
+			// post ID from the slug and theme, it won't match with what the server sent.
+			$template_part_query = new WP_Query(
 				array(
-					'post_content' => file_get_contents( $template_part_file_path ),
-					'post_title'   => $block['attrs']['slug'],
-					'post_status'  => 'auto-draft',
-					'post_type'    => 'wp_template_part',
-					'post_name'    => $block['attrs']['slug'],
-					'meta_input'   => array(
-						'theme' => $block['attrs']['theme'],
-					),
+					'post_type'      => 'wp_template_part',
+					'post_status'    => array( 'publish', 'auto-draft' ),
+					'name'           => $block['attrs']['slug'],
+					'meta_key'       => 'theme',
+					'meta_value'     => $block['attrs']['theme'],
+					'posts_per_page' => 1,
+					'no_found_rows'  => true,
 				)
 			);
+			$template_part_post  = $template_part_query->have_posts() ? $template_part_query->next_post() : null;
+			if ( $template_part_post ) {
+				$template_part_id = $template_part_post->ID;
+			} else {
+				// Template part is not customized, get it from a file and make an auto-draft for it.
+				$template_part_file_path =
+				get_stylesheet_directory() . '/block-template-parts/' . $block['attrs']['slug'] . '.html';
+				if ( ! file_exists( $template_part_file_path ) ) {
+					if ( gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing-demo' ) ) {
+						$template_part_file_path =
+							dirname( __FILE__ ) . '/demo-block-template-parts/' . $block['attrs']['slug'] . '.html';
+						if ( ! file_exists( $template_part_file_path ) ) {
+							return;
+						}
+					} else {
+						return;
+					}
+				}
+				$template_part_id = wp_insert_post(
+					array(
+						'post_content' => file_get_contents( $template_part_file_path ),
+						'post_title'   => $block['attrs']['slug'],
+						'post_status'  => 'auto-draft',
+						'post_type'    => 'wp_template_part',
+						'post_name'    => $block['attrs']['slug'],
+						'meta_input'   => array(
+							'theme' => $block['attrs']['theme'],
+						),
+					)
+				);
+			}
 		}
+		$template_part_ids[ $block['attrs']['slug'] ] = $template_part_id;
 	}
-
-	$template_part_ids = array( $block['attrs']['slug'] => $template_part_id );
 
 	foreach ( $block['innerBlocks'] as $inner_block ) {
 		$template_part_ids = array_merge( $template_part_ids, create_auto_draft_for_template_part_block( $inner_block ) );


### PR DESCRIPTION
## Description
This fixes an issue introduced by yours truly in #22143, and first [reported](https://wordpress.slack.com/archives/C02QB2JS7/p1591779711335800) by @carolinan in Slack:

> :woman_shrugging: With current master (and 8.3 rc1) FSE template parts are no longer showing in the site editor. Only templates (And only templates are exported with the theme exporter). Did something change for how we include template parts inside the templates?

The problem was that we were bailing early from `create_auto_draft_for_template_part_block` if the block type was not `core/template-part`. But this means that we also didn't descend into recursion of a block's inner blocks, and neglected e.g. the template part block children of a `group` block.

This probably went unnoticed for a while because many of us still had some auto-generated template part auto-drafts lingering from previous runs of the site editor.

Diff best viewed [with whitespace changes ignored](https://github.com/WordPress/gutenberg/pull/23050/files?diff=split&w=1).

Thanks @carolinan for reporting, and @nosolosw for bringing this to my attention!

## How has this been tested?

- There shouldn't be any `wp_template` CPTs (neither published nor `auto-draft`s) from previous Site Editor runs. (It's best to start with a fresh install, i.e. `npx wp-env clean all && npx wp-env start`. _Careful, this will wipe your WordPress install's data!_)
- Furthermore, the "Full Site Editing Demo Templates" checkbox in `/wp-admin/admin.php?page=gutenberg-experiments` _must not be ticked_. (Make sure the "Full Site Editing" checkbox is ticked -- since it also gets reset after a wipe.)
- Make sure you have linked your wp-env install to themes from the `theme-experiments` repo (see the [`wp-env` README](https://github.com/WordPress/gutenberg/blob/710373b254fbcd15d524afdeb31da0d93c4defd4/packages/env/README.md)).
- Activate the "Twenty Twenty Blocks" theme, and open the site editor. Verify that the header and footer template parts are shown in the editor, that they are present in the template switcher, and that no errors or notices are printed.

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/96308/84261773-a3936000-ab1c-11ea-8dc5-2ce283cc6a16.png)

### After

![image](https://user-images.githubusercontent.com/96308/84261254-c6714480-ab1b-11ea-9805-e10c058dc226.png)

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
