### PR TITLE
package-lock.json: Update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35801,9 +35801,9 @@
 					}
 				},
 				"extract-zip": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.0.tgz",
-					"integrity": "sha512-i42GQ498yibjdvIhivUsRslx608whtGoFIhF26Z7O4MYncBxp8CwalOs1lnHy21A9sIohWO2+uiE4SRtC9JXDg==",
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+					"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
 					"dev": true,
 					"requires": {
 						"@types/yauzl": "^2.9.1",


### PR DESCRIPTION
## Description
The build artifacts job is currently failing (e.g. for #23050). This PR updates `package-lock.json` which should hopefully fix the issue.

Diff created by running
```
rm -rf node_modules/
npm i
```

## How has this been tested?
Wait for Travis CI to finish its Build Artifacts job :crossed_fingers: 

## Types of changes
Bug fix.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
