### PR TITLE
[GB-Mobile]: Add accessibilty label to the RichText component

### DIFF
--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -110,7 +110,7 @@ class PostTitle extends Component {
 								title
 						  )
 				}
-				accessibilityHint={ __( 'Update the title.' ) }
+				accessibilityHint={ __( 'Updates the title.' ) }
 			>
 				<RichText
 					setRef={ this.setRef }
@@ -121,7 +121,6 @@ class PostTitle extends Component {
 							: /* translators: accessibility text. Name of the form field. */
 							  __( 'Title.' )
 					}
-					accessibilityHint={ __( 'Updates the title.' ) }
 					tagName={ 'p' }
 					tagsToEliminate={ [ 'strong' ] }
 					unstableOnFocus={ this.props.onSelect }

--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -121,7 +121,7 @@ class PostTitle extends Component {
 							: /* translators: accessibility text. Name of the form field. */
 							  __( 'Title.' )
 					}
-					accessibilityHint={ __( 'Update the title.' ) }
+					accessibilityHint={ __( 'Updates the title.' ) }
 					tagName={ 'p' }
 					tagsToEliminate={ [ 'strong' ] }
 					unstableOnFocus={ this.props.onSelect }

--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -76,6 +76,28 @@ class PostTitle extends Component {
 		this.richTextRef = richText;
 	}
 
+	getTitle( title, postType ) {
+		if ( 'page' === postType ) {
+			return isEmpty( title )
+				? /* translators: accessibility text. empty page title. */
+				  __( 'Page title. Empty' )
+				: sprintf(
+						/* translators: accessibility text. %s: text content of the page title. */
+						__( 'Page title. %s' ),
+						title
+				  );
+		}
+
+		return isEmpty( title )
+			? /* translators: accessibility text. empty post title. */
+			  __( 'Post title. Empty' )
+			: sprintf(
+					/* translators: accessibility text. %s: text content of the post title. */
+					__( 'Post title. %s' ),
+					title
+			  );
+	}
+
 	render() {
 		const {
 			placeholder,
@@ -84,6 +106,7 @@ class PostTitle extends Component {
 			focusedBorderColor,
 			borderStyle,
 			isDimmed,
+			postType,
 		} = this.props;
 
 		const decodedPlaceholder = decodeEntities( placeholder );
@@ -100,27 +123,12 @@ class PostTitle extends Component {
 					isDimmed && styles.dimmed,
 				] }
 				accessible={ ! this.props.isSelected }
-				accessibilityLabel={
-					isEmpty( title )
-						? /* translators: accessibility text. empty post title. */
-						  __( 'Title. Empty' )
-						: sprintf(
-								/* translators: accessibility text. %s: text content of the post title. */
-								__( 'Title. %s' ),
-								title
-						  )
-				}
+				accessibilityLabel={ this.getTitle( title, postType ) }
 				accessibilityHint={ __( 'Updates the title.' ) }
 			>
 				<RichText
 					setRef={ this.setRef }
-					accessibilityLabel={
-						isEmpty( title )
-							? /* translators: accessibility text. empty post title. */
-							  __( 'Title. Empty' )
-							: /* translators: accessibility text. Name of the form field. */
-							  __( 'Title.' )
-					}
+					accessibilityLabel={ this.getTitle( title, postType ) }
 					tagName={ 'p' }
 					tagsToEliminate={ [ 'strong' ] }
 					unstableOnFocus={ this.props.onSelect }
@@ -150,7 +158,9 @@ class PostTitle extends Component {
 
 export default compose(
 	withSelect( ( select ) => {
-		const { isPostTitleSelected } = select( 'core/editor' );
+		const { isPostTitleSelected, getEditedPostAttribute } = select(
+			'core/editor'
+		);
 
 		const { getSelectedBlockClientId, getBlockRootClientId } = select(
 			'core/block-editor'
@@ -160,6 +170,7 @@ export default compose(
 		const selectionIsNested = !! getBlockRootClientId( selectedId );
 
 		return {
+			postType: getEditedPostAttribute( 'type' ),
 			isAnyBlockSelected: !! selectedId,
 			isSelected: isPostTitleSelected(),
 			isDimmed: selectionIsNested,

--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -103,16 +103,25 @@ class PostTitle extends Component {
 				accessibilityLabel={
 					isEmpty( title )
 						? /* translators: accessibility text. empty post title. */
-						  __( 'Post title. Empty' )
+						  __( 'Title. Empty' )
 						: sprintf(
 								/* translators: accessibility text. %s: text content of the post title. */
-								__( 'Post title. %s' ),
+								__( 'Title. %s' ),
 								title
 						  )
 				}
+				accessibilityHint={ __( 'Update the title.' ) }
 			>
 				<RichText
 					setRef={ this.setRef }
+					accessibilityLabel={
+						isEmpty( title )
+							? /* translators: accessibility text. empty post title. */
+							  __( 'Title. Empty' )
+							: /* translators: accessibility text. Name of the form field. */
+							  __( 'Title.' )
+					}
+					accessibilityHint={ __( 'Update the title.' ) }
 					tagName={ 'p' }
 					tagsToEliminate={ [ 'strong' ] }
 					unstableOnFocus={ this.props.onSelect }

--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -740,7 +740,6 @@ export class RichText extends Component {
 			parentBlockStyles,
 			withoutInteractiveFormatting,
 			accessibilityLabel,
-			accessibilityHint,
 			capabilities,
 			disableEditingMenu = false,
 		} = this.props;
@@ -822,7 +821,6 @@ export class RichText extends Component {
 					} ) }
 				<RCTAztecView
 					accessibilityLabel={ accessibilityLabel }
-					accessibilityHint={ accessibilityHint }
 					ref={ ( ref ) => {
 						this._editor = ref;
 

--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -739,6 +739,8 @@ export class RichText extends Component {
 			formatTypes,
 			parentBlockStyles,
 			withoutInteractiveFormatting,
+			accessibilityLabel,
+			accessibilityHint,
 			capabilities,
 			disableEditingMenu = false,
 		} = this.props;
@@ -809,6 +811,7 @@ export class RichText extends Component {
 				? maxWidth
 				: this.state.width;
 
+
 		return (
 			<View>
 				{ children &&
@@ -819,6 +822,8 @@ export class RichText extends Component {
 						onFocus: () => {},
 					} ) }
 				<RCTAztecView
+					accessibilityLabel={ accessibilityLabel }
+					accessibilityHint={ accessibilityHint }
 					ref={ ( ref ) => {
 						this._editor = ref;
 

--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -811,7 +811,6 @@ export class RichText extends Component {
 				? maxWidth
 				: this.state.width;
 
-
 		return (
 			<View>
 				{ children &&


### PR DESCRIPTION
Fixes: https://github.com/wordpress-mobile/gutenberg-mobile/issues/2364
Related Gutenberg Mobile PR:
https://github.com/wordpress-mobile/gutenberg-mobile/pull/2368

## Description
This makes it possible PR makes it possible to pass the accessibilityLabel and accessibilityHint to the RichText component. Which helps us set the correct label on the input field. 


## How has this been tested?
This was tested using VoiceOver on iOS devices. 
See instruction in https://github.com/wordpress-mobile/gutenberg-mobile/pull/2368 

## Screenshots <!-- if applicable -->
https://cloudup.com/cjd-RHZpyQM


## Types of changes
This PR 
- updates the accessibility Label so that it is Less post type specifici. We just call the field Title instead of "Post title" when the user is editing a page.
- Update the accessibility Label to be more helpful when the Element is selected. 
 
## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
