### PR TITLE
Use a light block DOM for the Media & Text block

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10611,7 +10611,7 @@
 				"lodash": "^4.17.15",
 				"memize": "^1.1.0",
 				"moment": "^2.22.1",
-				"re-resizable": "^6.0.0",
+				"re-resizable": "^6.4.0",
 				"react-dates": "^17.1.1",
 				"react-spring": "^8.0.20",
 				"react-use-gesture": "^7.0.15",
@@ -10619,6 +10619,16 @@
 				"rememo": "^3.0.0",
 				"tinycolor2": "^1.4.1",
 				"uuid": "^7.0.2"
+			},
+			"dependencies": {
+				"re-resizable": {
+					"version": "6.4.0",
+					"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.4.0.tgz",
+					"integrity": "sha512-E8WOtM8RfcGv4kOdasdR10jw8IU45j5jVift/rSA6AZMnaBRxJdt6YAkPHFv/04vsMNNvNu3G8vlyNOsVwqPpA==",
+					"requires": {
+						"fast-memoize": "^2.5.1"
+					}
+				}
 			}
 		},
 		"@wordpress/compose": {
@@ -36748,14 +36758,6 @@
 				"ini": "~1.3.0",
 				"minimist": "^1.2.0",
 				"strip-json-comments": "~2.0.1"
-			}
-		},
-		"re-resizable": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.0.0.tgz",
-			"integrity": "sha512-RTrnhbGgYyZ4hTc6db4JeMnRfmloEPWtuYaXZEa2PRaEC4mreWNFnZtMVsHil3z3iX+WchD+da8BLlTJBcstMA==",
-			"requires": {
-				"fast-memoize": "^2.5.1"
 			}
 		},
 		"react": {

--- a/packages/block-library/src/media-text/block.json
+++ b/packages/block-library/src/media-text/block.json
@@ -83,6 +83,7 @@
 			"full"
 		],
 		"html": false,
+		"lightBlockWrapper": true,
 		"__experimentalColor": {
 			"gradients": true,
 			"linkColor": true

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -14,6 +14,7 @@ import {
 	BlockVerticalAlignmentToolbar,
 	InnerBlocks,
 	InspectorControls,
+	__experimentalBlock as Block,
 	__experimentalImageURLInputUI as ImageURLInputUI,
 } from '@wordpress/block-editor';
 import {
@@ -107,7 +108,7 @@ function attributesFromMedia( {
 	};
 }
 
-function MediaTextEdit( { attributes, className, isSelected, setAttributes } ) {
+function MediaTextEdit( { attributes, isSelected, setAttributes } ) {
 	const {
 		focalPoint,
 		href,
@@ -150,7 +151,7 @@ function MediaTextEdit( { attributes, className, isSelected, setAttributes } ) {
 		setTemporaryMediaWidth( applyWidthConstraints( width ) );
 	};
 
-	const classNames = classnames( className, {
+	const classNames = classnames( {
 		'has-media-on-the-right': 'right' === mediaPosition,
 		'is-selected': isSelected,
 		'is-stacked-on-mobile': isStackedOnMobile,
@@ -263,7 +264,7 @@ function MediaTextEdit( { attributes, className, isSelected, setAttributes } ) {
 					</ToolbarGroup>
 				) }
 			</BlockControls>
-			<div className={ classNames } style={ style }>
+			<Block.div className={ classNames } style={ style }>
 				<MediaContainer
 					className="wp-block-media-text__media"
 					onSelectMedia={ onSelectMedia }
@@ -283,10 +284,14 @@ function MediaTextEdit( { attributes, className, isSelected, setAttributes } ) {
 					} }
 				/>
 				<InnerBlocks
+					__experimentalTagName="div"
+					__experimentalPassedProps={ {
+						className: 'wp-block-media-text__content',
+					} }
 					template={ TEMPLATE }
 					templateInsertUpdatesSelection={ false }
 				/>
-			</div>
+			</Block.div>
 		</>
 	);
 }

--- a/packages/block-library/src/media-text/editor.scss
+++ b/packages/block-library/src/media-text/editor.scss
@@ -3,30 +3,7 @@
 	grid-row: 2;
 }
 
-.wp-block-media-text.is-vertically-aligned-top {
-	.block-editor-inner-blocks,
-	.editor-media-container__resizer {
-		align-self: start;
-	}
-}
-.wp-block-media-text,
-.wp-block-media-text.is-vertically-aligned-center {
-	.block-editor-inner-blocks,
-	.editor-media-container__resizer {
-		align-self: center;
-	}
-}
-
-.wp-block-media-text.is-vertically-aligned-bottom {
-	.block-editor-inner-blocks,
-	.editor-media-container__resizer {
-		align-self: end;
-	}
-}
-
 .wp-block-media-text .editor-media-container__resizer {
-	grid-column: 1;
-	grid-row: 1;
 	// The resizer sets a inline width but as we are using a grid layout,
 	// we set the width on container.
 	width: 100% !important;
@@ -37,47 +14,6 @@
 	height: 100% !important;
 }
 
-.wp-block-media-text.has-media-on-the-right .editor-media-container__resizer {
-	grid-column: 2;
-	grid-row: 1;
-}
-
-.wp-block-media-text > .block-editor-inner-blocks {
-	word-break: break-word;
-	grid-column: 2;
-	grid-row: 1;
-	text-align: initial;
-	padding: 0 8% 0 8%;
-}
-
-.wp-block-media-text.has-media-on-the-right .block-editor-inner-blocks {
-	grid-column: 1;
-	grid-row: 1;
-}
-
-.wp-block-media-text > .block-editor-inner-blocks > .block-editor-block-list__layout > .block-editor-block-list__block {
+.wp-block-media-text > .block-editor-block-list__layout > .block-editor-block-list__block {
 	max-width: unset;
-}
-
-@media (max-width: #{ ($break-small) }) {
-	.wp-block-media-text.is-stacked-on-mobile {
-		.block-editor-inner-blocks {
-			grid-column: 1;
-			grid-row: 2;
-		}
-		.editor-media-container__resizer {
-			grid-column: 1;
-			grid-row: 1;
-		}
-	}
-	.wp-block-media-text.is-stacked-on-mobile.has-media-on-the-right {
-		.block-editor-inner-blocks {
-			grid-column: 1;
-			grid-row: 1;
-		}
-		.editor-media-container__resizer {
-			grid-column: 1;
-			grid-row: 2;
-		}
-	}
 }

--- a/packages/block-library/src/media-text/media-container.js
+++ b/packages/block-library/src/media-text/media-container.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import { noop } from 'lodash';
 
 /**
@@ -137,7 +138,12 @@ function MediaContainer( props ) {
 
 		return (
 			<ResizableBoxContainer
-				className="editor-media-container__resizer"
+				as="figure"
+				className={ classnames(
+					className,
+					'editor-media-container__resizer'
+				) }
+				style={ backgroundStyles }
 				size={ { width: mediaWidth + '%' } }
 				minWidth="10%"
 				maxWidth="100%"
@@ -154,9 +160,7 @@ function MediaContainer( props ) {
 					mediaUrl={ mediaUrl }
 					mediaId={ mediaId }
 				/>
-				<figure className={ className } style={ backgroundStyles }>
-					{ ( mediaTypeRenderers[ mediaType ] || noop )() }
-				</figure>
+				{ ( mediaTypeRenderers[ mediaType ] || noop )() }
 			</ResizableBoxContainer>
 		);
 	}

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -50,7 +50,7 @@
 		"lodash": "^4.17.15",
 		"memize": "^1.1.0",
 		"moment": "^2.22.1",
-		"re-resizable": "^6.0.0",
+		"re-resizable": "^6.4.0",
 		"react-dates": "^17.1.1",
 		"react-spring": "^8.0.20",
 		"react-use-gesture": "^7.0.15",


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

This PR ultimately makes the Media & Text editor markup match that of the frontend by:

- Refactoring the Media & Text edit method to be a functional component
- Use light block DOM (needs update if https://github.com/WordPress/gutenberg/pull/23034 lands)
- Bump re-resizable for https://github.com/bokuweb/re-resizable/pull/614 to support using `<figure>` as the resizable wrapper.
  - I'm not sure I did this correctly? Looking at `package-lock.json` the dependency got moved around could someone verify if it's correct or not? FWIW I used `lerna boostrap`

## How has this been tested?

Tested adding video as well as image and toggling all the attributes to see that everything is working.

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
