### PR TITLE
Asynchronously load TinyMCE (when possible)

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -162,6 +162,36 @@ function gutenberg_rest_nonce() {
 }
 add_action( 'wp_ajax_gutenberg_rest_nonce', 'gutenberg_rest_nonce' );
 
+function gutenberg_does_post_have_classic_block( $post ) {
+	$parsed = parse_blocks( $post->post_content );
+
+	function check_for_classic_block_recursive( $block ) {
+		$block_name = $block['blockName'];
+		if ( is_null( $block_name ) || 'core/freeform' == $block_name ) {
+			return true;
+		}
+		if ( empty( $block->children ) ) {
+			return false;
+		}
+
+		foreach ( $block->children as $child ) {
+			if ( check_for_classic_block_recursive( $child ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	foreach ( $parsed as $block ) {
+		if ( check_for_classic_block_recursive( $block ) ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 /**
  * Prints TinyMCE scripts when we're outside of the block editor using
  * the default behavior by calling to the default action function from core.
@@ -177,7 +207,7 @@ add_action( 'wp_ajax_gutenberg_rest_nonce', 'gutenberg_rest_nonce' );
  * @since 7.9.1
  */
 function gutenberg_print_tinymce_scripts() {
-	global $wp_meta_boxes, $post_type;
+	global $wp_meta_boxes, $post_type, $post;
 	$current_screen = get_current_screen();
 
 	if ( ! $current_screen->is_block_editor() ) {
@@ -201,6 +231,12 @@ function gutenberg_print_tinymce_scripts() {
 				}
 			}
 		}
+	}
+
+	if ( gutenberg_does_post_have_classic_block( $post ) ) {
+		// if the classic block is already used then we cannot delay loading TinyMCE
+		wp_print_tinymce_scripts();
+		return;
 	}
 
 	// Otherwise we're in the block editor and should only print support scripts.

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -161,3 +161,25 @@ function gutenberg_rest_nonce() {
 	exit( wp_create_nonce( 'wp_rest' ) );
 }
 add_action( 'wp_ajax_gutenberg_rest_nonce', 'gutenberg_rest_nonce' );
+
+/**
+ * Prints TinyMCE scripts when we're outside of the block editor.
+ * Otherwise, use the default TinyMCE script printing behavior.
+ *
+ * @since 7.9.1
+ */
+function gutenberg_print_tinymce_scripts() {
+	$current_screen = get_current_screen();
+	if ( ! $current_screen->is_block_editor() ) {
+		// maybe also need to check a setting/feature flag? Put this behind phase 2?
+		wp_print_tinymce_scripts();
+	} else {
+		echo "<!-- Skipping TinyMCE in favor of loading async -->";
+		echo "<script type='text/javascript'>\n" .
+			"window.wpMceTranslation = function() {\n" .
+				_WP_Editors::wp_mce_translation() .
+			"\n};\n</script>\n";
+	}
+}
+remove_action( 'print_tinymce_scripts', 'wp_print_tinymce_scripts' );
+add_action( 'print_tinymce_scripts', 'gutenberg_print_tinymce_scripts' );

--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -5,6 +5,11 @@ import { Component } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import { BACKSPACE, DELETE, F10 } from '@wordpress/keycodes';
 
+/**
+ * Internal dependencies
+ */
+import LazyLoadTinyMCE from './lazy';
+
 const { wp } = window;
 
 function isTmceEmpty( editor ) {
@@ -23,7 +28,7 @@ function isTmceEmpty( editor ) {
 	return /^\n?$/.test( body.innerText || body.textContent );
 }
 
-export default class ClassicEdit extends Component {
+class ClassicEdit extends Component {
 	constructor( props ) {
 		super( props );
 		this.initialize = this.initialize.bind( this );
@@ -216,3 +221,11 @@ export default class ClassicEdit extends Component {
 		/* eslint-enable jsx-a11y/no-static-element-interactions */
 	}
 }
+
+const LazyClassicEdit = ( props ) => (
+	<LazyLoadTinyMCE>
+		<ClassicEdit { ...props } />
+	</LazyLoadTinyMCE>
+);
+
+export default LazyClassicEdit;

--- a/packages/block-library/src/classic/lazy.js
+++ b/packages/block-library/src/classic/lazy.js
@@ -3,28 +3,49 @@
  */
 import { useState, useEffect } from '@wordpress/element';
 
-const loadTinyMCEScripts = async () =>
-	window.wpTinyMCEOrderedScriptURIs.reduce(
-		async ( previousPromise, uri ) => {
+const alreadyLoadedURIs = new Set();
+
+const loadTinyMCEScripts = async () => {
+	let count;
+	await window.wpTinyMCEOrderedScriptURIs.reduce(
+		( previousPromise, uri ) => {
+			if ( alreadyLoadedURIs.has( uri ) ) {
+				// if the dependency has already been loaded, skip it
+				return previousPromise;
+			}
+
 			// we need to serially load depenendencies as each could depend on the previous
-			await previousPromise;
-			return new Promise( ( resolve, reject ) => {
-				const scriptElement = document.createElement( 'script' );
-				scriptElement.type = 'application/javascript';
-				scriptElement.src = uri;
-				scriptElement.onload = resolve;
-				scriptElement.onerror = reject;
-				document.head.appendChild( scriptElement );
-			} );
+			return previousPromise.then( () =>
+				new Promise( ( resolve, reject ) => {
+					const scriptElement = document.createElement( 'script' );
+					scriptElement.type = 'application/javascript';
+					scriptElement.src = uri;
+					scriptElement.onload = resolve;
+					scriptElement.onerror = reject;
+					document.head.appendChild( scriptElement );
+				} ).then( () => {
+					count++;
+					alreadyLoadedURIs.add( uri );
+				} )
+			);
 		},
 		Promise.resolve()
 	);
+	return count;
+};
 
 const LazyLoadTinyMCE = ( { children, placeholder } ) => {
 	const [ isLoaded, setIsLoaded ] = useState( false );
 	useEffect( () => {
-		loadTinyMCEScripts().then( () => {
-			window.wpMceTranslation();
+		loadTinyMCEScripts().then( ( loadedCount ) => {
+			if ( loadedCount > 0 ) {
+				/**
+				 * In the case when all the dependencies have already been loaded
+				 * for another instance of the classic block, we don't need to re-init
+				 * the translations, so we can safely skip it if the loaded count is 0.
+				 */
+				window.wpMceTranslation();
+			}
 			setIsLoaded( true );
 		} );
 	}, [] );

--- a/packages/block-library/src/classic/lazy.js
+++ b/packages/block-library/src/classic/lazy.js
@@ -1,0 +1,89 @@
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+
+/**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+
+export default class LazyLoad extends Component {
+	static loadedScripts = new Set();
+	static loadedStyles = new Set();
+	static defaultProps = {
+		scripts: [],
+		styles: [],
+		placeholder: null,
+		onLoaded: () => Promise.resolve(),
+		onError: noop,
+	};
+
+	state = {
+		loaded: false,
+	};
+
+	loadScripts = async () => {
+		const scriptsToLoad = this.props.scripts.filter(
+			( script ) => ! this.loadedScripts.has( script )
+		);
+
+		if ( scriptsToLoad.length === 0 ) {
+			return Promise.resolve();
+		}
+
+		await new Promise( ( resolve, reject ) => {
+			const scriptElement = document.createElement( 'script' );
+			// can't use load-scripts.php, so this would need to be replaced
+			scriptElement.src = `/wp-admin/load-scripts.php?load=${ scriptsToLoad.join(
+				','
+			) }`;
+			scriptElement.onload = resolve;
+			scriptElement.onerror = reject;
+			document.head.appendChild( scriptElement );
+		} );
+
+		scriptsToLoad.forEach( ( script ) => this.loadedScripts.add( script ) );
+	};
+
+	loadStyles = async () => {
+		const stylesToLoad = this.props.styles.filter(
+			( style ) => ! this.loadedStyles.has( style )
+		);
+
+		if ( stylesToLoad.length === 0 ) {
+			return Promise.resolve();
+		}
+
+		await new Promise( ( resolve, reject ) => {
+			const linkElement = document.createElement( 'link' );
+			linkElement.rel = 'stylesheet';
+			// can't use load-styles.php, so this would need to be replaced
+			linkElement.href = `/wp-admin/load-styles.php?load=${ stylesToLoad.join(
+				','
+			) }`;
+			linkElement.onload = resolve;
+			linkElement.onerror = reject;
+			document.head.appendChild( linkElement );
+		} );
+
+		stylesToLoad.forEach( ( style ) => this.loadedStyles.add( style ) );
+	};
+
+	componentDidMount() {
+		Promise.all( [ this.loadScripts(), this.loadStyles() ] )
+			.then( this.props.onLoaded )
+			.then( () => {
+				this.setState( { loaded: true } );
+			} )
+			.catch( this.props.onError );
+	}
+
+	render() {
+		if ( this.state.loaded ) {
+			return this.props.children;
+		}
+
+		return this.props.placeholder;
+	}
+}

--- a/packages/block-library/src/classic/lazy.js
+++ b/packages/block-library/src/classic/lazy.js
@@ -2,6 +2,8 @@
  * WordPress dependencies
  */
 import { useState, useEffect } from '@wordpress/element';
+import { speak } from '@wordpress/a11y';
+import { __ } from '@wordpress/i18n';
 
 const alreadyLoadedURIs = new Set();
 
@@ -27,7 +29,7 @@ const loadTinyMCEScripts = () =>
 		);
 	}, Promise.resolve() );
 
-const LazyLoadTinyMCE = ( { children, placeholder } ) => {
+const LazyLoadTinyMCE = ( { children } ) => {
 	/**
 	 * TinyMCE has already been loaded. This happens on page-load
 	 * when a the post type has custom metaboxes or, more commonly,
@@ -46,17 +48,16 @@ const LazyLoadTinyMCE = ( { children, placeholder } ) => {
 			return;
 		}
 
+		speak( __( 'The classic block is loading.' ) );
+
 		loadTinyMCEScripts().then( () => {
 			window.wpMceTranslation();
 			setIsLoaded( true );
+			speak( __( 'The classic block has finished loading.' ) );
 		} );
 	}, [ isLoaded ] );
 
-	return isLoaded ? children : placeholder;
-};
-
-LazyLoadTinyMCE.defaultProps = {
-	placeholder: null,
+	return isLoaded ? children : null;
 };
 
 export default LazyLoadTinyMCE;

--- a/packages/block-library/src/classic/lazy.js
+++ b/packages/block-library/src/classic/lazy.js
@@ -35,17 +35,25 @@ const loadTinyMCEScripts = async () => {
 };
 
 const LazyLoadTinyMCE = ( { children, placeholder } ) => {
-	const [ isLoaded, setIsLoaded ] = useState( false );
+	/**
+	 * TinyMCE has already been loaded. This happens on page-load
+	 * when a the post type has custom metaboxes or, more commonly,
+	 * when TinyMCE was already lazily-loaded for another instance
+	 * of the classic block.
+	 *
+	 * In this case there's nothing to lazily load, so we can go ahead
+	 * and set `isLoaded` to true.
+	 */
+	const isTinyMCEAlreadyLoaded = typeof window.tinymce !== 'undefined';
+
+	const [ isLoaded, setIsLoaded ] = useState( isTinyMCEAlreadyLoaded );
 	useEffect( () => {
-		loadTinyMCEScripts().then( ( loadedCount ) => {
-			if ( loadedCount > 0 ) {
-				/**
-				 * In the case when all the dependencies have already been loaded
-				 * for another instance of the classic block, we don't need to re-init
-				 * the translations, so we can safely skip it if the loaded count is 0.
-				 */
-				window.wpMceTranslation();
-			}
+		if ( isLoaded ) {
+			return;
+		}
+
+		loadTinyMCEScripts().then( () => {
+			window.wpMceTranslation();
 			setIsLoaded( true );
 		} );
 	}, [] );


### PR DESCRIPTION
## The problem

TinyMCE is a huge dependency that is used rarely in the context of the block editor. Primarily it is used to support the classic block and some meta boxes. In total (TinyMCE core and plugins) it costs 272.274KB in compressed trasferred JS and 1,007.209KB parsed (that's over a MB in parse!). This is a big cost to pay for something that many users will never interact with.

The solution I'm exploring in this PR is to offset loading TinyMCE as often as possible until it is needed. Given certain edge cases and exclusions, this would offset the cost of loading TinyMCE except in the following case, which are the minority of use cases:
1. We cannot do this when non-backwards compat meta boxes are installed as they may depend on TinyMCE (as in the case of [Advanced Custom Fields](https://wordpress.org/plugins/advanced-custom-fields/), for example).
2. We cannot do this when a classic block is already being used on a post (for reasons described in this comment https://github.com/WordPress/gutenberg/issues/2768#issuecomment-644313150 in the "Problems with blocks already used on a post" section).

Otherwise, when the classic block has not already been added to a post or when custom meta boxes aren't installed, we can offset the TinyMCE dependency until the block's `edit` is run. Indeed, in this case, if someone never uses the classic block, they will not pay the penalty for having it.

[There was an existing draft PR for asynchronously loading TinyMCE](https://github.com/WordPress/gutenberg/pull/21684) that built upon an existing PR in Gutenberg that introduced a REST API for retrieving a list of dependencies. This REST API isn't technically necessary for asynchronously loading TinyMCE for the classic block, it was included in the draft PR as a way of looking forward to enabling similar async behavior in other blocks.

However, the REST API itself presents some complexities and concerns:

1. REST calls to WP are expensive as all of WP needs to spin up, and in the current implementation it could require more than one call if someone ran with the experimental version.
2. While the REST API does return inline scripts, TinyMCE’s inline scripts are complex and varied (there are three, not all are "registered" in `WP_Scripts`).

Because we can get the URL for TinyMCE without using a REST API (partially it's already available in the `tinyMCEPreInit` object but this won't be sufficient as I describe below) I think we can shortcut getting a win against TinyMCE around the REST API.

To accomplish this async TinyMCE project, I propose the following:
1. Creat a `LazyLoadTinyMCE` component to wrap the `ClassicEdit` component.
    * This `LazyLoadTinyMCE` component is basically a TinyMCE specific version of the the solution described in [this PR](https://github.com/WordPress/gutenberg/issues/23098). 
2. Cutting TinyMCE from the initial pageload of the block editor whenever possible.

### TinyMCE URLs

There is one caveat about using `tinyMCEPreInit.baseURL` is that [we need to decide which TinyMCE script to use as different scripts are used for different environments and compression settings](https://github.com/WordPress/wordpress-develop/blob/4691f60b96b1cd9cba87942f6f998888f0139091/src/wp-includes/script-loader.php#L44-L65). I’m not totally sure how to get this information to the frontend. One potential solution is to use `$wp_scripts->registered['wp-tinymce']->deps` and then follow a strategy similar to [`get_url` in the REST API PR](https://github.com/WordPress/gutenberg/pull/21244/files#diff-b4433f8de6cf7e9adb0064642269095bR32) to retrieve the URI for the `wp-tinymce` scripts and then add those to an array the frontend can use. Adding functionality like `get_url` to `WP_Scripts` directly would be good for making the functionality available generally. It could alternatively be added as a utility function in Gutenberg's plugin, but in any case, it would need to be available outside the REST API.

### Stopping WordPress from equeueing TinyMCE

Along with that, we also need to be enable Gutenberg to prevent core from enqueuing the TinyMCE scripts. To do that we ought to move the printing of the editor scripts into an action that can be overwritten by the plugin. This trac ticket proposes that change: https://core.trac.wordpress.org/ticket/49964

### Edge cases/exclusions

#### Meta boxes

As stated above, there are some exceptions to when we can do this. Meta boxes present a backwards compatability issue as some of them depend directly on TinyMCE. Meta box development hasn’t stopped and widely used plugins like Advanced Custom Fields depend on them. Preserving the ability for meta boxes that depend on TinyMCE to continue to work is part of the work for v1. We’ll do this by disabling async TinyMCE when we detect that custom meta boxes are being used.

From what I understand at the moment [`edit-form-blocks.php` enqueues the editor scripts before processing metabox data](https://href.li/?https://github.com/WordPress/wordpress-develop/blob/4691f60b96b1cd9cba87942f6f998888f0139091/src/wp-admin/edit-form-blocks.php#L361:L383). Ideally we would like to have already run through processing meta boxes before we render scripts for the editor so that we have some basis for deciding whether meta boxes are really being used. `register_and_do_post_meta_boxes` takes care of processing meta boxes for a post. I think we can move this logic before the call to `wp_enqueue_editor` in `edit-form-blocks.php` without consequence and then look into the `global $wp_meta_boxes` in the action we'll add in Gutenberg to override TinyMCE script printing.

#### When the classic block is already used on a post

When a post is first loaded into the block editor, the `edit` for each block gets run. This means that when a classic block exists on a post, TinyMCE will be needed immediately on page load. Asynchronously loading TinyMCE here isn't possible because we need to render the block's contents into the editor. I think we should solve this by cutting this from the scope of the async TinyMCE project and instead solve it as part of the wider project to async all block dependencies whenever possible (if indeed it is a solvable problem).

We'll need to introspect into a posts `post_content` and decide whether we think the classic block is being used. There already exists a function `has_blocks`, however it relies on the block's boundaries being renderedinto the `post_content` and unfortunately, the classic block doesn't render block markup comments. So the only way I can think of right now to do it is to run the post through `parse_blocks` and then walk the block tree and see if a `core/freeform` block exists.

### Summary of changes

To summarize, we need to make changes to WordPress core and Gutenberg.

* Core
	1. Devise a way to detect whether meta boxes that use TinyMCE are present that would be usable the Gutenberg plugin so that it can decide when to follow the default path of eagerly loading TinyMCE.
	2. Start injecting the TinyMCE dependency URIs into the frontend.
	3. Move printing editor scripts into an action overridable by the Gutenberg plugin so that we can prevent TinyMCE scripts from being injected when meta boxes are not present and when the classic block is not already being used for the post being edited.
* Gutenberg
	1. Create a version of the LazyLoad component that is able to load dependencies from URIs and that does not use the REST API.
	2. Prevent TinyMCE from being loaded by overriding the action we created in core. Also print translation initialization into a JS function to be executed by `LazyLoadTinyMCE` once the dependency is loaded.
	3. Wrap the classic block’s edit component with `LazyLoadTinyMCE`.

Completing the above will deliver a significant decrease in JavaScript download and parse times for most Gutenberg users.

## Alternatives
We could move TinyMCE into the block directory, however then every post would pay the cost of the dependency, regardless of whether it was going to be used, so I don't think this is an adequate solution.

Alternatively, we could move it into the block directory and then have the block directory offset loading a block's dependencies until it is edited... but that's just the other more general solution documented in https://github.com/WordPress/gutenberg/issues/2768.

## What this PR actually does
This PR adds a `LazyLoadTinyMCE` component that wraps the classic block. This component delays the rendering of the classic block's edit component until TinyMCE has been loaded.

The PR depends on changes proposed in https://github.com/WordPress/wordpress-develop/pull/232.

On a clean WordPress and Gutenberg install, this offsets approximately 272.274KB in transfer and 1,007.209KB parsed (that's over a MB in parse!) after TinyMCE itself and all the various plugins.

## How has this been tested?
Using a WP installation running the changes in https://github.com/WordPress/wordpress-develop/pull/232:
1. Load the editor for both a post that does and does not have a classic block on it and verify that TinyMCE scripts were not requested on the initial page load by checking the network tab in the browser's development tools
2. Add a classic block to a post that does not already have a classic block. Verify that when this is done that:
    1. Request(s) for the TinyMCE script(s) are made
    2. `window.tinymce` exists
    3. The classic block is now editable
    4. Aside from the delay in the block being editable, that there are no differences in behavior from master
    5. Changes to the classic block's content are preserved and saved
    6. Subsequent classic blocks added or edited to no re-request the TinyMCE scripts
3. Open a post that already has a classic block. 
    1. Verify the classic block rendering matches master's behavior (the "Classic" bar appears above the content of the classic block)
    2. Verify you can edit the classic block.
    3. Verify you can add new classic blocks.
    4. Verify that there are no extra requests to retrieve TinyMCE aside from the initial page load.
4. Add a meta box that does not declare `__back_compat_meta_box` in its args (using [ACF](https://wordpress.org/plugins/advanced-custom-fields/) for example) for a specific post type. Edit and create a new post of that post type and verify that TinyMCE is loaded on page load and not re-loaded when a classic block is added or edited.
5. Add a meta box as described in (4) but then edit a post type that does _not_ have the custom meta box. Verify that TinyMCE is still asynchronously loaded and that the criteria from (2) still pass.

## Types of changes
This is a new feature. The only user-facing change in behavior will be a delay between when a classic block is "edited" and when it is actually "editable".

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
