### PR TITLE
Refactor CalendarEdit component

### DIFF
--- a/packages/block-library/src/calendar/edit.js
+++ b/packages/block-library/src/calendar/edit.js
@@ -24,11 +24,8 @@ const getYearMonth = memoize( ( date ) => {
 
 export default function CalendarEdit( { attributes } ) {
 	const date = useSelect( ( select ) => {
-		const coreEditorSelect = select( 'core/editor' );
-		if ( ! coreEditorSelect ) {
-			return;
-		}
-		const { getEditedPostAttribute } = coreEditorSelect;
+		const { getEditedPostAttribute } = select( 'core/editor' );
+
 		const postType = getEditedPostAttribute( 'type' );
 		// Dates are used to overwrite year and month used on the calendar.
 		// This overwrite should only happen for 'post' post types.

--- a/packages/block-library/src/calendar/edit.js
+++ b/packages/block-library/src/calendar/edit.js
@@ -8,69 +8,42 @@ import memoize from 'memize';
  * WordPress dependencies
  */
 import { Disabled } from '@wordpress/components';
-import { Component } from '@wordpress/element';
-import { withSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import ServerSideRender from '@wordpress/server-side-render';
 
-class CalendarEdit extends Component {
-	constructor() {
-		super( ...arguments );
-		this.getYearMonth = memoize( this.getYearMonth.bind( this ), {
-			maxSize: 1,
-		} );
-		this.getServerSideAttributes = memoize(
-			this.getServerSideAttributes.bind( this ),
-			{
-				maxSize: 1,
-			}
-		);
+const getYearMonth = memoize( ( date ) => {
+	if ( ! date ) {
+		return {};
 	}
-
-	getYearMonth( date ) {
-		if ( ! date ) {
-			return {};
-		}
-		const momentDate = moment( date );
-		return {
-			year: momentDate.year(),
-			month: momentDate.month() + 1,
-		};
-	}
-
-	getServerSideAttributes( attributes, date ) {
-		return {
-			...attributes,
-			...this.getYearMonth( date ),
-		};
-	}
-
-	render() {
-		return (
-			<Disabled>
-				<ServerSideRender
-					block="core/calendar"
-					attributes={ this.getServerSideAttributes(
-						this.props.attributes,
-						this.props.date
-					) }
-				/>
-			</Disabled>
-		);
-	}
-}
-
-export default withSelect( ( select ) => {
-	const coreEditorSelect = select( 'core/editor' );
-	if ( ! coreEditorSelect ) {
-		return;
-	}
-	const { getEditedPostAttribute } = coreEditorSelect;
-	const postType = getEditedPostAttribute( 'type' );
-	// Dates are used to overwrite year and month used on the calendar.
-	// This overwrite should only happen for 'post' post types.
-	// For other post types the calendar always displays the current month.
+	const momentDate = moment( date );
 	return {
-		date:
-			postType === 'post' ? getEditedPostAttribute( 'date' ) : undefined,
+		year: momentDate.year(),
+		month: momentDate.month() + 1,
 	};
-} )( CalendarEdit );
+} );
+
+export default function CalendarEdit( { attributes } ) {
+	const date = useSelect( ( select ) => {
+		const coreEditorSelect = select( 'core/editor' );
+		if ( ! coreEditorSelect ) {
+			return;
+		}
+		const { getEditedPostAttribute } = coreEditorSelect;
+		const postType = getEditedPostAttribute( 'type' );
+		// Dates are used to overwrite year and month used on the calendar.
+		// This overwrite should only happen for 'post' post types.
+		// For other post types the calendar always displays the current month.
+		return postType === 'post'
+			? getEditedPostAttribute( 'date' )
+			: undefined;
+	}, [] );
+
+	return (
+		<Disabled>
+			<ServerSideRender
+				block="core/calendar"
+				attributes={ { ...attributes, ...getYearMonth( date ) } }
+			/>
+		</Disabled>
+	);
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Related to #22890
<!-- Please describe what you have changed or added -->

## How has this been tested?
Tested this by inserting Calendar block in Post and Page post type. Compared the result with the previous component on the editor and frontend. Also, I compare the passed props on `ServerSideRender` and it looks fine.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
Removed the `getServerSideAttributes` function, I don't think it is needed. ~It has memoization but it is not working, I think it is because we pass an object `attributes` param and the `memize` library does not make a shallow comparison.~ Edit: The memoization actually works with non-primitive data types, I was just testing it wrong.
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->