### PR TITLE
[RNMmobile] Set default RichText fontSize and LineHeight

### DIFF
--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -702,7 +702,9 @@ export class RichText extends Component {
 		const {
 			color: defaultColor,
 			textDecorationColor: defaultTextDecorationColor,
+			fontSize: defaultFontSize,
 			fontFamily: defaultFontFamily,
+			lineHeight: defaultLineHeight,
 		} = getStylesFromColorScheme( styles.richText, styles.richTextDark );
 
 		let selection = null;
@@ -813,10 +815,17 @@ export class RichText extends Component {
 					maxImagesWidth={ 200 }
 					fontFamily={ this.props.fontFamily || defaultFontFamily }
 					fontSize={
-						this.props.fontSize || ( style && style.fontSize )
+						this.props.fontSize ||
+						( style && style.fontSize ) ||
+						defaultFontSize
 					}
 					fontWeight={ this.props.fontWeight }
 					fontStyle={ this.props.fontStyle }
+					lineHeight={
+						this.props.lineHeight ||
+						( style && style.lineHeight ) ||
+						defaultLineHeight
+					}
 					disableEditingMenu={ this.props.disableEditingMenu }
 					isMultiline={ this.isMultiline }
 					textAlign={ this.props.textAlign }

--- a/packages/rich-text/src/component/style.native.scss
+++ b/packages/rich-text/src/component/style.native.scss
@@ -3,6 +3,8 @@
 	font-family: $default-regular-font;
 	color: $gray-900;
 	text-decoration-color: $blue-500;
+	font-size: 16px;
+	line-height: 26px;
 	background-color: transparent;
 }
 


### PR DESCRIPTION
This PR add support for setting the default `fontSize` and `lineHeight` of the native mobile RichText component, by setting those values in its `style.native.scss` file.

The default values are set to:
* fontSize: 16px
* lineHeight: 26px

See https://github.com/wordpress-mobile/gutenberg-mobile/issues/550 for the related design.

## How has this been tested?
Using this gutenberg-mobile PR: TBD

## Types of changes
1. Sending the `lineHeight` prop to RCTAztecView
2. `lineHeight`'s value is taken from the `props`, the `style` or the scss file
3. `fontSize` is augmented to take into account the value set in the scss file too

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
