### PR TITLE
Remove padding inheritance on lists in editor-styles

### DIFF
--- a/packages/editor/src/editor-styles.scss
+++ b/packages/editor/src/editor-styles.scss
@@ -103,7 +103,6 @@ p {
 ul,
 ol {
 	margin-bottom: $default-block-margin;
-	padding: inherit;
 	padding-left: 1.3em;
 	margin-left: 1.3em;
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

Currently `<ul>` and `<ol>` elements displayed in the editor inherit their padding from their parent elements for a (to me) unknown reason. @jasmussen can you recall why [it was set](https://github.com/WordPress/gutenberg/pull/14407/files#diff-b175fef433360d2d2c873fdd717e5f05R106)?

The issue is that if a theme sets a padding on the inner container of eg. Media & Text, Cover or Group, on the editor side that same padding gets applied to child lists as well. Something that's becoming more apparent now with the lighter block DOM I guess.

Overall I'm not confident if it can be unset and someone else should probably have a look at this too.

The one thing it does change is that first level lists and lists within Media & text blocks no longer have a padding-right inherited but I dont see the purpose of this. Eg. paragraphs do not have this padding.

## How has this been tested?

I tested by enabling twentytwenty and toggling the removal of the attribute after creating a list block as a direct child of the post as well as within a Media & Text block, a Cover Block and a Group block.


## Types of changes

Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
