### PR TITLE
Set scroll velocity from drag distance

### DIFF
--- a/packages/block-editor/src/components/block-draggable/index.js
+++ b/packages/block-editor/src/components/block-draggable/index.js
@@ -128,9 +128,13 @@ const BlockDraggable = ( {
 			onDragOver={ ( event ) => {
 				const distanceY = event.clientY - dragStartY.current;
 				if ( distanceY > SCROLL_INACTIVE_DISTANCE_PX ) {
-					velocityY.current = VELOCITY_MULTIPLIER * ( distanceY - SCROLL_INACTIVE_DISTANCE_PX );
+					velocityY.current =
+						VELOCITY_MULTIPLIER *
+						( distanceY - SCROLL_INACTIVE_DISTANCE_PX );
 				} else if ( distanceY < -SCROLL_INACTIVE_DISTANCE_PX ) {
-					velocityY.current = VELOCITY_MULTIPLIER * ( distanceY + SCROLL_INACTIVE_DISTANCE_PX );
+					velocityY.current =
+						VELOCITY_MULTIPLIER *
+						( distanceY + SCROLL_INACTIVE_DISTANCE_PX );
 				} else {
 					velocityY.current = 0;
 				}

--- a/packages/block-editor/src/components/block-draggable/index.js
+++ b/packages/block-editor/src/components/block-draggable/index.js
@@ -5,6 +5,7 @@ import { Draggable } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
 
+const SCROLL_INACTIVE_DISTANCE_PX = 50;
 const SCROLL_INTERVAL_MS = 50;
 const PIXELS_PER_SECOND_PER_DISTANCE = 5;
 const VELOCITY_MULTIPLIER =
@@ -126,7 +127,13 @@ const BlockDraggable = ( {
 			} }
 			onDragOver={ ( event ) => {
 				const distanceY = event.clientY - dragStartY.current;
-				velocityY.current = VELOCITY_MULTIPLIER * distanceY;
+				if ( distanceY > SCROLL_INACTIVE_DISTANCE_PX ) {
+					velocityY.current = VELOCITY_MULTIPLIER * ( distanceY - SCROLL_INACTIVE_DISTANCE_PX );
+				} else if ( distanceY < -SCROLL_INACTIVE_DISTANCE_PX ) {
+					velocityY.current = VELOCITY_MULTIPLIER * ( distanceY + SCROLL_INACTIVE_DISTANCE_PX );
+				} else {
+					velocityY.current = 0;
+				}
 			} }
 			onDragEnd={ () => {
 				stopDraggingBlocks();

--- a/packages/block-editor/src/components/block-draggable/index.js
+++ b/packages/block-editor/src/components/block-draggable/index.js
@@ -107,10 +107,10 @@ const BlockDraggable = ( {
 			cloneClassname={ cloneClassname }
 			elementId={ blockElementId }
 			transferData={ transferData }
-			onDragStart={ ( clientX, clientY ) => {
+			onDragStart={ ( event ) => {
 				startDraggingBlocks();
 				isDragging.current = true;
-				dragStartY.current = clientY;
+				dragStartY.current = event.clientY;
 
 				// find nearest parent(s) to scroll
 				scrollParentY.current = getVerticalScrollParent(

--- a/packages/block-editor/src/components/block-draggable/index.js
+++ b/packages/block-editor/src/components/block-draggable/index.js
@@ -24,7 +24,6 @@ function startScrollingY( nodeRef, velocityRef ) {
 	}, SCROLL_INTERVAL_MS );
 }
 
-// @see https://stackoverflow.com/questions/35939886/find-first-scrollable-parent
 function getVerticalScrollParent( node ) {
 	if ( node === null ) {
 		return null;

--- a/packages/block-editor/src/components/block-draggable/index.js
+++ b/packages/block-editor/src/components/block-draggable/index.js
@@ -4,6 +4,7 @@
 import { Draggable } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
+import { getScrollContainer } from '@wordpress/dom';
 
 const SCROLL_INACTIVE_DISTANCE_PX = 50;
 const SCROLL_INTERVAL_MS = 25;
@@ -29,8 +30,7 @@ function getVerticalScrollParent( node ) {
 		return null;
 	}
 
-	// @todo - remove this hack and get a real reference to the scroll parent
-	return node.closest( '.interface-interface-skeleton__content' );
+	return getScrollContainer( node );
 }
 
 const BlockDraggable = ( {

--- a/packages/block-editor/src/components/block-draggable/index.js
+++ b/packages/block-editor/src/components/block-draggable/index.js
@@ -6,7 +6,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
 
 const SCROLL_INACTIVE_DISTANCE_PX = 50;
-const SCROLL_INTERVAL_MS = 50;
+const SCROLL_INTERVAL_MS = 25;
 const PIXELS_PER_SECOND_PER_DISTANCE = 5;
 const VELOCITY_MULTIPLIER =
 	PIXELS_PER_SECOND_PER_DISTANCE * ( SCROLL_INTERVAL_MS / 1000 );

--- a/packages/block-editor/src/components/block-draggable/index.js
+++ b/packages/block-editor/src/components/block-draggable/index.js
@@ -5,7 +5,41 @@ import { Draggable } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
 
-const BlockDraggable = ( { children, clientIds, cloneClassname } ) => {
+const SCROLL_INTERVAL_MS = 50;
+const PIXELS_PER_SECOND_PER_DISTANCE = 5;
+const VELOCITY_MULTIPLIER =
+	PIXELS_PER_SECOND_PER_DISTANCE * ( SCROLL_INTERVAL_MS / 1000 );
+
+function startScrollingY( nodeRef, velocityRef ) {
+	return setInterval( () => {
+		if ( nodeRef.current && velocityRef.current ) {
+			const newTop = nodeRef.current.scrollTop + velocityRef.current;
+
+			nodeRef.current.scroll( {
+				top: newTop,
+				// behavior: 'smooth' // seems to hurt performance, better to use a small scroll interval
+			} );
+		}
+	}, SCROLL_INTERVAL_MS );
+}
+
+// @see https://stackoverflow.com/questions/35939886/find-first-scrollable-parent
+function getVerticalScrollParent( node ) {
+	if ( node === null ) {
+		return null;
+	}
+
+	// @todo - remove this hack and get a real reference to the scroll parent
+	return node.closest( '.interface-interface-skeleton__content' );
+}
+
+const BlockDraggable = ( {
+	children,
+	clientIds,
+	cloneClassname,
+	onDragStart,
+	onDragEnd,
+} ) => {
 	const { srcRootClientId, index, isDraggable } = useSelect(
 		( select ) => {
 			const {
@@ -30,6 +64,14 @@ const BlockDraggable = ( { children, clientIds, cloneClassname } ) => {
 		[ clientIds ]
 	);
 	const isDragging = useRef( false );
+
+	// @todo - do this for horizontal scroll
+	const dragStartY = useRef( null );
+	const velocityY = useRef( null );
+	const scrollParentY = useRef( null );
+
+	const scrollEditorInterval = useRef( null );
+
 	const { startDraggingBlocks, stopDraggingBlocks } = useDispatch(
 		'core/block-editor'
 	);
@@ -39,6 +81,11 @@ const BlockDraggable = ( { children, clientIds, cloneClassname } ) => {
 		return () => {
 			if ( isDragging.current ) {
 				stopDraggingBlocks();
+			}
+
+			if ( scrollEditorInterval.current ) {
+				clearInterval( scrollEditorInterval.current );
+				scrollEditorInterval.current = null;
 			}
 		};
 	}, [] );
@@ -60,13 +107,41 @@ const BlockDraggable = ( { children, clientIds, cloneClassname } ) => {
 			cloneClassname={ cloneClassname }
 			elementId={ blockElementId }
 			transferData={ transferData }
-			onDragStart={ () => {
+			onDragStart={ ( clientX, clientY ) => {
 				startDraggingBlocks();
 				isDragging.current = true;
+				dragStartY.current = clientY;
+
+				// find nearest parent(s) to scroll
+				scrollParentY.current = getVerticalScrollParent(
+					document.getElementById( blockElementId )
+				);
+				scrollEditorInterval.current = startScrollingY(
+					scrollParentY,
+					velocityY
+				);
+				if ( onDragStart ) {
+					onDragStart();
+				}
+			} }
+			onDragOver={ ( event ) => {
+				const distanceY = event.clientY - dragStartY.current;
+				velocityY.current = VELOCITY_MULTIPLIER * distanceY;
 			} }
 			onDragEnd={ () => {
 				stopDraggingBlocks();
 				isDragging.current = false;
+				dragStartY.current = null;
+				scrollParentY.current = null;
+
+				if ( scrollEditorInterval.current ) {
+					clearInterval( scrollEditorInterval.current );
+					scrollEditorInterval.current = null;
+				}
+
+				if ( onDragEnd ) {
+					onDragEnd();
+				}
 			} }
 		>
 			{ ( { onDraggableStart, onDraggableEnd } ) => {

--- a/packages/block-editor/src/components/block-list/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-list/block-contextual-toolbar.js
@@ -39,7 +39,10 @@ function BlockContextualToolbar( { focusOnMount, ...props } ) {
 				aria-label={ __( 'Block tools' ) }
 				{ ...props }
 			>
-				<BlockToolbar />
+				<BlockToolbar
+					onDragStart={ props.onDragStart }
+					onDragEnd={ props.onDragEnd }
+				/>
 			</NavigableToolbar>
 		</div>
 	);

--- a/packages/block-editor/src/components/block-list/block-popover.js
+++ b/packages/block-editor/src/components/block-list/block-popover.js
@@ -177,7 +177,9 @@ function BlockPopover( {
 			onBlur={ () => setIsToolbarForced( false ) }
 			shouldAnchorIncludePadding
 			// Popover calculates the width once. Trigger a reset by remounting
-			// the component.
+			// the component. We include both shouldShowContextualToolbar and isToolbarForced
+			// in the key to prevent the component being unmounted unexpectedly when isToolbarForced = true,
+			// e.g. during drag and drop
 			key={ shouldShowContextualToolbar || isToolbarForced }
 		>
 			{ ( shouldShowContextualToolbar || isToolbarForced ) && (

--- a/packages/block-editor/src/components/block-list/block-popover.js
+++ b/packages/block-editor/src/components/block-list/block-popover.js
@@ -7,11 +7,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import {
-	useState,
-	useCallback,
-	useContext,
-} from '@wordpress/element';
+import { useState, useCallback, useContext } from '@wordpress/element';
 import { isUnmodifiedDefaultBlock } from '@wordpress/blocks';
 import { Popover } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';

--- a/packages/components/src/draggable/README.md
+++ b/packages/components/src/draggable/README.md
@@ -24,7 +24,15 @@ Arbitrary data object attached to the drag and drop event.
 
 ### onDragStart
 
-A function to be called when dragging starts.
+A function called when dragging starts. This callback receives the `event` object from the `dragstart` event as its first parameter.
+
+-   Type: `Function`
+-   Required: No
+-   Default: `noop`
+
+### onDragOver
+
+A function called when the element being dragged is dragged over a valid drop target. This callback receives the `event` object from the `dragover` event as its first parameter.
 
 -   Type: `Function`
 -   Required: No
@@ -32,7 +40,7 @@ A function to be called when dragging starts.
 
 ### onDragEnd
 
-A function to be called when dragging ends.
+A function called when dragging ends. This callback receives the `event` object from the `dragend` event as its first parameter.
 
 -   Type: `Function`
 -   Required: No

--- a/packages/components/src/draggable/index.js
+++ b/packages/components/src/draggable/index.js
@@ -38,7 +38,11 @@ class Draggable extends Component {
 		event.preventDefault();
 
 		this.resetDragState();
-		this.props.setTimeout( onDragEnd );
+
+		// Allow the Synthetic Event to be accessed from asynchronous code.
+		// https://reactjs.org/docs/events.html#event-pooling
+		event.persist();
+		this.props.setTimeout( onDragEnd.bind( this, event ) );
 	}
 
 	/**
@@ -64,6 +68,8 @@ class Draggable extends Component {
 
 		const { onDragOver = noop } = this.props;
 
+		// The `event` from `onDragOver` is not a SyntheticEvent
+		// and so it doesn't require `event.persist()`.
 		this.props.setTimeout( onDragOver.bind( this, event ) );
 	}
 
@@ -154,9 +160,10 @@ class Draggable extends Component {
 		document.body.classList.add( 'is-dragging-components-draggable' );
 		document.addEventListener( 'dragover', this.onDragOver );
 
-		this.props.setTimeout(
-			onDragStart.bind( this, event.clientX, event.clientY )
-		);
+		// Allow the Synthetic Event to be accessed from asynchronous code.
+		// https://reactjs.org/docs/events.html#event-pooling
+		event.persist();
+		this.props.setTimeout( onDragStart.bind( this, event ) );
 	}
 
 	/**

--- a/packages/components/src/draggable/index.js
+++ b/packages/components/src/draggable/index.js
@@ -61,6 +61,10 @@ class Draggable extends Component {
 		// Update cursor coordinates.
 		this.cursorLeft = event.clientX;
 		this.cursorTop = event.clientY;
+
+		const { onDragOver = noop } = this.props;
+
+		this.props.setTimeout( onDragOver.bind( this, event ) );
 	}
 
 	/**
@@ -150,7 +154,9 @@ class Draggable extends Component {
 		document.body.classList.add( 'is-dragging-components-draggable' );
 		document.addEventListener( 'dragover', this.onDragOver );
 
-		this.props.setTimeout( onDragStart );
+		this.props.setTimeout(
+			onDragStart.bind( this, event.clientX, event.clientY )
+		);
 	}
 
 	/**
@@ -164,6 +170,9 @@ class Draggable extends Component {
 			this.cloneWrapper.parentNode.removeChild( this.cloneWrapper );
 			this.cloneWrapper = null;
 		}
+
+		this.cursorLeft = null;
+		this.cursorTop = null;
 
 		// Reset cursor.
 		document.body.classList.remove( 'is-dragging-components-draggable' );

--- a/packages/components/src/draggable/style.scss
+++ b/packages/components/src/draggable/style.scss
@@ -16,6 +16,7 @@ body.is-dragging-components-draggable {
 	background: transparent;
 	pointer-events: none;
 	z-index: z-index(".components-draggable__clone");
+	opacity: 0.7;
 
 	> * {
 		// This needs specificity as a theme is meant to define these by default.


### PR DESCRIPTION
## Description

Current scrolling behaviour is somewhat unintuitive. The user needs to drag the item to the top of the viewport, and only then does scrolling begin. Also, the scroll placeholder is fully opaque. These two effects combine to make it hard to know where you're scrolling to, and to control scroll velocity.

This PR sets the vertical scroll velocity of the nearest suitable parent according to a function F of the vertical distance between the current mouse position and the Y position where the drag started. 

It also sets the opacity of the drag placeholder to 0.7.

## How has this been tested?

I just messed with it til it worked, sorry.

## Screenshots <!-- if applicable -->

Video of previous behaviour: https://cloudup.com/cMcikA6icrw

Video of new behaviour: https://cloudup.com/c7UJlVgp5ry

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Changes how scroll velocity reacts to cursor position while dragging.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
