### PR TITLE
Consolidate disparate "copy block" actions

### DIFF
--- a/packages/block-editor/src/components/block-actions/index.js
+++ b/packages/block-editor/src/components/block-actions/index.js
@@ -85,7 +85,6 @@ export default function BlockActions( { clientIds, children } ) {
 			}
 			replaceBlocks( clientIds, newBlocks );
 		},
-
 		onUngroup() {
 			if ( ! blocks.length ) {
 				return;

--- a/packages/block-editor/src/components/block-actions/index.js
+++ b/packages/block-editor/src/components/block-actions/index.js
@@ -22,6 +22,7 @@ function BlockActions( {
 	onRemove,
 	onUngroup,
 	blocks,
+	onCopy,
 } ) {
 	return children( {
 		canDuplicate,
@@ -34,6 +35,7 @@ function BlockActions( {
 		onRemove,
 		onUngroup,
 		blocks,
+		onCopy,
 	} );
 }
 
@@ -80,6 +82,7 @@ export default compose( [
 			duplicateBlocks,
 			insertAfterBlock,
 			insertBeforeBlock,
+			flashBlock,
 		} = dispatch( 'core/block-editor' );
 
 		return {
@@ -128,6 +131,10 @@ export default compose( [
 				}
 
 				replaceBlocks( clientIds, innerBlocks );
+			},
+			onCopy() {
+				const [ { clientId: selectedBlockClientId } ] = blocks;
+				flashBlock( selectedBlockClientId );
 			},
 		};
 	} ),

--- a/packages/block-editor/src/components/block-actions/index.js
+++ b/packages/block-editor/src/components/block-actions/index.js
@@ -6,136 +6,107 @@ import { castArray, first, last, every } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { compose } from '@wordpress/compose';
-import { withSelect, withDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { hasBlockSupport, switchToBlockType } from '@wordpress/blocks';
 
-function BlockActions( {
-	canDuplicate,
-	canInsertDefaultBlock,
-	children,
-	isLocked,
-	onDuplicate,
-	onGroup,
-	onInsertAfter,
-	onInsertBefore,
-	onRemove,
-	onUngroup,
-	blocks,
-	onCopy,
-} ) {
+/**
+ * Internal dependencies
+ */
+import { useNotifyCopy } from '../copy-handler';
+
+export default function BlockActions( { clientIds, children } ) {
+	const {
+		canInsertBlockType,
+		getBlockRootClientId,
+		getBlocksByClientId,
+		getTemplateLock,
+	} = useSelect( ( select ) => select( 'core/block-editor' ), [] );
+	const {
+		getDefaultBlockName,
+		getGroupingBlockName,
+	} = useSelect( ( select ) => select( 'core/blocks' ) );
+
+	const blocks = getBlocksByClientId( clientIds );
+	const rootClientId = getBlockRootClientId( clientIds[ 0 ] );
+	const canDuplicate = every( blocks, ( block ) => {
+		return (
+			!! block &&
+			hasBlockSupport( block.name, 'multiple', true ) &&
+			canInsertBlockType( block.name, rootClientId )
+		);
+	} );
+
+	const canInsertDefaultBlock = canInsertBlockType(
+		getDefaultBlockName(),
+		rootClientId
+	);
+
+	const {
+		removeBlocks,
+		replaceBlocks,
+		duplicateBlocks,
+		insertAfterBlock,
+		insertBeforeBlock,
+		flashBlock,
+	} = useDispatch( 'core/block-editor' );
+
+	const notifyCopy = useNotifyCopy();
+
 	return children( {
 		canDuplicate,
 		canInsertDefaultBlock,
-		isLocked,
-		onDuplicate,
-		onGroup,
-		onInsertAfter,
-		onInsertBefore,
-		onRemove,
-		onUngroup,
+		isLocked: !! getTemplateLock( rootClientId ),
+		rootClientId,
 		blocks,
-		onCopy,
+		onDuplicate() {
+			return duplicateBlocks( clientIds );
+		},
+		onRemove() {
+			removeBlocks( clientIds );
+		},
+		onInsertBefore() {
+			insertBeforeBlock( first( castArray( clientIds ) ) );
+		},
+		onInsertAfter() {
+			insertAfterBlock( last( castArray( clientIds ) ) );
+		},
+		onGroup() {
+			if ( ! blocks.length ) {
+				return;
+			}
+
+			const groupingBlockName = getGroupingBlockName();
+
+			// Activate the `transform` on `core/group` which does the conversion
+			const newBlocks = switchToBlockType( blocks, groupingBlockName );
+
+			if ( ! newBlocks ) {
+				return;
+			}
+			replaceBlocks( clientIds, newBlocks );
+		},
+
+		onUngroup() {
+			if ( ! blocks.length ) {
+				return;
+			}
+
+			const innerBlocks = blocks[ 0 ].innerBlocks;
+
+			if ( ! innerBlocks.length ) {
+				return;
+			}
+
+			replaceBlocks( clientIds, innerBlocks );
+		},
+		onCopy() {
+			const selectedBlockClientIds = blocks.map(
+				( { clientId } ) => clientId
+			);
+			if ( blocks.length === 1 ) {
+				flashBlock( selectedBlockClientIds[ 0 ] );
+			}
+			notifyCopy( 'copy', selectedBlockClientIds );
+		},
 	} );
 }
-
-export default compose( [
-	withSelect( ( select, props ) => {
-		const {
-			canInsertBlockType,
-			getBlockRootClientId,
-			getBlocksByClientId,
-			getTemplateLock,
-		} = select( 'core/block-editor' );
-		const { getDefaultBlockName } = select( 'core/blocks' );
-
-		const blocks = getBlocksByClientId( props.clientIds );
-		const rootClientId = getBlockRootClientId( props.clientIds[ 0 ] );
-		const canDuplicate = every( blocks, ( block ) => {
-			return (
-				!! block &&
-				hasBlockSupport( block.name, 'multiple', true ) &&
-				canInsertBlockType( block.name, rootClientId )
-			);
-		} );
-
-		const canInsertDefaultBlock = canInsertBlockType(
-			getDefaultBlockName(),
-			rootClientId
-		);
-
-		return {
-			blocks,
-			canDuplicate,
-			canInsertDefaultBlock,
-			extraProps: props,
-			isLocked: !! getTemplateLock( rootClientId ),
-			rootClientId,
-		};
-	} ),
-	withDispatch( ( dispatch, props, { select } ) => {
-		const { clientIds, blocks } = props;
-
-		const {
-			removeBlocks,
-			replaceBlocks,
-			duplicateBlocks,
-			insertAfterBlock,
-			insertBeforeBlock,
-			flashBlock,
-		} = dispatch( 'core/block-editor' );
-
-		return {
-			onDuplicate() {
-				return duplicateBlocks( clientIds );
-			},
-			onRemove() {
-				removeBlocks( clientIds );
-			},
-			onInsertBefore() {
-				insertBeforeBlock( first( castArray( clientIds ) ) );
-			},
-			onInsertAfter() {
-				insertAfterBlock( last( castArray( clientIds ) ) );
-			},
-			onGroup() {
-				if ( ! blocks.length ) {
-					return;
-				}
-
-				const { getGroupingBlockName } = select( 'core/blocks' );
-
-				const groupingBlockName = getGroupingBlockName();
-
-				// Activate the `transform` on `core/group` which does the conversion
-				const newBlocks = switchToBlockType(
-					blocks,
-					groupingBlockName
-				);
-
-				if ( ! newBlocks ) {
-					return;
-				}
-				replaceBlocks( clientIds, newBlocks );
-			},
-
-			onUngroup() {
-				if ( ! blocks.length ) {
-					return;
-				}
-
-				const innerBlocks = blocks[ 0 ].innerBlocks;
-
-				if ( ! innerBlocks.length ) {
-					return;
-				}
-
-				replaceBlocks( clientIds, innerBlocks );
-			},
-			onCopy() {
-				const [ { clientId: selectedBlockClientId } ] = blocks;
-				flashBlock( selectedBlockClientId );
-			},
-		};
-	} ),
-] )( BlockActions );

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -98,7 +98,6 @@ export function BlockSettingsDropdown( { clientIds, ...props } ) {
 									role="menuitem"
 									className="components-menu-item__button"
 									onCopy={ onCopy }
-									onFinishCopy={ onClose }
 								>
 									{ __( 'Copy' ) }
 								</ClipboardButton>

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -15,7 +15,6 @@ import {
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { moreHorizontal } from '@wordpress/icons';
-import { useState } from '@wordpress/element';
 import { serialize } from '@wordpress/blocks';
 
 /**
@@ -57,8 +56,6 @@ export function BlockSettingsDropdown( { clientIds, ...props } ) {
 		};
 	}, [] );
 
-	const [ hasCopied, setHasCopied ] = useState();
-
 	return (
 		<BlockActions clientIds={ clientIds }>
 			{ ( {
@@ -69,6 +66,7 @@ export function BlockSettingsDropdown( { clientIds, ...props } ) {
 				onInsertAfter,
 				onInsertBefore,
 				onRemove,
+				onCopy,
 				blocks,
 			} ) => (
 				<DropdownMenu
@@ -99,14 +97,10 @@ export function BlockSettingsDropdown( { clientIds, ...props } ) {
 									text={ () => serialize( blocks ) }
 									role="menuitem"
 									className="components-menu-item__button"
-									onCopy={ () => {
-										setHasCopied( true );
-									} }
-									onFinishCopy={ () => setHasCopied( false ) }
+									onCopy={ onCopy }
+									onFinishCopy={ onClose }
 								>
-									{ hasCopied
-										? __( 'Copied!' )
-										: __( 'Copy' ) }
+									{ __( 'Copy' ) }
 								</ClipboardButton>
 								{ canDuplicate && (
 									<MenuItem

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -15,7 +15,7 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import { getPasteEventData } from '../../utils/get-paste-event-data';
 
-function useNotifyCopy() {
+export function useNotifyCopy() {
 	const { getBlockName } = useSelect(
 		( select ) => select( 'core/block-editor' ),
 		[]

--- a/packages/components/src/clipboard-button/index.js
+++ b/packages/components/src/clipboard-button/index.js
@@ -31,9 +31,9 @@ export default function ClipboardButton( {
 			return;
 		}
 
-		if ( hasCopied && typeof onCopy === 'function' ) {
+		if ( hasCopied ) {
 			onCopy();
-		} else if ( typeof onFinishCopy === 'function' ) {
+		} else if ( onFinishCopy ) {
 			onFinishCopy();
 		}
 

--- a/packages/components/src/clipboard-button/index.js
+++ b/packages/components/src/clipboard-button/index.js
@@ -31,9 +31,9 @@ export default function ClipboardButton( {
 			return;
 		}
 
-		if ( hasCopied ) {
+		if ( hasCopied && typeof onCopy === 'function' ) {
 			onCopy();
-		} else {
+		} else if ( typeof onFinishCopy === 'function' ) {
 			onFinishCopy();
 		}
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Resolves #23031

Two recent PRs have added ways to more conveniently copy an entire block from the editor, one using the Ctrl-C and Ctrl-X keyboard shortcuts (#22186), one using a new "Copy" menu item in the block's advanced settings (#22214).

While these achieve the same result for the user, their implementations follow different User experience on how the user is notified about the **copy** action.

In this PR using the "Copy" menu item no longer results in the updating the label to "Copied", but rather results in flashing the block and displaying a snackbar notification.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
