### PR TITLE
[Gutenberg Mobile] Add External Link support to React Native

### DIFF
--- a/packages/components/src/external-link/index.native.js
+++ b/packages/components/src/external-link/index.native.js
@@ -8,7 +8,6 @@ import { TouchableOpacity, Text, Linking } from 'react-native';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { forwardRef } from '@wordpress/element';
 import { external, Icon } from '@wordpress/icons';
 
 export function ExternalLink( { href, children } ) {
@@ -23,4 +22,4 @@ export function ExternalLink( { href, children } ) {
 	);
 }
 
-export default forwardRef( ExternalLink );
+export default ExternalLink;

--- a/packages/components/src/external-link/index.native.js
+++ b/packages/components/src/external-link/index.native.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+
+import { TouchableOpacity, Text, Linking } from 'react-native';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { forwardRef } from '@wordpress/element';
+import { external, Icon } from '@wordpress/icons';
+
+export function ExternalLink( { href, children } ) {
+	return (
+		<TouchableOpacity
+			onPress={ () => Linking.openURL( href ) }
+			accessibilityLabel={ __( 'Open link in a browser' ) }
+		>
+			<Text>{ children }</Text>
+			<Icon icon={ external } />
+		</TouchableOpacity>
+	);
+}
+
+export default forwardRef( ExternalLink );

--- a/packages/components/src/index.native.js
+++ b/packages/components/src/index.native.js
@@ -33,6 +33,7 @@ export { default as PanelBody } from './panel/body';
 export { default as PanelActions } from './panel/actions';
 export { default as Button } from './button';
 export { default as __experimentalText } from './text';
+export { default as ExternalLink } from './external-link';
 export { default as TextControl } from './text-control';
 export { default as ToggleControl } from './toggle-control';
 export { default as SelectControl } from './select-control';


### PR DESCRIPTION
## Description
Related Gutenberg Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2374

Currently when you insert a Header Block you see the following error. 
<img width="1086" alt="Screen Shot 2020-06-11 at 3 53 18 PM" src="https://user-images.githubusercontent.com/115071/84393857-69998b00-abfc-11ea-9bb7-737edec10d16.png">

The regression was introduced in https://github.com/WordPress/gutenberg/commit/a9171623c40f5aa92ea797f1a6026b79651374ef#diff-78f749ce9638e8f9d7190a6ac691f1b7R24
it adds the the `anchor` hook that uses ExternalLink component hence giving the error in the console.

This PR tries to fix this by adding a new ExternalLink Component. 
Notice that this component is not visible anywhere in UI just yet. 

## How has this been tested?
On React Native insert a new Header Block Component. 
Notice that the error doesn't appear any more. 

## Types of changes
- Adds new ExternalLink Component.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
