### PR TITLE
Image block: split huge component

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -268,10 +268,14 @@ export function ImageEdit( {
 		[ `size-${ sizeSlug }` ]: sizeSlug,
 	} );
 
+	// Focussing the image caption after inserting an image relies on the
+	// component remounting. This needs to be fixed.
+	const key = !! url;
+
 	return (
 		<>
 			{ controls }
-			<Block.figure ref={ ref } className={ classes }>
+			<Block.figure ref={ ref } className={ classes } key={ key }>
 				{ url && (
 					<Image
 						attributes={ attributes }

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -2,54 +2,35 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { get, filter, map, last, omit, pick, includes } from 'lodash';
+import { get, omit, pick } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { getBlobByURL, isBlobURL, revokeBlobURL } from '@wordpress/blob';
-import {
-	ExternalLink,
-	PanelBody,
-	ResizableBox,
-	Spinner,
-	TextareaControl,
-	TextControl,
-	ToolbarGroup,
-	withNotices,
-} from '@wordpress/components';
-import { useViewportMatch } from '@wordpress/compose';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { withNotices } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 import {
 	BlockAlignmentToolbar,
 	BlockControls,
 	BlockIcon,
-	InspectorControls,
-	InspectorAdvancedControls,
 	MediaPlaceholder,
 	MediaReplaceFlow,
-	RichText,
 	__experimentalBlock as Block,
-	__experimentalImageSizeControl as ImageSizeControl,
-	__experimentalImageURLInputUI as ImageURLInputUI,
 } from '@wordpress/block-editor';
-import { useEffect, useState, useRef } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
-import { getPath } from '@wordpress/url';
+import { useEffect, useRef } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import { image as icon } from '@wordpress/icons';
-import { createBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
-import { createUpgradedEmbedBlock } from '../embed/util';
-import useImageSize from './image-size';
+import Image from './image';
 
 /**
  * Module constants
  */
 import {
-	MIN_SIZE,
 	LINK_DESTINATION_MEDIA,
 	LINK_DESTINATION_ATTACHMENT,
 	ALLOWED_MEDIA_TYPES,
@@ -87,30 +68,8 @@ const isTemporaryImage = ( id, url ) => ! id && isBlobURL( url );
  */
 const isExternalImage = ( id, url ) => url && ! id && ! isBlobURL( url );
 
-function getFilename( url ) {
-	const path = getPath( url );
-	if ( path ) {
-		return last( path.split( '/' ) );
-	}
-}
-
 export function ImageEdit( {
-	attributes: {
-		url = '',
-		alt,
-		caption,
-		align,
-		id,
-		href,
-		rel,
-		linkClass,
-		linkDestination,
-		title,
-		width,
-		height,
-		linkTarget,
-		sizeSlug,
-	},
+	attributes,
 	setAttributes,
 	isSelected,
 	className,
@@ -119,35 +78,22 @@ export function ImageEdit( {
 	noticeOperations,
 	onReplace,
 } ) {
+	const {
+		url = '',
+		alt,
+		caption,
+		align,
+		id,
+		linkDestination,
+		width,
+		height,
+		sizeSlug,
+	} = attributes;
 	const ref = useRef();
-	const { image, maxWidth, isRTL, imageSizes, mediaUpload } = useSelect(
-		( select ) => {
-			const { getMedia } = select( 'core' );
-			const { getSettings } = select( 'core/block-editor' );
-			return {
-				...pick( getSettings(), [
-					'mediaUpload',
-					'imageSizes',
-					'isRTL',
-					'maxWidth',
-				] ),
-				image: id && isSelected ? getMedia( id ) : null,
-			};
-		},
-		[ id, isSelected ]
-	);
-	const { toggleSelection } = useDispatch( 'core/block-editor' );
-	const isLargeViewport = useViewportMatch( 'medium' );
-	const [ captionFocused, setCaptionFocused ] = useState( false );
-	const isWideAligned = includes( [ 'wide', 'full' ], align );
-
-	function onResizeStart() {
-		toggleSelection( false );
-	}
-
-	function onResizeStop() {
-		toggleSelection( true );
-	}
+	const mediaUpload = useSelect( ( select ) => {
+		const { getSettings } = select( 'core/block-editor' );
+		return getSettings().mediaUpload;
+	} );
 
 	function onUploadError( message ) {
 		noticeOperations.removeAllNotices();
@@ -224,40 +170,6 @@ export function ImageEdit( {
 		}
 	}
 
-	function onImageError() {
-		// Check if there's an embed block that handles this URL.
-		const embedBlock = createUpgradedEmbedBlock( { attributes: { url } } );
-		if ( undefined !== embedBlock ) {
-			onReplace( embedBlock );
-		}
-	}
-
-	function onSetHref( props ) {
-		setAttributes( props );
-	}
-
-	function onSetTitle( value ) {
-		// This is the HTML title attribute, separate from the media object
-		// title.
-		setAttributes( { title: value } );
-	}
-
-	function onFocusCaption() {
-		if ( ! captionFocused ) {
-			setCaptionFocused( true );
-		}
-	}
-
-	function onImageClick() {
-		if ( captionFocused ) {
-			setCaptionFocused( false );
-		}
-	}
-
-	function updateAlt( newAlt ) {
-		setAttributes( { alt: newAlt } );
-	}
-
 	function updateAlignment( nextAlign ) {
 		const extraUpdatedAttributes = [ 'wide', 'full' ].includes( nextAlign )
 			? { width: undefined, height: undefined }
@@ -266,34 +178,6 @@ export function ImageEdit( {
 			...extraUpdatedAttributes,
 			align: nextAlign,
 		} );
-	}
-
-	function updateImage( newSizeSlug ) {
-		const newUrl = get( image, [
-			'media_details',
-			'sizes',
-			newSizeSlug,
-			'source_url',
-		] );
-		if ( ! newUrl ) {
-			return null;
-		}
-
-		setAttributes( {
-			url,
-			width: undefined,
-			height: undefined,
-			sizeSlug: newSizeSlug,
-		} );
-	}
-
-	function getImageSizeOptions() {
-		return map(
-			filter( imageSizes, ( { slug } ) =>
-				get( image, [ 'media_details', 'sizes', slug, 'source_url' ] )
-			),
-			( { name, slug } ) => ( { value: slug, label: name } )
-		);
 	}
 
 	const isTemp = isTemporaryImage( id, url );
@@ -332,12 +216,6 @@ export function ImageEdit( {
 		};
 	}, [ isTemp ] );
 
-	useEffect( () => {
-		if ( ! isSelected ) {
-			setCaptionFocused( false );
-		}
-	}, [ isSelected ] );
-
 	const isExternal = isExternalImage( id, url );
 	const controls = (
 		<BlockControls>
@@ -355,20 +233,6 @@ export function ImageEdit( {
 					onSelectURL={ onSelectURL }
 					onError={ onUploadError }
 				/>
-			) }
-			{ url && (
-				<ToolbarGroup>
-					<ImageURLInputUI
-						url={ href || '' }
-						onChangeUrl={ onSetHref }
-						linkDestination={ linkDestination }
-						mediaUrl={ image && image.source_url }
-						mediaLink={ image && image.link }
-						linkTarget={ linkTarget }
-						linkClass={ linkClass }
-						rel={ rel }
-					/>
-				</ToolbarGroup>
 			) }
 		</BlockControls>
 	);
@@ -397,22 +261,6 @@ export function ImageEdit( {
 		/>
 	);
 
-	const {
-		imageWidthWithinContainer,
-		imageHeightWithinContainer,
-		imageWidth,
-		imageHeight,
-	} = useImageSize( ref, url, [ align ] );
-
-	if ( ! url ) {
-		return (
-			<>
-				{ controls }
-				<Block.div>{ mediaPlaceholder }</Block.div>
-			</>
-		);
-	}
-
 	const classes = classnames( className, {
 		'is-transient': isBlobURL( url ),
 		'is-resized': !! width || !! height,
@@ -420,196 +268,18 @@ export function ImageEdit( {
 		[ `size-${ sizeSlug }` ]: sizeSlug,
 	} );
 
-	const isResizable = ! isWideAligned && isLargeViewport;
-	const imageSizeOptions = getImageSizeOptions();
-
-	const inspectorControls = (
-		<>
-			<InspectorControls>
-				<PanelBody title={ __( 'Image settings' ) }>
-					<TextareaControl
-						label={ __( 'Alt text (alternative text)' ) }
-						value={ alt }
-						onChange={ updateAlt }
-						help={
-							<>
-								<ExternalLink href="https://www.w3.org/WAI/tutorials/images/decision-tree">
-									{ __(
-										'Describe the purpose of the image'
-									) }
-								</ExternalLink>
-								{ __(
-									'Leave empty if the image is purely decorative.'
-								) }
-							</>
-						}
-					/>
-					<ImageSizeControl
-						onChangeImage={ updateImage }
-						onChange={ ( value ) => setAttributes( value ) }
-						slug={ sizeSlug }
-						width={ width }
-						height={ height }
-						imageSizeOptions={ imageSizeOptions }
-						isResizable={ isResizable }
-						imageWidth={ imageWidth }
-						imageHeight={ imageHeight }
-					/>
-				</PanelBody>
-			</InspectorControls>
-			<InspectorAdvancedControls>
-				<TextControl
-					label={ __( 'Title attribute' ) }
-					value={ title || '' }
-					onChange={ onSetTitle }
-					help={
-						<>
-							{ __(
-								'Describe the role of this image on the page.'
-							) }
-							<ExternalLink href="https://www.w3.org/TR/html52/dom.html#the-title-attribute">
-								{ __(
-									'(Note: many devices and browsers do not display this text.)'
-								) }
-							</ExternalLink>
-						</>
-					}
-				/>
-			</InspectorAdvancedControls>
-		</>
-	);
-
-	const filename = getFilename( url );
-	let defaultedAlt;
-
-	if ( alt ) {
-		defaultedAlt = alt;
-	} else if ( filename ) {
-		defaultedAlt = sprintf(
-			/* translators: %s: file name */
-			__( 'This image has an empty alt attribute; its file name is %s' ),
-			filename
-		);
-	} else {
-		defaultedAlt = __( 'This image has an empty alt attribute' );
-	}
-
-	let img = (
-		// Disable reason: Image itself is not meant to be interactive, but
-		// should direct focus to block.
-		/* eslint-disable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events */
-		<>
-			{ inspectorControls }
-			<img
-				src={ url }
-				alt={ defaultedAlt }
-				onClick={ onImageClick }
-				onError={ () => onImageError() }
-			/>
-			{ isBlobURL( url ) && <Spinner /> }
-		</>
-		/* eslint-enable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events */
-	);
-
-	if ( ! isResizable || ! imageWidthWithinContainer ) {
-		img = <div style={ { width, height } }>{ img }</div>;
-	} else {
-		const currentWidth = width || imageWidthWithinContainer;
-		const currentHeight = height || imageHeightWithinContainer;
-
-		const ratio = imageWidth / imageHeight;
-		const minWidth = imageWidth < imageHeight ? MIN_SIZE : MIN_SIZE * ratio;
-		const minHeight =
-			imageHeight < imageWidth ? MIN_SIZE : MIN_SIZE / ratio;
-
-		// With the current implementation of ResizableBox, an image needs an
-		// explicit pixel value for the max-width. In absence of being able to
-		// set the content-width, this max-width is currently dictated by the
-		// vanilla editor style. The following variable adds a buffer to this
-		// vanilla style, so 3rd party themes have some wiggleroom. This does,
-		// in most cases, allow you to scale the image beyond the width of the
-		// main column, though not infinitely.
-		// @todo It would be good to revisit this once a content-width variable
-		// becomes available.
-		const maxWidthBuffer = maxWidth * 2.5;
-
-		let showRightHandle = false;
-		let showLeftHandle = false;
-
-		/* eslint-disable no-lonely-if */
-		// See https://github.com/WordPress/gutenberg/issues/7584.
-		if ( align === 'center' ) {
-			// When the image is centered, show both handles.
-			showRightHandle = true;
-			showLeftHandle = true;
-		} else if ( isRTL ) {
-			// In RTL mode the image is on the right by default.
-			// Show the right handle and hide the left handle only when it is
-			// aligned left. Otherwise always show the left handle.
-			if ( align === 'left' ) {
-				showRightHandle = true;
-			} else {
-				showLeftHandle = true;
-			}
-		} else {
-			// Show the left handle and hide the right handle only when the
-			// image is aligned right. Otherwise always show the right handle.
-			if ( align === 'right' ) {
-				showLeftHandle = true;
-			} else {
-				showRightHandle = true;
-			}
-		}
-		/* eslint-enable no-lonely-if */
-
-		img = (
-			<ResizableBox
-				size={ { width, height } }
-				showHandle={ isSelected }
-				minWidth={ minWidth }
-				maxWidth={ maxWidthBuffer }
-				minHeight={ minHeight }
-				maxHeight={ maxWidthBuffer / ratio }
-				lockAspectRatio
-				enable={ {
-					top: false,
-					right: showRightHandle,
-					bottom: true,
-					left: showLeftHandle,
-				} }
-				onResizeStart={ onResizeStart }
-				onResizeStop={ ( event, direction, elt, delta ) => {
-					onResizeStop();
-					setAttributes( {
-						width: parseInt( currentWidth + delta.width, 10 ),
-						height: parseInt( currentHeight + delta.height, 10 ),
-					} );
-				} }
-			>
-				{ img }
-			</ResizableBox>
-		);
-	}
-
 	return (
 		<>
 			{ controls }
 			<Block.figure ref={ ref } className={ classes }>
-				{ img }
-				{ ( ! RichText.isEmpty( caption ) || isSelected ) && (
-					<RichText
-						tagName="figcaption"
-						placeholder={ __( 'Write caption…' ) }
-						value={ caption }
-						unstableOnFocus={ onFocusCaption }
-						onChange={ ( value ) =>
-							setAttributes( { caption: value } )
-						}
-						isSelected={ captionFocused }
-						inlineToolbar
-						__unstableOnSplitAtEnd={ () =>
-							insertBlocksAfter( createBlock( 'core/paragraph' ) )
-						}
+				{ url && (
+					<Image
+						attributes={ attributes }
+						setAttributes={ setAttributes }
+						isSelected={ isSelected }
+						insertBlocksAfter={ insertBlocksAfter }
+						onReplace={ onReplace }
+						containerRef={ ref }
 					/>
 				) }
 				{ mediaPlaceholder }

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -1,0 +1,376 @@
+/**
+ * External dependencies
+ */
+import { get, filter, map, last, pick, includes } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { isBlobURL } from '@wordpress/blob';
+import {
+	ExternalLink,
+	PanelBody,
+	ResizableBox,
+	Spinner,
+	TextareaControl,
+	TextControl,
+	ToolbarGroup,
+} from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
+import { useSelect, useDispatch } from '@wordpress/data';
+import {
+	BlockControls,
+	InspectorControls,
+	InspectorAdvancedControls,
+	RichText,
+	__experimentalImageSizeControl as ImageSizeControl,
+	__experimentalImageURLInputUI as ImageURLInputUI,
+} from '@wordpress/block-editor';
+import { useEffect, useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { getPath } from '@wordpress/url';
+import { createBlock } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { createUpgradedEmbedBlock } from '../embed/util';
+import useImageSize from './image-size';
+
+/**
+ * Module constants
+ */
+import { MIN_SIZE } from './constants';
+
+function getFilename( url ) {
+	const path = getPath( url );
+	if ( path ) {
+		return last( path.split( '/' ) );
+	}
+}
+
+export default function Image( {
+	attributes: {
+		url = '',
+		alt,
+		caption,
+		align,
+		id,
+		href,
+		rel,
+		linkClass,
+		linkDestination,
+		title,
+		width,
+		height,
+		linkTarget,
+		sizeSlug,
+	},
+	setAttributes,
+	isSelected,
+	insertBlocksAfter,
+	onReplace,
+	containerRef,
+} ) {
+	const image = useSelect(
+		( select ) => {
+			const { getMedia } = select( 'core' );
+			return id && isSelected ? getMedia( id ) : null;
+		},
+		[ id, isSelected ]
+	);
+	const { maxWidth, isRTL, imageSizes } = useSelect( ( select ) => {
+		const { getSettings } = select( 'core/block-editor' );
+		return pick( getSettings(), [ 'imageSizes', 'isRTL', 'maxWidth' ] );
+	} );
+	const { toggleSelection } = useDispatch( 'core/block-editor' );
+	const isLargeViewport = useViewportMatch( 'medium' );
+	const [ captionFocused, setCaptionFocused ] = useState( false );
+	const isWideAligned = includes( [ 'wide', 'full' ], align );
+	const {
+		imageWidthWithinContainer,
+		imageHeightWithinContainer,
+		imageWidth,
+		imageHeight,
+	} = useImageSize( containerRef, url, [ align ] );
+	const isResizable = ! isWideAligned && isLargeViewport;
+	const imageSizeOptions = map(
+		filter( imageSizes, ( { slug } ) =>
+			get( image, [ 'media_details', 'sizes', slug, 'source_url' ] )
+		),
+		( { name, slug } ) => ( { value: slug, label: name } )
+	);
+
+	useEffect( () => {
+		if ( ! isSelected ) {
+			setCaptionFocused( false );
+		}
+	}, [ isSelected ] );
+
+	function onResizeStart() {
+		toggleSelection( false );
+	}
+
+	function onResizeStop() {
+		toggleSelection( true );
+	}
+
+	function onImageError() {
+		// Check if there's an embed block that handles this URL.
+		const embedBlock = createUpgradedEmbedBlock( { attributes: { url } } );
+		if ( undefined !== embedBlock ) {
+			onReplace( embedBlock );
+		}
+	}
+
+	function onSetHref( props ) {
+		setAttributes( props );
+	}
+
+	function onSetTitle( value ) {
+		// This is the HTML title attribute, separate from the media object
+		// title.
+		setAttributes( { title: value } );
+	}
+
+	function onFocusCaption() {
+		if ( ! captionFocused ) {
+			setCaptionFocused( true );
+		}
+	}
+
+	function onImageClick() {
+		if ( captionFocused ) {
+			setCaptionFocused( false );
+		}
+	}
+
+	function updateAlt( newAlt ) {
+		setAttributes( { alt: newAlt } );
+	}
+
+	function updateImage( newSizeSlug ) {
+		const newUrl = get( image, [
+			'media_details',
+			'sizes',
+			newSizeSlug,
+			'source_url',
+		] );
+		if ( ! newUrl ) {
+			return null;
+		}
+
+		setAttributes( {
+			url,
+			width: undefined,
+			height: undefined,
+			sizeSlug: newSizeSlug,
+		} );
+	}
+
+	const controls = (
+		<>
+			<BlockControls>
+				{ url && (
+					<ToolbarGroup>
+						<ImageURLInputUI
+							url={ href || '' }
+							onChangeUrl={ onSetHref }
+							linkDestination={ linkDestination }
+							mediaUrl={ image && image.source_url }
+							mediaLink={ image && image.link }
+							linkTarget={ linkTarget }
+							linkClass={ linkClass }
+							rel={ rel }
+						/>
+					</ToolbarGroup>
+				) }
+			</BlockControls>
+			<InspectorControls>
+				<PanelBody title={ __( 'Image settings' ) }>
+					<TextareaControl
+						label={ __( 'Alt text (alternative text)' ) }
+						value={ alt }
+						onChange={ updateAlt }
+						help={
+							<>
+								<ExternalLink href="https://www.w3.org/WAI/tutorials/images/decision-tree">
+									{ __(
+										'Describe the purpose of the image'
+									) }
+								</ExternalLink>
+								{ __(
+									'Leave empty if the image is purely decorative.'
+								) }
+							</>
+						}
+					/>
+					<ImageSizeControl
+						onChangeImage={ updateImage }
+						onChange={ ( value ) => setAttributes( value ) }
+						slug={ sizeSlug }
+						width={ width }
+						height={ height }
+						imageSizeOptions={ imageSizeOptions }
+						isResizable={ isResizable }
+						imageWidth={ imageWidth }
+						imageHeight={ imageHeight }
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<InspectorAdvancedControls>
+				<TextControl
+					label={ __( 'Title attribute' ) }
+					value={ title || '' }
+					onChange={ onSetTitle }
+					help={
+						<>
+							{ __(
+								'Describe the role of this image on the page.'
+							) }
+							<ExternalLink href="https://www.w3.org/TR/html52/dom.html#the-title-attribute">
+								{ __(
+									'(Note: many devices and browsers do not display this text.)'
+								) }
+							</ExternalLink>
+						</>
+					}
+				/>
+			</InspectorAdvancedControls>
+		</>
+	);
+
+	const filename = getFilename( url );
+	let defaultedAlt;
+
+	if ( alt ) {
+		defaultedAlt = alt;
+	} else if ( filename ) {
+		defaultedAlt = sprintf(
+			/* translators: %s: file name */
+			__( 'This image has an empty alt attribute; its file name is %s' ),
+			filename
+		);
+	} else {
+		defaultedAlt = __( 'This image has an empty alt attribute' );
+	}
+
+	let img = (
+		// Disable reason: Image itself is not meant to be interactive, but
+		// should direct focus to block.
+		/* eslint-disable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events */
+		<>
+			{ controls }
+			<img
+				src={ url }
+				alt={ defaultedAlt }
+				onClick={ onImageClick }
+				onError={ () => onImageError() }
+			/>
+			{ isBlobURL( url ) && <Spinner /> }
+		</>
+		/* eslint-enable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events */
+	);
+
+	if ( ! isResizable || ! imageWidthWithinContainer ) {
+		img = <div style={ { width, height } }>{ img }</div>;
+	} else {
+		const currentWidth = width || imageWidthWithinContainer;
+		const currentHeight = height || imageHeightWithinContainer;
+
+		const ratio = imageWidth / imageHeight;
+		const minWidth = imageWidth < imageHeight ? MIN_SIZE : MIN_SIZE * ratio;
+		const minHeight =
+			imageHeight < imageWidth ? MIN_SIZE : MIN_SIZE / ratio;
+
+		// With the current implementation of ResizableBox, an image needs an
+		// explicit pixel value for the max-width. In absence of being able to
+		// set the content-width, this max-width is currently dictated by the
+		// vanilla editor style. The following variable adds a buffer to this
+		// vanilla style, so 3rd party themes have some wiggleroom. This does,
+		// in most cases, allow you to scale the image beyond the width of the
+		// main column, though not infinitely.
+		// @todo It would be good to revisit this once a content-width variable
+		// becomes available.
+		const maxWidthBuffer = maxWidth * 2.5;
+
+		let showRightHandle = false;
+		let showLeftHandle = false;
+
+		/* eslint-disable no-lonely-if */
+		// See https://github.com/WordPress/gutenberg/issues/7584.
+		if ( align === 'center' ) {
+			// When the image is centered, show both handles.
+			showRightHandle = true;
+			showLeftHandle = true;
+		} else if ( isRTL ) {
+			// In RTL mode the image is on the right by default.
+			// Show the right handle and hide the left handle only when it is
+			// aligned left. Otherwise always show the left handle.
+			if ( align === 'left' ) {
+				showRightHandle = true;
+			} else {
+				showLeftHandle = true;
+			}
+		} else {
+			// Show the left handle and hide the right handle only when the
+			// image is aligned right. Otherwise always show the right handle.
+			if ( align === 'right' ) {
+				showLeftHandle = true;
+			} else {
+				showRightHandle = true;
+			}
+		}
+		/* eslint-enable no-lonely-if */
+
+		img = (
+			<ResizableBox
+				size={ { width, height } }
+				showHandle={ isSelected }
+				minWidth={ minWidth }
+				maxWidth={ maxWidthBuffer }
+				minHeight={ minHeight }
+				maxHeight={ maxWidthBuffer / ratio }
+				lockAspectRatio
+				enable={ {
+					top: false,
+					right: showRightHandle,
+					bottom: true,
+					left: showLeftHandle,
+				} }
+				onResizeStart={ onResizeStart }
+				onResizeStop={ ( event, direction, elt, delta ) => {
+					onResizeStop();
+					setAttributes( {
+						width: parseInt( currentWidth + delta.width, 10 ),
+						height: parseInt( currentHeight + delta.height, 10 ),
+					} );
+				} }
+			>
+				{ img }
+			</ResizableBox>
+		);
+	}
+
+	return (
+		<>
+			{ img }
+			{ ( ! RichText.isEmpty( caption ) || isSelected ) && (
+				<RichText
+					tagName="figcaption"
+					placeholder={ __( 'Write caption…' ) }
+					value={ caption }
+					unstableOnFocus={ onFocusCaption }
+					onChange={ ( value ) =>
+						setAttributes( { caption: value } )
+					}
+					isSelected={ captionFocused }
+					inlineToolbar
+					__unstableOnSplitAtEnd={ () =>
+						insertBlocksAfter( createBlock( 'core/paragraph' ) )
+					}
+				/>
+			) }
+		</>
+	);
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

The image block component is becoming huge. I think it makes most sense to split between it having a url and having no url (placeholder and upload process). This also prevents hooks from running for the placeholder.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
