### PR TITLE
API description: Use a period at the end.

### DIFF
--- a/lib/class-wp-rest-block-types-controller.php
+++ b/lib/class-wp-rest-block-types-controller.php
@@ -79,11 +79,11 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 			array(
 				'args'   => array(
 					'name'      => array(
-						'description' => __( 'Block name', 'gutenberg' ),
+						'description' => __( 'Block name.', 'gutenberg' ),
 						'type'        => 'string',
 					),
 					'namespace' => array(
-						'description' => __( 'Block namespace', 'gutenberg' ),
+						'description' => __( 'Block namespace.', 'gutenberg' ),
 						'type'        => 'string',
 					),
 				),


### PR DESCRIPTION
## Description
Adds a period at the end of the argument description to unify it and simplify internationalization.