### PR TITLE
Remove volumes and networks in wp-env destroy

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `wp-env destroy` now removes dangling docker volumes and networks associated with the WordPress environment.
+
 ## 1.4.0 (2020-05-28)
 
 ### New Feature

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -258,7 +258,8 @@ wp> ^C
 ```sh
 wp-env destroy
 
-Destroy the WordPress environment. Delete docker containers and remove local files.
+Destroy the WordPress environment. Deletes docker containers, volumes, and
+networks associated with the WordPress environment and removes local files.
 ```
 
 ### `wp-env logs [environment]`

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -168,7 +168,7 @@ module.exports = function cli() {
 	yargs.command(
 		'destroy',
 		wpRed(
-			'Destroy the WordPress environment. Delete docker containers and remove local files.'
+			'Destroy the WordPress environment. Deletes docker containers, volumes, and networks associated with the WordPress environment and removes local files.'
 		),
 		() => {},
 		withSpinner( env.destroy )

--- a/packages/env/lib/commands/destroy.js
+++ b/packages/env/lib/commands/destroy.js
@@ -6,12 +6,12 @@ const util = require( 'util' );
 const fs = require( 'fs' ).promises;
 const path = require( 'path' );
 const inquirer = require( 'inquirer' );
-const exec = util.promisify( require( 'child_process' ).exec );
 
 /**
  * Promisified dependencies
  */
 const rimraf = util.promisify( require( 'rimraf' ) );
+const exec = util.promisify( require( 'child_process' ).exec );
 
 /**
  * Internal dependencies

--- a/packages/env/lib/commands/destroy.js
+++ b/packages/env/lib/commands/destroy.js
@@ -6,6 +6,7 @@ const util = require( 'util' );
 const fs = require( 'fs' ).promises;
 const path = require( 'path' );
 const inquirer = require( 'inquirer' );
+const exec = util.promisify( require( 'child_process' ).exec );
 
 /**
  * Promisified dependencies
@@ -15,7 +16,6 @@ const rimraf = util.promisify( require( 'rimraf' ) );
 /**
  * Internal dependencies
  */
-const stop = require( './stop' );
 const { readConfig } = require( '../../lib/config' );
 
 /**
@@ -38,7 +38,9 @@ module.exports = async function destroy( { spinner, debug } ) {
 		return;
 	}
 
-	spinner.info( 'WARNING! This will remove local volumes and containers.' );
+	spinner.info(
+		'WARNING! This will remove Docker containers, volumes, and networks associated with the WordPress instance.'
+	);
 
 	const { yesDelete } = await inquirer.prompt( [
 		{
@@ -56,14 +58,37 @@ module.exports = async function destroy( { spinner, debug } ) {
 		return;
 	}
 
-	await stop( { spinner, debug } );
-
 	spinner.text = 'Removing WordPress docker containers.';
 
 	await dockerCompose.rm( {
 		config: dockerComposeConfigPath,
+		commandOptions: [ '--stop', '-v' ],
 		log: debug,
 	} );
+
+	const directoryHash = path.basename( workDirectoryPath );
+
+	spinner.text = 'Removing docker networks and volumes.';
+	const getVolumes = `docker volume ls | grep "${ directoryHash }" | awk '/ / { print $2 }'`;
+	const removeVolumes = `docker volume rm $(${ getVolumes })`;
+
+	const getNetworks = `docker network ls | grep "${ directoryHash }" | awk '/ / { print $1 }'`;
+	const removeNetworks = `docker network rm $(${ getNetworks })`;
+
+	const command = `${ removeVolumes } && ${ removeNetworks }`;
+
+	if ( debug ) {
+		spinner.info(
+			`Running command to remove volumes and networks:\n${ command }\n`
+		);
+	}
+
+	const { stdout } = await exec( command );
+	if ( debug && stdout ) {
+		// Disable reason: Logging information in debug mode.
+		// eslint-disable-next-line no-console
+		console.log( `Removed volumes and networks:\n${ stdout }` );
+	}
 
 	spinner.text = 'Removing local files.';
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Previously, `wp-env destroy` did not remove volumes or networks. Practically, this meant that the database volume still existed after destroying the instance. Additionally, you would have dangling volumes & networks after running this command, which IMO is not expected behavior.

Effectively, this runs something like the following via nodejs exec:

```sh
id=41911d623e75a345e9ed228b9448cff6 # ~/.wp-env/ work directory basename

docker volume rm $(docker volume ls | grep "$id" | awk '/ / { print $2 }')

docker network rm $(docker network ls | grep "$id" | awk '/ / { print $1 }')
```

## How has this been tested?
by running `npx wp-env start` and then `npx wp-env destroy`. I compared the output of `docker volume ls` and `docker network ls` and verified that volumes & networks associated with the instance no longer show up.

## Screenshots <!-- if applicable -->

## Types of changes
Enhancement

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
