### PR TITLE
Add check theme support is an array before indexing

### DIFF
--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -199,33 +199,41 @@ function gutenberg_experimental_global_styles_get_core() {
 function gutenberg_experimental_global_styles_get_theme_presets() {
 	$theme_presets = array();
 
-	$theme_colors = get_theme_support( 'editor-color-palette' )[0];
-	if ( is_array( $theme_colors ) ) {
-		foreach ( $theme_colors as $color ) {
-			$theme_presets['global']['presets']['color'][] = array(
-				'slug'  => $color['slug'],
-				'value' => $color['color'],
-			);
+	$editor_color_palette_support = get_theme_support( 'editor-color-palette' );
+	if ( is_array( $editor_color_palette_support ) and count( $editor_color_palette_support ) >= 1 ) {
+		$theme_colors = $editor_color_palette_support[0];
+		if ( is_array( $theme_colors ) ) {
+			foreach ( $theme_colors as $color ) {
+				$theme_presets['global']['presets']['color'][] = array(
+					'slug'  => $color['slug'],
+					'value' => $color['color'],
+				);
+			}
 		}
 	}
 
-	$theme_gradients = get_theme_support( 'editor-gradient-presets' )[0];
-	if ( is_array( $theme_gradients ) ) {
-		foreach ( $theme_gradients as $gradient ) {
-			$theme_presets['global']['presets']['gradient'][] = array(
-				'slug'  => $gradient['slug'],
-				'value' => $gradient['gradient'],
-			);
+	$editor_gradient_preset_support = get_theme_support( 'editor-gradient-presets' );
+	if ( is_array( $editor_gradient_preset_support ) and count( $editor_gradient_preset_support ) >= 1 ) {
+		$theme_gradients = $editor_gradient_preset_support[0];
+		if ( is_array( $theme_gradients ) ) {
+			foreach ( $theme_gradients as $gradient ) {
+				$theme_presets['global']['presets']['gradient'][] = array(
+					'slug'  => $gradient['slug'],
+					'value' => $gradient['gradient'],
+				);
+			}
 		}
 	}
-
-	$theme_font_sizes = get_theme_support( 'editor-font-sizes' )[0];
-	if ( is_array( $theme_font_sizes ) ) {
-		foreach ( $theme_font_sizes as $font_size ) {
-			$theme_presets['global']['presets']['font-size'][] = array(
-				'slug'  => $font_size['slug'],
-				'value' => $font_size['size'],
-			);
+	$editor_font_size_support = get_theme_support( 'editor-font-sizes' );
+	if ( is_array( $editor_font_size_support ) and count( $editor_font_size_support ) >= 1 ) {
+		$theme_font_sizes = $editor_font_size_support[0];
+		if ( is_array( $theme_font_sizes ) ) {
+			foreach ( $theme_font_sizes as $font_size ) {
+				$theme_presets['global']['presets']['font-size'][] = array(
+					'slug'  => $font_size['slug'],
+					'value' => $font_size['size'],
+				);
+			}
 		}
 	}
 

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -199,7 +199,7 @@ function gutenberg_experimental_global_styles_get_core() {
 function gutenberg_experimental_global_styles_get_theme_presets() {
 	$theme_presets = array();
 
-	$theme_colors = gutenberg_experimental_get( get_theme_support( 'editor-color-palette' ), ['0'] );
+	$theme_colors = gutenberg_experimental_get( get_theme_support( 'editor-color-palette' ), array( '0' ) );
 	foreach ( $theme_colors as $color ) {
 		$theme_presets['global']['presets']['color'][] = array(
 			'slug'  => $color['slug'],
@@ -207,7 +207,7 @@ function gutenberg_experimental_global_styles_get_theme_presets() {
 		);
 	}
 
-	$theme_gradients = gutenberg_experimental_get( get_theme_support( 'editor-gradient-presets' ), ['0'] );
+	$theme_gradients = gutenberg_experimental_get( get_theme_support( 'editor-gradient-presets' ), array( '0' ) );
 	foreach ( $theme_gradients as $gradient ) {
 		$theme_presets['global']['presets']['gradient'][] = array(
 			'slug'  => $gradient['slug'],
@@ -215,7 +215,7 @@ function gutenberg_experimental_global_styles_get_theme_presets() {
 		);
 	}
 
-	$theme_font_sizes = gutenberg_experimental_get( get_theme_support( 'editor-font-sizes' ), ['0'] );
+	$theme_font_sizes = gutenberg_experimental_get( get_theme_support( 'editor-font-sizes' ), array( '0' ) );
 	foreach ( $theme_font_sizes as $font_size ) {
 		$theme_presets['global']['presets']['font-size'][] = array(
 			'slug'  => $font_size['slug'],

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -199,42 +199,28 @@ function gutenberg_experimental_global_styles_get_core() {
 function gutenberg_experimental_global_styles_get_theme_presets() {
 	$theme_presets = array();
 
-	$editor_color_palette_support = get_theme_support( 'editor-color-palette' );
-	if ( is_array( $editor_color_palette_support ) and count( $editor_color_palette_support ) >= 1 ) {
-		$theme_colors = $editor_color_palette_support[0];
-		if ( is_array( $theme_colors ) ) {
-			foreach ( $theme_colors as $color ) {
-				$theme_presets['global']['presets']['color'][] = array(
-					'slug'  => $color['slug'],
-					'value' => $color['color'],
-				);
-			}
-		}
+	$theme_colors = gutenberg_experimental_get( get_theme_support( 'editor-color-palette' ), ['0'] );
+	foreach ( $theme_colors as $color ) {
+		$theme_presets['global']['presets']['color'][] = array(
+			'slug'  => $color['slug'],
+			'value' => $color['color'],
+		);
 	}
 
-	$editor_gradient_preset_support = get_theme_support( 'editor-gradient-presets' );
-	if ( is_array( $editor_gradient_preset_support ) and count( $editor_gradient_preset_support ) >= 1 ) {
-		$theme_gradients = $editor_gradient_preset_support[0];
-		if ( is_array( $theme_gradients ) ) {
-			foreach ( $theme_gradients as $gradient ) {
-				$theme_presets['global']['presets']['gradient'][] = array(
-					'slug'  => $gradient['slug'],
-					'value' => $gradient['gradient'],
-				);
-			}
-		}
+	$theme_gradients = gutenberg_experimental_get( get_theme_support( 'editor-gradient-presets' ), ['0'] );
+	foreach ( $theme_gradients as $gradient ) {
+		$theme_presets['global']['presets']['gradient'][] = array(
+			'slug'  => $gradient['slug'],
+			'value' => $gradient['gradient'],
+		);
 	}
-	$editor_font_size_support = get_theme_support( 'editor-font-sizes' );
-	if ( is_array( $editor_font_size_support ) and count( $editor_font_size_support ) >= 1 ) {
-		$theme_font_sizes = $editor_font_size_support[0];
-		if ( is_array( $theme_font_sizes ) ) {
-			foreach ( $theme_font_sizes as $font_size ) {
-				$theme_presets['global']['presets']['font-size'][] = array(
-					'slug'  => $font_size['slug'],
-					'value' => $font_size['size'],
-				);
-			}
-		}
+
+	$theme_font_sizes = gutenberg_experimental_get( get_theme_support( 'editor-font-sizes' ), ['0'] );
+	foreach ( $theme_font_sizes as $font_size ) {
+		$theme_presets['global']['presets']['font-size'][] = array(
+			'slug'  => $font_size['slug'],
+			'value' => $font_size['size'],
+		);
 	}
 
 	return $theme_presets;

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -380,7 +380,7 @@ function gutenberg_experimental_global_styles_flatten_styles_tree( $styles ) {
 	$result = array();
 
 	foreach ( $mappings as $key => $path ) {
-		$value = gutenberg_experimental_get( $styles, $path );
+		$value = gutenberg_experimental_get( $styles, $path, null );
 		if ( null !== $value ) {
 			$result[ $key ] = $value;
 		}

--- a/lib/utils.php
+++ b/lib/utils.php
@@ -16,6 +16,9 @@
  * @return array Containing a set of css rules.
  */
 function gutenberg_experimental_get( $array, $path ) {
+	// Confirm an array is passed in to avoid notice warnings.
+	if ( ! is_array( $array ) ) { return array(); }
+
 	$path_length = count( $path );
 	for ( $i = 0; $i < $path_length; ++$i ) {
 		if ( empty( $array[ $path[ $i ] ] ) ) {

--- a/lib/utils.php
+++ b/lib/utils.php
@@ -14,7 +14,7 @@
  * @param array $path     An array containing the path we want to retrieve.
  * @param array $default  The return value if $array or $path is not expected input type.
  *
- * @return array Containing a set of css rules.
+ * @return array An array matching the path specified
  */
 function gutenberg_experimental_get( $array, $path, $default = array() ) {
 	// Confirm input values are expected type to avoid notice warnings.
@@ -25,7 +25,7 @@ function gutenberg_experimental_get( $array, $path, $default = array() ) {
 	$path_length = count( $path );
 	for ( $i = 0; $i < $path_length; ++$i ) {
 		if ( empty( $array[ $path[ $i ] ] ) ) {
-			return null;
+			return $default;
 		}
 		$array = $array[ $path[ $i ] ];
 	}

--- a/lib/utils.php
+++ b/lib/utils.php
@@ -10,15 +10,16 @@
  * It is equivalent to want lodash get provides for JavaScript and is useful to have something similar
  * in php so functions that do the same thing on the client and sever can have identical code.
  *
- * @param array $array  An array from where we want to retrieve some information from.
- * @param array $path   An array containing the path we want to retrieve.
+ * @param array $array    An array from where we want to retrieve some information from.
+ * @param array $path     An array containing the path we want to retrieve.
+ * @param array $default  The return value if $array or $path is not expected input type.
  *
  * @return array Containing a set of css rules.
  */
-function gutenberg_experimental_get( $array, $path ) {
-	// Confirm an array is passed in to avoid notice warnings.
-	if ( ! is_array( $array ) ) {
-		return array();
+function gutenberg_experimental_get( $array, $path, $default = array() ) {
+	// Confirm input values are expected type to avoid notice warnings.
+	if ( ! is_array( $array ) || ! is_array( $path ) ) {
+		return $default;
 	}
 
 	$path_length = count( $path );

--- a/lib/utils.php
+++ b/lib/utils.php
@@ -14,7 +14,7 @@
  * @param array $path     An array containing the path we want to retrieve.
  * @param array $default  The return value if $array or $path is not expected input type.
  *
- * @return array An array matching the path specified
+ * @return array An array matching the path specified.
  */
 function gutenberg_experimental_get( $array, $path, $default = array() ) {
 	// Confirm input values are expected type to avoid notice warnings.

--- a/lib/utils.php
+++ b/lib/utils.php
@@ -17,7 +17,9 @@
  */
 function gutenberg_experimental_get( $array, $path ) {
 	// Confirm an array is passed in to avoid notice warnings.
-	if ( ! is_array( $array ) ) { return array(); }
+	if ( ! is_array( $array ) ) {
+		return array();
+	}
 
 	$path_length = count( $path );
 	for ( $i = 0; $i < $path_length; ++$i ) {


### PR DESCRIPTION

## Description

Adds checks for return value from get_theme_support to validate it returns an array of at least size 1 that can be indexed into.

The get_theme_support may return false, and attempting to indexing causes a PHP notice.

Fixes #23085 

## How has this been tested?

Use a theme that does not support Global Styles, I had a Twenty Nineteen theme, but may not have been the most up-to-date.

Turn on PHP notice warnings as visible.

Load editor. Confirm warning does not show after fix.


## Types of changes

Adds a couple of additional checks of the value returned from `get_theme_support()`


