### PR TITLE
Fix updateSlot missing from default SlotFillContext

### DIFF
--- a/packages/components/src/slot-fill/bubbles-virtually/slot-fill-context.js
+++ b/packages/components/src/slot-fill/bubbles-virtually/slot-fill-context.js
@@ -7,6 +7,7 @@ const SlotFillContext = createContext( {
 	slots: {},
 	fills: {},
 	registerSlot: () => {},
+	updateSlot: () => {},
 	unregisterSlot: () => {},
 	registerFill: () => {},
 	unregisterFill: () => {},

--- a/packages/components/src/slot-fill/bubbles-virtually/slot-fill-provider.js
+++ b/packages/components/src/slot-fill/bubbles-virtually/slot-fill-provider.js
@@ -93,6 +93,7 @@ function useSlotRegistry() {
 			slots,
 			fills,
 			registerSlot,
+			updateSlot,
 			unregisterSlot,
 			registerFill,
 			unregisterFill,

--- a/packages/components/src/slot-fill/test/__snapshots__/slot.js.snap
+++ b/packages/components/src/slot-fill/test/__snapshots__/slot.js.snap
@@ -94,12 +94,6 @@ exports[`Slot bubblesVirtually true should unmount two slots with the same name 
 </div>
 `;
 
-exports[`Slot should not break without a Provider 1`] = `
-<div>
-  <div />
-</div>
-`;
-
 exports[`Slot should re-render Slot when not bubbling virtually 1`] = `
 <div>
   <div>

--- a/packages/components/src/slot-fill/test/__snapshots__/slot.js.snap
+++ b/packages/components/src/slot-fill/test/__snapshots__/slot.js.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Slot bubblesVirtually false should not break without a Provider 1`] = `
+<div>
+  <div />
+</div>
+`;
+
 exports[`Slot bubblesVirtually false should subsume another slot by the same name 1`] = `
 <div>
   <div
@@ -77,6 +83,12 @@ exports[`Slot bubblesVirtually true should unmount two slots with the same name 
   <div
     data-position="second"
   />
+</div>
+`;
+
+exports[`Slot should not break without a Provider 1`] = `
+<div>
+  <div />
 </div>
 `;
 

--- a/packages/components/src/slot-fill/test/__snapshots__/slot.js.snap
+++ b/packages/components/src/slot-fill/test/__snapshots__/slot.js.snap
@@ -43,6 +43,14 @@ exports[`Slot bubblesVirtually false should unmount two slots with the same name
 </div>
 `;
 
+exports[`Slot bubblesVirtually true should not break without a Provider 1`] = `
+<div>
+  <div>
+    <div />
+  </div>
+</div>
+`;
+
 exports[`Slot bubblesVirtually true should subsume another slot by the same name 1`] = `
 <div>
   <div

--- a/packages/components/src/slot-fill/test/slot.js
+++ b/packages/components/src/slot-fill/test/slot.js
@@ -300,6 +300,22 @@ describe( 'Slot', () => {
 				);
 				expect( container ).toMatchSnapshot();
 			} );
+
+			it( 'should not break without a Provider', () => {
+				const { container } = render(
+					<>
+						<div>
+							<Slot
+								name="chicken"
+								bubblesVirtually={ bubblesVirtually }
+							/>
+						</div>
+						<Fill name="chicken" />
+					</>
+				);
+
+				expect( container ).toMatchSnapshot();
+			} );
 		}
 	);
 } );


### PR DESCRIPTION
Closes #23014

Due to the convention that this module adopts, I think the preferred fix is to simply add `updateSlot` as a noop function to the default object that is returned by the context (when `SlotFillProvider` isn't present).

But I also wonder when using `Slot`/`Fill` without `SlotFillProvider` would make sense.

Failing test: https://travis-ci.com/github/WordPress/gutenberg/jobs/347817325#L3248