### PR TITLE
Docs: Move ESNext as default code example

### DIFF
--- a/docs/designers-developers/developers/block-api/block-attributes.md
+++ b/docs/designers-developers/developers/block-api/block-attributes.md
@@ -185,6 +185,16 @@ attributes: {
 From here, meta attributes can be read and written by a block using the same interface as any attribute:
 
 {% codetabs %}
+{% ESNext %}
+```js
+edit( { attributes, setAttributes } ) {
+	function onChange( event ) {
+		setAttributes( { author: event.target.value } );
+	}
+
+	return <input value={ attributes.author } onChange={ onChange } type="text" />;
+},
+```
 {% ES5 %}
 ```js
 edit: function( props ) {
@@ -196,16 +206,6 @@ edit: function( props ) {
 		value: props.attributes.author,
 		onChange: onChange,
 	} );
-},
-```
-{% ESNext %}
-```js
-edit( { attributes, setAttributes } ) {
-	function onChange( event ) {
-		setAttributes( { author: event.target.value } );
-	}
-
-	return <input value={ attributes.author } onChange={ onChange } type="text" />;
 },
 ```
 {% end %}

--- a/docs/designers-developers/developers/block-api/block-deprecation.md
+++ b/docs/designers-developers/developers/block-api/block-deprecation.md
@@ -20,6 +20,37 @@ It's important to note that `attributes`, `supports`, and `save` are not automat
 ### Example:
 
 {% codetabs %}
+{% ESNext %}
+```js
+const { registerBlockType } = wp.blocks;
+const attributes = {
+	text: {
+		type: 'string',
+		default: 'some random value',
+	}
+};
+
+registerBlockType( 'gutenberg/block-with-deprecated-version', {
+
+	// ... other block properties go here
+
+	attributes,
+
+	save( props ) {
+		return <div>{ props.attributes.text }</div>;
+	},
+
+	deprecated: [
+		{
+			attributes,
+
+			save( props ) {
+				return <p>{ props.attributes.text }</p>;
+			},
+		}
+	]
+} );
+```
 {% ES5 %}
 ```js
 var el = wp.element.createElement,
@@ -52,37 +83,6 @@ registerBlockType( 'gutenberg/block-with-deprecated-version', {
 	]
 } );
 ```
-{% ESNext %}
-```js
-const { registerBlockType } = wp.blocks;
-const attributes = {
-	text: {
-		type: 'string',
-		default: 'some random value',
-	}
-};
-
-registerBlockType( 'gutenberg/block-with-deprecated-version', {
-
-	// ... other block properties go here
-
-	attributes,
-
-	save( props ) {
-		return <div>{ props.attributes.text }</div>;
-	},
-
-	deprecated: [
-		{
-			attributes,
-
-			save( props ) {
-				return <p>{ props.attributes.text }</p>;
-			},
-		}
-	]
-} );
-```
 {% end %}
 
 In the example above we updated the markup of the block to use a `div` instead of `p`.
@@ -95,6 +95,47 @@ Sometimes, you need to update the attributes set to rename or modify old attribu
 ### Example:
 
 {% codetabs %}
+{% ESNext %}
+```js
+const { registerBlockType } = wp.blocks;
+
+registerBlockType( 'gutenberg/block-with-deprecated-version', {
+
+	// ... other block properties go here
+
+	attributes: {
+		content: {
+			type: 'string',
+			default: 'some random value',
+		}
+	},
+
+	save( props ) {
+		return <div>{ props.attributes.content }</div>;
+	},
+
+	deprecated: [
+		{
+			attributes: {
+				text: {
+					type: 'string',
+					default: 'some random value',
+				}
+			},
+
+			migrate( { text } ) {
+				return {
+					content: text
+				};
+			},
+
+			save( props ) {
+				return <p>{ props.attributes.text }</p>;
+			},
+		}
+	]
+} );
+```
 {% ES5 %}
 ```js
 var el = wp.element.createElement,
@@ -137,47 +178,6 @@ registerBlockType( 'gutenberg/block-with-deprecated-version', {
 	]
 } );
 ```
-{% ESNext %}
-```js
-const { registerBlockType } = wp.blocks;
-
-registerBlockType( 'gutenberg/block-with-deprecated-version', {
-
-	// ... other block properties go here
-
-	attributes: {
-		content: {
-			type: 'string',
-			default: 'some random value',
-		}
-	},
-
-	save( props ) {
-		return <div>{ props.attributes.content }</div>;
-	},
-
-	deprecated: [
-		{
-			attributes: {
-				text: {
-					type: 'string',
-					default: 'some random value',
-				}
-			},
-
-			migrate( { text } ) {
-				return {
-					content: text
-				};
-			},
-
-			save( props ) {
-				return <p>{ props.attributes.text }</p>;
-			},
-		}
-	]
-} );
-```
 {% end %}
 
 In the example above we updated the markup of the block to use a `div` instead of `p` and rename the `text` attribute to `content`.
@@ -191,45 +191,6 @@ E.g: a block wants to migrate a title attribute to a paragraph innerBlock.
 ### Example:
 
 {% codetabs %}
-{% ES5 %}
-```js
-var el = wp.element.createElement,
-	registerBlockType = wp.blocks.registerBlockType,
-	omit = lodash.omit;
-
-registerBlockType( 'gutenberg/block-with-deprecated-version', {
-
-	// ... block properties go here
-
-	deprecated: [
-		{
-			attributes: {
-				title: {
-					type: 'string',
-					source: 'html',
-					selector: 'p',
-				},
-			},
-
-			migrate: function( attributes, innerBlocks ) {
-				return [
-					omit( attributes, 'title' ),
-					[
-						createBlock( 'core/paragraph', {
-							content: attributes.title,
-							fontSize: 'large',
-						} ),
-					].concat( innerBlocks ),
-				];
-			},
-
-			save: function( props ) {
-				return el( 'p', {}, props.attributes.title );
-			},
-		}
-	]
-} );
-```
 {% ESNext %}
 ```js
 const { registerBlockType } = wp.blocks;
@@ -268,6 +229,45 @@ registerBlockType( 'gutenberg/block-with-deprecated-version', {
 
 			save( props ) {
 				return <p>{ props.attributes.title }</p>;
+			},
+		}
+	]
+} );
+```
+{% ES5 %}
+```js
+var el = wp.element.createElement,
+	registerBlockType = wp.blocks.registerBlockType,
+	omit = lodash.omit;
+
+registerBlockType( 'gutenberg/block-with-deprecated-version', {
+
+	// ... block properties go here
+
+	deprecated: [
+		{
+			attributes: {
+				title: {
+					type: 'string',
+					source: 'html',
+					selector: 'p',
+				},
+			},
+
+			migrate: function( attributes, innerBlocks ) {
+				return [
+					omit( attributes, 'title' ),
+					[
+						createBlock( 'core/paragraph', {
+							content: attributes.title,
+							fontSize: 'large',
+						} ),
+					].concat( innerBlocks ),
+				];
+			},
+
+			save: function( props ) {
+				return el( 'p', {}, props.attributes.title );
 			},
 		}
 	]

--- a/docs/designers-developers/developers/block-api/block-edit-save.md
+++ b/docs/designers-developers/developers/block-api/block-edit-save.md
@@ -7,6 +7,12 @@ When registering a block, the `edit` and `save` functions provide the interface 
 The `edit` function describes the structure of your block in the context of the editor. This represents what the editor will render when the block is used.
 
 {% codetabs %}
+{% ESNext %}
+```jsx
+edit: () => {
+	return <div>Your block.</div>;
+}
+```
 {% ES5 %}
 ```js
 // A static div
@@ -16,12 +22,6 @@ edit: function() {
 		null,
 		'Your block.'
 	);
-}
-```
-{% ESNext %}
-```jsx
-edit: () => {
-	return <div>Your block.</div>;
 }
 ```
 {% end %}
@@ -35,6 +35,12 @@ This property surfaces all the available attributes and their corresponding valu
 In this case, assuming we had defined an attribute of `content` during block registration, we would receive and use that value in our edit function:
 
 {% codetabs %}
+{% ESNext %}
+```js
+edit: ( { attributes } ) => {
+	return <div>{ attributes.content }</div>;
+}
+```
 {% ES5 %}
 ```js
 edit: function( props ) {
@@ -43,12 +49,6 @@ edit: function( props ) {
 		null,
 		props.attributes.content
 	);
-}
-```
-{% ESNext %}
-```js
-edit: ( { attributes } ) => {
-	return <div>{ attributes.content }</div>;
 }
 ```
 {% end %}
@@ -60,6 +60,12 @@ The value of `attributes.content` will be displayed inside the `div` when insert
 This property returns the class name for the wrapper element. This is automatically added in the `save` method, but not on `edit`, as the root element may not correspond to what is _visually_ the main element of the block. You can request it to add it to the correct element in your function.
 
 {% codetabs %}
+{% ESNext %}
+```js
+edit: ( { attributes, className } ) => {
+	return <div className={ className }>{ attributes.content }</div>;
+}
+```
 {% ES5 %}
 ```js
 edit: function( props ) {
@@ -70,12 +76,6 @@ edit: function( props ) {
 	);
 }
 ```
-{% ESNext %}
-```js
-edit: ( { attributes, className } ) => {
-	return <div className={ className }>{ attributes.content }</div>;
-}
-```
 {% end %}
 
 ### isSelected
@@ -83,6 +83,19 @@ edit: ( { attributes, className } ) => {
 The isSelected property is an object that communicates whether the block is currently selected.
 
 {% codetabs %}
+{% ESNext %}
+```jsx
+edit: ( { attributes, className, isSelected } ) => {
+	return (
+		<div className={ className }>
+			Your block.
+			{ isSelected &&
+				<span>Shows only when the block is selected.</span>
+			}
+		</div>
+	);
+}
+```
 {% ES5 %}
 ```js
 edit: function( props ) {
@@ -100,19 +113,6 @@ edit: function( props ) {
 	);
 }
 ```
-{% ESNext %}
-```jsx
-edit: ( { attributes, className, isSelected } ) => {
-	return (
-		<div className={ className }>
-			Your block.
-			{ isSelected &&
-				<span>Shows only when the block is selected.</span>
-			}
-		</div>
-	);
-}
-```
 {% end %}
 
 ### setAttributes
@@ -120,6 +120,24 @@ edit: ( { attributes, className, isSelected } ) => {
 This function allows the block to update individual attributes based on user interactions.
 
 {% codetabs %}
+{% ESNext %}
+```jsx
+edit: ( { attributes, setAttributes, className, isSelected } ) => {
+	// Simplify access to attributes
+	const { content, mySetting } = attributes;
+
+	// Toggle a setting when the user clicks the button
+	const toggleSetting = () => setAttributes( { mySetting: ! mySetting } );
+	return (
+		<div className={ className }>
+			{ content }
+			{ isSelected &&
+				<button onClick={ toggleSetting }>Toggle setting</button>
+			}
+		</div>
+	);
+}
+```
 {% ES5 %}
 ```js
 edit: function( props ) {
@@ -143,29 +161,24 @@ edit: function( props ) {
 	);
 },
 ```
-{% ESNext %}
-```jsx
-edit: ( { attributes, setAttributes, className, isSelected } ) => {
-	// Simplify access to attributes
-	const { content, mySetting } = attributes;
-
-	// Toggle a setting when the user clicks the button
-	const toggleSetting = () => setAttributes( { mySetting: ! mySetting } );
-	return (
-		<div className={ className }>
-			{ content }
-			{ isSelected &&
-				<button onClick={ toggleSetting }>Toggle setting</button>
-			}
-		</div>
-	);
-}
-```
 {% end %}
 
 When using attributes that are objects or arrays it's a good idea to copy or clone the attribute prior to updating it:
 
 {% codetabs %}
+{% ESNext %}
+```js
+// Good - a new array is created from the old list attribute and a new list item:
+const { list } = attributes;
+const addListItem = ( newListItem ) => setAttributes( { list: [ ...list, newListItem ] } );
+
+// Bad - the list from the existing attribute is modified directly to add the new list item:
+const { list } = attributes;
+const addListItem = ( newListItem ) => {
+	list.push( newListItem );
+	setAttributes( { list } );
+};
+```
 {% ES5 %}
 ```js
 // Good - cloning the old list
@@ -182,19 +195,6 @@ var addListItem = function( newListItem ) {
 	setAttributes( { list: list } );
 };
 ```
-{% ESNext %}
-```js
-// Good - a new array is created from the old list attribute and a new list item:
-const { list } = attributes;
-const addListItem = ( newListItem ) => setAttributes( { list: [ ...list, newListItem ] } );
-
-// Bad - the list from the existing attribute is modified directly to add the new list item:
-const { list } = attributes;
-const addListItem = ( newListItem ) => {
-	list.push( newListItem );
-	setAttributes( { list } );
-};
-```
 {% end %}
 
 Why do this? In JavaScript, arrays and objects are passed by reference, so this practice ensures changes won't affect other code that might hold references to the same data. Furthermore, the Gutenberg project follows the philosophy of the Redux library that [state should be immutable](https://redux.js.org/faq/immutable-data#what-are-the-benefits-of-immutability)—data should not be changed directly, but instead a new version of the data created containing the changes.
@@ -204,6 +204,12 @@ Why do this? In JavaScript, arrays and objects are passed by reference, so this 
 The `save` function defines the way in which the different attributes should be combined into the final markup, which is then serialized into `post_content`.
 
 {% codetabs %}
+{% ESNext %}
+```jsx
+save: () => {
+	return <div> Your block. </div>;
+}
+```
 {% ES5 %}
 ```js
 save: function() {
@@ -212,12 +218,6 @@ save: function() {
 		null,
 		'Your block.'
 	);
-}
-```
-{% ESNext %}
-```jsx
-save: () => {
-	return <div> Your block. </div>;
 }
 ```
 {% end %}
@@ -242,6 +242,12 @@ If left unspecified, the default implementation will save no markup in post cont
 As with `edit`, the `save` function also receives an object argument including attributes which can be inserted into the markup.
 
 {% codetabs %}
+{% ESNext %}
+```jsx
+save: ( { attributes } ) => {
+	return <div>{ attributes.content }</div>;
+}
+```
 {% ES5 %}
 ```js
 save: function( props ) {
@@ -250,12 +256,6 @@ save: function( props ) {
 		null,
 		props.attributes.content
 	);
-}
-```
-{% ESNext %}
-```jsx
-save: ( { attributes } ) => {
-	return <div>{ attributes.content }</div>;
 }
 ```
 {% end %}
@@ -270,6 +270,31 @@ Here are a couple examples of using attributes, edit, and save all together.  Fo
 ### Saving Attributes to Child Elements
 
 {% codetabs %}
+{% ESNext %}
+```jsx
+attributes: {
+	content: {
+		type: 'string',
+		source: 'html',
+		selector: 'p'
+	}
+},
+
+edit: ( { attributes, setAttributes } ) => {
+	const updateFieldValue = ( val ) => {
+		setAttributes( { content: val } );
+	}
+	return <TextControl
+			label='My Text Field'
+			value={ attributes.content }
+			onChange={ updateFieldValue }
+		/>;
+},
+
+save: ( { attributes } ) => {
+	return <p> { attributes.content } </p>;
+},
+```
 {% ES5 %}
 ```js
 attributes: {
@@ -299,31 +324,6 @@ save: function( props ) {
 	return el( 'p', {}, props.attributes.content );
 },
 ```
-{% ESNext %}
-```jsx
-attributes: {
-	content: {
-		type: 'string',
-		source: 'html',
-		selector: 'p'
-	}
-},
-
-edit: ( { attributes, setAttributes } ) => {
-	const updateFieldValue = ( val ) => {
-		setAttributes( { content: val } );
-	}
-	return <TextControl
-			label='My Text Field'
-			value={ attributes.content }
-			onChange={ updateFieldValue }
-		/>;
-},
-
-save: ( { attributes } ) => {
-	return <p> { attributes.content } </p>;
-},
-```
 {% end %}
 
 ### Saving Attributes via Serialization
@@ -333,6 +333,29 @@ Ideally, the attributes saved should be included in the markup. However, there a
 This example could be for a dynamic block, such as the [Latest Posts block](https://github.com/WordPress/gutenberg/blob/master/packages/block-library/src/latest-posts/index.js), which renders the markup server-side. The save function is still required, however in this case it simply returns null since the block is not saving content from the editor.
 
 {% codetabs %}
+{% ESNext %}
+```jsx
+attributes: {
+	postsToShow: {
+		type: 'number',
+	}
+},
+
+edit: ( { attributes, setAttributes } ) => {
+	return <TextControl
+			label='Number Posts to Show'
+			value={ attributes.postsToShow }
+			onChange={ ( val ) => {
+				setAttributes( { postsToShow: parseInt( val ) } );
+			}},
+		}
+	);
+},
+
+save: () => {
+	return null;
+}
+```
 {% ES5 %}
 ```js
 attributes: {
@@ -355,29 +378,6 @@ edit: function( props ) {
 },
 
 save: function() {
-	return null;
-}
-```
-{% ESNext %}
-```jsx
-attributes: {
-	postsToShow: {
-		type: 'number',
-	}
-},
-
-edit: ( { attributes, setAttributes } ) => {
-	return <TextControl
-			label='Number Posts to Show'
-			value={ attributes.postsToShow }
-			onChange={ ( val ) => {
-				setAttributes( { postsToShow: parseInt( val ) } );
-			}},
-		}
-	);
-},
-
-save: () => {
 	return null;
 }
 ```

--- a/docs/designers-developers/developers/block-api/block-transforms.md
+++ b/docs/designers-developers/developers/block-api/block-transforms.md
@@ -46,26 +46,7 @@ A transformation of type `block` is an object that takes the following parameter
 To declare this transformation we add the following code into the heading block configuration, which uses the `createBlock` function from the [`wp-blocks` package](/packages/blocks/README.md#createBlock).
 
 {% codetabs %}
-{% ES5 %}
-
-```js
-transforms: {
-    from: [
-        {
-            type: 'block',
-            blocks: [ 'core/paragraph' ],
-            transform: function ( attributes ) {
-                return createBlock( 'core/heading', {
-                    content: attributes.content,
-                } );
-            },
-        },
-    ]
-},
-```
-
 {% ESNext %}
-
 ```js
 transforms: {
     from: [
@@ -81,7 +62,22 @@ transforms: {
     ]
 },
 ```
-
+{% ES5 %}
+```js
+transforms: {
+    from: [
+        {
+            type: 'block',
+            blocks: [ 'core/paragraph' ],
+            transform: function ( attributes ) {
+                return createBlock( 'core/heading', {
+                    content: attributes.content,
+                } );
+            },
+        },
+    ]
+},
+```
 {% end %}
 
 **Example: blocks that have InnerBlocks**
@@ -89,28 +85,7 @@ transforms: {
 A block with InnerBlocks can also be transformed from and to another block with InnerBlocks.
 
 {% codetabs %}
-{% ES5 %}
-
-```js
-transforms: {
-    to: [
-        {
-            type: 'block',
-            blocks: [ 'some/block-with-innerblocks' ],
-            transform: function( attributes, innerBlocks ) {
-                return createBlock(
-                    'some/other-block-with-innerblocks',
-                    attributes,
-                    innerBlocks
-                );
-            },
-        },
-    ],
-},
-```
-
 {% ESNext %}
-
 ```js
 transforms: {
     to: [
@@ -128,7 +103,24 @@ transforms: {
     ],
 },
 ```
-
+{% ES5 %}
+```js
+transforms: {
+    to: [
+        {
+            type: 'block',
+            blocks: [ 'some/block-with-innerblocks' ],
+            transform: function( attributes, innerBlocks ) {
+                return createBlock(
+                    'some/other-block-with-innerblocks',
+                    attributes,
+                    innerBlocks
+                );
+            },
+        },
+    ],
+},
+```
 {% end %}
 
 ### Enter
@@ -147,9 +139,19 @@ A transformation of type `enter` is an object that takes the following parameter
 To create a separator block when the user types the hypen three times and then hits the ENTER key we can use the following code:
 
 {% codetabs %}
-
+{% ESNext %}
+```js
+transforms = {
+    from: [
+        {
+            type: 'enter',
+            regExp: /^-{3,}$/,
+            transform: () => createBlock( 'core/separator' ),
+        },
+    ]
+}
+```
 {% ES5 %}
-
 ```js
 transforms = {
     from: [
@@ -163,21 +165,6 @@ transforms = {
     ]
 }
 ```
-
-{% ESNext %}
-
-```js
-transforms = {
-    from: [
-        {
-            type: 'enter',
-            regExp: /^-{3,}$/,
-            transform: () => createBlock( 'core/separator' ),
-        },
-    ]
-}
-```
-
 {% end %}
 
 ### Files
@@ -196,8 +183,32 @@ A transformation of type `files` is an object that takes the following parameter
 To create a File block when the user drops a file into the editor we can use the following code:
 
 {% codetabs %}
+{% ESNext %}
+```js
+transforms: {
+    from: [
+        {
+            type: 'files',
+            isMatch: ( files ) => files.length === 1,
+            // By defining a lower priority than the default of 10,
+            // we make that the File block to be created as a fallback,
+            // if no other transform is found.
+            priority: 15,
+            transform: ( files ) => {
+                const file = files[ 0 ];
+                const blobURL = createBlobURL( file );
+                // File will be uploaded in componentDidMount()
+                return createBlock( 'core/file', {
+                    href: blobURL,
+                    fileName: file.name,
+                    textLinkHref: blobURL,
+                } );
+            },
+        },
+    ];
+}
+```
 {% ES5 %}
-
 ```js
 transforms: {
     from: [
@@ -224,34 +235,6 @@ transforms: {
     ];
 }
 ```
-
-{% ESNext %}
-
-```js
-transforms: {
-    from: [
-        {
-            type: 'files',
-            isMatch: ( files ) => files.length === 1,
-            // By defining a lower priority than the default of 10,
-            // we make that the File block to be created as a fallback,
-            // if no other transform is found.
-            priority: 15,
-            transform: ( files ) => {
-                const file = files[ 0 ];
-                const blobURL = createBlobURL( file );
-                // File will be uploaded in componentDidMount()
-                return createBlock( 'core/file', {
-                    href: blobURL,
-                    fileName: file.name,
-                    textLinkHref: blobURL,
-                } );
-            },
-        },
-    ];
-}
-```
-
 {% end %}
 
 ### Prefix
@@ -270,26 +253,7 @@ A transformation of type `prefix` is an object that takes the following paramete
 If we want to create a custom block when the user types the question mark, we could use this code:
 
 {% codetabs %}
-{% ES5 %}
-
-```js
-transforms: {
-    from: [
-        {
-            type: 'prefix',
-            prefix: '?',
-            transform: function( content ) {
-                return createBlock( 'my-plugin/question', {
-                    content,
-                } );
-            },
-        },
-    ];
-}
-```
-
 {% ESNext %}
-
 ```js
 transforms: {
     from: [
@@ -305,7 +269,22 @@ transforms: {
     ];
 }
 ```
-
+{% ES5 %}
+```js
+transforms: {
+    from: [
+        {
+            type: 'prefix',
+            prefix: '?',
+            transform: function( content ) {
+                return createBlock( 'my-plugin/question', {
+                    content,
+                } );
+            },
+        },
+    ];
+}
+```
 {% end %}
 
 ### Raw
@@ -326,8 +305,25 @@ A transformation of type `raw` is an object that takes the following parameters:
 If we want to create an Embed block when the user pastes some URL in the editor, we could use this code:
 
 {% codetabs %}
+{% ESNext %}
+```js
+transforms: {
+    from: [
+        {
+            type: 'raw',
+            isMatch: ( node ) =>
+                node.nodeName === 'P' &&
+                /^\s*(https?:\/\/\S+)\s*$/i.test( node.textContent ),
+            transform: ( node ) => {
+                return createBlock( 'core/embed', {
+                    url: node.textContent.trim(),
+                } );
+            },
+        },
+    ],
+}
+```
 {% ES5 %}
-
 ```js
 transforms: {
     from: [
@@ -346,27 +342,6 @@ transforms: {
     ],
 }
 ```
-
-{% ESNext %}
-
-```js
-transforms: {
-    from: [
-        {
-            type: 'raw',
-            isMatch: ( node ) =>
-                node.nodeName === 'P' &&
-                /^\s*(https?:\/\/\S+)\s*$/i.test( node.textContent ),
-            transform: ( node ) => {
-                return createBlock( 'core/embed', {
-                    url: node.textContent.trim(),
-                } );
-            },
-        },
-    ],
-}
-```
-
 {% end %}
 
 ### Shortcode
@@ -386,8 +361,41 @@ A transformation of type `shortcode` is an object that takes the following param
 An existing shortcode can be transformed into its block counterpart.
 
 {% codetabs %}
+{% ESNext %}
+```js
+transforms: {
+    from: [
+        {
+            type: 'shortcode',
+            tag: 'caption',
+            attributes: {
+                url: {
+                    type: 'string',
+                    source: 'attribute',
+                    attribute: 'src',
+                    selector: 'img',
+                },
+                align: {
+                    type: 'string',
+                    // The shortcode function will extract
+                    // the shortcode atts into a value
+                    // to be sourced in the block's comment.
+                    shortcode: ( { named: { align = 'alignnone' } } ) => {
+                        return align.replace( 'align', '' );
+                    },
+                },
+            },
+            // Prevent the shortcode to be converted
+            // into this block when it doesn't
+            // have the proper ID.
+            isMatch( { named: { id } } ) {
+                return id === 'my-id';
+            },
+        },
+    ]
+},
+```
 {% ES5 %}
-
 ```js
 transforms: {
     from: [
@@ -422,41 +430,4 @@ transforms: {
     ]
 },
 ```
-
-{% ESNext %}
-
-```js
-transforms: {
-    from: [
-        {
-            type: 'shortcode',
-            tag: 'caption',
-            attributes: {
-                url: {
-                    type: 'string',
-                    source: 'attribute',
-                    attribute: 'src',
-                    selector: 'img',
-                },
-                align: {
-                    type: 'string',
-                    // The shortcode function will extract
-                    // the shortcode atts into a value
-                    // to be sourced in the block's comment.
-                    shortcode: ( { named: { align = 'alignnone' } } ) => {
-                        return align.replace( 'align', '' );
-                    },
-                },
-            },
-            // Prevent the shortcode to be converted
-            // into this block when it doesn't
-            // have the proper ID.
-            isMatch( { named: { id } } ) {
-                return id === 'my-id';
-            },
-        },
-    ]
-},
-```
-
 {% end %}

--- a/docs/designers-developers/developers/filters/autocomplete-filters.md
+++ b/docs/designers-developers/developers/filters/autocomplete-filters.md
@@ -9,6 +9,41 @@ The `Autocomplete` component found in `@wordpress/block-editor` applies this fil
 Here is an example of using the `editor.Autocomplete.completers` filter to add an acronym completer. You can find full documentation for the autocompleter interface with the `Autocomplete` component in the `@wordpress/components` package.
 
 {% codetabs %}
+{% ESNext %}
+```jsx
+// Our completer
+const acronymCompleter = {
+	name: 'acronyms',
+	triggerPrefix: '::',
+	options: [
+		{ letters: 'FYI', expansion: 'For Your Information' },
+		{ letters: 'AFAIK', expansion: 'As Far As I Know' },
+		{ letters: 'IIRC', expansion: 'If I Recall Correctly' },
+	],
+	getOptionKeywords( { letters, expansion } ) {
+		const expansionWords = expansion.split( /\s+/ );
+		return [ letters, ...expansionWords ];
+	},
+	getOptionLabel: acronym => acronym.letters,
+	getOptionCompletion: ( { letters, expansion } ) => (
+		<abbr title={ expansion }>{ letters }</abbr>,
+	),
+};
+
+// Our filter function
+function appendAcronymCompleter( completers, blockName ) {
+	return blockName === 'my-plugin/foo' ?
+		[ ...completers, acronymCompleter ] :
+		completers;
+}
+
+// Adding the filter
+wp.hooks.addFilter(
+	'editor.Autocomplete.completers',
+	'my-plugin/autocompleters/acronym',
+	appendAcronymCompleter
+);
+```
 {% ES5 %}
 ```js
 // Our completer
@@ -47,41 +82,6 @@ function appendAcronymCompleter( completers, blockName ) {
 wp.hooks.addFilter(
 	'editor.Autocomplete.completers',
 	'my-plugin/autocompleters/acronyms',
-	appendAcronymCompleter
-);
-```
-{% ESNext %}
-```jsx
-// Our completer
-const acronymCompleter = {
-	name: 'acronyms',
-	triggerPrefix: '::',
-	options: [
-		{ letters: 'FYI', expansion: 'For Your Information' },
-		{ letters: 'AFAIK', expansion: 'As Far As I Know' },
-		{ letters: 'IIRC', expansion: 'If I Recall Correctly' },
-	],
-	getOptionKeywords( { letters, expansion } ) {
-		const expansionWords = expansion.split( /\s+/ );
-		return [ letters, ...expansionWords ];
-	},
-	getOptionLabel: acronym => acronym.letters,
-	getOptionCompletion: ( { letters, expansion } ) => (
-		<abbr title={ expansion }>{ letters }</abbr>,
-	),
-};
-
-// Our filter function
-function appendAcronymCompleter( completers, blockName ) {
-	return blockName === 'my-plugin/foo' ?
-		[ ...completers, acronymCompleter ] :
-		completers;
-}
-
-// Adding the filter
-wp.hooks.addFilter(
-	'editor.Autocomplete.completers',
-	'my-plugin/autocompleters/acronym',
 	appendAcronymCompleter
 );
 ```

--- a/docs/designers-developers/developers/filters/block-filters.md
+++ b/docs/designers-developers/developers/filters/block-filters.md
@@ -221,6 +221,30 @@ Used to modify the block's `edit` component. It receives the original block `Blo
 _Example:_
 
 {% codetabs %}
+{% ESNext %}
+```js
+const { createHigherOrderComponent } = wp.compose;
+const { Fragment } = wp.element;
+const { InspectorControls } = wp.blockEditor;
+const { PanelBody } = wp.components;
+
+const withInspectorControls =  createHigherOrderComponent( ( BlockEdit ) => {
+	return ( props ) => {
+		return (
+			<Fragment>
+				<BlockEdit { ...props } />
+				<InspectorControls>
+					<PanelBody>
+						My custom control
+					</PanelBody>
+				</InspectorControls>
+			</Fragment>
+		);
+	};
+}, "withInspectorControl" );
+
+wp.hooks.addFilter( 'editor.BlockEdit', 'my-plugin/with-inspector-controls', withInspectorControls );
+```
 {% ES5 %}
 ```js
 var el = wp.element.createElement;
@@ -249,30 +273,6 @@ var withInspectorControls = wp.compose.createHigherOrderComponent( function( Blo
 
 wp.hooks.addFilter( 'editor.BlockEdit', 'my-plugin/with-inspector-controls', withInspectorControls );
 ```
-{% ESNext %}
-```js
-const { createHigherOrderComponent } = wp.compose;
-const { Fragment } = wp.element;
-const { InspectorControls } = wp.blockEditor;
-const { PanelBody } = wp.components;
-
-const withInspectorControls =  createHigherOrderComponent( ( BlockEdit ) => {
-	return ( props ) => {
-		return (
-			<Fragment>
-				<BlockEdit { ...props } />
-				<InspectorControls>
-					<PanelBody>
-						My custom control
-					</PanelBody>
-				</InspectorControls>
-			</Fragment>
-		);
-	};
-}, "withInspectorControl" );
-
-wp.hooks.addFilter( 'editor.BlockEdit', 'my-plugin/with-inspector-controls', withInspectorControls );
-```
 {% end %}
 
 #### `editor.BlockListBlock`
@@ -282,8 +282,19 @@ Used to modify the block's wrapper component containing the block's `edit` compo
 _Example:_
 
 {% codetabs %}
-{% ES5 %}
+{% ESNext %}
+```js
+const { createHigherOrderComponent } = wp.compose;
 
+const withClientIdClassName = createHigherOrderComponent( ( BlockListBlock ) => {
+	return ( props ) => {
+		return <BlockListBlock { ...props } className={ "block-" + props.clientId } />;
+	};
+}, 'withClientIdClassName' );
+
+wp.hooks.addFilter( 'editor.BlockListBlock', 'my-plugin/with-client-id-class-name', withClientIdClassName );
+```
+{% ES5 %}
 ```js
 var el = wp.element.createElement;
 
@@ -305,21 +316,7 @@ var withClientIdClassName = wp.compose.createHigherOrderComponent( function( Blo
 }, 'withClientIdClassName' );
 
 wp.hooks.addFilter( 'editor.BlockListBlock', 'my-plugin/with-client-id-class-name', withClientIdClassName );
-
 ```
-{% ESNext %}
-```js
-const { createHigherOrderComponent } = wp.compose;
-
-const withClientIdClassName = createHigherOrderComponent( ( BlockListBlock ) => {
-	return ( props ) => {
-		return <BlockListBlock { ...props } className={ "block-" + props.clientId } />;
-	};
-}, 'withClientIdClassName' );
-
-wp.hooks.addFilter( 'editor.BlockListBlock', 'my-plugin/with-client-id-class-name', withClientIdClassName );
-```
-
 {% end %}
 
 ## Removing Blocks
@@ -329,13 +326,6 @@ wp.hooks.addFilter( 'editor.BlockListBlock', 'my-plugin/with-client-id-class-nam
 Adding blocks is easy enough, removing them is as easy. Plugin or theme authors have the possibility to "unregister" blocks.
 
 {% codetabs %}
-{% ES5 %}
-```js
-// my-plugin.js
-wp.domReady( function() {
-	wp.blocks.unregisterBlockType( 'core/verse' );
-} );
-```
 {% ESNext %}
 ```js
 // my-plugin.js
@@ -344,6 +334,13 @@ import domReady from '@wordpress/dom-ready'
 
 domReady( function() {
 	unregisterBlockType( 'core/verse' );
+} );
+```
+{% ES5 %}
+```js
+// my-plugin.js
+wp.domReady( function() {
+	wp.blocks.unregisterBlockType( 'core/verse' );
 } );
 ```
 {% end %}
@@ -436,6 +433,7 @@ You can also display an icon with your block category by setting an `icon` attri
 You can also set a custom icon in SVG format. To do so, the icon should be rendered and set on the frontend, so it can make use of WordPress SVG, allowing mobile compatibility and making the icon more accessible.
 
 To set an SVG icon for the category shown in the previous example, add the following example JavaScript code to the editor calling `wp.blocks.updateCategory` e.g:
+
 ```js
 ( function() {
 	var el = wp.element.createElement;

--- a/docs/designers-developers/developers/internationalization.md
+++ b/docs/designers-developers/developers/internationalization.md
@@ -34,9 +34,35 @@ function myguten_block_init() {
 add_action( 'init', 'myguten_block_init' );
 ```
 
-In your code, you can include the i18n functions. The most common function is **__** (a double underscore) which provides translation of a simple string. Here is a basic static block example, this is in a file called `block.js`:
+In your code, you can include the i18n functions. The most common function is **__** (a double underscore) which provides translation of a simple string. Here is a basic block example:
 
 {% codetabs %}
+{% ESNext %}
+```js
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
+
+registerBlockType( 'myguten/simple', {
+	title: __( 'Simple Block', 'myguten' ),
+	category: 'widgets',
+
+	edit: () => {
+		return (
+			<p style="color:red">
+				{ __( 'Hello World', 'myguten' ) }
+			</p>
+		);
+	},
+
+	save: () => {
+		return (
+			<p style="color:red">
+				{ __( 'Hello World', 'myguten' ) }
+			</p>
+		);
+	},
+} );
+```
 {% ES5 %}
 ```js
 const { __ } = wp.i18n;
@@ -60,32 +86,6 @@ registerBlockType( 'myguten/simple', {
 			'p',
 			{ style: { color: 'red' } },
 			__( 'Hello World', 'myguten' )
-		);
-	},
-} );
-```
-{% ESNext %}
-```js
-import { __ } from '@wordpress/i18n';
-import { registerBlockType } from '@wordpress/blocks';
-
-registerBlockType( 'myguten/simple', {
-	title: __( 'Simple Block', 'myguten' ),
-	category: 'widgets',
-
-	edit: () => {
-		return (
-			<p style="color:red">
-				{ __( 'Hello World', 'myguten' ) }
-			</p>
-		);
-	},
-
-	save: () => {
-		return (
-			<p style="color:red">
-				{ __( 'Hello World', 'myguten' ) }
-			</p>
 		);
 	},
 } );

--- a/docs/designers-developers/developers/internationalization.md
+++ b/docs/designers-developers/developers/internationalization.md
@@ -73,7 +73,7 @@ registerBlockType( 'myguten/simple', {
 	title: __( 'Simple Block', 'myguten' ),
 	category: 'widgets',
 
-	edit: () => {
+	edit: function() {
 		return el(
 			'p',
 			{ style: { color: 'red' } },
@@ -81,7 +81,7 @@ registerBlockType( 'myguten/simple', {
 		);
 	},
 
-	save: () => {
+	save: function() {
 		return el(
 			'p',
 			{ style: { color: 'red' } },

--- a/docs/designers-developers/developers/richtext.md
+++ b/docs/designers-developers/developers/richtext.md
@@ -26,39 +26,6 @@ There are a number of core blocks using the RichText component. The JavaScript e
 ## Example
 
 {% codetabs %}
-{% ES5 %}
-```js
-wp.blocks.registerBlockType( /* ... */, {
-	// ...
-
-	attributes: {
-		content: {
-			type: 'string',
-			source: 'html',
-			selector: 'h2',
-		},
-	},
-
-	edit: function( props ) {
-		return wp.element.createElement( wp.editor.RichText, {
-			tagName: 'h2',  // The tag here is the element output and editable in the admin
-			className: props.className,
-			value: props.attributes.content, // Any existing content, either from the database or an attribute default
-			formattingControls: [ 'bold', 'italic' ], // Allow the content to be made bold or italic, but do not allow other formatting options
-			onChange: function( content ) {
-				props.setAttributes( { content: content } ); // Store updated content as a block attribute
-			},
-			placeholder: __( 'Heading...' ), // Display this text before any content has been added by the user
-		} );
-	},
-
-	save: function( props ) {
-		return wp.element.createElement( wp.editor.RichText.Content, {
-			tagName: 'h2', value: props.attributes.content // Saves <h2>Content added in the editor...</h2> to the database for frontend display
-		} );
-	}
-} );
-```
 {% ESNext %}
 ```js
 import { registerBlockType } from '@wordpress/blocks';
@@ -90,6 +57,39 @@ registerBlockType( /* ... */, {
 
 	save( { attributes } ) {
 		return <RichText.Content tagName="h2" value={ attributes.content } />; // Saves <h2>Content added in the editor...</h2> to the database for frontend display
+	}
+} );
+```
+{% ES5 %}
+```js
+wp.blocks.registerBlockType( /* ... */, {
+	// ...
+
+	attributes: {
+		content: {
+			type: 'string',
+			source: 'html',
+			selector: 'h2',
+		},
+	},
+
+	edit: function( props ) {
+		return wp.element.createElement( wp.editor.RichText, {
+			tagName: 'h2',  // The tag here is the element output and editable in the admin
+			className: props.className,
+			value: props.attributes.content, // Any existing content, either from the database or an attribute default
+			formattingControls: [ 'bold', 'italic' ], // Allow the content to be made bold or italic, but do not allow other formatting options
+			onChange: function( content ) {
+				props.setAttributes( { content: content } ); // Store updated content as a block attribute
+			},
+			placeholder: __( 'Heading...' ), // Display this text before any content has been added by the user
+		} );
+	},
+
+	save: function( props ) {
+		return wp.element.createElement( wp.editor.RichText.Content, {
+			tagName: 'h2', value: props.attributes.content // Saves <h2>Content added in the editor...</h2> to the database for frontend display
+		} );
 	}
 } );
 ```


### PR DESCRIPTION

## Description

Per [documentation guidelines](https://github.com/WordPress/gutenberg/blob/master/docs/contributors/document.md#code-examples), the ESNext examples should be listed first. This PR swaps the placement with ESNext and ES5 to do so.

## How has this been tested?

Confirm no code changes, tags are setup right. Hard to confirm without generating since the codetabs do not render in Github.

## Types of changes

Documentation.
