### PR TITLE
Scripts: Clean up the build folder via clean-webpack-plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11058,6 +11058,7 @@
 				"babel-loader": "^8.1.0",
 				"chalk": "^4.0.0",
 				"check-node-version": "^3.1.1",
+				"clean-webpack-plugin": "^3.0.0",
 				"cross-spawn": "^5.1.0",
 				"css-loader": "^3.5.2",
 				"dir-glob": "^3.0.1",
@@ -14954,6 +14955,91 @@
 			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
 			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
 			"dev": true
+		},
+		"clean-webpack-plugin": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/clean-webpack-plugin/-/clean-webpack-plugin-3.0.0.tgz",
+			"integrity": "sha512-MciirUH5r+cYLGCOL5JX/ZLzOZbVr1ot3Fw+KcvbhUb6PM+yycqd9ZhIlcigQ5gl+XhppNmw3bEFuaaMNyLj3A==",
+			"dev": true,
+			"requires": {
+				"@types/webpack": "^4.4.31",
+				"del": "^4.1.1"
+			},
+			"dependencies": {
+				"del": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
+					"integrity": "sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==",
+					"dev": true,
+					"requires": {
+						"@types/glob": "^7.1.1",
+						"globby": "^6.1.0",
+						"is-path-cwd": "^2.0.0",
+						"is-path-in-cwd": "^2.0.0",
+						"p-map": "^2.0.0",
+						"pify": "^4.0.1",
+						"rimraf": "^2.6.3"
+					}
+				},
+				"globby": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+					"dev": true,
+					"requires": {
+						"array-union": "^1.0.1",
+						"glob": "^7.0.3",
+						"object-assign": "^4.0.1",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
+					},
+					"dependencies": {
+						"pify": {
+							"version": "2.3.0",
+							"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+							"dev": true
+						}
+					}
+				},
+				"p-map": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+					"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+					"dev": true
+				},
+				"pify": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+					"dev": true
+				},
+				"rimraf": {
+					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					},
+					"dependencies": {
+						"glob": {
+							"version": "7.1.6",
+							"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+							"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+							"dev": true,
+							"requires": {
+								"fs.realpath": "^1.0.0",
+								"inflight": "^1.0.4",
+								"inherits": "2",
+								"minimatch": "^3.0.4",
+								"once": "^1.3.0",
+								"path-is-absolute": "^1.0.0"
+							}
+						}
+					}
+				}
+			}
 		},
 		"cli-boxes": {
 			"version": "2.2.0",
@@ -23935,6 +24021,26 @@
 			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
 			"integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
 			"dev": true
+		},
+		"is-path-in-cwd": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
+			"integrity": "sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==",
+			"dev": true,
+			"requires": {
+				"is-path-inside": "^2.1.0"
+			},
+			"dependencies": {
+				"is-path-inside": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
+					"integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
+					"dev": true,
+					"requires": {
+						"path-is-inside": "^1.0.2"
+					}
+				}
+			}
 		},
 		"is-path-inside": {
 			"version": "3.0.1",
@@ -33967,6 +34073,12 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+		},
+		"path-is-inside": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+			"dev": true
 		},
 		"path-key": {
 			"version": "2.0.1",

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Bug fix
 
 -   Update webpack configuration to not run the Sass loader on CSS files. It's now limited to .scss and .sass files.
+-   During rebuilds, all webpack assets that are not used anymore will be removed automatically.
 
 ## 10.0.0 (2020-05-28)
 

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -5,6 +5,7 @@ const { BundleAnalyzerPlugin } = require( 'webpack-bundle-analyzer' );
 const IgnoreEmitPlugin = require( 'ignore-emit-webpack-plugin' );
 const LiveReloadPlugin = require( 'webpack-livereload-plugin' );
 const MiniCSSExtractPlugin = require( 'mini-css-extract-plugin' );
+const { CleanWebpackPlugin } = require( 'clean-webpack-plugin' );
 const path = require( 'path' );
 
 /**
@@ -131,6 +132,9 @@ const config = {
 		],
 	},
 	plugins: [
+		// During rebuilds, all webpack assets that are not used anymore
+		// will be removed automatically.
+		new CleanWebpackPlugin(),
 		// The WP_BUNDLE_ANALYZER global variable enables a utility that represents
 		// bundle content as a convenient interactive zoomable treemap.
 		process.env.WP_BUNDLE_ANALYZER && new BundleAnalyzerPlugin(),

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -45,6 +45,7 @@
 		"babel-loader": "^8.1.0",
 		"chalk": "^4.0.0",
 		"check-node-version": "^3.1.1",
+		"clean-webpack-plugin": "^3.0.0",
 		"cross-spawn": "^5.1.0",
 		"css-loader": "^3.5.2",
 		"dir-glob": "^3.0.1",


### PR DESCRIPTION
## Description

Adds [clean-webpack-plugin](https://www.npmjs.com/package/clean-webpack-plugin) as a default plugin to webpack config.

Fixes #23134.

## How has this been tested?
* Create a custom block setup for example with @wordpress/block
* Start the watch command and notice the source map files for CSS files
* Stop the watch command and run the build command
* The source map files should be removed now

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
