### PR TITLE
Create Block: Use the same version for stylesheets and scripts

### DIFF
--- a/packages/create-block/lib/templates/esnext/$slug.php.mustache
+++ b/packages/create-block/lib/templates/esnext/$slug.php.mustache
@@ -48,7 +48,7 @@ function {{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init() {
 		'{{namespace}}-{{slug}}-block-editor',
 		plugins_url( $editor_css, __FILE__ ),
 		array(),
-		filemtime( "$dir/$editor_css" )
+		$script_asset['version']
 	);
 
 	$style_css = 'build/style.css';
@@ -56,7 +56,7 @@ function {{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init() {
 		'{{namespace}}-{{slug}}-block',
 		plugins_url( $style_css, __FILE__ ),
 		array(),
-		filemtime( "$dir/$style_css" )
+		$script_asset['version']
 	);
 
 	register_block_type( '{{namespace}}/{{slug}}', array(


### PR DESCRIPTION
## Description
Since CSS and JS files are generated by the same build task at the same time we can also use the same version. This replaces the `filemtime()` call with the version provided by the assets file.
This prevents asking the file system for data which may be even unreliable when used in server setups with horizontal scaling. 