### PR TITLE
Editor: Fix post publish button for published/scheduled posts without publish_posts cap

### DIFF
--- a/docs/designers-developers/developers/data/data-core-editor.md
+++ b/docs/designers-developers/developers/data/data-core-editor.md
@@ -807,6 +807,7 @@ Returns true if post is already scheduled.
 _Parameters_
 
 -   _state_ `Object`: Global application state.
+-   _currentPost_ `?Object`: Explicit current post for bypassing registry selector.
 
 _Returns_
 
@@ -1041,6 +1042,18 @@ _Parameters_
 _Returns_
 
 -   `boolean`: Whether post is being saved.
+
+<a name="isSchedulingPost" href="#isSchedulingPost">#</a> **isSchedulingPost**
+
+Returns true if the post is being scheduled, or false otherwise.
+
+_Parameters_
+
+-   _state_ `Object`: Global application state.
+
+_Returns_
+
+-   `boolean`: Whether post is being scheduled.
 
 <a name="isSelectionEnabled" href="#isSelectionEnabled">#</a> **isSelectionEnabled**
 

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -119,12 +119,14 @@ export class PostPublishButton extends Component {
 			( ! isPublishable && ! forceIsDirty );
 
 		let publishStatus;
-		if ( ! isPublished && ! isBeingScheduled && ! hasPublishAction ) {
+		if ( ! isPublished && ! isBeingScheduled && ! isScheduled ) {
 			publishStatus = 'pending';
 		} else if ( visibility === 'private' ) {
 			publishStatus = 'private';
 		} else if ( isBeingScheduled || isScheduled ) {
 			publishStatus = 'future';
+		} else if ( ! hasPublishAction ) {
+			publishStatus = 'pending';
 		} else {
 			publishStatus = 'publish';
 		}

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -118,7 +118,7 @@ export class PostPublishButton extends Component {
 			( ! isPublishable && ! forceIsDirty );
 
 		let publishStatus;
-		if ( ! hasPublishAction ) {
+		if ( ! isPublished && ! isBeingScheduled && ! hasPublishAction ) {
 			publishStatus = 'pending';
 		} else if ( visibility === 'private' ) {
 			publishStatus = 'private';

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -88,6 +88,7 @@ export class PostPublishButton extends Component {
 			forceIsSaving,
 			hasPublishAction,
 			isBeingScheduled,
+			isScheduled,
 			isOpen,
 			isPostSavingLocked,
 			isPublishable,
@@ -122,7 +123,7 @@ export class PostPublishButton extends Component {
 			publishStatus = 'pending';
 		} else if ( visibility === 'private' ) {
 			publishStatus = 'private';
-		} else if ( isBeingScheduled ) {
+		} else if ( isBeingScheduled || isScheduled ) {
 			publishStatus = 'future';
 		} else {
 			publishStatus = 'publish';
@@ -198,6 +199,7 @@ export default compose( [
 		const {
 			isSavingPost,
 			isEditedPostBeingScheduled,
+			isCurrentPostScheduled,
 			getEditedPostVisibility,
 			isCurrentPostPublished,
 			isEditedPostSaveable,
@@ -211,6 +213,7 @@ export default compose( [
 		return {
 			isSaving: isSavingPost(),
 			isBeingScheduled: isEditedPostBeingScheduled(),
+			isScheduled: isCurrentPostScheduled(),
 			visibility: getEditedPostVisibility(),
 			isSaveable: isEditedPostSaveable(),
 			isPostSavingLocked: isPostSavingLocked(),

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -119,9 +119,7 @@ export class PostPublishButton extends Component {
 			( ! isPublishable && ! forceIsDirty );
 
 		let publishStatus;
-		if ( ! isPublished && ! isBeingScheduled && ! isScheduled ) {
-			publishStatus = 'pending';
-		} else if ( visibility === 'private' ) {
+		if ( visibility === 'private' ) {
 			publishStatus = 'private';
 		} else if ( isBeingScheduled || isScheduled ) {
 			publishStatus = 'future';

--- a/packages/editor/src/components/post-publish-button/label.js
+++ b/packages/editor/src/components/post-publish-button/label.js
@@ -12,6 +12,7 @@ import { withSelect } from '@wordpress/data';
 
 export function PublishButtonLabel( {
 	isPublished,
+	isScheduled,
 	isBeingScheduled,
 	isSaving,
 	isPublishing,
@@ -21,13 +22,13 @@ export function PublishButtonLabel( {
 } ) {
 	if ( isPublishing ) {
 		return __( 'Publishing…' );
-	} else if ( isPublished && isSaving && ! isAutosaving ) {
+	} else if ( ( isPublished || isScheduled ) && isSaving && ! isAutosaving ) {
 		return __( 'Updating…' );
 	} else if ( isBeingScheduled && isSaving && ! isAutosaving ) {
 		return __( 'Scheduling…' );
 	}
 
-	if ( isPublished ) {
+	if ( isPublished || isScheduled ) {
 		return hasNonPostEntityChanges ? __( 'Update…' ) : __( 'Update' );
 	} else if ( isBeingScheduled ) {
 		return hasNonPostEntityChanges ? __( 'Schedule…' ) : __( 'Schedule' );
@@ -44,6 +45,7 @@ export default compose( [
 	withSelect( ( select, { forceIsSaving } ) => {
 		const {
 			isCurrentPostPublished,
+			isCurrentPostScheduled,
 			isEditedPostBeingScheduled,
 			isSavingPost,
 			isPublishingPost,
@@ -53,6 +55,7 @@ export default compose( [
 		} = select( 'core/editor' );
 		return {
 			isPublished: isCurrentPostPublished(),
+			isScheduled: isCurrentPostScheduled(),
 			isBeingScheduled: isEditedPostBeingScheduled(),
 			isSaving: forceIsSaving || isSavingPost(),
 			isPublishing: isPublishingPost(),

--- a/packages/editor/src/components/post-publish-button/label.js
+++ b/packages/editor/src/components/post-publish-button/label.js
@@ -16,16 +16,17 @@ export function PublishButtonLabel( {
 	isBeingScheduled,
 	isSaving,
 	isPublishing,
+	isScheduling,
 	hasPublishAction,
 	isAutosaving,
 	hasNonPostEntityChanges,
 } ) {
 	if ( isPublishing ) {
 		return __( 'Publishing…' );
+	} else if ( isScheduling ) {
+		return __( 'Scheduling…' );
 	} else if ( ( isPublished || isScheduled ) && isSaving && ! isAutosaving ) {
 		return __( 'Updating…' );
-	} else if ( isBeingScheduled && isSaving && ! isAutosaving ) {
-		return __( 'Scheduling…' );
 	}
 
 	if ( isPublished || isScheduled ) {
@@ -49,6 +50,7 @@ export default compose( [
 			isEditedPostBeingScheduled,
 			isSavingPost,
 			isPublishingPost,
+			isSchedulingPost,
 			getCurrentPost,
 			getCurrentPostType,
 			isAutosavingPost,
@@ -59,6 +61,7 @@ export default compose( [
 			isBeingScheduled: isEditedPostBeingScheduled(),
 			isSaving: forceIsSaving || isSavingPost(),
 			isPublishing: isPublishingPost(),
+			isScheduling: isSchedulingPost(),
 			hasPublishAction: get(
 				getCurrentPost(),
 				[ '_links', 'wp:action-publish' ],

--- a/packages/editor/src/components/post-publish-button/label.js
+++ b/packages/editor/src/components/post-publish-button/label.js
@@ -27,14 +27,14 @@ export function PublishButtonLabel( {
 		return __( 'Scheduling…' );
 	}
 
-	if ( ! hasPublishAction ) {
-		return hasNonPostEntityChanges
-			? __( 'Submit for Review…' )
-			: __( 'Submit for Review' );
-	} else if ( isPublished ) {
+	if ( isPublished ) {
 		return hasNonPostEntityChanges ? __( 'Update…' ) : __( 'Update' );
 	} else if ( isBeingScheduled ) {
 		return hasNonPostEntityChanges ? __( 'Schedule…' ) : __( 'Schedule' );
+	} else if ( ! hasPublishAction ) {
+		return hasNonPostEntityChanges
+			? __( 'Submit for Review…' )
+			: __( 'Submit for Review' );
 	}
 
 	return __( 'Publish' );

--- a/packages/editor/src/components/post-publish-button/test/label.js
+++ b/packages/editor/src/components/post-publish-button/test/label.js
@@ -24,7 +24,7 @@ describe( 'PublishButtonLabel', () => {
 	it( 'should show scheduling if scheduled and saving in progress', () => {
 		const label = PublishButtonLabel( {
 			hasPublishAction: true,
-			isBeingScheduled: true,
+			isScheduling: true,
 			isSaving: true,
 		} );
 		expect( label ).toBe( 'Scheduling…' );

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -495,10 +495,7 @@ export function isCurrentPostPublished( state, currentPost ) {
 export function isCurrentPostScheduled( state, currentPost ) {
 	const post = currentPost || getCurrentPost( state );
 
-	return (
-		post.status === 'future' &&
-		! isCurrentPostPublished( state, currentPost )
-	);
+	return post.status === 'future' && ! isCurrentPostPublished( state, post );
 }
 
 /**


### PR DESCRIPTION
## Description

This updates the checks for `hasPublishAction`  to not check for the action if the post is already published to replicate the [behaviour in the classic editor](https://github.com/WordPress/wordpress-develop/blob/5b31b4eee4f3ef76c09e216a13050d6f8e5094cd/src/wp-admin/includes/meta-boxes.php#L349-L373).

Fixes #23119.

## How has this been tested?

* Create a new user with `edit_posts` and `edit_published_posts` caps
* Let the user create a new post and submit it for review
* Use another user to publish the post
* Switch back to original author and continue editing the posts without the need to submit it again for review/switching the status back to draft


## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
