### PR TITLE
Refactor column block to use hooks

### DIFF
--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -14,21 +14,42 @@ import {
 	__experimentalBlock as Block,
 } from '@wordpress/block-editor';
 import { PanelBody, RangeControl } from '@wordpress/components';
-import { withDispatch, withSelect } from '@wordpress/data';
-import { compose } from '@wordpress/compose';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 function ColumnEdit( {
-	attributes,
+	attributes: { verticalAlignment, width },
 	setAttributes,
-	updateAlignment,
-	hasChildBlocks,
+	clientId,
 } ) {
-	const { verticalAlignment, width } = attributes;
-
 	const classes = classnames( 'block-core-columns', {
 		[ `is-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,
 	} );
+
+	const { hasChildBlocks, rootClientId } = useSelect(
+		( select ) => {
+			const { getBlockOrder, getBlockRootClientId } = select(
+				'core/block-editor'
+			);
+
+			return {
+				hasChildBlocks: getBlockOrder( clientId ).length > 0,
+				rootClientId: getBlockRootClientId( clientId ),
+			};
+		},
+		[ clientId ]
+	);
+
+	const { updateBlockAttributes } = useDispatch( 'core/block-editor' );
+
+	const updateAlignment = ( value ) => {
+		// Update own alignment.
+		setAttributes( { verticalAlignment: value } );
+		// Reset Parent Columns Block
+		updateBlockAttributes( rootClientId, {
+			verticalAlignment: null,
+		} );
+	};
 
 	const hasWidth = Number.isFinite( width );
 
@@ -76,35 +97,4 @@ function ColumnEdit( {
 	);
 }
 
-export default compose(
-	withSelect( ( select, ownProps ) => {
-		const { clientId } = ownProps;
-		const { getBlockOrder } = select( 'core/block-editor' );
-
-		return {
-			hasChildBlocks: getBlockOrder( clientId ).length > 0,
-		};
-	} ),
-	withDispatch( ( dispatch, ownProps, registry ) => {
-		return {
-			updateAlignment( verticalAlignment ) {
-				const { clientId, setAttributes } = ownProps;
-				const { updateBlockAttributes } = dispatch(
-					'core/block-editor'
-				);
-				const { getBlockRootClientId } = registry.select(
-					'core/block-editor'
-				);
-
-				// Update own alignment.
-				setAttributes( { verticalAlignment } );
-
-				// Reset Parent Columns Block
-				const rootClientId = getBlockRootClientId( clientId );
-				updateBlockAttributes( rootClientId, {
-					verticalAlignment: null,
-				} );
-			},
-		};
-	} )
-)( ColumnEdit );
+export default ColumnEdit;

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -45,7 +45,7 @@ function ColumnEdit( {
 	const updateAlignment = ( value ) => {
 		// Update own alignment.
 		setAttributes( { verticalAlignment: value } );
-		// Reset Parent Columns Block
+		// Reset parent Columns block.
 		updateBlockAttributes( rootClientId, {
 			verticalAlignment: null,
 		} );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description


## How has this been tested?

Tested adding a a columns block, setting a vertical alignment then changing the vertical alignment of an inner column and checking that the parent Columns block alignment was reset.

## Screenshots <!-- if applicable -->

## Types of changes

Code quality

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
