### PR TITLE
Change Create Menu UI to use a Card instead of Panel

### DIFF
--- a/packages/edit-navigation/src/components/menus-editor/create-menu-area.js
+++ b/packages/edit-navigation/src/components/menus-editor/create-menu-area.js
@@ -8,8 +8,9 @@ import { some } from 'lodash';
  */
 import {
 	Button,
-	Panel,
-	PanelBody,
+	Card,
+	CardHeader,
+	CardBody,
 	TextControl,
 	withFocusReturn,
 } from '@wordpress/components';
@@ -23,7 +24,7 @@ const noticeId = 'edit-navigation-create-menu-error';
 const menuNameMatches = ( menuName ) => ( menu ) =>
 	menu.name.toLowerCase() === menuName.toLowerCase();
 
-export function CreateMenuForm( { onCancel, onCreateMenu, menus } ) {
+export function CreateMenuArea( { onCancel, onCreateMenu, menus } ) {
 	const [ menuName, setMenuName ] = useState( '' );
 	const [ isCreatingMenu, setIsCreatingMenu ] = useState( false );
 	const menuSaveError = useSelect( ( select ) =>
@@ -92,8 +93,9 @@ export function CreateMenuForm( { onCancel, onCreateMenu, menus } ) {
 	);
 
 	return (
-		<Panel className="edit-navigation-menus-editor__create-menu-panel">
-			<PanelBody title={ __( 'Create navigation menu' ) }>
+		<Card className="edit-navigation-menus-editor__create-menu-area">
+			<CardHeader>{ __( 'Create navigation menu' ) }</CardHeader>
+			<CardBody>
 				<form onSubmit={ createMenu }>
 					<TextControl
 						// Disable reason - autoFocus is legitimate in this usage,
@@ -125,9 +127,9 @@ export function CreateMenuForm( { onCancel, onCreateMenu, menus } ) {
 						</Button>
 					) }
 				</form>
-			</PanelBody>
-		</Panel>
+			</CardBody>
+		</Card>
 	);
 }
 
-export default withFocusReturn( CreateMenuForm );
+export default withFocusReturn( CreateMenuArea );

--- a/packages/edit-navigation/src/components/menus-editor/index.js
+++ b/packages/edit-navigation/src/components/menus-editor/index.js
@@ -15,7 +15,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import CreateMenuPanel from './create-menu-panel';
+import CreateMenuArea from './create-menu-area';
 import MenuEditor from '../menu-editor';
 
 export default function MenusEditor( { blockEditorSettings } ) {
@@ -95,7 +95,7 @@ export default function MenusEditor( { blockEditorSettings } ) {
 				</CardBody>
 			</Card>
 			{ isCreateMenuPanelVisible && (
-				<CreateMenuPanel
+				<CreateMenuArea
 					menus={ stateMenus }
 					onCancel={
 						// User can only cancel out of menu creation if there

--- a/packages/edit-navigation/src/components/menus-editor/style.scss
+++ b/packages/edit-navigation/src/components/menus-editor/style.scss
@@ -46,7 +46,7 @@
 	margin: 0;
 }
 
-.edit-navigation-menus-editor__create-menu-panel {
+.edit-navigation-menus-editor__create-menu-area {
 	margin-bottom: 10px;
 }
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
I noticed that the `Panel`s in the edit navigation page were mostly replaced with `Card`s. The Create Menu remained a panel though, so this updates it to a `Card` for consistency.

Also uses the same `Area` terminology for the component name used for other `Card`s on this page.

## How has this been tested?
1. Enable the edit navigation page experiment
2. Visit the experimental edit navigation page (http://localhost:8888/wp-admin/admin.php?page=gutenberg-navigation)
3. Try creating a new menu
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
<img width="777" alt="Screenshot 2020-06-15 at 2 39 07 pm" src="https://user-images.githubusercontent.com/677833/84625532-01a5b600-af16-11ea-9c0f-acb2b5e8da0f.png">

## Types of changes
Non-breaking task
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
