### PR TITLE
Change MenuLocationsEditor to use a card instead of a panel

### DIFF
--- a/packages/edit-navigation/src/components/menu-locations-editor/index.js
+++ b/packages/edit-navigation/src/components/menu-locations-editor/index.js
@@ -5,8 +5,9 @@ import { useSelect } from '@wordpress/data';
 import {
 	SelectControl,
 	Button,
-	Panel,
-	PanelBody,
+	Card,
+	CardHeader,
+	CardBody,
 	Spinner,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -39,27 +40,30 @@ export default function MenuLocationsEditor() {
 
 	if ( menuLocations.length === 0 ) {
 		return (
-			<Panel className="edit-navigation-menu-editor__panel">
-				<PanelBody title={ __( 'Menu locations' ) }>
+			<Card>
+				<CardHeader>{ __( 'Menu locations' ) }</CardHeader>
+				<CardBody>
 					<p>{ __( 'There are no available menu locations' ) }</p>
-				</PanelBody>
-			</Panel>
+				</CardBody>
+			</Card>
 		);
 	}
 
 	if ( menus.length === 0 ) {
 		return (
-			<Panel className="edit-navigation-menu-editor__panel">
-				<PanelBody title={ __( 'Menu locations' ) }>
+			<Card>
+				<CardHeader>{ __( 'Menu locations' ) }</CardHeader>
+				<CardBody>
 					<p>{ __( 'There are no available menus' ) }</p>
-				</PanelBody>
-			</Panel>
+				</CardBody>
+			</Card>
 		);
 	}
 
 	return (
-		<Panel className="edit-navigation-menu-editor__panel">
-			<PanelBody title={ __( 'Menu locations' ) }>
+		<Card>
+			<CardHeader>{ __( 'Menu locations' ) }</CardHeader>
+			<CardBody>
 				<form
 					onSubmit={ ( event ) => {
 						event.preventDefault();
@@ -97,7 +101,7 @@ export default function MenuLocationsEditor() {
 						{ __( 'Save' ) }
 					</Button>
 				</form>
-			</PanelBody>
-		</Panel>
+			</CardBody>
+		</Card>
 	);
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Closes #23069 

Update the Manage Locations area to be a Card instead of a Panel.

Removes an unused classname.
<!-- Please describe what you have changed or added -->

## How has this been tested?
1. Enable the edit navigation page experiment
2. Visit the experimental edit navigation page (http://localhost:8888/wp-admin/admin.php?page=gutenberg-navigation)
3. Try managing locations

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
<img width="781" alt="Screenshot 2020-06-15 at 2 58 54 pm" src="https://user-images.githubusercontent.com/677833/84627046-c658b680-af18-11ea-849b-2da10d4b2431.png">

## Types of changes
Task (non-breaking)
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
