### PR TITLE
[ Navigation screen ] Fix saving on navigation screen

### DIFF
--- a/packages/edit-navigation/src/components/menu-editor/index.js
+++ b/packages/edit-navigation/src/components/menu-editor/index.js
@@ -61,7 +61,7 @@ export default function MenuEditor( {
 					initialOpen={ isLargeViewport }
 				/>
 				<BlockEditorArea
-					saveBlocks={ eventuallySaveMenuItems }
+					saveBlocks={ saveMenuItems }
 					menuId={ menuId }
 					onDeleteMenu={ onDeleteMenu }
 				/>


### PR DESCRIPTION
## Description
Fixes: ##23067

## How has this been tested?
Tested locally by:

- going to the new navigation screen
- creating a new menu
- choosing 'create from existing top level pages'
- saving

## Types of changes
Fixed what most likely was a bad merge and used the correct saving function.