### PR TITLE
Make the Popover scrolling and position behavior adapt to the content changes

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -81,14 +81,12 @@ function InserterMenu( {
 	const blocksTab = (
 		<>
 			<div className="block-editor-inserter__block-list">
-				<div className="block-editor-inserter__scrollable">
-					<InserterBlockList
-						rootClientId={ destinationRootClientId }
-						onInsert={ onInsert }
-						onHover={ onHover }
-						filterValue={ filterValue }
-					/>
-				</div>
+				<InserterBlockList
+					rootClientId={ destinationRootClientId }
+					onInsert={ onInsert }
+					onHover={ onHover }
+					filterValue={ filterValue }
+				/>
 			</div>
 			{ showInserterHelpPanel && (
 				<div className="block-editor-inserter__tips">
@@ -102,9 +100,7 @@ function InserterMenu( {
 	);
 
 	const patternsTab = (
-		<div className="block-editor-inserter__scrollable">
-			<BlockPatterns onInsert={ onInsert } filterValue={ filterValue } />
-		</div>
+		<BlockPatterns onInsert={ onInsert } filterValue={ filterValue } />
 	);
 
 	// Disable reason (no-autofocus): The inserter menu is a modal display, not one which

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -16,11 +16,20 @@ $block-inserter-tabs-height: 44px;
 	}
 }
 
-.block-editor-inserter__popover > .components-popover__content {
-	@include break-medium {
-		overflow-y: visible;
-		height: 100vh;
-		padding: 0;
+.block-editor-inserter__popover .block-editor-inserter__menu {
+	margin: -$grid-unit-15;
+
+	.block-editor-inserter__search {
+		top: -$grid-unit-15;
+	}
+
+	.block-editor-inserter__tabs .components-tab-panel__tabs {
+		top: $grid-unit-10 + $grid-unit-20 + $grid-unit-60 - $grid-unit-15;
+	}
+
+	.block-editor-inserter__main-area {
+		overflow: visible;
+		height: auto;
 	}
 }
 
@@ -43,8 +52,7 @@ $block-inserter-tabs-height: 44px;
 
 .block-editor-inserter__main-area {
 	width: auto;
-	display: flex;
-	flex-direction: column;
+	overflow-y: auto;
 	height: 100%;
 	@include break-medium {
 		width: $block-inserter-width;
@@ -65,9 +73,10 @@ $block-inserter-tabs-height: 44px;
 
 .block-editor-inserter__search {
 	padding: $grid-unit-20;
+	position: sticky;
+	top: 0;
+	background: $white;
 	z-index: 1;
-	flex-shrink: 0;
-	position: relative;
 
 	input[type="search"].block-editor-inserter__search-input {
 		@include input-control;
@@ -103,11 +112,15 @@ $block-inserter-tabs-height: 44px;
 
 .block-editor-inserter__tabs {
 	display: flex;
-	flex-grow: 1;
 	flex-direction: column;
 	margin-top: -$grid-unit-10;
 
 	.components-tab-panel__tabs {
+		position: sticky;
+		// Computed based off the search input height and paddings
+		top: $grid-unit-10 + $grid-unit-20 + $grid-unit-60;
+		background: $white;
+		z-index: 1;
 		border-bottom: $border-width solid $light-gray-500;
 
 		.components-tab-panel__tabs-item {
@@ -145,18 +158,6 @@ $block-inserter-tabs-height: 44px;
 .block-editor-inserter__block-list {
 	flex-grow: 1;
 	position: relative;
-}
-
-// This extra div is needed because
-// flex grow and overflow auto doesn't work well together.
-.block-editor-inserter__scrollable {
-	overflow: auto;
-	position: absolute;
-	top: 0;
-	left: 0;
-	bottom: 0;
-	right: 0;
-	overflow-y: scroll;
 }
 
 .block-editor-inserter__popover .block-editor-block-types-list {

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -10,7 +10,7 @@ import { useRef, useState, useEffect } from '@wordpress/element';
 import { focus, getRectangleFromRange } from '@wordpress/dom';
 import { ESCAPE } from '@wordpress/keycodes';
 import deprecated from '@wordpress/deprecated';
-import { useViewportMatch } from '@wordpress/compose';
+import { useViewportMatch, useResizeObserver } from '@wordpress/compose';
 import { close } from '@wordpress/icons';
 
 /**
@@ -260,11 +260,11 @@ const Popover = ( {
 	const anchorRefFallback = useRef( null );
 	const contentRef = useRef( null );
 	const containerRef = useRef();
-	const contentRect = useRef();
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const [ animateOrigin, setAnimateOrigin ] = useState();
 	const slot = useSlot( __unstableSlotName );
 	const isExpanded = expandOnMobile && isMobileViewport;
+	const [ containerResizeListener, contentSize ] = useResizeObserver();
 
 	noArrow = isExpanded || noArrow;
 
@@ -297,10 +297,6 @@ const Popover = ( {
 
 			if ( ! anchor ) {
 				return;
-			}
-
-			if ( ! contentRect.current ) {
-				contentRect.current = contentRef.current.getBoundingClientRect();
 			}
 
 			let relativeOffsetTop = 0;
@@ -343,7 +339,7 @@ const Popover = ( {
 				contentWidth,
 			} = computePopoverPosition(
 				anchor,
-				contentRect.current,
+				contentSize,
 				position,
 				__unstableSticky,
 				containerRef.current,
@@ -481,6 +477,7 @@ const Popover = ( {
 		anchorRef,
 		shouldAnchorIncludePadding,
 		position,
+		contentSize,
 		__unstableSticky,
 		__unstableAllowVerticalSubpixelPosition,
 		__unstableAllowHorizontalSubpixelPosition,
@@ -603,7 +600,10 @@ const Popover = ( {
 							className="components-popover__content"
 							tabIndex="-1"
 						>
-							{ children }
+							<div style={ { position: 'relative' } }>
+								{ containerResizeListener }
+								{ children }
+							</div>
 						</div>
 					</IsolatedEventContainer>
 				) }

--- a/packages/components/src/popover/stories/index.js
+++ b/packages/components/src/popover/stories/index.js
@@ -4,10 +4,16 @@
 import { boolean, select, text } from '@storybook/addon-knobs';
 
 /**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import { DraggableWrapper } from './_utils';
 import Popover from '../';
+import Button from '../../button';
 
 export default { title: 'Components/Popover', component: Popover };
 
@@ -99,4 +105,53 @@ export const positioning = () => {
 	return (
 		<DragExample label={ label } content={ content } noArrow={ noArrow } />
 	);
+};
+
+function DynamicHeightPopover() {
+	const [ height, setHeight ] = useState( 200 );
+	const increase = () => setHeight( height + 100 );
+	const decrease = () => setHeight( height - 100 );
+
+	return (
+		<div style={ { padding: '20px' } }>
+			<div>
+				<Button
+					isPrimary
+					onClick={ increase }
+					style={ {
+						marginRight: '20px',
+					} }
+				>
+					Increase Size
+				</Button>
+
+				<Button isPrimary onClick={ decrease }>
+					Decrease Size
+				</Button>
+			</div>
+
+			<p>
+				When the height of the popover exceeds the available space in
+				the canvas, a scrollbar inside the popover should appear.
+			</p>
+
+			<div>
+				<Popover>
+					<div
+						style={ {
+							height,
+							background: '#eee',
+							padding: '20px',
+						} }
+					>
+						Content with dynamic height
+					</div>
+				</Popover>
+			</div>
+		</div>
+	);
+}
+
+export const dynamicHeight = () => {
+	return <DynamicHeightPopover />;
 };

--- a/packages/components/src/popover/style.scss
+++ b/packages/components/src/popover/style.scss
@@ -216,11 +216,6 @@ $arrow-size: 8px;
 	}
 }
 
-// The withFocusReturn div
-.components-popover__content > div {
-	height: 100%;
-}
-
 .components-popover__header {
 	align-items: center;
 	background: $white;

--- a/packages/components/src/popover/test/__snapshots__/index.js.snap
+++ b/packages/components/src/popover/test/__snapshots__/index.js.snap
@@ -15,7 +15,11 @@ exports[`Popover should pass additional props to portaled element 1`] = `
             class="components-popover__content"
             tabindex="-1"
           >
-            Hello
+            <div
+              style="position: relative;"
+            >
+              Hello
+            </div>
           </div>
         </div>
       </div>
@@ -38,7 +42,11 @@ exports[`Popover should render content 1`] = `
             class="components-popover__content"
             tabindex="-1"
           >
-            Hello
+            <div
+              style="position: relative;"
+            >
+              Hello
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Requirement for #22789 

This PR updates the Popover behavior to make its height adapt to its content and refresh the max-height and position accordingly.

To test this, I added a story to the Popover component where you can increase the height of the popover dynamically.

The inserter popover (used in the canvas inserter) though was incompatible with this behavior. because we can't have both height: 100vh for the popover and have the popover adapts to height at the same time. I adapted the inserter popover styles to fix this.

I'm also pretty sure this PR fixes some dropdown/popover scrolling issues (more menu, block settings). I'll have to retrieve the related tracked issues.

**Testing instructions**

 - Make sure all popovers show properly
 - Make sure the inserter in both the canvas and the panel shows properly.