### PR TITLE
RichText: Add missing param docs for getActiveFormats()

### DIFF
--- a/packages/rich-text/src/get-active-formats.js
+++ b/packages/rich-text/src/get-active-formats.js
@@ -2,7 +2,7 @@
  * Gets the all format objects at the start of the selection.
  *
  * @param {Object}        value                Value to inspect.
- * @param {Array<Object>} value.formats        Formats object data values.
+ * @param {Array<Array>}  value.formats        Formats object data values.
  * @param {number}        value.start          Index to start from.
  * @param {number}        value.end            Index to end.
  * @param {Array}         value.activeFormats  Array to return if there are active formats.

--- a/packages/rich-text/src/get-active-formats.js
+++ b/packages/rich-text/src/get-active-formats.js
@@ -1,9 +1,13 @@
 /**
  * Gets the all format objects at the start of the selection.
  *
- * @param {Object} value                Value to inspect.
- * @param {Array}  EMPTY_ACTIVE_FORMATS Array to return if there are no active
- *                                      formats.
+ * @param {Object}        value                Value to inspect.
+ * @param {Array<Object>} value.formats        Formats object data values.
+ * @param {number}        value.start          Index to start from.
+ * @param {number}        value.end            Index to end.
+ * @param {Array}         value.activeFormats  Array to return if there are active formats.
+ * @param {Array}         EMPTY_ACTIVE_FORMATS Array to return if there are no active
+ *                                             formats.
  *
  * @return {?Object} Active format objects.
  */


### PR DESCRIPTION
See #22907.

Fixes the JSDoc warnings of file:
`packages/rich-text/src/get-active-formats.js`

## How has this been tested?
`npm run lint-js packages/rich-text/src`

## Types of changes
Bug Fix
