### PR TITLE
Packages: Add "gutenberg" to the list of keywords in package.json

### DIFF
--- a/packages/a11y/package.json
+++ b/packages/a11y/package.json
@@ -8,6 +8,7 @@
 		"wordpress",
 		"gutenberg",
 		"accessibility",
+		"a11y",
 		"aria-live"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/a11y/README.md",

--- a/packages/a11y/package.json
+++ b/packages/a11y/package.json
@@ -6,7 +6,8 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
-		"a11y",
+		"gutenberg",
+		"accessibility",
 		"aria-live"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/a11y/README.md",

--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"annotations"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/annotations/README.md",

--- a/packages/api-fetch/package.json
+++ b/packages/api-fetch/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"rest-api",
 		"fetch"
 	],

--- a/packages/autop/package.json
+++ b/packages/autop/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"autop"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/autop/README.md",

--- a/packages/babel-plugin-import-jsx-pragma/package.json
+++ b/packages/babel-plugin-import-jsx-pragma/package.json
@@ -6,7 +6,9 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
-		"babel-plugin",
+		"gutenberg",
+		"babel",
+		"plugin",
 		"jsx",
 		"pragma",
 		"react"

--- a/packages/babel-plugin-import-jsx-pragma/package.json
+++ b/packages/babel-plugin-import-jsx-pragma/package.json
@@ -9,6 +9,7 @@
 		"gutenberg",
 		"babel",
 		"plugin",
+		"babel-plugin",
 		"jsx",
 		"pragma",
 		"react"

--- a/packages/babel-plugin-makepot/package.json
+++ b/packages/babel-plugin-makepot/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"i18n",
 		"babel",
 		"plugin"

--- a/packages/babel-preset-default/package.json
+++ b/packages/babel-preset-default/package.json
@@ -8,7 +8,8 @@
 		"wordpress",
 		"gutenberg",
 		"babel",
-		"preset"
+		"preset",
+		"babel-preset"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/babel-preset-default/README.md",
 	"repository": {

--- a/packages/babel-preset-default/package.json
+++ b/packages/babel-preset-default/package.json
@@ -6,9 +6,9 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"babel",
-		"preset",
-		"default"
+		"preset"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/babel-preset-default/README.md",
 	"repository": {

--- a/packages/base-styles/package.json
+++ b/packages/base-styles/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"sass",
 		"scss",
 		"css"

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"blob"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/blob/README.md",

--- a/packages/block-directory/package.json
+++ b/packages/block-directory/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"block directory"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/block-directory/README.md",

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"editor",
 		"blocks"
 	],

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"blocks"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/block-library/README.md",

--- a/packages/block-serialization-default-parser/package.json
+++ b/packages/block-serialization-default-parser/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"block",
 		"parser"
 	],

--- a/packages/block-serialization-spec-parser/package.json
+++ b/packages/block-serialization-spec-parser/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"block",
 		"spec",
 		"parser"

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"blocks"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/blocks/README.md",

--- a/packages/browserslist-config/package.json
+++ b/packages/browserslist-config/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"browserslist",
 		"browserslist-config"
 	],

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"components"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/components/README.md",

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -6,8 +6,10 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
-		"React",
-		"hoc"
+		"gutenberg",
+		"react",
+		"hoc",
+		"hooks"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/compose/README.md",
 	"repository": {

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"data",
 		"entities"
 	],

--- a/packages/create-block/package.json
+++ b/packages/create-block/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"block",
 		"scaffold"
 	],

--- a/packages/custom-templated-path-webpack-plugin/package.json
+++ b/packages/custom-templated-path-webpack-plugin/package.json
@@ -6,8 +6,9 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"webpack",
-		"webpack-plugin"
+		"plugin"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/blob/master/packages/custom-templated-path-webpack-plugin/README.md",
 	"repository": {

--- a/packages/custom-templated-path-webpack-plugin/package.json
+++ b/packages/custom-templated-path-webpack-plugin/package.json
@@ -8,7 +8,8 @@
 		"wordpress",
 		"gutenberg",
 		"webpack",
-		"plugin"
+		"plugin",
+		"webpack-plugin"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/blob/master/packages/custom-templated-path-webpack-plugin/README.md",
 	"repository": {

--- a/packages/data-controls/package.json
+++ b/packages/data-controls/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"data",
 		"controls"
 	],

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"data",
 		"redux"
 	],

--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"date"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/date/README.md",

--- a/packages/dependency-extraction-webpack-plugin/package.json
+++ b/packages/dependency-extraction-webpack-plugin/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"webpack",
 		"dependency"
 	],

--- a/packages/deprecated/package.json
+++ b/packages/deprecated/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"deprecated"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/deprecated/README.md",

--- a/packages/docgen/package.json
+++ b/packages/docgen/package.json
@@ -5,9 +5,10 @@
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [
+		"wordpress",
+		"gutenberg",
 		"jsdoc",
-		"documentation",
-		"wordpress"
+		"documentation"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/docgen/README.md",
 	"repository": {

--- a/packages/dom-ready/package.json
+++ b/packages/dom-ready/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"dom-ready"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/dom-ready/README.md",

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"dom",
 		"utils"
 	],

--- a/packages/e2e-test-utils/package.json
+++ b/packages/e2e-test-utils/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"e2e",
 		"utils"
 	],

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"e2e",
 		"tests"
 	],

--- a/packages/edit-navigation/package.json
+++ b/packages/edit-navigation/package.json
@@ -6,7 +6,10 @@
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [
-		"wordpress"
+		"wordpress",
+		"gutenberg",
+		"editor",
+		"navigation"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/edit-navigation/README.md",
 	"repository": {

--- a/packages/edit-post/package.json
+++ b/packages/edit-post/package.json
@@ -6,7 +6,9 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
-		"editor"
+		"gutenberg",
+		"editor",
+		"post"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/edit-post/README.md",
 	"repository": {

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -5,7 +5,10 @@
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [
-		"wordpress"
+		"wordpress",
+		"gutenberg",
+		"editor",
+		"site"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/edit-site/README.md",
 	"repository": {

--- a/packages/edit-widgets/package.json
+++ b/packages/edit-widgets/package.json
@@ -6,7 +6,10 @@
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [
-		"wordpress"
+		"wordpress",
+		"gutenberg",
+		"editor",
+		"widgets"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/edit-widgets/README.md",
 	"repository": {

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"editor"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/editor/README.md",

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"element",
 		"react"
 	],

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -6,8 +6,8 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"environment",
-		"wordpress-environment",
 		"docker"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/env#readme",

--- a/packages/escape-html/package.json
+++ b/packages/escape-html/package.json
@@ -5,7 +5,9 @@
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [
-		"wordpress"
+		"wordpress",
+		"gutenberg",
+		"html"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/escape-html/README.md",
 	"repository": {

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -6,7 +6,9 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
-		"eslint"
+		"gutenberg",
+		"eslint",
+		"plugin"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/eslint-plugin/README.md",
 	"repository": {

--- a/packages/format-library/package.json
+++ b/packages/format-library/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"formats"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/format-library/README.md",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"hooks"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/hooks/README.md",

--- a/packages/html-entities/package.json
+++ b/packages/html-entities/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"html",
 		"entities"
 	],

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"i18n"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/i18n/README.md",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -5,9 +5,10 @@
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [
+		"wordpress",
+		"gutenberg",
 		"icons",
-		"dashicon",
-		"wordpress"
+		"dashicon"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/icons/README.md",
 	"repository": {

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"interface",
 		"components"
 	],

--- a/packages/is-shallow-equal/package.json
+++ b/packages/is-shallow-equal/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"shallow",
 		"shallow-equal",
 		"shallowequal"

--- a/packages/jest-console/package.json
+++ b/packages/jest-console/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"jest",
 		"matchers",
 		"console"

--- a/packages/jest-preset-default/package.json
+++ b/packages/jest-preset-default/package.json
@@ -6,8 +6,8 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"jest",
-		"jest-preset",
 		"preset",
 		"react",
 		"enzyme"

--- a/packages/jest-puppeteer-axe/package.json
+++ b/packages/jest-puppeteer-axe/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"jest",
 		"puppeteer",
 		"axe",

--- a/packages/keyboard-shortcuts/package.json
+++ b/packages/keyboard-shortcuts/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"keycodes"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/keyboard-shortcuts/README.md",

--- a/packages/keycodes/package.json
+++ b/packages/keycodes/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"keycodes"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/keycodes/README.md",

--- a/packages/lazy-import/package.json
+++ b/packages/lazy-import/package.json
@@ -5,7 +5,9 @@
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [
-		"wordpress"
+		"wordpress",
+		"gutenberg",
+		"import"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/lazy-import/README.md",
 	"repository": {

--- a/packages/library-export-default-webpack-plugin/package.json
+++ b/packages/library-export-default-webpack-plugin/package.json
@@ -6,8 +6,10 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"webpack",
-		"webpack-plugin"
+		"plugin",
+		"export"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/library-export-default-webpack-plugin/README.md",
 	"repository": {

--- a/packages/library-export-default-webpack-plugin/package.json
+++ b/packages/library-export-default-webpack-plugin/package.json
@@ -9,6 +9,7 @@
 		"gutenberg",
 		"webpack",
 		"plugin",
+		"webpack-plugin",
 		"export"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/library-export-default-webpack-plugin/README.md",

--- a/packages/list-reusable-blocks/package.json
+++ b/packages/list-reusable-blocks/package.json
@@ -5,6 +5,8 @@
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [
+		"wordpress",
+		"gutenberg",
 		"templates",
 		"reusable blocks"
 	],

--- a/packages/media-utils/package.json
+++ b/packages/media-utils/package.json
@@ -6,9 +6,9 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"media",
-		"upload",
-		"media-upload"
+		"upload"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/master/packages/media-utils/README.md",
 	"repository": {

--- a/packages/notices/package.json
+++ b/packages/notices/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"notices"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/notices/README.md",

--- a/packages/npm-package-json-lint-config/package.json
+++ b/packages/npm-package-json-lint-config/package.json
@@ -6,8 +6,9 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"npm-package-json-lint",
-		"npm-package-json-lint-config"
+		"config"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/npm-package-json-lint-config/README.md",
 	"repository": {

--- a/packages/nux/package.json
+++ b/packages/nux/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"nux"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/nux/README.md",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"plugins"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/plugins/README.md",

--- a/packages/postcss-plugins-preset/package.json
+++ b/packages/postcss-plugins-preset/package.json
@@ -6,8 +6,11 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"postcss",
-		"css"
+		"css",
+		"plugins",
+		"preset"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/postcss-plugins-preset/README.md",
 	"repository": {

--- a/packages/postcss-themes/package.json
+++ b/packages/postcss-themes/package.json
@@ -10,6 +10,7 @@
 		"postcss",
 		"css",
 		"plugin",
+		"postcss-plugin",
 		"colors",
 		"themes"
 	],

--- a/packages/postcss-themes/package.json
+++ b/packages/postcss-themes/package.json
@@ -6,9 +6,10 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"postcss",
 		"css",
-		"postcss-plugin",
+		"plugin",
 		"colors",
 		"themes"
 	],

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -6,8 +6,9 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"prettier",
-		"prettier-config"
+		"config"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/prettier-config/README.md",
 	"repository": {

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"mobile",
 		"platform"
 	],

--- a/packages/priority-queue/package.json
+++ b/packages/priority-queue/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"browser",
 		"async"
 	],

--- a/packages/project-management-automation/package.json
+++ b/packages/project-management-automation/package.json
@@ -5,7 +5,10 @@
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [
-		"wordpress"
+		"wordpress",
+		"gutenberg",
+		"github",
+		"action"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/project-management-automation/README.md",
 	"repository": {

--- a/packages/redux-routine/package.json
+++ b/packages/redux-routine/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"redux",
 		"middleware",
 		"coroutine"

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"rich-text"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/rich-text/README.md",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -7,8 +7,7 @@
 	"keywords": [
 		"wordpress",
 		"gutenberg",
-		"scripts",
-		"reusable-scripts"
+		"scripts"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/scripts/README.md",
 	"repository": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -6,9 +6,9 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"scripts",
-		"reusable-scripts",
-		"wordpress-scripts"
+		"reusable-scripts"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/scripts/README.md",
 	"repository": {

--- a/packages/server-side-render/package.json
+++ b/packages/server-side-render/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"server-side",
 		"render"
 	],

--- a/packages/shortcode/package.json
+++ b/packages/shortcode/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"shortcode"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/shortcode/README.md",

--- a/packages/token-list/package.json
+++ b/packages/token-list/package.json
@@ -5,6 +5,8 @@
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [
+		"wordpress",
+		"gutenberg",
 		"domtokenlist"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/token-list/README.md",

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"url"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/url/README.md",

--- a/packages/viewport/package.json
+++ b/packages/viewport/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"viewport"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/viewport/README.md",

--- a/packages/warning/package.json
+++ b/packages/warning/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"warning"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/warning/README.md",

--- a/packages/wordcount/package.json
+++ b/packages/wordcount/package.json
@@ -6,6 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"wordpress",
+		"gutenberg",
 		"wordcount"
 	],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/wordcount/README.md",


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Suggested by @mtias in the comments under Matt's post after WordCamp EU:
https://ma.tt/2020/06/wceu-questions/#comment-590029

> > I was naively searching npm for Gutenberg. Should have thought to search WordPress.
> We should probably add the “gutenberg” keywords somewhere in those packages.
