### PR TITLE
[ Navigation Block ] Renamed navigation link title to Link

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -309,7 +309,7 @@
   - Add standard notices to nav menu page. ([22374](https://github.com/WordPress/gutenberg/pull/22374))
   - Implement the creation of menus on the edit navigation screen. ([22309](https://github.com/WordPress/gutenberg/pull/22309))
   - Add menu location management. ([21351](https://github.com/WordPress/gutenberg/pull/21351))
-  - Navigation Link block: Add RichText split-at-end/merge/remove behavior. ([21764](https://github.com/WordPress/gutenberg/pull/21764))
+  - Link block: Add RichText split-at-end/merge/remove behavior. ([21764](https://github.com/WordPress/gutenberg/pull/21764))
   - Fix navigation block placeholder overlap. ([22407](https://github.com/WordPress/gutenberg/pull/22407))
   - Adds orientation class on frontend for the navigation block. ([22272](https://github.com/WordPress/gutenberg/pull/22272))
   - Refactor block navigation block contents. ([22487](https://github.com/WordPress/gutenberg/pull/22487))
@@ -602,7 +602,7 @@
 - Fix image center alignment behavior. ([21911](https://github.com/WordPress/gutenberg/pull/21911))
 - Fix centered buttons margins. ([21947](https://github.com/WordPress/gutenberg/pull/21947))
 - Revert the button block to the previous markup. ([21923](https://github.com/WordPress/gutenberg/pull/21923))
-- Avoid using inline RichText element for navigation link. ([21856](https://github.com/WordPress/gutenberg/pull/21856))
+- Avoid using inline RichText element for Link. ([21856](https://github.com/WordPress/gutenberg/pull/21856))
 - Ensure `resetEditorBlocks` is synchronous. ([21839](https://github.com/WordPress/gutenberg/pull/21839))
 - Fix the button outline style for the old button markup. ([21816](https://github.com/WordPress/gutenberg/pull/21816))
 - Fix default attribute on audio preload. ([21735](https://github.com/WordPress/gutenberg/pull/21735))
@@ -993,7 +993,7 @@
 - Navigation Block:
 	- Fix dynamic rendering recursive function name typo [21078](https://github.com/WordPress/gutenberg/pull/21078)
 	- Avoid hiding submenu when adding a link [21035](https://github.com/WordPress/gutenberg/pull/21035)
-	- Fix toolbar overlap on navigation links [21033](https://github.com/WordPress/gutenberg/pull/21033)
+	- Fix toolbar overlap on Links [21033](https://github.com/WordPress/gutenberg/pull/21033)
 - PlainText v2 [21076](https://github.com/WordPress/gutenberg/pull/21076)
 	- Editable Component [18361](https://github.com/WordPress/gutenberg/pull/18361)
 ​
@@ -1501,13 +1501,13 @@
 	- Define allowedFormats option for NavigationLink [19507](https://github.com/WordPress/gutenberg/pull/19507)
 	- Rename the LinkControl's edit button title [19505](https://github.com/WordPress/gutenberg/pull/19505)
 	- Use underline instead of bottom border for nav links [19538](https://github.com/WordPress/gutenberg/pull/19538)
-	- Do not output navigation links with empty labels [19652](https://github.com/WordPress/gutenberg/pull/19652)
+	- Do not output Links with empty labels [19652](https://github.com/WordPress/gutenberg/pull/19652)
 	- Remove draggable from all navigation-link blocks [19648](https://github.com/WordPress/gutenberg/pull/19648)
-	- Remove duplicate CSS from Navigation that is aleady in Navigation Link CSS [19540](https://github.com/WordPress/gutenberg/pull/19540)
+	- Remove duplicate CSS from Navigation that is aleady in Link CSS [19540](https://github.com/WordPress/gutenberg/pull/19540)
 	- Remove the text color button double border on the navigation block toolbar [19567](https://github.com/WordPress/gutenberg/pull/19567)
-	- Replace, on editing a navigation link, the current label with the title of page or post [19461](https://github.com/WordPress/gutenberg/pull/19461)
+	- Replace, on editing a Link, the current label with the title of page or post [19461](https://github.com/WordPress/gutenberg/pull/19461)
 	- Add description for the Link Settings Description in the Link Block settings [19508](https://github.com/WordPress/gutenberg/pull/19508)
-	- Fix Navigation Link url escaping [19679](https://github.com/WordPress/gutenberg/pull/19679)
+	- Fix Link url escaping [19679](https://github.com/WordPress/gutenberg/pull/19679)
 	- Fix alignment on left border between menu navigation controls and menu item [19511](https://github.com/WordPress/gutenberg/pull/19511)
 	- Styling fixes after navigation feature merge [19455](https://github.com/WordPress/gutenberg/pull/19455)
 - Add support for align wide to deprecated versions of gallery block [19522](https://github.com/WordPress/gutenberg/pull/19522)
@@ -1519,7 +1519,7 @@
 - Fix small visual select glitch [19590](https://github.com/WordPress/gutenberg/pull/19590)
 - Fix the height of the tags tokens [19592](https://github.com/WordPress/gutenberg/pull/19592)
 - Fix buttons block Link shortcut not working with multiple buttons [19492](https://github.com/WordPress/gutenberg/pull/19492)
-- Disable HTML on navigation link [19483](https://github.com/WordPress/gutenberg/pull/19483)
+- Disable HTML on Link [19483](https://github.com/WordPress/gutenberg/pull/19483)
 - Fix managing page break in the block manager [19303](https://github.com/WordPress/gutenberg/pull/19303)
 - Show predefined colors in the navigation block [19493](https://github.com/WordPress/gutenberg/pull/19493)
 - Update CSS rule on the widgets screen required for drag & drop [19428](https://github.com/WordPress/gutenberg/pull/19428)
@@ -1820,7 +1820,7 @@
     * Fix [double click to open the appender](https://github.com/WordPress/gutenberg/pull/18379).
     * Add a **type=submit** to the [search suggestion buttons](https://github.com/WordPress/gutenberg/pull/18933).
     * Support [justifying the menu items](https://github.com/WordPress/gutenberg/pull/18909).
-    * Use [correct classnames](https://github.com/WordPress/gutenberg/pull/18926) for navigation link block save output.
+    * Use [correct classnames](https://github.com/WordPress/gutenberg/pull/18926) for Link block save output.
     * Remove the [inspector controls](https://github.com/WordPress/gutenberg/pull/18948).
 * Improve the block multi-selection:
     * A11y: [Use the browser’s selection](https://github.com/WordPress/gutenberg/pull/16835) default color. 

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -107,7 +107,7 @@ function NavigationLinkEdit( {
 	}, [ url ] );
 
 	/**
-	 * Focus the navigation link label text and select it.
+	 * Focus the Link label text and select it.
 	 */
 	function selectLabelText() {
 		ref.current.focus();

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -1,4 +1,4 @@
-// Normalize navigation link and edit containers, to look mostly the same.
+// Normalize Link and edit containers, to look mostly the same.
 .wp-block-navigation-link__field .components-text-control__input.components-text-control__input,
 .wp-block-navigation-link__container {
 	border-radius: 0;

--- a/packages/block-library/src/navigation-link/index.js
+++ b/packages/block-library/src/navigation-link/index.js
@@ -16,7 +16,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Navigation Link' ),
+	title: __( 'Link' ),
 	icon,
 	description: __( 'Add a page, link, or another item to your navigation.' ),
 	__experimentalLabel: ( { label } ) => label,

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -88,7 +88,7 @@ function block_core_navigation_build_css_font_sizes( $attributes ) {
 /**
  * Recursively filters out links with no labels to build a clean navigation block structure.
  *
- * @param array $blocks Navigation link inner blocks from the Navigation block.
+ * @param array $blocks Link inner blocks from the Navigation block.
  * @return array Blocks that had valid labels
  */
 function block_core_navigation_empty_navigation_links_recursive( $blocks ) {

--- a/packages/e2e-tests/fixtures/block-transforms.js
+++ b/packages/e2e-tests/fixtures/block-transforms.js
@@ -250,7 +250,7 @@ export const EXPECTED_TRANSFORMS = {
 		availableTransforms: [ 'Group' ],
 	},
 	'core__navigation-link': {
-		originalBlock: 'Navigation Link',
+		originalBlock: 'Link',
 		availableTransforms: [ 'Group' ],
 	},
 	core__nextpage: {

--- a/packages/e2e-tests/specs/experiments/navigation.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation.test.js
@@ -172,7 +172,7 @@ async function mockCreatePageResponse( title, slug ) {
  *
  * @param {Object} link link object to be tested
  * @param {string} link.url What will be typed in the search input
- * @param {string} link.label What the resulting label will be in the creating Navigation Link Block after the block is created.
+ * @param {string} link.label What the resulting label will be in the creating Link Block after the block is created.
  * @param {string} link.type What kind of suggestion should be clicked, ie. 'url', 'create', or 'entity'
  */
 async function updateActiveNavigationLink( { url, label, type } ) {
@@ -340,7 +340,7 @@ describe( 'Navigation', () => {
 			// Scope element selector to the Editor's "Content" region as otherwise it picks up on
 			// block previews.
 			const navBlockItemsLength = await page.$$eval(
-				'[aria-label="Content"][role="region"] li[aria-label="Block: Navigation Link"]',
+				'[aria-label="Content"][role="region"] li[aria-label="Block: Link"]',
 				( els ) => els.length
 			);
 
@@ -366,7 +366,7 @@ describe( 'Navigation', () => {
 			// Scope element selector to the "Editor content" as otherwise it picks up on
 			// Block Style live previews.
 			const navBlockItemsLength = await page.$$eval(
-				'[aria-label="Content"][role="region"] li[aria-label="Block: Navigation Link"]',
+				'[aria-label="Content"][role="region"] li[aria-label="Block: Link"]',
 				( els ) => els.length
 			);
 
@@ -420,7 +420,7 @@ describe( 'Navigation', () => {
 
 		await createEmptyNavBlock();
 
-		// Add a link to the default Navigation Link block.
+		// Add a link to the default Link block.
 		await updateActiveNavigationLink( {
 			url: 'https://wordpress.org',
 			label: 'WP',
@@ -430,7 +430,7 @@ describe( 'Navigation', () => {
 		// Move the mouse to reveal the block movers. Without this the test seems to fail.
 		await page.mouse.move( 100, 100 );
 
-		// Add another Navigation Link block.
+		// Add another Link block.
 		// Using 'click' here checks for regressions of https://github.com/WordPress/gutenberg/issues/18329,
 		// an issue where the block appender requires two clicks.
 		await page.click( '.wp-block-navigation .block-list-appender' );
@@ -470,14 +470,14 @@ describe( 'Navigation', () => {
 			{ title: 'Get in Touch', slug: 'get-in-touch' },
 		] );
 
-		// Add a link to the default Navigation Link block.
+		// Add a link to the default Link block.
 		await updateActiveNavigationLink( {
 			url: 'Get in Touch',
 			label: 'Contact',
 			type: 'entity',
 		} );
 
-		// Expect a Navigation Block with two Navigation Links in the snapshot.
+		// Expect a Navigation Block with two Links in the snapshot.
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 


### PR DESCRIPTION
## Description
Advances #22750

## How has this been tested?
Tested locally by:

- create a new post
- add a navigation block
- choose create empty
- verify the appender says "Add Link"

## Screenshots <!-- if applicable -->

<img width="653" alt="Screenshot 2020-06-15 at 17 19 49" src="https://user-images.githubusercontent.com/107534/84668550-74219080-af2c-11ea-8432-27b46e4c66a1.png">


## Types of changes
Updated the title of the Navigation Link block. It seems premature to rename the whole block before we decide it can be a standalone block.