### PR TITLE
Fix: Improve JSDoc comment in ESNext template in edit.js file

### DIFF
--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+- Fix an error reported by ESLint by improving JSDoc comment in ESNext template in `src/edit.js` file ([#23164](https://github.com/WordPress/gutenberg/pull/23164)).
+
 ## 0.14.0 (2020-06-15)
 
 ### Enhancements

--- a/packages/create-block/lib/templates/esnext/src/edit.js.mustache
+++ b/packages/create-block/lib/templates/esnext/src/edit.js.mustache
@@ -19,7 +19,8 @@ import './editor.scss';
  *
  * @see https://developer.wordpress.org/block-editor/developers/block-api/block-edit-save/#edit
  *
- * @param {Object} [props] Properties passed from the editor.
+ * @param {Object} [props]           Properties passed from the editor.
+ * @param {string} [props.className] Class name generated for the block.
  *
  * @return {WPElement} Element to render.
  */


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
I noticed some errors printed when executing `npm run lint:js` for the scaffolded block.

## Testing

```bash
npx wp-create-block esnext-example
cd esnext-example
npm run lint:js
```