### PR TITLE
Fix/navigation block dark style appender

### DIFF
--- a/packages/block-library/src/navigation-link/index.js
+++ b/packages/block-library/src/navigation-link/index.js
@@ -16,7 +16,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Navigation Link' ),
+	title: __( 'Link' ),
 	icon,
 	description: __( 'Add a page, link, or another item to your navigation.' ),
 	__experimentalLabel: ( { label } ) => label,

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -145,3 +145,14 @@ $color-control-label-height: 20px;
 	display: flex;
 	flex-direction: column;
 }
+
+// Dark style appender.
+.wp-block-navigation.is-style-dark {
+	.block-editor-button-block-appender.block-list-appender__toggle {
+		color: #fff;
+	}
+	.block-editor-button-block-appender.block-list-appender__toggle > svg {
+		color: #000;
+		background-color: #fff;
+	}
+}


### PR DESCRIPTION
## Description
Advances #22750

## How has this been tested?
Tested locally by:

- create a new post
- add a navigation block
- choose create empty
- set style from inspector to dark
- verify the appender is inverted


## Screenshots <!-- if applicable -->

<img width="656" alt="Screenshot 2020-06-15 at 17 49 12" src="https://user-images.githubusercontent.com/107534/84671874-8c93aa00-af30-11ea-921c-6cf52fa93b85.png">

## Types of changes
Added a CSS override for the appender in the editor CSS for the dark style.
