### PR TITLE
Packages: Fix the changelong updater for initial npm release

### DIFF
--- a/bin/plugin/commands/packages.js
+++ b/bin/plugin/commands/packages.js
@@ -145,7 +145,8 @@ async function updatePackageChangelogs(
 				// A version bump required. Found new changelog section.
 				if (
 					versionBump !== 'minor' &&
-					lineNormalized.startsWith( '### ' )
+					( lineNormalized.startsWith( '### ' ) ||
+						lineNormalized.startsWith( '- initial release' ) )
 				) {
 					versionBump = minimumVersionBump;
 				}

--- a/packages/lazy-import/CHANGELOG.md
+++ b/packages/lazy-import/CHANGELOG.md
@@ -2,4 +2,6 @@
 
 ## Unreleased
 
+## 1.0.0 (2020-06-15)
+
 - Initial release.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
During npm release today, the changelog file for `@wordpress/lazy-import` wasn't properly updated with the initial `1.0.0` version. This PR tries to fix that for the CHANGELOG file and for future releases.

I don't know how to test it properly without too much commenting out the code. It might be a good reason to write some unit tests one day for this functionality though :)