### PR TITLE
Editor: Extend PostTrashCheck with canUser() check for delete action

### DIFF
--- a/packages/editor/src/components/post-trash/check.js
+++ b/packages/editor/src/components/post-trash/check.js
@@ -3,8 +3,8 @@
  */
 import { withSelect } from '@wordpress/data';
 
-function PostTrashCheck( { isNew, postId, children } ) {
-	if ( isNew || ! postId ) {
+function PostTrashCheck( { isNew, postId, canUserDelete, children } ) {
+	if ( isNew || ! postId || ! canUserDelete ) {
 		return null;
 	}
 
@@ -12,9 +12,18 @@ function PostTrashCheck( { isNew, postId, children } ) {
 }
 
 export default withSelect( ( select ) => {
-	const { isEditedPostNew, getCurrentPostId } = select( 'core/editor' );
+	const { isEditedPostNew, getCurrentPostId, getCurrentPostType } = select(
+		'core/editor'
+	);
+	const { getPostType, canUser } = select( 'core' );
+	const postId = getCurrentPostId();
+	const postType = getPostType( getCurrentPostType() );
+	const resource = postType?.[ 'rest_base' ] || '';
+
 	return {
 		isNew: isEditedPostNew(),
-		postId: getCurrentPostId(),
+		postId,
+		canUserDelete:
+			postId && resource ? canUser( 'delete', resource, postId ) : false,
 	};
 } )( PostTrashCheck );


### PR DESCRIPTION
## Description
Fixes #23144.

This is a version which doesn't require a new `action-delete` action on the resource.

## How has this been tested?
* Create a user with only `read` and `edit_posts` capabilities
* Create a new post and notice that there's no longer a trash link.

For testing you can use WP-CLI to create a user "author" with the role "author_only_edit" which can only create/edit draft posts.

```
npx wp-env run cli wp role create author_only_edit AuthorOnlyEdit
npx wp-env run cli wp cap add author_only_edit read edit_posts
npx wp-env run cli wp user create author author@example.com
npx wp-env run cli wp user set-role author@example.com author_only_edit
```

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
