### PR TITLE
Add preset for padding and use it in the UI controls

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -461,20 +461,3 @@ add_filter( 'pre_render_block', 'gutenberg_render_block_with_assigned_block_cont
  * @see WP_Block::render
  */
 remove_action( 'enqueue_block_assets', 'wp_enqueue_registered_block_scripts_and_styles' );
-
-
-/**
- * Extends block editor settings to include a list of values for padding.
- *
- * @param array $settings Default editor settings.
- *
- * @return array Filtered editor settings.
- */
-function gutenberg_add_padding_presets( $settings ) {
-	list( $editor_padding ) = (array) get_theme_support( 'editor-spacing-padding' );
-	if ( false !== $editor_padding ) {
-		$settings['padding'] = $editor_padding;
-	}
-	return $settings;
-}
-add_filter( 'block_editor_settings', 'gutenberg_add_padding_presets' );

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -461,3 +461,20 @@ add_filter( 'pre_render_block', 'gutenberg_render_block_with_assigned_block_cont
  * @see WP_Block::render
  */
 remove_action( 'enqueue_block_assets', 'wp_enqueue_registered_block_scripts_and_styles' );
+
+
+/**
+ * Extends block editor settings to include a list of values for padding.
+ *
+ * @param array $settings Default editor settings.
+ *
+ * @return array Filtered editor settings.
+ */
+function gutenberg_add_padding_presets( $settings ) {
+	list( $editor_padding ) = (array) get_theme_support( 'editor-spacing-padding' );
+	if ( false !== $editor_padding ) {
+		$settings['padding'] = $editor_padding;
+	}
+	return $settings;
+}
+add_filter( 'block_editor_settings', 'gutenberg_add_padding_presets' );

--- a/lib/experimental-default-theme.json
+++ b/lib/experimental-default-theme.json
@@ -125,8 +125,8 @@
 			],
 			"padding": [
 				{ "slug": "small", "value": 4 },
-				{ "slug": "regular", "value": 14 },
-				{ "slug": "large", "value": 23 }
+				{ "slug": "regular", "value": 16 },
+				{ "slug": "large", "value": 32 }
 			]
 		},
 		"features": {

--- a/lib/experimental-default-theme.json
+++ b/lib/experimental-default-theme.json
@@ -122,6 +122,11 @@
 					"slug": "vivid-cyan-blue-to-vivid-purple",
 					"value": "linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)"
 				}
+			],
+			"padding": [
+				{ "slug": "small", "value": 4 },
+				{ "slug": "regular", "value": 14 },
+				{ "slug": "large", "value": 23 }
 			]
 		},
 		"features": {

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -478,6 +478,7 @@ _Properties_
 -   _colors_ `Array`: Palette colors
 -   _disableCustomColors_ `boolean`: Whether or not the custom colors are disabled
 -   _fontSizes_ `Array`: Available font sizes
+-   _padding_ `Array`: Available padding values
 -   _disableCustomFontSizes_ `boolean`: Whether or not the custom font sizes are disabled
 -   _imageSizes_ `Array`: Available image sizes
 -   _maxWidth_ `number`: Max width to constraint resizing

--- a/packages/block-editor/src/hooks/padding.js
+++ b/packages/block-editor/src/hooks/padding.js
@@ -11,6 +11,7 @@ import { __experimentalBoxControl as BoxControl } from '@wordpress/components';
  */
 import { cleanEmptyObject } from './utils';
 import { useCustomUnits } from '../components/unit-control';
+import { useSelect } from '@wordpress/data';
 
 export const PADDING_SUPPORT_KEY = '__experimentalPadding';
 
@@ -29,6 +30,9 @@ export function PaddingEdit( props ) {
 	} = props;
 
 	const units = useCustomUnits();
+	const { padding } = useSelect( ( select ) =>
+		select( 'core/block-editor' ).getSettings()
+	);
 
 	if ( ! hasBlockSupport( blockName, PADDING_SUPPORT_KEY ) ) {
 		return null;
@@ -64,6 +68,7 @@ export function PaddingEdit( props ) {
 		web: (
 			<>
 				<BoxControl
+					presetValues={ padding }
 					values={ style?.spacing?.padding }
 					onChange={ onChange }
 					onChangeShowVisualizer={ onChangeShowVisualizer }

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -134,8 +134,8 @@ export const SETTINGS_DEFAULTS = {
 
 	padding: [
 		{ slug: 'small', name: __( 'Small' ), value: 4 },
-		{ slug: 'regular', name: __( 'Regular' ), value: 14 },
-		{ slug: 'large', name: __( 'Large' ), value: 23 },
+		{ slug: 'regular', name: __( 'Regular' ), value: 16 },
+		{ slug: 'large', name: __( 'Large' ), value: 32 },
 	],
 
 	// This is current max width of the block inner area

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -131,6 +131,12 @@ export const SETTINGS_DEFAULTS = {
 		{ slug: 'full', name: __( 'Full Size' ) },
 	],
 
+	padding: [
+		{ slug: 'small', name: __( 'Small' ), value: 4 },
+		{ slug: 'regular', name: __( 'Regular' ), value: 14 },
+		{ slug: 'large', name: __( 'Large' ), value: 23 },
+	],
+
 	// This is current max width of the block inner area
 	// It's used to constraint image resizing and this value could be overridden later by themes
 	maxWidth: 580,

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -16,6 +16,7 @@ export const PREFERENCES_DEFAULTS = {
  * @property {Array} colors Palette colors
  * @property {boolean} disableCustomColors Whether or not the custom colors are disabled
  * @property {Array} fontSizes Available font sizes
+ * @property {Array} padding Available padding values
  * @property {boolean} disableCustomFontSizes Whether or not the custom font sizes are disabled
  * @property {Array} imageSizes Available image sizes
  * @property {number} maxWidth Max width to constraint resizing

--- a/packages/components/src/box-control/index.js
+++ b/packages/components/src/box-control/index.js
@@ -44,6 +44,7 @@ function useUniqueId( idProp ) {
 
 	return idProp || id;
 }
+
 export default function BoxControl( {
 	id: idProp,
 	inputProps = defaultInputProps,
@@ -121,6 +122,17 @@ export default function BoxControl( {
 					</Text>
 				</FlexItem>
 				<FlexItem>
+					<BoxControlIcon side={ side } />
+				</FlexItem>
+			</Header>
+			<HeaderControlWrapper className="component-box-control__header-control-wrapper">
+				<FlexBlock>
+					<AllInputControl
+						{ ...inputControlProps }
+						disabled={ ! isLinked }
+					/>
+				</FlexBlock>
+				<FlexItem>
 					<Button
 						className="component-box-control__reset-button"
 						isSecondary
@@ -131,16 +143,8 @@ export default function BoxControl( {
 						{ __( 'Reset' ) }
 					</Button>
 				</FlexItem>
-			</Header>
-			<HeaderControlWrapper className="component-box-control__header-control-wrapper">
-				<FlexItem>
-					<BoxControlIcon side={ side } />
-				</FlexItem>
-				{ isLinked && (
-					<FlexBlock>
-						<AllInputControl { ...inputControlProps } />
-					</FlexBlock>
-				) }
+			</HeaderControlWrapper>
+			<HeaderControlWrapper>
 				<FlexItem>
 					<LinkedButton
 						onClick={ toggleLinked }

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -145,6 +145,7 @@ class EditorProvider extends Component {
 				'isRTL',
 				'maxWidth',
 				'onUpdateDefaultBlockStyles',
+				'padding',
 				'styles',
 				'template',
 				'templateLock',


### PR DESCRIPTION
Implements https://github.com/WordPress/gutenberg/issues/23111

This PR adds a new preset for padding that themes can use similar to how they use colors, font-sizes, and gradients.

TODO:

- [x] Add default padding values to the block-editor settings.
- [x] Take data from the theme.
- [ ] UI: make padding control use the presets data.
