### PR TITLE
Add preset for line-height and use it in the UI controls

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -461,3 +461,20 @@ add_filter( 'pre_render_block', 'gutenberg_render_block_with_assigned_block_cont
  * @see WP_Block::render
  */
 remove_action( 'enqueue_block_assets', 'wp_enqueue_registered_block_scripts_and_styles' );
+
+
+/**
+ * Extends block editor settings to include a list of values for padding.
+ *
+ * @param array $settings Default editor settings.
+ *
+ * @return array Filtered editor settings.
+ */
+function gutenberg_add_line_height_presets( $settings ) {
+	list( $editor_line_height ) = (array) get_theme_support( 'editor-line-height' );
+	if ( false !== $editor_line_height ) {
+		$settings['lineHeight'] = $editor_line_height;
+	}
+	return $settings;
+}
+add_filter( 'block_editor_settings', 'gutenberg_add_line_height_presets' );

--- a/lib/experimental-default-theme.json
+++ b/lib/experimental-default-theme.json
@@ -122,6 +122,11 @@
 					"slug": "vivid-cyan-blue-to-vivid-purple",
 					"value": "linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)"
 				}
+			],
+			"line-height": [
+				{ "slug": "small", "value": 0.8 },
+				{ "slug": "regular", "value": 1.2 },
+				{ "slug": "large", "value": 1.6 }
 			]
 		},
 		"features": {

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -223,6 +223,14 @@ function gutenberg_experimental_global_styles_get_theme_presets() {
 		);
 	}
 
+	$theme_line_height = gutenberg_experimental_get( get_theme_support( 'editor-line-height' ), array( '0' ) );
+	foreach ( $theme_line_height as $line_height ) {
+		$theme_presets['global']['presets']['line-height'][] = array(
+			'slug'  => $line_height['slug'],
+			'value' => $line_height['value'],
+		);
+	}
+
 	return $theme_presets;
 }
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -480,6 +480,7 @@ _Properties_
 -   _fontSizes_ `Array`: Available font sizes
 -   _disableCustomFontSizes_ `boolean`: Whether or not the custom font sizes are disabled
 -   _imageSizes_ `Array`: Available image sizes
+-   _lineHeight_ `Array`: Available line height values
 -   _maxWidth_ `number`: Max width to constraint resizing
 -   _allowedBlockTypes_ `(boolean|Array)`: Allowed block types
 -   _hasFixedToolbar_ `boolean`: Whether or not the editor toolbar is fixed

--- a/packages/block-editor/src/components/line-height-control/index.js
+++ b/packages/block-editor/src/components/line-height-control/index.js
@@ -14,6 +14,17 @@ import { ZERO } from '@wordpress/keycodes';
  */
 import { RESET_VALUE, STEP } from './utils';
 
+const DEFAULT_OPTION = {
+	key: 'default',
+	name: __( 'Default' ),
+	value: undefined,
+};
+const CUSTOM_OPTION = {
+	key: 'custom',
+	name: __( 'Custom' ),
+	value: 'custom',
+};
+
 export default function LineHeightControl( { presetValues, value, onChange } ) {
 	const handleOnKeyDown = ( event ) => {
 		const { keyCode } = event;
@@ -34,11 +45,14 @@ export default function LineHeightControl( { presetValues, value, onChange } ) {
 	const handlePresetSelection = ( { selectedItem } ) =>
 		onChange( selectedItem.value );
 
-	const options = presetValues.map( ( presetValue ) => ( {
-		key: presetValue.slug,
-		name: presetValue.name,
-		value: presetValue.value,
-	} ) );
+	const options = [
+		DEFAULT_OPTION,
+		...presetValues.map( ( presetValue ) => ( {
+			key: presetValue.slug,
+			name: presetValue.name,
+			value: presetValue.value,
+		} ) ),
+	];
 
 	return (
 		<div className="block-editor-line-height-control">
@@ -47,9 +61,10 @@ export default function LineHeightControl( { presetValues, value, onChange } ) {
 					className={ 'block-editor-line-height-control__preset' }
 					label={ __( 'Line Height' ) }
 					options={ options }
-					value={ options.find(
-						( option ) => option.value === value
-					) }
+					value={
+						options.find( ( option ) => option.value === value ) ||
+						CUSTOM_OPTION
+					}
 					onChange={ handlePresetSelection }
 				/>
 			) }

--- a/packages/block-editor/src/components/line-height-control/index.js
+++ b/packages/block-editor/src/components/line-height-control/index.js
@@ -80,7 +80,7 @@ export default function LineHeightControl( {
 		<div className="block-editor-line-height-control">
 			{ presetValues?.length > 0 && (
 				<CustomSelectControl
-					className={ 'block-editor-line-height-control__select' }
+					className={ 'block-editor-line-height-control__preset' }
 					label={ __( 'Line Height' ) }
 					options={ options }
 					value={ options.find(
@@ -90,6 +90,7 @@ export default function LineHeightControl( {
 				/>
 			) }
 			<TextControl
+				className={ 'block-editor-line-height-control__custom' }
 				autoComplete="off"
 				onKeyDown={ handleOnKeyDown }
 				onChange={ handleOnChange }

--- a/packages/block-editor/src/components/line-height-control/index.js
+++ b/packages/block-editor/src/components/line-height-control/index.js
@@ -12,24 +12,13 @@ import { ZERO } from '@wordpress/keycodes';
 /**
  * Internal dependencies
  */
-import {
-	BASE_DEFAULT_VALUE,
-	RESET_VALUE,
-	STEP,
-	isLineHeightDefined,
-} from './utils';
+import { RESET_VALUE, STEP } from './utils';
 
-export default function LineHeightControl( {
-	presetValues,
-	value: lineHeight,
-	onChange,
-} ) {
-	const isDefined = isLineHeightDefined( lineHeight );
-
+export default function LineHeightControl( { presetValues, value, onChange } ) {
 	const handleOnKeyDown = ( event ) => {
 		const { keyCode } = event;
 
-		if ( keyCode === ZERO && ! isDefined ) {
+		if ( keyCode === ZERO ) {
 			/**
 			 * Prevents the onChange callback from firing, which prevents
 			 * the logic from assuming the change was triggered from
@@ -40,45 +29,16 @@ export default function LineHeightControl( {
 		}
 	};
 
-	const handleOnChange = ( nextValue ) => {
-		// Set the next value without modification if lineHeight has been defined
-		if ( isDefined ) {
-			onChange( nextValue );
-			return;
-		}
+	const handleOnChange = ( nextValue ) => onChange( nextValue );
 
-		// Otherwise...
-		/**
-		 * The following logic handles the initial up/down arrow CLICK of the
-		 * input element. This is so that the next values (from an undefined value state)
-		 * are more better suited for line-height rendering.
-		 */
-		let adjustedNextValue = nextValue;
-
-		switch ( nextValue ) {
-			case `${ STEP }`:
-				// Increment by step value
-				adjustedNextValue = BASE_DEFAULT_VALUE + STEP;
-				break;
-			case '0':
-				// Decrement by step value
-				adjustedNextValue = BASE_DEFAULT_VALUE - STEP;
-				break;
-		}
-
-		onChange( adjustedNextValue );
-	};
-
-	const value = isDefined ? lineHeight : RESET_VALUE;
+	const handlePresetSelection = ( { selectedItem } ) =>
+		onChange( selectedItem.value );
 
 	const options = presetValues.map( ( presetValue ) => ( {
 		key: presetValue.slug,
 		name: presetValue.name,
 		value: presetValue.value,
 	} ) );
-
-	const handlePresetSelection = ( { selectedItem } ) =>
-		onChange( selectedItem.value );
 
 	return (
 		<div className="block-editor-line-height-control">
@@ -99,10 +59,9 @@ export default function LineHeightControl( {
 				onKeyDown={ handleOnKeyDown }
 				onChange={ handleOnChange }
 				label={ __( 'Custom' ) }
-				placeholder={ BASE_DEFAULT_VALUE }
 				step={ STEP }
 				type="number"
-				value={ value }
+				value={ value || RESET_VALUE }
 				min={ 0 }
 			/>
 			<Button

--- a/packages/block-editor/src/components/line-height-control/index.js
+++ b/packages/block-editor/src/components/line-height-control/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { TextControl } from '@wordpress/components';
+import { TextControl, CustomSelectControl } from '@wordpress/components';
 import { ZERO } from '@wordpress/keycodes';
 
 /**
@@ -15,7 +15,11 @@ import {
 	isLineHeightDefined,
 } from './utils';
 
-export default function LineHeightControl( { value: lineHeight, onChange } ) {
+export default function LineHeightControl( {
+	presetValues,
+	value: lineHeight,
+	onChange,
+} ) {
 	const isDefined = isLineHeightDefined( lineHeight );
 
 	const handleOnKeyDown = ( event ) => {
@@ -63,13 +67,33 @@ export default function LineHeightControl( { value: lineHeight, onChange } ) {
 
 	const value = isDefined ? lineHeight : RESET_VALUE;
 
+	const options = presetValues.map( ( presetValue ) => ( {
+		key: presetValue.slug,
+		name: presetValue.name,
+		value: presetValue.value,
+	} ) );
+
+	const handlePresetSelection = ( { selectedItem } ) =>
+		onChange( selectedItem.value );
+
 	return (
 		<div className="block-editor-line-height-control">
+			{ presetValues?.length > 0 && (
+				<CustomSelectControl
+					className={ 'block-editor-line-height-control__select' }
+					label={ __( 'Line Height' ) }
+					options={ options }
+					value={ options.find(
+						( option ) => option.value === value
+					) }
+					onChange={ handlePresetSelection }
+				/>
+			) }
 			<TextControl
 				autoComplete="off"
 				onKeyDown={ handleOnKeyDown }
 				onChange={ handleOnChange }
-				label={ __( 'Line height' ) }
+				label={ __( 'Custom' ) }
 				placeholder={ BASE_DEFAULT_VALUE }
 				step={ STEP }
 				type="number"

--- a/packages/block-editor/src/components/line-height-control/index.js
+++ b/packages/block-editor/src/components/line-height-control/index.js
@@ -7,7 +7,6 @@ import {
 	TextControl,
 	CustomSelectControl,
 } from '@wordpress/components';
-import { ZERO } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -26,20 +25,6 @@ const CUSTOM_OPTION = {
 };
 
 export default function LineHeightControl( { presetValues, value, onChange } ) {
-	const handleOnKeyDown = ( event ) => {
-		const { keyCode } = event;
-
-		if ( keyCode === ZERO ) {
-			/**
-			 * Prevents the onChange callback from firing, which prevents
-			 * the logic from assuming the change was triggered from
-			 * an input arrow CLICK.
-			 */
-			event.preventDefault();
-			onChange( 0 );
-		}
-	};
-
 	const handleOnChange = ( nextValue ) => onChange( Number( nextValue ) );
 
 	const handlePresetSelection = ( { selectedItem } ) =>
@@ -71,7 +56,6 @@ export default function LineHeightControl( { presetValues, value, onChange } ) {
 			<TextControl
 				className={ 'block-editor-line-height-control__custom' }
 				autoComplete="off"
-				onKeyDown={ handleOnKeyDown }
 				onChange={ handleOnChange }
 				label={ __( 'Custom' ) }
 				step={ STEP }

--- a/packages/block-editor/src/components/line-height-control/index.js
+++ b/packages/block-editor/src/components/line-height-control/index.js
@@ -36,14 +36,14 @@ export default function LineHeightControl( { presetValues, value, onChange } ) {
 			 * an input arrow CLICK.
 			 */
 			event.preventDefault();
-			onChange( '0' );
+			onChange( 0 );
 		}
 	};
 
-	const handleOnChange = ( nextValue ) => onChange( nextValue );
+	const handleOnChange = ( nextValue ) => onChange( Number( nextValue ) );
 
 	const handlePresetSelection = ( { selectedItem } ) =>
-		onChange( selectedItem.value );
+		onChange( Number( selectedItem.value ) );
 
 	const options = [
 		DEFAULT_OPTION,

--- a/packages/block-editor/src/components/line-height-control/index.js
+++ b/packages/block-editor/src/components/line-height-control/index.js
@@ -2,7 +2,11 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { TextControl, CustomSelectControl } from '@wordpress/components';
+import {
+	Button,
+	TextControl,
+	CustomSelectControl,
+} from '@wordpress/components';
 import { ZERO } from '@wordpress/keycodes';
 
 /**
@@ -101,6 +105,15 @@ export default function LineHeightControl( {
 				value={ value }
 				min={ 0 }
 			/>
+			<Button
+				className={ 'block-editor-line-height-control__reset' }
+				disabled={ value === undefined }
+				onClick={ () => onChange( undefined ) }
+				isSmall
+				isSecondary
+			>
+				{ __( 'Reset' ) }
+			</Button>
 		</div>
 	);
 }

--- a/packages/block-editor/src/components/line-height-control/style.scss
+++ b/packages/block-editor/src/components/line-height-control/style.scss
@@ -1,8 +1,24 @@
 .block-editor-line-height-control {
-	margin-bottom: 24px;
+	max-width: $sidebar-width - ( 2 * $panel-padding );
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	margin-bottom: $grid-unit-30;
 
-	input {
-		display: block;
-		max-width: 60px;
+	.block-editor-line-height-control__preset {
+		margin-right: $grid-unit-10;
+	}
+
+	.components-base-control.block-editor-line-height-control__custom {
+		margin-bottom: 0;
+	}
+
+	.block-editor-line-height-control__custom {
+		max-width: 54px;
+		height: 53px;
+
+		.components-base-control__label {
+			margin-bottom: 5px;
+		}
 	}
 }

--- a/packages/block-editor/src/components/line-height-control/style.scss
+++ b/packages/block-editor/src/components/line-height-control/style.scss
@@ -16,9 +16,15 @@
 	.block-editor-line-height-control__custom {
 		max-width: 54px;
 		height: 53px;
+		margin-right: 8px;
 
 		.components-base-control__label {
 			margin-bottom: 5px;
 		}
+	}
+
+	.block-editor-line-height-control__reset {
+		height: 30px;
+		margin-top: 23px;
 	}
 }

--- a/packages/block-editor/src/components/line-height-control/utils.js
+++ b/packages/block-editor/src/components/line-height-control/utils.js
@@ -1,4 +1,3 @@
-export const BASE_DEFAULT_VALUE = 1.5;
 export const STEP = 0.1;
 /**
  * There are varying value types within LineHeightControl:
@@ -11,14 +10,3 @@ export const STEP = 0.1;
  * in order to be considered "controlled" by props (rather than internal state).
  */
 export const RESET_VALUE = '';
-
-/**
- * Determines if the lineHeight attribute has been properly defined.
- *
- * @param {any} lineHeight The value to check.
- *
- * @return {boolean} Whether the lineHeight attribute is valid.
- */
-export function isLineHeightDefined( lineHeight ) {
-	return lineHeight !== undefined && lineHeight !== RESET_VALUE;
-}

--- a/packages/block-editor/src/hooks/line-height.js
+++ b/packages/block-editor/src/hooks/line-height.js
@@ -24,6 +24,9 @@ export function LineHeightEdit( props ) {
 		attributes: { style },
 	} = props;
 	const isDisabled = useIsLineHeightDisabled( props );
+	const { lineHeight: presetValues } = useSelect( ( select ) =>
+		select( 'core/block-editor' ).getSettings()
+	);
 
 	if ( isDisabled ) {
 		return null;
@@ -43,6 +46,7 @@ export function LineHeightEdit( props ) {
 	};
 	return (
 		<LineHeightControl
+			presetValues={ presetValues }
 			value={ style?.typography?.lineHeight }
 			onChange={ onChange }
 		/>

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -18,6 +18,7 @@ export const PREFERENCES_DEFAULTS = {
  * @property {Array} fontSizes Available font sizes
  * @property {boolean} disableCustomFontSizes Whether or not the custom font sizes are disabled
  * @property {Array} imageSizes Available image sizes
+ * @property {Array} lineHeight Available line height values
  * @property {number} maxWidth Max width to constraint resizing
  * @property {boolean|Array} allowedBlockTypes Allowed block types
  * @property {boolean} hasFixedToolbar Whether or not the editor toolbar is fixed
@@ -129,6 +130,12 @@ export const SETTINGS_DEFAULTS = {
 		{ slug: 'medium', name: __( 'Medium' ) },
 		{ slug: 'large', name: __( 'Large' ) },
 		{ slug: 'full', name: __( 'Full Size' ) },
+	],
+
+	lineHeight: [
+		{ slug: 'small', name: __( 'Small' ), value: 0.8 },
+		{ slug: 'regular', name: __( 'Regular' ), value: 1.2 },
+		{ slug: 'large', name: __( 'Large' ), value: 1.6 },
 	],
 
 	// This is current max width of the block inner area

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -144,6 +144,7 @@ class EditorProvider extends Component {
 				'imageDimensions',
 				'isRTL',
 				'maxWidth',
+				'lineHeight',
 				'onUpdateDefaultBlockStyles',
 				'styles',
 				'template',


### PR DESCRIPTION
Implements https://github.com/WordPress/gutenberg/issues/23111

This PR adds a new preset for line-height that themes can use similar to how they use colors, font-sizes, and gradients. It also adds the ability to reset user-defined values.

**UI footprint**

![2006-16-line-height-control](https://user-images.githubusercontent.com/583546/84772804-c2da3380-afdb-11ea-81fc-7f72eefb2121.png)

**Interaction**

![2006-16-line-height-control](https://user-images.githubusercontent.com/583546/84772826-ca014180-afdb-11ea-8b25-34252dddbe97.gif)

## Test

* Using TwentyTwenty (or any other theme that doesn't opt-out from this), make sure that the controls work as expected and the values are the defaults.
* Using a theme that adds line-height presets (you can use this demo theme https://github.com/nosolosw/global-styles-theme/pull/11), make sure the controls work as expected and the values are the ones added by the theme (for the demo theme, they'll be "Tight", "Normal", "Breathe").

## Follow-ups

- Consolidate the font-size picker and the line-height controls.
- Consolidate the way style properties are used. See https://github.com/WordPress/gutenberg/pull/23177#discussion_r440954544