### PR TITLE
Scripts: Update changelog to move unreleased entries to Unreleased section

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   The bundled `stylelint` dependency has been updated from requiring `^9.10.1` to requiring `^13.6.0`.
+-   The bundled `stylelint-config-wordpress` dependency has been updated from requiring `^13.1.0` to requiring `^17.0.0`.
+
+### Bug Fixes
+
+-   During rebuilds, all webpack assets that are not used anymore will be removed automatically.
+
 ## 11.0.0 (2020-06-15)
 
 ### Breaking Changes
@@ -10,8 +19,6 @@
 -   The default Babel configuration has changed to only support stage-4 proposals. This affects the `build` and `start` commands that use the bundled Babel configuration; if a project provides its own, this change doesn't affect it ([#22083](https://github.com/WordPress/gutenberg/pull/22083)).
 -   The bundled `wp-prettier` dependency has been upgraded from `1.19.1` to `2.0.5`. Refer to the [Prettier 2.0 "2020" blog post](https://prettier.io/blog/2020/03/21/2.0.0.html) for full details about the major changes included in Prettier 2.0.
 -   The bundled `eslint` dependency has been updated from requiring `^6.8.0` to requiring `^7.1.0`.
--   The bundled `stylelint` dependency has been updated from requiring `^9.10.1` to requiring `^13.6.0`.
--   The bundled `stylelint-config-wordpress` dependency has been updated from requiring `^13.1.0` to requiring `^17.0.0`.
 
 ### New Feature
 
@@ -20,7 +27,6 @@
 ### Bug Fixes
 
 -   Update webpack configuration to not run the Sass loader on CSS files. It's now limited to .scss and .sass files.
--   During rebuilds, all webpack assets that are not used anymore will be removed automatically.
 -   Fix broken `style.(sc|sa|c)ss` handling in the `build` and `start` scripts ([#23127](https://github.com/WordPress/gutenberg/pull/23127)).
 
 ## 10.0.0 (2020-05-28)


### PR DESCRIPTION
## Description
Removes the changelog entries for https://github.com/WordPress/gutenberg/commit/6d1c6ef0fe4483caefb8e072a83f75017413c1ea and  https://github.com/WordPress/gutenberg/commit/7a5562ebdd2ca5c7c28c45f4709875f14cf5c006 from 11.0.0, see https://github.com/WordPress/gutenberg/blob/wp/trunk/packages/scripts/CHANGELOG.md

Related chat: https://wordpress.slack.com/archives/C5UNMSU4R/p1592248106446700