### PR TITLE
Add context property mapping to block registration

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -169,6 +169,7 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 		$property_mappings = array(
 			'title'       => 'title',
 			'category'    => 'category',
+			'context'     => 'context',
 			'parent'      => 'parent',
 			'icon'        => 'icon',
 			'description' => 'description',


### PR DESCRIPTION
Fixes #23179

## Description
Block context was not being parsed in block registration.

This broke dynamic blocks which relied on `$block->context`. The context properties were not being added to context from available_context because it only adds properties which existed in the block metadata... and context was not parsed in 

## How has this been tested?
Locally.

## Screenshots <!-- if applicable -->

### Before:

<img width="1718" alt="Screen Shot 2020-06-15 at 11 32 11 AM" src="https://user-images.githubusercontent.com/6265975/84699365-3c075700-af06-11ea-8a61-082ad38b3c88.png">

### After: (ignore the echo; it was for debugging)
<img width="1678" alt="Screen Shot 2020-06-15 at 12 45 01 PM" src="https://user-images.githubusercontent.com/6265975/84699343-327def00-af06-11ea-85bb-2965552c6e24.png">

## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
