### PR TITLE
FSE: Move initial template fetch to client

### DIFF
--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -160,12 +160,8 @@ function gutenberg_edit_site_init( $hook ) {
 		}
 	}
 
-	$current_template_id = $template_ids['front-page'];
-
 	$settings['editSiteInitialState'] = array();
 
-	$settings['editSiteInitialState']['homeTemplateId']  = $current_template_id;
-	$settings['editSiteInitialState']['templateId']      = $current_template_id;
 	$settings['editSiteInitialState']['templateType']    = 'wp_template';
 	$settings['editSiteInitialState']['templateIds']     = array_values( $template_ids );
 	$settings['editSiteInitialState']['templatePartIds'] = array_values( $template_part_ids );
@@ -192,7 +188,6 @@ function gutenberg_edit_site_init( $hook ) {
 		'/wp/v2/taxonomies?per_page=100&context=edit',
 		'/wp/v2/pages?per_page=100&context=edit',
 		'/wp/v2/themes?status=active',
-		sprintf( '/wp/v2/templates/%s?context=edit', $current_template_id ),
 		array( '/wp/v2/media', 'OPTIONS' ),
 	);
 	$preload_data  = array_reduce(

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -59,7 +59,7 @@ add_action( 'wp_loaded', 'gutenberg_add_template_loader_filters' );
  * @param string $template_type A template type.
  * @return string[] A list of template candidates, in descending order of priority.
  */
-function get_template_hierachy( $template_type ) {
+function get_template_hierarchy( $template_type ) {
 	if ( ! in_array( $template_type, get_template_types(), true ) ) {
 		return array();
 	}
@@ -220,9 +220,9 @@ function gutenberg_find_template_post_and_parts( $template_type, $template_hiera
 
 	if ( empty( $template_hierarchy ) ) {
 		if ( 'index' === $template_type ) {
-			$template_hierarchy = get_template_hierachy( 'index' );
+			$template_hierarchy = get_template_hierarchy( 'index' );
 		} else {
-			$template_hierarchy = array_merge( get_template_hierachy( $template_type ), get_template_hierachy( 'index' ) );
+			$template_hierarchy = array_merge( get_template_hierarchy( $template_type ), get_template_hierarchy( 'index' ) );
 		}
 	}
 

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -144,7 +144,7 @@ function Editor() {
 		} ),
 		[ page.context ]
 	);
-	return template ? (
+	return (
 		<>
 			<EditorStyles styles={ settings.styles } />
 			<FullscreenMode isActive={ isFullscreenActive } />
@@ -223,7 +223,7 @@ function Editor() {
 											>
 												<Notices />
 												<Popover.Slot name="block-toolbar" />
-												<BlockEditor />
+												{ template && <BlockEditor /> }
 												<KeyboardShortcuts />
 											</BlockSelectionClearer>
 										}
@@ -268,6 +268,6 @@ function Editor() {
 				</DropZoneProvider>
 			</SlotFillProvider>
 		</>
-	) : null;
+	);
 }
 export default Editor;

--- a/packages/edit-site/src/store/index.js
+++ b/packages/edit-site/src/store/index.js
@@ -14,7 +14,7 @@ import controls from './controls';
 import { STORE_KEY } from './constants';
 
 export default function registerEditSiteStore( initialState ) {
-	return registerStore( STORE_KEY, {
+	const store = registerStore( STORE_KEY, {
 		reducer,
 		actions,
 		selectors,
@@ -22,4 +22,9 @@ export default function registerEditSiteStore( initialState ) {
 		persist: [ 'preferences' ],
 		initialState,
 	} );
+
+	// We set the initial page here to include the template fetch which will
+	// resolve the correct homepage template.
+	store.dispatch( actions.setPage( initialState.page ) );
+	return store;
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This PR solves in issue with initial homepage template resolution in the site editor.

If a theme specifies three block templates (home, singular, index), the following behavior _should_ be true when visiting the root of your site:
1. When front page is set to show a static page, the `singular` template is resolved.
2. When front page is set to show posts, the `home` template is resolved.

This behavior is correct on the front end, but in the editor, it loaded `index` in each case. This is because we initialize the editor with the `front-page` template in PHP. Unfortunately, template resolution does not work like this: each template type does not resolve to its closest match. Rather, in most cases, each template type resolves to either itself or to `index`.

As a result, since the theme didn't have the `front-page` template, it resolved to `index`. Unfortunately, I did not see a clear way to do server-side template resolution because WordPress does not actually provide a function to give you the closest matching template. Instead, as it renders an individual page or post, it will use the first template which both exists and matches the criteria of the individual post. The emphasis here is that this happens during page/post render, and not via an easily consumable function. 

So I figured it'd be easiest for now to just use the existing front-end `findTemplate` helper by setting the page up front. It definitely solves the issue, but it does add some overhead to loading the editor. I've solved the overhead problem by displaying the editor even before the template loads. This should make the first meaningful paint more snappy in general, even without the client loading stuff.

## How has this been tested?
Locally in edit site

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
