### PR TITLE
Navigation: Improve flow when creating from menu

### DIFF
--- a/packages/block-library/src/navigation/placeholder.js
+++ b/packages/block-library/src/navigation/placeholder.js
@@ -245,6 +245,19 @@ function NavigationPlaceholder( { onCreate }, ref ) {
 		[ menus, hasMenus, hasPages ]
 	);
 
+	const createFromMenu = useCallback( () => {
+		// If an empty menu was selected, create an empty block.
+		if ( ! menuItems.length ) {
+			const blocks = [ createBlock( 'core/navigation-link' ) ];
+			onCreate( blocks );
+			return;
+		}
+
+		const blocks = convertMenuItemsToBlocks( menuItems );
+		const selectNavigationBlock = true;
+		onCreate( blocks, selectNavigationBlock );
+	} );
+
 	const onCreateButtonClick = useCallback( () => {
 		if ( ! selectedCreateOption ) {
 			return;
@@ -273,9 +286,7 @@ function NavigationPlaceholder( { onCreate }, ref ) {
 			default:
 				// If we have menu items, create the block right away.
 				if ( hasResolvedMenuItems ) {
-					const blocks = convertMenuItemsToBlocks( menuItems );
-					const selectNavigationBlock = true;
-					onCreate( blocks, selectNavigationBlock );
+					createFromMenu();
 					return;
 				}
 
@@ -288,9 +299,7 @@ function NavigationPlaceholder( { onCreate }, ref ) {
 		// If the user selected a menu but we had to wait for menu items to
 		// finish resolving, then create the block once resolution finishes.
 		if ( isCreatingFromMenu && hasResolvedMenuItems ) {
-			const blocks = convertMenuItemsToBlocks( menuItems );
-			const selectNavigationBlock = true;
-			onCreate( blocks, selectNavigationBlock );
+			createFromMenu();
 			setIsCreatingFromMenu( false );
 		}
 	}, [ isCreatingFromMenu, hasResolvedMenuItems ] );


### PR DESCRIPTION
Closes #23055.

![2020-06-16 12 20 02](https://user-images.githubusercontent.com/612155/84724559-d5e50780-afcb-11ea-9816-47cd857d9aca.gif)

When the user opts to create a Navigation block from an existing menu, let them click on the _Create_ button immediately while we fetch the menu items in the background. This way we avoid disabling the _Create_ button which is a pretty confusing UX.  

**To test:**

1. Ensure you have a Menu set up in `/wp-admin/nav-menus.php`.
1. Insert a Navigation block.
1. Use DevTools to throttle your network speed.
1. Select a menu from the dropdown.
1. **Immediately** click on _Create_.

Note that the _Create_ button remains enabled while menu items are loaded in the background.