### PR TITLE
Create Block: Fix errors reported by CSS linter in ESNext template

### DIFF
--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 ## Unreleased
 
+## 0.14.2 (2020-06-16)
+
+### Bug Fix
+
+- Fix errors reported by CSS linter in ESNext template by using hex colors in CSS files ([#23164](https://github.com/WordPress/gutenberg/pull/23164)).
+
 ## 0.14.1 (2020-06-15)
 
 ### Bug Fix
 
-- Fix an error reported by ESLint by improving JSDoc comment in ESNext template in `src/edit.js` file ([#23164](https://github.com/WordPress/gutenberg/pull/23164)).
+- Fix an error reported by JavaScript linter by improving JSDoc comment in ESNext template in `src/edit.js` file ([#23164](https://github.com/WordPress/gutenberg/pull/23164)).
 
 ## 0.14.0 (2020-06-15)
 

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Bug Fix
 
-- Fix errors reported by CSS linter in ESNext template by using hex colors in CSS files ([#23164](https://github.com/WordPress/gutenberg/pull/23164)).
+- Fix errors reported by CSS linter in ESNext template by using hex colors in CSS files ([#23188](https://github.com/WordPress/gutenberg/pull/23188)).
 
 ## 0.14.1 (2020-06-15)
 

--- a/packages/create-block/lib/templates/esnext/src/editor.scss.mustache
+++ b/packages/create-block/lib/templates/esnext/src/editor.scss.mustache
@@ -5,5 +5,5 @@
  */
 
 .wp-block-{{namespace}}-{{slug}} {
-	border: 1px dotted red;
+	border: 1px dotted #f00;
 }

--- a/packages/create-block/lib/templates/esnext/src/style.scss.mustache
+++ b/packages/create-block/lib/templates/esnext/src/style.scss.mustache
@@ -7,6 +7,6 @@
 
 .wp-block-{{namespace}}-{{slug}} {
 	background-color: theme(button);
-	color: white;
+	color: #fff;
 	padding: 2px;
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

When running the command for linting CSS in the scaffolded block I see the following errors reported:

```
$ npm run lint:css
src/editor.scss
 8:21  ✖  Unexpected named color "red"   color-named

src/style.scss
 10:9  ✖  Unexpected named color "white"   color-named
```

This PR fixes those issues by using hex values.

## How has this been tested?
```bash
$ npx wp-create-block my-test-block
$ cd my-test-block
$ npm run lint:css
```

## Follow-up task

We really need some CI integration that would ensure that those scripts in scaffolded blocks pass :)