### PR TITLE
ESLint plugin: Allow ESLint 7.x as peer dependency

### DIFF
--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+- Support ESLint `^7` as peer dependency.
+
 ## 7.0.0 (2020-06-15)
 
 ### Breaking Changes

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -41,7 +41,7 @@
 		"requireindex": "^1.2.0"
 	},
 	"peerDependencies": {
-		"eslint": "6.x"
+		"eslint": "^6 || ^7"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
## Description
This was missed in #22385 / #22771.

Fixes this npm warning:

> npm WARN @wordpress/eslint-plugin@7.0.0 requires a peer of eslint@6.x but none is installed. You must install peer dependencies yourself.