### PR TITLE
Fix pixel shift for toggles.

### DIFF
--- a/packages/interface/src/components/pinned-items/style.scss
+++ b/packages/interface/src/components/pinned-items/style.scss
@@ -2,15 +2,11 @@
 	display: flex;
 
 	.components-button {
-		margin-left: 4px;
-
-		&.is-pressed {
-			margin-left: 5px;
-		}
+		margin-left: $grid-unit-05;
 
 		svg {
-			max-width: 24px;
-			max-height: 24px;
+			max-width: $icon-size;
+			max-height: $icon-size;
 		}
 	}
 }


### PR DESCRIPTION
This one has bugged me for a while, and I'm not sure why it was added in the first place, because from the code, it looks intententional. 

Before:

![fix pixel shift](https://user-images.githubusercontent.com/1204802/84743991-f5236b00-afb2-11ea-9e3f-c76aca146241.gif)

After:

![after](https://user-images.githubusercontent.com/1204802/84744000-f8b6f200-afb2-11ea-8025-f9532dfec496.gif)
