### PR TITLE
Polish: Unify subheadings style.

### DIFF
--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -6,8 +6,11 @@ $tree-item-height: 36px;
 }
 
 .block-editor-block-navigation__label {
-	margin: 0 0 $grid-unit-10;
-	color: $dark-gray-300;
+	margin: 0 0 $grid-unit-15;
+	color: $medium-gray-text;
+	text-transform: uppercase;
+	font-size: 11px;
+	font-weight: 500;
 }
 
 .block-editor-block-navigation__container {

--- a/packages/block-editor/src/components/block-switcher/style.scss
+++ b/packages/block-editor/src/components/block-switcher/style.scss
@@ -91,8 +91,11 @@
 	}
 
 	.block-editor-block-switcher__label {
-		margin-bottom: $grid-unit-10;
+		margin-bottom: $grid-unit-15;
 		color: $medium-gray-text;
+		text-transform: uppercase;
+		font-size: 11px;
+		font-weight: 500;
 	}
 
 	@include break-medium {
@@ -136,8 +139,11 @@
 }
 
 .block-editor-block-switcher__preview-title {
-	margin-bottom: 10px;
-	color: $dark-gray-300;
+	margin-bottom: $grid-unit-15;
+	color: $medium-gray-text;
+	text-transform: uppercase;
+	font-size: 11px;
+	font-weight: 500;
 }
 
 // The block switcher in the contextual toolbar should be bigger.

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -135,11 +135,11 @@ $block-inserter-tabs-height: 44px;
 }
 
 .block-editor-inserter__panel-title {
-	color: $theme-color;
+	margin: 0 $grid-unit-15 0 0;
+	color: $medium-gray-text;
 	text-transform: uppercase;
 	font-size: 11px;
 	font-weight: 500;
-	margin: 0 $grid-unit-10 0 0;
 }
 
 .block-editor-inserter__block-list {

--- a/packages/components/src/dropdown-menu/style.scss
+++ b/packages/components/src/dropdown-menu/style.scss
@@ -82,6 +82,10 @@
 		margin-top: 0;
 		border-top: $border-width solid $light-gray-secondary;
 		padding: $grid-unit-15;
+
+		.is-alternate & {
+			border-color: $dark-gray-primary;
+		}
 	}
 }
 

--- a/packages/components/src/menu-group/style.scss
+++ b/packages/components/src/menu-group/style.scss
@@ -5,7 +5,10 @@
 }
 
 .components-menu-group__label {
-	margin-bottom: $grid-unit-10;
-	color: $medium-gray-text;
 	padding: 0;
+	margin-bottom: $grid-unit-15;
+	color: $medium-gray-text;
+	text-transform: uppercase;
+	font-size: 11px;
+	font-weight: 500;
 }


### PR DESCRIPTION
_This PR overlaps ever so slightly with #23028, but it uses the same CSS so the overlap should disappear in whatever PR needs to do the rebase first._

It does one thing primarily, which is to unify all subheadings to use the same style. The purpose, outside of consistency, is to better differentiate what is a subheading, and what is an actionable submenu _item_, while still maintaining contrast.

Before:

<img width="235" alt="Screenshot 2020-06-16 at 09 27 33" src="https://user-images.githubusercontent.com/1204802/84745236-96f78780-afb4-11ea-9467-ad16c1cb923d.png">

After:

<img width="229" alt="Screenshot 2020-06-16 at 09 28 37" src="https://user-images.githubusercontent.com/1204802/84745257-9e1e9580-afb4-11ea-9788-a23f15fa104b.png">

Before:

<img width="274" alt="Screenshot 2020-06-16 at 09 30 47" src="https://user-images.githubusercontent.com/1204802/84745361-bdb5be00-afb4-11ea-8ed4-db1a3e62c457.png">

After:

<img width="278" alt="Screenshot 2020-06-16 at 09 31 11" src="https://user-images.githubusercontent.com/1204802/84745374-c1494500-afb4-11ea-9527-8176cb12a320.png">

Before:

<img width="274" alt="Screenshot 2020-06-16 at 09 31 20" src="https://user-images.githubusercontent.com/1204802/84745416-d0c88e00-afb4-11ea-86f8-56118ccc9956.png">

After:

<img width="423" alt="Screenshot 2020-06-16 at 09 32 00" src="https://user-images.githubusercontent.com/1204802/84745424-d4f4ab80-afb4-11ea-9995-e821dfba1c01.png">

All of these are gray. But they are a darker gray that has better contrast. They are not blue, because although it makes for a nice bit of admin theming, it makes them appear actionable, and it clashes with the hover color of menu items. Notably that meant the following is also changed:

<img width="483" alt="Screenshot 2020-06-16 at 09 32 10" src="https://user-images.githubusercontent.com/1204802/84745522-ff466900-afb4-11ea-89be-8cd87c7dd657.png">

After:

<img width="475" alt="Screenshot 2020-06-16 at 09 32 41" src="https://user-images.githubusercontent.com/1204802/84745527-02415980-afb5-11ea-95b0-6f3ce86c2330.png">

It does one final thing, makes the separators in primary menus dark to match the border. Before:

<img width="339" alt="Screenshot 2020-06-16 at 09 28 19" src="https://user-images.githubusercontent.com/1204802/84745559-0ff6df00-afb5-11ea-9650-379c2d28d529.png">

After:

<img width="375" alt="Screenshot 2020-06-16 at 09 30 41" src="https://user-images.githubusercontent.com/1204802/84745563-11c0a280-afb5-11ea-82bb-73b405aaaa87.png">
