### PR TITLE
Try: Animate viewport switching.

### DIFF
--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -24,11 +24,6 @@
 		flex-basis: 100%;
 	}
 
-	// These have to be explicitly set in order for them to be animatable.
-	margin: auto;
-	width: 100%;
-	transition: width 0.1s ease;
-	@include reduce-motion("transition");
 }
 
 .editor-styles-wrapper {
@@ -41,6 +36,14 @@
 	> * {
 		cursor: auto;
 	}
+
+	// Animate the viewport.
+	transition: width 0.2s ease;
+	@include reduce-motion("transition");
+
+	// These have to be explicitly set in order for them to be animatable.
+	margin: auto;
+	width: 100%;
 }
 
 // Ideally this wrapper div is not needed but if we want to match the positioning of blocks

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -23,6 +23,12 @@
 	@supports (position: sticky) {
 		flex-basis: 100%;
 	}
+
+	// These have to be explicitly set in order for them to be animatable.
+	margin: auto;
+	width: 100%;
+	transition: width 0.1s ease;
+	@include reduce-motion("transition");
 }
 
 .editor-styles-wrapper {


### PR DESCRIPTION
This PR adds a small transition to the viewport container, so that it animates when changed.

Before:

![before](https://user-images.githubusercontent.com/1204802/84746470-484aed00-afb6-11ea-89fc-fa01d03595cd.gif)


After:

![after](https://user-images.githubusercontent.com/1204802/84746390-29e4f180-afb6-11ea-9e8e-11e448fedba1.gif)

This needs some testing with themes. @kjellr if you have time I'd really appreciate it. Primary reason it needs testing: it sets a couple of base properties on `.edit-post-visual-editor`, which is the element being animated. But this element also happens to be `.editor-styles-wrapper`, which is what theme styles are applied to. In other words, these might clash. 

We also need to test with longer document, as performance might get choppy on very long documents.

But I wanted to try this, and even if we decide that it doesn't work, at least we'll know.