### PR TITLE
Testing: Add verification for Create Block to Continues Integration

### DIFF
--- a/.github/workflows/create-block.yml
+++ b/.github/workflows/create-block.yml
@@ -20,14 +20,9 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: 12.x
-    - name: npm install, build, and test
+    - name: npm install, build, format and lint
       run: |
         npm ci
-        npx wp-create-block esnext-test --no-wp-scripts
-        cd esnext-test
-        ../node_modules/.bin/wp-scripts format-js
-        ../node_modules/.bin/wp-scripts build
-        ../node_modules/.bin/wp-scripts lint-style
-        ../node_modules/.bin/wp-scripts lint-js
+        npm run test:create-block
       env:
         CI: true

--- a/.github/workflows/create-block.yml
+++ b/.github/workflows/create-block.yml
@@ -2,7 +2,12 @@
 
 name: Create Block
 
-on: [push]
+on:
+  push:
+    paths:
+    - 'packages/**'
+    - '!packages/**/test/**'
+    - '!packages/**/*.md'
 
 jobs:
   build:
@@ -11,7 +16,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js 12.x
       uses: actions/setup-node@v1
       with:
         node-version: 12.x

--- a/.github/workflows/create-block.yml
+++ b/.github/workflows/create-block.yml
@@ -1,0 +1,28 @@
+
+
+name: Create Block
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - name: npm install, build, and test
+      run: |
+        npm ci
+        npx wp-create-block esnext-test --no-wp-scripts
+        cd esnext-test
+        ../node_modules/.bin/wp-scripts format-js
+        ../node_modules/.bin/wp-scripts build
+        ../node_modules/.bin/wp-scripts lint-style
+        ../node_modules/.bin/wp-scripts lint-js
+      env:
+        CI: true

--- a/.github/workflows/create-block.yml
+++ b/.github/workflows/create-block.yml
@@ -1,5 +1,3 @@
-
-
 name: Create Block
 
 on:

--- a/bin/test-create-block.sh
+++ b/bin/test-create-block.sh
@@ -9,12 +9,19 @@
 # Exit if any command fails.
 set -e
 
+DIRECTORY="$PWD"
+
 status () {
 	echo -e "\n\033[1;34m$1\033[0m\n"
 }
 
+cleanup() {
+	rm -rf "$DIRECTORY/esnext-test"
+}
+
+trap cleanup EXIT
+
 status "Scaffolding block..."
-rm -rf esnext-test
 npx wp-create-block esnext-test --no-wp-scripts
 cd esnext-test
 

--- a/bin/test-create-block.sh
+++ b/bin/test-create-block.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# This script validates whether `npm init @wordpress/block` works properly
+# with the latest changes applied to the `master` branch. It purpousfuly
+# avoids installing `@wordpress/scripts` package from npm when scaffolding
+# a test block and uses the local package by executing everything from the
+# root of the project.
+
+# Exit if any command fails.
+set -e
+
+status () {
+	echo -e "\n\033[1;34m$1\033[0m\n"
+}
+
+status "Scaffolding block..."
+rm -rf esnext-test
+npx wp-create-block esnext-test --no-wp-scripts
+cd esnext-test
+
+status "Formatting JavaScript files..."
+../node_modules/.bin/wp-scripts format-js
+
+status "Building block..."
+../node_modules/.bin/wp-scripts build
+
+status "Lintig CSS files..."
+../node_modules/.bin/wp-scripts lint-style
+
+status "Linting JavaScript files..."
+../node_modules/.bin/wp-scripts lint-js

--- a/bin/test-create-block.sh
+++ b/bin/test-create-block.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This script validates whether `npm init @wordpress/block` works properly
-# with the latest changes applied to the `master` branch. It purpousfuly
+# with the latest changes applied to the `master` branch. It purposefully
 # avoids installing `@wordpress/scripts` package from npm when scaffolding
 # a test block and uses the local package by executing everything from the
 # root of the project.

--- a/package.json
+++ b/package.json
@@ -227,6 +227,7 @@
 		"publish:patch": "npm run clean:package-types && npm run build:packages && lerna publish --dist-tag patch",
 		"publish:prod": "npm run clean:package-types && npm run build:packages && lerna publish",
 		"test": "npm run lint && npm run test-unit",
+		"test:create-block": "./bin/test-create-block.sh",
 		"test-e2e": "wp-scripts test-e2e --config packages/e2e-tests/jest.config.js",
 		"test-e2e:debug": "wp-scripts --inspect-brk test-e2e --config packages/e2e-tests/jest.config.js --puppeteer-devtools",
 		"test-e2e:watch": "npm run test-e2e -- --watch",

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+- Add new CLI options: `--no-wp-scripts` and `--wp-scripts` to let users override the settings that template defines for supports for `@wordpress/scripts` package integration ([#23195](https://github.com/WordPress/gutenberg/pull/23195)).
+
 ## 0.14.2 (2020-06-16)
 
 ### Bug Fix

--- a/packages/create-block/README.md
+++ b/packages/create-block/README.md
@@ -43,6 +43,8 @@ Options:
 --title <value>              display title for the block
 --short-description <value>  short description for the block
 --category <name>            category name for the block
+--wp-scripts                 enable integration with `@wordpress/scripts` package
+--no-wp-scripts              disable integration with `@wordpress/scripts` package
 -h, --help                   output usage information
 ```
 

--- a/packages/create-block/lib/index.js
+++ b/packages/create-block/lib/index.js
@@ -42,6 +42,14 @@ program
 	// The name "description" is used internally so it couldn't be used.
 	.option( '--short-description <value>', 'short description for the block' )
 	.option( '--category <name>', 'category name for the block' )
+	.option(
+		'--wp-scripts',
+		'enable integration with `@wordpress/scripts` package'
+	)
+	.option(
+		'--no-wp-scripts',
+		'disable integration with `@wordpress/scripts` package'
+	)
 	.action(
 		async (
 			slug,
@@ -51,18 +59,24 @@ program
 				shortDescription: description,
 				template: templateName,
 				title,
+				wpScripts,
 			}
 		) => {
 			await checkSystemRequirements( engines );
 			try {
 				const blockTemplate = await getBlockTemplate( templateName );
 				const defaultValues = getDefaultValues( blockTemplate );
-				const optionsValues = pickBy( {
-					category,
-					description,
-					namespace,
-					title,
-				} );
+				const optionsValues = pickBy(
+					{
+						category,
+						description,
+						namespace,
+						title,
+						wpScripts,
+					},
+					( value ) => value !== undefined
+				);
+
 				if ( slug ) {
 					const answers = {
 						...defaultValues,

--- a/packages/create-block/lib/init-package-json.js
+++ b/packages/create-block/lib/init-package-json.js
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+const { isEmpty, omitBy } = require( 'lodash' );
+const { join } = require( 'path' );
+const writePkg = require( 'write-pkg' );
+
+/**
+ * Internal dependencies
+ */
+const { info } = require( './log' );
+
+module.exports = async ( {
+	author,
+	description,
+	license,
+	slug,
+	version,
+	wpScripts,
+} ) => {
+	const cwd = join( process.cwd(), slug );
+
+	info( '' );
+	info( 'Creating a "package.json" file.' );
+	await writePkg(
+		cwd,
+		omitBy(
+			{
+				name: slug,
+				version,
+				description,
+				author,
+				license,
+				main: wpScripts && 'build/index.js',
+				scripts: wpScripts && {
+					build: 'wp-scripts build',
+					'format:js': 'wp-scripts format-js',
+					'lint:css': 'wp-scripts lint-style',
+					'lint:js': 'wp-scripts lint-js',
+					start: 'wp-scripts start',
+					'packages-update': 'wp-scripts packages-update',
+				},
+			},
+			isEmpty
+		)
+	);
+};

--- a/packages/create-block/lib/init-wp-scripts.js
+++ b/packages/create-block/lib/init-wp-scripts.js
@@ -2,42 +2,15 @@
  * External dependencies
  */
 const { command } = require( 'execa' );
-const { isEmpty, omitBy } = require( 'lodash' );
 const { join } = require( 'path' );
-const writePkg = require( 'write-pkg' );
 
 /**
  * Internal dependencies
  */
 const { info } = require( './log' );
 
-module.exports = async ( { author, description, license, slug, version } ) => {
+module.exports = async ( { slug } ) => {
 	const cwd = join( process.cwd(), slug );
-
-	info( '' );
-	info( 'Creating a "package.json" file.' );
-	await writePkg(
-		cwd,
-		omitBy(
-			{
-				name: slug,
-				version,
-				description,
-				author,
-				license,
-				main: 'build/index.js',
-				scripts: {
-					build: 'wp-scripts build',
-					'format:js': 'wp-scripts format-js',
-					'lint:css': 'wp-scripts lint-style',
-					'lint:js': 'wp-scripts lint-js',
-					start: 'wp-scripts start',
-					'packages-update': 'wp-scripts packages-update',
-				},
-			},
-			isEmpty
-		)
-	);
 
 	info( '' );
 	info( 'Installing packages. It might take a couple of minutes.' );

--- a/packages/create-block/lib/scaffold.js
+++ b/packages/create-block/lib/scaffold.js
@@ -10,9 +10,9 @@ const { dirname } = require( 'path' );
 /**
  * Internal dependencies
  */
+const initPackageJSON = require( './init-package-json' );
 const initWPScripts = require( './init-wp-scripts' );
 const { code, info, success } = require( './log' );
-const { hasWPScriptsEnabled } = require( './templates' );
 
 module.exports = async (
 	blockTemplate,
@@ -27,6 +27,7 @@ module.exports = async (
 		license,
 		licenseURI,
 		version,
+		wpScripts,
 	}
 ) => {
 	slug = slug.toLowerCase();
@@ -66,7 +67,9 @@ module.exports = async (
 		} )
 	);
 
-	if ( hasWPScriptsEnabled( blockTemplate ) ) {
+	await initPackageJSON( view );
+
+	if ( wpScripts ) {
 		await initWPScripts( view );
 	}
 
@@ -74,7 +77,7 @@ module.exports = async (
 	success(
 		`Done: block "${ title }" bootstrapped in the "${ slug }" folder.`
 	);
-	if ( hasWPScriptsEnabled( blockTemplate ) ) {
+	if ( wpScripts ) {
 		info( '' );
 		info( 'Inside that directory, you can run several commands:' );
 		info( '' );

--- a/packages/create-block/lib/templates.js
+++ b/packages/create-block/lib/templates.js
@@ -19,8 +19,8 @@ const predefinedBlockTemplates = {
 			title: 'ES5 Example',
 			description:
 				'Example block written with ES5 standard and no JSX – no build step required.',
+			wpScripts: false,
 		},
-		wpScripts: false,
 	},
 	esnext: {
 		defaultValues: {
@@ -78,6 +78,7 @@ const getDefaultValues = ( blockTemplate ) => {
 		license: 'GPL-2.0-or-later',
 		licenseURI: 'https://www.gnu.org/licenses/gpl-2.0.html',
 		version: '0.1.0',
+		wpScripts: true,
 		...blockTemplate.defaultValues,
 	};
 };
@@ -92,13 +93,8 @@ const getPrompts = ( blockTemplate ) => {
 	} );
 };
 
-const hasWPScriptsEnabled = ( blockTemplate ) => {
-	return blockTemplate.wpScripts !== false;
-};
-
 module.exports = {
 	getBlockTemplate,
 	getDefaultValues,
 	getPrompts,
-	hasWPScriptsEnabled,
 };


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

We had recently two regressions for scaffolded JS and CSS code using `ESNext` template through `npm init @wordpress/block`:
- #23188 (CSS)
- #23164 (JSDoc in JavaScript)

At least one of them (JSDoc) was introduced by breaking changes introduced in `@wordpress/scripts`. The other could be just a bug introduced during refactoring. Regardless to that, it's been on my mind for some time and it was also discussed several times in the past in PRs and on WordPress Slack. It was also raised by @ocean90 earlier today while I already started working on this PR 😄 (https://github.com/WordPress/gutenberg/pull/23188#pullrequestreview-431244947):
> Should we add some tests to make sure that future changes to scripts/ESLint plugin can be detected earlier?

This PR adds GitHub action that should automate the process of verification changes that could impact the default block scaffolded with Create Block. It uses a script that validates whether `npm init @wordpress/block` works properly with the latest changes applied to the `master` branch. It purposefully avoids installing `@wordpress/scripts` package from npm when scaffolding a test block and uses the local package by executing everything from the root of the project.

To make it possible and also to give the same amount of control to user two new CLI options were introduced:

> `--no-wp-scripts` and `--wp-scripts` to let users override the settings that template defines for supports for `@wordpress/scripts` package integration

## How has this been tested?

The script that is used for automated testing can be also executed locally:

```bash
$ npm run test:create-block
```

New GitHub action that will run on every PR opened:

![Screen Shot 2020-06-16 at 12 17 03](https://user-images.githubusercontent.com/699132/84762683-6c64f900-afcb-11ea-9448-d8da412816cd.png)
