### PR TITLE
Cover: don't show matrix button when no background

### DIFF
--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -302,13 +302,15 @@ function CoverEdit( {
 	const controls = (
 		<>
 			<BlockControls>
-				<BlockAlignmentMatrixToolbar
-					label={ __( 'Change content position' ) }
-					value={ contentPosition }
-					onChange={ ( nextPosition ) =>
-						setAttributes( { contentPosition: nextPosition } )
-					}
-				/>
+				{ hasBackground && (
+					<BlockAlignmentMatrixToolbar
+						label={ __( 'Change content position' ) }
+						value={ contentPosition }
+						onChange={ ( nextPosition ) =>
+							setAttributes( { contentPosition: nextPosition } )
+						}
+					/>
+				) }
 				{ hasBackground && (
 					<MediaReplaceFlow
 						mediaId={ id }

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -303,22 +303,25 @@ function CoverEdit( {
 		<>
 			<BlockControls>
 				{ hasBackground && (
-					<BlockAlignmentMatrixToolbar
-						label={ __( 'Change content position' ) }
-						value={ contentPosition }
-						onChange={ ( nextPosition ) =>
-							setAttributes( { contentPosition: nextPosition } )
-						}
-					/>
-				) }
-				{ hasBackground && (
-					<MediaReplaceFlow
-						mediaId={ id }
-						mediaURL={ url }
-						allowedTypes={ ALLOWED_MEDIA_TYPES }
-						accept="image/*,video/*"
-						onSelect={ onSelectMedia }
-					/>
+					<>
+						<BlockAlignmentMatrixToolbar
+							label={ __( 'Change content position' ) }
+							value={ contentPosition }
+							onChange={ ( nextPosition ) =>
+								setAttributes( {
+									contentPosition: nextPosition,
+								} )
+							}
+						/>
+
+						<MediaReplaceFlow
+							mediaId={ id }
+							mediaURL={ url }
+							allowedTypes={ ALLOWED_MEDIA_TYPES }
+							accept="image/*,video/*"
+							onSelect={ onSelectMedia }
+						/>
+					</>
 				) }
 			</BlockControls>
 			<InspectorControls>


### PR DESCRIPTION
## Description
It doesn't make sense showing the matrix alignment control button when the cover doesn't have a background since it doesn't show the text.
This PR hides the matrix button when the block doesn't have a background.

## How has this been tested?

Check that the matrix control button isn't shown when the block doesn't have a background.

## Screenshots <!-- if applicable -->


![image](https://user-images.githubusercontent.com/77539/84755789-6570c300-af98-11ea-9daa-4afe08af6915.png)

<img width="573" alt="Screen Shot 2020-06-16 at 6 13 19 AM" src="https://user-images.githubusercontent.com/77539/84755892-89340900-af98-11ea-8460-0d1d24677805.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->