### PR TITLE
Add anchor support to static blocks

### DIFF
--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -99,6 +99,7 @@ export const withInspectorControl = createHigherOrderComponent(
 										anchor: nextValue,
 									} );
 								} }
+								autoComplete="off"
 							/>
 						</InspectorAdvancedControls>
 					</>

--- a/packages/block-library/src/audio/block.json
+++ b/packages/block-library/src/audio/block.json
@@ -36,6 +36,7 @@
 		}
 	},
 	"supports": {
+		"anchor": true,
 		"align": true,
 		"lightBlockWrapper": true
 	}

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -54,6 +54,7 @@
 		}
 	},
 	"supports": {
+		"anchor": true,
 		"align": true,
 		"alignWide": false,
 		"reusable": false,

--- a/packages/block-library/src/buttons/block.json
+++ b/packages/block-library/src/buttons/block.json
@@ -2,6 +2,7 @@
 	"name": "core/buttons",
 	"category": "design",
 	"supports": {
+		"anchor": true,
 		"align": true,
 		"alignWide": false,
 		"lightBlockWrapper": true

--- a/packages/block-library/src/code/block.json
+++ b/packages/block-library/src/code/block.json
@@ -9,6 +9,7 @@
 		}
 	},
 	"supports": {
+		"anchor": true,
 		"html": false,
 		"lightBlockWrapper": true
 	}

--- a/packages/block-library/src/column/block.json
+++ b/packages/block-library/src/column/block.json
@@ -15,6 +15,7 @@
 		}
 	},
 	"supports": {
+		"anchor": true,
 		"reusable": false,
 		"html": false,
 		"lightBlockWrapper": true

--- a/packages/block-library/src/columns/block.json
+++ b/packages/block-library/src/columns/block.json
@@ -7,6 +7,7 @@
 		}
 	},
 	"supports": {
+		"anchor": true,
 		"align": [
 			"wide",
 			"full"

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -46,6 +46,7 @@
 		}
 	},
 	"supports": {
+		"anchor": true,
 		"align": true,
 		"html": false,
 		"lightBlockWrapper": true,

--- a/packages/block-library/src/cover/transforms.js
+++ b/packages/block-library/src/cover/transforms.js
@@ -13,24 +13,26 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/image' ],
-			transform: ( { caption, url, align, id } ) =>
+			transform: ( { caption, url, align, id, anchor } ) =>
 				createBlock( 'core/cover', {
 					title: caption,
 					url,
 					align,
 					id,
+					anchor,
 				} ),
 		},
 		{
 			type: 'block',
 			blocks: [ 'core/video' ],
-			transform: ( { caption, src, align, id } ) =>
+			transform: ( { caption, src, align, id, anchor } ) =>
 				createBlock( 'core/cover', {
 					title: caption,
 					url: src,
 					align,
 					id,
 					backgroundType: VIDEO_BACKGROUND_TYPE,
+					anchor,
 				} ),
 		},
 	],
@@ -58,12 +60,13 @@ const transforms = {
 					! customGradient
 				);
 			},
-			transform: ( { title, url, align, id } ) =>
+			transform: ( { title, url, align, id, anchor } ) =>
 				createBlock( 'core/image', {
 					caption: title,
 					url,
 					align,
 					id,
+					anchor,
 				} ),
 		},
 		{
@@ -89,12 +92,13 @@ const transforms = {
 					! customGradient
 				);
 			},
-			transform: ( { title, url, align, id } ) =>
+			transform: ( { title, url, align, id, anchor } ) =>
 				createBlock( 'core/video', {
 					caption: title,
 					src: url,
 					id,
 					align,
+					anchor,
 				} ),
 		},
 	],

--- a/packages/block-library/src/file/block.json
+++ b/packages/block-library/src/file/block.json
@@ -36,6 +36,7 @@
 		}
 	},
 	"supports": {
+		"anchor": true,
 		"align": true
 	}
 }

--- a/packages/block-library/src/file/transforms.js
+++ b/packages/block-library/src/file/transforms.js
@@ -48,6 +48,7 @@ const transforms = {
 					fileName: attributes.caption,
 					textLinkHref: attributes.src,
 					id: attributes.id,
+					anchor: attributes.anchor,
 				} );
 			},
 		},
@@ -60,6 +61,7 @@ const transforms = {
 					fileName: attributes.caption,
 					textLinkHref: attributes.src,
 					id: attributes.id,
+					anchor: attributes.anchor,
 				} );
 			},
 		},
@@ -72,6 +74,7 @@ const transforms = {
 					fileName: attributes.caption,
 					textLinkHref: attributes.url,
 					id: attributes.id,
+					anchor: attributes.anchor,
 				} );
 			},
 		},
@@ -93,6 +96,7 @@ const transforms = {
 					src: attributes.href,
 					caption: attributes.fileName,
 					id: attributes.id,
+					anchor: attributes.anchor,
 				} );
 			},
 		},
@@ -112,6 +116,7 @@ const transforms = {
 					src: attributes.href,
 					caption: attributes.fileName,
 					id: attributes.id,
+					anchor: attributes.anchor,
 				} );
 			},
 		},
@@ -131,6 +136,7 @@ const transforms = {
 					url: attributes.href,
 					caption: attributes.fileName,
 					id: attributes.id,
+					anchor: attributes.anchor,
 				} );
 			},
 		},

--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -77,6 +77,7 @@
 		}
 	},
 	"supports": {
+		"anchor": true,
 		"align": true
 	}
 }

--- a/packages/block-library/src/heading/transforms.js
+++ b/packages/block-library/src/heading/transforms.js
@@ -14,9 +14,10 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/paragraph' ],
-			transform: ( { content } ) => {
+			transform: ( { content, anchor } ) => {
 				return createBlock( name, {
 					content,
+					anchor,
 				} );
 			},
 		},
@@ -26,7 +27,7 @@ const transforms = {
 			schema: ( { phrasingContentSchema, isPaste } ) => {
 				const schema = {
 					children: phrasingContentSchema,
-					attributes: isPaste ? [] : [ 'style' ],
+					attributes: isPaste ? [] : [ 'style', 'id' ],
 				};
 				return {
 					h1: schema,
@@ -69,9 +70,10 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/paragraph' ],
-			transform: ( { content } ) => {
+			transform: ( { content, anchor } ) => {
 				return createBlock( 'core/paragraph', {
 					content,
+					anchor,
 				} );
 			},
 		},

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -71,6 +71,7 @@
 		}
 	},
 	"supports": {
+		"anchor": true,
 		"lightBlockWrapper": true
 	}
 }

--- a/packages/block-library/src/image/transforms.js
+++ b/packages/block-library/src/image/transforms.js
@@ -85,6 +85,7 @@ const transforms = {
 				const alignMatches = /(?:^|\s)align(left|center|right)(?:$|\s)/.exec(
 					className
 				);
+				const anchor = node.id === '' ? undefined : node.id;
 				const align = alignMatches ? alignMatches[ 1 ] : undefined;
 				const idMatches = /(?:^|\s)wp-image-(\d+)(?:$|\s)/.exec(
 					className
@@ -115,6 +116,7 @@ const transforms = {
 						href,
 						rel,
 						linkClass,
+						anchor,
 					}
 				);
 				return createBlock( 'core/image', attributes );

--- a/packages/block-library/src/list/block.json
+++ b/packages/block-library/src/list/block.json
@@ -28,6 +28,7 @@
 		}
 	},
 	"supports": {
+		"anchor": true,
 		"className": false,
 		"__unstablePasteTextInline": true,
 		"lightBlockWrapper": true

--- a/packages/block-library/src/list/transforms.js
+++ b/packages/block-library/src/list/transforms.js
@@ -61,18 +61,20 @@ const transforms = {
 						),
 						multilineTag: 'li',
 					} ),
+					anchor: blockAttributes.anchor,
 				} );
 			},
 		},
 		{
 			type: 'block',
 			blocks: [ 'core/quote' ],
-			transform: ( { value } ) => {
+			transform: ( { value, anchor } ) => {
 				return createBlock( 'core/list', {
 					values: toHTMLString( {
 						value: create( { html: value, multilineTag: 'p' } ),
 						multilineTag: 'li',
 					} ),
+					anchor,
 				} );
 			},
 		},
@@ -86,6 +88,7 @@ const transforms = {
 			transform( node ) {
 				const attributes = {
 					ordered: node.nodeName === 'OL',
+					anchor: node.id === '' ? undefined : node.id,
 				};
 
 				if ( attributes.ordered ) {
@@ -157,7 +160,7 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/quote' ],
-			transform: ( { values } ) => {
+			transform: ( { values, anchor } ) => {
 				return createBlock( 'core/quote', {
 					value: toHTMLString( {
 						value: create( {
@@ -167,6 +170,7 @@ const transforms = {
 						} ),
 						multilineTag: 'p',
 					} ),
+					anchor,
 				} );
 			},
 		},

--- a/packages/block-library/src/media-text/block.json
+++ b/packages/block-library/src/media-text/block.json
@@ -78,6 +78,7 @@
 		}
 	},
 	"supports": {
+		"anchor": true,
 		"align": [
 			"wide",
 			"full"

--- a/packages/block-library/src/media-text/transforms.js
+++ b/packages/block-library/src/media-text/transforms.js
@@ -8,22 +8,24 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/image' ],
-			transform: ( { alt, url, id } ) =>
+			transform: ( { alt, url, id, anchor } ) =>
 				createBlock( 'core/media-text', {
 					mediaAlt: alt,
 					mediaId: id,
 					mediaUrl: url,
 					mediaType: 'image',
+					anchor,
 				} ),
 		},
 		{
 			type: 'block',
 			blocks: [ 'core/video' ],
-			transform: ( { src, id } ) =>
+			transform: ( { src, id, anchor } ) =>
 				createBlock( 'core/media-text', {
 					mediaId: id,
 					mediaUrl: src,
 					mediaType: 'video',
+					anchor,
 				} ),
 		},
 	],
@@ -34,11 +36,12 @@ const transforms = {
 			isMatch: ( { mediaType, mediaUrl } ) => {
 				return ! mediaUrl || mediaType === 'image';
 			},
-			transform: ( { mediaAlt, mediaId, mediaUrl } ) => {
+			transform: ( { mediaAlt, mediaId, mediaUrl, anchor } ) => {
 				return createBlock( 'core/image', {
 					alt: mediaAlt,
 					id: mediaId,
 					url: mediaUrl,
+					anchor,
 				} );
 			},
 		},
@@ -48,10 +51,11 @@ const transforms = {
 			isMatch: ( { mediaType, mediaUrl } ) => {
 				return ! mediaUrl || mediaType === 'video';
 			},
-			transform: ( { mediaId, mediaUrl } ) => {
+			transform: ( { mediaId, mediaUrl, anchor } ) => {
 				return createBlock( 'core/video', {
 					id: mediaId,
 					src: mediaUrl,
+					anchor,
 				} );
 			},
 		},

--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -27,6 +27,7 @@
 		}
 	},
 	"supports": {
+		"anchor": true,
 		"className": false,
 		"lightBlockWrapper": true,
 		"__experimentalColor": {

--- a/packages/block-library/src/paragraph/transforms.js
+++ b/packages/block-library/src/paragraph/transforms.js
@@ -18,7 +18,7 @@ const transforms = {
 			schema: ( { phrasingContentSchema, isPaste } ) => ( {
 				p: {
 					children: phrasingContentSchema,
-					attributes: isPaste ? [] : [ 'style' ],
+					attributes: isPaste ? [] : [ 'style', 'id' ],
 				},
 			} ),
 			transform( node ) {

--- a/packages/block-library/src/preformatted/block.json
+++ b/packages/block-library/src/preformatted/block.json
@@ -11,6 +11,7 @@
 		}
 	},
 	"supports": {
+		"anchor": true,
 		"lightBlockWrapper": true
 	}
 }

--- a/packages/block-library/src/preformatted/transforms.js
+++ b/packages/block-library/src/preformatted/transforms.js
@@ -8,9 +8,10 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/code', 'core/paragraph' ],
-			transform: ( { content } ) =>
+			transform: ( { content, anchor } ) =>
 				createBlock( 'core/preformatted', {
 					content,
+					anchor,
 				} ),
 		},
 		{

--- a/packages/block-library/src/pullquote/block.json
+++ b/packages/block-library/src/pullquote/block.json
@@ -28,6 +28,7 @@
 		}
 	},
 	"supports": {
+		"anchor": true,
 		"align": [
 			"left",
 			"right",

--- a/packages/block-library/src/quote/block.json
+++ b/packages/block-library/src/quote/block.json
@@ -18,5 +18,8 @@
 		"align": {
 			"type": "string"
 		}
+	},
+	"supports": {
+		"anchor": true
 	}
 }

--- a/packages/block-library/src/quote/transforms.js
+++ b/packages/block-library/src/quote/transforms.js
@@ -21,25 +21,28 @@ const transforms = {
 						),
 						multilineTag: 'p',
 					} ),
+					anchor: attributes.anchor,
 				} );
 			},
 		},
 		{
 			type: 'block',
 			blocks: [ 'core/heading' ],
-			transform: ( { content } ) => {
+			transform: ( { content, anchor } ) => {
 				return createBlock( 'core/quote', {
 					value: `<p>${ content }</p>`,
+					anchor,
 				} );
 			},
 		},
 		{
 			type: 'block',
 			blocks: [ 'core/pullquote' ],
-			transform: ( { value, citation } ) =>
+			transform: ( { value, citation, anchor } ) =>
 				createBlock( 'core/quote', {
 					value,
 					citation,
+					anchor,
 				} ),
 		},
 		{
@@ -172,10 +175,11 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/pullquote' ],
-			transform: ( { value, citation } ) => {
+			transform: ( { value, citation, anchor } ) => {
 				return createBlock( 'core/pullquote', {
 					value,
 					citation,
+					anchor,
 				} );
 			},
 		},

--- a/packages/block-library/src/separator/block.json
+++ b/packages/block-library/src/separator/block.json
@@ -8,5 +8,8 @@
 		"customColor": {
 			"type": "string"
 		}
+	},
+	"supports": {
+		"anchor": true
 	}
 }

--- a/packages/block-library/src/social-links/block.json
+++ b/packages/block-library/src/social-links/block.json
@@ -7,6 +7,7 @@
 			"center",
 			"right"
 		],
-		"lightBlockWrapper": true
+		"lightBlockWrapper": true,
+		"anchor": true
 	}
 }

--- a/packages/block-library/src/spacer/block.json
+++ b/packages/block-library/src/spacer/block.json
@@ -6,5 +6,8 @@
 			"type": "number",
 			"default": 100
 		}
+	},
+	"supports": {
+		"anchor": true
 	}
 }

--- a/packages/block-library/src/table/block.json
+++ b/packages/block-library/src/table/block.json
@@ -122,6 +122,7 @@
 		}
 	},
 	"supports": {
+		"anchor": true,
 		"align": true
 	}
 }

--- a/packages/block-library/src/verse/block.json
+++ b/packages/block-library/src/verse/block.json
@@ -14,6 +14,7 @@
 		}
 	},
 	"supports": {
+		"anchor": true,
 		"lightBlockWrapper": true
 	}
 }

--- a/packages/block-library/src/video/block.json
+++ b/packages/block-library/src/video/block.json
@@ -62,6 +62,7 @@
 		}
 	},
 	"supports": {
+		"anchor": true,
 		"align": true,
 		"lightBlockWrapper": true
 	}


### PR DESCRIPTION
Related #21023

This PR adds anchor support to several blocks and updates the transforms to retain the attribute when transforming blocks.

the reasoning is:

 - id is supported by all DOM elements
 - it's an advanced config in the "advanced" section"
 - Several persons tweak the html to add these ids manually causing invalidation, this will prevent this kind of block invalidation.

**Notes**

I'd like to do the same for dynamic blocks too. Work around support flags for dynamic blocks is being done here #23007 We should circle back to the anchor support too once it lands.

**Testing instructions**

 - Test that you can set IDs to: paragraph, audio, video, button, buttons, column columns, code, preformatted, verse, image, galleries, cover, list, media and text, pullquote, quote, separator, spacer and table.
 - Converting between these blocks should retain the id.
 - Pasting HTML or converting to blocks should retain ids for these blocks.