### PR TITLE
RichText: Add missing param docs for getTextContent()

### DIFF
--- a/packages/rich-text/src/get-text-content.js
+++ b/packages/rich-text/src/get-text-content.js
@@ -2,7 +2,8 @@
  * Get the textual content of a Rich Text value. This is similar to
  * `Element.textContent`.
  *
- * @param {Object} value Value to use.
+ * @param {Object} value      Value to use.
+ * @param {string} value.text Text contents.
  *
  * @return {string} The text content.
  */


### PR DESCRIPTION
See #22907.

Fixes the JSDoc warnings of file:
`packages/rich-text/src/get-text-content.js`

`  1:1  warning  Missing JSDoc @param "value.text" declaration  jsdoc/require-param
   5:0  warning  Missing @param "value.text"                    jsdoc/check-param-names
`

## How has this been tested?
`npm run lint-js packages/rich-text/src`

## Types of changes
Bug Fix