### PR TITLE
Add back providesContext block attribute

### DIFF
--- a/lib/class-wp-block.php
+++ b/lib/class-wp-block.php
@@ -107,8 +107,8 @@ class WP_Block {
 
 		$this->available_context = $available_context;
 
-		if ( ! empty( $this->block_type->requiresContext ) ) {
-			foreach ( $this->block_type->requiresContext as $context_name ) {
+		if ( ! empty( $this->block_type->usesContext ) ) {
+			foreach ( $this->block_type->usesContext as $context_name ) {
 				if ( array_key_exists( $context_name, $this->available_context ) ) {
 					$this->context[ $context_name ] = $this->available_context[ $context_name ];
 				}

--- a/lib/class-wp-block.php
+++ b/lib/class-wp-block.php
@@ -107,8 +107,8 @@ class WP_Block {
 
 		$this->available_context = $available_context;
 
-		if ( ! empty( $this->block_type->usesContext ) ) {
-			foreach ( $this->block_type->usesContext as $context_name ) {
+		if ( ! empty( $this->block_type->context ) ) {
+			foreach ( $this->block_type->context as $context_name ) {
 				if ( array_key_exists( $context_name, $this->available_context ) ) {
 					$this->context[ $context_name ] = $this->available_context[ $context_name ];
 				}

--- a/lib/class-wp-block.php
+++ b/lib/class-wp-block.php
@@ -107,8 +107,8 @@ class WP_Block {
 
 		$this->available_context = $available_context;
 
-		if ( ! empty( $this->block_type->context ) ) {
-			foreach ( $this->block_type->context as $context_name ) {
+		if ( ! empty( $this->block_type->requiresContext ) ) {
+			foreach ( $this->block_type->requiresContext as $context_name ) {
 				if ( array_key_exists( $context_name, $this->available_context ) ) {
 					$this->context[ $context_name ] = $this->available_context[ $context_name ];
 				}

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -169,7 +169,7 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 		$property_mappings = array(
 			'title'           => 'title',
 			'category'        => 'category',
-			'context'         => 'usesContext',
+			'context'         => 'context',
 			'providesContext' => 'providesContext',
 			'parent'          => 'parent',
 			'icon'            => 'icon',

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -167,17 +167,18 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 
 		$settings          = array();
 		$property_mappings = array(
-			'title'       => 'title',
-			'category'    => 'category',
-			'context'     => 'context',
-			'parent'      => 'parent',
-			'icon'        => 'icon',
-			'description' => 'description',
-			'keywords'    => 'keywords',
-			'attributes'  => 'attributes',
-			'supports'    => 'supports',
-			'styles'      => 'styles',
-			'example'     => 'example',
+			'title'           => 'title',
+			'category'        => 'category',
+			'context'         => 'requiresContext',
+			'providesContext' => 'providesContext',
+			'parent'          => 'parent',
+			'icon'            => 'icon',
+			'description'     => 'description',
+			'keywords'        => 'keywords',
+			'attributes'      => 'attributes',
+			'supports'        => 'supports',
+			'styles'          => 'styles',
+			'example'         => 'example',
 		);
 
 		foreach ( $property_mappings as $key => $mapped_key ) {

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -169,7 +169,7 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 		$property_mappings = array(
 			'title'           => 'title',
 			'category'        => 'category',
-			'context'         => 'requiresContext',
+			'context'         => 'usesContext',
 			'providesContext' => 'providesContext',
 			'parent'          => 'parent',
 			'icon'            => 'icon',


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

- Adds back `providesContext` mapping (see #23180)

Note: converting `context` to `uses_context` and `providesContext` to `provides_context` will happen at the API level in #22686.
 
## How has this been tested?
Locally in edit site. Made sure block context still works for dynamic blocks.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
