### PR TITLE
Fix $theme-color CSS variable in template-part/editor

### DIFF
--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -64,11 +64,11 @@
 		border: $border-width solid transparent;
 
 		&:hover {
-			border: $border-width solid $theme-color;
+			border: $border-width solid $blue-wordpress-700;
 		}
 
 		&:focus {
-			box-shadow: inset 0 0 0 1px $white, 0 0 0 $border-width-focus $theme-color;
+			box-shadow: inset 0 0 0 1px $white, 0 0 0 $border-width-focus $blue-wordpress-700;
 
 			// Windows High Contrast mode will show this outline, but not the box-shadow.
 			outline: 2px solid transparent;
@@ -96,7 +96,7 @@
 	}
 
 	.wp-block-template-part__placeholder-panel-group-title {
-		color: $theme-color;
+		color: $blue-wordpress-700;
 		text-transform: uppercase;
 		font-size: 11px;
 		font-weight: 500;


### PR DESCRIPTION
This update fixes the node-sass build with the reference to`$theme-color`. This variable isn't defined, which causes an error in the build. It was replaced with `$blue-wordpress-700`.

Note: I'm not too sure what `$theme-color` may be. I used my best guess and picked the "theme" colour used in the Gutenberg editor.

## How has this been tested?

Local Gutenberg.

* Run `npm run dev`
* Webpack should build without issues
* Make sure local Gutenberg editor styles look ok 👍 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->

Fixes: https://github.com/WordPress/gutenberg/issues/23217