### PR TITLE
Block Directory: Use plugin API for installing & deleting block-plugins

### DIFF
--- a/packages/block-directory/src/store/actions.js
+++ b/packages/block-directory/src/store/actions.js
@@ -74,7 +74,8 @@ export function* installBlockType( block ) {
 			},
 			method: 'POST',
 		} );
-		yield addInstalledBlockType( { ...block, plugin: response.plugin } );
+		const endpoint = response?._links?.self[ 0 ]?.href;
+		yield addInstalledBlockType( { ...block, endpoint } );
 
 		yield loadAssets( assets );
 		const registeredBlocks = yield select( 'core/blocks', 'getBlockTypes' );
@@ -95,17 +96,16 @@ export function* installBlockType( block ) {
  * @param {Object} block The blockType object.
  */
 export function* uninstallBlockType( block ) {
-	const plugin = block.plugin.replace( '.php', '' );
 	try {
 		yield apiFetch( {
-			path: `__experimental/plugins/${ plugin }`,
+			url: block.endpoint,
 			data: {
 				status: 'inactive',
 			},
 			method: 'PUT',
 		} );
 		yield apiFetch( {
-			path: `__experimental/plugins/${ plugin }`,
+			url: block.endpoint,
 			method: 'DELETE',
 		} );
 		yield removeInstalledBlockType( block );

--- a/packages/block-directory/src/store/test/actions.js
+++ b/packages/block-directory/src/store/test/actions.js
@@ -4,17 +4,24 @@
 import { installBlockType, uninstallBlockType } from '../actions';
 
 describe( 'actions', () => {
+	const endpoint = '/wp-json/__experimental/plugins/block/block';
 	const item = {
 		id: 'block/block',
 		name: 'Test Block',
 		assets: [ 'script.js' ],
 	};
-
 	const plugin = {
 		plugin: 'block/block.php',
 		status: 'active',
 		name: 'Test Block',
 		version: '1.0.0',
+		_links: {
+			self: [
+				{
+					href: endpoint,
+				},
+			],
+		},
 	};
 
 	describe( 'installBlockType', () => {
@@ -41,10 +48,10 @@ describe( 'actions', () => {
 				},
 			} );
 
-			const itemWithPlugin = { ...item, plugin: plugin.plugin };
+			const itemWithEndpoint = { ...item, endpoint };
 			expect( generator.next( plugin ).value ).toEqual( {
 				type: 'ADD_INSTALLED_BLOCK_TYPE',
-				item: itemWithPlugin,
+				item: itemWithEndpoint,
 			} );
 
 			expect( generator.next().value ).toEqual( {
@@ -144,16 +151,16 @@ describe( 'actions', () => {
 	} );
 
 	describe( 'uninstallBlockType', () => {
-		const itemWithPlugin = { ...item, plugin: plugin.plugin };
+		const itemWithEndpoint = { ...item, endpoint };
 
 		it( 'should uninstall a block successfully', () => {
-			const generator = uninstallBlockType( itemWithPlugin );
+			const generator = uninstallBlockType( itemWithEndpoint );
 
 			// First the deactivation step
 			expect( generator.next().value ).toMatchObject( {
 				type: 'API_FETCH',
 				request: {
-					path: '__experimental/plugins/block/block',
+					url: endpoint,
 					method: 'PUT',
 				},
 			} );
@@ -162,14 +169,14 @@ describe( 'actions', () => {
 			expect( generator.next().value ).toMatchObject( {
 				type: 'API_FETCH',
 				request: {
-					path: '__experimental/plugins/block/block',
+					url: endpoint,
 					method: 'DELETE',
 				},
 			} );
 
 			expect( generator.next().value ).toEqual( {
 				type: 'REMOVE_INSTALLED_BLOCK_TYPE',
-				item: itemWithPlugin,
+				item: itemWithEndpoint,
 			} );
 
 			expect( generator.next() ).toEqual( {
@@ -179,12 +186,12 @@ describe( 'actions', () => {
 		} );
 
 		it( "should set a global notice if the plugin can't be deleted", () => {
-			const generator = uninstallBlockType( itemWithPlugin );
+			const generator = uninstallBlockType( itemWithEndpoint );
 
 			expect( generator.next().value ).toMatchObject( {
 				type: 'API_FETCH',
 				request: {
-					path: '__experimental/plugins/block/block',
+					url: endpoint,
 					method: 'PUT',
 				},
 			} );
@@ -192,7 +199,7 @@ describe( 'actions', () => {
 			expect( generator.next().value ).toMatchObject( {
 				type: 'API_FETCH',
 				request: {
-					path: '__experimental/plugins/block/block',
+					url: endpoint,
 					method: 'DELETE',
 				},
 			} );

--- a/packages/e2e-tests/specs/experiments/block-directory-add.test.js
+++ b/packages/e2e-tests/specs/experiments/block-directory-add.test.js
@@ -22,10 +22,8 @@ const SEARCH_URLS = [
 ];
 
 const INSTALL_URLS = [
-	'/__experimental/block-directory/install',
-	`rest_route=${ encodeURIComponent(
-		'/__experimental/block-directory/install'
-	) }`,
+	'/__experimental/plugins',
+	`rest_route=${ encodeURIComponent( '/__experimental/plugins' ) }`,
 ];
 
 // Example Blocks

--- a/phpunit/class-wp-rest-block-directory-controller-test.php
+++ b/phpunit/class-wp-rest-block-directory-controller-test.php
@@ -19,10 +19,6 @@ class WP_REST_Block_Directory_Controller_Test extends WP_Test_REST_Controller_Te
 		if ( is_multisite() ) {
 			grant_super_admin( self::$admin_id );
 		}
-
-		if ( ! defined( 'FS_METHOD' ) ) {
-			define( 'FS_METHOD', 'direct' );
-		}
 	}
 
 	public static function wpTearDownAfterClass() {
@@ -95,20 +91,7 @@ class WP_REST_Block_Directory_Controller_Test extends WP_Test_REST_Controller_Te
 	}
 
 	public function test_create_item() {
-		if ( isset( get_plugins()['hello-dolly/hello.php'] ) ) {
-			delete_plugins( array( 'hello-dolly/hello.php' ) );
-		}
-
-		wp_set_current_user( self::$admin_id );
-
-		$request = new WP_REST_Request( 'POST', '/__experimental/block-directory/install' );
-		$request->set_body_params( array( 'slug' => 'hello-dolly' ) );
-
-		$response = rest_do_request( $request );
-		$this->skip_on_filesystem_error( $response );
-		$this->assertNotWPError( $response->as_error() );
-		$this->assertEquals( 201, $response->get_status() );
-		$this->assertEquals( 'Hello Dolly', $response->get_data()['name'] );
+		$this->markTestSkipped( 'Controller does not have create_item route.' );
 	}
 
 	public function test_update_item() {
@@ -116,7 +99,7 @@ class WP_REST_Block_Directory_Controller_Test extends WP_Test_REST_Controller_Te
 	}
 
 	public function test_delete_item() {
-		$this->markTestSkipped( 'Covered by Plugins controller tests.' );
+		$this->markTestSkipped( 'Controller does not have delete_item route.' );
 	}
 
 	public function test_prepare_item() {
@@ -170,25 +153,6 @@ class WP_REST_Block_Directory_Controller_Test extends WP_Test_REST_Controller_Te
 		$this->assertArrayHasKey( 'icon', $properties );
 		$this->assertArrayHasKey( 'humanized_updated', $properties );
 		$this->assertArrayHasKey( 'assets', $properties );
-	}
-
-	/**
-	 * Skips the test if the response is an error due to the filesystem being unavailable.
-	 *
-	 * @since 5.5.0
-	 *
-	 * @param WP_REST_Response $response The response object to inspect.
-	 */
-	protected function skip_on_filesystem_error( WP_REST_Response $response ) {
-		if ( ! $response->is_error() ) {
-			return;
-		}
-
-		$code = $response->as_error()->get_error_code();
-
-		if ( 'fs_unavailable' === $code || false !== strpos( $code, 'mkdir_failed' ) ) {
-			$this->markTestSkipped( 'Filesystem is unavailable.' );
-		}
 	}
 
 	/**

--- a/phpunit/class-wp-rest-block-directory-controller-test.php
+++ b/phpunit/class-wp-rest-block-directory-controller-test.php
@@ -29,8 +29,6 @@ class WP_REST_Block_Directory_Controller_Test extends WP_Test_REST_Controller_Te
 		$routes = rest_get_server()->get_routes();
 
 		$this->assertArrayHasKey( '/__experimental/block-directory/search', $routes );
-		$this->assertArrayHasKey( '/__experimental/block-directory/install', $routes );
-		$this->assertArrayHasKey( '/__experimental/block-directory/uninstall', $routes );
 	}
 
 	public function test_context_param() {


### PR DESCRIPTION
## Description
The `/plugins` endpoints were introduced in #22454, and while `/block-directory/install` and `/block-directory/uninstall` were updated to use those endpoints in PHP, we can actually remove those endpoints and call the `plugins` methods directly. See https://github.com/WordPress/gutenberg/pull/22454#issuecomment-631849871

This PR updates the install flow to call `POST __experimental/plugins`, and the uninstall flow to call `PUT __experimental/plugins/${ plugin }` (to deactivate) and `DELETE __experimental/plugins/${ plugin }` to remove the files.

It also removes the install & uninstall endpoints from `__experimental/block-directory`, and updates all the tests.

## How has this been tested?
The php & js unit tests have been updated. I've also tested the block directory flow in browser (chrome):

- Open a post
- Search for a new block, add it
- It should install & be added to the post content
- In another tab, you can open the plugins screen to see it installed
- Back in the editor, remove the block, and save your post
- The block is silently removed, since it's unused
- Back on the plugins screen, the plugin should be gone

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
