### PR TITLE
FSE: Do not use demo templates if theme files exist

### DIFF
--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -258,7 +258,7 @@ function gutenberg_find_template_post_and_parts( $template_type, $template_hiera
 		$child_block_template_files = is_array( $child_block_template_files ) ? $child_block_template_files : array();
 		$block_template_files       = array_merge( $block_template_files, $child_block_template_files );
 	}
-	if ( gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing-demo' ) ) {
+	if ( count( $block_template_files ) === 0 && gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing-demo' ) ) {
 		$demo_block_template_files = glob( dirname( __FILE__ ) . '/demo-block-templates/*.html' );
 		$demo_block_template_files = is_array( $demo_block_template_files ) ? $demo_block_template_files : array();
 		$block_template_files      = array_merge( $block_template_files, $demo_block_template_files );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Do not resolve demo templates if theme files exist. Previously, the demo templates were often used if a theme did not provide specific-enough templates. Since we only require a theme to set the `index` template, we shouldn't override any pages with demo templates if the theme is specifying files.

## How has this been tested?
locally in edit site

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
