### PR TITLE
Buttons block: lighten editor DOM even more.

### DIFF
--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -23,15 +23,15 @@ const alignmentHooksSetting = {
 function ButtonsEdit() {
 	const blockWrapperProps = useBlockWrapperProps();
 	return (
-		<div { ...blockWrapperProps }>
-			<AlignmentHookSettingsProvider value={ alignmentHooksSetting }>
-				<InnerBlocks
-					allowedBlocks={ ALLOWED_BLOCKS }
-					template={ BUTTONS_TEMPLATE }
-					orientation="horizontal"
-				/>
-			</AlignmentHookSettingsProvider>
-		</div>
+		<AlignmentHookSettingsProvider value={ alignmentHooksSetting }>
+			<InnerBlocks
+				allowedBlocks={ ALLOWED_BLOCKS }
+				__experimentalPassedProps={ blockWrapperProps }
+				__experimentalTagName="div"
+				template={ BUTTONS_TEMPLATE }
+				orientation="horizontal"
+			/>
+		</AlignmentHookSettingsProvider>
 	);
 }
 

--- a/packages/block-library/src/buttons/editor.scss
+++ b/packages/block-library/src/buttons/editor.scss
@@ -1,7 +1,4 @@
-.wp-block-buttons .wp-block.block-editor-block-list__block[data-type="core/button"] {
-	display: inline-block;
-	width: auto;
-
+.wp-block-buttons > .wp-block {
 	// Override editor auto block margins.
 	margin-left: 0;
 }
@@ -18,6 +15,6 @@
 	justify-content: flex-end;
 }
 
-.wp-block-buttons .block-list-appender {
+.wp-block-buttons > .block-list-appender {
 	display: inline-block;
 }

--- a/packages/block-library/src/buttons/editor.scss
+++ b/packages/block-library/src/buttons/editor.scss
@@ -1,6 +1,9 @@
 .wp-block-buttons .wp-block.block-editor-block-list__block[data-type="core/button"] {
 	display: inline-block;
 	width: auto;
+
+	// Override editor auto block margins.
+	margin-left: 0;
 }
 
 .wp-block[data-align="center"] > .wp-block-buttons {


### PR DESCRIPTION
## Description
This makes the editor DOM of the Buttons block identical to the front-end (in terms of div-wrapping) by removing several wrapper divs thanks to the `__experimentalTagName` property on `<InnerBlocks />`.

Note that this PR does not change the React Native edit implementation.

Before:
![image](https://user-images.githubusercontent.com/19592990/84837183-1ad56200-affd-11ea-9f7a-3135a515368a.png)

After:
![image](https://user-images.githubusercontent.com/19592990/84837302-5f60fd80-affd-11ea-96ba-9df1285ebba8.png)

## How has this been tested?
I tested to make sure Buttons blocks still looked as expected in the editor, with or without a block alignment set.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
