### PR TITLE
Remove/tweak dark light variables

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -438,49 +438,46 @@
 	}
 }
 
-@mixin admin-scheme($color-primary-h, $color-primary-s, $color-primary-l) {
-	--wp-admin-theme-color: hsl(#{$color-primary-h}, #{$color-primary-s}, #{$color-primary-l});
+@mixin admin-scheme($color-primary) {
+	--wp-admin-theme-color: #{$color-primary};
 
 	// Darker shades.
-	--wp-admin-theme-color-darker-10: hsl(#{$color-primary-h}, #{$color-primary-s}, #{$color-primary-l - 5});
-	--wp-admin-theme-color-darker-20: hsl(#{$color-primary-h}, #{$color-primary-s}, #{$color-primary-l - 10});
+	--wp-admin-theme-color-darker-10: #{darken($color-primary, 5%)};
+	--wp-admin-theme-color-darker-20: #{darken($color-primary, 10%)};
 }
 
-// Using individual HSL (Hue, Saturation, Lightness) values, we can adjust the brightness
-// of a color, without using SASS.
-// You can convert an RGB color to HSL on https://www.w3schools.com/colors/colors_converter.asp.
 @mixin wordpress-admin-schemes() {
 	body.admin-color-light {
-		@include admin-scheme(197, 100%, 36%); // #0085ba
+		@include admin-scheme(#0085ba);
 	}
 
 	body.admin-color-blue {
-		@include admin-scheme(196, 87%, 28%); // #096484
+		@include admin-scheme(#096484);
 	}
 
 	body.admin-color-coffee {
-		@include admin-scheme(24, 8%, 25%); // #46403c
+		@include admin-scheme(#46403c);
 	}
 
 	body.admin-color-ectoplasm {
-		@include admin-scheme(265, 27%, 34%); // #523f6d
+		@include admin-scheme(#523f6d);
 	}
 
 	body.admin-color-midnight {
-		@include admin-scheme(4, 72%, 57%); // #e14d43
+		@include admin-scheme(#e14d43);
 	}
 
 	body.admin-color-ocean {
-		@include admin-scheme(193, 14%, 45%); // #627c83
+		@include admin-scheme(#627c83);
 	}
 
 	body.admin-color-sunrise {
-		@include admin-scheme(26, 70%, 55%); // #dd823b
+		@include admin-scheme(#dd823b);
 	}
 }
 
 // It is important to include these styles in all built stylesheets
 // This allows to CSS variables post CSS plugin to generate fallbacks.
 :root {
-	@include admin-scheme(200, 100%, 36%); // #007cba
+	@include admin-scheme(#007cba);
 }

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -438,48 +438,49 @@
 	}
 }
 
-@mixin admin-scheme($color-primary) {
-	--wp-admin-theme-color: #{$color-primary};
+@mixin admin-scheme($color-primary-h, $color-primary-s, $color-primary-l) {
+	--wp-admin-theme-color: hsl(#{$color-primary-h}, #{$color-primary-s}, #{$color-primary-l});
 
-	// Ideally, we should limit these computed variables,
-	// because we can"t compute colors based on CSS variables.
-	// This requires refactoring some existing styles.
-	--wp-admin-theme-color-darker-20: #{darken($color-primary, 20%)};
-	--wp-admin-theme-color-darker-10: #{darken($color-primary, 10%)};
+	// Darker shades.
+	--wp-admin-theme-color-darker-10: hsl(#{$color-primary-h}, #{$color-primary-s}, #{$color-primary-l - 5});
+	--wp-admin-theme-color-darker-20: hsl(#{$color-primary-h}, #{$color-primary-s}, #{$color-primary-l - 10});
 }
 
+// Using individual HSL (Hue, Saturation, Lightness) values, we can adjust the brightness
+// of a color, without using SASS.
+// You can convert an RGB color to HSL on https://www.w3schools.com/colors/colors_converter.asp.
 @mixin wordpress-admin-schemes() {
 	body.admin-color-light {
-		@include admin-scheme(#0085ba);
+		@include admin-scheme(197, 100%, 36%); // #0085ba
 	}
 
 	body.admin-color-blue {
-		@include admin-scheme(#096484);
+		@include admin-scheme(196, 87%, 28%); // #096484
 	}
 
 	body.admin-color-coffee {
-		@include admin-scheme(#46403c);
+		@include admin-scheme(24, 8%, 25%); // #46403c
 	}
 
 	body.admin-color-ectoplasm {
-		@include admin-scheme(#523f6d);
+		@include admin-scheme(265, 27%, 34%); // #523f6d
 	}
 
 	body.admin-color-midnight {
-		@include admin-scheme(#e14d43);
+		@include admin-scheme(4, 72%, 57%); // #e14d43
 	}
 
 	body.admin-color-ocean {
-		@include admin-scheme(#627c83);
+		@include admin-scheme(193, 14%, 45%); // #627c83
 	}
 
 	body.admin-color-sunrise {
-		@include admin-scheme(#dd823b);
+		@include admin-scheme(26, 70%, 55%); // #dd823b
 	}
 }
 
 // It is important to include these styles in all built stylesheets
 // This allows to CSS variables post CSS plugin to generate fallbacks.
 :root {
-	@include admin-scheme(#007cba);
+	@include admin-scheme(200, 100%, 36%); // #007cba
 }

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -446,8 +446,6 @@
 	// This requires refactoring some existing styles.
 	--wp-admin-theme-color-darker-20: #{darken($color-primary, 20%)};
 	--wp-admin-theme-color-darker-10: #{darken($color-primary, 10%)};
-	--wp-admin-theme-color-lighter-10: #{lighten($color-primary, 10%)};
-	--wp-admin-theme-color-lighter-40: #{lighten($color-primary, 40%)};
 }
 
 @mixin wordpress-admin-schemes() {

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -70,9 +70,9 @@
 		&[aria-disabled="true"],
 		&[aria-disabled="true"]:enabled, // This catches a situation where a Button is aria-disabled, but not disabled.
 		&[aria-disabled="true"]:active:enabled {
-			color: var(--wp-admin-theme-color-lighter-40);
-			background: var(--wp-admin-theme-color-lighter-10);
-			border-color: var(--wp-admin-theme-color-lighter-10);
+			color: rgba($white, 0.4);
+			background: var(--wp-admin-theme-color);
+			border-color: var(--wp-admin-theme-color);
 			opacity: 1;
 
 			&:focus:enabled {

--- a/packages/edit-post/src/components/header/header-toolbar/style.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.scss
@@ -38,7 +38,7 @@
 		}
 
 		&:focus:not(:disabled) {
-			box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+			box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color), inset 0 0 0 $border-width $white;
 			outline: 1px solid transparent;
 		}
 


### PR DESCRIPTION
The admin UI now uses CSS variables. But the SASS functions for lightening and darkening colors are not accurate, causing too saturated a disabled button:

<img width="359" alt="Screenshot 2020-06-17 at 08 46 47" src="https://user-images.githubusercontent.com/1204802/84866872-9e816400-b07a-11ea-9043-e30d10b3d0cf.png">

Additionally, it added some complexity as the variables could not be calculated from a single color.

This PR fixes both of these, using a clever trick from https://stackoverflow.com/questions/1625681/dynamically-change-color-to-lighter-or-darker-by-percentage-css-javascript.

The light colors I simply retired in favor of opacity:

<img width="393" alt="Screenshot 2020-06-17 at 08 54 06" src="https://user-images.githubusercontent.com/1204802/84866967-c375d700-b07a-11ea-8c1f-f7cdb7f4e5f4.png">

Now they match disabled buttons elsewhere in the admin.

The dark colors are still there:

<img width="260" alt="Screenshot 2020-06-17 at 09 11 27" src="https://user-images.githubusercontent.com/1204802/84866987-c83a8b00-b07a-11ea-99e3-5750152099cd.png">

But they now are rewritten using HSL so that the colors actually can be recalculated.