### PR TITLE
Change select parent button styles

### DIFF
--- a/packages/block-editor/src/components/block-parent-selector/style.scss
+++ b/packages/block-editor/src/components/block-parent-selector/style.scss
@@ -1,14 +1,10 @@
 .block-editor-block-parent-selector {
 	background: $white;
-	border: $border-width solid $dark-gray-primary;
-	border-radius: $radius-block-ui;
-	padding: $grid-unit-10 - $border-width;
-	line-height: 1;
 
 	.block-editor-block-parent-selector__button {
-		min-width: auto;
-		width: $grid-unit-40;
-		height: $grid-unit-40;
-		padding: 0;
+		width: $grid-unit-60;
+		height: $grid-unit-60;
+		border: $border-width solid $dark-gray-primary;
+		border-radius: $radius-block-ui;
 	}
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Fixes #22723

This is a small CSS fix for `select parent` button where the button's `click space` was not filling the button itself.


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
