### PR TITLE
Inserter: Fix handling of child blocks

### DIFF
--- a/packages/block-editor/src/components/inserter/block-list.js
+++ b/packages/block-editor/src/components/inserter/block-list.js
@@ -1,15 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	map,
-	includes,
-	findIndex,
-	flow,
-	sortBy,
-	groupBy,
-	isEmpty,
-} from 'lodash';
+import { map, findIndex, flow, sortBy, groupBy, isEmpty } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -48,13 +40,14 @@ export function InserterBlockList( {
 		rootClientId,
 		onInsert
 	);
-	const rootChildBlocks = useSelect(
+
+	const hasChildItems = useSelect(
 		( select ) => {
 			const { getBlockName } = select( 'core/block-editor' );
 			const { getChildBlockNames } = select( 'core/blocks' );
 			const rootBlockName = getBlockName( rootClientId );
 
-			return getChildBlockNames( rootBlockName );
+			return !! getChildBlockNames( rootBlockName ).length;
 		},
 		[ rootClientId ]
 	);
@@ -62,12 +55,6 @@ export function InserterBlockList( {
 	const filteredItems = useMemo( () => {
 		return searchBlockItems( items, categories, collections, filterValue );
 	}, [ filterValue, items, categories, collections ] );
-
-	const childItems = useMemo( () => {
-		return filteredItems.filter( ( { name } ) =>
-			includes( rootChildBlocks, name )
-		);
-	}, [ filteredItems, rootChildBlocks ] );
 
 	const suggestedItems = useMemo( () => {
 		return items.slice( 0, MAX_SUGGESTED_ITEMS );
@@ -127,16 +114,19 @@ export function InserterBlockList( {
 	}, [ filterValue, debouncedSpeak ] );
 
 	const hasItems = ! isEmpty( filteredItems );
-	const hasChildItems = childItems.length > 0;
 
 	return (
 		<div>
-			<ChildBlocks
-				rootClientId={ rootClientId }
-				items={ childItems }
-				onSelect={ onSelectItem }
-				onHover={ onHover }
-			/>
+			{ hasChildItems && (
+				<ChildBlocks
+					rootClientId={ rootClientId }
+					// Pass along every block, as getInserterItems() will have
+					// already filtered out non-child blocks.
+					items={ filteredItems }
+					onSelect={ onSelectItem }
+					onHover={ onHover }
+				/>
+			) }
 
 			{ ! hasChildItems && !! suggestedItems.length && ! filterValue && (
 				<InserterPanel title={ _x( 'Most used', 'blocks' ) }>

--- a/packages/block-editor/src/components/inserter/block-list.js
+++ b/packages/block-editor/src/components/inserter/block-list.js
@@ -118,14 +118,15 @@ export function InserterBlockList( {
 	return (
 		<div>
 			{ hasChildItems && (
-				<ChildBlocks
-					rootClientId={ rootClientId }
-					// Pass along every block, as getInserterItems() will have
-					// already filtered out non-child blocks.
-					items={ filteredItems }
-					onSelect={ onSelectItem }
-					onHover={ onHover }
-				/>
+				<ChildBlocks rootClientId={ rootClientId }>
+					<BlockTypesList
+						// Pass along every block, as getInserterItems() will have
+						// already filtered out non-child blocks.
+						items={ filteredItems }
+						onSelect={ onSelectItem }
+						onHover={ onHover }
+					/>
+				</ChildBlocks>
 			) }
 
 			{ ! hasChildItems && !! suggestedItems.length && ! filterValue && (

--- a/packages/block-editor/src/components/inserter/block-list.js
+++ b/packages/block-editor/src/components/inserter/block-list.js
@@ -120,8 +120,9 @@ export function InserterBlockList( {
 			{ hasChildItems && (
 				<ChildBlocks rootClientId={ rootClientId }>
 					<BlockTypesList
-						// Pass along every block, as getInserterItems() will have
-						// already filtered out non-child blocks.
+						// Pass along every block, as useBlockTypesState() and
+						// getInserterItems() will have already filtered out
+						// non-child blocks.
 						items={ filteredItems }
 						onSelect={ onSelectItem }
 						onHover={ onHover }

--- a/packages/block-editor/src/components/inserter/child-blocks.js
+++ b/packages/block-editor/src/components/inserter/child-blocks.js
@@ -1,32 +1,15 @@
 /**
  * WordPress dependencies
  */
-import { withSelect } from '@wordpress/data';
-import { ifCondition, compose } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import BlockTypesList from '../block-types-list';
 import BlockIcon from '../block-icon';
 
-function ChildBlocks( { rootBlockIcon, rootBlockTitle, items, ...props } ) {
-	return (
-		<div className="block-editor-inserter__child-blocks">
-			{ ( rootBlockIcon || rootBlockTitle ) && (
-				<div className="block-editor-inserter__parent-block-header">
-					<BlockIcon icon={ rootBlockIcon } showColors />
-					{ rootBlockTitle && <h2>{ rootBlockTitle }</h2> }
-				</div>
-			) }
-			<BlockTypesList items={ items } { ...props } />
-		</div>
-	);
-}
-
-export default compose(
-	ifCondition( ( { items } ) => items && items.length > 0 ),
-	withSelect( ( select, { rootClientId } ) => {
+export default function ChildBlocks( { rootClientId, children } ) {
+	const { rootBlockTitle, rootBlockIcon } = useSelect( ( select ) => {
 		const { getBlockType } = select( 'core/blocks' );
 		const { getBlockName } = select( 'core/block-editor' );
 		const rootBlockName = getBlockName( rootClientId );
@@ -35,5 +18,17 @@ export default compose(
 			rootBlockTitle: rootBlockType && rootBlockType.title,
 			rootBlockIcon: rootBlockType && rootBlockType.icon,
 		};
-	} )
-)( ChildBlocks );
+	} );
+
+	return (
+		<div className="block-editor-inserter__child-blocks">
+			{ ( rootBlockIcon || rootBlockTitle ) && (
+				<div className="block-editor-inserter__parent-block-header">
+					<BlockIcon icon={ rootBlockIcon } showColors />
+					{ rootBlockTitle && <h2>{ rootBlockTitle }</h2> }
+				</div>
+			) }
+			{ children }
+		</div>
+	);
+}

--- a/packages/block-editor/src/components/inserter/test/block-list.js
+++ b/packages/block-editor/src/components/inserter/test/block-list.js
@@ -13,6 +13,13 @@ import { useSelect } from '@wordpress/data';
  */
 import { InserterBlockList as BaseInserterBlockList } from '../block-list';
 import items, { categories, collections } from './fixtures';
+import useBlockTypesState from '../hooks/use-block-types-state';
+
+jest.mock( '../hooks/use-block-types-state', () => {
+	// This allows us to tweak the returned value on each test
+	const mock = jest.fn();
+	return mock;
+} );
 
 jest.mock( '@wordpress/data/src/components/use-select', () => {
 	// This allows us to tweak the returned value on each test
@@ -63,20 +70,22 @@ describe( 'InserterMenu', () => {
 	beforeEach( () => {
 		debouncedSpeak.mockClear();
 
-		useSelect.mockImplementation( () => ( {
+		useBlockTypesState.mockImplementation( () => [
+			items,
 			categories,
 			collections,
-			items,
-		} ) );
+		] );
+
+		useSelect.mockImplementation( () => false );
 	} );
 
 	it( 'should show nothing if there are no items', () => {
 		const noItems = [];
-		useSelect.mockImplementation( () => ( {
+		useBlockTypesState.mockImplementation( () => [
+			noItems,
 			categories,
 			collections,
-			items: noItems,
-		} ) );
+		] );
 		const { container } = render(
 			<InserterBlockList filterValue="random" />
 		);
@@ -145,6 +154,20 @@ describe( 'InserterMenu', () => {
 		expect( blocks[ 0 ].textContent ).toBe( 'Paragraph' );
 		expect( blocks[ 1 ].textContent ).toBe( 'Advanced Paragraph' );
 		expect( blocks[ 2 ].textContent ).toBe( 'Some Other Block' );
+
+		assertNoResultsMessageNotToBePresent( container );
+	} );
+
+	it( 'displays child blocks UI when root block has child blocks', () => {
+		useSelect.mockImplementation( () => true );
+
+		const { container } = render( <InserterBlockList /> );
+
+		const childBlocksContent = container.querySelector(
+			'.block-editor-inserter__child-blocks'
+		);
+
+		expect( childBlocksContent ).not.toBeNull();
 
 		assertNoResultsMessageNotToBePresent( container );
 	} );

--- a/packages/e2e-tests/plugins/child-blocks.php
+++ b/packages/e2e-tests/plugins/child-blocks.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Child Blocks
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-child-blocks
+ */
+
+/**
+ * Registers a custom script for the plugin.
+ */
+function enqueue_child_blocks_script() {
+	wp_enqueue_script(
+		'gutenberg-test-child-blocks',
+		plugins_url( 'child-blocks/index.js', __FILE__ ),
+		array(
+			'wp-blocks',
+			'wp-block-editor',
+			'wp-element',
+			'wp-i18n',
+		),
+		filemtime( plugin_dir_path( __FILE__ ) . 'child-blocks/index.js' ),
+		true
+	);
+}
+
+add_action( 'init', 'enqueue_child_blocks_script' );

--- a/packages/e2e-tests/plugins/child-blocks/index.js
+++ b/packages/e2e-tests/plugins/child-blocks/index.js
@@ -1,0 +1,79 @@
+( function() {
+	const { InnerBlocks } = wp.blockEditor;
+	const { createElement: el } = wp.element;
+	const { registerBlockType } = wp.blocks;
+
+	registerBlockType( 'test/child-blocks-unrestricted-parent', {
+		title: 'Child Blocks Unrestricted Parent',
+		icon: 'carrot',
+		category: 'text',
+
+		edit() {
+			return el(
+				'div',
+				{},
+				el( InnerBlocks )
+			);
+		},
+
+		save() {
+			return el(
+				'div',
+				{},
+				el( InnerBlocks.Content )
+			);
+		},
+	} );
+
+	registerBlockType( 'test/child-blocks-restricted-parent', {
+		title: 'Child Blocks Restricted Parent',
+		icon: 'carrot',
+		category: 'text',
+
+		edit() {
+			return el(
+				'div',
+				{},
+				el(
+					InnerBlocks,
+					{ allowedBlocks: [ 'core/paragraph', 'core/image' ] }
+				)
+			);
+		},
+
+		save() {
+			return el(
+				'div',
+				{},
+				el( InnerBlocks.Content )
+			);
+		},
+	} );
+
+	registerBlockType( 'test/child-blocks-child', {
+		title: 'Child Blocks Child',
+		icon: 'carrot',
+		category: 'text',
+
+		parent: [
+			'test/child-blocks-unrestricted-parent',
+			'test/child-blocks-restricted-parent',
+		],
+
+		edit() {
+			return el(
+				'div',
+				{},
+				'Child'
+			);
+		},
+
+		save() {
+			return el(
+				'div',
+				{},
+				'Child'
+			);
+		},
+	} );
+} )();

--- a/packages/e2e-tests/specs/editor/plugins/child-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/child-blocks.test.js
@@ -1,0 +1,65 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	activatePlugin,
+	closeGlobalBlockInserter,
+	createNewPost,
+	deactivatePlugin,
+	getAllBlockInserterItemTitles,
+	insertBlock,
+	openGlobalBlockInserter,
+} from '@wordpress/e2e-test-utils';
+
+describe( 'Child Blocks', () => {
+	beforeAll( async () => {
+		await activatePlugin( 'gutenberg-test-child-blocks' );
+	} );
+
+	beforeEach( async () => {
+		await createNewPost();
+	} );
+
+	afterAll( async () => {
+		await deactivatePlugin( 'gutenberg-test-child-blocks' );
+	} );
+
+	it( 'are hidden from the global block inserter', async () => {
+		await openGlobalBlockInserter();
+		await expect( await getAllBlockInserterItemTitles() ).not.toContain(
+			'Child Blocks Child'
+		);
+	} );
+
+	it( 'shows up in a parent block', async () => {
+		await insertBlock( 'Child Blocks Unrestricted Parent' );
+		await closeGlobalBlockInserter();
+		await page.waitForSelector(
+			'[data-type="test/child-blocks-unrestricted-parent"] .block-editor-default-block-appender'
+		);
+		await page.click(
+			'[data-type="test/child-blocks-unrestricted-parent"] .block-editor-default-block-appender'
+		);
+		await openGlobalBlockInserter();
+		const inserterItemTitles = await getAllBlockInserterItemTitles();
+		expect( inserterItemTitles ).toContain( 'Child Blocks Child' );
+		expect( inserterItemTitles.length ).toBeGreaterThan( 20 );
+	} );
+
+	it( 'display in a parent block with allowedItems', async () => {
+		await insertBlock( 'Child Blocks Restricted Parent' );
+		await closeGlobalBlockInserter();
+		await page.waitForSelector(
+			'[data-type="test/child-blocks-restricted-parent"] .block-editor-default-block-appender'
+		);
+		await page.click(
+			'[data-type="test/child-blocks-restricted-parent"] .block-editor-default-block-appender'
+		);
+		await openGlobalBlockInserter();
+		expect( await getAllBlockInserterItemTitles() ).toEqual( [
+			'Child Blocks Child',
+			'Image',
+			'Paragraph',
+		] );
+	} );
+} );


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/23227. Necessary for https://github.com/WordPress/gutenberg/pull/22656.

![2020-06-17 18 05 33](https://user-images.githubusercontent.com/612155/84872366-268c5b80-b0c5-11ea-8ab5-9192390db352.gif)

When a block C specifies `parent: [ P ]`, it means that C may only be added to P. It does NOT mean that P may *only* contain C. (Which is what `<InnerBlocks allowedBlocks={ [ C ] }>` means.)

This fixes the Inserter so that the correct blocks are shown when inserting into a block that is referenced by `parent`. It does so by leaning on `getInserterItems()` which already does the right thing.

**To test**
<ol>
<li>
<p>Paste the following snippet into the DevTools console:</p>
<details>
<summary>Snippet</summary>

```js
( function() {
	const { registerBlockType } = wp.blocks;
	const { createElement: el } = wp.element;
	const { InnerBlocks } = wp.blockEditor;

	registerBlockType( 'acme/product', {
		title: 'Product',
		icon: 'carrot',
		category: 'common',

		edit() {
			return el( 'div', { className: 'product', style: { outline: '1px solid gray', padding: 5 } },
				// Only paragraphs, images, and Add to Cart blocks:
				el( InnerBlocks, { allowedBlocks: [ 'core/paragraph', 'core/image' ] } )
				// Everything and Add to Cart blocks:
				//el( InnerBlocks )
			);
		},

		save() {
			return el( 'div', { className: 'product', style: { outline: '1px solid gray', padding: 5 } },
				el( InnerBlocks.Content )
			);
		},
	} );

	registerBlockType( 'acme/buy-button', {
		title: 'Buy Button',
		icon: 'cart',
		category: 'common',

		// Only allow in products:
		parent: [ 'acme/product' ],

		edit() {
			return el(
				'button',
				{
					className: 'buy-button',
					style: { display: 'block', margin: '0 auto', padding: '10px 30px' },
				},
				'Buy Now'
			);
		},

		save() {
			return el(
				'button',
				{
					className: 'buy-button',
					style: { display: 'block', margin: '0 auto', padding: '10px 30px' },
				},
				'Buy Now'
			);
		},
	} );
} )();
```
</details>
</li>
<li>Add a <I>Product</I> block to the post.</li>
<li>Select the <I>Product</I> block and open the Inserter.</li>
</ol>

The _Paragraph_, _Image_ and _Add to Cart_ blocks should appear in the Inserter.