### PR TITLE
Fix #22892 and print classnames in spacer block on editor side

### DIFF
--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -23,6 +23,7 @@ const SpacerEdit = ( {
 	setAttributes,
 	onResizeStart,
 	onResizeStop,
+	className,
 } ) => {
 	const [ isResizing, setIsResizing ] = useState( false );
 	const { height } = attributes;
@@ -52,6 +53,7 @@ const SpacerEdit = ( {
 			<View { ...useBlockProps() }>
 				<ResizableBox
 					className={ classnames(
+						className,
 						'block-library-spacer__resize-container',
 						{
 							'is-selected': isSelected,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

Fixes issue where css classes are not added to the spacer block on the editor side. 

Unfortunately I couldn't find a way to make this into a _light block_ so that the wrapper element isnt printed. Tested out #23034 but as I suspected it didn't work. @ellatrix is there a way to do this or would it somehow be possible if `useBlockProps()` gets merged?

## How has this been tested?

Ran `wp.blocks.registerBlockStyle( 'core/spacer', { name: 'custom', label: 'Custom Style' } );` and tested adding a spacer with the style and with a custom class name.

## Screenshots

<img width="783" alt="Screen Shot 2020-06-17 at 08 23 38" src="https://user-images.githubusercontent.com/302736/84892595-3fb8ec00-b074-11ea-8916-54356ccc1c8e.png">


## Types of changes

Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
