### PR TITLE
Upgrade Reakit to version 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6436,9 +6436,9 @@
 			}
 		},
 		"@popperjs/core": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.4.0.tgz",
-			"integrity": "sha512-NMrDy6EWh9TPdSRiHmHH2ye1v5U0gBD7pRYwSwJvomx7Bm4GG04vu63dYiVzebLOx2obPpJugew06xVP0Nk7hA=="
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.4.2.tgz",
+			"integrity": "sha512-JlGTGRYHC2QK+DDbePyXdBdooxFq2+noLfWpRqJtkxcb/oYWzOF0kcbfvvbWrwevCC1l6hLUg1wHYT+ona5BWQ=="
 		},
 		"@reach/router": {
 			"version": "1.2.1",
@@ -10615,7 +10615,7 @@
 				"react-dates": "^17.1.1",
 				"react-spring": "^8.0.20",
 				"react-use-gesture": "^7.0.15",
-				"reakit": "^1.0.4",
+				"reakit": "^1.1.0",
 				"rememo": "^3.0.0",
 				"tinycolor2": "^1.4.1",
 				"uuid": "^7.0.2"
@@ -38204,36 +38204,36 @@
 			}
 		},
 		"reakit": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/reakit/-/reakit-1.0.4.tgz",
-			"integrity": "sha512-v9tZoO40IBA7zX4SypyGco9z6+mDGcn/JsZfYRA+Qvmh2FjLX08m7FwhkQMgwccygHaZP+nEgVIsE6QUroCWrw==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/reakit/-/reakit-1.1.0.tgz",
+			"integrity": "sha512-d/ERtwgBndBPsyPBPUl5jueyfFgsglIfQCnLMKuxM0PaWiIZ6Ys3XsYaNy/AaG8k46Ee5cQPMdRrR30nVcSToQ==",
 			"requires": {
-				"@popperjs/core": "^2.4.0",
+				"@popperjs/core": "^2.4.2",
 				"body-scroll-lock": "^3.0.2",
-				"reakit-system": "^0.12.2",
-				"reakit-utils": "^0.12.1",
-				"reakit-warning": "^0.3.1"
+				"reakit-system": "^0.13.0",
+				"reakit-utils": "^0.13.0",
+				"reakit-warning": "^0.4.0"
 			}
 		},
 		"reakit-system": {
-			"version": "0.12.2",
-			"resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.12.2.tgz",
-			"integrity": "sha512-+/tZ/atDbHhDOapcIxniNZd7z0cze1L9MJBEnvykqM/bdqUE59Eb/OQ6odPZwK35gcN1lNyZtw7DgnFrmsDi4w==",
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.13.0.tgz",
+			"integrity": "sha512-33HCSab1WS08H8P4aFU7X7sf089B383GKWilyj+Z0U5XNJPzRklbqdsfsyasEm9vr/gQyu9ZMLxX1YJBN/iekw==",
 			"requires": {
-				"reakit-utils": "^0.12.1"
+				"reakit-utils": "^0.13.0"
 			}
 		},
 		"reakit-utils": {
-			"version": "0.12.1",
-			"resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.12.1.tgz",
-			"integrity": "sha512-P66TYzmQFD5CqNWcRvbPb6B5nXRLfiWqwTJhVGDUeOJTSdlnjfsBuOIauojfuS+p4yeyFVsUFsFwuBM6uZ8F3A=="
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.13.0.tgz",
+			"integrity": "sha512-/Ll+D4WllB6s2dNuWHTO32JNgdSHl1jf5y6QK3aCU4OEMtSCGz0TpXXHslWgRXWEQjKItVY640A8wugVQmKgWQ=="
 		},
 		"reakit-warning": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/reakit-warning/-/reakit-warning-0.3.1.tgz",
-			"integrity": "sha512-kFGASQG1ogpyknF0vlfab2emptCuW4a2Ku0SOeNkD+WGkMytJMNqrklqqfuWFEPqpuWGkBduOLbmEEyVLgSLZg==",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/reakit-warning/-/reakit-warning-0.4.0.tgz",
+			"integrity": "sha512-p5/dGY2AlWTV33AS9JPlm9Y5u0YUUyg53MIC90vl3p4J4VI2cxMnu42eCck1g0nwYgiEYLPU/90NNrAQf/Ck6g==",
 			"requires": {
-				"reakit-utils": "^0.12.1"
+				"reakit-utils": "^0.13.0"
 			}
 		},
 		"realpath-native": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -54,7 +54,7 @@
 		"react-dates": "^17.1.1",
 		"react-spring": "^8.0.20",
 		"react-use-gesture": "^7.0.15",
-		"reakit": "^1.0.4",
+		"reakit": "^1.1.0",
 		"rememo": "^3.0.0",
 		"tinycolor2": "^1.4.1",
 		"uuid": "^7.0.2"

--- a/packages/components/src/alignment-matrix-control/cell.js
+++ b/packages/components/src/alignment-matrix-control/cell.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { unstable_CompositeItem as CompositeItem } from 'reakit/Composite';
+import { CompositeItem } from 'reakit/Composite';
 
 /**
  * Internal dependencies

--- a/packages/components/src/alignment-matrix-control/index.js
+++ b/packages/components/src/alignment-matrix-control/index.js
@@ -3,11 +3,7 @@
  */
 import { noop } from 'lodash';
 import classnames from 'classnames';
-import {
-	unstable_useCompositeState as useCompositeState,
-	unstable_Composite as Composite,
-	unstable_CompositeGroup as CompositeGroup,
-} from 'reakit';
+import { useCompositeState, Composite, CompositeGroup } from 'reakit';
 
 /**
  * WordPress dependencies


### PR DESCRIPTION
This fixes the warning reported by @noahtallen on https://github.com/WordPress/gutenberg/issues/17355#issuecomment-625945382. It has been fixed on https://github.com/reakit/reakit/pull/672.

Also, the `Composite` module is now stable, so I removed the `unstable_` prefix from our code.

<details><summary>Changelog</summary>

# [1.1.0](https://github.com/reakit/reakit/compare/reakit@1.0.5...reakit@1.1.0) (2020-06-17)

### Features

* Add `Input` component ([#671](https://github.com/reakit/reakit/issues/671)) ([79d3926](https://github.com/reakit/reakit/commit/79d3926f91a33f9a7f2ab0840aa3933a0a7724b9)), closes [#665](https://github.com/reakit/reakit/issues/665)
* Add experimental `unstable_sort` method to `useCompositeState` ([57e409e](https://github.com/reakit/reakit/commit/57e409e1d656eec3c3959bfbb76e32841fe300ad))
* Mark `Composite` as stable ([#667](https://github.com/reakit/reakit/issues/667)) ([5e01f4c](https://github.com/reakit/reakit/commit/5e01f4c1cdd23a55cb2d8d870b268310d0f42681))

## [1.0.5](https://github.com/reakit/reakit/compare/reakit@1.0.4...reakit@1.0.5) (2020-06-17)

### Bug Fixes

* Fix `Composite` state update on unmounted components ([#672](https://github.com/reakit/reakit/issues/672)) ([1b1c9aa](https://github.com/reakit/reakit/commit/1b1c9aac60cc5b1c4dc440af6c4c5936fc57e333)), closes [#650](https://github.com/reakit/reakit/issues/650)

</details>

## How to test

- Check if there's no console warning when mounting/unmounting the block toolbar.
- Check if the alignment matrix control on the cover block is working.