### PR TITLE
Button Component - remove isLarge prop

### DIFF
--- a/packages/components/src/button/README.md
+++ b/packages/components/src/button/README.md
@@ -132,7 +132,6 @@ Name | Type | Default | Description
 `isPrimary` | `bool` | `false` | Renders a primary button style.
 `isTertiary` | `bool` | `false` | Renders a text-based button style.
 `isDestructive` | `bool` | `false` | Renders a red text-based button style to indicate destructive behavior.
-`isLarge` | `bool` | `false` | Increases the size of the button.
 `isSmall` | `bool` | `false` | Decreases the size of the button.
 `isPressed` | `bool` | `false` | Renders a pressed button style.
 `isBusy` | `bool` | `false` | Indicates activity while a action is being performed.

--- a/packages/components/src/button/index.js
+++ b/packages/components/src/button/index.js
@@ -23,7 +23,6 @@ export function Button( props, ref ) {
 		href,
 		target,
 		isPrimary,
-		isLarge,
 		isSmall,
 		isTertiary,
 		isPressed,
@@ -54,7 +53,6 @@ export function Button( props, ref ) {
 	const classes = classnames( 'components-button', className, {
 		'is-secondary': isDefault || isSecondary,
 		'is-primary': isPrimary,
-		'is-large': isLarge,
 		'is-small': isSmall,
 		'is-tertiary': isTertiary,
 		'is-pressed': isPressed,

--- a/packages/components/src/button/test/index.js
+++ b/packages/components/src/button/test/index.js
@@ -35,13 +35,6 @@ describe( 'Button', () => {
 			expect( button.hasClass( 'is-primary' ) ).toBe( true );
 		} );
 
-		it( 'should render a button element with is-large class', () => {
-			const button = shallow( <Button isSecondary isLarge /> );
-			expect( button.hasClass( 'is-large' ) ).toBe( true );
-			expect( button.hasClass( 'is-secondary' ) ).toBe( true );
-			expect( button.hasClass( 'is-primary' ) ).toBe( false );
-		} );
-
 		it( 'should render a button element with is-small class', () => {
 			const button = shallow( <Button isSecondary isSmall /> );
 			expect( button.hasClass( 'is-secondary' ) ).toBe( true );


### PR DESCRIPTION
 ... and class name + update the component docs to remove its reference - to finish the work done in - https://github.com/WordPress/gutenberg/issues/16541

## Description
The Button component was still accepting an `isLarge` prop, and adding an `is-large` class to the button when it should not be - https://github.com/WordPress/gutenberg/issues/16541

## How has this been tested?
We're removing a prop + class - I've test by passing `isLarge` as a prop and observing that the html class is no longer added.

This change should not affect other components but I have observed [some tests](https://github.com/WordPress/gutenberg/search?q=isLarge&unscoped_q=isLarge) using the isLarge prop.

## Types of changes
Prevents the use of isLarge to add a class to a button - removing as soon as possible will prevent adoption of this feature.

## Checklist:
- [x ] My code is tested.
- [x ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ x ] I've *removed developer documentation. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
