### PR TITLE
Fix plus radius.

### DIFF
--- a/packages/block-editor/src/components/button-block-appender/style.scss
+++ b/packages/block-editor/src/components/button-block-appender/style.scss
@@ -39,6 +39,7 @@
 			width: 24px;
 			background-color: $dark-gray-primary;
 			color: $white;
+			border-radius: $radius-block-ui;
 		}
 
 		.block-editor-button-block-appender__label {


### PR DESCRIPTION
This will not stand:

<img width="412" alt="Screenshot 2020-06-17 at 16 57 12" src="https://user-images.githubusercontent.com/1204802/84914487-f42a3080-b0bb-11ea-95cb-f3f16f21f3e1.png">

This is okay:

<img width="548" alt="Screenshot 2020-06-17 at 16 59 08" src="https://user-images.githubusercontent.com/1204802/84914500-f7bdb780-b0bb-11ea-8e9d-7adcf77f1d50.png">


Props @shaunandrews.
