### PR TITLE
Use correct package for importing useState in BoxControl examples

### DIFF
--- a/packages/components/src/box-control/README.md
+++ b/packages/components/src/box-control/README.md
@@ -6,7 +6,7 @@ BoxControl components let users set values for Top, Right, Bottom, and Left. Thi
 
 ```jsx
 import { __experimentalBoxControl as BoxControl } from '@wordpress/components';
-import { useState } from '@wordpress/compose';
+import { useState } from '@wordpress/element';
 
 const Example = () => {
 	const [ values, setValues ] = useState( {
@@ -31,7 +31,7 @@ BoxControl provides a companion component that visually renders value changes. P
 
 ```jsx
 import { __experimentalBoxControl as BoxControl } from '@wordpress/components';
-import { useState } from '@wordpress/compose';
+import { useState } from '@wordpress/element';
 
 import MyComponent from './my-component';
 
@@ -63,7 +63,7 @@ Alternatively, the `<Visualizer>` can be nested as a sibling to the component yo
 
 ```jsx
 import { __experimentalBoxControl as BoxControl } from '@wordpress/components';
-import { useState } from '@wordpress/compose';
+import { useState } from '@wordpress/element';
 
 import MyComponent from './my-component';
 


### PR DESCRIPTION
## Description
`useState` is exported in `@wordpress/element`.
