### PR TITLE
BlockListBlock: add missing useSelect dependency.

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -68,15 +68,18 @@ function BlockListBlock( {
 	// In addition to withSelect, we should favor using useSelect in this
 	// component going forward to avoid leaking new props to the public API
 	// (editor.BlockListBlock filter)
-	const { isDragging, isHighlighted } = useSelect( ( select ) => {
-		const { isDraggingBlocks, isBlockHighlighted } = select(
-			'core/block-editor'
-		);
-		return {
-			isDragging: isDraggingBlocks(),
-			isHighlighted: isBlockHighlighted( clientId ),
-		};
-	}, [] );
+	const { isDragging, isHighlighted } = useSelect(
+		( select ) => {
+			const { isDraggingBlocks, isBlockHighlighted } = select(
+				'core/block-editor'
+			);
+			return {
+				isDragging: isDraggingBlocks(),
+				isHighlighted: isBlockHighlighted( clientId ),
+			};
+		},
+		[ clientId ]
+	);
 	const { removeBlock } = useDispatch( 'core/block-editor' );
 	const onRemove = () => removeBlock( clientId );
 


### PR DESCRIPTION
## Description
This PR adds a missing dependency to the `useSelect` call in the `BlockListBlock` component. This might fix any obscure bugs involving `isHighlighted` not being updated when it should, but even if not, it's still a good idea to harden this code against potential future bugs by making this change.