### PR TITLE
Reduce unnecessary selector specificity for Button block

### DIFF
--- a/packages/block-library/src/buttons/style.scss
+++ b/packages/block-library/src/buttons/style.scss
@@ -1,5 +1,5 @@
 // Increased specificity to override blocks default margin.
-.wp-block-buttons .wp-block-button.wp-block-button {
+.wp-block-buttons .wp-block-button {
 	display: inline-block;
 	margin-right: $grid-unit-10;
 	margin-bottom: $grid-unit-10;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

See https://github.com/WordPress/gutenberg/pull/23222#discussion_r441455551.

The selector used is unnecessarily specific (0,3,0) and it only needs to be (0,2,0) to override the [block default margins](https://github.com/WordPress/gutenberg/commit/a3f1e6545af45904957bb7648938e33cf759938a#diff-ee2ed3adbe2578628039530c717a9a93R255) since it's enqueued after and thus take location precedence.

I'd still leave the comment about it being specific since ideally it would be just `.wp-block-button` but it cant because of the block default margin selector (which in turn is there to override [list margin-left properties](https://github.com/WordPress/gutenberg/commit/2ea41bf03762cd9874e066c5456181d168fddeaf#diff-b175fef433360d2d2c873fdd717e5f05R108).

There's some minor spacing difference between the buttons in editor and frontend but that's shown in master already and is unrelated to this.

One real world reason I'd argue this is needed is because it's much more common for themers use to `.wp-block-buttons .wp-block-button` than it would be for them to even know you can chain selectors like `.wp-block-buttons .wp-block-button.wp-block-button`. So to override it we'd probably see lots of `.entry-content .wp-block-buttons .wp-block-button`.

## How has this been tested?

Tested adding buttons in twentynineteen and twentytwenty

## Screenshots

Twentytwenty Editor:

<img width="804" alt="Screen Shot 2020-06-17 at 12 58 10" src="https://user-images.githubusercontent.com/302736/84921503-f0d27d00-b09a-11ea-9740-0b8e739270a9.png">

TwentyTwenty Frontend:
<img width="970" alt="Screen Shot 2020-06-17 at 12 57 54" src="https://user-images.githubusercontent.com/302736/84921515-f3cd6d80-b09a-11ea-9228-acea4be89161.png">

TwentyNinteen Editor:

<img width="735" alt="Screen Shot 2020-06-17 at 12 57 18" src="https://user-images.githubusercontent.com/302736/84921525-f5973100-b09a-11ea-8b44-9b2ffbd60cfd.png">

TwentyNineteen Frontend:

<img width="1068" alt="Screen Shot 2020-06-17 at 12 57 39" src="https://user-images.githubusercontent.com/302736/84921523-f4fe9a80-b09a-11ea-99d3-3f00aa402ce7.png">


## Types of changes


## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
