### PR TITLE
BlockSettingsMenuControlsSlot: add missing useSelect dependency.

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu-controls/index.js
+++ b/packages/block-editor/src/components/block-settings-menu-controls/index.js
@@ -14,19 +14,17 @@ const { Fill: BlockSettingsMenuControls, Slot } = createSlotFill(
 );
 
 const BlockSettingsMenuControlsSlot = ( { fillProps, clientIds = null } ) => {
-	const { selectedBlocks } = useSelect( ( select ) => {
-		const { getBlocksByClientId, getSelectedBlockClientIds } = select(
-			'core/block-editor'
-		);
-		const ids =
-			clientIds !== null ? clientIds : getSelectedBlockClientIds();
-		return {
-			selectedBlocks: map(
-				getBlocksByClientId( ids ),
-				( block ) => block.name
-			),
-		};
-	}, [] );
+	const selectedBlocks = useSelect(
+		( select ) => {
+			const { getBlocksByClientId, getSelectedBlockClientIds } = select(
+				'core/block-editor'
+			);
+			const ids =
+				clientIds !== null ? clientIds : getSelectedBlockClientIds();
+			return map( getBlocksByClientId( ids ), ( block ) => block.name );
+		},
+		[ clientIds ]
+	);
 
 	return (
 		<Slot fillProps={ { ...fillProps, selectedBlocks } }>


### PR DESCRIPTION
## Description
This PR adds a missing dependency to the `useSelect` call in the `BlockSettingsMenuControlsSlot` component. This might fix some obscure bugs, but even if not, it's still a good idea to harden this code against potential future bugs by making this change.