### PR TITLE
useDisplayBlockControls: add missing useSelect dependency.

### DIFF
--- a/packages/block-editor/src/components/use-display-block-controls/index.js
+++ b/packages/block-editor/src/components/use-display-block-controls/index.js
@@ -31,7 +31,7 @@ export default function useDisplayBlockControls() {
 				( id ) => getBlockName( id ) === name
 			);
 		},
-		[ clientId, name ]
+		[ clientId, isSelected, name ]
 	);
 
 	return isSelected || isFirstAndSameTypeMultiSelected;


### PR DESCRIPTION
## Description
This PR adds a missing dependency to the `useSelect` call in the `useDisplayBlockControls` hook. This might fix some obscure bugs, but even if not, it's still a good idea to harden this code against potential future bugs by making this change.