### PR TITLE
Fix block parent selector border radius

### DIFF
--- a/packages/block-editor/src/components/block-parent-selector/style.scss
+++ b/packages/block-editor/src/components/block-parent-selector/style.scss
@@ -1,5 +1,6 @@
 .block-editor-block-parent-selector {
 	background: $white;
+	border-radius: $radius-block-ui;
 
 	.block-editor-block-parent-selector__button {
 		width: $grid-unit-60;


### PR DESCRIPTION
This fixes a small styling issue on the block parent selector button. This is visible when the background is dark.

**Before:**

![image](https://user-images.githubusercontent.com/3068563/84931481-38600580-b0a9-11ea-99d1-1f00a0dc23d5.png)

![image](https://user-images.githubusercontent.com/3068563/84931506-401faa00-b0a9-11ea-95e0-77cab88fa95f.png)

**After:**

![image](https://user-images.githubusercontent.com/3068563/84931643-6f361b80-b0a9-11ea-90a7-f26c7b2584fd.png)

