### PR TITLE
Implement roving tabindex on the table block toolbar

### DIFF
--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -25,6 +25,7 @@ import {
 	TextControl,
 	ToggleControl,
 	ToolbarGroup,
+	__experimentalToolbarItem as ToolbarItem,
 } from '@wordpress/components';
 import {
 	alignLeft,
@@ -597,12 +598,17 @@ export class TableEdit extends Component {
 			<>
 				<BlockControls>
 					<ToolbarGroup>
-						<DropdownMenu
-							hasArrowIndicator
-							icon={ table }
-							label={ __( 'Edit table' ) }
-							controls={ this.getTableControls() }
-						/>
+						<ToolbarItem>
+							{ ( toggleProps ) => (
+								<DropdownMenu
+									hasArrowIndicator
+									icon={ table }
+									toggleProps={ toggleProps }
+									label={ __( 'Edit table' ) }
+									controls={ this.getTableControls() }
+								/>
+							) }
+						</ToolbarItem>
 					</ToolbarGroup>
 					<AlignmentToolbar
 						label={ __( 'Change column alignment' ) }

--- a/packages/e2e-tests/specs/editor/various/toolbar-roving-tabindex.test.js
+++ b/packages/e2e-tests/specs/editor/various/toolbar-roving-tabindex.test.js
@@ -84,4 +84,16 @@ describe( 'Toolbar roving tabindex', () => {
 		await wrapCurrentBlockWithGroup();
 		await testGroupKeyboardNavigation( 'Block: Image' );
 	} );
+
+	it( 'ensures table block toolbar uses roving tabindex', async () => {
+		await insertBlock( 'Table' );
+		await testBlockToolbarKeyboardNavigation( 'Block: Table' );
+		// Move focus to the first toolbar item
+		await page.keyboard.press( 'Home' );
+		await expectLabelToHaveFocus( 'Change block type or style' );
+		await page.click( '.blocks-table__placeholder-button' );
+		await testBlockToolbarKeyboardNavigation( 'Block: Table' );
+		await wrapCurrentBlockWithGroup();
+		await testGroupKeyboardNavigation( 'Block: Table' );
+	} );
 } );


### PR DESCRIPTION
This PR is part of #18619, whose main goal is to implement [roving tabindex](https://www.w3.org/TR/wai-aria-practices/#kbd_roving_tabindex) on the `@wordpress/components`' `Toolbar` component and use it on the header and block toolbars so they become a single tab stop as recommended by the [WAI-ARIA Toolbar Pattern](https://www.w3.org/TR/wai-aria-practices/#toolbar). Related issues are #15331 and #3383.

This PR implements the roving tabindex method on the table block toolbar.

## Screenshots

<details><summary>Top toolbar</summary>

![GIF showing the top toolbar with the table block toolbar items and using keyboard to navigate through the items](https://user-images.githubusercontent.com/3068563/84934263-765f2880-b0ad-11ea-88f9-e20f9bdddfdb.gif)

</details>

<details><summary>Contextual toolbar</summary>

![GIF showing the table block toolbar using keyboard to navigate through the items](https://user-images.githubusercontent.com/3068563/84934257-73643800-b0ad-11ea-974a-ba9e9a2123fb.gif)

</details>


## How to test

- Create a table block, add columns and rows and check if the toolbar is working properly with mouse and keyboard.