### PR TITLE
Add auto-drafting for theme supplied template parts.

### DIFF
--- a/lib/template-parts.php
+++ b/lib/template-parts.php
@@ -214,7 +214,7 @@ function filter_rest_wp_template_part_query( $args, $request ) {
 		);
 
 		// Ensure auto-drafts of all theme supplied template parts are created.
-		if( $request['theme'] === get_current_theme() ) {
+		if ( wp_get_theme() === $request['theme'] ) {
 			$template_part_files = glob( get_stylesheet_directory() . '/block-template-parts/*.html' );
 			$template_part_files = is_array( $template_part_files ) ? $template_part_files : array();
 			if ( is_child_theme() ) {
@@ -222,7 +222,8 @@ function filter_rest_wp_template_part_query( $args, $request ) {
 				$child_template_part_files = is_array( $child_template_part_files ) ? $child_template_part_files : array();
 				$template_part_files       = array_merge( $template_part_files, $child_template_part_files );
 			}
-			foreach ( $template_part_files as $template_part ) {
+			foreach ( $template_part_files as $template_part_file ) {
+				$template_part = parse_block( $template_part_file )[0];
 				create_auto_draft_for_template_part_block( $template_part );
 			}
 		};

--- a/lib/template-parts.php
+++ b/lib/template-parts.php
@@ -223,7 +223,17 @@ function filter_rest_wp_template_part_query( $args, $request ) {
 				$template_part_files       = array_merge( $template_part_files, $child_template_part_files );
 			}
 			foreach ( $template_part_files as $template_part_file ) {
-				$template_part = parse_block( $template_part_file )[0];
+				$content = file_get_contents( $template_part_file );
+				// Infer slug from filepath.
+				$slug = substr(
+					$template_part_file,
+					// Starting position of slug.
+					strpos( $template_part_file, 'block-template-parts/' ) + 21,
+					// Subtract ending '.html'.
+					-5
+				);
+				$template_part_string = '<!-- wp:template-part {"slug":"' . $slug . '","theme":"' . $request['theme'] . '"} -->' . $content . '<!-- /wp:template-part -->';
+				$template_part        = parse_blocks( $template_part_string )[0];
 				create_auto_draft_for_template_part_block( $template_part );
 			}
 		};

--- a/lib/template-parts.php
+++ b/lib/template-parts.php
@@ -215,12 +215,15 @@ function filter_rest_wp_template_part_query( $args, $request ) {
 
 		// Ensure auto-drafts of all theme supplied template parts are created.
 		if( $request['theme'] === get_current_theme() ) {
-			foreach ( get_template_types() as $template_type ) {
-				// Skip 'embed' for now because it is not a regular template type.
-				if ( in_array( $template_type, array( 'embed' ), true ) ) {
-					continue;
-				}
-				gutenberg_find_template_post_and_parts( $template_type );
+			$template_part_files = glob( get_stylesheet_directory() . '/block-template-parts/*.html' );
+			$template_part_files = is_array( $template_part_files ) ? $template_part_files : array();
+			if ( is_child_theme() ) {
+				$child_template_part_files = glob( get_template_directory() . '/block-template-parts/*.html' );
+				$child_template_part_files = is_array( $child_template_part_files ) ? $child_template_part_files : array();
+				$template_part_files       = array_merge( $template_part_files, $child_template_part_files );
+			}
+			foreach ( $template_part_files as $template_part ) {
+				create_auto_draft_for_template_part_block( $template_part );
 			}
 		};
 

--- a/lib/template-parts.php
+++ b/lib/template-parts.php
@@ -214,7 +214,8 @@ function filter_rest_wp_template_part_query( $args, $request ) {
 		);
 
 		// Ensure auto-drafts of all theme supplied template parts are created.
-		if ( wp_get_theme() === $request['theme'] ) {
+		if ( wp_get_theme()->get( 'TextDomain' ) === $request['theme'] ) {
+			// Get file paths for all theme supplied template parts.
 			$template_part_files = glob( get_stylesheet_directory() . '/block-template-parts/*.html' );
 			$template_part_files = is_array( $template_part_files ) ? $template_part_files : array();
 			if ( is_child_theme() ) {
@@ -222,6 +223,7 @@ function filter_rest_wp_template_part_query( $args, $request ) {
 				$child_template_part_files = is_array( $child_template_part_files ) ? $child_template_part_files : array();
 				$template_part_files       = array_merge( $template_part_files, $child_template_part_files );
 			}
+			// Build and save each template part.
 			foreach ( $template_part_files as $template_part_file ) {
 				$content = file_get_contents( $template_part_file );
 				// Infer slug from filepath.
@@ -232,9 +234,10 @@ function filter_rest_wp_template_part_query( $args, $request ) {
 					// Subtract ending '.html'.
 					-5
 				);
-				$template_part_string = '<!-- wp:template-part {"slug":"' . $slug . '","theme":"' . $request['theme'] . '"} -->' . $content . '<!-- /wp:template-part -->';
-				$template_part        = parse_blocks( $template_part_string )[0];
-				create_auto_draft_for_template_part_block( $template_part );
+				// Wrap content with the template part block, parse, and create auto-draft.
+				$template_part_string = '<!-- wp:template-part {"slug":"' . $slug . '","theme":"' . wp_get_theme()->get( 'TextDomain' ) . '"} -->' . $content . '<!-- /wp:template-part -->';
+				$template_part_block  = parse_blocks( $template_part_string )[0];
+				create_auto_draft_for_template_part_block( $template_part_block );
 			}
 		};
 

--- a/lib/template-parts.php
+++ b/lib/template-parts.php
@@ -213,6 +213,17 @@ function filter_rest_wp_template_part_query( $args, $request ) {
 			'value' => $request['theme'],
 		);
 
+		// Ensure auto-drafts of all theme supplied template parts are created.
+		if( $request['theme'] === get_current_theme() ) {
+			foreach ( get_template_types() as $template_type ) {
+				// Skip 'embed' for now because it is not a regular template type.
+				if ( in_array( $template_type, array( 'embed' ), true ) ) {
+					continue;
+				}
+				gutenberg_find_template_post_and_parts( $template_type );
+			}
+		};
+
 		$args['meta_query'] = $meta_query;
 	}
 

--- a/packages/block-library/src/template-part/edit/placeholder/template-part-previews.js
+++ b/packages/block-library/src/template-part/edit/placeholder/template-part-previews.js
@@ -178,7 +178,7 @@ export default function TemplateParts( { setAttributes, filterValue } ) {
 				per_page: -1,
 			}
 		);
-		const currentTheme = select( 'core' ).getCurrentTheme().textdomain;
+		const currentTheme = select( 'core' ).getCurrentTheme()?.textdomain;
 		const themeTemplateParts = select( 'core' ).getEntityRecords(
 			'postType',
 			'wp_template_part',

--- a/packages/block-library/src/template-part/edit/placeholder/template-part-previews.js
+++ b/packages/block-library/src/template-part/edit/placeholder/template-part-previews.js
@@ -178,11 +178,13 @@ export default function TemplateParts( { setAttributes, filterValue } ) {
 				per_page: -1,
 			}
 		);
-		const resolvedTemplateParts = select( 'core' ).getEntityRecords(
+		const currentTheme = select( 'core' ).getCurrentTheme().textdomain;
+		const themeTemplateParts = select( 'core' ).getEntityRecords(
 			'postType',
 			'wp_template_part',
 			{
-				resolved: true,
+				theme: currentTheme,
+				status: [ 'publish', 'auto-draft' ],
 				per_page: -1,
 			}
 		);
@@ -190,8 +192,8 @@ export default function TemplateParts( { setAttributes, filterValue } ) {
 		if ( publishedTemplateParts ) {
 			combinedTemplateParts.push( ...publishedTemplateParts );
 		}
-		if ( resolvedTemplateParts ) {
-			combinedTemplateParts.push( ...resolvedTemplateParts );
+		if ( themeTemplateParts ) {
+			combinedTemplateParts.push( ...themeTemplateParts );
 		}
 		return uniq( combinedTemplateParts );
 	}, [] );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
A follow up to #22760 - to prevent the potential issue of losing access to theme supplied template parts as discussed in https://github.com/WordPress/gutenberg/pull/22760#discussion_r439120461

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Local docker environment using twentynineteen-blocks theme.

Using the site editor experiment and a block based theme, add a new template part .html file to the themes /block-template-parts/ directory.  (you can copy the contents of one that already exists thre, just give it a new unique file name for the slug).  Then run this PR and verify the new template part loads in the template part placeholder's preview list.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
