### PR TITLE
E2E Tests: Try to improve heading custom color stability

### DIFF
--- a/packages/e2e-tests/specs/editor/blocks/heading.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/heading.test.js
@@ -80,6 +80,7 @@ describe( 'Heading', () => {
 		);
 
 		await customTextColorButton.click();
+		await page.waitForSelector( COLOR_INPUT_FIELD_SELECTOR );
 		await page.click( COLOR_INPUT_FIELD_SELECTOR );
 		await pressKeyWithModifier( 'primary', 'A' );
 		await page.keyboard.type( '#7700ff' );


### PR DESCRIPTION
Tries to improve stability of the `Heading › it should correctly apply custom colors` E2E test which keeps failing for me in https://github.com/WordPress/gutenberg/pull/23231.

I wasn't able to reproduce the failure locally so this is a total stab in the dark. I suspect that we need to wait for the colour picker popover to finish opening before proceeding.