### PR TITLE
Fix color picker saturation bug

### DIFF
--- a/packages/components/src/color-picker/style.scss
+++ b/packages/components/src/color-picker/style.scss
@@ -27,7 +27,7 @@
 
 .components-color-picker {
 	width: 100%;
-	overflow: hidden;
+	overflow: visible;
 
 	* {
 		box-sizing: border-box;
@@ -104,7 +104,7 @@
 }
 
 .components-color-picker__saturation-color {
-	overflow: hidden;
+	overflow: visible;
 }
 
 .components-color-picker__saturation-white {
@@ -116,17 +116,26 @@
 	background: linear-gradient(to top, #000, rgba(0, 0, 0, 0));
 }
 
-.components-color-picker__saturation-pointer {
+// Needs specificity.
+.components-button.components-color-picker__saturation-pointer {
 	width: 14px;
 	height: 14px;
 	padding: 0;
-	box-shadow:
-		0 0 0 1.5px #fff,
-		inset 0 0 1px 1px rgba(0, 0, 0, 0.3),
-		0 0 1px 2px rgba(0, 0, 0, 0.4);
 	border-radius: 50%;
 	background-color: transparent;
-	transform: translate(-4px, -4px);
+	transform: translate(-50%, -50%);
+
+	box-shadow:
+		0 0 0 1px $white,
+		inset 0 0 0 1px $black,
+		0 0 0 2px $black;
+
+	&:focus:not(:disabled) {
+		box-shadow:
+			0 0 0 2px $white,
+			inset 0 0 0 1px $black,
+			0 0 0 3px $black;
+	}
 }
 
 /* HUE & ALPHA BARS */

--- a/packages/components/src/color-picker/style.scss
+++ b/packages/components/src/color-picker/style.scss
@@ -27,7 +27,6 @@
 
 .components-color-picker {
 	width: 100%;
-	overflow: visible;
 
 	* {
 		box-sizing: border-box;


### PR DESCRIPTION
Fixes #19610. Alternative to #19693.

A bug exists where if you have a fully saturated color, the color dropper which is supposed to sit at the far right edge, causes the parent container to shift and mess up the layout.

This PR fixes that, by allowing the eye dropper to overflow:

![color](https://user-images.githubusercontent.com/1204802/85015447-46289000-b168-11ea-99a7-a5d343765122.gif)

It also adds a focus style. 