### PR TITLE
Implement roving tabindex on the Custom HTML block toolbar

### DIFF
--- a/packages/block-library/src/html/edit.js
+++ b/packages/block-library/src/html/edit.js
@@ -8,7 +8,12 @@ import {
 	PlainText,
 	transformStyles,
 } from '@wordpress/block-editor';
-import { Button, Disabled, SandBox, ToolbarGroup } from '@wordpress/components';
+import {
+	ToolbarButton,
+	Disabled,
+	SandBox,
+	ToolbarGroup,
+} from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 
 class HTMLEdit extends Component {
@@ -57,20 +62,20 @@ class HTMLEdit extends Component {
 			<div className="wp-block-html">
 				<BlockControls>
 					<ToolbarGroup>
-						<Button
+						<ToolbarButton
 							className="components-tab-button"
 							isPressed={ ! isPreview }
 							onClick={ this.switchToHTML }
 						>
 							<span>HTML</span>
-						</Button>
-						<Button
+						</ToolbarButton>
+						<ToolbarButton
 							className="components-tab-button"
 							isPressed={ isPreview }
 							onClick={ this.switchToPreview }
 						>
 							<span>{ __( 'Preview' ) }</span>
-						</Button>
+						</ToolbarButton>
 					</ToolbarGroup>
 				</BlockControls>
 				<Disabled.Consumer>

--- a/packages/e2e-tests/specs/editor/various/toolbar-roving-tabindex.test.js
+++ b/packages/e2e-tests/specs/editor/various/toolbar-roving-tabindex.test.js
@@ -84,4 +84,11 @@ describe( 'Toolbar roving tabindex', () => {
 		await wrapCurrentBlockWithGroup();
 		await testGroupKeyboardNavigation( 'Block: Image' );
 	} );
+
+	it( 'ensures custom html block toolbar uses roving tabindex', async () => {
+		await insertBlock( 'Custom HTML' );
+		await testBlockToolbarKeyboardNavigation( 'Block: Custom HTML' );
+		await wrapCurrentBlockWithGroup();
+		await testGroupKeyboardNavigation( 'Block: Custom HTML' );
+	} );
 } );


### PR DESCRIPTION
This PR is part of #18619, whose main goal is to implement [roving tabindex](https://www.w3.org/TR/wai-aria-practices/#kbd_roving_tabindex) on the `@wordpress/components`' `Toolbar` component and use it on the header and block toolbars so they become a single tab stop as recommended by the [WAI-ARIA Toolbar Pattern](https://www.w3.org/TR/wai-aria-practices/#toolbar). Related issues are #15331 and #3383.

This PR implements the roving tabindex method on the Custom HTML block toolbar.

## How to test

- Create a Custom HTML block and check if the toolbar is working properly with mouse and keyboard.