### PR TITLE
Implement roving tabindex on the Embed block toolbar

### DIFF
--- a/packages/block-library/src/embed/embed-controls.js
+++ b/packages/block-library/src/embed/embed-controls.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import {
-	Button,
+	ToolbarButton,
 	PanelBody,
 	ToggleControl,
 	ToolbarGroup,
@@ -26,7 +26,7 @@ const EmbedControls = ( props ) => {
 			<BlockControls>
 				<ToolbarGroup>
 					{ showEditButton && (
-						<Button
+						<ToolbarButton
 							className="components-toolbar__control"
 							label={ __( 'Edit URL' ) }
 							icon={ pencil }


### PR DESCRIPTION
This PR is part of #18619, whose main goal is to implement [roving tabindex](https://www.w3.org/TR/wai-aria-practices/#kbd_roving_tabindex) on the `@wordpress/components`' `Toolbar` component and use it on the header and block toolbars so they become a single tab stop as recommended by the [WAI-ARIA Toolbar Pattern](https://www.w3.org/TR/wai-aria-practices/#toolbar). Related issues are #15331 and #3383.

This PR implements the roving tabindex method on the Embed block toolbar.

![GIF demonstrating the use of the block toolbar with tab and arrow keys on the Twitter block](https://user-images.githubusercontent.com/3068563/85031030-8f6ee480-b154-11ea-9caa-4fb4b1a70750.gif)

## How to test

- Create an Embed block (like Twitter), add a link and check if the toolbar is working properly with mouse and keyboard.