### PR TITLE
Implement roving tabindex on the Navigation block toolbar

### DIFF
--- a/packages/block-editor/src/components/color-style-selector/index.js
+++ b/packages/block-editor/src/components/color-style-selector/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import {
-	Button,
+	ToolbarButton,
 	Dropdown,
 	ToolbarGroup,
 	SVG,
@@ -62,7 +62,7 @@ const renderToggleComponent = ( { TextColor, BackgroundColor } ) => ( {
 
 	return (
 		<ToolbarGroup>
-			<Button
+			<ToolbarButton
 				className="components-toolbar__control block-library-colors-selector__toggle"
 				label={ __( 'Open Colors Selector' ) }
 				onClick={ onToggle }

--- a/packages/block-library/src/navigation/block-colors-selector.js
+++ b/packages/block-library/src/navigation/block-colors-selector.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import {
-	Button,
+	ToolbarButton,
 	Dropdown,
 	ToolbarGroup,
 	SVG,
@@ -62,7 +62,7 @@ const renderToggleComponent = ( { TextColor, BackgroundColor } ) => ( {
 
 	return (
 		<ToolbarGroup>
-			<Button
+			<ToolbarButton
 				className="components-toolbar__control block-library-colors-selector__toggle"
 				label={ __( 'Open Colors Selector' ) }
 				onClick={ onToggle }

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -105,6 +105,11 @@ $colors-selector-size: 22px;
 		line-height: ($colors-selector-size - 2);
 		padding: 2px;
 
+		> svg {
+			// Override `min-width: $button-size-small` on toolbar-group/style.scss
+			min-width: auto !important;
+		}
+
 		// Styling icon color.
 		&.has-text-color {
 			> svg,

--- a/packages/block-library/src/navigation/use-block-navigator.js
+++ b/packages/block-library/src/navigation/use-block-navigator.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
-import { Button, SVG, Path, Modal } from '@wordpress/components';
+import { ToolbarButton, SVG, Path, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -25,7 +25,7 @@ export default function useBlockNavigator( clientId, __experimentalFeatures ) {
 	const [ isNavigationListOpen, setIsNavigationListOpen ] = useState( false );
 
 	const navigatorToolbarButton = (
-		<Button
+		<ToolbarButton
 			className="components-toolbar__control"
 			label={ __( 'Open block navigator' ) }
 			onClick={ () => setIsNavigationListOpen( true ) }


### PR DESCRIPTION
This PR is part of #18619, whose main goal is to implement [roving tabindex](https://www.w3.org/TR/wai-aria-practices/#kbd_roving_tabindex) on the `@wordpress/components`' `Toolbar` component and use it on the header and block toolbars so they become a single tab stop as recommended by the [WAI-ARIA Toolbar Pattern](https://www.w3.org/TR/wai-aria-practices/#toolbar). Related issues are #15331 and #3383.

This PR implements the roving tabindex method on the Navigation block toolbar. The update consists of using `ToolbarButton` instead of `Button`. There is also a specificity issue on the style that I had to fix here.

![GIF demonstration the use of the toolbar on the navigation block with tab and arrow keys](https://user-images.githubusercontent.com/3068563/85035914-14a8c800-b15a-11ea-8287-d503534df613.gif)

While working on this PR, I noticed that there are two files with the exact same content:

https://github.com/WordPress/gutenberg/blob/f0628c7cda1c6ad75d71e8b4bbd3b9e468dcba4e/packages/block-editor/src/components/color-style-selector/index.js#L1-L92

https://github.com/WordPress/gutenberg/blob/f0628c7cda1c6ad75d71e8b4bbd3b9e468dcba4e/packages/block-library/src/navigation/block-colors-selector.js#L1-L92

They represent the <img src="https://user-images.githubusercontent.com/3068563/85036754-e2e43100-b15a-11ea-938c-a784a3ef0185.png" alt="Open Colors Selector" height="32" align="center" /> button, and the former is used on a block called "Post Author". I updated both, ~but I couldn't find this block to test (@epiqueras do you know how can I do this?)~ (see https://github.com/WordPress/gutenberg/pull/23281#issuecomment-646153072).

## How to test

- Create a Navigation block (both horizontal and vertical), add some content and check if the toolbar is working properly with mouse and keyboard.
- Enable the Full Site Editing experiment and test the Post Author block.