### PR TITLE
Docs: Add documentation for setting up Prettier for markdown

### DIFF
--- a/docs/contributors/document.md
+++ b/docs/contributors/document.md
@@ -8,7 +8,7 @@ The [Make WordPress Docs blog](https://make.wordpress.org/docs/) is the primary 
 
 Real-time discussions for documentation take place in the `#docs` channel in [Make WordPress Slack](https://make.wordpress.org/chat) (registration required). Weekly meetings for the Documentation team are on Mondays at 14:00UTC.
 
-The Gutenberg project uses GitHub for managing code and tracking issues. The main repository is at: [https://github.com/WordPress/gutenberg](https://github.com/WordPress/gutenberg).  To find documentation issues to work on, browse [issues with documentation label](https://github.com/WordPress/gutenberg/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3A%22%5BType%5D+Documentation%22+).
+The Gutenberg project uses GitHub for managing code and tracking issues. The main repository is at: [https://github.com/WordPress/gutenberg](https://github.com/WordPress/gutenberg). To find documentation issues to work on, browse [issues with documentation label](https://github.com/WordPress/gutenberg/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3A%22%5BType%5D+Documentation%22+).
 
 ## Documentation Types
 
@@ -18,7 +18,6 @@ There are two major sets of documentation for the Gutenberg project:
 2. [Block Editor Handbook](https://developer.wordpress.org/block-editor/) is everything related to the Gutenberg project including: developing, extending, and—what you are reading right now—contributing specific to Gutenberg.
 
 The rest of this document covers contributing to the Block Editor Handbook.
-
 
 ## Block Editor Handbook Process
 
@@ -51,15 +50,15 @@ To add a new documentation page:
 
 It's likely that at some point you will want to link to other documentation pages. It's worth emphasizing that all documents can be browsed in different contexts:
 
-- Block Editor Handbook
-- GitHub website
-- npm website
+-   Block Editor Handbook
+-   GitHub website
+-   npm website
 
 To create links that work in all contexts, you should use absolute path links without the `https://github.com/WordPress/gutenberg` prefix. You can reference files using the following patterns:
 
-- `/docs/*.md`
-- `/packages/*/README.md`
-- `/packages/components/src/**/README.md`
+-   `/docs/*.md`
+-   `/packages/*/README.md`
+-   `/packages/components/src/**/README.md`
 
 This way they will be properly handled in all three aforementioned contexts.
 
@@ -71,23 +70,36 @@ A unique feature to the Gutenberg documentation is the `codetabs` toggle, this a
 
 Here is an example `codetabs` section:
 
-	{% codetabs %}
-	{% ESNext %}
-	```js
-		// ESNext code here
-	```
-	{% ES5 %}
-	```js
-		// ES5 code here
-	```
-	{% end %}
+    {% codetabs %}
+    {% ESNext %}
+    ```js
+    	// ESNext code here
+    ```
+    {% ES5 %}
+    ```js
+    	// ES5 code here
+    ```
+    {% end %}
 
 The preferred format for code examples is ESNext, which should also be the default viewed. The example placed first in source will be shown as the default.
 
 Note: not all code examples are required to include ES5 code. The guidance is to include `ES5` code for beginner tutorials, but the majority of code in Gutenberg packages and across the larger React and JavaScript ecosystem is in ESNext.
 
+### Editor Config
+
+You should configure your editor to use Prettier to auto-format markdown documents. See the [Getting Started documentation](/docs/contributors/develop/getting-started/) for complete details.
+
+An example config for using Visual Studio Code and the Prettier extensions:
+
+```json
+"\[markdown\]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+},
+```
+
 ## Resources
 
-- [Copy Guidelines](/docs/contributors/copy-guide.md) for writing instructions, documentations, or other contributions to Gutenberg project.
+-   [Copy Guidelines](/docs/contributors/copy-guide.md) for writing instructions, documentations, or other contributions to Gutenberg project.
 
-- [Tone and Voice Guide](https://make.wordpress.org/docs/handbook/documentation-team-handbook/tone-and-voice-guide/) from WordPress Documentation.
+-   [Tone and Voice Guide](https://make.wordpress.org/docs/handbook/documentation-team-handbook/tone-and-voice-guide/) from WordPress Documentation.

--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -1,11 +1,10 @@
 # Getting Started
 
-
 Gutenberg is built using the [latest active LTS release](https://github.com/nodejs/Release#release-schedule) of [Node.js](https://nodejs.org/en/), along with the latest version of [NPM](http://npmjs.com/).
 
 The easiest way to install and manage node and NPM (on macOS, Linux, or Windows 10 with the Linux Subsystem) is by using [nvm](https://github.com/creationix/nvm). Once nvm is installed, you can install the correct version of Node by running nvm install --latest-npm in the Gutenberg directory.
 
->**Note:** If you find yourself needing to build older versions of Gutenberg, nvm makes that process easier too. Because Gutenberg's `.nvmrc` file is regularly updated to the current available LTS release, running `nvm install` on an older branch will install whichever LTS version was active at that time.
+> **Note:** If you find yourself needing to build older versions of Gutenberg, nvm makes that process easier too. Because Gutenberg's `.nvmrc` file is regularly updated to the current available LTS release, running `nvm install` on an older branch will install whichever LTS version was active at that time.
 
 Once you have Node installed, run these scripts from within your local Gutenberg repository:
 
@@ -71,13 +70,11 @@ Another way to upload after building is to run `npm run build:plugin-zip` to cre
 
 > Storybook is an open source tool for developing UI components in isolation for React, React Native and more. It makes building stunning UIs organized and efficient.
 
-The Gutenberg repository also includes [Storybook] integration that allows testing and developing in a WordPress-agnostic context. This is very helpful for developing reusable components and trying generic JavaScript modules without any backend dependency.
+The Gutenberg repository also includes [Storybook](https://storybook.js.org/) integration that allows testing and developing in a WordPress-agnostic context. This is very helpful for developing reusable components and trying generic JavaScript modules without any backend dependency.
 
 You can launch Storybook by running `npm run storybook:dev` locally. It will open in your browser automatically.
 
 You can also test Storybook for the current `master` branch on GitHub Pages: [https://wordpress.github.io/gutenberg/](https://wordpress.github.io/gutenberg/)
-
-[Storybook]: https://storybook.js.org/
 
 ## Developer Tools
 
@@ -106,13 +103,17 @@ With the extension installed, ESLint will use the [.eslintrc.js](https://github.
 To use Prettier with Visual Studio Code, you should install the [Prettier - Code formatter extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode). You can then configure it to be the default formatter and to automatically fix issues on save, by adding the following to your settings.
 
 ```json
-"[javascript]": {
+"\[javascript\]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+},
+"\[markdown\]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true
 },
 ```
 
-This will use the `.prettierrc.js` file included in the root of the Gutenberg repository.
+This will use the `.prettierrc.js` file included in the root of the Gutenberg repository. The config is included from the [@wordpress/prettier-config](/packages/prettier-config/README.md) package.
 
 If you only want to use this configuration with the Gutenberg project, create a directory called .vscode at the top-level of Gutenberg, and place your settings in a settings.json there. Visual Studio Code refers to this as Workplace Settings, and only apply to the project.
 


### PR DESCRIPTION
## Description

Adds instructions for configuring Prettier for markdown in getting-started and documentation guide.

This also used Prettier to format those two documents, so includes additional white-space and other minor tweaks.

## How has this been tested?

See [Getting Started](https://github.com/WordPress/gutenberg/blob/docs/prettier-md/docs/contributors/getting-started.md) and [Documentation guide](https://github.com/WordPress/gutenberg/blob/docs/prettier-md/docs/contributors/document.md) rendered on branch.

Note: that `\[` where added to json config because the WordPress publishing thinks `[javascript]` in the code block is a short-code and removing it. I'm not sure this will work any better.

## Types of changes

Documentation.
