### PR TITLE
Fix useBlockSync race condition

### DIFF
--- a/packages/block-editor/src/components/provider/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/use-block-sync.js
@@ -108,8 +108,10 @@ export default function useBlockSync( {
 	// waiting for React renders for changes.
 	const onInputRef = useRef( onInput );
 	const onChangeRef = useRef( onChange );
-	onInputRef.current = onInput;
-	onChangeRef.current = onChange;
+	useEffect( () => {
+		onInputRef.current = onInput;
+		onChangeRef.current = onChange;
+	}, [ onInput, onChange ] );
 
 	useEffect( () => {
 		const {

--- a/packages/block-editor/src/components/provider/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/use-block-sync.js
@@ -108,6 +108,9 @@ export default function useBlockSync( {
 	// waiting for React renders for changes.
 	const onInputRef = useRef( onInput );
 	const onChangeRef = useRef( onChange );
+	onInputRef.current = onInput;
+	onChangeRef.current = onChange;
+
 	useEffect( () => {
 		const {
 			getSelectionStart,
@@ -120,17 +123,7 @@ export default function useBlockSync( {
 		let isPersistent = isLastBlockChangePersistent();
 		let previousAreBlocksDifferent = false;
 
-		onInputRef.current = onInput;
-		onChangeRef.current = onChange;
 		const unsubscribe = registry.subscribe( () => {
-			// Sometimes, subscriptions might trigger with stale callbacks
-			// before they are cleaned up. Avoid running them.
-			if (
-				onInputRef.current !== onInput ||
-				onChangeRef.current !== onChange
-			)
-				return;
-
 			// Sometimes, when changing block lists, lingering subscriptions
 			// might trigger before they are cleaned up. If the block for which
 			// the subscription runs is no longer in the store, this would clear
@@ -184,8 +177,9 @@ export default function useBlockSync( {
 			}
 			previousAreBlocksDifferent = areBlocksDifferent;
 		} );
+
 		return () => unsubscribe();
-	}, [ registry, onChange, onInput, clientId ] );
+	}, [ registry, clientId ] );
 
 	// Determine if blocks need to be reset when they change.
 	useEffect( () => {


### PR DESCRIPTION
I noticed this while working on https://github.com/youknowriad/asblocks.

Sometimes when you change something in blocks, like type a character, the `onChange` handler gets called twice for the same value, causing all sorts of issues if a new change happened in the meantime. I think it's related to the fact that the subscription is "renewed" each time onChange or onInput changes. This shouldn't be the case and subscriptions should just use the last callbacks. That's what this PR does (that solved the issue for me btw)