### PR TITLE
Add reusable block tab to inserter.

### DIFF
--- a/packages/block-editor/src/components/inserter/block-types-tab.js
+++ b/packages/block-editor/src/components/inserter/block-types-tab.js
@@ -8,8 +8,6 @@ import { map, findIndex, flow, sortBy, groupBy, isEmpty } from 'lodash';
  */
 import { __, _x, _n, sprintf } from '@wordpress/i18n';
 import { withSpokenMessages } from '@wordpress/components';
-import { addQueryArgs } from '@wordpress/url';
-import { controlsRepeat } from '@wordpress/icons';
 import { useMemo, useEffect } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 
@@ -59,12 +57,6 @@ export function BlockTypesTab( {
 	const suggestedItems = useMemo( () => {
 		return items.slice( 0, MAX_SUGGESTED_ITEMS );
 	}, [ items ] );
-
-	const reusableItems = useMemo( () => {
-		return filteredItems.filter(
-			( { category } ) => category === 'reusable'
-		);
-	}, [ filteredItems ] );
 
 	const uncategorizedItems = useMemo( () => {
 		return filteredItems.filter( ( item ) => ! item.category );
@@ -198,28 +190,6 @@ export function BlockTypesTab( {
 						</InserterPanel>
 					);
 				} ) }
-
-			{ ! hasChildItems && !! reusableItems.length && (
-				<InserterPanel
-					className="block-editor-inserter__reusable-blocks-panel"
-					title={ __( 'Reusable' ) }
-					icon={ controlsRepeat }
-				>
-					<BlockTypesList
-						items={ reusableItems }
-						onSelect={ onSelectItem }
-						onHover={ onHover }
-					/>
-					<a
-						className="block-editor-inserter__manage-reusable-blocks"
-						href={ addQueryArgs( 'edit.php', {
-							post_type: 'wp_block',
-						} ) }
-					>
-						{ __( 'Manage all reusable blocks' ) }
-					</a>
-				</InserterPanel>
-			) }
 
 			<__experimentalInserterMenuExtension.Slot
 				fillProps={ {

--- a/packages/block-editor/src/components/inserter/reusable-blocks-tab.js
+++ b/packages/block-editor/src/components/inserter/reusable-blocks-tab.js
@@ -1,0 +1,144 @@
+/**
+ * WordPress dependencies
+ */
+import { withSpokenMessages } from '@wordpress/components';
+import { useMemo, useEffect } from '@wordpress/element';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import BlockTypesList from '../block-types-list';
+import { searchBlockItems } from './search-items';
+import InserterPanel from './panel';
+import InserterNoResults from './no-results';
+import useBlockTypesState from './hooks/use-block-types-state';
+
+function ReusableBlocksSearchResults( {
+	debouncedSpeak,
+	filterValue,
+	onHover,
+	onInsert,
+	rootClientId,
+} ) {
+	const [ items, categories, collections, onSelectItem ] = useBlockTypesState(
+		rootClientId,
+		onInsert
+	);
+
+	const filteredItems = useMemo( () => {
+		return searchBlockItems(
+			items,
+			categories,
+			collections,
+			filterValue
+		).filter( ( { category } ) => category === 'reusable' );
+	}, [ filterValue, items, categories, collections ] );
+
+	// Announce search results on change.
+	useEffect( () => {
+		const resultsFoundMessage = sprintf(
+			/* translators: %d: number of results. */
+			_n( '%d result found.', '%d results found.', filteredItems.length ),
+			filteredItems.length
+		);
+		debouncedSpeak( resultsFoundMessage );
+	}, [ filterValue, debouncedSpeak ] );
+
+	if ( filterValue ) {
+		return !! filteredItems.length ? (
+			<InserterPanel title={ __( 'Search Results' ) }>
+				<BlockTypesList
+					items={ filteredItems }
+					onSelect={ onSelectItem }
+					onHover={ onHover }
+				/>
+			</InserterPanel>
+		) : (
+			<InserterNoResults />
+		);
+	}
+}
+
+export function InsertableReusableBlocks( {
+	onInsert,
+	onHover,
+	rootClientId,
+} ) {
+	const [ items, , , onSelectItem ] = useBlockTypesState(
+		rootClientId,
+		onInsert
+	);
+
+	const filteredItems = useMemo( () => {
+		return items.filter( ( { category } ) => category === 'reusable' );
+	}, [ items ] );
+
+	return (
+		<>
+			{ filteredItems.length > 0 && (
+				<InserterPanel title={ __( 'Reusable blocks' ) }>
+					<BlockTypesList
+						items={ filteredItems }
+						onSelect={ onSelectItem }
+						onHover={ onHover }
+					/>
+				</InserterPanel>
+			) }
+		</>
+	);
+}
+
+// The unwrapped component is only exported for use by unit tests.
+/**
+ * List of reusable blocks shown in the "Reusable" tab of the inserter.
+ *
+ * @param {Object}   props                Component props.
+ * @param {?string}  props.rootClientId   Client id of block to insert into.
+ * @param {Function} props.onInsert       Callback to run when item is inserted.
+ * @param {Function} props.onHover        Callback to run when item is hovered.
+ * @param {?string}  props.filterValue    Search term.
+ * @param {Function} props.debouncedSpeak Debounced speak function.
+ *
+ * @return {WPComponent} The component.
+ */
+export function ReusableBlocksTab( {
+	rootClientId,
+	onInsert,
+	onHover,
+	filterValue,
+	debouncedSpeak,
+} ) {
+	return (
+		<>
+			{ filterValue ? (
+				<ReusableBlocksSearchResults
+					debouncedSpeak={ debouncedSpeak }
+					filterValue={ filterValue }
+					onHover={ onHover }
+					onInsert={ onInsert }
+					rootClientId={ rootClientId }
+				/>
+			) : (
+				<InsertableReusableBlocks
+					onInsert={ onInsert }
+					onHover={ onHover }
+					rootClientId={ rootClientId }
+				/>
+			) }
+			<div className="block-editor-inserter__manage-reusable-blocks-container">
+				<a
+					className="block-editor-inserter__manage-reusable-blocks"
+					href={ addQueryArgs( 'edit.php', {
+						post_type: 'wp_block',
+					} ) }
+				>
+					{ __( 'Manage all reusable blocks' ) }
+				</a>
+			</div>
+		</>
+	);
+}
+
+export default withSpokenMessages( ReusableBlocksTab );

--- a/packages/block-editor/src/components/inserter/reusable-blocks-tab.js
+++ b/packages/block-editor/src/components/inserter/reusable-blocks-tab.js
@@ -15,8 +15,6 @@ import InserterPanel from './panel';
 import InserterNoResults from './no-results';
 import useBlockTypesState from './hooks/use-block-types-state';
 
-const reusableBlockFilter = ( { category } ) => category === 'reusable';
-
 function ReusableBlocksList( {
 	debouncedSpeak,
 	filterValue,
@@ -30,15 +28,19 @@ function ReusableBlocksList( {
 	);
 
 	const filteredItems = useMemo( () => {
+		const reusableItems = items.filter(
+			( { category } ) => category === 'reusable'
+		);
+
 		if ( ! filterValue ) {
-			return items.filter( reusableBlockFilter );
+			return reusableItems;
 		}
 		return searchBlockItems(
-			items,
+			reusableItems,
 			categories,
 			collections,
 			filterValue
-		).filter( reusableBlockFilter );
+		);
 	}, [ filterValue, items, categories, collections ] );
 
 	// Announce search results on change.

--- a/packages/block-editor/src/components/inserter/reusable-blocks-tab.js
+++ b/packages/block-editor/src/components/inserter/reusable-blocks-tab.js
@@ -15,7 +15,9 @@ import InserterPanel from './panel';
 import InserterNoResults from './no-results';
 import useBlockTypesState from './hooks/use-block-types-state';
 
-function ReusableBlocksSearchResults( {
+const reusableBlockFilter = ( { category } ) => category === 'reusable';
+
+function ReusableBlocksList( {
 	debouncedSpeak,
 	filterValue,
 	onHover,
@@ -28,12 +30,15 @@ function ReusableBlocksSearchResults( {
 	);
 
 	const filteredItems = useMemo( () => {
+		if ( ! filterValue ) {
+			return items.filter( reusableBlockFilter );
+		}
 		return searchBlockItems(
 			items,
 			categories,
 			collections,
 			filterValue
-		).filter( ( { category } ) => category === 'reusable' );
+		).filter( reusableBlockFilter );
 	}, [ filterValue, items, categories, collections ] );
 
 	// Announce search results on change.
@@ -46,47 +51,22 @@ function ReusableBlocksSearchResults( {
 		debouncedSpeak( resultsFoundMessage );
 	}, [ filterValue, debouncedSpeak ] );
 
-	if ( filterValue ) {
-		return !! filteredItems.length ? (
-			<InserterPanel title={ __( 'Search Results' ) }>
-				<BlockTypesList
-					items={ filteredItems }
-					onSelect={ onSelectItem }
-					onHover={ onHover }
-				/>
-			</InserterPanel>
-		) : (
-			<InserterNoResults />
-		);
+	if ( filteredItems.length === 0 ) {
+		return <InserterNoResults />;
 	}
-}
-
-export function InsertableReusableBlocks( {
-	onInsert,
-	onHover,
-	rootClientId,
-} ) {
-	const [ items, , , onSelectItem ] = useBlockTypesState(
-		rootClientId,
-		onInsert
-	);
-
-	const filteredItems = useMemo( () => {
-		return items.filter( ( { category } ) => category === 'reusable' );
-	}, [ items ] );
 
 	return (
-		<>
-			{ filteredItems.length > 0 && (
-				<InserterPanel title={ __( 'Reusable blocks' ) }>
-					<BlockTypesList
-						items={ filteredItems }
-						onSelect={ onSelectItem }
-						onHover={ onHover }
-					/>
-				</InserterPanel>
-			) }
-		</>
+		<InserterPanel
+			title={
+				filterValue ? __( 'Search Results' ) : __( 'Reusable blocks' )
+			}
+		>
+			<BlockTypesList
+				items={ filteredItems }
+				onSelect={ onSelectItem }
+				onHover={ onHover }
+			/>
+		</InserterPanel>
 	);
 }
 
@@ -112,21 +92,13 @@ export function ReusableBlocksTab( {
 } ) {
 	return (
 		<>
-			{ filterValue ? (
-				<ReusableBlocksSearchResults
-					debouncedSpeak={ debouncedSpeak }
-					filterValue={ filterValue }
-					onHover={ onHover }
-					onInsert={ onInsert }
-					rootClientId={ rootClientId }
-				/>
-			) : (
-				<InsertableReusableBlocks
-					onInsert={ onInsert }
-					onHover={ onHover }
-					rootClientId={ rootClientId }
-				/>
-			) }
+			<ReusableBlocksList
+				debouncedSpeak={ debouncedSpeak }
+				filterValue={ filterValue }
+				onHover={ onHover }
+				onInsert={ onInsert }
+				rootClientId={ rootClientId }
+			/>
 			<div className="block-editor-inserter__manage-reusable-blocks-container">
 				<a
 					className="block-editor-inserter__manage-reusable-blocks"

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -262,6 +262,10 @@ $block-inserter-tabs-height: 44px;
 	flex-shrink: 0;
 }
 
+.block-editor-inserter__manage-reusable-blocks-container {
+	padding: $grid-unit-20;
+}
+
 .block-editor-inserter__quick-inserter {
 	width: $block-inserter-width;
 }

--- a/packages/block-editor/src/components/inserter/tabs.js
+++ b/packages/block-editor/src/components/inserter/tabs.js
@@ -4,23 +4,38 @@
 import { TabPanel } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-function InserterTabs( { children } ) {
+const blocksTab = {
+	name: 'blocks',
+	/* translators: Blocks tab title in the block inserter. */
+	title: __( 'Blocks' ),
+};
+const patternsTab = {
+	name: 'patterns',
+	/* translators: Patterns tab title in the block inserter. */
+	title: __( 'Patterns' ),
+};
+const reusableBlocksTab = {
+	name: 'reusable',
+	/* translators: Reusable blocks tab title in the block inserter. */
+	title: __( 'Reusable' ),
+};
+
+function InserterTabs( {
+	children,
+	showPatterns = false,
+	showReusableBlocks = false,
+} ) {
+	const tabs = [ blocksTab ];
+
+	if ( showPatterns ) {
+		tabs.push( patternsTab );
+	}
+	if ( showReusableBlocks ) {
+		tabs.push( reusableBlocksTab );
+	}
+
 	return (
-		<TabPanel
-			className="block-editor-inserter__tabs"
-			tabs={ [
-				{
-					name: 'blocks',
-					/* translators: Blocks tab title in the block inserter. */
-					title: __( 'Blocks' ),
-				},
-				{
-					name: 'patterns',
-					/* translators: Patterns tab title in the block inserter. */
-					title: __( 'Patterns' ),
-				},
-			] }
-		>
+		<TabPanel className="block-editor-inserter__tabs" tabs={ tabs }>
 			{ children }
 		</TabPanel>
 	);

--- a/packages/block-editor/src/components/inserter/test/block-types-tab.js
+++ b/packages/block-editor/src/components/inserter/test/block-types-tab.js
@@ -116,25 +116,6 @@ describe( 'InserterMenu', () => {
 		assertNoResultsMessageNotToBePresent( container );
 	} );
 
-	it( 'should show reusable items in the reusable tab', () => {
-		const { container } = initializeAllClosedMenuState();
-		const reusableTabContent = container.querySelectorAll(
-			'.block-editor-inserter__panel-content'
-		)[ 5 ];
-		const reusableTabTitle = container.querySelectorAll(
-			'.block-editor-inserter__panel-title'
-		)[ 5 ];
-		const blocks = reusableTabContent.querySelectorAll(
-			'.block-editor-block-types-list__item-title'
-		);
-
-		expect( reusableTabTitle.textContent ).toBe( 'Reusable' );
-		expect( blocks ).toHaveLength( 1 );
-		expect( blocks[ 0 ].textContent ).toBe( 'My reusable block' );
-
-		assertNoResultsMessageNotToBePresent( container );
-	} );
-
 	it( 'should show the common category blocks', () => {
 		const { container } = initializeAllClosedMenuState();
 		const commonTabContent = container.querySelectorAll(
@@ -218,44 +199,17 @@ describe( 'InserterMenu', () => {
 		assertNoResultsMessageNotToBePresent( container );
 	} );
 
-	it( 'should allow searching for reusable blocks by title', () => {
-		const { container } = render(
-			<InserterBlockList filterValue="my reusable" />
-		);
-
-		const matchingCategories = container.querySelectorAll(
-			'.block-editor-inserter__panel-title'
-		);
-
-		expect( matchingCategories ).toHaveLength( 2 );
-		expect( matchingCategories[ 0 ].textContent ).toBe( 'Core' ); // "Core" namespace collection
-		expect( matchingCategories[ 1 ].textContent ).toBe( 'Reusable' );
-
-		const blocks = container.querySelectorAll(
-			'.block-editor-block-types-list__item-title'
-		);
-
-		// There are two buttons present for 1 total distinct result. The
-		// additional one accounts for the collection result (repeated).
-		expect( blocks ).toHaveLength( 2 );
-		expect( debouncedSpeak ).toHaveBeenCalledWith( '1 result found.' );
-		expect( blocks[ 0 ].textContent ).toBe( 'My reusable block' );
-		expect( blocks[ 1 ].textContent ).toBe( 'My reusable block' );
-
-		assertNoResultsMessageNotToBePresent( container );
-	} );
-
 	it( 'should speak after any change in search term', () => {
 		// The search result count should always be announced any time the user
 		// changes the search term, even if it results in the same count.
 		//
 		// See: https://github.com/WordPress/gutenberg/pull/22279#discussion_r423317161
 		const { rerender } = render(
-			<InserterBlockList filterValue="my reusab" />
+			<InserterBlockList filterValue="Advanced Para" />
 		);
 
-		rerender( <InserterBlockList filterValue="my reusable" /> );
-		rerender( <InserterBlockList filterValue="my reusable" /> );
+		rerender( <InserterBlockList filterValue="Advanced Paragraph" /> );
+		rerender( <InserterBlockList filterValue="Advanced Paragraph" /> );
 
 		expect( debouncedSpeak ).toHaveBeenCalledTimes( 2 );
 		expect( debouncedSpeak.mock.calls[ 0 ][ 0 ] ).toBe( '1 result found.' );

--- a/packages/block-editor/src/components/inserter/test/reusable-blocks-tab.js
+++ b/packages/block-editor/src/components/inserter/test/reusable-blocks-tab.js
@@ -1,0 +1,158 @@
+/**
+ * External dependencies
+ */
+import { render, fireEvent } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { ReusableBlocksTab } from '../reusable-blocks-tab';
+import items, { categories, collections } from './fixtures';
+import useBlockTypesState from '../hooks/use-block-types-state';
+
+jest.mock( '../hooks/use-block-types-state', () => {
+	// This allows us to tweak the returned value on each test
+	const mock = jest.fn();
+	return mock;
+} );
+
+jest.mock( '@wordpress/data/src/components/use-select', () => {
+	// This allows us to tweak the returned value on each test
+	const mock = jest.fn();
+	return mock;
+} );
+
+jest.mock( '@wordpress/data/src/components/use-dispatch', () => {
+	return {
+		useDispatch: () => ( {} ),
+	};
+} );
+
+const debouncedSpeak = jest.fn();
+
+function InserterBlockList( props ) {
+	return <ReusableBlocksTab debouncedSpeak={ debouncedSpeak } { ...props } />;
+}
+
+const initializeAllClosedMenuState = ( propOverrides ) => {
+	const result = render( <InserterBlockList { ...propOverrides } /> );
+	const activeTabs = result.container.querySelectorAll(
+		'.components-panel__body.is-opened button.components-panel__body-toggle'
+	);
+	activeTabs.forEach( ( tab ) => {
+		fireEvent.click( tab );
+	} );
+	return result;
+};
+
+const assertNoResultsMessageToBePresent = ( element ) => {
+	const noResultsMessage = element.querySelector(
+		'.block-editor-inserter__no-results'
+	);
+	expect( noResultsMessage.textContent ).toEqual( 'No results found.' );
+};
+
+const assertNoResultsMessageNotToBePresent = ( element ) => {
+	const noResultsMessage = element.querySelector(
+		'.block-editor-inserter__no-results'
+	);
+	expect( noResultsMessage ).toBe( null );
+};
+
+describe( 'InserterMenu', () => {
+	beforeEach( () => {
+		debouncedSpeak.mockClear();
+
+		useBlockTypesState.mockImplementation( () => [
+			items,
+			categories,
+			collections,
+		] );
+
+		useSelect.mockImplementation( () => false );
+	} );
+
+	it( 'should show nothing if there are no items', () => {
+		const noItems = [];
+		useBlockTypesState.mockImplementation( () => [
+			noItems,
+			categories,
+			collections,
+		] );
+		const { container } = render(
+			<InserterBlockList filterValue="random" />
+		);
+		const visibleBlocks = container.querySelector(
+			'.block-editor-block-types-list__item'
+		);
+
+		expect( visibleBlocks ).toBe( null );
+
+		assertNoResultsMessageToBePresent( container );
+	} );
+
+	it( 'should list reusable blocks', () => {
+		const { container } = initializeAllClosedMenuState();
+		const blocks = container.querySelectorAll(
+			'.block-editor-block-types-list__item-title'
+		);
+
+		expect( blocks ).toHaveLength( 1 );
+		expect( blocks[ 0 ].textContent ).toBe( 'My reusable block' );
+
+		assertNoResultsMessageNotToBePresent( container );
+	} );
+
+	it( 'should allow searching for reusable blocks by title', () => {
+		const { container } = render(
+			<InserterBlockList filterValue="my reusable" />
+		);
+
+		const blocks = container.querySelectorAll(
+			'.block-editor-block-types-list__item-title'
+		);
+
+		expect( blocks ).toHaveLength( 1 );
+		expect( debouncedSpeak ).toHaveBeenCalledWith( '1 result found.' );
+		expect( blocks[ 0 ].textContent ).toBe( 'My reusable block' );
+
+		assertNoResultsMessageNotToBePresent( container );
+	} );
+
+	it( 'should speak after any change in search term', () => {
+		// The search result count should always be announced any time the user
+		// changes the search term, even if it results in the same count.
+		//
+		// See: https://github.com/WordPress/gutenberg/pull/22279#discussion_r423317161
+		const { rerender } = render(
+			<InserterBlockList filterValue="my reusab" />
+		);
+
+		rerender( <InserterBlockList filterValue="my reusable" /> );
+		rerender( <InserterBlockList filterValue="my reusable" /> );
+
+		expect( debouncedSpeak ).toHaveBeenCalledTimes( 2 );
+		expect( debouncedSpeak.mock.calls[ 0 ][ 0 ] ).toBe( '1 result found.' );
+		expect( debouncedSpeak.mock.calls[ 1 ][ 0 ] ).toBe( '1 result found.' );
+	} );
+
+	it( 'should trim whitespace of search terms', () => {
+		const { container } = render(
+			<InserterBlockList filterValue=" my reusable" />
+		);
+
+		const blocks = container.querySelectorAll(
+			'.block-editor-block-types-list__item-title'
+		);
+
+		expect( blocks ).toHaveLength( 1 );
+		expect( blocks[ 0 ].textContent ).toBe( 'My reusable block' );
+
+		assertNoResultsMessageNotToBePresent( container );
+	} );
+} );

--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -302,6 +302,16 @@ _Parameters_
 
 -   _searchTerm_ `string`: The text to search the inserter for.
 
+<a name="insertReusableBlock" href="#insertReusableBlock">#</a> **insertReusableBlock**
+
+Opens the inserter, searches for the given reusable block, then selects the
+first result that appears. It then waits briefly for the block list to
+update.
+
+_Parameters_
+
+-   _searchTerm_ `string`: The text to search the inserter for.
+
 <a name="installPlugin" href="#installPlugin">#</a> **installPlugin**
 
 Installs a plugin from the WP.org repository.
@@ -429,6 +439,14 @@ _Parameters_
 <a name="searchForPattern" href="#searchForPattern">#</a> **searchForPattern**
 
 Search for pattern in the global inserter
+
+_Parameters_
+
+-   _searchTerm_ `string`: The text to search the inserter for.
+
+<a name="searchForReusableBlock" href="#searchForReusableBlock">#</a> **searchForReusableBlock**
+
+Search for reusable block in the global inserter.
 
 _Parameters_
 

--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -557,6 +557,18 @@ _Parameters_
 
 -   _name_ `string`: Block name.
 
+<a name="trashAllPosts" href="#trashAllPosts">#</a> **trashAllPosts**
+
+Navigates to the post listing screen and bulk-trashes any posts which exist.
+
+_Parameters_
+
+-   _postType_ `string`: String slug for type of post to trash.
+
+_Returns_
+
+-   `Promise`: Promise resolving once posts have been trashed.
+
 <a name="uninstallPlugin" href="#uninstallPlugin">#</a> **uninstallPlugin**
 
 Uninstalls a plugin.

--- a/packages/e2e-test-utils/src/index.js
+++ b/packages/e2e-test-utils/src/index.js
@@ -26,8 +26,10 @@ export { getPageError } from './get-page-error';
 export {
 	insertBlock,
 	insertPattern,
+	insertReusableBlock,
 	searchForBlock,
 	searchForPattern,
+	searchForReusableBlock,
 	openGlobalBlockInserter,
 	closeGlobalBlockInserter,
 } from './inserter';

--- a/packages/e2e-test-utils/src/index.js
+++ b/packages/e2e-test-utils/src/index.js
@@ -43,6 +43,7 @@ export {
 } from './observe-focus-loss';
 export { openDocumentSettingsSidebar } from './open-document-settings-sidebar';
 export { openPublishPanel } from './open-publish-panel';
+export { trashAllPosts } from './posts';
 export { pressKeyTimes } from './press-key-times';
 export { pressKeyWithModifier } from './press-key-with-modifier';
 export { publishPost } from './publish-post';

--- a/packages/e2e-test-utils/src/inserter.js
+++ b/packages/e2e-test-utils/src/inserter.js
@@ -81,6 +81,31 @@ export async function searchForPattern( searchTerm ) {
 }
 
 /**
+ * Search for reusable block in the global inserter.
+ *
+ * @param {string} searchTerm The text to search the inserter for.
+ */
+export async function searchForReusableBlock( searchTerm ) {
+	await openGlobalBlockInserter();
+
+	// The reusable blocks tab won't appear until the reusable blocks have been
+	// fetched. They aren't fetched until an inserter is used or the post
+	// already contains reusable blocks, so wait for the tab to appear.
+	await page.waitForXPath(
+		'//div[contains(@class, "block-editor-inserter__tabs")]//button[text()="Reusable"]'
+	);
+
+	// Select the reusable blocks tab.
+	const [ tab ] = await page.$x(
+		'//div[contains(@class, "block-editor-inserter__tabs")]//button[text()="Reusable"]'
+	);
+	await tab.click();
+	await page.focus( INSERTER_SEARCH_SELECTOR );
+	await pressKeyWithModifier( 'primary', 'a' );
+	await page.keyboard.type( searchTerm );
+}
+
+/**
  * Opens the inserter, searches for the given term, then selects the first
  * result that appears. It then waits briefly for the block list to update.
  *
@@ -106,6 +131,21 @@ export async function insertPattern( searchTerm ) {
 		await page.$x(
 			`//div[@role = 'button']//div[contains(text(), '${ searchTerm }')]`
 		)
+	 )[ 0 ];
+	await insertButton.click();
+}
+
+/**
+ * Opens the inserter, searches for the given reusable block, then selects the
+ * first result that appears. It then waits briefly for the block list to
+ * update.
+ *
+ * @param {string} searchTerm The text to search the inserter for.
+ */
+export async function insertReusableBlock( searchTerm ) {
+	await searchForReusableBlock( searchTerm );
+	const insertButton = (
+		await page.$x( `//button//span[contains(text(), '${ searchTerm }')]` )
 	 )[ 0 ];
 	await insertButton.click();
 }

--- a/packages/e2e-test-utils/src/posts.js
+++ b/packages/e2e-test-utils/src/posts.js
@@ -1,0 +1,45 @@
+/**
+ * WordPress dependencies
+ */
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import { switchUserToAdmin } from './switch-user-to-admin';
+import { switchUserToTest } from './switch-user-to-test';
+import { visitAdminPage } from './visit-admin-page';
+
+/**
+ * Navigates to the post listing screen and bulk-trashes any posts which exist.
+ *
+ * @param {string} postType - String slug for type of post to trash.
+ *
+ * @return {Promise} Promise resolving once posts have been trashed.
+ */
+export async function trashAllPosts( postType = 'post' ) {
+	await switchUserToAdmin();
+	// Visit `/wp-admin/edit.php` so we can see a list of posts and delete them.
+	const query = addQueryArgs( '', {
+		post_type: postType,
+	} ).slice( 1 );
+	await visitAdminPage( 'edit.php', query );
+
+	// If this selector doesn't exist there are no posts for us to delete.
+	const bulkSelector = await page.$( '#bulk-action-selector-top' );
+	if ( ! bulkSelector ) {
+		return;
+	}
+
+	// Select all posts.
+	await page.waitForSelector( '[id^=cb-select-all-]' );
+	await page.click( '[id^=cb-select-all-]' );
+	// Select the "bulk actions" > "trash" option.
+	await page.select( '#bulk-action-selector-top', 'trash' );
+	// Submit the form to send all draft/scheduled/published posts to the trash.
+	await page.click( '#doaction' );
+	await page.waitForXPath(
+		'//*[contains(@class, "updated notice")]/p[contains(text(), "moved to the Trash.")]'
+	);
+	await switchUserToTest();
+}

--- a/packages/e2e-tests/config/setup-test-framework.js
+++ b/packages/e2e-tests/config/setup-test-framework.js
@@ -12,11 +12,8 @@ import {
 	enablePageDialogAccept,
 	isOfflineMode,
 	setBrowserViewport,
-	switchUserToAdmin,
-	switchUserToTest,
-	visitAdminPage,
+	trashAllPosts,
 } from '@wordpress/e2e-test-utils';
-import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Timeout, in seconds, that the test should be allowed to run.
@@ -65,40 +62,6 @@ jest.setTimeout( PUPPETEER_TIMEOUT || 100000 );
 async function setupBrowser() {
 	await clearLocalStorage();
 	await setBrowserViewport( 'large' );
-}
-
-/**
- * Navigates to the post listing screen and bulk-trashes any posts which exist.
- *
- * @param {string} postType - String slug for type of post to trash.
- *
- * @return {Promise} Promise resolving once posts have been trashed.
- */
-export async function trashExistingPosts( postType = 'post' ) {
-	await switchUserToAdmin();
-	// Visit `/wp-admin/edit.php` so we can see a list of posts and delete them.
-	const query = addQueryArgs( '', {
-		post_type: postType,
-	} ).slice( 1 );
-	await visitAdminPage( 'edit.php', query );
-
-	// If this selector doesn't exist there are no posts for us to delete.
-	const bulkSelector = await page.$( '#bulk-action-selector-top' );
-	if ( ! bulkSelector ) {
-		return;
-	}
-
-	// Select all posts.
-	await page.waitForSelector( '[id^=cb-select-all-]' );
-	await page.click( '[id^=cb-select-all-]' );
-	// Select the "bulk actions" > "trash" option.
-	await page.select( '#bulk-action-selector-top', 'trash' );
-	// Submit the form to send all draft/scheduled/published posts to the trash.
-	await page.click( '#doaction' );
-	await page.waitForXPath(
-		'//*[contains(@class, "updated notice")]/p[contains(text(), "moved to the Trash.")]'
-	);
-	await switchUserToTest();
 }
 
 /**
@@ -289,7 +252,8 @@ beforeAll( async () => {
 	observeConsoleLogging();
 	await simulateAdverseConditions();
 
-	await trashExistingPosts();
+	await trashAllPosts();
+	await trashAllPosts( 'wp_block' );
 	await setupBrowser();
 	await activatePlugin( 'gutenberg-test-plugin-disables-the-css-animations' );
 } );

--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -3,10 +3,11 @@
  */
 import {
 	insertBlock,
+	insertReusableBlock,
 	createNewPost,
 	clickBlockToolbarButton,
 	pressKeyWithModifier,
-	searchForBlock,
+	searchForReusableBlock,
 	getEditedPostContent,
 } from '@wordpress/e2e-test-utils';
 
@@ -114,7 +115,7 @@ describe( 'Reusable blocks', () => {
 
 	it( 'can be inserted and edited', async () => {
 		// Insert the reusable block we created above
-		await insertBlock( 'Greeting block' );
+		await insertReusableBlock( 'Greeting block' );
 
 		// Put the reusable block in edit mode
 		const editButton = await page.waitForXPath(
@@ -198,7 +199,7 @@ describe( 'Reusable blocks', () => {
 
 		// Step 3. Insert the block created in Step 1.
 
-		await insertBlock( 'Awesome block' );
+		await insertReusableBlock( 'Awesome block' );
 
 		// Check that we have a reusable block on the page
 		const block = await page.$(
@@ -216,7 +217,7 @@ describe( 'Reusable blocks', () => {
 
 	it( 'can be converted to a regular block', async () => {
 		// Insert the reusable block we edited above
-		await insertBlock( 'Surprised greeting block' );
+		await insertReusableBlock( 'Surprised greeting block' );
 
 		// Convert block to a regular block
 		await clickBlockToolbarButton( 'More options' );
@@ -241,7 +242,7 @@ describe( 'Reusable blocks', () => {
 
 	it( 'can be deleted', async () => {
 		// Insert the reusable block we edited above
-		await insertBlock( 'Surprised greeting block' );
+		await insertReusableBlock( 'Surprised greeting block' );
 
 		// Delete the block and accept the confirmation dialog
 		await clickBlockToolbarButton( 'More options' );
@@ -259,7 +260,7 @@ describe( 'Reusable blocks', () => {
 		expect( await getEditedPostContent() ).toBe( '' );
 
 		// Search for the block in the inserter
-		await searchForBlock( 'Surprised greeting block' );
+		await searchForReusableBlock( 'Surprised greeting block' );
 
 		// Check that we couldn't find it
 		const items = await page.$$(
@@ -322,7 +323,7 @@ describe( 'Reusable blocks', () => {
 
 	it( 'multi-selection reusable block can be converted back to regular blocks', async () => {
 		// Insert the reusable block we edited above
-		await insertBlock( 'Multi-selection reusable block' );
+		await insertReusableBlock( 'Multi-selection reusable block' );
 
 		// Convert block to a regular block
 		await clickBlockToolbarButton( 'More options' );

--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -9,6 +9,7 @@ import {
 	pressKeyWithModifier,
 	searchForReusableBlock,
 	getEditedPostContent,
+	trashAllPosts,
 } from '@wordpress/e2e-test-utils';
 
 function waitForAndAcceptDialog() {
@@ -20,6 +21,10 @@ function waitForAndAcceptDialog() {
 describe( 'Reusable blocks', () => {
 	beforeAll( async () => {
 		await createNewPost();
+	} );
+
+	afterAll( async () => {
+		await trashAllPosts( 'wp_block' );
 	} );
 
 	beforeEach( async () => {

--- a/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
@@ -11,6 +11,7 @@ import {
 	visitAdminPage,
 	createNewPost,
 	publishPost,
+	trashAllPosts,
 } from '@wordpress/e2e-test-utils';
 import { addQueryArgs } from '@wordpress/url';
 
@@ -18,7 +19,6 @@ import { addQueryArgs } from '@wordpress/url';
  * Internal dependencies
  */
 import { useExperimentalFeatures } from '../../experimental-features';
-import { trashExistingPosts } from '../../config/setup-test-framework';
 
 const visitSiteEditor = async () => {
 	const query = addQueryArgs( '', {
@@ -164,8 +164,8 @@ describe( 'Multi-entity editor states', () => {
 	] );
 
 	beforeAll( async () => {
-		await trashExistingPosts( 'wp_template' );
-		await trashExistingPosts( 'wp_template_part' );
+		await trashAllPosts( 'wp_template' );
+		await trashAllPosts( 'wp_template_part' );
 	} );
 
 	it( 'should not display any dirty entities when loading the site editor', async () => {
@@ -194,8 +194,8 @@ describe( 'Multi-entity editor states', () => {
 
 	describe( 'Multi-entity edit', () => {
 		beforeAll( async () => {
-			await trashExistingPosts( 'wp_template' );
-			await trashExistingPosts( 'wp_template_part' );
+			await trashAllPosts( 'wp_template' );
+			await trashAllPosts( 'wp_template_part' );
 			await createNewPost( {
 				postType: 'wp_template',
 				title: kebabCase( templateName ),

--- a/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
@@ -6,6 +6,7 @@ import {
 	insertBlock,
 	publishPost,
 	visitAdminPage,
+	trashAllPosts,
 } from '@wordpress/e2e-test-utils';
 import { addQueryArgs } from '@wordpress/url';
 
@@ -13,7 +14,6 @@ import { addQueryArgs } from '@wordpress/url';
  * Internal dependencies
  */
 import { useExperimentalFeatures } from '../../experimental-features';
-import { trashExistingPosts } from '../../config/setup-test-framework';
 
 describe( 'Multi-entity save flow', () => {
 	// Selectors - usable between Post/Site editors.
@@ -58,8 +58,8 @@ describe( 'Multi-entity save flow', () => {
 	] );
 
 	beforeAll( async () => {
-		await trashExistingPosts( 'wp_template' );
-		await trashExistingPosts( 'wp_template_part' );
+		await trashAllPosts( 'wp_template' );
+		await trashAllPosts( 'wp_template_part' );
 	} );
 
 	describe( 'Post Editor', () => {

--- a/packages/e2e-tests/specs/experiments/template-part.test.js
+++ b/packages/e2e-tests/specs/experiments/template-part.test.js
@@ -6,6 +6,7 @@ import {
 	insertBlock,
 	disablePrePublishChecks,
 	visitAdminPage,
+	trashAllPosts,
 } from '@wordpress/e2e-test-utils';
 import { addQueryArgs } from '@wordpress/url';
 
@@ -13,7 +14,6 @@ import { addQueryArgs } from '@wordpress/url';
  * Internal dependencies
  */
 import { useExperimentalFeatures } from '../../experimental-features';
-import { trashExistingPosts } from '../../config/setup-test-framework';
 
 describe( 'Template Part', () => {
 	useExperimentalFeatures( [
@@ -22,12 +22,12 @@ describe( 'Template Part', () => {
 	] );
 
 	beforeAll( async () => {
-		await trashExistingPosts( 'wp_template' );
-		await trashExistingPosts( 'wp_template_part' );
+		await trashAllPosts( 'wp_template' );
+		await trashAllPosts( 'wp_template_part' );
 	} );
 	afterAll( async () => {
-		await trashExistingPosts( 'wp_template' );
-		await trashExistingPosts( 'wp_template_part' );
+		await trashAllPosts( 'wp_template' );
+		await trashAllPosts( 'wp_template_part' );
 	} );
 
 	describe( 'Template part block', () => {


### PR DESCRIPTION
## Description

closes #22860.
closes #23253

This PR moves reusable blocks from a category mostly hidden at the bottom of the standard blocks tab in the inserter to their own tab.

Currently, it uses the style of the block tab for presenting the reusable blocks. But I think it may make more sense to present them the same way as patterns. Let me know what you think in #22860.

## How has this been tested?
I tested to make sure the tab showed reusable blocks, that inserting reusable blocks worked, and that the reusable category was removed from the standard blocks tab.

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/19592990/85097343-d98bb080-b1bc-11ea-81b6-cf401b0f5b36.png)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
