### PR TITLE
[RNMobile][FIX] Columns block renders more than two columns in a row

### DIFF
--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -54,6 +54,7 @@ export class BlockList extends Component {
 			parentWidth: this.props.parentWidth,
 			renderFooterAppender: this.props.renderFooterAppender,
 			onDeleteBlock: this.props.onDeleteBlock,
+			contentStyle: this.props.contentstyle,
 		};
 		this.renderItem = this.renderItem.bind( this );
 		this.renderBlockListFooter = this.renderBlockListFooter.bind( this );
@@ -108,16 +109,23 @@ export class BlockList extends Component {
 	}
 
 	getExtraData() {
-		const { parentWidth, renderFooterAppender, onDeleteBlock } = this.props;
+		const {
+			parentWidth,
+			renderFooterAppender,
+			onDeleteBlock,
+			contentStyle,
+		} = this.props;
 		if (
 			this.extraData.parentWidth !== parentWidth ||
 			this.extraData.renderFooterAppender !== renderFooterAppender ||
-			this.extraData.onDeleteBlock !== onDeleteBlock
+			this.extraData.onDeleteBlock !== onDeleteBlock ||
+			this.extraData.contentStyle !== contentStyle
 		) {
 			this.extraData = {
 				parentWidth,
 				renderFooterAppender,
 				onDeleteBlock,
+				contentStyle,
 			};
 		}
 		return this.extraData;

--- a/packages/block-library/src/columns/edit.native.js
+++ b/packages/block-library/src/columns/edit.native.js
@@ -16,7 +16,7 @@ import {
 	BlockVerticalAlignmentToolbar,
 } from '@wordpress/block-editor';
 import { withDispatch, useSelect } from '@wordpress/data';
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect, useState, useMemo } from '@wordpress/element';
 import { useResizeObserver } from '@wordpress/compose';
 import { createBlock } from '@wordpress/blocks';
 /**
@@ -61,23 +61,25 @@ function ColumnsEditContainer( {
 	const [ resizeListener, sizes ] = useResizeObserver();
 	const [ columnsInRow, setColumnsInRow ] = useState( MIN_COLUMNS_NUMBER );
 
-	const containerMaxWidth = styles.columnsContainer.maxWidth;
-
 	const { verticalAlignment } = attributes;
 	const { width } = sizes || {};
 
 	useEffect( () => {
 		const newColumnCount = ! columnCount ? DEFAULT_COLUMNS : columnCount;
 		updateColumns( columnCount, newColumnCount );
-		setColumnsInRow( getColumnsInRow( width, newColumnCount ) );
+		if ( width ) {
+			setColumnsInRow( getColumnsInRow( width, newColumnCount ) );
+		}
 	}, [ columnCount ] );
 
 	useEffect( () => {
-		setColumnsInRow( getColumnsInRow( width, columnCount ) );
+		if ( width ) {
+			setColumnsInRow( getColumnsInRow( width, columnCount ) );
+		}
 	}, [ width ] );
 
-	const getColumnWidth = ( containerWidth = containerMaxWidth ) => {
-		const minWidth = Math.min( containerWidth, containerMaxWidth );
+	const getColumnWidth = useMemo( () => {
+		const minWidth = Math.min( width, styles.columnsContainer.maxWidth );
 		const columnBaseWidth = minWidth / columnsInRow;
 
 		let columnWidth = columnBaseWidth;
@@ -85,9 +87,8 @@ function ColumnsEditContainer( {
 			const margins = columnsInRow * 2 * styles.columnMargin.marginLeft;
 			columnWidth = ( minWidth - margins ) / columnsInRow;
 		}
-
-		return columnWidth;
-	};
+		return { width: columnWidth };
+	}, [ width, columnsInRow ] );
 
 	const getColumnsInRow = ( containerWidth, columnsNumber ) => {
 		if ( containerWidth < BREAKPOINTS.mobile ) {
@@ -137,20 +138,22 @@ function ColumnsEditContainer( {
 			</BlockControls>
 			<View style={ isSelected && styles.innerBlocksSelected }>
 				{ resizeListener }
-				<InnerBlocks
-					renderAppender={ renderAppender }
-					__experimentalMoverDirection={
-						columnsInRow > 1 ? 'horizontal' : undefined
-					}
-					horizontal={ true }
-					allowedBlocks={ ALLOWED_BLOCKS }
-					contentResizeMode="stretch"
-					onAddBlock={ onAddNextColumn }
-					onDeleteBlock={
-						columnCount === 1 ? onDeleteBlock : undefined
-					}
-					contentStyle={ { width: getColumnWidth( width ) } }
-				/>
+				{ width && (
+					<InnerBlocks
+						renderAppender={ renderAppender }
+						__experimentalMoverDirection={
+							columnsInRow > 1 ? 'horizontal' : undefined
+						}
+						horizontal={ true }
+						allowedBlocks={ ALLOWED_BLOCKS }
+						contentResizeMode="stretch"
+						onAddBlock={ onAddNextColumn }
+						onDeleteBlock={
+							columnCount === 1 ? onDeleteBlock : undefined
+						}
+						contentStyle={ getColumnWidth }
+					/>
+				) }
 			</View>
 		</>
 	);

--- a/packages/block-library/src/columns/edit.native.js
+++ b/packages/block-library/src/columns/edit.native.js
@@ -78,7 +78,7 @@ function ColumnsEditContainer( {
 		}
 	}, [ width ] );
 
-	const getColumnWidth = useMemo( () => {
+	const contentStyle = useMemo( () => {
 		const minWidth = Math.min( width, styles.columnsContainer.maxWidth );
 		const columnBaseWidth = minWidth / columnsInRow;
 
@@ -151,7 +151,7 @@ function ColumnsEditContainer( {
 						onDeleteBlock={
 							columnCount === 1 ? onDeleteBlock : undefined
 						}
-						contentStyle={ getColumnWidth }
+						contentStyle={ contentStyle }
 					/>
 				) }
 			</View>


### PR DESCRIPTION
## Description
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/2405
Gutenberg-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2407

In this PR i added `contentStyle` to the `extraData` in block-list component since we should re-render the list when `contentStyle` has changed. We have to keep in mind that passing a new reference as a `contentStyle` forces re-render every time. I suggest using `useMemo` in that case.

## How has this been tested?
- Make sure that your editor has more than two columns in a columns block
- Turn the device or emulator in landscape mode
- Start the Gutenberg-Mobile app or reload
- Observe that max two columns are rendered in each row
- Switch to the portrait mode
- Only one column should be rendered in a row



## Screenshots <!-- if applicable -->
![landcol](https://user-images.githubusercontent.com/16336501/85129205-024e8d00-b233-11ea-9d11-3746d1949546.gif)

## Types of changes
Fix number of rendered columns on init.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
