### PR TITLE
Update theme-support.md for experimental supports

### DIFF
--- a/docs/designers-developers/developers/themes/theme-support.md
+++ b/docs/designers-developers/developers/themes/theme-support.md
@@ -353,3 +353,19 @@ To make the content resize and keep its aspect ratio, the `<body>` element needs
 ```php
 add_theme_support( 'responsive-embeds' );
 ```
+
+## Experimental — Cover block padding
+
+In the Guteberg plugin 8.3, Cover blocks can provide padding controls in the editor for users. This is not avaialble by default, and requires the theme to opt in by declaring support:
+
+```php
+add_theme_support('experimental-custom-spacing');
+```
+
+## Experimental — Link color control
+
+In the Guteberg plugin 8.3, link color control is available to the Paragraph, Heading, Group, Columns, and Media & Text blocks. This is not avaialble by default, and requires the theme to opt in by declaring support:
+
+```php
+add_theme_support('experimental-link-color');
+```


### PR DESCRIPTION
Adding new opt-in feature available in Gutenberg 8.3

New padding control to cover block. (21492, 23041)
New link color control to paragraph, heading, group, columns, and media-text blocks. (22722, 23025, 23049)

Tested to be working as expected from release notes https://make.wordpress.org/core/2020/06/11/whats-new-in-gutenberg-11-june/