### PR TITLE
Use high-luminance colors in Gutenberg plugin

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -718,6 +718,23 @@ function gutenberg_extend_settings_link_color( $settings ) {
 }
 add_filter( 'block_editor_settings', 'gutenberg_extend_settings_link_color' );
 
+/**
+ * Override theme styles.
+ * Do not backport this to WordPress Core.
+ */
+function gutenberg_override_theme_styles() {
+	$theme_style = 'html body {
+		--wp-admin-theme-color: #3858e9;
+		--wp-admin-theme-color-darker-10: #2145e6;
+		--wp-admin-theme-color-darker-20: #183ad6;
+	}';
+	wp_add_inline_style( 'wp-edit-post', $theme_style );
+	wp_add_inline_style( 'wp-edit-site', $theme_style );
+	wp_add_inline_style( 'wp-edit-widgets', $theme_style );
+	wp_add_inline_style( 'wp-edit-navigation', $theme_style );
+}
+add_action( 'init', 'gutenberg_override_theme_styles' );
+
 /*
  * Register default patterns if not registered in Core already.
  */


### PR DESCRIPTION
This PR applies new default colors for the Gutenberg plugin. These colors won't apply to WordPress Core when backported because we need to ensure consistency with WordPress colors.

The idea is that we'll be able to quickly know whether the Gutenberg plugin is enabled or not.
Maybe longer term, consider using these colors in Core across WP Admin as these colors are better in terms of contrasts... (See #20460 for details).

<img width="1440" alt="Capture d’écran 2020-06-19 à 2 45 02 PM" src="https://user-images.githubusercontent.com/272444/85139101-d84d9880-b23b-11ea-9a0a-f8230a5d618d.png">
