### PR TITLE
Buttons block: remove margin from last button

### DIFF
--- a/packages/block-library/src/buttons/style.scss
+++ b/packages/block-library/src/buttons/style.scss
@@ -12,4 +12,8 @@
 
 .wp-block-buttons.aligncenter {
 	text-align: center;
+
+	.wp-block-button:last-child {
+		margin-right: 0;
+	}
 }

--- a/packages/block-library/src/buttons/style.scss
+++ b/packages/block-library/src/buttons/style.scss
@@ -3,17 +3,21 @@
 	display: inline-block;
 	margin-right: $grid-unit-10;
 	margin-bottom: $grid-unit-10;
+
+	&:last-child {
+		margin-right: 0;
+	}
 }
 
 .wp-block-buttons.alignright .wp-block-button {
 	margin-right: 0;
 	margin-left: $grid-unit-10;
+
+	&:first-child {
+		margin-left: 0;
+	}
 }
 
 .wp-block-buttons.aligncenter {
 	text-align: center;
-
-	.wp-block-button:last-child {
-		margin-right: 0;
-	}
 }


### PR DESCRIPTION
Fixes #23318.

## Description
The Buttons block adds right margin to each block so they are spaced. However, when buttons are centered, last button's margin pushes all buttons to the left. This PR removes the right margin of the last button in the Buttons block when they are centered.

## How has this been tested?
It's a pretty small change, the easiest way to test is creating a buttons block, center the buttons and verify the last one doesn't have right margin that pushes everything to the left.

## Screenshots
_Before:_
<img src="https://user-images.githubusercontent.com/3616980/85152101-e3f98900-b254-11ea-8307-ffd0a6bea000.png" width="192" alt="Before screenshot" />

_After:_
<img src="https://user-images.githubusercontent.com/3616980/85152524-65e9b200-b255-11ea-9cd2-3fb9c8ee9d90.png" width="192" alt="After screenshot" />