### PR TITLE
REST API: Sync /themes endpoint with Core's

### DIFF
--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -117,7 +117,7 @@ function gutenberg_filter_rest_prepare_theme( $response, $theme, $request ) {
 
 	foreach ( $rich_field_mappings as $field => $header ) {
 		if ( ! in_array( $field, $fields, true ) ) {
-			$data[ $field ]['raw'] = $theme->display( $header, false, true );
+			$data[ $field ]['raw']      = $theme->display( $header, false, true );
 			$data[ $field ]['rendered'] = $theme->display( $header );
 		}
 	}

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -55,7 +55,8 @@ add_filter( 'rest_request_after_callbacks', 'gutenberg_filter_oembed_result', 10
 /**
  * Add fields required for site editing to the /themes endpoint.
  *
- * @todo Remove once https://core.trac.wordpress.org/ticket/49906 is fixed.
+ * @todo Remove once Gutenberg's minimum required WordPress version is v5.5.
+ * @see https://core.trac.wordpress.org/ticket/49906
  * @see https://github.com/WordPress/wordpress-develop/pull/222
  *
  * @param WP_REST_Response $response The response object.
@@ -63,25 +64,63 @@ add_filter( 'rest_request_after_callbacks', 'gutenberg_filter_oembed_result', 10
  * @param WP_REST_Request  $request  Request object.
  */
 function gutenberg_filter_rest_prepare_theme( $response, $theme, $request ) {
-	$data           = $response->get_data();
-	$field_mappings = array(
-		'author'      => 'Author',
-		'author_name' => 'Author Name',
-		'author_uri'  => 'Author URI',
-		'description' => 'Description',
-		'name'        => 'Name',
-		'stylesheet'  => 'Stylesheet',
-		'template'    => 'Template',
-		'theme_uri'   => 'Theme URI',
-		'version'     => 'Version',
-	);
+	$data   = $response->get_data();
+	$fields = array_keys( $data );
 
-	foreach ( $field_mappings as $field => $theme_field ) {
-		$data[ $field ] = $theme[ $theme_field ];
+	/**
+	 * The following is basically copied from Core's WP_REST_Themes_Controller::prepare_item_for_response()
+	 * (as of WP v5.5), with `rest_is_field_included()` replaced by `! in_array()`.
+	 * This makes sure that we add all the fields that are missing from Core.
+	 *
+	 * @see https://github.com/WordPress/WordPress/blob/019bc2d244c4d536338d2c634419583e928143df/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php#L118-L167
+	 */
+	if ( ! in_array( 'stylesheet', $fields, true ) ) {
+		$data['stylesheet'] = $theme->get_stylesheet();
 	}
 
-	// Using $theme->get_screenshot() with no args to get absolute URL.
-	$data['screenshot'] = $theme->get_screenshot();
+	if ( ! in_array( 'template', $fields, true ) ) {
+		/**
+		 * Use the get_template() method, not the 'Template' header, for finding the template.
+		 * The 'Template' header is only good for what was written in the style.css, while
+		 * get_template() takes into account where WordPress actually located the theme and
+		 * whether it is actually valid.
+		 */
+		$data['template'] = $theme->get_template();
+	}
+
+	$plain_field_mappings = array(
+		'requires_php' => 'RequiresPHP',
+		'requires_wp'  => 'RequiresWP',
+		'textdomain'   => 'TextDomain',
+		'version'      => 'Version',
+	);
+
+	foreach ( $plain_field_mappings as $field => $header ) {
+		if ( ! in_array( $field, $fields, true ) ) {
+			$data[ $field ] = $theme->get( $header );
+		}
+	}
+
+	if ( ! in_array( 'screenshot', $fields, true ) ) {
+		// Using $theme->get_screenshot() with no args to get absolute URL.
+		$data['screenshot'] = $theme->get_screenshot() ? $theme->get_screenshot() : '';
+	}
+
+	$rich_field_mappings = array(
+		'author'      => 'Author',
+		'author_uri'  => 'AuthorURI',
+		'description' => 'Description',
+		'name'        => 'Name',
+		'tags'        => 'Tags',
+		'theme_uri'   => 'ThemeURI',
+	);
+
+	foreach ( $rich_field_mappings as $field => $header ) {
+		if ( ! in_array( $field, $fields, true ) ) {
+			$data[ $field ]['raw'] = $theme->display( $header, false, true );
+			$data[ $field ]['rendered'] = $theme->display( $header );
+		}
+	}
 
 	$response->set_data( $data );
 	return $response;

--- a/packages/edit-site/src/components/template-switcher/index.js
+++ b/packages/edit-site/src/components/template-switcher/index.js
@@ -204,7 +204,7 @@ export default function TemplateSwitcher( {
 								onMouseEnter={ onMouseEnterTheme }
 								onMouseLeave={ onMouseLeaveTheme }
 							>
-								{ currentTheme.name }
+								{ currentTheme.name.raw }
 							</MenuItem>
 						</MenuGroup>
 						{ !! hoveredTemplate?.id && (

--- a/packages/edit-site/src/components/template-switcher/theme-preview.js
+++ b/packages/edit-site/src/components/template-switcher/theme-preview.js
@@ -9,12 +9,12 @@ import { truncate } from 'lodash';
 import { __, sprintf } from '@wordpress/i18n';
 
 function ThemePreview( {
-	theme: { author_name: authorName, description, name, screenshot, version },
+	theme: { author, description, name, screenshot, version },
 } ) {
 	return (
 		<div className="edit-site-template-switcher__theme-preview">
 			<span className="edit-site-template-switcher__theme-preview-name">
-				{ name }
+				{ name.raw }
 			</span>{ ' ' }
 			<span className="edit-site-template-switcher__theme-preview-version">
 				{ 'v' + version }
@@ -22,7 +22,7 @@ function ThemePreview( {
 			<div className="edit-site-template-switcher__theme-preview-byline">
 				{
 					// translators: %s: theme author name.
-					sprintf( __( 'By %s' ), [ authorName ] )
+					sprintf( __( 'By %s' ), [ author.raw ] )
 				}
 			</div>
 			<img
@@ -31,7 +31,7 @@ function ThemePreview( {
 				alt={ 'Theme Preview' }
 			/>
 			<div className="edit-site-template-switcher__theme-preview-description">
-				{ truncate( description, {
+				{ truncate( description.raw, {
 					length: 120,
 					separator: /\. +/,
 				} ) }

--- a/packages/edit-site/src/components/template-switcher/theme-preview.js
+++ b/packages/edit-site/src/components/template-switcher/theme-preview.js
@@ -13,9 +13,13 @@ function ThemePreview( {
 } ) {
 	return (
 		<div className="edit-site-template-switcher__theme-preview">
-			<span className="edit-site-template-switcher__theme-preview-name">
-				{ name.raw }
-			</span>{ ' ' }
+			<span
+				className="edit-site-template-switcher__theme-preview-name"
+				dangerouslySetInnerHTML={ {
+					/* name.rendered is sanitized on the server side. */
+					__html: name.rendered,
+				} }
+			/>{ ' ' }
 			<span className="edit-site-template-switcher__theme-preview-version">
 				{ 'v' + version }
 			</span>
@@ -31,10 +35,14 @@ function ThemePreview( {
 				alt={ 'Theme Preview' }
 			/>
 			<div className="edit-site-template-switcher__theme-preview-description">
-				{ truncate( description.raw, {
-					length: 120,
-					separator: /\. +/,
-				} ) }
+				{ truncate(
+					/* Not using description.rendered here, as we might contain after an opening HTML tag. */
+					description.raw,
+					{
+						length: 120,
+						separator: /\. +/,
+					}
+				) }
 			</div>
 		</div>
 	);


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

In #21578, I added a few fields to Core's `/themes` endpoint, for use by the Site Editor's Template Switcher (see both #21578 and #21768). I then submitted those changes as a [PR](https://github.com/WordPress/wordpress-develop/pull/222) against Core. That PR underwent a number of modifications and was eventually merged; the new fields will be part of the `/themes` endpoint exposed by Core starting from the next WP release.

This PR updates the fields added by Gutenberg to follow the same semantics, as well as the callsites that use that endpoint.

Fixes #23054.

## How has this been tested?
Test the template switcher's theme preview as described in #21768. You need to do this both with WP 5.4, and WordPress' current `master` branch. Verify that the theme preview works in both cases.

Alternatively:
1. Check out Gutenberg's `master` branch, and make sure you're using it with WordPress' latest `master` branch.
2. Apply the following patches to disable preloading of the `/themes` endpoint, and to suppress Gutenberg's addition of fields to the `/themes` endpoint (so that we get the `/themes` endpoint to reply with the fields that are defined in Core):

```diff
diff --git a/lib/edit-site-page.php b/lib/edit-site-page.php
index 8371486663..e5a43ae479 100644
--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -187,7 +187,7 @@ function gutenberg_edit_site_init( $hook ) {
                '/wp/v2/types?context=edit',
                '/wp/v2/taxonomies?per_page=100&context=edit',
                '/wp/v2/pages?per_page=100&context=edit',
-               '/wp/v2/themes?status=active',
+               //'/wp/v2/themes?status=active',
                array( '/wp/v2/media', 'OPTIONS' ),
        );
        $preload_data  = array_reduce(
```

```diff
diff --git a/lib/rest-api.php b/lib/rest-api.php
index c0f1c2aa31..9d11fa23ce 100644
--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -126,7 +126,7 @@ function gutenberg_register_rest_block_directory() {
        $block_directory_controller = new WP_REST_Block_Directory_Controller();
        $block_directory_controller->register_routes();
 }
-add_filter( 'rest_api_init', 'gutenberg_register_rest_block_directory' );
+//add_filter( 'rest_api_init', 'gutenberg_register_rest_block_directory' );
 
 /**
  * Registers the Block types REST API routes.

```

3. Go to the Site Editor.
4. Check the Network tab for the `/themes` endpoint's response, and copy it (in JSON format) to a text editor.
5. Revert the `lib/rest-api.php` patch, but keep the `lib/edit-site-page.php` patch.
5. Switch to this branch.
6. Apply the following patch to remove all of the fields that Core's endpoint provides (except for `theme_supports`, which predates WordPress/wordpress-develop#222) in order to rely on Gutenberg to add those fields:

```
diff --git a/lib/rest-api.php b/lib/rest-api.php
index 5eccb8c3f9..a1e9409ab7 100644
--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -64,8 +64,9 @@ add_filter( 'rest_request_after_callbacks', 'gutenberg_filter_oembed_result', 10
  * @param WP_REST_Request  $request  Request object.
  */
 function gutenberg_filter_rest_prepare_theme( $response, $theme, $request ) {
-       $data   = $response->get_data();
-       $fields = array_keys( $data );
+       $theme_supports = $response->get_data()['theme_supports'];
+       $data           = array();
+       $fields         = array_keys( $data );
 
        /**
         * The following is basically copied from Core's WP_REST_Themes_Controller::prepare_item_for_response()
@@ -122,6 +123,8 @@ function gutenberg_filter_rest_prepare_theme( $response, $theme, $request ) {
                }
        }
 
+       $data['theme_supports'] = $theme_supports;
+
        $response->set_data( $data );
        return $response;
 }
```

7. Repeat step 4.
8. Compare the network responses -- they should be identical.

## Types of changes
Update to sync with Core.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
