### PR TITLE
Update no jitpack buld for monorepo

### DIFF
--- a/packages/react-native-bridge/android/build.gradle
+++ b/packages/react-native-bridge/android/build.gradle
@@ -280,10 +280,20 @@ If they are changed, the isBundleUpToDate flag is switched to false. That flag i
         onlyIf { !isBundleUpToDate() }
 
         def origFileName = 'App.js'
-        def origWithPath = "../../bundle/android/${origFileName}"
-        from origWithPath
+        def origWithPath = "$jsRootDir/bundle/android/${origFileName}"
+		from origWithPath
         into buildAssetsFolder
         rename origFileName, bundleName
+
+		// Prevent this task from silently failing
+		// Using onlyIf as a bit of a hack to perform this check at the time of execution
+		onlyIf {
+			if (inputs.sourceFiles.empty) {
+				throw new StopExecutionException("ERROR: Could not find bundle file to copy.")
+			}
+			true
+		}
+
         doLast {
             println "Done copying the Android JS bundle to assets folder"
         }
@@ -293,7 +303,7 @@ If they are changed, the isBundleUpToDate flag is switched to false. That flag i
         dependsOn bundleUpToDateCheck
         onlyIf { !isBundleUpToDate() }
 
-        delete '../../node_modules'
+        delete "$jsRootDir/node_modules"
     }
 
     task resetExtractedRNTools(type: Delete) {

--- a/packages/react-native-bridge/android/build.gradle
+++ b/packages/react-native-bridge/android/build.gradle
@@ -184,45 +184,32 @@ if (buildGutenbergMobileJSBundle) {
     def bundleName = 'index.android.bundle'
     def jsRootDir = '../../../..'
 
-    task bundleUpToDateCheck {
-        description("Checks if the inputs to the javascript bundle and the bundle itself are unchanged. \
+	task bundleUpToDateCheck {
+		description("Checks if the inputs to the javascript bundle and the bundle itself are unchanged. \
 If they are changed, the isBundleUpToDate flag is switched to false. That flag is used by other tasks.")
 
-        def isRelevantFile = { it.name.endsWithAny('.js', '.css') || it.name == 'package.json' }
-        def inputFiles = {
-            def jsFiles = []
-            def dirs = []
-            file(jsRootDir).eachDir { dir ->
-                if (dir.name != 'node_modules'
-                        && dir.name != 'bundle'
-                        && dir.name != 'gutenberg'
-                        && !dir.name.startsWith('symlinked')) {
-                    dirs << dir
-                }
-            }
-            file("$jsRootDir/gutenberg").eachDir { dir ->
-                if (dir.name != 'node_modules') {
-                    dirs << dir
-                }
-            }
+		def dirs = [jsRootDir]
+		file(jsRootDir).eachDirRecurse { dir ->
+			def isRelevantDir = !['react-native-bridge/android/build/intermediates',
+								 'node_modules'].any { dir.absolutePath.contains(it) } &&
+					dir.name != 'bundle' &&
+					!dir.name.startsWith('symlinked')
+			if (isRelevantDir) {
+				dirs << dir
+			}
+		}
 
-            dirs.forEach { dir ->
-                file(dir).eachFileRecurse {
-                    if (isRelevantFile(it)) {
-                        jsFiles << it
-                    }
-                }
-            }
+		def isRelevantFile = { it.name.endsWithAny('.js', '.css') || it.name ==~ /package(-lock)?\.json/ }
+		def inputFiles = []
+		dirs.forEach { dir ->
+			file(dir).eachFile {
+				if (isRelevantFile(it)) {
+					inputFiles << it
+				}
+			}
+		}
 
-            def jsRootDirFiles = file(jsRootDir).listFiles().findAll {
-                isRelevantFile(it)
-            }
-            def gutenbergRootDirFiles = file("$jsRootDir/gutenberg").listFiles().findAll {
-                isRelevantFile(it)
-            }
-            return jsFiles + jsRootDirFiles + gutenbergRootDirFiles
-        }
-        inputs.files(inputFiles())
+        inputs.files(inputFiles)
 
         // We cannot use the bundle file itself as an output because it does not yet exist when this
         // task finishes. Nevertheless, we have to declare something as an output because only tasks
@@ -230,11 +217,19 @@ If they are changed, the isBundleUpToDate flag is switched to false. That flag i
         // output. Since that file never exists, that "output" will always be considered "up-to-date".
         outputs.file("nonexistentfile")
 
-        // The bundle file can only be up-to-date if a bundle file exists. If this task runs, that
-        // means some of the inputs have changed, and the isBundleUpToDate flag is set back to false
-        // because the bundle should be rebuilt.
-        project.ext.isBundleUpToDate = file("$buildAssetsFolder/$bundleName").exists()
-        doLast {
+		// Using onlyIf here as a hack to run this check at the time of execution even if the task
+		// is otherwise up to date. For example, even if the task is up to date the isBundleUpToDate value
+		// should be false if the bundle file does not exist at the time this task runs. This must be run
+		// at execution time to catch the case where the clean task is also running and would remove the
+		// bundle file between the configuration phase and the execution of this task.
+		onlyIf {
+			project.ext.isBundleUpToDate = file("$buildAssetsFolder/$bundleName").exists()
+			true
+		}
+
+		// If this task runs, that means some of the inputs have changed, and the isBundleUpToDate
+		// flag needs should be false so that the bundle is rebuilt.
+		doLast {
             project.ext.isBundleUpToDate = false
         }
     }

--- a/packages/react-native-bridge/android/build.gradle
+++ b/packages/react-native-bridge/android/build.gradle
@@ -199,7 +199,7 @@ If they are changed, the isBundleUpToDate flag is switched to false. That flag i
 			}
 		}
 
-		def isRelevantFile = { it.name.endsWithAny('.js', '.css') || it.name ==~ /package(-lock)?\.json/ }
+		def isRelevantFile = { it.name.endsWithAny('.js', '.css', '.scss') || it.name ==~ /package(-lock)?\.json/ }
 		def inputFiles = []
 		dirs.forEach { dir ->
 			file(dir).eachFile {

--- a/packages/react-native-bridge/android/build.gradle
+++ b/packages/react-native-bridge/android/build.gradle
@@ -184,30 +184,30 @@ if (buildGutenbergMobileJSBundle) {
     def bundleName = 'index.android.bundle'
     def jsRootDir = '../../../..'
 
-	task bundleUpToDateCheck {
-		description("Checks if the inputs to the javascript bundle and the bundle itself are unchanged. \
+    task bundleUpToDateCheck {
+        description("Checks if the inputs to the javascript bundle and the bundle itself are unchanged. \
 If they are changed, the isBundleUpToDate flag is switched to false. That flag is used by other tasks.")
 
-		def dirs = [jsRootDir]
-		file(jsRootDir).eachDirRecurse { dir ->
-			def isRelevantDir = !['react-native-bridge/android/build/intermediates',
-					             file("$jsRootDir/bundle").absolutePath,
-								 'node_modules'].any { dir.absolutePath.contains(it) } &&
-					!dir.name.startsWith('symlinked')
-			if (isRelevantDir) {
-				dirs << dir
-			}
-		}
+        def dirs = [jsRootDir]
+        file(jsRootDir).eachDirRecurse { dir ->
+            def isRelevantDir = !['react-native-bridge/android/build/intermediates',
+                                  file("$jsRootDir/bundle").absolutePath,
+                                  'node_modules'].any { dir.absolutePath.contains(it) } &&
+                    !dir.name.startsWith('symlinked')
+            if (isRelevantDir) {
+                dirs << dir
+            }
+        }
 
-		def isRelevantFile = { it.name.endsWithAny('.js', '.css', '.scss') || it.name == 'package.json' }
-		def inputFiles = []
-		dirs.forEach { dir ->
-			file(dir).eachFile {
-				if (isRelevantFile(it)) {
-					inputFiles << it
-				}
-			}
-		}
+        def isRelevantFile = { it.name.endsWithAny('.js', '.css', '.scss') || it.name == 'package.json' }
+        def inputFiles = []
+        dirs.forEach { dir ->
+            file(dir).eachFile {
+                if (isRelevantFile(it)) {
+                    inputFiles << it
+                }
+            }
+        }
 
         inputs.files(inputFiles)
 
@@ -217,19 +217,19 @@ If they are changed, the isBundleUpToDate flag is switched to false. That flag i
         // output. Since that file never exists, that "output" will always be considered "up-to-date".
         outputs.file("nonexistentfile")
 
-		// Using onlyIf here as a hack to run this check at the time of execution even if the task
-		// is otherwise up to date. For example, even if the task is up to date the isBundleUpToDate value
-		// should be false if the bundle file does not exist at the time this task runs. This must be run
-		// at execution time to catch the case where the clean task is also running and would remove the
-		// bundle file between the configuration phase and the execution of this task.
-		onlyIf {
-			project.ext.isBundleUpToDate = file("$buildAssetsFolder/$bundleName").exists()
-			true
-		}
+        // Using onlyIf here as a hack to run this check at the time of execution even if the task
+        // is otherwise up to date. For example, even if the task is up to date the isBundleUpToDate value
+        // should be false if the bundle file does not exist at the time this task runs. This must be run
+        // at execution time to catch the case where the clean task is also running and would remove the
+        // bundle file between the configuration phase and the execution of this task.
+        onlyIf {
+            project.ext.isBundleUpToDate = file("$buildAssetsFolder/$bundleName").exists()
+            true
+        }
 
-		// If this task runs, that means some of the inputs have changed, and the isBundleUpToDate
-		// flag needs should be false so that the bundle is rebuilt.
-		doLast {
+        // If this task runs, that means some of the inputs have changed, and the isBundleUpToDate
+        // flag needs should be false so that the bundle is rebuilt.
+        doLast {
             project.ext.isBundleUpToDate = false
         }
     }
@@ -276,18 +276,18 @@ If they are changed, the isBundleUpToDate flag is switched to false. That flag i
 
         def origFileName = 'App.js'
         def origWithPath = "$jsRootDir/bundle/android/${origFileName}"
-		from origWithPath
+        from origWithPath
         into buildAssetsFolder
         rename origFileName, bundleName
 
-		// Prevent this task from silently failing
-		// Using onlyIf as a bit of a hack to perform this check at the time of execution
-		onlyIf {
-			if (inputs.sourceFiles.empty) {
-				throw new StopExecutionException("ERROR: Could not find bundle file to copy.")
-			}
-			true
-		}
+        // Prevent this task from silently failing
+        // Using onlyIf as a bit of a hack to perform this check at the time of execution
+        onlyIf {
+            if (inputs.sourceFiles.empty) {
+                throw new StopExecutionException("ERROR: Could not find bundle file to copy.")
+            }
+            true
+        }
 
         doLast {
             println "Done copying the Android JS bundle to assets folder"

--- a/packages/react-native-bridge/android/build.gradle
+++ b/packages/react-native-bridge/android/build.gradle
@@ -199,7 +199,7 @@ If they are changed, the isBundleUpToDate flag is switched to false. That flag i
 			}
 		}
 
-		def isRelevantFile = { it.name.endsWithAny('.js', '.css', '.scss') || it.name ==~ /package(-lock)?\.json/ }
+		def isRelevantFile = { it.name.endsWithAny('.js', '.css', '.scss') || it.name == 'package.json' }
 		def inputFiles = []
 		dirs.forEach { dir ->
 			file(dir).eachFile {

--- a/packages/react-native-bridge/android/build.gradle
+++ b/packages/react-native-bridge/android/build.gradle
@@ -191,8 +191,8 @@ If they are changed, the isBundleUpToDate flag is switched to false. That flag i
 		def dirs = [jsRootDir]
 		file(jsRootDir).eachDirRecurse { dir ->
 			def isRelevantDir = !['react-native-bridge/android/build/intermediates',
+					             file("$jsRootDir/bundle").absolutePath,
 								 'node_modules'].any { dir.absolutePath.contains(it) } &&
-					dir.name != 'bundle' &&
 					!dir.name.startsWith('symlinked')
 			if (isRelevantDir) {
 				dirs << dir


### PR DESCRIPTION
## Description

This PR addresses two issues that were found in the no-jitpack WPAndroid builds with the monorepo:

1. The bundle would not get included in the apk, so the app would crash upon loading the Gutenberg editor; and
2. The build was always rebuilding the bundle even when there were no changes.

In addition, while investigating the always-rebuilding issue, I discovered a problem where the bundle would not get properly generated when a build was run with the clean task. That is also fixed in this PR.

## How has this been tested?

For all of these tests:
1. the WPAndroid app must be built with wp.BUILD_GUTENBERG_FROM_SOURCE either (a) missing or (b) set to false in the `gradle.properties` file. These changes should have no effect when that variable is set to `true`; and
2. The bundler should not be running on the computer. We want to rely solely on the bundle that is included in the apk when testing this PR.

This is just a proposed set of commands that should cover all of the edge cases I have encountered, but it's not a bad idea to try different combinations since that could catch something I missed. All these commands should be run from the monorepo branch for WPAndroid, but with this `fix_no_jitpack_build` branch checked out for gutenberg.

1. Clean the project: `./gradlew clean`
2. Build and install: `./gradlew installWasabiDebug`
3. Run the app and confirm you can open the Gutenberg editor without crashing (establishes that the bundle is being included in the apk)
4. Build the app again with the same command `./gradlew installWasabiDebug`
5. Observe that this build takes under 1 minute whereas the first build took multiple minutes because this build is not regenerating the bundle file (establishes that the build detected there were no changes that would affect the bundle file)
6. Edit any file within the gutenberg-mobile or gutenberg projects that should alter the resulting bundle _other than_ a file within a `node_modules/` folder (the build is just checking the package.json and package-lock.json files for dependency changes).
7. Build the app again with the same command `./gradlew installWasabiDebug`
8. Observe that the app takes multiple minute to build this time because it detected the change and is regenerating the bundle (establishes that the build detected there were no changes that would affect the bundle file).
9. Run clean, build, and install in a single command: `./gradlew clean installWasabiDebug`
10. Run the app and confirm you can open the Gutenberg editor without crashing (establishes does not just check whether the bundle file exists at the beginning of the build, but instead checks it after the "clean" task has run).
11. Try building the `Vanilla` variant. Ideally, do a release build, but if your environment isn't set up for that a debug build is fine: `./gradlew installVanillaRelease`
12. Run the app and confirm you can open the Gutenberg editor without crashing.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [X] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
