### PR TITLE
inherit templateLock in column block

### DIFF
--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -81,7 +81,6 @@ function ColumnEdit( {
 				</PanelBody>
 			</InspectorControls>
 			<InnerBlocks
-				templateLock={ false }
 				renderAppender={
 					hasChildBlocks
 						? undefined

--- a/packages/e2e-tests/plugins/cpt-locking.php
+++ b/packages/e2e-tests/plugins/cpt-locking.php
@@ -20,7 +20,36 @@ function gutenberg_test_cpt_locking() {
 			),
 		),
 		array( 'core/quote' ),
-		array( 'core/columns' ),
+		array(
+			'core/columns',
+			array(),
+			array(
+				array(
+					'core/column',
+					array(),
+					array(
+						array(
+							'core/paragraph',
+							array(
+								'placeholder' => 'Add a description',
+							),
+						),
+					),
+				),
+				array(
+					'core/column',
+					array(),
+					array(
+						array(
+							'core/paragraph',
+							array(
+								'placeholder' => 'Add a description',
+							),
+						),
+					),
+				),
+			),
+		),
 	);
 	register_post_type(
 		'locked-all-post',

--- a/packages/e2e-tests/specs/editor/plugins/__snapshots__/cpt-locking.test.js.snap
+++ b/packages/e2e-tests/specs/editor/plugins/__snapshots__/cpt-locking.test.js.snap
@@ -14,7 +14,17 @@ exports[`cpt locking template_lock all should not error when deleting the cotent
 <!-- /wp:quote -->
 
 <!-- wp:columns -->
-<div class=\\"wp-block-columns\\"></div>
+<div class=\\"wp-block-columns\\"><!-- wp:column -->
+<div class=\\"wp-block-column\\"><!-- wp:paragraph {\\"placeholder\\":\\"Add a description\\"} -->
+<p></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class=\\"wp-block-column\\"><!-- wp:paragraph {\\"placeholder\\":\\"Add a description\\"} -->
+<p></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
 <!-- /wp:columns -->"
 `;
 
@@ -32,7 +42,17 @@ exports[`cpt locking template_lock false should allow blocks to be inserted 1`] 
 <!-- /wp:quote -->
 
 <!-- wp:columns -->
-<div class=\\"wp-block-columns\\"></div>
+<div class=\\"wp-block-columns\\"><!-- wp:column -->
+<div class=\\"wp-block-column\\"><!-- wp:paragraph {\\"placeholder\\":\\"Add a description\\"} -->
+<p></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class=\\"wp-block-column\\"><!-- wp:paragraph {\\"placeholder\\":\\"Add a description\\"} -->
+<p></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
 <!-- /wp:columns -->
 
 <!-- wp:list -->
@@ -54,7 +74,17 @@ exports[`cpt locking template_lock false should allow blocks to be moved 1`] = `
 <!-- /wp:quote -->
 
 <!-- wp:columns -->
-<div class=\\"wp-block-columns\\"></div>
+<div class=\\"wp-block-columns\\"><!-- wp:column -->
+<div class=\\"wp-block-column\\"><!-- wp:paragraph {\\"placeholder\\":\\"Add a description\\"} -->
+<p></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class=\\"wp-block-column\\"><!-- wp:paragraph {\\"placeholder\\":\\"Add a description\\"} -->
+<p></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
 <!-- /wp:columns -->"
 `;
 
@@ -68,7 +98,17 @@ exports[`cpt locking template_lock false should allow blocks to be removed 1`] =
 <!-- /wp:quote -->
 
 <!-- wp:columns -->
-<div class=\\"wp-block-columns\\"></div>
+<div class=\\"wp-block-columns\\"><!-- wp:column -->
+<div class=\\"wp-block-column\\"><!-- wp:paragraph {\\"placeholder\\":\\"Add a description\\"} -->
+<p></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class=\\"wp-block-column\\"><!-- wp:paragraph {\\"placeholder\\":\\"Add a description\\"} -->
+<p></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
 <!-- /wp:columns -->"
 `;
 
@@ -86,6 +126,16 @@ exports[`cpt locking template_lock insert should allow blocks to be moved 1`] = 
 <!-- /wp:quote -->
 
 <!-- wp:columns -->
-<div class=\\"wp-block-columns\\"></div>
+<div class=\\"wp-block-columns\\"><!-- wp:column -->
+<div class=\\"wp-block-column\\"><!-- wp:paragraph {\\"placeholder\\":\\"Add a description\\"} -->
+<p></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class=\\"wp-block-column\\"><!-- wp:paragraph {\\"placeholder\\":\\"Add a description\\"} -->
+<p></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
 <!-- /wp:columns -->"
 `;

--- a/packages/e2e-tests/specs/editor/plugins/cpt-locking.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/cpt-locking.test.js
@@ -104,22 +104,11 @@ describe( 'cpt locking', () => {
 			);
 		} );
 
-		it( 'can use the global inserter in inner blocks', async () => {
-			await page.click( 'button[aria-label="Two columns; equal split"]' );
+		it( 'should disable the inserter in inner blocks', async () => {
 			await page.click(
-				'.wp-block-column .block-editor-button-block-appender'
+				'.wp-block-column .block-editor-block-list__block[data-type="core/paragraph"]'
 			);
-			await page.type( '.block-editor-inserter__search-input', 'image' );
-			await pressKeyTimes( 'Tab', 2 );
-			await page.keyboard.press( 'Enter' );
-			await page.click( '.edit-post-header-toolbar__inserter-toggle' );
-			await page.type(
-				'.block-editor-inserter__search-input',
-				'gallery'
-			);
-			await pressKeyTimes( 'Tab', 2 );
-			await page.keyboard.press( 'Enter' );
-			expect( await page.$( '.wp-block-gallery' ) ).not.toBeNull();
+			shouldDisableTheInserter();
 		} );
 	} );
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

Second take on #17301 since #20465 was merged. As described in #17301 and #17262, when having `template_lock = 'all'` on a post template, the column blocks are not locked and allow any block to be inserted.

Now that the columns block doesn't explicitly set a `templateLock` the fix to inherit the locking settings seems to be as easy as removing the override in the Column block. 

## How has this been tested?

1. Added a template to the `post` post type.
```php
add_action('init', function () {
    $post_type_object = get_post_type_object('post');
    $post_type_object->template = [
      [ 'core/paragraph', [
        'placeholder' => 'test'
      ] ],
      [ 'core/columns', [ 'align' => 'wide' ], [
        [ 'core/column', [], [
          [ 'core/paragraph', [ 'placeholder' => 'col 1' ] ]
        ] ],
        [ 'core/column', [], [
          [ 'core/paragraph', [ 'placeholder' => 'col 2' ] ]
        ] ],
      ] ]
    ];
    $post_type_object->template_lock = 'all';
});
```

2. Create a new post and notice how the template is present and you cannot add new blocks within the column block.
3. Manually edit HTML content of a column, adding another paragraph and notice that _The content of your post doesn’t match the template assigned to your post type_ notice allowing you to reset the template.

## Screenshots <!-- if applicable -->

## Types of changes

Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
