### PR TITLE
fix #22550 and allow enter to insert line breaks even if template is locked

### DIFF
--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -248,7 +248,8 @@ const BlockComponent = forwardRef(
 				data-block={ clientId }
 				data-type={ name }
 				data-title={ blockTitle }
-				onKeyDown={ onKeyDown }
+				// Only allow shortcuts when a blocks is selected.
+				onKeyDown={ isSelected ? onKeyDown : undefined }
 				// Only allow selection to be started from a selected block.
 				onMouseLeave={ isSelected ? onMouseLeave : undefined }
 				// No need to have these listeners for hover class in edit mode.

--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -45,7 +45,6 @@ const BlockComponent = forwardRef(
 			enableAnimation,
 			index,
 			className,
-			isLocked,
 			name,
 			mode,
 			blockTitle,
@@ -249,8 +248,7 @@ const BlockComponent = forwardRef(
 				data-block={ clientId }
 				data-type={ name }
 				data-title={ blockTitle }
-				// Only allow shortcuts when a blocks is selected and not locked.
-				onKeyDown={ isSelected && ! isLocked ? onKeyDown : undefined }
+				onKeyDown={ onKeyDown }
 				// Only allow selection to be started from a selected block.
 				onMouseLeave={ isSelected ? onMouseLeave : undefined }
 				// No need to have these listeners for hover class in edit mode.

--- a/packages/e2e-tests/specs/editor/plugins/__snapshots__/cpt-locking.test.js.snap
+++ b/packages/e2e-tests/specs/editor/plugins/__snapshots__/cpt-locking.test.js.snap
@@ -1,5 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`cpt locking template_lock all should insert line breaks when using enter and shift-enter 1`] = `
+"<!-- wp:image -->
+<figure class=\\"wp-block-image\\"><img alt=\\"\\"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {\\"placeholder\\":\\"Add a description\\"} -->
+<p>First line<br>Second line<br>Third line</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\"><p></p></blockquote>
+<!-- /wp:quote -->
+
+<!-- wp:columns -->
+<div class=\\"wp-block-columns\\"></div>
+<!-- /wp:columns -->"
+`;
+
 exports[`cpt locking template_lock all should not error when deleting the cotents of a paragraph 1`] = `
 "<!-- wp:image -->
 <figure class=\\"wp-block-image\\"><img alt=\\"\\"/></figure>

--- a/packages/e2e-tests/specs/editor/plugins/cpt-locking.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/cpt-locking.test.js
@@ -9,6 +9,7 @@ import {
 	getEditedPostContent,
 	insertBlock,
 	pressKeyTimes,
+	pressKeyWithModifier,
 	setPostContent,
 } from '@wordpress/e2e-test-utils';
 
@@ -82,6 +83,18 @@ describe( 'cpt locking', () => {
 			const textToType = 'Paragraph';
 			await page.keyboard.type( 'Paragraph' );
 			await pressKeyTimes( 'Backspace', textToType.length + 1 );
+			expect( await getEditedPostContent() ).toMatchSnapshot();
+		} );
+
+		it( 'should insert line breaks when using enter and shift-enter', async () => {
+			await page.click(
+				'.block-editor-block-list__block[data-type="core/paragraph"]'
+			);
+			await page.keyboard.type( 'First line' );
+			await pressKeyTimes( 'Enter', 1 );
+			await page.keyboard.type( 'Second line' );
+			await pressKeyWithModifier( 'shift', 'Enter' );
+			await page.keyboard.type( 'Third line' );
 			expect( await getEditedPostContent() ).toMatchSnapshot();
 		} );
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

See #22550. I have no idea what I'm doing, I'm just opening up this PR for discussion and the off chance that this is actually okay. Ping @ellatrix or someone who actually knows what's happening in this flow should have a look.

Note that this is how it used to work at least some versions back.

## How has this been tested?

1. Added a template to the post post type.

```php
add_action('init', function () {
    $post_type_object = get_post_type_object('post');
    $post_type_object->template = [
      [ 'core/paragraph', [
        'placeholder' => 'test'
      ] ],
      [ 'core/list', [
        'placeholder' => 'test'
      ] ],
    ];
    $post_type_object->template_lock = 'all';
});
```

2. Pressed enter and shift-enter to check that both add a soft line break.
3. Press backspace and ensure the block is not removed.

## Screenshots <!-- if applicable -->

## Types of changes

Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
