### PR TITLE
Memoize useSelect callbacks on the header toolbar items

### DIFF
--- a/packages/editor/src/components/editor-history/redo.js
+++ b/packages/editor/src/components/editor-history/redo.js
@@ -9,8 +9,9 @@ import { redo as redoIcon } from '@wordpress/icons';
 import { forwardRef } from '@wordpress/element';
 
 function EditorHistoryRedo( props, ref ) {
-	const hasRedo = useSelect( ( select ) =>
-		select( 'core/editor' ).hasEditorRedo()
+	const hasRedo = useSelect(
+		( select ) => select( 'core/editor' ).hasEditorRedo(),
+		[]
 	);
 	const { redo } = useDispatch( 'core/editor' );
 	return (

--- a/packages/editor/src/components/editor-history/undo.js
+++ b/packages/editor/src/components/editor-history/undo.js
@@ -9,8 +9,9 @@ import { undo as undoIcon } from '@wordpress/icons';
 import { forwardRef } from '@wordpress/element';
 
 function EditorHistoryUndo( props, ref ) {
-	const hasUndo = useSelect( ( select ) =>
-		select( 'core/editor' ).hasEditorUndo()
+	const hasUndo = useSelect(
+		( select ) => select( 'core/editor' ).hasEditorUndo(),
+		[]
 	);
 	const { undo } = useDispatch( 'core/editor' );
 	return (

--- a/packages/editor/src/components/table-of-contents/index.js
+++ b/packages/editor/src/components/table-of-contents/index.js
@@ -14,7 +14,8 @@ import TableOfContentsPanel from './panel';
 
 function TableOfContents( { hasOutlineItemsDisabled, ...props }, ref ) {
 	const hasBlocks = useSelect(
-		( select ) => !! select( 'core/block-editor' ).getBlockCount()
+		( select ) => !! select( 'core/block-editor' ).getBlockCount(),
+		[]
 	);
 	return (
 		<Dropdown

--- a/packages/editor/src/components/table-of-contents/panel.js
+++ b/packages/editor/src/components/table-of-contents/panel.js
@@ -19,7 +19,8 @@ function TableOfContentsPanel( { hasOutlineItemsDisabled, onRequestClose } ) {
 				paragraphCount: getGlobalBlockCount( 'core/paragraph' ),
 				numberOfBlocks: getGlobalBlockCount(),
 			};
-		}
+		},
+		[]
 	);
 	return (
 		/*


### PR DESCRIPTION
This PR is a follow-up to #23315 and addresses https://github.com/WordPress/gutenberg/pull/23315#discussion_r443133713

## How to test

Check if Undo/Redo and the Table Of Contents buttons on the header toolbar are working properly.