### PR TITLE
RichText: Documented missing parameters for isEmpty and isEmptyLine

### DIFF
--- a/packages/rich-text/README.md
+++ b/packages/rich-text/README.md
@@ -183,12 +183,13 @@ _Returns_
 
 <a name="isEmpty" href="#isEmpty">#</a> **isEmpty**
 
-Check if a Rich Text value is Empty, meaning it contains no text or any
+Check if a Rich Text value is empty, meaning it contains no text or any
 objects (such as images).
 
 _Parameters_
 
--   _value_ `Object`: Value to use.
+-   _value_ `Object`: Object containing the value that should be checked.
+-   _value.text_ `string`: The text that should be check.
 
 _Returns_
 

--- a/packages/rich-text/README.md
+++ b/packages/rich-text/README.md
@@ -189,7 +189,7 @@ objects (such as images).
 _Parameters_
 
 -   _value_ `Object`: Object containing the value that should be checked.
--   _value.text_ `string`: The text that should be check.
+-   _value.text_ `string`: The text that should be checked.
 
 _Returns_
 

--- a/packages/rich-text/src/is-empty.js
+++ b/packages/rich-text/src/is-empty.js
@@ -9,7 +9,7 @@ import { LINE_SEPARATOR } from './special-characters';
  *
  * @param {Object}      value           Object containing the value that
  *                                      should be checked.
- * @param {string}      value.text      The text that should be check.
+ * @param {string}      value.text      The text that should be checked.
  *
  * @return {boolean}    True if the value is empty, false if not.
  */

--- a/packages/rich-text/src/is-empty.js
+++ b/packages/rich-text/src/is-empty.js
@@ -11,7 +11,7 @@ import { LINE_SEPARATOR } from './special-characters';
  *                                      should be checked.
  * @param {string}      value.text      The text that should be checked.
  *
- * @return {boolean}    True if the value is empty, false if not.
+ * @return {boolean} True if the value is empty, false if not.
  */
 export function isEmpty( { text } ) {
 	return text.length === 0;

--- a/packages/rich-text/src/is-empty.js
+++ b/packages/rich-text/src/is-empty.js
@@ -23,7 +23,7 @@ export function isEmpty( { text } ) {
  *
  * @param {Object}      value           Object containing the value that
  *                                      should be checked.
- * @param {string}      value.text      The text that should be check.
+ * @param {string}      value.text      The text that should be checked.
  * @param {number}      value.start     The starting index
  * @param {number}      value.end       The ending index
  *

--- a/packages/rich-text/src/is-empty.js
+++ b/packages/rich-text/src/is-empty.js
@@ -4,12 +4,14 @@
 import { LINE_SEPARATOR } from './special-characters';
 
 /**
- * Check if a Rich Text value is Empty, meaning it contains no text or any
+ * Check if a Rich Text value is empty, meaning it contains no text or any
  * objects (such as images).
  *
- * @param {Object} value Value to use.
+ * @param {Object}      value           Object containing the value that
+ *                                      should be checked.
+ * @param {string}      value.text      The text that should be check.
  *
- * @return {boolean} True if the value is empty, false if not.
+ * @return {boolean}    True if the value is empty, false if not.
  */
 export function isEmpty( { text } ) {
 	return text.length === 0;
@@ -19,7 +21,11 @@ export function isEmpty( { text } ) {
  * Check if the current collapsed selection is on an empty line in case of a
  * multiline value.
  *
- * @param  {Object} value Value te check.
+ * @param {Object}      value           Object containing the value that
+ *                                      should be checked.
+ * @param {string}      value.text      The text that should be check.
+ * @param {number}      value.start     The starting index
+ * @param {number}      value.end       The ending index
  *
  * @return {boolean} True if the line is empty, false if not.
  */

--- a/packages/rich-text/src/is-empty.js
+++ b/packages/rich-text/src/is-empty.js
@@ -7,9 +7,9 @@ import { LINE_SEPARATOR } from './special-characters';
  * Check if a Rich Text value is empty, meaning it contains no text or any
  * objects (such as images).
  *
- * @param {Object}      value           Object containing the value that
- *                                      should be checked.
- * @param {string}      value.text      The text that should be checked.
+ * @param {Object} value      Object containing the value that
+ *                            should be checked.
+ * @param {string} value.text The text that should be checked.
  *
  * @return {boolean} True if the value is empty, false if not.
  */
@@ -21,11 +21,11 @@ export function isEmpty( { text } ) {
  * Check if the current collapsed selection is on an empty line in case of a
  * multiline value.
  *
- * @param {Object}      value           Object containing the value that
- *                                      should be checked.
- * @param {string}      value.text      The text that should be checked.
- * @param {number}      value.start     The starting index
- * @param {number}      value.end       The ending index
+ * @param {Object} value       Object containing the value that
+ *                             should be checked.
+ * @param {string} value.text  The text that should be checked.
+ * @param {number} value.start The starting index
+ * @param {number} value.end   The ending index
  *
  * @return {boolean} True if the line is empty, false if not.
  */


### PR DESCRIPTION
See #22907.

## Description
Fixed the JSDoc warnings in  file packages/rich-text/src/is-empty.js

   6:1  warning  Missing JSDoc @param "value.text" declaration   jsdoc/require-param
  10:0  warning  Missing @param "value.text"                     jsdoc/check-param-names
  18:1  warning  Missing JSDoc @param "value.text" declaration   jsdoc/require-param
  18:1  warning  Missing JSDoc @param "value.start" declaration  jsdoc/require-param
  18:1  warning  Missing JSDoc @param "value.end" declaration    jsdoc/require-param
  22:0  warning  Missing @param "value.text"                     jsdoc/check-param-names
  22:0  warning  Missing @param "value.start"                    jsdoc/check-param-names
  22:0  warning  Missing @param "value.end"                      jsdoc/check-param-names

✖ 8 problems (0 errors, 8 warnings)
  0 errors and 4 warnings potentially fixable with the `--fix` option.
  
  
## How has this been tested?
npm run lint-js packages/rich-text/src/is-empty.js

## Types of changes
Bug fix