### PR TITLE
Fix inline images within wide/full Image block captions shown with full width

### DIFF
--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -10,10 +10,6 @@ figure.wp-block-image:not(.wp-block) {
 		opacity: 0.3;
 	}
 
-	figcaption img {
-		display: inline;
-	}
-
 	// Shown while image is being uploaded
 	.components-spinner {
 		position: absolute;

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -11,8 +11,8 @@
 		text-align: center;
 	}
 
-	&.alignfull img,
-	&.alignwide img {
+	&.alignfull > img,
+	&.alignwide > img {
 		width: 100%;
 	}
 

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -58,6 +58,10 @@
 	// so we supply the styles so as to not appear broken or unstyled in those themes.
 	figcaption {
 		@include caption-style();
+
+		img {
+			display: inline;
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

Fixes #22808 by not letting alingwide and alignfull `width: 100%` css style target inline images within captions. The use case of the issue is LaTeX which is added through JetPack but there could potentially be other plugins doing something similar so I'd say it's good to tighten this selector. The specificity of the selector remains the same even with the `>`-selector.

Gutenberg also supports inline images in the captions but the bug did not appear since they always have a explicitly set `width`.

I also ensured that inline images within captions are actually inlined (on the editor side this was already done). Technically this is a bug from Twentytwenty theme because it sets `img { display: block }` and doesnt override it for images within captions. But I don't see why this couldnt be a default set in Gutenberg?

One question is, does this break any legacy image markup from the early days of Gutenberg?

## How has this been tested?

Tested by enabling JetPack, adding a wide aligned image block and using `$latex d_f$` as a caption.

## Screenshots

<img width="1055" alt="Screen Shot 2020-06-20 at 14 46 25" src="https://user-images.githubusercontent.com/302736/85208341-e5cf5500-b305-11ea-9017-a180bb2eff2e.png">

<img width="1012" alt="Screen Shot 2020-06-20 at 14 46 56" src="https://user-images.githubusercontent.com/302736/85208338-e0720a80-b305-11ea-8b79-a67f57ede4e8.png">


## Types of changes

Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
