### PR TITLE
@wordpress/env - add login details to docs

### DIFF
--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -12,7 +12,7 @@ $ npm -g i @wordpress/env
 $ wp-env start
 ```
 
-The local environment will be available at http://localhost:8888.
+The local environment will be available at http://localhost:8888 (Username: `admin`, Password: `password`).
 
 ## Prerequisites
 


### PR DESCRIPTION
## Description
Closes #23147.

I updated the README.md with credentials in similar manner to what is presented in [Getting Started | Block Editor Handbook](https://developer.wordpress.org/block-editor/contributors/develop/getting-started/#step-2-accessing-and-configuring-the-local-wordpress-install).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
