### PR TITLE
Block Directory: Missing padding -> layout fixes

### DIFF
--- a/packages/block-directory/src/components/downloadable-block-list-item/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-list-item/style.scss
@@ -23,6 +23,10 @@
 	border-top: 0;
 }
 
+.block-directory-downloadable-block-list-item:last-child {
+	border-bottom: 0;
+}
+
 .block-directory-downloadable-block-list-item__panel {
 	display: flex;
 	flex-grow: 1;

--- a/packages/block-directory/src/components/downloadable-blocks-panel/style.scss
+++ b/packages/block-directory/src/components/downloadable-blocks-panel/style.scss
@@ -8,9 +8,10 @@
 }
 
 .block-directory-downloadable-blocks-panel__description.has-no-results {
+	$no-result-padding: $grid-unit-20 * 7;
 	font-style: normal;
 	padding: 0;
-	margin-top: 100px;
+	margin: $no-result-padding 0;
 	text-align: center;
 	color: $dark-gray-400;
 	.components-spinner {


### PR DESCRIPTION
## Description
This PR fixes layout issues with Block Directory component(s) that were introduced when the Gutenberg `Tip` in the inserter is no longer fixed. As a result the css needs to be updated to reflect these changes.




## How has this been tested?
Tested locally by searching for something in the block directory and observing the layout.

## Screenshots <!-- if applicable -->
|  Results | Before  | After |
| ------------- | ------------- | ------------- |
| Empty Results | ![](https://d.pr/i/kbxY0x.png)  | ![](https://d.pr/i/7tFGPt.png) |
| While Searching  | ![](https://d.pr/i/tMaKGB.png)  | ![](https://d.pr/i/XTsvJ5.png) |
| With Results  | ![](https://d.pr/i/g2cZKu.png)  | ![](https://d.pr/i/iHX554.png) |


## Types of changes
- Adding bottom margin to the loader/empty result container
- Remove the border on last item search item. 


## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
