### PR TITLE
[RNMobile] Replace panel-padding in favour of gird-unit

### DIFF
--- a/packages/components/src/custom-gradient-picker/style.native.scss
+++ b/packages/components/src/custom-gradient-picker/style.native.scss
@@ -1,3 +1,3 @@
 .angleControl {
-	padding-top: $panel-padding / 2;
+	padding-top: $grid-unit-20 / 2;
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

Replaced `$panel-padding` in favour of `$grid-unit-20` after merged [PR](https://github.com/WordPress/gutenberg/pull/23202)

## How has this been tested?

1. Run the mobile app
2. App mustn't crash

## Screenshots <!-- if applicable -->

## Types of changes

Replaced `$panel-padding` in favour of `$grid-unit-20`.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
