### PR TITLE
Add new command for pre-releasing npm packages 

### DIFF
--- a/bin/plugin/cli.js
+++ b/bin/plugin/cli.js
@@ -9,7 +9,10 @@ const program = require( 'commander' );
  * Internal dependencies
  */
 const { releaseRC, releaseStable } = require( './commands/release' );
-const { prepublishNpmStablePackages } = require( './commands/packages' );
+const {
+	prepareLatestDistTag,
+	prepareNextDistTag,
+} = require( './commands/packages' );
 const { getReleaseChangelog } = require( './commands/changelog' );
 const { runPerformanceTests } = require( './commands/performance' );
 
@@ -28,12 +31,20 @@ program
 	.action( releaseStable );
 
 program
-	.command( 'prepublish-packages-stable' )
+	.command( 'prepare-packages-stable' )
 	.alias( 'npm-stable' )
 	.description(
-		'Prepublish to npm steps for the next stable version of WordPress packages'
+		'Prepares the packages to be published to npm as stable (latest dist-tag, production version)'
 	)
-	.action( prepublishNpmStablePackages );
+	.action( prepareLatestDistTag );
+
+program
+	.command( 'prepare-packages-rc' )
+	.alias( 'npm-rc' )
+	.description(
+		'Prepares the packages to be published to npm as RC (next dist-tag, RC version)'
+	)
+	.action( prepareNextDistTag );
 
 program
 	.command( 'release-plugin-changelog' )

--- a/bin/plugin/commands/packages.js
+++ b/bin/plugin/commands/packages.js
@@ -288,22 +288,40 @@ async function prepublishPackages( minimumVersionBump ) {
 	await runCleanLocalFoldersStep( temporaryFolders, abortMessage );
 }
 
-async function prepublishNpmStablePackages() {
+async function prepareLatestDistTag() {
 	log(
 		formats.title(
 			'\n💃 Time to publish WordPress packages to npm 🕺\n\n'
 		),
-		'Welcome! This tool is going to help you with prepublish to npm steps for the next stable version of WordPress packages.\n',
+		'Welcome! This tool is going to help you with preparing everything for publishing a new stable version of WordPress packages.\n',
 		"To perform a release you'll have to be a member of the WordPress Team on npm.\n"
 	);
 
 	await prepublishPackages( 'minor' );
 
 	log(
-		'\n>> 🎉 WordPress packages are ready to publish.\n',
-		'Thanks for performing the prepublish process! You still need to run "npm run publish:prod" to perform the actual release.\n',
+		'\n>> 🎉 WordPress packages are ready to publish!\n',
+		'You need to run "npm run publish:prod" to release them to npm.\n',
 		'Let also people know on WordPress Slack when everything is finished.\n'
 	);
 }
 
-module.exports = { prepublishNpmStablePackages };
+async function prepareNextDistTag() {
+	log(
+		formats.title(
+			'\n💃 Time to publish WordPress packages to npm 🕺\n\n'
+		),
+		'Welcome! This tool is going to help you with preparing everything for publishing a new RC version of WordPress packages.\n',
+		"To perform a release you'll have to be a member of the WordPress Team on npm.\n"
+	);
+
+	await prepublishPackages( 'minor' );
+
+	log(
+		'\n>> 🎉 WordPress packages are ready to publish!\n',
+		'You need to run "npm run publish:dev" to release them to npm.\n',
+		'Let also people know on WordPress Slack when everything is finished.\n'
+	);
+}
+
+module.exports = { prepareLatestDistTag, prepareNextDistTag };

--- a/bin/plugin/commands/packages.js
+++ b/bin/plugin/commands/packages.js
@@ -88,7 +88,7 @@ async function runWordPressReleaseBranchSyncStep(
  *
  * @param {string} gitWorkingDirectoryPath Git working directory path.
  * @param {string} minimumVersionBump      Minimum version bump for the packages.
- * @param {boolean} isPrerelease           Whether the package version to publish is a pre-release.
+ * @param {boolean} isPrerelease           Whether the package version to publish is a prerelease.
  * @param {string} abortMessage            Abort Message.
  */
 async function updatePackages(
@@ -208,7 +208,9 @@ async function updatePackages(
 					changelogPath,
 					content.replace(
 						'## Unreleased',
-						`## Unreleased\n\n## ${ nextVersion }-rc.1 (${ publishDate })`
+						`## Unreleased\n\n## ${
+							isPrerelease ? nextVersion + '-rc.1' : nextVersion
+						} (${ publishDate })`
 					)
 				);
 
@@ -216,7 +218,9 @@ async function updatePackages(
 				const packageJson = readJSONFile( packageJSONPath );
 				const newPackageJson = {
 					...packageJson,
-					version: isPrerelease ? 'pre' + nextVersion : nextVersion,
+					version: isPrerelease
+						? '-prerelease' + nextVersion
+						: nextVersion,
 				};
 				fs.writeFileSync(
 					packageJSONPath,
@@ -298,8 +302,8 @@ async function prepareForPackageRelease( minimumVersionBump, isPrerelease ) {
 	await updatePackages(
 		gitWorkingDirectoryPath,
 		minimumVersionBump,
-		abortMessage,
-		isPrerelease
+		isPrerelease,
+		abortMessage
 	);
 
 	// Push the local changes


### PR DESCRIPTION
Explore adding a new command  `npm-rc` to release npm packages to the `next` tag as pre-release.

TODO:

- Investigate whether lerna can manage to update the package versions itself.
