### PR TITLE
Clarify the wp-block-styles documentation

### DIFF
--- a/docs/designers-developers/developers/themes/theme-support.md
+++ b/docs/designers-developers/developers/themes/theme-support.md
@@ -49,7 +49,7 @@ add_action( 'after_setup_theme', 'mytheme_setup_theme_supported_features' );
 
 ## Default block styles
 
-Core blocks include default structural styles. These are loaded in both the editor and the front end by default. An example of these styles is the CSS grid rules that power the columns block. Without these rules, the block would break entirely on the front end. 
+Core blocks include default structural styles. These are loaded in both the editor and the front end by default. An example of these styles is the CSS that powers the columns block. Without these rules, the block would break entirely on the front end. 
 
 The block editor also allows themes to opt-in to some slightly more opinionated styles for the front end. An example of these styles is the default color bar to the left of blockquotes. If you'd like to use these opinionated styles in your theme, add theme support for `wp-block-styles`:
 

--- a/docs/designers-developers/developers/themes/theme-support.md
+++ b/docs/designers-developers/developers/themes/theme-support.md
@@ -51,7 +51,7 @@ add_action( 'after_setup_theme', 'mytheme_setup_theme_supported_features' );
 
 Core blocks include default structural styles. These are loaded in both the editor and the front end by default. An example of these styles is the CSS that powers the columns block. Without these rules, the block would break entirely on the front end. 
 
-The block editor also allows themes to opt-in to some slightly more opinionated styles for the front end. An example of these styles is the default color bar to the left of blockquotes. If you'd like to use these opinionated styles in your theme, add theme support for `wp-block-styles`:
+The block editor allows themes to opt-in to slightly more opinionated styles for the front end. An example of these styles is the default color bar to the left of blockquotes. If you'd like to use these opinionated styles in your theme, add theme support for `wp-block-styles`:
 
 ```php
 add_theme_support( 'wp-block-styles' );

--- a/docs/designers-developers/developers/themes/theme-support.md
+++ b/docs/designers-developers/developers/themes/theme-support.md
@@ -49,7 +49,7 @@ add_action( 'after_setup_theme', 'mytheme_setup_theme_supported_features' );
 
 ## Default block styles
 
-Core blocks include default structural styles. These are loaded in both the editor and the front end by default. An example of these styles is the CSS that powers the columns block. Without these rules, the block would break entirely on the front end. 
+Core blocks include default structural styles. These are loaded in both the editor and the front end by default. An example of these styles is the CSS that powers the columns block. Without these rules, the block would result in a broken layout containing no columns at all.
 
 The block editor allows themes to opt-in to slightly more opinionated styles for the front end. An example of these styles is the default color bar to the left of blockquotes. If you'd like to use these opinionated styles in your theme, add theme support for `wp-block-styles`:
 

--- a/docs/designers-developers/developers/themes/theme-support.md
+++ b/docs/designers-developers/developers/themes/theme-support.md
@@ -49,7 +49,9 @@ add_action( 'after_setup_theme', 'mytheme_setup_theme_supported_features' );
 
 ## Default block styles
 
-Core blocks include default styles. The styles are enqueued for editing but are not enqueued for viewing unless the theme opts-in to the core styles. If you'd like to use default styles in your theme, add theme support for `wp-block-styles`:
+Core blocks include default structural styles. These are loaded in both the editor and the front end by default. An example of these styles is the CSS grid rules that power the columns block. Without these rules, the block would break entirely on the front end. 
+
+The block editor also allows themes to opt-in to some slightly more opinionated styles for the front end. An example of these styles is the default color bar to the left of blockquotes. If you'd like to use these opinionated styles in your theme, add theme support for `wp-block-styles`:
 
 ```php
 add_theme_support( 'wp-block-styles' );


### PR DESCRIPTION
This PR adds some clarification to the `wp-block-styles` documentation. 

Previously, it stated:

> Core blocks include default styles. The styles are enqueued for editing but are not enqueued for viewing unless the theme opts-in to the core styles. If you’d like to use default styles in your theme, add theme support for `wp-block-styles`

This is misleading, since what most folks would consider "default" styles (from `style.css`) _are_ enqueued by default. The opt-in actually applies only to the more opinionated styles in `theme.css`. This PR makes that distinction more clear: 

> Core blocks include default structural styles. These are loaded in both the editor and the front end by default. An example of these styles is the CSS that powers the columns block. Without these rules, the block would break entirely on the front end. 
> 
> The block editor allows themes to opt-in to slightly more opinionated styles for the front end. An example of these styles is the default color bar to the left of blockquotes. If you'd like to use these opinionated styles in your theme, add theme support for `wp-block-styles`