### PR TITLE
fix: [#23258] Nav text size is no longer overwritten

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -43,8 +43,6 @@
 		visibility: hidden;
 
 		> .wp-block-navigation-link {
-			font-size: 15px;
-
 			> .wp-block-navigation-link__content {
 				flex-grow: 1;
 			}
@@ -117,7 +115,6 @@
 }
 
 .wp-block-navigation-link__label {
-	font-size: 17px;
 	font-family: $default-font;
 
 	word-break: normal;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes #23258.
Removed `font-size` property from `.wp-block-navigation-link__label` because it was overwriting `.editor-styles-wrapper`'s font size. Before the user could not change the font-size on Navigation Block by using Text Settings options.
<!-- Please describe what you have changed or added -->
