### PR TITLE
Add support for hexadecimal colors in gradient presets

### DIFF
--- a/packages/components/src/custom-gradient-picker/serializer.js
+++ b/packages/components/src/custom-gradient-picker/serializer.js
@@ -4,7 +4,7 @@
 import { compact, get } from 'lodash';
 
 export function serializeGradientColor( { type, value } ) {
-	if ( type === 'literal' ) {
+	if ( type === 'literal' || type === 'hex' ) {
 		return value;
 	}
 	return `${ type }(${ value.join( ',' ) })`;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This PR makes sure that the custom gradient picker is able to parse colors in the hexadecimal format.

## How has this been tested?
1. Added this code to theme
```
add_theme_support( 
  'editor-gradient-presets', 
  array(
    array(
      'name'     => __( 'Hex gradient', 'themeslug'  ),
      'gradient' => 'linear-gradient(to bottom, #000000 50%, #123456 100%)',
      'slug'     => 'hex-gradient'
    )
  )
);

```

2. Set above described gradient background for a group block.
3. Success


This fixes the bug #23361 

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
