### PR TITLE
Fix React warning while unmounting slots

### DIFF
--- a/packages/components/src/slot-fill/slot.js
+++ b/packages/components/src/slot-fill/slot.js
@@ -22,6 +22,7 @@ class SlotComponent extends Component {
 	constructor() {
 		super( ...arguments );
 
+		this.isUnmounted = false;
 		this.bindNode = this.bindNode.bind( this );
 	}
 
@@ -33,7 +34,7 @@ class SlotComponent extends Component {
 
 	componentWillUnmount() {
 		const { unregisterSlot } = this.props;
-
+		this.isUnmounted = true;
 		unregisterSlot( this.props.name, this );
 	}
 
@@ -48,6 +49,13 @@ class SlotComponent extends Component {
 
 	bindNode( node ) {
 		this.node = node;
+	}
+
+	forceUpdate() {
+		if ( this.isUnmounted ) {
+			return;
+		}
+		super.forceUpdate();
 	}
 
 	render() {


### PR DESCRIPTION
related #17355 
closes #23355 

Ideally, we'd move forward with the new implementation of Slot/Fill #22027 (but we'd need mobile folks help with that to ensure there's a fallback for native cc @Tug). In the meantime, this is a small fix to the React warning we get each time we focus on a new RichText.