### PR TITLE
Clean up image editor REST route.

### DIFF
--- a/packages/block-library/src/image/image-editor.js
+++ b/packages/block-library/src/image/image-editor.js
@@ -170,17 +170,14 @@ export default function ImageEditor( {
 		}
 
 		apiFetch( {
-			path: `__experimental/richimage/${ id }/apply`,
-			headers: {
-				'Content-type': 'application/json',
-			},
+			path: `__experimental/image-editor/${ id }/apply`,
 			method: 'POST',
-			body: JSON.stringify( attrs ),
+			data: attrs,
 		} )
 			.then( ( response ) => {
 				setAttributes( {
-					id: response.media_id,
-					url: response.url,
+					id: response.id,
+					url: response.source_url,
 					height: height && width ? width / aspect : undefined,
 				} );
 			} )


### PR DESCRIPTION
## Description

- Changes the route to `image-editor`.
- Returns proper translated errors with status codes.
- On success, returns the new media item's full response.
- Updates apiFetch call to use `data` instead of manually constructing the JSON body.

## How has this been tested?
Manually tested editing an image.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
