### PR TITLE
Image Editor Batch API

### DIFF
--- a/lib/class-wp-rest-image-editor-controller.php
+++ b/lib/class-wp-rest-image-editor-controller.php
@@ -184,7 +184,7 @@ class WP_REST_Image_Editor_Controller extends WP_REST_Controller {
 			'type'       => 'object',
 			'properties' => array(
 				'angle' => array(
-					'type'     => 'integer',
+					'type'     => 'number',
 					'required' => $is_required,
 				),
 			),

--- a/lib/class-wp-rest-image-editor-controller.php
+++ b/lib/class-wp-rest-image-editor-controller.php
@@ -51,7 +51,6 @@ class WP_REST_Image_Editor_Controller extends WP_REST_Controller {
 
 						'modifiers' => array(
 							'type'     => 'array',
-							'required' => true,
 							'items'    => $this->schema_merge_object_properties(
 								$this->get_modifier_schema(),
 								$this->get_crop_schema( false ),

--- a/lib/class-wp-rest-image-editor-controller.php
+++ b/lib/class-wp-rest-image-editor-controller.php
@@ -44,43 +44,96 @@ class WP_REST_Image_Editor_Controller extends WP_REST_Controller {
 					'permission_callback' => array( $this, 'permission_callback' ),
 					'args'                => array(
 						// Src is required to check for correct $image_meta.
-						'src'      => array(
+						'src'       => array(
 							'type'     => 'string',
 							'required' => true,
 						),
 
 						'modifiers' => array(
-							'type'     => 'array',
-							'items'    => $this->schema_merge_object_properties(
-								$this->get_modifier_schema(),
-								$this->get_crop_schema( false ),
-								$this->get_rotate_schema( false )
+							'type'  => 'array',
+							'items' => array(
+								'type'  => 'object',
+								'oneOf' => array(
+									// Rotate. Angle is in degrees.
+									array(
+										'properties' => array(
+											'type'  => array(
+												'type'  => 'string',
+												'const' => 'rotate',
+											),
+											'angle' => array(
+												'type' => 'number',
+											),
+										),
+										'required'   => array(
+											'type',
+											'angle',
+										),
+									),
+
+									// Crop. Values are in percentages.
+									array(
+										'properties' => array(
+											'type'   => array(
+												'type'  => 'string',
+												'const' => 'crop',
+											),
+											'left'   => array(
+												'type'    => 'number',
+												'minimum' => 0,
+												'maximum' => 100,
+											),
+											'top'    => array(
+												'type'    => 'number',
+												'minimum' => 0,
+												'maximum' => 100,
+											),
+											'width'  => array(
+												'type'    => 'number',
+												'minimum' => 1,
+												'maximum' => 100,
+											),
+											'height' => array(
+												'type'    => 'number',
+												'minimum' => 1,
+												'maximum' => 100,
+											),
+										),
+										'required'   => array(
+											'type',
+											'left',
+											'top',
+											'width',
+											'height',
+										),
+									),
+								),
 							),
 						),
 
 						// Deprecated. Use `modifiers` instead.
-						'rotation' => array(
+						'rotation'  => array(
 							'type' => 'integer',
 						),
 
 						// Deprecated. Use `modifiers` instead.
 						// Crop values are in percents.
-						'x'        => array(
+						'x'         => array(
 							'type'    => 'number',
 							'minimum' => 0,
 							'maximum' => 100,
 						),
-						'y'        => array(
+						'y'         => array(
 							'type'    => 'number',
 							'minimum' => 0,
 							'maximum' => 100,
 						),
-						'width'    => array(
+						'width'     => array(
 							'type'    => 'number',
 							'minimum' => 0,
 							'maximum' => 100,
 						),
-						'height'   => array(
+						'height'    => array(
 							'type'    => 'number',
 							'minimum' => 0,
 							'maximum' => 100,
@@ -88,105 +141,6 @@ class WP_REST_Image_Editor_Controller extends WP_REST_Controller {
 					),
 				),
 			)
-		);
-	}
-
-
-	/**
-	 * Merge the properties of a list of schema.
-	 *
-	 * @return array New schema with object properties merged.
-	 */
-	private function schema_merge_object_properties() {
-		$schemas    = func_get_args();
-		$properties = array();
-		foreach ( $schemas as $schema ) {
-			if ( 'object' === $schema['type'] && count( $schema['properties'] ) > 0 ) {
-				foreach ( $schema['properties'] as $property => $value ) {
-					$properties[ $property ] = $value;
-				}
-			}
-		}
-		return array(
-			'type'       => 'object',
-			'properties' => $properties,
-		);
-	}
-
-	/**
-	 * Retrieves the modifier's shared schema, conforming to JSON Schema properties.
-	 *
-	 * @return array Modifier schema properties.
-	 */
-	private function get_modifier_schema() {
-		return array(
-			'type'       => 'object',
-			'properties' => array(
-				'type' => array(
-					'type'     => 'string',
-					'enum'     => array(
-						'crop',
-						'rotate',
-					),
-					'required' => true,
-				),
-			),
-		);
-	}
-
-	/**
-	 * Retrieves the crop modifier's properties, conforming to JSON Schema properties.
-	 *
-	 * @param boolean $is_required If the properties are required.
-	 * @return array Crop modifier schema properties.
-	 */
-	private function get_crop_schema( $is_required ) {
-		return array(
-			'type'       => 'object',
-			'properties' => array(
-				'left'   => array(
-					'type'     => 'number',
-					'minimum'  => 0,
-					'maximum'  => 100,
-					'required' => $is_required,
-				),
-				'top'    => array(
-					'type'     => 'number',
-					'minimum'  => 0,
-					'maximum'  => 100,
-					'required' => $is_required,
-				),
-				'width'  => array(
-					'type'     => 'number',
-					'minimum'  => 1,
-					'maximum'  => 100,
-					'required' => $is_required,
-				),
-				'height' => array(
-					'type'     => 'number',
-					'minimum'  => 1,
-					'maximum'  => 100,
-					'required' => $is_required,
-				),
-			),
-		);
-	}
-
-	/**
-	 * Retrieves the rotate modifier's properties, conforming to JSON Schema properties.
-	 *
-	 * @param boolean $is_required If the properties are required.
-	 * @return array Rotate modifier schema properties.
-	 */
-	private function get_rotate_schema( $is_required ) {
-		return array(
-			'type'       => 'object',
-			'properties' => array(
-				'angle' => array(
-					'type'     => 'number',
-					'required' => $is_required,
-				),
-			),
 		);
 	}
 
@@ -307,24 +261,6 @@ class WP_REST_Image_Editor_Controller extends WP_REST_Controller {
 		if ( 0 === count( $modifiers ) ) {
 			$error = __( 'The image was not edited. Edit the image before applying the changes.', 'gutenberg' );
 			return new WP_Error( 'rest_image_not_edited', $error, array( 'status' => 400 ) );
-		}
-
-		// Validate parameters more specifically since the part of JSON Schema validation that has been implemented so far can't handle unique array object items.
-		// Properties are marked as required on this check so you won't end up with, for example, a crop modifier without all the required crop properties.
-		foreach ( $modifiers as $modifier ) {
-			if ( 'rotate' === $modifier['type'] ) {
-				$valid_modifier = rest_validate_value_from_schema( $modifier, $this->get_rotate_schema( true ) );
-				if ( is_wp_error( $valid_modifier ) ) {
-					$error = __( 'Invalid rotate properties.', 'gutenberg' );
-					return new WP_Error( 'rest_image_rotation_properties', $error, array( 'status' => 400 ) );
-				}
-			} elseif ( 'crop' === $modifier['type'] ) {
-				$valid_modifier = rest_validate_value_from_schema( $modifier, $this->get_crop_schema( true ) );
-				if ( is_wp_error( $valid_modifier ) ) {
-					$error = __( 'Invalid crop properties.', 'gutenberg' );
-					return new WP_Error( 'rest_image_crop_properties', $error, array( 'status' => 400 ) );
-				}
-			}
 		}
 
 		// If the file doesn't exist, attempt a URL fopen on the src link.

--- a/packages/block-library/src/image/image-editor.js
+++ b/packages/block-library/src/image/image-editor.js
@@ -187,16 +187,27 @@ export default function ImageEditor( {
 	function apply() {
 		setIsProgress( true );
 
-		let attrs = {};
+		const attrs = {
+			modifiers: [],
+		};
 
 		// The crop script may return some very small, sub-pixel values when the image was not cropped.
 		// Crop only when the new size has changed by more than 0.1%.
 		if ( crop.width < 99.9 || crop.height < 99.9 ) {
-			attrs = crop;
+			attrs.modifiers.push( {
+				type: 'crop',
+				left: crop.x,
+				top: crop.y,
+				width: crop.width,
+				height: crop.height,
+			} );
 		}
 
 		if ( rotation > 0 ) {
-			attrs.rotation = rotation;
+			attrs.modifiers.push( {
+				type: 'rotate',
+				angle: rotation,
+			} );
 		}
 
 		attrs.src = url;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

This proposes a new API for image editing that should be more flexible and extensible than the existing API. The new API takes an array of modifiers that will be applied in the order they appear.

An example request body looks like this.

```json
{
  "modifiers": [
    {
      "type": "crop",
      "left": 12.875,
      "top": 0.125,
      "width": 50,
      "height": 50
    },
    {
      "type": "rotate",
      "angle": 90
    }
  ]
}
```

Crop values are as a percentage of the original image and rotation angle is in degrees clockwise.

The crop values need to be percentages because the image loaded on the frontend may not be a scaled version of the original image, so `naturalWidth` and `naturalHeight` cannot be trusted as the actual width and height of the original image.

The rotation value is in degrees to avoid rounding errors for the types of rotations that are most common like 90 degrees. Clockwise versus anticlockwise may be up for debate. When using degrees it seems more natural to me to rotate clockwise, but mathematically, when you've converted to radians, a positive value indicates an anticlockwise rotation.

Different front-end implementations may apply edits in a different order, so passing an array will allow them to use their edits as-is without converting to a fixed order. 

One example in the wild that actually uses both orders in different contexts is [BeFunky](https://www.befunky.com/create/photo-editor/). To see the difference, try one of their demo images with a horizon in it so you have a line that you can pay attention to. Then use the 'straighten' option followed by a 'horizontal flip' to see that the angle of the horizon hasn't changed even though you flipped the image. This means that the flip happens before the rotation. If you use the 'rotate' option instead of 'straighten, the rotation happens before the flip.

<details><summary>Original description</summary>
<p>

Applies just the REST API changes from #22959 and continues where the old PR left off for REST API changes. This PR reverts the API changes from 5886225b1c348645ded71f24a0a5765115917025 (#23284), so the diff may read better on [ajlende#484](https://github.com/ajlende/gutenberg/pull/484/files) which includes only the API changes compared to the commit prior to 5886225b1c348645ded71f24a0a5765115917025.

- Moves `richimage` route to `image-editor`
- Moves `/apply` to `/` since there is only one image editor endpoint now
- API takes an array of modifiers that can be applied in order instead of an object
- Updates x and y to be left and top which is more descriptive so you know which edge the offset is based off of

</p>
</details>

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
