### PR TITLE
Image editing: preserve crop position through rotations

### DIFF
--- a/lib/class-wp-rest-image-editor-controller.php
+++ b/lib/class-wp-rest-image-editor-controller.php
@@ -130,6 +130,10 @@ class WP_REST_Image_Editor_Controller extends WP_REST_Controller {
 			return new WP_Error( 'rest_cannot_load_editor', __( 'Unable to load original media file.', 'gutenberg' ), array( 'status' => 500 ) );
 		}
 
+		if ( isset( $params['rotation'] ) ) {
+			$image_editor->rotate( 0 - $params['rotation'] );
+		}
+
 		$size = $image_editor->get_size();
 
 		// Finally apply the modifications.
@@ -138,10 +142,6 @@ class WP_REST_Image_Editor_Controller extends WP_REST_Controller {
 		$width  = round( ( $size['width'] * floatval( $params['width'] ) ) / 100.0 );
 		$height = round( ( $size['height'] * floatval( $params['height'] ) ) / 100.0 );
 		$image_editor->crop( $crop_x, $crop_y, $width, $height );
-
-		if ( isset( $params['rotation'] ) ) {
-			$image_editor->rotate( 0 - $params['rotation'] );
-		}
 
 		// TODO: Generate filename based on edits.
 		$target_file = 'edited-' . $meta['original_name'];

--- a/packages/block-library/src/image/image-editor.js
+++ b/packages/block-library/src/image/image-editor.js
@@ -152,6 +152,7 @@ export default function ImageEditor( {
 	const [ aspect, setAspect ] = useState( naturalWidth / naturalHeight );
 	const [ rotation, setRotation ] = useState( 0 );
 	const [ editedUrl, setEditedUrl ] = useState();
+	const naturalAspectRatio = naturalWidth / naturalHeight;
 
 	const editedWidth = width;
 	let editedHeight = height || ( clientWidth * naturalHeight ) / naturalWidth;
@@ -205,6 +206,10 @@ export default function ImageEditor( {
 			setEditedUrl();
 			setRotation( angle );
 			setAspect( 1 / aspect );
+			setPosition( {
+				x: -( position.y * naturalAspectRatio ),
+				y: position.x * naturalAspectRatio,
+			} );
 			return;
 		}
 
@@ -240,6 +245,10 @@ export default function ImageEditor( {
 				setEditedUrl( URL.createObjectURL( blob ) );
 				setRotation( angle );
 				setAspect( 1 / aspect );
+				setPosition( {
+					x: -( position.y * naturalAspectRatio ),
+					y: position.x * naturalAspectRatio,
+				} );
 			} );
 		}
 

--- a/packages/block-library/src/image/image-editor.js
+++ b/packages/block-library/src/image/image-editor.js
@@ -152,13 +152,14 @@ export default function ImageEditor( {
 	const [ aspect, setAspect ] = useState( naturalWidth / naturalHeight );
 	const [ rotation, setRotation ] = useState( 0 );
 	const [ editedUrl, setEditedUrl ] = useState();
-	const naturalAspectRatio = naturalWidth / naturalHeight;
 
 	const editedWidth = width;
 	let editedHeight = height || ( clientWidth * naturalHeight ) / naturalWidth;
+	let naturalAspectRatio = naturalWidth / naturalHeight;
 
 	if ( rotation % 180 === 90 ) {
 		editedHeight = ( clientWidth * naturalWidth ) / naturalHeight;
+		naturalAspectRatio = naturalHeight / naturalWidth;
 	}
 
 	function apply() {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

In #23284, I didn't update the crop position x and y values after rotating on client side. I also messed up the order in which edits should be applied. On the client side, the crop is applied on top of the rotation, which should be the same on the server side.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1.  Crop an image and move the cropped area away from the centre. Ensure this position is maintained after a rotation.
2. Ensure an image is correctly cropped after applying changes when first cropping and then rotating.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
