### PR TITLE
Classic Block: fix undo keyboard shortcut

### DIFF
--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -34,7 +34,6 @@ export default class ClassicEdit extends Component {
 		this.initialize = this.initialize.bind( this );
 		this.onSetup = this.onSetup.bind( this );
 		this.focus = this.focus.bind( this );
-		this.state = { lastUndo: false };
 	}
 
 	componentDidMount() {
@@ -138,7 +137,8 @@ export default class ClassicEdit extends Component {
 
 		editor.on( 'keydown', ( event ) => {
 			if ( isKeyboardEvent.primary( event, 'z' ) ) {
-				this.handleUndo( event );
+				// Prevent the gutenberg undo kicking in so TinyMCE undo stack works as expected
+				event.stopPropagation();
 			}
 
 			if (
@@ -213,19 +213,6 @@ export default class ClassicEdit extends Component {
 		event.stopPropagation();
 		// Prevent Mousetrap from moving focus to the top toolbar when pressing `alt+f10` on this block toolbar.
 		event.nativeEvent.stopImmediatePropagation();
-	}
-
-	handleUndo( event ) {
-		// While there is content in the block prevent Gutenberg undo from kicking in so TinyMCE undo stack works.
-		// Need to also track if it is the last undo otherwise block is removed along with last bit of content.
-		if ( isTmceEmpty( this.editor ) && ! this.state.lastUndo ) {
-			this.setState( { lastUndo: true } );
-			event.stopPropagation();
-		}
-		if ( ! isTmceEmpty( this.editor ) ) {
-			this.setState( { lastUndo: false } );
-			event.stopPropagation();
-		}
 	}
 
 	render() {

--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -34,6 +34,7 @@ export default class ClassicEdit extends Component {
 		this.initialize = this.initialize.bind( this );
 		this.onSetup = this.onSetup.bind( this );
 		this.focus = this.focus.bind( this );
+		this.state = { lastUndo: false };
 	}
 
 	componentDidMount() {
@@ -136,9 +137,8 @@ export default class ClassicEdit extends Component {
 		);
 
 		editor.on( 'keydown', ( event ) => {
-			// Prevent Gutenberg undo from kicking in so TinyMCE undo stack works.
 			if ( isKeyboardEvent.primary( event, 'z' ) ) {
-				event.stopPropagation();
+				this.handleUndo( event )
 			}
 
 			if (
@@ -213,6 +213,19 @@ export default class ClassicEdit extends Component {
 		event.stopPropagation();
 		// Prevent Mousetrap from moving focus to the top toolbar when pressing `alt+f10` on this block toolbar.
 		event.nativeEvent.stopImmediatePropagation();
+	}
+
+	handleUndo( event ) {
+		// While there is content in the block prevent Gutenberg undo from kicking in so TinyMCE undo stack works.
+		// Need to also track if it is the last undo otherwise block is removed along with last bit of content.
+		if ( isTmceEmpty( this.editor ) && ! this.state.lastUndo ) {
+			this.setState( { lastUndo: true } );
+			event.stopPropagation();
+		}
+		if ( ! isTmceEmpty( this.editor ) )  {
+			this.setState( { lastUndo: false } );
+			event.stopPropagation();
+		}
 	}
 
 	render() {

--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -136,7 +136,7 @@ export default class ClassicEdit extends Component {
 		);
 
 		editor.on( 'keydown', ( event ) => {
-			 // Prevent Gutenberg undo from kicking in so TinyMCE undo stack works.
+			// Prevent Gutenberg undo from kicking in so TinyMCE undo stack works.
 			if ( isKeyboardEvent.primary( event, 'z' ) ) {
 				event.stopPropagation();
 			}

--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -138,7 +138,7 @@ export default class ClassicEdit extends Component {
 
 		editor.on( 'keydown', ( event ) => {
 			if ( isKeyboardEvent.primary( event, 'z' ) ) {
-				this.handleUndo( event )
+				this.handleUndo( event );
 			}
 
 			if (
@@ -222,7 +222,7 @@ export default class ClassicEdit extends Component {
 			this.setState( { lastUndo: true } );
 			event.stopPropagation();
 		}
-		if ( ! isTmceEmpty( this.editor ) )  {
+		if ( ! isTmceEmpty( this.editor ) ) {
 			this.setState( { lastUndo: false } );
 			event.stopPropagation();
 		}

--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -8,7 +8,7 @@ import { debounce } from 'lodash';
  */
 import { Component } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
-import { BACKSPACE, DELETE, F10 } from '@wordpress/keycodes';
+import { BACKSPACE, DELETE, F10, isKeyboardEvent } from '@wordpress/keycodes';
 
 const { wp } = window;
 
@@ -136,6 +136,11 @@ export default class ClassicEdit extends Component {
 		);
 
 		editor.on( 'keydown', ( event ) => {
+			 // Prevent Gutenberg undo from kicking in so TinyMCE undo stack works.
+			if ( isKeyboardEvent.primary( event, 'z' ) ) {
+				event.stopPropagation();
+			}
+
 			if (
 				( event.keyCode === BACKSPACE || event.keyCode === DELETE ) &&
 				isTmceEmpty( editor )


### PR DESCRIPTION
## Description
Traps undo keyboard shortcut in Classic box to allow TinyMCE undo stack to work, otherwise cmd-z/ctrl-z causes all classic block content to be deleted in a way that is not re-doable. 

Fixes #22797 

## To Test
Check out PR in local dev en
Add a Classic block
Add several paragraphs  in the block
Use cmd-z/ctrl-z undo keyboard shortcuts, and ensure that the Classic block stays in place and just the changes in the block are undo.
Focus another block and check that cmd-z/ctrl-z still works as expected with other blocks

## Screenshots 
Before:

![classic-before](https://user-images.githubusercontent.com/3629020/85353566-a484b280-b55c-11ea-9bb7-b8673d2b62c5.gif)

After:

![classic-after](https://user-images.githubusercontent.com/3629020/85353583-b23a3800-b55c-11ea-83d1-f2cc01b1171b.gif)

## Types of changes
Adds a keydown check in classic editor block

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. 
- [x] My code has proper inline documentation. 
