### PR TITLE
Fix centered legacy button.

### DIFF
--- a/packages/block-library/src/buttons/style.scss
+++ b/packages/block-library/src/buttons/style.scss
@@ -27,7 +27,7 @@
 	/*rtl:ignore*/
 	margin-right: $grid-unit-10;
 
-	&:first-child {
+	&:last-child {
 		/*rtl:ignore*/
 		margin-right: 0;
 	}

--- a/packages/block-library/src/buttons/style.scss
+++ b/packages/block-library/src/buttons/style.scss
@@ -10,19 +10,25 @@
 }
 
 .wp-block-buttons.alignright .wp-block-button {
+	/*rtl:ignore*/
 	margin-right: 0;
+	/*rtl:ignore*/
 	margin-left: $grid-unit-10;
 
 	&:first-child {
+		/*rtl:ignore*/
 		margin-left: 0;
 	}
 }
 
 .wp-block-buttons.alignleft .wp-block-button {
+	/*rtl:ignore*/
 	margin-left: 0;
+	/*rtl:ignore*/
 	margin-right: $grid-unit-10;
 
 	&:first-child {
+		/*rtl:ignore*/
 		margin-right: 0;
 	}
 }

--- a/packages/block-library/src/buttons/style.scss
+++ b/packages/block-library/src/buttons/style.scss
@@ -18,6 +18,16 @@
 	}
 }
 
+.wp-block-buttons.alignleft .wp-block-button {
+	margin-left: 0;
+	margin-right: $grid-unit-10;
+
+	&:first-child {
+		margin-right: 0;
+	}
+}
+
+.wp-block-button.aligncenter, // This is to support the legacy Button block.
 .wp-block-buttons.aligncenter {
 	text-align: center;
 }


### PR DESCRIPTION
Fixes #23291.

The legacy button (singular) block could not be centered.

Before:

<img width="777" alt="Screenshot 2020-06-23 at 08 56 39" src="https://user-images.githubusercontent.com/1204802/85371366-64a7d600-b530-11ea-9159-ed8fe2450269.png">

After:

<img width="776" alt="Screenshot 2020-06-23 at 08 56 29" src="https://user-images.githubusercontent.com/1204802/85371371-670a3000-b530-11ea-968b-f4ad82e36b38.png">

This PR also adds an explicit "align left" rule for the Buttons (plural) block, which matters in RTL contexts. 