### PR TITLE
Unify tooltip styles.

### DIFF
--- a/packages/components/src/range-control/styles/range-control-styles.js
+++ b/packages/components/src/range-control/styles/range-control-styles.js
@@ -215,59 +215,31 @@ const tooltipPosition = ( { position } ) => {
 
 	if ( isTop ) {
 		return css`
-			margin-top: -4px;
-			top: -100%;
-
-			&::after {
-				border-bottom: none;
-				border-top-style: solid;
-				bottom: -6px;
-			}
+			top: -80%;
 		`;
 	}
 
 	return css`
-		margin-bottom: -4px;
-		bottom: -100%;
-
-		&::after {
-			border-bottom-style: solid;
-			border-top: none;
-			top: -6px;
-		}
+		bottom: -80%;
 	`;
 };
 
 export const Tooltip = styled.span`
-	background: ${ color( 'darkGray.800' ) };
-	border-radius: 3px;
+	background: ${ color( 'ui.border' ) };
+	border-radius: 2px;
 	box-sizing: border-box;
 	color: white;
 	display: inline-block;
-	font-size: 11px;
+	font-size: 12px;
 	min-width: 32px;
 	opacity: 0;
-	padding: 8px;
+	padding: 4px 8px;
 	pointer-events: none;
 	position: absolute;
 	text-align: center;
 	transition: opacity 120ms ease;
 	user-select: none;
-
-	&::after {
-		border: 6px solid ${ color( 'darkGray.800' ) };
-		border-left-color: transparent;
-		border-right-color: transparent;
-		bottom: -6px;
-		box-sizing: border-box;
-		content: '';
-		height: 0;
-		left: 50%;
-		line-height: 0;
-		margin-left: -6px;
-		position: absolute;
-		width: 0;
-	}
+	line-height: 1.4;
 
 	${ tooltipShow };
 	${ tooltipPosition };
@@ -282,8 +254,9 @@ export const InputNumber = styled.input`
 	box-sizing: border-box;
 	display: inline-block;
 	margin-top: 0;
-	min-width: 54px;
+	min-width: 60px;
 	max-width: 120px;
+	font-size: 13px;
 
 	input[type='number']& {
 		${ rangeHeight };

--- a/packages/components/src/resizable-box/resize-tooltip/styles/resize-tooltip.styles.js
+++ b/packages/components/src/resizable-box/resize-tooltip/styles/resize-tooltip.styles.js
@@ -33,10 +33,10 @@ export const TooltipWrapper = styled.div`
 export const Tooltip = styled.div`
 	background: ${ color( 'ui.border' ) };
 	border-radius: 2px;
-	box-shadow: 0 0 0 1px rgba( 255, 255, 255, 0.2 );
 	box-sizing: border-box;
+	font-size: 12px;
 	color: ${ color( 'ui.textDark' ) };
-	padding: 4px 6px;
+	padding: 4px 8px;
 	position: relative;
 `;
 
@@ -48,6 +48,6 @@ export const LabelText = styled( Text )`
 		${ text };
 		display: block;
 		font-size: 13px;
-		line-height: 1;
+		line-height: 1.4;
 	}
 `;

--- a/packages/components/src/tooltip/style.scss
+++ b/packages/components/src/tooltip/style.scss
@@ -13,6 +13,9 @@
 	color: $white;
 	white-space: nowrap;
 	text-align: center;
+	line-height: 1.4;
+	font-size: 12px;
+	box-shadow: none;
 
 	// This prevents quickly hovering the tooltip from blocking hovering something else.
 	pointer-events: none;

--- a/packages/components/src/utils/colors-values.js
+++ b/packages/components/src/utils/colors-values.js
@@ -138,7 +138,7 @@ export const UI = {
 	background: BASE.white,
 	backgroundDisabled: LIGHT_GRAY[ 200 ],
 	brand: BLUE.wordpress[ 700 ],
-	border: BASE.black,
+	border: G2.darkGray.primary,
 	borderFocus: BLUE.medium.focus,
 	borderDisabled: DARK_GRAY[ 700 ],
 	borderLight: LIGHT_GRAY[ 600 ],


### PR DESCRIPTION
The tooltips were not all unified. This PR aims to do that. 

Before:

<img width="182" alt="Screenshot 2020-06-23 at 09 35 45" src="https://user-images.githubusercontent.com/1204802/85378395-cd944b80-b53a-11ea-92fa-e69248ac89ed.png">

<img width="302" alt="Screenshot 2020-06-23 at 09 37 46" src="https://user-images.githubusercontent.com/1204802/85378397-ce2ce200-b53a-11ea-83b8-735554ffcdda.png">

<img width="196" alt="Screenshot 2020-06-23 at 10 09 47" src="https://user-images.githubusercontent.com/1204802/85378402-cf5e0f00-b53a-11ea-9b5e-bf4490c78b59.png">

Here's the original design:

<img width="361" alt="Screenshot 2020-06-23 at 10 09 24" src="https://user-images.githubusercontent.com/1204802/85378459-e00e8500-b53a-11ea-9354-e9baa2710f80.png">

After:

<img width="196" alt="Screenshot 2020-06-23 at 10 09 47" src="https://user-images.githubusercontent.com/1204802/85378496-eb61b080-b53a-11ea-8872-77f0a537676d.png">

<img width="234" alt="Screenshot 2020-06-23 at 10 08 07" src="https://user-images.githubusercontent.com/1204802/85378505-ed2b7400-b53a-11ea-9f85-222b898a4423.png">

<img width="134" alt="Screenshot 2020-06-23 at 10 10 01" src="https://user-images.githubusercontent.com/1204802/85378508-ee5ca100-b53a-11ea-8d9d-ba404a651c57.png">

This one presented me with some challenges:

<img width="257" alt="Screenshot 2020-06-23 at 10 16 58" src="https://user-images.githubusercontent.com/1204802/85378528-f583af00-b53a-11ea-93c7-ea6888c8e44d.png">

It's not a tooltip, but looking at these styles, this input field is styled in JS, which means it has its styles overwritten by wp-includes/forms.scss, and it's hard to increase specificity without using `!important`. 