### PR TITLE
Fix clicking the slash inserter items

### DIFF
--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -264,7 +264,7 @@ const getAutoCompleterUI = ( autocompleter ) => {
 									'is-selected': index === selectedIndex,
 								}
 							) }
-							onClick={ () => onSelect }
+							onClick={ () => onSelect( option ) }
 						>
 							{ option.label }
 						</Button>
@@ -525,7 +525,7 @@ export class Autocomplete extends Component {
 						listBoxId={ listBoxId }
 						selectedIndex={ selectedIndex }
 						onChangeOptions={ this.onChangeOptions }
-						onSelect={ this.onSelect }
+						onSelect={ this.select }
 						onReset={ this.onReset }
 					/>
 				) }


### PR DESCRIPTION
Small regression in #22853 

**testing instructions**

 - You should be able to click the slash inserter using the mouse.