### PR TITLE
Remove block preview paddings

### DIFF
--- a/packages/block-editor/src/components/block-preview/style.scss
+++ b/packages/block-editor/src/components/block-preview/style.scss
@@ -9,6 +9,11 @@
 	width: 100%;
 
 	overflow: hidden;
+
+	// Overrides the default padding applied in editor styles otherwise preview centering break.
+	&.editor-styles-wrapper {
+		padding: 0;
+	}
 }
 
 .block-editor-block-preview__content {


### PR DESCRIPTION
Fix regression in #22213 

The block previews shouldn't have paddings

**Testing instructions**

Make sure the patterns and block previews show up properly in 2020.