### PR TITLE
Fix small RTL regression in Buttons block.

### DIFF
--- a/packages/block-library/src/buttons/style.scss
+++ b/packages/block-library/src/buttons/style.scss
@@ -16,7 +16,6 @@
 	margin-left: $grid-unit-10;
 
 	&:first-child {
-		/*rtl:ignore*/
 		margin-left: 0;
 	}
 }
@@ -28,7 +27,6 @@
 	margin-right: $grid-unit-10;
 
 	&:last-child {
-		/*rtl:ignore*/
 		margin-right: 0;
 	}
 }


### PR DESCRIPTION
Followup to https://github.com/WordPress/gutenberg/pull/23381#issuecomment-648121073.

Turns out, the last-child/first-child rules did not need RTL protection. Because last is on the left in RTL and on the right in LTR.

After:

<img width="930" alt="after" src="https://user-images.githubusercontent.com/1204802/85407299-545d1e80-b563-11ea-973e-6cafea256e27.png">

<img width="860" alt="after2" src="https://user-images.githubusercontent.com/1204802/85407555-a605a900-b563-11ea-90d5-3d729825192f.png">

After in RTL:

<img width="768" alt="ltr after" src="https://user-images.githubusercontent.com/1204802/85407569-a9009980-b563-11ea-8ca1-482730e49aa7.png">
<img width="906" alt="ltr after 2" src="https://user-images.githubusercontent.com/1204802/85407584-aaca5d00-b563-11ea-8433-0a8bfa417225.png">
