### PR TITLE
Delete node_modules when running gradle's clean task

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,3 +19,10 @@ indent_size = 2
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.{gradle,java,kt}]
+indent_style = space
+
+[packages/react-native-*/**.xml]
+indent_style = space
+

--- a/packages/react-native-bridge/android/build.gradle
+++ b/packages/react-native-bridge/android/build.gradle
@@ -189,9 +189,10 @@ if (buildGutenbergMobileJSBundle) {
 If they are changed, the isBundleUpToDate flag is switched to false. That flag is used by other tasks.")
 
         def dirs = [mobileGutenbergRootDir]
+        def bundlePath = file("$mobileGutenbergRootDir/bundle").absolutePath
         file(mobileGutenbergRootDir).eachDirRecurse { dir ->
             def isRelevantDir = !['react-native-bridge/android/build/intermediates',
-                                  file("$mobileGutenbergRootDir/bundle").absolutePath,
+                                  bundlePath,
                                   'node_modules'].any { dir.absolutePath.contains(it) } &&
                     !dir.name.startsWith('symlinked')
             if (isRelevantDir) {

--- a/packages/react-native-bridge/android/build.gradle
+++ b/packages/react-native-bridge/android/build.gradle
@@ -294,11 +294,14 @@ If they are changed, the isBundleUpToDate flag is switched to false. That flag i
         }
     }
 
-    task cleanupNodeModulesFolder(type: Delete) {
+    task cleanupNodeModulesFolders(type: Delete) {
+        doFirst {
+            println "Deleting node_modules folders"
+        }
         dependsOn bundleUpToDateCheck
         onlyIf { !isBundleUpToDate() }
 
-        delete "$mobileGutenbergRootDir/node_modules"
+        delete "$mobileGutenbergRootDir/node_modules", "$mobileGutenbergRootDir/gutenberg/node_modules"
     }
 
     task resetExtractedRNTools(type: Delete) {
@@ -308,11 +311,18 @@ If they are changed, the isBundleUpToDate flag is switched to false. That flag i
         delete nodeFolder, npmFolder
     }
 
-    preBuild.dependsOn(cleanupNodeModulesFolder)
-    cleanupNodeModulesFolder.dependsOn(backupHermesDebugAAR)
+    preBuild.dependsOn(cleanupNodeModulesFolders)
+    cleanupNodeModulesFolders.dependsOn(backupHermesDebugAAR)
     backupHermesDebugAAR.dependsOn(backupHermesReleaseAAR)
     backupHermesReleaseAAR.dependsOn(copyJSBundle)
     copyJSBundle.dependsOn(buildJSBundle)
     buildJSBundle.dependsOn(npm_install)
     nodeSetup.dependsOn(resetExtractedRNTools)
+
+    clean {
+        doFirst {
+            println "Executing extended clean task that also deletes node_modules folders"
+        }
+        delete "$mobileGutenbergRootDir/node_modules", "$mobileGutenbergRootDir/gutenberg/node_modules"
+    }
 }

--- a/packages/react-native-bridge/android/build.gradle
+++ b/packages/react-native-bridge/android/build.gradle
@@ -295,6 +295,7 @@ If they are changed, the isBundleUpToDate flag is switched to false. That flag i
         }
     }
 
+    def nodeModulesFolders = ["$mobileGutenbergRootDir/node_modules", "$mobileGutenbergRootDir/gutenberg/node_modules"] as String[]
     task cleanupNodeModulesFolders(type: Delete) {
         doFirst {
             println "Deleting node_modules folders"
@@ -302,7 +303,7 @@ If they are changed, the isBundleUpToDate flag is switched to false. That flag i
         dependsOn bundleUpToDateCheck
         onlyIf { !isBundleUpToDate() }
 
-        delete "$mobileGutenbergRootDir/node_modules", "$mobileGutenbergRootDir/gutenberg/node_modules"
+        delete nodeModulesFolders
     }
 
     task resetExtractedRNTools(type: Delete) {
@@ -324,6 +325,6 @@ If they are changed, the isBundleUpToDate flag is switched to false. That flag i
         doFirst {
             println "Executing extended clean task that also deletes node_modules folders"
         }
-        delete "$mobileGutenbergRootDir/node_modules", "$mobileGutenbergRootDir/gutenberg/node_modules"
+        delete nodeModulesFolders
     }
 }

--- a/packages/react-native-bridge/android/build.gradle
+++ b/packages/react-native-bridge/android/build.gradle
@@ -182,16 +182,16 @@ boolean isBundleUpToDate() {
 
 if (buildGutenbergMobileJSBundle) {
     def bundleName = 'index.android.bundle'
-    def jsRootDir = '../../../..'
+    def mobileGutenbergRootDir = '../../../..'
 
     task bundleUpToDateCheck {
         description("Checks if the inputs to the javascript bundle and the bundle itself are unchanged. \
 If they are changed, the isBundleUpToDate flag is switched to false. That flag is used by other tasks.")
 
-        def dirs = [jsRootDir]
-        file(jsRootDir).eachDirRecurse { dir ->
+        def dirs = [mobileGutenbergRootDir]
+        file(mobileGutenbergRootDir).eachDirRecurse { dir ->
             def isRelevantDir = !['react-native-bridge/android/build/intermediates',
-                                  file("$jsRootDir/bundle").absolutePath,
+                                  file("$mobileGutenbergRootDir/bundle").absolutePath,
                                   'node_modules'].any { dir.absolutePath.contains(it) } &&
                     !dir.name.startsWith('symlinked')
             if (isRelevantDir) {
@@ -275,7 +275,7 @@ If they are changed, the isBundleUpToDate flag is switched to false. That flag i
         onlyIf { !isBundleUpToDate() }
 
         def origFileName = 'App.js'
-        def origWithPath = "$jsRootDir/bundle/android/${origFileName}"
+        def origWithPath = "$mobileGutenbergRootDir/bundle/android/${origFileName}"
         from origWithPath
         into buildAssetsFolder
         rename origFileName, bundleName
@@ -298,7 +298,7 @@ If they are changed, the isBundleUpToDate flag is switched to false. That flag i
         dependsOn bundleUpToDateCheck
         onlyIf { !isBundleUpToDate() }
 
-        delete "$jsRootDir/node_modules"
+        delete "$mobileGutenbergRootDir/node_modules"
     }
 
     task resetExtractedRNTools(type: Delete) {

--- a/packages/react-native-bridge/android/build.gradle
+++ b/packages/react-native-bridge/android/build.gradle
@@ -302,7 +302,9 @@ If they are changed, the isBundleUpToDate flag is switched to false. That flag i
     }
 
     task resetExtractedRNTools(type: Delete) {
-        println "Deleting temporary folders with extracted RN tools"
+        doFirst {
+            println "Deleting temporary folders with extracted RN tools"
+        }
         delete nodeFolder, npmFolder
     }
 


### PR DESCRIPTION
## Description

Updating the `react-native-bridge`'s clean task to also delete the `node_modules` directory. This will help ensure that developers who are not familiar with js development have a good chance of recovering from a bad state using the gradle build.

In addition:

1. 8cda965 updates the message for the `resetExtractedRNTools` task to print during the execution phase instead of the configuration phase;
2. 0c81acb updates the name of the variable defining the (relative) path to the mobile gutenberg root to be more descriptive; and
3. db6769a updates the .editorconfig file to use spaces instead of tabs in .gradle, .java, .kt, and .xml files. For me Android Studio was picking up on the .edtorconfig file and, because that file [specifies tabs as the default](https://github.com/WordPress/gutenberg/blob/master/.editorconfig#L14) inside `gutenberg/`, Android Studio was overriding my settings and using tabs instead of spaces inside the `gutenberg-mobile/gutenberg` directory.

## How has this been tested?

### Cleaning

1. Within WPAndroid, ensure that your `libs/gutenberg-mobile/node_modules` and `libs/gutenberg-mobile/gutenberg/node_modules` directories are NOT empty. A dummy file is fine.
2. Ensure that WPAndroid's `gradle.properties` file has `wp.BUILD_GUTENBERG_FROM_SOURCE` set to false (or is missing that variable entirely).
3. From the WPAndroid root, run `./gradlew clean`
4. Verify that the `libs/gutenberg-mobile/node_modules` and `libs/gutenberg-mobile/gutenberg/node_modules` directories no longer exist
5. From the WPAndroid root, run `./gradlew clean installWasabiDebug`
6. Verify that you can load the gutenberg editor when running the generated apk
7. Verify that the `libs/gutenberg-mobile/node_modules` and `libs/gutenberg-mobile/gutenberg/node_modules` directories do not exist (confirms that the clean task does not interfere with the order of the tasks needed to generate the js bundle for android).

### .editorconfig

Do the following for a (1) .gradle, (2) .java, (3) .kt, and (4) .XML file somewhere within `packages/react-native-*/`. 

1. Enable EditorConfig support in Android Studio if not already enabled ( Settings → Editor → Code Style → Enable EditorConfig support )
2. Restart Android Studio and wait for it to fully restart so it has loaded .editorconfig (I don't actually know if a restart is necessary, but in my testing it was sufficient). 
3. Add a non-empty line of code to one of the files specified above^.
4. Verify that the line is prefixed with tabs if using the previous .editorconfig file and prefixed with spaces if using the updated .editorconfig from this PR.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [X] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
