### PR TITLE
Plugin Controller: Return the plugin without the extension.

### DIFF
--- a/lib/class-wp-rest-plugins-controller.php
+++ b/lib/class-wp-rest-plugins-controller.php
@@ -531,10 +531,10 @@ class WP_REST_Plugins_Controller extends WP_REST_Controller {
 	 */
 	public function prepare_item_for_response( $item, $request ) {
 		$item   = _get_plugin_data_markup_translate( $item['_file'], $item, false );
-		$marked = _get_plugin_data_markup_translate( $item['_file'], $item, true, false );
+		$marked = _get_plugin_data_markup_translate( $item['_file'], $item, true );
 
 		$data = array(
-			'plugin'       => $item['_file'],
+			'plugin'       => substr( $item['_file'], 0, - 4 ),
 			'status'       => $this->get_plugin_status( $item['_file'] ),
 			'name'         => $item['Name'],
 			'plugin_uri'   => $item['PluginURI'],

--- a/phpunit/class-wp-rest-plugins-controller-test.php
+++ b/phpunit/class-wp-rest-plugins-controller-test.php
@@ -121,7 +121,7 @@ class WP_REST_Plugins_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$response = rest_do_request( self::BASE );
 		$this->assertEquals( 200, $response->get_status() );
 
-		$items = wp_list_filter( $response->get_data(), array( 'plugin' => self::PLUGIN_FILE ) );
+		$items = wp_list_filter( $response->get_data(), array( 'plugin' => self::PLUGIN ) );
 
 		$this->assertCount( 1, $items );
 		$this->check_get_plugin_data( array_shift( $items ) );
@@ -139,7 +139,7 @@ class WP_REST_Plugins_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request = new WP_REST_Request( 'GET', self::BASE );
 		$request->set_query_params( array( 'search' => 'Cool' ) );
 		$response = rest_do_request( $request );
-		$this->assertCount( 1, wp_list_filter( $response->get_data(), array( 'plugin' => self::PLUGIN_FILE ) ) );
+		$this->assertCount( 1, wp_list_filter( $response->get_data(), array( 'plugin' => self::PLUGIN ) ) );
 	}
 
 	public function test_get_items_status() {
@@ -149,12 +149,12 @@ class WP_REST_Plugins_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request = new WP_REST_Request( 'GET', self::BASE );
 		$request->set_query_params( array( 'status' => 'inactive' ) );
 		$response = rest_do_request( $request );
-		$this->assertCount( 1, wp_list_filter( $response->get_data(), array( 'plugin' => self::PLUGIN_FILE ) ) );
+		$this->assertCount( 1, wp_list_filter( $response->get_data(), array( 'plugin' => self::PLUGIN ) ) );
 
 		$request = new WP_REST_Request( 'GET', self::BASE );
 		$request->set_query_params( array( 'status' => 'active' ) );
 		$response = rest_do_request( $request );
-		$this->assertCount( 0, wp_list_filter( $response->get_data(), array( 'plugin' => self::PLUGIN_FILE ) ) );
+		$this->assertCount( 0, wp_list_filter( $response->get_data(), array( 'plugin' => self::PLUGIN ) ) );
 	}
 
 	public function test_get_items_status_multiple() {
@@ -165,8 +165,8 @@ class WP_REST_Plugins_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request->set_query_params( array( 'status' => array( 'inactive', 'active' ) ) );
 		$response = rest_do_request( $request );
 
-		$this->assertGreaterThan( 1, count( wp_list_filter( $response->get_data(), array( 'plugin' => self::PLUGIN_FILE ), 'NOT' ) ) );
-		$this->assertCount( 1, wp_list_filter( $response->get_data(), array( 'plugin' => self::PLUGIN_FILE ) ) );
+		$this->assertGreaterThan( 1, count( wp_list_filter( $response->get_data(), array( 'plugin' => self::PLUGIN ), 'NOT' ) ) );
+		$this->assertCount( 1, wp_list_filter( $response->get_data(), array( 'plugin' => self::PLUGIN ) ) );
 	}
 
 	/**
@@ -179,13 +179,13 @@ class WP_REST_Plugins_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request = new WP_REST_Request( 'GET', self::BASE );
 		$request->set_query_params( array( 'status' => 'network-active' ) );
 		$response = rest_do_request( $request );
-		$this->assertCount( 0, wp_list_filter( $response->get_data(), array( 'plugin' => self::PLUGIN_FILE ) ) );
+		$this->assertCount( 0, wp_list_filter( $response->get_data(), array( 'plugin' => self::PLUGIN ) ) );
 
 		activate_plugin( self::PLUGIN_FILE, '', true );
 		$request = new WP_REST_Request( 'GET', self::BASE );
 		$request->set_query_params( array( 'status' => 'network-active' ) );
 		$response = rest_do_request( $request );
-		$this->assertCount( 1, wp_list_filter( $response->get_data(), array( 'plugin' => self::PLUGIN_FILE ) ) );
+		$this->assertCount( 1, wp_list_filter( $response->get_data(), array( 'plugin' => self::PLUGIN ) ) );
 	}
 
 	public function test_get_items_logged_out() {
@@ -235,7 +235,7 @@ class WP_REST_Plugins_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$response = rest_do_request( self::BASE );
 		$this->assertEquals( 200, $response->get_status() );
 
-		$items = wp_list_filter( $response->get_data(), array( 'plugin' => self::PLUGIN_FILE ) );
+		$items = wp_list_filter( $response->get_data(), array( 'plugin' => self::PLUGIN ) );
 		$this->assertCount( 0, $items );
 	}
 
@@ -249,7 +249,7 @@ class WP_REST_Plugins_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$response = rest_do_request( self::BASE );
 		$this->assertEquals( 200, $response->get_status() );
 
-		$items = wp_list_filter( $response->get_data(), array( 'plugin' => self::PLUGIN_FILE ) );
+		$items = wp_list_filter( $response->get_data(), array( 'plugin' => self::PLUGIN ) );
 		$this->assertCount( 1, $items );
 		$this->check_get_plugin_data( array_shift( $items ), true );
 	}
@@ -265,7 +265,7 @@ class WP_REST_Plugins_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$response = rest_do_request( self::BASE );
 		$this->assertEquals( 200, $response->get_status() );
 
-		$items = wp_list_filter( $response->get_data(), array( 'plugin' => self::PLUGIN_FILE ) );
+		$items = wp_list_filter( $response->get_data(), array( 'plugin' => self::PLUGIN ) );
 		$this->assertCount( 1, $items );
 		$this->check_get_plugin_data( array_shift( $items ), true );
 	}
@@ -743,7 +743,7 @@ class WP_REST_Plugins_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$this->assertNotWPError( $response->as_error() );
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertTrue( $response->get_data()['deleted'] );
-		$this->assertEquals( 'test-plugin/test-plugin.php', $response->get_data()['previous']['plugin'] );
+		$this->assertEquals( self::PLUGIN, $response->get_data()['previous']['plugin'] );
 		$this->assertFileNotExists( WP_PLUGIN_DIR . '/' . self::PLUGIN_FILE );
 	}
 
@@ -876,7 +876,7 @@ class WP_REST_Plugins_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	 * @param bool  $network_only Whether the plugin is network only.
 	 */
 	protected function check_get_plugin_data( $data, $network_only = false ) {
-		$this->assertEquals( 'test-plugin/test-plugin.php', $data['plugin'] );
+		$this->assertEquals( 'test-plugin/test-plugin', $data['plugin'] );
 		$this->assertEquals( '1.5.4', $data['version'] );
 		$this->assertEquals( 'inactive', $data['status'] );
 		$this->assertEquals( 'Test Plugin', $data['name'] );


### PR DESCRIPTION
## Description
This is more consistent with how the url is constructed.
Also fixes an issue with untranslated marked data being returned.

## How has this been tested?
Unit tested.

## Types of changes
Breaking change.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
