### PR TITLE
Create Block: Generate a block.json file

### DIFF
--- a/packages/create-block/lib/init-block-json.js
+++ b/packages/create-block/lib/init-block-json.js
@@ -11,16 +11,16 @@ const { writeFile } = require( 'fs' ).promises;
 const { info } = require( './log' );
 
 module.exports = async ( {
-		slug,
-		namespace,
-		title,
-		description,
-		category,
-		dashicon,
-		textdomain,
-		editorScript,
-		editorStyle,
-		style,
+	slug,
+	namespace,
+	title,
+	description,
+	category,
+	dashicon,
+	textdomain,
+	editorScript,
+	editorStyle,
+	style,
 } ) => {
 	const outputFile = join( process.cwd(), slug, 'block.json' );
 

--- a/packages/create-block/lib/init-block-json.js
+++ b/packages/create-block/lib/init-block-json.js
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+const { isEmpty, omitBy } = require( 'lodash' );
+const { join } = require( 'path' );
+const { writeFile } = require( 'fs' ).promises;
+
+/**
+ * Internal dependencies
+ */
+const { info } = require( './log' );
+
+module.exports = async (
+	blockTemplate,
+	{ slug, namespace, title, description, category, dashicon, textdomain }
+) => {
+	const outputFile = join( process.cwd(), slug, 'block.json' );
+	const template = blockTemplate.defaultValues.slug.split( '-' ).shift();
+	const editorScript = 'esnext' === template ? 'build/index.js' : 'index.js';
+	const editorStyle =
+		'esnext' === template ? 'build/index.css' : 'editor.css';
+
+	info( '' );
+	info( 'Creating a "block.json" file.' );
+	await writeFile(
+		outputFile,
+		JSON.stringify(
+			omitBy(
+				{
+					name: namespace + '/' + slug,
+					title,
+					category,
+					icon: dashicon,
+					description,
+					textdomain,
+					supports: {
+						html: false,
+					},
+					editorScript,
+					editorStyle,
+				},
+				isEmpty
+			),
+			null,
+			'\t'
+		)
+	);
+};

--- a/packages/create-block/lib/init-block-json.js
+++ b/packages/create-block/lib/init-block-json.js
@@ -10,15 +10,19 @@ const { writeFile } = require( 'fs' ).promises;
  */
 const { info } = require( './log' );
 
-module.exports = async (
-	blockTemplate,
-	{ slug, namespace, title, description, category, dashicon, textdomain }
-) => {
+module.exports = async ( {
+		slug,
+		namespace,
+		title,
+		description,
+		category,
+		dashicon,
+		textdomain,
+		editorScript,
+		editorStyle,
+		style,
+} ) => {
 	const outputFile = join( process.cwd(), slug, 'block.json' );
-	const template = blockTemplate.defaultValues.slug.split( '-' ).shift();
-	const editorScript = 'esnext' === template ? 'build/index.js' : 'index.js';
-	const editorStyle =
-		'esnext' === template ? 'build/index.css' : 'editor.css';
 
 	info( '' );
 	info( 'Creating a "block.json" file.' );
@@ -38,6 +42,7 @@ module.exports = async (
 					},
 					editorScript,
 					editorStyle,
+					style,
 				},
 				isEmpty
 			),

--- a/packages/create-block/lib/scaffold.js
+++ b/packages/create-block/lib/scaffold.js
@@ -29,6 +29,9 @@ module.exports = async (
 		licenseURI,
 		version,
 		wpScripts,
+		editorScript,
+		editorStyle,
+		style,
 	}
 ) => {
 	slug = slug.toLowerCase();
@@ -52,6 +55,9 @@ module.exports = async (
 		license,
 		licenseURI,
 		textdomain: namespace,
+		editorScript,
+		editorStyle,
+		style,
 	};
 	await Promise.all(
 		Object.keys( outputTemplates ).map( async ( outputFile ) => {
@@ -68,7 +74,7 @@ module.exports = async (
 		} )
 	);
 
-	await initBlockJSON( blockTemplate, view );
+	await initBlockJSON( view );
 	await initPackageJSON( view );
 
 	if ( wpScripts ) {

--- a/packages/create-block/lib/scaffold.js
+++ b/packages/create-block/lib/scaffold.js
@@ -10,6 +10,7 @@ const { dirname } = require( 'path' );
 /**
  * Internal dependencies
  */
+const initBlockJSON = require( './init-block-json' );
 const initPackageJSON = require( './init-package-json' );
 const initWPScripts = require( './init-wp-scripts' );
 const { code, info, success } = require( './log' );
@@ -67,6 +68,7 @@ module.exports = async (
 		} )
 	);
 
+	await initBlockJSON( blockTemplate, view );
 	await initPackageJSON( view );
 
 	if ( wpScripts ) {

--- a/packages/create-block/lib/templates.js
+++ b/packages/create-block/lib/templates.js
@@ -82,9 +82,9 @@ const getDefaultValues = ( blockTemplate ) => {
 		licenseURI: 'https://www.gnu.org/licenses/gpl-2.0.html',
 		version: '0.1.0',
 		wpScripts: true,
-		editorScript: 'file:build/index.js',
-		editorStyle: 'file:build/index.css',
-		style: 'file:build/style-index.css',
+		editorScript: 'file:./build/index.js',
+		editorStyle: 'file:./build/index.css',
+		style: 'file:./build/style-index.css',
 		...blockTemplate.defaultValues,
 	};
 };

--- a/packages/create-block/lib/templates.js
+++ b/packages/create-block/lib/templates.js
@@ -20,6 +20,9 @@ const predefinedBlockTemplates = {
 			description:
 				'Example block written with ES5 standard and no JSX – no build step required.',
 			wpScripts: false,
+			editorScript: 'file:index.js',
+			editorStyle: 'file:editor.css',
+			style: 'file:style.css',
 		},
 	},
 	esnext: {
@@ -79,6 +82,9 @@ const getDefaultValues = ( blockTemplate ) => {
 		licenseURI: 'https://www.gnu.org/licenses/gpl-2.0.html',
 		version: '0.1.0',
 		wpScripts: true,
+		editorScript: 'file:build/index.js',
+		editorStyle: 'file:build/index.css',
+		style: 'file:build/style-index.css',
 		...blockTemplate.defaultValues,
 	};
 };

--- a/packages/create-block/lib/templates.js
+++ b/packages/create-block/lib/templates.js
@@ -20,9 +20,9 @@ const predefinedBlockTemplates = {
 			description:
 				'Example block written with ES5 standard and no JSX – no build step required.',
 			wpScripts: false,
-			editorScript: 'file:index.js',
-			editorStyle: 'file:editor.css',
-			style: 'file:style.css',
+			editorScript: 'file:./index.js',
+			editorStyle: 'file:./editor.css',
+			style: 'file:./style.css',
 		},
 	},
 	esnext: {


### PR DESCRIPTION
## Description
#22151 suggests auto-generating the block.json file as a way to help block creators be set up for success in getting their blocks added to the block directory.

This adds block.json auto-generation to the `create-block` script during the scaffolding process. The file is pre-populated with the inputs/defaults from the script. The `editorScript`/`editorStyle` properties vary depending on which template is chosen (esnext or es5).

## How has this been tested?
Tested with a local checkout of Gutenberg, running `node path/to/create-block`. Tested with both `esnext` and `es5` values for the `template` parameter.

## Types of changes
* New feature: auto-generated block.json file

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
