### PR TITLE
Date: Add timezone hint

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -341,7 +341,6 @@ add_action( 'wp_default_scripts', 'gutenberg_add_dom_rect_polyfill', 20 );
  * The script registration occurs in core wp-includes/script-loader.php
  * wp_default_packages_inline_scripts()
  *
- *
  * @since 8.6.0
  *
  * @param WP_Scripts $scripts WP_Scripts object.
@@ -350,13 +349,13 @@ function gutenberg_add_date_settings_timezone( $scripts ) {
 	if ( did_action( 'init' ) ) {
 		global $wp_locale;
 
-		// calcualte the timezone abbr (EDT, PST) if possible
-		$timezone_string = get_option('timezone_string', 'UTC');
+		// calcualte the timezone abbr (EDT, PST) if possible.
+		$timezone_string = get_option( 'timezone_string', 'UTC' );
 		if ( empty( $timezone_string ) ) {
 			$timezone_abbr = '';
 		} else {
-			$timezone_date = new DateTime(null, new DateTimeZone($timezone_string));
-			$timezone_abbr = $timezone_date->format('T');
+			$timezone_date = new DateTime( null, new DateTimeZone( $timezone_string ) );
+			$timezone_abbr = $timezone_date->format( 'T' );
 		}
 
 		$scripts->add_inline_script(
@@ -364,40 +363,40 @@ function gutenberg_add_date_settings_timezone( $scripts ) {
 			sprintf(
 				'wp.date.setSettings( %s );',
 				wp_json_encode(
-						array(
-								'l10n'     => array(
-										'locale'        => get_user_locale(),
-										'months'        => array_values( $wp_locale->month ),
-										'monthsShort'   => array_values( $wp_locale->month_abbrev ),
-										'weekdays'      => array_values( $wp_locale->weekday ),
-										'weekdaysShort' => array_values( $wp_locale->weekday_abbrev ),
-										'meridiem'      => (object) $wp_locale->meridiem,
-										'relative'      => array(
-												/* translators: %s: Duration. */
-												'future' => __( '%s from now' ),
-												/* translators: %s: Duration. */
-												'past'   => __( '%s ago' ),
-										),
-								),
-								'formats'  => array(
-										/* translators: Time format, see https://www.php.net/date */
-										'time'                => get_option( 'time_format', __( 'g:i a' ) ),
-										/* translators: Date format, see https://www.php.net/date */
-										'date'                => get_option( 'date_format', __( 'F j, Y' ) ),
-										/* translators: Date/Time format, see https://www.php.net/date */
-										'datetime'            => __( 'F j, Y g:i a' ),
-										/* translators: Abbreviated date/time format, see https://www.php.net/date */
-										'datetimeAbbreviated' => __( 'M j, Y g:i a' ),
-								),
-								'timezone' => array(
-										'offset' => get_option( 'gmt_offset', 0 ),
-										'string' => get_option( 'timezone_string', 'UTC' ),
-										'abbr' => $timezone_abbr,
-								),
-						)
+					array(
+						'l10n'     => array(
+							'locale'        => get_user_locale(),
+							'months'        => array_values( $wp_locale->month ),
+							'monthsShort'   => array_values( $wp_locale->month_abbrev ),
+							'weekdays'      => array_values( $wp_locale->weekday ),
+							'weekdaysShort' => array_values( $wp_locale->weekday_abbrev ),
+							'meridiem'      => (object) $wp_locale->meridiem,
+							'relative'      => array(
+								/* translators: %s: Duration. */
+								'future' => __( '%s from now', 'default' ),
+								/* translators: %s: Duration. */
+								'past'   => __( '%s ago', 'default' ),
+							),
+						),
+						'formats'  => array(
+							/* translators: Time format, see https://www.php.net/date */
+							'time'                => get_option( 'time_format', __( 'g:i a', 'default' ) ),
+							/* translators: Date format, see https://www.php.net/date */
+							'date'                => get_option( 'date_format', __( 'F j, Y', 'default' ) ),
+							/* translators: Date/Time format, see https://www.php.net/date */
+							'datetime'            => __( 'F j, Y g:i a', 'default' ),
+							/* translators: Abbreviated date/time format, see https://www.php.net/date */
+							'datetimeAbbreviated' => __( 'M j, Y g:i a', 'default' ),
+						),
+						'timezone' => array(
+							'offset' => get_option( 'gmt_offset', 0 ),
+							'string' => get_option( 'timezone_string', 'UTC' ),
+							'abbr'   => $timezone_abbr,
+						),
+					)
 				)
 			),
-		'after'
+			'after'
 		);
 	}
 }

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -334,6 +334,76 @@ function gutenberg_add_dom_rect_polyfill( $scripts ) {
 add_action( 'wp_default_scripts', 'gutenberg_add_dom_rect_polyfill', 20 );
 
 /**
+ * Adds a wp.date.setSettings with timezone abbr parameter
+ *
+ * This can be removed when plugin support requires WordPress 5.6.0+.
+ *
+ * The script registration occurs in core wp-includes/script-loader.php
+ * wp_default_packages_inline_scripts()
+ *
+ *
+ * @since 8.6.0
+ *
+ * @param WP_Scripts $scripts WP_Scripts object.
+ */
+function gutenberg_add_date_settings_timezone( $scripts ) {
+	if ( did_action( 'init' ) ) {
+		global $wp_locale;
+
+		// calcualte the timezone abbr (EDT, PST) if possible
+		$timezone_string = get_option('timezone_string', 'UTC');
+		if ( empty( $timezone_string ) ) {
+			$timezone_abbr = '';
+		} else {
+			$timezone_date = new DateTime(null, new DateTimeZone($timezone_string));
+			$timezone_abbr = $timezone_date->format('T');
+		}
+
+		$scripts->add_inline_script(
+			'wp-date',
+			sprintf(
+				'wp.date.setSettings( %s );',
+				wp_json_encode(
+						array(
+								'l10n'     => array(
+										'locale'        => get_user_locale(),
+										'months'        => array_values( $wp_locale->month ),
+										'monthsShort'   => array_values( $wp_locale->month_abbrev ),
+										'weekdays'      => array_values( $wp_locale->weekday ),
+										'weekdaysShort' => array_values( $wp_locale->weekday_abbrev ),
+										'meridiem'      => (object) $wp_locale->meridiem,
+										'relative'      => array(
+												/* translators: %s: Duration. */
+												'future' => __( '%s from now' ),
+												/* translators: %s: Duration. */
+												'past'   => __( '%s ago' ),
+										),
+								),
+								'formats'  => array(
+										/* translators: Time format, see https://www.php.net/date */
+										'time'                => get_option( 'time_format', __( 'g:i a' ) ),
+										/* translators: Date format, see https://www.php.net/date */
+										'date'                => get_option( 'date_format', __( 'F j, Y' ) ),
+										/* translators: Date/Time format, see https://www.php.net/date */
+										'datetime'            => __( 'F j, Y g:i a' ),
+										/* translators: Abbreviated date/time format, see https://www.php.net/date */
+										'datetimeAbbreviated' => __( 'M j, Y g:i a' ),
+								),
+								'timezone' => array(
+										'offset' => get_option( 'gmt_offset', 0 ),
+										'string' => get_option( 'timezone_string', 'UTC' ),
+										'abbr' => $timezone_abbr,
+								),
+						)
+				)
+			),
+		'after'
+		);
+	}
+}
+add_action( 'wp_default_scripts', 'gutenberg_add_date_settings_timezone', 20 );
+
+/**
  * Filters default block categories to substitute legacy category names with new
  * block categories.
  *

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -346,59 +346,61 @@ add_action( 'wp_default_scripts', 'gutenberg_add_dom_rect_polyfill', 20 );
  * @param WP_Scripts $scripts WP_Scripts object.
  */
 function gutenberg_add_date_settings_timezone( $scripts ) {
-	if ( did_action( 'init' ) ) {
-		global $wp_locale;
-
-		// calcualte the timezone abbr (EDT, PST) if possible.
-		$timezone_string = get_option( 'timezone_string', 'UTC' );
-		if ( empty( $timezone_string ) ) {
-			$timezone_abbr = '';
-		} else {
-			$timezone_date = new DateTime( null, new DateTimeZone( $timezone_string ) );
-			$timezone_abbr = $timezone_date->format( 'T' );
-		}
-
-		$scripts->add_inline_script(
-			'wp-date',
-			sprintf(
-				'wp.date.setSettings( %s );',
-				wp_json_encode(
-					array(
-						'l10n'     => array(
-							'locale'        => get_user_locale(),
-							'months'        => array_values( $wp_locale->month ),
-							'monthsShort'   => array_values( $wp_locale->month_abbrev ),
-							'weekdays'      => array_values( $wp_locale->weekday ),
-							'weekdaysShort' => array_values( $wp_locale->weekday_abbrev ),
-							'meridiem'      => (object) $wp_locale->meridiem,
-							'relative'      => array(
-								/* translators: %s: Duration. */
-								'future' => __( '%s from now', 'default' ),
-								/* translators: %s: Duration. */
-								'past'   => __( '%s ago', 'default' ),
-							),
-						),
-						'formats'  => array(
-							/* translators: Time format, see https://www.php.net/date */
-							'time'                => get_option( 'time_format', __( 'g:i a', 'default' ) ),
-							/* translators: Date format, see https://www.php.net/date */
-							'date'                => get_option( 'date_format', __( 'F j, Y', 'default' ) ),
-							/* translators: Date/Time format, see https://www.php.net/date */
-							'datetime'            => __( 'F j, Y g:i a', 'default' ),
-							/* translators: Abbreviated date/time format, see https://www.php.net/date */
-							'datetimeAbbreviated' => __( 'M j, Y g:i a', 'default' ),
-						),
-						'timezone' => array(
-							'offset' => get_option( 'gmt_offset', 0 ),
-							'string' => get_option( 'timezone_string', 'UTC' ),
-							'abbr'   => $timezone_abbr,
-						),
-					)
-				)
-			),
-			'after'
-		);
+	if ( ! did_action( 'init' ) ) {
+		return;
 	}
+
+	global $wp_locale;
+
+	// Calculate the timezone abbr (EDT, PST) if possible.
+	$timezone_string = get_option( 'timezone_string', 'UTC' );
+	$timezone_abbr   = '';
+
+	if ( ! empty( $timezone_string ) ) {
+		$timezone_date = new DateTime( null, new DateTimeZone( $timezone_string ) );
+		$timezone_abbr = $timezone_date->format( 'T' );
+	}
+
+	$scripts->add_inline_script(
+		'wp-date',
+		sprintf(
+			'wp.date.setSettings( %s );',
+			wp_json_encode(
+				array(
+					'l10n'     => array(
+						'locale'        => get_user_locale(),
+						'months'        => array_values( $wp_locale->month ),
+						'monthsShort'   => array_values( $wp_locale->month_abbrev ),
+						'weekdays'      => array_values( $wp_locale->weekday ),
+						'weekdaysShort' => array_values( $wp_locale->weekday_abbrev ),
+						'meridiem'      => (object) $wp_locale->meridiem,
+						'relative'      => array(
+							/* translators: %s: Duration. */
+							'future' => __( '%s from now', 'default' ),
+							/* translators: %s: Duration. */
+							'past'   => __( '%s ago', 'default' ),
+						),
+					),
+					'formats'  => array(
+						/* translators: Time format, see https://www.php.net/date */
+						'time'                => get_option( 'time_format', __( 'g:i a', 'default' ) ),
+						/* translators: Date format, see https://www.php.net/date */
+						'date'                => get_option( 'date_format', __( 'F j, Y', 'default' ) ),
+						/* translators: Date/Time format, see https://www.php.net/date */
+						'datetime'            => __( 'F j, Y g:i a', 'default' ),
+						/* translators: Abbreviated date/time format, see https://www.php.net/date */
+						'datetimeAbbreviated' => __( 'M j, Y g:i a', 'default' ),
+					),
+					'timezone' => array(
+						'offset' => get_option( 'gmt_offset', 0 ),
+						'string' => $timezone_string,
+						'abbr'   => $timezone_abbr,
+					),
+				)
+			)
+		),
+		'after'
+	);
 }
 add_action( 'wp_default_scripts', 'gutenberg_add_date_settings_timezone', 20 );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11099,6 +11099,7 @@
 				"@emotion/styled": "^10.0.23",
 				"@wordpress/a11y": "file:packages/a11y",
 				"@wordpress/compose": "file:packages/compose",
+				"@wordpress/date": "file:packages/date",
 				"@wordpress/deprecated": "file:packages/deprecated",
 				"@wordpress/dom": "file:packages/dom",
 				"@wordpress/element": "file:packages/element",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -32,6 +32,7 @@
 		"@emotion/styled": "^10.0.23",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/compose": "file:../compose",
+		"@wordpress/date": "file:../date",
 		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/dom": "file:../dom",
 		"@wordpress/element": "file:../element",

--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -186,6 +186,13 @@
 	}
 }
 
+.components-datetime__timezone {
+	color: $dark-gray-500;
+	line-height: 30px;
+	margin-left: $grid-unit-05;
+	text-decoration: underline dotted;
+}
+
 .components-datetime__time-legend {
 	font-weight: 600;
 	margin-top: 0.5em;

--- a/packages/components/src/date-time/test/__snapshots__/time.js.snap
+++ b/packages/components/src/date-time/test/__snapshots__/time.js.snap
@@ -156,6 +156,7 @@ exports[`TimePicker matches the snapshot when the is12hour prop is false 1`] = `
           value="00"
         />
       </div>
+      <TimeZone />
     </div>
   </fieldset>
 </div>
@@ -337,6 +338,7 @@ exports[`TimePicker matches the snapshot when the is12hour prop is specified 1`]
           PM
         </ForwardRef(Button)>
       </ForwardRef(ButtonGroup)>
+      <TimeZone />
     </div>
   </fieldset>
 </div>
@@ -518,6 +520,7 @@ exports[`TimePicker matches the snapshot when the is12hour prop is true 1`] = `
           PM
         </ForwardRef(Button)>
       </ForwardRef(ButtonGroup)>
+      <TimeZone />
     </div>
   </fieldset>
 </div>
@@ -679,6 +682,7 @@ exports[`TimePicker matches the snapshot when the is12hour prop is undefined 1`]
           value="00"
         />
       </div>
+      <TimeZone />
     </div>
   </fieldset>
 </div>

--- a/packages/components/src/date-time/time.js
+++ b/packages/components/src/date-time/time.js
@@ -284,6 +284,9 @@ class TimePicker extends Component {
 			const { timezone } = getDateSettings();
 			const offset =
 				timezone.offset > 0 ? '+' + timezone.offset : timezone.offset;
+			const zoneAbbr = moment
+				.tz( new Date(), timezone.string )
+				.zoneAbbr();
 			const timezoneDetail =
 				'UTC' === timezone.string
 					? __( 'Coordinated Universal Time' )
@@ -292,9 +295,9 @@ class TimePicker extends Component {
 					  ') ' +
 					  timezone.string.replace( '_', ' ' );
 			const timezoneAbbr =
-				'' === timezone.string
-					? 'UTC' + offset
-					: moment.tz( new Date(), timezone.string ).zoneAbbr();
+				'' !== timezone.string && isNaN( zoneAbbr )
+					? zoneAbbr
+					: 'UTC' + offset;
 
 			return (
 				<Tooltip position="top center" text={ timezoneDetail }>

--- a/packages/components/src/date-time/time.js
+++ b/packages/components/src/date-time/time.js
@@ -10,14 +10,13 @@ import moment from 'moment';
  */
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { __experimentalGetSettings as getDateSettings } from '@wordpress/date';
 
 /**
  * Internal dependencies
  */
 import Button from '../button';
 import ButtonGroup from '../button-group';
-import Tooltip from '../tooltip';
+import TimeZone from './timezone';
 
 /**
  * Module Constants
@@ -279,34 +278,6 @@ class TimePicker extends Component {
 	render() {
 		const { is12Hour } = this.props;
 		const { year, minutes, hours, am } = this.state;
-
-		const TimeZone = () => {
-			const { timezone } = getDateSettings();
-			const offset =
-				timezone.offset > 0 ? '+' + timezone.offset : timezone.offset;
-			const zoneAbbr = moment
-				.tz( new Date(), timezone.string )
-				.zoneAbbr();
-			const timezoneDetail =
-				'UTC' === timezone.string
-					? __( 'Coordinated Universal Time' )
-					: '(UTC' +
-					  offset +
-					  ') ' +
-					  timezone.string.replace( '_', ' ' );
-			const timezoneAbbr =
-				'' !== timezone.string && isNaN( zoneAbbr )
-					? zoneAbbr
-					: 'UTC' + offset;
-
-			return (
-				<Tooltip position="top center" text={ timezoneDetail }>
-					<div className="components-datetime__timezone">
-						{ timezoneAbbr }
-					</div>
-				</Tooltip>
-			);
-		};
 
 		return (
 			<div className={ classnames( 'components-datetime__time' ) }>

--- a/packages/components/src/date-time/time.js
+++ b/packages/components/src/date-time/time.js
@@ -10,12 +10,14 @@ import moment from 'moment';
  */
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { __experimentalGetSettings as getDateSettings } from '@wordpress/date';
 
 /**
  * Internal dependencies
  */
 import Button from '../button';
 import ButtonGroup from '../button-group';
+import Tooltip from '../tooltip';
 
 /**
  * Module Constants
@@ -277,6 +279,32 @@ class TimePicker extends Component {
 	render() {
 		const { is12Hour } = this.props;
 		const { year, minutes, hours, am } = this.state;
+
+		const TimeZone = () => {
+			const { timezone } = getDateSettings();
+			const offset =
+				timezone.offset > 0 ? '+' + timezone.offset : timezone.offset;
+			const timezoneDetail =
+				'UTC' === timezone.string
+					? __( 'Coordinated Universal Time' )
+					: '(UTC' +
+					  offset +
+					  ') ' +
+					  timezone.string.replace( '_', ' ' );
+			const timezoneAbbr =
+				'' === timezone.string
+					? 'UTC' + offset
+					: moment.tz( new Date(), timezone.string ).zoneAbbr();
+
+			return (
+				<Tooltip position="top center" text={ timezoneDetail }>
+					<div className="components-datetime__timezone">
+						{ timezoneAbbr }
+					</div>
+				</Tooltip>
+			);
+		};
+
 		return (
 			<div className={ classnames( 'components-datetime__time' ) }>
 				<fieldset>
@@ -353,6 +381,8 @@ class TimePicker extends Component {
 								</Button>
 							</ButtonGroup>
 						) }
+
+						<TimeZone />
 					</div>
 				</fieldset>
 			</div>

--- a/packages/components/src/date-time/timezone.js
+++ b/packages/components/src/date-time/timezone.js
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import moment from 'moment';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { __experimentalGetSettings as getDateSettings } from '@wordpress/date';
+
+/**
+ * Internal dependencies
+ */
+import Tooltip from '../tooltip';
+
+const TimeZone = () => {
+	const { timezone } = getDateSettings();
+	const offset =
+		timezone.offset > 0 ? '+' + timezone.offset : timezone.offset;
+	const zoneAbbr = moment.tz( new Date(), timezone.string ).zoneAbbr();
+	const timezoneDetail =
+		'UTC' === timezone.string
+			? __( 'Coordinated Universal Time' )
+			: '(UTC' + offset + ') ' + timezone.string.replace( '_', ' ' );
+	const timezoneAbbr =
+		'' !== timezone.string && isNaN( zoneAbbr ) ? zoneAbbr : 'UTC' + offset;
+
+	return (
+		<Tooltip position="top center" text={ timezoneDetail }>
+			<div className="components-datetime__timezone">
+				{ timezoneAbbr }
+			</div>
+		</Tooltip>
+	);
+};
+
+export default TimeZone;

--- a/packages/components/src/date-time/timezone.js
+++ b/packages/components/src/date-time/timezone.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import moment from 'moment';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -19,31 +14,30 @@ import Tooltip from '../tooltip';
  */
 const TimeZone = () => {
 	const { timezone } = getDateSettings();
-	const userTimezone = moment.tz.guess( true );
 
-	if (
-		! timezone.string ||
-		timezone.string === userTimezone ||
-		'WP' === userTimezone
-	) {
+	// getTimezoneOffset() returns in minutes and opposite how you'd expect
+	// America/Los_Angeles = 420 and not -7
+	const userTimezoneOffset = -1 * ( new Date().getTimezoneOffset() / 60 );
+
+	// System timezone and user timezone match, nothing needed
+	// compare as numbers because it comes over as string
+	if ( Number( timezone.offset ) === userTimezoneOffset ) {
 		return null;
 	}
 
-	const offset =
-		timezone.offset > 0 ? '+' + timezone.offset : timezone.offset;
-	const zoneAbbr = moment.tz( new Date(), timezone.string ).zoneAbbr();
+	const offsetSymbol = timezone.offset >= 0 ? '+' : '';
+	const zoneAbbr = timezone.abbr
+		? timezone.abbr
+		: `UTC${ offsetSymbol }${ timezone.offset }`;
+
 	const timezoneDetail =
 		'UTC' === timezone.string
 			? __( 'Coordinated Universal Time' )
-			: '(UTC' + offset + ') ' + timezone.string.replace( '_', ' ' );
-	const timezoneAbbr =
-		'' !== timezone.string && isNaN( zoneAbbr ) ? zoneAbbr : 'UTC' + offset;
+			: `(${ zoneAbbr }) ${ timezone.string.replace( '_', ' ' ) }`;
 
 	return (
 		<Tooltip position="top center" text={ timezoneDetail }>
-			<div className="components-datetime__timezone">
-				{ timezoneAbbr }
-			</div>
+			<div className="components-datetime__timezone"> { zoneAbbr } </div>
 		</Tooltip>
 	);
 };

--- a/packages/components/src/date-time/timezone.js
+++ b/packages/components/src/date-time/timezone.js
@@ -14,8 +14,21 @@ import { __experimentalGetSettings as getDateSettings } from '@wordpress/date';
  */
 import Tooltip from '../tooltip';
 
+/**
+ * Displays timezone information when user timezone is different from site timezone.
+ */
 const TimeZone = () => {
 	const { timezone } = getDateSettings();
+	const userTimezone = moment.tz.guess( true );
+
+	if (
+		! timezone.string ||
+		timezone.string === userTimezone ||
+		'WP' === userTimezone
+	) {
+		return null;
+	}
+
 	const offset =
 		timezone.offset > 0 ? '+' + timezone.offset : timezone.offset;
 	const zoneAbbr = moment.tz( new Date(), timezone.string ).zoneAbbr();

--- a/packages/components/src/date-time/timezone.js
+++ b/packages/components/src/date-time/timezone.js
@@ -15,20 +15,20 @@ import Tooltip from '../tooltip';
 const TimeZone = () => {
 	const { timezone } = getDateSettings();
 
-	// getTimezoneOffset() returns in minutes and opposite how you'd expect
-	// America/Los_Angeles = 420 and not -7
+	// Convert timezone offset to hours.
 	const userTimezoneOffset = -1 * ( new Date().getTimezoneOffset() / 60 );
 
-	// System timezone and user timezone match, nothing needed
-	// compare as numbers because it comes over as string
+	// System timezone and user timezone match, nothing needed.
+	// Compare as numbers because it comes over as string.
 	if ( Number( timezone.offset ) === userTimezoneOffset ) {
 		return null;
 	}
 
 	const offsetSymbol = timezone.offset >= 0 ? '+' : '';
-	const zoneAbbr = timezone.abbr
-		? timezone.abbr
-		: `UTC${ offsetSymbol }${ timezone.offset }`;
+	const zoneAbbr =
+		'' !== timezone.abbr && isNaN( timezone.abbr )
+			? timezone.abbr
+			: `UTC${ offsetSymbol }${ timezone.offset }`;
 
 	const timezoneDetail =
 		'UTC' === timezone.string
@@ -37,7 +37,7 @@ const TimeZone = () => {
 
 	return (
 		<Tooltip position="top center" text={ timezoneDetail }>
-			<div className="components-datetime__timezone"> { zoneAbbr } </div>
+			<div className="components-datetime__timezone">{ zoneAbbr }</div>
 		</Tooltip>
 	);
 };

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -80,7 +80,7 @@ let settings = {
 		datetime: 'F j, Y g: i a',
 		datetimeAbbreviated: 'M j, Y g: i a',
 	},
-	timezone: { offset: '0', string: '' },
+	timezone: { offset: '0', string: '', abbr: '' },
 };
 
 /**


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This will add timezone information to the schedule post UI for users whose local timezone differs from the timezone set for the site. It shows the timezone abbreviation and a tooltip on hover with the full timezone name and UTC offset.

Fixes #15673.

## How has this been tested?
Tested locally with various timezones set in wp-admin.

To test:
* Got to Settings > General and select a timezone for your site.
* In the "Document" sidebar panel, click on the publish date to bring up the publish calender.
* Make sure the timezone information at the end of time component only gets displayed when your local timezone is different from the site's timezone.

## Screenshots <!-- if applicable -->
![82586619-b386d800-9b4c-11ea-8770-55bec0448124](https://user-images.githubusercontent.com/1398304/82945959-6347b580-9f52-11ea-8e65-8a807d8dbe2c.png)

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
