### PR TITLE
Polish block moving animation

### DIFF
--- a/packages/block-editor/src/components/use-moving-animation/index.js
+++ b/packages/block-editor/src/components/use-moving-animation/index.js
@@ -70,13 +70,13 @@ function useMovingAnimation(
 	// return a function to maintain that position by scrolling.
 	const preserveScrollPosition = useMemo( () => {
 		if ( ! adjustScrolling || ! ref.current ) {
-			return;
+			return () => {};
 		}
 
 		const scrollContainer = getScrollContainer( ref.current );
 
 		if ( ! scrollContainer ) {
-			return;
+			return () => {};
 		}
 
 		const prevRect = ref.current.getBoundingClientRect();
@@ -103,9 +103,7 @@ function useMovingAnimation(
 		if ( prefersReducedMotion ) {
 			// if the animation is disabled and the scroll needs to be adjusted,
 			// just move directly to the final scroll position.
-			if ( preserveScrollPosition ) {
-				preserveScrollPosition();
-			}
+			preserveScrollPosition();
 
 			return;
 		}
@@ -133,9 +131,7 @@ function useMovingAnimation(
 			: `translate3d(${ x }px,${ y }px,0)`;
 		ref.current.style.zIndex = ! isSelected || isMoving ? '' : '1';
 
-		if ( preserveScrollPosition ) {
-			preserveScrollPosition();
-		}
+		preserveScrollPosition();
 	}
 
 	// Called for every frame computed by useSpring.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

This PR fixes a long standing issue where moving a block **up** sometimes scrolls the page too much. This has been bugging me for a while... It seems like the browser itself already scrolls the page when moving the block in the DOM, so any scrolling done by us afterwards based on that will be off.

The solution is to calculate the block position before the block moves in the DOM. This can be done before rendering using `useMemo`. Once we have this scroll position, it's easy to restore the same position relative to the viewport.

Video of the bug being fixed:

![move-scroll](https://user-images.githubusercontent.com/4710635/85449426-67daaa80-b5a0-11ea-933f-f78440a21dce.gif)


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
