### PR TITLE
Use a more specific `<script>` matching

### DIFF
--- a/lib/block-directory.php
+++ b/lib/block-directory.php
@@ -22,18 +22,24 @@ if (
 	/**
 	 * Add data attribute of handle to all script tags output in the wp-admin.
 	 *
-	 * @param string $tag    The `<script>` tag for the enqueued script.
-	 * @param string $handle The script's registered handle.
+	 * @param string $tag     The `<script>` tag for the enqueued script.
+	 * @param string $handle  The script's registered handle.
+	 * @param string $src_esc The script's pre-escaped registered src.
 	 *
-	 * @return string  Filter script tag.
+	 * @return string  Filtered script tag.
 	 */
-	function gutenberg_change_script_tag( $tag, $handle ) {
+	function gutenberg_change_script_tag( $tag, $handle, $src_esc ) {
 		if ( ! is_admin() ) {
 			return $tag;
 		}
-		$tag = str_replace( '<script ', sprintf( '<script data-handle="%s" ', esc_attr( $handle ) ), $tag );
+
+		$tag = str_replace(
+			sprintf( "<script src='%s'></script>", $src_esc ),
+			sprintf( "<script data-handle='%s' src='%s'></script>", esc_attr( $handle ), $src_esc ),
+			$tag
+		);
 
 		return $tag;
 	}
-	add_filter( 'script_loader_tag', 'gutenberg_change_script_tag', 10, 2 );
+	add_filter( 'script_loader_tag', 'gutenberg_change_script_tag', 1, 3 );
 }

--- a/lib/block-directory.php
+++ b/lib/block-directory.php
@@ -24,18 +24,18 @@ if (
 	 *
 	 * @param string $tag     The `<script>` tag for the enqueued script.
 	 * @param string $handle  The script's registered handle.
-	 * @param string $src_esc The script's pre-escaped registered src.
+	 * @param string $esc_src The script's pre-escaped registered src.
 	 *
 	 * @return string  Filtered script tag.
 	 */
-	function gutenberg_change_script_tag( $tag, $handle, $src_esc ) {
+	function gutenberg_change_script_tag( $tag, $handle, $esc_src ) {
 		if ( ! is_admin() ) {
 			return $tag;
 		}
 
 		$tag = str_replace(
-			sprintf( "<script src='%s'></script>", $src_esc ),
-			sprintf( "<script data-handle='%s' src='%s'></script>", esc_attr( $handle ), $src_esc ),
+			sprintf( "<script src='%s'></script>", $esc_src ),
+			sprintf( "<script data-handle='%s' src='%s'></script>", esc_attr( $handle ), $esc_src ),
 			$tag
 		);
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Uses a more specific matching pattern to only affect the `<script>` tags which we're interested in.
This should resolve the issues in #23158 

This uses the full `<script>` produced by `WP_Scripts::do_item()` ignoring the Translations and before/after inline scripts, which allows for it to exclude `<script%` tags contained within the before/after html chunks.

The major change I see here after testing is two fold:
 1. Script tags in the JSON are not altered
 2. The sub-scripts of `wp-polyfill` no longer get `data-handle` elements, as they're not built the same way, where they previously were, eg:
```
( 'fetch' in window ) || document.write( '<script src="https://example.site/wp-includes/js/dist/vendor/wp-polyfill-fetch.min.js?ver=3.0.0"></scr' + 'ipt>' );
```
I'm unsure if this is a concern, as I don't believe scripts should be depending on individual `wp-polyfill-*` scripts and only the main polyfill library?

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
As in #23158 
 - Activate the Block experiment in Gutenberg -> Experiments and Yoast at the same time.
 - Verify that the editor does not WSOD
 - Verify that the HTML source contains `data-handle` attributes on appropriate script tags.
 - Visual diff comparison of the source of `post-new.php` comparing before/after.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug Fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
