### PR TITLE
Classic block: save content bug fix

### DIFF
--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -121,16 +121,19 @@ export default class ClassicEdit extends Component {
 			bookmark = null;
 		} );
 
-		editor.on( 'Paste Change input Undo Redo', debounce( () => {
-			const value = editor.getContent();
+		editor.on(
+			'Paste Change input Undo Redo',
+			debounce( () => {
+				const value = editor.getContent();
 
-			if ( value !== editor._lastChange ) {
-				editor._lastChange = value;
-				setAttributes( {
-					content: value,
-				} );
-			}
-		}, 250 ) );
+				if ( value !== editor._lastChange ) {
+					editor._lastChange = value;
+					setAttributes( {
+						content: value,
+					} );
+				}
+			}, 250 )
+		);
 
 		editor.on( 'keydown', ( event ) => {
 			if (

--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -112,6 +112,17 @@ export default class ClassicEdit extends Component {
 			bookmark = null;
 		} );
 
+		editor.on( 'Paste Change input Undo Redo', () => {
+			const value = editor.getContent();
+
+			if ( value !== editor._lastChange ) {
+				editor._lastChange = value;
+				setAttributes( {
+					content: value,
+				} );
+			}
+        });
+
 		editor.on( 'keydown', ( event ) => {
 			if (
 				( event.keyCode === BACKSPACE || event.keyCode === DELETE ) &&

--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -121,7 +121,7 @@ export default class ClassicEdit extends Component {
 					content: value,
 				} );
 			}
-        });
+		} );
 
 		editor.on( 'keydown', ( event ) => {
 			if (

--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { debounce } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
@@ -116,7 +121,7 @@ export default class ClassicEdit extends Component {
 			bookmark = null;
 		} );
 
-		editor.on( 'Paste Change input Undo Redo', () => {
+		editor.on( 'Paste Change input Undo Redo', debounce( () => {
 			const value = editor.getContent();
 
 			if ( value !== editor._lastChange ) {
@@ -125,7 +130,7 @@ export default class ClassicEdit extends Component {
 					content: value,
 				} );
 			}
-		} );
+		}, 250 ) );
 
 		editor.on( 'keydown', ( event ) => {
 			if (

--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -58,8 +58,9 @@ export default class ClassicEdit extends Component {
 		} = this.props;
 
 		const editor = window.tinymce.get( `editor-${ clientId }` );
-
-		if ( prevProps.attributes.content !== content ) {
+		const currentContent = editor.getContent();
+		
+		if ( prevProps.attributes.content !== content && currentContent !== content ) {
 			editor.setContent( content || '' );
 		}
 	}

--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -59,8 +59,11 @@ export default class ClassicEdit extends Component {
 
 		const editor = window.tinymce.get( `editor-${ clientId }` );
 		const currentContent = editor.getContent();
-		
-		if ( prevProps.attributes.content !== content && currentContent !== content ) {
+
+		if (
+			prevProps.attributes.content !== content &&
+			currentContent !== content
+		) {
 			editor.setContent( content || '' );
 		}
 	}


### PR DESCRIPTION
## Description
Fixes: #22935 
Fixes: #15577

Uses the TinyMCE change events to push changed content back out to gutenberg instead of just relying on the onblur event

## How has this been tested?
Manually

## Screenshots 
Before:

![onchange-before](https://user-images.githubusercontent.com/3629020/85626091-9a7bc480-b6c0-11ea-83a5-c5ec6820be60.gif)

After:

![onchange-after](https://user-images.githubusercontent.com/3629020/85626108-a1a2d280-b6c0-11ea-9ac8-40999c72a36f.gif)

## Types of changes


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
