### PR TITLE
Remove the overflow on the button.

### DIFF
--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -13,7 +13,6 @@
 	align-items: center;
 	box-sizing: border-box;
 	padding: 6px 12px;
-	overflow: hidden;
 	border-radius: $radius-block-ui;
 	color: $dark-gray-primary;
 


### PR DESCRIPTION
## Description
This pr removes `overflow: hidden` from the `Button` component to fix width issues.

The buttons style were updated in https://github.com/WordPress/gutenberg/pull/19058.

This issue was initially identified in that PR, in this conversation:
https://github.com/WordPress/gutenberg/pull/19058#discussion_r395529757

It has also introduced issues in buttons used in the Block Directory package.

## How to reproduce?
1. Search for `woocommerce` in the inserter
2. Expect a search result from the block directory
3. Notice overflow issue on the button.

## Screenshots <!-- if applicable -->
![Search Result](https://d.pr/i/iAv2Kp.png)


## How was this tested?
It was a total visual test. I navigated around look at the buttons to make sure everything is displayed properly.

## Types of changes
1. Removes overflow for the component button.


## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
