### PR TITLE
Add debounce to classic block autosave

### DIFF
--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -1,4 +1,8 @@
 /**
+ * External dependencies
+ */
+import { debounce } from 'lodash';
+/**
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
@@ -116,16 +120,19 @@ export default class ClassicEdit extends Component {
 			bookmark = null;
 		} );
 
-		editor.on( 'Paste Change input Undo Redo', () => {
-			const value = editor.getContent();
+		editor.on(
+			'Paste Change input Undo Redo',
+			debounce( () => {
+				const value = editor.getContent();
 
-			if ( value !== editor._lastChange ) {
-				editor._lastChange = value;
-				setAttributes( {
-					content: value,
-				} );
-			}
-		} );
+				if ( value !== editor._lastChange ) {
+					editor._lastChange = value;
+					setAttributes( {
+						content: value,
+					} );
+				}
+			}, 250 )
+		);
 
 		editor.on( 'keydown', ( event ) => {
 			if (


### PR DESCRIPTION
## Description
This adds a debounce to the proposed fix for the classic block's autosave.

## How has this been tested?
Manually

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
