### PR TITLE
Stabilize __experimentalMoverDirection InnerBlocks prop and rename to orientation

### DIFF
--- a/packages/block-editor/src/components/block-list/block-popover.js
+++ b/packages/block-editor/src/components/block-list/block-popover.js
@@ -47,7 +47,7 @@ function BlockPopover( {
 	clientId,
 	rootClientId,
 	isValid,
-	moverDirection,
+	blockListOrientation,
 	isEmptyDefaultBlock,
 	capturingClientId,
 } ) {
@@ -195,7 +195,7 @@ function BlockPopover( {
 				<BlockSelectionButton
 					clientId={ clientId }
 					rootClientId={ rootClientId }
-					moverDirection={ moverDirection }
+					moverDirection={ blockListOrientation }
 				/>
 			) }
 			{ showEmptyBlockSideInserter && (
@@ -234,7 +234,7 @@ function wrapperSelector( select ) {
 	const { name, attributes = {}, isValid } =
 		__unstableGetBlockWithoutInnerBlocks( clientId ) || {};
 	const blockParentsClientIds = getBlockParents( clientId );
-	const { __experimentalMoverDirection } =
+	const { __experimentalBlockListOrientation } =
 		getBlockListSettings( rootClientId ) || {};
 
 	// Get Block List Settings for all ancestors of the current Block clientId
@@ -263,7 +263,7 @@ function wrapperSelector( select ) {
 		rootClientId: getBlockRootClientId( clientId ),
 		name,
 		isValid,
-		moverDirection: __experimentalMoverDirection,
+		blockListOrientation: __experimentalBlockListOrientation,
 		isEmptyDefaultBlock:
 			name && isUnmodifiedDefaultBlock( { name, attributes } ),
 		capturingClientId,
@@ -282,7 +282,7 @@ export default function WrappedBlockPopover() {
 		rootClientId,
 		name,
 		isValid,
-		moverDirection,
+		blockListOrientation,
 		isEmptyDefaultBlock,
 		capturingClientId,
 	} = selected;
@@ -296,7 +296,7 @@ export default function WrappedBlockPopover() {
 			clientId={ clientId }
 			rootClientId={ rootClientId }
 			isValid={ isValid }
-			moverDirection={ moverDirection }
+			blockListOrientation={ blockListOrientation }
 			isEmptyDefaultBlock={ isEmptyDefaultBlock }
 			capturingClientId={ capturingClientId }
 		/>

--- a/packages/block-editor/src/components/block-list/block-popover.js
+++ b/packages/block-editor/src/components/block-list/block-popover.js
@@ -47,7 +47,7 @@ function BlockPopover( {
 	clientId,
 	rootClientId,
 	isValid,
-	blockListOrientation,
+	orientation,
 	isEmptyDefaultBlock,
 	capturingClientId,
 } ) {
@@ -195,7 +195,7 @@ function BlockPopover( {
 				<BlockSelectionButton
 					clientId={ clientId }
 					rootClientId={ rootClientId }
-					moverDirection={ blockListOrientation }
+					moverDirection={ orientation }
 				/>
 			) }
 			{ showEmptyBlockSideInserter && (
@@ -234,8 +234,7 @@ function wrapperSelector( select ) {
 	const { name, attributes = {}, isValid } =
 		__unstableGetBlockWithoutInnerBlocks( clientId ) || {};
 	const blockParentsClientIds = getBlockParents( clientId );
-	const { __experimentalBlockListOrientation } =
-		getBlockListSettings( rootClientId ) || {};
+	const { orientation } = getBlockListSettings( rootClientId ) || {};
 
 	// Get Block List Settings for all ancestors of the current Block clientId
 	const ancestorBlockListSettings = __experimentalGetBlockListSettingsForBlocks(
@@ -263,7 +262,7 @@ function wrapperSelector( select ) {
 		rootClientId: getBlockRootClientId( clientId ),
 		name,
 		isValid,
-		blockListOrientation: __experimentalBlockListOrientation,
+		orientation,
 		isEmptyDefaultBlock:
 			name && isUnmodifiedDefaultBlock( { name, attributes } ),
 		capturingClientId,
@@ -282,7 +281,7 @@ export default function WrappedBlockPopover() {
 		rootClientId,
 		name,
 		isValid,
-		blockListOrientation,
+		orientation,
 		isEmptyDefaultBlock,
 		capturingClientId,
 	} = selected;
@@ -296,7 +295,7 @@ export default function WrappedBlockPopover() {
 			clientId={ clientId }
 			rootClientId={ rootClientId }
 			isValid={ isValid }
-			blockListOrientation={ blockListOrientation }
+			orientation={ orientation }
 			isEmptyDefaultBlock={ isEmptyDefaultBlock }
 			capturingClientId={ capturingClientId }
 		/>

--- a/packages/block-editor/src/components/block-list/block-popover.js
+++ b/packages/block-editor/src/components/block-list/block-popover.js
@@ -47,7 +47,6 @@ function BlockPopover( {
 	clientId,
 	rootClientId,
 	isValid,
-	orientation,
 	isEmptyDefaultBlock,
 	capturingClientId,
 } ) {
@@ -195,7 +194,6 @@ function BlockPopover( {
 				<BlockSelectionButton
 					clientId={ clientId }
 					rootClientId={ rootClientId }
-					moverDirection={ orientation }
 				/>
 			) }
 			{ showEmptyBlockSideInserter && (
@@ -219,7 +217,6 @@ function wrapperSelector( select ) {
 		getBlockRootClientId,
 		__unstableGetBlockWithoutInnerBlocks,
 		getBlockParents,
-		getBlockListSettings,
 		__experimentalGetBlockListSettingsForBlocks,
 	} = select( 'core/block-editor' );
 
@@ -230,11 +227,9 @@ function wrapperSelector( select ) {
 		return;
 	}
 
-	const rootClientId = getBlockRootClientId( clientId );
 	const { name, attributes = {}, isValid } =
 		__unstableGetBlockWithoutInnerBlocks( clientId ) || {};
 	const blockParentsClientIds = getBlockParents( clientId );
-	const { orientation } = getBlockListSettings( rootClientId ) || {};
 
 	// Get Block List Settings for all ancestors of the current Block clientId
 	const ancestorBlockListSettings = __experimentalGetBlockListSettingsForBlocks(
@@ -262,7 +257,6 @@ function wrapperSelector( select ) {
 		rootClientId: getBlockRootClientId( clientId ),
 		name,
 		isValid,
-		orientation,
 		isEmptyDefaultBlock:
 			name && isUnmodifiedDefaultBlock( { name, attributes } ),
 		capturingClientId,
@@ -281,7 +275,6 @@ export default function WrappedBlockPopover() {
 		rootClientId,
 		name,
 		isValid,
-		orientation,
 		isEmptyDefaultBlock,
 		capturingClientId,
 	} = selected;
@@ -295,7 +288,6 @@ export default function WrappedBlockPopover() {
 			clientId={ clientId }
 			rootClientId={ rootClientId }
 			isValid={ isValid }
-			orientation={ orientation }
 			isEmptyDefaultBlock={ isEmptyDefaultBlock }
 			capturingClientId={ capturingClientId }
 		/>

--- a/packages/block-editor/src/components/block-list/block-selection-button.js
+++ b/packages/block-editor/src/components/block-list/block-selection-button.js
@@ -30,29 +30,31 @@ import BlockTitle from '../block-title';
  *
  * @return {WPComponent} The component to be rendered.
  */
-function BlockSelectionButton( {
-	clientId,
-	rootClientId,
-	moverDirection,
-	...props
-} ) {
+function BlockSelectionButton( { clientId, rootClientId, ...props } ) {
 	const selected = useSelect(
 		( select ) => {
 			const {
 				__unstableGetBlockWithoutInnerBlocks,
 				getBlockIndex,
 				hasBlockMovingClientId,
+				getBlockListSettings,
 			} = select( 'core/block-editor' );
 			const index = getBlockIndex( clientId, rootClientId );
 			const { name, attributes } = __unstableGetBlockWithoutInnerBlocks(
 				clientId
 			);
 			const blockMovingMode = hasBlockMovingClientId();
-			return { index, name, attributes, blockMovingMode };
+			return {
+				index,
+				name,
+				attributes,
+				blockMovingMode,
+				orientation: getBlockListSettings( rootClientId )?.orientation,
+			};
 		},
 		[ clientId, rootClientId ]
 	);
-	const { index, name, attributes, blockMovingMode } = selected;
+	const { index, name, attributes, blockMovingMode, orientation } = selected;
 	const { setNavigationMode, removeBlock } = useDispatch(
 		'core/block-editor'
 	);
@@ -77,7 +79,7 @@ function BlockSelectionButton( {
 		blockType,
 		attributes,
 		index + 1,
-		moverDirection
+		orientation
 	);
 
 	const classNames = classnames(

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -49,8 +49,7 @@ function BlockList(
 			blockClientIds: getBlockOrder( rootClientId ),
 			selectedBlockClientId: getSelectedBlockClientId(),
 			multiSelectedBlockClientIds: getMultiSelectedBlockClientIds(),
-			blockListOrientation: getBlockListSettings( rootClientId )
-				?.__experimentalBlockListOrientation,
+			orientation: getBlockListSettings( rootClientId )?.orientation,
 			hasMultiSelection: hasMultiSelection(),
 			enableAnimation:
 				! isTyping() &&
@@ -62,7 +61,7 @@ function BlockList(
 		blockClientIds,
 		selectedBlockClientId,
 		multiSelectedBlockClientIds,
-		blockListOrientation,
+		orientation,
 		hasMultiSelection,
 		enableAnimation,
 	} = useSelect( selector, [ rootClientId ] );
@@ -109,7 +108,7 @@ function BlockList(
 								'is-drop-target': isDropTarget,
 								'is-dropping-horizontally':
 									isDropTarget &&
-									blockListOrientation === 'horizontal',
+									orientation === 'horizontal',
 							} ) }
 						/>
 					</AsyncModeProvider>
@@ -122,8 +121,7 @@ function BlockList(
 				className={ classnames( {
 					'is-drop-target': isAppenderDropTarget,
 					'is-dropping-horizontally':
-						isAppenderDropTarget &&
-						blockListOrientation === 'horizontal',
+						isAppenderDropTarget && orientation === 'horizontal',
 				} ) }
 			/>
 		</Container>

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -49,8 +49,8 @@ function BlockList(
 			blockClientIds: getBlockOrder( rootClientId ),
 			selectedBlockClientId: getSelectedBlockClientId(),
 			multiSelectedBlockClientIds: getMultiSelectedBlockClientIds(),
-			moverDirection: getBlockListSettings( rootClientId )
-				?.__experimentalMoverDirection,
+			blockListOrientation: getBlockListSettings( rootClientId )
+				?.__experimentalBlockListOrientation,
 			hasMultiSelection: hasMultiSelection(),
 			enableAnimation:
 				! isTyping() &&
@@ -62,7 +62,7 @@ function BlockList(
 		blockClientIds,
 		selectedBlockClientId,
 		multiSelectedBlockClientIds,
-		moverDirection,
+		blockListOrientation,
 		hasMultiSelection,
 		enableAnimation,
 	} = useSelect( selector, [ rootClientId ] );
@@ -109,7 +109,7 @@ function BlockList(
 								'is-drop-target': isDropTarget,
 								'is-dropping-horizontally':
 									isDropTarget &&
-									moverDirection === 'horizontal',
+									blockListOrientation === 'horizontal',
 							} ) }
 						/>
 					</AsyncModeProvider>
@@ -122,7 +122,8 @@ function BlockList(
 				className={ classnames( {
 					'is-drop-target': isAppenderDropTarget,
 					'is-dropping-horizontally':
-						isAppenderDropTarget && moverDirection === 'horizontal',
+						isAppenderDropTarget &&
+						blockListOrientation === 'horizontal',
 				} ) }
 			/>
 		</Container>

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -311,44 +311,41 @@ export class BlockList extends Component {
 }
 
 export default compose( [
-	withSelect(
-		( select, { rootClientId, __experimentalBlockListOrientation } ) => {
-			const {
-				getBlockCount,
-				getBlockOrder,
-				getSelectedBlockClientId,
-				isBlockInsertionPointVisible,
-				getSettings,
-				getBlockHierarchyRootClientId,
-			} = select( 'core/block-editor' );
+	withSelect( ( select, { rootClientId, orientation } ) => {
+		const {
+			getBlockCount,
+			getBlockOrder,
+			getSelectedBlockClientId,
+			isBlockInsertionPointVisible,
+			getSettings,
+			getBlockHierarchyRootClientId,
+		} = select( 'core/block-editor' );
 
-			const isStackedHorizontally =
-				__experimentalBlockListOrientation === 'horizontal';
+		const isStackedHorizontally = orientation === 'horizontal';
 
-			const selectedBlockClientId = getSelectedBlockClientId();
-			const blockClientIds = getBlockOrder( rootClientId );
+		const selectedBlockClientId = getSelectedBlockClientId();
+		const blockClientIds = getBlockOrder( rootClientId );
 
-			const isReadOnly = getSettings().readOnly;
+		const isReadOnly = getSettings().readOnly;
 
-			const rootBlockId = getBlockHierarchyRootClientId(
-				selectedBlockClientId
-			);
-			const hasRootInnerBlocks = !! getBlockCount( rootBlockId );
+		const rootBlockId = getBlockHierarchyRootClientId(
+			selectedBlockClientId
+		);
+		const hasRootInnerBlocks = !! getBlockCount( rootBlockId );
 
-			const isFloatingToolbarVisible =
-				!! selectedBlockClientId && hasRootInnerBlocks;
+		const isFloatingToolbarVisible =
+			!! selectedBlockClientId && hasRootInnerBlocks;
 
-			return {
-				blockClientIds,
-				blockCount: getBlockCount( rootClientId ),
-				isBlockInsertionPointVisible: isBlockInsertionPointVisible(),
-				isReadOnly,
-				isRootList: rootClientId === undefined,
-				isFloatingToolbarVisible,
-				isStackedHorizontally,
-			};
-		}
-	),
+		return {
+			blockClientIds,
+			blockCount: getBlockCount( rootClientId ),
+			isBlockInsertionPointVisible: isBlockInsertionPointVisible(),
+			isReadOnly,
+			isRootList: rootClientId === undefined,
+			isFloatingToolbarVisible,
+			isStackedHorizontally,
+		};
+	} ),
 	withDispatch( ( dispatch ) => {
 		const { insertBlock, replaceBlock, clearSelectedBlock } = dispatch(
 			'core/block-editor'
@@ -385,32 +382,28 @@ class EmptyListComponent extends Component {
 }
 
 const EmptyListComponentCompose = compose( [
-	withSelect(
-		( select, { rootClientId, __experimentalBlockListOrientation } ) => {
-			const {
-				getBlockOrder,
-				getBlockInsertionPoint,
-				isBlockInsertionPointVisible,
-			} = select( 'core/block-editor' );
+	withSelect( ( select, { rootClientId, orientation } ) => {
+		const {
+			getBlockOrder,
+			getBlockInsertionPoint,
+			isBlockInsertionPointVisible,
+		} = select( 'core/block-editor' );
 
-			const isStackedHorizontally =
-				__experimentalBlockListOrientation === 'horizontal';
+		const isStackedHorizontally = orientation === 'horizontal';
+		const blockClientIds = getBlockOrder( rootClientId );
+		const insertionPoint = getBlockInsertionPoint();
+		const blockInsertionPointIsVisible = isBlockInsertionPointVisible();
+		const shouldShowInsertionPoint =
+			! isStackedHorizontally &&
+			blockInsertionPointIsVisible &&
+			insertionPoint.rootClientId === rootClientId &&
+			// if list is empty, show the insertion point (via the default appender)
+			( blockClientIds.length === 0 ||
+				// or if the insertion point is right before the denoted block
+				! blockClientIds[ insertionPoint.index ] );
 
-			const blockClientIds = getBlockOrder( rootClientId );
-			const insertionPoint = getBlockInsertionPoint();
-			const blockInsertionPointIsVisible = isBlockInsertionPointVisible();
-			const shouldShowInsertionPoint =
-				! isStackedHorizontally &&
-				blockInsertionPointIsVisible &&
-				insertionPoint.rootClientId === rootClientId &&
-				// if list is empty, show the insertion point (via the default appender)
-				( blockClientIds.length === 0 ||
-					// or if the insertion point is right before the denoted block
-					! blockClientIds[ insertionPoint.index ] );
-
-			return {
-				shouldShowInsertionPoint,
-			};
-		}
-	),
+		return {
+			shouldShowInsertionPoint,
+		};
+	} ),
 ] )( EmptyListComponent );

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -311,42 +311,44 @@ export class BlockList extends Component {
 }
 
 export default compose( [
-	withSelect( ( select, { rootClientId, __experimentalMoverDirection } ) => {
-		const {
-			getBlockCount,
-			getBlockOrder,
-			getSelectedBlockClientId,
-			isBlockInsertionPointVisible,
-			getSettings,
-			getBlockHierarchyRootClientId,
-		} = select( 'core/block-editor' );
+	withSelect(
+		( select, { rootClientId, __experimentalBlockListOrientation } ) => {
+			const {
+				getBlockCount,
+				getBlockOrder,
+				getSelectedBlockClientId,
+				isBlockInsertionPointVisible,
+				getSettings,
+				getBlockHierarchyRootClientId,
+			} = select( 'core/block-editor' );
 
-		const isStackedHorizontally =
-			__experimentalMoverDirection === 'horizontal';
+			const isStackedHorizontally =
+				__experimentalBlockListOrientation === 'horizontal';
 
-		const selectedBlockClientId = getSelectedBlockClientId();
-		const blockClientIds = getBlockOrder( rootClientId );
+			const selectedBlockClientId = getSelectedBlockClientId();
+			const blockClientIds = getBlockOrder( rootClientId );
 
-		const isReadOnly = getSettings().readOnly;
+			const isReadOnly = getSettings().readOnly;
 
-		const rootBlockId = getBlockHierarchyRootClientId(
-			selectedBlockClientId
-		);
-		const hasRootInnerBlocks = !! getBlockCount( rootBlockId );
+			const rootBlockId = getBlockHierarchyRootClientId(
+				selectedBlockClientId
+			);
+			const hasRootInnerBlocks = !! getBlockCount( rootBlockId );
 
-		const isFloatingToolbarVisible =
-			!! selectedBlockClientId && hasRootInnerBlocks;
+			const isFloatingToolbarVisible =
+				!! selectedBlockClientId && hasRootInnerBlocks;
 
-		return {
-			blockClientIds,
-			blockCount: getBlockCount( rootClientId ),
-			isBlockInsertionPointVisible: isBlockInsertionPointVisible(),
-			isReadOnly,
-			isRootList: rootClientId === undefined,
-			isFloatingToolbarVisible,
-			isStackedHorizontally,
-		};
-	} ),
+			return {
+				blockClientIds,
+				blockCount: getBlockCount( rootClientId ),
+				isBlockInsertionPointVisible: isBlockInsertionPointVisible(),
+				isReadOnly,
+				isRootList: rootClientId === undefined,
+				isFloatingToolbarVisible,
+				isStackedHorizontally,
+			};
+		}
+	),
 	withDispatch( ( dispatch ) => {
 		const { insertBlock, replaceBlock, clearSelectedBlock } = dispatch(
 			'core/block-editor'
@@ -383,30 +385,32 @@ class EmptyListComponent extends Component {
 }
 
 const EmptyListComponentCompose = compose( [
-	withSelect( ( select, { rootClientId, __experimentalMoverDirection } ) => {
-		const {
-			getBlockOrder,
-			getBlockInsertionPoint,
-			isBlockInsertionPointVisible,
-		} = select( 'core/block-editor' );
+	withSelect(
+		( select, { rootClientId, __experimentalBlockListOrientation } ) => {
+			const {
+				getBlockOrder,
+				getBlockInsertionPoint,
+				isBlockInsertionPointVisible,
+			} = select( 'core/block-editor' );
 
-		const isStackedHorizontally =
-			__experimentalMoverDirection === 'horizontal';
+			const isStackedHorizontally =
+				__experimentalBlockListOrientation === 'horizontal';
 
-		const blockClientIds = getBlockOrder( rootClientId );
-		const insertionPoint = getBlockInsertionPoint();
-		const blockInsertionPointIsVisible = isBlockInsertionPointVisible();
-		const shouldShowInsertionPoint =
-			! isStackedHorizontally &&
-			blockInsertionPointIsVisible &&
-			insertionPoint.rootClientId === rootClientId &&
-			// if list is empty, show the insertion point (via the default appender)
-			( blockClientIds.length === 0 ||
-				// or if the insertion point is right before the denoted block
-				! blockClientIds[ insertionPoint.index ] );
+			const blockClientIds = getBlockOrder( rootClientId );
+			const insertionPoint = getBlockInsertionPoint();
+			const blockInsertionPointIsVisible = isBlockInsertionPointVisible();
+			const shouldShowInsertionPoint =
+				! isStackedHorizontally &&
+				blockInsertionPointIsVisible &&
+				insertionPoint.rootClientId === rootClientId &&
+				// if list is empty, show the insertion point (via the default appender)
+				( blockClientIds.length === 0 ||
+					// or if the insertion point is right before the denoted block
+					! blockClientIds[ insertionPoint.index ] );
 
-		return {
-			shouldShowInsertionPoint,
-		};
-	} ),
+			return {
+				shouldShowInsertionPoint,
+			};
+		}
+	),
 ] )( EmptyListComponent );

--- a/packages/block-editor/src/components/block-mover/button.js
+++ b/packages/block-editor/src/components/block-mover/button.js
@@ -57,12 +57,7 @@ const getMovementDirectionLabel = ( moveDirection, orientation, isRTL ) => {
 
 const BlockMoverButton = forwardRef(
 	(
-		{
-			clientIds,
-			direction,
-			__experimentalOrientation: orientation,
-			...props
-		},
+		{ clientIds, direction, orientation: moverOrientation, ...props },
 		ref
 	) => {
 		const instanceId = useInstanceId( BlockMoverButton );
@@ -76,7 +71,7 @@ const BlockMoverButton = forwardRef(
 			isLast,
 			firstIndex,
 			isRTL,
-			moverOrientation,
+			orientation = 'vertical',
 		} = useSelect(
 			( select ) => {
 				const {
@@ -102,7 +97,7 @@ const BlockMoverButton = forwardRef(
 				const block = getBlock( firstClientId );
 				const isFirstBlock = firstBlockIndex === 0;
 				const isLastBlock = lastBlockIndex === blockOrder.length - 1;
-				const { __experimentalBlockListOrientation = 'vertical' } =
+				const { orientation: blockListOrientation } =
 					getBlockListSettings( blockRootClientId ) || {};
 
 				return {
@@ -113,8 +108,7 @@ const BlockMoverButton = forwardRef(
 					isFirst: isFirstBlock,
 					isLast: isLastBlock,
 					isRTL: getSettings().isRTL,
-					moverOrientation:
-						orientation || __experimentalBlockListOrientation,
+					orientation: moverOrientation || blockListOrientation,
 				};
 			},
 			[ clientIds, direction ]
@@ -143,10 +137,10 @@ const BlockMoverButton = forwardRef(
 						'block-editor-block-mover-button',
 						`is-${ direction }-button`
 					) }
-					icon={ getArrowIcon( direction, moverOrientation, isRTL ) }
+					icon={ getArrowIcon( direction, orientation, isRTL ) }
 					label={ getMovementDirectionLabel(
 						direction,
-						moverOrientation,
+						orientation,
 						isRTL
 					) }
 					aria-describedby={ descriptionId }
@@ -165,7 +159,7 @@ const BlockMoverButton = forwardRef(
 						isFirst,
 						isLast,
 						direction === 'up' ? -1 : 1,
-						moverOrientation,
+						orientation,
 						isRTL
 					) }
 				</span>

--- a/packages/block-editor/src/components/block-mover/button.js
+++ b/packages/block-editor/src/components/block-mover/button.js
@@ -102,7 +102,7 @@ const BlockMoverButton = forwardRef(
 				const block = getBlock( firstClientId );
 				const isFirstBlock = firstBlockIndex === 0;
 				const isLastBlock = lastBlockIndex === blockOrder.length - 1;
-				const { __experimentalMoverDirection = 'vertical' } =
+				const { __experimentalBlockListOrientation = 'vertical' } =
 					getBlockListSettings( blockRootClientId ) || {};
 
 				return {
@@ -114,7 +114,7 @@ const BlockMoverButton = forwardRef(
 					isLast: isLastBlock,
 					isRTL: getSettings().isRTL,
 					moverOrientation:
-						orientation || __experimentalMoverDirection,
+						orientation || __experimentalBlockListOrientation,
 				};
 			},
 			[ clientIds, direction ]

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -46,7 +46,7 @@ export default function BlockToolbar( { hideDragHandle } ) {
 		const selectedBlockClientId = selectedBlockClientIds[ 0 ];
 		const blockRootClientId = getBlockRootClientId( selectedBlockClientId );
 
-		const { __experimentalMoverDirection } =
+		const { __experimentalBlockListOrientation } =
 			getBlockListSettings( blockRootClientId ) || {};
 
 		return {
@@ -63,7 +63,7 @@ export default function BlockToolbar( { hideDragHandle } ) {
 			isVisual: selectedBlockClientIds.every(
 				( id ) => getBlockMode( id ) === 'visual'
 			),
-			moverDirection: __experimentalMoverDirection,
+			moverDirection: __experimentalBlockListOrientation,
 		};
 	}, [] );
 

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -31,7 +31,6 @@ export default function BlockToolbar( { hideDragHandle } ) {
 		hasFixedToolbar,
 		isValid,
 		isVisual,
-		moverDirection,
 	} = useSelect( ( select ) => {
 		const {
 			getBlockName,
@@ -39,15 +38,11 @@ export default function BlockToolbar( { hideDragHandle } ) {
 			getSelectedBlockClientIds,
 			isBlockValid,
 			getBlockRootClientId,
-			getBlockListSettings,
 			getSettings,
 		} = select( 'core/block-editor' );
 		const selectedBlockClientIds = getSelectedBlockClientIds();
 		const selectedBlockClientId = selectedBlockClientIds[ 0 ];
 		const blockRootClientId = getBlockRootClientId( selectedBlockClientId );
-
-		const { __experimentalBlockListOrientation } =
-			getBlockListSettings( blockRootClientId ) || {};
 
 		return {
 			blockClientIds: selectedBlockClientIds,
@@ -63,7 +58,6 @@ export default function BlockToolbar( { hideDragHandle } ) {
 			isVisual: selectedBlockClientIds.every(
 				( id ) => getBlockMode( id ) === 'visual'
 			),
-			moverDirection: __experimentalBlockListOrientation,
 		};
 	}, [] );
 
@@ -130,10 +124,7 @@ export default function BlockToolbar( { hideDragHandle } ) {
 								onDragEnd={ onDraggableEnd }
 							>
 								<BlockSwitcher clientIds={ blockClientIds } />
-								<BlockMover
-									clientIds={ blockClientIds }
-									__experimentalOrientation={ moverDirection }
-								/>
+								<BlockMover clientIds={ blockClientIds } />
 							</div>
 						) }
 					</BlockDraggable>

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -45,7 +45,7 @@ function UncontrolledInnerBlocks( props ) {
 		forwardedRef,
 		templateInsertUpdatesSelection,
 		__experimentalCaptureToolbars: captureToolbars,
-		__experimentalMoverDirection,
+		__experimentalBlockListOrientation,
 	} = props;
 
 	const isSmallScreen = useViewportMatch( 'medium', '<' );
@@ -73,7 +73,7 @@ function UncontrolledInnerBlocks( props ) {
 		allowedBlocks,
 		templateLock,
 		captureToolbars,
-		__experimentalMoverDirection
+		__experimentalBlockListOrientation
 	);
 
 	useInnerBlockTemplateSync(

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -45,7 +45,7 @@ function UncontrolledInnerBlocks( props ) {
 		forwardedRef,
 		templateInsertUpdatesSelection,
 		__experimentalCaptureToolbars: captureToolbars,
-		__experimentalBlockListOrientation,
+		orientation,
 	} = props;
 
 	const isSmallScreen = useViewportMatch( 'medium', '<' );
@@ -73,7 +73,7 @@ function UncontrolledInnerBlocks( props ) {
 		allowedBlocks,
 		templateLock,
 		captureToolbars,
-		__experimentalBlockListOrientation
+		orientation
 	);
 
 	useInnerBlockTemplateSync(

--- a/packages/block-editor/src/components/inner-blocks/index.native.js
+++ b/packages/block-editor/src/components/inner-blocks/index.native.js
@@ -36,7 +36,7 @@ function UncontrolledInnerBlocks( props ) {
 		template,
 		templateLock,
 		templateInsertUpdatesSelection,
-		__experimentalBlockListOrientation,
+		orientation,
 		renderAppender,
 		renderFooterAppender,
 		parentWidth,
@@ -72,9 +72,7 @@ function UncontrolledInnerBlocks( props ) {
 			renderAppender={ renderAppender }
 			renderFooterAppender={ renderFooterAppender }
 			withFooter={ false }
-			__experimentalBlockListOrientation={
-				__experimentalBlockListOrientation
-			}
+			orientation={ orientation }
 			parentWidth={ parentWidth }
 			horizontalAlignment={ horizontalAlignment }
 			horizontal={ horizontal }

--- a/packages/block-editor/src/components/inner-blocks/index.native.js
+++ b/packages/block-editor/src/components/inner-blocks/index.native.js
@@ -36,7 +36,7 @@ function UncontrolledInnerBlocks( props ) {
 		template,
 		templateLock,
 		templateInsertUpdatesSelection,
-		__experimentalMoverDirection,
+		__experimentalBlockListOrientation,
 		renderAppender,
 		renderFooterAppender,
 		parentWidth,
@@ -72,7 +72,9 @@ function UncontrolledInnerBlocks( props ) {
 			renderAppender={ renderAppender }
 			renderFooterAppender={ renderFooterAppender }
 			withFooter={ false }
-			__experimentalMoverDirection={ __experimentalMoverDirection }
+			__experimentalBlockListOrientation={
+				__experimentalBlockListOrientation
+			}
 			parentWidth={ parentWidth }
 			horizontalAlignment={ horizontalAlignment }
 			horizontal={ horizontal }

--- a/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
+++ b/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
@@ -6,10 +6,10 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 
 /**
- * This hook is a side efect which updates the block-editor store when changes
+ * This hook is a side effect which updates the block-editor store when changes
  * happen to inner block settings. The given props are transformed into a
  * settings object, and if that is different from the current settings object in
- * the block-ediotr store, then the store is updated with the new settings which
+ * the block-editor store, then the store is updated with the new settings which
  * came from props.
  *
  * @param {string}   clientId        The client ID of the block to update.
@@ -20,7 +20,7 @@ import isShallowEqual from '@wordpress/is-shallow-equal';
  * @param {boolean}  captureToolbars Whether or children toolbars should be shown
  *                                   in the inner blocks component rather than on
  *                                   the child block.
- * @param {string} __experimentalBlockListOrientation The direction in which the block
+ * @param {string}   orientation     The direction in which the block
  *                                   should face.
  */
 export default function useNestedSettingsUpdate(
@@ -28,7 +28,7 @@ export default function useNestedSettingsUpdate(
 	allowedBlocks,
 	templateLock,
 	captureToolbars,
-	__experimentalBlockListOrientation
+	orientation
 ) {
 	const { updateBlockListSettings } = useDispatch( 'core/block-editor' );
 
@@ -62,8 +62,8 @@ export default function useNestedSettingsUpdate(
 			newSettings.__experimentalCaptureToolbars = captureToolbars;
 		}
 
-		if ( __experimentalBlockListOrientation !== undefined ) {
-			newSettings.__experimentalBlockListOrientation = __experimentalBlockListOrientation;
+		if ( orientation !== undefined ) {
+			newSettings.orientation = orientation;
 		}
 
 		if ( ! isShallowEqual( blockListSettings, newSettings ) ) {
@@ -76,7 +76,7 @@ export default function useNestedSettingsUpdate(
 		templateLock,
 		parentLock,
 		captureToolbars,
-		__experimentalBlockListOrientation,
+		orientation,
 		updateBlockListSettings,
 	] );
 }

--- a/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
+++ b/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
@@ -20,7 +20,7 @@ import isShallowEqual from '@wordpress/is-shallow-equal';
  * @param {boolean}  captureToolbars Whether or children toolbars should be shown
  *                                   in the inner blocks component rather than on
  *                                   the child block.
- * @param {string} __experimentalMoverDirection The direction in which the block
+ * @param {string} __experimentalBlockListOrientation The direction in which the block
  *                                   should face.
  */
 export default function useNestedSettingsUpdate(
@@ -28,7 +28,7 @@ export default function useNestedSettingsUpdate(
 	allowedBlocks,
 	templateLock,
 	captureToolbars,
-	__experimentalMoverDirection
+	__experimentalBlockListOrientation
 ) {
 	const { updateBlockListSettings } = useDispatch( 'core/block-editor' );
 
@@ -62,8 +62,8 @@ export default function useNestedSettingsUpdate(
 			newSettings.__experimentalCaptureToolbars = captureToolbars;
 		}
 
-		if ( __experimentalMoverDirection !== undefined ) {
-			newSettings.__experimentalMoverDirection = __experimentalMoverDirection;
+		if ( __experimentalBlockListOrientation !== undefined ) {
+			newSettings.__experimentalBlockListOrientation = __experimentalBlockListOrientation;
 		}
 
 		if ( ! isShallowEqual( blockListSettings, newSettings ) ) {
@@ -76,7 +76,7 @@ export default function useNestedSettingsUpdate(
 		templateLock,
 		parentLock,
 		captureToolbars,
-		__experimentalMoverDirection,
+		__experimentalBlockListOrientation,
 		updateBlockListSettings,
 	] );
 }

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -173,8 +173,8 @@ export default function useBlockDropZone( {
 		} = select( 'core/block-editor' );
 		return {
 			getBlockIndex,
-			blockListOrientation: getBlockListSettings( targetRootClientId )
-				?.__experimentalBlockListOrientation,
+			orientation: getBlockListSettings( targetRootClientId )
+				?.orientation,
 			getClientIdsOfDescendants,
 			hasUploadPermissions: !! getSettings().mediaUpload,
 			isLockedAll: getTemplateLock( targetRootClientId ) === 'all',
@@ -186,7 +186,7 @@ export default function useBlockDropZone( {
 		getClientIdsOfDescendants,
 		hasUploadPermissions,
 		isLockedAll,
-		blockListOrientation,
+		orientation,
 	} = useSelect( selector, [ targetRootClientId ] );
 	const {
 		insertBlocks,
@@ -311,7 +311,7 @@ export default function useBlockDropZone( {
 			const targetIndex = getNearestBlockIndex(
 				blockElements,
 				position,
-				blockListOrientation
+				orientation
 			);
 
 			if ( targetIndex === undefined ) {

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -173,8 +173,8 @@ export default function useBlockDropZone( {
 		} = select( 'core/block-editor' );
 		return {
 			getBlockIndex,
-			moverDirection: getBlockListSettings( targetRootClientId )
-				?.__experimentalMoverDirection,
+			blockListOrientation: getBlockListSettings( targetRootClientId )
+				?.__experimentalBlockListOrientation,
 			getClientIdsOfDescendants,
 			hasUploadPermissions: !! getSettings().mediaUpload,
 			isLockedAll: getTemplateLock( targetRootClientId ) === 'all',
@@ -186,7 +186,7 @@ export default function useBlockDropZone( {
 		getClientIdsOfDescendants,
 		hasUploadPermissions,
 		isLockedAll,
-		moverDirection,
+		blockListOrientation,
 	} = useSelect( selector, [ targetRootClientId ] );
 	const {
 		insertBlocks,
@@ -311,7 +311,7 @@ export default function useBlockDropZone( {
 			const targetIndex = getNearestBlockIndex(
 				blockElements,
 				position,
-				moverDirection
+				blockListOrientation
 			);
 
 			if ( targetIndex === undefined ) {

--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -27,7 +27,7 @@ function ButtonsEdit() {
 				<InnerBlocks
 					allowedBlocks={ ALLOWED_BLOCKS }
 					template={ BUTTONS_TEMPLATE }
-					__experimentalBlockListOrientation="horizontal"
+					orientation="horizontal"
 				/>
 			</AlignmentHookSettingsProvider>
 		</Block.div>

--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -27,7 +27,7 @@ function ButtonsEdit() {
 				<InnerBlocks
 					allowedBlocks={ ALLOWED_BLOCKS }
 					template={ BUTTONS_TEMPLATE }
-					__experimentalMoverDirection="horizontal"
+					__experimentalBlockListOrientation="horizontal"
 				/>
 			</AlignmentHookSettingsProvider>
 		</Block.div>

--- a/packages/block-library/src/buttons/edit.native.js
+++ b/packages/block-library/src/buttons/edit.native.js
@@ -68,7 +68,7 @@ function ButtonsEdit( {
 				renderFooterAppender={
 					shouldRenderFooterAppender && renderFooterAppender.current
 				}
-				__experimentalBlockListOrientation="horizontal"
+				orientation="horizontal"
 				horizontalAlignment={ align }
 				onDeleteBlock={ shouldDelete ? onDelete : undefined }
 				onAddBlock={ onAddNextButton }

--- a/packages/block-library/src/buttons/edit.native.js
+++ b/packages/block-library/src/buttons/edit.native.js
@@ -68,7 +68,7 @@ function ButtonsEdit( {
 				renderFooterAppender={
 					shouldRenderFooterAppender && renderFooterAppender.current
 				}
-				__experimentalMoverDirection="horizontal"
+				__experimentalBlockListOrientation="horizontal"
 				horizontalAlignment={ align }
 				onDeleteBlock={ shouldDelete ? onDelete : undefined }
 				onAddBlock={ onAddNextButton }

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -91,7 +91,7 @@ function ColumnsEditContainer( {
 			</InspectorControls>
 			<InnerBlocks
 				allowedBlocks={ ALLOWED_BLOCKS }
-				__experimentalMoverDirection="horizontal"
+				__experimentalBlockListOrientation="horizontal"
 				__experimentalTagName={ Block.div }
 				__experimentalPassedProps={ {
 					className: classes,

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -91,7 +91,7 @@ function ColumnsEditContainer( {
 			</InspectorControls>
 			<InnerBlocks
 				allowedBlocks={ ALLOWED_BLOCKS }
-				__experimentalBlockListOrientation="horizontal"
+				orientation="horizontal"
 				__experimentalTagName={ Block.div }
 				__experimentalPassedProps={ {
 					className: classes,

--- a/packages/block-library/src/columns/edit.native.js
+++ b/packages/block-library/src/columns/edit.native.js
@@ -141,7 +141,7 @@ function ColumnsEditContainer( {
 				{ width && (
 					<InnerBlocks
 						renderAppender={ renderAppender }
-						__experimentalBlockListOrientation={
+						orientation={
 							columnsInRow > 1 ? 'horizontal' : undefined
 						}
 						horizontal={ true }

--- a/packages/block-library/src/columns/edit.native.js
+++ b/packages/block-library/src/columns/edit.native.js
@@ -141,7 +141,7 @@ function ColumnsEditContainer( {
 				{ width && (
 					<InnerBlocks
 						renderAppender={ renderAppender }
-						__experimentalMoverDirection={
+						__experimentalBlockListOrientation={
 							columnsInRow > 1 ? 'horizontal' : undefined
 						}
 						horizontal={ true }

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -202,7 +202,7 @@ function Navigation( {
 									: false
 							}
 							templateInsertUpdatesSelection={ false }
-							__experimentalMoverDirection={
+							__experimentalBlockListOrientation={
 								attributes.orientation || 'horizontal'
 							}
 							__experimentalTagName="ul"

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -202,7 +202,7 @@ function Navigation( {
 									: false
 							}
 							templateInsertUpdatesSelection={ false }
-							__experimentalBlockListOrientation={
+							orientation={
 								attributes.orientation || 'horizontal'
 							}
 							__experimentalTagName="ul"

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -28,7 +28,7 @@ export function SocialLinksEdit() {
 			allowedBlocks={ ALLOWED_BLOCKS }
 			templateLock={ false }
 			template={ TEMPLATE }
-			__experimentalBlockListOrientation={ 'horizontal' }
+			orientation={ 'horizontal' }
 			__experimentalTagName={ Block.ul }
 			__experimentalAppenderTagName="li"
 		/>

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -28,7 +28,7 @@ export function SocialLinksEdit() {
 			allowedBlocks={ ALLOWED_BLOCKS }
 			templateLock={ false }
 			template={ TEMPLATE }
-			__experimentalMoverDirection={ 'horizontal' }
+			__experimentalBlockListOrientation={ 'horizontal' }
 			__experimentalTagName={ Block.ul }
 			__experimentalAppenderTagName="li"
 		/>

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -28,7 +28,7 @@ export function SocialLinksEdit() {
 			allowedBlocks={ ALLOWED_BLOCKS }
 			templateLock={ false }
 			template={ TEMPLATE }
-			orientation={ 'horizontal' }
+			orientation="horizontal"
 			__experimentalTagName={ Block.ul }
 			__experimentalAppenderTagName="li"
 		/>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
As mentioned in https://github.com/WordPress/gutenberg/pull/23020#discussion_r438668441, the `__experimentalMoverDirection` block list setting is now being use for a lot more than establishing the mover direction. While it's experimental and not stable, it'd be a good opportunity to rename it.

This PR changes it to `__experimentalBlockListOrientation`. Other suggestions welcome.

Should we also consider stabilizing/documenting this API?

## How has this been tested?
Manual testing
- Check that block movers still appear correctly in horizontal block lists (e.g. buttons).
- Check that drag and drop still works in horizontal block lists

## Types of changes
Non-breaking code quality
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
