### PR TITLE
Image tools: Polish zoom slider

### DIFF
--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -106,7 +106,7 @@ figure.wp-block-image:not(.wp-block) {
 
 	.components-range-control {
 		flex: 1;
-		margin-right: 0;
+		margin-right: $grid-unit-15;
 		margin-left: $grid-unit-15;
 	}
 
@@ -114,26 +114,18 @@ figure.wp-block-image:not(.wp-block) {
 		display: flex;
 		margin-bottom: 0;
 	}
-}
 
-// Make the toolbar dropdowns blend in.
-.components-toolbar.richimage-toolbar__dropdown { // Needs specificity.
-	padding: 0;
-	border-left: none;
-	border-right: none;
+	.richimage__aspect-ratio {
+		height: $grid-unit-60;
+		margin-top: -$grid-unit-10;
+		margin-bottom: -$grid-unit-10;
+		display: flex;
+		align-items: center;
 
-	.components-icon-button.has-text svg {
-		margin-right: 0;
+		.components-button {
+			width: $button-size;
+			padding-left: 0;
+			padding-right: 0;
+		}
 	}
-
-	.components-dropdown-menu__indicator {
-		display: none;
-	}
-}
-
-// Make icons 24x24 unscaled.
-.richimage-toolbar__dropdown > .components-button,
-.richimage-toolbar__dropdown,
-.richimage-toolbar__control {
-	padding: 6px;
 }

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -94,15 +94,19 @@ figure.wp-block-image:not(.wp-block) {
 	border: $border-width solid $dark-gray-primary;
 	border-radius: $radius-block-ui;
 	background-color: $white;
-	margin-top: $grid-unit-15;
-	margin-bottom: $grid-unit-15;
 	padding: $grid-unit-10;
 	line-height: 1;
 	width: 100%;
-	max-width: $break-mobile;
+	max-width: 280px;
 	display: flex;
 	flex-direction: row;
 	align-items: center;
+
+	// Place as a stacked toolbar.
+	position: sticky;
+	top: $grid-unit-60 + $grid-unit-15;
+	z-index: z-index(".block-editor-block-list__block-popover");
+	float: left;
 
 	.components-range-control {
 		flex: 1;
@@ -116,7 +120,7 @@ figure.wp-block-image:not(.wp-block) {
 	}
 
 	.richimage__aspect-ratio {
-		height: $grid-unit-60;
+		height: $grid-unit-60 - $border-width - $border-width;
 		margin-top: -$grid-unit-10;
 		margin-bottom: -$grid-unit-10;
 		display: flex;

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -72,13 +72,13 @@ figure.wp-block-image:not(.wp-block) {
 	text-align: center;
 }
 
-.richimage__crop-area {
+.wp-block-image__crop-area {
 	position: relative;
 	max-width: 100%;
 	width: 100%;
 }
 
-.richimage__crop-icon {
+.wp-block-image__crop-icon {
 	padding: 0 8px;
 	min-width: 48px;
 	display: flex;
@@ -90,7 +90,7 @@ figure.wp-block-image:not(.wp-block) {
 	}
 }
 
-.richimage__zoom-control {
+.wp-block-image__zoom-control {
 	border: $border-width solid $dark-gray-primary;
 	border-radius: $radius-block-ui;
 	background-color: $white;
@@ -119,7 +119,7 @@ figure.wp-block-image:not(.wp-block) {
 		margin-bottom: 0;
 	}
 
-	.richimage__aspect-ratio {
+	.wp-block-image__aspect-ratio {
 		height: $grid-unit-60 - $border-width - $border-width;
 		margin-top: -$grid-unit-10;
 		margin-bottom: -$grid-unit-10;

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -96,8 +96,24 @@ figure.wp-block-image:not(.wp-block) {
 	background-color: $white;
 	margin-top: $grid-unit-15;
 	margin-bottom: $grid-unit-15;
-	padding: $grid-unit-15 $grid-unit-15 $grid-unit-10;
+	padding: $grid-unit-10;
 	line-height: 1;
+	width: 100%;
+	max-width: $break-mobile;
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+
+	.components-range-control {
+		flex: 1;
+		margin-right: 0;
+		margin-left: $grid-unit-15;
+	}
+
+	.components-base-control__field {
+		display: flex;
+		margin-bottom: 0;
+	}
 }
 
 // Make the toolbar dropdowns blend in.

--- a/packages/block-library/src/image/image-editor.js
+++ b/packages/block-library/src/image/image-editor.js
@@ -12,6 +12,7 @@ import classnames from 'classnames';
 import { BlockControls } from '@wordpress/block-editor';
 import { useState } from '@wordpress/element';
 import {
+	Icon, search,
 	rotateRight as rotateRightIcon,
 	aspectRatio as aspectRatioIcon,
 } from '@wordpress/icons';
@@ -285,14 +286,18 @@ export default function ImageEditor( {
 				{ inProgress && <Spinner /> }
 			</div>
 			{ ! inProgress && (
-				<RangeControl
+				<div
 					className="richimage__zoom-control"
-					label={ __( 'Zoom' ) }
-					min={ MIN_ZOOM }
-					max={ MAX_ZOOM }
-					value={ Math.round( zoom ) }
-					onChange={ setZoom }
-				/>
+					aria-label={ __( 'Zoom' ) }
+				>
+					<Icon icon={ search } />
+					<RangeControl
+						min={ MIN_ZOOM }
+						max={ MAX_ZOOM }
+						value={ Math.round( zoom ) }
+						onChange={ setZoom }
+					/>
+				</div>
 			) }
 			<BlockControls>
 				<ToolbarGroup>

--- a/packages/block-library/src/image/image-editor.js
+++ b/packages/block-library/src/image/image-editor.js
@@ -63,7 +63,7 @@ function AspectMenu( { isDisabled, onClick, toggleProps } ) {
 			label={ __( 'Aspect Ratio' ) }
 			popoverProps={ POPOVER_PROPS }
 			toggleProps={ toggleProps }
-			className="richimage__aspect-ratio"
+			className="wp-block-image__aspect-ratio"
 		>
 			{ ( { onClose } ) => (
 				<>
@@ -267,7 +267,7 @@ export default function ImageEditor( {
 		<>
 			{ ! inProgress && (
 				<div
-					className="richimage__zoom-control"
+					className="wp-block-image__zoom-control"
 					aria-label={ __( 'Zoom' ) }
 				>
 					<Icon icon={ search } />
@@ -289,7 +289,7 @@ export default function ImageEditor( {
 				</div>
 			) }
 			<div
-				className={ classnames( 'richimage__crop-area', {
+				className={ classnames( 'wp-block-image__crop-area', {
 					'is-applying': inProgress,
 				} ) }
 				style={ {

--- a/packages/block-library/src/image/image-editor.js
+++ b/packages/block-library/src/image/image-editor.js
@@ -265,6 +265,29 @@ export default function ImageEditor( {
 
 	return (
 		<>
+			{ ! inProgress && (
+				<div
+					className="richimage__zoom-control"
+					aria-label={ __( 'Zoom' ) }
+				>
+					<Icon icon={ search } />
+					<RangeControl
+						min={ MIN_ZOOM }
+						max={ MAX_ZOOM }
+						value={ Math.round( zoom ) }
+						onChange={ setZoom }
+					/>
+					<ToolbarItem>
+						{ ( toggleProps ) => (
+							<AspectMenu
+								toggleProps={ toggleProps }
+								isDisabled={ inProgress }
+								onClick={ setAspect }
+							/>
+						) }
+					</ToolbarItem>
+				</div>
+			) }
 			<div
 				className={ classnames( 'richimage__crop-area', {
 					'is-applying': inProgress,
@@ -290,29 +313,6 @@ export default function ImageEditor( {
 				/>
 				{ inProgress && <Spinner /> }
 			</div>
-			{ ! inProgress && (
-				<div
-					className="richimage__zoom-control"
-					aria-label={ __( 'Zoom' ) }
-				>
-					<Icon icon={ search } />
-					<RangeControl
-						min={ MIN_ZOOM }
-						max={ MAX_ZOOM }
-						value={ Math.round( zoom ) }
-						onChange={ setZoom }
-					/>
-					<ToolbarItem>
-						{ ( toggleProps ) => (
-							<AspectMenu
-								toggleProps={ toggleProps }
-								isDisabled={ inProgress }
-								onClick={ setAspect }
-							/>
-						) }
-					</ToolbarItem>
-				</div>
-			) }
 			<BlockControls>
 				<ToolbarGroup>
 					<ToolbarButton

--- a/packages/block-library/src/image/image-editor.js
+++ b/packages/block-library/src/image/image-editor.js
@@ -12,7 +12,8 @@ import classnames from 'classnames';
 import { BlockControls } from '@wordpress/block-editor';
 import { useState } from '@wordpress/element';
 import {
-	Icon, search,
+	Icon,
+	search,
 	rotateRight as rotateRightIcon,
 	aspectRatio as aspectRatioIcon,
 } from '@wordpress/icons';
@@ -32,7 +33,10 @@ import apiFetch from '@wordpress/api-fetch';
 
 const MIN_ZOOM = 100;
 const MAX_ZOOM = 300;
-const POPOVER_PROPS = { position: 'bottom right' };
+const POPOVER_PROPS = {
+	position: 'bottom right',
+	isAlternate: true,
+};
 
 function AspectGroup( { aspectRatios, isDisabled, label, onClick } ) {
 	return (
@@ -59,6 +63,7 @@ function AspectMenu( { isDisabled, onClick, toggleProps } ) {
 			label={ __( 'Aspect Ratio' ) }
 			popoverProps={ POPOVER_PROPS }
 			toggleProps={ toggleProps }
+			className="richimage__aspect-ratio"
 		>
 			{ ( { onClose } ) => (
 				<>
@@ -297,6 +302,15 @@ export default function ImageEditor( {
 						value={ Math.round( zoom ) }
 						onChange={ setZoom }
 					/>
+					<ToolbarItem>
+						{ ( toggleProps ) => (
+							<AspectMenu
+								toggleProps={ toggleProps }
+								isDisabled={ inProgress }
+								onClick={ setAspect }
+							/>
+						) }
+					</ToolbarItem>
 				</div>
 			) }
 			<BlockControls>
@@ -307,17 +321,6 @@ export default function ImageEditor( {
 						onClick={ rotate }
 						disabled={ inProgress }
 					/>
-				</ToolbarGroup>
-				<ToolbarGroup>
-					<ToolbarItem>
-						{ ( toggleProps ) => (
-							<AspectMenu
-								toggleProps={ toggleProps }
-								isDisabled={ inProgress }
-								onClick={ setAspect }
-							/>
-						) }
-					</ToolbarItem>
 				</ToolbarGroup>
 				<ToolbarGroup>
 					<ToolbarButton onClick={ apply } disabled={ inProgress }>

--- a/packages/block-library/src/image/image-editor.js
+++ b/packages/block-library/src/image/image-editor.js
@@ -20,7 +20,6 @@ import {
 import {
 	ToolbarGroup,
 	ToolbarButton,
-	__experimentalToolbarItem as ToolbarItem,
 	Spinner,
 	RangeControl,
 	DropdownMenu,
@@ -56,13 +55,12 @@ function AspectGroup( { aspectRatios, isDisabled, label, onClick } ) {
 	);
 }
 
-function AspectMenu( { isDisabled, onClick, toggleProps } ) {
+function AspectMenu( { isDisabled, onClick } ) {
 	return (
 		<DropdownMenu
 			icon={ aspectRatioIcon }
 			label={ __( 'Aspect Ratio' ) }
 			popoverProps={ POPOVER_PROPS }
-			toggleProps={ toggleProps }
 			className="wp-block-image__aspect-ratio"
 		>
 			{ ( { onClose } ) => (
@@ -277,15 +275,10 @@ export default function ImageEditor( {
 						value={ Math.round( zoom ) }
 						onChange={ setZoom }
 					/>
-					<ToolbarItem>
-						{ ( toggleProps ) => (
-							<AspectMenu
-								toggleProps={ toggleProps }
-								isDisabled={ inProgress }
-								onClick={ setAspect }
-							/>
-						) }
-					</ToolbarItem>
+					<AspectMenu
+						isDisabled={ inProgress }
+						onClick={ setAspect }
+					/>
 				</div>
 			) }
 			<div


### PR DESCRIPTION
This PR polishes the image cropping zoom slider.

It:

- Adds a zoom icon
- Adjusts the spacing and height of elements
- Moves the aspect ratio control to this bar
- Shows the bar as an overlay:

I still think that it's worth [moving the slider to the toolbar](https://github.com/WordPress/gutenberg/issues/22569#issuecomment-645616971), but the efforts here will a) benefit that effort, and b) can serve as a holdover if we don't make that in time.

![zoom overlay](https://user-images.githubusercontent.com/1204802/85540319-1faa9f00-b617-11ea-8179-2d429a4237de.gif)

Thoughts?