### PR TITLE
Add permission checks for file upload and file type to image editor endpoint.

### DIFF
--- a/lib/class-wp-rest-image-editor-controller.php
+++ b/lib/class-wp-rest-image-editor-controller.php
@@ -90,7 +90,7 @@ class WP_REST_Image_Editor_Controller extends WP_REST_Controller {
 		}
 
 		if ( ! current_user_can( 'upload_files' ) ) {
-			return new WP_Error( 'rest_cannot_create', __( 'Sorry, you are not allowed to upload media on this site.', 'gutenberg' ), array( 'status' => rest_authorization_required_code() ) );
+			return new WP_Error( 'rest_cannot_edit_image', __( 'Sorry, you are not allowed to upload media on this site.', 'gutenberg' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		$supported_types = array( 'image/jpeg', 'image/png', 'image/gif' );

--- a/lib/class-wp-rest-image-editor-controller.php
+++ b/lib/class-wp-rest-image-editor-controller.php
@@ -93,12 +93,6 @@ class WP_REST_Image_Editor_Controller extends WP_REST_Controller {
 			return new WP_Error( 'rest_cannot_edit_image', __( 'Sorry, you are not allowed to upload media on this site.', 'gutenberg' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
-		$supported_types = array( 'image/jpeg', 'image/png', 'image/gif' );
-		$mime_type       = get_post_mime_type( $request['media_id'] );
-		if ( ! in_array( $mime_type, $supported_types, true ) ) {
-			return new WP_Error( 'rest_cannot_edit_file_type', __( 'Sorry, you are not allowed to edit file type.', 'gutenberg' ), array( 'status' => 400 ) );
-		}
-
 		return true;
 	}
 

--- a/lib/class-wp-rest-image-editor-controller.php
+++ b/lib/class-wp-rest-image-editor-controller.php
@@ -89,6 +89,16 @@ class WP_REST_Image_Editor_Controller extends WP_REST_Controller {
 			return new WP_Error( 'rest_cannot_edit_image', $error, array( 'status' => rest_authorization_required_code() ) );
 		}
 
+		if ( ! current_user_can( 'upload_files' ) ) {
+			return new WP_Error( 'rest_cannot_create', __( 'Sorry, you are not allowed to upload media on this site.', 'gutenberg' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		$supported_types = array( 'image/jpeg', 'image/png', 'image/gif' );
+		$mime_type       = get_post_mime_type( $request['media_id'] );
+		if ( ! in_array( $mime_type, $supported_types, true ) ) {
+			return new WP_Error( 'rest_cannot_edit_file_type', __( 'Sorry, you are not allowed to edit file type.', 'gutenberg' ), array( 'status' => 400 ) );
+		}
+
 		return true;
 	}
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Currently the image editting endpoint doesn't check if the current user can upload files or if the file type supports the image editting. 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
