### PR TITLE
Add ajlende as a code owner of the image block

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,6 +15,7 @@
 /packages/block-library/src/gallery             @mkevins @pinarol
 /packages/block-library/src/social-links        @mkaz
 /packages/block-library/src/social-link         @mkaz
+/packages/block-library/src/image               @ajlende
 
 # Editor
 /packages/annotations                           @atimmer @ellatrix


### PR DESCRIPTION
I've been working closely on image editing recently, so I'd like to be notified of changes that happen with the image block.