### PR TITLE
Refactor Tag Cloud block to use React Hooks

### DIFF
--- a/packages/block-library/src/tag-cloud/edit.js
+++ b/packages/block-library/src/tag-cloud/edit.js
@@ -34,10 +34,6 @@ function TagCloudEdit( { attributes, setAttributes, taxonomies } ) {
 		return [ selectOption, ...taxonomyOptions ];
 	};
 
-	const toggleShowTagCounts = () => {
-		setAttributes( { showTagCounts: ! showTagCounts } );
-	};
-
 	const inspectorControls = (
 		<InspectorControls>
 			<PanelBody title={ __( 'Tag Cloud settings' ) }>
@@ -52,7 +48,9 @@ function TagCloudEdit( { attributes, setAttributes, taxonomies } ) {
 				<ToggleControl
 					label={ __( 'Show post counts' ) }
 					checked={ showTagCounts }
-					onChange={ toggleShowTagCounts }
+					onChange={ () =>
+						setAttributes( { showTagCounts: ! showTagCounts } )
+					}
 				/>
 			</PanelBody>
 		</InspectorControls>

--- a/packages/block-library/src/tag-cloud/edit.js
+++ b/packages/block-library/src/tag-cloud/edit.js
@@ -6,89 +6,68 @@ import { map, filter } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
 import { PanelBody, ToggleControl, SelectControl } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
 import ServerSideRender from '@wordpress/server-side-render';
 
-class TagCloudEdit extends Component {
-	constructor() {
-		super( ...arguments );
+function TagCloudEdit( { attributes, setAttributes, taxonomies } ) {
+	const { taxonomy, showTagCounts } = attributes;
 
-		this.state = {
-			editing: ! this.props.attributes.taxonomy,
-		};
-
-		this.setTaxonomy = this.setTaxonomy.bind( this );
-		this.toggleShowTagCounts = this.toggleShowTagCounts.bind( this );
-	}
-
-	getTaxonomyOptions() {
-		const taxonomies = filter( this.props.taxonomies, 'show_cloud' );
+	const getTaxonomyOptions = () => {
 		const selectOption = {
 			label: __( '- Select -' ),
 			value: '',
 			disabled: true,
 		};
-		const taxonomyOptions = map( taxonomies, ( taxonomy ) => {
-			return {
-				value: taxonomy.slug,
-				label: taxonomy.name,
-			};
-		} );
+		const taxonomyOptions = map(
+			filter( taxonomies, 'show_cloud' ),
+			( item ) => {
+				return {
+					value: item.slug,
+					label: item.name,
+				};
+			}
+		);
 
 		return [ selectOption, ...taxonomyOptions ];
-	}
+	};
 
-	setTaxonomy( taxonomy ) {
-		const { setAttributes } = this.props;
-
-		setAttributes( { taxonomy } );
-	}
-
-	toggleShowTagCounts() {
-		const { attributes, setAttributes } = this.props;
-		const { showTagCounts } = attributes;
-
+	const toggleShowTagCounts = () => {
 		setAttributes( { showTagCounts: ! showTagCounts } );
-	}
+	};
 
-	render() {
-		const { attributes } = this.props;
-		const { taxonomy, showTagCounts } = attributes;
-		const taxonomyOptions = this.getTaxonomyOptions();
-
-		const inspectorControls = (
-			<InspectorControls>
-				<PanelBody title={ __( 'Tag Cloud settings' ) }>
-					<SelectControl
-						label={ __( 'Taxonomy' ) }
-						options={ taxonomyOptions }
-						value={ taxonomy }
-						onChange={ this.setTaxonomy }
-					/>
-					<ToggleControl
-						label={ __( 'Show post counts' ) }
-						checked={ showTagCounts }
-						onChange={ this.toggleShowTagCounts }
-					/>
-				</PanelBody>
-			</InspectorControls>
-		);
-
-		return (
-			<>
-				{ inspectorControls }
-				<ServerSideRender
-					key="tag-cloud"
-					block="core/tag-cloud"
-					attributes={ attributes }
+	const inspectorControls = (
+		<InspectorControls>
+			<PanelBody title={ __( 'Tag Cloud settings' ) }>
+				<SelectControl
+					label={ __( 'Taxonomy' ) }
+					options={ getTaxonomyOptions() }
+					value={ taxonomy }
+					onChange={ ( selectedTaxonomy ) =>
+						setAttributes( { taxonomy: selectedTaxonomy } )
+					}
 				/>
-			</>
-		);
-	}
+				<ToggleControl
+					label={ __( 'Show post counts' ) }
+					checked={ showTagCounts }
+					onChange={ toggleShowTagCounts }
+				/>
+			</PanelBody>
+		</InspectorControls>
+	);
+
+	return (
+		<>
+			{ inspectorControls }
+			<ServerSideRender
+				key="tag-cloud"
+				block="core/tag-cloud"
+				attributes={ attributes }
+			/>
+		</>
+	);
 }
 
 export default withSelect( ( select ) => {


### PR DESCRIPTION
## Description
Related #22890.

## Types of changes
Refactor TagCloudEdit to use React Hooks.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
