### PR TITLE
Update bin/validate-package-lock.js error message.

### DIFF
--- a/bin/validate-package-lock.js
+++ b/bin/validate-package-lock.js
@@ -28,7 +28,7 @@ for ( const [ name, dependency ] of dependencies ) {
 
 ${ red( JSON.stringify( { [ name ]: dependency }, null, '\t' ) ) }
 
-To fix, try removing the node_modules directory and deleting package-lock.json, then run ${ yellow(
+To fix, try removing the node_modules directory and reverting package-lock.json, then run ${ yellow(
 				'npm install'
 			) }.
 `

--- a/bin/validate-package-lock.js
+++ b/bin/validate-package-lock.js
@@ -28,7 +28,7 @@ for ( const [ name, dependency ] of dependencies ) {
 
 ${ red( JSON.stringify( { [ name ]: dependency }, null, '\t' ) ) }
 
-To fix, try removing the node_modules directory, then run ${ yellow(
+To fix, try removing the node_modules directory and deleting package-lock.json, then run ${ yellow(
 				'npm install'
 			) }.
 `


### PR DESCRIPTION
If you don't delete `package-lock.json`, it will not update `resolved: false`, so I've made that explicit in the error message.