### PR TITLE
Classic block: Adjust placement of classic block toolbar when scrolled to top

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -6,7 +6,7 @@ $z-layers: (
 	".block-editor-block-list__block::before": 0,
 	".block-editor-block-switcher__arrow": 1,
 	".block-editor-block-list__block {core/image aligned wide or fullwide}": 20,
-	".block-library-classic__toolbar": 10,
+	".block-library-classic__toolbar": 31, // When scrolled to top this toolbar needs to sit over block-editor-block-toolbar
 	".block-editor-block-list__layout .reusable-block-indicator": 1,
 	".block-editor-block-list__block-selection-button": 22,
 	".components-form-toggle__input": 1,

--- a/packages/block-library/src/classic/editor.scss
+++ b/packages/block-library/src/classic/editor.scss
@@ -297,7 +297,7 @@ div[data-type="core/freeform"] {
 	margin: 0;
 	position: sticky;
 	z-index: z-index(".block-library-classic__toolbar");
-	top: $grid-unit-10;
+	top: 0;
 	border: $border-width solid $light-gray-500;
 	border-bottom: none;
 	border-radius: $radius-block-ui;


### PR DESCRIPTION
## Description
Fixes: #20969

## How has this been tested?
Manual testing

## Screenshots 

Before:

![classsic-scroll-before](https://user-images.githubusercontent.com/3629020/85636815-9b6b2100-b6d5-11ea-9170-6672d8751db6.gif)

After:

![classic-scroll-after](https://user-images.githubusercontent.com/3629020/85636829-a45bf280-b6d5-11ea-8daf-405b47d06f6b.gif)

## Types of changes
- minor css changes

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. 
