### PR TITLE
Block Directory: Throw error if we have an issue registering blocks.

### DIFF
--- a/packages/block-directory/src/components/downloadable-block-header/index.js
+++ b/packages/block-directory/src/components/downloadable-block-header/index.js
@@ -15,7 +15,8 @@ function DownloadableBlockHeader( {
 	title,
 	rating,
 	ratingCount,
-	isLoading,
+	isLoading = false,
+	isInstallable = true,
 	onClick,
 } ) {
 	return (
@@ -31,10 +32,10 @@ function DownloadableBlockHeader( {
 			<Button
 				isSecondary
 				isBusy={ isLoading }
-				disabled={ isLoading }
+				disabled={ isLoading || ! isInstallable }
 				onClick={ ( event ) => {
 					event.preventDefault();
-					if ( ! isLoading ) {
+					if ( ! isLoading && isInstallable ) {
 						onClick();
 					}
 				} }

--- a/packages/block-directory/src/components/downloadable-block-header/test/index.js
+++ b/packages/block-directory/src/components/downloadable-block-header/test/index.js
@@ -17,7 +17,8 @@ import { pluginWithIcon } from './fixtures';
 const getContainer = (
 	{ icon, title, rating, ratingCount },
 	onClick = jest.fn(),
-	isLoading = false
+	isLoading = false,
+	isInstallable = true
 ) => {
 	return shallow(
 		<DownloadableBlockHeader
@@ -27,6 +28,7 @@ const getContainer = (
 			rating={ rating }
 			ratingCount={ ratingCount }
 			isLoading={ isLoading }
+			isInstallable={ isInstallable }
 		/>
 	);
 };
@@ -53,6 +55,22 @@ describe( 'DownloadableBlockHeader', () => {
 			wrapper.find( Button ).simulate( 'click', event );
 			expect( event.preventDefault ).toHaveBeenCalled();
 			expect( onClickMock ).toHaveBeenCalledTimes( 0 );
+		} );
+
+		test( 'should trigger the onClick function if not installable', () => {
+			const onClickMock = jest.fn();
+			const wrapper = getContainer(
+				pluginWithIcon,
+				onClickMock,
+				false,
+				false
+			);
+			const event = {
+				preventDefault: jest.fn(),
+			};
+			wrapper.find( Button ).simulate( 'click', event );
+			expect( onClickMock ).toHaveBeenCalledTimes( 0 );
+			expect( event.preventDefault ).toHaveBeenCalled();
 		} );
 	} );
 } );

--- a/packages/block-directory/src/components/downloadable-block-header/test/index.js
+++ b/packages/block-directory/src/components/downloadable-block-header/test/index.js
@@ -57,7 +57,7 @@ describe( 'DownloadableBlockHeader', () => {
 			expect( onClickMock ).toHaveBeenCalledTimes( 0 );
 		} );
 
-		test( 'should trigger the onClick function if not installable', () => {
+		test( 'should not trigger the onClick function if not installable', () => {
 			const onClickMock = jest.fn();
 			const wrapper = getContainer(
 				pluginWithIcon,

--- a/packages/block-directory/src/components/downloadable-block-list-item/index.js
+++ b/packages/block-directory/src/components/downloadable-block-list-item/index.js
@@ -12,8 +12,18 @@ import DownloadableBlockInfo from '../downloadable-block-info';
 import DownloadableBlockNotice from '../downloadable-block-notice';
 
 export default function DownloadableBlockListItem( { item, onClick } ) {
-	const isLoading = useSelect(
-		( select ) => select( 'core/block-directory' ).isInstalling( item.id ),
+	const { isLoading, isInstallable } = useSelect(
+		( select ) => {
+			const { isInstalling, getErrorNoticeForBlock } = select(
+				'core/block-directory'
+			);
+			const notice = getErrorNoticeForBlock( item.id );
+			const hasFatal = notice && notice.isFatal;
+			return {
+				isLoading: isInstalling( item.id ),
+				isInstallable: ! hasFatal,
+			};
+		},
 		[ item ]
 	);
 
@@ -41,6 +51,7 @@ export default function DownloadableBlockListItem( { item, onClick } ) {
 						rating={ rating }
 						ratingCount={ ratingCount }
 						isLoading={ isLoading }
+						isInstallable={ isInstallable }
 					/>
 				</header>
 				<section className="block-directory-downloadable-block-list-item__body">

--- a/packages/block-directory/src/components/downloadable-block-list-item/test/__snapshots__/index.js.snap
+++ b/packages/block-directory/src/components/downloadable-block-list-item/test/__snapshots__/index.js.snap
@@ -12,6 +12,8 @@ exports[`DownloadableBlockListItem should render a block item 1`] = `
     >
       <DownloadableBlockHeader
         icon="block-default"
+        isInstallable={true}
+        isLoading={false}
         onClick={[MockFunction]}
         rating={5}
         title="Boxer"

--- a/packages/block-directory/src/components/downloadable-block-list-item/test/index.js
+++ b/packages/block-directory/src/components/downloadable-block-list-item/test/index.js
@@ -4,6 +4,11 @@
 import { shallow } from 'enzyme';
 
 /**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
  * Internal dependencies
  */
 import DownloadableBlockListItem from '../index';
@@ -18,6 +23,11 @@ jest.mock( '@wordpress/data/src/components/use-select', () => {
 
 describe( 'DownloadableBlockListItem', () => {
 	it( 'should render a block item', () => {
+		useSelect.mockImplementation( () => ( {
+			isLoading: false,
+			isInstallable: true,
+		} ) );
+
 		const wrapper = shallow(
 			<DownloadableBlockListItem onClick={ jest.fn() } item={ item } />
 		);

--- a/packages/block-directory/src/components/downloadable-block-notice/index.js
+++ b/packages/block-directory/src/components/downloadable-block-notice/index.js
@@ -25,17 +25,20 @@ export const DownloadableBlockNotice = ( { block, onClick } ) => {
 			<div className="block-directory-downloadable-block-notice__content">
 				{ errorNotice.msg }
 			</div>
-			{ ! errorNotice.isFatal && (
-				<Button
-					isSmall
-					isPrimary
-					onClick={ () => {
-						onClick( block );
-					} }
-				>
-					{ __( 'Retry' ) }
-				</Button>
-			) }
+			<Button
+				isSmall
+				isPrimary
+				onClick={ () => {
+					if ( errorNotice.isFatal ) {
+						window.location.reload();
+						return false;
+					}
+
+					onClick( block );
+				} }
+			>
+				{ errorNotice.isFatal ? __( 'Reload' ) : __( 'Retry' ) }
+			</Button>
 		</Notice>
 	);
 };

--- a/packages/block-directory/src/components/downloadable-block-notice/index.js
+++ b/packages/block-directory/src/components/downloadable-block-notice/index.js
@@ -23,7 +23,7 @@ export const DownloadableBlockNotice = ( { block, onClick } ) => {
 			className="block-directory-downloadable-block-notice"
 		>
 			<div className="block-directory-downloadable-block-notice__content">
-				{ errorNotice.msg }
+				{ errorNotice.message }
 			</div>
 			<Button
 				isSmall

--- a/packages/block-directory/src/components/downloadable-block-notice/index.js
+++ b/packages/block-directory/src/components/downloadable-block-notice/index.js
@@ -23,17 +23,19 @@ export const DownloadableBlockNotice = ( { block, onClick } ) => {
 			className="block-directory-downloadable-block-notice"
 		>
 			<div className="block-directory-downloadable-block-notice__content">
-				{ errorNotice }
+				{ errorNotice.msg }
 			</div>
-			<Button
-				isSmall
-				isPrimary
-				onClick={ () => {
-					onClick( block );
-				} }
-			>
-				{ __( 'Retry' ) }
-			</Button>
+			{ ! errorNotice.isFatal && (
+				<Button
+					isSmall
+					isPrimary
+					onClick={ () => {
+						onClick( block );
+					} }
+				>
+					{ __( 'Retry' ) }
+				</Button>
+			) }
 		</Notice>
 	);
 };

--- a/packages/block-directory/src/components/downloadable-block-notice/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-notice/style.scss
@@ -4,8 +4,5 @@
 
 .block-directory-downloadable-block-notice__content {
 	padding-right: 12px;
-}
-
-.block-directory-downloadable-block-notice__content + * {
-	margin-top: 8px;
+	margin-bottom: 8px;
 }

--- a/packages/block-directory/src/components/downloadable-block-notice/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-notice/style.scss
@@ -4,5 +4,8 @@
 
 .block-directory-downloadable-block-notice__content {
 	padding-right: 12px;
-	margin-bottom: 8px;
+}
+
+.block-directory-downloadable-block-notice__content + * {
+	margin-top: 8px;
 }

--- a/packages/block-directory/src/components/downloadable-block-notice/test/index.js
+++ b/packages/block-directory/src/components/downloadable-block-notice/test/index.js
@@ -35,7 +35,9 @@ describe( 'DownloadableBlockNotice', () => {
 		} );
 
 		it( 'should return something when there are error notices', () => {
-			useSelect.mockImplementation( () => 'Plugin not found.' );
+			useSelect.mockImplementation( () => {
+				return { message: 'Plugin not found.', isFatal: false };
+			} );
 			const wrapper = shallow(
 				<DownloadableBlockNotice
 					block={ plugin }

--- a/packages/block-directory/src/store/actions.js
+++ b/packages/block-directory/src/store/actions.js
@@ -79,9 +79,17 @@ export function* installBlockType( block ) {
 
 		yield loadAssets( assets );
 		const registeredBlocks = yield select( 'core/blocks', 'getBlockTypes' );
+
 		if ( ! registeredBlocks.length ) {
 			throw new Error( __( 'Unable to get block types.' ) );
 		}
+
+		if (
+			! registeredBlocks.filter( ( i ) => i.name === block.name ).length
+		) {
+			throw new Error( __( 'Error registering block.' ) );
+		}
+
 		success = true;
 	} catch ( error ) {
 		yield setErrorNotice( id, error.message || __( 'An error occurred.' ) );

--- a/packages/block-directory/src/store/actions.js
+++ b/packages/block-directory/src/store/actions.js
@@ -79,7 +79,6 @@ export function* installBlockType( block ) {
 
 		yield loadAssets( assets );
 		const registeredBlocks = yield select( 'core/blocks', 'getBlockTypes' );
-
 		if ( ! registeredBlocks.length ) {
 			throw new Error( __( 'Unable to get block types.' ) );
 		}

--- a/packages/block-directory/src/store/actions.js
+++ b/packages/block-directory/src/store/actions.js
@@ -79,14 +79,11 @@ export function* installBlockType( block ) {
 
 		yield loadAssets( assets );
 		const registeredBlocks = yield select( 'core/blocks', 'getBlockTypes' );
-		if ( ! registeredBlocks.length ) {
-			throw new Error( __( 'Unable to get block types.' ) );
-		}
-
 		if (
+			! registeredBlocks.length ||
 			! registeredBlocks.filter( ( i ) => i.name === block.name ).length
 		) {
-			throw new Error(
+			throw new TypeError(
 				__( 'Error registering block. Try reloading to the page.' )
 			);
 		}
@@ -94,6 +91,7 @@ export function* installBlockType( block ) {
 		success = true;
 	} catch ( error ) {
 		let msg = error.message || __( 'An error occurred.' );
+		const fatal = error instanceof TypeError;
 
 		if ( error.code && error.code === 'folder_exists' ) {
 			msg = __(
@@ -101,7 +99,7 @@ export function* installBlockType( block ) {
 			);
 		}
 
-		yield setErrorNotice( id, msg, true );
+		yield setErrorNotice( id, msg, fatal );
 	}
 	yield setIsInstalling( block.id, false );
 	return success;

--- a/packages/block-directory/src/store/actions.js
+++ b/packages/block-directory/src/store/actions.js
@@ -90,7 +90,7 @@ export function* installBlockType( block ) {
 
 		success = true;
 	} catch ( error ) {
-		let msg = error.message || __( 'An error occurred.' );
+		let message = error.message || __( 'An error occurred.' );
 
 		// Errors we throw are fatal
 		let isFatal = error instanceof Error;
@@ -107,10 +107,10 @@ export function* installBlockType( block ) {
 
 		if ( fatalAPIErrors[ error.code ] ) {
 			isFatal = true;
-			msg = fatalAPIErrors[ error.code ];
+			message = fatalAPIErrors[ error.code ];
 		}
 
-		yield setErrorNotice( id, msg, isFatal );
+		yield setErrorNotice( id, message, isFatal );
 	}
 	yield setIsInstalling( block.id, false );
 	return success;
@@ -192,17 +192,17 @@ export function setIsInstalling( blockId, isInstalling ) {
  * Sets an error notice string to be displayed to the user
  *
  * @param {string} blockId The ID of the block plugin. eg: my-block
- * @param {string} msg  The message shown in the notice.
+ * @param {string} message  The message shown in the notice.
  * @param {boolean} isFatal Whether the user can recover from the error
  *
  * @return {Object} Action object.
  */
-export function setErrorNotice( blockId, msg, isFatal = false ) {
+export function setErrorNotice( blockId, message, isFatal = false ) {
 	return {
 		type: 'SET_ERROR_NOTICE',
 		blockId,
 		notice: {
-			msg,
+			message,
 			isFatal,
 		},
 	};

--- a/packages/block-directory/src/store/actions.js
+++ b/packages/block-directory/src/store/actions.js
@@ -86,12 +86,22 @@ export function* installBlockType( block ) {
 		if (
 			! registeredBlocks.filter( ( i ) => i.name === block.name ).length
 		) {
-			throw new Error( __( 'Error registering block.' ) );
+			throw new Error(
+				__( 'Error registering block. Try reloading to the page.' )
+			);
 		}
 
 		success = true;
 	} catch ( error ) {
-		yield setErrorNotice( id, error.message || __( 'An error occurred.' ) );
+		let msg = error.message || __( 'An error occurred.' );
+
+		if ( error.code && error.code === 'folder_exists' ) {
+			msg = __(
+				'Block is already installed. Try reloading to the page.'
+			);
+		}
+
+		yield setErrorNotice( id, msg, true );
 	}
 	yield setIsInstalling( block.id, false );
 	return success;
@@ -173,15 +183,19 @@ export function setIsInstalling( blockId, isInstalling ) {
  * Sets an error notice string to be displayed to the user
  *
  * @param {string} blockId The ID of the block plugin. eg: my-block
- * @param {string} notice  The message shown in the notice.
+ * @param {string} msg  The message shown in the notice.
+ * @param {boolean} isFatal Whether the user can recover from the error
  *
  * @return {Object} Action object.
  */
-export function setErrorNotice( blockId, notice ) {
+export function setErrorNotice( blockId, msg, isFatal = false ) {
 	return {
 		type: 'SET_ERROR_NOTICE',
 		blockId,
-		notice,
+		notice: {
+			msg,
+			isFatal,
+		},
 	};
 }
 
@@ -196,6 +210,6 @@ export function clearErrorNotice( blockId ) {
 	return {
 		type: 'SET_ERROR_NOTICE',
 		blockId,
-		notice: false,
+		notice: undefined,
 	};
 }

--- a/packages/block-directory/src/store/actions.js
+++ b/packages/block-directory/src/store/actions.js
@@ -84,7 +84,7 @@ export function* installBlockType( block ) {
 			! registeredBlocks.filter( ( i ) => i.name === block.name ).length
 		) {
 			throw new Error(
-				__( 'Error registering block. Try reloading to the page.' )
+				__( 'Error registering block. Try reloading the page.' )
 			);
 		}
 
@@ -98,7 +98,7 @@ export function* installBlockType( block ) {
 		// Specific API errors that are fatal
 		const fatalAPIErrors = {
 			folder_exists: __(
-				'Block is already installed. Try reloading to the page.'
+				'This block is already installed. Try reloading the page.'
 			),
 			unable_to_connect_to_filesystem: __(
 				'Error installing block. You can reload the page and try again.'

--- a/packages/block-directory/src/store/actions.js
+++ b/packages/block-directory/src/store/actions.js
@@ -215,8 +215,7 @@ export function setErrorNotice( blockId, message, isFatal = false ) {
  */
 export function clearErrorNotice( blockId ) {
 	return {
-		type: 'SET_ERROR_NOTICE',
+		type: 'CLEAR_ERROR_NOTICE',
 		blockId,
-		notice: undefined,
 	};
 }

--- a/packages/block-directory/src/store/actions.js
+++ b/packages/block-directory/src/store/actions.js
@@ -201,10 +201,8 @@ export function setErrorNotice( blockId, message, isFatal = false ) {
 	return {
 		type: 'SET_ERROR_NOTICE',
 		blockId,
-		notice: {
-			message,
-			isFatal,
-		},
+		message,
+		isFatal,
 	};
 }
 

--- a/packages/block-directory/src/store/reducer.js
+++ b/packages/block-directory/src/store/reducer.js
@@ -1,4 +1,10 @@
 /**
+ * External dependencies
+ */
+
+import { omit } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { combineReducers } from '@wordpress/data';
@@ -109,6 +115,8 @@ export const errorNotices = ( state = {}, action ) => {
 					isFatal: action.isFatal,
 				},
 			};
+		case 'CLEAR_ERROR_NOTICE':
+			return omit( state, action.blockId );
 	}
 	return state;
 };

--- a/packages/block-directory/src/store/reducer.js
+++ b/packages/block-directory/src/store/reducer.js
@@ -104,7 +104,10 @@ export const errorNotices = ( state = {}, action ) => {
 		case 'SET_ERROR_NOTICE':
 			return {
 				...state,
-				[ action.blockId ]: action.notice,
+				[ action.blockId ]: {
+					message: action.message,
+					isFatal: action.isFatal,
+				},
 			};
 	}
 	return state;

--- a/packages/block-directory/src/store/selectors.js
+++ b/packages/block-directory/src/store/selectors.js
@@ -147,5 +147,5 @@ export function getErrorNotices( state ) {
  * @return {string|boolean} The error text, or false if no error.
  */
 export function getErrorNoticeForBlock( state, blockId ) {
-	return state.errorNotices[ blockId ] || false;
+	return state.errorNotices[ blockId ];
 }

--- a/packages/block-directory/src/store/test/actions.js
+++ b/packages/block-directory/src/store/test/actions.js
@@ -29,9 +29,8 @@ describe( 'actions', () => {
 			const generator = installBlockType( item );
 
 			expect( generator.next().value ).toEqual( {
-				type: 'SET_ERROR_NOTICE',
+				type: 'CLEAR_ERROR_NOTICE',
 				blockId: item.id,
-				notice: false,
 			} );
 
 			expect( generator.next().value ).toEqual( {
@@ -82,9 +81,8 @@ describe( 'actions', () => {
 			const generator = installBlockType( { ...item, assets: [] } );
 
 			expect( generator.next().value ).toEqual( {
-				type: 'SET_ERROR_NOTICE',
+				type: 'CLEAR_ERROR_NOTICE',
 				blockId: item.id,
-				notice: false,
 			} );
 
 			expect( generator.next().value ).toMatchObject( {
@@ -108,9 +106,8 @@ describe( 'actions', () => {
 			const generator = installBlockType( item );
 
 			expect( generator.next().value ).toEqual( {
-				type: 'SET_ERROR_NOTICE',
+				type: 'CLEAR_ERROR_NOTICE',
 				blockId: item.id,
-				notice: false,
 			} );
 
 			expect( generator.next().value ).toEqual( {

--- a/packages/block-directory/src/store/test/reducer.js
+++ b/packages/block-directory/src/store/test/reducer.js
@@ -103,62 +103,77 @@ describe( 'state', () => {
 	describe( 'errorNotices()', () => {
 		it( 'should set an error notice', () => {
 			const initialState = deepFreeze( {} );
+			const error = {
+				message: 'error',
+				isFatal: false,
+			};
+
 			const state = errorNotices( initialState, {
 				type: 'SET_ERROR_NOTICE',
 				blockId: 'block/has-error',
-				notice: 'Error',
+				...error,
 			} );
 
 			expect( state ).toEqual( {
-				'block/has-error': 'Error',
+				'block/has-error': error,
 			} );
 		} );
 
 		it( 'should set a second error notice', () => {
 			const initialState = deepFreeze( {
-				'block/has-error': 'Error',
+				'block/has-error': {
+					message: 'error',
+					isFatal: false,
+				},
 			} );
 			const state = errorNotices( initialState, {
 				type: 'SET_ERROR_NOTICE',
 				blockId: 'block/another-error',
-				notice: 'Error',
+				message: 'error',
+				isFatal: true,
 			} );
 
 			expect( state ).toEqual( {
-				'block/has-error': 'Error',
-				'block/another-error': 'Error',
+				'block/has-error': {
+					message: 'error',
+					isFatal: false,
+				},
+				'block/another-error': {
+					message: 'error',
+					isFatal: true,
+				},
 			} );
 		} );
 
 		it( 'should clear an existing error notice', () => {
 			const initialState = deepFreeze( {
-				'block/has-error': 'Error',
-			} );
-			const state = errorNotices( initialState, {
-				type: 'SET_ERROR_NOTICE',
-				blockId: 'block/has-error',
-				notice: false,
+				'block/has-error': {
+					message: 'existing error',
+					isFatal: false,
+				},
 			} );
 
-			expect( state ).toEqual( {
-				'block/has-error': false,
+			const state = errorNotices( initialState, {
+				type: 'CLEAR_ERROR_NOTICE',
+				blockId: 'block/has-error',
 			} );
+
+			expect( state ).toEqual( {} );
 		} );
 
 		it( 'should clear a nonexistent error notice', () => {
 			const initialState = deepFreeze( {
-				'block/has-error': 'Error',
+				'block/has-error': {
+					message: 'new error',
+					isFatal: true,
+				},
 			} );
 			const state = errorNotices( initialState, {
-				type: 'SET_ERROR_NOTICE',
+				type: 'CLEAR_ERROR_NOTICE',
 				blockId: 'block/no-error',
-				notice: false,
 			} );
 
-			expect( state ).toEqual( {
-				'block/has-error': 'Error',
-				'block/no-error': false,
-			} );
+			expect( state ).toEqual( initialState );
 		} );
 	} );
 } );

--- a/packages/block-directory/src/store/test/selectors.js
+++ b/packages/block-directory/src/store/test/selectors.js
@@ -175,7 +175,10 @@ describe( 'selectors', () => {
 	describe( 'getErrorNoticeForBlock', () => {
 		const state = {
 			errorNotices: {
-				'block/has-error': 'Error notice',
+				'block/has-error': {
+					message: 'Error notice',
+					isFatal: false,
+				},
 			},
 		};
 
@@ -184,7 +187,9 @@ describe( 'selectors', () => {
 				state,
 				'block/has-error'
 			);
-			expect( errorNotice ).toEqual( 'Error notice' );
+			expect( errorNotice ).toEqual(
+				state.errorNotices[ 'block/has-error' ]
+			);
 		} );
 
 		it( "should retrieve no error notice for a block that doesn't have one", () => {
@@ -192,7 +197,7 @@ describe( 'selectors', () => {
 				state,
 				'block/no-error'
 			);
-			expect( errorNotice ).toEqual( false );
+			expect( errorNotice ).toEqual( undefined );
 		} );
 	} );
 


### PR DESCRIPTION
## Description
When a third party block fails during the installation process, we should alert the user to give them context.

## How has this been tested?
1.  Search for "Waves" -> At the time of the PR, that block is currently breaking (but probably fixed by now)
2. Click 'Add Block' 
3. Expect to see an error messages below:

## Types of changes
1. Update the structure of Error Notice state.
2. Change button to`reload` from `retry` if error is known to be `fatal`.
3. Specifically handle API errors `folder_exists`, `unable_to_connect_to_filesystem`.

## Assumptions
This PR doesn't try to handle all the use cases but instead identifies the ones we know to be fatal or introduce and awkward experience. All other unhandled but thrown errors will allow user's the opportunity to retry.

## Screenshots
| Already Installed  |  Failed Install | Failed Registration |
| ------------- | ------------- | ------------- |
|  ![Error msg](https://d.pr/i/29lDoc.png)  | ![Error msg](https://d.pr/i/ImEbHi.png) |   ![Error msg](https://d.pr/i/swlQfc.png) |
|  | Note: Probably should add more error code handling. Currently only `unable_to_connect_to_filesystem` |  |

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
