### PR TITLE
Fix generating file names for edited files, and use wp_unique_filename()

### DIFF
--- a/lib/class-wp-rest-image-editor-controller.php
+++ b/lib/class-wp-rest-image-editor-controller.php
@@ -46,22 +46,18 @@ class WP_REST_Image_Editor_Controller extends WP_REST_Controller {
 						'x'        => array(
 							'type'     => 'number',
 							'minimum'  => 0,
-							'required' => true,
 						),
 						'y'        => array(
 							'type'     => 'number',
 							'minimum'  => 0,
-							'required' => true,
 						),
 						'width'    => array(
 							'type'     => 'number',
 							'minimum'  => 1,
-							'required' => true,
 						),
 						'height'   => array(
 							'type'     => 'number',
 							'minimum'  => 1,
-							'required' => true,
 						),
 						'rotation' => array(
 							'type' => 'integer',
@@ -124,13 +120,12 @@ class WP_REST_Image_Editor_Controller extends WP_REST_Controller {
 		}
 
 		if ( isset( $params['x'], $params['y'], $params['width'], $params['height'] ) ) {
-			// The crop script may return some very small, sub-pixel values when the image was not cropped.
-			// Crop only when the cropping coordinates values are changed by more than 0.1%.
+			// Check if the crop dimensions are whitin bounds.
 			if (
-				floatval( $params['x'] ) > 0.1 ||
-				floatval( $params['y'] ) > 0.1 ||
-				floatval( $params['width'] ) < 99.9 ||
-				floatval( $params['height'] ) < 99.9
+				( $params['x'] >= 0 && $params['x'] < 100 ) &&
+				( $params['y'] >= 0 && $params['y'] < 100 ) &&
+				( $params['width'] >= 1 && $params['width'] <= 100 ) &&
+				( $params['height'] >= 1 && $params['height'] <= 100 )
 			) {
 				$crop = true;
 			}

--- a/lib/class-wp-rest-image-editor-controller.php
+++ b/lib/class-wp-rest-image-editor-controller.php
@@ -101,90 +101,134 @@ class WP_REST_Image_Editor_Controller extends WP_REST_Controller {
 	public function apply_edits( $request ) {
 		require_once ABSPATH . 'wp-admin/includes/image.php';
 
-		$params = $request->get_params();
+		$params        = $request->get_params();
+		$attachment_id = $params['media_id'];
 
-		$media_id = $params['media_id'];
+		// This also confirms the attachment is an image.
+		$image_file = wp_get_original_image_path( $attachment_id );
+		$image_meta = wp_get_attachment_metadata( $attachment_id );
 
-		// Get image information.
-		$attachment_info = wp_get_attachment_metadata( $media_id );
-		$media_url       = wp_get_attachment_image_url( $media_id, 'original' );
-
-		if ( ! $attachment_info || ! $media_url ) {
+		if ( ! $image_meta || ! $image_file ) {
 			return new WP_Error( 'rest_unknown_attachment', __( 'Unable to get meta information for file.', 'gutenberg' ), array( 'status' => 404 ) );
 		}
 
-		$meta = array( 'original_name' => basename( $media_url ) );
+		$image_editor = wp_get_image_editor( $image_file );
 
-		if ( isset( $attachment_info['richimage'] ) ) {
-			$meta = array_merge( $meta, $attachment_info['richimage'] );
+		if ( is_wp_error( $image_editor ) ) {
+			// This image cannot be edited.
+			return new WP_Error( 'rest_unknown_image_file_type', __( 'Unable to edit this image.', 'gutenberg' ), array( 'status' => 500 ) );
 		}
 
-		// Try and load the image itself.
-		$image_path = get_attached_file( $media_id );
-		if ( empty( $image_path ) ) {
-			return new WP_Error( 'rest_cannot_find_attached_file', __( 'Unable to find original media file.', 'gutenberg' ), array( 'status' => 500 ) );
+		if ( isset( $params['rotation'] ) ) { // TODO: use `rotate` instead?
+			// CW / CCW
+			$result = $image_editor->rotate( 0 - $params['rotation'] );
+
+			// TODO: return the "real" error message?
+			if ( is_wp_error( $result ) ) {
+				return new WP_Error( 'rest_image_rotation_failed', __( 'Unable to rotate this image.', 'gutenberg' ), array( 'status' => 500 ) );
+			}
 		}
 
-		$image_editor = wp_get_image_editor( $image_path );
-		if ( ! $image_editor->load() ) {
-			return new WP_Error( 'rest_cannot_load_editor', __( 'Unable to load original media file.', 'gutenberg' ), array( 'status' => 500 ) );
+		if ( isset( $params['x'], $params['y'], $params['width'], $params['height'] ) ) {
+			$size = $image_editor->get_size();
+
+			// Crop
+			$crop_x = round( ( $size['width'] * floatval( $params['x'] ) ) / 100.0 );
+			$crop_y = round( ( $size['height'] * floatval( $params['y'] ) ) / 100.0 );
+			$width  = round( ( $size['width'] * floatval( $params['width'] ) ) / 100.0 );
+			$height = round( ( $size['height'] * floatval( $params['height'] ) ) / 100.0 );
+
+			$result = $image_editor->crop( $crop_x, $crop_y, $width, $height );
+
+			if ( is_wp_error( $result ) ) {
+				return new WP_Error( 'rest_image_crop_failed', __( 'Unable to crop this image.', 'gutenberg' ), array( 'status' => 500 ) );
+			}
 		}
 
-		if ( isset( $params['rotation'] ) ) {
-			$image_editor->rotate( 0 - $params['rotation'] );
+		// Calculate the file name.
+		$image_ext  = pathinfo( $image_file, PATHINFO_EXTENSION );
+		$image_name = wp_basename( $image_file, ".{$image_ext}" );
+
+		// Do not append multiple `-edited` to the file name.
+		// The user may be editing a previously edited image.
+		if ( preg_match( '/-edited(-\d+)?$/', $image_name ) ) {
+			// Remove any `-1`, `-2`, etc. `wp_unique_filename()` will add the proper number.
+			$image_name = preg_replace( '/-edited(-\d+)?$/', '-edited', $image_name );
+		} else {
+			// Append `-edited` before the extension.
+			$image_name .= '-edited';
 		}
 
-		$size = $image_editor->get_size();
+		$filename = "{$image_name}.{$image_ext}";
 
-		// Finally apply the modifications.
-		$crop_x = round( ( $size['width'] * floatval( $params['x'] ) ) / 100.0 );
-		$crop_y = round( ( $size['height'] * floatval( $params['y'] ) ) / 100.0 );
-		$width  = round( ( $size['width'] * floatval( $params['width'] ) ) / 100.0 );
-		$height = round( ( $size['height'] * floatval( $params['height'] ) ) / 100.0 );
-		$image_editor->crop( $crop_x, $crop_y, $width, $height );
+		// Create the uploads sub-directory if needed.
+		$uploads = wp_upload_dir();
 
-		// TODO: Generate filename based on edits.
-		$target_file = 'edited-' . $meta['original_name'];
-
-		$filename = rtrim( dirname( $image_path ), '/' ) . '/' . $target_file;
+		// Tests the file basename in the (proper/new) upload directory.
+		$filename = wp_unique_filename( $uploads['path'], $filename );
 
 		// Save to disk.
-		$saved = $image_editor->save( $filename );
+		$saved = $image_editor->save( $uploads['path'] . "/$filename" );
 
 		if ( is_wp_error( $saved ) ) {
 			return $saved;
 		}
 
-		// Update attachment details.
+		// Create new attachment post.
+		// TODO: Add possibility to preset the content and excerpt, and maybe the title?
 		$attachment_post = array(
-			'guid'           => $saved['path'],
 			'post_mime_type' => $saved['mime-type'],
-			'post_title'     => pathinfo( $target_file, PATHINFO_FILENAME ),
+			'guid'           => $uploads['url'] . "/$filename",
+			'post_title'     => $filename,
 			'post_content'   => '',
-			'post_status'    => 'inherit',
 		);
 
-		// Add this as an attachment.
-		$attachment_id = wp_insert_attachment( $attachment_post, $saved['path'], 0, true );
+		$new_attachment_id = wp_insert_attachment( $attachment_post, $saved['path'], 0, true );
 
-		if ( is_wp_error( $attachment_id ) ) {
-			if ( 'db_update_error' === $attachment_id->get_error_code() ) {
-				$attachment_id->add_data( array( 'status' => 500 ) );
+		if ( is_wp_error( $new_attachment_id ) ) {
+			if ( 'db_update_error' === $new_attachment_id->get_error_code() ) {
+				$new_attachment_id->add_data( array( 'status' => 500 ) );
 			} else {
-				$attachment_id->add_data( array( 'status' => 400 ) );
+				$new_attachment_id->add_data( array( 'status' => 400 ) );
 			}
 
-			return $attachment_id;
+			return $new_attachment_id;
 		}
 
-		// Generate thumbnails.
-		$metadata = wp_generate_attachment_metadata( $attachment_id, $saved['path'] );
+		// Generate image sub-sizes and meta.
+		$new_image_meta = wp_generate_attachment_metadata( $new_attachment_id, $saved['path'] );
 
-		$metadata['richimage'] = $meta;
+		// TODO: Keep?
+		// Copy the EXIF metadata from the original attachment if not generated for the edited image.
+		// (EXIF is removed when using GD.)
+		if ( ! empty( $image_meta['image_meta'] ) ) {
+			$empty_image_meta = true;
 
-		wp_update_attachment_metadata( $attachment_id, $metadata );
+			if ( isset( $new_image_meta['image_meta'] ) && is_array( $new_image_meta['image_meta'] ) ) {
+				$empty_image_meta = empty( array_filter( array_values( $new_image_meta['image_meta'] ) ) );
+			}
 
-		$path     = '/wp/v2/media/' . $attachment_id;
+			if ( $empty_image_meta ) {
+				$new_image_meta['image_meta'] = $image_meta['image_meta'];
+			}
+		}
+
+		// Reset orientation. At this point the image is edited and orientation is correct.
+		if ( ! empty( $new_image_meta['image_meta']['orientation'] ) ) {
+			$new_image_meta['image_meta']['orientation'] = 1;
+		}
+
+		// TODO: reference to the parent image: attachment_id? path? Anything else?
+		// The attachment_id may change if the site is exported and imported.
+		$new_image_meta['parent_image'] = array(
+			'attachment_id' => $attachment_id,
+			// Path to the originally uploaded image file relative to the uploads directory.
+			'file'          => _wp_relative_upload_path( $image_file ),
+		);
+
+		wp_update_attachment_metadata( $new_attachment_id, $new_image_meta );
+
+		$path     = '/wp/v2/media/' . $new_attachment_id;
 		$response = rest_do_request( $path );
 
 		if ( ! $response->is_error() ) {

--- a/lib/class-wp-rest-image-editor-controller.php
+++ b/lib/class-wp-rest-image-editor-controller.php
@@ -43,24 +43,30 @@ class WP_REST_Image_Editor_Controller extends WP_REST_Controller {
 					'callback'            => array( $this, 'apply_edits' ),
 					'permission_callback' => array( $this, 'permission_callback' ),
 					'args'                => array(
+						'rotation' => array(
+							'type' => 'integer',
+						),
+
+						// Crop values are in percents.
 						'x'        => array(
 							'type'    => 'number',
 							'minimum' => 0,
+							'maximum' => 100,
 						),
 						'y'        => array(
 							'type'    => 'number',
 							'minimum' => 0,
+							'maximum' => 100,
 						),
 						'width'    => array(
 							'type'    => 'number',
-							'minimum' => 1,
+							'minimum' => 0,
+							'maximum' => 100,
 						),
 						'height'   => array(
 							'type'    => 'number',
-							'minimum' => 1,
-						),
-						'rotation' => array(
-							'type' => 'integer',
+							'minimum' => 0,
+							'maximum' => 100,
 						),
 					),
 				),
@@ -120,15 +126,7 @@ class WP_REST_Image_Editor_Controller extends WP_REST_Controller {
 		}
 
 		if ( isset( $params['x'], $params['y'], $params['width'], $params['height'] ) ) {
-			// Check if the crop dimensions are whitin bounds.
-			if (
-				( $params['x'] >= 0 && $params['x'] < 100 ) &&
-				( $params['y'] >= 0 && $params['y'] < 100 ) &&
-				( $params['width'] >= 1 && $params['width'] <= 100 ) &&
-				( $params['height'] >= 1 && $params['height'] <= 100 )
-			) {
-				$crop = true;
-			}
+			$crop = true;
 		}
 
 		if ( ! $rotate && ! $crop ) {
@@ -144,7 +142,7 @@ class WP_REST_Image_Editor_Controller extends WP_REST_Controller {
 			return new WP_Error( 'rest_unknown_image_file_type', $error, array( 'status' => 500 ) );
 		}
 
-		if ( $rotate !== 0 ) {
+		if ( 0 !== $rotate ) {
 			$result = $image_editor->rotate( $rotate );
 
 			if ( is_wp_error( $result ) ) {

--- a/lib/class-wp-rest-image-editor-controller.php
+++ b/lib/class-wp-rest-image-editor-controller.php
@@ -130,7 +130,7 @@ class WP_REST_Image_Editor_Controller extends WP_REST_Controller {
 		}
 
 		if ( ! $rotate && ! $crop ) {
-			$error = __( 'The image was not erdited. Edit the image before applying the changes.', 'gutenberg' );
+			$error = __( 'The image was not edited. Edit the image before applying the changes.', 'gutenberg' );
 			return new WP_Error( 'rest_image_not_edited', $error, array( 'status' => 400 ) );
 		}
 

--- a/lib/class-wp-rest-image-editor-controller.php
+++ b/lib/class-wp-rest-image-editor-controller.php
@@ -44,20 +44,20 @@ class WP_REST_Image_Editor_Controller extends WP_REST_Controller {
 					'permission_callback' => array( $this, 'permission_callback' ),
 					'args'                => array(
 						'x'        => array(
-							'type'     => 'number',
-							'minimum'  => 0,
+							'type'    => 'number',
+							'minimum' => 0,
 						),
 						'y'        => array(
-							'type'     => 'number',
-							'minimum'  => 0,
+							'type'    => 'number',
+							'minimum' => 0,
 						),
 						'width'    => array(
-							'type'     => 'number',
-							'minimum'  => 1,
+							'type'    => 'number',
+							'minimum' => 1,
 						),
 						'height'   => array(
-							'type'     => 'number',
-							'minimum'  => 1,
+							'type'    => 'number',
+							'minimum' => 1,
 						),
 						'rotation' => array(
 							'type' => 'integer',

--- a/packages/block-library/src/image/image-editor.js
+++ b/packages/block-library/src/image/image-editor.js
@@ -164,7 +164,18 @@ export default function ImageEditor( {
 	function apply() {
 		setIsProgress( true );
 
-		const attrs = crop;
+		let attrs = {};
+
+		// The crop script may return some very small, sub-pixel values when the image was not cropped.
+		// Crop only when the cropping dimensions are changed by more than 0.1%.
+		if (
+			crop.x > 0.1 ||
+			crop.y > 0.1 ||
+			crop.width < 99.9 ||
+			crop.height < 99.9
+		) {
+			attrs = crop;
+		}
 
 		if ( rotation > 0 ) {
 			attrs.rotation = rotation;

--- a/packages/block-library/src/image/image-editor.js
+++ b/packages/block-library/src/image/image-editor.js
@@ -167,13 +167,8 @@ export default function ImageEditor( {
 		let attrs = {};
 
 		// The crop script may return some very small, sub-pixel values when the image was not cropped.
-		// Crop only when the cropping dimensions are changed by more than 0.1%.
-		if (
-			crop.x > 0.1 ||
-			crop.y > 0.1 ||
-			crop.width < 99.9 ||
-			crop.height < 99.9
-		) {
+		// Crop only when the new size has changed by more than 0.1%.
+		if ( crop.width < 99.9 || crop.height < 99.9 ) {
 			attrs = crop;
 		}
 


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/23284.

## Description
Fixes few errors and inconsistencies when editing an already-edited image file, and when creating the new attachment post. Also adds some better errors and some cleanup of vars, names, etc. and still has few TBD/TODO.

## How has this been tested?
When testing please monitor what files are created in the uploads dir (`wp-content/uploads/year/month/`).

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
