### PR TITLE
Block Directory: Support .svg extension for results list panel.

### DIFF
--- a/packages/block-directory/src/components/downloadable-block-icon/index.js
+++ b/packages/block-directory/src/components/downloadable-block-icon/index.js
@@ -7,7 +7,7 @@ import { BlockIcon } from '@wordpress/block-editor';
 function DownloadableBlockIcon( { icon, title } ) {
 	return (
 		<div className="block-directory-downloadable-block-icon">
-			{ icon.match( /\.(jpeg|jpg|gif|png)(?:\?.*)?$/ ) !== null ? (
+			{ icon.match( /\.(jpeg|jpg|gif|png|svg)(?:\?.*)?$/ ) !== null ? (
 				<img
 					src={ icon }
 					alt={ sprintf(


### PR DESCRIPTION
## Description
We are currently missing `.svg` as a supported file type for block directory result icons.


## How has this been tested?
1. Search for a block that lists a `.svg` icon (Starscape)
2. Notice the icon is not showing up next to the block title.


## Screenshots <!-- if applicable -->
| Before | After |
| ------------- | ------------- |
| ![Error](https://d.pr/i/zshRMh.png)  | ![Fixed](https://d.pr/i/DF4sxQ.png) |

## Types of changes
1. Add `svg` to the regex.

## Testing
I considered writing more tests to test the extension but thought its probably more debt than anything. If we think we need one, I can add it.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
