### PR TITLE
Create Block: Fix missing `scripts` section in scaffolded `package.json`

### DIFF
--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fix
 
--   Fix the error in the scaffolding process caused by the missing `scripts` section in `package.json` file ([#23399](https://github.com/WordPress/gutenberg/pull/23399)).
+-   Fix the error in the scaffolding process caused by the missing `scripts` section in `package.json` file ([#23443](https://github.com/WordPress/gutenberg/pull/23443)).
 
 ## 0.15.0-rc.0 (2020-06-24)
 

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -2,9 +2,17 @@
 
 ## Unreleased
 
+### New Feature
+
+-   Generate `block.json` file with all metadata necessary for Block Directory ([#23399](https://github.com/WordPress/gutenberg/pull/23399)).
+
+### Bug Fix
+
+-   Fix the error in the scaffolding process caused by the missing `scripts` section in `package.json` file ([#23399](https://github.com/WordPress/gutenberg/pull/23399)).
+
 ## 0.15.0-rc.0 (2020-06-24)
 
-### New Features
+### New Feature
 
 -   Add new CLI options: `--no-wp-scripts` and `--wp-scripts` to let users override the settings that template defines for supports for `@wordpress/scripts` package integration ([#23195](https://github.com/WordPress/gutenberg/pull/23195)).
 

--- a/packages/create-block/lib/scaffold.js
+++ b/packages/create-block/lib/scaffold.js
@@ -58,6 +58,7 @@ module.exports = async (
 		editorScript,
 		editorStyle,
 		style,
+		wpScripts,
 	};
 	await Promise.all(
 		Object.keys( outputTemplates ).map( async ( outputFile ) => {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes the error in the scaffolding process caused by the missing `scripts` section in `package.json` file.

## How has this been tested?
`npx wp-create-block esnext-block`


