### PR TITLE
Try using the scroll container boundaries to determine scroll velocity

### DIFF
--- a/packages/block-editor/src/components/block-draggable/use-scroll-when-dragging.js
+++ b/packages/block-editor/src/components/block-draggable/use-scroll-when-dragging.js
@@ -4,7 +4,7 @@
 import { getScrollContainer } from '@wordpress/dom';
 import { useCallback, useEffect, useRef } from '@wordpress/element';
 
-const SCROLL_INACTIVE_DISTANCE_PX = 50;
+const BOUNDARY_ZONE_PERCENTAGE_SIZE = 0.33;
 const SCROLL_INTERVAL_MS = 25;
 const PIXELS_PER_SECOND_PER_PERCENTAGE = 1000;
 const VELOCITY_MULTIPLIER =
@@ -61,36 +61,30 @@ export default function useScrollWhenDragging( dragElement ) {
 
 	const scrollOnDragOver = useCallback( ( event ) => {
 		const scrollParentHeight = scrollParentY.current.offsetHeight;
+		const scrollParentBoundaryHeight =
+			BOUNDARY_ZONE_PERCENTAGE_SIZE * scrollParentHeight;
+		const offsetDragPosition =
+			event.clientY - scrollParentY.current.offsetTop;
 
 		if ( event.clientY > dragStartY.current ) {
-			// User is dragging downwards.
-			const moveableDistance = Math.max(
-				scrollParentHeight -
-					dragStartY.current -
-					SCROLL_INACTIVE_DISTANCE_PX,
-				0
+			// User is dragging down.
+			const scrollParentBoundaryTop =
+				scrollParentHeight - scrollParentBoundaryHeight;
+			const distanceIntoBoundary = Math.max(
+				0,
+				offsetDragPosition - scrollParentBoundaryTop
 			);
-			const dragDistance = Math.max(
-				event.clientY -
-					dragStartY.current -
-					SCROLL_INACTIVE_DISTANCE_PX,
-				0
-			);
-			const distancePercentage = dragDistance / moveableDistance;
+			const distancePercentage =
+				distanceIntoBoundary / scrollParentBoundaryHeight;
 			velocityY.current = VELOCITY_MULTIPLIER * distancePercentage;
 		} else if ( event.clientY < dragStartY.current ) {
-			// User is dragging upwards.
-			const moveableDistance = Math.max(
-				dragStartY.current - SCROLL_INACTIVE_DISTANCE_PX,
-				0
+			// User is dragging up.
+			const distanceIntoBoundary = Math.max(
+				0,
+				scrollParentBoundaryHeight - offsetDragPosition
 			);
-			const dragDistance = Math.max(
-				dragStartY.current -
-					event.clientY -
-					SCROLL_INACTIVE_DISTANCE_PX,
-				0
-			);
-			const distancePercentage = dragDistance / moveableDistance;
+			const distancePercentage =
+				distanceIntoBoundary / scrollParentBoundaryHeight;
 			velocityY.current = -VELOCITY_MULTIPLIER * distancePercentage;
 		} else {
 			velocityY.current = 0;

--- a/packages/block-editor/src/components/block-draggable/use-scroll-when-dragging.js
+++ b/packages/block-editor/src/components/block-draggable/use-scroll-when-dragging.js
@@ -6,9 +6,9 @@ import { useCallback, useEffect, useRef } from '@wordpress/element';
 
 const SCROLL_INACTIVE_DISTANCE_PX = 50;
 const SCROLL_INTERVAL_MS = 25;
-const PIXELS_PER_SECOND_PER_DISTANCE = 5;
+const PIXELS_PER_SECOND_PER_PERCENTAGE = 1000;
 const VELOCITY_MULTIPLIER =
-	PIXELS_PER_SECOND_PER_DISTANCE * ( SCROLL_INTERVAL_MS / 1000 );
+	PIXELS_PER_SECOND_PER_PERCENTAGE * ( SCROLL_INTERVAL_MS / 1000 );
 
 /**
  * React hook that scrolls the scroll container when a block is being dragged.
@@ -60,15 +60,38 @@ export default function useScrollWhenDragging( dragElement ) {
 	);
 
 	const scrollOnDragOver = useCallback( ( event ) => {
-		const distanceY = event.clientY - dragStartY.current;
-		if ( distanceY > SCROLL_INACTIVE_DISTANCE_PX ) {
-			velocityY.current =
-				VELOCITY_MULTIPLIER *
-				( distanceY - SCROLL_INACTIVE_DISTANCE_PX );
-		} else if ( distanceY < -SCROLL_INACTIVE_DISTANCE_PX ) {
-			velocityY.current =
-				VELOCITY_MULTIPLIER *
-				( distanceY + SCROLL_INACTIVE_DISTANCE_PX );
+		const scrollParentHeight = scrollParentY.current.offsetHeight;
+
+		if ( event.clientY > dragStartY.current ) {
+			// User is dragging downwards.
+			const moveableDistance = Math.max(
+				scrollParentHeight -
+					dragStartY.current -
+					SCROLL_INACTIVE_DISTANCE_PX,
+				0
+			);
+			const dragDistance = Math.max(
+				event.clientY -
+					dragStartY.current -
+					SCROLL_INACTIVE_DISTANCE_PX,
+				0
+			);
+			const distancePercentage = dragDistance / moveableDistance;
+			velocityY.current = VELOCITY_MULTIPLIER * distancePercentage;
+		} else if ( event.clientY < dragStartY.current ) {
+			// User is dragging upwards.
+			const moveableDistance = Math.max(
+				dragStartY.current - SCROLL_INACTIVE_DISTANCE_PX,
+				0
+			);
+			const dragDistance = Math.max(
+				dragStartY.current -
+					event.clientY -
+					SCROLL_INACTIVE_DISTANCE_PX,
+				0
+			);
+			const distancePercentage = dragDistance / moveableDistance;
+			velocityY.current = -VELOCITY_MULTIPLIER * distancePercentage;
 		} else {
 			velocityY.current = 0;
 		}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This tries an iteration on the behavior in #23082. 

See also #23448 for an alternative.

It's based on the refactor to hooks in #23444, so the diff looks bigger than it is. That PR should ideally be merged first.

#### How does this differ from #23082

In #23082, when the user drags more than 50px the page starts scrolling in the direction they've dragged. The speed of the scrolling is based on how far the user drags.

I found that sometimes with that behaviour it was a little difficult to stop the page from scrolling, since it's not always easy to connect that scrolling speed is related to where the I started dragging from.

This PR treats the center of the scroll container as the neutral zone, and only starts scrolling when the user moves the cursor towards the boundaries of the scroll container. It's similar to what browsers are supposed to do when dragging to the edge of a page, but much more exaggerated.

Drawbacks—the page starts scrolling when the block being dragged is already near the edge of the page.

## How has this been tested?
1. Create a post with lots of blocks
2. Try dragging blocks to an off-screen position.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
Non-breaking enhancement
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
