### PR TITLE
Add title block top margin.

### DIFF
--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -50,6 +50,9 @@
 // We need to have two DOM elements.
 .edit-post-visual-editor__post-title-wrapper {
 	.editor-post-title {
+		// Add some top margin.
+		margin-top: 2em;
+
 		// Center.
 		margin-left: auto;
 		margin-right: auto;


### PR DESCRIPTION
The post title block its a little closely to the top of the screen now:

<img width="1337" alt="before" src="https://user-images.githubusercontent.com/1204802/85683969-f8fb6f80-b6cd-11ea-9368-33c2637d0aba.png">

This is sort of a regression from #22213 where the big and complex padding rules around the canvas pushed it down.

This PR simply adds some margin:

<img width="1016" alt="after" src="https://user-images.githubusercontent.com/1204802/85684075-129cb700-b6ce-11ea-8c94-d308a98e6e36.png">

Seems to work well on mobile also:

<img width="703" alt="Screenshot 2020-06-25 at 10 24 29" src="https://user-images.githubusercontent.com/1204802/85684092-16c8d480-b6ce-11ea-8590-378ffde5f520.png">
