### PR TITLE
Polish transforms and styles

### DIFF
--- a/packages/block-editor/src/components/block-styles/style.scss
+++ b/packages/block-editor/src/components/block-styles/style.scss
@@ -41,7 +41,6 @@
 .block-editor-block-styles__item-preview {
 	outline: $border-width solid transparent; // Shown in Windows High Contrast mode.
 	padding: 0;
-	border: $border-width solid rgba($dark-gray-primary, 0.2);
 	border-radius: $radius-block-ui;
 	display: flex;
 	overflow: hidden;
@@ -49,6 +48,10 @@
 	align-items: center;
 	flex-grow: 1;
 	min-height: 80px;
+}
+
+.block-editor-block-switcher__styles__menugroup {
+	position: relative;
 }
 
 .block-editor-block-styles__item-label {

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -181,31 +181,6 @@ export class BlockSwitcher extends Component {
 								( hasBlockStyles ||
 									hasPossibleBlockTransformations ) && (
 									<div className="block-editor-block-switcher__container">
-										{ hoveredClassName !== null && (
-											<PreviewBlockPopover
-												hoveredBlock={ hoveredBlock }
-												hoveredClassName={
-													hoveredClassName
-												}
-											/>
-										) }
-										{ hasBlockStyles && (
-											<MenuGroup
-												label={ __( 'Styles' ) }
-												className="block-editor-block-switcher__styles__menugroup"
-											>
-												<BlockStyles
-													clientId={
-														hoveredBlock.clientId
-													}
-													onSwitch={ onClose }
-													onHoverClassName={
-														this.onHoverClassName
-													}
-													itemRole="menuitem"
-												/>
-											</MenuGroup>
-										) }
 										{ hasPossibleBlockTransformations && (
 											<BlockTransformationsMenu
 												className="block-editor-block-switcher__transforms__menugroup"
@@ -217,6 +192,33 @@ export class BlockSwitcher extends Component {
 													onClose();
 												} }
 											/>
+										) }
+										{ hasBlockStyles && (
+											<MenuGroup
+												label={ __( 'Styles' ) }
+												className="block-editor-block-switcher__styles__menugroup"
+											>
+												{ hoveredClassName !== null && (
+													<PreviewBlockPopover
+														hoveredBlock={
+															hoveredBlock
+														}
+														hoveredClassName={
+															hoveredClassName
+														}
+													/>
+												) }
+												<BlockStyles
+													clientId={
+														hoveredBlock.clientId
+													}
+													onSwitch={ onClose }
+													onHoverClassName={
+														this.onHoverClassName
+													}
+													itemRole="menuitem"
+												/>
+											</MenuGroup>
 										) }
 									</div>
 								)

--- a/packages/block-editor/src/components/block-switcher/style.scss
+++ b/packages/block-editor/src/components/block-switcher/style.scss
@@ -88,10 +88,6 @@
 		margin: 0 -3px; // Remove the panel body padding while keeping it for the title.
 	}
 
-	.block-editor-block-styles__item-label {
-		text-align: left;
-	}
-
 	// Hide the bottom border on the last panel so it stacks with the popover.
 	.components-panel__body {
 		border: 0;


### PR DESCRIPTION
The transforms menu was recently made more functional and lovely. This PR polishes that further by:

- Refining the style preview to have no border and match patterns
- Moving styles below transforms

Before:

![before](https://user-images.githubusercontent.com/1204802/85689389-e0418880-b6d2-11ea-99eb-3a8eb53772a6.gif)

After:

![after](https://user-images.githubusercontent.com/1204802/85689404-e2a3e280-b6d2-11ea-920b-6e686858b361.gif)

The styles are also updated in the sidebar:

<img width="293" alt="Screenshot 2020-06-25 at 10 55 53" src="https://user-images.githubusercontent.com/1204802/85689437-e9caf080-b6d2-11ea-9f39-5edf8e8b3172.png">

Patterns, for comparison:

<img width="389" alt="Screenshot 2020-06-25 at 10 56 08" src="https://user-images.githubusercontent.com/1204802/85689480-f2bbc200-b6d2-11ea-90a4-df71b1889df4.png">
