### PR TITLE
[RNMobile] Unsupported block fallback send block title and name

### DIFF
--- a/packages/block-library/src/missing/edit.native.js
+++ b/packages/block-library/src/missing/edit.native.js
@@ -70,7 +70,7 @@ export class UnsupportedBlockEdit extends Component {
 		this.setState( { sendFallbackMessage: true } );
 	}
 
-	renderSheet( title ) {
+	renderSheet( blockTitle, blockName ) {
 		const { getStylesFromColorScheme, attributes, clientId } = this.props;
 		const infoTextStyle = getStylesFromColorScheme(
 			styles.infoText,
@@ -95,7 +95,7 @@ export class UnsupportedBlockEdit extends Component {
 				  __( "'%s' isn't yet supported on WordPress for Android" )
 				: // translators: %s: Name of the block
 				  __( "'%s' isn't yet supported on WordPress for iOS" );
-		const infoTitle = sprintf( titleFormat, title );
+		const infoTitle = sprintf( titleFormat, blockTitle );
 
 		const actionButtonStyle = getStylesFromColorScheme(
 			styles.actionButton,
@@ -115,7 +115,8 @@ export class UnsupportedBlockEdit extends Component {
 							requestUnsupportedBlockFallback(
 								attributes.originalContent,
 								clientId,
-								title
+								blockName,
+								blockTitle
 							);
 						}, 100 );
 						this.setState( { sendFallbackMessage: false } );
@@ -209,7 +210,7 @@ export class UnsupportedBlockEdit extends Component {
 				/>
 				<Text style={ titleStyle }>{ title }</Text>
 				{ subtitle }
-				{ this.renderSheet( title ) }
+				{ this.renderSheet( title, originalName ) }
 			</View>
 		);
 	}

--- a/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergBridgeJS2Parent.java
+++ b/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergBridgeJS2Parent.java
@@ -145,7 +145,8 @@ public interface GutenbergBridgeJS2Parent extends RequestExecutor {
     void gutenbergDidRequestUnsupportedBlockFallback(ReplaceUnsupportedBlockCallback replaceUnsupportedBlockCallback,
                                                      String content,
                                                      String blockId,
-                                                     String blockName);
+                                                     String blockName,
+                                                     String blockTitle);
 
     void onAddMention(Consumer<String> onSuccess);
     

--- a/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
+++ b/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
@@ -258,9 +258,9 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
     }
 
     @ReactMethod
-    public void requestUnsupportedBlockFallback(String content, String blockId, String blockName) {
+    public void requestUnsupportedBlockFallback(String content, String blockId, String blockName, String blockTitle) {
         mGutenbergBridgeJS2Parent.gutenbergDidRequestUnsupportedBlockFallback((savedContent, savedBlockId) ->
-                replaceBlock(savedContent, savedBlockId), content, blockId, blockName);
+                replaceBlock(savedContent, savedBlockId), content, blockId, blockName, blockTitle);
     }
 
     private void replaceBlock(String content, String blockId) {

--- a/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/UnsupportedBlock.java
+++ b/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/UnsupportedBlock.java
@@ -4,11 +4,13 @@ public class UnsupportedBlock {
 
     private String mId;
     private String mName;
+    private String mTitle;
     private String mContent;
 
-    public UnsupportedBlock(String id, String name, String content) {
+    public UnsupportedBlock(String id, String name, String title, String content) {
         mId = id;
         mName = name;
+        mTitle = title;
         mContent = content;
     }
 
@@ -18,6 +20,10 @@ public class UnsupportedBlock {
 
     public String getName() {
         return mName;
+    }
+
+    public String getTitle() {
+        return mTitle;
     }
 
     public String getContent() {

--- a/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
+++ b/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
@@ -373,10 +373,11 @@ public class WPAndroidGlueCode {
             public void gutenbergDidRequestUnsupportedBlockFallback(ReplaceUnsupportedBlockCallback replaceUnsupportedBlockCallback,
                                                                     String content,
                                                                     String blockId,
-                                                                    String blockName) {
+                                                                    String blockName,
+                                                                    String blockTitle) {
                 mReplaceUnsupportedBlockCallback = replaceUnsupportedBlockCallback;
                 mOnGutenbergDidRequestUnsupportedBlockFallbackListener.
-                        gutenbergDidRequestUnsupportedBlockFallback(new UnsupportedBlock(blockId, blockName, content));
+                        gutenbergDidRequestUnsupportedBlockFallback(new UnsupportedBlock(blockId, blockName, blockTitle, content));
             }
 
             @Override 

--- a/packages/react-native-bridge/index.js
+++ b/packages/react-native-bridge/index.js
@@ -136,7 +136,7 @@ export function requestUnsupportedBlockFallback(
 	htmlContent,
 	blockClientId,
 	blockName,
-	blockTitle,
+	blockTitle
 ) {
 	RNReactNativeGutenbergBridge.requestUnsupportedBlockFallback(
 		htmlContent,

--- a/packages/react-native-bridge/index.js
+++ b/packages/react-native-bridge/index.js
@@ -129,17 +129,20 @@ export function requestMediaPicker( source, filter, multiple, callback ) {
  *
  * @param {string} htmlContent Raw html content of the block.
  * @param {string} blockClientId the clientId of the block.
- * @param {string} blockName the user-facing, localized block name.
+ * @param {string} blockName the internal system block name.
+ * @param {string} blockTitle the user-facing, localized block name.
  */
 export function requestUnsupportedBlockFallback(
 	htmlContent,
 	blockClientId,
-	blockName
+	blockName,
+	blockTitle,
 ) {
 	RNReactNativeGutenbergBridge.requestUnsupportedBlockFallback(
 		htmlContent,
 		blockClientId,
-		blockName
+		blockName,
+		blockTitle
 	);
 }
 

--- a/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
+++ b/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
@@ -12,12 +12,20 @@ public struct MediaInfo {
     }
 }
 
+/// Wrapper for single block data
 public struct Block {
+    /// Gutenberg internal block ID
     public let id: String
+    /// Gutenberg internal block name
     public let name: String
+    /// User facing block name string (localized)
     public let title: String
+    /// Block HTML content
     public let content: String
 
+    /// Creates a copy of the receiver modifying only its content field.
+    /// - Parameter newContent: The content for the new block instance.
+    /// - Returns: A new block instance with copied fields and new content.
     public func replacingContent(with newContent: String) -> Block {
         Block(id: id, name: name, title: title, content: newContent)
     }

--- a/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
+++ b/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
@@ -15,10 +15,11 @@ public struct MediaInfo {
 public struct Block {
     public let id: String
     public let name: String
+    public let title: String
     public let content: String
 
     public func replacingContent(with newContent: String) -> Block {
-        Block(id: id, name: name, content: newContent)
+        Block(id: id, name: name, title: title, content: newContent)
     }
 }
 

--- a/packages/react-native-bridge/ios/GutenbergWebFallback/GutenbergWebSingleBlockViewController.swift
+++ b/packages/react-native-bridge/ios/GutenbergWebFallback/GutenbergWebSingleBlockViewController.swift
@@ -82,7 +82,7 @@ open class GutenbergWebSingleBlockViewController: UIViewController {
         navigationItem.rightBarButtonItem = saveButton
         navigationItem.leftBarButtonItem = cancelButton
         let localizedTitle = NSLocalizedString("Edit %@ block", comment: "Title of Gutenberg WEB editor running on a Web View. %@ is the localized block name.")
-        title = String(format: localizedTitle, block.name)
+        title = String(format: localizedTitle, block.title)
     }
 
     func addCoverView() {

--- a/packages/react-native-bridge/ios/RNReactNativeGutenbergBridge.m
+++ b/packages/react-native-bridge/ios/RNReactNativeGutenbergBridge.m
@@ -19,7 +19,7 @@ RCT_EXTERN_METHOD(fetchRequest:(NSString *)path resolver:(RCTPromiseResolveBlock
 RCT_EXTERN_METHOD(requestImageFullscreenPreview:(NSString *)currentImageUrlString originalImageUrlString:(NSString *)originalImageUrlString)
 RCT_EXTERN_METHOD(requestMediaEditor:(NSString *)mediaUrl callback:(RCTResponseSenderBlock)callback)
 RCT_EXTERN_METHOD(logUserEvent:(NSString *)event properties:(NSDictionary *)properties)
-RCT_EXTERN_METHOD(requestUnsupportedBlockFallback:(NSString *)content blockId:(NSString *)blockId blockName:(NSString *)blockName)
+RCT_EXTERN_METHOD(requestUnsupportedBlockFallback:(NSString *)content blockId:(NSString *)blockId blockName:(NSString *)blockName blockTitle:(NSString *)blockTitle)
 RCT_EXTERN_METHOD(addMention:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)rejecter)
 RCT_EXTERN_METHOD(requestStarterPageTemplatesTooltipShown:(RCTResponseSenderBlock)callback)
 RCT_EXTERN_METHOD(setStarterPageTemplatesTooltipShown:(BOOL)tooltipShown)

--- a/packages/react-native-bridge/ios/RNReactNativeGutenbergBridge.swift
+++ b/packages/react-native-bridge/ios/RNReactNativeGutenbergBridge.swift
@@ -60,9 +60,9 @@ public class RNReactNativeGutenbergBridge: RCTEventEmitter {
     }
 
     @objc
-    func requestUnsupportedBlockFallback(_ content: String, blockId: String, blockName: String) {
+    func requestUnsupportedBlockFallback(_ content: String, blockId: String, blockName: String, blockTitle: String) {
         DispatchQueue.main.async {
-            let block = Block(id: blockId, name: blockName, content: content)
+            let block = Block(id: blockId, name: blockName, title: blockTitle, content: content)
             self.delegate?.gutenbergDidRequestUnsupportedBlockFallback(for: block)
         }
     }

--- a/packages/react-native-editor/android/app/src/main/java/com/gutenberg/MainApplication.java
+++ b/packages/react-native-editor/android/app/src/main/java/com/gutenberg/MainApplication.java
@@ -155,9 +155,10 @@ public class MainApplication extends Application implements ReactApplication, Gu
             public void gutenbergDidRequestUnsupportedBlockFallback(ReplaceUnsupportedBlockCallback replaceUnsupportedBlockCallback,
                                                                     String content,
                                                                     String blockId,
-                                                                    String blockName) {
+                                                                    String blockName,
+                                                                    String blockTitle) {
                 mReplaceUnsupportedBlockCallback = replaceUnsupportedBlockCallback;
-                openGutenbergWebView(content, blockId, blockName);
+                openGutenbergWebView(content, blockId, blockTitle);
             }
 
             @Override

--- a/packages/react-native-editor/ios/Podfile.lock
+++ b/packages/react-native-editor/ios/Podfile.lock
@@ -21,7 +21,7 @@ PODS:
     - DoubleConversion
     - glog
   - glog (0.3.5)
-  - Gutenberg (8.4.0-rc.1):
+  - Gutenberg (8.4.0):
     - React (= 0.61.5)
     - React-CoreModules (= 0.61.5)
     - React-RCTImage (= 0.61.5)
@@ -372,7 +372,7 @@ SPEC CHECKSUMS:
   FBReactNativeSpec: 118d0d177724c2d67f08a59136eb29ef5943ec75
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
-  Gutenberg: f7055103da8a673d813ecec75875d973e3d25445
+  Gutenberg: 42a3ed491af07194744d45aa7fc44b8202ea1a5b
   RCTRequired: b153add4da6e7dbc44aebf93f3cf4fcae392ddf1
   RCTTypeSafety: 9aa1b91d7f9310fc6eadc3cf95126ffe818af320
   React: b6a59ef847b2b40bb6e0180a97d0ca716969ac78


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

This PR adds the block internal name to the data sent to native side to show the gutenberg web-view for unsupported block edition.

To be in pair with Gutenberg, I have renamed the user-facing block name to `title` while the internal block name will get the `name` field.
I have added both iOS and Android required changes.

@marecar3 - feel free to add any needed change to Android in case there's any mistake.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
- Run the demo project.
- Open the RSS unsupported block at the end on the web view.
- Check that it shows `Edit RSS block` at the top.
- Check in code that the block `name` fields is received as `core/rss`.
  - On iOS you can check the Xcode logs.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
