### PR TITLE
Allow env to accept named args. 

### DIFF
--- a/packages/env/lib/commands/run.js
+++ b/packages/env/lib/commands/run.js
@@ -21,7 +21,27 @@ const initConfig = require( '../init-config' );
  * @param {Object}   options.spinner   A CLI spinner which indicates progress.
  * @param {boolean}  options.debug     True if debug mode is enabled.
  */
-module.exports = async function run( { container, command, spinner, debug } ) {
+module.exports = async function run( options ) {
+	let { container, command, spinner, debug } = options;
+
+	// Add properties.
+	Object.keys( options )
+		.filter(
+			( key ) =>
+				// '_' and '$0' internal property for yargs.
+				! [
+					'_',
+					'$0',
+					'container',
+					'command',
+					'spinner',
+					'debug',
+				].includes( key )
+		)
+		.forEach( ( key ) => {
+			command.push( `--${ key }=${ options[ key ] }` );
+		} );
+
 	const config = await initConfig( { spinner, debug } );
 
 	command = command.join( ' ' );


### PR DESCRIPTION
* Part of #23320 

## Description

`wp-env` doesn't allow named args on windows. (e.g. `wp-env run cli "wp --help"` shows the wp-env help command, it does not pass it to "CLI")

## How has this been tested?

I ran `npx wp-env run cli wp import data.xml --authors=create`.

**KNOWN ISSUE:** It doesn't allow numbers like `npx wp-env run cli wp plugin install woocommerce --version='4.2.2'`.

## Screenshots <!-- if applicable -->

N/A

## Types of changes

Bug fix.

## Checklist:
- [ ] My code is tested. => How should I test this?
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [N/A] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [N/A] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [N/A] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
