### PR TITLE
[Mobile] Media-Text: Removed the block type limitation when adding blocks

### DIFF
--- a/packages/block-library/src/media-text/edit.native.js
+++ b/packages/block-library/src/media-text/edit.native.js
@@ -26,15 +26,6 @@ import { pullLeft, pullRight } from '@wordpress/icons';
 import MediaContainer from './media-container';
 import styles from './style.scss';
 
-/**
- * Constants
- */
-const ALLOWED_BLOCKS = [
-	'core/button',
-	'core/paragraph',
-	'core/heading',
-	'core/list',
-];
 const TEMPLATE = [ [ 'core/paragraph' ] ];
 // this limits the resize to a safe zone to avoid making broken layouts
 const WIDTH_CONSTRAINT_PERCENTAGE = 15;
@@ -284,7 +275,6 @@ class MediaTextEdit extends Component {
 						} }
 					>
 						<InnerBlocks
-							allowedBlocks={ ALLOWED_BLOCKS }
 							template={ TEMPLATE }
 							templateInsertUpdatesSelection={ false }
 						/>


### PR DESCRIPTION
**Fixes** https://github.com/wordpress-mobile/gutenberg-mobile/issues/2386

## Related PRs:
gutenberg-mobile https://github.com/wordpress-mobile/gutenberg-mobile/pull/2441

## Description
This fix Removes the block type limitation when adding blocks in the Media-Text

## How has this been tested?
* Add a Media-Text block
* Press the add button
* See that all blocks can be added

## Screenshots

|Add menu|Rendering|
|---|---|
|![Simulator Screen Shot - iPhone 11 - 2020-06-25 at 13 40 57](https://user-images.githubusercontent.com/304044/85705440-e1ca7b00-b6e9-11ea-94a3-0d0018960c5c.png)|![Simulator Screen Shot - iPhone 11 - 2020-06-25 at 13 42 05](https://user-images.githubusercontent.com/304044/85705449-e3943e80-b6e9-11ea-9071-28e8ca6eacd8.png)|

|Landscape|
|---|
|![Simulator Screen Shot - iPhone 11 - 2020-06-25 at 13 42 45](https://user-images.githubusercontent.com/304044/85705913-57cee200-b6ea-11ea-82ba-91e2cece9f07.png)|



## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
