### PR TITLE
Add a description to the Site Title block.

### DIFF
--- a/packages/block-library/src/site-title/index.js
+++ b/packages/block-library/src/site-title/index.js
@@ -15,6 +15,9 @@ export { metadata, name };
 
 export const settings = {
 	title: __( 'Site Title' ),
+	description: __(
+		'Displays and allows editing the name of the site. The site title usually appears in the browser title bar, in search results, and more. Also available in Settings > General.'
+	),
 	icon,
 	edit,
 };


### PR DESCRIPTION
Block descriptions are a crucial pieces of information to teach users about the different aspects of a site. We should pay extra care in crafting them.