### PR TITLE
Fix Site builder inspector panels buttons

### DIFF
--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -11,3 +11,16 @@
 		margin-right: -$block-padding;
 	}
 }
+
+// The button element easily inherits styles that are meant for the editor style.
+// These rules enhance the specificity to reduce that inheritance.
+// This is duplicated in visual-editor.
+.edit-site-block-editor__editor-styles-wrapper  .components-button {
+	font-family: $default-font;
+	font-size: $default-font-size;
+	padding: 6px 12px;
+
+	&.is-tertiary {
+		padding: 6px;
+	}
+}

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -56,19 +56,6 @@ body.toplevel_page_gutenberg-edit-site {
 	.interface-interface-skeleton__content {
 		background-color: $light-gray-700;
 	}
-
-	// The button element easily inherits styles that are meant for the editor style.
-	// These rules enhance the specificity to reduce that inheritance.
-	// This is duplicated in visual-editor.
-	& .components-button {
-		font-family: $default-font;
-		font-size: $default-font-size;
-		padding: 6px 12px;
-
-		&.is-tertiary {
-			padding: 6px;
-		}
-	}
 }
 
 /**


### PR DESCRIPTION
Small regression introduced in #22460 
The inspector panel headers on the Site Builder page lost their paddings. This PR fixes it by moving the button styles to the canvas.