### PR TITLE
Block toolbar: remove data-align attribute

### DIFF
--- a/packages/block-editor/src/components/block-list/block-popover.js
+++ b/packages/block-editor/src/components/block-list/block-popover.js
@@ -48,7 +48,6 @@ function selector( select ) {
 function BlockPopover( {
 	clientId,
 	rootClientId,
-	align,
 	isValid,
 	moverDirection,
 	isEmptyDefaultBlock,
@@ -207,7 +206,6 @@ function BlockPopover( {
 					// If the toolbar is being shown because of being forced
 					// it should focus the toolbar right after the mount.
 					focusOnMount={ isToolbarForced }
-					data-align={ align }
 					onDragStart={ onDragStart }
 					onDragEnd={ onDragEnd }
 				/>
@@ -217,7 +215,6 @@ function BlockPopover( {
 					clientId={ clientId }
 					rootClientId={ rootClientId }
 					moverDirection={ moverDirection }
-					data-align={ align }
 				/>
 			) }
 			{ showEmptyBlockSideInserter && (
@@ -284,7 +281,6 @@ function wrapperSelector( select ) {
 		clientId,
 		rootClientId: getBlockRootClientId( clientId ),
 		name,
-		align: attributes.align,
 		isValid,
 		moverDirection: __experimentalMoverDirection,
 		isEmptyDefaultBlock:
@@ -304,7 +300,6 @@ export default function WrappedBlockPopover() {
 		clientId,
 		rootClientId,
 		name,
-		align,
 		isValid,
 		moverDirection,
 		isEmptyDefaultBlock,
@@ -319,7 +314,6 @@ export default function WrappedBlockPopover() {
 		<BlockPopover
 			clientId={ clientId }
 			rootClientId={ rootClientId }
-			align={ align }
 			isValid={ isValid }
 			moverDirection={ moverDirection }
 			isEmptyDefaultBlock={ isEmptyDefaultBlock }

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -528,13 +528,6 @@
 
 
 /**
- * Block Toolbar, top and contextual.
- */
-.block-editor-block-contextual-toolbar-wrapper {
-	padding-left: $block-toolbar-height; // Provide space for the mover control on full-wide items.
-}
-
-/**
  * Block Toolbar when contextual.
  */
 
@@ -651,9 +644,6 @@
 		border-radius: $radius-block-ui - $border-width; // Border is outset, so so subtract the width to achieve correct radius.
 		background-color: $white;
 
-		// Indent to align with block toolbar.
-		margin-left: $block-toolbar-height + $border-width;
-
 		// When button is focused, it receives a box-shadow instead of the border.
 		&:focus {
 			box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color);
@@ -720,12 +710,6 @@
 		.block-editor-block-list__block-selection-button,
 		.block-editor-block-contextual-toolbar {
 			margin-bottom: $grid-unit-15;
-			margin-left: - $block-toolbar-height;
-		}
-
-		.block-editor-block-contextual-toolbar[data-align="full"],
-		.block-editor-block-list__block-selection-button[data-align="full"] {
-			margin-left: 0;
 		}
 	}
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

Since the block movers have been moved within the block toolbar, there's no longer a need to keep extra space for block movers sliding out to the left. This also allows us to finally remove the data-align attribute from the popover wrapper. 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
