### PR TITLE
Replace the travis linting jobs with Github checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,26 @@
+name: Linting
+
+on: [pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Use Node.js 12.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - name: npm install, build
+      run: |
+        npm ci
+        npm run test:create-block
+        npm run build
+    - name: Lint JavaScript and Styles
+      run: npm run lint
+    - name: Lint ES5 built files (IE11)
+      run: npx eslint --parser-options=ecmaVersion:5 --no-eslintrc --no-ignore ./build/**/*.js
+    - name: Type checking
+      run: npm run build:package-types

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,9 +13,13 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: 12.x
-    - name: npm install, build
+    - name: Npm install and build
+      # A "full" install is executed, since `npm ci` does not always exit
+      # with an error status code if the lock file is inaccurate.
+      #
+      # See: https://github.com/WordPress/gutenberg/issues/16157
       run: |
-        npm ci
+        npm install
         npm run test:create-block
         npm run build
     - name: Lint JavaScript and Styles
@@ -24,3 +28,7 @@ jobs:
       run: npx eslint --parser-options=ecmaVersion:5 --no-eslintrc --no-ignore ./build/**/*.js
     - name: Type checking
       run: npm run build:package-types
+    - name: Build artifacts
+      run: npm run check-local-changes
+    - name: License compatibility
+      run: npm run check-licenses

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,6 @@ jobs:
       # See: https://github.com/WordPress/gutenberg/issues/16157
       run: |
         npm install
-        npm run test:create-block
         npm run build
     - name: Lint JavaScript and Styles
       run: npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,22 +65,6 @@ install:
 
 jobs:
   include:
-    - name: Build artifacts
-      install:
-        # A "full" install is executed, since `npm ci` does not always exit
-        # with an error status code if the lock file is inaccurate.
-        #
-        # See: https://github.com/WordPress/gutenberg/issues/16157
-        - npm install
-      script:
-        - npm run check-local-changes
-
-    - name: License compatibility
-      install:
-        - npm ci
-      script:
-        - npm run check-licenses
-
     - name: JavaScript unit tests
       env: INSTALL_WORDPRESS=false
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,32 +65,6 @@ install:
 
 jobs:
   include:
-    - name: Lint
-      install:
-        - npm ci
-        # eslint-plugin-import/no-extraneous-dependencies relies on modules to
-        # be "installed", which in practice requires that packages be built,
-        # presumably so that pkg.main can be resolved.
-        #
-        # See: https://github.com/benmosher/eslint-plugin-import/blob/92caa35/resolvers/node/index.js
-        - node ./bin/packages/build.js
-      script:
-        - npm run lint
-
-    - name: Lint ES5 only
-      install:
-        - npm ci
-        - npm run build
-      script:
-        - npx eslint --parser-options=ecmaVersion:5 --no-eslintrc --no-ignore ./build/**/*.js
-
-    - name: Typecheck
-      install:
-        - npm ci
-      script:
-        - npm run build:package-types
-
-
     - name: Build artifacts
       install:
         # A "full" install is executed, since `npm ci` does not always exit


### PR DESCRIPTION
The idea is to reduce the load on Travis and maybe ultimately move entirely to Github actions.