### PR TITLE
Gallery: Update button rendering (Move backward, Move forward, Remove)

### DIFF
--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -121,11 +121,16 @@ figure.wp-block-gallery {
 	left: -2px;
 }
 
-.blocks-gallery-item__move-backward.components-button,
-.blocks-gallery-item__move-forward.components-button,
-.blocks-gallery-item__remove.components-button {
-	padding: 0;
+// Increases specificity
+// Resolves: https://github.com/WordPress/gutenberg/issues/23469
+.wp-block-gallery {
+	.blocks-gallery-item__move-backward.components-button,
+	.blocks-gallery-item__move-forward.components-button,
+	.blocks-gallery-item__remove.components-button {
+		padding: 0;
+	}
 }
+
 
 .blocks-gallery-item .components-spinner {
 	position: absolute;

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -15,7 +15,7 @@ import { withSelect, withDispatch } from '@wordpress/data';
 import { RichText } from '@wordpress/block-editor';
 import { isBlobURL } from '@wordpress/blob';
 import { compose } from '@wordpress/compose';
-import { close, chevronLeft, chevronRight } from '@wordpress/icons';
+import { closeSmall, chevronLeft, chevronRight } from '@wordpress/icons';
 
 class GalleryImage extends Component {
 	constructor() {
@@ -212,7 +212,7 @@ class GalleryImage extends Component {
 				</div>
 				<div className="block-library-gallery-item__inline-menu">
 					<Button
-						icon={ close }
+						icon={ closeSmall }
 						onClick={ onRemove }
 						className="blocks-gallery-item__remove"
 						label={ __( 'Remove image' ) }


### PR DESCRIPTION
<img width="347" alt="Screen Shot 2020-06-25 at 10 12 42 AM" src="https://user-images.githubusercontent.com/2322354/85736357-6c03e680-b6cc-11ea-8950-d165d07a563a.png">

This update fixes the Move backward, Move forwarded, and Remove button rendering for the Gallery block.

The issue seemed to come from some newer styles overridding the padding resets of the Gallery buttons.

<img width="304" alt="Screen Shot 2020-06-25 at 10 08 24 AM" src="https://user-images.githubusercontent.com/2322354/85736505-8b027880-b6cc-11ea-8fa9-1a41eb8d32d4.png">

The solution involved increasing the specificity of the Gallery button selectors.

## How has this been tested?

* Run `npm run dev`
* Add a Gallery block
* Add several images
* Click on an image
* Ensure the buttons look okay

(Test in Chrome, Safari, and Firefox)


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [n/a] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->

Resolves: https://github.com/WordPress/gutenberg/issues/23469