### PR TITLE
Docs: Update ESNext usage in public API

### DIFF
--- a/packages/edit-post/README.md
+++ b/packages/edit-post/README.md
@@ -72,8 +72,8 @@ function MyPluginBlockSettingsMenuItem() {
 
 ```jsx
 // Using ESNext syntax
-import { __ } from wp.i18n;
-import { PluginBlockSettingsMenuItem } from wp.editPost;
+import { __ } from '@wordpress/i18n';
+import { PluginBlockSettingsMenuItem } from '@wordpress/edit-post';
 
 const doOnClick = ( ) => {
     // To be called when the user clicks the menu item.
@@ -133,8 +133,8 @@ registerPlugin( 'my-document-setting-plugin', {
 
 ```jsx
 // Using ESNext syntax
-const { registerPlugin } = wp.plugins;
-const { PluginDocumentSettingPanel } = wp.editPost;
+import { registerPlugin } from '@wordpress/plugins';
+import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 
 const MyDocumentSettingTest = () => (
 		<PluginDocumentSettingPanel className="my-document-setting-plugin" title="My Panel">
@@ -245,8 +245,8 @@ function MyPluginPostPublishPanel() {
 
 ```jsx
 // Using ESNext syntax
-const { __ } = wp.i18n;
-const { PluginPostPublishPanel } = wp.editPost;
+import { __ } from '@wordpress/i18n';
+import { PluginPostPublishPanel } from '@wordpress/edit-post';
 
 const MyPluginPostPublishPanel = () => (
 	<PluginPostPublishPanel
@@ -297,8 +297,8 @@ function MyPluginPostStatusInfo() {
 
 ```jsx
 // Using ESNext syntax
-const { __ } = wp.i18n;
-const { PluginPostStatusInfo } = wp.editPost;
+import { __ } from '@wordpress/i18n';
+import { PluginPostStatusInfo } from '@wordpress/edit-post';
 
 const MyPluginPostStatusInfo = () => (
 	<PluginPostStatusInfo
@@ -346,8 +346,8 @@ function MyPluginPrePublishPanel() {
 
 ```jsx
 // Using ESNext syntax
-const { __ } = wp.i18n;
-const { PluginPrePublishPanel } = wp.editPost;
+import { __ } from '@wordpress/i18n';
+import { PluginPrePublishPanel } from '@wordpress/edit-post';
 
 const MyPluginPrePublishPanel = () => (
 	<PluginPrePublishPanel

--- a/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
+++ b/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
@@ -68,8 +68,8 @@ const shouldRenderItem = ( selectedBlocks, allowedBlocks ) =>
  * <caption>ESNext</caption>
  * ```jsx
  * // Using ESNext syntax
- * import { __ } from wp.i18n;
- * import { PluginBlockSettingsMenuItem } from wp.editPost;
+ * import { __ } from '@wordpress/i18n';
+ * import { PluginBlockSettingsMenuItem } from '@wordpress/edit-post';
  *
  * const doOnClick = ( ) => {
  *     // To be called when the user clicks the menu item.

--- a/packages/edit-post/src/components/sidebar/plugin-document-setting-panel/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-document-setting-panel/index.js
@@ -89,8 +89,8 @@ const PluginDocumentSettingFill = ( {
  * <caption>ESNext</caption>
  * ```jsx
  * // Using ESNext syntax
- * const { registerPlugin } = wp.plugins;
- * const { PluginDocumentSettingPanel } = wp.editPost;
+ * import { registerPlugin } from '@wordpress/plugins';
+ * import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
  *
  * const MyDocumentSettingTest = () => (
  * 		<PluginDocumentSettingPanel className="my-document-setting-plugin" title="My Panel">

--- a/packages/edit-post/src/components/sidebar/plugin-post-publish-panel/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-post-publish-panel/index.js
@@ -59,8 +59,8 @@ const PluginPostPublishPanelFill = ( {
  * <caption>ESNext</caption>
  * ```jsx
  * // Using ESNext syntax
- * const { __ } = wp.i18n;
- * const { PluginPostPublishPanel } = wp.editPost;
+ * import { __ } from '@wordpress/i18n';
+ * import { PluginPostPublishPanel } from '@wordpress/edit-post';
  *
  * const MyPluginPostPublishPanel = () => (
  * 	<PluginPostPublishPanel

--- a/packages/edit-post/src/components/sidebar/plugin-post-status-info/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-post-status-info/index.js
@@ -40,8 +40,8 @@ export const { Fill, Slot } = createSlotFill( 'PluginPostStatusInfo' );
  * <caption>ESNext</caption>
  * ```jsx
  * // Using ESNext syntax
- * const { __ } = wp.i18n;
- * const { PluginPostStatusInfo } = wp.editPost;
+ * import { __ } from '@wordpress/i18n';
+ * import { PluginPostStatusInfo } from '@wordpress/edit-post';
  *
  * const MyPluginPostStatusInfo = () => (
  * 	<PluginPostStatusInfo

--- a/packages/edit-post/src/components/sidebar/plugin-pre-publish-panel/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-pre-publish-panel/index.js
@@ -62,8 +62,8 @@ const PluginPrePublishPanelFill = ( {
  * <caption>ESNext</caption>
  * ```jsx
  * // Using ESNext syntax
- * const { __ } = wp.i18n;
- * const { PluginPrePublishPanel } = wp.editPost;
+ * import { __ } from '@wordpress/i18n';
+ * import { PluginPrePublishPanel } from '@wordpress/edit-post';
  *
  * const MyPluginPrePublishPanel = () => (
  * 	<PluginPrePublishPanel

--- a/packages/plugins/README.md
+++ b/packages/plugins/README.md
@@ -59,7 +59,7 @@ function Layout() {
 
 ```js
 // Using ESNext syntax
-const { PluginArea } = wp.plugins;
+import { PluginArea } from '@wordpress/plugins';
 
 const Layout = () => (
 	<div>
@@ -167,7 +167,7 @@ unregisterPlugin( 'plugin-name' );
 
 ```js
 // Using ESNext syntax
-const { unregisterPlugin } = wp.plugins;
+import { unregisterPlugin } from '@wordpress/plugins';
 
 unregisterPlugin( 'plugin-name' );
 ```

--- a/packages/plugins/src/api/index.js
+++ b/packages/plugins/src/api/index.js
@@ -168,7 +168,7 @@ export function registerPlugin( name, settings ) {
  * <caption>ESNext</caption>
  * ```js
  * // Using ESNext syntax
- * const { unregisterPlugin } = wp.plugins;
+ * import { unregisterPlugin } from '@wordpress/plugins';
  *
  * unregisterPlugin( 'plugin-name' );
  * ```

--- a/packages/plugins/src/components/plugin-area/index.js
+++ b/packages/plugins/src/components/plugin-area/index.js
@@ -39,7 +39,7 @@ import { getPlugins } from '../../api';
  * <caption>ESNext</caption>
  * ```js
  * // Using ESNext syntax
- * const { PluginArea } = wp.plugins;
+ * import { PluginArea } from '@wordpress/plugins';
  *
  * const Layout = () => (
  * 	<div>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This PR updates documentation for public API for two packages `@wordpress/edit-post` and `@wordpress/plugins`. It refactors ESNext examples to use ES modules rather than wp globals. Now that `@wordpress/scripts` is getting more widely used, it's more beneficial to use import statements that work nicely with automatic asset generation.

My inspiration comes also from this tutorial by @leoloso:

https://css-tricks.com/adding-a-custom-welcome-guide-to-the-wordpress-block-editor/

and the following issue described:

>There is a last problem to solve: the `<PluginDocumentSettingPanel>` component is not statically imported, but instead obtained from `wp.editPost`, and since `wp` is a global variable loaded by WordPress on runtime, this dependency is not present in `index.asset.php` (which is auto-generated during build). We must manually add a dependency to the `wp-edit-post` script when registering the script to make sure it loads ...

It's a clear sign that docs are confusing in the current shape.