### PR TITLE
Editor: Remove unnecessary block directory dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11285,7 +11285,6 @@
 				"@wordpress/api-fetch": "file:packages/api-fetch",
 				"@wordpress/autop": "file:packages/autop",
 				"@wordpress/blob": "file:packages/blob",
-				"@wordpress/block-directory": "file:packages/block-directory",
 				"@wordpress/block-editor": "file:packages/block-editor",
 				"@wordpress/blocks": "file:packages/blocks",
 				"@wordpress/components": "file:packages/components",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -30,7 +30,6 @@
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/autop": "file:../autop",
 		"@wordpress/blob": "file:../blob",
-		"@wordpress/block-directory": "file:../block-directory",
 		"@wordpress/block-editor": "file:../block-editor",
 		"@wordpress/blocks": "file:../blocks",
 		"@wordpress/components": "file:../components",


### PR DESCRIPTION
It was [mentioned in slack](https://wordpress.slack.com/archives/C5UNMSU4R/p1593015686159900) that the `@wordpress/editor` package depends on the block-directory package, which is causing a circular dependency. It seems this is leftover from [the first iteration of the block directory,](https://github.com/WordPress/gutenberg/pull/17431) before it was pulled out into a standalone plugin. Since it's not used in the editor package, this line is safe to remove.

The error:
```
lerna WARN ECYCLE @wordpress/block-directory -> @wordpress/edit-post -> @wordpress/block-library -> @wordpress/editor -> @wordpress/block-directory
```
