### PR TITLE
Drag and drop: enable for multi selection

### DIFF
--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -19,6 +19,21 @@ _Returns_
 
 -   `boolean`: True if the block has controlled inner blocks.
 
+<a name="canInsertBlocks" href="#canInsertBlocks">#</a> **canInsertBlocks**
+
+Determines if the given blocks are allowed to be inserted into the block
+list.
+
+_Parameters_
+
+-   _state_ `Object`: Editor state.
+-   _clientIds_ `string`: The block client IDs to be inserted.
+-   _rootClientId_ `?string`: Optional root client ID of block list.
+
+_Returns_
+
+-   `boolean`: Whether the given blocks are allowed to be inserted.
+
 <a name="canInsertBlockType" href="#canInsertBlockType">#</a> **canInsertBlockType**
 
 Determines if the given block type is allowed to be inserted into the block list.
@@ -1073,21 +1088,33 @@ _Returns_
 
 Undocumented declaration.
 
+<a name="moveBlocksToPosition" href="#moveBlocksToPosition">#</a> **moveBlocksToPosition**
+
+Returns an action object signalling that the given blocks should be moved to
+a new position.
+
+_Parameters_
+
+-   _clientIds_ `?string`: The client IDs of the blocks.
+-   _fromRootClientId_ `?string`: Root client ID source.
+-   _toRootClientId_ `?string`: Root client ID destination.
+-   _index_ `number`: The index to move the blocks to.
+
 <a name="moveBlocksUp" href="#moveBlocksUp">#</a> **moveBlocksUp**
 
 Undocumented declaration.
 
 <a name="moveBlockToPosition" href="#moveBlockToPosition">#</a> **moveBlockToPosition**
 
-Returns an action object signalling that an indexed block should be moved
-to a new index.
+Returns an action object signalling that the given block should be moved to a
+new position.
 
 _Parameters_
 
 -   _clientId_ `?string`: The client ID of the block.
 -   _fromRootClientId_ `?string`: Root client ID source.
 -   _toRootClientId_ `?string`: Root client ID destination.
--   _index_ `number`: The index to move the block into.
+-   _index_ `number`: The index to move the block to.
 
 <a name="multiSelect" href="#multiSelect">#</a> **multiSelect**
 

--- a/packages/block-editor/src/components/block-draggable/draggable-chip.js
+++ b/packages/block-editor/src/components/block-draggable/draggable-chip.js
@@ -4,7 +4,7 @@
 import { getBlockType } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 import { Flex, FlexItem } from '@wordpress/components';
-import { menu, handle } from '@wordpress/icons';
+import { layout, handle } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -22,7 +22,7 @@ export default function BlockDraggableChip( { clientIds } ) {
 			);
 
 			if ( ! isOfSameType ) {
-				return menu;
+				return layout;
 			}
 
 			return getBlockType( blockName ).icon;
@@ -43,6 +43,7 @@ export default function BlockDraggableChip( { clientIds } ) {
 					<FlexItem>
 						<BlockIcon icon={ icon } />
 					</FlexItem>
+					<FlexItem>{ `(${ clientIds.length })` }</FlexItem>
 				</Flex>
 			</div>
 		</div>

--- a/packages/block-editor/src/components/block-draggable/index.js
+++ b/packages/block-editor/src/components/block-draggable/index.js
@@ -52,10 +52,7 @@ const BlockDraggable = ( {
 				getBlockRootClientId,
 				getTemplateLock,
 			} = select( 'core/block-editor' );
-			const rootClientId =
-				clientIds.length === 1
-					? getBlockRootClientId( clientIds[ 0 ] )
-					: null;
+			const rootClientId = getBlockRootClientId( clientIds[ 0 ] );
 			const templateLock = rootClientId
 				? getTemplateLock( rootClientId )
 				: null;
@@ -63,7 +60,7 @@ const BlockDraggable = ( {
 			return {
 				index: getBlockIndex( clientIds[ 0 ], rootClientId ),
 				srcRootClientId: rootClientId,
-				isDraggable: clientIds.length === 1 && 'all' !== templateLock,
+				isDraggable: 'all' !== templateLock,
 			};
 		},
 		[ clientIds ]
@@ -103,7 +100,7 @@ const BlockDraggable = ( {
 	const transferData = {
 		type: 'block',
 		srcIndex: index,
-		srcClientId: clientIds[ 0 ],
+		srcClientIds: clientIds,
 		srcRootClientId,
 	};
 

--- a/packages/block-editor/src/components/block-draggable/style.scss
+++ b/packages/block-editor/src/components/block-draggable/style.scss
@@ -27,7 +27,7 @@
 
 // This hides the block being dragged.
 // The effect is that the block being dragged appears to be "lifted".
-.is-dragging.is-selected {
+.is-dragging.is-selected,
+.is-dragging.is-multi-selected {
 	display: none !important;
 }
-

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -123,7 +123,7 @@ export function getNearestBlockIndex( elements, position, orientation ) {
 function parseDropEvent( event ) {
 	let result = {
 		srcRootClientId: null,
-		srcClientId: null,
+		srcClientIds: null,
 		srcIndex: null,
 		type: null,
 	};
@@ -191,7 +191,7 @@ export default function useBlockDropZone( {
 	const {
 		insertBlocks,
 		updateBlockAttributes,
-		moveBlockToPosition,
+		moveBlocksToPosition,
 	} = useDispatch( 'core/block-editor' );
 
 	const onFilesDrop = useCallback(
@@ -238,7 +238,7 @@ export default function useBlockDropZone( {
 		( event ) => {
 			const {
 				srcRootClientId: sourceRootClientId,
-				srcClientId: sourceClientId,
+				srcClientIds: sourceClientIds,
 				srcIndex: sourceBlockIndex,
 				type: dropType,
 			} = parseDropEvent( event );
@@ -260,8 +260,8 @@ export default function useBlockDropZone( {
 			// nested blocks, return early as this would create infinite
 			// recursion.
 			if (
-				targetRootClientId === sourceClientId ||
-				getClientIdsOfDescendants( [ sourceClientId ] ).some(
+				sourceClientIds.includes( targetRootClientId ) ||
+				getClientIdsOfDescendants( sourceClientIds ).some(
 					( id ) => id === targetRootClientId
 				)
 			) {
@@ -280,8 +280,8 @@ export default function useBlockDropZone( {
 					? targetBlockIndex - 1
 					: targetBlockIndex;
 
-			moveBlockToPosition(
-				sourceClientId,
+			moveBlocksToPosition(
+				sourceClientIds,
 				sourceRootClientId,
 				targetRootClientId,
 				insertIndex
@@ -291,7 +291,7 @@ export default function useBlockDropZone( {
 			getClientIdsOfDescendants,
 			getBlockIndex,
 			targetBlockIndex,
-			moveBlockToPosition,
+			moveBlocksToPosition,
 			targetRootClientId,
 		]
 	);

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -368,18 +368,18 @@ export const moveBlocksDown = createOnMove( 'MOVE_BLOCKS_DOWN' );
 export const moveBlocksUp = createOnMove( 'MOVE_BLOCKS_UP' );
 
 /**
- * Returns an action object signalling that an indexed block should be moved
- * to a new index.
+ * Returns an action object signalling that the given blocks should be moved to
+ * a new position.
  *
- * @param  {?string} clientId         The client ID of the block.
+ * @param  {?string} clientIds        The client IDs of the blocks.
  * @param  {?string} fromRootClientId Root client ID source.
  * @param  {?string} toRootClientId   Root client ID destination.
- * @param  {number}  index            The index to move the block into.
+ * @param  {number}  index            The index to move the blocks to.
  *
  * @yield {Object} Action object.
  */
-export function* moveBlockToPosition(
-	clientId,
+export function* moveBlocksToPosition(
+	clientIds,
 	fromRootClientId = '',
 	toRootClientId = '',
 	index
@@ -397,12 +397,13 @@ export function* moveBlockToPosition(
 	}
 
 	const action = {
-		type: 'MOVE_BLOCK_TO_POSITION',
+		type: 'MOVE_BLOCKS_TO_POSITION',
 		fromRootClientId,
 		toRootClientId,
-		clientId,
+		clientIds,
 		index,
 	};
+
 	// If moving inside the same root block the move is always possible.
 	if ( fromRootClientId === toRootClientId ) {
 		yield action;
@@ -410,28 +411,48 @@ export function* moveBlockToPosition(
 	}
 
 	// If templateLock is insert we can not remove the block from the parent.
-	// Given that here we know that we are moving the block to a different parent, the move should not be possible if the condition is true.
+	// Given that here we know that we are moving the block to a different
+	// parent, the move should not be possible if the condition is true.
 	if ( templateLock === 'insert' ) {
 		return;
 	}
 
-	const blockName = yield select(
+	const canInsertBlocks = yield select(
 		'core/block-editor',
-		'getBlockName',
-		clientId
-	);
-
-	const canInsertBlock = yield select(
-		'core/block-editor',
-		'canInsertBlockType',
-		blockName,
+		'canInsertBlocks',
+		clientIds,
 		toRootClientId
 	);
 
 	// If moving to other parent block, the move is possible if we can insert a block of the same type inside the new parent block.
-	if ( canInsertBlock ) {
+	if ( canInsertBlocks ) {
 		yield action;
 	}
+}
+
+/**
+ * Returns an action object signalling that the given block should be moved to a
+ * new position.
+ *
+ * @param  {?string} clientId         The client ID of the block.
+ * @param  {?string} fromRootClientId Root client ID source.
+ * @param  {?string} toRootClientId   Root client ID destination.
+ * @param  {number}  index            The index to move the block to.
+ *
+ * @yield {Object} Action object.
+ */
+export function* moveBlockToPosition(
+	clientId,
+	fromRootClientId = '',
+	toRootClientId = '',
+	index
+) {
+	yield moveBlocksToPosition(
+		[ clientId ],
+		fromRootClientId,
+		toRootClientId,
+		index
+	);
 }
 
 /**

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -332,8 +332,8 @@ const withBlockCache = ( reducer ) => ( state = {}, action ) => {
 				),
 			};
 			break;
-		case 'MOVE_BLOCK_TO_POSITION': {
-			const updatedBlockUids = [ action.clientId ];
+		case 'MOVE_BLOCKS_TO_POSITION': {
+			const updatedBlockUids = [ ...action.clientIds ];
 			if ( action.fromRootClientId ) {
 				updatedBlockUids.push( action.fromRootClientId );
 			}
@@ -905,24 +905,25 @@ export const blocks = flow(
 				};
 			}
 
-			case 'MOVE_BLOCK_TO_POSITION': {
+			case 'MOVE_BLOCKS_TO_POSITION': {
 				const {
 					fromRootClientId = '',
 					toRootClientId = '',
-					clientId,
+					clientIds,
 				} = action;
 				const { index = state[ toRootClientId ].length } = action;
 
 				// Moving inside the same parent block
 				if ( fromRootClientId === toRootClientId ) {
 					const subState = state[ toRootClientId ];
-					const fromIndex = subState.indexOf( clientId );
+					const fromIndex = subState.indexOf( clientIds[ 0 ] );
 					return {
 						...state,
 						[ toRootClientId ]: moveTo(
 							state[ toRootClientId ],
 							fromIndex,
-							index
+							index,
+							clientIds.length
 						),
 					};
 				}
@@ -932,11 +933,11 @@ export const blocks = flow(
 					...state,
 					[ fromRootClientId ]: without(
 						state[ fromRootClientId ],
-						clientId
+						...clientIds
 					),
 					[ toRootClientId ]: insertAt(
 						state[ toRootClientId ],
-						clientId,
+						clientIds,
 						index
 					),
 				};
@@ -1069,10 +1070,13 @@ export const blocks = flow(
 					),
 				};
 
-			case 'MOVE_BLOCK_TO_POSITION': {
+			case 'MOVE_BLOCKS_TO_POSITION': {
 				return {
 					...state,
-					[ action.clientId ]: action.toRootClientId || '',
+					...action.clientIds.reduce( ( accumulator, id ) => {
+						accumulator[ id ] = action.toRootClientId || '';
+						return accumulator;
+					}, {} ),
 				};
 			}
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1203,6 +1203,22 @@ export const canInsertBlockType = createSelector(
 );
 
 /**
+ * Determines if the given blocks are allowed to be inserted into the block
+ * list.
+ *
+ * @param {Object}  state        Editor state.
+ * @param {string}  clientIds    The block client IDs to be inserted.
+ * @param {?string} rootClientId Optional root client ID of block list.
+ *
+ * @return {boolean} Whether the given blocks are allowed to be inserted.
+ */
+export function canInsertBlocks( state, clientIds, rootClientId = null ) {
+	return clientIds.every( ( id ) =>
+		canInsertBlockType( state, getBlockName( state, id ), rootClientId )
+	);
+}
+
+/**
  * Returns information about how recently and frequently a block has been inserted.
  *
  * @param {Object} state Global application state.

--- a/packages/block-editor/src/store/test/actions.js
+++ b/packages/block-editor/src/store/test/actions.js
@@ -617,10 +617,10 @@ describe( 'actions', () => {
 		} );
 	} );
 
-	describe( 'moveBlockToPosition', () => {
+	describe( 'moveBlocksToPosition', () => {
 		it( 'should yield MOVE_BLOCKS_TO_POSITION action if locking is insert and move is not changing the root block', () => {
 			const moveBlockToPositionGenerator = moveBlocksToPosition(
-				'chicken',
+				[ 'chicken' ],
 				'ribs',
 				'ribs',
 				5
@@ -639,7 +639,7 @@ describe( 'actions', () => {
 				type: 'MOVE_BLOCKS_TO_POSITION',
 				fromRootClientId: 'ribs',
 				toRootClientId: 'ribs',
-				clientIds: 'chicken',
+				clientIds: [ 'chicken' ],
 				index: 5,
 			} );
 
@@ -648,7 +648,7 @@ describe( 'actions', () => {
 
 		it( 'should not yield MOVE_BLOCKS_TO_POSITION action if locking is all', () => {
 			const moveBlockToPositionGenerator = moveBlocksToPosition(
-				'chicken',
+				[ 'chicken' ],
 				'ribs',
 				'ribs',
 				5
@@ -750,6 +750,34 @@ describe( 'actions', () => {
 				done: true,
 				value: undefined,
 			} );
+		} );
+	} );
+
+	describe( 'moveBlockToPosition', () => {
+		it( 'should yield MOVE_BLOCKS_TO_POSITION action with a single block', () => {
+			const moveBlockToPositionGenerator = moveBlocksToPosition(
+				'chicken',
+				'ribs',
+				'ribs',
+				5
+			);
+
+			expect( moveBlockToPositionGenerator.next().value ).toEqual( {
+				args: [ 'ribs' ],
+				selectorName: 'getTemplateLock',
+				storeName: 'core/block-editor',
+				type: 'SELECT',
+			} );
+
+			expect( moveBlockToPositionGenerator.next().value ).toEqual( {
+				type: 'MOVE_BLOCKS_TO_POSITION',
+				fromRootClientId: 'ribs',
+				toRootClientId: 'ribs',
+				clientIds: 'chicken',
+				index: 5,
+			} );
+
+			expect( moveBlockToPositionGenerator.next().done ).toBe( true );
 		} );
 	} );
 

--- a/packages/block-editor/src/store/test/actions.js
+++ b/packages/block-editor/src/store/test/actions.js
@@ -9,7 +9,7 @@ import {
 	insertBlock,
 	insertBlocks,
 	mergeBlocks,
-	moveBlockToPosition,
+	moveBlocksToPosition,
 	multiSelect,
 	removeBlock,
 	removeBlocks,
@@ -618,8 +618,8 @@ describe( 'actions', () => {
 	} );
 
 	describe( 'moveBlockToPosition', () => {
-		it( 'should yield MOVE_BLOCK_TO_POSITION action if locking is insert and move is not changing the root block', () => {
-			const moveBlockToPositionGenerator = moveBlockToPosition(
+		it( 'should yield MOVE_BLOCKS_TO_POSITION action if locking is insert and move is not changing the root block', () => {
+			const moveBlockToPositionGenerator = moveBlocksToPosition(
 				'chicken',
 				'ribs',
 				'ribs',
@@ -636,18 +636,18 @@ describe( 'actions', () => {
 			expect(
 				moveBlockToPositionGenerator.next( 'insert' ).value
 			).toEqual( {
-				type: 'MOVE_BLOCK_TO_POSITION',
+				type: 'MOVE_BLOCKS_TO_POSITION',
 				fromRootClientId: 'ribs',
 				toRootClientId: 'ribs',
-				clientId: 'chicken',
+				clientIds: 'chicken',
 				index: 5,
 			} );
 
 			expect( moveBlockToPositionGenerator.next().done ).toBe( true );
 		} );
 
-		it( 'should not yield MOVE_BLOCK_TO_POSITION action if locking is all', () => {
-			const moveBlockToPositionGenerator = moveBlockToPosition(
+		it( 'should not yield MOVE_BLOCKS_TO_POSITION action if locking is all', () => {
+			const moveBlockToPositionGenerator = moveBlocksToPosition(
 				'chicken',
 				'ribs',
 				'ribs',
@@ -667,9 +667,9 @@ describe( 'actions', () => {
 			} );
 		} );
 
-		it( 'should not yield MOVE_BLOCK_TO_POSITION action if locking is insert and move is changing the root block', () => {
-			const moveBlockToPositionGenerator = moveBlockToPosition(
-				'chicken',
+		it( 'should not yield MOVE_BLOCKS_TO_POSITION action if locking is insert and move is changing the root block', () => {
+			const moveBlockToPositionGenerator = moveBlocksToPosition(
+				[ 'chicken' ],
 				'ribs',
 				'chicken-ribs',
 				5
@@ -688,9 +688,9 @@ describe( 'actions', () => {
 			} );
 		} );
 
-		it( 'should yield MOVE_BLOCK_TO_POSITION action if there is not locking in the original root block and block can be inserted in the destination', () => {
-			const moveBlockToPositionGenerator = moveBlockToPosition(
-				'chicken',
+		it( 'should yield MOVE_BLOCKS_TO_POSITION action if there is not locking in the original root block and block can be inserted in the destination', () => {
+			const moveBlockToPositionGenerator = moveBlocksToPosition(
+				[ 'chicken' ],
 				'ribs',
 				'chicken-ribs',
 				5
@@ -704,27 +704,17 @@ describe( 'actions', () => {
 			} );
 
 			expect( moveBlockToPositionGenerator.next().value ).toEqual( {
-				args: [ 'chicken' ],
-				selectorName: 'getBlockName',
-				storeName: 'core/block-editor',
-				type: 'SELECT',
-			} );
-
-			expect(
-				moveBlockToPositionGenerator.next( 'myblock/chicken-block' )
-					.value
-			).toEqual( {
-				args: [ 'myblock/chicken-block', 'chicken-ribs' ],
-				selectorName: 'canInsertBlockType',
+				args: [ [ 'chicken' ], 'chicken-ribs' ],
+				selectorName: 'canInsertBlocks',
 				storeName: 'core/block-editor',
 				type: 'SELECT',
 			} );
 
 			expect( moveBlockToPositionGenerator.next( true ).value ).toEqual( {
-				type: 'MOVE_BLOCK_TO_POSITION',
+				type: 'MOVE_BLOCKS_TO_POSITION',
 				fromRootClientId: 'ribs',
 				toRootClientId: 'chicken-ribs',
-				clientId: 'chicken',
+				clientIds: [ 'chicken' ],
 				index: 5,
 			} );
 
@@ -734,9 +724,9 @@ describe( 'actions', () => {
 			} );
 		} );
 
-		it( 'should not yield MOVE_BLOCK_TO_POSITION action if there is not locking in the original root block and block can be inserted in the destination', () => {
-			const moveBlockToPositionGenerator = moveBlockToPosition(
-				'chicken',
+		it( 'should not yield MOVE_BLOCKS_TO_POSITION action if there is not locking in the original root block and block can be inserted in the destination', () => {
+			const moveBlockToPositionGenerator = moveBlocksToPosition(
+				[ 'chicken' ],
 				'ribs',
 				'chicken-ribs',
 				5
@@ -750,18 +740,8 @@ describe( 'actions', () => {
 			} );
 
 			expect( moveBlockToPositionGenerator.next().value ).toEqual( {
-				args: [ 'chicken' ],
-				selectorName: 'getBlockName',
-				storeName: 'core/block-editor',
-				type: 'SELECT',
-			} );
-
-			expect(
-				moveBlockToPositionGenerator.next( 'myblock/chicken-block' )
-					.value
-			).toEqual( {
-				args: [ 'myblock/chicken-block', 'chicken-ribs' ],
-				selectorName: 'canInsertBlockType',
+				args: [ [ 'chicken' ], 'chicken-ribs' ],
+				selectorName: 'canInsertBlocks',
 				storeName: 'core/block-editor',
 				type: 'SELECT',
 			} );

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -1489,8 +1489,8 @@ describe( 'state', () => {
 				],
 			} );
 			const state = blocks( original, {
-				type: 'MOVE_BLOCK_TO_POSITION',
-				clientId: 'ribs',
+				type: 'MOVE_BLOCKS_TO_POSITION',
+				clientIds: [ 'ribs' ],
 				index: 0,
 			} );
 
@@ -1526,8 +1526,8 @@ describe( 'state', () => {
 				],
 			} );
 			const state = blocks( original, {
-				type: 'MOVE_BLOCK_TO_POSITION',
-				clientId: 'ribs',
+				type: 'MOVE_BLOCKS_TO_POSITION',
+				clientIds: [ 'ribs' ],
 				index: 2,
 			} );
 
@@ -1563,8 +1563,8 @@ describe( 'state', () => {
 				],
 			} );
 			const state = blocks( original, {
-				type: 'MOVE_BLOCK_TO_POSITION',
-				clientId: 'ribs',
+				type: 'MOVE_BLOCKS_TO_POSITION',
+				clientIds: [ 'ribs' ],
 				index: 1,
 			} );
 

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -1575,6 +1575,79 @@ describe( 'state', () => {
 			] );
 		} );
 
+		it( 'should move multiple blocks', () => {
+			const original = blocks( undefined, {
+				type: 'RESET_BLOCKS',
+				blocks: [
+					{
+						clientId: 'chicken',
+						name: 'core/test-block',
+						attributes: {},
+						innerBlocks: [],
+					},
+					{
+						clientId: 'ribs',
+						name: 'core/test-block',
+						attributes: {},
+						innerBlocks: [],
+					},
+					{
+						clientId: 'veggies',
+						name: 'core/test-block',
+						attributes: {},
+						innerBlocks: [],
+					},
+				],
+			} );
+			const state = blocks( original, {
+				type: 'MOVE_BLOCKS_TO_POSITION',
+				clientIds: [ 'ribs', 'veggies' ],
+				index: 0,
+			} );
+
+			expect( state.order[ '' ] ).toEqual( [
+				'ribs',
+				'veggies',
+				'chicken',
+			] );
+		} );
+
+		it( 'should move multiple blocks to different parent', () => {
+			const original = blocks( undefined, {
+				type: 'RESET_BLOCKS',
+				blocks: [
+					{
+						clientId: 'chicken',
+						name: 'core/test-block',
+						attributes: {},
+						innerBlocks: [],
+					},
+					{
+						clientId: 'ribs',
+						name: 'core/test-block',
+						attributes: {},
+						innerBlocks: [],
+					},
+					{
+						clientId: 'veggies',
+						name: 'core/test-block',
+						attributes: {},
+						innerBlocks: [],
+					},
+				],
+			} );
+			const state = blocks( original, {
+				type: 'MOVE_BLOCKS_TO_POSITION',
+				clientIds: [ 'ribs', 'veggies' ],
+				fromRootClientId: '',
+				toRootClientId: 'chicken',
+				index: 0,
+			} );
+
+			expect( state.order[ '' ] ).toEqual( [ 'chicken' ] );
+			expect( state.order.chicken ).toEqual( [ 'ribs', 'veggies' ] );
+		} );
+
 		describe( 'blocks', () => {
 			it( 'should not reset any blocks that are not in the post', () => {
 				const actions = [

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -55,6 +55,7 @@ const {
 	isBlockInsertionPointVisible,
 	isSelectionEnabled,
 	canInsertBlockType,
+	canInsertBlocks,
 	getInserterItems,
 	isValidTemplate,
 	getTemplate,
@@ -2273,6 +2274,59 @@ describe( 'selectors', () => {
 			expect(
 				canInsertBlockType( state, 'core/post-content-child' )
 			).toBe( true );
+		} );
+	} );
+
+	describe( 'canInsertBlocks', () => {
+		it( 'should allow blocks', () => {
+			const state = {
+				blocks: {
+					byClientId: {
+						1: { name: 'core/test-block-a' },
+						2: { name: 'core/test-block-b' },
+						3: { name: 'core/test-block-c' },
+					},
+					attributes: {
+						1: {},
+						2: {},
+						3: {},
+					},
+				},
+				blockListSettings: {
+					1: {
+						allowedBlocks: [
+							'core/test-block-b',
+							'core/test-block-c',
+						],
+					},
+				},
+				settings: {},
+			};
+			expect( canInsertBlocks( state, [ '2', '3' ], '1' ) ).toBe( true );
+		} );
+
+		it( 'should deny blocks', () => {
+			const state = {
+				blocks: {
+					byClientId: {
+						1: { name: 'core/test-block-a' },
+						2: { name: 'core/test-block-b' },
+						3: { name: 'core/test-block-c' },
+					},
+					attributes: {
+						1: {},
+						2: {},
+						3: {},
+					},
+				},
+				blockListSettings: {
+					1: {
+						allowedBlocks: [ 'core/test-block-c' ],
+					},
+				},
+				settings: {},
+			};
+			expect( canInsertBlocks( state, [ '2', '3' ], '1' ) ).toBe( false );
 		} );
 	} );
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

Fixes #7283.

There's nothing to stop us from allowing multiple blocks to be dragged and dropped since #23024. We don't have put them in a clone, and it won't be a huge thing you'll have to move around.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
