### PR TITLE
Tools: Always append prerelease to version update in package.json when preparing npm release

### DIFF
--- a/bin/plugin/commands/packages.js
+++ b/bin/plugin/commands/packages.js
@@ -218,9 +218,7 @@ async function updatePackages(
 				const packageJson = readJSONFile( packageJSONPath );
 				const newPackageJson = {
 					...packageJson,
-					version: isPrerelease
-						? nextVersion + '-prerelease'
-						: nextVersion,
+					version: nextVersion + '-prerelease',
 				};
 				fs.writeFileSync(
 					packageJSONPath,


### PR DESCRIPTION

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

Another follow-up for #23357. We should always set `-prerelase` suffix when updating the version in the package to let Lerna do version bump to the same version regardless of the type of bump is selected there. The idea is that we make informed decisions based on the CHANGELOG entries.

Example:

Current version: `1.2.3`
Changes type detected: `minor`
New version: `1.3.0-prerelease`
Lerna updates to: `1.3.0`.