### PR TITLE
Add npm cache to Github workflows and use checkout v2

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -8,9 +8,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2-beta
+    - uses: actions/checkout@v2
       with:
         fetch-depth: 1
+
     - uses: preactjs/compressed-size-action@v1
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/create-block.yml
+++ b/.github/workflows/create-block.yml
@@ -13,11 +13,26 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+
+    - name: Cache node modules
+      uses: actions/cache@v2
+      env:
+        cache-name: cache-node-modules
+      with:
+        # npm cache files are stored in `~/.npm` on Linux/macOS
+        path: ~/.npm
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+
     - name: Use Node.js 12.x
       uses: actions/setup-node@v1
       with:
         node-version: 12.x
+
     - name: npm install, build, format and lint
       run: |
         npm ci

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,11 +8,26 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+
+    - name: Cache node modules
+      uses: actions/cache@v2
+      env:
+        cache-name: cache-node-modules
+      with:
+        # npm cache files are stored in `~/.npm` on Linux/macOS
+        path: ~/.npm
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+
     - name: Use Node.js 12.x
       uses: actions/setup-node@v1
       with:
         node-version: 12.x
+
     - name: Npm install and build
       # A "full" install is executed, since `npm ci` does not always exit
       # with an error status code if the lock file is inaccurate.
@@ -21,13 +36,18 @@ jobs:
       run: |
         npm install
         npm run build
+
     - name: Lint JavaScript and Styles
       run: npm run lint
+
     - name: Lint ES5 built files (IE11)
       run: npx eslint --parser-options=ecmaVersion:5 --no-eslintrc --no-ignore ./build/**/*.js
+
     - name: Type checking
       run: npm run build:package-types
+
     - name: Build artifacts
       run: npm run check-local-changes
+
     - name: License compatibility
       run: npm run check-licenses

--- a/.github/workflows/pull-request-automation.yml
+++ b/.github/workflows/pull-request-automation.yml
@@ -8,14 +8,16 @@ jobs:
   pull-request-automation:
     runs-on: ubuntu-latest
     steps:
-      # Checkout defaults to using the branch which triggered the event, which
-      # isn't necessarily `master` (e.g. in the case of a merge).
-      - uses: actions/checkout@v2
-        with:
-          ref: master
-      # Changing into the action's directory and running `npm install` is much
-      # faster than a full project-wide `npm ci`.
-      - run: cd packages/project-management-automation && npm install
-      - uses: ./packages/project-management-automation
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+    # Checkout defaults to using the branch which triggered the event, which
+    # isn't necessarily `master` (e.g. in the case of a merge).
+    - uses: actions/checkout@v2
+      with:
+        ref: master
+
+    # Changing into the action's directory and running `npm install` is much
+    # faster than a full project-wide `npm ci`.
+    - run: cd packages/project-management-automation && npm install
+
+    - uses: ./packages/project-management-automation
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/storybook-pages.yml
+++ b/.github/workflows/storybook-pages.yml
@@ -9,24 +9,37 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          ref: master
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        ref: master
 
-      - name: Setup Node
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
+    - name: Cache node modules
+      uses: actions/cache@v2
+      env:
+        cache-name: cache-node-modules
+      with:
+        # npm cache files are stored in `~/.npm` on Linux/macOS
+        path: ~/.npm
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
 
-      - name: Install Dependencies
-        run: npm ci
+    - name: Setup Node
+      uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
 
-      - name: Build Storybook
-        run: npm run storybook:build
+    - name: Install Dependencies
+      run: npm ci
 
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./playground/dist
+    - name: Build Storybook
+      run: npm run storybook:build
+
+    - name: Deploy
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./playground/dist


### PR DESCRIPTION
I'm hoping to improve the performance of the actions with both the checkout v2 and the npm cache.