### PR TITLE
Add `max-width` for the post publish panel buttons.

### DIFF
--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -31,6 +31,10 @@
 .editor-post-publish-panel__header-publish-button,
 .editor-post-publish-panel__header-cancel-button {
 	flex-grow: 1;
+
+	@include break-mobile() {
+		max-width: $admin-sidebar-width;
+	}
 }
 
 .editor-post-publish-panel__header-publish-button {


### PR DESCRIPTION
## Description
Adding `max-width` for the new post publish panel buttons distribution for the `break-mobile()` breakpoint. Applying @MichaelArestad's [suggestion here](https://github.com/WordPress/gutenberg/pull/22390#issuecomment-649614751).

## How has this been tested?
Checked the new styles at different screen sizes.

## Screenshots

<img src="https://cldup.com/esAcBrPHgr.gif" >

## Types of changes
- Adding a max-width on an element for a certain viewport.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
