### PR TITLE
Edit Site: Allow wide alignment

### DIFF
--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -127,6 +127,7 @@ function gutenberg_edit_site_init( $hook ) {
 	}
 
 	$settings = array(
+		'alignWide'              => get_theme_support( 'align-wide' ),
 		'disableCustomColors'    => get_theme_support( 'disable-custom-colors' ),
 		'disableCustomFontSizes' => get_theme_support( 'disable-custom-font-sizes' ),
 		'imageSizes'             => $available_image_sizes,

--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -233,7 +233,7 @@ const BlockComponent = forwardRef(
 				// Overrideable props.
 				aria-label={ blockLabel }
 				role="group"
-				{ ...omit( wrapperProps, [ 'data-align' ] ) }
+				{ ...wrapperProps }
 				{ ...props }
 				id={ blockElementId }
 				ref={ wrapper }

--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -233,7 +233,7 @@ const BlockComponent = forwardRef(
 				// Overrideable props.
 				aria-label={ blockLabel }
 				role="group"
-				{ ...wrapperProps }
+				{ ...omit( wrapperProps, [ 'data-align' ] ) }
 				{ ...props }
 				id={ blockElementId }
 				ref={ wrapper }

--- a/packages/block-library/src/post-content/block.json
+++ b/packages/block-library/src/post-content/block.json
@@ -6,6 +6,7 @@
 		"postType"
 	],
 	"supports": {
+		"align": true,
 		"html": false
 	}
 }

--- a/packages/block-library/src/template-part/block.json
+++ b/packages/block-library/src/template-part/block.json
@@ -13,6 +13,7 @@
 		}
 	},
 	"supports": {
+		"align": true,
 		"html": false
 	}
 }

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -1,17 +1,3 @@
-.edit-site-block-editor__block-list {
-	padding-bottom: $grid-unit-30;
-	padding-top: $grid-unit-30 + 5;
-
-	padding-left: $block-padding;
-	padding-right: $block-padding;
-
-	// Full-wide. (to account for the padddings added above)
-	.wp-block[data-align="full"] {
-		margin-left: -$block-padding;
-		margin-right: -$block-padding;
-	}
-}
-
 // The button element easily inherits styles that are meant for the editor style.
 // These rules enhance the specificity to reduce that inheritance.
 // This is duplicated in visual-editor.


### PR DESCRIPTION
## Description

For the Site Editor, we want to allow post content to be inserted at full width (e.g. Cover Blocks). This is currently impossible (see https://github.com/Automattic/wp-calypso/issues/43640) due to ~3~ 2 independent problems. This PR fixes all of them.

To provide some context for those issues -- the alignment handling is somewhat complex, and happens mostly at [`BlockListBlock`](https://github.com/WordPress/gutenberg/blob/f9543e708a789e0bf08dc508cc3fc1b8692675ed/packages/block-editor/src/components/block-list/block.js#L158-L169) level, using the [`withDataAlign`](https://github.com/WordPress/gutenberg/blob/f9543e708a789e0bf08dc508cc3fc1b8692675ed/packages/block-editor/src/hooks/align.js) HOC.

1. [Unlike the Post Editor](https://github.com/WordPress/WordPress/blob/f18870ae4e1cb3cd81136424e43c99d705aa2912/wp-admin/edit-form-blocks.php#L286), we're currently not setting `alignWide` in the Site Editor's settings, which becomes a problem here: https://github.com/WordPress/gutenberg/blob/9cd07a92d463377767f56c2b3985badbd363d98f/packages/block-editor/src/hooks/align.js#L173-L196.
~2. In `block-list/block-wrapper.js`, we're [omitting](https://github.com/WordPress/gutenberg/blob/f9543e708a789e0bf08dc508cc3fc1b8692675ed/packages/block-editor/src/components/block-list/block-wrapper.js#L244) the `data-align` prop from wrapper props, before passing them on to the actual element. I believe that this is an oversight from a refactor PR (#23089) that moved some logic from the block wrapper into `BlockListBlock`. cc/ @ellatrix~ _Reverted, see [this discussion](https://github.com/WordPress/gutenberg/pull/23488#discussion_r445892360)._
3. In order to specifically make the Post Content block full-width, we need to add `align` to its `supports` attribute. (It's still conceivable to use this block at other widths, e.g. in a setting with a sidebar.)

Fixes https://github.com/Automattic/wp-calypso/issues/43640.

## How has this been tested?

- There shouldn't be any `wp_template` CPTs (neither published nor `auto-draft`s) from previous Site Editor runs. (It's best to start with a fresh install, i.e. `npx wp-env clean all && npx wp-env start`. _Careful, this will wipe your WordPress install's data!_)
- Furthermore, the "Full Site Editing Demo Templates" checkbox in `/wp-admin/admin.php?page=gutenberg-experiments` _must not be ticked_. (Make sure the "Full Site Editing" checkbox is ticked -- since it also gets reset after a wipe.)
- Make sure you have linked your wp-env install to themes from the `theme-experiments` repo (see the [`wp-env` README](https://github.com/WordPress/gutenberg/blob/710373b254fbcd15d524afdeb31da0d93c4defd4/packages/env/README.md)).
- Activate the "Twenty Twenty Blocks" theme.
- Create a Home page (under Pages), and insert a full-width Cover block into it. (Verify that it takes up the entire (editor) screen width.)
- In 'Settings > Reading', set the front page to that Home page.
- Open the Site Editor. Make sure the template used for the front page contains a Post Content block (insert one if it doesn't).
- Set that Post Content block to Full Width.
- Verify that it takes up the entire (editor) screen width, as it should. ~_(There's currently still a 10px padding which I'll address separately.)_~ _Fixed, see 6ae4c63._

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/96308/85801033-5af5bc80-b742-11ea-92d2-e469ca456a42.png)

### After

![image](https://user-images.githubusercontent.com/96308/86047152-be3b6380-ba4e-11ea-95e0-2e6dd882a9b9.png)

## Types of changes
Bugfix

## Follow-up PRs

- ~There's still a 10px padding that needs to be removed.~ _Fixed, see 6ae4c63._
- Some theme styles aren't being loaded.
- Maybe we can infer theme support for wide/full alignment from the theme endpoint (`theme_supports`) rather than via the `settings` var? Edit: Exploring this in #23566.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
