### PR TITLE
Show a warning when SlotFillProvider is missing

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -21,7 +21,7 @@ import {
 	WritingFlow,
 	ObserveTyping
 } from '@wordpress/block-editor';
-import { Popover } from '@wordpress/components';
+import { SlotFillProvider, Popover } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 
 function MyEditorComponent () {
@@ -33,13 +33,15 @@ function MyEditorComponent () {
 			onInput={ updateBlocks }
 			onChange={ updateBlocks }
 		>
-			<Popover.Slot name="block-toolbar" />
-			<WritingFlow>
-				<ObserveTyping>
-					<BlockList />
-				</ObserveTyping>
-			</WritingFlow>
-			<Popover.Slot />
+			<SlotFillProvider>
+				<Popover.Slot name="block-toolbar" />
+				<WritingFlow>
+					<ObserveTyping>
+						<BlockList />
+					</ObserveTyping>
+				</WritingFlow>
+				<Popover.Slot />
+			</SlotFillProvider>
 		</BlockEditorProvider>
 	);
 }

--- a/packages/components/src/slot-fill/bubbles-virtually/slot-fill-context.js
+++ b/packages/components/src/slot-fill/bubbles-virtually/slot-fill-context.js
@@ -4,6 +4,7 @@
 import { createContext } from '@wordpress/element';
 
 const SlotFillContext = createContext( {
+	__unstableDefaultContext: true,
 	slots: {},
 	fills: {},
 	registerSlot: () => {},

--- a/packages/components/src/slot-fill/bubbles-virtually/slot-fill-context.js
+++ b/packages/components/src/slot-fill/bubbles-virtually/slot-fill-context.js
@@ -2,12 +2,17 @@
  * WordPress dependencies
  */
 import { createContext } from '@wordpress/element';
+import warning from '@wordpress/warning';
 
 const SlotFillContext = createContext( {
-	__unstableDefaultContext: true,
 	slots: {},
 	fills: {},
-	registerSlot: () => {},
+	registerSlot: () => {
+		warning(
+			'Components must be wrapped within `SlotFillProvider`. ' +
+				'See https://developer.wordpress.org/block-editor/components/slot-fill/'
+		);
+	},
 	updateSlot: () => {},
 	unregisterSlot: () => {},
 	registerFill: () => {},

--- a/packages/components/src/slot-fill/bubbles-virtually/slot.js
+++ b/packages/components/src/slot-fill/bubbles-virtually/slot.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { useRef, useLayoutEffect, useContext } from '@wordpress/element';
+import warning from '@wordpress/warning';
 
 /**
  * Internal dependencies
@@ -16,6 +17,13 @@ export default function Slot( {
 } ) {
 	const registry = useContext( SlotFillContext );
 	const ref = useRef();
+
+	if ( registry.__unstableDefaultContext ) {
+		warning(
+			'Components must be wrapped within `SlotFillProvider`. ' +
+				'See https://developer.wordpress.org/block-editor/components/slot-fill/'
+		);
+	}
 
 	useLayoutEffect( () => {
 		registry.registerSlot( name, ref, fillProps );

--- a/packages/components/src/slot-fill/bubbles-virtually/slot.js
+++ b/packages/components/src/slot-fill/bubbles-virtually/slot.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { useRef, useLayoutEffect, useContext } from '@wordpress/element';
-import warning from '@wordpress/warning';
 
 /**
  * Internal dependencies
@@ -17,13 +16,6 @@ export default function Slot( {
 } ) {
 	const registry = useContext( SlotFillContext );
 	const ref = useRef();
-
-	if ( registry.__unstableDefaultContext ) {
-		warning(
-			'Components must be wrapped within `SlotFillProvider`. ' +
-				'See https://developer.wordpress.org/block-editor/components/slot-fill/'
-		);
-	}
 
 	useLayoutEffect( () => {
 		registry.registerSlot( name, ref, fillProps );

--- a/packages/components/src/slot-fill/test/__snapshots__/slot.js.snap
+++ b/packages/components/src/slot-fill/test/__snapshots__/slot.js.snap
@@ -1,11 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Slot bubblesVirtually false should not break without a Provider 1`] = `
-<div>
-  <div />
-</div>
-`;
-
 exports[`Slot bubblesVirtually false should subsume another slot by the same name 1`] = `
 <div>
   <div
@@ -40,14 +34,6 @@ exports[`Slot bubblesVirtually false should unmount two slots with the same name
   <div
     data-position="second"
   />
-</div>
-`;
-
-exports[`Slot bubblesVirtually true should not break without a Provider 1`] = `
-<div>
-  <div>
-    <div />
-  </div>
 </div>
 `;
 
@@ -176,5 +162,13 @@ exports[`Slot should render in expected order 1`] = `
   <button
     type="button"
   />
+</div>
+`;
+
+exports[`Slot should warn without a Provider 1`] = `
+<div>
+  <div>
+    <div />
+  </div>
 </div>
 `;

--- a/packages/components/src/slot-fill/test/slot.js
+++ b/packages/components/src/slot-fill/test/slot.js
@@ -208,6 +208,20 @@ describe( 'Slot', () => {
 		expect( container ).toMatchSnapshot();
 	} );
 
+	it( 'should warn without a Provider', () => {
+		const { container } = render(
+			<>
+				<div>
+					<Slot name="chicken" bubblesVirtually />
+				</div>
+				<Fill name="chicken" />
+			</>
+		);
+
+		expect( container ).toMatchSnapshot();
+		expect( console ).toHaveWarned();
+	} );
+
 	describe.each( [ false, true ] )(
 		'bubblesVirtually %p',
 		( bubblesVirtually ) => {
@@ -298,22 +312,6 @@ describe( 'Slot', () => {
 						<Fill name="egg">Content</Fill>
 					</Provider>
 				);
-				expect( container ).toMatchSnapshot();
-			} );
-
-			it( 'should not break without a Provider', () => {
-				const { container } = render(
-					<>
-						<div>
-							<Slot
-								name="chicken"
-								bubblesVirtually={ bubblesVirtually }
-							/>
-						</div>
-						<Fill name="chicken" />
-					</>
-				);
-
 				expect( container ).toMatchSnapshot();
 			} );
 		}


### PR DESCRIPTION
This PR closes #23388

Here I'm only adding a warning on the `Slot` component, and not on the `useSlot` hook. `SlotFillProvider` and `Slot` are optional for some components that call `useSlot`. For example, `Popover` will render its contents within a `Fill` component only if `Slot` and `SlotFillProvider` are present:

https://github.com/WordPress/gutenberg/blob/f9543e708a789e0bf08dc508cc3fc1b8692675ed/packages/components/src/popover/index.js#L590-L592

I also updated the `@wordpress/block-editor` package README, as it was causing confusion when people just copied and pasted the example code.

## How to test?

- Make sure there's no warning on the console.
- Check automated tests.
