### PR TITLE
Scripts: Remove default exclude rule for node_modules for SVG, CSS and Sass files

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Allow the CSS, SVG, and Sass loaders to process files from node_modules directory.
+
 ## 12.0.0-rc.0 (2020-06-24)
 
 ### Breaking Changes

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -108,17 +108,14 @@ const config = {
 			},
 			{
 				test: /\.svg$/,
-				exclude: /node_modules/,
 				use: [ '@svgr/webpack', 'url-loader' ],
 			},
 			{
 				test: /\.css$/,
-				exclude: /node_modules/,
 				use: cssLoaders,
 			},
 			{
 				test: /\.(sc|sa)ss$/,
-				exclude: /node_modules/,
 				use: [
 					...cssLoaders,
 					{


### PR DESCRIPTION
## Description

Removes the default `exclude: /node_modules/,` rule for CSS and SVG loaders.

Fixes #23402.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
