### PR TITLE
Add Post Tags block description and icon

### DIFF
--- a/packages/block-library/src/post-tags/index.js
+++ b/packages/block-library/src/post-tags/index.js
@@ -15,7 +15,7 @@ export { metadata, name };
 
 export const settings = {
 	title: __( 'Post Tags' ),
-	description: __( 'Display a post\'s tags.' ),
+	description: __( "Display a post's tags." ),
 	icon,
 	edit,
 };

--- a/packages/block-library/src/post-tags/index.js
+++ b/packages/block-library/src/post-tags/index.js
@@ -15,7 +15,7 @@ export { metadata, name };
 
 export const settings = {
 	title: __( 'Post Tags' ),
-	description: __( 'Insert a list of tags to your document.' ),
+	description: __( 'Display a post\'s tags.' ),
 	icon,
 	edit,
 };

--- a/packages/block-library/src/post-tags/index.js
+++ b/packages/block-library/src/post-tags/index.js
@@ -15,7 +15,7 @@ export { metadata, name };
 
 export const settings = {
 	title: __( 'Post Tags' ),
-	description: __ ( 'Insert a list of tags to your document.' ),
+	description: __( 'Insert a list of tags to your document.' ),
 	icon,
 	edit,
 };

--- a/packages/block-library/src/post-tags/index.js
+++ b/packages/block-library/src/post-tags/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { tag as icon } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -14,5 +15,7 @@ export { metadata, name };
 
 export const settings = {
 	title: __( 'Post Tags' ),
+	description: __ ( 'Insert a list of tags to your document.' ),
+	icon,
 	edit,
 };


### PR DESCRIPTION
The Post Tags block displays the post's tags in a horizontal list.

Description proposal:

 > Insert a list of tags to your document.

#### Screenshot

![image](https://user-images.githubusercontent.com/1123119/85797600-2e698280-b6f9-11ea-97c3-4f0fcd1c517f.png)
