### PR TITLE
Use CDN for block directory assets

### DIFF
--- a/lib/class-wp-rest-block-directory-controller.php
+++ b/lib/class-wp-rest-block-directory-controller.php
@@ -143,8 +143,18 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 		);
 
 		foreach ( $plugin['block_assets'] as $asset ) {
-			// TODO: Return from API, not client-set.
-			$block['assets'][] = 'https://plugins.svn.wordpress.org/' . $plugin['slug'] . $asset;
+			// Allow for fully qualified URLs in future
+			if ( 'https' === wp_parse_url( $asset,  PHP_URL_SCHEME ) && !empty( wp_parse_url( $asset,  PHP_URL_HOST ) ) ) {
+				$block['assets'][] = esc_url_raw(
+					$asset,
+					array( 'https' )
+				);
+			} else {
+				$block['assets'][] = esc_url_raw( 
+					add_query_arg( 'v', strtotime( $block['last_updated'] ), 'https://ps.w.org/' . $plugin['slug'] . $asset ),
+					array( 'https' )
+				);
+			}
 		}
 
 		$this->add_additional_fields_to_object( $block, $request );

--- a/lib/class-wp-rest-block-directory-controller.php
+++ b/lib/class-wp-rest-block-directory-controller.php
@@ -144,7 +144,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 
 		foreach ( $plugin['block_assets'] as $asset ) {
 			// Allow for fully qualified URLs in future
-			if ( 'https' === wp_parse_url( $asset,  PHP_URL_SCHEME ) && !empty( wp_parse_url( $asset,  PHP_URL_HOST ) ) ) {
+			if ( 'https' === wp_parse_url( $asset, PHP_URL_SCHEME ) && !empty( wp_parse_url( $asset, PHP_URL_HOST ) ) ) {
 				$block['assets'][] = esc_url_raw(
 					$asset,
 					array( 'https' )

--- a/lib/class-wp-rest-block-directory-controller.php
+++ b/lib/class-wp-rest-block-directory-controller.php
@@ -143,14 +143,14 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 		);
 
 		foreach ( $plugin['block_assets'] as $asset ) {
-			// Allow for fully qualified URLs in future
-			if ( 'https' === wp_parse_url( $asset, PHP_URL_SCHEME ) && !empty( wp_parse_url( $asset, PHP_URL_HOST ) ) ) {
+			// Allow for fully qualified URLs in future.
+			if ( 'https' === wp_parse_url( $asset, PHP_URL_SCHEME ) && ! empty( wp_parse_url( $asset, PHP_URL_HOST ) ) ) {
 				$block['assets'][] = esc_url_raw(
 					$asset,
 					array( 'https' )
 				);
 			} else {
-				$block['assets'][] = esc_url_raw( 
+				$block['assets'][] = esc_url_raw(
 					add_query_arg( 'v', strtotime( $block['last_updated'] ), 'https://ps.w.org/' . $plugin['slug'] . $asset ),
 					array( 'https' )
 				);

--- a/phpunit/class-wp-rest-block-directory-controller-test.php
+++ b/phpunit/class-wp-rest-block-directory-controller-test.php
@@ -120,6 +120,11 @@ class WP_REST_Block_Directory_Controller_Test extends WP_Test_REST_Controller_Te
 			$this->assertArrayHasKey( 'author_block_rating', $plugin );
 			$this->assertArrayHasKey( 'assets', $plugin );
 			$this->assertArrayHasKey( 'humanized_updated', $plugin );
+
+			// Assets should be fully qualified https URLs
+			foreach ( $plugin[ 'assets' ] as $asset ) {
+				$this->assertEquals( 'https', wp_parse_url( $asset,  PHP_URL_SCHEME ) );
+			}
 		}
 	}
 

--- a/phpunit/class-wp-rest-block-directory-controller-test.php
+++ b/phpunit/class-wp-rest-block-directory-controller-test.php
@@ -122,7 +122,7 @@ class WP_REST_Block_Directory_Controller_Test extends WP_Test_REST_Controller_Te
 			$this->assertArrayHasKey( 'humanized_updated', $plugin );
 
 			// Assets should be fully qualified https URLs
-			foreach ( $plugin[ 'assets' ] as $asset ) {
+			foreach ( $plugin['assets'] as $asset ) {
 				$this->assertEquals( 'https', wp_parse_url( $asset, PHP_URL_SCHEME ) );
 			}
 		}

--- a/phpunit/class-wp-rest-block-directory-controller-test.php
+++ b/phpunit/class-wp-rest-block-directory-controller-test.php
@@ -123,7 +123,7 @@ class WP_REST_Block_Directory_Controller_Test extends WP_Test_REST_Controller_Te
 
 			// Assets should be fully qualified https URLs
 			foreach ( $plugin[ 'assets' ] as $asset ) {
-				$this->assertEquals( 'https', wp_parse_url( $asset,  PHP_URL_SCHEME ) );
+				$this->assertEquals( 'https', wp_parse_url( $asset, PHP_URL_SCHEME ) );
 			}
 		}
 	}


### PR DESCRIPTION
This changes the block directory REST API to use CDN urls for script and CSS assets. It also allows for absolute URLs when returned by the remote API.

## How has this been tested?
Unit tests, including new additions to WP_REST_Block_Directory_Controller_Test::test_prepare_item().

## Types of changes
This also supports fully qualified URLs in future, and incorporates some raw escaping.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
