### PR TITLE
Try removing BlockPopover key and related code.

### DIFF
--- a/packages/block-editor/src/components/block-list/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-list/block-contextual-toolbar.js
@@ -39,10 +39,7 @@ function BlockContextualToolbar( { focusOnMount, ...props } ) {
 				aria-label={ __( 'Block tools' ) }
 				{ ...props }
 			>
-				<BlockToolbar
-					onDragStart={ props.onDragStart }
-					onDragEnd={ props.onDragEnd }
-				/>
+				<BlockToolbar />
 			</NavigableToolbar>
 		</div>
 	);

--- a/packages/block-editor/src/components/block-list/block-popover.js
+++ b/packages/block-editor/src/components/block-list/block-popover.js
@@ -31,7 +31,6 @@ function selector( select ) {
 		isCaretWithinFormattedText,
 		getSettings,
 		getLastMultiSelectedBlockClientId,
-		isDraggingBlocks,
 	} = select( 'core/block-editor' );
 	return {
 		isNavigationMode: isNavigationMode(),
@@ -41,7 +40,6 @@ function selector( select ) {
 		hasMultiSelection: hasMultiSelection(),
 		hasFixedToolbar: getSettings().hasFixedToolbar,
 		lastClientId: getLastMultiSelectedBlockClientId(),
-		isDragging: isDraggingBlocks(),
 	};
 }
 
@@ -61,7 +59,6 @@ function BlockPopover( {
 		hasMultiSelection,
 		hasFixedToolbar,
 		lastClientId,
-		isDragging,
 	} = useSelect( selector, [] );
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const [ isToolbarForced, setIsToolbarForced ] = useState( false );
@@ -98,8 +95,7 @@ function BlockPopover( {
 		! shouldShowBreadcrumb &&
 		! shouldShowContextualToolbar &&
 		! isToolbarForced &&
-		! showEmptyBlockSideInserter &&
-		! isDragging
+		! showEmptyBlockSideInserter
 	) {
 		return null;
 	}
@@ -139,14 +135,6 @@ function BlockPopover( {
 		setIsInserterShown( false );
 	}
 
-	function onDragStart() {
-		setIsToolbarForced( true );
-	}
-
-	function onDragEnd() {
-		setIsToolbarForced( false );
-	}
-
 	// Position above the anchor, pop out towards the right, and position in the
 	// left corner. For the side inserter, pop out towards the left, and
 	// position in the right corner.
@@ -170,11 +158,6 @@ function BlockPopover( {
 			__unstableObserveElement={ node }
 			onBlur={ () => setIsToolbarForced( false ) }
 			shouldAnchorIncludePadding
-			// Popover calculates the width once. Trigger a reset by remounting
-			// the component. We include both shouldShowContextualToolbar and isToolbarForced
-			// in the key to prevent the component being unmounted unexpectedly when isToolbarForced = true,
-			// e.g. during drag and drop
-			key={ shouldShowContextualToolbar || isToolbarForced }
 		>
 			{ ( shouldShowContextualToolbar || isToolbarForced ) && (
 				<div
@@ -206,8 +189,6 @@ function BlockPopover( {
 					// If the toolbar is being shown because of being forced
 					// it should focus the toolbar right after the mount.
 					focusOnMount={ isToolbarForced }
-					onDragStart={ onDragStart }
-					onDragEnd={ onDragEnd }
 				/>
 			) }
 			{ shouldShowBreadcrumb && (


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Related to these comments ...
- https://github.com/WordPress/gutenberg/pull/23082/files#r444180517
- https://github.com/WordPress/gutenberg/pull/23444#pullrequestreview-437278675

... this PR removes the BlockPopover `key` and some of the related code. 

## How has this been tested?
Manual testing of drag and drop and block toolbar.

## Types of changes
Non-breaking code quality change
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
