### PR TITLE
[RNMobile] Fix gutenberg related warnings on xcode project

### DIFF
--- a/packages/react-native-bridge/ios/Gutenberg.swift
+++ b/packages/react-native-bridge/ios/Gutenberg.swift
@@ -222,7 +222,7 @@ extension Gutenberg {
 }
 
 public extension Gutenberg.MediaSource {
-    public init(id: String, label: String, types: [Gutenberg.MediaType]) {
+    init(id: String, label: String, types: [Gutenberg.MediaType]) {
         self.id = id
         self.label = label
         self.types = Set(types)

--- a/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
+++ b/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
@@ -80,6 +80,9 @@ extension LogLevel {
         case .warning: self = .warn
         case .error: self = .error
         case .fatal: self = .fatal
+        @unknown default:
+            assertionFailure("Unknown log level: \(rnLogLevel)")
+            self = .trace
         }
     }
 }

--- a/packages/react-native-editor/ios/Podfile.lock
+++ b/packages/react-native-editor/ios/Podfile.lock
@@ -21,7 +21,7 @@ PODS:
     - DoubleConversion
     - glog
   - glog (0.3.5)
-  - Gutenberg (8.4.0-rc.1):
+  - Gutenberg (8.4.0):
     - React (= 0.61.5)
     - React-CoreModules (= 0.61.5)
     - React-RCTImage (= 0.61.5)
@@ -372,7 +372,7 @@ SPEC CHECKSUMS:
   FBReactNativeSpec: 118d0d177724c2d67f08a59136eb29ef5943ec75
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
-  Gutenberg: f7055103da8a673d813ecec75875d973e3d25445
+  Gutenberg: 42a3ed491af07194744d45aa7fc44b8202ea1a5b
   RCTRequired: b153add4da6e7dbc44aebf93f3cf4fcae392ddf1
   RCTTypeSafety: 9aa1b91d7f9310fc6eadc3cf95126ffe818af320
   React: b6a59ef847b2b40bb6e0180a97d0ca716969ac78

--- a/packages/react-native-editor/ios/gutenberg/GutenbergViewController.swift
+++ b/packages/react-native-editor/ios/gutenberg/GutenbergViewController.swift
@@ -71,7 +71,7 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
         print("↳ Content changed: \(changed)")
         print("↳ Title: \(title)")
         print("↳ HTML: \(html)")
-        print("↳ Content Info: \(contentInfo)")
+        print("↳ Content Info: \(String(describing: contentInfo))")
         self.contentInfo = contentInfo
     }
 


### PR DESCRIPTION
This PR fixes a few warnings on the example Xcode project.

To test:
- Open `ios/gutenberg.xcworkspace` with Xcode.
- Build the project.
- Check that there are no warnings under `gutenberg` pod and `gutenberg` project.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
