### PR TITLE
[iOS] Adding the posibility for the client to addd a loading view

### DIFF
--- a/packages/react-native-bridge/ios/Gutenberg.swift
+++ b/packages/react-native-bridge/ios/Gutenberg.swift
@@ -13,7 +13,9 @@ public class Gutenberg: NSObject {
     private var extraModules: [RCTBridgeModule];
 
     public lazy var rootView: UIView = {
-        return RCTRootView(bridge: bridge, moduleName: "gutenberg", initialProperties: initialProps)
+        let view = RCTRootView(bridge: bridge, moduleName: "gutenberg", initialProperties: initialProps)
+        view.loadingView = dataSource.loadingView
+        return view
     }()
 
     public var delegate: GutenbergBridgeDelegate? {

--- a/packages/react-native-bridge/ios/GutenbergBridgeDataSource.swift
+++ b/packages/react-native-bridge/ios/GutenbergBridgeDataSource.swift
@@ -37,13 +37,16 @@ public protocol GutenbergBridgeDataSource: class {
     /// - Returns: Gutenberg related localization key value pairs for the current locale.
     func gutenbergTranslations() -> [String : [String]]?
 
-    /// Asks the delegate for a list of Media Sources to show on the Media Source Picker.
+    /// Asks the data source for a list of Media Sources to show on the Media Source Picker.
     func gutenbergMediaSources() -> [Gutenberg.MediaSource]
 
     func gutenbergCapabilities() -> [String: Bool]?
 
-    /// Asks the delegate for a list of theme colors
+    /// Asks the data source for a list of theme colors.
     func gutenbergEditorTheme() -> GutenbergEditorTheme?
+
+    /// Asks the data source for a view to show while the Editor is loading.
+     var loadingView: UIView? { get }
 }
 
 public extension GutenbergBridgeDataSource {
@@ -54,6 +57,10 @@ public extension GutenbergBridgeDataSource {
     func gutenbergPostType() -> String {
         return "post"
     }
+
+    var loadingView: UIView? {
+         return nil
+     }
 }
 
 public protocol GutenbergEditorTheme {


### PR DESCRIPTION
This PR adds support for the client to set a custom loading view while the editor is starting up.

Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1179

Gutenberg-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2382
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14310

To test:
- Check out WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14310
- Follow the steps described in that PR.

![skeleton](https://user-images.githubusercontent.com/9772967/84534223-d3dc2980-ace9-11ea-93cd-25e4480be1f8.gif)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
