### PR TITLE
[RN-MOBILE] fix line height crash

### DIFF
--- a/packages/react-native-aztec/src/AztecView.js
+++ b/packages/react-native-aztec/src/AztecView.js
@@ -162,11 +162,28 @@ class AztecView extends React.Component {
 
 	render() {
 		// eslint-disable-next-line no-unused-vars
-		const { onActiveFormatsChange, onFocus, ...otherProps } = this.props;
+		const {
+			onActiveFormatsChange,
+			style,
+			...otherProps
+		} = this.props;
+
+		if ( style.hasOwnProperty( 'lineHeight' ) ) {
+			delete style.lineHeight;
+			window.console.warn(
+				"Removing lineHeight style as it's not supported by native AztecView"
+			);
+			// IMPORTANT: Current Gutenberg implementation is supporting line-height without unit e.g. 'line-height':1.5
+			// and library which we are using to convert css to react-native requires unit to be included with dimension
+			// https://github.com/kristerkari/css-to-react-native-transform/blob/945866e84a505fdfb1a43b03ebe4bd32784a7f22/src/index.spec.js#L1234
+			// which means that we would need to patch the library if we want to support line-height from native AztecView in the future.
+		}
+
 		return (
 			<TouchableWithoutFeedback onPress={ this._onPress }>
 				<RCTAztecView
 					{ ...otherProps }
+					style={ style }
 					onContentSizeChange={ this._onContentSizeChange }
 					onHTMLContentWithCursor={ this._onHTMLContentWithCursor }
 					onSelectionChange={ this._onSelectionChange }

--- a/packages/react-native-aztec/src/AztecView.js
+++ b/packages/react-native-aztec/src/AztecView.js
@@ -162,11 +162,7 @@ class AztecView extends React.Component {
 
 	render() {
 		// eslint-disable-next-line no-unused-vars
-		const {
-			onActiveFormatsChange,
-			style,
-			...otherProps
-		} = this.props;
+		const { onActiveFormatsChange, style, ...otherProps } = this.props;
 
 		if ( style.hasOwnProperty( 'lineHeight' ) ) {
 			delete style.lineHeight;

--- a/packages/react-native-editor/src/initial-html.js
+++ b/packages/react-native-editor/src/initial-html.js
@@ -242,4 +242,8 @@ else:
 <!-- /wp:heading -->
 
 <!-- wp:rss /-->
+
+<!-- wp:heading {"align":"left","level":4,"className":"has-primary-background-color has-background","style":{"typography":{"lineHeight":"2.5"}}} -->
+<h4 class="has-text-align-left has-primary-background-color has-background" style="line-height:2.5">Heading with line-height set</h4>
+<!-- /wp:heading -->
 `;


### PR DESCRIPTION
Fixes: https://github.com/wordpress-mobile/WordPress-Android/issues/12211

## Description
Current Gutenberg implementation is supporting line-height without unit e.g. 'line-height':1.5
and library which we are using to [convert css to react-native](https://github.com/kristerkari/css-to-react-native-transform/blob/945866e84a505fdfb1a43b03ebe4bd32784a7f22/src/index.spec.js#L1234) requires unit to be included with dimension and that scenario is leading to crash _of the Aztec wrapper on Android_.

However, we didn't choose to fix (patch) the library as native AztevView doesn't support lineHeight at this moment so focus on this fix was to remove lineHeight from style.


## How has this been tested?
Run the Demo app and app shouldn't crash

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
