### PR TITLE
Table block: Fix focus loss in between row/column insertions.

### DIFF
--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -291,14 +291,21 @@ export class TableEdit extends Component {
 
 		const { attributes, setAttributes } = this.props;
 		const { sectionName, rowIndex } = selectedCell;
+		const newRowIndex = rowIndex + delta;
 
-		this.setState( { selectedCell: null } );
 		setAttributes(
 			insertRow( attributes, {
 				sectionName,
-				rowIndex: rowIndex + delta,
+				rowIndex: newRowIndex,
 			} )
 		);
+		// this just allows to be able to add more rows, by enabling the corresponding
+		// buttons. It needs to be revised when programmatically focus to RichText is handled
+		this.createOnFocus( {
+			sectionName,
+			rowIndex: newRowIndex,
+			columnIndex: 0,
+		} );
 	}
 
 	/**
@@ -346,13 +353,19 @@ export class TableEdit extends Component {
 
 		const { attributes, setAttributes } = this.props;
 		const { columnIndex } = selectedCell;
+		const newColumnIndex = columnIndex + delta;
 
-		this.setState( { selectedCell: null } );
 		setAttributes(
 			insertColumn( attributes, {
-				columnIndex: columnIndex + delta,
+				columnIndex: newColumnIndex,
 			} )
 		);
+		// this just allows to be able to add more rows, by enabling the corresponding
+		// buttons. It needs to be revised when programmatically focus to RichText is handled
+		this.createOnFocus( {
+			rowIndex: 0,
+			columnIndex: newColumnIndex,
+		} );
 	}
 
 	/**

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -301,10 +301,13 @@ export class TableEdit extends Component {
 		);
 		// this just allows to be able to add more rows, by enabling the corresponding
 		// buttons. It needs to be revised when programmatically focus to RichText is handled
-		this.createOnFocus( {
-			sectionName,
-			rowIndex: newRowIndex,
-			columnIndex: 0,
+		this.setState( {
+			selectedCell: {
+				sectionName,
+				rowIndex: newRowIndex,
+				columnIndex: 0,
+				type: 'cell',
+			},
 		} );
 	}
 
@@ -362,9 +365,12 @@ export class TableEdit extends Component {
 		);
 		// this just allows to be able to add more rows, by enabling the corresponding
 		// buttons. It needs to be revised when programmatically focus to RichText is handled
-		this.createOnFocus( {
-			rowIndex: 0,
-			columnIndex: newColumnIndex,
+		this.setState( {
+			selectedCell: {
+				rowIndex: 0,
+				columnIndex: newColumnIndex,
+				type: 'cell',
+			},
 		} );
 	}
 

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -299,8 +299,7 @@ export class TableEdit extends Component {
 				rowIndex: newRowIndex,
 			} )
 		);
-		// this just allows to be able to add more rows, by enabling the corresponding
-		// buttons. It needs to be revised when programmatically focus to RichText is handled
+		// Select the first cell of the new row
 		this.setState( {
 			selectedCell: {
 				sectionName,

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -362,8 +362,7 @@ export class TableEdit extends Component {
 				columnIndex: newColumnIndex,
 			} )
 		);
-		// this just allows to be able to add more rows, by enabling the corresponding
-		// buttons. It needs to be revised when programmatically focus to RichText is handled
+		// Select the first cell of the new column
 		this.setState( {
 			selectedCell: {
 				rowIndex: 0,


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

Fixes #23103

This PR just allows to be able to add more rows/columns, by enabling the corresponding buttons, after having added a row/column.

To reproduce what happens now:
- Go to a post/page
- Add a `Table` block ( ex 2x2 ) and insert some text in a cell
- Go to the `Toolbar` and click `Add a row Before/After`
- Go to the `Toolbar` again and in the Dropdown menu for adding rows you'll see that everything is disabled

Other enhancements on `Table` block can be handled separately, such as adding keyboard support for some actions. 

It needs to be revised when programmatically focus to RichText is handled, as mentioned here #9740.



## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
