### PR TITLE
Allow new a new default to be set when registering a Block Style

### DIFF
--- a/packages/blocks/src/store/test/reducer.js
+++ b/packages/blocks/src/store/test/reducer.js
@@ -90,6 +90,39 @@ describe( 'blockStyles', () => {
 		} );
 	} );
 
+	it( 'should allow a new default block style to be assigned', () => {
+		const original = deepFreeze( {
+			'core/image': [ { name: 'posh', isDefault: true } ],
+		} );
+
+		let state = blockStyles( original, {
+			type: 'ADD_BLOCK_STYLES',
+			blockName: 'core/image',
+			styles: [ { name: 'fancy', isDefault: true } ],
+		} );
+
+		expect( state ).toEqual( {
+			'core/image': [
+				{ name: 'fancy', isDefault: true },
+				{ name: 'posh', isDefault: false },
+			],
+		} );
+
+		state = blockStyles( state, {
+			type: 'ADD_BLOCK_STYLES',
+			blockName: 'core/image',
+			styles: [ { name: 'lightbox', isDefault: true } ],
+		} );
+
+		expect( state ).toEqual( {
+			'core/image': [
+				{ name: 'lightbox', isDefault: true },
+				{ name: 'fancy', isDefault: false },
+				{ name: 'posh', isDefault: false },
+			],
+		} );
+	} );
+
 	it( 'should add block styles when adding a block', () => {
 		const original = deepFreeze( {
 			'core/image': [ { name: 'fancy' } ],


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Half fixes #23211.

This change needs some thought, as I'm not sure what the exact behavior should be.

Props to @oxyc for the debugging in the issue. This PR follows the suggestion of removing prior defaults, and also moves the newly set default to be the first in the list.

It doesn't solve the issue of the default classname not being present on the block. However that also wasn't the case prior to https://github.com/WordPress/gutenberg/pull/22266, so I'm unsure if it needs to be fixed.

## How has this been tested?
1. Run the following in the console:
```js
wp.blocks.registerBlockStyle( 'core/button', {
    name: 'cpl-button--action',
    label: 'CPL\'s Link default action ',
    isDefault: true
} );
```
2. Add a Buttons block.
3. Select the Button
4. Use the styles panel for a button block
5. All styles should be selectable
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
<img width="271" alt="Screenshot 2020-06-26 at 7 05 00 pm" src="https://user-images.githubusercontent.com/677833/85850749-fab55800-b7df-11ea-938f-375e3a399473.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
