### PR TITLE
Add missing notices dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10831,6 +10831,7 @@
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/icons": "file:packages/icons",
+				"@wordpress/notices": "file:packages/notices",
 				"@wordpress/plugins": "file:packages/plugins",
 				"lodash": "^4.17.15"
 			}
@@ -10855,6 +10856,7 @@
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"@wordpress/keyboard-shortcuts": "file:packages/keyboard-shortcuts",
 				"@wordpress/keycodes": "file:packages/keycodes",
+				"@wordpress/notices": "file:packages/notices",
 				"@wordpress/rich-text": "file:packages/rich-text",
 				"@wordpress/shortcode": "file:packages/shortcode",
 				"@wordpress/token-list": "file:packages/token-list",
@@ -10902,6 +10904,7 @@
 				"@wordpress/icons": "file:packages/icons",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"@wordpress/keycodes": "file:packages/keycodes",
+				"@wordpress/notices": "file:packages/notices",
 				"@wordpress/primitives": "file:packages/primitives",
 				"@wordpress/rich-text": "file:packages/rich-text",
 				"@wordpress/server-side-render": "file:packages/server-side-render",

--- a/packages/block-directory/package.json
+++ b/packages/block-directory/package.json
@@ -37,6 +37,7 @@
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
+		"@wordpress/notices": "file:../notices",
 		"@wordpress/plugins": "file:../plugins",
 		"lodash": "^4.17.15"
 	},

--- a/packages/block-directory/src/index.js
+++ b/packages/block-directory/src/index.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import '@wordpress/notices';
+
+/**
  * Internal dependencies
  */
 import './store';

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -44,6 +44,7 @@
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
 		"@wordpress/keycodes": "file:../keycodes",
+		"@wordpress/notices": "file:../notices",
 		"@wordpress/rich-text": "file:../rich-text",
 		"@wordpress/shortcode": "file:../shortcode",
 		"@wordpress/token-list": "file:../token-list",

--- a/packages/block-editor/src/index.js
+++ b/packages/block-editor/src/index.js
@@ -5,6 +5,7 @@ import '@wordpress/blocks';
 import '@wordpress/rich-text';
 import '@wordpress/viewport';
 import '@wordpress/keyboard-shortcuts';
+import '@wordpress/notices';
 
 /**
  * Internal dependencies

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -47,6 +47,7 @@
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/keycodes": "file:../keycodes",
+		"@wordpress/notices": "file:../notices",
 		"@wordpress/primitives": "file:../primitives",
 		"@wordpress/rich-text": "file:../rich-text",
 		"@wordpress/server-side-render": "file:../server-side-render",

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import '@wordpress/core-data';
+import '@wordpress/notices';
 import '@wordpress/block-editor';
 import {
 	registerBlockType,


### PR DESCRIPTION
When we use stores, we often forget to add the related dependency. Missing a dependency can cause breakage in contexts that are not  "WordPress" or "Gutenberg plugin".

This PR fixes the playground (typing  on the  playground is broken without this PR)