### PR TITLE
Cover: Show Resize Tooltip on Drag

### DIFF
--- a/packages/block-library/src/cover/edit/resizable-cover.js
+++ b/packages/block-library/src/cover/edit/resizable-cover.js
@@ -49,6 +49,12 @@ export default function ResizableCover( {
 				onResizeStop( elt.clientHeight );
 				setIsResizing( false );
 			} }
+			__experimentalShowTooltip
+			__experimentalTooltipProps={ {
+				axis: 'y',
+				position: 'bottom',
+				isVisible: isResizing,
+			} }
 			{ ...props }
 		/>
 	);


### PR DESCRIPTION
![cover-resize-tooltip](https://user-images.githubusercontent.com/2322354/85886778-a8ab0d00-b7b4-11ea-9d11-bfcd3ee9686f.gif)

This update enables the Resize tooltip for the Cover block. It appears below the cover block when dragging.

## How has this been tested?

Tested in local Gutenberg

* Run `npm run dev`
* Add a Cover block
* Drag to resize
* Ensure tooltip renders


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [n/a] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [n/a] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [n/a] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
