### PR TITLE
Updated styling to match the post editor

### DIFF
--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -84,7 +84,7 @@ export default function Header( {
 				<Button
 					isPrimary
 					isPressed={ isInserterOpen }
-					className='edit-site-header-toolbar__inserter-toggle'
+					className="edit-site-header-toolbar__inserter-toggle"
 					onClick={ onToggleInserter }
 					icon={ plus }
 					label={ _x(

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -84,6 +84,7 @@ export default function Header( {
 				<Button
 					isPrimary
 					isPressed={ isInserterOpen }
+					className='edit-site-header-toolbar__inserter-toggle'
 					onClick={ onToggleInserter }
 					icon={ plus }
 					label={ _x(

--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -9,11 +9,16 @@
 .edit-site-header__toolbar {
 	display: flex;
 	flex-grow: 1;
-	padding-left: $grid-unit-10;
+	padding-left: $grid-unit-30;
 	align-items: center;
 
-	& > * {
+	.edit-site-header-toolbar__inserter-toggle {
 		margin-left: 5px;
+		margin-right: $grid-unit-10;
+		min-width: $grid-unit-40;
+		width: $grid-unit-40;
+		height: $grid-unit-40;
+		padding: 0;
 	}
 }
 


### PR DESCRIPTION
Fixes #23183 and a padding/spacing issue with the top bar inserter (and other buttons). Everything should be pretty close, now (though I do think they should share styles rather than repeat them).

#### Before

![image](https://user-images.githubusercontent.com/1123119/85791772-a2069200-b6ef-11ea-9c19-aa3a1b3c7ee3.png)


#### After

![image](https://user-images.githubusercontent.com/1123119/85791628-653a9b00-b6ef-11ea-89e4-f26d060bf1e8.png)
