### PR TITLE
Image Editor: Stabilize endpoint

### DIFF
--- a/lib/class-wp-rest-image-editor-controller.php
+++ b/lib/class-wp-rest-image-editor-controller.php
@@ -23,8 +23,8 @@ class WP_REST_Image_Editor_Controller extends WP_REST_Controller {
 	 * @access public
 	 */
 	public function __construct() {
-		$this->namespace = '__experimental';
-		$this->rest_base = '/image-editor/(?P<media_id>[\d]+)';
+		$this->namespace = 'wp/v2';
+		$this->rest_base = 'media';
 	}
 
 	/**
@@ -36,7 +36,7 @@ class WP_REST_Image_Editor_Controller extends WP_REST_Controller {
 	public function register_routes() {
 		register_rest_route(
 			$this->namespace,
-			$this->rest_base . '/apply',
+			'/' . $this->rest_base . '/(?P<id>[\d]+)/edit',
 			array(
 				array(
 					'methods'             => WP_REST_Server::EDITABLE,
@@ -84,7 +84,7 @@ class WP_REST_Image_Editor_Controller extends WP_REST_Controller {
 	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
 	 */
 	public function permission_callback( $request ) {
-		if ( ! current_user_can( 'edit_post', $request['media_id'] ) ) {
+		if ( ! current_user_can( 'edit_post', $request['id'] ) ) {
 			$error = __( 'Sorry, you are not allowed to edit images.', 'gutenberg' );
 			return new WP_Error( 'rest_cannot_edit_image', $error, array( 'status' => rest_authorization_required_code() ) );
 		}
@@ -109,7 +109,7 @@ class WP_REST_Image_Editor_Controller extends WP_REST_Controller {
 		require_once ABSPATH . 'wp-admin/includes/image.php';
 
 		$params        = $request->get_params();
-		$attachment_id = $params['media_id'];
+		$attachment_id = $params['id'];
 
 		// This also confirms the attachment is an image.
 		$image_file = wp_get_original_image_path( $attachment_id );

--- a/lib/class-wp-rest-image-editor-controller.php
+++ b/lib/class-wp-rest-image-editor-controller.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Start: Include for phase 2
- * REST API: WP_REST_Menus_Controller class
+ * REST API: WP_REST_Image_Editor_Controller class
  *
  * @package    WordPress
  * @subpackage REST_API

--- a/lib/class-wp-rest-image-editor-controller.php
+++ b/lib/class-wp-rest-image-editor-controller.php
@@ -120,6 +120,16 @@ class WP_REST_Image_Editor_Controller extends WP_REST_Controller {
 			return new WP_Error( 'rest_unknown_attachment', $error, array( 'status' => 404 ) );
 		}
 
+		$supported_types = array( 'image/jpeg', 'image/png', 'image/gif' );
+		$mime_type       = get_post_mime_type( $request['id'] );
+		if ( ! in_array( $mime_type, $supported_types, true ) ) {
+			return new WP_Error(
+				'rest_cannot_edit_file_type',
+				__( 'Sorry, you are not allowed to edit file type.', 'gutenberg' ),
+				array( 'status' => 400 )
+			);
+		}
+
 		// Check if we need to do anything.
 		$rotate = 0;
 		$crop   = false;

--- a/lib/class-wp-rest-image-editor-controller.php
+++ b/lib/class-wp-rest-image-editor-controller.php
@@ -108,8 +108,7 @@ class WP_REST_Image_Editor_Controller extends WP_REST_Controller {
 	public function apply_edits( $request ) {
 		require_once ABSPATH . 'wp-admin/includes/image.php';
 
-		$params        = $request->get_params();
-		$attachment_id = $params['id'];
+		$attachment_id = $request['id'];
 
 		// This also confirms the attachment is an image.
 		$image_file = wp_get_original_image_path( $attachment_id );
@@ -134,12 +133,12 @@ class WP_REST_Image_Editor_Controller extends WP_REST_Controller {
 		$rotate = 0;
 		$crop   = false;
 
-		if ( ! empty( $params['rotation'] ) ) {
+		if ( ! empty( $request['rotation'] ) ) {
 			// Rotation direction: clockwise vs. counter clockwise.
-			$rotate = 0 - (int) $params['rotation'];
+			$rotate = 0 - (int) $request['rotation'];
 		}
 
-		if ( isset( $params['x'], $params['y'], $params['width'], $params['height'] ) ) {
+		if ( isset( $request['x'], $request['y'], $request['width'], $request['height'] ) ) {
 			$crop = true;
 		}
 
@@ -168,10 +167,10 @@ class WP_REST_Image_Editor_Controller extends WP_REST_Controller {
 		if ( $crop ) {
 			$size = $image_editor->get_size();
 
-			$crop_x = round( ( $size['width'] * floatval( $params['x'] ) ) / 100.0 );
-			$crop_y = round( ( $size['height'] * floatval( $params['y'] ) ) / 100.0 );
-			$width  = round( ( $size['width'] * floatval( $params['width'] ) ) / 100.0 );
-			$height = round( ( $size['height'] * floatval( $params['height'] ) ) / 100.0 );
+			$crop_x = round( ( $size['width'] * floatval( $request['x'] ) ) / 100.0 );
+			$crop_y = round( ( $size['height'] * floatval( $request['y'] ) ) / 100.0 );
+			$width  = round( ( $size['width'] * floatval( $request['width'] ) ) / 100.0 );
+			$height = round( ( $size['height'] * floatval( $request['height'] ) ) / 100.0 );
 
 			$result = $image_editor->crop( $crop_x, $crop_y, $width, $height );
 

--- a/lib/class-wp-rest-image-editor-controller.php
+++ b/lib/class-wp-rest-image-editor-controller.php
@@ -124,7 +124,7 @@ class WP_REST_Image_Editor_Controller extends WP_REST_Controller {
 		if ( ! in_array( $mime_type, $supported_types, true ) ) {
 			return new WP_Error(
 				'rest_cannot_edit_file_type',
-				__( 'Sorry, you are not allowed to edit file type.', 'gutenberg' ),
+				__( 'This type of file cannot be edited.', 'gutenberg' ),
 				array( 'status' => 400 )
 			);
 		}

--- a/lib/class-wp-rest-image-editor-controller.php
+++ b/lib/class-wp-rest-image-editor-controller.php
@@ -259,8 +259,10 @@ class WP_REST_Image_Editor_Controller extends WP_REST_Controller {
 
 		wp_update_attachment_metadata( $new_attachment_id, $new_image_meta );
 
-		$path     = '/wp/v2/media/' . $new_attachment_id;
-		$response = rest_do_request( $path );
+		$path        = '/wp/v2/media/' . $new_attachment_id;
+		$new_request = new WP_REST_Request( 'GET', $path );
+		$new_request->set_query_params( array( 'context' => 'edit' ) );
+		$response = rest_do_request( $new_request );
 
 		if ( ! $response->is_error() ) {
 			$response->set_status( 201 );

--- a/lib/class-wp-rest-image-editor-controller.php
+++ b/lib/class-wp-rest-image-editor-controller.php
@@ -217,7 +217,7 @@ class WP_REST_Image_Editor_Controller extends WP_REST_Controller {
 			'post_content'   => '',
 		);
 
-		$new_attachment_id = wp_insert_attachment( $attachment_post, $saved['path'], 0, true );
+		$new_attachment_id = wp_insert_attachment( wp_slash( $attachment_post ), $saved['path'], 0, true );
 
 		if ( is_wp_error( $new_attachment_id ) ) {
 			if ( 'db_update_error' === $new_attachment_id->get_error_code() ) {

--- a/lib/class-wp-rest-image-editor-controller.php
+++ b/lib/class-wp-rest-image-editor-controller.php
@@ -120,7 +120,7 @@ class WP_REST_Image_Editor_Controller extends WP_REST_Controller {
 		}
 
 		$supported_types = array( 'image/jpeg', 'image/png', 'image/gif' );
-		$mime_type       = get_post_mime_type( $request['id'] );
+		$mime_type       = get_post_mime_type( $attachment_id );
 		if ( ! in_array( $mime_type, $supported_types, true ) ) {
 			return new WP_Error(
 				'rest_cannot_edit_file_type',

--- a/packages/block-library/src/image/image-editor.js
+++ b/packages/block-library/src/image/image-editor.js
@@ -25,7 +25,7 @@ import {
 	MenuGroup,
 	MenuItem,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
 
@@ -188,10 +188,12 @@ export default function ImageEditor( {
 					height: height && width ? width / aspect : undefined,
 				} );
 			} )
-			.catch( () => {
+			.catch( ( error ) => {
 				createErrorNotice(
-					__(
-						'Unable to perform the image modification. Please check your media storage.'
+					sprintf(
+						/* translators: 1. Error message */
+						__( 'Could not edit image. %s' ),
+						error.message
 					),
 					{
 						id: 'image-editing-error',

--- a/packages/block-library/src/image/image-editor.js
+++ b/packages/block-library/src/image/image-editor.js
@@ -177,7 +177,7 @@ export default function ImageEditor( {
 		}
 
 		apiFetch( {
-			path: `__experimental/image-editor/${ id }/apply`,
+			path: `wp/v2/media/${ id }/edit`,
 			method: 'POST',
 			data: attrs,
 		} )


### PR DESCRIPTION
## Description
- Changes the namespace to `wp/v2` and the endpoint to `/media/<id>/edit`.
- Makes some code style changes for Core.
- Includes REST API error message in error notice.
- Checks if mime type is valid.

## How has this been tested?
Manually tested editing an image.

## Types of changes
Breaking change.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
