### PR TITLE
Docs: Remove errant </a> tag

### DIFF
--- a/docs/contributors/reference.md
+++ b/docs/contributors/reference.md
@@ -14,4 +14,4 @@ Released under GPL license, made by [Cristel Rossignol](https://twitter.com/cris
 
 ## Mockups
 
-Mockup Sketch files are available in [the Design section](/docs/designers-developers/designers/design-resources.md)</a>.
+Mockup Sketch files are available in [the Design section](/docs/designers-developers/designers/design-resources.md).


### PR DESCRIPTION

## Description

I noticed this page has an errant `</a>` tag that does not belong.
This removes it.

## How has this been tested?

Confirm the markdown looks right.

## Types of changes

Documentation.
