### PR TITLE
Classic block: Add scroll to last edit position

### DIFF
--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -73,6 +73,19 @@ export default class ClassicEdit extends Component {
 		}
 	}
 
+	isElementInViewport( el ) {
+		const rect = el.getBoundingClientRect();
+		return (
+			rect.top >= 0 &&
+			rect.left >= 0 &&
+			rect.bottom <=
+				( window.innerHeight ||
+					document.documentElement.clientHeight ) &&
+			rect.right <=
+				( window.innerWidth || document.documentElement.clientWidth )
+		);
+	}
+
 	initialize() {
 		const { clientId } = this.props;
 		const { settings } = window.wpEditorL10n.tinymce;
@@ -91,6 +104,7 @@ export default class ClassicEdit extends Component {
 		const {
 			attributes: { content },
 			setAttributes,
+			isSelected,
 		} = this.props;
 		const { ref } = this;
 		let bookmark;
@@ -104,14 +118,19 @@ export default class ClassicEdit extends Component {
 		editor.on( 'blur', () => {
 			bookmark = editor.selection.getBookmark( 2, true );
 
-			setAttributes( {
-				content: editor.getContent(),
-			} );
+			if ( ! isSelected ) {
+				setAttributes( {
+					content: editor.getContent(),
+				} );
+			}
 
 			editor.once( 'focus', () => {
 				if ( bookmark ) {
 					editor.selection.moveToBookmark( bookmark );
-					editor.selection.getNode().scrollIntoView( false );
+					const selectedNode = editor.selection.getNode();
+					if ( ! this.isElementInViewport( selectedNode ) ) {
+						selectedNode.scrollIntoView( false );
+					}
 				}
 			} );
 

--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -111,6 +111,7 @@ export default class ClassicEdit extends Component {
 			editor.once( 'focus', () => {
 				if ( bookmark ) {
 					editor.selection.moveToBookmark( bookmark );
+					editor.selection.getNode().scrollIntoView( false );
 				}
 			} );
 

--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -120,7 +120,9 @@ export default class ClassicEdit extends Component {
 			// There is an issue with Chrome and the editor.focus call in core at https://core.trac.wordpress.org/browser/trunk/src/js/_enqueues/lib/link.js#L451.
 			// This causes a scroll to the top of editor content on return from some content updating dialogs tracking
 			// scroll position until this is fixed in core.
-			const scrollContainer = document.querySelector('.interface-interface-skeleton__content');
+			const scrollContainer = document.querySelector(
+				'.interface-interface-skeleton__content'
+			);
 			const scrollPosition = scrollContainer.scrollTop;
 			if ( ! isSelected ) {
 				setAttributes( {

--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -104,7 +104,6 @@ export default class ClassicEdit extends Component {
 		const {
 			attributes: { content },
 			setAttributes,
-			isSelected,
 		} = this.props;
 		const { ref } = this;
 		let bookmark;
@@ -124,11 +123,10 @@ export default class ClassicEdit extends Component {
 				'.interface-interface-skeleton__content'
 			);
 			const scrollPosition = scrollContainer.scrollTop;
-			if ( ! isSelected ) {
-				setAttributes( {
-					content: editor.getContent(),
-				} );
-			}
+
+			setAttributes( {
+				content: editor.getContent(),
+			} );
 
 			editor.once( 'focus', () => {
 				if ( bookmark ) {

--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -73,19 +73,6 @@ export default class ClassicEdit extends Component {
 		}
 	}
 
-	isElementInViewport( el ) {
-		const rect = el.getBoundingClientRect();
-		return (
-			rect.top >= 0 &&
-			rect.left >= 0 &&
-			rect.bottom <=
-				( window.innerHeight ||
-					document.documentElement.clientHeight ) &&
-			rect.right <=
-				( window.innerWidth || document.documentElement.clientWidth )
-		);
-	}
-
 	initialize() {
 		const { clientId } = this.props;
 		const { settings } = window.wpEditorL10n.tinymce;
@@ -131,8 +118,7 @@ export default class ClassicEdit extends Component {
 			editor.once( 'focus', () => {
 				if ( bookmark ) {
 					editor.selection.moveToBookmark( bookmark );
-					const selectedNode = editor.selection.getNode();
-					if ( ! this.isElementInViewport( selectedNode ) ) {
+					if ( scrollContainer.scrollTop !== scrollPosition ) {
 						scrollContainer.scrollTop = scrollPosition;
 					}
 				}

--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -117,7 +117,11 @@ export default class ClassicEdit extends Component {
 
 		editor.on( 'blur', () => {
 			bookmark = editor.selection.getBookmark( 2, true );
-
+			// There is an issue with Chrome and the editor.focus call in core at https://core.trac.wordpress.org/browser/trunk/src/js/_enqueues/lib/link.js#L451.
+			// This causes a scroll to the top of editor content on return from some content updating dialogs tracking
+			// scroll position until this is fixed in core.
+			const scrollContainer = document.querySelector('.interface-interface-skeleton__content');
+			const scrollPosition = scrollContainer.scrollTop;
 			if ( ! isSelected ) {
 				setAttributes( {
 					content: editor.getContent(),
@@ -129,7 +133,7 @@ export default class ClassicEdit extends Component {
 					editor.selection.moveToBookmark( bookmark );
 					const selectedNode = editor.selection.getNode();
 					if ( ! this.isElementInViewport( selectedNode ) ) {
-						selectedNode.scrollIntoView( false );
+						scrollContainer.scrollTop = scrollPosition;
 					}
 				}
 			} );

--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -118,7 +118,7 @@ export default class ClassicEdit extends Component {
 		editor.on( 'blur', () => {
 			bookmark = editor.selection.getBookmark( 2, true );
 			// There is an issue with Chrome and the editor.focus call in core at https://core.trac.wordpress.org/browser/trunk/src/js/_enqueues/lib/link.js#L451.
-			// This causes a scroll to the top of editor content on return from some content updating dialogs tracking
+			// This causes a scroll to the top of editor content on return from some content updating dialogs so tracking
 			// scroll position until this is fixed in core.
 			const scrollContainer = document.querySelector(
 				'.interface-interface-skeleton__content'


### PR DESCRIPTION
Temporary patch for #14134 

## Description
Adds a scollTo to the last bookmarked edit position when returning from onBlur caused by link and image edit dialogs


## How has this been tested?
Just tested manually so far

## Screenshots 

Before:

<img src="https://user-images.githubusercontent.com/3629020/85960773-388dc880-b9fa-11ea-9619-12bad32e1695.gif" width="600">

After:

<img src="https://user-images.githubusercontent.com/3629020/85960774-3d527c80-b9fa-11ea-8996-99fec39a775a.gif" width="600">

## Types of changes
Adds a scrollIntoView call in order to bring selected node into view 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. 
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
