### PR TITLE
Documentation: Add block submission guidelines.

### DIFF
--- a/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
+++ b/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
@@ -49,11 +49,11 @@ Examples for an Image Slider block:
 Gutenberg allows you to indicate which category your block fits in. Choosing the right category makes it easy for users to find in the Gutenberg menu.
 
 **Possible Values**:
-- Text
-- Media
-- Design
-- Widgets
-- Embeds
+- text
+- media
+- design
+- widgets
+- embeds
 
 [Read more](https://github.com/WordPress/gutenberg/blob/master/docs/rfc/block-registration.md#category) about categories.
 

--- a/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
+++ b/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
@@ -49,11 +49,11 @@ Examples for an Image Slider block:
 Gutenberg allows you to indicate which category your block fits in. Choosing the right category makes it easy for users to find in the Gutenberg menu.
 
 **Possible Values**:
-- Common
--  Formatting
--  Layout
--  Widgets
--  embed
+- Text
+- Media
+- Design
+- Widgets
+- Embeds
 
 [Read more](https://github.com/WordPress/gutenberg/blob/master/docs/rfc/block-registration.md#category) about categories.
 

--- a/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
+++ b/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
@@ -1,0 +1,88 @@
+#Share your Gutenberg Block with the World
+So you’ve created an awesome block have you? Care to share? Here is some basic information on how to submit a block to the Block Directory.
+
+Need help building a block? Check out our block tutorials to get started. 
+
+**Contents**:
+1. Help users understand your block
+2. Analyze your plugin
+3. Zip & Submit
+
+
+## Step 1: Help users understand your block
+Providing straightforward, easy to understand block information is important to the block directory and our end users.
+
+**Guidelines**:
+
+- Name your block based on what it does
+- Clearly describe what your block does
+- Add Keywords for all contexts
+- Choose the right category
+
+### Name your block based on what it does
+Users typically search the block directory within gutenberg and do so in the context of a task. For example, when building their post, a user may search the Block Directory for an “image gallery”. Naming your block accordingly will help the Block Directory surface it when it’s needed.
+
+**Not So Good**: WebTeam5 Image Works
+**Good**: Responsive Image Slider
+
+
+**Question**: What happens when there are multiple blocks with similar names?
+TODO
+
+### Clearly describe what your block does
+The description really helps to communicate what your block does.The quicker a user understands how your block will help them, the more likely it is a user will use your block. Users will be reading your block’s description within Gutenberg where space can be limited. Try to keep it short and concise.
+
+**Not So Good**: The best way to show images on your website using jQuery and CSS.
+**Good**: An easy to use, responsive, Image gallery block. 
+
+**Note**: It’s not about marketing your block, in fact we want to avoid marketing in blocks. You can read more about it in the [plugin guidelines]. Stick to being as clear as you can. The block directory will provide metrics to let users know how awesome your block is!
+
+### Add Keywords for broader context
+Keywords add extra context to your block and make it more likely to be found in the inserter. 
+
+Examples for an Image Slider block:
+- slider
+- carousel
+- gallery
+
+[Read more]() about keywords.
+
+### Choose the right category
+Gutenberg allows you to indicate which category your block fits in. Choosing the right category makes it easy for users to find in the Gutenberg menu.
+
+**Possible Values**:
+- Common
+-  Formatting
+-  Layout
+-  Widgets
+-  embed
+
+[Read more]() about categories.
+
+Wondering where to input all this information? Read the next section :)
+
+
+## Step 2: Analyze your plugin
+
+The `block.json` file lives in the root folder of your block and provides the Block Directory and Gutenberg important information about your block. Along with being the place to store contextual information about your block like the: `name`, `description`, `keywords` and `category`, the `block.json` file stores the location of your block’s files.
+
+Double check that the following is true for your block:
+`editorScript` is pointing to the JavaScript bundle that includes all the code used in the editor.
+`editorStyle` is pointing to the CSS bundle that includes all the css used in the editor.
+`script` is pointing to the JavaScript bundle that includes all the code used on the website.
+`style` is pointing to the CSS bundle that includes all the code used on the website.
+I have included example data (Optional, but useful)
+
+Although it isn’t necessary that you have both an `editorScript/editorStyle` and `script/style` listed in your `block.json` we encourage the separation of code used for editing and code used for displaying your block in order to keep both interfaces running quickly.
+
+The `block.json` file also contains other important properties. Take a look at an example block.json file for reference.
+
+
+## Step 3: Zip & Submit
+The community is ecstatic you made it this far! Time to submit your plugin!
+
+Take a few moments to read the block guidelines (https://github.com/WordPress/wporg-plugin-guidelines/blob/block-guidelines/blocks.md)
+
+TODO - ADD MORE STUFF HERE
+
+

--- a/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
+++ b/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
@@ -1,8 +1,6 @@
 #Share your Gutenberg Block with the World
 So you’ve created an awesome block have you? Care to share? Here is some basic information on how to submit a block to the Block Directory.
 
-Need help building a block? Check out our block tutorials to get started. 
-
 **Contents**:
 1. Help users understand your block
 2. Analyze your plugin
@@ -15,27 +13,27 @@ Providing straightforward, easy to understand block information is important to 
 **Guidelines**:
 
 - Name your block based on what it does
-- Clearly describe what your block does
+- Clearly describe your block
 - Add Keywords for all contexts
 - Choose the right category
 
 ### Name your block based on what it does
-Users typically search the block directory within gutenberg and do so in the context of a task. For example, when building their post, a user may search the Block Directory for an “image gallery”. Naming your block accordingly will help the Block Directory surface it when it’s needed.
+Users typically search the block directory within gutenberg and do so in the context of a task. For example, when building their post, a user may search the Block Directory for an “image gallery”. Naming your block accordingly will help the Block Directory surface it when it's needed.
 
 **Not So Good**: WebTeam5 Image Works
-**Good**: Responsive Image Slider
+**Good**: Responsive Image Slider by WebTeam5
+
+**Question: What happens when there are multiple blocks with similar names?**
+Try your best to make your block's name functional and unique to make it stand out. Look for applicable synonyms or include a prefix if necessary.
 
 
-**Question**: What happens when there are multiple blocks with similar names?
-TODO
-
-### Clearly describe what your block does
-The description really helps to communicate what your block does.The quicker a user understands how your block will help them, the more likely it is a user will use your block. Users will be reading your block’s description within Gutenberg where space can be limited. Try to keep it short and concise.
+### Clearly describe your block
+The description really helps to communicate what your block does.The quicker a user understands how your block will help them, the more likely it is a user will use your block. Users will be reading your block's description within Gutenberg where space can be limited. Try to keep it short and concise.
 
 **Not So Good**: The best way to show images on your website using jQuery and CSS.
 **Good**: An easy to use, responsive, Image gallery block. 
 
-**Note**: It’s not about marketing your block, in fact we want to avoid marketing in blocks. You can read more about it in the [plugin guidelines]. Stick to being as clear as you can. The block directory will provide metrics to let users know how awesome your block is!
+**Tip**: It’s not about marketing your block, in fact we want to avoid marketing in blocks. You can read more about it in the [plugin guidelines]. Stick to being as clear as you can. The block directory will provide metrics to let users know how awesome your block is!
 
 ### Add Keywords for broader context
 Keywords add extra context to your block and make it more likely to be found in the inserter. 
@@ -45,7 +43,7 @@ Examples for an Image Slider block:
 - carousel
 - gallery
 
-[Read more]() about keywords.
+[Read more](https://github.com/WordPress/gutenberg/blob/master/docs/rfc/block-registration.md#keyword) about keywords.
 
 ### Choose the right category
 Gutenberg allows you to indicate which category your block fits in. Choosing the right category makes it easy for users to find in the Gutenberg menu.
@@ -57,7 +55,7 @@ Gutenberg allows you to indicate which category your block fits in. Choosing the
 -  Widgets
 -  embed
 
-[Read more]() about categories.
+[Read more](https://github.com/WordPress/gutenberg/blob/master/docs/rfc/block-registration.md#category) about categories.
 
 Wondering where to input all this information? Read the next section :)
 
@@ -67,15 +65,15 @@ Wondering where to input all this information? Read the next section :)
 The `block.json` file lives in the root folder of your block and provides the Block Directory and Gutenberg important information about your block. Along with being the place to store contextual information about your block like the: `name`, `description`, `keywords` and `category`, the `block.json` file stores the location of your block’s files.
 
 Double check that the following is true for your block:
-`editorScript` is pointing to the JavaScript bundle that includes all the code used in the editor.
-`editorStyle` is pointing to the CSS bundle that includes all the css used in the editor.
-`script` is pointing to the JavaScript bundle that includes all the code used on the website.
-`style` is pointing to the CSS bundle that includes all the code used on the website.
+`editorScript` is pointing to the JavaScript bundle that includes all the code used in the **editor**.
+`editorStyle` is pointing to the CSS bundle that includes all the css used in the **editor**.
+`script` is pointing to the JavaScript bundle that includes all the code used on the **website**.
+`style` is pointing to the CSS bundle that includes all the code used on the **website**.
 I have included example data (Optional, but useful)
 
 Although it isn’t necessary that you have both an `editorScript/editorStyle` and `script/style` listed in your `block.json` we encourage the separation of code used for editing and code used for displaying your block in order to keep both interfaces running quickly.
 
-The `block.json` file also contains other important properties. Take a look at an example block.json file for reference.
+The `block.json` file also contains other important properties. Take a look at an [example block.json](https://github.com/WordPress/gutenberg/blob/master/docs/rfc/block-registration.md#registering-a-block-type) file for reference.
 
 
 ## Step 3: Zip & Submit

--- a/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
+++ b/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
@@ -20,7 +20,7 @@ It is important to the Block Directory and our end users to provide easy to unde
 
 ### Name your block based on what it does
 
-Users typically search the block directory within the Block Editor and do so in the context of a task. For example, when building their post, a user may search the Block Directory for an “image gallery”. Naming your block accordingly will help the Block Directory surface it when it's needed.
+Users typically search the Block Directory within the Block Editor and do so in the context of a task. For example, when building their post, a user may search the Block Directory for an “image gallery”. Naming your block accordingly will help the Block Directory surface it when it's needed.
 
 **Not So Good**: WebTeam5 Image Works
 **Good**: Responsive Image Slider by WebTeam5
@@ -35,7 +35,7 @@ The description really helps to communicate what your block does.The quicker a u
 **Not So Good**: The best way to show images on your website using jQuery and CSS.
 **Good**: An easy to use, responsive, Image gallery block. 
 
-**Tip**: It’s not about marketing your block, in fact we want to avoid marketing in blocks. You can read more about it in the [plugin guidelines]. Stick to being as clear as you can. The block directory will provide metrics to let users know how awesome your block is!
+**Tip**: It’s not about marketing your block, in fact we want to avoid marketing in blocks. You can read more about it in the [plugin guidelines]. Stick to being as clear as you can. The Block Directory will provide metrics to let users know how awesome your block is!
 
 ### Add Keywords for broader context
 

--- a/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
+++ b/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
@@ -46,7 +46,7 @@ Examples for an Image Slider block:
 - carousel
 - gallery
 
-[Read more](https://github.com/WordPress/gutenberg/blob/master/docs/rfc/block-registration.md#keyword) about keywords.
+[Read more about keywords.](https://github.com/WordPress/gutenberg/blob/master/docs/rfc/block-registration.md#keyword)
 
 ### Choose the right category
 
@@ -59,7 +59,7 @@ The Block Editor allows you to indicate the category your block belongs in, maki
 - widgets
 - embed
 
-[Read more](https://github.com/WordPress/gutenberg/blob/master/docs/rfc/block-registration.md#category) about categories.
+[Read more about categories.](https://github.com/WordPress/gutenberg/blob/master/docs/rfc/block-registration.md#category)
 
 Wondering where to input all this information? Read the next section :)
 
@@ -83,7 +83,6 @@ The `block.json` file also contains other important properties. Take a look at a
 
 The community is ecstatic you made it this far! Time to submit your plugin!
 
-Take a few moments to read the block guidelines (https://github.com/WordPress/wporg-plugin-guidelines/blob/block-guidelines/blocks.md). Create a zip file of your block and navigate over to the [block plugin validator](https://wordpress.org/plugins/developers/block-plugin-validator/) and upload your plugin. 
-
+Take a few moments to read [the block guidelines](https://github.com/WordPress/wporg-plugin-guidelines/blob/block-guidelines/blocks.md). Create a zip file of your block and navigate over to the [block plugin validator](https://wordpress.org/plugins/developers/block-plugin-validator/) and upload your plugin. 
 
 

--- a/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
+++ b/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
@@ -1,5 +1,5 @@
 #Share your Block with the World
-So you’ve created an awesome block have you? Care to share? Here is some basic information on how to submit a block to the Block Directory.
+So you've created an awesome block? Care to share?
 
 **Contents**:
 1. Help users understand your block

--- a/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
+++ b/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
@@ -95,7 +95,7 @@ The `block.json` file also contains other important properties. Take a look at a
 
 ## Step 3: Zip & Submit
 
-The community is ecstatic you made it this far! Time to submit your plugin!
+The community is thankful for your contribution. It is time to submit your plugin.
 
 Take a few moments to read [the block guidelines](https://github.com/WordPress/wporg-plugin-guidelines/blob/block-guidelines/blocks.md). Create a zip file of your block and navigate over to the [block plugin validator](https://wordpress.org/plugins/developers/block-plugin-validator/) and upload your plugin. 
 

--- a/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
+++ b/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
@@ -1,4 +1,4 @@
-#Share your Gutenberg Block with the World
+#Share your Block with the World
 So you’ve created an awesome block have you? Care to share? Here is some basic information on how to submit a block to the Block Directory.
 
 **Contents**:
@@ -18,7 +18,7 @@ Providing straightforward, easy to understand block information is important to 
 - Choose the right category
 
 ### Name your block based on what it does
-Users typically search the block directory within gutenberg and do so in the context of a task. For example, when building their post, a user may search the Block Directory for an “image gallery”. Naming your block accordingly will help the Block Directory surface it when it's needed.
+Users typically search the block directory within the block editor and do so in the context of a task. For example, when building their post, a user may search the Block Directory for an “image gallery”. Naming your block accordingly will help the Block Directory surface it when it's needed.
 
 **Not So Good**: WebTeam5 Image Works
 **Good**: Responsive Image Slider by WebTeam5
@@ -28,7 +28,7 @@ Try your best to make your block's name functional and unique to make it stand o
 
 
 ### Clearly describe your block
-The description really helps to communicate what your block does.The quicker a user understands how your block will help them, the more likely it is a user will use your block. Users will be reading your block's description within Gutenberg where space can be limited. Try to keep it short and concise.
+The description really helps to communicate what your block does.The quicker a user understands how your block will help them, the more likely it is a user will use your block. Users will be reading your block's description within the block editor where space can be limited. Try to keep it short and concise.
 
 **Not So Good**: The best way to show images on your website using jQuery and CSS.
 **Good**: An easy to use, responsive, Image gallery block. 
@@ -46,7 +46,7 @@ Examples for an Image Slider block:
 [Read more](https://github.com/WordPress/gutenberg/blob/master/docs/rfc/block-registration.md#keyword) about keywords.
 
 ### Choose the right category
-Gutenberg allows you to indicate which category your block fits in. Choosing the right category makes it easy for users to find in the Gutenberg menu.
+You have the ability to indicate which category your block fits in. Choosing the right category makes it easy for users to find in the block menu.
 
 **Possible Values**:
 - text
@@ -62,7 +62,7 @@ Wondering where to input all this information? Read the next section :)
 
 ## Step 2: Analyze your plugin
 
-The `block.json` file lives in the root folder of your block and provides the Block Directory and Gutenberg important information about your block. Along with being the place to store contextual information about your block like the: `name`, `description`, `keywords` and `category`, the `block.json` file stores the location of your block’s files.
+The `block.json` file lives in the root folder of your block and provides the Block Directory important information about your block. Along with being the place to store contextual information about your block like the: `name`, `description`, `keywords` and `category`, the `block.json` file stores the location of your block’s files.
 
 Double check that the following is true for your block:
 `editorScript` is pointing to the JavaScript bundle that includes all the code used in the **editor**.

--- a/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
+++ b/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
@@ -84,6 +84,3 @@ The `block.json` file also contains other important properties. Take a look at a
 The community is ecstatic you made it this far! Time to submit your plugin!
 
 Take a few moments to read the block guidelines (https://github.com/WordPress/wporg-plugin-guidelines/blob/block-guidelines/blocks.md). Create a zip file of your block and navigate over to the [block plugin validator](https://wordpress.org/plugins/developers/block-plugin-validator/) and upload your plugin. 
-
-
-

--- a/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
+++ b/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
@@ -46,7 +46,7 @@ Examples for an Image Slider block:
 - carousel
 - gallery
 
-[Read more about keywords.](https://github.com/WordPress/gutenberg/blob/master/docs/rfc/block-registration.md#keyword)
+[Read more about keywords.](https://github.com/WordPress/gutenberg/blob/master/docs/rfc/block-registration.md#keywords)
 
 ### Choose the right category
 

--- a/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
+++ b/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
@@ -1,4 +1,5 @@
-#Share your Block with the World
+# Share your Block with the World
+
 So you've created an awesome block? Care to share?
 
 **Contents**:
@@ -6,8 +7,8 @@ So you've created an awesome block? Care to share?
 2. Analyze your plugin
 3. Zip & Submit
 
-
 ## Step 1: Help users understand your block
+
 Providing straightforward, easy to understand block information is important to the block directory and our end users.
 
 **Guidelines**:
@@ -18,6 +19,7 @@ Providing straightforward, easy to understand block information is important to 
 - Choose the right category
 
 ### Name your block based on what it does
+
 Users typically search the block directory within the Block Editor and do so in the context of a task. For example, when building their post, a user may search the Block Directory for an “image gallery”. Naming your block accordingly will help the Block Directory surface it when it's needed.
 
 **Not So Good**: WebTeam5 Image Works
@@ -26,8 +28,8 @@ Users typically search the block directory within the Block Editor and do so in 
 **Question: What happens when there are multiple blocks with similar names?**
 Try your best to make your block's name functional and unique to make it stand out. Look for applicable synonyms or include a prefix if necessary.
 
-
 ### Clearly describe your block
+
 The description really helps to communicate what your block does.The quicker a user understands how your block will help them, the more likely it is a user will use your block. Users will be reading your block's description within the Block Editor where space can be limited. Try to keep it short and concise.
 
 **Not So Good**: The best way to show images on your website using jQuery and CSS.
@@ -36,6 +38,7 @@ The description really helps to communicate what your block does.The quicker a u
 **Tip**: It’s not about marketing your block, in fact we want to avoid marketing in blocks. You can read more about it in the [plugin guidelines]. Stick to being as clear as you can. The block directory will provide metrics to let users know how awesome your block is!
 
 ### Add Keywords for broader context
+
 Keywords add extra context to your block and make it more likely to be found in the inserter. 
 
 Examples for an Image Slider block:
@@ -46,6 +49,7 @@ Examples for an Image Slider block:
 [Read more](https://github.com/WordPress/gutenberg/blob/master/docs/rfc/block-registration.md#keyword) about keywords.
 
 ### Choose the right category
+
 The Block Editor allows you to indicate the category your block belongs in, making it easier for users to locate your block in the menu.
 
 **Possible Values**:
@@ -58,7 +62,6 @@ The Block Editor allows you to indicate the category your block belongs in, maki
 [Read more](https://github.com/WordPress/gutenberg/blob/master/docs/rfc/block-registration.md#category) about categories.
 
 Wondering where to input all this information? Read the next section :)
-
 
 ## Step 2: Analyze your plugin
 
@@ -77,6 +80,7 @@ The `block.json` file also contains other important properties. Take a look at a
 
 
 ## Step 3: Zip & Submit
+
 The community is ecstatic you made it this far! Time to submit your plugin!
 
 Take a few moments to read the block guidelines (https://github.com/WordPress/wporg-plugin-guidelines/blob/block-guidelines/blocks.md)

--- a/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
+++ b/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
@@ -53,7 +53,7 @@ Gutenberg allows you to indicate which category your block fits in. Choosing the
 - media
 - design
 - widgets
-- embeds
+- embed
 
 [Read more](https://github.com/WordPress/gutenberg/blob/master/docs/rfc/block-registration.md#category) about categories.
 

--- a/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
+++ b/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
@@ -69,7 +69,7 @@ Double check that the following is true for your block:
 `editorStyle` is pointing to the CSS bundle that includes all the css used in the **editor**.
 `script` is pointing to the JavaScript bundle that includes all the code used on the **website**.
 `style` is pointing to the CSS bundle that includes all the code used on the **website**.
-I have included example data (Optional, but useful)
+Includes example data (Optional, but useful)
 
 Although it isn’t necessary that you have both an `editorScript/editorStyle` and `script/style` listed in your `block.json` we encourage the separation of code used for editing and code used for displaying your block in order to keep both interfaces running quickly.
 

--- a/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
+++ b/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
@@ -18,7 +18,7 @@ Providing straightforward, easy to understand block information is important to 
 - Choose the right category
 
 ### Name your block based on what it does
-Users typically search the block directory within the block editor and do so in the context of a task. For example, when building their post, a user may search the Block Directory for an “image gallery”. Naming your block accordingly will help the Block Directory surface it when it's needed.
+Users typically search the block directory within the Block Editor and do so in the context of a task. For example, when building their post, a user may search the Block Directory for an “image gallery”. Naming your block accordingly will help the Block Directory surface it when it's needed.
 
 **Not So Good**: WebTeam5 Image Works
 **Good**: Responsive Image Slider by WebTeam5
@@ -28,7 +28,7 @@ Try your best to make your block's name functional and unique to make it stand o
 
 
 ### Clearly describe your block
-The description really helps to communicate what your block does.The quicker a user understands how your block will help them, the more likely it is a user will use your block. Users will be reading your block's description within the block editor where space can be limited. Try to keep it short and concise.
+The description really helps to communicate what your block does.The quicker a user understands how your block will help them, the more likely it is a user will use your block. Users will be reading your block's description within the Block Editor where space can be limited. Try to keep it short and concise.
 
 **Not So Good**: The best way to show images on your website using jQuery and CSS.
 **Good**: An easy to use, responsive, Image gallery block. 
@@ -46,7 +46,7 @@ Examples for an Image Slider block:
 [Read more](https://github.com/WordPress/gutenberg/blob/master/docs/rfc/block-registration.md#keyword) about keywords.
 
 ### Choose the right category
-You have the ability to indicate which category your block fits in. Choosing the right category makes it easy for users to find in the block menu.
+The Block Editor allows you to indicate the category your block belongs in, making it easier for users to locate your block in the menu.
 
 **Possible Values**:
 - text

--- a/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
+++ b/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
@@ -90,7 +90,7 @@ Here is an example of a basic block.json file.
 }
 ```
 
-The `block.json` file also contains other important properties. Take a look at an [example block.json](https://github.com/WordPress/gutenberg/blob/master/docs/rfc/block-registration.md#registering-a-block-type) file for reference.
+The `block.json` file also contains other important properties. Take a look at an [example block.json](https://github.com/WordPress/gutenberg/blob/master/docs/rfc/block-registration.md#registering-a-block-type) for additional properties to be included in the block.json file.
 
 
 ## Step 3: Zip & Submit

--- a/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
+++ b/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
@@ -33,7 +33,7 @@ Try your best to make your block's name functional and unique to make it stand o
 The description really helps to communicate what your block does.The quicker a user understands how your block will help them, the more likely it is a user will use your block. Users will be reading your block's description within the Block Editor where space can be limited. Try to keep it short and concise.
 
 **Not So Good**: The best way to show images on your website using jQuery and CSS.
-**Good**: An easy to use, responsive, Image gallery block. 
+**Good**: A responsive image gallery block. 
 
 **Tip**: It’s not about marketing your block, in fact we want to avoid marketing in blocks. You can read more about it in the [plugin guidelines]. Stick to being as clear as you can. The Block Directory will provide metrics to let users know how awesome your block is!
 

--- a/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
+++ b/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
@@ -64,17 +64,31 @@ The Block Editor allows you to indicate the category your block belongs in, maki
 Wondering where to input all this information? Read the next section :)
 
 ## Step 2: Analyze your plugin
+Each block in your plugin should have a corresponding `block.json` file. This file provides the Block Directory important information about your block. Along with being the place to store contextual information about your block like the: `name`, `description`, `keywords` and `category`, the `block.json` file stores the location of your block’s files.
 
-The `block.json` file lives in the root folder of your block and provides the Block Directory important information about your block. Along with being the place to store contextual information about your block like the: `name`, `description`, `keywords` and `category`, the `block.json` file stores the location of your block’s files.
+Block plugins submitted to the Block Directory can contain mutliple blocks only if they are children of a single parent/ancestor. There should only be one main block. For example, a list block can contain list-item blocks. Children blocks must set the `parent` property in their `block.json` file.
 
 Double check that the following is true for your block:
-`editorScript` is pointing to the JavaScript bundle that includes all the code used in the **editor**.
-`editorStyle` is pointing to the CSS bundle that includes all the css used in the **editor**.
-`script` is pointing to the JavaScript bundle that includes all the code used on the **website**.
-`style` is pointing to the CSS bundle that includes all the code used on the **website**.
-Includes example data (Optional, but useful)
+
+- `editorScript` is pointing to the JavaScript bundle that includes all the code used in the **editor**.
+- `editorStyle` is pointing to the CSS bundle that includes all the css used in the **editor**.
+- `script` is pointing to the JavaScript bundle that includes all the code used on the **website**.
+- `style` is pointing to the CSS bundle that includes all the code used on the **website**.
 
 Although it isn’t necessary that you have both an `editorScript/editorStyle` and `script/style` listed in your `block.json` we encourage the separation of code used for editing and code used for displaying your block in order to keep both interfaces running quickly.
+
+The most basic `block.json` you need looks like this.
+
+```json
+{
+  "name": "plugin-slug/image-slider",
+  "title": "Responsive Image Slider",
+  "description": "A responsive and easy to use image gallery block.",
+  "keywords": [ "slider", "carousel", "gallery" ],
+  "category": "media",
+  "editorScript": "file:./dist/editor.js",
+}
+```
 
 The `block.json` file also contains other important properties. Take a look at an [example block.json](https://github.com/WordPress/gutenberg/blob/master/docs/rfc/block-registration.md#registering-a-block-type) file for reference.
 

--- a/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
+++ b/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
@@ -97,6 +97,5 @@ The `block.json` file also contains other important properties. Take a look at a
 
 The community is thankful for your contribution. It is time to submit your plugin.
 
-Take a few moments to read [the block guidelines](https://github.com/WordPress/wporg-plugin-guidelines/blob/block-guidelines/blocks.md). Create a zip file of your block and navigate over to the [block plugin validator](https://wordpress.org/plugins/developers/block-plugin-validator/) and upload your plugin. 
-
+Go through [the block guidelines](https://github.com/WordPress/wporg-plugin-guidelines/blob/block-guidelines/blocks.md). Create a zip file of your block and go to the [block plugin validator](https://wordpress.org/plugins/developers/block-plugin-validator/) and upload your plugin.
 

--- a/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
+++ b/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
@@ -83,8 +83,7 @@ The `block.json` file also contains other important properties. Take a look at a
 
 The community is ecstatic you made it this far! Time to submit your plugin!
 
-Take a few moments to read the block guidelines (https://github.com/WordPress/wporg-plugin-guidelines/blob/block-guidelines/blocks.md)
+Take a few moments to read the block guidelines (https://github.com/WordPress/wporg-plugin-guidelines/blob/block-guidelines/blocks.md). Create a zip file of your block and navigate over to the [block plugin validator](https://wordpress.org/plugins/developers/block-plugin-validator/) and upload your plugin. 
 
-TODO - ADD MORE STUFF HERE
 
 

--- a/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
+++ b/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
@@ -77,7 +77,7 @@ Double check that the following is true for your block:
 
 We encourage the separation of code by using both editorScript/editorStyle and script/style files listed in your block.json to keep the backend and frontend interfaces running smoothly. Even though only one file is required.
 
-The most basic `block.json` you need looks like this.
+Here is an example of a basic block.json file.
 
 ```json
 {

--- a/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
+++ b/docs/designers-developers/developers/tutorials/create-block/submitting-to-block-directory.md
@@ -9,7 +9,7 @@ So you've created an awesome block? Care to share?
 
 ## Step 1: Help users understand your block
 
-Providing straightforward, easy to understand block information is important to the block directory and our end users.
+It is important to the Block Directory and our end users to provide easy to understand information on how your block was created.
 
 **Guidelines**:
 
@@ -74,7 +74,7 @@ Double check that the following is true for your block:
 `style` is pointing to the CSS bundle that includes all the code used on the **website**.
 Includes example data (Optional, but useful)
 
-Although it isn’t necessary that you have both an `editorScript/editorStyle` and `script/style` listed in your `block.json` we encourage the separation of code used for editing and code used for displaying your block in order to keep both interfaces running quickly.
+We encourage the separation of code by using both editorScript/editorStyle and script/style files listed in your block.json to keep the backend and frontend interfaces running smoothly. Even though only one file is required.
 
 The `block.json` file also contains other important properties. Take a look at an [example block.json](https://github.com/WordPress/gutenberg/blob/master/docs/rfc/block-registration.md#registering-a-block-type) file for reference.
 


### PR DESCRIPTION
## Description
This PR exposes documentation to help block developers submit blocks to the block directory in the hope of getting more collaboration. The end document doesn't need to live where this PR proposes it.  

This PR is associated to #23484 