### PR TITLE
Classic block: Add height: auto to content wrapper 

### DIFF
--- a/packages/block-library/src/classic/editor.scss
+++ b/packages/block-library/src/classic/editor.scss
@@ -1,4 +1,5 @@
 .wp-block-freeform.block-library-rich-text__tinymce {
+	height: auto; /* Allow height of embed iframes to be calculated properly */
 	p,
 	li {
 		line-height: $editor-line-height;


### PR DESCRIPTION
Fixes: #10806

## Description
Adds a height: auto setting to editor content wrapper others embed iframe heights are not calculated correctly in /wp-includes/js/mce-view.min.js

## How has this been tested?
Just manually so far

## Screenshots 

Before:

![height-before](https://user-images.githubusercontent.com/3629020/85973079-c4691a00-ba25-11ea-8466-bd62320e2d48.gif)

After:

![height-after](https://user-images.githubusercontent.com/3629020/85973095-cf23af00-ba25-11ea-97ba-8317593e4a63.gif)

## Types of changes
MInor css change

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
