### PR TITLE
Revert "Remove the style CSS class when the default style variation is chosen"

### DIFF
--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -63,9 +63,7 @@ export function replaceActiveStyle( className, activeStyle, newStyle ) {
 		list.remove( 'is-style-' + activeStyle.name );
 	}
 
-	if ( ! newStyle.isDefault ) {
-		list.add( 'is-style-' + newStyle.name );
-	}
+	list.add( 'is-style-' + newStyle.name );
 
 	return list.value;
 }


### PR DESCRIPTION
Reverts WordPress/gutenberg#22266

Fixes #23211

For more details see https://github.com/WordPress/gutenberg/issues/23211#issuecomment-650924247

#22266 changed block styles so that default block styles would never apply class names. Unfortunately, the `registerBlockStyle` api allows third parties to register a new default, and the changes in #23211 made that new style unselectable.