### PR TITLE
Fix close button.

### DIFF
--- a/packages/editor/src/components/post-publish-panel/index.js
+++ b/packages/editor/src/components/post-publish-panel/index.js
@@ -17,6 +17,7 @@ import {
 } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
+import { closeSmall } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -80,11 +81,9 @@ export class PostPublishPanel extends Component {
 					{ isPostPublish ? (
 						<Button
 							onClick={ onClose }
+							icon={ closeSmall }
 							label={ __( 'Close panel' ) }
-							className="is-secondary"
-						>
-							{ __( 'Close' ) }
-						</Button>
+						/>
 					) : (
 						<>
 							<div className="editor-post-publish-panel__header-publish-button">
@@ -99,7 +98,7 @@ export class PostPublishPanel extends Component {
 								<Button
 									onClick={ onClose }
 									label={ __( 'Close panel' ) }
-									className="is-secondary"
+									isSecondary
 								>
 									{ __( 'Cancel' ) }
 								</Button>

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -26,6 +26,11 @@
 		width: 100%;
 		justify-content: center;
 	}
+
+	.has-icon {
+		margin-left: auto;
+		width: auto;
+	}
 }
 
 .editor-post-publish-panel__header-publish-button,

--- a/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
@@ -8,11 +8,18 @@ exports[`PostPublishPanel should render the post-publish panel if the post is pu
     className="editor-post-publish-panel__header"
   >
     <ForwardRef(Button)
-      className="is-secondary"
+      icon={
+        <SVG
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <Path
+            d="M13 11.9l3.3-3.4-1.1-1-3.2 3.3-3.2-3.3-1.1 1 3.3 3.4-3.5 3.6 1 1L12 13l3.5 3.5 1-1z"
+          />
+        </SVG>
+      }
       label="Close panel"
-    >
-      Close
-    </ForwardRef(Button)>
+    />
   </div>
   <div
     className="editor-post-publish-panel__content"
@@ -39,11 +46,18 @@ exports[`PostPublishPanel should render the post-publish panel if the post is sc
     className="editor-post-publish-panel__header"
   >
     <ForwardRef(Button)
-      className="is-secondary"
+      icon={
+        <SVG
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <Path
+            d="M13 11.9l3.3-3.4-1.1-1-3.2 3.3-3.2-3.3-1.1 1 3.3 3.4-3.5 3.6 1 1L12 13l3.5 3.5 1-1z"
+          />
+        </SVG>
+      }
       label="Close panel"
-    >
-      Close
-    </ForwardRef(Button)>
+    />
   </div>
   <div
     className="editor-post-publish-panel__content"
@@ -81,7 +95,7 @@ exports[`PostPublishPanel should render the pre-publish panel if post status is 
       className="editor-post-publish-panel__header-cancel-button"
     >
       <ForwardRef(Button)
-        className="is-secondary"
+        isSecondary={true}
         label="Close panel"
       >
         Cancel
@@ -122,7 +136,7 @@ exports[`PostPublishPanel should render the pre-publish panel if the post is not
       className="editor-post-publish-panel__header-cancel-button"
     >
       <ForwardRef(Button)
-        className="is-secondary"
+        isSecondary={true}
         label="Close panel"
       >
         Cancel
@@ -163,7 +177,7 @@ exports[`PostPublishPanel should render the spinner if the post is being saved 1
       className="editor-post-publish-panel__header-cancel-button"
     >
       <ForwardRef(Button)
-        className="is-secondary"
+        isSecondary={true}
         label="Close panel"
       >
         Cancel


### PR DESCRIPTION
Close buttons across the block editor uses the x icon. This PR brings that consistency back to the recently improved post-publish panel.

<img width="353" alt="Screenshot 2020-06-29 at 10 36 14" src="https://user-images.githubusercontent.com/1204802/85991990-8e5f7200-b9f4-11ea-8e80-83285fa6ad6f.png">

It also fixes an issue where the `is-secondary` as added via a classname rather than the isSecondary prop.