### PR TITLE
Fix upload icon.

### DIFF
--- a/packages/components/src/drop-zone/index.js
+++ b/packages/components/src/drop-zone/index.js
@@ -89,7 +89,6 @@ function DropZoneComponent( {
 			<div className="components-drop-zone__content">
 				<Icon
 					icon={ upload }
-					size="40"
 					className="components-drop-zone__content-icon"
 				/>
 				<span className="components-drop-zone__content-text">

--- a/packages/icons/src/library/upload.js
+++ b/packages/icons/src/library/upload.js
@@ -5,7 +5,7 @@ import { SVG, Path } from '@wordpress/primitives';
 
 const upload = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-		<Path d="M18.5 15v3.5H13V6.7l4.5 4.1 1-1.1-5.7-5.3-.6.6-.5-.5-5.2 5.2 1 1.1 4-4v11.7h-6V15H4v5h16v-5z" />
+		<Path d="M18.5 15v3.5H13V6.7l4.5 4.1 1-1.1-6.2-5.8-5.8 5.8 1 1.1 4-4v11.7h-6V15H4v5h16v-5z" />
 	</SVG>
 );
 


### PR DESCRIPTION
This fixes a vector error in the upload icon, and sizes it correctly. Before:

<img width="266" alt="Screenshot 2020-06-29 at 10 59 13" src="https://user-images.githubusercontent.com/1204802/85994500-29a61680-b9f8-11ea-9140-ea1f3d009b22.png">

After:

<img width="351" alt="Screenshot 2020-06-29 at 11 02 33" src="https://user-images.githubusercontent.com/1204802/85994481-2579f900-b9f8-11ea-9303-87e267172919.png">

Note how the top of the arrow was abruptly cropped off. That's been fixed. The size prop has also been removed, as the bigger icon did not add value, just complexity, and with #23454 the blue color will make it more visible anyway.