### PR TITLE
[RNMobile] Unsupported Block Fallback: Fix multiline Markdown problems

### DIFF
--- a/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergWebViewActivity.java
+++ b/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergWebViewActivity.java
@@ -212,7 +212,7 @@ public class GutenbergWebViewActivity extends AppCompatActivity {
                     String insertBlock = getFileContentFromAssets("gutenberg-web-single-block/insert-block.js").replace("%@","%s");
                     String blockContent = getIntent().getExtras().getString(ARG_BLOCK_CONTENT);
                     insertBlock = String.format(insertBlock, blockContent);
-                    evaluateJavaScript(removeNewLines(insertBlock));
+                    evaluateJavaScript(removeNewLines(insertBlock.replace("\\n", "\\\\n")));
 
                     view.setVisibility(View.VISIBLE);
                 }, 2000);

--- a/packages/react-native-bridge/ios/GutenbergWebFallback/FallbackJavascriptInjection.swift
+++ b/packages/react-native-bridge/ios/GutenbergWebFallback/FallbackJavascriptInjection.swift
@@ -68,7 +68,7 @@ public struct FallbackJavascriptInjection {
             try script(with: .retrieveHtml),
         ]
 
-        insertBlockScript = try script(with: .insertBlock, argument: blockHTML)
+        insertBlockScript = try script(with: .insertBlock, argument: blockHTML.replacingOccurrences(of: "\\n", with: "\\\\n"))
         injectCssScript = try script(with: .injectCss)
         injectWPBarsCssScript = try getInjectCssScript(with: .wpBarsStyle)
         injectEditorCssScript = try getInjectCssScript(with: .editorStyle)


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
The original problem described [here](https://github.com/wordpress-mobile/WordPress-Android/pull/11919#pullrequestreview-423147166) renders a Markdown block with multiple lines as with invalid content.

This happens because of the `source` property being a JSON String with new-lines characters. JSON Strings must have escaped any new lines `\\n`, but when we send the block HTML code to JS, using backquotes (``), it will remove one level of escaped newlines, leaving `\\n` as `\n`. This is then interpreted as an actual new line and breaks the JSON String.

I have tried sending a JSON String, using different kinds of quotes, and mixes of both. Always arriving to some sort of new lines, quotes, JSON decoding, or JS syntax error.

Since the problem is with new lines that are expected to be escaped, and backquotes will remove one level of escaping, I tried adding one extra level of escaping to already escaped new lines. This seems to work well, leaving untouched normal new lines.

Sending:
```
<!-- wp:jetpack/markdown {\"source\":\"Markdown\\\\nwith\\\\nmulti\\\\nline\"} -->\n<div class=\"wp-block-jetpack-markdown\"><p>Markdown\nwith\nmulti\nline</p>\n</div>\n<!-- /wp:jetpack/markdown -->
```
Arrives to JS:
```
"<!-- wp:jetpack/markdown {\"source\":\"Markdown\\nwith\\nmulti\\nline\"} -->
<div class=\"wp-block-jetpack-markdown\"><p>Markdown
with
multi
line</p>
</div>
<!-- /wp:jetpack/markdown -->"
```

PD: @marecar3 we will need this same kind of change on Android 🙏 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

I have tested many core and jetpack unsupported blocks and everything seems to work as expected:
- RSS
- Calendar
- Audio
- Table
- File
- YouTube
- Social Links
- Logos
- Maps
- Markdown
- Tiled Gallery

To test:
- Run this branch on WP Apps.
- On web, create a Markdown block with multiple lines.
- Open that post on mobile.
- Display the block on gutenberg web-view.
- Check that it shows properly.
- Smoke test other unsupported blocks.
## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
