### PR TITLE
Add modern color scheme.

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -451,6 +451,10 @@
 		@include admin-scheme(#0085ba);
 	}
 
+	body.admin-color-modern {
+		@include admin-scheme(#3858e9);
+	}
+
 	body.admin-color-blue {
 		@include admin-scheme(#096484);
 	}


### PR DESCRIPTION
This is an addon PR to https://github.com/WordPress/wordpress-develop/pull/369, which adds a new color scheme called "Modern". This PR simply treats that scheme as all the others, and add a new spot color for it.

There is a separate effort in https://core.trac.wordpress.org/ticket/49999 that aims to rewite in SCSS and refresh the existing color schemes. This effort could create one unified place for all color schemes in the core project itself. But in the mean time, this PR along with #369 brings an immediate contrast and consistency benefit to WordPress and the block editor, and is small enough that it could ship with 5.5.

<img width="1747" alt="Screenshot 2020-06-29 at 15 08 49" src="https://user-images.githubusercontent.com/1204802/86009702-cf6a7d00-ba1a-11ea-9ad4-a923fbc6e761.png">

I will work on any followups to improve the SCSS bits.

**Note that this PR should not be merged unless the trac ticket receives a blessing.** 