### PR TITLE
Fix broken navigation save

### DIFF
--- a/packages/edit-navigation/src/store/actions.js
+++ b/packages/edit-navigation/src/store/actions.js
@@ -252,7 +252,10 @@ function serializeProcessing( callback ) {
 		};
 
 		try {
-			yield* callback( post );
+			yield* callback(
+				// re-select the post as it could be outdated by now
+				yield getNavigationPostForMenu( post.meta.menuId )
+			);
 		} finally {
 			yield {
 				type: 'FINISH_PROCESSING_POST',
@@ -266,10 +269,7 @@ function serializeProcessing( callback ) {
 					pendingActions[ 0 ]
 				);
 
-				// re-fetch the post as running the callback() likely updated it
-				yield* serializedCallback(
-					yield getNavigationPostForMenu( post.meta.menuId )
-				);
+				yield* serializedCallback( post );
 			}
 		}
 	};


### PR DESCRIPTION
## Description
This PR fixes saving a navigation after appending a new menu item. The root cause of the problem is that `createMissingMenuItems` is being called with an outdated version of a post due to how the `edit-navigation` package uses core hooks and gets caught in a complex chain of cached effects. Specifically, rendering `<EditorProvider onChange={callback}` caches the `callback` passed on the first render, and will keep calling that initial version even if an updated callback is passed on subsequent render. This in turn means that `createMissingMenuItems` is always being called with the very first version of the navigation post.

While refactoring that code is possible, it is also complex. The fix proposed in this PR does not address the issue directly, but it solves it by making the behavior of `serializeProcessing` more internally consistent - each callback awaiting it's serial execution gets a freshly selected post. This is exactly the same as before, except the first callback in the queue will also benefit from this behavior.

## How has this been tested?
1. Enable a experimental navigation screen and go there
1. Create a new menu or edit an existing one
1. Add a few menu items
1. Save
1. Confirm it worked

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
