### PR TITLE
Scroll on drag: remove blockNodes context dependency

### DIFF
--- a/packages/block-editor/src/components/block-draggable/index.js
+++ b/packages/block-editor/src/components/block-draggable/index.js
@@ -3,14 +3,13 @@
  */
 import { Draggable } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useContext, useEffect, useRef } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import BlockDraggableChip from './draggable-chip';
 import useScrollWhenDragging from './use-scroll-when-dragging';
-import { BlockNodes } from '../block-list/root-container';
 
 const BlockDraggable = ( {
 	children,
@@ -40,14 +39,11 @@ const BlockDraggable = ( {
 		[ clientIds ]
 	);
 	const isDragging = useRef( false );
-	const [ firstClientId ] = clientIds;
-	const blockNodes = useContext( BlockNodes );
-	const blockElement = blockNodes ? blockNodes[ firstClientId ] : undefined;
 	const [
 		startScrolling,
 		scrollOnDragOver,
 		stopScrolling,
-	] = useScrollWhenDragging( blockElement );
+	] = useScrollWhenDragging();
 
 	const { startDraggingBlocks, stopDraggingBlocks } = useDispatch(
 		'core/block-editor'

--- a/packages/block-editor/src/components/block-draggable/use-scroll-when-dragging.js
+++ b/packages/block-editor/src/components/block-draggable/use-scroll-when-dragging.js
@@ -13,13 +13,11 @@ const VELOCITY_MULTIPLIER =
 /**
  * React hook that scrolls the scroll container when a block is being dragged.
  *
- * @param {Element} dragElement The DOM element being dragged.
- *
  * @return {Function[]} `startScrolling`, `scrollOnDragOver`, `stopScrolling`
  *                      functions to be called in `onDragStart`, `onDragOver`
  *                      and `onDragEnd` events respectively.
  */
-export default function useScrollWhenDragging( dragElement ) {
+export default function useScrollWhenDragging() {
 	const dragStartY = useRef( null );
 	const velocityY = useRef( null );
 	const scrollParentY = useRef( null );
@@ -36,28 +34,25 @@ export default function useScrollWhenDragging( dragElement ) {
 		[]
 	);
 
-	const startScrolling = useCallback(
-		( event ) => {
-			dragStartY.current = event.clientY;
+	const startScrolling = useCallback( ( event ) => {
+		dragStartY.current = event.clientY;
 
-			// Find nearest parent(s) to scroll.
-			scrollParentY.current = getScrollContainer( dragElement );
+		// Find nearest parent(s) to scroll.
+		scrollParentY.current = getScrollContainer( event.target );
 
-			scrollEditorInterval.current = setInterval( () => {
-				if ( scrollParentY.current && velocityY.current ) {
-					const newTop =
-						scrollParentY.current.scrollTop + velocityY.current;
+		scrollEditorInterval.current = setInterval( () => {
+			if ( scrollParentY.current && velocityY.current ) {
+				const newTop =
+					scrollParentY.current.scrollTop + velocityY.current;
 
-					// Setting `behavior: 'smooth'` as a scroll property seems to hurt performance.
-					// Better to use a small scroll interval.
-					scrollParentY.current.scroll( {
-						top: newTop,
-					} );
-				}
-			}, SCROLL_INTERVAL_MS );
-		},
-		[ dragElement ]
-	);
+				// Setting `behavior: 'smooth'` as a scroll property seems to hurt performance.
+				// Better to use a small scroll interval.
+				scrollParentY.current.scroll( {
+					top: newTop,
+				} );
+			}
+		}, SCROLL_INTERVAL_MS );
+	}, [] );
 
 	const scrollOnDragOver = useCallback( ( event ) => {
 		const scrollParentHeight = scrollParentY.current.offsetHeight;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

There's no need for the block node to be passed since the scroll container can be derived from the drag handle.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
