### PR TITLE
Add pullquote tranformations

### DIFF
--- a/packages/block-library/src/list/transforms.js
+++ b/packages/block-library/src/list/transforms.js
@@ -79,6 +79,19 @@ const transforms = {
 			},
 		},
 		{
+			type: 'block',
+			blocks: [ 'core/pullquote' ],
+			transform: ( { value, anchor } ) => {
+				return createBlock( 'core/list', {
+					values: toHTMLString( {
+						value: create( { html: value, multilineTag: 'p' } ),
+						multilineTag: 'li',
+					} ),
+					anchor,
+				} );
+			},
+		},
+		{
 			type: 'raw',
 			selector: 'ol,ul',
 			schema: ( args ) => ( {
@@ -162,6 +175,23 @@ const transforms = {
 			blocks: [ 'core/quote' ],
 			transform: ( { values, anchor } ) => {
 				return createBlock( 'core/quote', {
+					value: toHTMLString( {
+						value: create( {
+							html: values,
+							multilineTag: 'li',
+							multilineWrapperTags: [ 'ul', 'ol' ],
+						} ),
+						multilineTag: 'p',
+					} ),
+					anchor,
+				} );
+			},
+		},
+		{
+			type: 'block',
+			blocks: [ 'core/pullquote' ],
+			transform: ( { values, anchor } ) => {
+				return createBlock( 'core/pullquote', {
 					value: toHTMLString( {
 						value: create( {
 							html: values,

--- a/packages/block-library/src/list/transforms.js
+++ b/packages/block-library/src/list/transforms.js
@@ -67,20 +67,7 @@ const transforms = {
 		},
 		{
 			type: 'block',
-			blocks: [ 'core/quote' ],
-			transform: ( { value, anchor } ) => {
-				return createBlock( 'core/list', {
-					values: toHTMLString( {
-						value: create( { html: value, multilineTag: 'p' } ),
-						multilineTag: 'li',
-					} ),
-					anchor,
-				} );
-			},
-		},
-		{
-			type: 'block',
-			blocks: [ 'core/pullquote' ],
+			blocks: [ 'core/quote', 'core/pullquote' ],
 			transform: ( { value, anchor } ) => {
 				return createBlock( 'core/list', {
 					values: toHTMLString( {

--- a/packages/block-library/src/pullquote/index.js
+++ b/packages/block-library/src/pullquote/index.js
@@ -12,6 +12,7 @@ import deprecated from './deprecated';
 import edit from './edit';
 import metadata from './block.json';
 import save from './save';
+import transforms from './transforms';
 
 const { name } = metadata;
 
@@ -43,6 +44,7 @@ export const settings = {
 		},
 		{ name: SOLID_COLOR_STYLE_NAME, label: __( 'Solid color' ) },
 	],
+	transforms,
 	edit,
 	save,
 	deprecated,

--- a/packages/block-library/src/pullquote/transforms.js
+++ b/packages/block-library/src/pullquote/transforms.js
@@ -1,0 +1,150 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+import { create, join, split, toHTMLString } from '@wordpress/rich-text';
+
+const transforms = {
+	from: [
+		{
+			type: 'block',
+			isMultiBlock: true,
+			blocks: [ 'core/paragraph' ],
+			transform: ( attributes ) => {
+				return createBlock( 'core/pullquote', {
+					value: toHTMLString( {
+						value: join(
+							attributes.map( ( { content } ) =>
+								create( { html: content } )
+							),
+							'\u2028'
+						),
+						multilineTag: 'p',
+					} ),
+					anchor: attributes.anchor,
+				} );
+			},
+		},
+		{
+			type: 'block',
+			blocks: [ 'core/heading' ],
+			transform: ( { content, anchor } ) => {
+				return createBlock( 'core/pullquote', {
+					value: `<p>${ content }</p>`,
+					anchor,
+				} );
+			},
+		},
+		{
+			type: 'raw',
+			isMatch: ( node ) => {
+				const isParagraphOrSingleCite = ( () => {
+					let hasCitation = false;
+					return ( child ) => {
+						// Child is a paragraph.
+						if ( child.nodeName === 'P' ) {
+							return true;
+						}
+						// Child is a cite and no other cite child exists before it.
+						if ( ! hasCitation && child.nodeName === 'CITE' ) {
+							hasCitation = true;
+							return true;
+						}
+					};
+				} )();
+				return (
+					node.nodeName === 'BLOCKQUOTE' &&
+					// The quote block can only handle multiline paragraph
+					// content with an optional cite child.
+					Array.from( node.childNodes ).every(
+						isParagraphOrSingleCite
+					)
+				);
+			},
+			schema: ( { phrasingContentSchema } ) => ( {
+				blockquote: {
+					children: {
+						p: {
+							children: phrasingContentSchema,
+						},
+						cite: {
+							children: phrasingContentSchema,
+						},
+					},
+				},
+			} ),
+		},
+	],
+	to: [
+		{
+			type: 'block',
+			blocks: [ 'core/paragraph' ],
+			transform: ( { value, citation } ) => {
+				const paragraphs = [];
+				if ( value && value !== '<p></p>' ) {
+					paragraphs.push(
+						...split(
+							create( { html: value, multilineTag: 'p' } ),
+							'\u2028'
+						).map( ( piece ) =>
+							createBlock( 'core/paragraph', {
+								content: toHTMLString( { value: piece } ),
+							} )
+						)
+					);
+				}
+				if ( citation && citation !== '<p></p>' ) {
+					paragraphs.push(
+						createBlock( 'core/paragraph', {
+							content: citation,
+						} )
+					);
+				}
+				if ( paragraphs.length === 0 ) {
+					return createBlock( 'core/paragraph', {
+						content: '',
+					} );
+				}
+				return paragraphs;
+			},
+		},
+		{
+			type: 'block',
+			blocks: [ 'core/heading' ],
+			transform: ( { value, citation, ...attrs } ) => {
+				// If there is no pullquote content, use the citation as the
+				// content of the resulting heading. A nonexistent citation
+				// will result in an empty heading.
+				if ( value === '<p></p>' ) {
+					return createBlock( 'core/heading', {
+						content: citation,
+					} );
+				}
+				const pieces = split(
+					create( { html: value, multilineTag: 'p' } ),
+					'\u2028'
+				);
+				const headingBlock = createBlock( 'core/heading', {
+					content: toHTMLString( { value: pieces[ 0 ] } ),
+				} );
+				if ( ! citation && pieces.length === 1 ) {
+					return headingBlock;
+				}
+				const quotePieces = pieces.slice( 1 );
+				const pullquoteBlock = createBlock( 'core/pullquote', {
+					...attrs,
+					citation,
+					value: toHTMLString( {
+						value: quotePieces.length
+							? join( pieces.slice( 1 ), '\u2028' )
+							: create(),
+						multilineTag: 'p',
+					} ),
+				} );
+				return [ headingBlock, pullquoteBlock ];
+			},
+		},
+	],
+};
+
+export default transforms;

--- a/packages/block-library/src/pullquote/transforms.js
+++ b/packages/block-library/src/pullquote/transforms.js
@@ -35,45 +35,6 @@ const transforms = {
 				} );
 			},
 		},
-		{
-			type: 'raw',
-			isMatch: ( node ) => {
-				const isParagraphOrSingleCite = ( () => {
-					let hasCitation = false;
-					return ( child ) => {
-						// Child is a paragraph.
-						if ( child.nodeName === 'P' ) {
-							return true;
-						}
-						// Child is a cite and no other cite child exists before it.
-						if ( ! hasCitation && child.nodeName === 'CITE' ) {
-							hasCitation = true;
-							return true;
-						}
-					};
-				} )();
-				return (
-					node.nodeName === 'BLOCKQUOTE' &&
-					// The quote block can only handle multiline paragraph
-					// content with an optional cite child.
-					Array.from( node.childNodes ).every(
-						isParagraphOrSingleCite
-					)
-				);
-			},
-			schema: ( { phrasingContentSchema } ) => ( {
-				blockquote: {
-					children: {
-						p: {
-							children: phrasingContentSchema,
-						},
-						cite: {
-							children: phrasingContentSchema,
-						},
-					},
-				},
-			} ),
-		},
 	],
 	to: [
 		{

--- a/packages/e2e-tests/specs/editor/various/block-switcher.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-switcher.test.js
@@ -28,6 +28,7 @@ describe( 'Block Switcher', () => {
 			'Group',
 			'Paragraph',
 			'Quote',
+			'Pullquote',
 		] );
 	} );
 
@@ -49,15 +50,19 @@ describe( 'Block Switcher', () => {
 		expect( await getAvailableBlockTransforms() ).toEqual( [
 			'Group',
 			'Paragraph',
+			'Pullquote',
 		] );
 	} );
 
 	it( 'Should not show the block switcher if all the blocks the list block transforms into are removed', async () => {
 		// Remove the paragraph and quote block from the list of registered blocks.
 		await page.evaluate( () => {
-			[ 'core/quote', 'core/paragraph', 'core/group' ].map( ( block ) =>
-				wp.blocks.unregisterBlockType( block )
-			);
+			[
+				'core/quote',
+				'core/pullquote',
+				'core/paragraph',
+				'core/group',
+			].map( ( block ) => wp.blocks.unregisterBlockType( block ) );
 		} );
 
 		// Insert a list block.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Resolves #14159

Now,  the `Pullquote` transformations are handled in an inconsistent way compared to a `Quote` block, that is quite similar.

For example you can achieve transformation from a `Paragraph` to `Pullquote`, by first transforming the `Paragraph` to a `Quote` and then the `Quote` to a `Pullquote`.

This PR will allow `Pullquote` block to be transformed from and to all the available blocks that are allowed for `Quote` block.


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
