### PR TITLE
Add a documentation page explaining how the repository is organized

### DIFF
--- a/docs/architecture/folder-structure.md
+++ b/docs/architecture/folder-structure.md
@@ -2,38 +2,38 @@
 
 The following snippet explains how the Gutenberg repository is structured omitting irrelevant or obvious items with further explanations:
 
-	│
+    │
     ├── LICENSE
     ├── README.md
     ├── SECURITY.md
     ├── CONTRIBUTING.md
     ├── CONTRIBUTORS.md
     ├── CODE_OF_CONDUCT.md
-	│
+    │
     ├── .editorconfig
-	├── .eslintignore 
-	├── .eslintrc 
-	├── .jshintignore 
-	├── .eslintignore 
-	├── .prettierrc.js
-	├── .stylelintrc.json
-	├── .markdownlintignore
-	├── .npmpackagejsonlintrc.json
-	├── phpcs.xml.dist
-	│   Dot files and config files used to configure the various linting tools 
-	│   used in the repository (PHP, JS, styles...).
-	│
-	├── .browserslistrc
+    ├── .eslintignore 
+    ├── .eslintrc 
+    ├── .jshintignore 
+    ├── .eslintignore 
+    ├── .prettierrc.js
+    ├── .stylelintrc.json
+    ├── .markdownlintignore
+    ├── .npmpackagejsonlintrc.json
+    ├── phpcs.xml.dist
+    │   Dot files and config files used to configure the various linting tools 
+    │   used in the repository (PHP, JS, styles...).
+    │
+    ├── .browserslistrc
     ├── babel.config.js
     ├── jsconfig.json
     ├── tsconfig.json
     ├── tsconfig.base.json
     ├── webpack.config.js
-	│   Transpilation and bundling Config files.
-	│
+    │   Transpilation and bundling Config files.
+    │
     ├── .wp-env.json
     │   Config file for the development and testing environment. 
-	│   Includes WordPress and the Gutenberg plugin.
+    │   Includes WordPress and the Gutenberg plugin.
     │
     ├── composer.lock
     ├── composer.json
@@ -42,25 +42,25 @@ The following snippet explains how the Gutenberg repository is structured omitti
     │
     ├── package-lock.json
     ├── package.json
-	│	Handling of JavaScript dependencies. Both for development tools and  
-	│   production dependencies.
-	│   The package.json also serves to define common tasks and scripts 
-	|   used for day to day development.
-	│
+    │	Handling of JavaScript dependencies. Both for development tools and  
+    │   production dependencies.
+    │   The package.json also serves to define common tasks and scripts 
+    |   used for day to day development.
+    │
     ├── changelog.txt
     ├── readme.txt
     │   Readme and Changelog of the Gutenberg plugin hosted on the WordPress
     │   plugin repository.
     │
     ├── gutenberg.php
-	│   Entry point of the Gutenberg plugin.
-	│
+    │   Entry point of the Gutenberg plugin.
+    │
     ├── post-content.php
-	│   Demo post content used on the Gutenberg plugin to showcase the editor.
+    │   Demo post content used on the Gutenberg plugin to showcase the editor.
     │
     ├── .github/*
-	│   Config of the different Github features (issues and PR templates, CI, owners).
-	│
+    │   Config of the different Github features (issues and PR templates, CI, owners).
+    │
     ├── bin/api-docs
     │   Tool/script used to generate the API Docs.
     │
@@ -77,13 +77,13 @@ The following snippet explains how the Gutenberg repository is structured omitti
     │   Set of documentation pages composing the [Block editor handbook](https://developer.wordpress.org/block-editor/).
     │
     ├── lib
-	│   PHP Source code of the Gutenberg plugin.
+    │   PHP Source code of the Gutenberg plugin.
     │
     ├── packages
-	│   Source code of the WordPress packages. 
-	│   Packages can be:
-	│    - Production JavaScript scripts and styles loaded on WordPress 
-	│      and the Gutenberg plugin or distributed as npm packages.
+    │   Source code of the WordPress packages. 
+    │   Packages can be:
+    │    - Production JavaScript scripts and styles loaded on WordPress 
+    │      and the Gutenberg plugin or distributed as npm packages.
     │    - Development tools available on npm.
     │
     ├── packages/{packageName}/package.json
@@ -97,23 +97,23 @@ The following snippet explains how the Gutenberg repository is structured omitti
     │   Source code of a given package.
     |
     ├── packages/{packageName}/src/**/*.test.js
-	│   JavaScript unit tests.
+    │   JavaScript unit tests.
     |
     ├── packages/{packageName}/src/**/{ComponentName}/index.js
-	│   Entry point of a given component.
+    │   Entry point of a given component.
     |
     ├── packages/{packageName}/src/**/{ComponentName}/style.scss
-	│   Style entry point for a given component.
-	│
+    │   Style entry point for a given component.
+    │
     ├── packages/{packageName}/src/**/{ComponentName}/stories/*.js
-	│   Component Stories to load on the Gutenberg storybook.
+    │   Component Stories to load on the Gutenberg storybook.
     │
     ├── packages/e2e-tests
-	│   End-2-end tests of the Gutenberg plugin. 
-	│   Distributed as a package for potential reuse in Core and other plugins.
+    │   End-2-end tests of the Gutenberg plugin. 
+    │   Distributed as a package for potential reuse in Core and other plugins.
     │
     ├── phpunit
-	│   Unit tests for the PHP code of the Gutenberg plugin.
+    │   Unit tests for the PHP code of the Gutenberg plugin.
     │
     ├── storybook
     │   Config of the [Gutenberg Storybook](http://wordpress.github.io).

--- a/docs/architecture/folder-structure.md
+++ b/docs/architecture/folder-structure.md
@@ -1,0 +1,129 @@
+# Folder Structure
+
+The following snippet explains how the Gutenberg repository is structured omitting irrelevant or obvious items with further explanations:
+
+	│
+    ├── LICENSE
+    ├── README.md
+    ├── SECURITY.md
+    ├── CONTRIBUTING.md
+    ├── CONTRIBUTORS.md
+    ├── CODE_OF_CONDUCT.md
+	│
+    ├── .editorconfig
+	├── .eslintignore 
+	├── .eslintrc 
+	├── .jshintignore 
+	├── .eslintignore 
+	├── .prettierrc.js
+	├── .stylelintrc.json
+	├── .markdownlintignore
+	├── .npmpackagejsonlintrc.json
+	├── phpcs.xml.dist
+	│   Dot files and config files used to configure the various linting tools 
+	│   used in the repository (PHP, JS, styles...).
+	│
+	├── .browserslistrc
+    ├── babel.config.js
+    ├── jsconfig.json
+    ├── tsconfig.json
+    ├── tsconfig.base.json
+    ├── webpack.config.js
+	│   Transpilation and bundling Config files.
+	│
+    ├── .wp-env.json
+    │   Config file for the development and testing environment. 
+	│   Includes WordPress and the Gutenberg plugin.
+    │
+    ├── composer.lock
+    ├── composer.json
+    │   Handling of PHP dependencies. Essentially used for development tools.
+    │   The production code don't use external PHP dependencies.
+    │
+    ├── package-lock.json
+    ├── package.json
+	│	Handling of JavaScript dependencies. Both for development tools and  
+	│   production dependencies.
+	│   The package.json also serves to define common tasks and scripts 
+	|   used for day to day development.
+	│
+    ├── changelog.txt
+    ├── readme.txt
+    │   Readme and Changelog of the Gutenberg plugin hosted on the WordPress
+    │   plugin repository.
+    │
+    ├── gutenberg.php
+	│   Entry point of the Gutenberg plugin.
+	│
+    ├── post-content.php
+	│   Demo post content used on the Gutenberg plugin to showcase the editor.
+    │
+    ├── .github/*
+	│   Config of the different Github features (issues and PR templates, CI, owners).
+	│
+    ├── bin/api-docs
+    │   Tool/script used to generate the API Docs.
+    │
+    ├── bin/packages
+    │   Set of scripts used to build the WordPress packages.
+    │
+    ├── bin/plugin
+    │   Tool use to perform the Gutenberg plugin release and the npm releases as well.
+    │
+    ├── docs/tool
+    │   Tool used to generate the Block editor handbook's markdown pages.
+    │
+    ├── docs/*.md
+    │   Set of documentation pages composing the [Block editor handbook](https://developer.wordpress.org/block-editor/).
+    │
+    ├── lib
+	│   PHP Source code of the Gutenberg plugin.
+    │
+    ├── packages
+	│   Source code of the WordPress packages. 
+	│   Packages can be:
+	│    - Production JavaScript scripts and styles loaded on WordPress 
+	│      and the Gutenberg plugin or distributed as npm packages.
+    │    - Development tools available on npm.
+    │
+    ├── packages/{packageName}/package.json
+    │   Dependencies of the current package.
+    │
+    ├── packages/{packageName}/CHANGELOG.md
+    ├── packages/{packageName}/README.md
+    │
+    ├── packages/{packageName}/src/**/*.js
+    ├── packages/{packageName}/src/**/*.scss
+    │   Source code of a given package.
+    |
+    ├── packages/{packageName}/src/**/*.test.js
+	│   JavaScript unit tests.
+    |
+    ├── packages/{packageName}/src/**/{ComponentName}/index.js
+	│   Entry point of a given component.
+    |
+    ├── packages/{packageName}/src/**/{ComponentName}/style.scss
+	│   Style entry point for a given component.
+	│
+    ├── packages/{packageName}/src/**/{ComponentName}/stories/*.js
+	│   Component Stories to load on the Gutenberg storybook.
+    │
+    ├── packages/e2e-tests
+	│   End-2-end tests of the Gutenberg plugin. 
+	│   Distributed as a package for potential reuse in Core and other plugins.
+    │
+    ├── phpunit
+	│   Unit tests for the PHP code of the Gutenberg plugin.
+    │
+    ├── storybook
+    │   Config of the [Gutenberg Storybook](http://wordpress.github.io).
+    │
+    ├── test/integration
+    │   Set of WordPress packages integration tests.
+    │
+    ├── test/native
+    │   Configuration for the Gutenberg Mobile unit tests.
+    │
+    └── test/unit
+        Configuration for the Packages unit tests.
+

--- a/docs/architecture/readme.md
+++ b/docs/architecture/readme.md
@@ -2,6 +2,7 @@
 
 This living document serves as a high-level documentation to explain the conceptual choices and tool choices in the Gutenberg repository.
 
+- [Understand the repository folder structure](/docs/architecture/folder-structure.md).
 - [Modularity and WordPress Packages](/docs/architecture/modularity.md).
 - [Block Editor Performance](/docs/architecture/performance.md).
 - What are the decision decisions behind the Data Module?

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -18,6 +18,12 @@
 		"parent": "principles"
 	},
 	{
+		"title": "Folder Structure",
+		"slug": "folder-structure",
+		"markdown_source": "../docs/architecture/folder-structure.md",
+		"parent": "architecture"
+	},
+	{
 		"title": "Modularity",
 		"slug": "modularity",
 		"markdown_source": "../docs/architecture/modularity.md",

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -3,6 +3,7 @@
 
 	{ "docs/contributors/principles.md": [
 		{ "docs/architecture/readme.md": [
+			{ "docs/architecture/folder-structure.md": [] },
 			{ "docs/architecture/modularity.md": [] },
 			{ "docs/architecture/performance.md": [] },
 			{ "docs/architecture/automated-testing.md": [] }


### PR DESCRIPTION
This is not exhaustive and needs to be refined but I found similar documentation on other repositories and thought that's very useful for new contributors. What do you think?