### PR TITLE
Image block: allow uploading external image if image host allows it

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -181,7 +181,7 @@ export function ImageEdit( {
 
 	const isTemp = isTemporaryImage( id, url );
 
-	// Upload a temporary image on mount.
+	// Upload temporary images.
 	useEffect( () => {
 		if ( ! isTemp ) {
 			return;
@@ -201,7 +201,7 @@ export function ImageEdit( {
 				},
 			} );
 		}
-	}, [] );
+	}, [ isTemp ] );
 
 	// If an image is temporary, revoke the Blob url when it is uploaded (and is
 	// no longer temporary).

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -65,7 +65,7 @@ const isTemporaryImage = ( id, url ) => ! id && isBlobURL( url );
  *
  * @return {boolean} Is the url an externally hosted url?
  */
-const isExternalImage = ( id, url ) => url && ! id && ! isBlobURL( url );
+export const isExternalImage = ( id, url ) => url && ! id && ! isBlobURL( url );
 
 export function ImageEdit( {
 	attributes,

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -181,7 +181,7 @@ export function ImageEdit( {
 
 	const isTemp = isTemporaryImage( id, url );
 
-	// Upload temporary images.
+	// Upload a temporary image on mount.
 	useEffect( () => {
 		if ( ! isTemp ) {
 			return;
@@ -201,7 +201,7 @@ export function ImageEdit( {
 				},
 			} );
 		}
-	}, [ isTemp ] );
+	}, [] );
 
 	// If an image is temporary, revoke the Blob url when it is uploaded (and is
 	// no longer temporary).

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -6,7 +6,7 @@ import { get, filter, map, last, pick, includes } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { isBlobURL } from '@wordpress/blob';
+import { isBlobURL, createBlobURL } from '@wordpress/blob';
 import {
 	ExternalLink,
 	PanelBody,
@@ -32,7 +32,7 @@ import { useEffect, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { getPath } from '@wordpress/url';
 import { createBlock } from '@wordpress/blocks';
-import { crop } from '@wordpress/icons';
+import { crop, external } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -172,6 +172,17 @@ export default function Image( {
 		} );
 	}
 
+	function uploadExternal() {
+		window
+			.fetch( url )
+			.then( ( response ) => response.blob() )
+			.then( ( blob ) => {
+				onSelectImage( {
+					url: createBlobURL( blob ),
+				} );
+			} );
+	}
+
 	useEffect( () => {
 		if ( ! isSelected ) {
 			setIsEditingImage( false );
@@ -203,6 +214,15 @@ export default function Image( {
 							onClick={ () => setIsEditingImage( true ) }
 							icon={ crop }
 							label={ __( 'Crop' ) }
+						/>
+					</ToolbarGroup>
+				) }
+				{ ! id && (
+					<ToolbarGroup>
+						<ToolbarButton
+							onClick={ uploadExternal }
+							icon={ external }
+							label={ __( 'Upload external image' ) }
 						/>
 					</ToolbarGroup>
 				) }

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -32,7 +32,7 @@ import { useEffect, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { getPath } from '@wordpress/url';
 import { createBlock } from '@wordpress/blocks';
-import { crop, external } from '@wordpress/icons';
+import { crop, upload } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -233,7 +233,7 @@ export default function Image( {
 					<ToolbarGroup>
 						<ToolbarButton
 							onClick={ uploadExternal }
-							icon={ external }
+							icon={ upload }
 							label={ __( 'Upload external image' ) }
 						/>
 					</ToolbarGroup>

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -91,6 +91,7 @@ export default function Image( {
 		return pick( getSettings(), [ 'imageSizes', 'isRTL', 'maxWidth' ] );
 	} );
 	const { toggleSelection } = useDispatch( 'core/block-editor' );
+	const { createErrorNotice } = useDispatch( 'core/notices' );
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const [ captionFocused, setCaptionFocused ] = useState( false );
 	const isWideAligned = includes( [ 'wide', 'full' ], align );
@@ -180,6 +181,17 @@ export default function Image( {
 				onSelectImage( {
 					url: createBlobURL( blob ),
 				} );
+			} )
+			.catch( () => {
+				createErrorNotice(
+					__(
+						'The image host doesn’t allow access from a script. Please download and upload the image manually.'
+					),
+					{
+						id: 'external-image-upload-error',
+						type: 'snackbar',
+					}
+				);
 			} );
 	}
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

See #2515 (partial fix).

This is a pretty simple change to allow the user to upload an external (hot linked) image. External images may be international, but may also be the result of paste (such as from Google Docs). Currently, we don't offer the user an option to upload these images (from the Google CDN for example). There's a risk that these images may disappear.

Ideally, from paste, we never insert external image URLs and upload them instead, but this would mean that paste is async and will mess with undo levels. This problem has to be fixed first.

The button only works if the host allows cross origin resource sharing. Google Docs and the Google CDN allows it, so does Cloudup and services like that. It usually won't work when trying to upload images from normal sites after paste. 

In the future, we can try to make this automatic.

## How has this been tested?

Create a Google Doc and upload an image. Copy paste to Gutenberg. You'll see an image, but it's external. Upload the image with the new button. You can now also edit the image. :)

## Screenshots <!-- if applicable -->

![upload-external-image](https://user-images.githubusercontent.com/4710635/86351725-6464b480-bc6d-11ea-9be5-ea4b1bca5deb.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
