### PR TITLE
Data: Use getThemeSupports() instead of getSettings()

### DIFF
--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -126,7 +126,6 @@ function gutenberg_edit_site_init( $hook ) {
 	}
 
 	$settings = array(
-		'alignWide'         => get_theme_support( 'align-wide' ),
 		'imageSizes'        => $available_image_sizes,
 		'isRTL'             => is_rtl(),
 		'maxUploadFileSize' => $max_upload_size,

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Removed the `alignWide` property from the object returned by the `getSettings` selector. Use `select( 'core' ).getThemeSupports()[ 'align-wide' ]` instead.
+
 ## 4.0.0 (2020-05-28)
 
 ### Breaking Changes

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -475,7 +475,6 @@ _Type Definition_
 
 _Properties_
 
--   _alignWide_ `boolean`: Enable/Disable Wide/Full Alignments
 -   _availableLegacyWidgets_ `Array`: Array of objects representing the legacy widgets available.
 -   _colors_ `Array`: Palette colors
 -   _fontSizes_ `Array`: Available font sizes

--- a/packages/block-editor/src/components/block-alignment-toolbar/index.js
+++ b/packages/block-editor/src/components/block-alignment-toolbar/index.js
@@ -89,10 +89,10 @@ export function BlockAlignmentToolbar( {
 
 export default compose(
 	withSelect( ( select ) => {
-		const { getSettings } = select( 'core/block-editor' );
-		const settings = getSettings();
+		const { getThemeSupports } = select( 'core' );
+		const themeSupports = getThemeSupports();
 		return {
-			wideControlsEnabled: settings.alignWide,
+			wideControlsEnabled: themeSupports.alignWide,
 		};
 	} )
 )( BlockAlignmentToolbar );

--- a/packages/block-editor/src/components/block-alignment-toolbar/index.js
+++ b/packages/block-editor/src/components/block-alignment-toolbar/index.js
@@ -92,7 +92,7 @@ export default compose(
 		const { getThemeSupports } = select( 'core' );
 		const themeSupports = getThemeSupports();
 		return {
-			wideControlsEnabled: themeSupports.alignWide,
+			wideControlsEnabled: themeSupports[ 'align-wide' ],
 		};
 	} )
 )( BlockAlignmentToolbar );

--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -174,8 +174,7 @@ export const withDataAlign = createHigherOrderComponent(
 		const { name, attributes } = props;
 		const { align } = attributes;
 		const hasWideEnabled = useSelect(
-			( select ) =>
-				!! select( 'core/block-editor' ).getSettings().alignWide,
+			( select ) => !! select( 'core' ).getThemeSupports().alignWide,
 			[]
 		);
 

--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -174,7 +174,8 @@ export const withDataAlign = createHigherOrderComponent(
 		const { name, attributes } = props;
 		const { align } = attributes;
 		const hasWideEnabled = useSelect(
-			( select ) => !! select( 'core' ).getThemeSupports().alignWide,
+			( select ) =>
+				!! select( 'core' ).getThemeSupports()[ 'align-wide' ],
 			[]
 		);
 

--- a/packages/block-editor/src/hooks/test/align.js
+++ b/packages/block-editor/src/hooks/test/align.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { noop } from 'lodash';
-import renderer, { act } from 'react-test-renderer';
+import renderer from 'react-test-renderer';
 
 /**
  * WordPress dependencies
@@ -13,17 +13,23 @@ import {
 	registerBlockType,
 	unregisterBlockType,
 } from '@wordpress/blocks';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import BlockEditorProvider from '../../components/provider';
 import {
 	getValidAlignments,
 	withToolbarControls,
 	withDataAlign,
 	addAssignedAlign,
 } from '../align';
+
+jest.mock( '@wordpress/data/src/components/use-select', () => {
+	// This allows us to tweak the returned value on each test
+	const mock = jest.fn();
+	return mock;
+} );
 
 describe( 'align', () => {
 	const blockSettings = {
@@ -186,6 +192,8 @@ describe( 'align', () => {
 
 	describe( 'withDataAlign', () => {
 		it( 'should render with wrapper props', () => {
+			useSelect.mockImplementation( () => true );
+
 			registerBlockType( 'core/foo', {
 				...blockSettings,
 				supports: {
@@ -198,28 +206,22 @@ describe( 'align', () => {
 				<div { ...wrapperProps } />
 			) );
 
-			let wrapper;
-			act( () => {
-				wrapper = renderer.create(
-					<BlockEditorProvider
-						settings={ { alignWide: true } }
-						value={ [] }
-					>
-						<EnhancedComponent
-							attributes={ {
-								align: 'wide',
-							} }
-							name="core/foo"
-						/>
-					</BlockEditorProvider>
-				);
-			} );
+			const wrapper = renderer.create(
+				<EnhancedComponent
+					attributes={ {
+						align: 'wide',
+					} }
+					name="core/foo"
+				/>
+			);
 			expect( wrapper.root.findByType( 'div' ).props ).toEqual( {
 				'data-align': 'wide',
 			} );
 		} );
 
 		it( 'should not render wide/full wrapper props if wide controls are not enabled', () => {
+			useSelect.mockImplementation( () => false );
+
 			registerBlockType( 'core/foo', {
 				...blockSettings,
 				supports: {
@@ -232,26 +234,20 @@ describe( 'align', () => {
 				<div { ...wrapperProps } />
 			) );
 
-			let wrapper;
-			act( () => {
-				wrapper = renderer.create(
-					<BlockEditorProvider
-						settings={ { alignWide: false } }
-						value={ [] }
-					>
-						<EnhancedComponent
-							name="core/foo"
-							attributes={ {
-								align: 'wide',
-							} }
-						/>
-					</BlockEditorProvider>
-				);
-			} );
+			const wrapper = renderer.create(
+				<EnhancedComponent
+					name="core/foo"
+					attributes={ {
+						align: 'wide',
+					} }
+				/>
+			);
 			expect( wrapper.root.findByType( 'div' ).props ).toEqual( {} );
 		} );
 
 		it( 'should not render invalid align', () => {
+			useSelect.mockImplementation( () => true );
+
 			registerBlockType( 'core/foo', {
 				...blockSettings,
 				supports: {
@@ -264,22 +260,14 @@ describe( 'align', () => {
 				<div { ...wrapperProps } />
 			) );
 
-			let wrapper;
-			act( () => {
-				wrapper = renderer.create(
-					<BlockEditorProvider
-						settings={ { alignWide: true } }
-						value={ [] }
-					>
-						<EnhancedComponent
-							name="core/foo"
-							attributes={ {
-								align: 'wide',
-							} }
-						/>
-					</BlockEditorProvider>
-				);
-			} );
+			const wrapper = renderer.create(
+				<EnhancedComponent
+					name="core/foo"
+					attributes={ {
+						align: 'wide',
+					} }
+				/>
+			);
 			expect( wrapper.root.findByType( 'div' ).props ).toEqual( {} );
 		} );
 	} );

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -11,7 +11,6 @@ export const PREFERENCES_DEFAULTS = {
  * The default editor settings
  *
  * @typedef {Object} SETTINGS_DEFAULT
- * @property {boolean} alignWide Enable/Disable Wide/Full Alignments
  * @property {Array} availableLegacyWidgets Array of objects representing the legacy widgets available.
  * @property {Array} colors Palette colors
  * @property {Array} fontSizes Available font sizes
@@ -36,7 +35,6 @@ export const PREFERENCES_DEFAULTS = {
  * @property {Array} __experimentalBlockPatternCategories Array of objects representing the block pattern categories
  */
 export const SETTINGS_DEFAULTS = {
-	alignWide: false,
 	colors: [
 		{
 			name: __( 'Black' ),

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -170,7 +170,6 @@ class EditorProvider extends Component {
 				'__experimentalGlobalStylesContexts',
 				'__experimentalPreferredStyleVariations',
 				'__experimentalSetIsInserterOpened',
-				'alignWide',
 				'allowedBlockTypes',
 				'availableLegacyWidgets',
 				'bodyPlaceholder',


### PR DESCRIPTION
## Description
For determining if the current theme supports `alignWide`, replace calls of `select( 'core/block-editor' ).getSettings().alignWide` with `select( 'core' ).getThemeSupports()[ 'align-wide' ]`, to reduce our dependency on the `settings` variable, and move to using the REST API instead.

This is a first iteration that's scoped to only tackle `alignWide`. It's supposed to serve as an RFC; if people think that this is a good idea, we can make the same kind of change to a number of other `settings`.

## How has this been tested?
Verify that unit tests are green, and do some smoke testing of the affected code.

Specifically: Make sure you're using a theme that supports wide alignment (e.g. Twenty Twenty), and insert a Cover block in the editor. Select alignment options from the block toolbar, and verify that it includes wide and full alignment. Select one of those, publish the post, and verify that the alignment is correctly applied on the frontend. Then, try the same for a theme without wide alignment support. 

Furthermore, verify that there are no other instances of `alignWide` that are still coming from `select( 'core/block-editor' ).getSettings()`, except in some `.native.js` files. (A number of remaining `alignWide` values are coming from invidual _blocks'_ support of wide alignment, rather than _themes'_.)

## Note

This PR doesn't touch code that's relevant for mobile apps (i.e. `.native.js` files), which introduced support for wide alignment only recently (in #24598). Moving forward, we should make sure that those files also use `getThemeSupports()` rather than `getSettings()` cc/ @geriux 

## Types of changes
Refactor.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
