### PR TITLE
Remove DropZone position argument from documentation to reflect removal in WP5.4

### DIFF
--- a/packages/components/src/drop-zone/README.md
+++ b/packages/components/src/drop-zone/README.md
@@ -44,7 +44,7 @@ A string to be shown within the drop zone area.
 
 ### onFilesDrop
 
-The function is called when dropping a file into the `DropZone`. It receives two arguments: an array of dropped files and a position object which the following shape: `{ x: 'left|right', y: 'top|bottom' }`. The position object indicates whether the drop event happened closer to the top or bottom edges and left or right ones.
+The function is called when dropping a file into the `DropZone`. It receives an array of dropped files as an argument.
 
 - Type: `Function`
 - Required: No
@@ -52,7 +52,7 @@ The function is called when dropping a file into the `DropZone`. It receives two
 
 ### onHTMLDrop
 
-The function is called when dropping a file into the `DropZone`. It receives two arguments: the HTML being dropped and a position object.
+The function is called when dropping a file into the `DropZone`. It receives the HTML being dropped as an argument.
 
 - Type: `Function`
 - Required: No
@@ -60,7 +60,7 @@ The function is called when dropping a file into the `DropZone`. It receives two
 
 ### onDrop
 
-The function is generic drop handler called if the `onFilesDrop` or `onHTMLDrop` are not called. It receives two arguments: The drop `event` object and the position object.
+The function is generic drop handler called if the `onFilesDrop` or `onHTMLDrop` are not called. It receives the drop `event` object as an argument.
 
 - Type: `Function`
 - Required: No


### PR DESCRIPTION
## Description
Fixes  #23149.

The position argument for DropZone callbacks was removed as part of WordPress 5.4 (see the dev note here: https://github.com/WordPress/gutenberg/issues/20185#issuecomment-592485163).

This PR updates the docs to reflect the removal of the argument.

## Types of changes
Documentation
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
