### PR TITLE
[Mobile] Reduce spacing between label and slider control

### DIFF
--- a/packages/components/src/mobile/bottom-sheet/cellRowStyles.android.scss
+++ b/packages/components/src/mobile/bottom-sheet/cellRowStyles.android.scss
@@ -1,0 +1,6 @@
+.cellRowStyles {
+	min-height: 48px;
+	margin-bottom: -37px;
+	width: 100%;
+	justify-content: space-between;
+}

--- a/packages/components/src/mobile/bottom-sheet/cellRowStyles.ios.scss
+++ b/packages/components/src/mobile/bottom-sheet/cellRowStyles.ios.scss
@@ -1,0 +1,6 @@
+.cellRowStyles {
+	min-height: 48px;
+	margin-bottom: -27px;
+	width: 100%;
+	justify-content: space-between;
+}

--- a/packages/components/src/mobile/bottom-sheet/range-cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/range-cell.native.js
@@ -24,6 +24,7 @@ import { withPreferredColorScheme } from '@wordpress/compose';
  */
 import Cell from './cell';
 import styles from './range-cell.scss';
+import rowStyles from './cellRowStyles.scss';
 import borderStyles from './borderStyles.scss';
 
 class BottomSheetRangeCell extends Component {
@@ -179,7 +180,7 @@ class BottomSheetRangeCell extends Component {
 			<Cell
 				{ ...cellProps }
 				cellContainerStyle={ styles.cellContainerStyles }
-				cellRowContainerStyle={ styles.cellRowStyles }
+				cellRowContainerStyle={ rowStyles.cellRowStyles }
 				accessibilityRole={ 'none' }
 				value={ '' }
 				editable={ false }

--- a/packages/components/src/mobile/bottom-sheet/range-cell.native.scss
+++ b/packages/components/src/mobile/bottom-sheet/range-cell.native.scss
@@ -31,10 +31,3 @@
 	flex-direction: column;
 	align-items: flex-start;
 }
-
-.cellRowStyles {
-	min-height: 48px;
-	margin-bottom: -13px;
-	width: 100%;
-	justify-content: space-between;
-}


### PR DESCRIPTION
**Fixes** https://github.com/wordpress-mobile/gutenberg-mobile/issues/2126

## Related PRs:
gutenberg-mobile https://github.com/wordpress-mobile/gutenberg-mobile/pull/2451

## Description
Reduces spacing between label and slider control by:
* 14px on iOS
* 24px on Android

## How has this been tested?
* Add a block that has as slider control in the settings (e.g. spacer)
* Press on the settings button
* Verify that the space between the label and the slider control is appropriate

## Screenshots

|Android|iOS|
|---|---|
|![Screenshot_1593521798](https://user-images.githubusercontent.com/304044/86128720-69e5c180-baea-11ea-83f5-2ea045b000b3.png)|![Simulator Screen Shot - iPhone 11 - 2020-06-30 at 15 52 30](https://user-images.githubusercontent.com/304044/86128513-20957200-baea-11ea-94f8-e1461b6d935c.png)|

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
