### PR TITLE
Cancel previous running workflows when a new commit is made

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -1,5 +1,5 @@
 name: Cancel
-on: [push]
+on: [push, pull_request]
 jobs:
   cancel:
     name: 'Cancel Previous Runs'

--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -2,7 +2,7 @@ name: Cancel
 on: [push]
 jobs:
   cancel:
-    name: 'Cancel Previous Runs test'
+    name: 'Cancel Previous Runs'
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:

--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -1,0 +1,15 @@
+name: Cancel
+on: [push]
+jobs:
+  cancel:
+    name: 'Cancel Previous Runs'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Get all workflow ids and set to env variable
+        run: echo ::set-env name=WORKFLOW_IDS_TO_CANCEL::$(curl https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows -s | jq -r '.workflows | map(.id|tostring) | join(",")')
+
+      - uses: styfle/cancel-workflow-action@0.4.0
+        with:
+          workflow_id: ${{ env.WORKFLOW_IDS_TO_CANCEL }}
+          access_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -2,7 +2,7 @@ name: Cancel
 on: pull_request
 jobs:
   cancel:
-    name: 'Cancel Previous Runs'
+    name: 'Cancel Previous Runs test'
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:

--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -1,5 +1,5 @@
 name: Cancel
-on: [push, pull_request]
+on: pull_request
 jobs:
   cancel:
     name: 'Cancel Previous Runs'

--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -2,7 +2,7 @@ name: Cancel
 on: [push]
 jobs:
   cancel:
-    name: 'Cancel Previous Runs'
+    name: 'Cancel Previous Runs test'
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:

--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -2,7 +2,7 @@ name: Cancel
 on: pull_request
 jobs:
   cancel:
-    name: 'Cancel Previous Runs test'
+    name: 'Cancel Previous Runs'
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

Added a new GitHub action workflow named `Cancel` using [styfle/cancel-workflow-action](https://github.com/styfle/cancel-workflow-action) to cancel all running workflows on a branch when a new commit is made.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

See the commits `Test 1` and `Test 2` cancelling previous runs. Force-pushes also work.
