### PR TITLE
Fix build hang on Windows 10

### DIFF
--- a/bin/packages/build.js
+++ b/bin/packages/build.js
@@ -263,7 +263,8 @@ stream
 				console.error( error );
 			}
 
-			if ( ended && ++complete === files.length ) {
+			++complete;
+			if ( ended && complete === files.length ) {
 				workerFarm.end( worker );
 			}
 		} )


### PR DESCRIPTION
On Windows 10, I seem to be unable to build. The build completion rises to 100%, but the process never finishes. I can build if I manually set the number of workers in the farm to 4, but not if it's any higher.

It appears that some files are not being counted as "complete". It's probably files that finish before the "ended" signal is received (meaning everything has been queued.) Moving the increment out of the conditional fixes this.

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fix build hang on Windows 10

## How has this been tested?
The build would hang on my Windows 10 machine, but succeed on my Mac. Making this change causes the build to succeed on my Windows 10 machine.

## Types of changes
Bug Fix (Build tools)

## Checklist:
- [ Y ] My code is tested.
- [ Y ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ NA ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ NA ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ NA ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ NA ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
