### PR TITLE
Fix typos in theme support documentation

### DIFF
--- a/docs/designers-developers/developers/themes/theme-support.md
+++ b/docs/designers-developers/developers/themes/theme-support.md
@@ -358,7 +358,7 @@ add_theme_support( 'responsive-embeds' );
 
 ## Experimental — Cover block padding
 
-In the Guteberg plugin 8.3, Cover blocks can provide padding controls in the editor for users. This is not avaialble by default, and requires the theme to opt in by declaring support:
+Using the Gutenberg plugin (version 8.3 or later), Cover blocks can provide padding controls in the editor for users. This is off by default, and requires the theme to opt in by declaring support:
 
 ```php
 add_theme_support('experimental-custom-spacing');
@@ -366,7 +366,7 @@ add_theme_support('experimental-custom-spacing');
 
 ## Experimental — Link color control
 
-In the Guteberg plugin 8.3, link color control is available to the Paragraph, Heading, Group, Columns, and Media & Text blocks. This is not avaialble by default, and requires the theme to opt in by declaring support:
+Using the Gutenberg plugin (version 8.3 or later), link color control is available to the Paragraph, Heading, Group, Columns, and Media & Text blocks. This is off by default, and  requires the theme to opt in by declaring support:
 
 ```php
 add_theme_support('experimental-link-color');


### PR DESCRIPTION
Fixes a few small typos in the theme support documentation ("Guteberg" and "avaialble") and rewords things to be a little more clear. 

I think the link color control documentation could be improved too, and I'm happy to wrap that into this PR. Presumably, any theme that would opt into this would also want to provide a default value. Is that correct, @nosolosw? (And if so, what's the best way for them to do that?)