### PR TITLE
Unsupported block editor is on all mobile builds

### DIFF
--- a/packages/block-library/src/missing/edit.native.js
+++ b/packages/block-library/src/missing/edit.native.js
@@ -7,8 +7,13 @@ import { Platform, View, Text, TouchableWithoutFeedback } from 'react-native';
  * WordPress dependencies
  */
 import { requestUnsupportedBlockFallback } from '@wordpress/react-native-bridge';
-import { BottomSheet, Icon } from '@wordpress/components';
-import { withPreferredColorScheme } from '@wordpress/compose';
+import {
+	BottomSheet,
+	Icon,
+	withSiteCapabilities,
+	isUnsupportedBlockEditorSupported,
+} from '@wordpress/components';
+import { compose, withPreferredColorScheme } from '@wordpress/compose';
 import { coreBlocks } from '@wordpress/block-library';
 import { normalizeIconObject } from '@wordpress/blocks';
 import { Component } from '@wordpress/element';
@@ -71,7 +76,12 @@ export class UnsupportedBlockEdit extends Component {
 	}
 
 	renderSheet( blockTitle, blockName ) {
-		const { getStylesFromColorScheme, attributes, clientId } = this.props;
+		const {
+			getStylesFromColorScheme,
+			attributes,
+			clientId,
+			capabilities,
+		} = this.props;
 		const infoTextStyle = getStylesFromColorScheme(
 			styles.infoText,
 			styles.infoTextDark
@@ -133,37 +143,31 @@ export class UnsupportedBlockEdit extends Component {
 						{ infoTitle }
 					</Text>
 					<Text style={ [ infoTextStyle, infoDescriptionStyle ] }>
-						{
-							// eslint-disable-next-line no-undef
-							__DEV__
-								? __(
-										"We are working hard to add more blocks with each release. In the meantime, you can also edit this block using your device's web browser."
-								  )
-								: __(
-										'We are working hard to add more blocks with each release. In the meantime, you can also edit this post on the web.'
-								  )
-						}
+						{ isUnsupportedBlockEditorSupported( capabilities )
+							? __(
+									"We are working hard to add more blocks with each release. In the meantime, you can also edit this block using your device's web browser."
+							  )
+							: __(
+									'We are working hard to add more blocks with each release. In the meantime, you can also edit this post on the web.'
+							  ) }
 					</Text>
 				</View>
-				{
-					// eslint-disable-next-line no-undef
-					__DEV__ && (
-						<>
-							<BottomSheet.Cell
-								label={ __( 'Edit block in web browser' ) }
-								separatorType="topFullWidth"
-								onPress={ this.requestFallback }
-								labelStyle={ actionButtonStyle }
-							/>
-							<BottomSheet.Cell
-								label={ __( 'Dismiss' ) }
-								separatorType="topFullWidth"
-								onPress={ this.toggleSheet }
-								labelStyle={ actionButtonStyle }
-							/>
-						</>
-					)
-				}
+				{ isUnsupportedBlockEditorSupported( capabilities ) && (
+					<>
+						<BottomSheet.Cell
+							label={ __( 'Edit block in web browser' ) }
+							separatorType="topFullWidth"
+							onPress={ this.requestFallback }
+							labelStyle={ actionButtonStyle }
+						/>
+						<BottomSheet.Cell
+							label={ __( 'Dismiss' ) }
+							separatorType="topFullWidth"
+							onPress={ this.toggleSheet }
+							labelStyle={ actionButtonStyle }
+						/>
+					</>
+				) }
 			</BottomSheet>
 		);
 	}
@@ -216,4 +220,6 @@ export class UnsupportedBlockEdit extends Component {
 	}
 }
 
-export default withPreferredColorScheme( UnsupportedBlockEdit );
+export default compose( [ withPreferredColorScheme, withSiteCapabilities ] )(
+	UnsupportedBlockEdit
+);

--- a/packages/components/src/mobile/site-capabilities/index.js
+++ b/packages/components/src/mobile/site-capabilities/index.js
@@ -7,6 +7,10 @@ export function isMentionsSupported( capabilities ) {
 	return capabilities.mentions === true;
 }
 
+export function isUnsupportedBlockEditorSupported( capabilities ) {
+	return capabilities.unsupportedBlockEditor === true;
+}
+
 export const SiteCapabilitiesContext = createContext( {} );
 
 export const useSiteCapabilities = () => {

--- a/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
+++ b/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
@@ -111,6 +111,7 @@ public class WPAndroidGlueCode {
     private static final String PROP_NAME_TRANSLATIONS = "translations";
     public static final String PROP_NAME_CAPABILITIES = "capabilities";
     public static final String PROP_NAME_CAPABILITIES_MENTIONS = "mentions";
+    public static final String PROP_NAME_CAPABILITIES_UNSUPPORTED_BLOCK_EDITOR = "unsupportedBlockEditor";
     private static final String PROP_NAME_COLORS = "colors";
     private static final String PROP_NAME_GRADIENTS = "gradients";
 
@@ -380,7 +381,7 @@ public class WPAndroidGlueCode {
                         gutenbergDidRequestUnsupportedBlockFallback(new UnsupportedBlock(blockId, blockName, blockTitle, content));
             }
 
-            @Override 
+            @Override
             public void onAddMention(Consumer<String> onSuccess) {
                 mAddMentionUtil.getMention(onSuccess);
             }
@@ -431,7 +432,8 @@ public class WPAndroidGlueCode {
                              Consumer<Exception> exceptionLogger,
                              Consumer<String> breadcrumbLogger,
                              @Nullable Boolean isSiteUsingWpComRestApi,
-                             @Nullable Bundle editorTheme) {
+                             @Nullable Bundle editorTheme,
+                             boolean siteJetpackIsConnected) {
         mIsDarkMode = isDarkMode;
         mExceptionLogger = exceptionLogger;
         mBreadcrumbLogger = breadcrumbLogger;
@@ -467,6 +469,7 @@ public class WPAndroidGlueCode {
         Bundle capabilities = new Bundle();
         if (isSiteUsingWpComRestApi != null) {
             capabilities.putBoolean(PROP_NAME_CAPABILITIES_MENTIONS, isSiteUsingWpComRestApi);
+            capabilities.putBoolean(PROP_NAME_CAPABILITIES_UNSUPPORTED_BLOCK_EDITOR, !siteJetpackIsConnected);
         }
         initialProps.putBundle(PROP_NAME_CAPABILITIES, capabilities);
 

--- a/packages/react-native-editor/RELEASE-NOTES.txt
+++ b/packages/react-native-editor/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+1.32.0
+------
+* [***] The block editor now gives users the ability to individually edit unsupported blocks found in posts or pages. 
+
 1.31.0
 ------
 * [**] Add support for customizing gradient type and angle in Buttons and Cover blocks.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Previously, mobile's [unsupported block editor](https://github.com/wordpress-mobile/gutenberg-mobile/issues/2358#issue-634693891) was only available on development builds. It is now ready to be made available on all builds, so this PR removes that restriction.

Related:
- Gutenberg Mobile: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2457
- iOS demo build: https://github.com/wordpress-mobile/WordPress-iOS/pull/14403
- Android demo build: https://github.com/wordpress-mobile/WordPress-Android/pull/12331
- Test cases: https://github.com/wordpress-mobile/test-cases/pull/39

## How has this been tested?

1. Download the test build for iOS: https://github.com/wordpress-mobile/WordPress-iOS/pull/14403#issuecomment-652053754
2. Perform the test cases for the Unsupported Block Editor from https://github.com/wordpress-mobile/test-cases/pull/39
   - TC001: New edits are persisted 
   - TC002: Discarded edits are not persisted
   - TC003: WP.com Business (Atomic) sites are supported 
   - TC004: Self-hosted sites are supported

5. Repeat steps 1 and 2 for the test build for Android: https://github.com/wordpress-mobile/WordPress-Android/pull/12331#issuecomment-652089871

## Screenshots <!-- if applicable -->

_Note: the black navigation bar title on the iOS gif below looks like a bug but not part of this PR — I see it on the v15.2 build of WPiOS and have reported it [here](https://github.com/wordpress-mobile/WordPress-iOS/issues/14404)._

| iOS (light mode) | Android (dark mode) |
| -- | -- |
| <img width="250" src="https://user-images.githubusercontent.com/1898325/86193322-9fee6a00-bb19-11ea-878b-25f7055f70ed.gif"> | <img width="250" src="https://user-images.githubusercontent.com/1898325/86193344-b09ee000-bb19-11ea-90a6-1e3d8b638fb8.gif"> |


## Types of changes
This code introduces a new feature: the ability for users to edit in a web-view blocks that are not yet supported on mobile 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
