### PR TITLE
Fix odd usage of transform-styles wrap function (and tighten types).

### DIFF
--- a/packages/block-editor/src/utils/transform-styles/transforms/test/wrap.js
+++ b/packages/block-editor/src/utils/transform-styles/transforms/test/wrap.js
@@ -22,7 +22,7 @@ describe( 'CSS selector wrap', () => {
 	} );
 
 	it( 'should ignore selectors', () => {
-		const callback = wrap( '.my-namespace', 'body' );
+		const callback = wrap( '.my-namespace', [ 'body' ] );
 		const input = `h1, body { color: red; }`;
 		const output = traverse( input, callback );
 

--- a/packages/block-editor/src/utils/transform-styles/transforms/wrap.js
+++ b/packages/block-editor/src/utils/transform-styles/transforms/wrap.js
@@ -3,7 +3,23 @@
  */
 const IS_ROOT_TAG = /^(body|html|:root).*$/;
 
+/**
+ * Creates a callback to modify selectors so they only apply within a certain
+ * namespace.
+ *
+ * @param {string}   namespace Namespace to prefix selectors with.
+ * @param {string[]} ignore    Selectors to not prefix.
+ *
+ * @return {(node: Object) => Object} Callback to wrap selectors.
+ */
 const wrap = ( namespace, ignore = [] ) => ( node ) => {
+	/**
+	 * Updates selector if necessary.
+	 *
+	 * @param {string} selector Selector to modify.
+	 *
+	 * @return {string} Updated selector.
+	 */
 	const updateSelector = ( selector ) => {
 		if ( ignore.includes( selector.trim() ) ) {
 			return selector;


### PR DESCRIPTION
## Description
One of the unit tests for the `wrap` function in `packages/block-editor/src/utils/transform-styles/transforms/wrap.js` was using the function incorrectly, passing a string as the second argument rather than an array of strings. This didn't cause a test failure, because the code coincidentally still worked, due to strings and arrays both having a method called `includes`, which in the case of a string is used to find substrings.

While in this case it was harmless, this undefined behavior could result in issues if the `ignore` argument was something like `a`, which would match not only `a`, but also `article`, `address`, and other selectors that happen to contain the substring `a`.

This PR fixes the unit test and tightens the types on the `wrap` function to try and prevent future misuse.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
