### PR TITLE
Use controlled InnerBlocks in reusable blocks

### DIFF
--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -11,7 +11,7 @@ import {
 	BlockList,
 	WritingFlow,
 } from '@wordpress/block-editor';
-import { parse, serialize } from '@wordpress/blocks';
+import { serialize } from '@wordpress/blocks';
 import { Placeholder, Spinner, Disabled } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
@@ -37,7 +37,10 @@ export default function ReusableBlockEdit( { attributes, isSelected } ) {
 	} = useSelect(
 		( select ) => {
 			const { canUser } = select( 'core' );
-			const { getSettings } = select( 'core/block-editor' );
+			const {
+				__experimentalGetParsedReusableBlock: getParsedReusableBlock,
+				getSettings,
+			} = select( 'core/block-editor' );
 			const {
 				__experimentalGetReusableBlock: getReusableBlock,
 				__experimentalIsFetchingReusableBlock: isFetchingReusableBlock,
@@ -50,7 +53,9 @@ export default function ReusableBlockEdit( { attributes, isSelected } ) {
 				isFetching: isFetchingReusableBlock( ref ),
 				isSaving: isSavingReusableBlock( ref ),
 				isTemporary: _reusableBlock?.isTemporary ?? null,
-				blocks: _reusableBlock ? parse( _reusableBlock.content ) : null,
+				blocks: _reusableBlock
+					? getParsedReusableBlock( _reusableBlock.id )
+					: null,
 				canUpdateBlock:
 					!! _reusableBlock &&
 					! _reusableBlock.isTemporary &&

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -6,11 +6,7 @@ import { partial } from 'lodash';
 /**
  * WordPress dependencies
  */
-import {
-	BlockEditorProvider,
-	BlockList,
-	WritingFlow,
-} from '@wordpress/block-editor';
+import { InnerBlocks } from '@wordpress/block-editor';
 import { parse, serialize } from '@wordpress/blocks';
 import { Placeholder, Spinner, Disabled } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -33,13 +29,11 @@ export default function ReusableBlockEdit( {
 		blocks,
 		title,
 		canUpdateBlock,
-		settings,
 	} = useSelect(
 		( select ) => {
 			const { canUser } = select( 'core' );
 			const {
 				__experimentalGetParsedReusableBlock: getParsedReusableBlock,
-				getSettings,
 			} = select( 'core/block-editor' );
 			const {
 				__experimentalGetReusableBlock: getReusableBlock,
@@ -71,7 +65,6 @@ export default function ReusableBlockEdit( {
 					!! _reusableBlock &&
 					! _reusableBlock.isTemporary &&
 					!! canUser( 'update', 'blocks', ref ),
-				settings: getSettings(),
 			};
 		},
 		[ ref ]
@@ -160,18 +153,12 @@ export default function ReusableBlockEdit( {
 	}
 
 	let content = (
-		<BlockEditorProvider
-			settings={ settings }
+		<InnerBlocks
 			// If editing, use local state; otherwise, load the blocks from the
 			// saved reusable block.
 			value={ isEditing ? localBlocks : blocks }
 			onChange={ handleModifyBlocks }
-			onInput={ handleModifyBlocks }
-		>
-			<WritingFlow>
-				<BlockList />
-			</WritingFlow>
-		</BlockEditorProvider>
+		/>
 	);
 
 	if ( ! isEditing ) {

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -158,6 +158,7 @@ export default function ReusableBlockEdit( {
 			// saved reusable block.
 			value={ isEditing ? localBlocks : blocks }
 			onChange={ handleModifyBlocks }
+			onInput={ handleModifyBlocks }
 		/>
 	);
 


### PR DESCRIPTION
## Description
A small PR branched from #21427 which switches reusable blocks from a nested BlockEditorProvider area to the controlled InnerBlocks API introduced in #21368.

## How has this been tested?
Tested in browser.

## Types of changes
Non-breaking change to reusable blocks.