### PR TITLE
Sync Block Context changes from core to compat to avoid a PHP Warning  

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -423,8 +423,10 @@ function gutenberg_render_block_with_assigned_block_context( $pre_render, $parse
 	/** This filter is documented in src/wp-includes/blocks.php */
 	$parsed_block = apply_filters( 'render_block_data', $parsed_block, $source_block );
 
-	$context = array(
-		'postId'   => $post ? $post->ID : 0,
+	$context = array();
+
+	if ( $post instanceof WP_Post ) {
+		$context['postId'] = $post->ID;
 
 		/*
 		 * The `postType` context is largely unnecessary server-side, since the
@@ -432,12 +434,12 @@ function gutenberg_render_block_with_assigned_block_context( $pre_render, $parse
 		 * manifest is expected to be shared between the server and the client,
 		 * it should be included to consistently fulfill the expectation.
 		 */
-		'postType' => $post ? $post->post_type : false,
-
-		'query'    => array( 'categoryIds' => array() ),
-	);
+		$context['postType'] = $post->post_type;
+	}
 
 	if ( isset( $wp_query->tax_query->queried_terms['category'] ) ) {
+		$context['query'] = array( 'categoryIds' => array() );
+
 		foreach ( $wp_query->tax_query->queried_terms['category']['terms'] as $category_slug_or_id ) {
 			$context['query']['categoryIds'][] = 'slug' === $wp_query->tax_query->queried_terms['category']['field'] ? get_cat_ID( $category_slug_or_id ) : $category_slug_or_id;
 		}

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -424,7 +424,7 @@ function gutenberg_render_block_with_assigned_block_context( $pre_render, $parse
 	$parsed_block = apply_filters( 'render_block_data', $parsed_block, $source_block );
 
 	$context = array(
-		'postId'   => $post->ID,
+		'postId'   => $post ? $post->ID : 0,
 
 		/*
 		 * The `postType` context is largely unnecessary server-side, since the
@@ -432,7 +432,7 @@ function gutenberg_render_block_with_assigned_block_context( $pre_render, $parse
 		 * manifest is expected to be shared between the server and the client,
 		 * it should be included to consistently fulfill the expectation.
 		 */
-		'postType' => $post->post_type,
+		'postType' => $post ? $post->post_type : false,
 
 		'query'    => array( 'categoryIds' => array() ),
 	);


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Sync's the Block context between core and Gutenberg Compat functions.

This avoids a PHP warning when `apply_filters( 'the_content' )` is used without a global `$post` object.

See https://github.com/WordPress/wordpress-develop/commit/910de8f6890c87f93359c6f2edc6c27b9a3f3292 and additionally merges https://github.com/WordPress/wordpress-develop/pull/372

Fixes #22720 

## How has this been tested?
Very basic. Only in-editor publishing following steps in #22720.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug Fix.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
