### PR TITLE
Polish drag chip

### DIFF
--- a/packages/block-editor/src/components/block-draggable/draggable-chip.js
+++ b/packages/block-editor/src/components/block-draggable/draggable-chip.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { getBlockType } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 import { Flex, FlexItem } from '@wordpress/components';
@@ -44,7 +45,9 @@ export default function BlockDraggableChip( { clientIds } ) {
 						<BlockIcon icon={ icon } />
 					</FlexItem>
 					{ clientIds.length > 1 && (
-						<FlexItem>{ `(${ clientIds.length })` }</FlexItem>
+						<FlexItem>
+							{ `${ clientIds.length }` } { __( 'blocks' ) }
+						</FlexItem>
 					) }
 				</Flex>
 			</div>

--- a/packages/block-editor/src/components/block-draggable/draggable-chip.js
+++ b/packages/block-editor/src/components/block-draggable/draggable-chip.js
@@ -43,7 +43,9 @@ export default function BlockDraggableChip( { clientIds } ) {
 					<FlexItem>
 						<BlockIcon icon={ icon } />
 					</FlexItem>
-					<FlexItem>{ `(${ clientIds.length })` }</FlexItem>
+					{ clientIds.length > 1 && (
+						<FlexItem>{ `(${ clientIds.length })` }</FlexItem>
+					) }
 				</Flex>
 			</div>
 		</div>

--- a/packages/block-editor/src/components/block-draggable/draggable-chip.js
+++ b/packages/block-editor/src/components/block-draggable/draggable-chip.js
@@ -4,7 +4,7 @@
 import { getBlockType } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 import { Flex, FlexItem } from '@wordpress/components';
-import { layout, handle } from '@wordpress/icons';
+import { stack, handle } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -22,7 +22,7 @@ export default function BlockDraggableChip( { clientIds } ) {
 			);
 
 			if ( ! isOfSameType ) {
-				return layout;
+				return stack;
 			}
 
 			return getBlockType( blockName ).icon;

--- a/packages/block-editor/src/components/block-draggable/draggable-chip.js
+++ b/packages/block-editor/src/components/block-draggable/draggable-chip.js
@@ -41,9 +41,11 @@ export default function BlockDraggableChip( { clientIds } ) {
 					<FlexItem>
 						<BlockIcon icon={ handle } />
 					</FlexItem>
-					<FlexItem>
-						<BlockIcon icon={ icon } />
-					</FlexItem>
+					{ clientIds.length === 1 && (
+						<FlexItem>
+							<BlockIcon icon={ icon } />
+						</FlexItem>
+					) }
 					{ clientIds.length > 1 && (
 						<FlexItem>
 							{ `${ clientIds.length }` } { __( 'blocks' ) }

--- a/packages/block-editor/src/components/block-draggable/draggable-chip.js
+++ b/packages/block-editor/src/components/block-draggable/draggable-chip.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { getBlockType } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 import { Flex, FlexItem } from '@wordpress/components';
@@ -15,6 +15,10 @@ import BlockIcon from '../block-icon';
 export default function BlockDraggableChip( { clientIds } ) {
 	const icon = useSelect(
 		( select ) => {
+			if ( clientIds.length !== 1 ) {
+				return;
+			}
+
 			const { getBlockName } = select( 'core/block-editor' );
 			const [ firstId ] = clientIds;
 			const blockName = getBlockName( firstId );
@@ -34,16 +38,17 @@ export default function BlockDraggableChip( { clientIds } ) {
 					<FlexItem>
 						<BlockIcon icon={ handle } />
 					</FlexItem>
-					{ clientIds.length === 1 && (
-						<FlexItem>
+					<FlexItem>
+						{ icon ? (
 							<BlockIcon icon={ icon } />
-						</FlexItem>
-					) }
-					{ clientIds.length > 1 && (
-						<FlexItem>
-							{ `${ clientIds.length }` } { __( 'blocks' ) }
-						</FlexItem>
-					) }
+						) : (
+							sprintf(
+								/* translators: %d: number of blocks. */
+								__( '%d blocks' ),
+								clientIds.length
+							)
+						) }
+					</FlexItem>
 				</Flex>
 			</div>
 		</div>

--- a/packages/block-editor/src/components/block-draggable/draggable-chip.js
+++ b/packages/block-editor/src/components/block-draggable/draggable-chip.js
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { getBlockType } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 import { Flex, FlexItem } from '@wordpress/components';
-import { stack, handle } from '@wordpress/icons';
+import { handle } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -18,13 +18,6 @@ export default function BlockDraggableChip( { clientIds } ) {
 			const { getBlockName } = select( 'core/block-editor' );
 			const [ firstId ] = clientIds;
 			const blockName = getBlockName( firstId );
-			const isOfSameType = clientIds.every(
-				( id ) => getBlockName( id ) === blockName
-			);
-
-			if ( ! isOfSameType ) {
-				return stack;
-			}
 
 			return getBlockType( blockName ).icon;
 		},

--- a/packages/block-editor/src/components/block-draggable/style.scss
+++ b/packages/block-editor/src/components/block-draggable/style.scss
@@ -23,6 +23,11 @@
 	&__content {
 		margin: auto;
 	}
+
+	.components-flex__item {
+		font-family: $default-font;
+		font-size: $default-font-size;
+	}
 }
 
 // This hides the block being dragged.

--- a/packages/block-editor/src/components/block-draggable/style.scss
+++ b/packages/block-editor/src/components/block-draggable/style.scss
@@ -7,7 +7,7 @@
 	background-color: $dark-gray-primary;
 	border-radius: $radius-block-ui;
 	border: $border-width solid $dark-gray-primary;
-	box-shadow: $shadow-popover;
+	box-shadow: 0 4px 6px rgba($black, 0.3);
 	color: $white;
 	cursor: grabbing;
 	display: inline-flex;
@@ -20,7 +20,7 @@
 		fill: currentColor;
 	}
 
-	&__content {
+	.block-editor-block-draggable-chip__content {
 		margin: auto;
 	}
 

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -25,7 +25,7 @@ import {
 import { Component } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
-import { layout } from '@wordpress/icons';
+import { stack } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -123,7 +123,7 @@ export class BlockSwitcher extends Component {
 			const blockType = getBlockType( sourceBlockName );
 			icon = blockType.icon;
 		} else {
-			icon = layout;
+			icon = stack;
 		}
 
 		const hasPossibleBlockTransformations = !! possibleBlockTransformations.length;

--- a/packages/block-editor/src/components/block-switcher/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/block-switcher/test/__snapshots__/index.js.snap
@@ -9,11 +9,11 @@ exports[`BlockSwitcher should render disabled block switcher with multi block of
       <BlockIcon
         icon={
           <SVG
-            viewBox="-2 -2 24 24"
+            viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
           >
             <Path
-              d="M2 2h5v11H2V2zm6 0h5v5H8V2zm6 0h4v16h-4V2zM8 8h5v5H8V8zm-6 6h11v4H2v-4z"
+              d="M20.2 8v11c0 .7-.6 1.2-1.2 1.2H6v1.5h13c1.5 0 2.7-1.2 2.7-2.8V8zM18 16.4V4.6c0-.9-.7-1.6-1.6-1.6H4.6C3.7 3 3 3.7 3 4.6v11.8c0 .9.7 1.6 1.6 1.6h11.8c.9 0 1.6-.7 1.6-1.6zm-13.5 0V4.6c0-.1.1-.1.1-.1h11.8c.1 0 .1.1.1.1v11.8c0 .1-.1.1-.1.1H4.6l-.1-.1z"
             />
           </SVG>
         }

--- a/packages/block-editor/src/components/multi-selection-inspector/index.js
+++ b/packages/block-editor/src/components/multi-selection-inspector/index.js
@@ -5,7 +5,7 @@ import { sprintf, _n } from '@wordpress/i18n';
 import { withSelect } from '@wordpress/data';
 import { serialize } from '@wordpress/blocks';
 import { count as wordCount } from '@wordpress/wordcount';
-import { Path, SVG } from '@wordpress/components';
+import { stack } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -18,11 +18,7 @@ function MultiSelectionInspector( { blocks } ) {
 	return (
 		<div className="block-editor-multi-selection-inspector__card">
 			<BlockIcon
-				icon={
-					<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-						<Path d="M3 5H1v16c0 1.1.9 2 2 2h16v-2H3V5zm18-4H7c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V3c0-1.1-.9-2-2-2zm0 16H7V3h14v14z" />
-					</SVG>
-				}
+				icon={ stack }
 				showColors
 			/>
 			<div className="block-editor-multi-selection-inspector__card-content">

--- a/packages/block-editor/src/components/multi-selection-inspector/index.js
+++ b/packages/block-editor/src/components/multi-selection-inspector/index.js
@@ -17,10 +17,7 @@ function MultiSelectionInspector( { blocks } ) {
 
 	return (
 		<div className="block-editor-multi-selection-inspector__card">
-			<BlockIcon
-				icon={ stack }
-				showColors
-			/>
+			<BlockIcon icon={ stack } showColors />
 			<div className="block-editor-multi-selection-inspector__card-content">
 				<div className="block-editor-multi-selection-inspector__card-title">
 					{ sprintf(

--- a/packages/icons/src/index.js
+++ b/packages/icons/src/index.js
@@ -135,6 +135,7 @@ export { default as search } from './library/search';
 export { default as separator } from './library/separator';
 export { default as share } from './library/share';
 export { default as shortcode } from './library/shortcode';
+export { default as stack } from './library/stack';
 export { default as starEmpty } from './library/star-empty';
 export { default as starFilled } from './library/star-filled';
 export { default as starHalf } from './library/star-half';

--- a/packages/icons/src/library/stack.js
+++ b/packages/icons/src/library/stack.js
@@ -1,0 +1,12 @@
+/**
+ * WordPress dependencies
+ */
+import { SVG, Path } from '@wordpress/primitives';
+
+const stack = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path d="M20.2 8v11c0 .7-.6 1.2-1.2 1.2H6v1.5h13c1.5 0 2.7-1.2 2.7-2.8V8zM18 16.4V4.6c0-.9-.7-1.6-1.6-1.6H4.6C3.7 3 3 3.7 3 4.6v11.8c0 .9.7 1.6 1.6 1.6h11.8c.9 0 1.6-.7 1.6-1.6zm-13.5 0V4.6c0-.1.1-.1.1-.1h11.8c.1 0 .1.1.1.1v11.8c0 .1-.1.1-.1.1H4.6l-.1-.1z" />
+	</SVG>
+);
+
+export default stack;


### PR DESCRIPTION
This polishes the drag chip, and the multi select icon. Before:

<img width="383" alt="Screenshot 2020-07-01 at 12 20 41" src="https://user-images.githubusercontent.com/1204802/86235237-66a90f00-bb98-11ea-96f1-e1ba2bba34c2.png">

<img width="155" alt="Screenshot 2020-07-01 at 12 20 48" src="https://user-images.githubusercontent.com/1204802/86235243-690b6900-bb98-11ea-8e21-ad95dd24fa26.png">

<img width="395" alt="Screenshot 2020-07-01 at 12 24 27" src="https://user-images.githubusercontent.com/1204802/86235280-76285800-bb98-11ea-834d-ca9299e435bf.png">


After:

<img width="459" alt="Screenshot 2020-07-01 at 12 18 11" src="https://user-images.githubusercontent.com/1204802/86235214-5f820100-bb98-11ea-962a-875783349bd8.png">

<img width="221" alt="Screenshot 2020-07-01 at 12 22 34" src="https://user-images.githubusercontent.com/1204802/86235267-71fc3a80-bb98-11ea-8115-157650326fc1.png">

<img width="489" alt="Screenshot 2020-07-01 at 12 24 37" src="https://user-images.githubusercontent.com/1204802/86235317-88a29180-bb98-11ea-92b6-c5ed0235d228.png">

<img width="440" alt="Screenshot 2020-07-01 at 12 39 02" src="https://user-images.githubusercontent.com/1204802/86235324-8b9d8200-bb98-11ea-843c-0c7c74dbe1b8.png">

I also made it so when you're only dragging a single block, you don't see the number.
