### PR TITLE
[RNMobile] Correct Buttons block width

### DIFF
--- a/packages/react-native-aztec/src/AztecView.js
+++ b/packages/react-native-aztec/src/AztecView.js
@@ -210,7 +210,10 @@ class AztecView extends React.Component {
 
 	render() {
 		// eslint-disable-next-line no-unused-vars
-		const { onActiveFormatsChange, style, ...otherProps } = this.props;
+		const { onActiveFormatsChange, ...otherProps } = this.props;
+		// `style` has to be destructured separately, without `otherProps`, because of:
+		// https://github.com/WordPress/gutenberg/issues/23611
+		const { style } = this.props;
 
 		if ( style.hasOwnProperty( 'lineHeight' ) ) {
 			delete style.lineHeight;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

Looks like `style` cannot be destructured along with `...otherProps` that's why I had to separate them.

However, I would like to ask @dratwas to check what happens on the native side ✌️ 

## How has this been tested?

1. Add a Buttons block
2. Add a second button (The first one is added by default)
3. Select the first one and try to type 
4. Expect:  button's wrapper should grow its width when new content is typed in.

## Screenshots <!-- if applicable -->

<img src="https://user-images.githubusercontent.com/22746080/86254946-d928e780-bbb6-11ea-8d9a-68348b60396e.gif"  width="300" />

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
