### PR TITLE
Mobile - Buttons block - Update block appender logic

### DIFF
--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -104,6 +104,7 @@ export class BlockList extends Component {
 			<EmptyListComponentCompose
 				rootClientId={ this.props.rootClientId }
 				renderAppender={ this.props.renderAppender }
+				renderFooterAppender={ this.props.renderFooterAppender }
 			/>
 		);
 	}
@@ -367,7 +368,13 @@ class EmptyListComponent extends Component {
 			shouldShowInsertionPoint,
 			rootClientId,
 			renderAppender,
+			renderFooterAppender,
 		} = this.props;
+
+		if ( renderFooterAppender ) {
+			return null;
+		}
+
 		return (
 			<View style={ styles.defaultAppender }>
 				<ReadableContentView>

--- a/packages/block-library/src/buttons/edit.native.js
+++ b/packages/block-library/src/buttons/edit.native.js
@@ -103,13 +103,10 @@ export default compose(
 		};
 	} ),
 	withDispatch( ( dispatch, { clientId }, registry ) => {
-		const { replaceInnerBlocks, selectBlock, removeBlock } = dispatch(
+		const { selectBlock, removeBlock, insertBlock } = dispatch(
 			'core/block-editor'
 		);
-		const { getBlocks, getBlockOrder } = registry.select(
-			'core/block-editor'
-		);
-		const innerBlocks = getBlocks( clientId );
+		const { getBlockOrder } = registry.select( 'core/block-editor' );
 
 		return {
 			// The purpose of `onAddNextButton` is giving the ability to automatically
@@ -127,9 +124,7 @@ export default compose(
 
 				const insertedBlock = createBlock( 'core/button' );
 
-				innerBlocks.splice( index + 1, 0, insertedBlock );
-
-				replaceInnerBlocks( clientId, innerBlocks, true );
+				insertBlock( insertedBlock, index, clientId );
 				selectBlock( insertedBlock.clientId );
 			},
 			onDelete: () => {


### PR DESCRIPTION
`Gutenberg Mobile PR` -> https://github.com/wordpress-mobile/gutenberg-mobile/pull/2459

## Description
While testing the [Copy / Cut / Paste / Duplicate feature](https://github.com/WordPress/gutenberg/pull/23110), it was found that after "Cutting" the Button within the Buttons block a couple of times and then adding new ones they'd start duplicating.

I updated the logic of the Buttons appender to use the same one as the menu inserter.

## How has this been tested?
- Start the demo app with metro running
- Add a Buttons block
- "Cut" the Button block that's within.
- Tap on the Buttons block (it's hard to see when there aren't any Buttons inside, another issue will fix this)
- Tap on the + button within the block
- **Expect** to see an empty button
- "Cut" the Button again
- Tap on the + button within the Buttons block
- **Expect** to see an empty button (without duplicates)

## Screenshots <!-- if applicable -->

Before | After
-|-
<img src="https://user-images.githubusercontent.com/4885740/86262052-ae8f5c80-bbbf-11ea-8a60-c0e2a6aa8207.gif" width="250" /> | <img src="https://user-images.githubusercontent.com/4885740/86262060-afc08980-bbbf-11ea-9a05-1656701dee87.gif" width="250" />

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
