### PR TITLE
Block Directory: Remove custom permission check in favor of `canUser`

### DIFF
--- a/packages/block-directory/src/components/downloadable-blocks-panel/index.js
+++ b/packages/block-directory/src/components/downloadable-blocks-panel/index.js
@@ -21,7 +21,7 @@ function DownloadableBlocksPanel( {
 	isWaiting,
 	debouncedSpeak,
 } ) {
-	if ( ! hasPermission ) {
+	if ( false === hasPermission ) {
 		debouncedSpeak(
 			__(
 				'No blocks found in your library. Please contact your site administrator to install new blocks.'
@@ -38,7 +38,7 @@ function DownloadableBlocksPanel( {
 		);
 	}
 
-	if ( isLoading || isWaiting ) {
+	if ( typeof hasPermission === 'undefined' || isLoading || isWaiting ) {
 		return (
 			<p className="block-directory-downloadable-blocks-panel__description has-no-results">
 				<Spinner />

--- a/packages/block-directory/src/components/downloadable-blocks-panel/index.js
+++ b/packages/block-directory/src/components/downloadable-blocks-panel/index.js
@@ -86,11 +86,13 @@ export default compose( [
 	withSelect( ( select, { filterValue } ) => {
 		const {
 			getDownloadableBlocks,
-			hasInstallBlocksPermission,
 			isRequestingDownloadableBlocks,
 		} = select( 'core/block-directory' );
 
-		const hasPermission = hasInstallBlocksPermission();
+		const hasPermission = select( 'core' ).canUser(
+			'read',
+			'block-directory/search'
+		);
 		const downloadableItems = hasPermission
 			? getDownloadableBlocks( filterValue )
 			: [];

--- a/packages/block-directory/src/store/actions.js
+++ b/packages/block-directory/src/store/actions.js
@@ -39,18 +39,6 @@ export function receiveDownloadableBlocks( downloadableBlocks, filterValue ) {
 }
 
 /**
- * Returns an action object used in signalling that the user does not have
- * permission to install blocks.
- *
- * @param {boolean} hasPermission User has permission to install blocks.
- *
- * @return {Object} Action object.
- */
-export function setInstallBlocksPermission( hasPermission ) {
-	return { type: 'SET_INSTALL_BLOCKS_PERMISSION', hasPermission };
-}
-
-/**
  * Action triggered to install a block plugin.
  *
  * @param {Object} block The block item returned by search.

--- a/packages/block-directory/src/store/reducer.js
+++ b/packages/block-directory/src/store/reducer.js
@@ -76,22 +76,6 @@ export const blockManagement = (
 };
 
 /**
- * Reducer returning an array of downloadable blocks.
- *
- * @param {Object} state  Current state.
- * @param {Object} action Dispatched action.
- *
- * @return {Object} Updated state.
- */
-export function hasPermission( state = true, action ) {
-	if ( action.type === 'SET_INSTALL_BLOCKS_PERMISSION' ) {
-		return action.hasPermission;
-	}
-
-	return state;
-}
-
-/**
  * Reducer returning an object of error notices.
  *
  * @param {Object} state  Current state.
@@ -113,6 +97,5 @@ export const errorNotices = ( state = {}, action ) => {
 export default combineReducers( {
 	downloadableBlocks,
 	blockManagement,
-	hasPermission,
 	errorNotices,
 } );

--- a/packages/block-directory/src/store/resolvers.js
+++ b/packages/block-directory/src/store/resolvers.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { camelCase, get, hasIn, includes, mapKeys } from 'lodash';
+import { camelCase, mapKeys } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -11,11 +11,7 @@ import { apiFetch } from '@wordpress/data-controls';
 /**
  * Internal dependencies
  */
-import {
-	fetchDownloadableBlocks,
-	receiveDownloadableBlocks,
-	setInstallBlocksPermission,
-} from './actions';
+import { fetchDownloadableBlocks, receiveDownloadableBlocks } from './actions';
 
 export default {
 	*getDownloadableBlocks( filterValue ) {
@@ -35,35 +31,6 @@ export default {
 			);
 
 			yield receiveDownloadableBlocks( blocks, filterValue );
-		} catch ( error ) {
-			if ( error.code === 'rest_block_directory_cannot_view' ) {
-				yield setInstallBlocksPermission( false );
-			}
-		}
-	},
-	*hasInstallBlocksPermission() {
-		try {
-			const response = yield apiFetch( {
-				method: 'OPTIONS',
-				path: `wp/v2/block-directory/search`,
-				parse: false,
-			} );
-
-			let allowHeader;
-			if ( hasIn( response, [ 'headers', 'get' ] ) ) {
-				// If the request is fetched using the fetch api, the header can be
-				// retrieved using the 'get' method.
-				allowHeader = response.headers.get( 'allow' );
-			} else {
-				// If the request was preloaded server-side and is returned by the
-				// preloading middleware, the header will be a simple property.
-				allowHeader = get( response, [ 'headers', 'Allow' ], '' );
-			}
-
-			const isAllowed = includes( allowHeader, 'GET' );
-			yield setInstallBlocksPermission( isAllowed );
-		} catch ( error ) {
-			yield setInstallBlocksPermission( false );
-		}
+		} catch ( error ) {}
 	},
 };

--- a/packages/block-directory/src/store/selectors.js
+++ b/packages/block-directory/src/store/selectors.js
@@ -46,17 +46,6 @@ export function getDownloadableBlocks( state, filterValue ) {
 }
 
 /**
- * Returns true if user has permission to install blocks.
- *
- * @param {Object} state Global application state.
- *
- * @return {boolean} User has permission to install blocks.
- */
-export function hasInstallBlocksPermission( state ) {
-	return state.hasPermission;
-}
-
-/**
  * Returns the block types that have been installed on the server.
  *
  * @param {Object} state Global application state.

--- a/packages/block-directory/src/store/test/reducer.js
+++ b/packages/block-directory/src/store/test/reducer.js
@@ -6,12 +6,7 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import {
-	blockManagement,
-	downloadableBlocks,
-	errorNotices,
-	hasPermission,
-} from '../reducer';
+import { blockManagement, downloadableBlocks, errorNotices } from '../reducer';
 import { blockTypeInstalled, downloadableBlock } from './fixtures';
 
 describe( 'state', () => {
@@ -86,17 +81,6 @@ describe( 'state', () => {
 			} );
 
 			expect( state.installedBlockTypes ).toHaveLength( 0 );
-		} );
-	} );
-
-	describe( 'hasPermission()', () => {
-		it( 'should update permissions appropriately', () => {
-			const state = hasPermission( true, {
-				type: 'SET_INSTALL_BLOCKS_PERMISSION',
-				hasPermission: false,
-			} );
-
-			expect( state ).toEqual( false );
 		} );
 	} );
 

--- a/packages/e2e-tests/specs/editor/plugins/block-directory-add.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/block-directory-add.test.js
@@ -83,53 +83,21 @@ const block = `( function() {
 	} );
 } )();`;
 
-const MOCK_OPTIONS = {
-	namespace: 'wp/v2',
-	methods: [ 'GET' ],
-	endpoints: [
-		{
-			methods: [ 'GET' ],
-			args: {},
-		},
-	],
-	schema: {
-		$schema: 'http://json-schema.org/draft-04/schema#',
-		title: 'block-directory-item',
-		type: 'object',
-		properties: {},
-	},
-};
-
-const MOCK_OPTIONS_RESPONSE = {
-	match: ( request ) =>
-		matchUrl( request.url(), SEARCH_URLS ) &&
-		request.method() === 'OPTIONS',
-	onRequestMatch: async ( request ) => {
-		const response = {
-			content: 'application/json',
-			body: JSON.stringify( MOCK_OPTIONS ),
-			headers: {
-				Allow: 'GET',
-			},
-		};
-
-		return request.respond( response );
-	},
-};
-
 const MOCK_EMPTY_RESPONSES = [
-	MOCK_OPTIONS_RESPONSE,
 	{
-		match: ( request ) => matchUrl( request.url(), SEARCH_URLS ),
+		match: ( request ) =>
+			matchUrl( request.url(), SEARCH_URLS ) &&
+			request.method() === 'GET',
 		onRequestMatch: createJSONResponse( [] ),
 	},
 ];
 
 const MOCK_BLOCKS_RESPONSES = [
-	MOCK_OPTIONS_RESPONSE,
 	{
 		// Mock response for search with the block
-		match: ( request ) => matchUrl( request.url(), SEARCH_URLS ),
+		match: ( request ) =>
+			matchUrl( request.url(), SEARCH_URLS ) &&
+			request.method() === 'GET',
 		onRequestMatch: createJSONResponse( [ MOCK_BLOCK1, MOCK_BLOCK2 ] ),
 	},
 	{


### PR DESCRIPTION
## Description
See https://github.com/WordPress/gutenberg/pull/16524/files#r315493053, https://github.com/WordPress/gutenberg/pull/23528#issuecomment-652143967 — Now that the endpoints are out of `__experimental`, we can use the `canUser` helper to get user permissions for the block-directory. This removes our custom code for `hasPermission` & related tests. 

There should be no functionality changes. Users with the ability to install & activate plugins (admins) should be able to use the block directory, while everyone else is told "Please contact your site administrator to install new blocks."

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
