### PR TITLE
Block Directory: Fix double border in block list

### DIFF
--- a/packages/block-directory/src/components/downloadable-block-list-item/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-list-item/style.scss
@@ -17,6 +17,10 @@
 	position: relative;
 	text-align: left;
 	overflow: hidden;
+
+	& + .block-directory-downloadable-block-list-item {
+		border-top: none;
+	}
 }
 
 .block-directory-downloadable-block-list-item:last-child:not(:only-of-type) {


### PR DESCRIPTION
## Description
When searching for blocks in the directory, if there are multiple results, there's a double border between blocks. This seems like a bug, so this PR just removes the top border when there are multiple results. (if this was intentional, the PR can be closed 🙂 )

## Screenshots

| Before | After |
|--------|-------|
| ![double-border](https://user-images.githubusercontent.com/541093/86290205-0a0b1b80-bbbb-11ea-9852-28ad72c9fbd1.png) | ![single-border](https://user-images.githubusercontent.com/541093/86290222-14c5b080-bbbb-11ea-9169-54cbbcd38c06.png) |
