### PR TITLE
[RNMobile] Activate Unsupported block editor on demo app

### DIFF
--- a/packages/react-native-editor/android/app/src/main/java/com/gutenberg/MainActivity.java
+++ b/packages/react-native-editor/android/app/src/main/java/com/gutenberg/MainActivity.java
@@ -29,6 +29,7 @@ public class MainActivity extends ReactActivity {
                 Bundle bundle = new Bundle();
                 Bundle capabilities = new Bundle();
                 capabilities.putBoolean(WPAndroidGlueCode.PROP_NAME_CAPABILITIES_MENTIONS, true);
+                capabilities.putBoolean(WPAndroidGlueCode.PROP_NAME_CAPABILITIES_UNSUPPORTED_BLOCK_EDITOR, true);
                 bundle.putBundle(WPAndroidGlueCode.PROP_NAME_CAPABILITIES, capabilities);
                 return bundle;
             }

--- a/packages/react-native-editor/ios/gutenberg/GutenbergViewController.swift
+++ b/packages/react-native-editor/ios/gutenberg/GutenbergViewController.swift
@@ -260,7 +260,10 @@ extension GutenbergViewController: GutenbergBridgeDataSource {
     }
 
     func gutenbergCapabilities() -> [String : Bool]? {
-        return ["mentions": true]
+        return [
+            "mentions": true,
+            "unsupportedBlockEditor": true,
+        ]
     }
 
     func aztecAttachmentDelegate() -> TextViewAttachmentDelegate {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
This PR activates the Unsupported block editor feature on the demo apps.

To test:
- Run the demo app on Android and iOS.
- Scroll to the last RSS block.
- Press the (?) button.
- Check that the `Edit block in web browser` button is present.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
