### PR TITLE
Block Editor: use optional chaining and nullish coalescing instead of Lodash.get.

### DIFF
--- a/packages/block-editor/src/components/block-icon/index.js
+++ b/packages/block-editor/src/components/block-icon/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -11,7 +10,7 @@ import { Icon } from '@wordpress/components';
 import { blockDefault } from '@wordpress/icons';
 
 export default function BlockIcon( { icon, showColors = false, className } ) {
-	if ( get( icon, [ 'src' ] ) === 'block-default' ) {
+	if ( icon?.src === 'block-default' ) {
 		icon = {
 			src: blockDefault,
 		};

--- a/packages/block-editor/src/components/block-icon/index.native.js
+++ b/packages/block-editor/src/components/block-icon/index.native.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
 import { View } from 'react-native';
 
 /**
@@ -11,7 +10,7 @@ import { Icon } from '@wordpress/components';
 import { blockDefault } from '@wordpress/icons';
 
 export default function BlockIcon( { icon, showColors = false } ) {
-	if ( get( icon, [ 'src' ] ) === 'block-default' ) {
+	if ( icon?.src === 'block-default' ) {
 		icon = {
 			src: blockDefault,
 		};

--- a/packages/block-editor/src/components/colors/with-colors.js
+++ b/packages/block-editor/src/components/colors/with-colors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, isString, kebabCase, reduce, upperFirst } from 'lodash';
+import { isString, kebabCase, reduce, upperFirst } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -161,9 +161,7 @@ function createColorHOC( colorTypes, withColorPalette ) {
 
 							const previousColorObject =
 								previousState[ colorAttributeName ];
-							const previousColor = get( previousColorObject, [
-								'color',
-							] );
+							const previousColor = previousColorObject?.color;
 							/**
 							 * The "and previousColorObject" condition checks that a previous color object was already computed.
 							 * At the start previousColorObject and colorValue are both equal to undefined

--- a/packages/block-editor/src/components/default-style-picker/index.js
+++ b/packages/block-editor/src/components/default-style-picker/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useMemo, useCallback } from '@wordpress/element';
@@ -22,15 +17,9 @@ export default function DefaultStylePicker( { blockName } ) {
 			const preferredStyleVariations =
 				settings.__experimentalPreferredStyleVariations;
 			return {
-				preferredStyle: get( preferredStyleVariations, [
-					'value',
-					blockName,
-				] ),
-				onUpdatePreferredStyleVariations: get(
-					preferredStyleVariations,
-					[ 'onChange' ],
-					null
-				),
+				preferredStyle: preferredStyleVariations?.value?.[ blockName ],
+				onUpdatePreferredStyleVariations:
+					preferredStyleVariations?.onChange ?? null,
 				styles: select( 'core/blocks' ).getBlockStyles( blockName ),
 			};
 		},

--- a/packages/block-editor/src/components/use-simulated-media-query/index.js
+++ b/packages/block-editor/src/components/use-simulated-media-query/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { filter, get } from 'lodash';
+import { filter } from 'lodash';
 import { match } from 'css-mediaquery';
 
 /**
@@ -20,18 +20,15 @@ function getStyleSheetsThatMatchHostname() {
 		return [];
 	}
 
-	return filter(
-		get( window, [ 'document', 'styleSheets' ], [] ),
-		( styleSheet ) => {
-			if ( ! styleSheet.href ) {
-				return false;
-			}
-			return (
-				getProtocol( styleSheet.href ) === window.location.protocol &&
-				getAuthority( styleSheet.href ) === window.location.host
-			);
+	return filter( window?.document?.styleSheets ?? [], ( styleSheet ) => {
+		if ( ! styleSheet.href ) {
+			return false;
 		}
-	);
+		return (
+			getProtocol( styleSheet.href ) === window.location.protocol &&
+			getAuthority( styleSheet.href ) === window.location.host
+		);
+	} );
 }
 
 function isReplaceableMediaRule( rule ) {

--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { get, has, without } from 'lodash';
+import { has, without } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -135,11 +135,7 @@ export const withToolbarControls = createHigherOrderComponent(
 		const updateAlignment = ( nextAlign ) => {
 			if ( ! nextAlign ) {
 				const blockType = getBlockType( props.name );
-				const blockDefaultAlign = get( blockType, [
-					'attributes',
-					'align',
-					'default',
-				] );
+				const blockDefaultAlign = blockType.attributes?.align?.default;
 				if ( blockDefaultAlign ) {
 					nextAlign = '';
 				}

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { castArray, first, get, last, some } from 'lodash';
+import { castArray, first, last, some } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -252,11 +252,9 @@ export function toggleSelection( isSelectionEnabled = true ) {
 }
 
 function getBlocksWithDefaultStylesApplied( blocks, blockEditorSettings ) {
-	const preferredStyleVariations = get(
-		blockEditorSettings,
-		[ '__experimentalPreferredStyleVariations', 'value' ],
-		{}
-	);
+	const preferredStyleVariations =
+		blockEditorSettings?.__experimentalPreferredStyleVariations?.value ??
+		{};
 	return blocks.map( ( block ) => {
 		const blockName = block.name;
 		if ( ! hasBlockSupport( blockName, 'defaultStylePicker', true ) ) {
@@ -265,7 +263,7 @@ function getBlocksWithDefaultStylesApplied( blocks, blockEditorSettings ) {
 		if ( ! preferredStyleVariations[ blockName ] ) {
 			return block;
 		}
-		const className = get( block, [ 'attributes', 'className' ] );
+		const className = block.attributes?.className;
 		if ( className?.includes( 'is-style-' ) ) {
 			return block;
 		}

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -12,7 +12,6 @@ import {
 	keys,
 	isEqual,
 	isEmpty,
-	get,
 	identity,
 	difference,
 	omitBy,
@@ -411,11 +410,7 @@ function withPersistentBlockChange( reducer ) {
 			markNextChangeAsNotPersistent =
 				action.type === 'MARK_NEXT_CHANGE_AS_NOT_PERSISTENT';
 
-			const nextIsPersistentChange = get(
-				state,
-				[ 'isPersistentChange' ],
-				true
-			);
+			const nextIsPersistentChange = state?.isPersistentChange ?? true;
 			if ( state.isPersistentChange === nextIsPersistentChange ) {
 				return state;
 			}

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -5,7 +5,6 @@ import {
 	castArray,
 	flatMap,
 	first,
-	get,
 	isArray,
 	isBoolean,
 	last,
@@ -1273,9 +1272,7 @@ const canInsertBlockTypeUnmemoized = (
 		return false;
 	}
 
-	const parentAllowedBlocks = get( parentBlockListSettings, [
-		'allowedBlocks',
-	] );
+	const parentAllowedBlocks = parentBlockListSettings?.allowedBlocks;
 	const hasParentAllowedBlock = checkAllowList(
 		parentAllowedBlocks,
 		blockName
@@ -1345,7 +1342,7 @@ export function canInsertBlocks( state, clientIds, rootClientId = null ) {
  *                                            the number of inserts that have occurred.
  */
 function getInsertUsage( state, id ) {
-	return get( state.preferences.insertUsage, [ id ], null );
+	return state.preferences.insertUsage?.[ id ] ?? null;
 }
 
 /**
@@ -1735,11 +1732,7 @@ export function __experimentalGetLastBlockAttributeChanges( state ) {
  * @return {Array} Reusable blocks
  */
 function getReusableBlocks( state ) {
-	return get(
-		state,
-		[ 'settings', '__experimentalReusableBlocks' ],
-		EMPTY_ARRAY
-	);
+	return state?.settings?.__experimentalReusableBlocks ?? EMPTY_ARRAY;
 }
 
 /**


### PR DESCRIPTION
## Description
See title. Optional chaining and nullish coalescing are (recent) standard JS features that we already use across our codebase, so this PR helps increase consistency by updating cases where we were using Lodash.get. The native JS syntax is also a lot easier to comprehend, in my opinion.

Since there are a lot of places where `_.get` is being used right now, I'm doing this one package at a time, to make it easier to review.

It's worth noting there are a few cases where using `_.get` actually does make sense: cases where the object path has a dynamic level of nesting, which as far as I am aware, cannot be expressed using optional chaining. Those cases have been left unchanged.

This is part of a series of code quality PRs I am working on. The long-term goal is to reduce `lodash` usage in cases where a standard JS function/syntax works just as well or better, which should reduce our packages' bundle sizes for 3rd parties using them. This will also increase clarity by making nullish value handling more explicit (Lodash often silently ignores nullish values) and avoiding the use of external libraries when simple equivalents exist in standard JS.