### PR TITLE
Annotations: use optional chaining and nullish coalescing instead of Lodash.get.

### DIFF
--- a/packages/annotations/src/store/reducer.js
+++ b/packages/annotations/src/store/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, isNumber, mapValues } from 'lodash';
+import { isNumber, mapValues } from 'lodash';
 
 /**
  * Filters an array based on the predicate, but keeps the reference the same if
@@ -37,7 +37,7 @@ function isValidAnnotationRange( annotation ) {
 /**
  * Reducer managing annotations.
  *
- * @param {Array} state The annotations currently shown in the editor.
+ * @param {Object} state  The annotations currently shown in the editor.
  * @param {Object} action Dispatched action.
  *
  * @return {Array} Updated state.
@@ -62,7 +62,7 @@ export function annotations( state = {}, action ) {
 				return state;
 			}
 
-			const previousAnnotationsForBlock = get( state, blockClientId, [] );
+			const previousAnnotationsForBlock = state?.[ blockClientId ] ?? [];
 
 			return {
 				...state,

--- a/packages/annotations/src/store/selectors.js
+++ b/packages/annotations/src/store/selectors.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import createSelector from 'rememo';
-import { get, flatMap } from 'lodash';
+import { flatMap } from 'lodash';
 
 /**
  * Shared reference to an empty array for cases where it is important to avoid
@@ -25,18 +25,18 @@ const EMPTY_ARRAY = [];
  */
 export const __experimentalGetAnnotationsForBlock = createSelector(
 	( state, blockClientId ) => {
-		return get( state, blockClientId, [] ).filter( ( annotation ) => {
+		return ( state?.[ blockClientId ] ?? [] ).filter( ( annotation ) => {
 			return annotation.selector === 'block';
 		} );
 	},
-	( state, blockClientId ) => [ get( state, blockClientId, EMPTY_ARRAY ) ]
+	( state, blockClientId ) => [ state?.[ blockClientId ] ?? EMPTY_ARRAY ]
 );
 
 export function __experimentalGetAllAnnotationsForBlock(
 	state,
 	blockClientId
 ) {
-	return get( state, blockClientId, EMPTY_ARRAY );
+	return state?.[ blockClientId ] ?? EMPTY_ARRAY;
 }
 
 /**
@@ -53,7 +53,7 @@ export function __experimentalGetAllAnnotationsForBlock(
  */
 export const __experimentalGetAnnotationsForRichText = createSelector(
 	( state, blockClientId, richTextIdentifier ) => {
-		return get( state, blockClientId, [] )
+		return ( state?.[ blockClientId ] ?? [] )
 			.filter( ( annotation ) => {
 				return (
 					annotation.selector === 'range' &&
@@ -69,7 +69,7 @@ export const __experimentalGetAnnotationsForRichText = createSelector(
 				};
 			} );
 	},
-	( state, blockClientId ) => [ get( state, blockClientId, EMPTY_ARRAY ) ]
+	( state, blockClientId ) => [ state?.[ blockClientId ] ?? EMPTY_ARRAY ]
 );
 
 /**


### PR DESCRIPTION
## Description
See title. Optional chaining and nullish coalescing are (recent) standard JS features that we already use across our codebase, so this PR helps increase consistency by updating cases where we were using Lodash.get. The native JS syntax is also a lot easier to comprehend, in my opinion.

Since there are a lot of places where `_.get` is being used right now, I'm doing this one package at a time, to make it easier to review.

It's worth noting there are a few cases where using `_.get` actually does make sense: cases where the object path has a dynamic level of nesting, which as far as I am aware, cannot be expressed using optional chaining. Those cases have been left unchanged.

This is part of a series of code quality PRs I am working on. The long-term goal is to reduce `lodash` usage in cases where a standard JS function/syntax works just as well or better, which should reduce our packages' bundle sizes for 3rd parties using them. This will also increase clarity by making nullish value handling more explicit (Lodash often silently ignores nullish values) and avoiding the use of external libraries when simple equivalents exist in standard JS.