### PR TITLE
Remove unused getBlockIndex selector from useBlockDropZone hook

### DIFF
--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -165,14 +165,12 @@ export default function useBlockDropZone( {
 
 	function selector( select ) {
 		const {
-			getBlockIndex,
 			getBlockListSettings,
 			getClientIdsOfDescendants,
 			getSettings,
 			getTemplateLock,
 		} = select( 'core/block-editor' );
 		return {
-			getBlockIndex,
 			orientation: getBlockListSettings( targetRootClientId )
 				?.orientation,
 			getClientIdsOfDescendants,
@@ -182,7 +180,6 @@ export default function useBlockDropZone( {
 	}
 
 	const {
-		getBlockIndex,
 		getClientIdsOfDescendants,
 		hasUploadPermissions,
 		isLockedAll,
@@ -289,7 +286,6 @@ export default function useBlockDropZone( {
 		},
 		[
 			getClientIdsOfDescendants,
-			getBlockIndex,
 			targetBlockIndex,
 			moveBlocksToPosition,
 			targetRootClientId,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Tiny PR that removes some unused code.