### PR TITLE
Block Directory: use optional chaining and nullish coalescing instead of Lodash.get.

### DIFF
--- a/packages/block-directory/src/store/resolvers.js
+++ b/packages/block-directory/src/store/resolvers.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { camelCase, get, hasIn, includes, mapKeys } from 'lodash';
+import { camelCase, hasIn, includes, mapKeys } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -57,7 +57,7 @@ export default {
 			} else {
 				// If the request was preloaded server-side and is returned by the
 				// preloading middleware, the header will be a simple property.
-				allowHeader = get( response, [ 'headers', 'Allow' ], '' );
+				allowHeader = response?.headers?.Allow ?? '';
 			}
 
 			const isAllowed = includes( allowHeader, 'GET' );


### PR DESCRIPTION
## Description
See title. Optional chaining and nullish coalescing are (recent) standard JS features that we already use across our codebase, so this PR helps increase consistency by updating cases where we were using Lodash.get. The native JS syntax is also a lot easier to comprehend, in my opinion.

Since there are a lot of places where `_.get` is being used right now, I'm doing this one package at a time, to make it easier to review.

It's worth noting there are a few cases where using `_.get` actually does make sense: cases where the object path has a dynamic level of nesting, which as far as I am aware, cannot be expressed using optional chaining. Those cases have been left unchanged.

This is part of a series of code quality PRs I am working on. The long-term goal is to reduce `lodash` usage in cases where a standard JS function/syntax works just as well or better, which should reduce our packages' bundle sizes for 3rd parties using them. This will also increase clarity by making nullish value handling more explicit (Lodash often silently ignores nullish values) and avoiding the use of external libraries when simple equivalents exist in standard JS.