### PR TITLE
Issue #13618 - only request three fields: id, title and parent to populate the Parent page select list

### DIFF
--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -66,6 +66,7 @@ const applyWithSelect = withSelect( ( select ) => {
 		parent_exclude: postId,
 		orderby: 'menu_order',
 		order: 'asc',
+		_fields: 'id,title,parent',
 	};
 
 	return {


### PR DESCRIPTION
closes  #13618

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This is a fix for the performance issue reported in #13618 
The REST requests now pass the `_fields` parameter, requesting only 3 fields: id, title and parent.


<!-- Please describe what you have changed or added -->

## How has this been tested?
I tested the fix in my development environment where I reported the problem initially. 
I measured the server response time of the requests using my oik-bwtrace plugin. 

Here's the raw data.

Before:

```
/oikcom/wp-json/wp/v2/pages?per_page=100&exclude=7413&parent_exclude=7413&orderby=menu_order&order=asc&context=edit&_locale=user,,14.389279,7.3.8,1291,4073,539,45,705,58,33,15,375,0.76585483551025,C:/apache/htdocs/oikcom/bwtrace/bwtrace.rest.14,829,0,367789,127.0.0.1,14.374432,2020-07-02T05:41:44+00:00,Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML; like Gecko) Chrome/83.0.4103.116 Safari/537.36,GET

/oikcom/wp-json/wp/v2/pages?per_page=100&exclude%5B0%5D=7413&parent_exclude%5B0%5D=7413&orderby=menu_order&order=asc&context=edit&_locale=user&page=2,,12.952587,7.3.8,1291,4062,539,45,704,58,33,15,379,0.60033750534058,C:/apache/htdocs/oikcom/bwtrace/bwtrace.rest.15,817,0,392390,127.0.0.1,12.938389,2020-07-02T05:41:58+00:00,Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML; like Gecko) Chrome/83.0.4103.116 Safari/537.36,GET

/oikcom/wp-json/wp/v2/pages?per_page=100&exclude%5B0%5D=7413&parent_exclude%5B0%5D=7413&orderby=menu_order&order=asc&context=edit&_locale=user&page=3,,15.117301,7.3.8,1291,4062,539,45,704,58,33,15,394,0.72246360778809,C:/apache/htdocs/oikcom/bwtrace/bwtrace.rest.17,858,0,368139,127.0.0.1,15.098362,2020-07-02T05:42:13+00:00,Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML; like Gecko) Chrome/83.0.4103.116 Safari/537.36,GET

/oikcom/wp-json/wp/v2/pages?per_page=100&exclude%5B0%5D=7413&parent_exclude%5B0%5D=7413&orderby=menu_order&order=asc&context=edit&_locale=user&page=4,,8.023179,7.3.8,1291,4062,539,45,704,58,33,15,288,0.52651596069336,C:/apache/htdocs/oikcom/bwtrace/bwtrace.rest.16,614,0,214852,127.0.0.1,8.009388,2020-07-02T05:42:21+00:00,Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML; like Gecko) Chrome/83.0.4103.116 Safari/537.36,GET
```
After

```
/oikcom/wp-json/wp/v2/pages?per_page=100&exclude=7413&parent_exclude=7413&orderby=menu_order&order=asc&_fields=id%2Ctitle%2Cparent&context=edit&_locale=user,,2.413475,7.3.8,1291,4035,479,45,643,58,33,15,118,0.26945757865906,C:/apache/htdocs/oikcom/bwtrace/bwtrace.rest.19,129,0,34319,127.0.0.1,2.409543,2020-07-02T05:46:13+00:00,Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML; like Gecko) Chrome/83.0.4103.116 Safari/537.36,GET

/oikcom/wp-json/wp/v2/pages?per_page=100&exclude%5B0%5D=7413&parent_exclude%5B0%5D=7413&orderby=menu_order&order=asc&_fields=id%2Ctitle%2Cparent&context=edit&_locale=user&page=2,,3.262983,7.3.8,1291,4024,479,45,642,58,33,15,116,0.27022075653076,C:/apache/htdocs/oikcom/bwtrace/bwtrace.rest.20,117,0,34177,127.0.0.1,3.252519,2020-07-02T05:46:17+00:00,Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML; like Gecko) Chrome/83.0.4103.116 Safari/537.36,GET

/oikcom/wp-json/wp/v2/pages?per_page=100&exclude%5B0%5D=7413&parent_exclude%5B0%5D=7413&orderby=menu_order&order=asc&_fields=id%2Ctitle%2Cparent&context=edit&_locale=user&page=3,,1.740284,7.3.8,1291,4024,479,45,642,58,33,15,118,0.44018483161926,C:/apache/htdocs/oikcom/bwtrace/bwtrace.rest.3,158,0,34457,127.0.0.1,1.729080,2020-07-02T05:46:19+00:00,Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML; like Gecko) Chrome/83.0.4103.116 Safari/537.36,GET

/oikcom/wp-json/wp/v2/pages?per_page=100&exclude%5B0%5D=7413&parent_exclude%5B0%5D=7413&orderby=menu_order&order=asc&_fields=id%2Ctitle%2Cparent&context=edit&_locale=user&page=4,,2.088225,7.3.8,1291,4024,479,45,642,58,33,15,86,0.55468797683716,C:/apache/htdocs/oikcom/bwtrace/bwtrace.rest.4,124,0,27440,127.0.0.1,2.077574,2020-07-02T05:46:21+00:00,Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML; like Gecko) Chrome/83.0.4103.116 Safari/537.36,GET
```

From this raw data you can glean.

Page | Elapsed before | Elapsed after | Queries before | Queries after
--- | ----- | ----- | --- | ----- 
1 | 14.39 | 2.41 | 375 | 118
2 | 12.95 | 3.26 | 379 | 116
3 | 15.11 | 1.74 | 394 | 118 
4 | 8.02 | 2.08 | 288 | 86

The detailed trace output shows which actions and filters were invoked.

For page 1 the total number was 367789 before. This reduced to 34319 after.
Before the change the `the_content` filter was called once for each page returned.
Afterwards, it wasn't called at all. Nor, for that matter was `the_excerpt`.

<!-- Please describe in detail how you tested your changes. -->

<!-- Include details of your testing environment, tests ran to see how -->
My testing environment is a local copy ( s.b/oikcom ) of a website called oik-plugins.com 
The before and after tests summarised above were performed against pages - 373 published

I also ran the after tests against the oik-file CPT, which is also hierarchical, with 330 published posts.
server times were: 1.08, 0.86, 0.86 and 0.64 


<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
The Parent Page: select list is populated as before applying the fix.
The duplicate entries are still present. See #12795
![image](https://user-images.githubusercontent.com/2474435/86323230-62caca80-bc34-11ea-93fe-f45fff7ce0c6.png)

The order doesn't match the order shown in Quick Edit either. But that's another issue... to be raised.
![image](https://user-images.githubusercontent.com/2474435/86323371-a1608500-bc34-11ea-8e6f-da7c5b46e4b1.png)



## Types of changes
Performance improvement. On slow systems with complex page content it should prevent the user experiencing 500 error codes, mostly due to elapsed execution time being exceeded.
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
