### PR TITLE
Fix invisible drop target indicator caused by is-drop-target class being applied to dragged block

### DIFF
--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -103,7 +103,7 @@ export function getNearestBlockIndex( elements, position, orientation ) {
 		);
 
 		// If no candidate has been assigned yet or this is the nearest
-		// block edge to the cursor, then assign it as the candidate.
+		// block edge to the cursor, then assign the next block as the candidate.
 		if ( Math.abs( trailingEdgeDistance ) < candidateDistance ) {
 			candidateDistance = trailingEdgeDistance;
 			let nextBlockOffset = 1;

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -106,7 +106,20 @@ export function getNearestBlockIndex( elements, position, orientation ) {
 		// block edge to the cursor, then assign it as the candidate.
 		if ( Math.abs( trailingEdgeDistance ) < candidateDistance ) {
 			candidateDistance = trailingEdgeDistance;
-			candidateIndex = index + 1;
+			let nextBlockOffset = 1;
+
+			// If the next block is the one being dragged, skip it and consider
+			// the block afterwards the drop target. This is needed as the
+			// block being dragged is set to display: none and won't display
+			// any drop target styling.
+			if (
+				elements[ index + 1 ] &&
+				elements[ index + 1 ].classList.contains( 'is-dragging' )
+			) {
+				nextBlockOffset = 2;
+			}
+
+			candidateIndex = index + nextBlockOffset;
 		}
 	} );
 

--- a/packages/block-editor/src/components/use-block-drop-zone/test/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/test/index.js
@@ -31,6 +31,14 @@ const elementData = [
 	},
 ];
 
+const createMockClassList = ( isDragging ) => {
+	return {
+		contains() {
+			return isDragging;
+		},
+	};
+};
+
 const mapElements = ( orientation ) => (
 	{ top, right, bottom, left },
 	index
@@ -52,6 +60,7 @@ const mapElements = ( orientation ) => (
 						right: bottom,
 				  };
 		},
+		classList: createMockClassList( false ),
 	};
 };
 
@@ -198,6 +207,27 @@ describe( 'getNearestBlockIndex', () => {
 
 			expect( result ).toBe( 4 );
 		} );
+
+		it( 'skips the block being dragged', () => {
+			const position = { x: 0, y: 450 };
+
+			const verticalElementsWithDraggedBlock = [
+				...verticalElements.slice( 0, 2 ),
+				{
+					...verticalElements[ 2 ],
+					classList: createMockClassList( true ),
+				},
+				...verticalElements.slice( 3, 4 ),
+			];
+
+			const result = getNearestBlockIndex(
+				verticalElementsWithDraggedBlock,
+				position,
+				orientation
+			);
+
+			expect( result ).toBe( 3 );
+		} );
 	} );
 
 	describe( 'Horizontal block lists', () => {
@@ -309,6 +339,27 @@ describe( 'getNearestBlockIndex', () => {
 			);
 
 			expect( result ).toBe( 4 );
+		} );
+
+		it( 'skips the block being dragged', () => {
+			const position = { x: 450, y: 0 };
+
+			const horizontalElementsWithDraggedBlock = [
+				...horizontalElements.slice( 0, 2 ),
+				{
+					...horizontalElements[ 2 ],
+					classList: createMockClassList( true ),
+				},
+				...horizontalElements.slice( 3, 4 ),
+			];
+
+			const result = getNearestBlockIndex(
+				horizontalElementsWithDraggedBlock,
+				position,
+				orientation
+			);
+
+			expect( result ).toBe( 3 );
 		} );
 	} );
 } );


### PR DESCRIPTION

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Since https://github.com/WordPress/gutenberg/pull/23024 the block being dragged is set to `display: none`.

I noticed a small issue where if that block is the one considered a drop target, it would have the `is-drop-target` class name applied, but because it's set to `display: none`, the drop target would not be visible.

To users, it'd seem like they were dragging a block into a valid position, but the blue drop target indicator wouldn't appear.

This PR fixes things by making sure the block being dragged is never considered a drop target.

In the future, I think it'd be great to not use the block border itself as the thing that indicates a drop zone, but in the short term this seems like the best way to fix the issue.

## How has this been tested?
1. Bigger blocks are easier to test with, so add three image blocks. No need to upload an image, just keep the placeholder visible.
2. Drag the middle image block, and position the cursor so that it's on the lower half of the first block
3. Observe that on this branch the blue drop indicator displays, while on `master` it's not visible.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
