### PR TITLE
Fix drop target visibility for last block

### DIFF
--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -72,7 +72,8 @@ function BlockList(
 		rootClientId,
 	} );
 
-	const isAppenderDropTarget = dropTargetIndex === blockClientIds.length;
+	const isDroppingAtEndOfBlockList =
+		dropTargetIndex === blockClientIds.length;
 
 	return (
 		<Container
@@ -89,7 +90,10 @@ function BlockList(
 					? multiSelectedBlockClientIds.includes( clientId )
 					: selectedBlockClientId === clientId;
 
-				const isDropTarget = dropTargetIndex === index;
+				const isDroppingBefore = dropTargetIndex === index;
+				const isDroppingAfter =
+					isDroppingAtEndOfBlockList &&
+					index === blockClientIds.length - 1;
 
 				return (
 					<AsyncModeProvider
@@ -105,9 +109,10 @@ function BlockList(
 							index={ index }
 							enableAnimation={ enableAnimation }
 							className={ classnames( {
-								'is-drop-target': isDropTarget,
+								'is-dropping-before': isDroppingBefore,
+								'is-dropping-after': isDroppingAfter,
 								'is-dropping-horizontally':
-									isDropTarget &&
+									( isDroppingBefore || isDroppingAfter ) &&
 									orientation === 'horizontal',
 							} ) }
 						/>
@@ -118,11 +123,6 @@ function BlockList(
 				tagName={ __experimentalAppenderTagName }
 				rootClientId={ rootClientId }
 				renderAppender={ renderAppender }
-				className={ classnames( {
-					'is-drop-target': isAppenderDropTarget,
-					'is-dropping-horizontally':
-						isAppenderDropTarget && orientation === 'horizontal',
-				} ) }
 			/>
 		</Container>
 	);

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -98,12 +98,11 @@
 	}
 }
 
-.block-editor-block-list__layout .block-editor-block-list__block,
-.block-editor-block-list__layout .block-list-appender {
+.block-editor-block-list__layout .block-editor-block-list__block {
 	position: relative;
 
 	// Between-blocks dropzone line indicator.
-	&.is-drop-target::before {
+	&.is-dropping-before::before {
 		content: "";
 		position: absolute;
 		z-index: 0;
@@ -115,13 +114,35 @@
 		border-top: 4px solid var(--wp-admin-theme-color);
 	}
 
-	&.is-drop-target.is-dropping-horizontally::before {
+	&.is-dropping-after::before {
+		content: "";
+		position: absolute;
+		z-index: 0;
+		pointer-events: none;
+		transition: border-color 0.1s linear, border-style 0.1s linear, box-shadow 0.1s linear;
+		right: 0;
+		left: 0;
+		bottom: -$default-block-margin / 2;
+		border-top: none;
+		border-bottom: 4px solid var(--wp-admin-theme-color);
+	}
+
+	&.is-dropping-before.is-dropping-horizontally::before {
 		top: 0;
 		bottom: 0;
 		// Drop target border-width plus a couple of pixels so that the border looks between blocks.
 		left: -6px;
 		border-top: none;
 		border-left: 4px solid var(--wp-admin-theme-color);
+	}
+
+	&.is-dropping-after.is-dropping-horizontally::before {
+		bottom: 0;
+		// Drop target border-width plus a couple of pixels so that the border looks between blocks.
+		right: -6px;
+		left: 0;
+		border-top: none;
+		border-right: 4px solid var(--wp-admin-theme-color);
 	}
 }
 

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -123,7 +123,6 @@
 		right: 0;
 		left: 0;
 		bottom: -$default-block-margin / 2;
-		border-top: none;
 		border-bottom: 4px solid var(--wp-admin-theme-color);
 	}
 
@@ -137,11 +136,11 @@
 	}
 
 	&.is-dropping-after.is-dropping-horizontally::before {
+		top: 0;
+		right: -6px;
 		bottom: 0;
 		// Drop target border-width plus a couple of pixels so that the border looks between blocks.
-		right: -6px;
-		left: 0;
-		border-top: none;
+		border-bottom: none;
 		border-right: 4px solid var(--wp-admin-theme-color);
 	}
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
When dragging a block to the end of a block list the visibility of the drop target indicator is unreliable. Currently, a class is being used on the BlockListAppender to indicate the drop target, but the BlockListAppender is often hidden when not needed, which results in the drop target not being displayed.

This PR moves responsibility for displaying the drop target to the last block in the list, which should always be present.

Along with #23638 the known issues with the drop target not being displayed should be resolved.

## How has this been tested?
1. Try dragging to the end of a block list
2. Observe that the drop target should appear.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
