### PR TITLE
Fix horizontal Block Mover Layout

### DIFF
--- a/packages/block-editor/src/components/block-mover/index.js
+++ b/packages/block-editor/src/components/block-mover/index.js
@@ -50,7 +50,7 @@ export class BlockMover extends Component {
 			isLocked,
 			isHidden,
 			rootClientId,
-			__experimentalOrientation: orientation,
+			orientation,
 		} = this.props;
 		const { isFocused } = this.state;
 		if ( isLocked || ( isFirst && isLast && ! rootClientId ) ) {
@@ -101,6 +101,7 @@ export default withSelect( ( select, { clientIds } ) => {
 	const {
 		getBlock,
 		getBlockIndex,
+		getBlockListSettings,
 		getTemplateLock,
 		getBlockOrder,
 		getBlockRootClientId,
@@ -125,5 +126,6 @@ export default withSelect( ( select, { clientIds } ) => {
 		firstIndex,
 		isFirst,
 		isLast,
+		orientation: getBlockListSettings( rootClientId )?.orientation,
 	};
 } )( BlockMover );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
In https://github.com/WordPress/gutenberg/pull/23416 I accidentally broke the layout of the horizontal block movers. This PR fixes the regression by ensuring the `orientation` prop is specified for the `BlockMover` component, which applies the `is-horizontal` class name.

## How has this been tested?
1. Add a Buttons block
2. Add multiple buttons
3. Observe that the mover buttons for a button block look correct in their horizontal configuration

## Screenshots <!-- if applicable -->
Before:
<img width="339" alt="Screenshot 2020-07-02 at 4 13 24 pm" src="https://user-images.githubusercontent.com/677833/86333814-fc1ece80-bc7e-11ea-9a3c-f5770c9cd372.png">

After:
<img width="316" alt="Screenshot 2020-07-02 at 4 13 05 pm" src="https://user-images.githubusercontent.com/677833/86333825-00e38280-bc7f-11ea-90f7-149d39445f27.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
