### PR TITLE
Avoid ordering block types per frecency inside block categories

### DIFF
--- a/packages/block-editor/src/components/inserter/block-types-tab.js
+++ b/packages/block-editor/src/components/inserter/block-types-tab.js
@@ -1,7 +1,15 @@
 /**
  * External dependencies
  */
-import { map, findIndex, flow, sortBy, groupBy, isEmpty } from 'lodash';
+import {
+	map,
+	findIndex,
+	flow,
+	sortBy,
+	groupBy,
+	isEmpty,
+	orderBy,
+} from 'lodash';
 
 /**
  * WordPress dependencies
@@ -57,7 +65,10 @@ export function BlockTypesTab( {
 	}, [ filterValue, items, categories, collections ] );
 
 	const suggestedItems = useMemo( () => {
-		return items.slice( 0, MAX_SUGGESTED_ITEMS );
+		return orderBy( items, [ 'frecency' ], [ 'desc' ] ).slice(
+			0,
+			MAX_SUGGESTED_ITEMS
+		);
 	}, [ items ] );
 
 	const reusableItems = useMemo( () => {

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -10,7 +10,6 @@ import {
 	isBoolean,
 	last,
 	map,
-	orderBy,
 	reduce,
 	some,
 	find,
@@ -1385,11 +1384,7 @@ export const getInserterItems = createSelector(
 			? getReusableBlocks( state ).map( buildReusableBlockInserterItem )
 			: [];
 
-		return orderBy(
-			[ ...blockTypeInserterItems, ...reusableBlockInserterItems ],
-			[ 'frecency' ],
-			[ 'desc', 'desc' ]
-		);
+		return [ ...blockTypeInserterItems, ...reusableBlockInserterItems ];
 	},
 	( state, rootClientId ) => [
 		state.blockListSettings[ rootClientId ],

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -2396,54 +2396,6 @@ describe( 'selectors', () => {
 			} );
 		} );
 
-		it( 'should order items by descending frecency', () => {
-			const state = {
-				blocks: {
-					byClientId: {},
-					attributes: {},
-					order: {},
-					parents: {},
-					cache: {},
-				},
-				settings: {
-					__experimentalReusableBlocks: [
-						{
-							id: 1,
-							isTemporary: false,
-							clientId: 'block1',
-							title: 'Reusable Block 1',
-							content: '<!-- /wp:test-block-a -->',
-						},
-						{
-							id: 2,
-							isTemporary: false,
-							clientId: 'block2',
-							title: 'Reusable Block 2',
-							content: '<!-- /wp:test-block-b -->',
-						},
-					],
-				},
-				preferences: {
-					insertUsage: {
-						'core/block/1': { count: 10, time: 1000 },
-						'core/block/2': { count: 20, time: 1000 },
-					},
-				},
-				blockListSettings: {},
-			};
-			const itemIDs = getInserterItems( state ).map(
-				( item ) => item.id
-			);
-			expect( itemIDs ).toEqual( [
-				'core/block/2',
-				'core/block/1',
-				'core/test-block-a',
-				'core/test-block-b',
-				'core/test-freeform',
-				'core/post-content-child',
-			] );
-		} );
-
 		it( 'should correctly cache the return values', () => {
 			const state = {
 				blocks: {


### PR DESCRIPTION
closes #23074 
closes #22406 

The frecency should only be used on the "Most Used" category while the other categories should respect the registration order to avoid block type jumps when we insert items.

While this is not exactly what #23074 suggests, I think it's a sufficient resolution since the "most used" blocks section can be disabled.