### PR TITLE
Image editing: try transparent zoom control

### DIFF
--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -90,46 +90,10 @@ figure.wp-block-image:not(.wp-block) {
 	}
 }
 
-.wp-block-image__zoom-control {
-	border: $border-width solid $dark-gray-primary;
-	border-radius: $radius-block-ui;
-	background-color: $white;
-	padding: $grid-unit-10;
-	line-height: 1;
-	width: 100%;
-	max-width: 280px;
-	display: flex;
-	flex-direction: row;
-	align-items: center;
-
-	// Place as a stacked toolbar.
-	position: sticky;
-	top: $grid-unit-60 + $grid-unit-15;
+.components-range-control {
 	z-index: z-index(".block-editor-block-list__block-popover");
-	float: left;
-
-	.components-range-control {
-		flex: 1;
-		margin-right: $grid-unit-15;
-		margin-left: $grid-unit-15;
-	}
-
-	.components-base-control__field {
-		display: flex;
-		margin-bottom: 0;
-	}
-
-	.wp-block-image__aspect-ratio {
-		height: $grid-unit-60 - $border-width - $border-width;
-		margin-top: -$grid-unit-10;
-		margin-bottom: -$grid-unit-10;
-		display: flex;
-		align-items: center;
-
-		.components-button {
-			width: $button-size;
-			padding-left: 0;
-			padding-right: 0;
-		}
-	}
+	position: absolute;
+	top: $grid-unit-15;
+	left: $grid-unit-15;
+	right: $grid-unit-15;
 }

--- a/packages/block-library/src/image/image-editor.js
+++ b/packages/block-library/src/image/image-editor.js
@@ -12,14 +12,13 @@ import classnames from 'classnames';
 import { BlockControls } from '@wordpress/block-editor';
 import { useState } from '@wordpress/element';
 import {
-	Icon,
-	search,
 	rotateRight as rotateRightIcon,
 	aspectRatio as aspectRatioIcon,
 } from '@wordpress/icons';
 import {
 	ToolbarGroup,
 	ToolbarButton,
+	__experimentalToolbarItem as ToolbarItem,
 	Spinner,
 	RangeControl,
 	DropdownMenu,
@@ -272,22 +271,12 @@ export default function ImageEditor( {
 	return (
 		<>
 			{ ! inProgress && (
-				<div
-					className="wp-block-image__zoom-control"
-					aria-label={ __( 'Zoom' ) }
-				>
-					<Icon icon={ search } />
-					<RangeControl
-						min={ MIN_ZOOM }
-						max={ MAX_ZOOM }
-						value={ Math.round( zoom ) }
-						onChange={ setZoom }
-					/>
-					<AspectMenu
-						isDisabled={ inProgress }
-						onClick={ setAspect }
-					/>
-				</div>
+				<RangeControl
+					min={ MIN_ZOOM }
+					max={ MAX_ZOOM }
+					value={ Math.round( zoom ) }
+					onChange={ setZoom }
+				/>
 			) }
 			<div
 				className={ classnames( 'wp-block-image__crop-area', {
@@ -324,6 +313,17 @@ export default function ImageEditor( {
 						onClick={ rotate }
 						disabled={ inProgress }
 					/>
+				</ToolbarGroup>
+				<ToolbarGroup>
+					<ToolbarItem>
+						{ ( toggleProps ) => (
+							<AspectMenu
+								toggleProps={ toggleProps }
+								isDisabled={ inProgress }
+								onClick={ setAspect }
+							/>
+						) }
+					</ToolbarItem>
 				</ToolbarGroup>
 				<ToolbarGroup>
 					<ToolbarButton onClick={ apply } disabled={ inProgress }>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

Follow up to #23418.
For now it's not possible to put the range control inside the toolbar because it already handles horizontal keyboard navigation. In #23418 an additional toolbar was created, but I find it quite tightly packed for smaller images and it obscures the image.

|Before|After|
|---|---|
|<img width="550" alt="Screenshot 2020-07-02 at 14 34 53" src="https://user-images.githubusercontent.com/4710635/86354408-aee83000-bc71-11ea-9649-52e283297650.png">|<img width="510" alt="Screenshot 2020-07-02 at 14 33 10" src="https://user-images.githubusercontent.com/4710635/86354439-ba3b5b80-bc71-11ea-84a1-5932a95ac4f7.png">|

Another reason why I like this more is that the image, the scrolling and pinching gesture for zooming are closely connected to the slider control.

![zoom-control](https://user-images.githubusercontent.com/4710635/86354730-39309400-bc72-11ea-8e8e-703c9330f41e.gif)


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
