### PR TITLE
Issue #12795 - alter orderby for menu_order to ensure unique ordering

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -472,3 +472,24 @@ add_filter( 'pre_render_block', 'gutenberg_render_block_with_assigned_block_cont
  * @see WP_Block::render
  */
 remove_action( 'enqueue_block_assets', 'wp_enqueue_registered_block_scripts_and_styles' );
+
+/**
+ * Filters a REST query ordered by menu_order to ensure a repeatable sequence over multiple pages.
+ *
+ * This can be removed when WordPress core supports pagination of requests ordering on menu_order.
+ *
+ * @see https://core.trac.wordpress.org/ticket/46294
+ *
+ * @param string $orderby Current orderby value.
+ * @param WP_Query $query Query object.
+ */
+function gutenberg_posts_orderby( $orderby, $query ) {
+	global $wpdb;
+	if ( defined('REST_REQUEST') && REST_REQUEST ) {
+		if ( $query->query['orderby'] === 'menu_order' ) {
+			$orderby = "$wpdb->posts.menu_order,post_title,id asc";
+		}
+	}
+	return $orderby;
+}
+add_filter( 'posts_orderby', 'gutenberg_posts_orderby', 10, 2 );

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -480,14 +480,14 @@ remove_action( 'enqueue_block_assets', 'wp_enqueue_registered_block_scripts_and_
  *
  * @see https://core.trac.wordpress.org/ticket/46294
  *
- * @param string $orderby Current orderby value.
+ * @param string   $orderby Current orderby value.
  * @param WP_Query $query Query object.
  */
 function gutenberg_posts_orderby( $orderby, $query ) {
 	global $wpdb;
-	if ( defined('REST_REQUEST') && REST_REQUEST ) {
-		if ( $query->query['orderby'] === 'menu_order' ) {
-			$orderby = "$wpdb->posts.menu_order,post_title,id asc";
+	if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+		if ( 'menu_order' === $query->query['orderby'] ) {
+			$orderby = "$wpdb->posts.menu_order,$wpdb->posts.post_title,$wpdb->posts.id " . $query->query['order'] ;
 		}
 	}
 	return $orderby;

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -487,7 +487,7 @@ function gutenberg_posts_orderby( $orderby, $query ) {
 	global $wpdb;
 	if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
 		if ( 'menu_order' === $query->query['orderby'] ) {
-			$orderby = "$wpdb->posts.menu_order,$wpdb->posts.post_title,$wpdb->posts.id " . $query->query['order'] ;
+			$orderby = "$wpdb->posts.menu_order,$wpdb->posts.post_title,$wpdb->posts.id " . $query->query['order'];
 		}
 	}
 	return $orderby;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
When populating the Parent page: drop down in the Page Attributes settings the editor may perform multiple REST requests.  The requested sort sequence is `menu_order asc`.  For sites where there are more than 100 posts to be returned the results can vary, depending on the values of the menu_order on the posts. 

- Some users get to see hardly anything at all - #20430  
- Others get a load of duplicate entries - #12795.

Additionally the sequence of pages actually display is nothing like the list found in Quick Edit or in the Classic Editor.

The explanation ( documented in TRAC 46294 - https://core.trac.wordpress.org/ticket/46294 ) is that there's a MySQL bug that needs to be worked around by passing a unique value in the sort sequence.  

- The unique field is the post ID.
- The post_title is used to ensure the sequence matches what's seen in Quick Edit.

While the solution for TRAC 46294 is still under development a workaround for Gutenberg is to hook into the `posts_orderby` filter. 

When it's a REST request and the requested sort order is 'menu_order' then it is modified to include the additional fields, with post title coming before post ID. The sort sequence is assumed to be `asc` for all of the order by fields.  



<!-- Please describe what you have changed or added -->

## How has this been tested?
I tested this in my development environment where I previously noted the problem. 

See https://github.com/WordPress/gutenberg/pull/23637 for some details of the content being handled and screen captures showing the incorrect results still being obtained with that attempted fix, and the expected sequence from Quick Edit. 

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

I don't believe `desc` is actually used when the requested order is `menu_order`. Not by core anyway.
If support were to be needed then a minor modification would be to replace `'asc'` by `$query->query['order']`.

## Screenshots <!-- if applicable -->
New results obtained with the additional sorting.
![image](https://user-images.githubusercontent.com/2474435/86353925-febdfb80-bc5f-11ea-9ce0-8410ff313f10.png)


## Types of changes

I implemented the code in `lib/compat.php` since it should only be temporary. When WordPress TRAC 46294 is resolved then it should no longer be necessary.

I tried an alternative solution to change the orderby in the requests being sent but that required WordPress core changes in the REST API to accept the additional sort fields and sort sequences.

Users may notice that the new sort order matches what they see in Quick Edit. 

This change is not dependent upon a working solution for #13618, but it certainly does benefit from it.

<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
