### PR TITLE
Remove more colors

### DIFF
--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -44,4 +44,3 @@ $light-gray-700: #ccd0d4;
 $light-gray-600: #d7dade;
 $light-gray-500: #e2e4e7;
 $light-gray-400: #e8eaeb;
-$light-gray-300: #edeff0;

--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -28,7 +28,6 @@ $alert-green: #4ab866;
  * Please avoid using these.
  */
 
-$dark-gray-800: #23282d;
 $dark-gray-700: #32373c;
 $dark-gray-600: #40464d;
 $dark-gray-500: #555d66;

--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -43,4 +43,3 @@ $light-gray-800: #b5bcc2;
 $light-gray-700: #ccd0d4;
 $light-gray-600: #d7dade;
 $light-gray-500: #e2e4e7;
-$light-gray-400: #e8eaeb;

--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -2,19 +2,19 @@
  * Colors
  */
 
-// WordPress colors.
-$black: #000;					// Use only when you truly need pure black. For UI, use $dark-gray-primary.
-$dark-gray-primary: #1e1e1e;
-$medium-gray-text: #757575;		// Meets 4.6:1 text contrast against white.
-$light-gray-ui: #949494;		// Meets 3:1 UI or large text contrast against white.
-$light-gray-secondary: #ccc;
-$light-gray-tertiary: #e7e8e9;
+// WordPress grays.
+$black: #000;			// Use only when you truly need pure black. For UI, use $gray-900.
+$gray-900: #1e1e1e;
+$gray-700: #757575;		// Meets 4.6:1 text contrast against white.
+$gray-600: #949494;		// Meets 3:1 UI or large text contrast against white.
+$gray-400: #ccc;
+$gray-200: #e7e8e9;
 $white: #fff;
-$blue-medium-focus-dark: $white;	// Focus color when the theme is dark.
 
-// Opacities. For use when transparency is needed.
-$dark-gray-placeholder: rgba($dark-gray-primary, 0.62);
-$medium-gray-placeholder: rgba($dark-gray-primary, 0.55);
+// Opacities & additional colors.
+$blue-medium-focus-dark: $white;	// Focus color when the theme is dark.
+$dark-gray-placeholder: rgba($gray-900, 0.62);
+$medium-gray-placeholder: rgba($gray-900, 0.55);
 $light-gray-placeholder: rgba($white, 0.65);
 
 // Alert colors.

--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -45,5 +45,3 @@ $light-gray-600: #d7dade;
 $light-gray-500: #e2e4e7;
 $light-gray-400: #e8eaeb;
 $light-gray-300: #edeff0;
-$light-gray-200: #f3f4f5;
-

--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -8,7 +8,7 @@ $gray-900: #1e1e1e;
 $gray-700: #757575;		// Meets 4.6:1 text contrast against white.
 $gray-600: #949494;		// Meets 3:1 UI or large text contrast against white.
 $gray-400: #ccc;
-$gray-200: #e7e8e9;
+$gray-200: #ddd;
 $gray-100: #f0f0f0;
 $white: #fff;
 

--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -9,6 +9,7 @@ $gray-700: #757575;		// Meets 4.6:1 text contrast against white.
 $gray-600: #949494;		// Meets 3:1 UI or large text contrast against white.
 $gray-400: #ccc;
 $gray-200: #e7e8e9;
+$gray-100: #f0f0f0;
 $white: #fff;
 
 // Opacities & additional colors.
@@ -45,5 +46,4 @@ $light-gray-500: #e2e4e7;
 $light-gray-400: #e8eaeb;
 $light-gray-300: #edeff0;
 $light-gray-200: #f3f4f5;
-$light-gray-100: #f8f9f9;
 

--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -12,7 +12,7 @@ $gray-200: #e7e8e9;
 $white: #fff;
 
 // Opacities & additional colors.
-$blue-medium-focus-dark: $white;	// Focus color when the theme is dark.
+$dark-theme-focus: $white;	// Focus color when the theme is dark.
 $dark-gray-placeholder: rgba($gray-900, 0.62);
 $medium-gray-placeholder: rgba($gray-900, 0.55);
 $light-gray-placeholder: rgba($white, 0.65);
@@ -47,4 +47,3 @@ $light-gray-300: #edeff0;
 $light-gray-200: #f3f4f5;
 $light-gray-100: #f8f9f9;
 
-$blue-medium-100: #e5f5fa;

--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -28,7 +28,6 @@ $alert-green: #4ab866;
  * Please avoid using these.
  */
 
-$dark-gray-900: #191e23;
 $dark-gray-800: #23282d;
 $dark-gray-700: #32373c;
 $dark-gray-600: #40464d;

--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -8,7 +8,7 @@ $gray-900: #1e1e1e;
 $gray-700: #757575;		// Meets 4.6:1 text contrast against white.
 $gray-600: #949494;		// Meets 3:1 UI or large text contrast against white.
 $gray-400: #ccc;
-$gray-200: #ddd;
+$gray-200: #ddd;		// Used for most borders.
 $gray-100: #f0f0f0;
 $white: #fff;
 
@@ -42,4 +42,3 @@ $light-gray-900: #a2aab2;
 $light-gray-800: #b5bcc2;
 $light-gray-700: #ccd0d4;
 $light-gray-600: #d7dade;
-$light-gray-500: #e2e4e7;

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -129,7 +129,7 @@
 	box-shadow: 0 0 0 transparent;
 	transition: box-shadow 0.1s linear;
 	border-radius: $radius-block-ui;
-	border: $border-width solid $medium-gray-text;
+	border: $border-width solid $gray-700;
 	@include reduce-motion("transition");
 }
 
@@ -289,7 +289,7 @@
 
 @mixin checkbox-control {
 	@include input-control;
-	border: $border-width solid $dark-gray-primary;
+	border: $border-width solid $gray-900;
 	margin-right: $grid-unit-15;
 	transition: none;
 	border-radius: $radius-block-ui;
@@ -350,7 +350,7 @@
 
 @mixin radio-control {
 	@include input-control;
-	border: $border-width solid $dark-gray-primary;
+	border: $border-width solid $gray-900;
 	margin-right: $grid-unit-15;
 	transition: none;
 	border-radius: $radius-round;

--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -100,6 +100,5 @@ $block-selected-to-content: $block-edge-to-content - $block-selected-margin - $b
  * Border radii.
  */
 
-$radius-round-rectangle: 4px;
 $radius-round: 50%;
 $radius-block-ui: 2px;

--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -60,7 +60,7 @@ $mobile-color-swatch: 48px;
  */
 
 $shadow-popover: 0 2px 6px rgba($black, 0.05);
-$shadow-modal: 0 3px 30px rgba($dark-gray-900, 0.2);
+$shadow-modal: 0 3px 30px rgba($black, 0.2);
 
 
 /**
@@ -94,7 +94,6 @@ $block-selected-border-width: 1px;
 $block-selected-padding: 0;
 $block-selected-child-margin: 5px;
 $block-selected-to-content: $block-edge-to-content - $block-selected-margin - $block-selected-border-width;
-
 
 /**
  * Border radii.

--- a/packages/block-directory/src/components/downloadable-block-icon/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-icon/style.scss
@@ -6,6 +6,6 @@
 		width: $button-size;
 		height: $button-size;
 		font-size: $button-size;
-		background-color: $light-gray-300;
+		background-color: $gray-200;
 	}
 }

--- a/packages/block-directory/src/components/downloadable-block-list-item/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-list-item/style.scss
@@ -53,7 +53,7 @@
 	display: flex;
 	flex-direction: column;
 	padding: $grid-unit-20;
-	background-color: $light-gray-200;
+	background-color: $gray-100;
 }
 
 .block-directory-downloadable-block-list-item__content {

--- a/packages/block-directory/src/components/downloadable-block-list-item/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-list-item/style.scss
@@ -10,8 +10,8 @@
 	justify-content: center;
 	background: transparent;
 	word-break: break-word;
-	border-top: $border-width solid $light-gray-500;
-	border-bottom: $border-width solid $light-gray-500;
+	border-top: $border-width solid $gray-200;
+	border-bottom: $border-width solid $gray-200;
 	transition: all 0.05s ease-in-out;
 	@include reduce-motion("transition");
 	position: relative;

--- a/packages/block-editor/src/components/block-breadcrumb/style.scss
+++ b/packages/block-editor/src/components/block-breadcrumb/style.scss
@@ -47,7 +47,7 @@
 
 .block-editor-block-breadcrumb__button.components-button,
 .block-editor-block-breadcrumb__current {
-	color: $dark-gray-primary;
+	color: $gray-900;
 	padding: 0 $grid-unit-10;
 	font-size: inherit;
 }

--- a/packages/block-editor/src/components/block-compare/style.scss
+++ b/packages/block-editor/src/components/block-compare/style.scss
@@ -38,7 +38,7 @@
 	.block-editor-block-compare__html {
 		font-family: $editor-html-font;
 		font-size: 12px;
-		color: $dark-gray-800;
+		color: $dark-gray-primary;
 		border-bottom: 1px solid #ddd;
 		padding-bottom: 15px;
 		line-height: 1.7;

--- a/packages/block-editor/src/components/block-compare/style.scss
+++ b/packages/block-editor/src/components/block-compare/style.scss
@@ -38,7 +38,7 @@
 	.block-editor-block-compare__html {
 		font-family: $editor-html-font;
 		font-size: 12px;
-		color: $dark-gray-primary;
+		color: $gray-900;
 		border-bottom: 1px solid #ddd;
 		padding-bottom: 15px;
 		line-height: 1.7;

--- a/packages/block-editor/src/components/block-draggable/style.scss
+++ b/packages/block-editor/src/components/block-draggable/style.scss
@@ -4,9 +4,9 @@
 }
 
 .block-editor-block-draggable-chip {
-	background-color: $dark-gray-primary;
+	background-color: $gray-900;
 	border-radius: $radius-block-ui;
-	border: $border-width solid $dark-gray-primary;
+	border: $border-width solid $gray-900;
 	box-shadow: 0 4px 6px rgba($black, 0.3);
 	color: $white;
 	cursor: grabbing;

--- a/packages/block-editor/src/components/block-inspector/style.scss
+++ b/packages/block-editor/src/components/block-inspector/style.scss
@@ -8,7 +8,7 @@
 	}
 	.components-panel__body {
 		border: none;
-		border-top: $border-width solid $light-gray-500;
+		border-top: $border-width solid $gray-100;
 	}
 
 	.block-editor-block-card {

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -1,15 +1,4 @@
 .block-editor-block-list__layout .block-editor-block-list__block { // Needs specificity to override inherited styles.
-	// While block is being dragged, dim the slot dragged from, and hide some UI.
-	&.is-dragging {
-		> * {
-			background: $light-gray-100;
-		}
-
-		> * > * {
-			visibility: hidden;
-		}
-	}
-
 	.reusable-block-edit-panel * {
 		z-index: z-index(".block-editor-block-list__block .reusable-block-edit-panel *");
 	}

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -80,7 +80,7 @@
 
 			// Show a light color for dark themes.
 			.is-dark-theme & {
-				box-shadow: 0 0 0 $border-width-focus $blue-medium-focus-dark;
+				box-shadow: 0 0 0 $border-width-focus $dark-theme-focus;
 			}
 		}
 	}
@@ -163,7 +163,7 @@
 
 			// Show a lighter color for dark themes.
 			.is-dark-theme & {
-				box-shadow: 0 0 0 $border-width-focus $blue-medium-focus-dark;
+				box-shadow: 0 0 0 $border-width-focus $dark-theme-focus;
 			}
 		}
 

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -176,7 +176,7 @@
 	}
 
 	.is-navigate-mode & .block-editor-block-list__block.is-hovered:not(.is-selected)::after {
-		box-shadow: 0 0 0 1px $light-gray-ui;
+		box-shadow: 0 0 0 1px $gray-600;
 	}
 
 	.is-block-moving-mode & .block-editor-block-list__block.has-child-selected {
@@ -199,7 +199,7 @@
 			left: 0;
 			top: -$default-block-margin / 2;
 			border-radius: $radius-block-ui;
-			border-top: 4px solid $light-gray-secondary;
+			border-top: 4px solid $gray-400;
 		}
 
 		&::after {
@@ -424,7 +424,7 @@
 .block-editor-block-list__block-popover-inserter {
 	.block-editor-inserter__toggle.components-button.has-icon {
 		// Basic look
-		background: $dark-gray-primary;
+		background: $gray-900;
 		border-radius: $radius-block-ui;
 		color: $white;
 		padding: 0;
@@ -533,14 +533,14 @@
 
 .block-editor-block-contextual-toolbar {
 	// Block UI appearance.
-	border: $border-width solid $dark-gray-primary;
+	border: $border-width solid $gray-900;
 	border-radius: $radius-block-ui;
 	background-color: $white;
 
 	.block-editor-block-toolbar .components-toolbar-group,
 	.block-editor-block-toolbar .components-toolbar,
 	.block-editor-block-toolbar__mover-switcher-container {
-		border-right-color: $dark-gray-primary;
+		border-right-color: $gray-900;
 	}
 
 	.block-editor-block-toolbar__mover-switcher-container {
@@ -643,7 +643,7 @@
 		top: -$border-width;
 
 		// Block UI appearance.
-		box-shadow: 0 0 0 $border-width $dark-gray-primary;
+		box-shadow: 0 0 0 $border-width $gray-900;
 		border-radius: $radius-block-ui - $border-width; // Border is outset, so so subtract the width to achieve correct radius.
 		background-color: $white;
 

--- a/packages/block-editor/src/components/block-mobile-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-mobile-toolbar/style.scss
@@ -6,7 +6,7 @@
 	.block-editor-block-mover-button {
 		width: $button-size;
 		height: $button-size;
-		border-radius: $radius-round-rectangle;
+		border-radius: $radius-block-ui;
 		padding: 3px;
 		margin: 0;
 		justify-content: center;

--- a/packages/block-editor/src/components/block-mobile-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-mobile-toolbar/style.scss
@@ -1,7 +1,7 @@
 .block-editor-block-mobile-toolbar {
 	display: flex;
 	flex-direction: row;
-	border-right: $border-width solid $light-gray-500;
+	border-right: $border-width solid $gray-200;
 
 	.block-editor-block-mover-button {
 		width: $button-size;

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -7,7 +7,7 @@ $tree-item-height: 36px;
 
 .block-editor-block-navigation__label {
 	margin: 0 0 $grid-unit-15;
-	color: $medium-gray-text;
+	color: $gray-700;
 	text-transform: uppercase;
 	font-size: 11px;
 	font-weight: 500;
@@ -157,7 +157,7 @@ $tree-item-height: 36px;
 	}
 
 	.block-editor-inserter__toggle {
-		background: $dark-gray-primary;
+		background: $gray-900;
 		color: $white;
 		height: $grid-unit-30;
 		margin: 6px 6px 6px 1px;

--- a/packages/block-editor/src/components/block-parent-selector/style.scss
+++ b/packages/block-editor/src/components/block-parent-selector/style.scss
@@ -5,7 +5,7 @@
 	.block-editor-block-parent-selector__button {
 		width: $grid-unit-60;
 		height: $grid-unit-60;
-		border: $border-width solid $dark-gray-primary;
+		border: $border-width solid $gray-900;
 		border-radius: $radius-block-ui;
 	}
 }

--- a/packages/block-editor/src/components/block-styles/style.scss
+++ b/packages/block-editor/src/components/block-styles/style.scss
@@ -32,7 +32,7 @@
 		}
 
 		.block-editor-block-styles__item-preview {
-			border: 2px solid $dark-gray-primary;
+			border: 2px solid $gray-900;
 		}
 	}
 }

--- a/packages/block-editor/src/components/block-switcher/style.scss
+++ b/packages/block-editor/src/components/block-switcher/style.scss
@@ -98,7 +98,7 @@
 	}
 
 	.components-panel__body + .components-panel__body {
-		border-top: $border-width solid $light-gray-500;
+		border-top: $border-width solid $gray-100;
 	}
 }
 

--- a/packages/block-editor/src/components/block-switcher/style.scss
+++ b/packages/block-editor/src/components/block-switcher/style.scss
@@ -36,7 +36,7 @@
 	// Since it's not clickable, though, don't show a hover state.
 	&,
 	.block-editor-block-icon.has-colors {
-		color: $dark-gray-primary !important;
+		color: $gray-900 !important;
 	}
 }
 
@@ -125,7 +125,7 @@
 
 	.components-popover__content {
 		box-shadow: none;
-		border: $border-width solid $dark-gray-primary;
+		border: $border-width solid $gray-900;
 		background: $white;
 		border-radius: $radius-block-ui;
 	}
@@ -139,7 +139,7 @@
 
 .block-editor-block-switcher__preview-title {
 	margin-bottom: $grid-unit-15;
-	color: $medium-gray-text;
+	color: $gray-700;
 	text-transform: uppercase;
 	font-size: 11px;
 	font-weight: 500;

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -34,7 +34,7 @@
 		border: 0;
 
 		// Add a border after item groups to show as separator in the block toolbar.
-		border-right: $border-width solid $light-gray-500;
+		border-right: $border-width solid $gray-200;
 	}
 
 	> :last-child,

--- a/packages/block-editor/src/components/button-block-appender/style.scss
+++ b/packages/block-editor/src/components/button-block-appender/style.scss
@@ -6,8 +6,8 @@
 	padding: $grid-unit-10;
 	width: 100%;
 	height: auto;
-	color: $dark-gray-primary;
-	box-shadow: inset 0 0 0 $border-width $dark-gray-primary;
+	color: $gray-900;
+	box-shadow: inset 0 0 0 $border-width $gray-900;
 
 	&:hover {
 		box-shadow: inset 0 0 0 $border-width var(--wp-admin-theme-color);
@@ -25,7 +25,7 @@
 	&.block-list-appender__toggle {
 		display: flex;
 		flex-direction: row;
-		color: $dark-gray-primary;
+		color: $gray-900;
 		box-shadow: none;
 		height: 24px;
 		padding: 0;
@@ -37,7 +37,7 @@
 
 		& > svg {
 			width: 24px;
-			background-color: $dark-gray-primary;
+			background-color: $gray-900;
 			color: $white;
 			border-radius: $radius-block-ui;
 		}

--- a/packages/block-editor/src/components/inserter-list-item/style.scss
+++ b/packages/block-editor/src/components/inserter-list-item/style.scss
@@ -37,7 +37,7 @@
 
 		&.is-active {
 			color: $white;
-			background: $dark-gray-primary;
+			background: $gray-900;
 
 			// Windows High Contrast mode will show this outline, but not the box-shadow.
 			outline: 2px solid transparent;
@@ -49,7 +49,7 @@
 .block-editor-block-types-list__item-icon {
 	padding: 12px 20px;
 	border-radius: $radius-block-ui;
-	color: $dark-gray-primary;
+	color: $gray-900;
 	transition: all 0.05s ease-in-out;
 	@include reduce-motion("transition");
 

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -82,7 +82,7 @@ $block-inserter-tabs-height: 44px;
 		@include input-control;
 		display: block;
 		padding: $grid-unit-20 $grid-unit-60 $grid-unit-20 $grid-unit-20;
-		background: $light-gray-200;
+		background: $gray-100;
 		border: none;
 		width: 100%;
 		height: $grid-unit-60;
@@ -240,7 +240,7 @@ $block-inserter-tabs-height: 44px;
 
 .block-editor-inserter__preview-content {
 	min-height: $grid-unit-60 * 3;
-	background: $light-gray-200;
+	background: $gray-100;
 	display: grid;
 	flex-grow: 1;
 	align-items: center;
@@ -253,7 +253,7 @@ $block-inserter-tabs-height: 44px;
 	align-items: center;
 	min-height: $grid-unit-60 * 3;
 	color: $dark-gray-400;
-	background: $light-gray-200;
+	background: $gray-100;
 }
 
 .block-editor-inserter__tips {

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -135,7 +135,7 @@ $block-inserter-tabs-height: 44px;
 		top: $grid-unit-10 + $grid-unit-20 + $grid-unit-60;
 		background: $white;
 		z-index: 1;
-		border-bottom: $border-width solid $light-gray-500;
+		border-bottom: $border-width solid $gray-200;
 
 		.components-tab-panel__tabs-item {
 			flex-grow: 1;
@@ -220,7 +220,7 @@ $block-inserter-tabs-height: 44px;
 	width: 300px;
 	background: $white;
 	border-radius: $radius-block-ui;
-	border: $border-width solid $light-gray-500;
+	border: $border-width solid $gray-200;
 	position: absolute;
 	top: $grid-unit-20;
 	left: calc(100% + #{$grid-unit-20});
@@ -257,7 +257,7 @@ $block-inserter-tabs-height: 44px;
 }
 
 .block-editor-inserter__tips {
-	border-top: $border-width solid $light-gray-500;
+	border-top: $border-width solid $gray-200;
 	padding: $grid-unit-20;
 	flex-shrink: 0;
 }
@@ -283,7 +283,7 @@ $block-inserter-tabs-height: 44px;
 }
 
 .block-editor-inserter__quick-inserter-separator {
-	border-top: $border-width solid $light-gray-500;
+	border-top: $border-width solid $gray-200;
 }
 
 .block-editor-inserter__popover.is-quick > .components-popover__content > div {

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -163,7 +163,7 @@ $block-inserter-tabs-height: 44px;
 
 .block-editor-inserter__panel-title {
 	margin: 0 $grid-unit-15 0 0;
-	color: $medium-gray-text;
+	color: $gray-700;
 	text-transform: uppercase;
 	font-size: 11px;
 	font-weight: 500;
@@ -294,7 +294,7 @@ $block-inserter-tabs-height: 44px;
 
 .block-editor-inserter__quick-inserter-expand.components-button {
 	display: block;
-	background: $dark-gray-primary;
+	background: $gray-900;
 	color: $white;
 	width: 100%;
 	height: ($button-size + $grid-unit-10);
@@ -305,6 +305,6 @@ $block-inserter-tabs-height: 44px;
 	}
 
 	&:focus:not(:disabled) {
-		box-shadow: inset 0 0 0 $border-width-focus $dark-gray-primary, inset 0 0 0 2px $white;
+		box-shadow: inset 0 0 0 $border-width-focus $gray-900, inset 0 0 0 2px $white;
 	}
 }

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -28,7 +28,7 @@ $block-editor-link-control-number-of-actions: 1;
 		padding-right: ( $button-size * $block-editor-link-control-number-of-actions ); // width of reset and submit buttons
 		margin: $grid-unit-20;
 		position: relative;
-		border: 1px solid $light-gray-500;
+		border: 1px solid $gray-200;
 		border-radius: $radius-block-ui;
 	}
 
@@ -228,7 +228,7 @@ $block-editor-link-control-number-of-actions: 1;
 		left: 0;
 		display: block;
 		width: 100%;
-		border-top: 1px solid $light-gray-500;
+		border-top: 1px solid $gray-200;
 	}
 }
 
@@ -238,7 +238,7 @@ $block-editor-link-control-number-of-actions: 1;
 }
 
 .block-editor-link-control__settings {
-	border-top: 1px solid $light-gray-500;
+	border-top: 1px solid $gray-200;
 	margin: 0;
 	padding: $grid-unit-20 $grid-unit-30;
 

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -167,7 +167,7 @@ $block-editor-link-control-number-of-actions: 1;
 	}
 
 	.block-editor-link-control__search-item-title mark {
-		color: $dark-gray-primary;
+		color: $gray-900;
 	}
 
 	.block-editor-link-control__search-item-title {

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -131,7 +131,7 @@ $block-editor-link-control-number-of-actions: 1;
 	}
 
 	&.is-selected {
-		background: $light-gray-200;
+		background: $gray-100;
 
 		.block-editor-link-control__search-item-type {
 			background: $white;
@@ -198,7 +198,7 @@ $block-editor-link-control-number-of-actions: 1;
 		padding: 3px 8px;
 		margin-left: auto;
 		font-size: 0.9em;
-		background-color: $light-gray-200;
+		background-color: $gray-100;
 		border-radius: 2px;
 	}
 }

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -167,7 +167,7 @@ $block-editor-link-control-number-of-actions: 1;
 	}
 
 	.block-editor-link-control__search-item-title mark {
-		color: $dark-gray-900;
+		color: $dark-gray-primary;
 	}
 
 	.block-editor-link-control__search-item-title {

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -29,7 +29,7 @@ $block-editor-link-control-number-of-actions: 1;
 		margin: $grid-unit-20;
 		position: relative;
 		border: 1px solid $light-gray-500;
-		border-radius: $radius-round-rectangle;
+		border-radius: $radius-block-ui;
 	}
 
 	.components-base-control__field {

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -122,7 +122,7 @@ $block-editor-link-control-number-of-actions: 1;
 
 	&:hover,
 	&:focus {
-		background-color: $light-gray-300;
+		background-color: $gray-200;
 	}
 
 	// The added specificity is needed to override.

--- a/packages/block-editor/src/components/preview-options/style.scss
+++ b/packages/block-editor/src/components/preview-options/style.scss
@@ -18,7 +18,7 @@
 	}
 
 	.components-menu-group + .components-menu-group {
-		border-top: $border-width solid $light-gray-secondary;
+		border-top: $border-width solid $gray-400;
 		padding: $grid-unit-10 $grid-unit-15;
 		margin-left: -$grid-unit-15;
 		margin-right: -$grid-unit-15;

--- a/packages/block-editor/src/components/rich-text/style.scss
+++ b/packages/block-editor/src/components/rich-text/style.scss
@@ -46,7 +46,7 @@ figcaption.block-editor-rich-text__editable [data-rich-text-placeholder]::before
 		box-shadow: none;
 
 		// Block UI appearance.
-		border: $border-width solid $dark-gray-primary;
+		border: $border-width solid $gray-900;
 		border-radius: $radius-block-ui;
 		background-color: $white;
 	}

--- a/packages/block-editor/src/components/tool-selector/style.scss
+++ b/packages/block-editor/src/components/tool-selector/style.scss
@@ -4,6 +4,6 @@
 	margin-right: -$grid-unit-15;
 	margin-bottom: -$grid-unit-15;
 	padding: $grid-unit-15 ($grid-unit-15 + $grid-unit-10);
-	border-top: 1px solid $light-gray-500;
+	border-top: 1px solid $gray-200;
 	color: $dark-gray-300;
 }

--- a/packages/block-editor/src/components/url-input/style.scss
+++ b/packages/block-editor/src/components/url-input/style.scss
@@ -88,7 +88,7 @@ $input-size: 300px;
 	box-shadow: none;
 
 	&:hover {
-		background: $light-gray-500;
+		background: $gray-200;
 	}
 
 	&:focus,
@@ -116,13 +116,13 @@ $input-size: 300px;
 		width: 1px;
 		height: 24px;
 		right: -1px;
-		background: $light-gray-500;
+		background: $gray-200;
 	}
 }
 
 .block-editor-url-input__button-modal {
 	box-shadow: $shadow-popover;
-	border: 1px solid $light-gray-500;
+	border: 1px solid $gray-200;
 	background: $white;
 }
 

--- a/packages/block-editor/src/components/url-popover/style.scss
+++ b/packages/block-editor/src/components/url-popover/style.scss
@@ -26,7 +26,7 @@
 
 	> svg {
 		padding: 5px;
-		border-radius: $radius-round-rectangle;
+		border-radius: $radius-block-ui;
 		height: 30px;
 		width: 30px;
 	}

--- a/packages/block-editor/src/components/url-popover/style.scss
+++ b/packages/block-editor/src/components/url-popover/style.scss
@@ -1,5 +1,5 @@
 .block-editor-url-popover__additional-controls {
-	border-top: $border-width solid $light-gray-500;
+	border-top: $border-width solid $gray-200;
 }
 
 .block-editor-url-popover__additional-controls > div[role="menu"] .components-button:not(:disabled):not([aria-disabled="true"]):not(.is-secondary) > svg {
@@ -45,7 +45,7 @@
 
 	// Add a left divider to the toggle button.
 	border-radius: 0;
-	border-left: $border-width solid $light-gray-500;
+	border-left: $border-width solid $gray-200;
 	margin-left: 1px;
 
 	&[aria-expanded="true"] .dashicon {
@@ -62,7 +62,7 @@
 .block-editor-url-popover__settings {
 	display: block;
 	padding: $grid-unit-20;
-	border-top: $border-width solid $light-gray-500;
+	border-top: $border-width solid $gray-200;
 }
 
 .block-editor-url-popover__link-editor,

--- a/packages/block-editor/src/components/warning/style.scss
+++ b/packages/block-editor/src/components/warning/style.scss
@@ -7,7 +7,7 @@
 	padding: ($grid-unit-10 - $border-width - $border-width) $grid-unit-15;
 
 	// Block UI appearance.
-	border: $border-width solid $dark-gray-primary;
+	border: $border-width solid $gray-900;
 	border-radius: $radius-block-ui;
 	background-color: $white;
 

--- a/packages/block-library/src/block/edit-panel/editor.scss
+++ b/packages/block-library/src/block/edit-panel/editor.scss
@@ -9,7 +9,7 @@
 	// Block UI appearance.
 	border-radius: $radius-block-ui;
 	background-color: $white;
-	box-shadow: 0 0 0 $border-width $dark-gray-primary;
+	box-shadow: 0 0 0 $border-width $gray-900;
 	outline: 1px solid transparent; // Shown for Windows 10 High Contrast mode.
 
 	.reusable-block-edit-panel__info {

--- a/packages/block-library/src/calendar/style.scss
+++ b/packages/block-library/src/calendar/style.scss
@@ -19,7 +19,7 @@
 
 	table th {
 		font-weight: 400;
-		background: $light-gray-300;
+		background: $gray-200;
 	}
 
 	a {

--- a/packages/block-library/src/calendar/style.scss
+++ b/packages/block-library/src/calendar/style.scss
@@ -4,7 +4,7 @@
 	th,
 	tbody td {
 		padding: 4px;
-		border: 1px solid $light-gray-500;
+		border: 1px solid $gray-200;
 	}
 
 	tfoot td {

--- a/packages/block-library/src/classic/editor.scss
+++ b/packages/block-library/src/classic/editor.scss
@@ -53,7 +53,7 @@
 		padding: 2px;
 		border-radius: 2px;
 		color: $gray-900;
-		background: $light-gray-200;
+		background: $gray-100;
 		font-family: $editor-html-font;
 		font-size: 14px;
 	}

--- a/packages/block-library/src/classic/editor.scss
+++ b/packages/block-library/src/classic/editor.scss
@@ -22,7 +22,7 @@
 		white-space: pre-wrap;
 		font-family: $editor-html-font;
 		font-size: $text-editor-font-size;
-		color: $dark-gray-800;
+		color: $dark-gray-primary;
 	}
 
 	> *:first-child {
@@ -52,7 +52,7 @@
 	code {
 		padding: 2px;
 		border-radius: 2px;
-		color: $dark-gray-800;
+		color: $dark-gray-primary;
 		background: $light-gray-200;
 		font-family: $editor-html-font;
 		font-size: 14px;
@@ -275,7 +275,7 @@ div[data-type="core/freeform"] {
 	.mce-btn.mce-active:hover button,
 	.mce-btn.mce-active i,
 	.mce-btn.mce-active:hover i {
-		color: $dark-gray-800;
+		color: $dark-gray-primary;
 	}
 
 	// Prevent toolbar clipping on heading style in RTL languages

--- a/packages/block-library/src/classic/editor.scss
+++ b/packages/block-library/src/classic/editor.scss
@@ -13,7 +13,7 @@
 
 	blockquote {
 		margin: 0;
-		box-shadow: inset 0 0 0 0 $light-gray-500;
+		box-shadow: inset 0 0 0 0 $gray-200;
 		border-left: 4px solid $black;
 		padding-left: 1em;
 	}
@@ -244,7 +244,7 @@ div[data-type="core/freeform"] {
 	&::before {
 		transition: border-color 0.1s linear, box-shadow 0.1s linear;
 		@include reduce-motion("transition");
-		border: $border-width solid $light-gray-500;
+		border: $border-width solid $gray-200;
 
 		// Windows High Contrast mode will show this outline.
 		outline: $border-width solid transparent;
@@ -299,7 +299,7 @@ div[data-type="core/freeform"] {
 	position: sticky;
 	z-index: z-index(".block-library-classic__toolbar");
 	top: 0;
-	border: $border-width solid $light-gray-500;
+	border: $border-width solid $gray-200;
 	border-bottom: none;
 	border-radius: $radius-block-ui;
 	margin-bottom: $grid-unit-10;

--- a/packages/block-library/src/classic/editor.scss
+++ b/packages/block-library/src/classic/editor.scss
@@ -59,7 +59,7 @@
 	}
 
 	&:focus code[data-mce-selected] {
-		background: $light-gray-400;
+		background: $gray-200;
 	}
 
 	.alignright {
@@ -152,12 +152,12 @@
 		}
 
 		.loading-placeholder {
-			border: 1px dashed $light-gray-400;
+			border: 1px dashed $gray-200;
 			padding: 10px;
 		}
 
 		.wpview-error {
-			border: 1px solid $light-gray-400;
+			border: 1px solid $gray-200;
 			padding: 1em 0;
 			margin: 0;
 			word-wrap: break-word;

--- a/packages/block-library/src/classic/editor.scss
+++ b/packages/block-library/src/classic/editor.scss
@@ -22,7 +22,7 @@
 		white-space: pre-wrap;
 		font-family: $editor-html-font;
 		font-size: $text-editor-font-size;
-		color: $dark-gray-primary;
+		color: $gray-900;
 	}
 
 	> *:first-child {
@@ -52,7 +52,7 @@
 	code {
 		padding: 2px;
 		border-radius: 2px;
-		color: $dark-gray-primary;
+		color: $gray-900;
 		background: $light-gray-200;
 		font-family: $editor-html-font;
 		font-size: 14px;
@@ -251,7 +251,7 @@ div[data-type="core/freeform"] {
 	}
 
 	&.is-selected::before {
-		border-color: $dark-gray-primary;
+		border-color: $gray-900;
 	}
 
 	.block-editor-block-contextual-toolbar + div {
@@ -275,7 +275,7 @@ div[data-type="core/freeform"] {
 	.mce-btn.mce-active:hover button,
 	.mce-btn.mce-active i,
 	.mce-btn.mce-active:hover i {
-		color: $dark-gray-primary;
+		color: $gray-900;
 	}
 
 	// Prevent toolbar clipping on heading style in RTL languages
@@ -313,7 +313,7 @@ div[data-type="core/freeform"] {
 	div[data-type="core/freeform"].is-selected &,
 	div[data-type="core/freeform"].is-typing & {
 		display: block;
-		border-color: $dark-gray-primary;
+		border-color: $gray-900;
 	}
 
 	// Remove the box shadow to mimic other Gutenberg UI.
@@ -341,7 +341,7 @@ div[data-type="core/freeform"] {
 	}
 
 	div.mce-toolbar-grp {
-		border-bottom: 1px solid $dark-gray-primary;
+		border-bottom: 1px solid $gray-900;
 	}
 
 	// Overwrite inline styles.

--- a/packages/block-library/src/classic/editor.scss
+++ b/packages/block-library/src/classic/editor.scss
@@ -45,8 +45,8 @@
 		padding: 0 2px;
 		margin: 0 -2px;
 		border-radius: 2px;
-		box-shadow: 0 0 0 $border-width $blue-medium-100;
-		background: $blue-medium-100;
+		box-shadow: 0 0 0 $border-width #e5f5fa;
+		background: #e5f5fa;
 	}
 
 	code {

--- a/packages/block-library/src/code/theme.scss
+++ b/packages/block-library/src/code/theme.scss
@@ -1,7 +1,7 @@
 .wp-block-code {
 	font-family: $editor-html-font;
 	font-size: $text-editor-font-size;
-	color: $dark-gray-800;
+	color: $dark-gray-primary;
 	padding: 0.8em 1em;
 	border: 1px solid $light-gray-500;
 	border-radius: 4px;

--- a/packages/block-library/src/code/theme.scss
+++ b/packages/block-library/src/code/theme.scss
@@ -1,7 +1,7 @@
 .wp-block-code {
 	font-family: $editor-html-font;
 	font-size: $text-editor-font-size;
-	color: $dark-gray-primary;
+	color: $gray-900;
 	padding: 0.8em 1em;
 	border: 1px solid $light-gray-500;
 	border-radius: 4px;

--- a/packages/block-library/src/code/theme.scss
+++ b/packages/block-library/src/code/theme.scss
@@ -3,6 +3,6 @@
 	font-size: $text-editor-font-size;
 	color: $gray-900;
 	padding: 0.8em 1em;
-	border: 1px solid $light-gray-500;
+	border: 1px solid $gray-200;
 	border-radius: 4px;
 }

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -94,7 +94,7 @@
 	.wp-block-cover__inner-container {
 		width: calc(100% - 70px);
 		z-index: z-index(".wp-block-cover__inner-container");
-		color: $light-gray-100;
+		color: $white;
 	}
 
 	p,

--- a/packages/block-library/src/embed/editor.scss
+++ b/packages/block-library/src/embed/editor.scss
@@ -15,7 +15,12 @@
 		padding: 1em;
 		min-height: 200px;
 		text-align: center;
-		background: $light-gray-100;
+
+		// Block UI appearance.
+		border-radius: $radius-block-ui;
+		background-color: $white;
+		box-shadow: inset 0 0 0 $border-width $gray-900;
+
 		p {
 			font-family: $default-font;
 			font-size: $default-font-size;

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -80,7 +80,7 @@ figure.wp-block-gallery {
 	@include reduce-motion("transition");
 	border-radius: $radius-block-ui;
 	background: $white;
-	border: $border-width solid $dark-gray-primary;
+	border: $border-width solid $gray-900;
 
 	&:hover {
 		box-shadow: $shadow-popover;

--- a/packages/block-library/src/html/editor.scss
+++ b/packages/block-library/src/html/editor.scss
@@ -11,7 +11,7 @@
 
 	.block-editor-plain-text {
 		font-family: $editor-html-font;
-		color: $dark-gray-primary;
+		color: $gray-900;
 		padding: 0.8em 1em;
 		border: 1px solid $light-gray-500;
 		border-radius: 4px;

--- a/packages/block-library/src/html/editor.scss
+++ b/packages/block-library/src/html/editor.scss
@@ -11,7 +11,7 @@
 
 	.block-editor-plain-text {
 		font-family: $editor-html-font;
-		color: $dark-gray-800;
+		color: $dark-gray-primary;
 		padding: 0.8em 1em;
 		border: 1px solid $light-gray-500;
 		border-radius: 4px;

--- a/packages/block-library/src/html/editor.scss
+++ b/packages/block-library/src/html/editor.scss
@@ -13,7 +13,7 @@
 		font-family: $editor-html-font;
 		color: $gray-900;
 		padding: 0.8em 1em;
-		border: 1px solid $light-gray-500;
+		border: 1px solid $gray-200;
 		border-radius: 4px;
 		max-height: 250px;
 

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -91,7 +91,7 @@ figure.wp-block-image:not(.wp-block) {
 }
 
 .wp-block-image__zoom-control {
-	border: $border-width solid $dark-gray-primary;
+	border: $border-width solid $gray-900;
 	border-radius: $radius-block-ui;
 	background-color: $white;
 	padding: $grid-unit-10;

--- a/packages/block-library/src/legacy-widget/editor.scss
+++ b/packages/block-library/src/legacy-widget/editor.scss
@@ -26,8 +26,8 @@
 }
 
 .wp-block-legacy-widget__edit-widget-title {
-	background: $light-gray-100;
-	color: $dark-gray-500;
+	background: $gray-200;
+	color: $gray-900;
 	font-family: $default-font;
 	font-size: $default-font-size;
 	padding: $grid-unit-10 $block-padding;

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -38,7 +38,7 @@
 // Separator
 .wp-block-navigation-link__separator {
 	margin: $grid-unit-10 0 $grid-unit-10;
-	border-top: $border-width solid $light-gray-500;
+	border-top: $border-width solid $gray-200;
 }
 
 // Popover styles

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -189,7 +189,7 @@ $color-control-label-height: 20px;
 				left: 25px; // match list item padding
 				right: 25px; // match list item padding
 				height: 15px;
-				border-top: 1px solid $medium-gray-text;
+				border-top: 1px solid $gray-700;
 			}
 		}
 	}

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -2,7 +2,7 @@
 .wp-block-navigation,
 .wp-block-navigation.is-style-light {
 	.wp-block-navigation-link:not(.has-text-color) {
-		color: $dark-gray-primary;
+		color: $gray-900;
 	}
 	&:not(.has-background) .wp-block-navigation__container {
 		background-color: $white;
@@ -15,7 +15,7 @@
 		color: $white;
 	}
 	&:not(.has-background) .wp-block-navigation__container {
-		background-color: $dark-gray-primary;
+		background-color: $gray-900;
 	}
 }
 

--- a/packages/block-library/src/search/editor.scss
+++ b/packages/block-library/src/search/editor.scss
@@ -1,6 +1,6 @@
 .wp-block-search {
 	&__input {
-		border-radius: $radius-round-rectangle;
+		border-radius: $radius-block-ui;
 		border: 1px solid $dark-gray-200;
 		color: $dark-gray-placeholder;
 		font-family: $default-font;
@@ -14,7 +14,7 @@
 
 	&__button {
 		background: #f7f7f7;
-		border-radius: $radius-round-rectangle;
+		border-radius: $radius-block-ui;
 		border: 1px solid #ccc;
 		box-shadow: inset 0 -1px 0 #ccc;
 		font-family: $default-font;

--- a/packages/block-library/src/spacer/editor.scss
+++ b/packages/block-library/src/spacer/editor.scss
@@ -1,5 +1,5 @@
 .block-library-spacer__resize-container.has-show-handle {
-	background: $light-gray-200;
+	background: $gray-100;
 
 	.is-dark-theme & {
 		background: rgba($white, 0.15);

--- a/packages/block-library/src/table/style.scss
+++ b/packages/block-library/src/table/style.scss
@@ -61,7 +61,7 @@
 		background-color: transparent;
 
 		tbody tr:nth-child(odd) {
-			background-color: $light-gray-200;
+			background-color: $gray-100;
 		}
 
 		&.has-subtle-light-gray-background-color {
@@ -93,6 +93,6 @@
 			border-color: transparent;
 		}
 
-		border-bottom: 1px solid $light-gray-200;
+		border-bottom: 1px solid $gray-100;
 	}
 }

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -62,7 +62,7 @@
 .wp-block-template-part__name-panel {
 	background-color: $white;
 	border-radius: $radius-block-ui;
-	box-shadow: 0 0 0 $border-width $dark-gray-primary;
+	box-shadow: 0 0 0 $border-width $gray-900;
 	outline: 1px solid transparent;
 	padding: ($grid-unit-10 - $border-width - $border-width) $grid-unit-15;
 

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -7,7 +7,7 @@
 }
 
 .wp-block-template-part__placeholder-preview-search-form {
-	border-bottom: $border-width solid $light-gray-500;
+	border-bottom: $border-width solid $gray-200;
 }
 
 .wp-block-template-part__placeholder-preview-container {

--- a/packages/block-library/src/text-columns/editor.scss
+++ b/packages/block-library/src/text-columns/editor.scss
@@ -1,5 +1,5 @@
 .wp-block-text-columns {
 	.block-editor-rich-text__editable:focus {
-		outline: $border-width solid $light-gray-500;
+		outline: $border-width solid $gray-200;
 	}
 }

--- a/packages/block-library/src/verse/editor.scss
+++ b/packages/block-library/src/verse/editor.scss
@@ -1,5 +1,5 @@
 pre.wp-block-verse {
-	color: $dark-gray-900;
+	color: $dark-gray-primary;
 	white-space: nowrap;
 	font-family: inherit;
 	font-size: inherit;

--- a/packages/block-library/src/verse/editor.scss
+++ b/packages/block-library/src/verse/editor.scss
@@ -1,5 +1,5 @@
 pre.wp-block-verse {
-	color: $dark-gray-primary;
+	color: $gray-900;
 	white-space: nowrap;
 	font-family: inherit;
 	font-size: inherit;

--- a/packages/components/src/button-group/style.scss
+++ b/packages/components/src/button-group/style.scss
@@ -4,8 +4,8 @@
 	.components-button {
 		border-radius: 0;
 		display: inline-flex;
-		color: $dark-gray-primary;
-		box-shadow: inset 0 0 0 $border-width $dark-gray-primary;
+		color: $gray-900;
+		box-shadow: inset 0 0 0 $border-width $gray-900;
 
 		& + .components-button {
 			margin-left: -1px;
@@ -29,7 +29,7 @@
 
 		// The active button should look pressed.
 		&.is-primary {
-			box-shadow: inset 0 0 0 $border-width $dark-gray-primary;
+			box-shadow: inset 0 0 0 $border-width $gray-900;
 		}
 	}
 }

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -14,7 +14,7 @@
 	box-sizing: border-box;
 	padding: 6px 12px;
 	border-radius: $radius-block-ui;
-	color: $dark-gray-primary;
+	color: $gray-900;
 
 	&[aria-expanded="true"],
 	&:hover {
@@ -107,7 +107,7 @@
 	&.is-secondary,
 	&.is-tertiary {
 		&:active:not(:disabled) {
-			background: $light-gray-tertiary;
+			background: $gray-200;
 			color: var(--wp-admin-theme-color-darker-10);
 			box-shadow: none;
 		}
@@ -120,8 +120,8 @@
 		&:disabled,
 		&[aria-disabled="true"],
 		&[aria-disabled="true"]:hover {
-			color: lighten($medium-gray-text, 5%);
-			background: lighten($light-gray-tertiary, 5%);
+			color: lighten($gray-700, 5%);
+			background: lighten($gray-200, 5%);
 			transform: none;
 			opacity: 1;
 			box-shadow: none;
@@ -281,7 +281,7 @@
 	// Toggled style.
 	&.is-pressed {
 		color: $white;
-		background: $dark-gray-primary;
+		background: $gray-900;
 
 		&:focus:not(:disabled) {
 			box-shadow: inset 0 0 0 1px $white, 0 0 0 $border-width-focus var(--wp-admin-theme-color);
@@ -291,7 +291,7 @@
 		}
 
 		&:hover:not(:disabled) {
-			background: $dark-gray-primary;
+			background: $gray-900;
 		}
 	}
 

--- a/packages/components/src/checkbox-control/style.scss
+++ b/packages/components/src/checkbox-control/style.scss
@@ -4,7 +4,7 @@ $checkbox-input-size-sm: 24px; // Width & height for small viewports.
 .components-checkbox-control__input[type="checkbox"] {
 	@include checkbox-control;
 	background: $white;
-	color: $dark-gray-primary;
+	color: $gray-900;
 	clear: none;
 	cursor: pointer;
 	display: inline-block;

--- a/packages/components/src/combobox-control/style.scss
+++ b/packages/components/src/combobox-control/style.scss
@@ -60,7 +60,7 @@
 	padding: 10px 5px 10px 25px;
 
 	&.is-highlighted {
-		background: $light-gray-500;
+		background: $gray-200;
 	}
 
 	&-icon {

--- a/packages/components/src/custom-select-control/style.scss
+++ b/packages/components/src/custom-select-control/style.scss
@@ -8,7 +8,7 @@
 }
 
 .components-custom-select-control__button {
-	border: 1px solid $medium-gray-text;
+	border: 1px solid $gray-700;
 	border-radius: $radius-block-ui;
 	min-height: 30px;
 	min-width: 130px;
@@ -41,7 +41,7 @@
 	// Show border around the dropdown menu when open.
 	&:focus {
 		// Block UI appearance.
-		border: $border-width solid $dark-gray-primary;
+		border: $border-width solid $gray-900;
 		border-radius: $radius-block-ui;
 		outline: none;
 		transition: none;

--- a/packages/components/src/custom-select-control/style.scss
+++ b/packages/components/src/custom-select-control/style.scss
@@ -64,7 +64,7 @@
 
 
 	&.is-highlighted {
-		background: $light-gray-500;
+		background: $gray-200;
 	}
 
 	&-icon {

--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -48,7 +48,7 @@
 
 .components-datetime__date {
 	min-height: 236px;
-	border-top: 1px solid $light-gray-500;
+	border-top: 1px solid $gray-200;
 
 	// Override external DatePicker styles.
 	.DayPickerNavigation_leftButton__horizontalDefault {

--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -178,10 +178,10 @@
 	&.is-12-hour {
 		.components-datetime__time-field-day input {
 			margin: 0 -$grid-unit-05 0 0 !important;
-			border-radius: $radius-round-rectangle 0 0 $radius-round-rectangle !important;
+			border-radius: $radius-block-ui 0 0 $radius-block-ui !important;
 		}
 		.components-datetime__time-field-year input {
-			border-radius: 0 $radius-round-rectangle $radius-round-rectangle 0 !important;
+			border-radius: 0 $radius-block-ui $radius-block-ui 0 !important;
 		}
 	}
 }

--- a/packages/components/src/dropdown-menu/style.scss
+++ b/packages/components/src/dropdown-menu/style.scss
@@ -26,7 +26,7 @@
 			display: block;
 			content: "";
 			box-sizing: content-box;
-			background-color: $light-gray-500;
+			background-color: $gray-200;
 			position: absolute;
 			top: -3px;
 			left: 0;

--- a/packages/components/src/dropdown-menu/style.scss
+++ b/packages/components/src/dropdown-menu/style.scss
@@ -37,8 +37,8 @@
 		&.is-active svg {
 			// Block UI appearance.
 			color: $white;
-			background: $dark-gray-primary;
-			box-shadow: 0 0 0 $border-width $dark-gray-primary;
+			background: $gray-900;
+			box-shadow: 0 0 0 $border-width $gray-900;
 			border-radius: $border-width;
 		}
 
@@ -80,11 +80,11 @@
 
 	.components-menu-group + .components-menu-group {
 		margin-top: 0;
-		border-top: $border-width solid $light-gray-secondary;
+		border-top: $border-width solid $gray-400;
 		padding: $grid-unit-15;
 
 		.is-alternate & {
-			border-color: $dark-gray-primary;
+			border-color: $gray-900;
 		}
 	}
 }

--- a/packages/components/src/focal-point-picker/style.scss
+++ b/packages/components/src/focal-point-picker/style.scss
@@ -1,6 +1,6 @@
 .components-focal-point-picker-wrapper {
 	background-color: transparent;
-	border: 1px solid $light-gray-500;
+	border: 1px solid $gray-200;
 	height: 200px;
 	width: 100%;
 	padding: 14px;

--- a/packages/components/src/form-toggle/style.scss
+++ b/packages/components/src/form-toggle/style.scss
@@ -13,7 +13,7 @@ $toggle-border-width: 1px;
 		box-sizing: border-box;
 		vertical-align: top;
 		background-color: $white;
-		border: $toggle-border-width solid $dark-gray-primary;
+		border: $toggle-border-width solid $gray-900;
 		width: $toggle-width;
 		height: $toggle-height;
 		border-radius: $toggle-height / 2;
@@ -32,8 +32,8 @@ $toggle-border-width: 1px;
 		border-radius: 50%;
 		transition: 0.1s transform ease;
 		@include reduce-motion("transition");
-		background-color: $dark-gray-primary;
-		border: 5px solid $dark-gray-primary; // Has explicit border to act as a fill in Windows High Contrast Mode.
+		background-color: $gray-900;
+		border: 5px solid $gray-900; // Has explicit border to act as a fill in Windows High Contrast Mode.
 	}
 
 	// Checked state.

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -10,7 +10,7 @@
 
 
 	&.is-disabled {
-		background: $light-gray-500;
+		background: $gray-200;
 		border-color: $light-gray-700;
 	}
 
@@ -126,7 +126,7 @@
 	display: inline-block;
 	line-height: 24px;
 	height: auto;
-	background: $light-gray-500;
+	background: $gray-200;
 	transition: all 0.2s cubic-bezier(0.4, 1, 0.4, 1);
 	@include reduce-motion;
 }

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -24,7 +24,7 @@
 		min-height: 24px;
 		background: inherit;
 		border: 0;
-		color: $dark-gray-800;
+		color: $dark-gray-primary;
 		box-shadow: none;
 
 		&:focus,
@@ -109,7 +109,7 @@
 
 		&.is-validating {
 			.components-form-token-field__token-text {
-				color: $dark-gray-800;
+				color: $dark-gray-primary;
 			}
 		}
 	}

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -24,7 +24,7 @@
 		min-height: 24px;
 		background: inherit;
 		border: 0;
-		color: $dark-gray-primary;
+		color: $gray-900;
 		box-shadow: none;
 
 		&:focus,
@@ -109,7 +109,7 @@
 
 		&.is-validating {
 			.components-form-token-field__token-text {
-				color: $dark-gray-primary;
+				color: $gray-900;
 			}
 		}
 	}

--- a/packages/components/src/menu-group/style.scss
+++ b/packages/components/src/menu-group/style.scss
@@ -1,13 +1,13 @@
 .components-menu-group + .components-menu-group {
 	margin-top: $grid-unit-10;
 	padding-top: $grid-unit-10;
-	border-top: $border-width solid $dark-gray-primary;
+	border-top: $border-width solid $gray-900;
 }
 
 .components-menu-group__label {
 	padding: 0;
 	margin-bottom: $grid-unit-15;
-	color: $medium-gray-text;
+	color: $gray-700;
 	text-transform: uppercase;
 	font-size: 11px;
 	font-weight: 500;

--- a/packages/components/src/menu-item/style.scss
+++ b/packages/components/src/menu-item/style.scss
@@ -25,7 +25,7 @@
 .components-menu-item__info {
 	margin-top: $grid-unit-05;
 	font-size: $default-font-size - 1px;
-	color: $medium-gray-text;
+	color: $gray-700;
 }
 
 .components-menu-item__shortcut {

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -23,7 +23,7 @@
 	left: 0;
 	box-sizing: border-box;
 	margin: 0;
-	border: $border-width solid $light-gray-500;
+	border: $border-width solid $gray-200;
 	background: $white;
 	box-shadow: $shadow-modal;
 	overflow: auto;
@@ -60,7 +60,7 @@
 // modal screen).
 .components-modal__header {
 	box-sizing: border-box;
-	border-bottom: $border-width solid $light-gray-500;
+	border-bottom: $border-width solid $gray-200;
 	padding: 0 $grid-unit-30;
 	display: flex;
 	flex-direction: row;

--- a/packages/components/src/notice/style.scss
+++ b/packages/components/src/notice/style.scss
@@ -54,7 +54,7 @@
 	&:not(:disabled):not([aria-disabled="true"]):not(.is-secondary):hover,
 	&:not(:disabled):not([aria-disabled="true"]):not(.is-secondary):active,
 	&:not(:disabled):not([aria-disabled="true"]):focus {
-		color: $dark-gray-primary;
+		color: $gray-900;
 		background-color: transparent;
 	}
 

--- a/packages/components/src/notice/style.scss
+++ b/packages/components/src/notice/style.scss
@@ -54,7 +54,7 @@
 	&:not(:disabled):not([aria-disabled="true"]):not(.is-secondary):hover,
 	&:not(:disabled):not([aria-disabled="true"]):not(.is-secondary):active,
 	&:not(:disabled):not([aria-disabled="true"]):focus {
-		color: $dark-gray-900;
+		color: $dark-gray-primary;
 		background-color: transparent;
 	}
 

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -81,7 +81,7 @@
 	width: 100%;
 	font-weight: 500;
 	text-align: left;
-	color: $dark-gray-primary;
+	color: $gray-900;
 	border: none;
 	box-shadow: none;
 	transition: 0.1s background ease-in-out;
@@ -98,7 +98,7 @@
 		right: $grid-unit-20;
 		top: 50%;
 		transform: translateY(-50%);
-		color: $dark-gray-primary;
+		color: $gray-900;
 		fill: currentColor;
 		transition: 0.1s color ease-in-out;
 		@include reduce-motion("transition");

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -98,7 +98,7 @@
 		right: $grid-unit-20;
 		top: 50%;
 		transform: translateY(-50%);
-		color: $dark-gray-900;
+		color: $dark-gray-primary;
 		fill: currentColor;
 		transition: 0.1s color ease-in-out;
 		@include reduce-motion("transition");

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -1,6 +1,6 @@
 .components-panel {
 	background: $white;
-	border: $border-width solid $light-gray-500;
+	border: $border-width solid $gray-100;
 
 	> .components-panel__header:first-child,
 	> .components-panel__body:first-child {
@@ -18,8 +18,8 @@
 }
 
 .components-panel__body {
-	border-top: $border-width solid $light-gray-500;
-	border-bottom: $border-width solid $light-gray-500;
+	border-top: $border-width solid $gray-100;
+	border-bottom: $border-width solid $gray-100;
 
 	h3 {
 		margin: 0 0 0.5em;
@@ -36,8 +36,8 @@
 	align-items: center;
 	padding: 0 $grid-unit-20;
 	height: $grid-unit-60;
-	border-top: $border-width solid $light-gray-500;
-	border-bottom: $border-width solid $light-gray-500;
+	border-top: $border-width solid $gray-200;
+	border-bottom: $border-width solid $gray-200;
 
 	h2 {
 		margin: 0;

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -70,7 +70,7 @@
 // Hover States
 .components-panel__body > .components-panel__body-title:hover {
 	// Override the default button hover style
-	background: $light-gray-200;
+	background: $gray-100;
 	border: none;
 }
 

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -5,7 +5,7 @@
 	width: 100%;
 	text-align: left;
 	margin: 0;
-	color: $dark-gray-primary;
+	color: $gray-900;
 
 	// Some editor styles unset this.
 	-moz-font-smoothing: subpixel-antialiased;
@@ -22,7 +22,7 @@
 	// Block UI appearance.
 	border-radius: $radius-block-ui;
 	background-color: $white;
-	box-shadow: inset 0 0 0 $border-width $dark-gray-primary;
+	box-shadow: inset 0 0 0 $border-width $gray-900;
 	outline: 1px solid transparent; // Shown for Windows 10 High Contrast mode.
 
 	.components-base-control__label {

--- a/packages/components/src/popover/style.scss
+++ b/packages/components/src/popover/style.scss
@@ -29,7 +29,7 @@ $arrow-size: 8px;
 		margin-left: 2px;
 
 		&::before {
-			border: $arrow-size solid $dark-gray-primary;
+			border: $arrow-size solid $gray-900;
 		}
 
 		&::after {
@@ -162,13 +162,13 @@ $arrow-size: 8px;
 .components-popover__content {
 	height: 100%;
 	background: $white;
-	border: $border-width solid $light-gray-secondary;
+	border: $border-width solid $gray-400;
 	box-shadow: $shadow-popover;
 	border-radius: $radius-block-ui;
 
 	// Alternate treatment for popovers that put them at elevation zero with high contrast.
 	.is-alternate & {
-		border: $border-width solid $dark-gray-primary;
+		border: $border-width solid $gray-900;
 		box-shadow: none;
 	}
 
@@ -185,7 +185,7 @@ $arrow-size: 8px;
 		overflow-y: visible;
 		min-width: auto;
 		border: none;
-		border-top: $border-width solid $dark-gray-primary;
+		border-top: $border-width solid $gray-900;
 	}
 
 	.components-popover[data-y-axis="top"] & {

--- a/packages/components/src/snackbar/style.scss
+++ b/packages/components/src/snackbar/style.scss
@@ -2,7 +2,7 @@
 	font-family: $default-font;
 	font-size: $default-font-size;
 	background-color: $dark-gray-700;
-	border-radius: $radius-round-rectangle;
+	border-radius: $radius-block-ui;
 	box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
 	color: $white;
 	padding: 16px 24px;

--- a/packages/components/src/snackbar/style.scss
+++ b/packages/components/src/snackbar/style.scss
@@ -1,7 +1,7 @@
 .components-snackbar {
 	font-family: $default-font;
 	font-size: $default-font-size;
-	background-color: $dark-gray-700;
+	background-color: $dark-gray-primary;
 	border-radius: $radius-block-ui;
 	box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
 	color: $white;
@@ -15,12 +15,7 @@
 		width: fit-content;
 	}
 
-	&:hover {
-		background-color: $dark-gray-900;
-	}
-
 	&:focus {
-		background-color: $dark-gray-900;
 		box-shadow:
 			0 0 0 1px $white,
 			0 0 0 3px var(--wp-admin-theme-color);

--- a/packages/components/src/snackbar/style.scss
+++ b/packages/components/src/snackbar/style.scss
@@ -1,7 +1,7 @@
 .components-snackbar {
 	font-family: $default-font;
 	font-size: $default-font-size;
-	background-color: $dark-gray-primary;
+	background-color: $gray-900;
 	border-radius: $radius-block-ui;
 	box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
 	color: $white;

--- a/packages/components/src/toolbar-group/style.scss
+++ b/packages/components/src/toolbar-group/style.scss
@@ -1,6 +1,6 @@
 .components-toolbar-group {
 	min-height: $block-toolbar-height;
-	border-right: $border-width solid $dark-gray-primary;
+	border-right: $border-width solid $gray-900;
 	background-color: $white;
 	display: inline-flex;
 	flex-shrink: 0;
@@ -19,7 +19,7 @@
 .components-toolbar {
 	min-height: $block-toolbar-height;
 	margin: 0;
-	border: $border-width solid $dark-gray-primary;
+	border: $border-width solid $gray-900;
 	border-radius: $radius-block-ui;
 	background-color: $white;
 	display: inline-flex;

--- a/packages/components/src/toolbar-group/style.scss
+++ b/packages/components/src/toolbar-group/style.scss
@@ -49,7 +49,7 @@ div.components-toolbar {
 			display: inline-block;
 			content: "";
 			box-sizing: content-box;
-			background-color: $light-gray-500;
+			background-color: $gray-200;
 			position: absolute;
 			top: 8px;
 			left: -3px;

--- a/packages/components/src/toolbar/style.scss
+++ b/packages/components/src/toolbar/style.scss
@@ -1,6 +1,6 @@
 .components-accessible-toolbar {
 	display: inline-flex;
-	border: $border-width solid $dark-gray-primary;
+	border: $border-width solid $gray-900;
 	border-radius: $radius-block-ui;
 	flex-shrink: 0;
 
@@ -62,7 +62,7 @@
 			}
 
 			&::before {
-				background: $dark-gray-primary;
+				background: $gray-900;
 			}
 		}
 

--- a/packages/components/src/tooltip/style.scss
+++ b/packages/components/src/tooltip/style.scss
@@ -7,7 +7,7 @@
 }
 
 .components-tooltip .components-popover__content {
-	background: $dark-gray-primary;
+	background: $gray-900;
 	border-radius: $radius-block-ui;
 	border-width: 0;
 	color: $white;

--- a/packages/components/src/visually-hidden/style.scss
+++ b/packages/components/src/visually-hidden/style.scss
@@ -13,7 +13,7 @@
 }
 
 .components-visually-hidden:focus {
-	background-color: $light-gray-500;
+	background-color: $gray-200;
 	clip: auto !important;
 	clip-path: none;
 	color: #444;

--- a/packages/edit-navigation/src/components/navigation-editor/style.scss
+++ b/packages/edit-navigation/src/components/navigation-editor/style.scss
@@ -34,7 +34,7 @@
 		border: 0;
 
 		// Add a border after item groups to show as separator in the block toolbar.
-		border-right: $border-width solid $light-gray-500;
+		border-right: $border-width solid $gray-200;
 	}
 
 

--- a/packages/edit-navigation/src/components/navigation-editor/style.scss
+++ b/packages/edit-navigation/src/components/navigation-editor/style.scss
@@ -108,5 +108,5 @@
 	padding-top: $grid-unit-20;
 	width: 100%;
 	text-align: left;
-	border-top: 1px solid $light-gray-300;
+	border-top: 1px solid $gray-200;
 }

--- a/packages/edit-post/src/components/header/header-toolbar/style.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.scss
@@ -34,7 +34,7 @@
 		padding: 6px;
 
 		&.is-pressed {
-			background: $dark-gray-primary;
+			background: $gray-900;
 		}
 
 		&:focus:not(:disabled) {

--- a/packages/edit-post/src/components/header/header-toolbar/style.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.scss
@@ -56,7 +56,7 @@
 	left: 0;
 	right: 0;
 	background: $white;
-	border-bottom: $border-width solid $light-gray-500;
+	border-bottom: $border-width solid $gray-200;
 
 	&:empty {
 		display: none;
@@ -93,7 +93,7 @@
 		}
 
 		.block-editor-block-toolbar {
-			border-left: $border-width solid $light-gray-500;
+			border-left: $border-width solid $gray-200;
 		}
 
 		.block-editor-block-toolbar .components-toolbar-group,

--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -83,7 +83,7 @@
 	.components-button.editor-post-switch-to-draft,
 	.components-button.editor-post-preview,
 	.components-button.block-editor-post-preview__button-toggle {
-		color: $dark-gray-primary;
+		color: $gray-900;
 	}
 
 	.components-button.block-editor-post-preview__dropdown,

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/style.scss
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/style.scss
@@ -17,11 +17,11 @@
 		display: flex;
 		align-items: baseline;
 		padding: 0.6rem 0;
-		border-top: 1px solid $light-gray-500;
+		border-top: 1px solid $gray-200;
 		margin-bottom: 0;
 
 		&:last-child {
-			border-bottom: 1px solid $light-gray-500;
+			border-bottom: 1px solid $gray-200;
 		}
 
 		&:empty {

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -2,7 +2,7 @@
 	flex-shrink: 0;
 }
 .edit-post-layout__metaboxes:not(:empty) {
-	border-top: $border-width solid $light-gray-500;
+	border-top: $border-width solid $gray-200;
 	padding: 10px 0 10px;
 	clear: both;
 
@@ -35,7 +35,7 @@
 		top: $admin-bar-height;
 		left: auto;
 		width: $sidebar-width + $border-width;
-		border-left: $border-width solid $light-gray-500;
+		border-left: $border-width solid $gray-200;
 		transform: translateX(+100%);
 		animation: edit-post-post-publish-panel__slide-in-animation 0.1s forwards;
 		@include reduce-motion("animation");
@@ -77,7 +77,7 @@
 	right: 0;
 	width: $sidebar-width;
 	background-color: $white;
-	border: 1px dotted $light-gray-500;
+	border: 1px dotted $gray-200;
 	height: auto !important; // Need to override the default sidebar positionnings
 	padding: $grid-unit-30;
 	display: flex;

--- a/packages/edit-post/src/components/manage-blocks-modal/style.scss
+++ b/packages/edit-post/src/components/manage-blocks-modal/style.scss
@@ -46,7 +46,7 @@
 }
 
 .edit-post-manage-blocks-modal__disabled-blocks-count {
-	border-top: 1px solid $light-gray-500;
+	border-top: 1px solid $gray-200;
 	margin-left: -$grid-unit-30;
 	margin-right: -$grid-unit-30;
 	padding-top: 0.6rem;
@@ -88,10 +88,10 @@
 .edit-post-manage-blocks-modal__checklist-item {
 	margin-bottom: 0;
 	padding-left: $grid-unit-20;
-	border-top: 1px solid $light-gray-500;
+	border-top: 1px solid $gray-200;
 
 	&:last-child {
-		border-bottom: 1px solid $light-gray-500;
+		border-bottom: 1px solid $gray-200;
 	}
 
 	.components-base-control__field {
@@ -125,5 +125,5 @@
 	margin-right: -$grid-unit-30;
 	padding-left: $grid-unit-30;
 	padding-right: $grid-unit-30;
-	border-top: $border-width solid $light-gray-500;
+	border-top: $border-width solid $gray-200;
 }

--- a/packages/edit-post/src/components/manage-blocks-modal/style.scss
+++ b/packages/edit-post/src/components/manage-blocks-modal/style.scss
@@ -40,8 +40,8 @@
 	}
 
 	input[type="search"].components-text-control__input {
-		padding: 0.75 * $grid-unit-20;
-		border-radius: $radius-round-rectangle;
+		padding: $grid-unit-10;
+		border-radius: $radius-block-ui;
 	}
 }
 

--- a/packages/edit-post/src/components/manage-blocks-modal/style.scss
+++ b/packages/edit-post/src/components/manage-blocks-modal/style.scss
@@ -53,7 +53,7 @@
 	padding-bottom: 0.6rem;
 	padding-left: $grid-unit-30;
 	padding-right: $grid-unit-30;
-	background-color: $light-gray-200;
+	background-color: $gray-100;
 }
 
 .edit-post-manage-blocks-modal__category {

--- a/packages/edit-post/src/components/meta-boxes/meta-boxes-area/style.scss
+++ b/packages/edit-post/src/components/meta-boxes/meta-boxes-area/style.scss
@@ -30,7 +30,7 @@
 	#poststuff h3.hndle,
 	#poststuff .stuffbox > h3,
 	#poststuff h2.hndle { /* WordPress selectors yolo */
-		border-bottom: $border-width solid $light-gray-500;
+		border-bottom: $border-width solid $gray-200;
 		box-sizing: border-box;
 		color: inherit;
 		font-weight: 600;
@@ -47,7 +47,7 @@
 	}
 
 	.postbox > .inside {
-		border-bottom: $border-width solid $light-gray-500;
+		border-bottom: $border-width solid $gray-200;
 		color: inherit;
 		padding: 0 $block-padding $block-padding;
 		margin: 0;

--- a/packages/edit-post/src/components/options-modal/style.scss
+++ b/packages/edit-post/src/components/options-modal/style.scss
@@ -9,10 +9,10 @@
 	}
 
 	&__option {
-		border-top: 1px solid $light-gray-500;
+		border-top: 1px solid $gray-200;
 
 		&:last-child {
-			border-bottom: 1px solid $light-gray-500;
+			border-bottom: 1px solid $gray-200;
 		}
 
 		.components-base-control__field {

--- a/packages/edit-post/src/components/text-editor/style.scss
+++ b/packages/edit-post/src/components/text-editor/style.scss
@@ -18,7 +18,7 @@
 
 		// Always show outlines in code editor
 		.editor-post-title__input {
-			border: $border-width solid $light-gray-secondary;
+			border: $border-width solid $gray-400;
 			margin-bottom: -$border-width;
 
 			// Same padding as body.
@@ -28,7 +28,7 @@
 			}
 
 			&:focus {
-				border: $border-width solid $dark-gray-primary;
+				border: $border-width solid $gray-900;
 			}
 		}
 
@@ -75,7 +75,7 @@
 		line-height: $button-size;
 		margin: 0 auto 0 0;
 		font-size: $default-font-size;
-		color: $dark-gray-primary;
+		color: $gray-900;
 	}
 
 	.components-button svg {

--- a/packages/edit-site/src/components/editor/style.scss
+++ b/packages/edit-site/src/components/editor/style.scss
@@ -7,7 +7,7 @@
 	right: 0;
 	width: $sidebar-width;
 	background-color: $white;
-	border: 1px dotted $light-gray-500;
+	border: 1px dotted $gray-200;
 	height: auto !important; // Need to override the default sidebar positioning
 	padding: $grid-unit-30;
 	display: flex;

--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -57,7 +57,7 @@
 	left: 0;
 	right: 0;
 	background: $white;
-	border-bottom: $border-width solid $light-gray-500;
+	border-bottom: $border-width solid $gray-200;
 
 	&:empty {
 		display: none;
@@ -94,7 +94,7 @@
 		}
 
 		.block-editor-block-toolbar {
-			border-left: $border-width solid $light-gray-500;
+			border-left: $border-width solid $gray-200;
 		}
 
 		.block-editor-block-toolbar .components-toolbar-group,

--- a/packages/edit-site/src/components/sidebar/style.scss
+++ b/packages/edit-site/src/components/sidebar/style.scss
@@ -8,7 +8,7 @@
 		margin-top: -1px;
 
 		> .components-panel__header {
-			background: $light-gray-200;
+			background: $gray-100;
 		}
 	}
 

--- a/packages/edit-site/src/components/template-switcher/style.scss
+++ b/packages/edit-site/src/components/template-switcher/style.scss
@@ -40,7 +40,7 @@
 .edit-site-template-switcher__template-preview,
 .edit-site-template-switcher__theme-preview {
 	display: none;
-	border: $border-width solid $light-gray-secondary;
+	border: $border-width solid $gray-400;
 	width: 300px;
 	padding: $grid-unit-20;
 	background: $white;

--- a/packages/edit-widgets/src/components/customizer-edit-widgets-initializer/style.scss
+++ b/packages/edit-widgets/src/components/customizer-edit-widgets-initializer/style.scss
@@ -2,7 +2,7 @@
 	position: relative;
 	.edit-widgets-header {
 		margin-top: -16px;
-		border-top: 1px solid $light-gray-500;
+		border-top: 1px solid $gray-200;
 	}
 
 	.edit-widgets-header,

--- a/packages/edit-widgets/src/components/header/style.scss
+++ b/packages/edit-widgets/src/components/header/style.scss
@@ -17,6 +17,6 @@
 }
 
 .edit-widgets-header__block-toolbar {
-	border-bottom: 1px solid $light-gray-500;
-	border-top: 1px solid $light-gray-500;
+	border-bottom: 1px solid $gray-200;
+	border-top: 1px solid $gray-200;
 }

--- a/packages/edit-widgets/src/components/sidebar/style.scss
+++ b/packages/edit-widgets/src/components/sidebar/style.scss
@@ -32,7 +32,7 @@
 	padding: 3px 15px; // Use padding to offset the is-active border, this benefits Windows High Contrast mode
 	margin-left: 0;
 	font-weight: 400;
-	color: $dark-gray-primary;
+	color: $gray-900;
 
 	// This pseudo-element "duplicates" the tab label and sets the text to bold.
 	// This ensures that the tab doesn't change width when selected.

--- a/packages/edit-widgets/src/components/sidebar/style.scss
+++ b/packages/edit-widgets/src/components/sidebar/style.scss
@@ -32,7 +32,7 @@
 	padding: 3px 15px; // Use padding to offset the is-active border, this benefits Windows High Contrast mode
 	margin-left: 0;
 	font-weight: 400;
-	color: $dark-gray-900;
+	color: $dark-gray-primary;
 
 	// This pseudo-element "duplicates" the tab label and sets the text to bold.
 	// This ensures that the tab doesn't change width when selected.

--- a/packages/edit-widgets/src/components/sidebar/style.scss
+++ b/packages/edit-widgets/src/components/sidebar/style.scss
@@ -90,9 +90,9 @@
 
 	li {
 		margin: 0;
-		border-bottom: $border-width solid $light-gray-500;
+		border-bottom: $border-width solid $gray-200;
 		&:first-child {
-			border-top: $border-width solid $light-gray-500;
+			border-top: $border-width solid $gray-200;
 		}
 
 		button {

--- a/packages/editor/src/components/document-outline/style.scss
+++ b/packages/editor/src/components/document-outline/style.scss
@@ -16,7 +16,7 @@
 	}
 
 	.document-outline__emdash::before {
-		color: $light-gray-500;
+		color: $gray-200;
 		margin-right: 4px;
 	}
 
@@ -66,7 +66,7 @@
 }
 
 .document-outline__level {
-	background: $light-gray-500;
+	background: $gray-200;
 	color: $gray-900;
 	border-radius: 3px;
 	font-size: $default-font-size;

--- a/packages/editor/src/components/document-outline/style.scss
+++ b/packages/editor/src/components/document-outline/style.scss
@@ -49,7 +49,7 @@
 	align-items: flex-start;
 	margin: 0 0 0 -1px;
 	padding: 2px 5px 2px 1px;
-	color: $dark-gray-primary;
+	color: $gray-900;
 	text-align: left;
 	border-radius: $radius-block-ui;
 
@@ -67,7 +67,7 @@
 
 .document-outline__level {
 	background: $light-gray-500;
-	color: $dark-gray-primary;
+	color: $gray-900;
 	border-radius: 3px;
 	font-size: $default-font-size;
 	padding: 1px 6px;

--- a/packages/editor/src/components/document-outline/style.scss
+++ b/packages/editor/src/components/document-outline/style.scss
@@ -49,7 +49,7 @@
 	align-items: flex-start;
 	margin: 0 0 0 -1px;
 	padding: 2px 5px 2px 1px;
-	color: $dark-gray-800;
+	color: $dark-gray-primary;
 	text-align: left;
 	border-radius: $radius-block-ui;
 
@@ -67,7 +67,7 @@
 
 .document-outline__level {
 	background: $light-gray-500;
-	color: $dark-gray-800;
+	color: $dark-gray-primary;
 	border-radius: 3px;
 	font-size: $default-font-size;
 	padding: 1px 6px;

--- a/packages/editor/src/components/editor-notices/style.scss
+++ b/packages/editor/src/components/editor-notices/style.scss
@@ -3,7 +3,7 @@
 	position: sticky;
 	top: 0;
 	right: 0;
-	color: $dark-gray-900;
+	color: $dark-gray-primary;
 }
 
 // Non-dismissible notices.
@@ -12,7 +12,7 @@
 	left: 0;
 	top: 0;
 	right: 0;
-	color: $dark-gray-900;
+	color: $dark-gray-primary;
 }
 
 .components-editor-notices__dismissible,

--- a/packages/editor/src/components/editor-notices/style.scss
+++ b/packages/editor/src/components/editor-notices/style.scss
@@ -3,7 +3,7 @@
 	position: sticky;
 	top: 0;
 	right: 0;
-	color: $dark-gray-primary;
+	color: $gray-900;
 }
 
 // Non-dismissible notices.
@@ -12,7 +12,7 @@
 	left: 0;
 	top: 0;
 	right: 0;
-	color: $dark-gray-primary;
+	color: $gray-900;
 }
 
 .components-editor-notices__dismissible,

--- a/packages/editor/src/components/entities-saved-states/style.scss
+++ b/packages/editor/src/components/entities-saved-states/style.scss
@@ -22,7 +22,7 @@
 		top: $admin-bar-height;
 		left: auto;
 		width: $sidebar-width;
-		border-left: $border-width solid $light-gray-500;
+		border-left: $border-width solid $gray-200;
 
 		body.is-fullscreen-mode & {
 			top: 0;
@@ -41,7 +41,7 @@
 		padding-left: $grid-unit-10;
 		padding-right: $grid-unit-10;
 		height: $header-height + $border-width;
-		border-bottom: $border-width solid $light-gray-500;
+		border-bottom: $border-width solid $gray-200;
 		display: flex;
 		align-items: center;
 		align-content: space-between;
@@ -57,7 +57,7 @@
 	}
 
 	.entities-saved-states__text-prompt {
-		border-bottom: $border-width solid $light-gray-500;
+		border-bottom: $border-width solid $gray-200;
 		padding: $grid-unit-20;
 		padding-bottom: $grid-unit-05;
 	}

--- a/packages/editor/src/components/post-featured-image/style.scss
+++ b/packages/editor/src/components/post-featured-image/style.scss
@@ -47,14 +47,15 @@
 }
 
 .editor-post-featured-image__toggle {
-	border: $border-width dashed $light-gray-900;
-	background-color: $light-gray-300;
+	border-radius: $radius-block-ui;
+	background-color: $gray-100;
 	min-height: 90px;
 	line-height: 20px;
 	padding: $grid-unit-10 0;
 	text-align: center;
 
 	&:hover {
-		background-color: $light-gray-100;
+		background: $gray-200;
+		color: $gray-900;
 	}
 }

--- a/packages/editor/src/components/post-last-revision/style.scss
+++ b/packages/editor/src/components/post-last-revision/style.scss
@@ -13,7 +13,7 @@
 	&:hover,
 	&:active {
 		// Override the default button hover style
-		background: $light-gray-200;
+		background: $gray-100;
 	}
 
 	&:focus {

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -17,7 +17,7 @@
 	padding-left: $grid-unit-20;
 	padding-right: $grid-unit-20;
 	height: $header-height + $border-width;
-	border-bottom: $border-width solid $light-gray-500;
+	border-bottom: $border-width solid $gray-200;
 	display: flex;
 	align-items: center;
 	align-content: space-between;
@@ -95,7 +95,7 @@
 }
 
 .post-publish-panel__postpublish .components-panel__body {
-	border-bottom: $border-width solid $light-gray-500;
+	border-bottom: $border-width solid $gray-100;
 	border-top: none;
 }
 

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -80,7 +80,7 @@
 	padding: 16px;
 
 	strong {
-		color: $dark-gray-900;
+		color: $dark-gray-primary;
 	}
 
 	.components-panel__body {

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -80,7 +80,7 @@
 	padding: 16px;
 
 	strong {
-		color: $dark-gray-primary;
+		color: $gray-900;
 	}
 
 	.components-panel__body {

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -129,7 +129,7 @@
 
 	input[readonly] {
 		padding: 10px;
-		background: $light-gray-400;
+		background: $gray-200;
 		overflow: hidden;
 		text-overflow: ellipsis;
 	}

--- a/packages/editor/src/components/post-saved-state/style.scss
+++ b/packages/editor/src/components/post-saved-state/style.scss
@@ -3,7 +3,7 @@
 	align-items: center;
 	width: $button-size - $grid-unit-10;
 	padding: #{ $grid-unit-05 * 3 } $grid-unit-05;
-	color: $medium-gray-text;
+	color: $gray-700;
 	overflow: hidden;
 	white-space: nowrap;
 

--- a/packages/editor/src/components/post-text-editor/style.scss
+++ b/packages/editor/src/components/post-text-editor/style.scss
@@ -1,5 +1,5 @@
 .edit-post-text-editor__body textarea.editor-post-text-editor {
-	border: $border-width solid $light-gray-secondary;
+	border: $border-width solid $gray-400;
 	display: block;
 	margin: 0;
 	width: 100%;
@@ -24,7 +24,7 @@
 	}
 
 	&:focus {
-		border: $border-width solid $dark-gray-primary;
+		border: $border-width solid $gray-900;
 		box-shadow: none;
 
 		// Elevate the z-index on focus so the focus style is uncropped.

--- a/packages/editor/src/editor-styles.scss
+++ b/packages/editor/src/editor-styles.scss
@@ -12,7 +12,7 @@ body {
 	font-family: $editor-font;
 	font-size: $editor-font-size;
 	line-height: $editor-line-height;
-	color: $dark-gray-primary;
+	color: $gray-900;
 	padding: 10px;
 }
 

--- a/packages/interface/src/components/complementary-area/style.scss
+++ b/packages/interface/src/components/complementary-area/style.scss
@@ -1,6 +1,6 @@
 .interface-complementary-area {
 	background: $white;
-	color: $dark-gray-primary;
+	color: $gray-900;
 	overflow: visible;
 
 	@include break-small() {
@@ -55,7 +55,7 @@
 	h2,
 	h3 {
 		font-size: $default-font-size;
-		color: $dark-gray-primary;
+		color: $gray-900;
 		margin-bottom: 1.5em;
 	}
 

--- a/packages/interface/src/components/complementary-area/style.scss
+++ b/packages/interface/src/components/complementary-area/style.scss
@@ -61,7 +61,7 @@
 
 	hr {
 		border-top: none;
-		border-bottom: 1px solid $light-gray-500;
+		border-bottom: 1px solid $gray-100;
 		margin: 1.5em 0;
 	}
 

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -97,20 +97,20 @@ html.interface-interface-skeleton__html-container {
 .interface-interface-skeleton__sidebar {
 	@include break-medium() {
 		overflow: auto;
-		border-left: $border-width solid $light-gray-500;
+		border-left: $border-width solid $gray-100;
 	}
 }
 
 .interface-interface-skeleton__left-sidebar {
 	@include break-medium() {
-		border-right: $border-width solid $light-gray-500;
+		border-right: $border-width solid $gray-100;
 	}
 }
 
 .interface-interface-skeleton__header {
 	flex-shrink: 0;
 	height: auto;  // Keep the height flexible.
-	border-bottom: $border-width solid $light-gray-500;
+	border-bottom: $border-width solid $gray-100;
 	z-index: z-index(".interface-interface-skeleton__header");
 	color: $gray-900;
 
@@ -128,7 +128,7 @@ html.interface-interface-skeleton__html-container {
 .interface-interface-skeleton__footer {
 	height: auto;  // Keep the height flexible.
 	flex-shrink: 0;
-	border-top: $border-width solid $light-gray-500;
+	border-top: $border-width solid $gray-100;
 	color: $gray-900;
 
 	// On Mobile the footer is hidden

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -85,7 +85,7 @@ html.interface-interface-skeleton__html-container {
 	bottom: 0;
 	left: 0;
 	background: $white;
-	color: $dark-gray-primary;
+	color: $gray-900;
 
 	// On Mobile the header is fixed to keep HTML as scrollable.
 	@include break-medium() {
@@ -112,7 +112,7 @@ html.interface-interface-skeleton__html-container {
 	height: auto;  // Keep the height flexible.
 	border-bottom: $border-width solid $light-gray-500;
 	z-index: z-index(".interface-interface-skeleton__header");
-	color: $dark-gray-primary;
+	color: $gray-900;
 
 	// On Mobile the header is sticky.
 	position: sticky;
@@ -129,7 +129,7 @@ html.interface-interface-skeleton__html-container {
 	height: auto;  // Keep the height flexible.
 	flex-shrink: 0;
 	border-top: $border-width solid $light-gray-500;
-	color: $dark-gray-primary;
+	color: $gray-900;
 
 	// On Mobile the footer is hidden
 	display: none;
@@ -146,7 +146,7 @@ html.interface-interface-skeleton__html-container {
 	left: auto;
 	right: 0;
 	width: $sidebar-width;
-	color: $dark-gray-primary;
+	color: $gray-900;
 
 	&:focus {
 		top: auto;

--- a/storybook/stories/playground/editor-styles.scss
+++ b/storybook/stories/playground/editor-styles.scss
@@ -2,7 +2,7 @@
 	font-family: $editor-font;
 	font-size: $editor-font-size;
 	line-height: $editor-line-height;
-	color: $dark-gray-primary;
+	color: $gray-900;
 
 	p {
 		font-size: inherit;

--- a/storybook/stories/playground/editor-styles.scss
+++ b/storybook/stories/playground/editor-styles.scss
@@ -2,7 +2,7 @@
 	font-family: $editor-font;
 	font-size: $editor-font-size;
 	line-height: $editor-line-height;
-	color: $dark-gray-900;
+	color: $dark-gray-primary;
 
 	p {
 		font-size: inherit;

--- a/storybook/stories/playground/style.scss
+++ b/storybook/stories/playground/style.scss
@@ -34,7 +34,7 @@
 	right: 0;
 	bottom: 0;
 	width: $sidebar-width;
-	border-left: $border-width solid $light-gray-500;
+	border-left: $border-width solid $gray-200;
 	height: auto;
 	overflow: auto;
 	-webkit-overflow-scrolling: touch;


### PR DESCRIPTION
This is a big one, that touches a lot of files. More than anything, it needs a good testing. 

The purpose of this PR, as it was with the last one (#23454) is to reduce the total number of colors registered in the global variables sheet. In doing so, we encourage consistent use of a more controlled set of colors, ultimately resulting in a more consistent interface. 

Screenshots:

<img width="452" alt="Screenshot 2020-07-01 at 09 52 31" src="https://user-images.githubusercontent.com/1204802/86359774-bdcee280-bc71-11ea-9523-e465b936beba.png">

<img width="300" alt="Screenshot 2020-07-01 at 09 52 34" src="https://user-images.githubusercontent.com/1204802/86359782-c0313c80-bc71-11ea-8e20-03efa90db699.png">

<img width="354" alt="Screenshot 2020-07-01 at 09 52 56" src="https://user-images.githubusercontent.com/1204802/86359791-c32c2d00-bc71-11ea-9a05-67864c6d04d8.png">

<img width="351" alt="Screenshot 2020-07-02 at 12 11 16" src="https://user-images.githubusercontent.com/1204802/86359798-c6271d80-bc71-11ea-961d-5d80fe08d9f1.png">

<img width="651" alt="Screenshot 2020-07-02 at 13 32 41" src="https://user-images.githubusercontent.com/1204802/86359808-c9baa480-bc71-11ea-963f-e30573c0a693.png">

 (the text inside cover with a dark background is now white by default, vs. light gray)

<img width="795" alt="Screenshot 2020-07-02 at 13 36 36" src="https://user-images.githubusercontent.com/1204802/86359853-d6d79380-bc71-11ea-9521-048695e40c3b.png">

<img width="641" alt="Screenshot 2020-07-02 at 13 41 27" src="https://user-images.githubusercontent.com/1204802/86359863-da6b1a80-bc71-11ea-864f-a792943684fe.png">

<img width="314" alt="Screenshot 2020-07-02 at 13 46 33" src="https://user-images.githubusercontent.com/1204802/86359869-dd660b00-bc71-11ea-93bd-ffb7f1a8f48c.png">

<img width="529" alt="Screenshot 2020-07-02 at 13 55 20" src="https://user-images.githubusercontent.com/1204802/86359885-e22abf00-bc71-11ea-8a70-3f0d1cc26f67.png">

<img width="1747" alt="Screenshot 2020-07-02 at 14 35 50" src="https://user-images.githubusercontent.com/1204802/86359890-e525af80-bc71-11ea-8afe-1a8ea597a3fb.png">

In most cases, you shouldn't see a big difference. Nothing should jump out at you, at least. The improvements to visuals is a positive side-effect, but the primary intention with this cleanup is to reduce the surface area of our grays, from 40+ to 8 or 10.

