### PR TITLE
Restore old typing perf measurement

### DIFF
--- a/packages/e2e-tests/config/performance-reporter.js
+++ b/packages/e2e-tests/config/performance-reporter.js
@@ -25,7 +25,9 @@ class PerformanceReporter {
 		}
 
 		const results = readFileSync( path, 'utf8' );
-		const { load, domcontentloaded, type, focus } = JSON.parse( results );
+		const { load, domcontentloaded, type, oldType, focus } = JSON.parse(
+			results
+		);
 
 		if ( load && load.length ) {
 			// eslint-disable-next-line no-console
@@ -47,6 +49,21 @@ Slowest time to type character: ${ success(
 			) }
 Fastest time to type character: ${ success(
 				round( Math.min( ...type ) ) + 'ms'
+			) }` );
+		}
+
+		if ( oldType && oldType.length ) {
+			// eslint-disable-next-line no-console
+			console.log( `
+${ title( 'Old Typing Performance:' ) }
+Average time to type character: ${ success(
+				round( average( oldType ) ) + 'ms'
+			) }
+Slowest time to type character: ${ success(
+				round( Math.max( ...oldType ) ) + 'ms'
+			) }
+Fastest time to type character: ${ success(
+				round( Math.min( ...oldType ) ) + 'ms'
 			) }` );
 		}
 

--- a/packages/e2e-tests/specs/performance/performance.test.js
+++ b/packages/e2e-tests/specs/performance/performance.test.js
@@ -77,6 +77,7 @@ describe( 'Performance', () => {
 			load: [],
 			domcontentloaded: [],
 			type: [],
+			oldType: [],
 			focus: [],
 		};
 
@@ -131,8 +132,13 @@ describe( 'Performance', () => {
 			screenshots: false,
 			categories: [ 'devtools.timeline' ],
 		} );
+
+		let startTime;
+
 		while ( i-- ) {
+			startTime = new Date();
 			await page.keyboard.type( 'x' );
+			results.oldType.push( new Date() - startTime );
 		}
 
 		await page.tracing.stop();


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Just for information. Would be valuable to track regression by the old way of measuring typing performance.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
