### PR TITLE
Add .markdownlint.json config extending scripts config

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,3 @@
+{
+	"extends": "packages/scripts/config/.markdownlint.json"
+}


### PR DESCRIPTION

## Description

If a developer is using markdownlint in their editor, the config is not used by default. It would need to be configured by hand for each developer's editor. This PR adds a top-level json file to extend the config defined in the scripts directory, which is what is used if you run `npm run lint-md-docs`


## How has this been tested?

Confirm the config is used if using markdownlint in your editor, for example the markdownlint extension in VS Code. You can install running: 

1. Type `Ctrl-Shift-X` to open the Extensions tab
2. Type `markdownlint` to find the extension
3. Click the `Install` button, and enable the plugin.

The easiest config test is WordPress documentation prefers hard-tabs, whereas the default markdownlint config warns about using hard tabs. So check a document that includes a hard tab and confim there is no lint warning.

## Types of changes

This adds a top-level `.markdownlint.json` file that extends the config in the script directory.

## Related

This is related to #23286 that is looking at using Prettier to auto format markdown, the linter is more powerful and configurable, for example it gives warnings for code fence blocks without a specified language, something Prettier can't auto fix. 

We still need to sync the rule set between linter and Prettier before enabling Prettier to auto format. By including this config it makes it easier to see the differences.