### PR TITLE
Try: Add line height rule to the post title

### DIFF
--- a/packages/editor/src/components/post-title/style.scss
+++ b/packages/editor/src/components/post-title/style.scss
@@ -14,7 +14,6 @@
 
 		// Inherit the styles set by the theme.
 		font-family: inherit;
-		line-height: inherit;
 		color: inherit;
 
 		// Stack borders on mobile.
@@ -33,6 +32,7 @@
 		// Match h1 heading.
 		font-size: 2.44em;
 		font-weight: bold;
+		line-height: 1.4;
 
 		// Large text needs a 3:1 contrast ratio.
 		&::-webkit-input-placeholder {


### PR DESCRIPTION
When using Gutenberg's default editor styles, the line height of the post title seems really tall to me. The post title mimics the font size of the `h1` block, but it does not set its own line height. This PR tries syncing up the line height with the `h1` block. 

The post title did have a `line-height` rule, but it was set to `inherit`, under a `Inherit the styles set by the theme.` comment. If a theme sets its own line height, it'll be overridden here anyway. If a theme does not set its own line height, it's quite likely that at this font size, a line height of 1.4 will be more appropriate than whatever the `body` line height is set to anyway. I tried with a number of themes (Twenty Nineteen, Twenty Twenty, Go, etc), and this seemed to work just fine. 

---

Before

<img width="1326" alt="Screen Shot 2020-07-02 at 1 37 44 PM" src="https://user-images.githubusercontent.com/1202812/86392861-25812f80-bc6a-11ea-848f-1ca546265e61.png">


After

<img width="1325" alt="Screen Shot 2020-07-02 at 1 39 14 PM" src="https://user-images.githubusercontent.com/1202812/86392870-27e38980-bc6a-11ea-8323-6ef96babe299.png">
