### PR TITLE
Image editing: add original aspect to dropdown

### DIFF
--- a/packages/block-library/src/image/image-editor.js
+++ b/packages/block-library/src/image/image-editor.js
@@ -14,6 +14,7 @@ import { useState } from '@wordpress/element';
 import {
 	Icon,
 	search,
+	check,
 	rotateRight as rotateRightIcon,
 	aspectRatio as aspectRatioIcon,
 } from '@wordpress/icons';
@@ -37,7 +38,7 @@ const POPOVER_PROPS = {
 	isAlternate: true,
 };
 
-function AspectGroup( { aspectRatios, isDisabled, label, onClick } ) {
+function AspectGroup( { aspectRatios, isDisabled, label, onClick, value } ) {
 	return (
 		<MenuGroup label={ label }>
 			{ aspectRatios.map( ( { title, aspect } ) => (
@@ -47,6 +48,9 @@ function AspectGroup( { aspectRatios, isDisabled, label, onClick } ) {
 					onClick={ () => {
 						onClick( aspect );
 					} }
+					role="menuitemradio"
+					isSelected={ aspect === value }
+					icon={ aspect === value ? check : undefined }
 				>
 					{ title }
 				</MenuItem>
@@ -55,7 +59,7 @@ function AspectGroup( { aspectRatios, isDisabled, label, onClick } ) {
 	);
 }
 
-function AspectMenu( { isDisabled, onClick } ) {
+function AspectMenu( { isDisabled, onClick, value, defaultValue } ) {
 	return (
 		<DropdownMenu
 			icon={ aspectRatioIcon }
@@ -66,12 +70,31 @@ function AspectMenu( { isDisabled, onClick } ) {
 			{ ( { onClose } ) => (
 				<>
 					<AspectGroup
+						isDisabled={ isDisabled }
+						onClick={ ( aspect ) => {
+							onClick( aspect );
+							onClose();
+						} }
+						value={ value }
+						aspectRatios={ [
+							{
+								title: __( 'Original' ),
+								aspect: defaultValue,
+							},
+							{
+								title: __( 'Square' ),
+								aspect: 1,
+							},
+						] }
+					/>
+					<AspectGroup
 						label={ __( 'Landscape' ) }
 						isDisabled={ isDisabled }
 						onClick={ ( aspect ) => {
 							onClick( aspect );
 							onClose();
 						} }
+						value={ value }
 						aspectRatios={ [
 							{
 								title: __( '16:10' ),
@@ -98,6 +121,7 @@ function AspectMenu( { isDisabled, onClick } ) {
 							onClick( aspect );
 							onClose();
 						} }
+						value={ value }
 						aspectRatios={ [
 							{
 								title: __( '10:16' ),
@@ -114,19 +138,6 @@ function AspectMenu( { isDisabled, onClick } ) {
 							{
 								title: __( '2:3' ),
 								aspect: 2 / 3,
-							},
-						] }
-					/>
-					<AspectGroup
-						isDisabled={ isDisabled }
-						onClick={ ( aspect ) => {
-							onClick( aspect );
-							onClose();
-						} }
-						aspectRatios={ [
-							{
-								title: __( 'Square' ),
-								aspect: 1,
 							},
 						] }
 					/>
@@ -286,6 +297,8 @@ export default function ImageEditor( {
 					<AspectMenu
 						isDisabled={ inProgress }
 						onClick={ setAspect }
+						value={ aspect }
+						defaultValue={ naturalWidth / naturalHeight }
 					/>
 				</div>
 			) }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

Adds original aspect to the dropdown and adds checkmarks for the selected item.

<img width="586" alt="Screenshot 2020-07-02 at 22 42 02" src="https://user-images.githubusercontent.com/4710635/86403008-8550f800-bcb5-11ea-8f1a-0669191dce88.png">


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
