### PR TITLE
Template Part: Improve title editing interactions.

### DIFF
--- a/packages/block-library/src/template-part/edit/name-panel.js
+++ b/packages/block-library/src/template-part/edit/name-panel.js
@@ -30,6 +30,7 @@ export default function TemplatePartNamePanel( { postId, setAttributes } ) {
 					setSlug( newSlug );
 					setAttributes( { slug: newSlug } );
 				} }
+				onFocus={ ( event ) => event.target.select() }
 			/>
 		</div>
 	);

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -217,7 +217,7 @@ export const __experimentalGetDirtyEntityRecords = createSelector(
 				if ( primaryKeys.length ) {
 					const entity = getEntity( state, kind, name );
 					primaryKeys.forEach( ( primaryKey ) => {
-						const entityRecord = getEntityRecord(
+						const entityRecord = getEditedEntityRecord(
 							state,
 							kind,
 							name,


### PR DESCRIPTION
## Description

This PR makes two changes:

- Template Part: Select all text on name panel focus.
So that it is easy to replace the initial title.

- Core Data: Use the edited entity record for the multi-entity saving panel.
So that edited titles are reflected in the panel's list.

## How has this been tested?

It was verified that the changes described above are applied.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->