### PR TITLE
Created mixin to fix focus shadow styles on 1x screens

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -117,11 +117,52 @@
  * Focus styles.
  */
 
-@mixin block-toolbar-button-style__focus() {
-	box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color), inset 0 0 0 4px $white;
+@mixin focus-shadow(
+	$color-1: var(--wp-admin-theme-color),
+	$size-1: $border-width-focus,
+	$fallback-size-1: 2px,
+	$inset-1: false,
+	$color-2: false,
+	$size-2: $border-width-tab,
+	$fallback-size-2: $size-2,
+	$inset-2: $inset-1,
+	$outline: false
+) {
+	@if $inset-1 == false {
+		$inset-1: null;
+	}
+	@else {
+		$inset-1: inset;
+	}
 
-	// Windows High Contrast mode will show this outline, but not the box-shadow.
-	outline: 2px solid transparent;
+	@if $inset-2 == false {
+		$inset-2: null;
+	}
+	@else {
+		$inset-2: inset;
+	}
+
+	@if $color-2 == false {
+		box-shadow: $inset-1 0 0 0 $size-1 $color-1;
+
+		// Whole px values render better on 1x screens.
+		@media ( max-resolution: 96dpi ) {
+			box-shadow: $inset-1 0 0 0 $fallback-size-1 $color-1;
+		}
+	}
+	@else {
+		box-shadow: $inset-1 0 0 0 $size-1 $color-1, $inset-2 0 0 0 $size-2 $color-2;
+
+		// Whole px values render better on 1x screens.
+		@media ( max-resolution: 96dpi ) {
+			box-shadow: $inset-1 0 0 0 $fallback-size-1, $inset-2 0 0 0 $fallback-size-2 $color-2;
+		}
+	}
+
+	@if $outline == true {
+		// Windows High Contrast mode will show this outline, but not the box-shadow.
+		outline: 2px solid transparent;
+	}
 }
 
 // Tabs, Inputs, Square buttons.
@@ -133,15 +174,15 @@
 	@include reduce-motion("transition");
 }
 
-
 @mixin input-style__focus() {
 	border-color: var(--wp-admin-theme-color);
-	box-shadow: 0 0 0 ($border-width-focus - $border-width) var(--wp-admin-theme-color);
 
-	// Windows High Contrast mode will show this outline, but not the box-shadow.
-	outline: 2px solid transparent;
+	@include focus-shadow(
+		$size-1: ($border-width-focus - $border-width),
+		$fallback-size-1: (2px - $border-width),
+		$outline: true
+	);
 }
-
 
 /**
  * Applies editor left position to the selector passed as argument
@@ -295,10 +336,15 @@
 	border-radius: $radius-block-ui;
 
 	&:focus {
-		box-shadow: 0 0 0 ($border-width * 2) $white, 0 0 0 ($border-width * 2 + $border-width-focus) var(--wp-admin-theme-color);
-
-		// Only visible in Windows High Contrast mode.
-		outline: 2px solid transparent;
+		@include focus-shadow(
+			$color-1: $white,
+			$size-1: ($border-width * 2),
+			$fallback-size-1: ($border-width * 2),
+			$color-2: var(--wp-admin-theme-color),
+			$size-2: ($border-width * 2 + $border-width-focus),
+			$fallback-size-2: ($border-width * 2 + 2px),
+			$outline: true
+		);
 	}
 
 	&:checked {
@@ -369,10 +415,15 @@
 	}
 
 	&:focus {
-		box-shadow: 0 0 0 ($border-width * 2) $white, 0 0 0 ($border-width * 2 + $border-width-focus) var(--wp-admin-theme-color);
-
-		// Only visible in Windows High Contrast mode.
-		outline: 2px solid transparent;
+		@include focus-shadow(
+			$color-1: $white,
+			$size-1: ($border-width * 2),
+			$fallback-size-1: ($border-width * 2),
+			$color-2: var(--wp-admin-theme-color),
+			$size-2: ($border-width * 2 + $border-width-focus),
+			$fallback-size-2: ($border-width * 2 + 2px),
+			$outline: true
+		);
 	}
 
 	&:checked {

--- a/packages/block-editor/src/components/block-breadcrumb/style.scss
+++ b/packages/block-editor/src/components/block-breadcrumb/style.scss
@@ -37,7 +37,7 @@
 		right: $border-width;
 		bottom: $border-width;
 		left: $border-width;
-		box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+		@include focus-shadow;
 	}
 }
 

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -133,7 +133,12 @@ $tree-item-height: 36px;
 		}
 
 		&:focus::before {
-			@include block-toolbar-button-style__focus();
+			@include focus-shadow(
+				$inset-1: true,
+				$color-2: $white,
+				$inset-2: true,
+				$outline: true
+			);
 		}
 
 		// Focus and toggle pseudo elements.

--- a/packages/block-editor/src/components/block-styles/style.scss
+++ b/packages/block-editor/src/components/block-styles/style.scss
@@ -16,10 +16,7 @@
 	flex-direction: column;
 
 	&:focus {
-		box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color);
-
-		// Windows High Contrast mode will show this outline, but not the box-shadow.
-		outline: 2px solid transparent;
+		@include focus-shadow( $outline: true );
 	}
 
 	&:hover .block-editor-block-styles__item-preview {

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -127,7 +127,7 @@ $block-editor-link-control-number-of-actions: 1;
 
 	// The added specificity is needed to override.
 	&:focus:not(:disabled) {
-		box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color) inset;
+		@include focus-shadow( $inset-1: true );
 	}
 
 	&.is-selected {

--- a/packages/block-editor/src/components/url-popover/style.scss
+++ b/packages/block-editor/src/components/url-popover/style.scss
@@ -35,7 +35,12 @@
 		box-shadow: none;
 
 		> svg {
-			@include block-toolbar-button-style__focus();
+			@include focus-shadow(
+				$inset-1: true,
+				$color-2: $white,
+				$inset-2: true,
+				$outline: true
+			);
 		}
 	}
 }

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -89,7 +89,7 @@
 	height: auto;
 
 	&:focus {
-		box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+		@include focus-shadow( $inset-1: true );
 		border-radius: 0;
 	}
 

--- a/packages/components/src/toolbar/style.scss
+++ b/packages/components/src/toolbar/style.scss
@@ -68,7 +68,12 @@
 
 		// Focus style.
 		&:focus::before {
-			@include block-toolbar-button-style__focus();
+			@include focus-shadow(
+				$inset-1: true,
+				$color-2: $white,
+				$inset-2: true,
+				$outline: true
+			);
 		}
 
 		// Ensure the icon buttons remain square.

--- a/packages/editor/src/components/document-outline/style.scss
+++ b/packages/editor/src/components/document-outline/style.scss
@@ -58,10 +58,7 @@
 	}
 
 	&:focus {
-		box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color);
-
-		// Windows High Contrast mode will show this outline, but not the box-shadow.
-		outline: 2px solid transparent;
+		@include focus-shadow( $outline: true );
 	}
 }
 


### PR DESCRIPTION
Many of the focus styles in Gutenberg are box shadows with a `1.5px` value. This is really nice looking on hidpi screens, but looks a bit rough on 1x screens. I thought I'd try a mixin that does a few things:

1. It will add consistency to the focus styles, while remaining somewhat flexible.
2. It has a smart default. I did an audit of current styles and chose the most common patterns as a default.
3. Uses the `resolution` media query to target 1x screens and use a `2px` value on those screens. This can be overwritten.
4. Has the ability to add the windows high contrast mode transparent `outline. I suspect many of the implementations of the focus style could benefit from this.

On the other hand it's a complicated mixin... It might be better just to manually write the media query in each of the 45+ places.

I only implemented it in a few places so you could get an idea for its use in a variety of situations. I'd like feedback before I do the rest.

It's likely easiest to play with it and see the output [in this Sass playground](https://www.sassmeister.com/gist/69b3ebe16453e272d2eb4440119ab0f2).

What do you think?

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->

