### PR TITLE
Fix issue where block inserted in wrong place when selection is in nested block list, but root appender is used.

### DIFF
--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -183,14 +183,11 @@ export default compose( [
 			getBlockRootClientId,
 			hasInserterItems,
 			__experimentalGetAllowedBlocks,
-			getBlockSelectionEnd,
 		} = select( 'core/block-editor' );
 		const { getBlockVariations } = select( 'core/blocks' );
 
 		rootClientId =
-			rootClientId ||
-			getBlockRootClientId( clientId || getBlockSelectionEnd() ) ||
-			undefined;
+			rootClientId || getBlockRootClientId( clientId ) || undefined;
 
 		const allowedBlocks = __experimentalGetAllowedBlocks( rootClientId );
 

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/adding-blocks.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/adding-blocks.test.js.snap
@@ -52,3 +52,15 @@ Foo</pre>
 lines preserved[/myshortcode]
 <!-- /wp:shortcode -->"
 `;
+
+exports[`adding blocks inserts blocks at root level when using the root appender while selection is in an inner block 1`] = `
+"<!-- wp:buttons -->
+<div class=\\"wp-block-buttons\\"><!-- wp:button -->
+<div class=\\"wp-block-button\\"><a class=\\"wp-block-button__link\\">1.1</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons -->
+
+<!-- wp:paragraph -->
+<p>2</p>
+<!-- /wp:paragraph -->"
+`;

--- a/packages/e2e-tests/specs/editor/various/adding-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/adding-blocks.test.js
@@ -190,4 +190,31 @@ describe( 'adding blocks', () => {
 			'block-editor-inserter__toggle'
 		);
 	} );
+
+	// Check for regression of https://github.com/WordPress/gutenberg/issues/23263
+	it( 'inserts blocks at root level when using the root appender while selection is in an inner block', async () => {
+		await insertBlock( 'Buttons' );
+		await page.keyboard.type( '1.1' );
+
+		// After inserting the Buttons block the inner button block should be selected.
+		const selectedButtonBlocks = await page.$$(
+			'.wp-block-button.is-selected'
+		);
+		expect( selectedButtonBlocks.length ).toBe( 1 );
+
+		// Specifically click the root container appender.
+		await page.click(
+			'.block-editor-block-list__layout.is-root-container > .block-list-appender .block-editor-inserter__toggle'
+		);
+
+		// Insert a paragraph block.
+		await page.waitForSelector( '.block-editor-inserter__search-input' );
+		await page.keyboard.type( 'Paragraph' );
+		await page.click( '.editor-block-list-item-paragraph' );
+		await page.keyboard.type( '2' );
+
+		// The snapshot should show a buttons block followed by a paragraph.
+		// The buttons block should contain a single button.
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

Fixes #23263. This also seems to fix an issue where the trailing inserter is sometimes on the left and sometimes on the right.

When clicking the trailing root appender while selection is in an inner blocks list, the block will be inserted where selection is instead of at the root level.

I did some digging and it looks like the code was added in #22140 for the widgets screen, so this PR essentially reverted part of that. This change might break things there, but it's hard to tell what.

## How has this been tested?
1. Start a new post
2. Add a buttons block
3. Make sure a button block in the buttons block is selected
4. Click the '+' appender that appears at the end of the post
5. Notice a button is inserted within the buttons block

## Screenshots <!-- if applicable -->
<img width="603" alt="Screenshot 2020-06-18 at 3 47 04 pm" src="https://user-images.githubusercontent.com/677833/84992856-0cad5000-b17b-11ea-8f22-fc01b700a658.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
