### PR TITLE
Fix empty block list appender visibility on aligned blocks

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -481,7 +481,7 @@
 	@include reduce-motion("animation");
 }
 
-.wp-block:not(.is-selected):not(.has-child-selected) .block-editor-default-block-appender {
+.block-editor-block-list__block:not(.is-selected):not(.has-child-selected) .block-editor-default-block-appender {
 	display: none;
 
 	.block-editor-inserter__toggle {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes #23665

The block list appender wasn't visible in the media and text block after deleting all inner blocks.

The issue was that the selector `.wp-block:not(.is-selected):not(.has-child-selected)` was used to hide the appender when the block didn't have selection. Because the media text block is by default aligned, `.wp-block` is applied to a separate wrapping element to `.is-selected`:
<img width="446" alt="Screenshot 2020-07-03 at 4 43 14 pm" src="https://user-images.githubusercontent.com/677833/86450555-5043b480-bd4c-11ea-805c-38df790d1fd7.png">

Resulting in this selector being triggered even when the block was selected.

Changing the selector to use `.block-editor-block-list__block` seems to resolve things.


## How has this been tested?
1. Add a media text block
2. Click on the Heading that's added by default and press backspace (sometimes you have to do this twice)
3. Observe the default appender becomes visible (this seems to only happen after clicking away, though)

## Screenshots <!-- if applicable -->
Before:
<img width="641" alt="Screenshot 2020-07-03 at 4 45 49 pm" src="https://user-images.githubusercontent.com/677833/86451033-ebd52500-bd4c-11ea-98e1-9c5cc3e6f005.png">

After:
<img width="639" alt="Screenshot 2020-07-03 at 4 45 05 pm" src="https://user-images.githubusercontent.com/677833/86451046-f099d900-bd4c-11ea-827d-d5f18dcbd4b6.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
