### PR TITLE
Use global registry on the experimental navigation screen

### DIFF
--- a/packages/edit-navigation/src/components/navigation-editor/index.js
+++ b/packages/edit-navigation/src/components/navigation-editor/index.js
@@ -63,6 +63,7 @@ function NavigationPostEditor( { post, blockEditorSettings, onDeleteMenu } ) {
 				templateLock: 'all',
 				hasFixedToolbar: true,
 			} }
+			useSubRegistry={ false }
 		>
 			<BlockEditorKeyboardShortcuts />
 			<NavigationEditorShortcuts saveBlocks={ save } />


### PR DESCRIPTION
## Description

Solves #22022

The `<BlockEditorProvider />` used on the experimental navigation screen uses sub registry and breaks public API calls like this one:

```js
wp.data.select( 'core/block-editor' ).getSelectedBlock() 
```

This PR disables the sub registry which makes it possible to select the data from the global store.

## How has this been tested?
1. Go to the experimental navigation screen
1. Select a block
1. Paste the snippet above in the devtools
1. Confirm it returns null before applying this PR
1. Confirm it returns selected block after applying this PR
1. Play with the interface and confirm nothing else got broken in the process

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
