### PR TITLE
[Experimental navigation screen] Show block appender by default

### DIFF
--- a/packages/edit-navigation/src/components/navigation-editor/navigation-structure-area.js
+++ b/packages/edit-navigation/src/components/navigation-editor/navigation-structure-area.js
@@ -14,7 +14,9 @@ import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 export default function NavigationStructureArea( { blocks, initialOpen } ) {
-	const [ selectedBlockId, setSelectedBlockId ] = useState( null );
+	const [ selectedBlockId, setSelectedBlockId ] = useState(
+		blocks[ 0 ]?.clientId
+	);
 	const isSmallScreen = useViewportMatch( 'medium', '<' );
 	const showNavigationStructure = !! blocks.length;
 


### PR DESCRIPTION
## Description
Related to https://github.com/WordPress/gutenberg/issues/23308

When opening the experimental navigation screen, block appender is not present in the navigator initially. This PR ensures it shows up by default before the first interaction.

**Before:**

<img width="311" alt="Zrzut ekranu 2020-07-3 o 13 59 07" src="https://user-images.githubusercontent.com/205419/86467257-5ed2a180-bd35-11ea-926e-05c287a68358.png">

**After:**

<img width="295" alt="Zrzut ekranu 2020-07-3 o 13 58 31" src="https://user-images.githubusercontent.com/205419/86467217-4ebac200-bd35-11ea-8d1b-9cd2fea76842.png">

## How has this been tested?

Go to the experimental navigation screen before and after applying this PR, confirm it's consistent with the screenshots above
## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
