### PR TITLE
Image editing: move zoom control to toolbar dropdown

### DIFF
--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -90,46 +90,31 @@ figure.wp-block-image:not(.wp-block) {
 	}
 }
 
-.wp-block-image__zoom-control {
-	border: $border-width solid $gray-900;
-	border-radius: $radius-block-ui;
-	background-color: $white;
-	padding: $grid-unit-10;
-	line-height: 1;
-	width: 100%;
-	max-width: 280px;
-	display: flex;
-	flex-direction: row;
-	align-items: center;
-
-	// Place as a stacked toolbar.
-	position: sticky;
-	top: $grid-unit-60 + $grid-unit-15;
-	z-index: z-index(".block-editor-block-list__block-popover");
-	float: left;
+.wp-block-image__zoom {
+	.components-popover__content {
+		overflow: visible;
+	}
 
 	.components-range-control {
 		flex: 1;
-		margin-right: $grid-unit-15;
-		margin-left: $grid-unit-15;
 	}
 
 	.components-base-control__field {
 		display: flex;
 		margin-bottom: 0;
 	}
+}
 
-	.wp-block-image__aspect-ratio {
-		height: $grid-unit-60 - $border-width - $border-width;
-		margin-top: -$grid-unit-10;
-		margin-bottom: -$grid-unit-10;
-		display: flex;
-		align-items: center;
+.wp-block-image__aspect-ratio {
+	height: $grid-unit-60 - $border-width - $border-width;
+	margin-top: -$grid-unit-10;
+	margin-bottom: -$grid-unit-10;
+	display: flex;
+	align-items: center;
 
-		.components-button {
-			width: $button-size;
-			padding-left: 0;
-			padding-right: 0;
-		}
+	.components-button {
+		width: $button-size;
+		padding-left: 0;
+		padding-right: 0;
 	}
 }

--- a/packages/block-library/src/image/image-editor.js
+++ b/packages/block-library/src/image/image-editor.js
@@ -12,7 +12,6 @@ import classnames from 'classnames';
 import { BlockControls } from '@wordpress/block-editor';
 import { useState } from '@wordpress/element';
 import {
-	Icon,
 	search,
 	check,
 	rotateRight as rotateRightIcon,
@@ -21,11 +20,13 @@ import {
 import {
 	ToolbarGroup,
 	ToolbarButton,
+	__experimentalToolbarItem as ToolbarItem,
 	Spinner,
 	RangeControl,
 	DropdownMenu,
 	MenuGroup,
 	MenuItem,
+	Dropdown,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
@@ -282,26 +283,6 @@ export default function ImageEditor( {
 
 	return (
 		<>
-			{ ! inProgress && (
-				<div
-					className="wp-block-image__zoom-control"
-					aria-label={ __( 'Zoom' ) }
-				>
-					<Icon icon={ search } />
-					<RangeControl
-						min={ MIN_ZOOM }
-						max={ MAX_ZOOM }
-						value={ Math.round( zoom ) }
-						onChange={ setZoom }
-					/>
-					<AspectMenu
-						isDisabled={ inProgress }
-						onClick={ setAspect }
-						value={ aspect }
-						defaultValue={ naturalWidth / naturalHeight }
-					/>
-				</div>
-			) }
 			<div
 				className={ classnames( 'wp-block-image__crop-area', {
 					'is-applying': inProgress,
@@ -330,6 +311,40 @@ export default function ImageEditor( {
 				{ inProgress && <Spinner /> }
 			</div>
 			<BlockControls>
+				<ToolbarGroup>
+					<Dropdown
+						contentClassName="wp-block-image__zoom"
+						popoverProps={ POPOVER_PROPS }
+						renderToggle={ ( { isOpen, onToggle } ) => (
+							<ToolbarButton
+								icon={ search }
+								label={ __( 'Zoom' ) }
+								onClick={ onToggle }
+								aria-expanded={ isOpen }
+								disabled={ inProgress }
+							/>
+						) }
+						renderContent={ () => (
+							<RangeControl
+								min={ MIN_ZOOM }
+								max={ MAX_ZOOM }
+								value={ Math.round( zoom ) }
+								onChange={ setZoom }
+							/>
+						) }
+					/>
+					<ToolbarItem>
+						{ ( toggleProps ) => (
+							<AspectMenu
+								toggleProps={ toggleProps }
+								isDisabled={ inProgress }
+								onClick={ setAspect }
+								value={ aspect }
+								defaultValue={ naturalWidth / naturalHeight }
+							/>
+						) }
+					</ToolbarItem>
+				</ToolbarGroup>
 				<ToolbarGroup>
 					<ToolbarButton
 						icon={ rotateRightIcon }

--- a/packages/components/src/dropdown/index.js
+++ b/packages/components/src/dropdown/index.js
@@ -95,6 +95,7 @@ export default function Dropdown( {
 					headerTitle={ headerTitle }
 					focusOnMount={ focusOnMount }
 					{ ...popoverProps }
+					anchorRef={ containerRef.current }
 					className={ classnames(
 						'components-dropdown__content',
 						popoverProps ? popoverProps.className : undefined,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

See #22569.

This PR moves the zoom range control to the block toolbar as a dropdown.

* The zoom control doesn't belong in the block itself.
* Worth noting that this slider is a back-up for zooming the image. You can also "scroll" or pinch the image to zoom (and move!) the image.
* There was talk to put the slider in the toolbar itself, instead of a drop down.
  * Horizontal arrow keys will clash, so it would need a special way to enter and leave the control with the keyboard.
  * Not sure if it's worth overloading the toolbar with a controls that's meant as a back-up.
  * Tbh, sometimes I wonder if we need this control at all. You might be able to zoom, but you still can't move the image with keyboard only. 🙂

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

<img width="724" alt="Screenshot 2020-07-03 at 15 04 42" src="https://user-images.githubusercontent.com/4710635/86468233-a4946780-bd3f-11ea-97ec-c3a5c539bf16.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
