### PR TITLE
Add error boundary to experimental navigation screen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45262,9 +45262,9 @@
 					}
 				},
 				"tar-stream": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.2.tgz",
-					"integrity": "sha512-UaF6FoJ32WqALZGOIAApXx+OdxhekNMChu6axLJR85zMMjXKWFGjbIRe+J6P4UnRGg9rAwWvbTT0oI7hD/Un7Q==",
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.3.tgz",
+					"integrity": "sha512-Z9yri56Dih8IaK8gncVPx4Wqt86NDmQTSh49XLZgjWpGZL9GK9HKParS2scqHCC4w6X9Gh2jwaU45V47XTKwVA==",
 					"dev": true,
 					"requires": {
 						"bl": "^4.0.1",
@@ -45275,9 +45275,9 @@
 					}
 				},
 				"ws": {
-					"version": "7.3.0",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-7.3.0.tgz",
-					"integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w==",
+					"version": "7.3.1",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+					"integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
 					"dev": true
 				},
 				"yauzl": {

--- a/packages/edit-navigation/src/components/error-boundary/index.js
+++ b/packages/edit-navigation/src/components/error-boundary/index.js
@@ -1,0 +1,51 @@
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+import { Warning } from '@wordpress/block-editor';
+
+class ErrorBoundary extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.reboot = this.reboot.bind( this );
+
+		this.state = {
+			error: null,
+		};
+	}
+
+	componentDidCatch( error ) {
+		this.setState( { error } );
+	}
+
+	reboot() {
+		this.props.onError();
+	}
+
+	render() {
+		const { error } = this.state;
+		if ( ! error ) {
+			return this.props.children;
+		}
+
+		return (
+			<Warning
+				className="navigation-editor-error-boundary"
+				actions={ [
+					<Button key="recovery" onClick={ this.reboot } isSecondary>
+						{ __( 'Attempt Recovery' ) }
+					</Button>,
+				] }
+			>
+				{ __(
+					'The navigation editor has encountered an unexpected error.'
+				) }
+			</Warning>
+		);
+	}
+}
+
+export default ErrorBoundary;

--- a/packages/edit-navigation/src/components/error-boundary/index.js
+++ b/packages/edit-navigation/src/components/error-boundary/index.js
@@ -22,7 +22,9 @@ class ErrorBoundary extends Component {
 	}
 
 	reboot() {
-		this.props.onError();
+		if ( this.props.onError ) {
+			this.props.onError();
+		}
 	}
 
 	render() {

--- a/packages/edit-navigation/src/components/error-boundary/style.scss
+++ b/packages/edit-navigation/src/components/error-boundary/style.scss
@@ -1,0 +1,7 @@
+.navigation-editor-error-boundary {
+	margin: auto;
+	max-width: 780px;
+	padding: 20px;
+	margin-top: 60px;
+	box-shadow: $shadow-modal;
+}

--- a/packages/edit-navigation/src/components/layout/index.js
+++ b/packages/edit-navigation/src/components/layout/index.js
@@ -16,46 +16,49 @@ import { __ } from '@wordpress/i18n';
 import Notices from '../notices';
 import MenusEditor from '../menus-editor';
 import MenuLocationsEditor from '../menu-locations-editor';
+import ErrorBoundary from '../error-boundary';
 
 export default function Layout( { blockEditorSettings } ) {
 	return (
 		<>
-			<SlotFillProvider>
-				<DropZoneProvider>
-					<FocusReturnProvider>
-						<Notices />
-						<TabPanel
-							className="edit-navigation-layout__tab-panel"
-							tabs={ [
-								{
-									name: 'menus',
-									title: __( 'Edit Navigation' ),
-								},
-								{
-									name: 'menu-locations',
-									title: __( 'Manage Locations' ),
-								},
-							] }
-						>
-							{ ( tab ) => (
-								<>
-									{ tab.name === 'menus' && (
-										<MenusEditor
-											blockEditorSettings={
-												blockEditorSettings
-											}
-										/>
-									) }
-									{ tab.name === 'menu-locations' && (
-										<MenuLocationsEditor />
-									) }
-								</>
-							) }
-						</TabPanel>
-						<Popover.Slot />
-					</FocusReturnProvider>
-				</DropZoneProvider>
-			</SlotFillProvider>
+			<ErrorBoundary>
+				<SlotFillProvider>
+					<DropZoneProvider>
+						<FocusReturnProvider>
+							<Notices />
+							<TabPanel
+								className="edit-navigation-layout__tab-panel"
+								tabs={ [
+									{
+										name: 'menus',
+										title: __( 'Edit Navigation' ),
+									},
+									{
+										name: 'menu-locations',
+										title: __( 'Manage Locations' ),
+									},
+								] }
+							>
+								{ ( tab ) => (
+									<ErrorBoundary>
+										{ tab.name === 'menus' && (
+											<MenusEditor
+												blockEditorSettings={
+													blockEditorSettings
+												}
+											/>
+										) }
+										{ tab.name === 'menu-locations' && (
+											<MenuLocationsEditor />
+										) }
+									</ErrorBoundary>
+								) }
+							</TabPanel>
+							<Popover.Slot />
+						</FocusReturnProvider>
+					</DropZoneProvider>
+				</SlotFillProvider>
+			</ErrorBoundary>
 		</>
 	);
 }

--- a/packages/edit-navigation/src/style.scss
+++ b/packages/edit-navigation/src/style.scss
@@ -9,3 +9,4 @@
 @import "./components/menus-editor/style.scss";
 @import "./components/delete-menu-button/style.scss";
 @import "./components/notices/style.scss";
+@import "./components/error-boundary/style.scss";


### PR DESCRIPTION
## Description
Solves https://github.com/WordPress/gutenberg/issues/23417 by adding an error boundary to inform the user about any problems (instead of displaying the blank page).

There is a [similar component in the editor package](https://github.com/WordPress/gutenberg/blob/master/packages/editor/src/components/error-boundary/index.js), but it's editor-specific enough to justify creating a "private" component for the purposes of edit-navigation package. Bringing a configurable ErrorBoundary component to `@wordpress/components` is definitely worth discussing as there are more places that could benefit from it (e.g. the widgets screen).

## How has this been tested?
1. Update e.g. navigation editor to throw an error
1. Go to the navigation screen
1. Confirm you see the following error message:

<img width="1387" alt="Zrzut ekranu 2020-07-3 o 15 13 03" src="https://user-images.githubusercontent.com/205419/86472749-f4732e80-bd3f-11ea-93e2-4a993fa4b2a7.png">

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
