### PR TITLE
[Navigation screen] Restore block movers for blocks with just one sibling

### DIFF
--- a/packages/block-editor/src/components/block-navigation/block.js
+++ b/packages/block-editor/src/components/block-navigation/block.js
@@ -51,7 +51,7 @@ export default function BlockNavigationBlock( {
 
 	// Subtract 1 from rowCount, as it includes the block appender.
 	const siblingCount = rowCount - 1;
-	const hasSiblings = siblingCount > 1;
+	const hasSiblings = siblingCount > 0;
 	const hasRenderedMovers = showBlockMovers && hasSiblings;
 	const hasVisibleMovers = isHovered || isFocused;
 	const moverCellClassName = classnames(


### PR DESCRIPTION
## Description
Fixes https://github.com/WordPress/gutenberg/issues/23309 which reported missing block movers when there are exactly two links

## How has this been tested?
1. Go to the experimental navigation screen
1. Create a nav menu with just two top-level items, one of which has two nested links
1. Confirm them overs are visible on hover (in the navigator on the left)

## Screenshots

<img width="303" alt="Zrzut ekranu 2020-07-3 o 15 39 45" src="https://user-images.githubusercontent.com/205419/86474587-7022aa80-bd43-11ea-922c-67c887073535.png">

(By the way these movers seem wrong - they should be vertical! Let's track it separately from this PR though)

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
