### PR TITLE
Replace SEO settings nofollow toggle with rel text widget

### DIFF
--- a/packages/block-library/src/navigation-link/block.json
+++ b/packages/block-library/src/navigation-link/block.json
@@ -8,10 +8,6 @@
 		"label": {
 			"type": "string"
 		},
-		"nofollow": {
-			"type": "boolean",
-			"default": false
-		},
 		"type": {
 			"type": "string"
 		},

--- a/packages/block-library/src/navigation-link/block.json
+++ b/packages/block-library/src/navigation-link/block.json
@@ -14,6 +14,9 @@
 		"description": {
 			"type": "string"
 		},
+		"rel": {
+			"type": "string"
+		},
 		"id": {
 			"type": "number"
 		},

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -14,6 +14,7 @@ import {
 	KeyboardShortcuts,
 	PanelBody,
 	Popover,
+	TextControl,
 	TextareaControl,
 	ToolbarButton,
 	ToolbarGroup,
@@ -58,7 +59,7 @@ function NavigationLinkEdit( {
 	mergeBlocks,
 	onReplace,
 } ) {
-	const { label, opensInNewTab, url, description } = attributes;
+	const { label, opensInNewTab, url, description, rel } = attributes;
 	const link = {
 		url,
 		opensInNewTab,
@@ -169,6 +170,14 @@ function NavigationLinkEdit( {
 						help={ __(
 							'The description will be displayed in the menu if the current theme supports it.'
 						) }
+					/>
+					<TextControl
+						value={ rel || '' }
+						onChange={ ( relValue ) => {
+							setAttributes( { rel: relValue } );
+						} }
+						label={ __( 'Link rel' ) }
+						autoComplete="off"
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -11,12 +11,10 @@ import { compose } from '@wordpress/compose';
 import { createBlock } from '@wordpress/blocks';
 import { withDispatch, withSelect } from '@wordpress/data';
 import {
-	ExternalLink,
 	KeyboardShortcuts,
 	PanelBody,
 	Popover,
 	TextareaControl,
-	ToggleControl,
 	ToolbarButton,
 	ToolbarGroup,
 } from '@wordpress/components';
@@ -60,7 +58,7 @@ function NavigationLinkEdit( {
 	mergeBlocks,
 	onReplace,
 } ) {
-	const { label, opensInNewTab, url, nofollow, description } = attributes;
+	const { label, opensInNewTab, url, description } = attributes;
 	const link = {
 		url,
 		opensInNewTab,
@@ -161,30 +159,6 @@ function NavigationLinkEdit( {
 				</ToolbarGroup>
 			</BlockControls>
 			<InspectorControls>
-				<PanelBody title={ __( 'SEO settings' ) }>
-					<ToggleControl
-						checked={ nofollow }
-						onChange={ ( nofollowValue ) => {
-							setAttributes( { nofollow: nofollowValue } );
-						} }
-						label={ __( 'Add nofollow to link' ) }
-						help={
-							<Fragment>
-								{ __(
-									"Don't let search engines follow this link."
-								) }
-								<ExternalLink
-									className="wp-block-navigation-link__nofollow-external-link"
-									href={ __(
-										'https://codex.wordpress.org/Nofollow'
-									) }
-								>
-									{ __( "What's this?" ) }
-								</ExternalLink>
-							</Fragment>
-						}
-					/>
-				</PanelBody>
 				<PanelBody title={ __( 'Link settings' ) }>
 					<TextareaControl
 						value={ description || '' }

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -31,10 +31,6 @@
 	}
 }
 
-.wp-block-navigation-link__nofollow-external-link {
-	display: block;
-}
-
 // Separator
 .wp-block-navigation-link__separator {
 	margin: $grid-unit-10 0 $grid-unit-10;

--- a/packages/block-library/src/navigation-link/index.js
+++ b/packages/block-library/src/navigation-link/index.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { mapMarker as icon } from '@wordpress/icons';
+import { InnerBlocks } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -28,4 +29,47 @@ export const settings = {
 	},
 	edit,
 	save,
+
+	deprecated: [
+		{
+			isEligible( attributes ) {
+				return attributes.nofollow;
+			},
+
+			attributes: {
+				label: {
+					type: 'string',
+				},
+				type: {
+					type: 'string',
+				},
+				nofollow: {
+					type: 'boolean',
+				},
+				description: {
+					type: 'string',
+				},
+				id: {
+					type: 'number',
+				},
+				opensInNewTab: {
+					type: 'boolean',
+					default: false,
+				},
+				url: {
+					type: 'string',
+				},
+			},
+
+			migrate( { nofollow } ) {
+				return {
+					rel: nofollow ? 'nofollow' : '',
+				};
+			},
+
+			save() {
+				return <InnerBlocks.Content />;
+			},
+		},
+	],
 };

--- a/packages/block-library/src/navigation-link/index.js
+++ b/packages/block-library/src/navigation-link/index.js
@@ -61,9 +61,10 @@ export const settings = {
 				},
 			},
 
-			migrate( { nofollow } ) {
+			migrate( { nofollow, ...rest } ) {
 				return {
 					rel: nofollow ? 'nofollow' : '',
+					...rest,
 				};
 			},
 

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -144,7 +144,7 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 	// Start appending HTML attributes to anchor tag.
 	if ( isset( $attributes['rel'] ) ) {
 		$html .= ' rel="' . esc_attr( $attributes['rel'] ) . '"';
-	} else if ( isset( $attributes['nofollow'] ) && $attributes['nofollow'] ) {
+	} elseif ( isset( $attributes['nofollow'] ) && $attributes['nofollow'] ) {
 		$html .= ' rel="nofollow"';
 	}
 

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -130,7 +130,7 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 
 	$html = '<li class="' . esc_attr( $css_classes . ( $has_submenu ? ' has-child' : '' ) ) .
 		( $is_active ? ' current-menu-item' : '' ) . '"' . $style_attribute . '>' .
-		'<a class="wp-block-navigation-link__content"';
+		'<a class="wp-block-navigation-link__content" ';
 
 	// Start appending HTML attributes to anchor tag.
 	if ( isset( $attributes['url'] ) ) {
@@ -140,6 +140,14 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 	if ( isset( $attributes['opensInNewTab'] ) && true === $attributes['opensInNewTab'] ) {
 		$html .= ' target="_blank"  ';
 	}
+
+	// Start appending HTML attributes to anchor tag.
+	if ( isset( $attributes['rel'] ) ) {
+		$html .= ' rel="' . esc_attr( $attributes['rel'] ) . '"';
+	} else if ( isset( $attributes['nofollow'] ) && $attributes['nofollow'] ) {
+		$html .= ' rel="nofollow"';
+	}
+
 	// End appending HTML attributes to anchor tag.
 
 	// Start anchor tag content.

--- a/packages/e2e-tests/fixtures/blocks/core__navigation-link.json
+++ b/packages/e2e-tests/fixtures/blocks/core__navigation-link.json
@@ -5,7 +5,6 @@
         "isValid": true,
         "attributes": {
             "label": "WordPress",
-            "nofollow": false,
             "opensInNewTab": false,
             "url": "https://wordpress.org/"
         },


### PR DESCRIPTION
## Description

Fixes https://github.com/WordPress/gutenberg/issues/23153 by removing SEO settings footgun from the navigation link block

## How has this been tested?

1. Don't apply this PR just yet
1. Go to post editor
1. Add a navigation block with navigation link inside
1. Select navigation link
1. Enable the "Add nofollow to link" toggle
1. Create another navigation link with that toggle unselected
1. Save the post
1. Confirm that on the actual website 
1. Save the post check the website, confirm the link is there, confirm that `ref="nofollow"` is NOT there (yup, it's actually broken :D)
1. Apply this PR
1. Refresh the website, confirm that the link now has `rel="nofollow"`
1. Go to the editor, confirm the inspector allows you to type in an arbitrary rel.
1. Confirm that particular menu item already has the inspector field pre-filled with `nofollow`.
1. Confirm you're able to set rel to an arbitrary value and that it's reflected on subsequent refresh of both the editor and the actual website.

<img width="294" alt="Zrzut ekranu 2020-07-7 o 16 24 41" src="https://user-images.githubusercontent.com/205419/86796129-91023d00-c06e-11ea-9fc4-b34477df5f64.png">

<img width="501" alt="Zrzut ekranu 2020-07-7 o 16 23 33" src="https://user-images.githubusercontent.com/205419/86797160-a3c94180-c06f-11ea-9bfe-a7a7ab450219.png">

## Types of changes
Non-breaking change

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
