### PR TITLE
[RNMobile] Correct post title focus

### DIFF
--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -26,13 +26,19 @@ import { pasteHandler } from '@wordpress/blocks';
 import styles from './style.scss';
 
 class PostTitle extends Component {
+	constructor( props ) {
+		super( props );
+
+		this.setRef = this.setRef.bind( this );
+	}
 	componentDidUpdate( prevProps ) {
-		// Unselect if any other block is selected
+		// Unselect if any other block is selected and blur the RichText
 		if (
 			this.props.isSelected &&
 			! prevProps.isAnyBlockSelected &&
 			this.props.isAnyBlockSelected
 		) {
+			this.richTextRef.blur();
 			this.props.onUnselect();
 		}
 	}
@@ -62,6 +68,10 @@ class PostTitle extends Component {
 			const valueToInsert = create( { html: content } );
 			onChange( insert( value, valueToInsert ) );
 		}
+	}
+
+	setRef( richText ) {
+		this.richTextRef = richText;
 	}
 
 	render() {
@@ -100,6 +110,7 @@ class PostTitle extends Component {
 				}
 			>
 				<RichText
+					setRef={ this.setRef }
 					tagName={ 'p' }
 					tagsToEliminate={ [ 'strong' ] }
 					unstableOnFocus={ this.props.onSelect }

--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -38,7 +38,9 @@ class PostTitle extends Component {
 			! prevProps.isAnyBlockSelected &&
 			this.props.isAnyBlockSelected
 		) {
-			this.richTextRef.blur();
+			if ( this.richTextRef ) {
+				this.richTextRef.blur();
+			}
 			this.props.onUnselect();
 		}
 	}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

Correct post title focus behaviour which should be blurred when another block is selected

## How has this been tested?

1. Open mobile app
2. Create a new post
3. Select post title and type something
4. Press inserter and add block such as `Media & Text` or `Latest Posts` 
5. Expect the post title is not focused either selected.

## Screenshots <!-- if applicable -->

before | after
--- | ---
![title_wrong](https://user-images.githubusercontent.com/22746080/86476721-5d11d980-bd47-11ea-892e-c5e2d751cd17.gif) | ![title_correct](https://user-images.githubusercontent.com/22746080/86476731-5f743380-bd47-11ea-9293-f4cc54878598.gif)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [X] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
