### PR TITLE
Block Directory: Return inactive plugins in search results

### DIFF
--- a/lib/class-wp-rest-block-directory-controller.php
+++ b/lib/class-wp-rest-block-directory-controller.php
@@ -97,10 +97,6 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 		$result = array();
 
 		foreach ( $response->plugins as $plugin ) {
-			if ( $this->find_plugin_for_slug( $plugin['slug'] ) ) {
-				continue;
-			}
-
 			$data     = $this->prepare_item_for_response( $plugin, $request );
 			$result[] = $this->prepare_response_for_collection( $data );
 		}

--- a/packages/block-directory/src/store/test/actions.js
+++ b/packages/block-directory/src/store/test/actions.js
@@ -111,9 +111,8 @@ describe( 'actions', () => {
 			const generator = installBlockType( inactiveBlock );
 
 			expect( generator.next().value ).toEqual( {
-				type: 'SET_ERROR_NOTICE',
+				type: 'CLEAR_ERROR_NOTICE',
 				blockId: inactiveBlock.id,
-				notice: false,
 			} );
 
 			expect( generator.next().value ).toEqual( {

--- a/packages/block-directory/src/store/test/actions.js
+++ b/packages/block-directory/src/store/test/actions.js
@@ -4,11 +4,20 @@
 import { installBlockType, uninstallBlockType } from '../actions';
 
 describe( 'actions', () => {
-	const endpoint = '/wp-json/wp/v2/plugins/block/block';
+	const pluginEndpoint =
+		'https://example.com/wp-json/wp/v2/plugins/block/block';
 	const item = {
 		id: 'block/block',
 		name: 'Test Block',
 		assets: [ 'script.js' ],
+		links: {
+			'wp:install-plugin': [
+				{
+					href:
+						'https://example.com/wp-json/wp/v2/plugins?slug=waves',
+				},
+			],
+		},
 	};
 	const plugin = {
 		plugin: 'block/block.php',
@@ -18,24 +27,25 @@ describe( 'actions', () => {
 		_links: {
 			self: [
 				{
-					href: endpoint,
+					href: pluginEndpoint,
 				},
 			],
 		},
 	};
 
 	describe( 'installBlockType', () => {
+		const block = item;
 		it( 'should install a block successfully', () => {
-			const generator = installBlockType( item );
+			const generator = installBlockType( block );
 
 			expect( generator.next().value ).toEqual( {
 				type: 'CLEAR_ERROR_NOTICE',
-				blockId: item.id,
+				blockId: block.id,
 			} );
 
 			expect( generator.next().value ).toEqual( {
 				type: 'SET_INSTALLING_BLOCK',
-				blockId: item.id,
+				blockId: block.id,
 				isInstalling: true,
 			} );
 
@@ -47,15 +57,24 @@ describe( 'actions', () => {
 				},
 			} );
 
-			const itemWithEndpoint = { ...item, endpoint };
 			expect( generator.next( plugin ).value ).toEqual( {
 				type: 'ADD_INSTALLED_BLOCK_TYPE',
-				item: itemWithEndpoint,
+				item: {
+					...block,
+					links: {
+						...block.links,
+						self: [
+							{
+								href: pluginEndpoint,
+							},
+						],
+					},
+				},
 			} );
 
 			expect( generator.next().value ).toEqual( {
 				type: 'LOAD_ASSETS',
-				assets: item.assets,
+				assets: block.assets,
 			} );
 
 			expect( generator.next().value ).toEqual( {
@@ -65,9 +84,72 @@ describe( 'actions', () => {
 				type: 'SELECT',
 			} );
 
-			expect( generator.next( [ item ] ).value ).toEqual( {
+			expect( generator.next( [ block ] ).value ).toEqual( {
 				type: 'SET_INSTALLING_BLOCK',
-				blockId: item.id,
+				blockId: block.id,
+				isInstalling: false,
+			} );
+
+			expect( generator.next() ).toEqual( {
+				value: true,
+				done: true,
+			} );
+		} );
+
+		it( 'should activate an inactive block plugin successfully', () => {
+			const inactiveBlock = {
+				...block,
+				links: {
+					...block.links,
+					'wp:plugin': [
+						{
+							href: pluginEndpoint,
+						},
+					],
+				},
+			};
+			const generator = installBlockType( inactiveBlock );
+
+			expect( generator.next().value ).toEqual( {
+				type: 'SET_ERROR_NOTICE',
+				blockId: inactiveBlock.id,
+				notice: false,
+			} );
+
+			expect( generator.next().value ).toEqual( {
+				type: 'SET_INSTALLING_BLOCK',
+				blockId: inactiveBlock.id,
+				isInstalling: true,
+			} );
+
+			expect( generator.next().value ).toMatchObject( {
+				type: 'API_FETCH',
+				request: {
+					url: pluginEndpoint,
+					method: 'PUT',
+				},
+			} );
+
+			expect( generator.next( plugin ).value ).toEqual( {
+				type: 'ADD_INSTALLED_BLOCK_TYPE',
+				item: inactiveBlock,
+			} );
+
+			expect( generator.next().value ).toEqual( {
+				type: 'LOAD_ASSETS',
+				assets: inactiveBlock.assets,
+			} );
+
+			expect( generator.next().value ).toEqual( {
+				args: [],
+				selectorName: 'getBlockTypes',
+				storeKey: 'core/blocks',
+				type: 'SELECT',
+			} );
+
+			expect( generator.next( [ inactiveBlock ] ).value ).toEqual( {
+				type: 'SET_INSTALLING_BLOCK',
+				blockId: inactiveBlock.id,
 				isInstalling: false,
 			} );
 
@@ -78,21 +160,21 @@ describe( 'actions', () => {
 		} );
 
 		it( 'should set an error if the plugin has no assets', () => {
-			const generator = installBlockType( { ...item, assets: [] } );
+			const generator = installBlockType( { ...block, assets: [] } );
 
 			expect( generator.next().value ).toEqual( {
 				type: 'CLEAR_ERROR_NOTICE',
-				blockId: item.id,
+				blockId: block.id,
 			} );
 
 			expect( generator.next().value ).toMatchObject( {
 				type: 'SET_ERROR_NOTICE',
-				blockId: item.id,
+				blockId: block.id,
 			} );
 
 			expect( generator.next().value ).toEqual( {
 				type: 'SET_INSTALLING_BLOCK',
-				blockId: item.id,
+				blockId: block.id,
 				isInstalling: false,
 			} );
 
@@ -103,16 +185,16 @@ describe( 'actions', () => {
 		} );
 
 		it( "should set an error if the plugin can't install", () => {
-			const generator = installBlockType( item );
+			const generator = installBlockType( block );
 
 			expect( generator.next().value ).toEqual( {
 				type: 'CLEAR_ERROR_NOTICE',
-				blockId: item.id,
+				blockId: block.id,
 			} );
 
 			expect( generator.next().value ).toEqual( {
 				type: 'SET_INSTALLING_BLOCK',
-				blockId: item.id,
+				blockId: block.id,
 				isInstalling: true,
 			} );
 
@@ -131,12 +213,12 @@ describe( 'actions', () => {
 			};
 			expect( generator.throw( apiError ).value ).toMatchObject( {
 				type: 'SET_ERROR_NOTICE',
-				blockId: item.id,
+				blockId: block.id,
 			} );
 
 			expect( generator.next().value ).toEqual( {
 				type: 'SET_INSTALLING_BLOCK',
-				blockId: item.id,
+				blockId: block.id,
 				isInstalling: false,
 			} );
 
@@ -148,16 +230,26 @@ describe( 'actions', () => {
 	} );
 
 	describe( 'uninstallBlockType', () => {
-		const itemWithEndpoint = { ...item, endpoint };
+		const block = {
+			...item,
+			links: {
+				...item.links,
+				self: [
+					{
+						href: pluginEndpoint,
+					},
+				],
+			},
+		};
 
 		it( 'should uninstall a block successfully', () => {
-			const generator = uninstallBlockType( itemWithEndpoint );
+			const generator = uninstallBlockType( block );
 
 			// First the deactivation step
 			expect( generator.next().value ).toMatchObject( {
 				type: 'API_FETCH',
 				request: {
-					url: endpoint,
+					url: pluginEndpoint,
 					method: 'PUT',
 				},
 			} );
@@ -166,14 +258,14 @@ describe( 'actions', () => {
 			expect( generator.next().value ).toMatchObject( {
 				type: 'API_FETCH',
 				request: {
-					url: endpoint,
+					url: pluginEndpoint,
 					method: 'DELETE',
 				},
 			} );
 
 			expect( generator.next().value ).toEqual( {
 				type: 'REMOVE_INSTALLED_BLOCK_TYPE',
-				item: itemWithEndpoint,
+				item: block,
 			} );
 
 			expect( generator.next() ).toEqual( {
@@ -183,12 +275,12 @@ describe( 'actions', () => {
 		} );
 
 		it( "should set a global notice if the plugin can't be deleted", () => {
-			const generator = uninstallBlockType( itemWithEndpoint );
+			const generator = uninstallBlockType( block );
 
 			expect( generator.next().value ).toMatchObject( {
 				type: 'API_FETCH',
 				request: {
-					url: endpoint,
+					url: pluginEndpoint,
 					method: 'PUT',
 				},
 			} );
@@ -196,7 +288,7 @@ describe( 'actions', () => {
 			expect( generator.next().value ).toMatchObject( {
 				type: 'API_FETCH',
 				request: {
-					url: endpoint,
+					url: pluginEndpoint,
 					method: 'DELETE',
 				},
 			} );

--- a/packages/block-directory/src/store/utils/get-plugin-url.js
+++ b/packages/block-directory/src/store/utils/get-plugin-url.js
@@ -1,0 +1,17 @@
+/**
+ * Get the plugin's direct API link out of a block-directory response.
+ *
+ * @param {Object} block The block object
+ *
+ * @return {string} The plugin URL, if exists.
+ */
+export default function getPluginUrl( block ) {
+	if ( ! block ) {
+		return false;
+	}
+	const link = block.links[ 'wp:plugin' ] || block.links.self;
+	if ( link && link.length ) {
+		return link[ 0 ].href;
+	}
+	return false;
+}

--- a/packages/e2e-tests/specs/editor/plugins/block-directory-add.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/block-directory-add.test.js
@@ -55,6 +55,15 @@ const MOCK_INSTALLED_BLOCK_PLUGIN_DETAILS = {
 	requires_wp: '',
 	requires_php: '',
 	text_domain: 'block-directory-test-block',
+	_links: [
+		{
+			self: [
+				{
+					href: '',
+				},
+			],
+		},
+	],
 };
 
 const MOCK_BLOCK2 = {

--- a/packages/e2e-tests/specs/editor/plugins/block-directory-add.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/block-directory-add.test.js
@@ -37,6 +37,7 @@ const MOCK_BLOCK1 = {
 		'https://fake_url.com/block.js', // we will mock this
 	],
 	humanized_updated: '5 months ago',
+	links: {},
 };
 
 const MOCK_INSTALLED_BLOCK_PLUGIN_DETAILS = {
@@ -55,15 +56,13 @@ const MOCK_INSTALLED_BLOCK_PLUGIN_DETAILS = {
 	requires_wp: '',
 	requires_php: '',
 	text_domain: 'block-directory-test-block',
-	_links: [
-		{
-			self: [
-				{
-					href: '',
-				},
-			],
-		},
-	],
+	_links: {
+		self: [
+			{
+				href: '',
+			},
+		],
+	},
 };
 
 const MOCK_BLOCK2 = {


### PR DESCRIPTION
## Description
Fixes #23570 — This skips the check in the search results endpoint that filters out installed blocks, so that installed-but-deactivated blocks are returned. Blocks that are installed will contain an extra link property in the result, which we can use in the install flow to just activate the plugin.

This also changes the uninstallation flow to use the same link property, instead of a custom endpoint property.

## How has this been tested?
I updated the unit tests, and manually tested with a combination of locally installed block plugins.

From the original issue:

1. Install a block from the directory (Boxer)
2. Disable plugin via wp-admin/plugins.php
3. Reload page
4. Search for the same block
5. The result is should now be returned

## Types of changes
Bug fix (non-breaking change which fixes an issue)
