### PR TITLE
Block Library: Standardize post block placeholders.

### DIFF
--- a/packages/block-library/src/post-author/edit.js
+++ b/packages/block-library/src/post-author/edit.js
@@ -209,7 +209,7 @@ function PostAuthorEdit( { isSelected, context, attributes, setAttributes } ) {
 								/>
 							) }
 							<p className="wp-block-post-author__name">
-								{ authorDetails?.name }
+								{ authorDetails?.name || 'Post Author' }
 							</p>
 							{ showBio && (
 								<p className="wp-block-post-author__bio">

--- a/packages/block-library/src/post-comments-count/edit.js
+++ b/packages/block-library/src/post-comments-count/edit.js
@@ -32,7 +32,7 @@ function PostCommentsCountDisplay( { className } ) {
 
 export default function PostCommentsCountEdit( { className } ) {
 	if ( ! useEntityId( 'postType', 'post' ) ) {
-		return 'Post Comments Count Placeholder';
+		return 'Post Comments Count';
 	}
 	return <PostCommentsCountDisplay className={ className } />;
 }

--- a/packages/block-library/src/post-comments-form/edit.js
+++ b/packages/block-library/src/post-comments-form/edit.js
@@ -1,3 +1,3 @@
 export default function PostCommentsFormEdit() {
-	return 'Post Comments Form Placeholder';
+	return 'Post Comments Form';
 }

--- a/packages/block-library/src/post-comments/edit.js
+++ b/packages/block-library/src/post-comments/edit.js
@@ -30,7 +30,7 @@ export default function PostCommentsEdit() {
 	// TODO: Update to handle multiple post types.
 	const postId = useEntityId( 'postType', 'post' );
 	if ( ! postId ) {
-		return 'Post Comments Placeholder';
+		return 'Post Comments';
 	}
 	return <PostCommentsDisplay postId={ postId } />;
 }

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -104,7 +104,7 @@ export default function PostExcerptEdit( {
 	isSelected,
 } ) {
 	if ( ! useEntityId( 'postType', 'post' ) ) {
-		return 'Post Excerpt Placeholder';
+		return 'Post Excerpt';
 	}
 	return (
 		<PostExcerptEditor

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -28,7 +28,7 @@ function PostFeaturedImageDisplay() {
 
 export default function PostFeaturedImageEdit() {
 	if ( ! useEntityId( 'postType', 'post' ) ) {
-		return 'Post Featured Image Placeholder';
+		return 'Post Featured Image';
 	}
 	return <PostFeaturedImageDisplay />;
 }

--- a/packages/block-library/src/post-tags/edit.js
+++ b/packages/block-library/src/post-tags/edit.js
@@ -36,7 +36,7 @@ function PostTagsDisplay() {
 
 export default function PostTagsEdit() {
 	if ( ! useEntityId( 'postType', 'post' ) ) {
-		return 'Post Tags Placeholder';
+		return 'Post Tags';
 	}
 	return <PostTagsDisplay />;
 }

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -66,7 +66,7 @@ export default function PostTitleEdit( {
 					[ `has-text-align-${ align }` ]: align,
 				} ) }
 			>
-				{ post.title }
+				{ post.title || 'Post Title' }
 			</Block>
 		</>
 	);


### PR DESCRIPTION
## Description

Some post blocks were not rendering anything when missing a post context. The placeholder content was also inconsistent. This PR fixes both points.

## How has this been tested?

It was verified that post blocks used outside a post context, E.g., in the site editor's front template, render their name and all their relevant toolbar and inspector controls.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->