### PR TITLE
Fix quote left border color in dark mode.

### DIFF
--- a/packages/primitives/src/block-quotation/index.native.js
+++ b/packages/primitives/src/block-quotation/index.native.js
@@ -6,12 +6,19 @@ import { View } from 'react-native';
  * WordPress dependencies
  */
 import { Children, cloneElement } from '@wordpress/element';
+import { withPreferredColorScheme } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
 import styles from './style.scss';
 
-export const BlockQuotation = ( props ) => {
+export const BlockQuotation = withPreferredColorScheme( ( props ) => {
+	const { getStylesFromColorScheme } = props;
+
+	const blockQuoteStyle = getStylesFromColorScheme(
+		styles.wpBlockQuoteLight,
+		styles.wpBlockQuoteDark
+	);
 	const newChildren = Children.map( props.children, ( child ) => {
 		if ( child && child.props.identifier === 'citation' ) {
 			return cloneElement( child, {
@@ -23,5 +30,5 @@ export const BlockQuotation = ( props ) => {
 		}
 		return child;
 	} );
-	return <View style={ styles.wpBlockQuote }>{ newChildren }</View>;
-};
+	return <View style={ blockQuoteStyle }>{ newChildren }</View>;
+} );

--- a/packages/primitives/src/block-quotation/style.native.scss
+++ b/packages/primitives/src/block-quotation/style.native.scss
@@ -1,9 +1,18 @@
-.wpBlockQuote {
+%wpBlockQuote-shared {
 	border-left-width: 4px;
-	border-left-color: $black;
 	border-left-style: solid;
 	padding-left: 8px;
 	margin-left: 0;
+}
+
+.wpBlockQuoteLight {
+	@extend %wpBlockQuote-shared;
+	border-left-color: $black;
+}
+
+.wpBlockQuoteDark {
+	@extend %wpBlockQuote-shared;
+	border-left-color: $white;
 }
 
 .wpBlockQuoteCitation {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Restored the styles on the quote block for the RN implementation to support correctly dark and light modes.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

| Before | After |
|--------|--------|
| <img src="https://user-images.githubusercontent.com/651601/86497608-45a01400-bd7a-11ea-8666-dfd818b90e99.png" width=300> | <img src="https://user-images.githubusercontent.com/651601/86497615-46d14100-bd7a-11ea-8c22-777197cf9522.png" width=300> |


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
