### PR TITLE
Re-adding jsc-android to fix android demo build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11754,6 +11754,7 @@
 				"@wordpress/react-native-bridge": "file:packages/react-native-bridge",
 				"fast-average-color": "^4.3.0",
 				"jed": "^1.1.1",
+				"jsc-android": "^241213.1.0",
 				"jsdom-jscore-rn": "git+https://github.com/iamcco/jsdom-jscore-rn.git#a562f3d57c27c13e5bfc8cf82d496e69a3ba2800",
 				"metro-react-native-babel-preset": "0.57.0",
 				"metro-react-native-babel-transformer": "0.56.0",
@@ -11771,6 +11772,13 @@
 				"react-native-svg": "git+https://github.com/wordpress-mobile/react-native-svg.git#a628e92990a2404e30a0086f168bd2b5b7b4ce96",
 				"react-native-url-polyfill": "^1.1.2",
 				"react-native-video": "git+https://github.com/wordpress-mobile/react-native-video.git#1b964b107863351ed744fc104d7952bbec3e2d4f"
+			},
+			"dependencies": {
+				"jsc-android": {
+					"version": "241213.1.0",
+					"resolved": "https://registry.npmjs.org/jsc-android/-/jsc-android-241213.1.0.tgz",
+					"integrity": "sha512-AH8NYyMNLNhcUEF97QbMxPNLNW+oiSBlvm1rsMNzgJ1d5TQzdh/AOJGsxeeESp3m9YIWGLCgUvGTVoVLs0p68A=="
+				}
 			}
 		},
 		"@wordpress/redux-routine": {

--- a/packages/react-native-editor/package.json
+++ b/packages/react-native-editor/package.json
@@ -46,6 +46,7 @@
 		"@wordpress/react-native-bridge": "file:../react-native-bridge",
 		"fast-average-color": "^4.3.0",
 		"jed": "^1.1.1",
+		"jsc-android": "^241213.1.0",
 		"jsdom-jscore-rn": "git+https://github.com/iamcco/jsdom-jscore-rn.git#a562f3d57c27c13e5bfc8cf82d496e69a3ba2800",
 		"metro-react-native-babel-preset": "0.57.0",
 		"metro-react-native-babel-transformer": "0.56.0",


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Fixes https://github.com/WordPress/gutenberg/issues/23693

The linked issue above shows a new error when running the default process for running the android demo project. This change re-adds a recently removed dependency (removed in https://github.com/WordPress/gutenberg/pull/23550) which seems to fix this issue. 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. On a fresh clone of gutenberg on master branch, run `npm install`
3. in another terminal, run `npm run native start`
4. `npm run native android`
5. The demo app should run as expected

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
