### PR TITLE
Add getCategoryWithFallbacks API function to `@wordpress/blocks`

### DIFF
--- a/packages/blocks/src/api/categories.js
+++ b/packages/blocks/src/api/categories.js
@@ -33,3 +33,38 @@ export function setCategories( categories ) {
 export function updateCategory( slug, category ) {
 	dispatch( 'core/blocks' ).updateCategory( slug, category );
 }
+
+/**
+ * Accepts an array of category names and returns the first one that
+ * exists in the categories returned by `getCategories`. This allows
+ * for a "graceful degradation" strategy to category names, where
+ * we just add the new category name as the first item in the array
+ * argument, and leave the old ones for environments where they still
+ * exist and are used.
+ *
+ * @example
+ * // Prefer passing the new category first in the array, followed by
+ * // older fallback categories. Considering the 'new' category is
+ * // registered:
+ * getCategoryWithFallbacks( 'new', 'old', 'older' );
+ * // => 'new'
+ *
+ * @param {string[]} requestedCategories - an array of categories.
+ * @return {string} the first category name found.
+ * @throws {Error} if the no categories could be found.
+ */
+export function getCategoryWithFallbacks( ...requestedCategories ) {
+	const knownCategories = getCategories();
+	for ( const requestedCategory of requestedCategories ) {
+		if (
+			knownCategories.some( ( { slug } ) => slug === requestedCategory )
+		) {
+			return requestedCategory;
+		}
+	}
+	throw new Error(
+		`Could not find a category from the provided list: ${ requestedCategories.join(
+			','
+		) }`
+	);
+}

--- a/packages/blocks/src/api/test/categories.js
+++ b/packages/blocks/src/api/test/categories.js
@@ -1,0 +1,48 @@
+/**
+ * Internal dependencies
+ */
+import { getCategoryWithFallbacks } from '../categories';
+/**
+ * WordPress dependencies
+ */
+import { registerStore } from '@wordpress/data';
+
+describe( 'getCategoryWithFallbacks', () => {
+	beforeEach( () => {
+		registerStore( 'core/blocks', {
+			reducer: () => ( {
+				categories: [ { slug: 'foobar' }, { slug: 'barfoo' } ],
+			} ),
+			selectors: { getCategories: ( state ) => state.categories },
+		} );
+	} );
+
+	describe( 'single category passed', () => {
+		it( 'returns the category if it exists', () => {
+			expect( getCategoryWithFallbacks( 'foobar' ) ).toBe( 'foobar' );
+		} );
+		it( 'throws an error if it does not exist', () => {
+			expect( () => getCategoryWithFallbacks( 'nah' ) ).toThrow( /nah/ );
+		} );
+	} );
+
+	describe( 'multiple categories are passed', () => {
+		it( 'throws an error if none of the categories exist', () => {
+			expect( () =>
+				getCategoryWithFallbacks( 'nah', 'meh', 'wut', 'foo' )
+			).toThrow( /nah,meh,wut,foo/ );
+		} );
+
+		it( 'ignores all unexisting categories until it finds the *first one* that exists, then returns it', () => {
+			expect(
+				getCategoryWithFallbacks( 'foobar', 'meh', 'barfoo' )
+			).toBe( 'foobar' );
+			expect(
+				getCategoryWithFallbacks( 'nah', 'foobar', 'barfoo', 'foo' )
+			).toBe( 'foobar' );
+			expect( getCategoryWithFallbacks( 'nah', 'meh', 'foobar' ) ).toBe(
+				'foobar'
+			);
+		} );
+	} );
+} );


### PR DESCRIPTION
## Description

This adds a function to the `@wordpress/blocks`'s public API that can be used to provide graceful degradation of block categories when used to assign the block category by only returning the first available category in the store from an array of categories passed to it.

Related to pbAok1-18e-p2 and https://github.com/Automattic/wp-calypso/pull/43670#discussion_r445732682.

### Why?

Block categories have been changed and might change again. It makes sense to have a utility function that is aware of the available categories for the current block editor environment and returns only the (first) one available from the list provided. The alternative is to have this function duplicated across many repositories (almost all repos that implement blocks).

Let me know if this is the right place for it :)


## How has this been tested?


I've tested by linking the local dev package to a local WordPress instance running modified calypso/jetpack branches, then consumed this function and used it to set the block's categories and verified that it was working as expected.

## Types of changes

New feature (non-breaking change which adds functionality)

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
