### PR TITLE
Fix radio control in Windows High Contrast mode.

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -361,6 +361,9 @@
 		margin: 8px 0 0 8px;
 		background-color: $white;
 
+		// This border serves as a background color in Windows High Contrast mode.
+		border: 3px solid $white;
+
 		@include break-medium() {
 			width: 6px;
 			height: 6px;


### PR DESCRIPTION
The radio control was broken in Windows high contrast mode. In this mode all box shadows and background colors are removed, only borders and outlines are not.

Before:

<img width="363" alt="before" src="https://user-images.githubusercontent.com/1204802/86573868-45b83380-bf75-11ea-97a0-21ab182dfa6a.png">

After:

<img width="413" alt="after" src="https://user-images.githubusercontent.com/1204802/86573874-4781f700-bf75-11ea-87c3-21c686b87a48.png">

In normal mode:

<img width="352" alt="Screenshot 2020-07-06 at 10 40 00" src="https://user-images.githubusercontent.com/1204802/86573884-4bae1480-bf75-11ea-878d-2c1ec242ee69.png">
