### PR TITLE
Release: WordPress 5.5 beta 1 finishing touches

### DIFF
--- a/lib/block-directory.php
+++ b/lib/block-directory.php
@@ -29,6 +29,7 @@ if (
 	 * This filter can be removed when plugin support requires WordPress 5.5.0+.
 	 *
 	 * @see https://core.trac.wordpress.org/ticket/48654
+	 * @see https://core.trac.wordpress.org/changeset/48295
 	 *
 	 * @param string $tag     The `<script>` tag for the enqueued script.
 	 * @param string $handle  The script's registered handle.

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -721,6 +721,8 @@ add_filter( 'block_editor_settings', 'gutenberg_extend_settings_link_color' );
 /*
  * Register default patterns if not registered in Core already.
  *
+ * This can be removed when plugin support requires WordPress 5.5.0+.
+ *
  * @see https://core.trac.wordpress.org/ticket/50550
  */
 if ( class_exists( 'WP_Block_Patterns_Registry' ) && ! WP_Block_Patterns_Registry::get_instance()->is_registered( 'text-two-columns' ) ) {
@@ -738,6 +740,8 @@ if ( class_exists( 'WP_Block_Patterns_Registry' ) && ! WP_Block_Patterns_Registr
 
 /*
  * Register default pattern categories if not registered in Core already.
+ *
+ * This can be removed when plugin support requires WordPress 5.5.0+.
  *
  * @see https://core.trac.wordpress.org/ticket/50550
  */

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -721,7 +721,7 @@ add_filter( 'block_editor_settings', 'gutenberg_extend_settings_link_color' );
 /*
  * Register default patterns if not registered in Core already.
  *
- * @TODO: Add link to Core ticket.
+ * @see https://core.trac.wordpress.org/ticket/50550
  */
 if ( class_exists( 'WP_Block_Patterns_Registry' ) && ! WP_Block_Patterns_Registry::get_instance()->is_registered( 'text-two-columns' ) ) {
 	register_block_pattern( 'core/text-two-columns', gutenberg_load_block_pattern( 'text-two-columns' ) );
@@ -739,7 +739,7 @@ if ( class_exists( 'WP_Block_Patterns_Registry' ) && ! WP_Block_Patterns_Registr
 /*
  * Register default pattern categories if not registered in Core already.
  *
- * @TODO: Add link to Core ticket.
+ * @see https://core.trac.wordpress.org/ticket/50550
  */
 if ( class_exists( 'WP_Block_Pattern_Categories_Registry' ) ) {
 	register_block_pattern_category( 'text', array( 'label' => _x( 'Text', 'Block pattern category', 'gutenberg' ) ) );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -720,8 +720,9 @@ add_filter( 'block_editor_settings', 'gutenberg_extend_settings_link_color' );
 
 /*
  * Register default patterns if not registered in Core already.
+ *
+ * @TODO: Add link to Core ticket.
  */
-
 if ( class_exists( 'WP_Block_Patterns_Registry' ) && ! WP_Block_Patterns_Registry::get_instance()->is_registered( 'text-two-columns' ) ) {
 	register_block_pattern( 'core/text-two-columns', gutenberg_load_block_pattern( 'text-two-columns' ) );
 	register_block_pattern( 'core/two-buttons', gutenberg_load_block_pattern( 'two-buttons' ) );
@@ -737,6 +738,8 @@ if ( class_exists( 'WP_Block_Patterns_Registry' ) && ! WP_Block_Patterns_Registr
 
 /*
  * Register default pattern categories if not registered in Core already.
+ *
+ * @TODO: Add link to Core ticket.
  */
 if ( class_exists( 'WP_Block_Pattern_Categories_Registry' ) ) {
 	register_block_pattern_category( 'text', array( 'label' => _x( 'Text', 'Block pattern category', 'gutenberg' ) ) );

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -340,6 +340,7 @@ add_action( 'wp_default_scripts', 'gutenberg_add_dom_rect_polyfill', 20 );
  * This can be removed when plugin support requires WordPress 5.5.0+.
  *
  * @see https://core.trac.wordpress.org/ticket/50278
+ * @see https://core.trac.wordpress.org/changeset/48177
  *
  * @param array[] $default_categories Array of block categories.
  *
@@ -401,6 +402,7 @@ add_filter( 'block_categories', 'gutenberg_replace_default_block_categories' );
  * This can be removed when plugin support requires WordPress 5.5.0+.
  *
  * @see https://core.trac.wordpress.org/ticket/49927
+ * @see https://core.trac.wordpress.org/changeset/48243
  *
  * @param string|null $pre_render   The pre-rendered content. Defaults to null.
  * @param array       $parsed_block The parsed block being rendered.
@@ -458,20 +460,6 @@ function gutenberg_render_block_with_assigned_block_context( $pre_render, $parse
 	return $block->render();
 }
 add_filter( 'pre_render_block', 'gutenberg_render_block_with_assigned_block_context', 9, 2 );
-
-/**
- * Avoid enqueueing block assets of all registered blocks for all posts, instead
- * deferring to block render mechanics to enqueue scripts, thereby ensuring only
- * blocks of the content have their assets enqueued.
- *
- * This can be removed once minimum support for the plugin is outside the range
- * of the version associated with closure of the following ticket.
- *
- * @see https://core.trac.wordpress.org/ticket/50328
- *
- * @see WP_Block::render
- */
-remove_action( 'enqueue_block_assets', 'wp_enqueue_registered_block_scripts_and_styles' );
 
 /**
  * Shim that hooks into `wp_update_nav_menu_item` and makes it so that nav menu

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -57,7 +57,7 @@ add_filter( 'rest_request_after_callbacks', 'gutenberg_filter_oembed_result', 10
  *
  * @todo Remove once Gutenberg's minimum required WordPress version is v5.5.
  * @see https://core.trac.wordpress.org/ticket/49906
- * @see https://github.com/WordPress/wordpress-develop/pull/222
+ * @see https://core.trac.wordpress.org/changeset/47921
  *
  * @param WP_REST_Response $response The response object.
  * @param WP_Theme         $theme    Theme object used to create response.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

This PR reverts #22754 based on multiple reports that enqueue assets for rendered blocks only doesn't work in all cases. It needs to be further investigated after WordPress 5.5 beta 1 is ready.

I also included notes with lings to changesets for backported functionalities. As far as I can tell, we have all changes synced with WordPress core.

