### PR TITLE
Scripts: Fix build script with style.css files

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 -   Allow the CSS, SVG, and Sass loaders to process files from node_modules directory.
 -   Improve the way licenses are validated with `check-licenses` by falling back to license files verification when the entry in `package.json` doesn't contain an allowed match ([#23550](https://github.com/WordPress/gutenberg/pull/23550)).
+-   Fix `build` script error when importing `style.css` files ([#23710](https://github.com/WordPress/gutenberg/pull/23710)).
 
 ## 12.0.0-rc.0 (2020-06-24)
 

--- a/packages/scripts/config/fix-style-webpack-plugin/index.js
+++ b/packages/scripts/config/fix-style-webpack-plugin/index.js
@@ -37,8 +37,8 @@ class FixStyleWebpackPlugin {
 							}
 							compilation.updateAsset( file, ( oldSource ) => {
 								return new ConcatSource(
-									oldSource,
-									'\n\n' + styleFileAsset.source.source()
+									styleFileAsset.source.source() + '\n\n',
+									oldSource
 								);
 							} );
 						}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Fixes #23498.


## How has this been tested?

I tested with the plugin (with some fixes to import statements) shared by @tschortsch in https://github.com/WordPress/gutenberg/issues/23498#issuecomment-653421830:

> Here you go: [wp-scripts-plugin.zip](https://github.com/WordPress/gutenberg/files/4868610/wp-scripts-plugin.zip)

It errors without this patch, it works correctly with this patch.