### PR TITLE
Scripts: Exclude node_modules from source map processing in start script

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -11,6 +11,7 @@
 -   Allow the CSS, SVG, and Sass loaders to process files from node_modules directory.
 -   Improve the way licenses are validated with `check-licenses` by falling back to license files verification when the entry in `package.json` doesn't contain an allowed match ([#23550](https://github.com/WordPress/gutenberg/pull/23550)).
 -   Fix `build` script error when importing `style.css` files ([#23710](https://github.com/WordPress/gutenberg/pull/23710)).
+-   Exclude `node_modules` from source map processing in `start` script ([#23711](https://github.com/WordPress/gutenberg/pull/23711)).
 
 ## 12.0.0-rc.0 (2020-06-24)
 

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -177,6 +177,7 @@ if ( ! isProduction ) {
 	config.devtool = process.env.WP_DEVTOOL || 'source-map';
 	config.module.rules.unshift( {
 		test: /\.js$/,
+		exclude: [ /node_modules/ ],
 		use: require.resolve( 'source-map-loader' ),
 		enforce: 'pre',
 	} );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

Fixes #23513.

From @leoloso:

> When compiling a block using the @wordpress/create-block package with npm start, and having this dependency, it throws an error

> The problem happens in [this piece of code](https://github.com/WordPress/gutenberg/blob/master/packages/scripts/config/webpack.config.js#L160):
> 
> ```js
> if ( ! isProduction ) {
> 	// WP_DEVTOOL global variable controls how source maps are generated.
> 	// See: https://webpack.js.org/configuration/devtool/#devtool.
> 	config.devtool = process.env.WP_DEVTOOL || 'source-map';
> 	config.module.rules.unshift( {
> 		test: /\.js$/,
> 		use: require.resolve( 'source-map-loader' ),
> 		enforce: 'pre',
> 	} );
> }
> ```
> 
> And the solution is just to exclude this rule from the `node_modules` folder.

## How has this been tested?
`npm start` in the test plugin. 
