### PR TITLE
Create block: Add support for external templates installed from npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17714,6 +17714,7 @@
 			"version": "file:packages/create-block",
 			"dev": true,
 			"requires": {
+				"@wordpress/lazy-import": "file:packages/lazy-import",
 				"chalk": "^4.0.0",
 				"check-node-version": "^3.1.1",
 				"commander": "^4.1.0",

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   Added basic support for external templates hosted on npm ([#23712](https://github.com/WordPress/gutenberg/pull/23712)).
+
 ## 0.18.0 (2020-10-30)
 
 ### Breaking Changes

--- a/packages/create-block/README.md
+++ b/packages/create-block/README.md
@@ -34,11 +34,11 @@ The following command generates PHP, JS and CSS code for registering a block.
 $ npx @wordpress/create-block [options] [slug]
 ```
 
-`[slug]` is optional. When provided it triggers the quick mode where it is used as the block slug used for its identification, the output location for scaffolded files, and the name of the WordPress plugin. The rest of the configuration is set to all default values unless overriden with some of the options listed below.
+`[slug]` is optional. When provided it triggers the quick mode where it is used as the block slug used for its identification, the output location for scaffolded files, and the name of the WordPress plugin. The rest of the configuration is set to all default values unless overridden with some of the options listed below.
 
 Options:
 
-```sh
+```bash
 -V, --version                output the version number
 -t, --template <name>        block template type name, allowed values: "es5", "esnext", or the name of an external npm package (default: "esnext")
 --namespace <value>          internal namespace for the block name
@@ -76,7 +76,7 @@ When you scaffold a block, you must provide at least a `slug` name, the `namespa
 
 ## Available Commands [ESNext template]
 
-When bootstraped with the `esnext` template, you can run several commands inside the directory:
+When bootstrapped with the `esnext` template (or any external template with `wpScripts` flag enabled), you can run several commands inside the directory:
 
 ```bash
 $ npm start
@@ -116,44 +116,52 @@ Updates WordPress packages to the latest version. [Learn more](/packages/scripts
 
 ## External Templates
 
-Since version `0.19.0` it is possible to use external templates hosted on npm. These packages need to contain `.mustache` files inside the `templates` folder that will be used in the scaffolding and one `create-block` section in `package.json` for the metadata.
+Since version `0.19.0` it is possible to use external templates hosted on npm. These packages need to contain `.mustache` files that will be used during the block scaffolding process.
 
-### Available Variables:
+### Template Configuration
 
-The following variables are passed to the template files:
+It is mandatory to provide the main file for the package that returns a configuration object. It must containing at least `templatesPath` field with the path pointing to the location where template files live (nested folders are also supported).
 
+_Example:_
+
+```js
+module.exports = {
+	templatesPath: __dirname,
+};
+```
+
+It is also possible to override the default template configuration using the `defaultValues` field.
+
+_Example:_
+
+```js
+module.exports = {
+	defaultValues: {
+		slug: 'my-fantastic-block',
+		title: 'My fantastic block',
+		dashicon: 'palmtree',
+		version: '1.2.3',
+	},
+	templatesPath: __dirname,
+};
+```
+
+The following configurable variables are used with the template files. Template authors can change default values to use when users don't provide their data:
+
+-   `slug` (no default)
 -   `namespace` (default: `create-block`)
--   `namespaceSnakeCase` (auto-generated from `namespace`)
--   `slug` (always provided from CLI)
--   `slugSnakeCase` (auto-generated from `slug`)
 -   `title` (no default)
 -   `description` (no default)
 -   `dashicon` (no default)
 -   `category` (default: `widgets`)
--   `version` (default: `0.1.0`)
 -   `author` (default: `The WordPress Contributors`)
 -   `license` (default: `GPL-2.0-or-later`)
 -   `licenseURI` (default: `https://www.gnu.org/licenses/gpl-2.0.html`)
--   `textdomain` (auto-generated from `namespace`)
+-   `version` (default: `0.1.0`)
+-   `wpScripts` (default: `true`)
 -   `editorScript` (default: `file:./build/index.js`)
 -   `editorStyle` (default: `file:./build/index.css`)
 -   `style` (default: `file:./build/style-index.css`)
--   `wpScripts` (default: `true`)
-
-### `package.json`
-
-_Example:_
-
-```json
-{
-	"create-block": {
-		"namespace": "my-plugin",
-		"title": "My plugin",
-		"dashicon": "palmtree",
-		"version": "1.2.3"
-	}
-}
-```
 
 ## WP-CLI
 

--- a/packages/create-block/README.md
+++ b/packages/create-block/README.md
@@ -40,7 +40,7 @@ Options:
 
 ```sh
 -V, --version                output the version number
--t, --template <name>        block template type name, allowed values: "es5", "esnext" (default: "esnext")
+-t, --template <name>        block template type name, allowed values: "es5", "esnext", or the name of an external npm package (default: "esnext")
 --namespace <value>          internal namespace for the block name
 --title <value>              display title for the block
 --short-description <value>  short description for the block
@@ -74,9 +74,9 @@ $ npx @wordpress/create-block --help
 
 When you scaffold a block, you must provide at least a `slug` name, the `namespace` which usually corresponds to either the `theme` or `plugin` name, and the `category`. In most cases, we recommended pairing blocks with plugins rather than themes, because only using plugin ensures that all blocks still work when your theme changes.
 
-## Available Commands
+## Available Commands [ESNext template]
 
-Inside that bootstrapped directory _(it doesn't apply to `es5` template)_, you can run several commands:
+When bootstraped with the `esnext` template, you can run several commands inside the directory:
 
 ```bash
 $ npm start
@@ -113,6 +113,47 @@ $ npm run packages-update
 ```
 
 Updates WordPress packages to the latest version. [Learn more](/packages/scripts#packages-update).
+
+## External Templates
+
+Since version `0.19.0` it is possible to use external templates hosted on npm. These packages need to contain `.mustache` files inside the `templates` folder that will be used in the scaffolding and one `create-block` section in `package.json` for the metadata.
+
+### Available Variables:
+
+The following variables are passed to the template files:
+
+-   `namespace` (default: `create-block`)
+-   `namespaceSnakeCase` (auto-generated from `namespace`)
+-   `slug` (always provided from CLI)
+-   `slugSnakeCase` (auto-generated from `slug`)
+-   `title` (no default)
+-   `description` (no default)
+-   `dashicon` (no default)
+-   `category` (default: `widgets`)
+-   `version` (default: `0.1.0`)
+-   `author` (default: `The WordPress Contributors`)
+-   `license` (default: `GPL-2.0-or-later`)
+-   `licenseURI` (default: `https://www.gnu.org/licenses/gpl-2.0.html`)
+-   `textdomain` (auto-generated from `namespace`)
+-   `editorScript` (default: `file:./build/index.js`)
+-   `editorStyle` (default: `file:./build/index.css`)
+-   `style` (default: `file:./build/style-index.css`)
+-   `wpScripts` (default: `true`)
+
+### `package.json`
+
+_Example:_
+
+```json
+{
+	"create-block": {
+		"namespace": "my-plugin",
+		"title": "My plugin",
+		"dashicon": "palmtree",
+		"version": "1.2.3"
+	}
+}
+```
 
 ## WP-CLI
 

--- a/packages/create-block/lib/index.js
+++ b/packages/create-block/lib/index.js
@@ -34,7 +34,7 @@ program
 	.arguments( '[slug]' )
 	.option(
 		'-t, --template <name>',
-		'block template type name, allowed values: "es5", "esnext"',
+		'block template type name, allowed values: "es5", "esnext", or the name of an external npm package',
 		'esnext'
 	)
 	.option( '--namespace <value>', 'internal namespace for the block name' )

--- a/packages/create-block/lib/index.js
+++ b/packages/create-block/lib/index.js
@@ -91,6 +91,8 @@ program
 						( { name } ) =>
 							! Object.keys( optionsValues ).includes( name )
 					);
+					log.info( '' );
+					log.info( "Let's customize your block:" );
 					const answers = await inquirer.prompt( prompts );
 					await scaffold( blockTemplate, {
 						...defaultValues,

--- a/packages/create-block/lib/init-wp-scripts.js
+++ b/packages/create-block/lib/init-wp-scripts.js
@@ -13,7 +13,7 @@ module.exports = async ( { slug } ) => {
 	const cwd = join( process.cwd(), slug );
 
 	info( '' );
-	info( 'Installing packages. It might take a couple of minutes.' );
+	info( 'Installing packages. It might take a couple of minutes...' );
 	await command( 'npm install @wordpress/scripts --save-dev', {
 		cwd,
 	} );

--- a/packages/create-block/lib/templates.js
+++ b/packages/create-block/lib/templates.js
@@ -19,6 +19,7 @@ const predefinedBlockTemplates = {
 			title: 'ES5 Example',
 			description:
 				'Example block written with ES5 standard and no JSX – no build step required.',
+			dashicon: 'smiley',
 			wpScripts: false,
 			editorScript: 'file:./index.js',
 			editorStyle: 'file:./editor.css',
@@ -31,6 +32,7 @@ const predefinedBlockTemplates = {
 			title: 'ESNext Example',
 			description:
 				'Example block written with ESNext standard and JSX support – build step required.',
+			dashicon: 'smiley',
 		},
 	},
 };
@@ -75,7 +77,6 @@ const getBlockTemplate = async ( templateName ) => {
 const getDefaultValues = ( blockTemplate ) => {
 	return {
 		namespace: 'create-block',
-		dashicon: 'smiley',
 		category: 'widgets',
 		author: 'The WordPress Contributors',
 		license: 'GPL-2.0-or-later',

--- a/packages/create-block/lib/templates.js
+++ b/packages/create-block/lib/templates.js
@@ -16,6 +16,7 @@ const lazyImport = require( '@wordpress/lazy-import' );
  * Internal dependencies
  */
 const CLIError = require( './cli-error' );
+const { info } = require( './log' );
 const prompts = require( './prompts' );
 
 const predefinedBlockTemplates = {
@@ -94,12 +95,16 @@ const getBlockTemplate = async ( templateName ) => {
 	}
 
 	try {
+		info( '' );
+		info( 'Downloading template files. It might take some time...' );
+
 		const { defaultValues = {}, templatesPath } = await lazyImport(
 			templateName
 		);
 		if ( ! isObject( defaultValues ) || ! templatesPath ) {
 			throw new Error();
 		}
+
 		return {
 			defaultValues,
 			outputTemplates: await getOutputTemplates( templatesPath ),

--- a/packages/create-block/package.json
+++ b/packages/create-block/package.json
@@ -31,6 +31,7 @@
 		"wp-create-block": "./index.js"
 	},
 	"dependencies": {
+		"@wordpress/lazy-import": "file:../lazy-import",
 		"chalk": "^4.0.0",
 		"check-node-version": "^3.1.1",
 		"commander": "^4.1.0",


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Replaces #22175 and continues work started by @fabiankaegy.  Description copied over:

> The biggest motivation to support templates comes from the fact that https://github.com/WordPress/gutenberg-examples contains multiple examples of blocks that are used in the block editor tutorials (https://developer.wordpress.org/block-editor/tutorials/block-tutorial/). The idea is that we make it easier for folks and let them running one command to install such block in the plugins directory in WordPress when going through the tutorial with one command:
> ```bash
> npm init @wordpress/block -t 05-recipe-card-esnext
> ```
> As of today, they need to either copy the folder from the repository or recreate it manually when going through the tutorial.
> 
> With this PR I have introduced the ability to pull templates for the `create-block` package from `npm`. This would allow for anyone to contribute / use the starter template they would like with the ease of use the `create-block` cli provides.
> 

### External templates
> The external templates need to contain the `.mustache` files and one `template.json` file with the metadata that is currently being stored in the `templates.js` file. 

To make it easier to use the existing `@wordpress/lazy-import` package, we better use `index.js` file (or anything that `main` field allows overriding) as an entry point for the package that contains all definitions.

### Template Configuration

 It is mandatory to provide the main file for the package that returns a configuration object. It must contain at least `templatesPath` field with the path pointing to the location where template files live (nested folders are also supported).

 _Example:_

 ```js
 module.exports = {
 	templatesPath: __dirname,
 };
 ```

_It's a bit unfortunate that `templatesPath` has to be explicitly set  but `@wordpress/lazy-import` package would require some further development first to make the discovery automatic for external packages._ 

 It is also possible to override the default template configuration using the `defaultValues` field.

 _Example:_

 ```js
 module.exports = {
 	defaultValues: {
 		slug: 'my-fantastic-block',
 		title: 'My fantastic block',
 		dashicon: 'palmtree',
 		version: '1.2.3',
 	},
 	templatesPath: __dirname,
 };
 ```
 
## How has this been tested?

This is being tested by running `npx wp-create-block` with different `--template` (or `-t`) parameters.

To test things directly from NPM you can use two test templates:

1. [wp-block-directory-template](https://www.npmjs.com/package/wp-block-directory-template) from @gziolo - a copy of ESNext template with some changes to default values:
  ```bash
  $ npx wp-create-block --template wp-block-directory-template
  ```
2. [gutenberg-esnext-template](https://www.npmjs.com/package/gutenberg-esnext-template) from @fabiankaegy:
  ```bash
  $ npx wp-create-block --template gutenberg-esnext-template
  ```