### PR TITLE
FormTokenField: handle disabled in Token; add storybook stories

### DIFF
--- a/packages/components/src/form-token-field/stories/index.js
+++ b/packages/components/src/form-token-field/stories/index.js
@@ -1,0 +1,34 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import FormTokenField from '../';
+
+export default {
+	title: 'Components/FormTokenField',
+	component: FormTokenField,
+};
+
+const FormTokenFieldWithState = ( { initialValue, ...props } ) => {
+	const [ value, setValue ] = useState( initialValue );
+	return (
+		<FormTokenField
+			{ ...props }
+			value={ value }
+			suggestions={ [ 'Foo', 'Bar', 'Baz' ] }
+			onChange={ setValue }
+		/>
+	);
+};
+
+export const _default = () => {
+	return <FormTokenFieldWithState initialValue={ [ 'Foo' ] } />;
+};
+
+export const disabled = () => {
+	return <FormTokenFieldWithState initialValue={ [ 'Foo' ] } disabled />;
+};

--- a/packages/components/src/form-token-field/token.js
+++ b/packages/components/src/form-token-field/token.js
@@ -72,6 +72,7 @@ export default function Token( {
 				className="components-form-token-field__remove-token"
 				icon={ closeCircleFilled }
 				onClick={ ! disabled && onClick }
+				disabled={ disabled }
 				label={ messages.remove }
 				aria-describedby={ `components-form-token-field__token-text-${ instanceId }` }
 			/>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

In `FormTokenField` component, the `disabled` prop was not passed to the `Button`, which made the delete button clickable. The click would not be handled, but the DOM element was focusable. This PR fixes that by passing the `disabled` prop to the `Button`.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Locally. Storybook stories were added for the `FormTokenField` component for ease of testing.

## Screenshots <!-- if applicable -->

Focusing on the token when the component is disabled:

![image](https://user-images.githubusercontent.com/7383192/86598009-c9d1e180-bf9c-11ea-8778-e6f672bfe37f.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
