### PR TITLE
Inline font-sizes: avoid modifying the BlockListBlock props object

### DIFF
--- a/packages/block-editor/src/hooks/font-size.js
+++ b/packages/block-editor/src/hooks/font-size.js
@@ -90,7 +90,7 @@ function addEditProps( settings ) {
 	return settings;
 }
 
-function useFontizes() {
+function useFontSizes() {
 	return useSelect(
 		( select ) => select( 'core/block-editor' ).getSettings().fontSizes
 	);
@@ -109,7 +109,7 @@ export function FontSizeEdit( props ) {
 		setAttributes,
 	} = props;
 	const isDisabled = useIsFontSizeDisabled( props );
-	const fontSizes = useFontizes();
+	const fontSizes = useFontSizes();
 
 	if ( isDisabled ) {
 		return null;
@@ -147,7 +147,7 @@ export function FontSizeEdit( props ) {
  * @return {boolean} Whether setting is disabled.
  */
 export function useIsFontSizeDisabled( { name: blockName } = {} ) {
-	const fontSizes = useFontizes();
+	const fontSizes = useFontSizes();
 	const hasFontSizes = fontSizes.length;
 
 	return (
@@ -165,7 +165,7 @@ export function useIsFontSizeDisabled( { name: blockName } = {} ) {
  */
 const withFontSizeInlineStyles = createHigherOrderComponent(
 	( BlockListBlock ) => ( props ) => {
-		const fontSizes = useFontizes();
+		const fontSizes = useFontSizes();
 		const {
 			name: blockName,
 			attributes: { fontSize, style },

--- a/packages/block-editor/src/hooks/font-size.js
+++ b/packages/block-editor/src/hooks/font-size.js
@@ -172,6 +172,8 @@ const withFontSizeInlineStyles = createHigherOrderComponent(
 			wrapperProps,
 		} = props;
 
+		const newProps = { ...props };
+
 		// Only add inline styles if the block supports font sizes, doesn't
 		// already have an inline font size, and does have a class to extract
 		// the font size from.
@@ -186,21 +188,16 @@ const withFontSizeInlineStyles = createHigherOrderComponent(
 				style?.typography?.fontSize
 			).size;
 
-			const newProps = {
-				...props,
-				wrapperProps: {
-					...wrapperProps,
-					style: {
-						fontSize: fontSizeValue,
-						...wrapperProps?.style,
-					},
+			newProps.wrapperProps = {
+				...wrapperProps,
+				style: {
+					fontSize: fontSizeValue,
+					...wrapperProps?.style,
 				},
 			};
-
-			return <BlockListBlock { ...newProps } />;
 		}
 
-		return <BlockListBlock { ...props } />;
+		return <BlockListBlock { ...newProps } />;
 	},
 	'withFontSizeInlineStyles'
 );

--- a/packages/block-editor/src/hooks/font-size.js
+++ b/packages/block-editor/src/hooks/font-size.js
@@ -186,13 +186,18 @@ const withFontSizeInlineStyles = createHigherOrderComponent(
 				style?.typography?.fontSize
 			).size;
 
-			props.wrapperProps = {
-				...wrapperProps,
-				style: {
-					fontSize: fontSizeValue,
-					...wrapperProps?.style,
+			const newProps = {
+				...props,
+				wrapperProps: {
+					...wrapperProps,
+					style: {
+						fontSize: fontSizeValue,
+						...wrapperProps?.style,
+					},
 				},
 			};
+
+			return <BlockListBlock { ...newProps } />;
 		}
 
 		return <BlockListBlock { ...props } />;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

- Avoid changing the `BlockListBlock` props object in the `withFontSizeInlineStyles` HOC.
- Also fix a typo in the `useFontSizes` hook name.

## How has this been tested?

Tested with `wp-env` on both Firefox 78 and Chrome 83 on macOS 10.15.5.
The issue appeared in the Site Editor while editing the `home` template of the theme Seedlet (Blocks).

## Screenshots <!-- if applicable -->

<img width="1638" alt="Screenshot 2020-07-06 at 16 01 05" src="https://user-images.githubusercontent.com/2070010/86608030-ecb2c480-bfa1-11ea-9c79-45e9831f8208.png">

This screenshot was captured while testing the Site Editor.
Both `Section` blocks were breaking because of an `Uncaught TypeError: can't define property "wrapperProps": Object is not extensible`, thrown by this line:

https://github.com/WordPress/gutenberg/pull/22668/files#diff-7e9533138d2d1bd1c8f0f4b32d2d3aa4R189

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
