### PR TITLE
Add UI tests to unsupported block editor

### DIFF
--- a/packages/block-library/src/missing/edit.native.js
+++ b/packages/block-library/src/missing/edit.native.js
@@ -69,6 +69,9 @@ export class UnsupportedBlockEdit extends Component {
 			<TouchableHighlight
 				onPress={ this.onHelpButtonPressed }
 				style={ styles.helpIconContainer }
+				accessibilityLabel={ __( 'Help button' ) }
+				accessibilityRole={ 'button' }
+				accessibilityHint={ __( 'Tap here to show help' ) }
 			>
 				<Icon
 					className="unsupported-icon-help"

--- a/packages/block-library/src/missing/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/missing/test/__snapshots__/edit.native.js.snap
@@ -16,6 +16,9 @@ exports[`Missing block renders without crashing 1`] = `
   onStartShouldSetResponder={[Function]}
 >
   <View
+    accessibilityHint="Tap here to show help"
+    accessibilityLabel="Help button"
+    accessibilityRole="button"
     accessible={true}
     focusable={true}
     isTVSelectable={true}

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-paragraph.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-paragraph.test.js
@@ -171,7 +171,7 @@ describe( 'Gutenberg Editor tests for Paragraph Block', () => {
 	// Restricting these test to Android because I was not able to update the html on iOS
 	if ( isAndroid() ) {
 		it( 'should be able to merge blocks with unknown html elements', async () => {
-			await editorPage.setHtmlContentAndroid( `
+			await editorPage.setHtmlContent( `
 <!-- wp:paragraph -->
 <p><unknownhtmlelement>abc</unknownhtmlelement>D</p>
 <!-- /wp:paragraph -->
@@ -205,7 +205,7 @@ describe( 'Gutenberg Editor tests for Paragraph Block', () => {
 
 		// Based on https://github.com/wordpress-mobile/gutenberg-mobile/pull/1507
 		it( 'should handle multiline paragraphs from web', async () => {
-			await editorPage.setHtmlContentAndroid( `
+			await editorPage.setHtmlContent( `
 	<!-- wp:paragraph -->
 	<p>multiple lines<br><br></p>
 	<!-- /wp:paragraph -->

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-paste.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-paste.test.js
@@ -91,7 +91,7 @@ describe( 'Gutenberg Editor paste tests', () => {
 
 	it( 'copies styled text from one paragraph block and pastes in another', async () => {
 		// create paragraph block with styled text by editing html
-		await editorPage.setHtmlContentAndroid( testData.pasteHtmlText );
+		await editorPage.setHtmlContent( testData.pasteHtmlText );
 		const paragraphBlockElement = await editorPage.getBlockAtPosition(
 			paragraphBlockName
 		);

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-unsupported-blocks.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-unsupported-blocks.test.js
@@ -1,0 +1,58 @@
+/**
+ * Internal dependencies
+ */
+import EditorPage from './pages/editor-page';
+import { setupDriver, isLocalEnvironment, stopDriver } from './helpers/utils';
+import testData from './helpers/test-data';
+
+jest.setTimeout( 1000000 );
+
+describe( 'Gutenberg Editor Unsupported Block Editor Tests', () => {
+	let driver;
+	let editorPage;
+	let allPassed = true;
+
+	// Use reporter for setting status for saucelabs Job
+	if ( ! isLocalEnvironment() ) {
+		const reporter = {
+			specDone: async ( result ) => {
+				allPassed = allPassed && result.status !== 'failed';
+			},
+		};
+
+		jasmine.getEnv().addReporter( reporter );
+	}
+
+	beforeAll( async () => {
+		driver = await setupDriver();
+		editorPage = new EditorPage( driver );
+	} );
+
+	it( 'should be able to see visual editor', async () => {
+		await expect( editorPage.getBlockList() ).resolves.toBe( true );
+	} );
+
+	it( 'should be able to open the unsupported block web view editor', async () => {
+		await editorPage.setHtmlContent( testData.unsupportedBlockHtml );
+
+		const firstVisibleBlock = await editorPage.getFirstBlockVisible();
+		await firstVisibleBlock.click();
+
+		const helpButton = await editorPage.getUnsupportedBlockHelpButton();
+		await helpButton.click();
+
+		const editButton = await editorPage.getUnsupportedBlockBottomSheetEditButton();
+		await editButton.click();
+
+		await expect(
+			editorPage.getUnsupportedBlockWebView()
+		).resolves.toBeTruthy();
+	} );
+
+	afterAll( async () => {
+		if ( ! isLocalEnvironment() ) {
+			driver.sauceJobStatus( allPassed );
+		}
+		await stopDriver( driver );
+	} );
+} );

--- a/packages/react-native-editor/__device-tests__/helpers/caps.js
+++ b/packages/react-native-editor/__device-tests__/helpers/caps.js
@@ -15,7 +15,7 @@ const ios = {
 
 exports.iosLocal = {
 	...ios,
-	platformVersion: '13.5',
+	platformVersion: '13.4',
 	deviceName: 'iPhone 11',
 };
 

--- a/packages/react-native-editor/__device-tests__/helpers/caps.js
+++ b/packages/react-native-editor/__device-tests__/helpers/caps.js
@@ -15,7 +15,7 @@ const ios = {
 
 exports.iosLocal = {
 	...ios,
-	platformVersion: '13.4',
+	platformVersion: '13.5',
 	deviceName: 'iPhone 11',
 };
 

--- a/packages/react-native-editor/__device-tests__/helpers/test-data.js
+++ b/packages/react-native-editor/__device-tests__/helpers/test-data.js
@@ -98,3 +98,8 @@ exports.imageShorteHtml = `<!-- wp:image {"id":1,"sizeslug":"large"} -->
 <!-- wp:paragraph -->
 <p>rock music approaches at high velocity.</p>
 <!-- /wp:paragraph -->`;
+
+exports.unsupportedBlockHtml = `<!-- wp:audio -->
+<figure class="wp-block-audio"><audio controls src="https://www2.cs.uic.edu/~i101/SoundFiles/StarWars60.wav"></audio></figure>
+<!-- /wp:audio -->
+`;

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -489,9 +489,9 @@ export default class EditorPage {
 	// =============================
 
 	async getUnsupportedBlockHelpButton() {
-		const accessibilityId = 'Help icon';
+		const accessibilityId = 'Help button';
 		let blockLocator =
-			'//android.widget.Button[@content-desc="Help icon, Tap here to show help"]';
+			'//android.widget.Button[@content-desc="Help button, Tap here to show help"]';
 
 		if ( ! isAndroid() ) {
 			blockLocator = `//XCUIElementTypeButton[@name="${ accessibilityId }"]`;
@@ -500,9 +500,9 @@ export default class EditorPage {
 	}
 
 	async getUnsupportedBlockBottomSheetEditButton() {
-		const accessibilityId = 'Edit block in web browser';
+		const accessibilityId = 'Edit using web editor';
 		let blockLocator =
-			'//android.widget.Button[@content-desc="Edit block in web browser"]';
+			'//android.widget.Button[@content-desc="Edit using web editor"]';
 
 		if ( ! isAndroid() ) {
 			blockLocator = `//XCUIElementTypeButton[@name="${ accessibilityId }"]`;

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -125,7 +125,7 @@ export default class EditorPage {
 		let blockLocator = `//*[@${ this.accessibilityIdXPathAttrib }="${ accessibilityId }"]`;
 
 		if ( ! isAndroid() ) {
-			blockLocator += '//XCUIElementTypeTextView';
+			blockLocator = `//XCUIElementTypeTextView[starts-with(@${ this.accessibilityIdXPathAttrib }, "${ accessibilityId }")]`;
 		}
 		return await this.driver.elementByXPath( blockLocator );
 	}
@@ -143,11 +143,11 @@ export default class EditorPage {
 	}
 
 	// set html editor content explicitly
-	async setHtmlContentAndroid( html ) {
+	async setHtmlContent( html ) {
 		await toggleHtmlMode( this.driver, true );
 
 		const htmlContentView = await this.getTextViewForHtmlViewContent();
-		await htmlContentView.setText( html );
+		await htmlContentView.type( html );
 
 		await toggleHtmlMode( this.driver, false );
 	}
@@ -482,5 +482,44 @@ export default class EditorPage {
 			true
 		);
 		return await typeString( this.driver, textViewElement, text, clear );
+	}
+
+	// =============================
+	// Unsupported Block functions
+	// =============================
+
+	async getUnsupportedBlockHelpButton() {
+		const accessibilityId = 'Help icon';
+		let blockLocator =
+			'//android.widget.Button[@content-desc="Help icon, Tap here to show help"]';
+
+		if ( ! isAndroid() ) {
+			blockLocator = `//XCUIElementTypeButton[@name="${ accessibilityId }"]`;
+		}
+		return await this.driver.elementByXPath( blockLocator );
+	}
+
+	async getUnsupportedBlockBottomSheetEditButton() {
+		const accessibilityId = 'Edit block in web browser';
+		let blockLocator =
+			'//android.widget.Button[@content-desc="Edit block in web browser"]';
+
+		if ( ! isAndroid() ) {
+			blockLocator = `//XCUIElementTypeButton[@name="${ accessibilityId }"]`;
+		}
+		return await this.driver.elementByXPath( blockLocator );
+	}
+
+	async getUnsupportedBlockWebView() {
+		let blockLocator = '//android.webkit.WebView';
+
+		if ( ! isAndroid() ) {
+			blockLocator = '//XCUIElementTypeWebView';
+		}
+
+		this.driver.setImplicitWaitTimeout( 20000 );
+		const element = await this.driver.elementByXPath( blockLocator );
+		this.driver.setImplicitWaitTimeout( 5000 );
+		return element;
 	}
 }


### PR DESCRIPTION

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
After the unsupported block editor was enabled on all mobile builds, this PR adds UI tests to ensure the functionality is working as expected. (This [couldn't be added before editor was made available on non-dev builds](https://github.com/wordpress-mobile/gutenberg-mobile/pull/2345#issuecomment-646843978).)

The UI tests check:
- That tapping on the help button of an unsupported block shows the bottom sheet. 
- That tapping on the edit button in the bottom sheet shows the unsupported block web view editor.

## How has this been tested?
I've ran the tests locally and visually verified that the UI test runs as described above. Also, if all tests pass on this PR, these tests have succeeded. 

To check on iOS locally, from inside the `gutenberg` folder, run:
```
npm run native test:e2e:ios:local __device-tests__/gutenberg-editor-unsupported-blocks.test.js
```

To check on Android locally, from inside the `gutenberg` folder, run:
```
npm run native test:e2e:android:local __device-tests__/gutenberg-editor-unsupported-blocks.test.js
```

## Screenshots <!-- if applicable -->

| Android | iOS |
| -- | -- |
| <img width="250" src="https://user-images.githubusercontent.com/1898325/83586559-cae59e00-a51a-11ea-82cf-b7f200699014.gif"> | <img width="250" src="https://user-images.githubusercontent.com/1898325/83586573-d769f680-a51a-11ea-8ae5-a6616b3b5d40.gif"> |

## Types of changes
This PR only adds UI tests.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
