### PR TITLE
Navigation screen: Add .editor-styles-wrapper

### DIFF
--- a/packages/edit-navigation/src/components/navigation-editor/block-editor-area.js
+++ b/packages/edit-navigation/src/components/navigation-editor/block-editor-area.js
@@ -113,11 +113,13 @@ export default function BlockEditorArea( {
 					) }
 				</NavigableToolbar>
 				<Popover.Slot name="block-toolbar" />
-				<WritingFlow>
-					<ObserveTyping>
-						<BlockList />
-					</ObserveTyping>
-				</WritingFlow>
+				<div className="editor-styles-wrapper">
+					<WritingFlow>
+						<ObserveTyping>
+							<BlockList />
+						</ObserveTyping>
+					</WritingFlow>
+				</div>
 			</CardBody>
 			<CardFooter>
 				<CheckboxControl


### PR DESCRIPTION
Follows https://github.com/WordPress/gutenberg/pull/22656.
Fixes bug described in https://github.com/WordPress/gutenberg/pull/22656#pullrequestreview-420622082.

Surrounds the Navigation screen's `BlockList` with a `.editor-styles-wrapper`. This is [what is suggested in the docs](https://developer.wordpress.org/block-editor/developers/platform/custom-block-editor/tutorial/#understanding-the-render).

Doing this allows CSS rules which attempt to override default block styling to work in the Navigation screen. This includes the `margin: 0` which fixes the issue described in https://github.com/WordPress/gutenberg/pull/22656#pullrequestreview-420622082:

https://github.com/WordPress/gutenberg/blob/791be9711b2f8681e3a4979cd3c444e90ab11175/packages/block-library/src/navigation/editor.scss#L12-L14


**Before**

<img width="958" alt="Screen Shot 2020-07-07 at 17 03 47" src="https://user-images.githubusercontent.com/612155/86734952-be9eb480-c075-11ea-9e80-0a84a2827e46.png">

**After**

<img width="960" alt="Screen Shot 2020-07-07 at 17 03 21" src="https://user-images.githubusercontent.com/612155/86734982-c2cad200-c075-11ea-9ad7-d8951f472431.png">