### PR TITLE
Block Navigation: Use quick inserter

### DIFF
--- a/packages/block-editor/src/components/block-navigation/appender.js
+++ b/packages/block-editor/src/components/block-navigation/appender.js
@@ -50,6 +50,7 @@ export default function BlockNavigationAppender( {
 						/>
 						<Inserter
 							rootClientId={ parentBlockClientId }
+							__experimentalIsQuick
 							__experimentalSelectBlockOnInsert={ false }
 							aria-describedby={ descriptionId }
 							toggleProps={ { ref, tabIndex, onFocus } }

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -27,6 +27,7 @@ import { speak } from '@wordpress/a11y';
  * @return {Array} Insertion Point State (rootClientID, onInsertBlocks and onToggle).
  */
 function useInsertionPoint( {
+	onSelect,
 	rootClientId,
 	clientId,
 	isAppender,
@@ -115,6 +116,10 @@ function useInsertionPoint( {
 				blocks.length
 			);
 			speak( message );
+		}
+
+		if ( onSelect ) {
+			onSelect();
 		}
 	};
 

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -128,6 +128,7 @@ class Inserter extends Component {
 		if ( isQuick ) {
 			return (
 				<QuickInserter
+					onSelect={ onClose }
 					rootClientId={ rootClientId }
 					clientId={ clientId }
 					isAppender={ isAppender }

--- a/packages/block-editor/src/components/inserter/quick-inserter.js
+++ b/packages/block-editor/src/components/inserter/quick-inserter.js
@@ -107,6 +107,7 @@ function QuickInserterList( {
 }
 
 function QuickInserter( {
+	onSelect,
 	rootClientId,
 	clientId,
 	isAppender,
@@ -119,6 +120,7 @@ function QuickInserter( {
 		onInsertBlocks,
 		onToggleInsertionPoint,
 	] = useInsertionPoint( {
+		onSelect,
 		rootClientId,
 		clientId,
 		isAppender,

--- a/packages/block-editor/src/components/inserter/quick-inserter.js
+++ b/packages/block-editor/src/components/inserter/quick-inserter.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { orderBy } from 'lodash';
+import classnames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -152,7 +153,7 @@ function QuickInserter( {
 		[ filterValue, patterns ]
 	);
 
-	const setInsererIsOpened = useSelect(
+	const setInserterIsOpened = useSelect(
 		( select ) =>
 			select( 'core/block-editor' ).getSettings()
 				.__experimentalSetIsInserterOpened,
@@ -160,10 +161,10 @@ function QuickInserter( {
 	);
 
 	useEffect( () => {
-		if ( setInsererIsOpened ) {
-			setInsererIsOpened( false );
+		if ( setInserterIsOpened ) {
+			setInserterIsOpened( false );
 		}
-	}, [ setInsererIsOpened ] );
+	}, [ setInserterIsOpened ] );
 
 	// Announce search results on change
 	useEffect( () => {
@@ -187,7 +188,10 @@ function QuickInserter( {
 	/* eslint-disable jsx-a11y/no-autofocus, jsx-a11y/no-static-element-interactions */
 	return (
 		<div
-			className="block-editor-inserter__quick-inserter"
+			className={ classnames( 'block-editor-inserter__quick-inserter', {
+				'has-search': showSearch,
+				'has-expand': setInserterIsOpened,
+			} ) }
 			onKeyPress={ stopKeyPropagation }
 			onKeyDown={ preventArrowKeysPropagation }
 		>
@@ -208,10 +212,10 @@ function QuickInserter( {
 				onHover={ onToggleInsertionPoint }
 			/>
 
-			{ setInsererIsOpened && (
+			{ setInserterIsOpened && (
 				<Button
 					className="block-editor-inserter__quick-inserter-expand"
-					onClick={ () => setInsererIsOpened( true ) }
+					onClick={ () => setInserterIsOpened( true ) }
 					aria-label={ __(
 						'Browse all. This will open the main inserter panel in the editor toolbar.'
 					) }

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -274,14 +274,14 @@ $block-inserter-tabs-height: 44px;
 	}
 }
 
-.block-editor-inserter__quick-inserter-results {
-	padding-bottom: $grid-unit-20;
+.block-editor-inserter__quick-inserter-results .block-editor-inserter__panel-header {
+	height: 0;
+	padding: 0;
+	float: left;
+}
 
-	.block-editor-inserter__panel-header {
-		height: 0;
-		padding: 0;
-		float: left;
-	}
+.block-editor-inserter__quick-inserter:not(.has-search):not(.has-expand) .block-editor-inserter__panel-content {
+	padding: 0 $grid-unit-10;
 }
 
 .block-editor-inserter__quick-inserter-patterns {
@@ -305,6 +305,7 @@ $block-inserter-tabs-height: 44px;
 	width: 100%;
 	height: ($button-size + $grid-unit-10);
 	border-radius: 0;
+	margin-top: $grid-unit-20;
 
 	&:hover {
 		color: $white;

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -280,8 +280,13 @@ $block-inserter-tabs-height: 44px;
 	float: left;
 }
 
-.block-editor-inserter__quick-inserter:not(.has-search):not(.has-expand) .block-editor-inserter__panel-content {
+.block-editor-inserter__quick-inserter .block-editor-inserter__panel-content {
 	padding: 0 $grid-unit-10;
+}
+
+.block-editor-inserter__quick-inserter.has-search .block-editor-inserter__panel-content,
+.block-editor-inserter__quick-inserter.has-expand .block-editor-inserter__panel-content {
+	padding: 0 $grid-unit-20;
 }
 
 .block-editor-inserter__quick-inserter-patterns {


### PR DESCRIPTION
Updates the Block Navigation component to use the quick inserter added in https://github.com/WordPress/gutenberg/pull/22789.

This removes the superfluous category labels and search field when adding a block using Block Navigation in the Navigation screen. It also creates consistency between the two ways to insert blocks on this screen.

Block Navigation in the regular block editor is unaffected by these changes as it does not let you add blocks.

**Before**

<img width="403" alt="Screen Shot 2020-07-07 at 17 38 50" src="https://user-images.githubusercontent.com/612155/86738842-c14ed900-c078-11ea-9e36-47885aacbf1f.png">

**After**

<img width="408" alt="Screen Shot 2020-07-07 at 17 38 30" src="https://user-images.githubusercontent.com/612155/86738850-c3189c80-c078-11ea-88dc-f3dca395368b.png">