### PR TITLE
Add more space for german.

### DIFF
--- a/packages/edit-post/src/components/sidebar/post-schedule/style.scss
+++ b/packages/edit-post/src/components/sidebar/post-schedule/style.scss
@@ -5,7 +5,7 @@
 
 	span {
 		display: block;
-		width: 35%;
+		width: 45%;
 	}
 }
 

--- a/packages/edit-post/src/components/sidebar/post-visibility/style.scss
+++ b/packages/edit-post/src/components/sidebar/post-visibility/style.scss
@@ -4,7 +4,7 @@
 
 	span {
 		display: block;
-		width: 35%;
+		width: 45%;
 	}
 }
 


### PR DESCRIPTION
Fixes #23724 

I've increased the width to allow more space for the labels.
<img width="299" alt="Screenshot 2020-07-07 at 09 41 10" src="https://user-images.githubusercontent.com/1204802/86739379-21705b80-c036-11ea-9d85-4f418fbc50bf.png">
