### PR TITLE
Improve the togglecontrol documentation

### DIFF
--- a/packages/components/src/toggle-control/README.md
+++ b/packages/components/src/toggle-control/README.md
@@ -6,6 +6,9 @@ ToggleControl is used to generate a toggle user interface.
 ## Usage
 
 Render a user interface to change fixed background setting.
+
+Here is an example using local state:
+
 ```jsx
 import { ToggleControl } from '@wordpress/components';
 import { withState } from '@wordpress/compose';
@@ -20,6 +23,38 @@ const MyToggleControl = withState( {
 		onChange={ () => setState( ( state ) => ( { hasFixedBackground: ! state.hasFixedBackground } ) ) }
 	/>
 ) );
+```
+
+To use this inside a block to toggle a saveable value, use block attributes, e.g.
+
+```jsx
+import { registerBlockType } from '@wordpress/blocks';
+import { ToggleControl } from '@wordpress/components';
+
+registerBlockType( 'example/toggle', {
+	title: __( 'Example: Toggle Block', 'gutenberg-examples' ),
+	icon: 'universal-access-alt',
+	category: 'layout',
+	edit( { attributes, setAttributes } ) {
+		function onChange( event ) {
+			setAttributes( { toggleValue: !attributes.toggleValue } );
+		}
+
+		return (
+			<ToggleControl
+				label="Example Toggle"
+				help={ attributes.toggleValue ? 'Toggle is on' : 'Toggle is off' }
+				checked={ attributes.toggleValue }
+				onChange={ onChange }
+			/>
+		);
+	},
+	save( { attributes } ) {
+		return (
+			<p>{ attributes.toggleValue ? 'Toggle is on' : 'Toggle is off' }</p>
+		);
+	},
+} );
 ```
 
 ## Props

--- a/packages/components/src/toggle-control/README.md
+++ b/packages/components/src/toggle-control/README.md
@@ -1,31 +1,30 @@
 # ToggleControl
 
-ToggleControl is used to generate a toggle user interface.
+This component implements a standalone toggle user interface `ToggleControl` is used to generate a toggle user interface.
 
 
-## Usage
+## Example Usage
+
+### With `useState`
 
 Render a user interface to change fixed background setting.
 
-Here is an example using local state:
-
 ```jsx
+import React, { useState } from 'react';
 import { ToggleControl } from '@wordpress/components';
-import { withState } from '@wordpress/compose';
 
-const MyToggleControl = withState( {
-	hasFixedBackground: false,
-} )( ( { hasFixedBackground, setState } ) => (
-	<ToggleControl
-		label="Fixed Background"
-		help={ hasFixedBackground ? 'Has fixed background.' : 'No fixed background.' }
-		checked={ hasFixedBackground }
-		onChange={ () => setState( ( state ) => ( { hasFixedBackground: ! state.hasFixedBackground } ) ) }
-	/>
-) );
+const MyToggleControl = ( ) => {
+	const [ checked, setChecked ] = useState( false );
+	return <ToggleControl
+		label="Toggle control label"
+		help={ checked ? 'Is active.' : 'Is not active.' }
+		checked={ checked }
+		onChange={ () => setChecked( !checked ) }
+	/>;
+};
 ```
 
-To use this inside a block to toggle a saveable value, use block attributes, e.g.
+### Inside a WP Block
 
 ```jsx
 import { registerBlockType } from '@wordpress/blocks';
@@ -36,16 +35,12 @@ registerBlockType( 'example/toggle', {
 	icon: 'universal-access-alt',
 	category: 'layout',
 	edit( { attributes, setAttributes } ) {
-		function onChange( event ) {
-			setAttributes( { toggleValue: !attributes.toggleValue } );
-		}
-
 		return (
 			<ToggleControl
 				label="Example Toggle"
 				help={ attributes.toggleValue ? 'Toggle is on' : 'Toggle is off' }
 				checked={ attributes.toggleValue }
-				onChange={ onChange }
+				onChange={ () => setAttributes( { toggleValue: !attributes.toggleValue } ) }
 			/>
 		);
 	},


### PR DESCRIPTION
## Description

Closes #23740 by documenting how to use the control inside a block

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
