### PR TITLE
Image Edit endpoint: Load remote image if local not present

### DIFF
--- a/lib/class-wp-rest-image-editor-controller.php
+++ b/lib/class-wp-rest-image-editor-controller.php
@@ -147,7 +147,15 @@ class WP_REST_Image_Editor_Controller extends WP_REST_Controller {
 			return new WP_Error( 'rest_image_not_edited', $error, array( 'status' => 400 ) );
 		}
 
-		$image_editor = wp_get_image_editor( $image_file );
+		// If the file doesn't exist, attempt a URL fopen on the src link.
+		// This can occur with certain file replication plugins.
+		// Keep the original file path to get a modified name later.
+		$image_file_to_edit = $image_file;
+		if ( ! file_exists( $image_file_to_edit ) ) {
+			$image_file_to_edit = _load_image_to_edit_path( $attachment_id );
+		}
+
+		$image_editor = wp_get_image_editor( $image_file_to_edit );
 
 		if ( is_wp_error( $image_editor ) ) {
 			// This image cannot be edited.


### PR DESCRIPTION
## Description

Fixes https://github.com/WordPress/gutenberg/issues/23686

Inspired by existing core functionality:
https://github.com/WordPress/wordpress-develop/blob/88c91eeaa6ab8d73bb3f5b301f9a0faf41e8e3e2/src/wp-admin/includes/image.php#L27-L37

Changes originally introduced to handle this case in:
https://core.trac.wordpress.org/changeset/20384

## How has this been tested?

Manual test via wp-env (no change on typical install).
Manually tested on system that manifests https://github.com/WordPress/gutenberg/issues/23686.

I've tested via the Image block:
- Add an image block.
- Modify the zoom and position of the iamge.
- Apply the changes.
- The new image is correctly created and shown in the block.

## Types of changes

Bug fix:

FIxes https://github.com/WordPress/gutenberg/issues/23686, where images not on the local filesystem cannot be edited.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
