### PR TITLE
Tool Selector: Render the edit icon as an Icon component

### DIFF
--- a/packages/block-editor/src/components/tool-selector/index.js
+++ b/packages/block-editor/src/components/tool-selector/index.js
@@ -12,7 +12,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { forwardRef } from '@wordpress/element';
-import { edit as editIcon } from '@wordpress/icons';
+import { Icon, edit as editIcon } from '@wordpress/icons';
 
 const selectIcon = (
 	<SVG
@@ -60,7 +60,7 @@ function ToolSelector( props, ref ) {
 									value: 'edit',
 									label: (
 										<>
-											{ editIcon }
+											<Icon icon={ editIcon } />
 											{ __( 'Edit' ) }
 										</>
 									),


### PR DESCRIPTION
## Description

Currently, the edit icon in the Tool Selector is rendered as a simple SVG element without size attributes, which makes it show up at an incorrect size.
This PR renders the icon through the Icon component, which automatically takes care of the size.

## How has this been tested?

Tested with wp-env on both Firefox 78 and Chrome 83 on macOS 10.15.5.

## Screenshots

| Before | After |
| - | - |
| <img width="309" alt="Screenshot 2020-07-07 at 12 25 08" src="https://user-images.githubusercontent.com/2070010/86773619-bcc0fb00-c04d-11ea-8f22-19bdf6f3945d.png"> | <img width="310" alt="Screenshot 2020-07-07 at 12 24 45" src="https://user-images.githubusercontent.com/2070010/86773634-bfbbeb80-c04d-11ea-9978-cf0e2f2bcf63.png"> |

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
