### PR TITLE
apply the reset mixin to the inserter panel

### DIFF
--- a/packages/block-editor/src/components/block-preview/style.scss
+++ b/packages/block-editor/src/components/block-preview/style.scss
@@ -13,6 +13,7 @@
 	// Overrides the default padding applied in editor styles otherwise preview centering break.
 	&.editor-styles-wrapper {
 		padding: 0;
+		margin: 0;
 	}
 }
 

--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -57,7 +57,8 @@ body.block-editor-page {
 .edit-post-sidebar,
 .editor-post-publish-panel,
 .components-popover,
-.components-modal__frame {
+.components-modal__frame,
+.edit-post-layout__inserter-panel {
 	@include reset;
 }
 


### PR DESCRIPTION
closes #23720 

Ideally the theme editor styles shouldn't depend on global resets like this but this makes it consistent in the editor regardless.

**testing instructions**

- Make sure the patterns are centered properly on the inserter panel on 2019