### PR TITLE
Fix duplicated patterns list

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -640,23 +640,8 @@ function gutenberg_load_block_pattern( $name ) {
  * @return array Filtered editor settings.
  */
 function gutenberg_extend_settings_block_patterns( $settings ) {
-	if ( empty( $settings['__experimentalBlockPatterns'] ) ) {
-		$settings['__experimentalBlockPatterns'] = array();
-	}
-
-	$settings['__experimentalBlockPatterns'] = array_merge(
-		WP_Block_Patterns_Registry::get_instance()->get_all_registered(),
-		$settings['__experimentalBlockPatterns']
-	);
-
-	if ( empty( $settings['__experimentalBlockPatternCategories'] ) ) {
-		$settings['__experimentalBlockPatternCategories'] = array();
-	}
-
-	$settings['__experimentalBlockPatternCategories'] = array_merge(
-		WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered(),
-		$settings['__experimentalBlockPatternCategories']
-	);
+	$settings['__experimentalBlockPatterns']          = WP_Block_Patterns_Registry::get_instance()->get_all_registered();
+	$settings['__experimentalBlockPatternCategories'] = WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered();
 
 	return $settings;
 }


### PR DESCRIPTION
Now that the patterns API is on Core, the previous implementation of the `gutenberg_extend_settings_block_patterns` hook on the plugin was resulting on the patterns being duplicated. The hook is still needed for folks using the plugin with WP 5.4 and before. 

**Testing instructions**

 - Run the Gutenberg plugin + WordPress trunk
 - Make sure the patterns are not duplicated.
