### PR TITLE
Link to theme-experiments repo in block-based theme documentation.

### DIFF
--- a/docs/designers-developers/developers/themes/block-based-themes.md
+++ b/docs/designers-developers/developers/themes/block-based-themes.md
@@ -96,3 +96,4 @@ One of the most important aspects of themes (if not the most important) is the s
 ## Resources
 
 - [Full Site Editing](https://github.com/WordPress/gutenberg/labels/%5BFeature%5D%20Full%20Site%20Editing) label.
+- [Theme Experiments](https://github.com/WordPress/theme-experiments) repository, full of block-based theme examples created by the WordPress community.


### PR DESCRIPTION
As per a discussion in [last week's Block-based Themes meeting](https://make.wordpress.org/themes/2020/07/02/block-based-theme-meeting-notes-1-july-2020/), this PR adds a Theme Experiments repository link to the Block-based Themes documentation.