### PR TITLE
Lazy Import: Allow local paths as an option when importing

### DIFF
--- a/packages/is-shallow-equal/benchmark/index.js
+++ b/packages/is-shallow-equal/benchmark/index.js
@@ -26,23 +26,8 @@ Promise.all( [
 	lazyImport( 'shallow-equal@^1.2.1' ),
 	lazyImport( 'is-equal-shallow@^0.1.3' ),
 	lazyImport( 'shallow-equals@^1.0.0' ),
-	new Promise( async ( resolve ) => {
-		try {
-			await lazyImport( 'fbjs@^1.0.0' );
-		} catch ( error ) {
-			// The fjbs package throws an error when imported directly. Since
-			// lazyImport will automatically require the module for the resolved
-			// value, anticipate and disregard the error, as long as it's the
-			// expected error message.
-			if (
-				'The fbjs package should not be required without a full path.' !==
-				error.message
-			) {
-				throw error;
-			}
-		}
-
-		resolve( require( 'fbjs/lib/shallowEqual' ) );
+	lazyImport( 'fbjs@^1.0.0', {
+		localPath: './lib/shallowEqual',
 	} ),
 ] ).then(
 	( [

--- a/packages/lazy-import/CHANGELOG.md
+++ b/packages/lazy-import/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Feature
+
+-   Allow local paths as an option when trying to import a specific file from the package ([#23751](https://github.com/WordPress/gutenberg/pull/23751)).
+
 ## 1.0.0 (2020-06-15)
 
-- Initial release.
+-   Initial release.

--- a/packages/lazy-import/README.md
+++ b/packages/lazy-import/README.md
@@ -52,7 +52,10 @@ function onInstall() {
 	console.log( 'Installing…' );
 }
 
-lazyImport( 'is-equal-shallow@^0.1.3', { onInstall } ).then( /* ... */ );
+lazyImport( 'fbjs@^1.0.0', {
+	localPath: './lib/shallowEqual',
+	onInstall,
+} ).then(/* ... */);
 ```
 
 Note that `lazyImport` can throw an error when offline and unable to install the dependency using NPM. You may want to anticipate this and provide remediation steps for a failed install, such as logging a warning messsage:
@@ -69,10 +72,17 @@ try {
 
 ### Options
 
+#### `localPath`
+
+-   Type: `string`
+-   Required: No
+
+Local path pointing to a file or directory that can be used when other script that `main` needs to be imported.
+
 #### `onInstall`
 
-- Type: `Function`
-- Required: No
+-   Type: `Function`
+-   Required: No
 
 Function to call if and when the module is being installed. Since installation can cause a delay in script execution, this can be useful to output logging information or display a spinner.
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

A try to unblock #23712 where we want to add support for external templates installed from npm in `@wordpress/create-block`.

We miss a way to lazy import a local path from a package. It was only possible to import the script listed as `main` by the package.

This PR adds a new option `localPath` that allows importing files other than those listed as `main` for the package.

## How has this been tested?

```sh
$ rm -rf node_modules
$ npm install
$ node packages/is-shallow-equal/benchmark/index.js`
```

Should run all the benchmarks on the `@wordpress/is-shallow-equal` package.

## Types of changes
New feature (non-breaking change which adds functionality).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [N/A] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
