### PR TITLE
Refactor more block

### DIFF
--- a/packages/block-library/src/more/edit.js
+++ b/packages/block-library/src/more/edit.js
@@ -10,7 +10,9 @@ import { getDefaultBlockName, createBlock } from '@wordpress/blocks';
 const DEFAULT_TEXT = __( 'Read more' );
 
 export default function MoreEdit( {
-	// we provide a default value as previously we allowed to save `undefined`, even though it wasn't clear to the UI
+	// Before refactoring we allowed saving empty customText with an `undefined` value
+	// but we misleadingly were showing the DEFAULT_TEXT.
+	// So for backwards compatibility we set the same Default value to custom text.
 	attributes: { customText = DEFAULT_TEXT, noTeaser },
 	insertBlocksAfter,
 	setAttributes,

--- a/packages/block-library/src/more/edit.js
+++ b/packages/block-library/src/more/edit.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { PanelBody, ToggleControl } from '@wordpress/components';
+import { useState } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/block-editor';
 import { ENTER } from '@wordpress/keycodes';
 import { getDefaultBlockName, createBlock } from '@wordpress/blocks';
@@ -10,26 +11,21 @@ import { getDefaultBlockName, createBlock } from '@wordpress/blocks';
 const DEFAULT_TEXT = __( 'Read more' );
 
 export default function MoreEdit( {
-	// Before refactoring we allowed saving empty customText with an `undefined` value
-	// but we misleadingly were showing the DEFAULT_TEXT.
-	// So for backwards compatibility we set the same Default value to custom text.
-	attributes: { customText = DEFAULT_TEXT, noTeaser },
+	attributes: { customText, noTeaser },
 	insertBlocksAfter,
 	setAttributes,
 } ) {
+	const [ placeholder, setPlaceholder ] = useState( DEFAULT_TEXT );
+
 	const onChangeInput = ( event ) => {
-		setAttributes( { customText: event.target.value } );
+		// Set defaultText to an empty string, allowing the user to clear/replace the input field's text
+		setPlaceholder( '' );
+		setAttributes( { customText: event.target.value ?? undefined } );
 	};
 
 	const onKeyDown = ( { keyCode } ) => {
 		if ( keyCode === ENTER ) {
 			insertBlocksAfter( [ createBlock( getDefaultBlockName() ) ] );
-		}
-	};
-
-	const onBlur = () => {
-		if ( ! customText ) {
-			setAttributes( { customText: DEFAULT_TEXT } );
 		}
 	};
 
@@ -39,7 +35,8 @@ export default function MoreEdit( {
 			: __( 'The excerpt is visible.' );
 
 	const toggleHideExcerpt = () => setAttributes( { noTeaser: ! noTeaser } );
-	const style = { width: `${ customText.length + 1.2 }em` };
+	const value = customText || placeholder;
+	const style = { width: `${ value.length + 1.2 }em` };
 
 	return (
 		<>
@@ -58,10 +55,9 @@ export default function MoreEdit( {
 			<div className="wp-block-more">
 				<input
 					type="text"
-					value={ customText }
+					value={ value }
 					onChange={ onChangeInput }
 					onKeyDown={ onKeyDown }
-					onBlur={ onBlur }
 					style={ style }
 				/>
 			</div>

--- a/packages/block-library/src/more/edit.js
+++ b/packages/block-library/src/more/edit.js
@@ -3,82 +3,66 @@
  */
 import { __ } from '@wordpress/i18n';
 import { PanelBody, ToggleControl } from '@wordpress/components';
-import { Component } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/block-editor';
 import { ENTER } from '@wordpress/keycodes';
 import { getDefaultBlockName, createBlock } from '@wordpress/blocks';
 
-export default class MoreEdit extends Component {
-	constructor() {
-		super( ...arguments );
-		this.onChangeInput = this.onChangeInput.bind( this );
-		this.onKeyDown = this.onKeyDown.bind( this );
+const DEFAULT_TEXT = __( 'Read more' );
 
-		this.state = {
-			defaultText: __( 'Read more' ),
-		};
-	}
+export default function MoreEdit( {
+	// we provide a default value as previously we allowed to save `undefined`, even though it wasn't clear to the UI
+	attributes: { customText = DEFAULT_TEXT, noTeaser },
+	insertBlocksAfter,
+	setAttributes,
+} ) {
+	const onChangeInput = ( event ) => {
+		setAttributes( { customText: event.target.value } );
+	};
 
-	onChangeInput( event ) {
-		// Set defaultText to an empty string, allowing the user to clear/replace the input field's text
-		this.setState( {
-			defaultText: '',
-		} );
-
-		const value =
-			event.target.value.length === 0 ? undefined : event.target.value;
-		this.props.setAttributes( { customText: value } );
-	}
-
-	onKeyDown( event ) {
-		const { keyCode } = event;
-		const { insertBlocksAfter } = this.props;
+	const onKeyDown = ( { keyCode } ) => {
 		if ( keyCode === ENTER ) {
 			insertBlocksAfter( [ createBlock( getDefaultBlockName() ) ] );
 		}
-	}
+	};
 
-	getHideExcerptHelp( checked ) {
-		return checked
+	const onBlur = () => {
+		if ( ! customText ) {
+			setAttributes( { customText: DEFAULT_TEXT } );
+		}
+	};
+
+	const getHideExcerptHelp = ( checked ) =>
+		checked
 			? __( 'The excerpt is hidden.' )
 			: __( 'The excerpt is visible.' );
-	}
 
-	render() {
-		const { customText, noTeaser } = this.props.attributes;
-		const { setAttributes } = this.props;
+	const toggleHideExcerpt = () => setAttributes( { noTeaser: ! noTeaser } );
+	const style = { width: `${ customText.length + 1.2 }em` };
 
-		const toggleHideExcerpt = () =>
-			setAttributes( { noTeaser: ! noTeaser } );
-		const { defaultText } = this.state;
-		const value = customText !== undefined ? customText : defaultText;
-		const inputLength = value.length + 1.2;
-		const currentWidth = { width: inputLength + 'em' };
-
-		return (
-			<>
-				<InspectorControls>
-					<PanelBody>
-						<ToggleControl
-							label={ __(
-								'Hide the excerpt on the full content page'
-							) }
-							checked={ !! noTeaser }
-							onChange={ toggleHideExcerpt }
-							help={ this.getHideExcerptHelp }
-						/>
-					</PanelBody>
-				</InspectorControls>
-				<div className="wp-block-more">
-					<input
-						type="text"
-						value={ value }
-						onChange={ this.onChangeInput }
-						onKeyDown={ this.onKeyDown }
-						style={ currentWidth }
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody>
+					<ToggleControl
+						label={ __(
+							'Hide the excerpt on the full content page'
+						) }
+						checked={ !! noTeaser }
+						onChange={ toggleHideExcerpt }
+						help={ getHideExcerptHelp }
 					/>
-				</div>
-			</>
-		);
-	}
+				</PanelBody>
+			</InspectorControls>
+			<div className="wp-block-more">
+				<input
+					type="text"
+					value={ customText }
+					onChange={ onChangeInput }
+					onKeyDown={ onKeyDown }
+					onBlur={ onBlur }
+					style={ style }
+				/>
+			</div>
+		</>
+	);
 }

--- a/packages/block-library/src/more/edit.js
+++ b/packages/block-library/src/more/edit.js
@@ -20,7 +20,7 @@ export default function MoreEdit( {
 	const onChangeInput = ( event ) => {
 		// Set defaultText to an empty string, allowing the user to clear/replace the input field's text
 		setPlaceholder( '' );
-		setAttributes( { customText: event.target.value ?? undefined } );
+		setAttributes( { customText: event.target.value || undefined } );
 	};
 
 	const onKeyDown = ( { keyCode } ) => {
@@ -35,7 +35,7 @@ export default function MoreEdit( {
 			: __( 'The excerpt is visible.' );
 
 	const toggleHideExcerpt = () => setAttributes( { noTeaser: ! noTeaser } );
-	const value = customText || placeholder;
+	const value = customText ?? placeholder;
 	const style = { width: `${ value.length + 1.2 }em` };
 
 	return (

--- a/packages/block-library/src/more/save.js
+++ b/packages/block-library/src/more/save.js
@@ -8,9 +8,7 @@ import { compact } from 'lodash';
  */
 import { RawHTML } from '@wordpress/element';
 
-export default function save( { attributes } ) {
-	const { customText, noTeaser } = attributes;
-
+export default function save( { attributes: { customText, noTeaser } } ) {
 	const moreTag = customText ? `<!--more ${ customText }-->` : '<!--more-->';
 
 	const noTeaserTag = noTeaser ? '<!--noteaser-->' : '';

--- a/packages/block-library/src/more/test/__snapshots__/edit.js.snap
+++ b/packages/block-library/src/more/test/__snapshots__/edit.js.snap
@@ -16,7 +16,6 @@ exports[`core/more/edit should match snapshot when noTeaser is false 1`] = `
     className="wp-block-more"
   >
     <input
-      onBlur={[Function]}
       onChange={[Function]}
       onKeyDown={[Function]}
       style={
@@ -47,7 +46,6 @@ exports[`core/more/edit should match snapshot when noTeaser is true 1`] = `
     className="wp-block-more"
   >
     <input
-      onBlur={[Function]}
       onChange={[Function]}
       onKeyDown={[Function]}
       style={

--- a/packages/block-library/src/more/test/__snapshots__/edit.js.snap
+++ b/packages/block-library/src/more/test/__snapshots__/edit.js.snap
@@ -16,6 +16,7 @@ exports[`core/more/edit should match snapshot when noTeaser is false 1`] = `
     className="wp-block-more"
   >
     <input
+      onBlur={[Function]}
       onChange={[Function]}
       onKeyDown={[Function]}
       style={
@@ -46,6 +47,7 @@ exports[`core/more/edit should match snapshot when noTeaser is true 1`] = `
     className="wp-block-more"
   >
     <input
+      onBlur={[Function]}
       onChange={[Function]}
       onKeyDown={[Function]}
       style={


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This PR refactors `More` block to a function component.

Related https://github.com/WordPress/gutenberg/issues/22890


## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
