### PR TITLE
Mover control: Remove drag cursor.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -572,14 +572,6 @@
 		.components-button.has-icon.block-editor-block-mover-button.block-editor-block-mover-button {
 			min-width: $button-size;
 			width: $button-size;
-
-			[draggable="true"] & {
-				cursor: grab;
-
-				&:active {
-					cursor: grabbing;
-				}
-			}
 		}
 
 		&.is-horizontal .components-button.has-icon.block-editor-block-mover-button.block-editor-block-mover-button {

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -94,11 +94,6 @@
 .block-editor-block-toolbar__block-switcher-wrapper {
 	display: flex;
 
-	// Drag and drop is only enabled in contextual toolbars.
-	&:not([draggable="false"]) * {
-		cursor: grab;
-	}
-
 	.block-editor-block-switcher {
 		display: block;
 	}


### PR DESCRIPTION
This removes the grabbable cursor from the block mover control.

This addresses feedback from https://github.com/WordPress/gutenberg/issues/21935#issuecomment-654405787