### PR TITLE
Movers: Add bigger visible focus rectangle.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -550,6 +550,12 @@
 			&.is-down-button svg {
 				margin-bottom: 3px;
 			}
+
+			&:focus::before {
+				left: 0 !important;
+				min-width: 0;
+				width: calc(100% + #{ $border-width });
+			}
 		}
 	}
 }

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -554,7 +554,7 @@
 			&:focus::before {
 				left: 0 !important;
 				min-width: 0;
-				width: calc(100% + #{ $border-width });
+				width: 100%;
 			}
 		}
 	}

--- a/packages/block-editor/src/components/block-mover/style.scss
+++ b/packages/block-editor/src/components/block-mover/style.scss
@@ -47,7 +47,7 @@
 		// Focus style.
 		&::before {
 			bottom: 0;
-			height: 100%;
+			height: calc(100% - #{ $border-width });
 		}
 	}
 
@@ -60,7 +60,7 @@
 		// Focus style.
 		&::before {
 			top: 0;
-			height: 100%;
+			height: calc(100% - #{ $border-width });
 		}
 	}
 

--- a/packages/block-editor/src/components/block-mover/style.scss
+++ b/packages/block-editor/src/components/block-mover/style.scss
@@ -32,8 +32,8 @@
 		// Focus style.
 		// Overrides .components-toolbar-group styles
 		&::before {
-			left: $grid-unit-10 !important;
-			right: $grid-unit-10 !important;
+			left: 0 !important;
+			right: 0 !important;
 		}
 	}
 
@@ -47,7 +47,7 @@
 		// Focus style.
 		&::before {
 			bottom: 0;
-			height: calc(100% - #{ $grid-unit-10 });
+			height: 100%;
 		}
 	}
 
@@ -60,7 +60,7 @@
 		// Focus style.
 		&::before {
 			top: 0;
-			height: calc(100% - #{ $grid-unit-10 });
+			height: 100%;
 		}
 	}
 
@@ -76,8 +76,8 @@
 
 			// Focus style.
 			&::before {
-				top: $grid-unit-10;
-				bottom: $grid-unit-10;
+				top: 0;
+				bottom: 0;
 				min-width: 0;
 				width: auto;
 				height: auto;
@@ -95,7 +95,7 @@
 			// Focus style.
 			// Overrides .components-toolbar-group styles
 			&::before {
-				left: $grid-unit-10 !important;
+				left: 0 !important;
 				right: 0 !important;
 			}
 		}
@@ -111,7 +111,8 @@
 			// Overrides .components-toolbar-group styles
 			&::before {
 				left: 0 !important;
-				right: $grid-unit-10 !important;
+				right: 0 !important;
+				width: calc(100% + #{ $border-width });
 			}
 		}
 	}


### PR DESCRIPTION
This PR makes the focus rectangle the same size as the button itself. This is a purely visual change.

This addresses feedback from https://github.com/WordPress/gutenberg/issues/21935#issuecomment-654405787.

Before:

<img width="399" alt="focus-before" src="https://user-images.githubusercontent.com/1204802/86791837-39fa6900-c06a-11ea-8b16-2fe172edaa04.png">

After:

<img width="815" alt="focus-after" src="https://user-images.githubusercontent.com/1204802/86791894-41ba0d80-c06a-11ea-943e-634381179add.png">

<img width="549" alt="focus-after-hoz" src="https://user-images.githubusercontent.com/1204802/86791940-47175800-c06a-11ea-8695-b0e6dececedd.png">
