### PR TITLE
Change references to section back to template part

### DIFF
--- a/packages/block-library/src/template-part/edit/placeholder/index.js
+++ b/packages/block-library/src/template-part/edit/placeholder/index.js
@@ -22,7 +22,7 @@ import TemplatePartPreviews from './template-part-previews';
 export default function TemplatePartPlaceholder( { setAttributes } ) {
 	const { saveEntityRecord } = useDispatch( 'core' );
 	const onCreate = useCallback( async () => {
-		const title = 'Untitled Section';
+		const title = 'Untitled Template Part';
 		const slug = cleanForSlug( title );
 		const templatePart = await saveEntityRecord(
 			'postType',
@@ -45,9 +45,9 @@ export default function TemplatePartPlaceholder( { setAttributes } ) {
 	return (
 		<Placeholder
 			icon={ blockDefault }
-			label={ __( 'Section' ) }
+			label={ __( 'Template Part' ) }
 			instructions={ __(
-				'Create a new section or pick one from a list of available sections.'
+				'Create a new template part or pick an existing one from the list.'
 			) }
 		>
 			<Dropdown
@@ -63,7 +63,7 @@ export default function TemplatePartPlaceholder( { setAttributes } ) {
 							{ __( 'Choose existing' ) }
 						</Button>
 						<Button onClick={ onCreate }>
-							{ __( 'New section' ) }
+							{ __( 'New template part' ) }
 						</Button>
 					</ButtonGroup>
 				) }

--- a/packages/block-library/src/template-part/index.js
+++ b/packages/block-library/src/template-part/index.js
@@ -18,7 +18,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Section' ),
+	title: __( 'Template Part' ),
 	keywords: [ __( 'template part' ) ],
 	__experimentalLabel: ( { slug } ) => startCase( slug ),
 	edit,

--- a/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
@@ -52,9 +52,9 @@ const createTemplatePart = async (
 	isNested = false
 ) => {
 	// Create new template part.
-	await insertBlock( 'Section' );
+	await insertBlock( 'Template Part' );
 	const [ createNewButton ] = await page.$x(
-		'//button[contains(text(), "New section")]'
+		'//button[contains(text(), "New template part")]'
 	);
 	await createNewButton.click();
 	await page.waitForSelector(

--- a/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
@@ -24,7 +24,8 @@ describe( 'Multi-entity save flow', () => {
 	const activatedTemplatePartSelector = `${ templatePartSelector } .block-editor-inner-blocks`;
 	const savePanelSelector = '.entities-saved-states__panel';
 	const closePanelButtonSelector = 'button[aria-label="Close panel"]';
-	const createNewButtonSelector = '//button[contains(text(), "New section")]';
+	const createNewButtonSelector =
+		'//button[contains(text(), "New template part")]';
 
 	// Reusable assertions across Post/Site editors.
 	const assertAllBoxesChecked = async () => {
@@ -108,7 +109,7 @@ describe( 'Multi-entity save flow', () => {
 
 			it( 'Should trigger multi-entity save button once template part edited', async () => {
 				// Create new template part.
-				await insertBlock( 'Section' );
+				await insertBlock( 'Template Part' );
 				const [ createNewButton ] = await page.$x(
 					createNewButtonSelector
 				);
@@ -234,7 +235,7 @@ describe( 'Multi-entity save flow', () => {
 			await demoTemplateButton.click();
 
 			// Insert a new template part placeholder.
-			await insertBlock( 'Section' );
+			await insertBlock( 'Template Part' );
 
 			const enabledButton = await page.waitForSelector(
 				activeSaveSiteSelector

--- a/packages/e2e-tests/specs/experiments/template-part.test.js
+++ b/packages/e2e-tests/specs/experiments/template-part.test.js
@@ -90,7 +90,7 @@ describe( 'Template Part', () => {
 		const activatedTemplatePartSelector = `${ templatePartSelector } .block-editor-inner-blocks`;
 		const testContentSelector = `//p[contains(., "${ testContent }")]`;
 		const createNewButtonSelector =
-			'//button[contains(text(), "New section")]';
+			'//button[contains(text(), "New template part")]';
 		const chooseExistingButtonSelector =
 			'//button[contains(text(), "Choose existing")]';
 
@@ -98,7 +98,7 @@ describe( 'Template Part', () => {
 			await createNewPost();
 			await disablePrePublishChecks();
 			// Create new template part.
-			await insertBlock( 'Section' );
+			await insertBlock( 'Template Part' );
 			const [ createNewButton ] = await page.$x(
 				createNewButtonSelector
 			);
@@ -120,7 +120,7 @@ describe( 'Template Part', () => {
 		it( 'Should preview newly added template part', async () => {
 			await createNewPost();
 			// Try to insert the template part we created.
-			await insertBlock( 'Section' );
+			await insertBlock( 'Template Part' );
 			const [ chooseExistingButton ] = await page.$x(
 				chooseExistingButtonSelector
 			);


### PR DESCRIPTION
## Description
This resolves #23657, changing the "section" block back to "template part". I mostly followed #23295 to see which files had been change to use "section". Let me know if there are further changes to make; this is everything I could find so far!


## How has this been tested?
Locally, in edit site. Additionally, e2e tests have been updated and should pass.

## Screenshots <!-- if applicable -->

## Types of changes
Rename a term.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
