### PR TITLE
Env: Add breaking change to changelog

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   The `config` and `mappings` options in `.wp-env.json` are now merged with any overrides instead of being overwritten.
+
 ### New Feature
 
 -   You may now specify specific configuration for different environments using `env.tests` or `env.development` in `.wp-env.json`.
-
-### Bug Fixes
-
--   The `config` and `mappings` options in `.wp-env.json` are now merged with any overrides instead of being overwritten.
 
 ## 1.6.0-rc.0 (2020-06-24)
 

--- a/packages/env/lib/config/test/__snapshots__/config.js.snap
+++ b/packages/env/lib/config/test/__snapshots__/config.js.snap
@@ -1,5 +1,56 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`readConfig config file should match snapshot 1`] = `
+Object {
+  "configDirectoryPath": ".",
+  "env": Object {
+    "development": Object {
+      "config": Object {
+        "SCRIPT_DEBUG": true,
+        "TEST": 100,
+        "TEST_VAL1": 1,
+        "TEST_VAL2": "hello",
+        "TEST_VAL3": false,
+        "WP_DEBUG": true,
+        "WP_HOME": "http://localhost:2000/",
+        "WP_PHP_BINARY": "php",
+        "WP_SITEURL": "http://localhost:2000/",
+        "WP_TESTS_DOMAIN": "http://localhost:2000/",
+        "WP_TESTS_EMAIL": "admin@example.org",
+        "WP_TESTS_TITLE": "Test Blog",
+      },
+      "coreSource": null,
+      "mappings": Object {},
+      "pluginSources": Array [],
+      "port": 2000,
+      "themeSources": Array [],
+    },
+    "tests": Object {
+      "config": Object {
+        "SCRIPT_DEBUG": false,
+        "TEST": 200,
+        "TEST_VAL1": 1,
+        "TEST_VAL2": "hello",
+        "TEST_VAL3": false,
+        "WP_DEBUG": false,
+        "WP_HOME": "http://localhost:1000/",
+        "WP_PHP_BINARY": "php",
+        "WP_SITEURL": "http://localhost:1000/",
+        "WP_TESTS_DOMAIN": "http://localhost:1000/",
+        "WP_TESTS_EMAIL": "admin@example.org",
+        "WP_TESTS_TITLE": "Test Blog",
+      },
+      "coreSource": null,
+      "mappings": Object {},
+      "pluginSources": Array [],
+      "port": 1000,
+      "themeSources": Array [],
+    },
+  },
+  "name": ".",
+}
+`;
+
 exports[`readConfig wp config values should use default config values 1`] = `
 Object {
   "SCRIPT_DEBUG": false,

--- a/packages/env/lib/config/test/config.js
+++ b/packages/env/lib/config/test/config.js
@@ -155,6 +155,41 @@ describe( 'readConfig', () => {
 				true
 			);
 		} );
+
+		it( 'should match snapshot', async () => {
+			// Note: did not add sources to this config because they include absolute
+			// paths which would be different elsewhere.
+			readFile.mockImplementation( () =>
+				Promise.resolve(
+					JSON.stringify( {
+						port: 2000,
+						config: {
+							TEST_VAL1: 1,
+							TEST_VAL2: 'hello',
+							TEST_VAL3: false,
+						},
+						env: {
+							development: {
+								config: {
+									TEST: 100,
+								},
+							},
+							tests: {
+								port: 1000,
+								config: {
+									TEST: 200,
+								},
+							},
+						},
+					} )
+				)
+			);
+			const config = await readConfig( '.wp-env.json' );
+			// Remove generated values which are different on other machines.
+			delete config.dockerComposeConfigPath;
+			delete config.workDirectoryPath;
+			expect( config ).toMatchSnapshot();
+		} );
 	} );
 
 	describe( 'source parsing', () => {


### PR DESCRIPTION
## Description
Mark fix where config/mappings values are merged as a breaking change in the changelog. Add tests commit which I forgot about locally.

## How has this been tested?
Locally in wp-env, unit tests.

## Screenshots <!-- if applicable -->

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
