### PR TITLE
Search: Fix attribute defaults

### DIFF
--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -15,6 +15,18 @@
 function render_block_core_search( $attributes ) {
 	static $instance_id = 0;
 
+	// Older versions of the Search block defaulted the label and buttonText
+	// attributes to `__( 'Search' )` meaning that many posts contain `<!--
+	// wp:search /-->`. Support these by defaulting an undefined label and
+	// buttonText to `__( 'Search' )`.
+	$attributes = wp_parse_args(
+		$attributes,
+		array(
+			'label'      => __( 'Search' ),
+			'buttonText' => __( 'Search' ),
+		)
+	);
+
 	$input_id      = 'wp-block-search__input-' . ++$instance_id;
 	$label_markup  = '';
 	$button_markup = '';


### PR DESCRIPTION
Fixes https://core.trac.wordpress.org/ticket/50608.

Prior to https://github.com/WordPress/gutenberg/pull/22422, the Search block's `label` and `buttonText` attributes defaulted to `__( 'Search' )`. This meant that adding a Search block to a post or page resulted in `<!-- wp:search /-->` being inserted into the HTML.

In https://github.com/WordPress/gutenberg/pull/22422, the defaults were removed so that Search could use a `block.json` file. The default values were instead implemented using a default block variation.

This, however, meant that Search blocks added prior to https://github.com/WordPress/gutenberg/pull/22422 would render with a blank label and button. This is the bug outlined in the ticket above.

This fix is to default label and buttonText to `__( 'Search' )` in the block's `render_callback`. Note that care must be taken here to permit these attributes to be `''` which hides the label and/or button.

| Before | After |
| - | - |
| <img width="531" alt="Screen Shot 2020-07-08 at 12 23 49" src="https://user-images.githubusercontent.com/612155/86867291-e9404a00-c115-11ea-9558-a4f8cf219e17.png"> | <img width="540" alt="Screen Shot 2020-07-08 at 12 23 23" src="https://user-images.githubusercontent.com/612155/86867294-eb0a0d80-c115-11ea-962d-1ede96529956.png"> |

**To test:**

1. Manually insert `<!-- wp:search /-->` into a post's markup.
2. Test that it renders with a label and button text on the frontend.
