### PR TITLE
Fix block movers in navigator on experimental navigation page displaying horizontally

### DIFF
--- a/packages/block-editor/src/components/block-mobile-toolbar/index.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/index.js
@@ -8,7 +8,7 @@ import { useViewportMatch } from '@wordpress/compose';
  */
 import BlockMover from '../block-mover';
 
-function BlockMobileToolbar( { clientId, moverDirection } ) {
+function BlockMobileToolbar( { clientId } ) {
 	const isMobile = useViewportMatch( 'small', '<' );
 	if ( ! isMobile ) {
 		return null;
@@ -16,10 +16,7 @@ function BlockMobileToolbar( { clientId, moverDirection } ) {
 
 	return (
 		<div className="block-editor-block-mobile-toolbar">
-			<BlockMover
-				clientIds={ [ clientId ] }
-				__experimentalOrientation={ moverDirection }
-			/>
+			<BlockMover clientIds={ [ clientId ] } />
 		</div>
 	);
 }

--- a/packages/block-editor/src/components/block-navigation/block.js
+++ b/packages/block-editor/src/components/block-navigation/block.js
@@ -120,7 +120,7 @@ export default function BlockNavigationBlock( {
 						<TreeGridItem>
 							{ ( { ref, tabIndex, onFocus } ) => (
 								<BlockMoverUpButton
-									__experimentalOrientation="vertical"
+									orientation="vertical"
 									clientIds={ [ clientId ] }
 									ref={ ref }
 									tabIndex={ tabIndex }
@@ -131,7 +131,7 @@ export default function BlockNavigationBlock( {
 						<TreeGridItem>
 							{ ( { ref, tabIndex, onFocus } ) => (
 								<BlockMoverDownButton
-									__experimentalOrientation="vertical"
+									orientation="vertical"
 									clientIds={ [ clientId ] }
 									ref={ ref }
 									tabIndex={ tabIndex }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes two small issues from https://github.com/WordPress/gutenberg/pull/23416.

1. `BlockMobileToolbar` (which is the web-based responsive mobile toolbar) had a `moverDirection` prop, which wasn't being used and didn't do anything, as `BlockMover` handles its own orientation so this can be omitted.
2. `BlockMoverUpButton` and `BlockMoverDownButton` are both used in the block navigator on the experimental navigation page. The prop for these components should have been renamed to `orientation` from `__experimentalOrientation` but was somehow missed. This fixes an issue where the block movers in the navigator are sometimes shown horizontally instead of vertically—the prop is used to force the movers to display vertically.

## How has this been tested?
1. Open up the experimental navigation page and create a menu with a few links
2. Try the movers in the Navigation Structure area.
3. Observe the movers are correctly oriented.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
#### Before
<img width="291" alt="Screenshot 2020-07-08 at 12 53 30 pm" src="https://user-images.githubusercontent.com/677833/86877968-8ef5b800-c11a-11ea-93b8-f6cea5081e4b.png">

#### After
<img width="291" alt="Screenshot 2020-07-08 at 12 57 32 pm" src="https://user-images.githubusercontent.com/677833/86877998-9ddc6a80-c11a-11ea-8496-d73db976fc44.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
