### PR TITLE
LinkControl: Add suggestions-only mode

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -482,7 +482,7 @@ function LinkControl( {
 
 		return (
 			<div className="block-editor-link-control__search-results-wrapper">
-				{ searchResultsLabel }
+				{ ! onlySuggestions && searchResultsLabel }
 				<div
 					{ ...suggestionsListProps }
 					className={ resultsListClasses }

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -547,12 +547,12 @@ function LinkControl( {
 		);
 	};
 
+	const className = classnames( 'block-editor-link-control', {
+		'is-lite': onlySuggestions || 1,
+	} );
+
 	return (
-		<div
-			tabIndex={ -1 }
-			ref={ wrapperNode }
-			className="block-editor-link-control"
-		>
+		<div tabIndex={ -1 } ref={ wrapperNode } className={ className }>
 			{ isResolvingLink && (
 				<div className="block-editor-link-control__loading">
 					<Spinner /> { __( 'Creating' ) }…

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -165,15 +165,18 @@ function LinkControl( {
 	showInitialSuggestions,
 	forceIsEditingLink,
 	createSuggestion,
+	onlySuggestions = false,
+	inputValue: propInputValue = '',
 } ) {
 	const cancelableOnCreate = useRef();
 	const cancelableCreateSuggestion = useRef();
 
 	const wrapperNode = useRef();
 	const instanceId = useInstanceId( LinkControl );
-	const [ inputValue, setInputValue ] = useState(
+	const [ internalInputValue, setInternalInputValue ] = useState(
 		( value && value.url ) || ''
 	);
+	const currentInputValue = propInputValue || internalInputValue;
 	const [ isEditingLink, setIsEditingLink ] = useState(
 		forceIsEditingLink !== undefined
 			? forceIsEditingLink
@@ -249,7 +252,7 @@ function LinkControl( {
 	 * @param {string} val Current value returned by the search.
 	 */
 	const onInputChange = ( val = '' ) => {
-		setInputValue( val );
+		setInternalInputValue( val );
 	};
 
 	const handleDirectEntry = noDirectEntry
@@ -283,10 +286,10 @@ function LinkControl( {
 
 	const handleEntitySearch = async ( val, args ) => {
 		let results = await Promise.all( [
+			handleDirectEntry( val ),
 			fetchSearchSuggestions( val, {
 				...( args.isInitialSuggestions ? { perPage: 3 } : {} ),
 			} ),
-			handleDirectEntry( val ),
 		] );
 
 		const couldBeURL = ! val.includes( ' ' );
@@ -460,7 +463,7 @@ function LinkControl( {
 			: sprintf(
 					/* translators: %s: search term. */
 					__( 'Search results for "%s"' ),
-					inputValue
+					currentInputValue
 			  );
 
 		// VisuallyHidden rightly doesn't accept custom classNames
@@ -492,7 +495,7 @@ function LinkControl( {
 						) {
 							return (
 								<LinkControlSearchCreate
-									searchTerm={ inputValue }
+									searchTerm={ currentInputValue }
 									onClick={ async () => {
 										await handleOnCreate(
 											suggestion.title
@@ -534,7 +537,8 @@ function LinkControl( {
 								isURL={ directLinkEntryTypes.includes(
 									suggestion.type.toLowerCase()
 								) }
-								searchTerm={ inputValue }
+								searchTerm={ currentInputValue }
+								onlySuggestions={ onlySuggestions }
 							/>
 						);
 					} ) }
@@ -558,11 +562,11 @@ function LinkControl( {
 			{ ( isEditingLink || ! value ) && ! isResolvingLink && (
 				<LinkControlSearchInput
 					placeholder={ searchInputPlaceholder }
-					value={ inputValue }
+					value={ currentInputValue }
 					onChange={ onInputChange }
 					onSelect={ async ( suggestion ) => {
 						if ( CREATE_TYPE === suggestion.type ) {
-							await handleOnCreate( inputValue );
+							await handleOnCreate( currentInputValue );
 						} else if (
 							! noDirectEntry ||
 							Object.keys( suggestion ).length > 1
@@ -577,6 +581,7 @@ function LinkControl( {
 					fetchSuggestions={ getSearchHandler }
 					showInitialSuggestions={ showInitialSuggestions }
 					errorMessage={ errorMessage }
+					onlySuggestions={ onlySuggestions }
 				/>
 			) }
 
@@ -617,11 +622,13 @@ function LinkControl( {
 					</div>
 				</Fragment>
 			) }
-			<LinkControlSettingsDrawer
-				value={ value }
-				settings={ settings }
-				onChange={ onChange }
-			/>
+			{ ! onlySuggestions && (
+				<LinkControlSettingsDrawer
+					value={ value }
+					settings={ settings }
+					onChange={ onChange }
+				/>
+			) }
 		</div>
 	);
 }

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -548,7 +548,7 @@ function LinkControl( {
 	};
 
 	const className = classnames( 'block-editor-link-control', {
-		'is-lite': onlySuggestions || 1,
+		'is-lite': onlySuggestions,
 	} );
 
 	return (

--- a/packages/block-editor/src/components/link-control/search-create-button.js
+++ b/packages/block-editor/src/components/link-control/search-create-button.js
@@ -6,9 +6,8 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { Button, Icon } from '@wordpress/components';
-import { createInterpolateElement } from '@wordpress/element';
 
 export const LinkControlSearchCreate = ( {
 	searchTerm,
@@ -33,19 +32,16 @@ export const LinkControlSearchCreate = ( {
 		>
 			<Icon
 				className="block-editor-link-control__search-item-icon"
-				icon="insert"
+				size={ 18 }
+				icon="plus"
 			/>
 
 			<span className="block-editor-link-control__search-item-header">
 				<span className="block-editor-link-control__search-item-title">
-					{ createInterpolateElement(
-						sprintf(
-							/* translators: %s: search term. */
-							__( 'New page: <mark>%s</mark>' ),
-							searchTerm
-						),
-						{ mark: <mark /> }
-					) }
+					<mark>{ searchTerm }</mark>
+				</span>
+				<span className="block-editor-link-control__search-item-info">
+					{ __( 'Create a new page' ) }
 				</span>
 			</span>
 		</Button>

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -19,6 +19,7 @@ const LinkControlSearchInput = ( {
 	renderSuggestions,
 	fetchSuggestions,
 	showInitialSuggestions,
+	onlySuggestions,
 	errorMessage,
 } ) => {
 	const [ selectedSuggestion, setSelectedSuggestion ] = useState();
@@ -54,19 +55,22 @@ const LinkControlSearchInput = ( {
 					placeholder={ placeholder ?? __( 'Search or type url' ) }
 					__experimentalRenderSuggestions={ renderSuggestions }
 					__experimentalFetchLinkSuggestions={ fetchSuggestions }
+					__experimentalOnlySuggestions={ onlySuggestions }
 					__experimentalHandleURLSuggestions={ true }
 					__experimentalShowInitialSuggestions={
 						showInitialSuggestions
 					}
 				/>
-				<div className="block-editor-link-control__search-actions">
-					<Button
-						type="submit"
-						label={ __( 'Submit' ) }
-						icon={ keyboardReturn }
-						className="block-editor-link-control__search-submit"
-					/>
-				</div>
+				{ ! onlySuggestions && (
+					<div className="block-editor-link-control__search-actions">
+						<Button
+							type="submit"
+							label={ __( 'Submit' ) }
+							icon={ keyboardReturn }
+							className="block-editor-link-control__search-submit"
+						/>
+					</div>
+				) }
 			</div>
 
 			{ errorMessage && (

--- a/packages/block-editor/src/components/link-control/search-item.js
+++ b/packages/block-editor/src/components/link-control/search-item.js
@@ -9,7 +9,6 @@ import classnames from 'classnames';
 import { safeDecodeURI, filterURLForDisplay } from '@wordpress/url';
 import { __ } from '@wordpress/i18n';
 import { Button, TextHighlight } from '@wordpress/components';
-import { Icon, globe } from '@wordpress/icons';
 
 export const LinkControlSearchItem = ( {
 	itemProps,
@@ -29,12 +28,6 @@ export const LinkControlSearchItem = ( {
 				'is-entity': ! isURL,
 			} ) }
 		>
-			{ isURL && (
-				<Icon
-					className="block-editor-link-control__search-item-icon"
-					icon={ globe }
-				/>
-			) }
 			<span className="block-editor-link-control__search-item-header">
 				<span className="block-editor-link-control__search-item-title">
 					<TextHighlight
@@ -51,7 +44,7 @@ export const LinkControlSearchItem = ( {
 							safeDecodeURI( suggestion.url )
 						) ||
 							'' ) }
-					{ isURL && __( 'Press ENTER to add this link' ) }
+					{ isURL && __( 'Add a link to this URL' ) }
 				</span>
 			</span>
 			{ suggestion.type && (

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -22,11 +22,11 @@ $block-editor-link-control-number-of-actions: 1;
 	// Specificity override.
 	&.block-editor-link-control__search-input input[type="text"] {
 		@include input-control;
-		width: calc(100% - #{$grid-unit-20*2});
+		width: calc(100% - #{$grid-unit-05*2});
 		display: block;
 		padding: 11px $grid-unit-20;
 		padding-right: ( $button-size * $block-editor-link-control-number-of-actions ); // width of reset and submit buttons
-		margin: $grid-unit-20;
+		margin: $grid-unit-05;
 		position: relative;
 		border: 1px solid $gray-200;
 		border-radius: $radius-block-ui;
@@ -55,38 +55,13 @@ $block-editor-link-control-number-of-actions: 1;
 	 *  - Horizontally, pad to the minimum of: default input padding, or the
 	 *    equivalent of the vertical padding.
 	 */
-	top: $grid-unit-20 + 1px + ( ( 40px - $button-size ) / 2 );
-	right: $grid-unit-20 + 1px + min($grid-unit-10, ( 40px - $button-size ) / 2);
+	top: $grid-unit-05 + 1px + ( ( 40px - $button-size ) / 2 );
+	right: $grid-unit-05 + 1px + min($grid-unit-10, ( 40px - $button-size ) / 2);
 }
 
 .block-editor-link-control__search-results-wrapper {
 	position: relative;
-	margin-top: -$grid-unit-20 + 1px;
-
-	&::before,
-	&::after {
-		content: "";
-		position: absolute;
-		left: -1px;
-		right: $grid-unit-20; // avoid overlaying scrollbars
-		display: block;
-		pointer-events: none;
-		z-index: 100;
-	}
-
-	&::before {
-		height: $grid-unit-20/2;
-		top: 0;
-		bottom: auto;
-		background: linear-gradient(to bottom, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 0) 100%);
-	}
-
-	&::after {
-		height: $grid-unit-20;
-		bottom: 0;
-		top: auto;
-		background: linear-gradient(to bottom, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 1) 100%);
-	}
+	margin-top: 1px;
 }
 
 .block-editor-link-control__search-results-label {
@@ -97,7 +72,7 @@ $block-editor-link-control-number-of-actions: 1;
 
 .block-editor-link-control__search-results {
 	margin: 0;
-	padding: $grid-unit-20/2 $grid-unit-20 $grid-unit-20/2;
+	padding: $grid-unit-05;
 	max-height: 200px;
 	overflow-y: auto; // allow results list to scroll
 
@@ -116,8 +91,8 @@ $block-editor-link-control-number-of-actions: 1;
 	width: 100%;
 	border: none;
 	text-align: left;
-	padding: 10px 15px;
-	border-radius: 5px;
+	padding: 6px 10px;
+	border-radius: 2px;
 	height: auto;
 
 	&:hover,
@@ -215,16 +190,16 @@ $block-editor-link-control-number-of-actions: 1;
 
 // Separate Create button when following other suggestions.
 .components-button + .block-editor-link-control__search-create {
-	margin-top: 20px;
+	margin-top: $block-selected-child-margin*2;
 	overflow: visible;
-	padding: 12px 15px;
+	//padding: 12px 15px;
 
 	// Create fake border. We cannot use border because the button has a border
 	// radius applied to it
 	&::before {
 		content: "";
 		position: absolute;
-		top: -#{$block-selected-child-margin*2};
+		top: -#{$block-selected-child-margin};
 		left: 0;
 		display: block;
 		width: 100%;
@@ -240,7 +215,7 @@ $block-editor-link-control-number-of-actions: 1;
 .block-editor-link-control__settings {
 	border-top: 1px solid $gray-200;
 	margin: 0;
-	padding: $grid-unit-20 $grid-unit-30;
+	padding: $grid-unit-20 15px;
 
 	:last-child {
 		margin-bottom: 0;
@@ -274,8 +249,8 @@ $block-editor-link-control-number-of-actions: 1;
 		 *    then artificially create spacing that mimics as if the spinner
 		 *    were center-padded to the same width as an icon button.
 		 */
-		top: $grid-unit-20 + 1px + ( ( 40px - $spinner-size ) / 2 );
-		right: $grid-unit-20 + 1px + ( $button-size * $block-editor-link-control-number-of-actions ) + ( ( $button-size - $spinner-size ) / 2 );
+		top: $grid-unit-05 + 1px + ( ( 40px - $spinner-size ) / 2 );
+		right: $grid-unit-05 + 1px + ( $button-size * $block-editor-link-control-number-of-actions ) + ( ( $button-size - $spinner-size ) / 2 );
 	}
 }
 

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -22,11 +22,11 @@ $block-editor-link-control-number-of-actions: 1;
 	// Specificity override.
 	&.block-editor-link-control__search-input input[type="text"] {
 		@include input-control;
-		width: calc(100% - #{$grid-unit-05*2});
+		width: calc(100% - #{$grid-unit-20*2});
 		display: block;
 		padding: 11px $grid-unit-20;
 		padding-right: ( $button-size * $block-editor-link-control-number-of-actions ); // width of reset and submit buttons
-		margin: $grid-unit-05;
+		margin: $grid-unit-20;
 		position: relative;
 		border: 1px solid $gray-200;
 		border-radius: $radius-block-ui;
@@ -55,13 +55,38 @@ $block-editor-link-control-number-of-actions: 1;
 	 *  - Horizontally, pad to the minimum of: default input padding, or the
 	 *    equivalent of the vertical padding.
 	 */
-	top: $grid-unit-05 + 1px + ( ( 40px - $button-size ) / 2 );
-	right: $grid-unit-05 + 1px + min($grid-unit-10, ( 40px - $button-size ) / 2);
+	top: $grid-unit-20 + 1px + ( ( 40px - $button-size ) / 2 );
+	right: $grid-unit-20 + 1px + min($grid-unit-10, ( 40px - $button-size ) / 2);
 }
 
 .block-editor-link-control__search-results-wrapper {
 	position: relative;
-	margin-top: 1px;
+	margin-top: -$grid-unit-20 + 1px;
+
+	&::before,
+	&::after {
+		content: "";
+		position: absolute;
+		left: -1px;
+		right: $grid-unit-20; // avoid overlaying scrollbars
+		display: block;
+		pointer-events: none;
+		z-index: 100;
+	}
+
+	&::before {
+		height: $grid-unit-20/2;
+		top: 0;
+		bottom: auto;
+		background: linear-gradient(to bottom, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 0) 100%);
+	}
+
+	&::after {
+		height: $grid-unit-20;
+		bottom: 0;
+		top: auto;
+		background: linear-gradient(to bottom, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 1) 100%);
+	}
 }
 
 .block-editor-link-control__search-results-label {
@@ -72,7 +97,7 @@ $block-editor-link-control-number-of-actions: 1;
 
 .block-editor-link-control__search-results {
 	margin: 0;
-	padding: $grid-unit-05;
+	padding: $grid-unit-20/2 $grid-unit-20 $grid-unit-20/2;
 	max-height: 200px;
 	overflow-y: auto; // allow results list to scroll
 
@@ -91,8 +116,8 @@ $block-editor-link-control-number-of-actions: 1;
 	width: 100%;
 	border: none;
 	text-align: left;
-	padding: 6px 10px;
-	border-radius: 2px;
+	padding: 10px 15px;
+	border-radius: 5px;
 	height: auto;
 
 	&:hover,
@@ -178,6 +203,7 @@ $block-editor-link-control-number-of-actions: 1;
 	}
 }
 
+
 .block-editor-link-control__loading {
 	margin: $grid-unit-20; // when only loading control is shown it requires it's own spacing.
 	display: flex;
@@ -190,16 +216,16 @@ $block-editor-link-control-number-of-actions: 1;
 
 // Separate Create button when following other suggestions.
 .components-button + .block-editor-link-control__search-create {
-	margin-top: $block-selected-child-margin*2;
+	margin-top: 20px;
 	overflow: visible;
-	//padding: 12px 15px;
+	padding: 12px 15px;
 
 	// Create fake border. We cannot use border because the button has a border
 	// radius applied to it
 	&::before {
 		content: "";
 		position: absolute;
-		top: -#{$block-selected-child-margin};
+		top: -#{$block-selected-child-margin*2};
 		left: 0;
 		display: block;
 		width: 100%;
@@ -215,7 +241,7 @@ $block-editor-link-control-number-of-actions: 1;
 .block-editor-link-control__settings {
 	border-top: 1px solid $gray-200;
 	margin: 0;
-	padding: $grid-unit-20 15px;
+	padding: $grid-unit-20 $grid-unit-30;
 
 	:last-child {
 		margin-bottom: 0;
@@ -249,12 +275,66 @@ $block-editor-link-control-number-of-actions: 1;
 		 *    then artificially create spacing that mimics as if the spinner
 		 *    were center-padded to the same width as an icon button.
 		 */
-		top: $grid-unit-05 + 1px + ( ( 40px - $spinner-size ) / 2 );
-		right: $grid-unit-05 + 1px + ( $button-size * $block-editor-link-control-number-of-actions ) + ( ( $button-size - $spinner-size ) / 2 );
+		top: $grid-unit-20 + 1px + ( ( 40px - $spinner-size ) / 2 );
+		right: $grid-unit-20 + 1px + ( $button-size * $block-editor-link-control-number-of-actions ) + ( ( $button-size - $spinner-size ) / 2 );
 	}
 }
+
 
 .block-editor-link-control__search-item-action {
 	margin-left: auto; // push to far right hand side
 	flex-shrink: 0;
+}
+
+.block-editor-link-control.is-lite {
+	.block-editor-link-control__search-input {
+		// Specificity override.
+		&.block-editor-link-control__search-input input[type="text"] {
+			width: calc(100% - #{$grid-unit-05*2});
+			margin: $grid-unit-05;
+		}
+	}
+
+	.block-editor-link-control__search-actions {
+		top: $grid-unit-05 + 1px + ( ( 40px - $button-size ) / 2 );
+		right: $grid-unit-05 + 1px + min($grid-unit-10, ( 40px - $button-size ) / 2);
+	}
+
+	.block-editor-link-control__search-input .components-spinner {
+		&.components-spinner {
+			top: $grid-unit-05 + 1px + ( ( 40px - $spinner-size ) / 2 );
+			right: $grid-unit-05 + 1px + ( $button-size * $block-editor-link-control-number-of-actions ) + ( ( $button-size - $spinner-size ) / 2 );
+		}
+	}
+
+	.block-editor-link-control__settings {
+		padding: $grid-unit-20 15px;
+	}
+
+	.block-editor-link-control__search-results-wrapper {
+		margin-top: 1px;
+
+		&::before,
+		&::after {
+			display: none;
+		}
+	}
+
+	.block-editor-link-control__search-results {
+		padding: $grid-unit-05;
+	}
+
+	.block-editor-link-control__search-item {
+		padding: 6px 10px;
+		border-radius: 2px;
+	}
+
+	.components-button + .block-editor-link-control__search-create {
+		margin-top: $block-selected-child-margin*2;
+		padding: inherit;
+
+		&::before {
+			top: -#{$block-selected-child-margin};
+		}
+	}
 }

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -82,17 +82,20 @@ class URLInput extends Component {
 		}
 
 		// Only attempt an update on suggestions if the input value has actually changed.
-		if (
-			prevProps.value !== value &&
-			this.shouldShowInitialSuggestions()
-		) {
-			this.updateSuggestions();
+		if ( prevProps.value !== value ) {
+			if ( this.shouldShowInitialSuggestions() ) {
+				this.updateSuggestions();
+			} else if ( this.shouldRefreshSuggestions() ) {
+				this.updateSuggestions( value );
+			}
 		}
 	}
 
 	componentDidMount() {
 		if ( this.shouldShowInitialSuggestions() ) {
 			this.updateSuggestions();
+		} else if ( this.shouldRefreshSuggestions() ) {
+			this.updateSuggestions( this.props.value );
 		}
 	}
 
@@ -118,6 +121,11 @@ class URLInput extends Component {
 			! ( value && value.length ) &&
 			! ( suggestions && suggestions.length )
 		);
+	}
+
+	shouldRefreshSuggestions() {
+		const { __experimentalOnlySuggestions = false } = this.props;
+		return ! this.isUpdatingSuggestions && __experimentalOnlySuggestions;
 	}
 
 	updateSuggestions( value = '' ) {
@@ -384,6 +392,7 @@ class URLInput extends Component {
 			value = '',
 			autoFocus = true,
 			__experimentalShowInitialSuggestions = false,
+			__experimentalOnlySuggestions: onlySuggestions = false,
 		} = this.props;
 
 		const {
@@ -423,29 +432,31 @@ class URLInput extends Component {
 					'is-full-width': isFullWidth,
 				} ) }
 			>
-				<input
-					className="block-editor-url-input__input"
-					autoFocus={ autoFocus }
-					type="text"
-					aria-label={ __( 'URL' ) }
-					required
-					value={ value }
-					onChange={ this.onChange }
-					onFocus={ this.onFocus }
-					onInput={ stopEventPropagation }
-					placeholder={ placeholder }
-					onKeyDown={ this.onKeyDown }
-					role="combobox"
-					aria-expanded={ showSuggestions }
-					aria-autocomplete="list"
-					aria-owns={ suggestionsListboxId }
-					aria-activedescendant={
-						selectedSuggestion !== null
-							? `${ suggestionOptionIdPrefix }-${ selectedSuggestion }`
-							: undefined
-					}
-					ref={ this.inputRef }
-				/>
+				{ ! onlySuggestions && (
+					<input
+						className="block-editor-url-input__input"
+						autoFocus={ autoFocus }
+						type="text"
+						aria-label={ __( 'URL' ) }
+						required
+						value={ value }
+						onChange={ this.onChange }
+						onFocus={ this.onFocus }
+						onInput={ stopEventPropagation }
+						placeholder={ placeholder }
+						onKeyDown={ this.onKeyDown }
+						role="combobox"
+						aria-expanded={ showSuggestions }
+						aria-autocomplete="list"
+						aria-owns={ suggestionsListboxId }
+						aria-activedescendant={
+							selectedSuggestion !== null
+								? `${ suggestionOptionIdPrefix }-${ selectedSuggestion }`
+								: undefined
+						}
+						ref={ this.inputRef }
+					/>
+				) }
 
 				{ loading && <Spinner /> }
 


### PR DESCRIPTION
## Description

This PR adds support for suggestions-only mode to `<LinkControl />`. This is necessary to make progress on https://github.com/WordPress/gutenberg/issues/23375#issuecomment-649817195, in particular implement this interaction where `LinkControl` is controlled by another input field:

![linke-ui-nav](https://user-images.githubusercontent.com/191598/85795303-06cce700-b706-11ea-87a5-0b782213eb61.gif)

## How has this been tested?

1. Apply this PR
1. Add a navigation block in the post editor, edit a link
1. Confirm the `<LinkControl />` is unchanged
1. Manually edit `<LinkControl />` and update `onlySuggestions=false` to `onlySuggestions=true`
1. Refresh the post editor
1. Edit a link that's already assigned to a page
1. Confirm the lite version shows up as on the screenshot below

## Screenshots

Without `onlySuggestions={ true }`:

<img width="373" alt="Zrzut ekranu 2020-07-8 o 16 18 47" src="https://user-images.githubusercontent.com/205419/86930044-d38f4c80-c136-11ea-823a-979cb6d42562.png">
<img width="368" alt="Zrzut ekranu 2020-07-8 o 16 18 41" src="https://user-images.githubusercontent.com/205419/86930052-d5591000-c136-11ea-90c0-4b2e806b375a.png">

With `onlySuggestions={ true }`:

<img width="367" alt="Zrzut ekranu 2020-07-8 o 17 27 00" src="https://user-images.githubusercontent.com/205419/86938048-418c4180-c140-11ea-97bb-e7d68e003d51.png">

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
