### PR TITLE
Block Navigation: Change the visible labels for "Block navigation" to "List view".

### DIFF
--- a/packages/block-editor/src/components/block-navigation/index.js
+++ b/packages/block-editor/src/components/block-navigation/index.js
@@ -34,7 +34,7 @@ function BlockNavigation( {
 	return (
 		<div className="block-editor-block-navigation__container">
 			<p className="block-editor-block-navigation__label">
-				{ __( 'Block navigation' ) }
+				{ __( 'List view' ) }
 			</p>
 			{ hasHierarchy && (
 				<BlockNavigationTree

--- a/packages/edit-post/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-post/src/components/keyboard-shortcuts/index.js
@@ -58,7 +58,7 @@ function KeyboardShortcuts() {
 		registerShortcut( {
 			name: 'core/edit-post/toggle-block-navigation',
 			category: 'global',
-			description: __( 'Open the block navigation menu.' ),
+			description: __( 'Open the block list view.' ),
 			keyCombination: {
 				modifier: 'access',
 				character: 'o',


### PR DESCRIPTION
Fixes #22814 

This PR changes the label "Block navigation" to "List view":

<img width="328" alt="image" src="https://user-images.githubusercontent.com/191598/86951522-a6836f80-c11f-11ea-9149-63dddfc4af48.png">

Unclear to me if we should rename the component in general.