### PR TITLE
Make table figure wrapping optional

### DIFF
--- a/packages/block-library/src/table/block.json
+++ b/packages/block-library/src/table/block.json
@@ -12,7 +12,7 @@
 		"caption": {
 			"type": "string",
 			"source": "html",
-			"selector": "figcaption",
+			"selector": "caption, figcaption",
 			"default": ""
 		},
 		"head": {
@@ -119,6 +119,10 @@
 					}
 				}
 			}
+		},
+		"figure": {
+			"type": "boolean",
+			"default": true
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/table/deprecated.js
+++ b/packages/block-library/src/table/deprecated.js
@@ -175,6 +175,12 @@ const deprecated = [
 				</table>
 			);
 		},
+		migrate( attributes ) {
+			return {
+				figure: true,
+				...attributes,
+			};
+		},
 	},
 ];
 

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -129,6 +129,7 @@ export class TableEdit extends Component {
 			this
 		);
 		this.getCellAlignment = this.getCellAlignment.bind( this );
+		this.onChangeWrapFigure = this.onChangeWrapFigure.bind( this );
 
 		this.state = {
 			initialRowCount: 2,
@@ -185,6 +186,16 @@ export class TableEdit extends Component {
 		const { hasFixedLayout } = attributes;
 
 		setAttributes( { hasFixedLayout: ! hasFixedLayout } );
+	}
+
+	/**
+	 * Toggles whether the table has a fixed layout or not.
+	 */
+	onChangeWrapFigure() {
+		const { attributes, setAttributes } = this.props;
+		const { figure } = attributes;
+
+		setAttributes( { figure: ! figure } );
 	}
 
 	/**
@@ -560,7 +571,14 @@ export class TableEdit extends Component {
 			insertBlocksAfter,
 		} = this.props;
 		const { initialRowCount, initialColumnCount } = this.state;
-		const { hasFixedLayout, caption, head, body, foot } = attributes;
+		const {
+			hasFixedLayout,
+			caption,
+			head,
+			body,
+			foot,
+			figure,
+		} = attributes;
 		const isEmpty =
 			isEmptyTableSection( head ) &&
 			isEmptyTableSection( body ) &&
@@ -656,6 +674,11 @@ export class TableEdit extends Component {
 							label={ __( 'Footer section' ) }
 							checked={ !! ( foot && foot.length ) }
 							onChange={ this.onToggleFooterSection }
+						/>
+						<ToggleControl
+							label={ __( 'Wrap table in figure tag' ) }
+							checked={ !! figure }
+							onChange={ this.onChangeWrapFigure }
 						/>
 					</PanelBody>
 					<PanelColorSettings

--- a/packages/block-library/src/table/save.js
+++ b/packages/block-library/src/table/save.js
@@ -16,6 +16,7 @@ export default function save( { attributes } ) {
 		foot,
 		backgroundColor,
 		caption,
+		figure,
 	} = attributes;
 	const isEmpty = ! head.length && ! body.length && ! foot.length;
 
@@ -34,6 +35,8 @@ export default function save( { attributes } ) {
 	} );
 
 	const hasCaption = ! RichText.isEmpty( caption );
+
+	const Wrapper = figure ? 'figure' : 'div';
 
 	const Section = ( { type, rows } ) => {
 		if ( ! rows.length ) {
@@ -77,15 +80,18 @@ export default function save( { attributes } ) {
 	};
 
 	return (
-		<figure>
+		<Wrapper>
 			<table className={ classes === '' ? undefined : classes }>
+				{ hasCaption && ! figure && (
+					<RichText.Content tagName="caption" value={ caption } />
+				) }
 				<Section type="head" rows={ head } />
 				<Section type="body" rows={ body } />
 				<Section type="foot" rows={ foot } />
 			</table>
-			{ hasCaption && (
+			{ hasCaption && figure && (
 				<RichText.Content tagName="figcaption" value={ caption } />
 			) }
-		</figure>
+		</Wrapper>
 	);
 }

--- a/packages/e2e-tests/fixtures/blocks/core__table.json
+++ b/packages/e2e-tests/fixtures/blocks/core__table.json
@@ -1,146 +1,147 @@
 [
-    {
-        "clientId": "_clientId_0",
-        "name": "core/table",
-        "isValid": true,
-        "attributes": {
-            "hasFixedLayout": false,
-            "caption": "",
-            "head": [
-                {
-                    "cells": [
-                        {
-                            "content": "Version",
-                            "tag": "th"
-                        },
-                        {
-                            "content": "Musician",
-                            "tag": "th"
-                        },
-                        {
-                            "content": "Date",
-                            "tag": "th"
-                        }
-                    ]
-                }
-            ],
-            "body": [
-                {
-                    "cells": [
-                        {
-                            "content": "<a href=\"https://wordpress.org/news/2003/05/wordpress-now-available/\">.70</a>",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "No musician chosen.",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "May 27, 2003",
-                            "tag": "td"
-                        }
-                    ]
-                },
-                {
-                    "cells": [
-                        {
-                            "content": "<a href=\"https://wordpress.org/news/2004/01/wordpress-10/\">1.0</a>",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "Miles Davis",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "January 3, 2004",
-                            "tag": "td"
-                        }
-                    ]
-                },
-                {
-                    "cells": [
-                        {
-                            "content": "Lots of versions skipped, see <a href=\"https://codex.wordpress.org/WordPress_Versions\">the full list</a>",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "…",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "…",
-                            "tag": "td"
-                        }
-                    ]
-                },
-                {
-                    "cells": [
-                        {
-                            "content": "<a href=\"https://wordpress.org/news/2015/12/clifford/\">4.4</a>",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "Clifford Brown",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "December 8, 2015",
-                            "tag": "td"
-                        }
-                    ]
-                },
-                {
-                    "cells": [
-                        {
-                            "content": "<a href=\"https://wordpress.org/news/2016/04/coleman/\">4.5</a>",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "Coleman Hawkins",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "April 12, 2016",
-                            "tag": "td"
-                        }
-                    ]
-                },
-                {
-                    "cells": [
-                        {
-                            "content": "<a href=\"https://wordpress.org/news/2016/08/pepper/\">4.6</a>",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "Pepper Adams",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "August 16, 2016",
-                            "tag": "td"
-                        }
-                    ]
-                },
-                {
-                    "cells": [
-                        {
-                            "content": "<a href=\"https://wordpress.org/news/2016/12/vaughan/\">4.7</a>",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "Sarah Vaughan",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "December 6, 2016",
-                            "tag": "td"
-                        }
-                    ]
-                }
-            ],
-            "foot": []
-        },
-        "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-table\"><table><thead><tr><th>Version</th><th>Musician</th><th>Date</th></tr></thead><tbody><tr><td><a href=\"https://wordpress.org/news/2003/05/wordpress-now-available/\">.70</a></td><td>No musician chosen.</td><td>May 27, 2003</td></tr><tr><td><a href=\"https://wordpress.org/news/2004/01/wordpress-10/\">1.0</a></td><td>Miles Davis</td><td>January 3, 2004</td></tr><tr><td>Lots of versions skipped, see <a href=\"https://codex.wordpress.org/WordPress_Versions\">the full list</a></td><td>&hellip;</td><td>&hellip;</td></tr><tr><td><a href=\"https://wordpress.org/news/2015/12/clifford/\">4.4</a></td><td>Clifford Brown</td><td>December 8, 2015</td></tr><tr><td><a href=\"https://wordpress.org/news/2016/04/coleman/\">4.5</a></td><td>Coleman Hawkins</td><td>April 12, 2016</td></tr><tr><td><a href=\"https://wordpress.org/news/2016/08/pepper/\">4.6</a></td><td>Pepper Adams</td><td>August 16, 2016</td></tr><tr><td><a href=\"https://wordpress.org/news/2016/12/vaughan/\">4.7</a></td><td>Sarah Vaughan</td><td>December 6, 2016</td></tr></tbody></table></figure>"
-    }
+	{
+		"clientId": "_clientId_0",
+		"name": "core/table",
+		"isValid": true,
+		"attributes": {
+			"hasFixedLayout": false,
+			"caption": "",
+			"figure": true,
+			"head": [
+				{
+					"cells": [
+						{
+							"content": "Version",
+							"tag": "th"
+						},
+						{
+							"content": "Musician",
+							"tag": "th"
+						},
+						{
+							"content": "Date",
+							"tag": "th"
+						}
+					]
+				}
+			],
+			"body": [
+				{
+					"cells": [
+						{
+							"content": "<a href=\"https://wordpress.org/news/2003/05/wordpress-now-available/\">.70</a>",
+							"tag": "td"
+						},
+						{
+							"content": "No musician chosen.",
+							"tag": "td"
+						},
+						{
+							"content": "May 27, 2003",
+							"tag": "td"
+						}
+					]
+				},
+				{
+					"cells": [
+						{
+							"content": "<a href=\"https://wordpress.org/news/2004/01/wordpress-10/\">1.0</a>",
+							"tag": "td"
+						},
+						{
+							"content": "Miles Davis",
+							"tag": "td"
+						},
+						{
+							"content": "January 3, 2004",
+							"tag": "td"
+						}
+					]
+				},
+				{
+					"cells": [
+						{
+							"content": "Lots of versions skipped, see <a href=\"https://codex.wordpress.org/WordPress_Versions\">the full list</a>",
+							"tag": "td"
+						},
+						{
+							"content": "…",
+							"tag": "td"
+						},
+						{
+							"content": "…",
+							"tag": "td"
+						}
+					]
+				},
+				{
+					"cells": [
+						{
+							"content": "<a href=\"https://wordpress.org/news/2015/12/clifford/\">4.4</a>",
+							"tag": "td"
+						},
+						{
+							"content": "Clifford Brown",
+							"tag": "td"
+						},
+						{
+							"content": "December 8, 2015",
+							"tag": "td"
+						}
+					]
+				},
+				{
+					"cells": [
+						{
+							"content": "<a href=\"https://wordpress.org/news/2016/04/coleman/\">4.5</a>",
+							"tag": "td"
+						},
+						{
+							"content": "Coleman Hawkins",
+							"tag": "td"
+						},
+						{
+							"content": "April 12, 2016",
+							"tag": "td"
+						}
+					]
+				},
+				{
+					"cells": [
+						{
+							"content": "<a href=\"https://wordpress.org/news/2016/08/pepper/\">4.6</a>",
+							"tag": "td"
+						},
+						{
+							"content": "Pepper Adams",
+							"tag": "td"
+						},
+						{
+							"content": "August 16, 2016",
+							"tag": "td"
+						}
+					]
+				},
+				{
+					"cells": [
+						{
+							"content": "<a href=\"https://wordpress.org/news/2016/12/vaughan/\">4.7</a>",
+							"tag": "td"
+						},
+						{
+							"content": "Sarah Vaughan",
+							"tag": "td"
+						},
+						{
+							"content": "December 6, 2016",
+							"tag": "td"
+						}
+					]
+				}
+			],
+			"foot": []
+		},
+		"innerBlocks": [],
+		"originalContent": "<figure class=\"wp-block-table\"><table><thead><tr><th>Version</th><th>Musician</th><th>Date</th></tr></thead><tbody><tr><td><a href=\"https://wordpress.org/news/2003/05/wordpress-now-available/\">.70</a></td><td>No musician chosen.</td><td>May 27, 2003</td></tr><tr><td><a href=\"https://wordpress.org/news/2004/01/wordpress-10/\">1.0</a></td><td>Miles Davis</td><td>January 3, 2004</td></tr><tr><td>Lots of versions skipped, see <a href=\"https://codex.wordpress.org/WordPress_Versions\">the full list</a></td><td>&hellip;</td><td>&hellip;</td></tr><tr><td><a href=\"https://wordpress.org/news/2015/12/clifford/\">4.4</a></td><td>Clifford Brown</td><td>December 8, 2015</td></tr><tr><td><a href=\"https://wordpress.org/news/2016/04/coleman/\">4.5</a></td><td>Coleman Hawkins</td><td>April 12, 2016</td></tr><tr><td><a href=\"https://wordpress.org/news/2016/08/pepper/\">4.6</a></td><td>Pepper Adams</td><td>August 16, 2016</td></tr><tr><td><a href=\"https://wordpress.org/news/2016/12/vaughan/\">4.7</a></td><td>Sarah Vaughan</td><td>December 6, 2016</td></tr></tbody></table></figure>"
+	}
 ]

--- a/packages/e2e-tests/fixtures/blocks/core__table__caption.json
+++ b/packages/e2e-tests/fixtures/blocks/core__table__caption.json
@@ -1,146 +1,147 @@
 [
-    {
-        "clientId": "_clientId_0",
-        "name": "core/table",
-        "isValid": true,
-        "attributes": {
-            "hasFixedLayout": false,
-            "caption": "A table for testing",
-            "head": [
-                {
-                    "cells": [
-                        {
-                            "content": "Version",
-                            "tag": "th"
-                        },
-                        {
-                            "content": "Musician",
-                            "tag": "th"
-                        },
-                        {
-                            "content": "Date",
-                            "tag": "th"
-                        }
-                    ]
-                }
-            ],
-            "body": [
-                {
-                    "cells": [
-                        {
-                            "content": "<a href=\"https://wordpress.org/news/2003/05/wordpress-now-available/\">.70</a>",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "No musician chosen.",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "May 27, 2003",
-                            "tag": "td"
-                        }
-                    ]
-                },
-                {
-                    "cells": [
-                        {
-                            "content": "<a href=\"https://wordpress.org/news/2004/01/wordpress-10/\">1.0</a>",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "Miles Davis",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "January 3, 2004",
-                            "tag": "td"
-                        }
-                    ]
-                },
-                {
-                    "cells": [
-                        {
-                            "content": "Lots of versions skipped, see <a href=\"https://codex.wordpress.org/WordPress_Versions\">the full list</a>",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "…",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "…",
-                            "tag": "td"
-                        }
-                    ]
-                },
-                {
-                    "cells": [
-                        {
-                            "content": "<a href=\"https://wordpress.org/news/2015/12/clifford/\">4.4</a>",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "Clifford Brown",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "December 8, 2015",
-                            "tag": "td"
-                        }
-                    ]
-                },
-                {
-                    "cells": [
-                        {
-                            "content": "<a href=\"https://wordpress.org/news/2016/04/coleman/\">4.5</a>",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "Coleman Hawkins",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "April 12, 2016",
-                            "tag": "td"
-                        }
-                    ]
-                },
-                {
-                    "cells": [
-                        {
-                            "content": "<a href=\"https://wordpress.org/news/2016/08/pepper/\">4.6</a>",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "Pepper Adams",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "August 16, 2016",
-                            "tag": "td"
-                        }
-                    ]
-                },
-                {
-                    "cells": [
-                        {
-                            "content": "<a href=\"https://wordpress.org/news/2016/12/vaughan/\">4.7</a>",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "Sarah Vaughan",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "December 6, 2016",
-                            "tag": "td"
-                        }
-                    ]
-                }
-            ],
-            "foot": []
-        },
-        "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-table\"><table><thead><tr><th>Version</th><th>Musician</th><th>Date</th></tr></thead><tbody><tr><td><a href=\"https://wordpress.org/news/2003/05/wordpress-now-available/\">.70</a></td><td>No musician chosen.</td><td>May 27, 2003</td></tr><tr><td><a href=\"https://wordpress.org/news/2004/01/wordpress-10/\">1.0</a></td><td>Miles Davis</td><td>January 3, 2004</td></tr><tr><td>Lots of versions skipped, see <a href=\"https://codex.wordpress.org/WordPress_Versions\">the full list</a></td><td>&hellip;</td><td>&hellip;</td></tr><tr><td><a href=\"https://wordpress.org/news/2015/12/clifford/\">4.4</a></td><td>Clifford Brown</td><td>December 8, 2015</td></tr><tr><td><a href=\"https://wordpress.org/news/2016/04/coleman/\">4.5</a></td><td>Coleman Hawkins</td><td>April 12, 2016</td></tr><tr><td><a href=\"https://wordpress.org/news/2016/08/pepper/\">4.6</a></td><td>Pepper Adams</td><td>August 16, 2016</td></tr><tr><td><a href=\"https://wordpress.org/news/2016/12/vaughan/\">4.7</a></td><td>Sarah Vaughan</td><td>December 6, 2016</td></tr></tbody></table><figcaption>A table for testing</figcaption></figure>"
-    }
+	{
+		"clientId": "_clientId_0",
+		"name": "core/table",
+		"isValid": true,
+		"attributes": {
+			"hasFixedLayout": false,
+			"caption": "A table for testing",
+			"figure": true,
+			"head": [
+				{
+					"cells": [
+						{
+							"content": "Version",
+							"tag": "th"
+						},
+						{
+							"content": "Musician",
+							"tag": "th"
+						},
+						{
+							"content": "Date",
+							"tag": "th"
+						}
+					]
+				}
+			],
+			"body": [
+				{
+					"cells": [
+						{
+							"content": "<a href=\"https://wordpress.org/news/2003/05/wordpress-now-available/\">.70</a>",
+							"tag": "td"
+						},
+						{
+							"content": "No musician chosen.",
+							"tag": "td"
+						},
+						{
+							"content": "May 27, 2003",
+							"tag": "td"
+						}
+					]
+				},
+				{
+					"cells": [
+						{
+							"content": "<a href=\"https://wordpress.org/news/2004/01/wordpress-10/\">1.0</a>",
+							"tag": "td"
+						},
+						{
+							"content": "Miles Davis",
+							"tag": "td"
+						},
+						{
+							"content": "January 3, 2004",
+							"tag": "td"
+						}
+					]
+				},
+				{
+					"cells": [
+						{
+							"content": "Lots of versions skipped, see <a href=\"https://codex.wordpress.org/WordPress_Versions\">the full list</a>",
+							"tag": "td"
+						},
+						{
+							"content": "…",
+							"tag": "td"
+						},
+						{
+							"content": "…",
+							"tag": "td"
+						}
+					]
+				},
+				{
+					"cells": [
+						{
+							"content": "<a href=\"https://wordpress.org/news/2015/12/clifford/\">4.4</a>",
+							"tag": "td"
+						},
+						{
+							"content": "Clifford Brown",
+							"tag": "td"
+						},
+						{
+							"content": "December 8, 2015",
+							"tag": "td"
+						}
+					]
+				},
+				{
+					"cells": [
+						{
+							"content": "<a href=\"https://wordpress.org/news/2016/04/coleman/\">4.5</a>",
+							"tag": "td"
+						},
+						{
+							"content": "Coleman Hawkins",
+							"tag": "td"
+						},
+						{
+							"content": "April 12, 2016",
+							"tag": "td"
+						}
+					]
+				},
+				{
+					"cells": [
+						{
+							"content": "<a href=\"https://wordpress.org/news/2016/08/pepper/\">4.6</a>",
+							"tag": "td"
+						},
+						{
+							"content": "Pepper Adams",
+							"tag": "td"
+						},
+						{
+							"content": "August 16, 2016",
+							"tag": "td"
+						}
+					]
+				},
+				{
+					"cells": [
+						{
+							"content": "<a href=\"https://wordpress.org/news/2016/12/vaughan/\">4.7</a>",
+							"tag": "td"
+						},
+						{
+							"content": "Sarah Vaughan",
+							"tag": "td"
+						},
+						{
+							"content": "December 6, 2016",
+							"tag": "td"
+						}
+					]
+				}
+			],
+			"foot": []
+		},
+		"innerBlocks": [],
+		"originalContent": "<figure class=\"wp-block-table\"><table><thead><tr><th>Version</th><th>Musician</th><th>Date</th></tr></thead><tbody><tr><td><a href=\"https://wordpress.org/news/2003/05/wordpress-now-available/\">.70</a></td><td>No musician chosen.</td><td>May 27, 2003</td></tr><tr><td><a href=\"https://wordpress.org/news/2004/01/wordpress-10/\">1.0</a></td><td>Miles Davis</td><td>January 3, 2004</td></tr><tr><td>Lots of versions skipped, see <a href=\"https://codex.wordpress.org/WordPress_Versions\">the full list</a></td><td>&hellip;</td><td>&hellip;</td></tr><tr><td><a href=\"https://wordpress.org/news/2015/12/clifford/\">4.4</a></td><td>Clifford Brown</td><td>December 8, 2015</td></tr><tr><td><a href=\"https://wordpress.org/news/2016/04/coleman/\">4.5</a></td><td>Coleman Hawkins</td><td>April 12, 2016</td></tr><tr><td><a href=\"https://wordpress.org/news/2016/08/pepper/\">4.6</a></td><td>Pepper Adams</td><td>August 16, 2016</td></tr><tr><td><a href=\"https://wordpress.org/news/2016/12/vaughan/\">4.7</a></td><td>Sarah Vaughan</td><td>December 6, 2016</td></tr></tbody></table><figcaption>A table for testing</figcaption></figure>"
+	}
 ]

--- a/packages/e2e-tests/fixtures/blocks/core__table__deprecated-1.json
+++ b/packages/e2e-tests/fixtures/blocks/core__table__deprecated-1.json
@@ -1,145 +1,146 @@
 [
-    {
-        "clientId": "_clientId_0",
-        "name": "core/table",
-        "isValid": true,
-        "attributes": {
-            "hasFixedLayout": false,
-            "head": [
-                {
-                    "cells": [
-                        {
-                            "content": "Version",
-                            "tag": "th"
-                        },
-                        {
-                            "content": "Musician",
-                            "tag": "th"
-                        },
-                        {
-                            "content": "Date",
-                            "tag": "th"
-                        }
-                    ]
-                }
-            ],
-            "body": [
-                {
-                    "cells": [
-                        {
-                            "content": "<a href=\"https://wordpress.org/news/2003/05/wordpress-now-available/\">.70</a>",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "No musician chosen.",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "May 27, 2003",
-                            "tag": "td"
-                        }
-                    ]
-                },
-                {
-                    "cells": [
-                        {
-                            "content": "<a href=\"https://wordpress.org/news/2004/01/wordpress-10/\">1.0</a>",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "Miles Davis",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "January 3, 2004",
-                            "tag": "td"
-                        }
-                    ]
-                },
-                {
-                    "cells": [
-                        {
-                            "content": "Lots of versions skipped, see <a href=\"https://codex.wordpress.org/WordPress_Versions\">the full list</a>",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "…",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "…",
-                            "tag": "td"
-                        }
-                    ]
-                },
-                {
-                    "cells": [
-                        {
-                            "content": "<a href=\"https://wordpress.org/news/2015/12/clifford/\">4.4</a>",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "Clifford Brown",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "December 8, 2015",
-                            "tag": "td"
-                        }
-                    ]
-                },
-                {
-                    "cells": [
-                        {
-                            "content": "<a href=\"https://wordpress.org/news/2016/04/coleman/\">4.5</a>",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "Coleman Hawkins",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "April 12, 2016",
-                            "tag": "td"
-                        }
-                    ]
-                },
-                {
-                    "cells": [
-                        {
-                            "content": "<a href=\"https://wordpress.org/news/2016/08/pepper/\">4.6</a>",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "Pepper Adams",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "August 16, 2016",
-                            "tag": "td"
-                        }
-                    ]
-                },
-                {
-                    "cells": [
-                        {
-                            "content": "<a href=\"https://wordpress.org/news/2016/12/vaughan/\">4.7</a>",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "Sarah Vaughan",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "December 6, 2016",
-                            "tag": "td"
-                        }
-                    ]
-                }
-            ],
-            "foot": []
-        },
-        "innerBlocks": [],
-        "originalContent": "<table class=\"wp-block-table\"><thead><tr><th>Version</th><th>Musician</th><th>Date</th></tr></thead><tbody><tr><td><a href=\"https://wordpress.org/news/2003/05/wordpress-now-available/\">.70</a></td><td>No musician chosen.</td><td>May 27, 2003</td></tr><tr><td><a href=\"https://wordpress.org/news/2004/01/wordpress-10/\">1.0</a></td><td>Miles Davis</td><td>January 3, 2004</td></tr><tr><td>Lots of versions skipped, see <a href=\"https://codex.wordpress.org/WordPress_Versions\">the full list</a></td><td>&hellip;</td><td>&hellip;</td></tr><tr><td><a href=\"https://wordpress.org/news/2015/12/clifford/\">4.4</a></td><td>Clifford Brown</td><td>December 8, 2015</td></tr><tr><td><a href=\"https://wordpress.org/news/2016/04/coleman/\">4.5</a></td><td>Coleman Hawkins</td><td>April 12, 2016</td></tr><tr><td><a href=\"https://wordpress.org/news/2016/08/pepper/\">4.6</a></td><td>Pepper Adams</td><td>August 16, 2016</td></tr><tr><td><a href=\"https://wordpress.org/news/2016/12/vaughan/\">4.7</a></td><td>Sarah Vaughan</td><td>December 6, 2016</td></tr></tbody></table>"
-    }
+	{
+		"clientId": "_clientId_0",
+		"name": "core/table",
+		"isValid": true,
+		"attributes": {
+			"hasFixedLayout": false,
+			"head": [
+				{
+					"cells": [
+						{
+							"content": "Version",
+							"tag": "th"
+						},
+						{
+							"content": "Musician",
+							"tag": "th"
+						},
+						{
+							"content": "Date",
+							"tag": "th"
+						}
+					]
+				}
+			],
+			"body": [
+				{
+					"cells": [
+						{
+							"content": "<a href=\"https://wordpress.org/news/2003/05/wordpress-now-available/\">.70</a>",
+							"tag": "td"
+						},
+						{
+							"content": "No musician chosen.",
+							"tag": "td"
+						},
+						{
+							"content": "May 27, 2003",
+							"tag": "td"
+						}
+					]
+				},
+				{
+					"cells": [
+						{
+							"content": "<a href=\"https://wordpress.org/news/2004/01/wordpress-10/\">1.0</a>",
+							"tag": "td"
+						},
+						{
+							"content": "Miles Davis",
+							"tag": "td"
+						},
+						{
+							"content": "January 3, 2004",
+							"tag": "td"
+						}
+					]
+				},
+				{
+					"cells": [
+						{
+							"content": "Lots of versions skipped, see <a href=\"https://codex.wordpress.org/WordPress_Versions\">the full list</a>",
+							"tag": "td"
+						},
+						{
+							"content": "…",
+							"tag": "td"
+						},
+						{
+							"content": "…",
+							"tag": "td"
+						}
+					]
+				},
+				{
+					"cells": [
+						{
+							"content": "<a href=\"https://wordpress.org/news/2015/12/clifford/\">4.4</a>",
+							"tag": "td"
+						},
+						{
+							"content": "Clifford Brown",
+							"tag": "td"
+						},
+						{
+							"content": "December 8, 2015",
+							"tag": "td"
+						}
+					]
+				},
+				{
+					"cells": [
+						{
+							"content": "<a href=\"https://wordpress.org/news/2016/04/coleman/\">4.5</a>",
+							"tag": "td"
+						},
+						{
+							"content": "Coleman Hawkins",
+							"tag": "td"
+						},
+						{
+							"content": "April 12, 2016",
+							"tag": "td"
+						}
+					]
+				},
+				{
+					"cells": [
+						{
+							"content": "<a href=\"https://wordpress.org/news/2016/08/pepper/\">4.6</a>",
+							"tag": "td"
+						},
+						{
+							"content": "Pepper Adams",
+							"tag": "td"
+						},
+						{
+							"content": "August 16, 2016",
+							"tag": "td"
+						}
+					]
+				},
+				{
+					"cells": [
+						{
+							"content": "<a href=\"https://wordpress.org/news/2016/12/vaughan/\">4.7</a>",
+							"tag": "td"
+						},
+						{
+							"content": "Sarah Vaughan",
+							"tag": "td"
+						},
+						{
+							"content": "December 6, 2016",
+							"tag": "td"
+						}
+					]
+				}
+			],
+			"figure": true,
+			"foot": []
+		},
+		"innerBlocks": [],
+		"originalContent": "<table class=\"wp-block-table\"><thead><tr><th>Version</th><th>Musician</th><th>Date</th></tr></thead><tbody><tr><td><a href=\"https://wordpress.org/news/2003/05/wordpress-now-available/\">.70</a></td><td>No musician chosen.</td><td>May 27, 2003</td></tr><tr><td><a href=\"https://wordpress.org/news/2004/01/wordpress-10/\">1.0</a></td><td>Miles Davis</td><td>January 3, 2004</td></tr><tr><td>Lots of versions skipped, see <a href=\"https://codex.wordpress.org/WordPress_Versions\">the full list</a></td><td>&hellip;</td><td>&hellip;</td></tr><tr><td><a href=\"https://wordpress.org/news/2015/12/clifford/\">4.4</a></td><td>Clifford Brown</td><td>December 8, 2015</td></tr><tr><td><a href=\"https://wordpress.org/news/2016/04/coleman/\">4.5</a></td><td>Coleman Hawkins</td><td>April 12, 2016</td></tr><tr><td><a href=\"https://wordpress.org/news/2016/08/pepper/\">4.6</a></td><td>Pepper Adams</td><td>August 16, 2016</td></tr><tr><td><a href=\"https://wordpress.org/news/2016/12/vaughan/\">4.7</a></td><td>Sarah Vaughan</td><td>December 6, 2016</td></tr></tbody></table>"
+	}
 ]

--- a/packages/e2e-tests/fixtures/blocks/core__table__scope-attribute.json
+++ b/packages/e2e-tests/fixtures/blocks/core__table__scope-attribute.json
@@ -1,149 +1,150 @@
 [
-    {
-        "clientId": "_clientId_0",
-        "name": "core/table",
-        "isValid": true,
-        "attributes": {
-            "hasFixedLayout": false,
-            "caption": "",
-            "head": [
-                {
-                    "cells": [
-                        {
-                            "content": "Version",
-                            "tag": "th",
-                            "scope": "col"
-                        },
-                        {
-                            "content": "Musician",
-                            "tag": "th",
-                            "scope": "col"
-                        },
-                        {
-                            "content": "Date",
-                            "tag": "th",
-                            "scope": "col"
-                        }
-                    ]
-                }
-            ],
-            "body": [
-                {
-                    "cells": [
-                        {
-                            "content": "<a href=\"https://wordpress.org/news/2003/05/wordpress-now-available/\">.70</a>",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "No musician chosen.",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "May 27, 2003",
-                            "tag": "td"
-                        }
-                    ]
-                },
-                {
-                    "cells": [
-                        {
-                            "content": "<a href=\"https://wordpress.org/news/2004/01/wordpress-10/\">1.0</a>",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "Miles Davis",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "January 3, 2004",
-                            "tag": "td"
-                        }
-                    ]
-                },
-                {
-                    "cells": [
-                        {
-                            "content": "Lots of versions skipped, see <a href=\"https://codex.wordpress.org/WordPress_Versions\">the full list</a>",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "…",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "…",
-                            "tag": "td"
-                        }
-                    ]
-                },
-                {
-                    "cells": [
-                        {
-                            "content": "<a href=\"https://wordpress.org/news/2015/12/clifford/\">4.4</a>",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "Clifford Brown",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "December 8, 2015",
-                            "tag": "td"
-                        }
-                    ]
-                },
-                {
-                    "cells": [
-                        {
-                            "content": "<a href=\"https://wordpress.org/news/2016/04/coleman/\">4.5</a>",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "Coleman Hawkins",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "April 12, 2016",
-                            "tag": "td"
-                        }
-                    ]
-                },
-                {
-                    "cells": [
-                        {
-                            "content": "<a href=\"https://wordpress.org/news/2016/08/pepper/\">4.6</a>",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "Pepper Adams",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "August 16, 2016",
-                            "tag": "td"
-                        }
-                    ]
-                },
-                {
-                    "cells": [
-                        {
-                            "content": "<a href=\"https://wordpress.org/news/2016/12/vaughan/\">4.7</a>",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "Sarah Vaughan",
-                            "tag": "td"
-                        },
-                        {
-                            "content": "December 6, 2016",
-                            "tag": "td"
-                        }
-                    ]
-                }
-            ],
-            "foot": []
-        },
-        "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-table\"><table><thead><tr><th scope=\"col\">Version</th><th scope=\"col\">Musician</th><th scope=\"col\">Date</th></tr></thead><tbody><tr><td><a href=\"https://wordpress.org/news/2003/05/wordpress-now-available/\">.70</a></td><td>No musician chosen.</td><td>May 27, 2003</td></tr><tr><td><a href=\"https://wordpress.org/news/2004/01/wordpress-10/\">1.0</a></td><td>Miles Davis</td><td>January 3, 2004</td></tr><tr><td>Lots of versions skipped, see <a href=\"https://codex.wordpress.org/WordPress_Versions\">the full list</a></td><td>…</td><td>…</td></tr><tr><td><a href=\"https://wordpress.org/news/2015/12/clifford/\">4.4</a></td><td>Clifford Brown</td><td>December 8, 2015</td></tr><tr><td><a href=\"https://wordpress.org/news/2016/04/coleman/\">4.5</a></td><td>Coleman Hawkins</td><td>April 12, 2016</td></tr><tr><td><a href=\"https://wordpress.org/news/2016/08/pepper/\">4.6</a></td><td>Pepper Adams</td><td>August 16, 2016</td></tr><tr><td><a href=\"https://wordpress.org/news/2016/12/vaughan/\">4.7</a></td><td>Sarah Vaughan</td><td>December 6, 2016</td></tr></tbody></table></figure>"
-    }
+	{
+		"clientId": "_clientId_0",
+		"name": "core/table",
+		"isValid": true,
+		"attributes": {
+			"hasFixedLayout": false,
+			"caption": "",
+			"figure": true,
+			"head": [
+				{
+					"cells": [
+						{
+							"content": "Version",
+							"tag": "th",
+							"scope": "col"
+						},
+						{
+							"content": "Musician",
+							"tag": "th",
+							"scope": "col"
+						},
+						{
+							"content": "Date",
+							"tag": "th",
+							"scope": "col"
+						}
+					]
+				}
+			],
+			"body": [
+				{
+					"cells": [
+						{
+							"content": "<a href=\"https://wordpress.org/news/2003/05/wordpress-now-available/\">.70</a>",
+							"tag": "td"
+						},
+						{
+							"content": "No musician chosen.",
+							"tag": "td"
+						},
+						{
+							"content": "May 27, 2003",
+							"tag": "td"
+						}
+					]
+				},
+				{
+					"cells": [
+						{
+							"content": "<a href=\"https://wordpress.org/news/2004/01/wordpress-10/\">1.0</a>",
+							"tag": "td"
+						},
+						{
+							"content": "Miles Davis",
+							"tag": "td"
+						},
+						{
+							"content": "January 3, 2004",
+							"tag": "td"
+						}
+					]
+				},
+				{
+					"cells": [
+						{
+							"content": "Lots of versions skipped, see <a href=\"https://codex.wordpress.org/WordPress_Versions\">the full list</a>",
+							"tag": "td"
+						},
+						{
+							"content": "…",
+							"tag": "td"
+						},
+						{
+							"content": "…",
+							"tag": "td"
+						}
+					]
+				},
+				{
+					"cells": [
+						{
+							"content": "<a href=\"https://wordpress.org/news/2015/12/clifford/\">4.4</a>",
+							"tag": "td"
+						},
+						{
+							"content": "Clifford Brown",
+							"tag": "td"
+						},
+						{
+							"content": "December 8, 2015",
+							"tag": "td"
+						}
+					]
+				},
+				{
+					"cells": [
+						{
+							"content": "<a href=\"https://wordpress.org/news/2016/04/coleman/\">4.5</a>",
+							"tag": "td"
+						},
+						{
+							"content": "Coleman Hawkins",
+							"tag": "td"
+						},
+						{
+							"content": "April 12, 2016",
+							"tag": "td"
+						}
+					]
+				},
+				{
+					"cells": [
+						{
+							"content": "<a href=\"https://wordpress.org/news/2016/08/pepper/\">4.6</a>",
+							"tag": "td"
+						},
+						{
+							"content": "Pepper Adams",
+							"tag": "td"
+						},
+						{
+							"content": "August 16, 2016",
+							"tag": "td"
+						}
+					]
+				},
+				{
+					"cells": [
+						{
+							"content": "<a href=\"https://wordpress.org/news/2016/12/vaughan/\">4.7</a>",
+							"tag": "td"
+						},
+						{
+							"content": "Sarah Vaughan",
+							"tag": "td"
+						},
+						{
+							"content": "December 6, 2016",
+							"tag": "td"
+						}
+					]
+				}
+			],
+			"foot": []
+		},
+		"innerBlocks": [],
+		"originalContent": "<figure class=\"wp-block-table\"><table><thead><tr><th scope=\"col\">Version</th><th scope=\"col\">Musician</th><th scope=\"col\">Date</th></tr></thead><tbody><tr><td><a href=\"https://wordpress.org/news/2003/05/wordpress-now-available/\">.70</a></td><td>No musician chosen.</td><td>May 27, 2003</td></tr><tr><td><a href=\"https://wordpress.org/news/2004/01/wordpress-10/\">1.0</a></td><td>Miles Davis</td><td>January 3, 2004</td></tr><tr><td>Lots of versions skipped, see <a href=\"https://codex.wordpress.org/WordPress_Versions\">the full list</a></td><td>…</td><td>…</td></tr><tr><td><a href=\"https://wordpress.org/news/2015/12/clifford/\">4.4</a></td><td>Clifford Brown</td><td>December 8, 2015</td></tr><tr><td><a href=\"https://wordpress.org/news/2016/04/coleman/\">4.5</a></td><td>Coleman Hawkins</td><td>April 12, 2016</td></tr><tr><td><a href=\"https://wordpress.org/news/2016/08/pepper/\">4.6</a></td><td>Pepper Adams</td><td>August 16, 2016</td></tr><tr><td><a href=\"https://wordpress.org/news/2016/12/vaughan/\">4.7</a></td><td>Sarah Vaughan</td><td>December 6, 2016</td></tr></tbody></table></figure>"
+	}
 ]


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Added a toggle to turn the wrapping of tables in figure tags off.
(See issue: https://github.com/WordPress/gutenberg/issues/23617 )

## How has this been tested?
I ran under `npm run test-unit` to ensure all the existing tests ran correctly, and I verified the new functionality in a local wordpress environment with gutenberg loaded as a plugin from a git checkout

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [ Y ] My code is tested.
- [ Y ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ I think so  ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ I think so ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ N/A ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ N/A ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
