### PR TITLE
Env: Improve install performance

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -5,10 +5,15 @@
 ### Breaking Changes
 
 -   The `config` and `mappings` options in `.wp-env.json` are now merged with any overrides instead of being overwritten.
+-   The first listed theme is no longer activated when running wp-env start, since this overwrote whatever theme the user manually activated.
 
 ### New Feature
 
 -   You may now specify specific configuration for different environments using `env.tests` or `env.development` in `.wp-env.json`.
+
+### Bug Fixes
+
+-   `wp-env start` performance is now 2x faster after first install.
 
 ## 1.6.0-rc.0 (2020-06-24)
 

--- a/packages/env/lib/commands/start.js
+++ b/packages/env/lib/commands/start.js
@@ -99,10 +99,12 @@ module.exports = async function start( { spinner, debug } ) {
 
 	// Retry WordPress installation in case MySQL *still* wasn't ready.
 	await Promise.all( [
-		retry( () => configureWordPress( 'development', config ), {
+		retry( () => configureWordPress( 'development', config, spinner ), {
 			times: 2,
 		} ),
-		retry( () => configureWordPress( 'tests', config ), { times: 2 } ),
+		retry( () => configureWordPress( 'tests', config, spinner ), {
+			times: 2,
+		} ),
 	] );
 
 	spinner.text = 'WordPress started.';

--- a/packages/env/lib/wordpress.js
+++ b/packages/env/lib/wordpress.js
@@ -94,10 +94,6 @@ async function configureWordPress( environment, config, spinner ) {
 		setupCommands.push( `wp plugin activate ${ pluginSource.basename }` );
 	}
 
-	setupCommands.push(
-		'sed "/^require.*wp-settings.php/d" /var/www/html/wp-config.php > /var/www/html/phpunit-wp-config.php'
-	);
-
 	if ( config.debug ) {
 		spinner.info(
 			`Running the following setup commands on the ${ environment } instance:\n - ${ setupCommands.join(
@@ -116,23 +112,31 @@ async function configureWordPress( environment, config, spinner ) {
 		}
 	);
 
-	// // Since wp-phpunit loads wp-settings.php at the end of its wp-config.php
-	// // file, we need to avoid loading it too early in our own wp-config.php. If
-	// // we load it too early, then some things (like MULTISITE) will be defined
-	// // before wp-phpunit has a chance to configure them. To avoid this, create a
-	// // copy of wp-config.php for phpunit which doesn't require wp-settings.php.
-	// await dockerCompose.exec(
-	// 	environment === 'development' ? 'wordpress' : 'tests-wordpress',
-	// 	[
-	// 		'sh',
-	// 		'-c',
-	// 		'sed "/^require.*wp-settings.php/d" /var/www/html/wp-config.php > /var/www/html/phpunit-wp-config.php',
-	// 	],
-	// 	{
-	// 		config: config.dockerComposeConfigPath,
-	// 		log: config.debug,
-	// 	}
-	// );
+	/**
+	 * Since wp-phpunit loads wp-settings.php at the end of its wp-config.php
+	 * file, we need to avoid loading it too early in our own wp-config.php. If
+	 * we load it too early, then some things (like MULTISITE) will be defined
+	 * before wp-phpunit has a chance to configure them. To avoid this, create a
+	 * copy of wp-config.php for phpunit which doesn't require wp-settings.php.
+	 *
+	 * Note that This needs to be executed using `exec` on the wordpress service
+	 * so that file permissions work properly.
+	 *
+	 * This will be removed in the future. @see https://github.com/WordPress/gutenberg/issues/23171
+	 *
+	 */
+	await dockerCompose.exec(
+		environment === 'development' ? 'wordpress' : 'tests-wordpress',
+		[
+			'sh',
+			'-c',
+			'sed "/^require.*wp-settings.php/d" /var/www/html/wp-config.php > /var/www/html/phpunit-wp-config.php',
+		],
+		{
+			config: config.dockerComposeConfigPath,
+			log: config.debug,
+		}
+	);
 }
 
 /**

--- a/packages/env/lib/wordpress.js
+++ b/packages/env/lib/wordpress.js
@@ -116,15 +116,6 @@ async function configureWordPress( environment, config, spinner ) {
 		setupCommands.push( `wp plugin activate ${ pluginSource.basename }` );
 	}
 
-	// Since wp-phpunit loads wp-settings.php at the end of its wp-config.php
-	// file, we need to avoid loading it too early in our own wp-config.php. If
-	// we load it too early, then some things (like MULTISITE) will be defined
-	// before wp-phpunit has a chance to configure them. To avoid this, create a
-	// copy of wp-config.php for phpunit which doesn't require wp-settings.php.
-	setupCommands.push(
-		'sed "/^require.*wp-settings.php/d" /var/www/html/wp-config.php > /var/www/html/phpunit-wp-config.php'
-	);
-
 	if ( config.debug ) {
 		spinner.info(
 			`Running the following setup commands on the ${ environment } instance:\n - ${ setupCommands.join(
@@ -137,6 +128,24 @@ async function configureWordPress( environment, config, spinner ) {
 	await dockerRun( [ 'bash', '-c', setupCommands.join( ' && ' ) ], {
 		commandOptions: [ '--rm' ],
 	} );
+
+	// Since wp-phpunit loads wp-settings.php at the end of its wp-config.php
+	// file, we need to avoid loading it too early in our own wp-config.php. If
+	// we load it too early, then some things (like MULTISITE) will be defined
+	// before wp-phpunit has a chance to configure them. To avoid this, create a
+	// copy of wp-config.php for phpunit which doesn't require wp-settings.php.
+	await dockerCompose.exec(
+		environment === 'development' ? 'wordpress' : 'tests-wordpress',
+		[
+			'sh',
+			'-c',
+			'sed "/^require.*wp-settings.php/d" /var/www/html/wp-config.php > /var/www/html/phpunit-wp-config.php',
+		],
+		{
+			config: config.dockerComposeConfigPath,
+			log: config.debug,
+		}
+	);
 }
 
 /**


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Resolves #23175. Improves startup performance by not re-launching the docker service over and over again. Rather, we run all the commands in bash with a single service execution.

Additionally, I removed the behavior which activates the first theme in the list. I personally think this is ok to do since it's really annoying to have your chosen theme be overwritten every time you start wp-env.

## How has this been tested?
Locally in wp-env; CI should pass

## Performance improvement

Each value below is the fastest run time out of 5 runs.

|            | Fresh Install* | Fresh Start | Restart (already running) |
| ---------- | ------------- | ----------- | ------------------------- |
| Previously | 63 seconds    | 24 seconds  | 29 seconds                |
| Now 🔥     | 49 seconds    | 10 seconds  | 13 seconds                |

In general, we see that wp-env runs around 14 seconds faster, which about twice as fast in normal use cases. We can further improve this by avoiding WordPress configuration when nothing has changed in the config files.

* The performance of a fresh install is mostly affected by your internet connection for downloading WordPress.

## Types of changes

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
