### PR TITLE
Env: Only perform expensive install work when required

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -7,17 +7,16 @@
 -   The `config` and `mappings` options in `.wp-env.json` are now merged with any overrides instead of being overwritten.
 -   The first listed theme is no longer activated when running wp-env start, since this overwrote whatever theme the user manually activated.
 -   `wp-env start` no longer stops the WordPress instance if it was already started unless it needs to configure WordPress.
--   `wp-env start` no longer downloads remote source updates. Use `wp-env start --update` to update sources.
+-   `wp-env start` no longer updates remote sources after first install if the configuration is the same. Use `wp-env start --update` to update sources.
 
 ### New Feature
 
 -   You may now specify specific configuration for different environments using `env.tests` or `env.development` in `.wp-env.json`.
-
-### Bug Fixes
-
--   `wp-env start` performance is now 2x faster after first install.
+-   `wp-env start` is significantly faster after first install.
 
 ## 1.6.0-rc.0 (2020-06-24)
+
+### Bug Fixes
 
 -   `wp-env destroy` now removes dangling docker volumes and networks associated with the WordPress environment.
 

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 -   The `config` and `mappings` options in `.wp-env.json` are now merged with any overrides instead of being overwritten.
 -   The first listed theme is no longer activated when running wp-env start, since this overwrote whatever theme the user manually activated.
+-   `wp-env start` no longer stops the WordPress instance if it was already started unless it needs to configure WordPress.
+-   `wp-env start` no longer downloads remote source updates. Use `wp-env start --update` to update sources.
 
 ### New Feature
 

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -172,20 +172,22 @@ $ wp-env start
 
 `wp-env` creates generated files in the `wp-env` home directory. By default, this is `~/.wp-env`. The exception is Linux, where files are placed at `~/wp-env` [for compatibility with Snap Packages](https://github.com/WordPress/gutenberg/issues/20180#issuecomment-587046325). The `wp-env` home directory contains a subdirectory for each project named `/$md5_of_project_path`. To change the `wp-env` home directory, set the `WP_ENV_HOME` environment variable. For example, running `WP_ENV_HOME="something" wp-env start` will download the project files to the directory `./something/$md5_of_project_path` (relative to the current directory).
 
-### `wp-env start [ref]`
+### `wp-env start`
+
+The start command installs and initalizes the WordPress environment, which includes downloading any specified remote sources. By default, `wp-env` will not update or re-configure WordPress except when the configuration file changes. Tell `wp-env` to update sources and apply the configuration options again with `wp-env start --update`.
 
 ```sh
 wp-env start
 
-Starts WordPress for development on port 8888 (​http://localhost:8888​)
-(override with WP_ENV_PORT) and tests on port 8889 (​http://localhost:8889​)
-(override with WP_ENV_TESTS_PORT). The current working directory must be a
-WordPress installation, a plugin, a theme, or contain a .wp-env.json file.
+Starts WordPress for development on port 8888 (override with WP_ENV_PORT) and
+tests on port 8889 (override with WP_ENV_TESTS_PORT). The current working
+directory must be a WordPress installation, a plugin, a theme, or contain a
+.wp-env.json file. Use the '--update' flag to download updates to mapped sources
+and to re-apply WordPress configuration options.
 
-
-Positionals:
-  ref  A `https://github.com/WordPress/WordPress` git repo branch or commit for
-       choosing a specific version.                 [string] [default: "master"]
+Options:
+  --update   Download source updates and re-configures WordPress.
+                                                      [boolean] [default: false]
 ```
 
 ### `wp-env stop`
@@ -286,14 +288,14 @@ You can customize the WordPress installation, plugins and themes that the develo
 
 `.wp-env.json` supports six fields for options applicable to both the tests and development instances.
 
-| Field        | Type           | Default                                | Description                                                                                                               |
-| ------------ | -------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `"core"`     | `string\|null` | `null`                                 | The WordPress installation to use. If `null` is specified, `wp-env` will use the latest production release of WordPress.  |
-| `"plugins"`  | `string[]`     | `[]`                                   | A list of plugins to install and activate in the environment.                                                             |
-| `"themes"`   | `string[]`     | `[]`                                   | A list of themes to install in the environment. The first theme in the list will be activated.                            |
+| Field        | Type           | Default                                | Description                                                                                                                |
+| ------------ | -------------- | -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `"core"`     | `string\|null` | `null`                                 | The WordPress installation to use. If `null` is specified, `wp-env` will use the latest production release of WordPress.   |
+| `"plugins"`  | `string[]`     | `[]`                                   | A list of plugins to install and activate in the environment.                                                              |
+| `"themes"`   | `string[]`     | `[]`                                   | A list of themes to install in the environment. The first theme in the list will be activated.                             |
 | `"port"`     | `integer`      | `8888` (`8889` for the tests instance) | The primary port number to use for the installation. You'll access the instance through the port: 'http://localhost:8888'. |
-| `"config"`   | `Object`       | See below.                             | Mapping of wp-config.php constants to their desired values.                                                               |
-| `"mappings"` | `Object`       | `"{}"`                                 | Mapping of WordPress directories to local directories to be mounted in the WordPress instance.                            |
+| `"config"`   | `Object`       | See below.                             | Mapping of wp-config.php constants to their desired values.                                                                |
+| `"mappings"` | `Object`       | `"{}"`                                 | Mapping of WordPress directories to local directories to be mounted in the WordPress instance.                             |
 
 _Note: the port number environment variables (`WP_ENV_PORT` and `WP_ENV_TESTS_PORT`) take precedent over the .wp-env.json values._
 

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -174,7 +174,7 @@ $ wp-env start
 
 ### `wp-env start`
 
-The start command installs and initalizes the WordPress environment, which includes downloading any specified remote sources. By default, `wp-env` will not update or re-configure WordPress except when the configuration file changes. Tell `wp-env` to update sources and apply the configuration options again with `wp-env start --update`.
+The start command installs and initalizes the WordPress environment, which includes downloading any specified remote sources. By default, `wp-env` will not update or re-configure the environment except when the configuration file changes. Tell `wp-env` to update sources and apply the configuration options again with `wp-env start --update`. This will not overrwrite any existing content.
 
 ```sh
 wp-env start
@@ -182,11 +182,11 @@ wp-env start
 Starts WordPress for development on port 8888 (override with WP_ENV_PORT) and
 tests on port 8889 (override with WP_ENV_TESTS_PORT). The current working
 directory must be a WordPress installation, a plugin, a theme, or contain a
-.wp-env.json file. Use the '--update' flag to download updates to mapped sources
-and to re-apply WordPress configuration options.
+.wp-env.json file. After first insall, use the '--update' flag to download updates
+to mapped sources and to re-apply WordPress configuration options.
 
 Options:
-  --update   Download source updates and re-configures WordPress.
+  --update   Download source updates and apply WordPress configuration.
                                                       [boolean] [default: false]
 ```
 

--- a/packages/env/lib/cache.js
+++ b/packages/env/lib/cache.js
@@ -1,0 +1,89 @@
+/**
+ * External dependencies
+ */
+const path = require( 'path' );
+const fs = require( 'fs' ).promises;
+
+/**
+ * Options for cache parsing.
+ *
+ * @typedef WPEnvCacheOptions
+ * @property {string}  workDirectoryPath Path to the work directory located in ~/.wp-env.
+ */
+
+const CACHE_FILE_NAME = 'wp-env-cache.json';
+
+/**
+ * This function can be used to compare a possible new cache value against an
+ * existing cache value. For example, we can use this to check if the configuration
+ * has changed in a new run of wp-env start.
+ *
+ * @param {string}           key     A unique identifier for the cache.
+ * @param {any}              value   The value to check against the existing cache.
+ * @param {WPEnvCacheOptions} options Parsing options
+ *
+ * @return {boolean} If true, the value is different from the cache which exists.
+ */
+async function didCacheChange( key, value, options ) {
+	const existingValue = await getCache( key, options );
+	return value !== existingValue;
+}
+
+/**
+ * This function persists the given cache value to the cache file. It creates the
+ * file if it does not exist yet, and overwrites the existing cache value for the
+ * given key if it already exists.
+ *
+ * @param {string}           key     A unique identifier for the cache.
+ * @param {any}              value   The value to persist.
+ * @param {WPEnvCacheOptions} options Parsing options
+ */
+async function setCache( key, value, options ) {
+	const existingCache = getCacheFile( options );
+	existingCache[ key ] = value;
+
+	await fs.writeFile(
+		getPathToCacheFile( options.workDirectoryPath ),
+		JSON.stringify( existingCache )
+	);
+}
+
+/**
+ * This function retrieves the cache associated with the given key from the file.
+ * Returns undefined if the key does not exist or if the cache file has not been
+ * created yet.
+ *
+ * @param {string}           key     The unique identifier for the cache value.
+ * @param {WPEnvCacheOptions} options Parsing options
+ *
+ * @return {any?} The cache value. Undefined if it has not been set or if the cache
+ *                file has not been created.
+ */
+async function getCache( key, options ) {
+	const cache = await getCacheFile( options );
+	return cache[ key ];
+}
+
+/**
+ * Returns the data stored in the cache file as a JS object. Instead of throwing
+ * an error, simply returns an empty object if the file cannot be retrieved.
+ *
+ * @param {WPEnvCacheOptions} options Parsing options
+ *
+ * @return {Object} The data from the cache file. Empty if the file does not exist.
+ */
+async function getCacheFile( { workDirectoryPath } ) {
+	const filename = getPathToCacheFile( workDirectoryPath );
+	try {
+		const rawCache = await fs.readFile( filename );
+		return JSON.parse( rawCache );
+	} catch {
+		return {};
+	}
+}
+
+function getPathToCacheFile( workDirectoryPath ) {
+	return path.resolve( workDirectoryPath, CACHE_FILE_NAME );
+}
+
+module.exports = { didCacheChange, setCache };

--- a/packages/env/lib/cache.js
+++ b/packages/env/lib/cache.js
@@ -39,7 +39,7 @@ async function didCacheChange( key, value, options ) {
  * @param {WPEnvCacheOptions} options Parsing options
  */
 async function setCache( key, value, options ) {
-	const existingCache = getCacheFile( options );
+	const existingCache = await getCacheFile( options );
 	existingCache[ key ] = value;
 
 	await fs.writeFile(
@@ -86,4 +86,4 @@ function getPathToCacheFile( workDirectoryPath ) {
 	return path.resolve( workDirectoryPath, CACHE_FILE_NAME );
 }
 
-module.exports = { didCacheChange, setCache };
+module.exports = { didCacheChange, setCache, getCache, getCacheFile };

--- a/packages/env/lib/cache.js
+++ b/packages/env/lib/cache.js
@@ -18,8 +18,8 @@ const CACHE_FILE_NAME = 'wp-env-cache.json';
  * existing cache value. For example, we can use this to check if the configuration
  * has changed in a new run of wp-env start.
  *
- * @param {string}           key     A unique identifier for the cache.
- * @param {any}              value   The value to check against the existing cache.
+ * @param {string}            key     A unique identifier for the cache.
+ * @param {any}               value   The value to check against the existing cache.
  * @param {WPEnvCacheOptions} options Parsing options
  *
  * @return {boolean} If true, the value is different from the cache which exists.
@@ -34,8 +34,8 @@ async function didCacheChange( key, value, options ) {
  * file if it does not exist yet, and overwrites the existing cache value for the
  * given key if it already exists.
  *
- * @param {string}           key     A unique identifier for the cache.
- * @param {any}              value   The value to persist.
+ * @param {string}            key     A unique identifier for the cache.
+ * @param {any}               value   The value to persist.
  * @param {WPEnvCacheOptions} options Parsing options
  */
 async function setCache( key, value, options ) {
@@ -53,7 +53,7 @@ async function setCache( key, value, options ) {
  * Returns undefined if the key does not exist or if the cache file has not been
  * created yet.
  *
- * @param {string}           key     The unique identifier for the cache value.
+ * @param {string}            key     The unique identifier for the cache value.
  * @param {WPEnvCacheOptions} options Parsing options
  *
  * @return {any?} The cache value. Undefined if it has not been set or if the cache

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -90,7 +90,7 @@ module.exports = function cli() {
 			) }} (override with WP_ENV_PORT) and tests on port {bold.underline ${ terminalLink(
 				'8889',
 				'http://localhost:8889'
-			) }} (override with WP_ENV_TESTS_PORT). The current working directory must be a WordPress installation, a plugin, a theme, or contain a .wp-env.json file. Use the '--update' flag to download updates to mapped sources and to re-apply WordPress configuration options.`
+			) }} (override with WP_ENV_TESTS_PORT). The current working directory must be a WordPress installation, a plugin, a theme, or contain a .wp-env.json file. After first insall, use the '--update' flag to download updates to mapped sources and to re-apply WordPress configuration options.`
 		),
 		( args ) => {
 			args.option( 'update', {

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -90,9 +90,16 @@ module.exports = function cli() {
 			) }} (override with WP_ENV_PORT) and tests on port {bold.underline ${ terminalLink(
 				'8889',
 				'http://localhost:8889'
-			) }} (override with WP_ENV_TESTS_PORT). The current working directory must be a WordPress installation, a plugin, a theme, or contain a .wp-env.json file.`
+			) }} (override with WP_ENV_TESTS_PORT). The current working directory must be a WordPress installation, a plugin, a theme, or contain a .wp-env.json file. Use the '--update' flag to download updates to mapped sources and to re-apply WordPress configuration options.`
 		),
-		() => {},
+		( args ) => {
+			args.option( 'update', {
+				type: 'boolean',
+				describe:
+					'Download source updates and apply WordPress configuration.',
+				default: false,
+			} );
+		},
 		withSpinner( env.start )
 	);
 	yargs.command(

--- a/packages/env/lib/commands/start.js
+++ b/packages/env/lib/commands/start.js
@@ -48,6 +48,14 @@ module.exports = async function start( { spinner, debug, update } ) {
 
 	const config = await initConfig( { spinner, debug } );
 
+	if ( ! config.detectedLocalConfig ) {
+		const { configDirectoryPath } = config;
+		spinner.warn(
+			`Warning: could not find a .wp-env.json configuration file and could not determine if '${ configDirectoryPath }' is a WordPress installation, a plugin, or a theme.`
+		);
+		spinner.start();
+	}
+
 	// Check if the hash of the config has changed. If so, run configuration.
 	const configHash = md5( config );
 	const workDirectoryPath = config.workDirectoryPath;
@@ -71,14 +79,6 @@ module.exports = async function start( { spinner, debug, update } ) {
 	if ( shouldConfigureWp ) {
 		await stop( { spinner, debug } );
 		spinner.text = 'Downloading sources.';
-	}
-
-	if ( ! config.detectedLocalConfig ) {
-		const { configDirectoryPath } = config;
-		spinner.warn(
-			`Warning: could not find a .wp-env.json configuration file and could not determine if '${ configDirectoryPath }' is a WordPress installation, a plugin, or a theme.`
-		);
-		spinner.start();
 	}
 
 	await Promise.all( [

--- a/packages/env/lib/commands/start.js
+++ b/packages/env/lib/commands/start.js
@@ -26,10 +26,13 @@ const {
 	configureWordPress,
 	setupWordPressDirectories,
 } = require( '../wordpress' );
+const { didCacheChange, setCache } = require( '../cache' );
+const md5 = require( '../md5' );
 
 /**
  * @typedef {import('../config').Config} Config
  */
+const CONFIG_CACHE_KEY = 'config_checksum';
 
 /**
  * Starts the development server.
@@ -37,8 +40,23 @@ const {
  * @param {Object}  options
  * @param {Object}  options.spinner A CLI spinner which indicates progress.
  * @param {boolean} options.debug   True if debug mode is enabled.
+ * @param {boolean} options.update  If true, update sources.
  */
-module.exports = async function start( { spinner, debug } ) {
+module.exports = async function start( { spinner, debug, update } ) {
+	spinner.text = 'Reading configuration.';
+	await checkForLegacyInstall( spinner );
+
+	const config = await initConfig( { spinner, debug } );
+
+	// Check if the hash of the config has changed. If so, run configuration.
+	const configHash = md5( config );
+	const workDirectoryPath = config.workDirectoryPath;
+	const shouldConfigureWp =
+		update ||
+		( await didCacheChange( CONFIG_CACHE_KEY, configHash, {
+			workDirectoryPath,
+		} ) );
+
 	/**
 	 * If the Docker image is already running and the `wp-env` files have been
 	 * deleted, the start command will not complete successfully. Stopping
@@ -50,11 +68,10 @@ module.exports = async function start( { spinner, debug } ) {
 	 *
 	 * @see https://github.com/WordPress/gutenberg/pull/20253#issuecomment-587228440
 	 */
-	await stop( { spinner, debug } );
-
-	await checkForLegacyInstall( spinner );
-
-	const config = await initConfig( { spinner, debug } );
+	if ( shouldConfigureWp ) {
+		await stop( { spinner, debug } );
+		spinner.text = 'Downloading sources.';
+	}
 
 	if ( ! config.detectedLocalConfig ) {
 		const { configDirectoryPath } = config;
@@ -64,18 +81,17 @@ module.exports = async function start( { spinner, debug } ) {
 		spinner.start();
 	}
 
-	spinner.text = 'Downloading WordPress.';
-
 	await Promise.all( [
-		// Preemptively start the database while we wait for sources to download.
 		dockerCompose.upOne( 'mysql', {
 			config: config.dockerComposeConfigPath,
 			log: config.debug,
 		} ),
-		downloadSources( config, spinner ),
+		shouldConfigureWp && downloadSources( config, spinner ),
 	] );
 
-	await setupWordPressDirectories( config );
+	if ( shouldConfigureWp ) {
+		await setupWordPressDirectories( config );
+	}
 
 	spinner.text = 'Starting WordPress.';
 
@@ -84,36 +100,46 @@ module.exports = async function start( { spinner, debug } ) {
 		log: config.debug,
 	} );
 
-	if ( config.coreSource === null ) {
-		// Don't chown wp-content when it exists on the user's local filesystem.
+	// Only run WordPress install/configuration when config has changed.
+	if ( shouldConfigureWp ) {
+		spinner.text = 'Configuring WordPress.';
+
+		if ( config.coreSource === null ) {
+			// Don't chown wp-content when it exists on the user's local filesystem.
+			await Promise.all( [
+				makeContentDirectoriesWritable( 'development', config ),
+				makeContentDirectoriesWritable( 'tests', config ),
+			] );
+		}
+
+		try {
+			await checkDatabaseConnection( config );
+		} catch ( error ) {
+			// Wait 30 seconds for MySQL to accept connections.
+			await retry( () => checkDatabaseConnection( config ), {
+				times: 30,
+				delay: 1000,
+			} );
+
+			// It takes 3-4 seconds for MySQL to be ready after it starts accepting connections.
+			await sleep( 4000 );
+		}
+
+		// Retry WordPress installation in case MySQL *still* wasn't ready.
 		await Promise.all( [
-			makeContentDirectoriesWritable( 'development', config ),
-			makeContentDirectoriesWritable( 'tests', config ),
+			retry( () => configureWordPress( 'development', config, spinner ), {
+				times: 2,
+			} ),
+			retry( () => configureWordPress( 'tests', config, spinner ), {
+				times: 2,
+			} ),
 		] );
-	}
 
-	try {
-		await checkDatabaseConnection( config );
-	} catch ( error ) {
-		// Wait 30 seconds for MySQL to accept connections.
-		await retry( () => checkDatabaseConnection( config ), {
-			times: 30,
-			delay: 1000,
+		// Set the cache key once everything has been configured.
+		await setCache( CONFIG_CACHE_KEY, configHash, {
+			workDirectoryPath,
 		} );
-
-		// It takes 3-4 seconds for MySQL to be ready after it starts accepting connections.
-		await sleep( 4000 );
 	}
-
-	// Retry WordPress installation in case MySQL *still* wasn't ready.
-	await Promise.all( [
-		retry( () => configureWordPress( 'development', config, spinner ), {
-			times: 2,
-		} ),
-		retry( () => configureWordPress( 'tests', config, spinner ), {
-			times: 2,
-		} ),
-	] );
 
 	spinner.text = 'WordPress started.';
 };

--- a/packages/env/lib/config/config.js
+++ b/packages/env/lib/config/config.js
@@ -5,7 +5,6 @@
 const fs = require( 'fs' ).promises;
 const path = require( 'path' );
 const os = require( 'os' );
-const crypto = require( 'crypto' );
 
 /**
  * Internal dependencies
@@ -14,6 +13,7 @@ const detectDirectoryType = require( './detect-directory-type' );
 const { validateConfig, ValidationError } = require( './validate-config' );
 const readRawConfigFile = require( './read-raw-config-file' );
 const parseConfig = require( './parse-config' );
+const md5 = require( '../md5' );
 
 /**
  * wp-env configuration.
@@ -331,14 +331,4 @@ async function getHomeDirectory() {
 			? 'wp-env'
 			: '.wp-env'
 	);
-}
-
-/**
- * Hashes the given string using the MD5 algorithm.
- *
- * @param {string} data The string to hash.
- * @return {string} An MD5 hash string.
- */
-function md5( data ) {
-	return crypto.createHash( 'md5' ).update( data ).digest( 'hex' );
 }

--- a/packages/env/lib/md5.js
+++ b/packages/env/lib/md5.js
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+const crypto = require( 'crypto' );
+
+/**
+ * Hashes the given string using the MD5 algorithm.
+ *
+ * @param {any} data The data to hash. If not a string, converted with JSON.stringify.
+ * @return {string} An MD5 hash string.
+ */
+module.exports = function md5( data ) {
+	const convertedData =
+		typeof data === 'string' ? data : JSON.stringify( data );
+
+	return crypto.createHash( 'md5' ).update( convertedData ).digest( 'hex' );
+};

--- a/packages/env/test/__snapshots__/md5.js.snap
+++ b/packages/env/test/__snapshots__/md5.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`md5 creates a hash of a number 1`] = `"55587a910882016321201e6ebbc9f595"`;
+
+exports[`md5 creates a hash of a object 1`] = `"a0294b0e88367a0ff800d78413356538"`;
+
+exports[`md5 creates a hash of a string 1`] = `"5d41402abc4b2a76b9719d911017c592"`;
+
+exports[`md5 creates a hash of null 1`] = `"37a6259cc0c1dae299a7866489dff0bd"`;

--- a/packages/env/test/cache.js
+++ b/packages/env/test/cache.js
@@ -1,0 +1,153 @@
+/**
+ * External dependencies
+ */
+const { readFile, writeFile } = require( 'fs' ).promises;
+
+/**
+ * Internal dependencies
+ */
+const {
+	didCacheChange,
+	setCache,
+	getCache,
+	getCacheFile,
+} = require( '../lib/cache' );
+
+jest.mock( 'fs', () => ( {
+	promises: {
+		readFile: jest.fn(),
+		writeFile: jest.fn(),
+	},
+} ) );
+
+const cacheOptions = {
+	workDirectoryPath: '/a/b/c',
+};
+
+function deleteCacheFile() {
+	readFile.mockImplementation( () => Promise.reject( 'No file!' ) );
+}
+
+function setCacheFile( data ) {
+	readFile.mockImplementation( () =>
+		Promise.resolve( JSON.stringify( data ) )
+	);
+}
+
+function setupWriteFile() {
+	writeFile.mockImplementation( ( fileName, data ) => {
+		readFile.mockClear();
+		readFile.mockImplementation( () => Promise.resolve( data ) );
+	} );
+}
+
+describe( 'cache file', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	describe( 'didCacheChange', () => {
+		it( 'returns true if the existing cache value is different', async () => {
+			setCacheFile( { test: 'test1' } );
+			const result = await didCacheChange( 'test', 'nope', cacheOptions );
+			expect( result ).toBe( true );
+		} );
+		it( 'returns false if the existing cache value is the same', async () => {
+			setCacheFile( { test: 'test1' } );
+			const result = await didCacheChange(
+				'test',
+				'test1',
+				cacheOptions
+			);
+			expect( result ).toBe( false );
+		} );
+		it( 'returns true if the existing cache value does not exist', async () => {
+			expect.assertions( 2 );
+
+			setCacheFile( { howdy: 'test1' } );
+			const result = await didCacheChange( 'test', 'nope', cacheOptions );
+			expect( result ).toBe( true );
+
+			deleteCacheFile();
+			const result2 = await didCacheChange(
+				'test',
+				'nope',
+				cacheOptions
+			);
+			expect( result2 ).toBe( true );
+		} );
+	} );
+
+	describe( 'setCache', () => {
+		it( 'saves a new cache value to the file', async () => {
+			setupWriteFile();
+			await setCache( 'test', 'abc', cacheOptions );
+			const result = await getCacheFile( cacheOptions );
+			expect( result ).toEqual( { test: 'abc' } );
+		} );
+		it( 'overwrites an existing key', async () => {
+			expect.assertions( 2 );
+			setCacheFile( { test: 'abc' } );
+			const result = await getCacheFile( cacheOptions );
+			expect( result ).toEqual( { test: 'abc' } );
+
+			await setCache( 'test', '123', cacheOptions );
+			const result2 = await getCacheFile( cacheOptions );
+			expect( result2 ).toEqual( { test: '123' } );
+		} );
+		it( 'does not overwrite other keys', async () => {
+			setCacheFile( { test: 'abc' } );
+
+			await setCache( 'test2', 1234, cacheOptions );
+			const result = await getCacheFile( cacheOptions );
+			expect( result ).toEqual( { test: 'abc', test2: 1234 } );
+		} );
+	} );
+
+	describe( 'getCache', () => {
+		it( 'returns the cache value associated with the key', async () => {
+			const value = 'test1';
+			setCacheFile( { test: value } );
+			const result = await getCache( 'test', cacheOptions );
+			expect( result ).toBe( value );
+		} );
+		it( 'returns undefined if there is no existing value', async () => {
+			setCacheFile( { anotherValue: 'hello' } );
+			const result = await getCache( 'test', cacheOptions );
+			expect( result ).toBe( undefined );
+		} );
+		it( 'returns undefined if the file does not exist', async () => {
+			deleteCacheFile();
+			const result = await getCache( 'test', cacheOptions );
+			expect( result ).toBe( undefined );
+		} );
+	} );
+
+	describe( 'getCacheFile', () => {
+		it( 'returns the stored JSON data as an Object', async () => {
+			const testData = {
+				a: 'test',
+				b: 1,
+				c: true,
+				d: null,
+				e: {
+					foo: 'test2',
+				},
+			};
+			setCacheFile( testData );
+
+			const result = await getCacheFile( cacheOptions );
+			expect( result ).toEqual( testData );
+		} );
+		it( 'returns an empty object if the file does not exist', async () => {
+			deleteCacheFile();
+			const result = await getCacheFile( cacheOptions );
+			expect( result ).toEqual( {} );
+		} );
+		it( 'returns an empty object if the file is invalid', async () => {
+			readFile.mockImplementation( () => Promise.resolve( '{' ) );
+			const result = await getCacheFile( cacheOptions );
+			expect( result ).toEqual( {} );
+		} );
+	} );
+} );

--- a/packages/env/test/md5.js
+++ b/packages/env/test/md5.js
@@ -1,0 +1,34 @@
+/**
+ * Internal dependencies
+ */
+const md5 = require( '../lib/md5' );
+
+describe( 'md5', () => {
+	it( 'creates a hash of a string', () => {
+		const result = md5( 'hello' );
+		expect( result ).toMatchSnapshot();
+	} );
+	it( 'creates a hash of a object', () => {
+		const result = md5( { foo: 'xyz', test: { anotherFoo: 123 } } );
+		expect( result ).toMatchSnapshot();
+	} );
+	it( 'creates a hash of a number', () => {
+		const result = md5( 123789 );
+		expect( result ).toMatchSnapshot();
+	} );
+	it( 'creates a hash of null', () => {
+		const result = md5( null );
+		expect( result ).toMatchSnapshot();
+	} );
+	it( 'uses the same hash for the same values', () => {
+		const testObj = {
+			test: 1,
+			otherTest: {
+				foo: 'hello',
+			},
+		};
+		const result1 = md5( testObj );
+		const result2 = md5( { ...testObj } );
+		expect( result1 ).toBe( result2 );
+	} );
+} );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

TLDR: wp-env start only takes 1-2 seconds in common use cases.

`wp-env start` is now much lazier, only doing time-intensive work when required.

`wp-env` previously did the following actions on every run:

- WordPress configuration is applied (e.g. `wp core install` and `wp config set`)
- Download specified remote sources like WordPress
- Ran wp-env stop as a "restart" mechanism to handle some edge cases

Now, these actions are only performed in two situations:
1. The parsed wp-env configuration is different. (Configuration is considered different on first install, when updating `*.wp-env.json` files, and when different environment variables change.)
2. The user specifies the `--update` flag.

To accomplish this, I added a little library to read/write cache values to a cache JSON file stored in the wp-env work directory. This might be useful in the future, particularly if we want to get more granular about this behavior.

_Note that the WordPress install and source downloads still happen each run so that they stay up-to-date._

## How has this been tested?
Locally, in wp-env; CI should work. You can test with `npx wp-env start` locally with this branch checked out and it will run sourcecode.

## Screenshots <!-- if applicable -->

The first run is before this change. The second is with this improvement:

<img width="575" alt="Screen Shot 2020-07-08 at 6 20 12 PM" src="https://user-images.githubusercontent.com/6265975/86988501-355ab100-c14d-11ea-98e1-fb9270dc83b1.png">

## Types of changes
Performance improvement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
