### PR TITLE
[Mobile] Remove block - Show notice message

### DIFF
--- a/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
@@ -125,8 +125,8 @@ const BlockActionsMenu = ( {
 			case deleteOption.value:
 				onDelete();
 				createInfoNotice(
-					// translators: displayed right after the block is deleted.
-					__( 'Block deleted' )
+					// translators: displayed right after the block is removed.
+					__( 'Block removed' )
 				);
 				break;
 			case settingsOption.value:

--- a/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
@@ -124,6 +124,10 @@ const BlockActionsMenu = ( {
 		switch ( value ) {
 			case deleteOption.value:
 				onDelete();
+				createInfoNotice(
+					// translators: displayed right after the block is deleted.
+					__( 'Block deleted' )
+				);
 				break;
 			case settingsOption.value:
 				openGeneralSidebar();


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/23795

## Description
This PR adds displaying a notice message when removing a block from the block options menu.

## How has this been tested?
- Open the demo app
- Select a block
- Tap on the three dots button to open the block options menu
- Tap on **Remove block**
- Expect to see the notice bar at the top displaying `Block removed`

## Screenshots <!-- if applicable -->

<kbd><img src="https://user-images.githubusercontent.com/4885740/87013913-a6d94480-c1cb-11ea-995f-1ef84822c3ff.gif" width=250 /></kbd>

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
