### PR TITLE
Improve fetch all middleware and preloading

### DIFF
--- a/packages/api-fetch/src/index.js
+++ b/packages/api-fetch/src/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -63,8 +64,8 @@ const checkStatus = ( response ) => {
 };
 
 const defaultFetchHandler = ( nextOptions ) => {
-	const { url, path, data, parse = true, ...remainingOptions } = nextOptions;
-	let { body, headers } = nextOptions;
+	const { data, envelope = false, ...remainingOptions } = nextOptions;
+	let { body, headers, url, path, parse = true } = nextOptions;
 
 	// Merge explicitly-provided headers with default values.
 	headers = { ...DEFAULT_HEADERS, ...headers };
@@ -73,6 +74,15 @@ const defaultFetchHandler = ( nextOptions ) => {
 	if ( data ) {
 		body = JSON.stringify( data );
 		headers[ 'Content-Type' ] = 'application/json';
+	}
+	// Envelope request for easier access to headers and status.
+	if ( envelope ) {
+		parse = false;
+		const queryArgs = {
+			_envelope: 1,
+		};
+		url = url && addQueryArgs( url, queryArgs );
+		path = path && addQueryArgs( path, queryArgs );
 	}
 
 	const responsePromise = window.fetch( url || path, {

--- a/packages/api-fetch/src/middlewares/fetch-all-middleware.js
+++ b/packages/api-fetch/src/middlewares/fetch-all-middleware.js
@@ -80,7 +80,7 @@ const fetchAllMiddleware = async ( options, next ) => {
 		} );
 		const nextResults = await parseResponse( nextResponse );
 		mergedResults = mergedResults.concat( nextResults.body );
-		nextPage = getNextPageUrl( nextResponse );
+		nextPage = getNextPageUrl( nextResults );
 	}
 	return mergedResults;
 };

--- a/packages/api-fetch/src/middlewares/preloading.js
+++ b/packages/api-fetch/src/middlewares/preloading.js
@@ -40,13 +40,15 @@ function createPreloadingMiddleware( preloadedData ) {
 	}, {} );
 
 	return ( options, next ) => {
-		const { parse = true } = options;
+		const { parse = true, envelope = false } = options;
 		if ( typeof options.path === 'string' ) {
 			const method = options.method || 'GET';
 			const path = getStablePath( options.path );
 
 			if ( parse && 'GET' === method && cache[ path ] ) {
-				return Promise.resolve( cache[ path ].body );
+				return Promise.resolve(
+					envelope ? cache[ path ] : cache[ path ].body
+				);
 			} else if (
 				'OPTIONS' === method &&
 				cache[ method ] &&


### PR DESCRIPTION
## Description

Use the `_envelope?=1` param passed to the REST API request. This returns the headers and status in the body of the request. Meaning that `parse: false` and get headers is not required. As `parse: false` is not being passed, the preloaded values can be used. 

Fixes #23674 
Fixes #23673 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
