### PR TITLE
[InputControl] Add prefix prop

### DIFF
--- a/packages/components/src/input-control/README.md
+++ b/packages/components/src/input-control/README.md
@@ -66,6 +66,13 @@ A function that receives the value of the input.
 -   Type: `Function`
 -   Required: Yes
 
+### prefix
+
+Renders an element on the left side of the input.
+
+-   Type: `React.ReactNode`
+-   Required: No
+
 ### size
 
 Adjusts the size of the input.

--- a/packages/components/src/input-control/index.js
+++ b/packages/components/src/input-control/index.js
@@ -16,7 +16,7 @@ import { useState, forwardRef } from '@wordpress/element';
 import Backdrop from './backdrop';
 import InputField from './input-field';
 import Label from './label';
-import { Container, Root, Suffix } from './styles/input-control-styles';
+import { Container, Root, Prefix, Suffix } from './styles/input-control-styles';
 import { isValueEmpty } from '../utils/values';
 
 function useUniqueId( idProp ) {
@@ -42,6 +42,7 @@ export function InputControl(
 		onFocus = noop,
 		onValidate = noop,
 		onKeyDown = noop,
+		prefix,
 		size = 'default',
 		suffix,
 		value,
@@ -93,6 +94,11 @@ export function InputControl(
 				disabled={ disabled }
 				isFocused={ isFocused }
 			>
+				{ prefix && (
+					<Prefix className="components-input-control__prefix">
+						{ prefix }
+					</Prefix>
+				) }
 				<InputField
 					{ ...props }
 					className="components-input-control__input"

--- a/packages/components/src/input-control/stories/index.js
+++ b/packages/components/src/input-control/stories/index.js
@@ -37,14 +37,17 @@ function Example() {
 			'default'
 		),
 		suffix: text( 'suffix', '' ),
+		prefix: text( 'prefix', '' ),
 	};
 
 	const suffixMarkup = props.suffix ? <div>{ props.suffix }</div> : null;
+	const prefixMarkup = props.prefix ? <div>{ props.prefix }</div> : null;
 
 	return (
 		<InputControl
 			{ ...props }
 			onChange={ ( v ) => setValue( v ) }
+			prefix={ prefixMarkup }
 			suffix={ suffixMarkup }
 			value={ value }
 		/>

--- a/packages/components/src/input-control/styles/input-control-styles.js
+++ b/packages/components/src/input-control/styles/input-control-styles.js
@@ -352,6 +352,11 @@ export const LegendText = ( props ) => (
 	<BaseLegendText { ...props } as="span" />
 );
 
+export const Prefix = styled.span`
+	box-sizing: border-box;
+	display: block;
+`;
+
 export const Suffix = styled.span`
 	box-sizing: border-box;
 	display: block;


### PR DESCRIPTION
## Description
This PR adds a `prefix` property to the InputControl component. The implementation is pretty straightforward - it's just a counterpart of the already existing `suffix` property. The need was created by the following design from #23375 

<img width="391" alt="Zrzut ekranu 2020-07-9 o 13 38 39" src="https://user-images.githubusercontent.com/205419/87035426-9b951180-c1e9-11ea-9ee9-fde92ad19a76.png">


## How has this been tested?
1. Run storybook (` npm run storybook:dev`)
1. Navigate to InputControl
1. Play with the prefix property and confirm it works as you'd expect

## Screenshots <!-- if applicable -->

<img width="374" alt="Zrzut ekranu 2020-07-9 o 13 33 53" src="https://user-images.githubusercontent.com/205419/87035491-b2d3ff00-c1e9-11ea-91b2-c3fa5da08ac0.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
