### PR TITLE
Small performance tweaks

### DIFF
--- a/packages/block-editor/src/components/block-draggable/index.js
+++ b/packages/block-editor/src/components/block-draggable/index.js
@@ -18,20 +18,17 @@ const BlockDraggable = ( {
 	onDragStart,
 	onDragEnd,
 } ) => {
-	const { srcRootClientId, index, isDraggable } = useSelect(
+	const { srcRootClientId, isDraggable } = useSelect(
 		( select ) => {
-			const {
-				getBlockIndex,
-				getBlockRootClientId,
-				getTemplateLock,
-			} = select( 'core/block-editor' );
+			const { getBlockRootClientId, getTemplateLock } = select(
+				'core/block-editor'
+			);
 			const rootClientId = getBlockRootClientId( clientIds[ 0 ] );
 			const templateLock = rootClientId
 				? getTemplateLock( rootClientId )
 				: null;
 
 			return {
-				index: getBlockIndex( clientIds[ 0 ], rootClientId ),
 				srcRootClientId: rootClientId,
 				isDraggable: 'all' !== templateLock,
 			};
@@ -64,7 +61,6 @@ const BlockDraggable = ( {
 
 	const transferData = {
 		type: 'block',
-		srcIndex: index,
 		srcClientIds: clientIds,
 		srcRootClientId,
 	};

--- a/packages/block-editor/src/components/spacing-panel-control/index.js
+++ b/packages/block-editor/src/components/spacing-panel-control/index.js
@@ -19,7 +19,7 @@ export default function SpacingPanelControl( { children, ...props } ) {
 	const isSpacingEnabled = useSelect( ( select ) => {
 		const { getSettings } = select( 'core/block-editor' );
 		return get( getSettings(), '__experimentalEnableCustomSpacing' );
-	} );
+	}, [] );
 
 	if ( ! isSpacingEnabled ) return null;
 

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -137,7 +137,6 @@ function parseDropEvent( event ) {
 	let result = {
 		srcRootClientId: null,
 		srcClientIds: null,
-		srcIndex: null,
 		type: null,
 	};
 
@@ -176,28 +175,32 @@ export default function useBlockDropZone( {
 } ) {
 	const [ targetBlockIndex, setTargetBlockIndex ] = useState( null );
 
-	function selector( select ) {
-		const {
-			getBlockListSettings,
-			getClientIdsOfDescendants,
-			getSettings,
-			getTemplateLock,
-		} = select( 'core/block-editor' );
-		return {
-			orientation: getBlockListSettings( targetRootClientId )
-				?.orientation,
-			getClientIdsOfDescendants,
-			hasUploadPermissions: !! getSettings().mediaUpload,
-			isLockedAll: getTemplateLock( targetRootClientId ) === 'all',
-		};
-	}
-
 	const {
 		getClientIdsOfDescendants,
+		getBlockIndex,
 		hasUploadPermissions,
 		isLockedAll,
 		orientation,
-	} = useSelect( selector, [ targetRootClientId ] );
+	} = useSelect(
+		( select ) => {
+			const {
+				getBlockListSettings,
+				getClientIdsOfDescendants: _getClientIdsOfDescendants,
+				getBlockIndex: _getBlockIndex,
+				getSettings,
+				getTemplateLock,
+			} = select( 'core/block-editor' );
+			return {
+				orientation: getBlockListSettings( targetRootClientId )
+					?.orientation,
+				getClientIdsOfDescendants: _getClientIdsOfDescendants,
+				getBlockIndex: _getBlockIndex,
+				hasUploadPermissions: !! getSettings().mediaUpload,
+				isLockedAll: getTemplateLock( targetRootClientId ) === 'all',
+			};
+		},
+		[ targetRootClientId ]
+	);
 	const {
 		insertBlocks,
 		updateBlockAttributes,
@@ -249,7 +252,6 @@ export default function useBlockDropZone( {
 			const {
 				srcRootClientId: sourceRootClientId,
 				srcClientIds: sourceClientIds,
-				srcIndex: sourceBlockIndex,
 				type: dropType,
 			} = parseDropEvent( event );
 
@@ -257,6 +259,8 @@ export default function useBlockDropZone( {
 			if ( dropType !== 'block' ) {
 				return;
 			}
+
+			const sourceBlockIndex = getBlockIndex( sourceClientIds[ 0 ] );
 
 			// If the user is dropping to the same position, return early.
 			if (
@@ -299,6 +303,7 @@ export default function useBlockDropZone( {
 		},
 		[
 			getClientIdsOfDescendants,
+			getBlockIndex,
 			targetBlockIndex,
 			moveBlocksToPosition,
 			targetRootClientId,


### PR DESCRIPTION
Not certain how much these small tweaks will improve performance but this PR could serve at least to raise some awareness.
Using `useSelect` is not without costs. Everytime  you return a value from useSelect, 

 - make sure that this value is needed for rendering and not for event handlers (otherwise the selector call can be moved to the event handler instead)
 - make sure it's not a value that changes often and cause too frequent rerenders. For example, `getBlockIndex` change often for blocks after the current selection. (Everytime a new block is added or removed)