### PR TITLE
Hide inserter's block preview when searching

### DIFF
--- a/packages/block-editor/src/components/inserter/block-types-tab.js
+++ b/packages/block-editor/src/components/inserter/block-types-tab.js
@@ -9,6 +9,7 @@ import {
 	groupBy,
 	isEmpty,
 	orderBy,
+	noop,
 } from 'lodash';
 
 /**
@@ -41,6 +42,7 @@ export function BlockTypesTab( {
 	filterValue,
 	debouncedSpeak,
 	showMostUsedBlocks,
+	__experimentalOnUnmount: onUnmount = noop,
 } ) {
 	const [ items, categories, collections, onSelectItem ] = useBlockTypesState(
 		rootClientId,
@@ -105,6 +107,9 @@ export function BlockTypesTab( {
 
 		return result;
 	}, [ filteredItems, collections ] );
+
+	// hide block preview on unmount
+	useEffect( () => () => onUnmount(), [] );
 
 	// Announce search results on change
 	useEffect( () => {

--- a/packages/block-editor/src/components/inserter/block-types-tab.js
+++ b/packages/block-editor/src/components/inserter/block-types-tab.js
@@ -9,7 +9,6 @@ import {
 	groupBy,
 	isEmpty,
 	orderBy,
-	noop,
 } from 'lodash';
 
 /**
@@ -42,7 +41,6 @@ export function BlockTypesTab( {
 	filterValue,
 	debouncedSpeak,
 	showMostUsedBlocks,
-	__experimentalOnUnmount: onUnmount = noop,
 } ) {
 	const [ items, categories, collections, onSelectItem ] = useBlockTypesState(
 		rootClientId,
@@ -109,7 +107,7 @@ export function BlockTypesTab( {
 	}, [ filteredItems, collections ] );
 
 	// hide block preview on unmount
-	useEffect( () => () => onUnmount(), [] );
+	useEffect( () => () => onHover( null ), [] );
 
 	// Announce search results on change
 	useEffect( () => {

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -86,7 +86,6 @@ function InserterMenu( {
 					onHover={ onHover }
 					filterValue={ filterValue }
 					showMostUsedBlocks={ showMostUsedBlocks }
-					__experimentalOnUnmount={ () => setHoveredItem( null ) }
 				/>
 			</div>
 			{ showInserterHelpPanel && (

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -86,6 +86,7 @@ function InserterMenu( {
 					onHover={ onHover }
 					filterValue={ filterValue }
 					showMostUsedBlocks={ showMostUsedBlocks }
+					__experimentalOnUnmount={ () => setHoveredItem( null ) }
 				/>
 			</div>
 			{ showInserterHelpPanel && (
@@ -128,7 +129,10 @@ function InserterMenu( {
 				{ /* the following div is necessary to fix the sticky position of the search form */ }
 				<div className="block-editor-inserter__content">
 					<InserterSearchForm
-						onChange={ setFilterValue }
+						onChange={ ( value ) => {
+							if ( hoveredItem ) setHoveredItem( null );
+							setFilterValue( value );
+						} }
 						value={ filterValue }
 					/>
 					{ ( showPatterns || hasReusableBlocks ) && (

--- a/packages/block-editor/src/components/inserter/test/block-types-tab.js
+++ b/packages/block-editor/src/components/inserter/test/block-types-tab.js
@@ -36,7 +36,13 @@ jest.mock( '@wordpress/data/src/components/use-dispatch', () => {
 const debouncedSpeak = jest.fn();
 
 function InserterBlockList( props ) {
-	return <BlockTypesTab debouncedSpeak={ debouncedSpeak } { ...props } />;
+	return (
+		<BlockTypesTab
+			debouncedSpeak={ debouncedSpeak }
+			onHover={ () => {} }
+			{ ...props }
+		/>
+	);
 }
 
 const initializeAllClosedMenuState = ( propOverrides ) => {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

Fixes https://github.com/WordPress/gutenberg/issues/23596

When searching for blocks to use, from the inserter menu, hovering over a block button shows a preview.

If we start typing/searching, the preview stays visible and If no blocks are found, there's no way to reset the hovered item, so the preview can't close.

Details steps to reproduce are in the related issue https://github.com/WordPress/gutenberg/issues/23596

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
