### PR TITLE
Avoid rerendering the PostSavedState component on each change

### DIFF
--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -242,6 +242,10 @@ _Returns_
 
 -   `boolean`: Whether viewport matches query.
 
+<a name="useWarnOnChange" href="#useWarnOnChange">#</a> **useWarnOnChange**
+
+Undocumented declaration.
+
 <a name="withGlobalEvents" href="#withGlobalEvents">#</a> **withGlobalEvents**
 
 Higher-order component creator which, given an object of DOM event types and

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -244,7 +244,24 @@ _Returns_
 
 <a name="useWarnOnChange" href="#useWarnOnChange">#</a> **useWarnOnChange**
 
-Undocumented declaration.
+Hook that performs a shallow comparison between the preview value of an object
+and the new one, if there's a difference, it prints it to the console.
+this is useful in performance related work, to check why some component re-render.
+
+_Usage_
+
+```jsx
+function MyComponent(props) {
+   useWarnOnChange(props);
+
+   return "Something";
+}
+```
+
+_Parameters_
+
+-   _object_ `Object`: Object which changes to compare.
+-   _prefix_ `string`: Just a prefix to show when console logging.
 
 <a name="withGlobalEvents" href="#withGlobalEvents">#</a> **withGlobalEvents**
 

--- a/packages/compose/src/hooks/use-warn-on-change/index.js
+++ b/packages/compose/src/hooks/use-warn-on-change/index.js
@@ -10,7 +10,7 @@ function useWarnOnChange( object, prefix = 'Change detection' ) {
 		if ( value !== object[ key ] ) {
 			// eslint-disable-next-line no-console
 			console.warn(
-				prefix + ': ' + key + ' key changed:',
+				`${ prefix }: ${ key } key changed:`,
 				value,
 				object[ key ]
 			);

--- a/packages/compose/src/hooks/use-warn-on-change/index.js
+++ b/packages/compose/src/hooks/use-warn-on-change/index.js
@@ -6,7 +6,7 @@ import usePrevious from '../use-previous';
 /**
  * Hook that performs a shallow comparison between the preview value of an object
  * and the new one, if there's a difference, it prints it to the console.
- * this is useful in performance related work, to check why some component re-render.
+ * this is useful in performance related work, to check why a component re-renders.
  *
  *  @example
  *

--- a/packages/compose/src/hooks/use-warn-on-change/index.js
+++ b/packages/compose/src/hooks/use-warn-on-change/index.js
@@ -3,6 +3,24 @@
  */
 import usePrevious from '../use-previous';
 
+/**
+ * Hook that performs a shallow comparison between the preview value of an object
+ * and the new one, if there's a difference, it prints it to the console.
+ * this is useful in performance related work, to check why some component re-render.
+ *
+ *  @example
+ *
+ * ```jsx
+ * function MyComponent(props) {
+ *    useWarnOnChange(props);
+ *
+ *    return "Something";
+ * }
+ * ```
+ *
+ * @param {Object} object Object which changes to compare.
+ * @param {string} prefix Just a prefix to show when console logging.
+ */
 function useWarnOnChange( object, prefix = 'Change detection' ) {
 	const previousValues = usePrevious( object );
 

--- a/packages/compose/src/hooks/use-warn-on-change/index.js
+++ b/packages/compose/src/hooks/use-warn-on-change/index.js
@@ -1,0 +1,21 @@
+/**
+ * Internal dependencies
+ */
+import usePrevious from '../use-previous';
+
+function useWarnOnChange( object, prefix = 'Change detection' ) {
+	const previousValues = usePrevious( object );
+
+	Object.entries( previousValues || [] ).forEach( ( [ key, value ] ) => {
+		if ( value !== object[ key ] ) {
+			// eslint-disable-next-line no-console
+			console.warn(
+				prefix + ': ' + key + ' key changed:',
+				value,
+				object[ key ]
+			);
+		}
+	} );
+}
+
+export default useWarnOnChange;

--- a/packages/compose/src/hooks/use-warn-on-change/index.js
+++ b/packages/compose/src/hooks/use-warn-on-change/index.js
@@ -6,7 +6,7 @@ import usePrevious from '../use-previous';
 function useWarnOnChange( object, prefix = 'Change detection' ) {
 	const previousValues = usePrevious( object );
 
-	Object.entries( previousValues || [] ).forEach( ( [ key, value ] ) => {
+	Object.entries( previousValues ?? [] ).forEach( ( [ key, value ] ) => {
 		if ( value !== object[ key ] ) {
 			// eslint-disable-next-line no-console
 			console.warn(

--- a/packages/compose/src/index.js
+++ b/packages/compose/src/index.js
@@ -23,3 +23,4 @@ export { default as useReducedMotion } from './hooks/use-reduced-motion';
 export { default as useViewportMatch } from './hooks/use-viewport-match';
 export { default as useResizeObserver } from './hooks/use-resize-observer';
 export { default as useAsyncList } from './hooks/use-async-list';
+export { default as useWarnOnChange } from './hooks/use-warn-on-change';

--- a/packages/editor/src/components/post-saved-state/index.js
+++ b/packages/editor/src/components/post-saved-state/index.js
@@ -33,7 +33,6 @@ import PostSwitchToDraftButton from '../post-switch-to-draft-button';
  */
 export default function PostSavedState( { forceIsDirty, forceIsSaving } ) {
 	const [ forceSavedMessage, setForceSavedMessage ] = useState( false );
-
 	const isLargeViewport = useViewportMatch( 'small' );
 
 	const {
@@ -45,7 +44,7 @@ export default function PostSavedState( { forceIsDirty, forceIsSaving } ) {
 		isSaveable,
 		isSaving,
 		isScheduled,
-		post,
+		hasPublishAction,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -69,7 +68,9 @@ export default function PostSavedState( { forceIsDirty, forceIsSaving } ) {
 				isSaving: forceIsSaving || isSavingPost(),
 				isSaveable: isEditedPostSaveable(),
 				isScheduled: isCurrentPostScheduled(),
-				post: getCurrentPost(),
+				hasPublishAction:
+					getCurrentPost()?.[ '_links' ]?.[ 'wp:action-publish' ] ??
+					false,
 			};
 		},
 		[ forceIsDirty, forceIsSaving ]
@@ -131,8 +132,6 @@ export default function PostSavedState( { forceIsDirty, forceIsSaving } ) {
 
 	// Once the post has been submitted for review this button
 	// is not needed for the contributor role.
-	const hasPublishAction =
-		post?.[ '_links' ]?.[ 'wp:action-publish' ] ?? false;
 
 	if ( ! hasPublishAction && isPending ) {
 		return null;


### PR DESCRIPTION
It's better to return just the small bit of information we need from useSelect, the more granular the better as it doesn't change often.

Notice that with this change as you type, the component doesn't always rerender.