### PR TITLE
Enable unsupported block editor on Atomic sites

### DIFF
--- a/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
+++ b/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
@@ -433,7 +433,7 @@ public class WPAndroidGlueCode {
                              Consumer<String> breadcrumbLogger,
                              @Nullable Boolean isSiteUsingWpComRestApi,
                              @Nullable Bundle editorTheme,
-                             boolean siteJetpackIsConnected) {
+                             boolean isUnsupportedBlockEditorEnabled) {
         mIsDarkMode = isDarkMode;
         mExceptionLogger = exceptionLogger;
         mBreadcrumbLogger = breadcrumbLogger;
@@ -469,8 +469,8 @@ public class WPAndroidGlueCode {
         Bundle capabilities = new Bundle();
         if (isSiteUsingWpComRestApi != null) {
             capabilities.putBoolean(PROP_NAME_CAPABILITIES_MENTIONS, isSiteUsingWpComRestApi);
-            capabilities.putBoolean(PROP_NAME_CAPABILITIES_UNSUPPORTED_BLOCK_EDITOR, !siteJetpackIsConnected);
         }
+        capabilities.putBoolean(PROP_NAME_CAPABILITIES_UNSUPPORTED_BLOCK_EDITOR, isUnsupportedBlockEditorEnabled);
         initialProps.putBundle(PROP_NAME_CAPABILITIES, capabilities);
 
         Serializable colors = editorTheme != null ? editorTheme.getSerializable(PROP_NAME_COLORS) : null;


### PR DESCRIPTION
#Description
Please, read the description in the fellow PR: https://github.com/wordpress-mobile/WordPress-Android/pull/12405

## How has this been tested?
Please, find tests in the fellow PR: https://github.com/wordpress-mobile/WordPress-Android/pull/12405

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
