### PR TITLE
Automation: Limit tests to not run on docs only changes

### DIFF
--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -2,8 +2,18 @@ name: End-to-End Tests
 
 on:
   pull_request:
+    paths:
+    - 'lib/**'
+    - 'packages/**'
+    - '!packages/**/*.md'
+    - '!docs/**/*.md'
   push:
     branches: [master]
+    paths:
+    - 'lib/**'
+    - 'packages/**'
+    - '!packages/**/*.md'
+    - '!docs/**/*.md'
 
 jobs:
   admin-1:

--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -3,17 +3,11 @@ name: End-to-End Tests
 on:
   pull_request:
     paths:
-    - 'lib/**'
-    - 'packages/**'
-    - '!packages/**/*.md'
-    - '!docs/**/*.md'
+    - '!**/*.md'
   push:
     branches: [master]
     paths:
-    - 'lib/**'
-    - 'packages/**'
-    - '!packages/**/*.md'
-    - '!docs/**/*.md'
+    - '!**/*.md'
 
 jobs:
   admin-1:

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,6 +1,11 @@
 name: Performances Tests
 
 on: [pull_request]
+  paths:
+  - 'lib/**'
+  - 'packages/**'
+  - '!packages/**/*.md'
+  - '!docs/**/*.md'
 
 jobs:
   performance:

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -2,10 +2,7 @@ name: Performances Tests
 
 on: [pull_request]
   paths:
-  - 'lib/**'
-  - 'packages/**'
-  - '!packages/**/*.md'
-  - '!docs/**/*.md'
+  - '!**/*.md'
 
 jobs:
   performance:

--- a/.github/workflows/rnmobile-android-runner.yml
+++ b/.github/workflows/rnmobile-android-runner.yml
@@ -2,10 +2,7 @@ name: React Native E2E Tests (Android)
 
 on: pull_request
   paths:
-  - 'lib/**'
-  - 'packages/**'
-  - '!packages/**/*.md'
-  - '!docs/**/*.md'
+  - '!**/*.md'
 
 jobs:
   test:

--- a/.github/workflows/rnmobile-android-runner.yml
+++ b/.github/workflows/rnmobile-android-runner.yml
@@ -1,5 +1,11 @@
 name: React Native E2E Tests (Android)
+
 on: pull_request
+  paths:
+  - 'lib/**'
+  - 'packages/**'
+  - '!packages/**/*.md'
+  - '!docs/**/*.md'
 
 jobs:
   test:

--- a/.github/workflows/rnmobile-ios-runner.yml
+++ b/.github/workflows/rnmobile-ios-runner.yml
@@ -1,5 +1,10 @@
 name: React Native E2E Tests (iOS)
 on: pull_request
+  paths:
+  - 'lib/**'
+  - 'packages/**'
+  - '!packages/**/*.md'
+  - '!docs/**/*.md'
 
 jobs:
   test:
@@ -31,7 +36,7 @@ jobs:
       with:
         path: packages/react-native-editor/ios/build/gutenberg/Build/Products/Release-iphonesimulator/GutenbergDemo.app
         key: ${{ runner.os }}-ios-build-${{ hashFiles('ios-checksums.txt') }}
-    
+
     - name: Restore pods cache
       uses: actions/cache@v2
       with:

--- a/.github/workflows/rnmobile-ios-runner.yml
+++ b/.github/workflows/rnmobile-ios-runner.yml
@@ -1,10 +1,7 @@
 name: React Native E2E Tests (iOS)
 on: pull_request
   paths:
-  - 'lib/**'
-  - 'packages/**'
-  - '!packages/**/*.md'
-  - '!docs/**/*.md'
+  - '!**/*.md'
 
 jobs:
   test:

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,6 +1,6 @@
 # Block Editor Handbook
 
-The Gutenberg project is transforming the way content is created on WordPress. A block editor was the first product launched creating a new methodology for working with content. 
+The Gutenberg project is transforming the way content is created on WordPress. A block editor was the first product launched creating a new methodology for working with content.
 
 The Block Editor handbook provides documentation for designers and developers on how to extend the editor, and also how you can start contributing to the project. For authors, writers, and users of the block editor see the [block editor support documentation](https://wordpress.org/support/article/wordpress-editor/).
 
@@ -11,3 +11,4 @@ Using a system of Blocks to compose and format content, the new block-based edit
 Blocks treat Paragraphs, Headings, Media, and Embeds all as components that, when strung together, make up the content stored in the WordPress database, replacing the traditional concept of freeform text with embedded media and shortcodes. The new editor is designed with progressive enhancement, meaning that it is back-compatible with all legacy content, and it also offers a process to try to convert and split a Classic block into equivalent blocks using client-side parsing. Finally, the blocks offer enhanced editing and format controls.
 
 The Editor offers rich new value to users with visual, drag-and-drop creation tools and powerful developer enhancements with modern vendor packages, reusable components, rich APIs and hooks to modify and extend the editor through Custom Blocks, Custom Block Styles and Plugins.
+


### PR DESCRIPTION
#23535  Description

Add filters for E2E, mobile, and performance tests to not run on documentation only changes, defined by *.md files in /docs/ and /packages/ directory

## How has this been tested?

Trying to figure out how to test. Ideally make a change to a markdown file and confirm that the E2E, Mobile, and Performance tests don't run, and don't block the PR.


## Types of changes

Github Actions workflow update adding exclude paths