### PR TITLE
More block: use an actual placeholder for input text.

### DIFF
--- a/packages/block-library/src/more/edit.js
+++ b/packages/block-library/src/more/edit.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { PanelBody, ToggleControl } from '@wordpress/components';
-import { useState } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/block-editor';
 import { ENTER } from '@wordpress/keycodes';
 import { getDefaultBlockName, createBlock } from '@wordpress/blocks';
@@ -15,12 +14,11 @@ export default function MoreEdit( {
 	insertBlocksAfter,
 	setAttributes,
 } ) {
-	const [ placeholder, setPlaceholder ] = useState( DEFAULT_TEXT );
-
 	const onChangeInput = ( event ) => {
-		// Set defaultText to an empty string, allowing the user to clear/replace the input field's text
-		setPlaceholder( '' );
-		setAttributes( { customText: event.target.value || undefined } );
+		setAttributes( {
+			customText:
+				event.target.value !== '' ? event.target.value : undefined,
+		} );
 	};
 
 	const onKeyDown = ( { keyCode } ) => {
@@ -35,8 +33,10 @@ export default function MoreEdit( {
 			: __( 'The excerpt is visible.' );
 
 	const toggleHideExcerpt = () => setAttributes( { noTeaser: ! noTeaser } );
-	const value = customText ?? placeholder;
-	const style = { width: `${ value.length + 1.2 }em` };
+
+	const style = {
+		width: `${ ( customText ? customText : DEFAULT_TEXT ).length + 1.2 }em`,
+	};
 
 	return (
 		<>
@@ -54,8 +54,10 @@ export default function MoreEdit( {
 			</InspectorControls>
 			<div className="wp-block-more">
 				<input
+					aria-label={ __( 'Read more link label' ) }
 					type="text"
-					value={ value }
+					value={ customText }
+					placeholder={ DEFAULT_TEXT }
 					onChange={ onChangeInput }
 					onKeyDown={ onKeyDown }
 					style={ style }

--- a/packages/block-library/src/more/edit.js
+++ b/packages/block-library/src/more/edit.js
@@ -54,7 +54,7 @@ export default function MoreEdit( {
 			</InspectorControls>
 			<div className="wp-block-more">
 				<input
-					aria-label={ __( 'Read more link label' ) }
+					aria-label={ __( 'Read more link text' ) }
 					type="text"
 					value={ customText }
 					placeholder={ DEFAULT_TEXT }

--- a/packages/block-library/src/more/test/__snapshots__/edit.js.snap
+++ b/packages/block-library/src/more/test/__snapshots__/edit.js.snap
@@ -16,11 +16,13 @@ exports[`core/more/edit should match snapshot when noTeaser is false 1`] = `
     className="wp-block-more"
   >
     <input
+      aria-label="Read more link label"
       onChange={[Function]}
       onKeyDown={[Function]}
+      placeholder="Read more"
       style={
         Object {
-          "width": "1.2em",
+          "width": "10.2em",
         }
       }
       type="text"
@@ -46,11 +48,13 @@ exports[`core/more/edit should match snapshot when noTeaser is true 1`] = `
     className="wp-block-more"
   >
     <input
+      aria-label="Read more link label"
       onChange={[Function]}
       onKeyDown={[Function]}
+      placeholder="Read more"
       style={
         Object {
-          "width": "1.2em",
+          "width": "10.2em",
         }
       }
       type="text"

--- a/packages/block-library/src/more/test/__snapshots__/edit.js.snap
+++ b/packages/block-library/src/more/test/__snapshots__/edit.js.snap
@@ -16,7 +16,7 @@ exports[`core/more/edit should match snapshot when noTeaser is false 1`] = `
     className="wp-block-more"
   >
     <input
-      aria-label="Read more link label"
+      aria-label="Read more link text"
       onChange={[Function]}
       onKeyDown={[Function]}
       placeholder="Read more"
@@ -48,7 +48,7 @@ exports[`core/more/edit should match snapshot when noTeaser is true 1`] = `
     className="wp-block-more"
   >
     <input
-      aria-label="Read more link label"
+      aria-label="Read more link text"
       onChange={[Function]}
       onKeyDown={[Function]}
       placeholder="Read more"


### PR DESCRIPTION
## Description
The More block has been using this weird default text system for a while. This PR updates it to just use a standard placeholder, eliminating the weirdness around when the theme's default text is used on the front-end or not. It also adds an `aria-label` to the label input, improving accessibility.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
