### PR TITLE
Switch workflows to use paths-ignore and **.md

### DIFF
--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -2,12 +2,12 @@ name: End-to-End Tests
 
 on:
   pull_request:
-    paths:
-    - '!**/*.md'
+    paths-ignore:
+    - '**.md'
   push:
     branches: [master]
-    paths:
-    - '!**/*.md'
+    paths-ignore:
+    - '**.md'
 
 jobs:
   admin-1:

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,8 +1,8 @@
 name: Performances Tests
 
 on: [pull_request]
-  paths:
-  - '!**/*.md'
+  paths-ignore:
+  - '**.md'
 
 jobs:
   performance:

--- a/.github/workflows/rnmobile-android-runner.yml
+++ b/.github/workflows/rnmobile-android-runner.yml
@@ -1,8 +1,8 @@
 name: React Native E2E Tests (Android)
 
 on: pull_request
-  paths:
-  - '!**/*.md'
+  paths-ignore:
+  - '**.md'
 
 jobs:
   test:

--- a/.github/workflows/rnmobile-ios-runner.yml
+++ b/.github/workflows/rnmobile-ios-runner.yml
@@ -1,7 +1,7 @@
 name: React Native E2E Tests (iOS)
 on: pull_request
-  paths:
-  - '!**/*.md'
+  paths-ignore:
+  - '**.md'
 
 jobs:
   test:


### PR DESCRIPTION

## Description

Related to #23834 this simplifies ignoring markdown using `paths-ignore` and `**.md` syntax.

See [Github documentation here for reference](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-ignoring-paths)

> When using the push and pull_request events, you can configure a workflow to run when at least one file does not match paths-ignore or at least one modified file matches the configured paths. Path filters are not evaluated for pushes to tags.

> The paths-ignore and paths keywords accept glob patterns that use the * and ** wildcard characters to match more than one path name. For more information, see the "Filter pattern cheat sheet."

## How has this been tested?

Confirm workflows run as expected for PRs that only include markdown, and for those that do not include, and for ones that include both.

## Types of changes

Workflow
