### PR TITLE
Add paths-ignore **.md for unit tests checks

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -2,8 +2,12 @@ name: Unit Tests
 
 on:
   pull_request:
+    paths-ignore:
+    - '**.md'
   push:
     branches: [master]
+    paths-ignore:
+    - '**.md'
 
 jobs:
   unit-js:


### PR DESCRIPTION

## Description

Adds paths-ignore to unit tests to not run if only markdown changes.

See: #23843 #23844 

## How has this been tested?

Confirm that unit-tests don't run if only markdown files change.
Confirm that unit-tests run if other file type or a mix with md files


## Types of changes

Github Actions workflow
