### PR TITLE
Use blockLabel for BlockTitle component

### DIFF
--- a/packages/block-editor/src/components/block-title/index.js
+++ b/packages/block-editor/src/components/block-title/index.js
@@ -31,7 +31,7 @@ export default function BlockTitle( { clientId } ) {
 	const { attributes, name } = useSelect(
 		( select ) => {
 			if ( ! clientId ) {
-				return null;
+				return {};
 			}
 			const { getBlockName, getBlockAttributes } = select(
 				'core/block-editor'

--- a/packages/block-editor/src/components/block-title/index.js
+++ b/packages/block-editor/src/components/block-title/index.js
@@ -57,7 +57,7 @@ export default function BlockTitle( { clientId } ) {
 	const label = getBlockLabel( blockType, attributes );
 
 	// Label will often fall back to the title if no label is defined for the
-	// clurrent label context. We do not want "Paragraph: Paragraph".
+	// current label context. We do not want "Paragraph: Paragraph".
 	if ( label !== title ) {
 		return `${ title }: ${ truncate( label, { length: 15 } ) }`;
 	}

--- a/packages/block-editor/src/components/block-title/index.js
+++ b/packages/block-editor/src/components/block-title/index.js
@@ -53,17 +53,13 @@ export default function BlockTitle( { clientId } ) {
 		return null;
 	}
 
-	const { __experimentalLabel, title } = blockType;
+	const { title } = blockType;
+	const label = getBlockLabel( blockType, attributes );
 
-	// Check if it supports the label first. getBlockLabel will return the title
-	// if no label exists. We want to know if the label is undefined so that we
-	// can format it uniquely.
-	const label =
-		__experimentalLabel &&
-		truncate( getBlockLabel( blockType, attributes ), { length: 15 } );
-
-	if ( label ) {
-		return `${ title } - ${ label }`;
+	// Label will often fall back to the title if no label is defined for the
+	// clurrent label context. We do not want "Paragraph: Paragraph".
+	if ( label !== title ) {
+		return `${ title }: ${ truncate( label, { length: 15 } ) }`;
 	}
 	return title;
 }

--- a/packages/block-editor/src/components/block-title/index.js
+++ b/packages/block-editor/src/components/block-title/index.js
@@ -60,10 +60,10 @@ export default function BlockTitle( { clientId } ) {
 	// can format it uniquely.
 	const label =
 		__experimentalLabel &&
-		truncate( getBlockLabel( blockType, attributes ), { length: 25 } );
+		truncate( getBlockLabel( blockType, attributes ), { length: 15 } );
 
 	if ( label ) {
-		return `${ title } (${ label })`;
+		return `${ title } - ${ label }`;
 	}
 	return title;
 }

--- a/packages/block-editor/src/components/block-title/test/index.js
+++ b/packages/block-editor/src/components/block-title/test/index.js
@@ -22,6 +22,24 @@ jest.mock( '@wordpress/blocks', () => {
 
 				case 'name-exists':
 					return { title: 'Block Title' };
+
+				case 'name-with-label':
+					return { title: 'Block With Label' };
+
+				case 'name-with-long-label':
+					return { title: 'Block With Long Label' };
+			}
+		},
+		__experimentalGetBlockLabel( { title } ) {
+			switch ( title ) {
+				case 'Block With Label':
+					return 'Test Label';
+
+				case 'Block With Long Label':
+					return 'This is a longer label than typical for blocks to have.';
+
+				default:
+					return title;
 			}
 		},
 	};
@@ -34,14 +52,22 @@ jest.mock( '@wordpress/data/src/components/use-select', () => {
 } );
 
 describe( 'BlockTitle', () => {
-	it( 'renders nothing if name is falsey', () => {
+	it( 'renders nothing if name is falsey2', () => {
+		useSelect.mockImplementation( () => ( {
+			name: null,
+			attributes: null,
+		} ) );
+
 		const wrapper = shallow( <BlockTitle /> );
 
 		expect( wrapper.type() ).toBe( null );
 	} );
 
 	it( 'renders nothing if block type does not exist', () => {
-		useSelect.mockImplementation( () => 'name-not-exists' );
+		useSelect.mockImplementation( () => ( {
+			name: 'name-not-exists',
+			attributes: null,
+		} ) );
 		const wrapper = shallow(
 			<BlockTitle clientId="afd1cb17-2c08-4e7a-91be-007ba7ddc3a1" />
 		);
@@ -50,11 +76,43 @@ describe( 'BlockTitle', () => {
 	} );
 
 	it( 'renders title if block type exists', () => {
-		useSelect.mockImplementation( () => 'name-exists' );
+		useSelect.mockImplementation( () => ( {
+			name: 'name-exists',
+			attributes: null,
+		} ) );
+
 		const wrapper = shallow(
 			<BlockTitle clientId="afd1cb17-2c08-4e7a-91be-007ba7ddc3a1" />
 		);
 
 		expect( wrapper.text() ).toBe( 'Block Title' );
+	} );
+
+	it( 'renders label if it is set', () => {
+		useSelect.mockImplementation( () => ( {
+			name: 'name-with-label',
+			attributes: null,
+		} ) );
+
+		const wrapper = shallow(
+			<BlockTitle clientId="afd1cb17-2c08-4e7a-91be-007ba7ddc3a1" />
+		);
+
+		expect( wrapper.text() ).toBe( 'Block With Label: Test Label' );
+	} );
+
+	it( 'truncates the label if it is too long', () => {
+		useSelect.mockImplementation( () => ( {
+			name: 'name-with-long-label',
+			attributes: null,
+		} ) );
+
+		const wrapper = shallow(
+			<BlockTitle clientId="afd1cb17-2c08-4e7a-91be-007ba7ddc3a1" />
+		);
+
+		expect( wrapper.text() ).toBe(
+			'Block With Long Label: This is a lo...'
+		);
 	} );
 } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Changes the `BlockTitle` component to use the block label instead of just the title. (Note that the label will fall back to the title if no label is set.)

Fixes #23463

## How has this been tested?
Locally, in edit-site. You can verify the change by looking for a computed label in the block breadcrumb.

## Screenshots <!-- if applicable -->
<img width="1614" alt="Screen Shot 2020-07-09 at 1 14 37 PM" src="https://user-images.githubusercontent.com/6265975/87086441-73f07a00-c1e6-11ea-88b5-c09a678420c0.png">

## Types of changes
Enhancement

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
