### PR TITLE
Update labels of buttons of 'Two buttons' pattern

### DIFF
--- a/lib/patterns/two-buttons.php
+++ b/lib/patterns/two-buttons.php
@@ -7,7 +7,7 @@
 
 return array(
 	'title'         => __( 'Two buttons', 'gutenberg' ),
-	'content'       => "<!-- wp:buttons {\"align\":\"center\"} -->\n<div class=\"wp-block-buttons aligncenter\"><!-- wp:button {\"backgroundColor\":\"very-dark-gray\",\"borderRadius\":0} -->\n<div class=\"wp-block-button\"><a class=\"wp-block-button__link has-background has-very-dark-gray-background-color no-border-radius\">" . __( 'Button One', 'gutenberg' ) . "</a></div>\n<!-- /wp:button -->\n\n<!-- wp:button {\"textColor\":\"very-dark-gray\",\"borderRadius\":0,\"className\":\"is-style-outline\"} -->\n<div class=\"wp-block-button is-style-outline\"><a class=\"wp-block-button__link has-text-color has-very-dark-gray-color no-border-radius\">" . __( 'Button Two', 'gutenberg' ) . "</a></div>\n<!-- /wp:button --></div>\n<!-- /wp:buttons -->",
+	'content'       => "<!-- wp:buttons {\"align\":\"center\"} -->\n<div class=\"wp-block-buttons aligncenter\"><!-- wp:button {\"backgroundColor\":\"very-dark-gray\",\"borderRadius\":0} -->\n<div class=\"wp-block-button\"><a class=\"wp-block-button__link has-background has-very-dark-gray-background-color no-border-radius\">" . __( 'Get started', 'gutenberg' ) . "</a></div>\n<!-- /wp:button -->\n\n<!-- wp:button {\"textColor\":\"very-dark-gray\",\"borderRadius\":0,\"className\":\"is-style-outline\"} -->\n<div class=\"wp-block-button is-style-outline\"><a class=\"wp-block-button__link has-text-color has-very-dark-gray-color no-border-radius\">" . __( 'Learn more', 'gutenberg' ) . "</a></div>\n<!-- /wp:button --></div>\n<!-- /wp:buttons -->",
 	'viewportWidth' => 500,
 	'categories'    => array( 'buttons' ),
 );

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/adding-patterns.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/adding-patterns.test.js.snap
@@ -3,11 +3,11 @@
 exports[`adding blocks should insert a block pattern 1`] = `
 "<!-- wp:buttons {\\"align\\":\\"center\\"} -->
 <div class=\\"wp-block-buttons aligncenter\\"><!-- wp:button {\\"borderRadius\\":0,\\"backgroundColor\\":\\"very-dark-gray\\"} -->
-<div class=\\"wp-block-button\\"><a class=\\"wp-block-button__link has-very-dark-gray-background-color has-background no-border-radius\\">Button One</a></div>
+<div class=\\"wp-block-button\\"><a class=\\"wp-block-button__link has-very-dark-gray-background-color has-background no-border-radius\\">Get started</a></div>
 <!-- /wp:button -->
 
 <!-- wp:button {\\"borderRadius\\":0,\\"textColor\\":\\"very-dark-gray\\",\\"className\\":\\"is-style-outline\\"} -->
-<div class=\\"wp-block-button is-style-outline\\"><a class=\\"wp-block-button__link has-very-dark-gray-color has-text-color no-border-radius\\">Button Two</a></div>
+<div class=\\"wp-block-button is-style-outline\\"><a class=\\"wp-block-button__link has-very-dark-gray-color has-text-color no-border-radius\\">Learn more</a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons -->"
 `;


### PR DESCRIPTION
Updates to the button labels of the 'Two buttons' patterns.

Before:
<img width="341" alt="Screen Shot 2020-07-09 at 15 19 12" src="https://user-images.githubusercontent.com/3276087/87086705-90e17900-c1f7-11ea-8761-0dab51798969.png">

After:
<img width="371" alt="Screen Shot 2020-07-09 at 15 19 03" src="https://user-images.githubusercontent.com/3276087/87086718-95a62d00-c1f7-11ea-9b3e-f1805a1a270a.png">

