### PR TITLE
Docs: Title and markdown formatting for table

### DIFF
--- a/docs/contributors/versions-in-wordpress.md
+++ b/docs/contributors/versions-in-wordpress.md
@@ -1,40 +1,42 @@
-With each WordPress release cycle, various versions of Gutenberg are included. This has created confusion over time as people try to figure out how best to debug problems and report bugs appropriately. To make this easier for everyone to keep track of, this document serves as a canonical list of the Gutenberg versions integrated into each WordPress release. Of note, during the beta period for WordPress releases, additional bug fixes from later Gutenberg releases than those noted are cherry-picked into the WordPress release as necessary. 
+# Versions in WordPress
 
-If anything looks incorrect here, please bring it up in #core-editor in [WordPress.org slack](https://make.wordpress.org/chat/).   
+With each WordPress release cycle, various versions of Gutenberg are included. This has created confusion over time as people try to figure out how best to debug problems and report bugs appropriately. To make this easier for everyone to keep track of, this document serves as a canonical list of the Gutenberg versions integrated into each WordPress release. Of note, during the beta period for WordPress releases, additional bug fixes from later Gutenberg releases than those noted are cherry-picked into the WordPress release as necessary.
 
-Gutenberg Versions | WordPress Version
--- | --
-7.6-8.5 | 5.5
-6.6-7.5 | 5.4.2
-6.6-7.5 | 5.4.0
-5.5-6.5 | 5.3.4
-5.5-6.5 | 5.3.3
-5.5-6.5 | 5.3.2
-5.5-6.5| 5.3.1
-5.5-6.5 | 5.3.0
-4.9-5.4 | 5.2.7
-4.9-5.4 | 5.2.6
-4.9-5.4 | 5.2.5
-4.9-5.4 | 5.2.4
-4.9-5.4 | 5.2.3
-4.9-5.4 | 5.2.2
-4.9-5.4 | 5.2.1
-4.9-5.4 | 5.2.0
-4.8 | 5.1.6
-4.8 | 5.1.5
-4.8 | 5.1.4
-4.8 | 5.1.3
-4.8 | 5.1.2
-4.8 | 5.1.1
-4.8 | 5.1.0
-4.7.1 | 5.0.10
-4.7.1 | 5.0.9
-4.7.1 | 5.0.8
-4.7.1 | 5.0.7
-4.7.1 | 5.0.6
-4.7.1 | 5.0.5
-4.7.1 | 5.0.4
-4.7.1 | 5.0.3
-4.7.0 | 5.0.2
-4.6.1 | 5.0.1
-4.6.1 | 5.0.0
+If anything looks incorrect here, please bring it up in #core-editor in [WordPress.org slack](https://make.wordpress.org/chat/).
+
+| Gutenberg Versions | WordPress Version |
+| ------------------ | ----------------- |
+| 7.6-8.5            | 5.5               |
+| 6.6-7.5            | 5.4.2             |
+| 6.6-7.5            | 5.4.0             |
+| 5.5-6.5            | 5.3.4             |
+| 5.5-6.5            | 5.3.3             |
+| 5.5-6.5            | 5.3.2             |
+| 5.5-6.5            | 5.3.1             |
+| 5.5-6.5            | 5.3.0             |
+| 4.9-5.4            | 5.2.7             |
+| 4.9-5.4            | 5.2.6             |
+| 4.9-5.4            | 5.2.5             |
+| 4.9-5.4            | 5.2.4             |
+| 4.9-5.4            | 5.2.3             |
+| 4.9-5.4            | 5.2.2             |
+| 4.9-5.4            | 5.2.1             |
+| 4.9-5.4            | 5.2.0             |
+| 4.8                | 5.1.6             |
+| 4.8                | 5.1.5             |
+| 4.8                | 5.1.4             |
+| 4.8                | 5.1.3             |
+| 4.8                | 5.1.2             |
+| 4.8                | 5.1.1             |
+| 4.8                | 5.1.0             |
+| 4.7.1              | 5.0.10            |
+| 4.7.1              | 5.0.9             |
+| 4.7.1              | 5.0.8             |
+| 4.7.1              | 5.0.7             |
+| 4.7.1              | 5.0.6             |
+| 4.7.1              | 5.0.5             |
+| 4.7.1              | 5.0.4             |
+| 4.7.1              | 5.0.3             |
+| 4.7.0              | 5.0.2             |
+| 4.6.1              | 5.0.1             |
+| 4.6.1              | 5.0.0             |

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -60,7 +60,7 @@
 		"parent": "principles"
 	},
 	{
-		"title": "VersionsInWordpress",
+		"title": "Versions in WordPress",
 		"slug": "versions-in-wordpress",
 		"markdown_source": "../docs/contributors/versions-in-wordpress.md",
 		"parent": "principles"


### PR DESCRIPTION

## Description

It looks like WP markdown conversion prefers a different table format.
Also, I missed on review the document requires a H1 title.

## How has this been tested?

Confirm document looks right on render.

## Types of changes

Documentation
