### PR TITLE
Add a mobile-specific bug reporting issue template with labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/Mobile_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Mobile_bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report (mobile app)
+about: Create a report to help us improve
+title: ''
+labels: '[Type] Bug, Mobile App Android/iOS'
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6, Pixel 4]
+ - OS: [e.g. iOS 8.1,  Android X]
+ - Version [e.g. 22]
+
+**Additional context**
+
+Add any other context about the problem here.
+
+- To report a security issue, please visit the WordPress HackerOne program: https://hackerone.com/wordpress.


### PR DESCRIPTION
## Description
This PR adds a mobile-specific bug reporting issue template with labels to be automatically applied.

Note: the labels frontmatter probably needs tweaking to properly auto-apply multiple labels