### PR TITLE
Change 'Two images' pattern to wide width

### DIFF
--- a/lib/patterns/two-images.php
+++ b/lib/patterns/two-images.php
@@ -9,5 +9,5 @@ return array(
 	'title'       => __( 'Two images side by side', 'gutenberg' ),
 	'categories'  => array( 'gallery' ),
 	'description' => _x( 'An image gallery with two cropped example images.', 'Block pattern description', 'gutenberg' ),
-	'content'     => "<!-- wp:gallery {\"ids\":[null,null],\"align\":\"wide\"} -->\n<figure class=\"wp-block-gallery alignwide columns-2 is-cropped\"><ul class=\"blocks-gallery-grid\"><li class=\"blocks-gallery-item\"><figure><img src=\"https://s.w.org/images/core/5.3/Glacial_lakes,_Bhutan.jpg\" alt=\"\" data-id=\"\"/></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"https://s.w.org/images/core/5.3/Sediment_off_the_Yucatan_Peninsula.jpg\" alt=\"\" data-id=\"\"/></figure></li></ul></figure>\n<!-- /wp:gallery -->",
+	'content'     => "<!-- wp:gallery {\"ids\":[null,null],\"align\":\"wide\"} -->\n<figure class=\"wp-block-gallery alignwide columns-2 is-cropped\"><ul class=\"blocks-gallery-grid\"><li class=\"blocks-gallery-item\"><figure><img src=\"https://s.w.org/images/core/5.5/Glacial_lakes,_Bhutan.jpg\" alt=\"\" data-id=\"\"/></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"https://s.w.org/images/core/5.5/Sediment_off_the_Yucatan_Peninsula.jpg\" alt=\"\" data-id=\"\"/></figure></li></ul></figure>\n<!-- /wp:gallery -->",
 );

--- a/lib/patterns/two-images.php
+++ b/lib/patterns/two-images.php
@@ -9,5 +9,5 @@ return array(
 	'title'       => __( 'Two images side by side', 'gutenberg' ),
 	'categories'  => array( 'gallery' ),
 	'description' => _x( 'An image gallery with two cropped example images.', 'Block pattern description', 'gutenberg' ),
-	'content'     => "<!-- wp:gallery {\"ids\":[null,null]} -->\n<figure class=\"wp-block-gallery columns-2 is-cropped\"><ul class=\"blocks-gallery-grid\"><li class=\"blocks-gallery-item\"><figure><img src=\"https://s.w.org/images/core/5.3/Glacial_lakes,_Bhutan.jpg\" alt=\"\" data-id=\"\"/></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"https://s.w.org/images/core/5.3/Sediment_off_the_Yucatan_Peninsula.jpg\" alt=\"\" data-id=\"\"/></figure></li></ul></figure>\n<!-- /wp:gallery -->",
+	'content'     => "<!-- wp:gallery {\"ids\":[null,null],\"align\":\"wide\"} -->\n<figure class=\"wp-block-gallery alignwide columns-2 is-cropped\"><ul class=\"blocks-gallery-grid\"><li class=\"blocks-gallery-item\"><figure><img src=\"https://s.w.org/images/core/5.3/Glacial_lakes,_Bhutan.jpg\" alt=\"\" data-id=\"\"/></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"https://s.w.org/images/core/5.3/Sediment_off_the_Yucatan_Peninsula.jpg\" alt=\"\" data-id=\"\"/></figure></li></ul></figure>\n<!-- /wp:gallery -->",
 );


### PR DESCRIPTION
Updates the 'Two images' pattern to be wide width.

Before:
<img width="644" alt="Screen Shot 2020-07-09 at 19 54 24" src="https://user-images.githubusercontent.com/3276087/87105755-71f7dc80-c221-11ea-94aa-662bbca4be7c.png">


After:
<img width="1136" alt="Screen Shot 2020-07-09 at 19 54 37" src="https://user-images.githubusercontent.com/3276087/87105761-758b6380-c221-11ea-8a0f-17a6efe6ddb5.png">

One issue after this update is that the images are not high-res enough for this size, especially the left one.  Considering that we are constrained by the images we can source for the Core patterns library in Core, it might be OK to go with this until we come up with a solution re: images.