### PR TITLE
Autocomplete: Fix closing slash inserter with ESC

### DIFF
--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -409,7 +409,7 @@ export class Autocomplete extends Component {
 				break;
 
 			case ESCAPE:
-				this.setState( { autocompleter: null } );
+				this.setState( { autocompleter: null, AutocompleterUI: null } );
 				break;
 
 			case ENTER:
@@ -428,6 +428,7 @@ export class Autocomplete extends Component {
 		// Any handled keycode should prevent original behavior. This relies on
 		// the early return in the default case.
 		event.preventDefault();
+		event.stopPropagation();
 	}
 
 	componentDidUpdate( prevProps ) {


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/23821.

Ensure that the slash inserter closes when the user presses ESC by properly resetting both `autocompleter` and `AutocompleterUI` (added in https://github.com/WordPress/gutenberg/pull/22853) from component state.

Also prevent the block editor from going into Select mode by stopping event propagation when the Autocomplete component handles a key press.

**To test:**

1. Open a post.
2. Type `/` in the paragraph.
3. Press `esc`.
4. Autocomplete popover should cloys and block editor should remain in Edit mode.