### PR TITLE
Add store icon

### DIFF
--- a/packages/icons/src/index.js
+++ b/packages/icons/src/index.js
@@ -139,6 +139,7 @@ export { default as stack } from './library/stack';
 export { default as starEmpty } from './library/star-empty';
 export { default as starFilled } from './library/star-filled';
 export { default as starHalf } from './library/star-half';
+export { default as store } from './library/store';
 export { default as stretchFullWidth } from './library/stretch-full-width';
 export { default as shipping } from './library/shipping';
 export { default as stretchWide } from './library/stretch-wide';

--- a/packages/icons/src/library/store.js
+++ b/packages/icons/src/library/store.js
@@ -1,0 +1,16 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, SVG } from '@wordpress/primitives';
+
+const store = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path
+			fillRule="evenodd"
+			d="M19.75 11H21V8.667L19.875 4H4.125L3 8.667V11h1.25v8.75h15.5V11zm-1.5 0H5.75v7.25H10V13h4v5.25h4.25V11zm-5.5-5.5h2.067l.486 3.24.028.76H12.75v-4zm-3.567 0h2.067v4H8.669l.028-.76.486-3.24zm7.615 3.1l-.464-3.1h2.36l.806 3.345V9.5h-2.668l-.034-.9zM7.666 5.5h-2.36L4.5 8.845V9.5h2.668l.034-.9.464-3.1z"
+			clipRule="evenodd"
+		/>
+	</SVG>
+);
+
+export default store;


### PR DESCRIPTION
Closes #23835

Adds a new "Store" icon to the Icons package, based on the existing icon for "Home":

<img src="https://cldup.com/a2KU0tLm3r-3000x3000.png" width="102" />

Figma [here](https://www.figma.com/file/fnyj380i05vGzuuH60frLQ/G2-Design?node-id=3234%3A24162).