### PR TITLE
Disable Page Template picker if modal layout picker is available

### DIFF
--- a/packages/block-editor/src/components/page-template-picker/with-page-template-picker.native.js
+++ b/packages/block-editor/src/components/page-template-picker/with-page-template-picker.native.js
@@ -17,11 +17,11 @@ const __experimentalWithPageTemplatePicker = createHigherOrderComponent(
 			props.capabilities.modalLayoutPicker ?? false
 		);
 		const isTemplatePickerVisible =
-			__experimentalUsePageTemplatePickerVisible() &&
-			isTemplatePickerEnabled;
+			isTemplatePickerEnabled &&
+			__experimentalUsePageTemplatePickerVisible();
 		const isTemplatePickerAvailable =
-			__experimentalUsePageTemplatePickerAvailable() &&
-			isTemplatePickerEnabled;
+			isTemplatePickerEnabled &&
+			__experimentalUsePageTemplatePickerAvailable();
 
 		return (
 			<WrappedComponent

--- a/packages/block-editor/src/components/page-template-picker/with-page-template-picker.native.js
+++ b/packages/block-editor/src/components/page-template-picker/with-page-template-picker.native.js
@@ -13,8 +13,15 @@ import {
 
 const __experimentalWithPageTemplatePicker = createHigherOrderComponent(
 	( WrappedComponent ) => ( props ) => {
-		const isTemplatePickerVisible = __experimentalUsePageTemplatePickerVisible();
-		const isTemplatePickerAvailable = __experimentalUsePageTemplatePickerAvailable();
+		const isTemplatePickerEnabled = ! (
+			props.capabilities.modalLayoutPicker ?? false
+		);
+		const isTemplatePickerVisible =
+			__experimentalUsePageTemplatePickerVisible() &&
+			isTemplatePickerEnabled;
+		const isTemplatePickerAvailable =
+			__experimentalUsePageTemplatePickerAvailable() &&
+			isTemplatePickerEnabled;
 
 		return (
 			<WrappedComponent

--- a/packages/edit-post/src/components/layout/index.native.js
+++ b/packages/edit-post/src/components/layout/index.native.js
@@ -20,6 +20,7 @@ import {
 	HTMLTextInput,
 	KeyboardAvoidingView,
 	NoticeList,
+	withSiteCapabilities,
 } from '@wordpress/components';
 import { AutosaveMonitor } from '@wordpress/editor';
 import { sendNativeEditorDidLayout } from '@wordpress/react-native-bridge';
@@ -181,5 +182,6 @@ export default compose( [
 		};
 	} ),
 	withPreferredColorScheme,
+	withSiteCapabilities,
 	__experimentalWithPageTemplatePicker,
 ] )( Layout );


### PR DESCRIPTION
Fixes: https://github.com/wordpress-mobile/gutenberg-mobile/issues/2419

Related PRs:
- `gutenberg-mobile`: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2478
- `WordPress-iOS`: https://github.com/wordpress-mobile/WordPress-iOS/pull/14456

## Description
This change enables the mobile editor to accept the capability `modalLayoutPicker` and based on that conditionally show or hide the Template Picker.

Android hasn't started Modal Layout Picker yet so this only needs to 

## How has this been tested?
To disable or enable the development version of Modal Layout Picker
- Open the app from the build https://github.com/wordpress-mobile/WordPress-iOS/pull/14456#issuecomment-656759183 or a local development build
    - By default, the modal layout picker will be enabled.
    - From the site page:
        - Click on your Gravatar.
        - Click on App Settings.
        - Click on Debug.
        - Toggle "Gutenberg Modal Layout Picker" to enable or disable the picker
            <details>
            <summary>To toggle: </summary>
            <img width=300 src="https://user-images.githubusercontent.com/3384451/87160515-106f5680-c291-11ea-9d49-fac5e6b7e66c.gif" />
            </details>


### On iOS using the build options mentioned above
- With Gutenberg Modal Layout Picker toggled on:
    - Select to create a new page
    - Expect to see the container for the new modal Layout Picker
    - Select "Create Blank Page"
    - Expect the current template picker to be hidden

- With Gutenberg Modal Layout Picker toggled on:
    - Select an existing page or draft without content (just a title)
    - You should not see the new Modal Layout Picker
    - Expect the current template picker to be hidden

- With Gutenberg Modal Layout Picker toggled off:
    - Select to create a new page
    - You should not see the new Modal Layout Picker
    - Expect the current template picker to be shown. 

- With Gutenberg Modal Layout Picker toggled off:
    - Select an existing page or draft without content (just a title)
    - You should not see the new Modal Layout Picker
    - Expect the current template picker to be shown

- With Gutenberg Modal Layout Picker toggled on or off:
    - Select an existing page or draft with content
    - Expect the current template picker to be hidden

### On Android running a metro server or generating a build

- Existing Blank Page
    - Select an existing page or draft without content (just a title)
    - Expect the current template picker to be shown
- New Page
    - Select to create a new page
    - Expect the current template picker to be shown. 
- Existing Page
    - Select an existing page or draft with content
    - Expect the current template picker to be hidden

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
