### PR TITLE
REST API: Check for WP5.5 and skip registering routes

### DIFF
--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -318,11 +318,11 @@ add_filter( 'get_sample_permalink', 'gutenberg_auto_draft_get_sample_permalink',
 function gutenberg_register_image_editor() {
 	global $wp_version;
 
-	// Strip -beta and -src from the version string. Messes up version_compare().
-	$version = explode( '-', $wp_version, 2 )[0];
+	// Strip '-src' from the version string. Messes up version_compare().
+	$version = str_replace( '-src', '', $wp_version );
 
 	// Only register routes for versions older than WP 5.5.
-	if ( version_compare( $version, '5.5', '<' ) ) {
+	if ( version_compare( $version, '5.5-beta', '<' ) ) {
 		$image_editor = new WP_REST_Image_Editor_Controller();
 		$image_editor->register_routes();
 	}

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -316,7 +316,15 @@ add_filter( 'get_sample_permalink', 'gutenberg_auto_draft_get_sample_permalink',
  * @since 7.x.0
  */
 function gutenberg_register_image_editor() {
-	$image_editor = new WP_REST_Image_Editor_Controller();
-	$image_editor->register_routes();
+	global $wp_version;
+
+	// Strip -beta and -src from the version string. Messes up version_compare().
+	$version = explode( '-', $wp_version, 2 )[0];
+
+	// Only register routes for versions older than WP 5.5.
+	if ( version_compare( $version, '5.5', '<' ) ) {
+		$image_editor = new WP_REST_Image_Editor_Controller();
+		$image_editor->register_routes();
+	}
 }
 add_filter( 'rest_api_init', 'gutenberg_register_image_editor' );


### PR DESCRIPTION

## Description

The Image Editor routes are included in WP 5.5, so do not need to be registered in the plugin. This change adds a check and only registers if the version is less than 5.5

## How has this been tested?

Use WordPress 5.4.x and the Gutenberg plugin and confirm the routes load as expected.
Use WordPress 5.5-beta+ and the Gutenberg plugin and confirm the routes are loaded from core and not the plugin.

## Types of changes

Adds a logic check for version around the route registration using PHP's version_compare function.


## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [X] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
