### PR TITLE
Button: Fixed bug causing colors picked from theme colors not reflecting on the button in the editor

### DIFF
--- a/packages/block-library/src/button/color-props.js
+++ b/packages/block-library/src/button/color-props.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { find } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -10,12 +11,13 @@ import {
 	getColorClassName,
 	__experimentalGetGradientClass,
 } from '@wordpress/block-editor';
+import { select } from '@wordpress/data';
 
 // The code in this file is copied entirely from the "color" and "style" support flags
 // The flag can't be used at the moment because of the extra wrapper around
 // the button block markup.
 
-export default function getColorAndStyleProps( attributes ) {
+export function getColorAndStyleProps( attributes ) {
 	// I'd have prefered to avoid the "style" attribute usage here
 	const { backgroundColor, textColor, gradient, style } = attributes;
 
@@ -52,4 +54,59 @@ export default function getColorAndStyleProps( attributes ) {
 		className: !! className ? className : undefined,
 		style: styleProp,
 	};
+}
+
+// This function is a copy of the one above except it converts backgroundColor,
+// textColor and gradient to css styles.
+export function getColorAndStylePropsForEditor( attributes ) {
+	const { backgroundColor, textColor, gradient, style } = attributes;
+
+	const { colors, gradients } = select( 'core/block-editor' ).getSettings();
+
+	const bgColorObject = getColorOrGradientObjectBySlug(
+		colors,
+		backgroundColor
+	);
+
+	let bgColor = bgColorObject?.color ? bgColorObject?.color : undefined;
+	if ( bgColor === undefined && style?.color?.background )
+		bgColor = style?.color?.background;
+
+	const textColorObject = getColorOrGradientObjectBySlug( colors, textColor );
+	let txtColor = textColorObject?.color ? textColorObject?.color : undefined;
+	if ( txtColor === undefined && style?.color?.text )
+		txtColor = style?.color?.text;
+
+	const gradientObject = getColorOrGradientObjectBySlug(
+		gradients,
+		gradient
+	);
+
+	let gradientStyle = gradientObject?.gradient
+		? gradientObject?.gradient
+		: undefined;
+	if ( gradientStyle === undefined && style?.color?.gradient )
+		gradientStyle = style?.color?.gradient;
+
+	const styleProp =
+		!! bgColor || !! txtColor || !! gradientStyle
+			? {
+					background: gradientStyle,
+					backgroundColor: bgColor,
+					color: txtColor,
+			  }
+			: {};
+
+	const className = classnames( {
+		'has-background': !! bgColor || !! gradientStyle,
+	} );
+
+	return {
+		className: !! className ? className : undefined,
+		style: styleProp,
+	};
+}
+
+function getColorOrGradientObjectBySlug( colors, slugValue ) {
+	return find( colors, { slug: slugValue } );
 }

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -33,7 +33,7 @@ import { createBlock } from '@wordpress/blocks';
  * Internal dependencies
  */
 import ColorEdit from './color-edit';
-import getColorAndStyleProps from './color-props';
+import { getColorAndStylePropsForEditor } from './color-props';
 
 const NEW_TAB_REL = 'noreferrer noopener';
 const MIN_BORDER_RADIUS_VALUE = 0;
@@ -187,7 +187,7 @@ function ButtonEdit( props ) {
 		[ rel, setAttributes ]
 	);
 
-	const colorProps = getColorAndStyleProps( attributes );
+	const colorProps = getColorAndStylePropsForEditor( attributes );
 
 	return (
 		<>

--- a/packages/block-library/src/button/edit.native.js
+++ b/packages/block-library/src/button/edit.native.js
@@ -32,7 +32,7 @@ import richTextStyle from './rich-text.scss';
 import styles from './editor.scss';
 import ColorBackground from './color-background';
 import ColorEdit from './color-edit';
-import getColorAndStyleProps from './color-props';
+import { getColorAndStyleProps } from './color-props';
 
 const MIN_BORDER_RADIUS_VALUE = 0;
 const MAX_BORDER_RADIUS_VALUE = 50;

--- a/packages/block-library/src/button/save.js
+++ b/packages/block-library/src/button/save.js
@@ -11,7 +11,7 @@ import { RichText } from '@wordpress/block-editor';
 /**
  * Internal dependencies
  */
-import getColorAndStyleProps from './color-props';
+import { getColorAndStyleProps } from './color-props';
 
 export default function save( { attributes } ) {
 	const { borderRadius, linkTarget, rel, text, title, url } = attributes;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
When assigning one of the theme's colors to a button in the editor, the button's color remains the same. It does show the correct colors in the preview and published post, however. This issue is caused by the css classes associated with each of the theme's colors not being made available in the editor.
To fix this, I wrote a function that extracts the colors from the theme and apply them explicitly to the button's inline style. This is done right before the block is rendered in the editor and no changes to the object's attributes are made. The background color and text color change as they should. Gradients work too.

## How has this been tested?
Add a Button block
Assign one of the theme's colors to it

## Screenshots <!-- if applicable -->
Before the fix:
![colorbroken](https://user-images.githubusercontent.com/1708550/87248197-bea80700-c41d-11ea-9749-eed7d76df956.gif)

After the fix:
![colorfix](https://user-images.githubusercontent.com/1708550/87248199-c071ca80-c41d-11ea-8a6a-c0bc298f5201.gif)

## Types of changes
Bug Fix

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
