### PR TITLE
Set quick inserter content width to 100% on screens below 782px

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -268,6 +268,10 @@ $block-inserter-tabs-height: 44px;
 
 .block-editor-inserter__quick-inserter {
 	width: $block-inserter-width;
+
+	@media (max-width: #{ ($break-medium) }) {
+		width: 100%;
+	}
 }
 
 .block-editor-inserter__quick-inserter-results {
@@ -291,9 +295,7 @@ $block-inserter-tabs-height: 44px;
 }
 
 .block-editor-inserter__popover.is-quick > .components-popover__content > div {
-	@include break-medium {
-		padding: 0;
-	}
+	padding: 0;
 }
 
 .block-editor-inserter__quick-inserter-expand.components-button {

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -267,10 +267,10 @@ $block-inserter-tabs-height: 44px;
 }
 
 .block-editor-inserter__quick-inserter {
-	width: $block-inserter-width;
+	width: 100%;
 
-	@media (max-width: #{ ($break-medium) }) {
-		width: 100%;
+	@include break-medium {
+		width: $block-inserter-width;
 	}
 }
 


### PR DESCRIPTION
## Description
This pull request addressed #23755. When the browser widow width reaches 782 pixels or less, the inserter moves to cover the entire page however the content does not fill the entire width.

## How has this been tested?
Observed on Ubuntu 20.04 with the following browsers
- Chromium Version 83.0.4103.116 (Official Build) snap (64-bit) 
- Firefox 78.0.1 (64-bit)

## Screenshots
**Original**
![image](https://user-images.githubusercontent.com/7422055/86794337-ae360c00-c06c-11ea-8b50-a309edf65bee.png)

**Fixed**
![image](https://user-images.githubusercontent.com/4966719/87257148-fdf64800-c45d-11ea-94ca-bac5392733c8.png)

## Types of changes
Bug fix