### PR TITLE
Refactored PostTextEditor to use React Hook

### DIFF
--- a/packages/editor/src/components/post-text-editor/index.js
+++ b/packages/editor/src/components/post-text-editor/index.js
@@ -14,24 +14,20 @@ import { useInstanceId } from '@wordpress/compose';
 import { VisuallyHidden } from '@wordpress/components';
 
 export default function PostTextEditor() {
-	const val = useSelect(
+	const postContent = useSelect(
 		( select ) => select( 'core/editor' ).getEditedPostContent(),
 		[]
 	);
 
 	const { editPost, resetEditorBlocks } = useDispatch( 'core/editor' );
 
-	const [ value, setValue ] = useState( val );
+	const [ value, setValue ] = useState( postContent );
 	const [ isDirty, setIsDirty ] = useState( false );
 	const instanceId = useInstanceId( PostTextEditor );
 
-	if ( ! isDirty && value !== val ) {
-		setValue( val );
+	if ( ! isDirty && value !== postContent ) {
+		setValue( postContent );
 	}
-
-	const onChange = ( content ) => {
-		editPost( { content } );
-	};
 
 	const onPersist = ( content ) => {
 		const blocks = parse( content );
@@ -50,12 +46,12 @@ export default function PostTextEditor() {
 	 *
 	 * @param {Event} event Change event.
 	 */
-	const edit = ( event ) => {
-		const v = event.target.value;
+	const onChange = ( event ) => {
+		const newValue = event.target.value;
 
-		onChange( v );
+		editPost( { content: newValue } );
 
-		setValue( v );
+		setValue( newValue );
 		setIsDirty( true );
 	};
 
@@ -83,7 +79,7 @@ export default function PostTextEditor() {
 				autoComplete="off"
 				dir="auto"
 				value={ value }
-				onChange={ edit }
+				onChange={ onChange }
 				onBlur={ stopEditing }
 				className="editor-post-text-editor"
 				id={ `post-content-${ instanceId }` }

--- a/packages/editor/src/components/post-text-editor/index.js
+++ b/packages/editor/src/components/post-text-editor/index.js
@@ -13,14 +13,31 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useInstanceId } from '@wordpress/compose';
 import { VisuallyHidden } from '@wordpress/components';
 
-export function PostTextEditor( { onChange, onPersist, ...props } ) {
-	const [ value, setValue ] = useState( props.value );
+export default function PostTextEditor() {
+	const val = useSelect(
+		( select ) => select( 'core/editor' ).getEditedPostContent(),
+		[]
+	);
+
+	const { editPost, resetEditorBlocks } = useDispatch( 'core/editor' );
+
+	const [ value, setValue ] = useState( val );
 	const [ isDirty, setIsDirty ] = useState( false );
 	const instanceId = useInstanceId( PostTextEditor );
 
-	if ( ! isDirty && value !== props.value ) {
-		setValue( props.value );
+	if ( ! isDirty && value !== val ) {
+		setValue( val );
 	}
+
+	const onChange = ( content ) => {
+		editPost( { content } );
+	};
+
+	const onPersist = ( content ) => {
+		const blocks = parse( content );
+
+		resetEditorBlocks( blocks );
+	};
 
 	/**
 	 * Handles a textarea change event to notify the onChange prop callback and
@@ -34,11 +51,11 @@ export function PostTextEditor( { onChange, onPersist, ...props } ) {
 	 * @param {Event} event Change event.
 	 */
 	const edit = ( event ) => {
-		const val = event.target.value;
+		const v = event.target.value;
 
-		onChange( val );
+		onChange( v );
 
-		setValue( val );
+		setValue( v );
 		setIsDirty( true );
 	};
 
@@ -73,28 +90,5 @@ export function PostTextEditor( { onChange, onPersist, ...props } ) {
 				placeholder={ __( 'Start writing with text or HTML' ) }
 			/>
 		</>
-	);
-}
-
-export default function ComposedPostTextEditor() {
-	const value = useSelect(
-		( select ) => select( 'core/editor' ).getEditedPostContent(),
-		[]
-	);
-
-	const { editPost, resetEditorBlocks } = useDispatch( 'core/editor' );
-
-	return (
-		<PostTextEditor
-			value={ value }
-			onChange={ ( content ) => {
-				editPost( { content } );
-			} }
-			onPersist={ ( content ) => {
-				const blocks = parse( content );
-
-				resetEditorBlocks( blocks );
-			} }
-		/>
 	);
 }

--- a/packages/editor/src/components/post-text-editor/index.js
+++ b/packages/editor/src/components/post-text-editor/index.js
@@ -9,8 +9,8 @@ import Textarea from 'react-autosize-textarea';
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import { parse } from '@wordpress/blocks';
-import { withSelect, withDispatch } from '@wordpress/data';
-import { useInstanceId, compose } from '@wordpress/compose';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useInstanceId } from '@wordpress/compose';
 import { VisuallyHidden } from '@wordpress/components';
 
 export function PostTextEditor( { onChange, onPersist, ...props } ) {
@@ -76,23 +76,25 @@ export function PostTextEditor( { onChange, onPersist, ...props } ) {
 	);
 }
 
-export default compose( [
-	withSelect( ( select ) => {
-		const { getEditedPostContent } = select( 'core/editor' );
-		return {
-			value: getEditedPostContent(),
-		};
-	} ),
-	withDispatch( ( dispatch ) => {
-		const { editPost, resetEditorBlocks } = dispatch( 'core/editor' );
-		return {
-			onChange( content ) {
+export default function ComposedPostTextEditor() {
+	const value = useSelect(
+		( select ) => select( 'core/editor' ).getEditedPostContent(),
+		[]
+	);
+
+	const { editPost, resetEditorBlocks } = useDispatch( 'core/editor' );
+
+	return (
+		<PostTextEditor
+			value={ value }
+			onChange={ ( content ) => {
 				editPost( { content } );
-			},
-			onPersist( content ) {
+			} }
+			onPersist={ ( content ) => {
 				const blocks = parse( content );
+
 				resetEditorBlocks( blocks );
-			},
-		};
-	} ),
-] )( PostTextEditor );
+			} }
+		/>
+	);
+}

--- a/packages/editor/src/components/post-text-editor/index.js
+++ b/packages/editor/src/components/post-text-editor/index.js
@@ -10,17 +10,13 @@ import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import { parse } from '@wordpress/blocks';
 import { withSelect, withDispatch } from '@wordpress/data';
-import { withInstanceId, compose } from '@wordpress/compose';
+import { useInstanceId, compose } from '@wordpress/compose';
 import { VisuallyHidden } from '@wordpress/components';
 
-export function PostTextEditor( {
-	instanceId,
-	onChange,
-	onPersist,
-	...props
-} ) {
+export function PostTextEditor( { onChange, onPersist, ...props } ) {
 	const [ value, setValue ] = useState( props.value );
 	const [ isDirty, setIsDirty ] = useState( false );
+	const instanceId = useInstanceId( PostTextEditor );
 
 	if ( ! isDirty && value !== props.value ) {
 		setValue( props.value );
@@ -99,5 +95,4 @@ export default compose( [
 			},
 		};
 	} ),
-	withInstanceId,
 ] )( PostTextEditor );

--- a/packages/editor/src/components/post-text-editor/index.js
+++ b/packages/editor/src/components/post-text-editor/index.js
@@ -7,31 +7,23 @@ import Textarea from 'react-autosize-textarea';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { parse } from '@wordpress/blocks';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { withInstanceId, compose } from '@wordpress/compose';
 import { VisuallyHidden } from '@wordpress/components';
 
-export class PostTextEditor extends Component {
-	constructor() {
-		super( ...arguments );
+export function PostTextEditor( {
+	instanceId,
+	onChange,
+	onPersist,
+	...props
+} ) {
+	const [ value, setValue ] = useState( props.value );
+	const [ isDirty, setIsDirty ] = useState( false );
 
-		this.edit = this.edit.bind( this );
-		this.stopEditing = this.stopEditing.bind( this );
-
-		this.state = {};
-	}
-
-	static getDerivedStateFromProps( props, state ) {
-		if ( state.isDirty ) {
-			return null;
-		}
-
-		return {
-			value: props.value,
-			isDirty: false,
-		};
+	if ( ! isDirty && value !== props.value ) {
+		setValue( props.value );
 	}
 
 	/**
@@ -45,48 +37,47 @@ export class PostTextEditor extends Component {
 	 *
 	 * @param {Event} event Change event.
 	 */
-	edit( event ) {
-		const value = event.target.value;
-		this.props.onChange( value );
-		this.setState( { value, isDirty: true } );
-	}
+	const edit = ( event ) => {
+		const val = event.target.value;
+
+		onChange( val );
+
+		setValue( val );
+		setIsDirty( true );
+	};
 
 	/**
 	 * Function called when the user has completed their edits, responsible for
 	 * ensuring that changes, if made, are surfaced to the onPersist prop
 	 * callback and resetting dirty state.
 	 */
-	stopEditing() {
-		if ( this.state.isDirty ) {
-			this.props.onPersist( this.state.value );
-			this.setState( { isDirty: false } );
+	const stopEditing = () => {
+		if ( isDirty ) {
+			onPersist( value );
+			setIsDirty( false );
 		}
-	}
+	};
 
-	render() {
-		const { value } = this.state;
-		const { instanceId } = this.props;
-		return (
-			<>
-				<VisuallyHidden
-					as="label"
-					htmlFor={ `post-content-${ instanceId }` }
-				>
-					{ __( 'Type text or HTML' ) }
-				</VisuallyHidden>
-				<Textarea
-					autoComplete="off"
-					dir="auto"
-					value={ value }
-					onChange={ this.edit }
-					onBlur={ this.stopEditing }
-					className="editor-post-text-editor"
-					id={ `post-content-${ instanceId }` }
-					placeholder={ __( 'Start writing with text or HTML' ) }
-				/>
-			</>
-		);
-	}
+	return (
+		<>
+			<VisuallyHidden
+				as="label"
+				htmlFor={ `post-content-${ instanceId }` }
+			>
+				{ __( 'Type text or HTML' ) }
+			</VisuallyHidden>
+			<Textarea
+				autoComplete="off"
+				dir="auto"
+				value={ value }
+				onChange={ edit }
+				onBlur={ stopEditing }
+				className="editor-post-text-editor"
+				id={ `post-content-${ instanceId }` }
+				placeholder={ __( 'Start writing with text or HTML' ) }
+			/>
+		</>
+	);
 }
 
 export default compose( [

--- a/packages/editor/src/components/post-text-editor/index.js
+++ b/packages/editor/src/components/post-text-editor/index.js
@@ -29,12 +29,6 @@ export default function PostTextEditor() {
 		setValue( postContent );
 	}
 
-	const onPersist = ( content ) => {
-		const blocks = parse( content );
-
-		resetEditorBlocks( blocks );
-	};
-
 	/**
 	 * Handles a textarea change event to notify the onChange prop callback and
 	 * reflect the new value in the component's own state. This marks the start
@@ -62,7 +56,9 @@ export default function PostTextEditor() {
 	 */
 	const stopEditing = () => {
 		if ( isDirty ) {
-			onPersist( value );
+			const blocks = parse( value );
+			resetEditorBlocks( blocks );
+
 			setIsDirty( false );
 		}
 	};

--- a/packages/editor/src/components/post-text-editor/test/index.js
+++ b/packages/editor/src/components/post-text-editor/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { create } from 'react-test-renderer';
+import { act, create } from 'react-test-renderer';
 import Textarea from 'react-autosize-textarea';
 
 /**
@@ -17,7 +17,11 @@ jest.mock( 'react-autosize-textarea', () => ( props ) => (
 
 describe( 'PostTextEditor', () => {
 	it( 'should render via the prop value', () => {
-		const wrapper = create( <PostTextEditor value="Hello World" /> );
+		let wrapper;
+
+		act( () => {
+			wrapper = create( <PostTextEditor value="Hello World" /> );
+		} );
 
 		const textarea = wrapper.root.findByType( Textarea );
 		expect( textarea.props.value ).toBe( 'Hello World' );
@@ -25,12 +29,20 @@ describe( 'PostTextEditor', () => {
 
 	it( 'should render via the state value when edits made', () => {
 		const onChange = jest.fn();
-		const wrapper = create(
-			<PostTextEditor value="Hello World" onChange={ onChange } />
-		);
+
+		let wrapper;
+
+		act( () => {
+			wrapper = create(
+				<PostTextEditor value="Hello World" onChange={ onChange } />
+			);
+		} );
 
 		const textarea = wrapper.root.findByType( Textarea );
-		textarea.props.onChange( { target: { value: 'Hello Chicken' } } );
+
+		act( () =>
+			textarea.props.onChange( { target: { value: 'Hello Chicken' } } )
+		);
 
 		expect( textarea.props.value ).toBe( 'Hello Chicken' );
 		expect( onChange ).toHaveBeenCalledWith( 'Hello Chicken' );
@@ -38,12 +50,26 @@ describe( 'PostTextEditor', () => {
 
 	it( 'should render via the state value when edits made, even if prop value changes', () => {
 		const onChange = jest.fn();
-		const wrapper = create(
-			<PostTextEditor value="Hello World" onChange={ onChange } />
-		);
+
+		let wrapper;
+
+		act( () => {
+			wrapper = create(
+				<PostTextEditor value="Hello World" onChange={ onChange } />
+			);
+		} );
 
 		const textarea = wrapper.root.findByType( Textarea );
-		textarea.props.onChange( { target: { value: 'Hello Chicken' } } );
+
+		act( () =>
+			textarea.props.onChange( { target: { value: 'Hello Chicken' } } )
+		);
+
+		act( () => {
+			wrapper.update(
+				<PostTextEditor value="Goodbye World" onChange={ onChange } />
+			);
+		} );
 
 		wrapper.update(
 			<PostTextEditor value="Goodbye World" onChange={ onChange } />
@@ -55,16 +81,22 @@ describe( 'PostTextEditor', () => {
 
 	it( 'should render via the state value when edits made, even if prop value changes and state value empty', () => {
 		const onChange = jest.fn();
-		const wrapper = create(
-			<PostTextEditor value="Hello World" onChange={ onChange } />
-		);
+		let wrapper;
+
+		act( () => {
+			wrapper = create(
+				<PostTextEditor value="Hello World" onChange={ onChange } />
+			);
+		} );
 
 		const textarea = wrapper.root.findByType( Textarea );
-		textarea.props.onChange( { target: { value: '' } } );
 
-		wrapper.update(
-			<PostTextEditor value="Goodbye World" onChange={ onChange } />
-		);
+		act( () => textarea.props.onChange( { target: { value: '' } } ) );
+		act( () => {
+			wrapper.update(
+				<PostTextEditor value="Goodbye World" onChange={ onChange } />
+			);
+		} );
 
 		expect( textarea.props.value ).toBe( '' );
 		expect( onChange ).toHaveBeenCalledWith( '' );
@@ -72,33 +104,44 @@ describe( 'PostTextEditor', () => {
 
 	it( 'calls onPersist after changes made and user stops editing', () => {
 		const onPersist = jest.fn();
-		const wrapper = create(
-			<PostTextEditor
-				value="Hello World"
-				onChange={ () => {} }
-				onPersist={ onPersist }
-			/>
-		);
+
+		let wrapper;
+
+		act( () => {
+			wrapper = create(
+				<PostTextEditor
+					value="Hello World"
+					onChange={ () => {} }
+					onPersist={ onPersist }
+				/>
+			);
+		} );
 
 		const textarea = wrapper.root.findByType( Textarea );
-		textarea.props.onChange( { target: { value: '' } } );
-		textarea.props.onBlur();
+
+		act( () => textarea.props.onChange( { target: { value: '' } } ) );
+		act( () => textarea.props.onBlur() );
 
 		expect( onPersist ).toHaveBeenCalledWith( '' );
 	} );
 
 	it( 'does not call onPersist after user stops editing without changes', () => {
 		const onPersist = jest.fn();
-		const wrapper = create(
-			<PostTextEditor
-				value="Hello World"
-				onChange={ () => {} }
-				onPersist={ onPersist }
-			/>
-		);
+
+		let wrapper;
+
+		act( () => {
+			wrapper = create(
+				<PostTextEditor
+					value="Hello World"
+					onChange={ () => {} }
+					onPersist={ onPersist }
+				/>
+			);
+		} );
 
 		const textarea = wrapper.root.findByType( Textarea );
-		textarea.props.onBlur();
+		act( () => textarea.props.onBlur() );
 
 		expect( onPersist ).not.toHaveBeenCalled();
 	} );
@@ -108,26 +151,32 @@ describe( 'PostTextEditor', () => {
 		// parent renderer to pass the value as it had received onPersist. The
 		// test here is more an edge case to stress that it's intentionally
 		// differentiating between state and prop values.
-		const wrapper = create(
-			<PostTextEditor
-				value="Hello World"
-				onChange={ () => {} }
-				onPersist={ () => {} }
-			/>
-		);
+		let wrapper;
+
+		act( () => {
+			wrapper = create(
+				<PostTextEditor
+					value="Hello World"
+					onChange={ () => {} }
+					onPersist={ () => {} }
+				/>
+			);
+		} );
 
 		const textarea = wrapper.root.findByType( Textarea );
-		textarea.props.onChange( { target: { value: '' } } );
+		act( () => textarea.props.onChange( { target: { value: '' } } ) );
 
-		wrapper.update(
-			<PostTextEditor
-				value="Goodbye World"
-				onChange={ () => {} }
-				onPersist={ () => {} }
-			/>
-		);
+		act( () => {
+			wrapper.update(
+				<PostTextEditor
+					value="Goodbye World"
+					onChange={ () => {} }
+					onPersist={ () => {} }
+				/>
+			);
+		} );
 
-		textarea.props.onBlur();
+		act( () => textarea.props.onBlur() );
 
 		expect( textarea.props.value ).toBe( 'Goodbye World' );
 	} );


### PR DESCRIPTION
## Description
See #22890

Refactored PostTextEditor to use React Hook.

## How has this been tested?
Tested using existing unit tests.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
