### PR TITLE
Fix block merging regression

### DIFF
--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -15,7 +15,7 @@ import {
 	forwardRef,
 } from '@wordpress/element';
 import { focus, isTextField, placeCaretAtHorizontalEdge } from '@wordpress/dom';
-import { ENTER } from '@wordpress/keycodes';
+import { ENTER, BACKSPACE, DELETE } from '@wordpress/keycodes';
 import { __, sprintf } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 
@@ -75,7 +75,9 @@ const BlockComponent = forwardRef(
 			},
 			[ isSelected ]
 		);
-		const { insertDefaultBlock } = useDispatch( 'core/block-editor' );
+		const { insertDefaultBlock, removeBlock } = useDispatch(
+			'core/block-editor'
+		);
 		const fallbackRef = useRef();
 		const isAligned = wrapperProps && !! wrapperProps[ 'data-align' ];
 		wrapper = wrapper || fallbackRef;
@@ -169,7 +171,11 @@ const BlockComponent = forwardRef(
 				props.onKeyDown( event );
 			}
 
-			if ( keyCode !== ENTER ) {
+			if (
+				keyCode !== ENTER &&
+				keyCode !== BACKSPACE &&
+				keyCode !== DELETE
+			) {
 				return;
 			}
 
@@ -181,6 +187,8 @@ const BlockComponent = forwardRef(
 
 			if ( keyCode === ENTER ) {
 				insertDefaultBlock( {}, rootClientId, index + 1 );
+			} else {
+				removeBlock( clientId );
 			}
 		};
 

--- a/packages/block-editor/src/components/keyboard-shortcuts/index.js
+++ b/packages/block-editor/src/components/keyboard-shortcuts/index.js
@@ -131,7 +131,7 @@ function KeyboardShortcuts() {
 			},
 			[ clientIds, removeBlocks ]
 		),
-		{ isDisabled: clientIds.length < 1 }
+		{ isDisabled: clientIds.length < 2 }
 	);
 
 	useShortcut(

--- a/packages/e2e-tests/specs/editor/blocks/image.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/image.test.js
@@ -81,6 +81,7 @@ describe( 'Image', () => {
 		);
 		expect( await getEditedPostContent() ).toMatch( regex3 );
 
+		await page.click( '.wp-block-image img' );
 		await page.keyboard.press( 'Backspace' );
 
 		expect( await getEditedPostContent() ).toBe( '' );

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/writing-flow.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/writing-flow.test.js.snap
@@ -116,6 +116,12 @@ exports[`Writing Flow should merge forwards 1`] = `
 <!-- /wp:paragraph -->"
 `;
 
+exports[`Writing Flow should merge paragraphs 1`] = `
+"<!-- wp:paragraph -->
+<p>12</p>
+<!-- /wp:paragraph -->"
+`;
+
 exports[`Writing Flow should navigate around inline boundaries 1`] = `
 "<!-- wp:paragraph -->
 <p>FirstAfter</p>

--- a/packages/e2e-tests/specs/editor/various/writing-flow.test.js
+++ b/packages/e2e-tests/specs/editor/various/writing-flow.test.js
@@ -410,6 +410,17 @@ describe( 'Writing Flow', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
+	it( 'should merge paragraphs', async () => {
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '1' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '2' );
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'Backspace' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
 	it( 'should merge forwards', async () => {
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '1' );


### PR DESCRIPTION
closes #23808 regressed in #23394

Fixes merging two textual blocks together. The keyboard shortcut for multi blocks removal was being triggered.

 - [x] Add an end2end test.

**Testing instructions**

 - Make sure merging paragraphs work
 - Make sure removing an image block if it's selected works (backspace)
 - Make sure backspaces removes multi-selection.