### PR TITLE
Update Line-Height Settings for opt-in (rather than opt-out)

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -655,7 +655,7 @@ add_filter( 'block_editor_settings', 'gutenberg_extend_settings_block_patterns',
  * @return array Filtered editor settings.
  */
 function gutenberg_extend_settings_custom_line_height( $settings ) {
-	$settings['__experimentalDisableCustomLineHeight'] = get_theme_support( 'disable-custom-line-height' );
+	$settings['__experimentalEnableCustomLineHeight'] = get_theme_support( 'experimental-line-height' );
 	return $settings;
 }
 add_filter( 'block_editor_settings', 'gutenberg_extend_settings_custom_line_height' );

--- a/packages/block-editor/src/hooks/line-height.js
+++ b/packages/block-editor/src/hooks/line-height.js
@@ -59,7 +59,7 @@ export function useIsLineHeightDisabled( { name: blockName } = {} ) {
 	const isDisabled = useSelect( ( select ) => {
 		const editorSettings = select( 'core/block-editor' ).getSettings();
 
-		return editorSettings.__experimentalDisableCustomLineHeight;
+		return ! editorSettings.__experimentalEnableCustomLineHeight;
 	} );
 
 	return (

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -115,7 +115,7 @@ class EditorProvider extends Component {
 				'__experimentalBlockPatterns',
 				'__experimentalBlockPatternCategories',
 				'__experimentalDisableCustomUnits',
-				'__experimentalDisableCustomLineHeight',
+				'__experimentalEnableCustomLineHeight',
 				'__experimentalEnableCustomSpacing',
 				'__experimentalEnableLegacyWidgetBlock',
 				'__experimentalEnableLinkColor',


### PR DESCRIPTION
This update adjusts the line-height theme support setting to be opt-in via `add_theme_support( 'experimental-line-height' );` rather than enabled by default. This keeps it consistent with the other recently added style theme support settings like padding (spacing).



## How has this been tested?

Tested locally in Gutenberg

* Run `npm run dev`
* Add a Paragraph or Heading block
* Line-height controls should not be there
* Add `add_theme_support( 'experimental-line-height' );` to an applicable theme PHP file (e.g. `functions.php`)
* Check a Paragraph or Heading block
* Line-height controls should be visible



## Types of changes

* Adjusted an `add_theme_support` value from `disable-custom-line-height` to `experimental-line-height`

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [n/a] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [n/a] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [n/a] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
