### PR TITLE
Allow wp-env to start without config

### DIFF
--- a/packages/env/lib/commands/start.js
+++ b/packages/env/lib/commands/start.js
@@ -56,6 +56,14 @@ module.exports = async function start( { spinner, debug } ) {
 
 	const config = await initConfig( { spinner, debug } );
 
+	if ( ! config.detectedLocalConfig ) {
+		const { configDirectoryPath } = config;
+		spinner.warn(
+			`Warning: could not find a .wp-env.json configuration file and could not determine if '${ configDirectoryPath }' is a WordPress installation, a plugin, or a theme.`
+		);
+		spinner.start();
+	}
+
 	spinner.text = 'Downloading WordPress.';
 
 	await Promise.all( [

--- a/packages/env/lib/config/config.js
+++ b/packages/env/lib/config/config.js
@@ -23,6 +23,7 @@ const parseConfig = require( './parse-config' );
  * @property {string}                           configDirectoryPath     Path to the .wp-env.json file.
  * @property {string}                           workDirectoryPath       Path to the work directory located in ~/.wp-env.
  * @property {string}                           dockerComposeConfigPath Path to the docker-compose.yml file.
+ * @property {boolean}                          detectedLocalConfig     If true, wp-env detected local config and used it.
  * @property {Object.<string, WPServiceConfig>} env                     Specific config for different environments.
  * @property {boolean}                          debug                   True if debug mode is enabled.
  */
@@ -104,6 +105,9 @@ module.exports = async function readConfig( configPath ) {
 			configPath.replace( /\.wp-env\.json$/, '.wp-env.override.json' )
 		) ) || {};
 
+	const detectedLocalConfig =
+		Object.keys( { ...baseConfig, ...overrideConfig } ).length > 0;
+
 	// A quick validation before merging on a service by service level allows us
 	// to check the root configuration options and provide more helpful errors.
 	validateConfig(
@@ -166,6 +170,7 @@ module.exports = async function readConfig( configPath ) {
 		),
 		configDirectoryPath,
 		workDirectoryPath,
+		detectedLocalConfig,
 		env,
 	} );
 };

--- a/packages/env/lib/config/config.js
+++ b/packages/env/lib/config/config.js
@@ -214,7 +214,8 @@ function mergeWpServiceConfigs( configs ) {
  * added to the default plugin sources.
  *
  * @param {string} configPath A path to the config file for the source to detect.
- * @return {Object} Basic config options for the detected source type.
+ * @return {Object} Basic config options for the detected source type. Empty
+ *                  object if no config detected.
  */
 async function getDefaultBaseConfig( configPath ) {
 	const configDirectoryPath = path.dirname( configPath );
@@ -228,9 +229,7 @@ async function getDefaultBaseConfig( configPath ) {
 		return { themes: [ '.' ] };
 	}
 
-	throw new ValidationError(
-		`No .wp-env.json file found at '${ configPath }' and could not determine if '${ configDirectoryPath }' is a WordPress installation, a plugin, or a theme.`
-	);
+	return {};
 }
 
 /**

--- a/packages/env/lib/config/test/__snapshots__/config.js.snap
+++ b/packages/env/lib/config/test/__snapshots__/config.js.snap
@@ -3,6 +3,7 @@
 exports[`readConfig config file should match snapshot 1`] = `
 Object {
   "configDirectoryPath": ".",
+  "detectedLocalConfig": true,
   "env": Object {
     "development": Object {
       "config": Object {

--- a/packages/env/lib/wordpress.js
+++ b/packages/env/lib/wordpress.js
@@ -171,7 +171,10 @@ async function resetDatabase(
 }
 
 async function setupWordPressDirectories( config ) {
-	if ( hasSameCoreSource( [ config.env.development, config.env.tests ] ) ) {
+	if (
+		config.env.development.coreSource &&
+		hasSameCoreSource( [ config.env.development, config.env.tests ] )
+	) {
 		await copyCoreFiles(
 			config.env.development.coreSource.path,
 			config.env.development.coreSource.testsPath


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Previously, if you ran `wp-env start` without a config (or if it couldn't detect a plugin to mount), it would fail. I'm not convinced this is expected behavior. Why not just allow people to create an empty WordPress instance?

There are a few concerns I have with this:
- The error message makes it clear that you need to `cd` to the correct location in case you accidentally ran `wp-env start` from somewhere random
- If folks ran `wp-env start` from different directories on their machine, each instance would be different. (To be fair, it will error out when you have instances with the same port number.)

This was motivated by discussion around documentation for starting your local environment and how to start it if you did not have a local source. (#23593)

I think this was also the behavior at some point in the past (it didn't fail if it couldn't find a config)


Additionally, this fixes a crash which occurred if you did not set a WordPress source.
 
## How has this been tested?
Locally with `wp-env`

## Screenshots <!-- if applicable -->

<img width="742" alt="Screen Shot 2020-07-13 at 3 00 09 PM" src="https://user-images.githubusercontent.com/6265975/87357837-8ede2980-c519-11ea-995d-6dd25191d27d.png">

## Types of changes
enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
