### PR TITLE
Fix drag and drop for aligned blocks

### DIFF
--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -50,8 +50,8 @@ export function getNearestBlockIndex( elements, position, orientation ) {
 	let candidateDistance;
 
 	elements.forEach( ( element, index ) => {
-		// Ensure the element is a block. It should have the `data-block` attribute.
-		if ( ! element.dataset.block ) {
+		// Ensure the element is a block. It should have the `wp-block` class.
+		if ( ! element.classList.contains( 'wp-block' ) ) {
 			return;
 		}
 

--- a/packages/block-editor/src/components/use-block-drop-zone/test/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/test/index.js
@@ -83,8 +83,10 @@ describe( 'getNearestBlockIndex', () => {
 		expect( result ).toBeUndefined();
 	} );
 
-	it( 'returns `undefined` if the elements do not have the `data-block` attribute', () => {
-		const nonBlockElements = [ { dataset: {} } ];
+	it( 'returns `undefined` if the elements do not have the `wp-block` class', () => {
+		const nonBlockElements = [
+			{ classList: createMockClassList( 'some-other-class' ) },
+		];
 		const position = { x: 0, y: 0 };
 		const orientation = 'horizontal';
 

--- a/packages/block-editor/src/components/use-block-drop-zone/test/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/test/index.js
@@ -31,10 +31,10 @@ const elementData = [
 	},
 ];
 
-const createMockClassList = ( isDragging ) => {
+const createMockClassList = ( classes ) => {
 	return {
-		contains() {
-			return isDragging;
+		contains( textToMatch ) {
+			return classes.includes( textToMatch );
 		},
 	};
 };
@@ -60,7 +60,7 @@ const mapElements = ( orientation ) => (
 						right: bottom,
 				  };
 		},
-		classList: createMockClassList( false ),
+		classList: createMockClassList( 'wp-block' ),
 	};
 };
 
@@ -208,14 +208,14 @@ describe( 'getNearestBlockIndex', () => {
 			expect( result ).toBe( 4 );
 		} );
 
-		it( 'skips the block being dragged', () => {
+		it( 'skips the block being dragged by checking for the `is-dragging` classname', () => {
 			const position = { x: 0, y: 450 };
 
 			const verticalElementsWithDraggedBlock = [
 				...verticalElements.slice( 0, 2 ),
 				{
 					...verticalElements[ 2 ],
-					classList: createMockClassList( true ),
+					classList: createMockClassList( 'wp-block is-dragging' ),
 				},
 				...verticalElements.slice( 3, 4 ),
 			];
@@ -341,14 +341,14 @@ describe( 'getNearestBlockIndex', () => {
 			expect( result ).toBe( 4 );
 		} );
 
-		it( 'skips the block being dragged', () => {
+		it( 'skips the block being dragged by checking for the `is-dragging` classname', () => {
 			const position = { x: 450, y: 0 };
 
 			const horizontalElementsWithDraggedBlock = [
 				...horizontalElements.slice( 0, 2 ),
 				{
 					...horizontalElements[ 2 ],
-					classList: createMockClassList( true ),
+					classList: createMockClassList( 'wp-block is-dragging' ),
 				},
 				...horizontalElements.slice( 3, 4 ),
 			];


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
In #23020, I made a false assumption that the root element for a block would always have the `data-block` attribute. More recently I noticed that aligned blocks have an extra wrapper that just has the `wp-block` class, so #23020 resulted in blocks not being able to be dropped between aligned blocks.

This fixes the issue by changing the `if` statement to check for the `wp-block` class instead.

## How has this been tested?
1. Add a paragraph and two image blocks (no need to upload media)
2. Set the two image blocks so that they're both aligned wide or full
3. Try dragging and dropping the paragraph between the two image blocks

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
