### PR TITLE
Refactored URLPopover to use React Hook

### DIFF
--- a/packages/block-editor/src/components/url-popover/index.js
+++ b/packages/block-editor/src/components/url-popover/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { Button, Popover } from '@wordpress/components';
 import { chevronDown } from '@wordpress/icons';
 
@@ -12,73 +12,55 @@ import { chevronDown } from '@wordpress/icons';
 import LinkViewer from './link-viewer';
 import LinkEditor from './link-editor';
 
-class URLPopover extends Component {
-	constructor() {
-		super( ...arguments );
+function URLPopover( {
+	additionalControls,
+	children,
+	renderSettings,
+	position = 'bottom center',
+	focusOnMount = 'firstElement',
+	...popoverProps
+} ) {
+	const [ isSettingsExpanded, setIsSettingsExpanded ] = useState( false );
 
-		this.toggleSettingsVisibility = this.toggleSettingsVisibility.bind(
-			this
-		);
+	const showSettings = !! renderSettings && isSettingsExpanded;
 
-		this.state = {
-			isSettingsExpanded: false,
-		};
-	}
+	const toggleSettingsVisibility = () => {
+		setIsSettingsExpanded( ! isSettingsExpanded );
+	};
 
-	toggleSettingsVisibility() {
-		this.setState( {
-			isSettingsExpanded: ! this.state.isSettingsExpanded,
-		} );
-	}
-
-	render() {
-		const {
-			additionalControls,
-			children,
-			renderSettings,
-			position = 'bottom center',
-			focusOnMount = 'firstElement',
-			...popoverProps
-		} = this.props;
-
-		const { isSettingsExpanded } = this.state;
-
-		const showSettings = !! renderSettings && isSettingsExpanded;
-
-		return (
-			<Popover
-				className="block-editor-url-popover"
-				focusOnMount={ focusOnMount }
-				position={ position }
-				{ ...popoverProps }
-			>
-				<div className="block-editor-url-popover__input-container">
-					<div className="block-editor-url-popover__row">
-						{ children }
-						{ !! renderSettings && (
-							<Button
-								className="block-editor-url-popover__settings-toggle"
-								icon={ chevronDown }
-								label={ __( 'Link settings' ) }
-								onClick={ this.toggleSettingsVisibility }
-								aria-expanded={ isSettingsExpanded }
-							/>
-						) }
-					</div>
-					{ showSettings && (
-						<div className="block-editor-url-popover__row block-editor-url-popover__settings">
-							{ renderSettings() }
-						</div>
+	return (
+		<Popover
+			className="block-editor-url-popover"
+			focusOnMount={ focusOnMount }
+			position={ position }
+			{ ...popoverProps }
+		>
+			<div className="block-editor-url-popover__input-container">
+				<div className="block-editor-url-popover__row">
+					{ children }
+					{ !! renderSettings && (
+						<Button
+							className="block-editor-url-popover__settings-toggle"
+							icon={ chevronDown }
+							label={ __( 'Link settings' ) }
+							onClick={ toggleSettingsVisibility }
+							aria-expanded={ isSettingsExpanded }
+						/>
 					) }
 				</div>
-				{ additionalControls && ! showSettings && (
-					<div className="block-editor-url-popover__additional-controls">
-						{ additionalControls }
+				{ showSettings && (
+					<div className="block-editor-url-popover__row block-editor-url-popover__settings">
+						{ renderSettings() }
 					</div>
 				) }
-			</Popover>
-		);
-	}
+			</div>
+			{ additionalControls && ! showSettings && (
+				<div className="block-editor-url-popover__additional-controls">
+					{ additionalControls }
+				</div>
+			) }
+		</Popover>
+	);
 }
 
 URLPopover.LinkEditor = LinkEditor;

--- a/packages/block-editor/src/components/url-popover/stories/index.js
+++ b/packages/block-editor/src/components/url-popover/stories/index.js
@@ -1,0 +1,52 @@
+/**
+ * WordPress dependencies
+ */
+import { Button, ToggleControl } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { keyboardReturn } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import URLPopover from '../';
+
+export default { title: 'BlockEditor/URLPopover' };
+
+const TestURLPopover = () => {
+	const [ isVisible, setVisiblility ] = useState( false );
+	const [ url, setUrl ] = useState( '' );
+
+	const close = () => setVisiblility( false );
+	const setTarget = () => {};
+
+	return (
+		<>
+			<Button onClick={ () => setVisiblility( true ) }>Edit URL</Button>
+			{ isVisible && (
+				<URLPopover
+					onClose={ close }
+					renderSettings={ () => (
+						<ToggleControl
+							label={ __( 'Open in new tab' ) }
+							onChange={ setTarget }
+						/>
+					) }
+				>
+					<form onSubmit={ close }>
+						<input type="url" value={ url } onChange={ setUrl } />
+						<Button
+							icon={ keyboardReturn }
+							label={ __( 'Apply' ) }
+							type="submit"
+						/>
+					</form>
+				</URLPopover>
+			) }
+		</>
+	);
+};
+
+export const _default = () => {
+	return <TestURLPopover />;
+};


### PR DESCRIPTION
## Description
Related to #22890

Refactored URLPopover to use React Hooks

## How has this been tested?
Tested using existing unit tests.
View changes in Storybook

## Types of changes
Refactored URLPopover to use React Hooks

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [ ] My code follows the accessibility standards.
- [ ] My code has proper inline documentation.
- [ ] I've included developer documentation if appropriate.
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR.