### PR TITLE
Fix drag and drop to empty block lists

### DIFF
--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -322,17 +322,14 @@ export default function useBlockDropZone( {
 	useEffect( () => {
 		if ( position ) {
 			const blockElements = Array.from( element.current.children );
+
 			const targetIndex = getNearestBlockIndex(
 				blockElements,
 				position,
 				orientation
 			);
 
-			if ( targetIndex === undefined ) {
-				return;
-			}
-
-			setTargetBlockIndex( targetIndex );
+			setTargetBlockIndex( targetIndex === undefined ? 0 : targetIndex );
 		}
 	}, [ position ] );
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Since #23020, dragging to an empty block lists hasn't worked.

This PR fixes the issue, though I think there are two separate issues that could improve the situation further:
- In Media & Text, the empty block list is only 8px high, and the user has to drag over this tiny element before being able to drop.
- In Group, the Button Appender doesn't highlight very clearly as a drop target—it shows a border above it like other drop targets. I feel like this might have regressed separately at some point.

I'll also start writing some E2E tests so that there's coverage for some of these complex behaviors.

## How has this been tested?
1. Add a Media & Text Block
2. Add a paragraph after the Media & Text block
3. Delete the default header in the Media & Text block
4. Try dragging the paragraph into the empty Media & Text block (it's a little tricky to find the right spot, but keep trying!)

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
