### PR TITLE
Build: Use `.min.js` suffix for bundled JavaScript

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -120,7 +120,7 @@ function gutenberg_override_translation_file( $file, $handle ) {
 	}
 
 	// Ignore scripts that are not found in the expected `build/` location.
-	$script_path = gutenberg_dir_path() . 'build/' . substr( $handle, 3 ) . '/index.js';
+	$script_path = gutenberg_dir_path() . 'build/' . substr( $handle, 3 ) . '/index.min.js';
 	if ( ! file_exists( $script_path ) ) {
 		return $file;
 	}
@@ -247,9 +247,9 @@ add_action( 'wp_default_scripts', 'gutenberg_register_vendor_scripts' );
  * @param WP_Scripts $scripts WP_Scripts instance.
  */
 function gutenberg_register_packages_scripts( $scripts ) {
-	foreach ( glob( gutenberg_dir_path() . 'build/*/index.js' ) as $path ) {
+	foreach ( glob( gutenberg_dir_path() . 'build/*/index.min.js' ) as $path ) {
 		// Prefix `wp-` to package directory to get script handle.
-		// For example, `…/build/a11y/index.js` becomes `wp-a11y`.
+		// For example, `…/build/a11y/index.min.js` becomes `wp-a11y`.
 		$handle = 'wp-' . basename( dirname( $path ) );
 
 		// Replace `.js` extension with `.asset.php` to find the generated dependencies file.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -68,7 +68,7 @@ module.exports = {
 	}, {} ),
 	output: {
 		devtoolNamespace: 'wp',
-		filename: './build/[basename]/index.js',
+		filename: './build/[basename]/index.min.js',
 		path: __dirname,
 		library: [ 'wp', '[name]' ],
 		libraryTarget: 'this',


### PR DESCRIPTION
## Description

The webpack-bundled packages intended for consumption via WordPress scripts in `build/` are shipped with the Gutenberg plugin as minified sources.

Contrary to [WordPress convention](https://github.com/WordPress/WordPress/tree/master/wp-includes/js/dist), these minified sources use the `.js` extension rather than `.min.js`.

Use the `.min.js` extension for bundled sources.

**Note:**
The `.min.js` extension is hard-coded in a few places. This is optimized for the most common use case — when the scripts are used as part of the Gutenberg plugin.

This is not accurate in development (`npm run dev`) where the scripts are not minified. I consider this to be an acceptable tradeoff. Developers are unlikely to be confused by the `.min.js` extension containing readable source.

## How has this been tested?

The Gutenberg plugin enqueues `.min.js` from `build` and their dependencies correctly.
Build (`npm run build:plugin-zip`) and install the plugin on a site. The editor works correctly.

## Types of changes
Internal.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
