### PR TITLE
Fix edited Classic block's content deletion when switching to Code editor

### DIFF
--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { debounce } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { BlockControls } from '@wordpress/block-editor';
@@ -138,19 +133,16 @@ export default class ClassicEdit extends Component {
 			bookmark = null;
 		} );
 
-		editor.on(
-			'Paste Change input Undo Redo',
-			debounce( () => {
-				const value = editor.getContent();
+		editor.on( 'Paste Change input Undo Redo', () => {
+			const value = editor.getContent();
 
-				if ( value !== editor._lastChange ) {
-					editor._lastChange = value;
-					setAttributes( {
-						content: value,
-					} );
-				}
-			}, 250 )
-		);
+			if ( value !== editor._lastChange ) {
+				editor._lastChange = value;
+				setAttributes( {
+					content: value,
+				} );
+			}
+		} );
 
 		editor.on( 'keydown', ( event ) => {
 			if ( isKeyboardEvent.primary( event, 'z' ) ) {

--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -144,7 +144,7 @@ export default class ClassicEdit extends Component {
 				// We need this check because when we remove the editor (onUnmount)
 				// due to the usage of `debounce`, this callback is executed in
 				// another tick. This results in setting the content to empty.
-				if ( editor._isRemoved ) return;
+				if ( editor._hasBeenRemoved ) return;
 
 				const value = editor.getContent();
 
@@ -154,11 +154,11 @@ export default class ClassicEdit extends Component {
 						content: value,
 					} );
 				}
-			} )
+			}, 250 )
 		);
 
 		editor.on( 'remove', () => {
-			editor._isRemoved = true;
+			editor._hasBeenRemoved = true;
 		} );
 
 		editor.on( 'keydown', ( event ) => {

--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { debounce } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { BlockControls } from '@wordpress/block-editor';
@@ -133,15 +138,27 @@ export default class ClassicEdit extends Component {
 			bookmark = null;
 		} );
 
-		editor.on( 'Paste Change input Undo Redo', () => {
-			const value = editor.getContent();
+		editor.on(
+			'Paste Change input Undo Redo',
+			debounce( () => {
+				// We need this check because when we remove the editor (onUnmount)
+				// due to the usage of `debounce`, this callback is executed in
+				// another tick. This results in setting the content to empty.
+				if ( editor._isRemoved ) return;
 
-			if ( value !== editor._lastChange ) {
-				editor._lastChange = value;
-				setAttributes( {
-					content: value,
-				} );
-			}
+				const value = editor.getContent();
+
+				if ( value !== editor._lastChange ) {
+					editor._lastChange = value;
+					setAttributes( {
+						content: value,
+					} );
+				}
+			} )
+		);
+
+		editor.on( 'remove', () => {
+			editor._isRemoved = true;
 		} );
 
 		editor.on( 'keydown', ( event ) => {

--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -138,28 +138,22 @@ export default class ClassicEdit extends Component {
 			bookmark = null;
 		} );
 
-		editor.on(
-			'Paste Change input Undo Redo',
-			debounce( () => {
-				// We need this check because when we remove the editor (onUnmount)
-				// due to the usage of `debounce`, this callback is executed in
-				// another tick. This results in setting the content to empty.
-				if ( editor._hasBeenRemoved ) return;
+		const debouncedOnChange = debounce( () => {
+			const value = editor.getContent();
 
-				const value = editor.getContent();
+			if ( value !== editor._lastChange ) {
+				editor._lastChange = value;
+				setAttributes( {
+					content: value,
+				} );
+			}
+		}, 250 );
+		editor.on( 'Paste Change input Undo Redo', debouncedOnChange );
 
-				if ( value !== editor._lastChange ) {
-					editor._lastChange = value;
-					setAttributes( {
-						content: value,
-					} );
-				}
-			}, 250 )
-		);
-
-		editor.on( 'remove', () => {
-			editor._hasBeenRemoved = true;
-		} );
+		// We need to cancel the debounce call because when we remove
+		// the editor (onUnmount) this callback is executed in
+		// another tick. This results in setting the content to empty.
+		editor.on( 'remove', debouncedOnChange.cancel );
 
 		editor.on( 'keydown', ( event ) => {
 			if ( isKeyboardEvent.primary( event, 'z' ) ) {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Fixes: https://github.com/WordPress/gutenberg/issues/23924

If you edit the content of a `Classic` block and then switch to `Code editor`, the content disappears.

This was happening because with the switch ( and possibly other actions as well? ) the `Classic` block unmounts and calls the `wp.oldEditor` ( tinymce ) function `remove`. This function in a series of internal actions with `save` ended up calling our debounced function. Since it was set to execute to another `tick`, the editor had already cleared its content (caused by the above `remove` call) resulting in the disappearance of the content.

There might be some performance issues on "edge" cases, as previously discussed here: https://github.com/WordPress/gutenberg/pull/23408#discussion_r445881412, in the PR that introduced this side effect.

> We didn't actually start to see any visible performance degradation until you got upwards of 50,000 words in a post, and adding a debounce made it performant again even with a massive post.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
