### PR TITLE
Prevent content loss after refreshing an editor with unsaved auto-draft post

### DIFF
--- a/packages/editor/src/components/local-autosave-monitor/index.js
+++ b/packages/editor/src/components/local-autosave-monitor/index.js
@@ -7,7 +7,7 @@ import { once, uniqueId, omit } from 'lodash';
  * WordPress dependencies
  */
 import { useCallback, useEffect, useRef } from '@wordpress/element';
-import { ifCondition } from '@wordpress/compose';
+import { ifCondition, usePrevious } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { parse } from '@wordpress/blocks';
@@ -118,6 +118,15 @@ function useAutosaveNotice() {
 				],
 			}
 		);
+	}, [ isEditedPostNew, postId ] );
+
+	// Once the isEditedPostNew changes from true to false, let's clear the auto-draft autosave.
+	const wasEditedPostNew = usePrevious( isEditedPostNew );
+	const prevPostId = usePrevious( postId );
+	useEffect( () => {
+		if ( prevPostId === postId && wasEditedPostNew && ! isEditedPostNew ) {
+			localAutosaveClear( postId, true );
+		}
 	}, [ isEditedPostNew, postId ] );
 }
 

--- a/packages/editor/src/components/local-autosave-monitor/index.js
+++ b/packages/editor/src/components/local-autosave-monitor/index.js
@@ -119,15 +119,6 @@ function useAutosaveNotice() {
 			}
 		);
 	}, [ isEditedPostNew, postId ] );
-
-	// Once the isEditedPostNew changes from true to false, let's clear the auto-draft autosave.
-	const wasEditedPostNew = usePrevious( isEditedPostNew );
-	const prevPostId = usePrevious( postId );
-	useEffect( () => {
-		if ( prevPostId === postId && wasEditedPostNew && ! isEditedPostNew ) {
-			localAutosaveClear( postId, true );
-		}
-	}, [ isEditedPostNew, postId ] );
 }
 
 /**
@@ -166,6 +157,15 @@ function useAutosavePurge() {
 		lastIsDirty.current = isDirty;
 		lastIsAutosaving.current = isAutosaving;
 	}, [ isDirty, isAutosaving, didError ] );
+
+	// Once the isEditedPostNew changes from true to false, let's clear the auto-draft autosave.
+	const wasEditedPostNew = usePrevious( isEditedPostNew );
+	const prevPostId = usePrevious( postId );
+	useEffect( () => {
+		if ( prevPostId === postId && wasEditedPostNew && ! isEditedPostNew ) {
+			localAutosaveClear( postId, true );
+		}
+	}, [ isEditedPostNew, postId ] );
 }
 
 function LocalAutosaveMonitor() {

--- a/packages/editor/src/components/local-autosave-monitor/index.js
+++ b/packages/editor/src/components/local-autosave-monitor/index.js
@@ -45,9 +45,15 @@ const hasSessionStorageSupport = once( () => {
  * restore a local autosave, if one exists.
  */
 function useAutosaveNotice() {
-	const { postId, getEditedPostAttribute, hasRemoteAutosave } = useSelect(
+	const {
+		postId,
+		isEditedPostNew,
+		getEditedPostAttribute,
+		hasRemoteAutosave,
+	} = useSelect(
 		( select ) => ( {
 			postId: select( 'core/editor' ).getCurrentPostId(),
+			isEditedPostNew: select( 'core/editor' ).isEditedPostNew(),
 			getEditedPostAttribute: select( 'core/editor' )
 				.getEditedPostAttribute,
 			hasRemoteAutosave: !! select( 'core/editor' ).getEditorSettings()
@@ -60,7 +66,7 @@ function useAutosaveNotice() {
 	const { editPost, resetEditorBlocks } = useDispatch( 'core/editor' );
 
 	useEffect( () => {
-		let localAutosave = localAutosaveGet( postId );
+		let localAutosave = localAutosaveGet( postId, isEditedPostNew );
 		if ( ! localAutosave ) {
 			return;
 		}
@@ -84,7 +90,7 @@ function useAutosaveNotice() {
 
 			if ( ! hasDifference ) {
 				// If there is no difference, it can be safely ejected from storage.
-				localAutosaveClear( postId );
+				localAutosaveClear( postId, isEditedPostNew );
 				return;
 			}
 		}
@@ -112,16 +118,23 @@ function useAutosaveNotice() {
 				],
 			}
 		);
-	}, [ postId ] );
+	}, [ isEditedPostNew, postId ] );
 }
 
 /**
  * Custom hook which ejects a local autosave after a successful save occurs.
  */
 function useAutosavePurge() {
-	const { postId, isDirty, isAutosaving, didError } = useSelect(
+	const {
+		postId,
+		isEditedPostNew,
+		isDirty,
+		isAutosaving,
+		didError,
+	} = useSelect(
 		( select ) => ( {
 			postId: select( 'core/editor' ).getCurrentPostId(),
+			isEditedPostNew: select( 'core/editor' ).isEditedPostNew(),
 			isDirty: select( 'core/editor' ).isEditedPostDirty(),
 			isAutosaving: select( 'core/editor' ).isAutosavingPost(),
 			didError: select( 'core/editor' ).didPostSaveRequestFail(),
@@ -138,7 +151,7 @@ function useAutosavePurge() {
 			( ( lastIsAutosaving.current && ! isAutosaving ) ||
 				( lastIsDirty.current && ! isDirty ) )
 		) {
-			localAutosaveClear( postId );
+			localAutosaveClear( postId, isEditedPostNew );
 		}
 
 		lastIsDirty.current = isDirty;

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -352,6 +352,7 @@ export function* autosave( options ) {
 
 export function* __experimentalLocalAutosave() {
 	const post = yield select( STORE_KEY, 'getCurrentPost' );
+	const isPostNew = yield select( STORE_KEY, 'isEditedPostNew' );
 	const title = yield select( STORE_KEY, 'getEditedPostAttribute', 'title' );
 	const content = yield select(
 		STORE_KEY,
@@ -366,6 +367,7 @@ export function* __experimentalLocalAutosave() {
 	yield {
 		type: 'LOCAL_AUTOSAVE_SET',
 		postId: post.id,
+		isPostNew,
 		title,
 		content,
 		excerpt,

--- a/packages/editor/src/store/controls.js
+++ b/packages/editor/src/store/controls.js
@@ -32,20 +32,23 @@ export function getRegistry() {
  *
  * @see https://github.com/WordPress/wordpress-develop/blob/6dad32d2aed47e6c0cf2aee8410645f6d7aba6bd/src/wp-login.php#L103
  *
- * @param {string} postId  Post ID.
- * @return {string}        sessionStorage key
+ * @param {string}  postId     Post ID.
+ * @param {boolean} isPostNew  Whether post new.
+ * @return {string}            sessionStorage key
  */
-function postKey( postId ) {
-	return `wp-autosave-block-editor-post-${ postId }`;
+function postKey( postId, isPostNew ) {
+	return `wp-autosave-block-editor-post-${
+		isPostNew ? 'auto-draft' : postId
+	}`;
 }
 
-export function localAutosaveGet( postId ) {
-	return window.sessionStorage.getItem( postKey( postId ) );
+export function localAutosaveGet( postId, isPostNew ) {
+	return window.sessionStorage.getItem( postKey( postId, isPostNew ) );
 }
 
-export function localAutosaveSet( postId, title, content, excerpt ) {
+export function localAutosaveSet( postId, isPostNew, title, content, excerpt ) {
 	window.sessionStorage.setItem(
-		postKey( postId ),
+		postKey( postId, isPostNew ),
 		JSON.stringify( {
 			post_title: title,
 			content,
@@ -54,8 +57,8 @@ export function localAutosaveSet( postId, title, content, excerpt ) {
 	);
 }
 
-export function localAutosaveClear( postId ) {
-	window.sessionStorage.removeItem( postKey( postId ) );
+export function localAutosaveClear( postId, isPostNew ) {
+	window.sessionStorage.removeItem( postKey( postId, isPostNew ) );
 }
 
 const controls = {
@@ -68,8 +71,8 @@ const controls = {
 		} )
 	),
 	GET_REGISTRY: createRegistryControl( ( registry ) => () => registry ),
-	LOCAL_AUTOSAVE_SET( { postId, title, content, excerpt } ) {
-		localAutosaveSet( postId, title, content, excerpt );
+	LOCAL_AUTOSAVE_SET( { postId, isPostNew, title, content, excerpt } ) {
+		localAutosaveSet( postId, isPostNew, title, content, excerpt );
 	},
 };
 


### PR DESCRIPTION
## Description
See https://github.com/WordPress/gutenberg/issues/23781

The autosave stores the content in `window.sessionStorage` under the ID of the currently edited post. When the page is refreshed, WordPress creates a new auto-draft post, which means there's a new ID, which means that after refreshing the page the autosave code looks for a backup under a **different** cache key. For a user it seems like all my previous content is gone forever:

<img width="1077" alt="Zrzut ekranu 2020-07-14 o 13 33 17" src="https://user-images.githubusercontent.com/205419/87421022-98799700-c5d6-11ea-9528-0a5d13901cb1.png">

This PR adds an `auto-draft` autosave key to backup the content of new posts.

## How has this been tested?
What I managed to reproduce:

1. I created a very long post and run `wp-env stop`.
2. Refresh the page.
3. Confirm you're able to see a notice about a backup being available.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
