### PR TITLE
Galleries: Tiled style

### DIFF
--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -43,6 +43,12 @@
 					"type": "string",
 					"source": "html",
 					"selector": ".blocks-gallery-item__caption"
+				},
+				"ratio": {
+					"type": "string",
+					"source": "attribute",
+					"selector": "img",
+					"attribute": "data-ratio"
 				}
 			}
 		},

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -36,7 +36,11 @@ import { withViewportMatch } from '@wordpress/viewport';
  * Internal dependencies
  */
 import { sharedIcon } from './shared-icon';
-import { defaultColumnsNumber, pickRelevantMediaFiles } from './shared';
+import {
+	defaultColumnsNumber,
+	pickRelevantMediaFiles,
+	getImageRatio,
+} from './shared';
 import Gallery from './gallery';
 
 const MAX_COLUMNS = 8;
@@ -96,6 +100,12 @@ class GalleryEdit extends Component {
 		if ( attributes.images ) {
 			attributes = {
 				...attributes,
+				images: map( attributes.images, ( image ) => {
+					return {
+						...image,
+						ratio: getImageRatio( image.url ),
+					};
+				} ),
 				// Unlike images[ n ].id which is a string, always ensure the
 				// ids array contains numbers as per its attribute type.
 				ids: map( attributes.images, ( { id } ) => parseInt( id, 10 ) ),
@@ -320,6 +330,10 @@ class GalleryEdit extends Component {
 				onFileChange: this.onSelectImages,
 				allowedTypes: [ 'image' ],
 			} );
+		}
+
+		if ( ! every( images, ( { ratio } ) => !! ratio ) ) {
+			this.setAttributes( { images } );
 		}
 	}
 

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -36,11 +36,7 @@ import { withViewportMatch } from '@wordpress/viewport';
  * Internal dependencies
  */
 import { sharedIcon } from './shared-icon';
-import {
-	defaultColumnsNumber,
-	pickRelevantMediaFiles,
-	getImageRatio,
-} from './shared';
+import { defaultColumnsNumber, pickRelevantMediaFiles } from './shared';
 import Gallery from './gallery';
 
 const MAX_COLUMNS = 8;
@@ -100,12 +96,6 @@ class GalleryEdit extends Component {
 		if ( attributes.images ) {
 			attributes = {
 				...attributes,
-				images: map( attributes.images, ( image ) => {
-					return {
-						...image,
-						ratio: getImageRatio( image.url ),
-					};
-				} ),
 				// Unlike images[ n ].id which is a string, always ensure the
 				// ids array contains numbers as per its attribute type.
 				ids: map( attributes.images, ( { id } ) => parseInt( id, 10 ) ),
@@ -330,10 +320,6 @@ class GalleryEdit extends Component {
 				onFileChange: this.onSelectImages,
 				allowedTypes: [ 'image' ],
 			} );
-		}
-
-		if ( ! every( images, ( { ratio } ) => !! ratio ) ) {
-			this.setAttributes( { images } );
 		}
 	}
 

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -26,7 +26,7 @@ import {
 /**
  * Internal dependencies
  */
-import { pickRelevantMediaFiles } from './shared';
+import { pickRelevantMediaFiles, getImageRatio } from './shared';
 
 const isTemporaryImage = ( id, url ) => ! id && isBlobURL( url );
 
@@ -43,6 +43,7 @@ class GalleryImage extends Component {
 			this
 		);
 		this.onSelectCustomURL = this.onSelectCustomURL.bind( this );
+		this.onLoad = this.onLoad.bind( this );
 		this.state = {
 			captionSelected: false,
 			isEditing: false,
@@ -51,6 +52,10 @@ class GalleryImage extends Component {
 
 	bindContainer( ref ) {
 		this.container = ref;
+	}
+
+	onLoad() {
+		this.props.setAttributes( { ratio: getImageRatio( this.container ) } );
 	}
 
 	onSelectCaption() {
@@ -210,6 +215,7 @@ class GalleryImage extends Component {
 					onClick={ this.onSelectImage }
 					onFocus={ this.onSelectImage }
 					onKeyDown={ this.onRemoveImage }
+					onLoad={ this.onLoad }
 					tabIndex="0"
 					aria-label={ ariaLabel }
 					ref={ this.bindContainer }

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -54,6 +54,14 @@ class GalleryImage extends Component {
 		this.container = ref;
 	}
 
+	componentDidMount() {
+		// Sometimes React won't trigger the onLoad event on the img. If an aspect ratio
+		// hasn't been calculated, assume the onLoad has been skipped, and run it manually.
+		if ( ! this.props.ratio && this.container && this.container.complete ) {
+			this.onLoad();
+		}
+	}
+
 	onLoad() {
 		this.props.setAttributes( { ratio: getImageRatio( this.container ) } );
 	}

--- a/packages/block-library/src/gallery/gallery.js
+++ b/packages/block-library/src/gallery/gallery.js
@@ -71,6 +71,7 @@ export const Gallery = ( props ) => {
 								url={ img.url }
 								alt={ img.alt }
 								id={ img.id }
+								ratio={ img.ratio }
 								isFirstItem={ index === 0 }
 								isLastItem={ index + 1 === images.length }
 								isSelected={

--- a/packages/block-library/src/gallery/gallery.js
+++ b/packages/block-library/src/gallery/gallery.js
@@ -62,7 +62,9 @@ export const Gallery = ( props ) => {
 
 					return (
 						<li
-							className="blocks-gallery-item"
+							className={ classnames( 'blocks-gallery-item', {
+								[ `image-ratio-${ img.ratio }` ]: img.ratio,
+							} ) }
 							key={ img.id || img.url }
 						>
 							<GalleryImage

--- a/packages/block-library/src/gallery/index.js
+++ b/packages/block-library/src/gallery/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { gallery as icon } from '@wordpress/icons';
 
 /**
@@ -34,6 +34,13 @@ export const settings = {
 					url:
 						'https://s.w.org/images/core/5.3/Sediment_off_the_Yucatan_Peninsula.jpg',
 				},
+				{
+					url:
+						'https://s.w.org/images/core/5.3/Biologia_Centrali-Americana_-_Cantorchilus_semibadius_1902.jpg',
+				},
+				{
+					url: 'https://s.w.org/images/core/5.3/Windbuchencom.jpg',
+				},
 			],
 		},
 	},
@@ -41,4 +48,15 @@ export const settings = {
 	edit,
 	save,
 	deprecated,
+	styles: [
+		{
+			name: 'default',
+			label: _x( 'Default', 'block style' ),
+			isDefault: true,
+		},
+		{
+			name: 'tiled',
+			label: _x( 'Tiled', 'block style' ),
+		},
+	],
 };

--- a/packages/block-library/src/gallery/save.js
+++ b/packages/block-library/src/gallery/save.js
@@ -43,6 +43,7 @@ export default function save( { attributes } ) {
 							data-id={ image.id }
 							data-full-url={ image.fullUrl }
 							data-link={ image.link }
+							data-ratio={ image.ratio }
 							className={
 								image.id ? `wp-image-${ image.id }` : null
 							}

--- a/packages/block-library/src/gallery/save.js
+++ b/packages/block-library/src/gallery/save.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { RichText } from '@wordpress/block-editor';
@@ -53,7 +58,9 @@ export default function save( { attributes } ) {
 					return (
 						<li
 							key={ image.id || image.url }
-							className="blocks-gallery-item"
+							className={ classnames( 'blocks-gallery-item', {
+								[ `image-ratio-${ image.ratio }` ]: image.ratio,
+							} ) }
 						>
 							<figure>
 								{ href ? <a href={ href }>{ img }</a> : img }

--- a/packages/block-library/src/gallery/shared.js
+++ b/packages/block-library/src/gallery/shared.js
@@ -22,16 +22,7 @@ export const pickRelevantMediaFiles = ( image, sizeSlug = 'large' ) => {
 	return imageProps;
 };
 
-export async function getImageRatio( url ) {
-	const img = document.createElement( 'img' );
-	const imgPromise = new Promise( ( resolve, reject ) => {
-		img.onload = () => resolve( img );
-		img.onerror = reject;
-	} );
-
-	img.src = url;
-	await imgPromise;
-
+export function getImageRatio( img ) {
 	if ( ! img ) {
 		return false;
 	}

--- a/packages/block-library/src/gallery/shared.js
+++ b/packages/block-library/src/gallery/shared.js
@@ -21,3 +21,36 @@ export const pickRelevantMediaFiles = ( image, sizeSlug = 'large' ) => {
 	}
 	return imageProps;
 };
+
+export async function getImageRatio( url ) {
+	const img = document.createElement( 'img' );
+	const imgPromise = new Promise( ( resolve, reject ) => {
+		img.onload = () => resolve( img );
+		img.onerror = reject;
+	} );
+
+	img.src = url;
+	await imgPromise;
+
+	if ( ! img ) {
+		return false;
+	}
+
+	if ( ! img.naturalWidth || ! img.naturalHeight ) {
+		return false;
+	}
+
+	const ratio = img.naturalWidth / img.naturalHeight;
+
+	if ( ratio < 0.5 ) {
+		return 'tall';
+	} else if ( ratio < 0.9 ) {
+		return 'portrait';
+	} else if ( ratio < 1.1 ) {
+		return 'square';
+	} else if ( ratio < 1.9 ) {
+		return 'landscape';
+	}
+
+	return 'wide';
+}

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -144,11 +144,14 @@
 		display: grid;
 		grid-gap: $grid-gap;
 		grid-auto-flow: dense;
+		width: 100%;
 
 		.blocks-gallery-item {
 			position: relative;
 			width: 100%;
 			margin: 0;
+			grid-column: auto / span 2;
+			grid-row: auto / span 2;
 
 			&::before {
 				content: "";
@@ -156,6 +159,7 @@
 				display: inline-block;
 				width: 1px;
 				position: relative;
+				padding-bottom: 100%;
 			}
 
 			figure {
@@ -188,14 +192,6 @@
 				grid-row: auto / span 3;
 			}
 
-			&.image-ratio-square {
-				&::before {
-					padding-bottom: 100%;
-				}
-				grid-column: auto / span 2;
-				grid-row: auto / span 2;
-			}
-
 			&.image-ratio-landscape {
 				&::before {
 					padding-bottom: calc(100% / ( 3 / 2 ));
@@ -222,59 +218,30 @@
 			$grid-columns: $column-count * 2;
 			grid-template-columns: repeat(#{ $grid-columns }, 1fr);
 
-			// @if $column-count > 4 {
-			// 	.blocks-gallery-item:nth-child( #{ $column-count - 3 }n ) {
-			// 		&.image-ratio-portrait {
-			// 			grid-column: auto / span 4;
-			// 			grid-row: auto / span 8;
-			// 		}
+			.blocks-gallery-item:nth-child(4n) {
+				grid-column: auto / span 4;
+				grid-row: auto / span 4;
 
-			// 		&.image-ratio-landscape {
-			// 			grid-column: auto / span 4;
-			// 			grid-row: auto / span 4;
-			// 		}
+				&.image-ratio-tall {
+					grid-column: auto / span 4;
+					grid-row: auto / span 8;
+				}
 
-			// 		&.image-ratio-wide {
-			// 			grid-column: auto / span 8;
-			// 			grid-row: auto / span 4;
-			// 		}
-			// 	}
+				&.image-ratio-portrait {
+					grid-column: auto / span 4;
+					grid-row: auto / span 6;
+				}
 
-			// 	.blocks-gallery-item:nth-child( #{ $column-count * 2 }n ) {
-			// 		&.image-ratio-portrait {
-			// 			grid-column: auto / span $column-count;
-			// 			grid-row: auto / span #{ $column-count * 2 };
-			// 		}
+				&.image-ratio-landscape {
+					grid-column: auto / span 6;
+					grid-row: auto / span 4;
+				}
 
-			// 		&.image-ratio-landscape {
-			// 			grid-column: auto / span $grid-columns;
-			// 			grid-row: auto / span #{ $column-count - 1 };
-			// 		}
-
-			// 		&.image-ratio-wide {
-			// 			grid-column: auto / span $grid-columns;
-			// 			grid-row: auto / span #{ $column-count - 2 };
-			// 		}
-			// 	}
-			// }
-			// @else {
-			// 	.blocks-gallery-item:nth-child( #{ $column-count * 2 }n ) {
-			// 		&.image-ratio-portrait {
-			// 			grid-column: auto / span 4;
-			// 			grid-row: auto / span 8;
-			// 		}
-
-			// 		&.image-ratio-landscape {
-			// 			grid-column: auto / span 4;
-			// 			grid-row: auto / span 4;
-			// 		}
-
-			// 		&.image-ratio-wide {
-			// 			grid-column: auto / span 8;
-			// 			grid-row: auto / span 4;
-			// 		}
-			// 	}
-			// }
+				&.image-ratio-wide {
+					grid-column: auto / span 8;
+					grid-row: auto / span 4;
+				}
+			}
 		}
 	}
 }

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -138,49 +138,29 @@
 }
 
 .is-style-tiled {
-	@for $column-count from 1 through 8 {
-		&.columns-#{ $column-count } .blocks-gallery-grid {
-			$half-columns: 1;
-			@if $column-count % 2 == 0 {
-				$half-columns: $column-count / 2;
-			}
-			@else {
-				$half-columns: $column-count / 2 + 0.5;
-			}
-
-			grid-template-columns: repeat(#{ $column-count }, 1fr);
-
-			.blocks-gallery-item:nth-child( #{ $half-columns }n ) {
-				grid-column: auto / span 2;
-				grid-row: auto / span 1;
-			}
-
-			.blocks-gallery-item:nth-child( #{ $column-count * 2 }n ) {
-				grid-column: auto / span $column-count;
-				grid-row: auto / span 2;
-			}
-
-			.blocks-gallery-item:nth-child( #{ $column-count - 1 }n ) {
-				grid-column: auto / span $half-columns;
-				grid-row: auto / span 3;
-			}
-
-			.blocks-gallery-item:nth-child( #{ ( $column-count - 1 ) * 2 }n ) {
-				grid-column: #{ $half-columns + 1 } / span $half-columns;
-				grid-row: auto / span 3;
-			}
-		}
-	}
-
 	.blocks-gallery-grid {
 		display: grid;
 		grid-gap: 4px;
-		grid-auto-rows: minmax(100px, 200px);
 		grid-auto-flow: dense;
 
 		.blocks-gallery-item {
 			width: 100%;
 			margin: 0;
+
+			&.image-ratio-portrait {
+				grid-column: auto / span 2;
+				grid-row: auto / span 4;
+			}
+
+			&.image-ratio-landscape {
+				grid-column: auto / span 2;
+				grid-row: auto / span 2;
+			}
+
+			&.image-ratio-wide {
+				grid-column: auto / span 4;
+				grid-row: auto / span 2;
+			}
 		}
 
 		.blocks-gallery-item figure {
@@ -189,14 +169,77 @@
 			height: 100%;
 		}
 
-		.blocks-gallery-item {
-			grid-column: auto / span 1;
-		}
-
 		.blocks-gallery-item img {
 			width: 100%;
 			height: 100%;
 			object-fit: cover;
+		}
+	}
+
+	@for $column-count from 3 through 8 {
+		&.columns-#{ $column-count } .blocks-gallery-grid {
+			// As we add more rows, the rows need to be shorter, to maintain
+			// a reasonable aspect ratio.
+			grid-auto-rows: 40px + ( 8 - $column-count ) * 10px;
+
+			// Use double the columns behind the scenes, so we have easy
+			// access to "half" the number of columns.
+			$grid-columns: $column-count * 2;
+			grid-template-columns: repeat(#{ $grid-columns }, 1fr);
+
+			@if $column-count > 4 {
+				.blocks-gallery-item:nth-child( #{ $column-count - 3 }n ) {
+					&.image-ratio-portrait {
+						grid-column: auto / span 4;
+						grid-row: auto / span 8;
+					}
+
+					&.image-ratio-landscape {
+						grid-column: auto / span 4;
+						grid-row: auto / span 4;
+					}
+
+					&.image-ratio-wide {
+						grid-column: auto / span 8;
+						grid-row: auto / span 4;
+					}
+				}
+
+				.blocks-gallery-item:nth-child( #{ $column-count * 2 }n ) {
+					&.image-ratio-portrait {
+						grid-column: auto / span $column-count;
+						grid-row: auto / span #{ $column-count * 2 };
+					}
+
+					&.image-ratio-landscape {
+						grid-column: auto / span $grid-columns;
+						grid-row: auto / span #{ $column-count - 1 };
+					}
+
+					&.image-ratio-wide {
+						grid-column: auto / span $grid-columns;
+						grid-row: auto / span #{ $column-count - 2 };
+					}
+				}
+			}
+			@else {
+				.blocks-gallery-item:nth-child( #{ $column-count * 2 }n ) {
+					&.image-ratio-portrait {
+						grid-column: auto / span 4;
+						grid-row: auto / span 8;
+					}
+
+					&.image-ratio-landscape {
+						grid-column: auto / span 4;
+						grid-row: auto / span 4;
+					}
+
+					&.image-ratio-wide {
+						grid-column: auto / span 8;
+						grid-row: auto / span 4;
+					}
+				}
+			}
 		}
 	}
 }

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -137,3 +137,66 @@
 	}
 }
 
+.is-style-tiled {
+	@for $column-count from 1 through 8 {
+		&.columns-#{ $column-count } .blocks-gallery-grid {
+			$half-columns: 1;
+			@if $column-count % 2 == 0 {
+				$half-columns: $column-count / 2;
+			}
+			@else {
+				$half-columns: $column-count / 2 + 0.5;
+			}
+
+			grid-template-columns: repeat(#{ $column-count }, 1fr);
+
+			.blocks-gallery-item:nth-child( #{ $half-columns }n ) {
+				grid-column: auto / span 2;
+				grid-row: auto / span 1;
+			}
+
+			.blocks-gallery-item:nth-child( #{ $column-count * 2 }n ) {
+				grid-column: auto / span $column-count;
+				grid-row: auto / span 2;
+			}
+
+			.blocks-gallery-item:nth-child( #{ $column-count - 1 }n ) {
+				grid-column: auto / span $half-columns;
+				grid-row: auto / span 3;
+			}
+
+			.blocks-gallery-item:nth-child( #{ ( $column-count - 1 ) * 2 }n ) {
+				grid-column: #{ $half-columns + 1 } / span $half-columns;
+				grid-row: auto / span 3;
+			}
+		}
+	}
+
+	.blocks-gallery-grid {
+		display: grid;
+		grid-gap: 4px;
+		grid-auto-rows: minmax(100px, 200px);
+		grid-auto-flow: dense;
+
+		.blocks-gallery-item {
+			width: 100%;
+			margin: 0;
+		}
+
+		.blocks-gallery-item figure {
+			display: block;
+			width: 100%;
+			height: 100%;
+		}
+
+		.blocks-gallery-item {
+			grid-column: auto / span 1;
+		}
+
+		.blocks-gallery-item img {
+			width: 100%;
+			height: 100%;
+			object-fit: cover;
+		}
+	}
+}

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -139,107 +139,142 @@
 
 .is-style-tiled {
 	.blocks-gallery-grid {
+		$grid-gap: 4px;
+
 		display: grid;
-		grid-gap: 4px;
+		grid-gap: $grid-gap;
 		grid-auto-flow: dense;
 
 		.blocks-gallery-item {
+			position: relative;
 			width: 100%;
 			margin: 0;
 
-			&.image-ratio-portrait {
+			&::before {
+				content: "";
+				height: 0;
+				display: inline-block;
+				width: 1px;
+				position: relative;
+			}
+
+			figure {
+				position: absolute;
+				top: 0;
+				left: 0;
+				bottom: 0;
+				width: 100%;
+
+				img {
+					width: 100%;
+					height: 100%;
+					object-fit: cover;
+				}
+			}
+
+			&.image-ratio-tall {
+				&::before {
+					padding-bottom: calc(100% / ( 4 / 2 ));
+				}
 				grid-column: auto / span 2;
 				grid-row: auto / span 4;
 			}
 
-			&.image-ratio-landscape {
+			&.image-ratio-portrait {
+				&::before {
+					padding-bottom: calc(100% / ( 2 / 3 ));
+				}
+				grid-column: auto / span 2;
+				grid-row: auto / span 3;
+			}
+
+			&.image-ratio-square {
+				&::before {
+					padding-bottom: 100%;
+				}
 				grid-column: auto / span 2;
 				grid-row: auto / span 2;
 			}
 
+			&.image-ratio-landscape {
+				&::before {
+					padding-bottom: calc(100% / ( 3 / 2 ));
+				}
+				grid-column: auto / span 3;
+				grid-row: auto / span 2;
+			}
+
 			&.image-ratio-wide {
+				&::before {
+					padding-bottom: calc(100% / ( 4 / 2 ));
+				}
 				grid-column: auto / span 4;
 				grid-row: auto / span 2;
 			}
-		}
-
-		.blocks-gallery-item figure {
-			display: block;
-			width: 100%;
-			height: 100%;
-		}
-
-		.blocks-gallery-item img {
-			width: 100%;
-			height: 100%;
-			object-fit: cover;
 		}
 	}
 
 	@for $column-count from 3 through 8 {
 		&.columns-#{ $column-count } .blocks-gallery-grid {
-			// As we add more rows, the rows need to be shorter, to maintain
-			// a reasonable aspect ratio.
-			grid-auto-rows: 40px + ( 8 - $column-count ) * 10px;
 
 			// Use double the columns behind the scenes, so we have easy
 			// access to "half" the number of columns.
 			$grid-columns: $column-count * 2;
 			grid-template-columns: repeat(#{ $grid-columns }, 1fr);
 
-			@if $column-count > 4 {
-				.blocks-gallery-item:nth-child( #{ $column-count - 3 }n ) {
-					&.image-ratio-portrait {
-						grid-column: auto / span 4;
-						grid-row: auto / span 8;
-					}
+			// @if $column-count > 4 {
+			// 	.blocks-gallery-item:nth-child( #{ $column-count - 3 }n ) {
+			// 		&.image-ratio-portrait {
+			// 			grid-column: auto / span 4;
+			// 			grid-row: auto / span 8;
+			// 		}
 
-					&.image-ratio-landscape {
-						grid-column: auto / span 4;
-						grid-row: auto / span 4;
-					}
+			// 		&.image-ratio-landscape {
+			// 			grid-column: auto / span 4;
+			// 			grid-row: auto / span 4;
+			// 		}
 
-					&.image-ratio-wide {
-						grid-column: auto / span 8;
-						grid-row: auto / span 4;
-					}
-				}
+			// 		&.image-ratio-wide {
+			// 			grid-column: auto / span 8;
+			// 			grid-row: auto / span 4;
+			// 		}
+			// 	}
 
-				.blocks-gallery-item:nth-child( #{ $column-count * 2 }n ) {
-					&.image-ratio-portrait {
-						grid-column: auto / span $column-count;
-						grid-row: auto / span #{ $column-count * 2 };
-					}
+			// 	.blocks-gallery-item:nth-child( #{ $column-count * 2 }n ) {
+			// 		&.image-ratio-portrait {
+			// 			grid-column: auto / span $column-count;
+			// 			grid-row: auto / span #{ $column-count * 2 };
+			// 		}
 
-					&.image-ratio-landscape {
-						grid-column: auto / span $grid-columns;
-						grid-row: auto / span #{ $column-count - 1 };
-					}
+			// 		&.image-ratio-landscape {
+			// 			grid-column: auto / span $grid-columns;
+			// 			grid-row: auto / span #{ $column-count - 1 };
+			// 		}
 
-					&.image-ratio-wide {
-						grid-column: auto / span $grid-columns;
-						grid-row: auto / span #{ $column-count - 2 };
-					}
-				}
-			}
-			@else {
-				.blocks-gallery-item:nth-child( #{ $column-count * 2 }n ) {
-					&.image-ratio-portrait {
-						grid-column: auto / span 4;
-						grid-row: auto / span 8;
-					}
+			// 		&.image-ratio-wide {
+			// 			grid-column: auto / span $grid-columns;
+			// 			grid-row: auto / span #{ $column-count - 2 };
+			// 		}
+			// 	}
+			// }
+			// @else {
+			// 	.blocks-gallery-item:nth-child( #{ $column-count * 2 }n ) {
+			// 		&.image-ratio-portrait {
+			// 			grid-column: auto / span 4;
+			// 			grid-row: auto / span 8;
+			// 		}
 
-					&.image-ratio-landscape {
-						grid-column: auto / span 4;
-						grid-row: auto / span 4;
-					}
+			// 		&.image-ratio-landscape {
+			// 			grid-column: auto / span 4;
+			// 			grid-row: auto / span 4;
+			// 		}
 
-					&.image-ratio-wide {
-						grid-column: auto / span 8;
-						grid-row: auto / span 4;
-					}
-				}
-			}
+			// 		&.image-ratio-wide {
+			// 			grid-column: auto / span 8;
+			// 			grid-row: auto / span 4;
+			// 		}
+			// 	}
+			// }
 		}
 	}
 }


### PR DESCRIPTION
## Description

This is an experiment in generating tiled gallery styles. Feedback is welcome. 🙂

## How has this been tested?

It hasn't been tested, really.

## Screenshots

<img width="1280" alt="" src="https://user-images.githubusercontent.com/352291/87641239-26967e80-c78b-11ea-9a8d-8f050244abb8.png">
<img width="1280" alt="" src="https://user-images.githubusercontent.com/352291/87641225-1ed6da00-c78b-11ea-8add-5cb307df512f.png">

## Types of changes

Enhancement to the existing gallery block.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
