### PR TITLE
Post Date Block: Add style attributes and restructure the edit function

### DIFF
--- a/packages/block-library/src/post-date/block.json
+++ b/packages/block-library/src/post-date/block.json
@@ -2,14 +2,24 @@
 	"name": "core/post-date",
 	"category": "design",
 	"attributes": {
+		"align": {
+			"type": "string"
+		},
 		"format": {
 			"type": "string"
 		}
 	},
 	"usesContext": [
-		"postId"
+		"postId",
+		"postType"
 	],
 	"supports": {
-		"html": false
+		"html": false,
+		"lightBlockWrapper": true,
+		"__experimentalColor": {
+			"gradients": true
+		},
+		"__experimentalFontSize": true,
+		"__experimentalLineHeight": true
 	}
 }

--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -1,10 +1,20 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
-import { useEntityProp, useEntityId } from '@wordpress/core-data';
+import { useEntityProp } from '@wordpress/core-data';
 import { useState } from '@wordpress/element';
 import { __experimentalGetSettings, dateI18n } from '@wordpress/date';
-import { BlockControls, InspectorControls } from '@wordpress/block-editor';
+import {
+	AlignmentToolbar,
+	BlockControls,
+	InspectorControls,
+	__experimentalBlock as Block,
+} from '@wordpress/block-editor';
 import {
 	ToolbarGroup,
 	ToolbarButton,
@@ -15,9 +25,17 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-function PostDateEditor( { format, setAttributes } ) {
+export default function PostDateEdit( { attributes, context, setAttributes } ) {
+	const { align, format } = attributes;
+	const { postId, postType } = context;
+
 	const [ siteFormat ] = useEntityProp( 'root', 'site', 'date_format' );
-	const [ date, setDate ] = useEntityProp( 'postType', 'post', 'date' );
+	const [ date, setDate ] = useEntityProp(
+		'postType',
+		postType,
+		'date',
+		postId
+	);
 	const [ isPickerOpen, setIsPickerOpen ] = useState( false );
 	const settings = __experimentalGetSettings();
 	// To know if the current time format is a 12 hour time, look for "a".
@@ -37,31 +55,32 @@ function PostDateEditor( { format, setAttributes } ) {
 		} )
 	);
 	const resolvedFormat = format || siteFormat || settings.formats.date;
-	return date ? (
-		<time dateTime={ dateI18n( 'c', date ) }>
+
+	return (
+		<>
 			<BlockControls>
-				<ToolbarGroup>
-					<ToolbarButton
-						icon="edit"
-						title={ __( 'Change Date' ) }
-						onClick={ () =>
-							setIsPickerOpen(
-								( _isPickerOpen ) => ! _isPickerOpen
-							)
-						}
-					/>
-				</ToolbarGroup>
+				<AlignmentToolbar
+					value={ align }
+					onChange={ ( nextAlign ) => {
+						setAttributes( { align: nextAlign } );
+					} }
+				/>
+
+				{ date && (
+					<ToolbarGroup>
+						<ToolbarButton
+							icon="edit"
+							title={ __( 'Change Date' ) }
+							onClick={ () =>
+								setIsPickerOpen(
+									( _isPickerOpen ) => ! _isPickerOpen
+								)
+							}
+						/>
+					</ToolbarGroup>
+				) }
 			</BlockControls>
-			{ dateI18n( resolvedFormat, date ) }
-			{ isPickerOpen && (
-				<Popover onClose={ setIsPickerOpen.bind( null, false ) }>
-					<DateTimePicker
-						currentDate={ date }
-						onChange={ setDate }
-						is12Hour={ is12Hour }
-					/>
-				</Popover>
-			) }
+
 			<InspectorControls>
 				<PanelBody title={ __( 'Format settings' ) }>
 					<CustomSelectControl
@@ -79,18 +98,31 @@ function PostDateEditor( { format, setAttributes } ) {
 					/>
 				</PanelBody>
 			</InspectorControls>
-		</time>
-	) : (
-		__( 'No Date' )
-	);
-}
 
-export default function PostDateEdit( {
-	attributes: { format },
-	setAttributes,
-} ) {
-	if ( ! useEntityId( 'postType', 'post' ) ) {
-		return <p>{ __( 'Jan 1st, 1440' ) }</p>;
-	}
-	return <PostDateEditor format={ format } setAttributes={ setAttributes } />;
+			<Block.div
+				className={ classnames( {
+					[ `has-text-align-${ align }` ]: align,
+				} ) }
+			>
+				{ date && (
+					<time dateTime={ dateI18n( 'c', date ) }>
+						{ dateI18n( resolvedFormat, date ) }
+
+						{ isPickerOpen && (
+							<Popover
+								onClose={ setIsPickerOpen.bind( null, false ) }
+							>
+								<DateTimePicker
+									currentDate={ date }
+									onChange={ setDate }
+									is12Hour={ is12Hour }
+								/>
+							</Popover>
+						) }
+					</time>
+				) }
+				{ ! date && __( 'No Date' ) }
+			</Block.div>
+		</>
+	);
 }

--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -18,10 +18,14 @@ function render_block_core_post_date( $attributes, $content, $block ) {
 		return '';
 	}
 
-	return '<time datetime="'
-		. get_the_date( 'c', $block->context['postId'] ) . '">'
-		. get_the_date( isset( $attributes['format'] ) ? $attributes['format'] : '', $block->context['postId'] )
-		. '</time>';
+	$align_class_name = empty( $attributes['align'] ) ? '' : ' ' . "has-text-align-{$attributes['align']}";
+
+	return sprintf(
+		'<div class="%1$s"><time datetime="%2$s">%3$s</time></div>',
+		'wp-block-post-date' . esc_attr( $align_class_name ),
+		get_the_date( 'c', $block->context['postId'] ),
+		get_the_date( isset( $attributes['format'] ) ? $attributes['format'] : '', $block->context['postId'] )
+	);
 }
 
 /**


### PR DESCRIPTION
## Description

Update the Post Date block:
- Add support for colors, font size, line height, and text alignment.
- Convert the to light block wrapper.
- Simplify the use of the post date entity.

## How has this been tested?

Tested in the Site Editor while displaying a post in the page content.

## Screenshots

| Editor | Front End |
| - | - |
| <img width="1109" alt="Screenshot 2020-07-14 at 16 06 39" src="https://user-images.githubusercontent.com/2070010/87442363-1eeca380-c5ec-11ea-9d26-f76b02991d37.png"> | <img width="661" alt="Screenshot 2020-07-14 at 16 07 21" src="https://user-images.githubusercontent.com/2070010/87442370-214efd80-c5ec-11ea-8a2e-c421c92e0d45.png"> |

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
