### PR TITLE
RangeControl: Adapt slider color to color scheme

### DIFF
--- a/packages/components/src/utils/colors-values.js
+++ b/packages/components/src/utils/colors-values.js
@@ -137,9 +137,9 @@ export const ALERT = {
 export const UI = {
 	background: BASE.white,
 	backgroundDisabled: LIGHT_GRAY[ 200 ],
-	brand: BLUE.wordpress[ 700 ],
+	brand: `var( --wp-admin-theme-color, ${ BLUE.wordpress[ 700 ] })`,
 	border: G2.darkGray.primary,
-	borderFocus: BLUE.medium.focus,
+	borderFocus: `var( --wp-admin-theme-color-darker-10, ${ BLUE.medium.focus })`,
 	borderDisabled: DARK_GRAY[ 700 ],
 	borderLight: LIGHT_GRAY[ 600 ],
 	label: DARK_GRAY[ 500 ],


### PR DESCRIPTION
This update adjusts the color values retrieved from the JS `color()` function to use the `--wp-admin-theme-color` CSS variable. This enables it to tap into values defined by a color scheme.

## Checklist:
- [x] My code is tested.
- [n/a] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [n/a] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [n/a] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [n/a] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->

Resolves: https://github.com/WordPress/gutenberg/issues/23932