### PR TITLE
Post excerpt block - add color, fontSize, lineHeight, and text alignment.

### DIFF
--- a/packages/block-library/src/post-excerpt/block.json
+++ b/packages/block-library/src/post-excerpt/block.json
@@ -2,6 +2,9 @@
 	"name": "core/post-excerpt",
 	"category": "design",
 	"attributes": {
+		"align": {
+			"type": "string"
+		},
 		"wordCount": {
 			"type": "number",
 			"default": 55
@@ -18,6 +21,12 @@
 		"postId"
 	],
 	"supports": {
-		"html": false
+		"html": false,
+		"__experimentalFontSize": true,
+		"__experimentalColor": {
+			"gradients": true,
+			"linkColor": true
+		},
+		"__experimentalLineHeight": true
 	}
 }

--- a/packages/block-library/src/post-excerpt/block.json
+++ b/packages/block-library/src/post-excerpt/block.json
@@ -18,7 +18,8 @@
 		}
 	},
 	"usesContext": [
-		"postId"
+		"postId",
+		"postType"
 	],
 	"supports": {
 		"html": false,

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -99,7 +99,7 @@ function PostExcerptEditor( {
 				/>
 				{ ! showMoreOnNewLine && ' ' }
 				{ showMoreOnNewLine ? (
-					<p>
+					<p className="wp-block-post-excerpt__more-text">
 						<RichText
 							tagName="a"
 							placeholder={ __( 'Read more…' ) }

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useEntityProp, useEntityId } from '@wordpress/core-data';
+import { useEntityProp } from '@wordpress/core-data';
 import { useMemo } from '@wordpress/element';
 import {
 	AlignmentToolbar,
@@ -17,11 +17,12 @@ import {
 import { PanelBody, RangeControl, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-function usePostContentExcerpt( wordCount ) {
+function usePostContentExcerpt( wordCount, postId, postType ) {
 	const [ , , { raw: rawPostContent } ] = useEntityProp(
 		'postType',
-		'post',
-		'content'
+		postType,
+		'content',
+		postId
 	);
 	return useMemo( () => {
 		if ( ! rawPostContent ) {
@@ -39,13 +40,19 @@ function PostExcerptEditor( {
 	attributes: { align, wordCount, moreText, showMoreOnNewLine },
 	setAttributes,
 	isSelected,
+	context: { postId, postType },
 } ) {
 	const [ excerpt, setExcerpt ] = useEntityProp(
 		'postType',
-		'post',
-		'excerpt'
+		postType,
+		'excerpt',
+		postId
 	);
-	const postContentExcerpt = usePostContentExcerpt( wordCount );
+	const postContentExcerpt = usePostContentExcerpt(
+		wordCount,
+		postId,
+		postType
+	);
 	return (
 		<>
 			<BlockControls>
@@ -128,15 +135,18 @@ export default function PostExcerptEdit( {
 	attributes,
 	setAttributes,
 	isSelected,
+	context,
 } ) {
-	if ( ! useEntityId( 'postType', 'post' ) ) {
-		return __( 'Post Excerpt' );
-	}
+	// This check doesn't work in site editor? always false.
+	// if ( ! useEntityId( 'postType', 'post' ) ) {
+	// 	return __( 'Post Excerpt' );
+	// }
 	return (
 		<PostExcerptEditor
 			attributes={ attributes }
 			setAttributes={ setAttributes }
 			isSelected={ isSelected }
+			context={ context }
 		/>
 	);
 }

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { useEntityProp } from '@wordpress/core-data';
-import { useMemo, useEffect } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 import {
 	AlignmentToolbar,
 	BlockControls,
@@ -42,14 +42,6 @@ export default function PostExcerptEdit( {
 	isSelected,
 	context: { postId, postType },
 } ) {
-	// Set the initial moreText based on local.
-	useEffect( () => {
-		if ( moreText === null || moreText === undefined ) {
-			// eslint-disable-next-line @wordpress/i18n-ellipsis
-			setAttributes( { moreText: __( 'Read more...' ) } );
-		}
-	}, [] );
-
 	const [ excerpt, setExcerpt ] = useEntityProp(
 		'postType',
 		postType,

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -13,6 +13,7 @@ import {
 	BlockControls,
 	InspectorControls,
 	RichText,
+	Warning,
 } from '@wordpress/block-editor';
 import { PanelBody, RangeControl, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -38,7 +39,7 @@ function usePostContentExcerpt( wordCount, postId, postType ) {
 	}, [ rawPostContent, wordCount ] );
 }
 
-export default function PostExcerptEdit( {
+function PostExcerptEditor( {
 	attributes: { align, wordCount, moreText, showMoreOnNewLine },
 	setAttributes,
 	isSelected,
@@ -134,5 +135,26 @@ export default function PostExcerptEdit( {
 				) }
 			</div>
 		</>
+	);
+}
+
+export default function PostExcerptEdit( {
+	attributes,
+	setAttributes,
+	isSelected,
+	context,
+} ) {
+	if ( ! context.postType || ! context.postId ) {
+		return (
+			<Warning>{ __( 'Post excerpt block: no post found.' ) }</Warning>
+		);
+	}
+	return (
+		<PostExcerptEditor
+			attributes={ attributes }
+			setAttributes={ setAttributes }
+			isSelected={ isSelected }
+			context={ context }
+		/>
 	);
 }

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -13,6 +13,7 @@ import {
 	BlockControls,
 	InspectorControls,
 	RichText,
+	Warning,
 } from '@wordpress/block-editor';
 import { PanelBody, RangeControl, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -36,7 +37,7 @@ function usePostContentExcerpt( wordCount, postId, postType ) {
 	}, [ rawPostContent, wordCount ] );
 }
 
-export default function PostExcerptEdit( {
+function PostExcerptEditor( {
 	attributes: { align, wordCount, moreText, showMoreOnNewLine },
 	setAttributes,
 	isSelected,
@@ -132,5 +133,26 @@ export default function PostExcerptEdit( {
 				) }
 			</div>
 		</>
+	);
+}
+
+export default function PostExcerptEdit( {
+	attributes,
+	setAttributes,
+	isSelected,
+	context,
+} ) {
+	if ( ! context.postType || ! context.postId ) {
+		return (
+			<Warning>{ __( 'Post excerpt block: no post found.' ) }</Warning>
+		);
+	}
+	return (
+		<PostExcerptEditor
+			attributes={ attributes }
+			setAttributes={ setAttributes }
+			isSelected={ isSelected }
+			context={ context }
+		/>
 	);
 }

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -1,9 +1,19 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { useEntityProp, useEntityId } from '@wordpress/core-data';
 import { useMemo } from '@wordpress/element';
-import { InspectorControls, RichText } from '@wordpress/block-editor';
+import {
+	AlignmentToolbar,
+	BlockControls,
+	InspectorControls,
+	RichText,
+} from '@wordpress/block-editor';
 import { PanelBody, RangeControl, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
@@ -26,7 +36,7 @@ function usePostContentExcerpt( wordCount ) {
 }
 
 function PostExcerptEditor( {
-	attributes: { wordCount, moreText, showMoreOnNewLine },
+	attributes: { align, wordCount, moreText, showMoreOnNewLine },
 	setAttributes,
 	isSelected,
 } ) {
@@ -38,6 +48,14 @@ function PostExcerptEditor( {
 	const postContentExcerpt = usePostContentExcerpt( wordCount );
 	return (
 		<>
+			<BlockControls>
+				<AlignmentToolbar
+					value={ align }
+					onChange={ ( newAlign ) =>
+						setAttributes( { align: newAlign } )
+					}
+				/>
+			</BlockControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Post Excerpt Settings' ) }>
 					{ ! excerpt && (
@@ -62,19 +80,36 @@ function PostExcerptEditor( {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<RichText
-				className={
-					! showMoreOnNewLine &&
-					'wp-block-post-excerpt__excerpt is-inline'
-				}
-				placeholder={ postContentExcerpt }
-				value={ excerpt || ( isSelected ? '' : postContentExcerpt ) }
-				onChange={ setExcerpt }
-				keepPlaceholderOnFocus
-			/>
-			{ ! showMoreOnNewLine && ' ' }
-			{ showMoreOnNewLine ? (
-				<p>
+			<div
+				className={ classnames( 'wp-block-post-excerpt', {
+					[ `has-text-align-${ align }` ]: align,
+				} ) }
+			>
+				<RichText
+					className={
+						! showMoreOnNewLine &&
+						'wp-block-post-excerpt__excerpt is-inline'
+					}
+					placeholder={ postContentExcerpt }
+					value={
+						excerpt || ( isSelected ? '' : postContentExcerpt )
+					}
+					onChange={ setExcerpt }
+					keepPlaceholderOnFocus
+				/>
+				{ ! showMoreOnNewLine && ' ' }
+				{ showMoreOnNewLine ? (
+					<p>
+						<RichText
+							tagName="a"
+							placeholder={ __( 'Read more…' ) }
+							value={ moreText }
+							onChange={ ( newMoreText ) =>
+								setAttributes( { moreText: newMoreText } )
+							}
+						/>
+					</p>
+				) : (
 					<RichText
 						tagName="a"
 						placeholder={ __( 'Read more…' ) }
@@ -83,17 +118,8 @@ function PostExcerptEditor( {
 							setAttributes( { moreText: newMoreText } )
 						}
 					/>
-				</p>
-			) : (
-				<RichText
-					tagName="a"
-					placeholder={ __( 'Read more…' ) }
-					value={ moreText }
-					onChange={ ( newMoreText ) =>
-						setAttributes( { moreText: newMoreText } )
-					}
-				/>
-			) }
+				) }
+			</div>
 		</>
 	);
 }

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { useEntityProp } from '@wordpress/core-data';
-import { useMemo } from '@wordpress/element';
+import { useMemo, useEffect } from '@wordpress/element';
 import {
 	AlignmentToolbar,
 	BlockControls,
@@ -36,12 +36,19 @@ function usePostContentExcerpt( wordCount, postId, postType ) {
 	}, [ rawPostContent, wordCount ] );
 }
 
-function PostExcerptEditor( {
+export default function PostExcerptEdit( {
 	attributes: { align, wordCount, moreText, showMoreOnNewLine },
 	setAttributes,
 	isSelected,
 	context: { postId, postType },
 } ) {
+	// Set the initial moreText based on local.
+	useEffect( () => {
+		if ( moreText === null || moreText === undefined ) {
+			setAttributes( { moreText: __( 'Read more…' ) } );
+		}
+	}, [] );
+
 	const [ excerpt, setExcerpt ] = useEntityProp(
 		'postType',
 		postType,
@@ -99,7 +106,11 @@ function PostExcerptEditor( {
 					}
 					placeholder={ postContentExcerpt }
 					value={
-						excerpt || ( isSelected ? '' : postContentExcerpt )
+						excerpt ||
+						( isSelected
+							? ''
+							: postContentExcerpt ||
+							  __( 'No post excerpt found' ) )
 					}
 					onChange={ setExcerpt }
 					keepPlaceholderOnFocus
@@ -128,25 +139,5 @@ function PostExcerptEditor( {
 				) }
 			</div>
 		</>
-	);
-}
-
-export default function PostExcerptEdit( {
-	attributes,
-	setAttributes,
-	isSelected,
-	context,
-} ) {
-	// This check doesn't work in site editor? always false.
-	// if ( ! useEntityId( 'postType', 'post' ) ) {
-	// 	return __( 'Post Excerpt' );
-	// }
-	return (
-		<PostExcerptEditor
-			attributes={ attributes }
-			setAttributes={ setAttributes }
-			isSelected={ isSelected }
-			context={ context }
-		/>
 	);
 }

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -45,7 +45,8 @@ export default function PostExcerptEdit( {
 	// Set the initial moreText based on local.
 	useEffect( () => {
 		if ( moreText === null || moreText === undefined ) {
-			setAttributes( { moreText: __( 'Read more…' ) } );
+			// eslint-disable-next-line @wordpress/i18n-ellipsis
+			setAttributes( { moreText: __( 'Read more...' ) } );
 		}
 	}, [] );
 

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -13,18 +13,19 @@ import {
 	BlockControls,
 	InspectorControls,
 	RichText,
-	Warning,
 } from '@wordpress/block-editor';
 import { PanelBody, RangeControl, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 function usePostContentExcerpt( wordCount, postId, postType ) {
-	const [ , , { raw: rawPostContent } ] = useEntityProp(
+	// Don't destrcuture items from content here, it can be undefined.
+	const [ , , content ] = useEntityProp(
 		'postType',
 		postType,
 		'content',
 		postId
 	);
+	const rawPostContent = content?.raw;
 	return useMemo( () => {
 		if ( ! rawPostContent ) {
 			return '';
@@ -37,7 +38,7 @@ function usePostContentExcerpt( wordCount, postId, postType ) {
 	}, [ rawPostContent, wordCount ] );
 }
 
-function PostExcerptEditor( {
+export default function PostExcerptEdit( {
 	attributes: { align, wordCount, moreText, showMoreOnNewLine },
 	setAttributes,
 	isSelected,
@@ -133,26 +134,5 @@ function PostExcerptEditor( {
 				) }
 			</div>
 		</>
-	);
-}
-
-export default function PostExcerptEdit( {
-	attributes,
-	setAttributes,
-	isSelected,
-	context,
-} ) {
-	if ( ! context.postType || ! context.postId ) {
-		return (
-			<Warning>{ __( 'Post excerpt block: no post found.' ) }</Warning>
-		);
-	}
-	return (
-		<PostExcerptEditor
-			attributes={ attributes }
-			setAttributes={ setAttributes }
-			isSelected={ isSelected }
-			context={ context }
-		/>
 	);
 }

--- a/packages/block-library/src/post-excerpt/editor.scss
+++ b/packages/block-library/src/post-excerpt/editor.scss
@@ -1,3 +1,12 @@
-.wp-block-post-excerpt__excerpt.is-inline {
-	display: inline-block;
+.wp-block-post-excerpt {
+
+	.wp-block-post-excerpt__excerpt.is-inline {
+		display: inline-block;
+	}
+
+
+}
+
+.wp-block[data-type="core/post-excerpt"].has-link-color .wp-block-post-excerpt a {
+	color: var(--wp--style--color--link);
 }

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -29,11 +29,11 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	);
 
 	$classes = 'wp-block-post-excerpt';
-	if( isset($attributes['align']) ) {
+	if ( isset( $attributes['align'] ) ) {
 		$classes .= ' has-text-align-' . $attributes['align'];
 	}
 
-	$output = sprintf('<div class="%1$s">', esc_attr( $classes) ) . '<p class="wp-block-post-excerpt__excerpt">' . get_the_excerpt( $block->context['postId'] );
+	$output = sprintf( '<div class="%1$s">', esc_attr( $classes ) ) . '<p class="wp-block-post-excerpt__excerpt">' . get_the_excerpt( $block->context['postId'] );
 	if ( ! isset( $attributes['showMoreOnNewLine'] ) || $attributes['showMoreOnNewLine'] ) {
 		$output .= '</p>' . '<p class="wp-block-post-excerpt__more-text">' . $more_text . '</p>';
 	} else {

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -28,11 +28,16 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 		$filter_excerpt_length
 	);
 
-	$output = '<p>' . get_the_excerpt( $block->context['postId'] );
+	$classes = 'wp-block-post-excerpt';
+	if( isset($attributes['align']) ) {
+		$classes .= ' has-text-align-' . $attributes['align'];
+	}
+
+	$output = sprintf('<div class="%1$s">', esc_attr( $classes) ) . '<p>' . get_the_excerpt( $block->context['postId'] );
 	if ( ! isset( $attributes['showMoreOnNewLine'] ) || $attributes['showMoreOnNewLine'] ) {
 		$output .= '</p>' . '<p>' . $more_text . '</p>';
 	} else {
-		$output .= ' ' . $more_text . '</p>';
+		$output .= ' ' . $more_text . '</p>' . '</div>';
 	}
 
 	remove_filter(

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -33,9 +33,9 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 		$classes .= ' has-text-align-' . $attributes['align'];
 	}
 
-	$output = sprintf('<div class="%1$s">', esc_attr( $classes) ) . '<p>' . get_the_excerpt( $block->context['postId'] );
+	$output = sprintf('<div class="%1$s">', esc_attr( $classes) ) . '<p class="wp-block-post-excerpt__excerpt">' . get_the_excerpt( $block->context['postId'] );
 	if ( ! isset( $attributes['showMoreOnNewLine'] ) || $attributes['showMoreOnNewLine'] ) {
-		$output .= '</p>' . '<p>' . $more_text . '</p>';
+		$output .= '</p>' . '<p class="wp-block-post-excerpt__more-text">' . $more_text . '</p>';
 	} else {
 		$output .= ' ' . $more_text . '</p>' . '</div>';
 	}

--- a/packages/block-library/src/post-excerpt/style.scss
+++ b/packages/block-library/src/post-excerpt/style.scss
@@ -1,0 +1,6 @@
+.wp-block-post-excerpt {
+	.wp-block-post-excerpt__excerpt,
+	.wp-block-post-excerpt__more-text {
+		line-height: inherit;
+	}
+}

--- a/packages/block-library/src/post-excerpt/style.scss
+++ b/packages/block-library/src/post-excerpt/style.scss
@@ -5,6 +5,7 @@
 	}
 }
 
-.wp-block-post-excerpt.has-link-color a {
-	color: var(--wp--style--color--link) !important;
+.wp-block-post-excerpt.has-link-color a,
+.wp-block-post-excerpt.has-background.has-link-color a {
+	color: var(--wp--style--color--link);
 }

--- a/packages/block-library/src/post-excerpt/style.scss
+++ b/packages/block-library/src/post-excerpt/style.scss
@@ -4,3 +4,7 @@
 		line-height: inherit;
 	}
 }
+
+.wp-block-post-excerpt.has-link-color a {
+	color: var(--wp--style--color--link) !important;
+}

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -34,6 +34,7 @@
 @import "./table/style.scss";
 @import "./text-columns/style.scss";
 @import "./video/style.scss";
+@import "./post-excerpt/style.scss";
 
 // The following selectors have increased specificity (using the :root prefix)
 // to assure colors take effect over another base class color, mainly to let


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
As part of #21087 to add feature parity to FSE blocks.  This adds settings (and some necessary restructuring/styles to support) text alignment and the experimental flags for color, fontSize, and lineHeight.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Tested on local docker env.

Verify settings applied and saved in the editor for colors, font size, line height, and text alignment are appropriately reflected in the editor and on the front-end.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
