### PR TITLE
Fix blocks dropping to incorrect position in inner block lists

### DIFF
--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -260,7 +260,10 @@ export default function useBlockDropZone( {
 				return;
 			}
 
-			const sourceBlockIndex = getBlockIndex( sourceClientIds[ 0 ] );
+			const sourceBlockIndex = getBlockIndex(
+				sourceClientIds[ 0 ],
+				sourceRootClientId
+			);
 
 			// If the user is dropping to the same position, return early.
 			if (


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
There was a small error in #23825, that resulted in blocks  dropping to the incorrect position when moving a block upwards in an inner blocks list.

`getBlockIndex` requires the second argument rootClientId, otherwise it assumes the block is in the root block list:
https://github.com/WordPress/gutenberg/pull/23825/files#diff-9be26376df0fb6bdabd07fa42395e4ffR263

This PR adds that second argument.

## How has this been tested?
1. Add a few paragraphs in a group.
2. Try dragging one of the block up in the group
3. Observe the block drops in the correct position.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
