### PR TITLE
Remove the experimental flag from the block patterns documentation

### DIFF
--- a/docs/designers-developers/developers/block-api/README.md
+++ b/docs/designers-developers/developers/block-api/README.md
@@ -11,4 +11,4 @@ The following sections will walk you through the existing block APIs:
 - [Transformations](/docs/designers-developers/developers/block-api/block-transforms.md)
 - [Templates](/docs/designers-developers/developers/block-api/block-templates.md)
 - [Annotations](/docs/designers-developers/developers/block-api/block-annotations.md)
-- [Patterns (experimental)](/docs/designers-developers/developers/block-api/block-patterns.md)
+- [Block Patterns](/docs/designers-developers/developers/block-api/block-patterns.md)

--- a/docs/designers-developers/developers/block-api/block-patterns.md
+++ b/docs/designers-developers/developers/block-api/block-patterns.md
@@ -1,22 +1,20 @@
-# Patterns (Experimental)
+# Block Patterns
 
-Patterns are predefined block layouts, ready to insert and tweak. 
+Block Patterns are predefined block layouts, ready to insert and tweak.
 
-**Note** Patterns are still under heavy development and the APIs are subject to change.
-
-## Patterns Registration
+## Block Patterns Registration
 
 ### register_block_pattern
 
-The editor comes with a list of built-in patterns. Theme and plugin authors can register addition custom patterns using the `register_block_pattern` function.
+The editor comes with a list of built-in block patterns. Theme and plugin authors can register addition custom block patterns using the `register_block_pattern` function.
 
 The `register_block_pattern` function receives the name of the pattern as the first argument and an array describing properties of the pattern as the second argument.
 
-The properties of the pattern include:
+The properties of the block pattern include:
  - `title` (required): A human-readable title for the pattern.
  - `content` (required): Raw HTML content for the pattern.
  - `description`: A visually hidden text used to describe the pattern in the inserter. A description is optional but it is strongly encouraged when the title does not fully describe what the pattern does.
- - `categories`: A list of pattern categories used to group patterns. Patterns can be shown on multiple categories.
+ - `categories`: A list of pattern categories used to group block patterns. Block patterns can be shown on multiple categories.
  - `keywords`: Aliases or keywords that help users discover it while searching.
  - `viewportWidth`: Specify the width of the pattern in the inserter.
 
@@ -43,9 +41,9 @@ The following code sample unregisters the style named 'my-plugin/my-awesome-patt
 unregister_block_pattern( 'my-plugin/my-awesome-pattern' );
 ```
 
-## Pattern Categories
+## Block Pattern Categories
 
-Patterns can be grouped using categories. The block editor comes with bundled categories you can use on your custom patterns. You can also register your own pattern categories.
+Block patterns can be grouped using categories. The block editor comes with bundled categories you can use on your custom block patterns. You can also register your own pattern categories.
 
 ### register_block_pattern_category
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -132,7 +132,7 @@
 		"parent": "block-api"
 	},
 	{
-		"title": "Patterns (Experimental)",
+		"title": "Block Patterns",
 		"slug": "block-patterns",
 		"markdown_source": "../docs/designers-developers/developers/block-api/block-patterns.md",
 		"parent": "block-api"


### PR DESCRIPTION
Block Patterns are shipping on 5.5. It's time to remove the experimental mention.