### PR TITLE
[RNMobile] Capabilities type safety

### DIFF
--- a/packages/react-native-bridge/ios/Gutenberg.swift
+++ b/packages/react-native-bridge/ios/Gutenberg.swift
@@ -68,8 +68,11 @@ public class Gutenberg: NSObject {
             initialProps["translations"] = translations
         }
 
-        if let capabilities = dataSource.gutenbergCapabilities() {
-            initialProps["capabilities"] = capabilities
+        let capabilities = dataSource.gutenbergCapabilities()
+        if capabilities.isEmpty == false {
+            initialProps["capabilities"] = Dictionary<String, Bool>(uniqueKeysWithValues: capabilities.map { key, value in
+                (key.rawValue, value)
+            })
         }
 
         let editorTheme = dataSource.gutenbergEditorTheme()

--- a/packages/react-native-bridge/ios/GutenbergBridgeDataSource.swift
+++ b/packages/react-native-bridge/ios/GutenbergBridgeDataSource.swift
@@ -40,7 +40,10 @@ public protocol GutenbergBridgeDataSource: class {
     /// Asks the data source for a list of Media Sources to show on the Media Source Picker.
     func gutenbergMediaSources() -> [Gutenberg.MediaSource]
 
-    func gutenbergCapabilities() -> [String: Bool]?
+    /// Ask the data source what capabilities should be enabled.
+    /// Implement this method to enable one or more capabilities.
+    /// Defaults are not enabled.
+    func gutenbergCapabilities() -> [Capabilities: Bool]
 
     /// Asks the data source for a list of theme colors.
     func gutenbergEditorTheme() -> GutenbergEditorTheme?
@@ -61,6 +64,10 @@ public extension GutenbergBridgeDataSource {
     var loadingView: UIView? {
          return nil
      }
+
+    func gutenbergCapabilities() -> [Capabilities: Bool] {
+        return [:]
+    }
 }
 
 public protocol GutenbergEditorTheme {

--- a/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
+++ b/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
@@ -12,6 +12,12 @@ public struct MediaInfo {
     }
 }
 
+/// Definition of capabilities to enable in the Block Editor
+public enum Capabilities: String {
+    case mentions
+    case unsupportedBlockEditor
+}
+
 /// Wrapper for single block data
 public struct Block {
     /// Gutenberg internal block ID

--- a/packages/react-native-editor/ios/gutenberg/GutenbergViewController.swift
+++ b/packages/react-native-editor/ios/gutenberg/GutenbergViewController.swift
@@ -259,10 +259,10 @@ extension GutenbergViewController: GutenbergBridgeDataSource {
         return nil
     }
 
-    func gutenbergCapabilities() -> [String : Bool]? {
+    func gutenbergCapabilities() -> [Capabilities : Bool] {
         return [
-            "mentions": true,
-            "unsupportedBlockEditor": true,
+            .mentions: true,
+            .unsupportedBlockEditor: true,
         ]
     }
 


### PR DESCRIPTION
This PR implements a `Capabilities` enum for type safety on the client side.

gutenberg-mobile: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2486
WPiOS: https://github.com/wordpress-mobile/WordPress-iOS/pull/14473

To test:
- Run the example project.
- Check that @-Mentions works as expected.
- Check that Unsupported Block Editor works as expected.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
