### PR TITLE
Block toolbar: split switcher from mover and simplify styles.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -527,80 +527,27 @@
 	background-color: $white;
 
 	.block-editor-block-toolbar .components-toolbar-group,
-	.block-editor-block-toolbar .components-toolbar,
-	.block-editor-block-toolbar__mover-switcher-container {
+	.block-editor-block-toolbar .components-toolbar {
 		border-right-color: $gray-900;
 	}
 
-	.block-editor-block-toolbar__mover-switcher-container {
-		border-right-style: solid;
-		border-right-width: $border-width;
+	.block-editor-block-mover-button {
+		overflow: hidden;
 	}
 
-	// Adjust the mover control to fit as a unit next to the block switcher.
-	.block-editor-block-toolbar__block-switcher-wrapper {
-		// Adjust the focus rectangle for the switcher.
-		.block-editor-block-switcher__no-switcher-icon::before,
-		.block-editor-block-switcher__toggle::before {
-			width: $grid-unit-60 - $grid-unit-10 - $grid-unit-15;
-		}
-
-		// Adjust the positioning of the icon to better balance the new unit.
-		.block-editor-block-icon svg {
-			margin-left: 10px;
-		}
-
-		.block-editor-block-switcher:last-child .block-editor-block-icon svg {
-			margin-left: auto;
-		}
-
-		.components-toolbar,
-		.components-toolbar-group {
-			border-right: none;
-		}
-	}
-
-	.block-editor-block-mover {
-		margin-left: -$grid-unit-15;
-		width: $button-size;
-
-		&.is-horizontal {
-			width: $block-toolbar-height;
-		}
-
-		// Needs specificity to override a first-child rule.
-		.components-button.has-icon.block-editor-block-mover-button.block-editor-block-mover-button {
-			min-width: $button-size;
-			width: $button-size;
-			overflow: hidden;
-		}
-
-		&.is-horizontal .components-button.has-icon.block-editor-block-mover-button.block-editor-block-mover-button {
-			min-width: $block-toolbar-height/2;
-			width: $block-toolbar-height/2;
-			overflow: hidden;
-		}
+	.block-editor-block-mover.is-horizontal .components-button.has-icon.block-editor-block-mover-button.block-editor-block-mover-button {
+		min-width: $block-toolbar-height/2;
+		width: $block-toolbar-height/2;
 	}
 
 	.block-editor-block-mover:not(.is-horizontal) {
-
 		.block-editor-block-mover-button {
-			> svg {
-				margin-left: 2px;
-			}
-
 			&.is-up-button svg {
 				margin-top: 3px;
 			}
 
 			&.is-down-button svg {
 				margin-bottom: 3px;
-			}
-
-			&:focus::before {
-				left: 0 !important;
-				min-width: 0;
-				width: 28px;
 			}
 		}
 	}

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -535,7 +535,8 @@
 		overflow: hidden;
 	}
 
-	.block-editor-block-mover.is-horizontal .components-button.has-icon.block-editor-block-mover-button.block-editor-block-mover-button {
+	// Extra specificity to override standard toolbar button styles.
+	.block-editor-block-mover.is-horizontal .block-editor-block-mover-button.block-editor-block-mover-button {
 		min-width: $block-toolbar-height/2;
 		width: $block-toolbar-height/2;
 	}

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -106,40 +106,33 @@ export default function BlockToolbar( {
 
 	return (
 		<Wrapper className={ classes }>
-			<div
-				className="block-editor-block-toolbar__mover-switcher-container"
-				ref={ nodeRef }
-				{ ...showMoversGestures }
-			>
+			<div ref={ nodeRef } { ...showMoversGestures }>
 				{ ! isMultiToolbar && (
 					<div className="block-editor-block-toolbar__block-parent-selector-wrapper">
 						<BlockParentSelector clientIds={ blockClientIds } />
 					</div>
 				) }
-
 				{ ( shouldShowVisualToolbar || isMultiToolbar ) && (
-					<BlockDraggable
-						clientIds={ blockClientIds }
-						cloneClassname="block-editor-block-toolbar__drag-clone"
-					>
-						{ ( {
-							isDraggable,
-							onDraggableStart,
-							onDraggableEnd,
-						} ) => (
-							<div
-								className="block-editor-block-toolbar__block-switcher-wrapper"
-								draggable={ isDraggable && ! hideDragHandle }
-								onDragStart={ onDraggableStart }
-								onDragEnd={ onDraggableEnd }
-							>
-								<BlockSwitcher clientIds={ blockClientIds } />
-								<BlockMover clientIds={ blockClientIds } />
-							</div>
-						) }
-					</BlockDraggable>
+					<BlockSwitcher clientIds={ blockClientIds } />
 				) }
 			</div>
+			{ ( shouldShowVisualToolbar || isMultiToolbar ) && (
+				<BlockDraggable
+					clientIds={ blockClientIds }
+					cloneClassname="block-editor-block-toolbar__drag-clone"
+				>
+					{ ( { isDraggable, onDraggableStart, onDraggableEnd } ) => (
+						<div
+							className="block-editor-block-toolbar__drag-handle-area"
+							draggable={ isDraggable && ! hideDragHandle }
+							onDragStart={ onDraggableStart }
+							onDragEnd={ onDraggableEnd }
+						>
+							<BlockMover clientIds={ blockClientIds } />
+						</div>
+					) }
+				</BlockDraggable>
+			) }
 			{ shouldShowVisualToolbar && (
 				<>
 					<BlockControls.Slot

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -87,18 +87,6 @@
 	}
 }
 
-.block-editor-block-toolbar__mover-switcher-container {
-	display: flex;
-}
-
-.block-editor-block-toolbar__block-switcher-wrapper {
-	display: flex;
-
-	.block-editor-block-switcher {
-		display: block;
-	}
-}
-
 .block-editor-block-toolbar-animated-width-container {
 	position: relative;
 	overflow: hidden;


### PR DESCRIPTION
## Description
Following the discussion starting [here](https://github.com/WordPress/gutenberg/issues/21935#issuecomment-654405787), this PR simplifies the block toolbar styles so that the switcher and movers are shown in separate toolbar groups, with the standard spacing between the two. They were already technically in separate toolbar groups, but the styles obscured this to try and show them closer together.

To ensure that the parent block selector button and block outline only show when the block icon is hovered, I had to move some elements around a bit. As it turns out, this allowed me to remove even more special-case CSS.

I initially tried to create a PR that simply increased the space between the switcher and mover, following [this comment](https://github.com/WordPress/gutenberg/issues/21935#issuecomment-657902142) by @diegohaz. However, this proved to be really, really complicated to try and implement. As it turns out, going the next step and just using the standard styles was a **drastically** simpler solution.

As the accessibility report found the combined switcher/mover area to be a regression, accessibility-wise, I'm tagging this with the "Backport to WP Core" label in the hope that it will be included in WP 5.5, as [suggested](https://github.com/WordPress/gutenberg/pull/23760#issuecomment-658170074) by @afercia.

## Screenshots

![image](https://user-images.githubusercontent.com/19592990/87616844-ab29c400-c6db-11ea-9c58-7d2867fa9a30.png)
![image](https://user-images.githubusercontent.com/19592990/87616853-b7158600-c6db-11ea-8490-d86c64228f2a.png)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
