### PR TITLE
Fix block icon mouse-out gesture issue.

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -107,6 +107,7 @@ export default function BlockToolbar( {
 			<div
 				className="block-editor-block-toolbar__mover-switcher-container"
 				ref={ nodeRef }
+				{ ...showMoversGestures }
 			>
 				{ ! isMultiToolbar && (
 					<div className="block-editor-block-toolbar__block-parent-selector-wrapper">
@@ -125,7 +126,6 @@ export default function BlockToolbar( {
 							onDraggableEnd,
 						} ) => (
 							<div
-								{ ...showMoversGestures }
 								className="block-editor-block-toolbar__block-switcher-wrapper"
 								draggable={ isDraggable && ! hideDragHandle }
 								onDragStart={ onDraggableStart }


### PR DESCRIPTION
## Description
Extracted from #23971.

After showing the parent block selector and block outline, if you moved your mouse into the parent block selector button for a few seconds and then moved it out (without moving it back through the block icon), the move-out gesture would not be triggered.

This PR fixes that.

## Reproduction steps (for `master`)
1. Insert a Group block.
2. Insert a Heading block inside the Group block.
3. Select the Heading block.
4. Make sure you're using the Edit tool.
5. Hover over the block icon (block switcher) in the block toolbar.
6. Hover over the parent block selector button that has now been revealed.
7. Wait 3 seconds.
8. Move your mouse up, left, or right, so that it is no longer within the bounds of the parent selector button.
9. Notice that the parent selector button and block outline remain visible.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
