### PR TITLE
Remove unsupported core-embed/hulu block

### DIFF
--- a/packages/block-library/src/embed/core-embeds.js
+++ b/packages/block-library/src/embed/core-embeds.js
@@ -195,16 +195,6 @@ export const others = [
 		patterns: [ /^https?:\/\/(www\.)?dailymotion\.com\/.+/i ],
 	},
 	{
-		name: 'core-embed/hulu',
-		settings: {
-			title: 'Hulu',
-			icon: embedVideoIcon,
-			keywords: [ __( 'video' ) ],
-			description: __( 'Embed Hulu content.' ),
-		},
-		patterns: [ /^https?:\/\/(www\.)?hulu\.com\/.+/i ],
-	},
-	{
 		name: 'core-embed/imgur',
 		settings: {
 			title: 'Imgur',


### PR DESCRIPTION
## Description
Removed unsupported core-embed/hulu block
Refer: https://github.com/WordPress/gutenberg/issues/23920
https://core.trac.wordpress.org/ticket/50676


