### PR TITLE
Core: Adding block styles via editor.BlockEdit filter

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -5,7 +5,6 @@ import { __ } from '@wordpress/i18n';
 import {
 	getBlockType,
 	getUnregisteredTypeHandlerName,
-	hasBlockSupport,
 	store as blocksStore,
 } from '@wordpress/blocks';
 import {
@@ -21,9 +20,7 @@ import SkipToSelectedBlock from '../skip-to-selected-block';
 import BlockCard from '../block-card';
 import InspectorControls from '../inspector-controls';
 import InspectorAdvancedControls from '../inspector-advanced-controls';
-import BlockStyles from '../block-styles';
 import MultiSelectionInspector from '../multi-selection-inspector';
-import DefaultStylePicker from '../default-style-picker';
 import BlockVariationTransforms from '../block-variation-transforms';
 import useBlockDisplayInformation from '../use-block-display-information';
 import { store as blockEditorStore } from '../../store';
@@ -103,29 +100,12 @@ const BlockInspector = ( {
 	);
 };
 
-const BlockInspectorSingleBlock = ( {
-	clientId,
-	blockName,
-	hasBlockStyles,
-	bubblesVirtually,
-} ) => {
+const BlockInspectorSingleBlock = ( { clientId, bubblesVirtually } ) => {
 	const blockInformation = useBlockDisplayInformation( clientId );
 	return (
 		<div className="block-editor-block-inspector">
 			<BlockCard { ...blockInformation } />
 			<BlockVariationTransforms blockClientId={ clientId } />
-			{ hasBlockStyles && (
-				<div>
-					<PanelBody title={ __( 'Styles' ) }>
-						<BlockStyles clientId={ clientId } />
-						{ hasBlockSupport(
-							blockName,
-							'defaultStylePicker',
-							true
-						) && <DefaultStylePicker blockName={ blockName } /> }
-					</PanelBody>
-				</div>
-			) }
 			<InspectorControls.Slot bubblesVirtually={ bubblesVirtually } />
 			<div>
 				<AdvancedControls

--- a/packages/block-editor/src/hooks/block-styles.js
+++ b/packages/block-editor/src/hooks/block-styles.js
@@ -1,0 +1,80 @@
+/**
+ * WordPress dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+import { createHigherOrderComponent, compose } from '@wordpress/compose';
+import { withSelect } from '@wordpress/data';
+import { Fragment } from '@wordpress/element';
+import { hasBlockSupport, getBlockType } from '@wordpress/blocks';
+import { PanelBody } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import InspectorControls from '../components/inspector-controls';
+import BlockStyles from '../components/block-styles';
+import DefaultStylePicker from '../components/default-style-picker';
+
+export const withInspectorControls = createHigherOrderComponent(
+	compose( [
+		withSelect( ( select ) => {
+			const { getSelectedBlockClientId, getBlockName } = select(
+				'core/block-editor'
+			);
+			const { getBlockStyles } = select( 'core/blocks' );
+			const selectedBlockClientId = getSelectedBlockClientId();
+			const selectedBlockName =
+				selectedBlockClientId && getBlockName( selectedBlockClientId );
+			const blockType =
+				selectedBlockClientId && getBlockType( selectedBlockName );
+			const blockStyles =
+				selectedBlockClientId && getBlockStyles( selectedBlockName );
+			return {
+				blockType,
+				selectedBlockClientId,
+				hasBlockStyles: blockStyles && blockStyles.length > 0,
+			};
+		} ),
+
+		( WrappedComponent ) => ( props ) => {
+			if ( ! props?.hasBlockStyles ) {
+				return <WrappedComponent { ...props } />;
+			}
+
+			const { selectedBlockClientId, blockType } = props;
+
+			return (
+				<Fragment>
+					<WrappedComponent { ...props } />
+
+					<InspectorControls>
+						<div>
+							<PanelBody title={ __( 'Styles' ) }>
+								<BlockStyles
+									clientId={ selectedBlockClientId }
+								/>
+								{ hasBlockSupport(
+									blockType.name,
+									'defaultStylePicker',
+									true
+								) && (
+									<DefaultStylePicker
+										blockName={ blockType.name }
+									/>
+								) }
+							</PanelBody>
+						</div>
+					</InspectorControls>
+				</Fragment>
+			);
+		},
+	] ),
+	'withInspectorControls'
+);
+
+addFilter(
+	'editor.BlockEdit',
+	'core/editor/block-styles/with-inspector-controls',
+	withInspectorControls
+);

--- a/packages/block-editor/src/hooks/block-styles.js
+++ b/packages/block-editor/src/hooks/block-styles.js
@@ -46,8 +46,6 @@ export const withInspectorControls = createHigherOrderComponent(
 
 			return (
 				<Fragment>
-					<WrappedComponent { ...props } />
-
 					<InspectorControls>
 						<div>
 							<PanelBody title={ __( 'Styles' ) }>
@@ -66,6 +64,8 @@ export const withInspectorControls = createHigherOrderComponent(
 							</PanelBody>
 						</div>
 					</InspectorControls>
+
+					<WrappedComponent { ...props } />
 				</Fragment>
 			);
 		},

--- a/packages/block-editor/src/hooks/block-styles.js
+++ b/packages/block-editor/src/hooks/block-styles.js
@@ -73,5 +73,6 @@ export const withInspectorControls = createHigherOrderComponent(
 addFilter(
 	'editor.BlockEdit',
 	'core/editor/block-styles/with-inspector-controls',
-	withInspectorControls
+	withInspectorControls,
+	20
 );

--- a/packages/block-editor/src/hooks/block-styles.js
+++ b/packages/block-editor/src/hooks/block-styles.js
@@ -21,7 +21,7 @@ export const withInspectorControls = createHigherOrderComponent(
 		const { name, clientId, isSelected } = props;
 
 		const hasBlockStyles = useSelect(
-			( select ) => select( blocksStore ).getBlockStyles( name ),
+			( select ) => select( blocksStore ).getBlockStyles( name )?.length > 0,
 			[ name ]
 		);
 
@@ -29,7 +29,7 @@ export const withInspectorControls = createHigherOrderComponent(
 			return <WrappedComponent { ...props } />;
 		}
 
-		if ( ! hasBlockStyles?.length ) {
+		if ( hasBlockStyles ) {
 			return <WrappedComponent { ...props } />;
 		}
 

--- a/packages/block-editor/src/hooks/block-styles.js
+++ b/packages/block-editor/src/hooks/block-styles.js
@@ -29,7 +29,7 @@ export const withInspectorControls = createHigherOrderComponent(
 			return <WrappedComponent { ...props } />;
 		}
 
-		if ( hasBlockStyles ) {
+		if ( ! hasBlockStyles ) {
 			return <WrappedComponent { ...props } />;
 		}
 

--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -6,6 +6,7 @@ import './anchor';
 import './custom-class-name';
 import './generated-class-name';
 import './style';
+import './block-styles';
 import './color';
 import './duotone';
 import './font-size';


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

This PR inserts the `<BlockStyles />` component to the Inspector Controls hooking a function to the `editor.BlockEdit` instead of hardcoding. It doesn't add anything new to the API just an improvement in terms of functionality.

It allows to handler properly the components inner the Inspector Controls via the hooks, since right now the BlockStyles locates always at the top and it isn't possible to deal with it, because, as I said before, it's hardcoded 😢 .

## How has this been tested?
* Apply the changes and confirm that `<BlockStyles />` shows as usual for these blocks that have defined style variations.
* Also, you can add a new component at the top of the Inserter Controls defining the priority f the bound function to the filter. It needs to be more than 10:


```es6
import { addFilter } from '@wordpress/hooks';
import { Fragment } from '@wordpress/element';
import { InspectorControls } from '@wordpress/block-editor';

const myEditComponent = OriginalBlockEdit => props => {
	return (
		<Fragment>
			<InspectorControls>
				<div>This is at the top!</div>
			</InspectorControls>
			<OriginalBlockEdit { ...props } />
		</Fragment>
	);
};

addFilter( 'editor.BlockEdit', 'my-block/editComponent', myEditComponent, 20 );
```

<img alt="Screen Shot 2020-07-16 at 4 18 32 PM" src="https://user-images.githubusercontent.com/77539/87713263-4aa09280-c780-11ea-9aab-8c63c3935785.png" width="313px" />

## Screenshots <!-- if applicable -->

<img width="992" alt="Screen Shot 2020-07-16 at 3 00 15 PM" src="https://user-images.githubusercontent.com/77539/87706235-8aae4800-c775-11ea-84cb-354bb965a056.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->