### PR TITLE
Build: Make the watch rate slower to avoid using a lot of CPU while developing

### DIFF
--- a/bin/packages/watch.js
+++ b/bin/packages/watch.js
@@ -44,7 +44,7 @@ getPackages().forEach( ( p ) => {
 		fs.accessSync( srcDir, fs.F_OK );
 		watch(
 			path.resolve( p, 'src' ),
-			{ recursive: true },
+			{ recursive: true, delay: 500 },
 			( event, filename ) => {
 				if ( ! isSourceFile( filename ) ) {
 					return;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -216,6 +216,7 @@ module.exports = {
 	].filter( Boolean ),
 	watchOptions: {
 		ignored: '!packages/*/!(src)/**/*',
+		aggregateTimeout: 500,
 	},
 	devtool,
 };


### PR DESCRIPTION
By default it's 200ms, I'm using 500ms now but I believe we can also consider a higher number to take care of our CPUs.