### PR TITLE
Block Patterns: Override patterns that were registered by Core

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -703,24 +703,27 @@ function gutenberg_extend_settings_link_color( $settings ) {
 }
 add_filter( 'block_editor_settings', 'gutenberg_extend_settings_link_color' );
 
-/*
+/**
  * Register default patterns, potentially overriding ones that were already registered in Core.
  *
  * This can be removed when plugin support requires WordPress 5.5.0+, and patterns have been synced back to Core.
  *
  * @see https://core.trac.wordpress.org/ticket/50550
  */
-if ( class_exists( 'WP_Block_Patterns_Registry' ) ) {
-	register_block_pattern( 'core/text-two-columns', gutenberg_load_block_pattern( 'text-two-columns' ) );
-	register_block_pattern( 'core/two-buttons', gutenberg_load_block_pattern( 'two-buttons' ) );
-	register_block_pattern( 'core/two-images', gutenberg_load_block_pattern( 'two-images' ) );
-	register_block_pattern( 'core/text-two-columns-with-images', gutenberg_load_block_pattern( 'text-two-columns-with-images' ) );
-	register_block_pattern( 'core/text-three-columns-buttons', gutenberg_load_block_pattern( 'text-three-columns-buttons' ) );
-	register_block_pattern( 'core/large-header', gutenberg_load_block_pattern( 'large-header' ) );
-	register_block_pattern( 'core/large-header-paragraph', gutenberg_load_block_pattern( 'large-header-paragraph' ) );
-	register_block_pattern( 'core/three-buttons', gutenberg_load_block_pattern( 'three-buttons' ) );
-	register_block_pattern( 'core/quote', gutenberg_load_block_pattern( 'quote' ) );
+function gutenberg_register_block_patterns() {
+	if ( class_exists( 'WP_Block_Patterns_Registry' ) ) {
+		register_block_pattern( 'core/text-two-columns', gutenberg_load_block_pattern( 'text-two-columns' ) );
+		register_block_pattern( 'core/two-buttons', gutenberg_load_block_pattern( 'two-buttons' ) );
+		register_block_pattern( 'core/two-images', gutenberg_load_block_pattern( 'two-images' ) );
+		register_block_pattern( 'core/text-two-columns-with-images', gutenberg_load_block_pattern( 'text-two-columns-with-images' ) );
+		register_block_pattern( 'core/text-three-columns-buttons', gutenberg_load_block_pattern( 'text-three-columns-buttons' ) );
+		register_block_pattern( 'core/large-header', gutenberg_load_block_pattern( 'large-header' ) );
+		register_block_pattern( 'core/large-header-paragraph', gutenberg_load_block_pattern( 'large-header-paragraph' ) );
+		register_block_pattern( 'core/three-buttons', gutenberg_load_block_pattern( 'three-buttons' ) );
+		register_block_pattern( 'core/quote', gutenberg_load_block_pattern( 'quote' ) );
+	}
 }
+add_action( 'init', 'gutenberg_register_block_patterns' );
 
 /*
  * Register default pattern categories if not registered in Core already.

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -704,13 +704,13 @@ function gutenberg_extend_settings_link_color( $settings ) {
 add_filter( 'block_editor_settings', 'gutenberg_extend_settings_link_color' );
 
 /*
- * Register default patterns if not registered in Core already.
+ * Register default patterns, potentially overriding ones that were already registered in Core.
  *
- * This can be removed when plugin support requires WordPress 5.5.0+.
+ * This can be removed when plugin support requires WordPress 5.5.0+, and patterns have been synced back to Core.
  *
  * @see https://core.trac.wordpress.org/ticket/50550
  */
-if ( class_exists( 'WP_Block_Patterns_Registry' ) && ! WP_Block_Patterns_Registry::get_instance()->is_registered( 'text-two-columns' ) ) {
+if ( class_exists( 'WP_Block_Patterns_Registry' ) ) {
 	register_block_pattern( 'core/text-two-columns', gutenberg_load_block_pattern( 'text-two-columns' ) );
 	register_block_pattern( 'core/two-buttons', gutenberg_load_block_pattern( 'two-buttons' ) );
 	register_block_pattern( 'core/two-images', gutenberg_load_block_pattern( 'two-images' ) );


### PR DESCRIPTION
## Description

Unconditionally register Gutenberg's block patterns, potentially overriding ones that were registered by Core.

This is to make sure that Gutenberg is using its own block patterns (rather than Core's), since they might have changes that haven't been synced to Core yet.

Specifically, this fixes #23996.

## How has this been tested?

Easiest way: Verify that the "Admin - 4" GH Action goes green.

More difficult: Test locally by using a `.wp-env.override.json` that links to a current WP snapshot (rather than a released version), and run `npm run test-e2e -- packages/e2e-tests/specs/editor/various/adding-patterns.test.js`. Or insert the "Two Buttons" block pattern in the editor, and verify that the default button labels are `Get started` and `Learn more`, rather than `Button One` and `Button Two`.

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
