### PR TITLE
Post Content Block: Disable when editing content

### DIFF
--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -174,9 +174,9 @@ export const registerCoreBlocks = () => {
 /**
  * Function to register experimental core blocks depending on editor settings.
  *
- * @param {Object} settings         Editor settings.
- * @param {Object} context          Post context.
- * @param {string} context.postType Post Type
+ * @param {Object} settings           Editor settings.
+ * @param {Object} [context]          Post context.
+ * @param {string} [context.postType] Post Type
  *
  * @example
  * ```js
@@ -187,7 +187,7 @@ export const registerCoreBlocks = () => {
  */
 export const __experimentalRegisterExperimentalCoreBlocks =
 	process.env.GUTENBERG_PHASE === 2
-		? ( settings, { postType } ) => {
+		? ( settings, { postType } = {} ) => {
 				const {
 					__experimentalEnableLegacyWidgetBlock,
 					__experimentalEnableFullSiteEditing,

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -211,9 +211,9 @@ export const __experimentalRegisterExperimentalCoreBlocks =
 								queryPagination,
 								postTitle,
 								/*
-								 * Only provide the Post Content block in templates,
-								 * so there's no risk of posts including themselves through
-								 * a Post Content block (leading to infinite recursion).
+								 * Only provide the Post Content block when editing templates or,
+								 * template parts so there's no risk of posts including themselves
+								 * through a Post Content block (leading to infinite recursion).
 								 */
 								[ 'wp_template', 'wp_template_part' ].includes(
 									postType

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -174,7 +174,9 @@ export const registerCoreBlocks = () => {
 /**
  * Function to register experimental core blocks depending on editor settings.
  *
- * @param {Object} settings Editor settings.
+ * @param {Object} settings         Editor settings.
+ * @param {Object} context          Post context.
+ * @param {string} context.postType Post Type
  *
  * @example
  * ```js
@@ -185,7 +187,7 @@ export const registerCoreBlocks = () => {
  */
 export const __experimentalRegisterExperimentalCoreBlocks =
 	process.env.GUTENBERG_PHASE === 2
-		? ( settings ) => {
+		? ( settings, { postType } ) => {
 				const {
 					__experimentalEnableLegacyWidgetBlock,
 					__experimentalEnableFullSiteEditing,
@@ -208,7 +210,16 @@ export const __experimentalRegisterExperimentalCoreBlocks =
 								queryLoop,
 								queryPagination,
 								postTitle,
-								postContent,
+								/*
+								 * Only provide the Post Content block in templates,
+								 * so there's no risk of posts including themselves through
+								 * a Post Content block (leading to infinite recursion).
+								 */
+								[ 'wp_template', 'wp_template_part' ].includes(
+									postType
+								)
+									? postContent
+									: null,
 								postAuthor,
 								postComments,
 								postCommentsCount,
@@ -217,7 +228,7 @@ export const __experimentalRegisterExperimentalCoreBlocks =
 								postExcerpt,
 								postFeaturedImage,
 								postTags,
-						  ]
+						  ].filter( Boolean )
 						: [] ),
 				].forEach( registerBlock );
 		  }

--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -37,3 +37,21 @@ function register_block_core_post_content() {
 	);
 }
 add_action( 'init', 'register_block_core_post_content' );
+
+/**
+ * Only show the `core/post-content` block when editing templates and template parts.
+ * This is to prevent infinite recursions (post content containing a Post Content block
+ * that attempts to embed the post content it is part of).
+ *
+ * @param bool|array $allowed_block_types Array of block type slugs, or
+ *                                        boolean to enable/disable all.
+ * @param WP_Post    $post                The post resource data.
+ */
+function disallow_core_post_content_block_outside_templates( $allowed_block_types, $post ) {
+	if ( in_array( $post->post_type, array( 'wp_template', 'wp_template_part' ), true ) ) {
+		return $allowed_block_types;
+	}
+	return array_diff( $allowed_block_types, array( 'core/post-content' ) );
+}
+
+add_filter( 'allowed_block_types', 'disallow_core_post_content_block_outside_templates', 10, 2 );

--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -37,21 +37,3 @@ function register_block_core_post_content() {
 	);
 }
 add_action( 'init', 'register_block_core_post_content' );
-
-/**
- * Only show the `core/post-content` block when editing templates and template parts.
- * This is to prevent infinite recursions (post content containing a Post Content block
- * that attempts to embed the post content it is part of).
- *
- * @param bool|array $allowed_block_types Array of block type slugs, or
- *                                        boolean to enable/disable all.
- * @param WP_Post    $post                The post resource data.
- */
-function disallow_core_post_content_block_outside_templates( $allowed_block_types, $post ) {
-	if ( in_array( $post->post_type, array( 'wp_template', 'wp_template_part' ), true ) ) {
-		return $allowed_block_types;
-	}
-	return array_diff( $allowed_block_types, array( 'core/post-content' ) );
-}
-
-add_filter( 'allowed_block_types', 'disallow_core_post_content_block_outside_templates', 10, 2 );

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -96,7 +96,7 @@ export function initializeEditor(
 	);
 	registerCoreBlocks();
 	if ( process.env.GUTENBERG_PHASE === 2 ) {
-		__experimentalRegisterExperimentalCoreBlocks( settings );
+		__experimentalRegisterExperimentalCoreBlocks( settings, { postType } );
 	}
 
 	// Show a console log warning if the browser is not in Standards rendering mode.

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -58,7 +58,9 @@ export function initialize( id, settings ) {
 
 	registerCoreBlocks();
 	if ( process.env.GUTENBERG_PHASE === 2 ) {
-		__experimentalRegisterExperimentalCoreBlocks( settings );
+		__experimentalRegisterExperimentalCoreBlocks( settings, {
+			postType: 'wp_template',
+		} );
 	}
 
 	render( <Editor />, document.getElementById( id ) );

--- a/test/integration/full-content/full-content.test.js
+++ b/test/integration/full-content/full-content.test.js
@@ -73,7 +73,15 @@ describe( 'full post content fixture', () => {
 		require( '../../../packages/editor/src/hooks' );
 		registerCoreBlocks();
 		if ( process.env.GUTENBERG_PHASE === 2 ) {
-			__experimentalRegisterExperimentalCoreBlocks( settings );
+			/**
+			 * We're loading these blocks with a `wp_template` post context,
+			 * since most of them are meant to be used in Site Editor templates,
+			 * to the point that e.g. the Post Content block is unavailable in
+			 * a Post Editor (`post`) context.
+			 */
+			__experimentalRegisterExperimentalCoreBlocks( settings, {
+				postType: 'wp_template',
+			} );
 		}
 	} );
 


### PR DESCRIPTION
## Description

Tentative partial fix for #22080: Remove the Post Content block when editing content, in order to prevent blockception (an infinite recursion of the Post Content block embedding the current post content, which includes itself, and so on).

Note that I'm passing the `postType` as an extra argument to `__experimentalRegisterExperimentalCoreBlocks`. I _think_ this is probably okay (since it's experimental, and we don't seem to be too picky about what we're passing to that function, since the existing `settings` argument lumps together a bunch of different concerns already).  

## How has this been tested?
- Verify that in the Post Editor, the Post Content Block is no longer available from the block inserter.
- Verify that in the _Site_ Editor, the Post Content Block is still longer available from the block inserter.
- Verify that in the Template and Template Part Editors (found in the Appearance menu), the Post Block is still available from the inserter.
- Verify that the Post Content Block isn't available in the Widgets and Navigation Editors, and that no errors are thrown in the console. (Your have to enable those editors on the Gutenberg > Experiments wp-admin page first; this will enable the corresponding menu items in the Gutenberg menu.)

## Screenshots <!-- if applicable -->
N/A

## Types of changes
Bug fix.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
