### PR TITLE
Post content: show placeholder if trying to render itself

### DIFF
--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -30,6 +30,7 @@
 @import "./navigation-link/editor.scss";
 @import "./nextpage/editor.scss";
 @import "./paragraph/editor.scss";
+@import "./post-content/editor.scss";
 @import "./post-excerpt/editor.scss";
 @import "./post-author/editor.scss";
 @import "./pullquote/editor.scss";

--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -9,10 +10,20 @@ import { __ } from '@wordpress/i18n';
 import PostContentInnerBlocks from './inner-blocks';
 
 export default function PostContentEdit( { context: { postId, postType } } ) {
-	if ( postId && postType && postType !== 'wp_template' ) {
+	const { id, type } = useSelect( ( select ) => {
+		return select( 'core/editor' ).getCurrentPost() ?? {};
+	} );
+
+	// Only render InnerBlocks if the context is different from the active post
+	// to avoid infinite recursion of post content.
+	if ( postId && postType && postId !== id && postType !== type ) {
 		return (
 			<PostContentInnerBlocks postType={ postType } postId={ postId } />
 		);
 	}
-	return <p>{ __( 'This is a placeholder for post content.' ) }</p>;
+	return (
+		<div className="wp-block-post-content__placeholder">
+			<span>{ __( 'This is a placeholder for post content.' ) }</span>
+		</div>
+	);
 }

--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -9,7 +9,7 @@ import { __ } from '@wordpress/i18n';
 import PostContentInnerBlocks from './inner-blocks';
 
 export default function PostContentEdit( { context: { postId, postType } } ) {
-	if ( postId && postType ) {
+	if ( postId && postType && postType !== 'wp_template' ) {
 		return (
 			<PostContentInnerBlocks postType={ postType } postId={ postId } />
 		);

--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -9,16 +9,26 @@ import { useSelect } from '@wordpress/data';
  */
 import PostContentInnerBlocks from './inner-blocks';
 
-export default function PostContentEdit( { context: { postId, postType } } ) {
-	const { id, type } = useSelect( ( select ) => {
-		return select( 'core/editor' ).getCurrentPost() ?? {};
-	} );
+export default function PostContentEdit( {
+	context: { postId: contextPostId, postType: contextPostType },
+} ) {
+	const { id: currentPostId, type: currentPostType } = useSelect(
+		( select ) => select( 'core/editor' ).getCurrentPost() ?? {}
+	);
 
 	// Only render InnerBlocks if the context is different from the active post
 	// to avoid infinite recursion of post content.
-	if ( postId && postType && postId !== id && postType !== type ) {
+	if (
+		contextPostId &&
+		contextPostType &&
+		contextPostId !== currentPostId &&
+		contextPostType !== currentPostType
+	) {
 		return (
-			<PostContentInnerBlocks postType={ postType } postId={ postId } />
+			<PostContentInnerBlocks
+				postType={ contextPostType }
+				postId={ contextPostId }
+			/>
 		);
 	}
 	return (

--- a/packages/block-library/src/post-content/editor.scss
+++ b/packages/block-library/src/post-content/editor.scss
@@ -1,0 +1,11 @@
+.wp-block-post-content__placeholder {
+	height: 100px;
+	border: 1px dashed;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+
+	span {
+		font-style: italic;
+	}
+}

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -20,11 +20,7 @@ import { __ } from '@wordpress/i18n';
  */
 import HeadingLevelDropdown from '../heading/heading-level-dropdown';
 
-export default function PostTitleEdit( {
-	attributes,
-	setAttributes,
-	context,
-} ) {
+function PostTitleEditor( { attributes, setAttributes, context } ) {
 	const { level, textAlign } = attributes;
 	const { postType, postId } = context;
 	const tagName = 0 === level ? 'p' : 'h' + level;

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -73,3 +73,20 @@ export default function PostTitleEdit( {
 		</>
 	);
 }
+
+export default function PostTitleEdit( {
+	attributes,
+	setAttributes,
+	context,
+} ) {
+	if ( ! context.postType || context.postType === 'wp_template' ) {
+		return <p>{ __( 'This is a placeholder for post title.' ) }</p>;
+	}
+	return (
+		<PostTitleEditor
+			attributes={ attributes }
+			setAttributes={ setAttributes }
+			context={ context }
+		/>
+	);
+}

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -20,7 +20,11 @@ import { __ } from '@wordpress/i18n';
  */
 import HeadingLevelDropdown from '../heading/heading-level-dropdown';
 
-function PostTitleEditor( { attributes, setAttributes, context } ) {
+export default function PostTitleEdit( {
+	attributes,
+	setAttributes,
+	context,
+} ) {
 	const { level, textAlign } = attributes;
 	const { postType, postId } = context;
 	const tagName = 0 === level ? 'p' : 'h' + level;
@@ -67,22 +71,5 @@ function PostTitleEditor( { attributes, setAttributes, context } ) {
 				{ post.title || __( 'Post Title' ) }
 			</BlockWrapper>
 		</>
-	);
-}
-
-export default function PostTitleEdit( {
-	attributes,
-	setAttributes,
-	context,
-} ) {
-	if ( ! context.postType || context.postType === 'wp_template' ) {
-		return <p>{ __( 'This is a placeholder for post title.' ) }</p>;
-	}
-	return (
-		<PostTitleEditor
-			attributes={ attributes }
-			setAttributes={ setAttributes }
-			context={ context }
-		/>
 	);
 }

--- a/packages/block-library/src/query-loop/edit.js
+++ b/packages/block-library/src/query-loop/edit.js
@@ -18,12 +18,12 @@ import { useQueryContext } from '../query';
 const TEMPLATE = [ [ 'core/post-title' ], [ 'core/post-content' ] ];
 export default function QueryLoopEdit( {
 	clientId,
-	context: {
-		query: { perPage, offset, categoryIds },
-		queryContext,
-	},
+	context: { query: _query, queryContext },
 } ) {
-	const [ { page } ] = useQueryContext() || queryContext;
+	const perPage = _query?.perPage;
+	const offset = _query?.offset;
+	const categoryIds = _query?.categoryIds;
+	const [ { page } ] = useQueryContext() || queryContext || [ {} ];
 	const [ activeBlockContext, setActiveBlockContext ] = useState();
 
 	const { posts, blocks } = useSelect(

--- a/packages/block-library/src/query-loop/edit.js
+++ b/packages/block-library/src/query-loop/edit.js
@@ -18,9 +18,8 @@ import { useQueryContext } from '../query';
 const TEMPLATE = [ [ 'core/post-title' ], [ 'core/post-content' ] ];
 export default function QueryLoopEdit( {
 	clientId,
-	context: { query: _query = {}, queryContext },
+	context: { query: { perPage, offset, categoryIds } = {}, queryContext },
 } ) {
-	const { perPage, offset, categoryIds } = _query;
 	const [ { page } ] = useQueryContext() || queryContext || [ {} ];
 	const [ activeBlockContext, setActiveBlockContext ] = useState();
 

--- a/packages/block-library/src/query-loop/edit.js
+++ b/packages/block-library/src/query-loop/edit.js
@@ -18,11 +18,9 @@ import { useQueryContext } from '../query';
 const TEMPLATE = [ [ 'core/post-title' ], [ 'core/post-content' ] ];
 export default function QueryLoopEdit( {
 	clientId,
-	context: { query: _query, queryContext },
+	context: { query: _query = {}, queryContext },
 } ) {
-	const perPage = _query?.perPage;
-	const offset = _query?.offset;
-	const categoryIds = _query?.categoryIds;
+	const { perPage, offset, categoryIds } = _query;
 	const [ { page } ] = useQueryContext() || queryContext || [ {} ];
 	const [ activeBlockContext, setActiveBlockContext ] = useState();
 


### PR DESCRIPTION
Fixes #22080, fixes #23762 (by stopping those crashes from occurring when a post content block exists.)

Related to #24006.

## Description

* Adds Placeholder content for Post Title block which displays when editing wp_template.
* Adds placeholder for post content block, which displays when the root post is different from the post content (to avoid a crash. This works because there is no root post in FSE, but there is in all the other editors.)
* Restructuring of how we pull props in the Query Loop component.  This would break with a block error when loaded in the old editor due to lack of expected props being supplied through context.  Now it just finds the posts without a supplied query.

Although it will show all posts retrieved from the entity records as there is no query to control or limit them. 🤔 

## How has this been tested?
locally in edit site, edit post (while editing posts and templates)

## Screenshots <!-- if applicable -->

For the Singular template, instead of looking totally broken we get:

![Screen Shot 2020-07-16 at 7 18 04 PM](https://user-images.githubusercontent.com/28742426/87731885-8431c780-c799-11ea-8a73-6746142902a5.png)

(note that the post content placeholder has since been updated to look like this:)
<img width="1697" alt="Screen Shot 2020-07-20 at 3 02 53 PM" src="https://user-images.githubusercontent.com/6265975/87991034-2273a500-ca9a-11ea-975e-f3f8ebc5ec49.png">

And for the Index template the broken query loop block:
![Screen Shot 2020-07-16 at 5 57 49 PM](https://user-images.githubusercontent.com/28742426/87726922-f56b7d80-c78d-11ea-8d1d-151517754d1c.png)

Shows posts:
![Screen Shot 2020-07-16 at 5 57 05 PM](https://user-images.githubusercontent.com/28742426/87726956-04523000-c78e-11ea-86ad-34afc96b1f2d.png)

## Types of changes
Bug fix, enhancement

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
