### PR TITLE
useBlockSync: Fix race condition when onChange callback changes

### DIFF
--- a/packages/block-editor/src/components/provider/test/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/test/use-block-sync.js
@@ -362,4 +362,78 @@ describe( 'useBlockSync hook', () => {
 		);
 		expect( onInput ).not.toHaveBeenCalled();
 	} );
+
+	it( 'should use fresh callbacks if onChange/onInput have been updated', async () => {
+		const fakeBlocks = [
+			{ clientId: 'a', innerBlocks: [], attributes: { foo: 1 } },
+		];
+		const onChange1 = jest.fn();
+		const onInput = jest.fn();
+
+		let registry;
+		const setRegistry = ( reg ) => {
+			registry = reg;
+		};
+		let root;
+		await act( async () => {
+			root = create(
+				<TestWrapper
+					setRegistry={ setRegistry }
+					value={ fakeBlocks }
+					onChange={ onChange1 }
+					onInput={ onInput }
+				/>
+			);
+		} );
+
+		// Create a persistent change.
+		registry
+			.dispatch( 'core/block-editor' )
+			.updateBlockAttributes( 'a', { foo: 2 } );
+
+		const updatedBlocks1 = [
+			{ clientId: 'a', innerBlocks: [], attributes: { foo: 2 } },
+		];
+
+		expect( onChange1 ).toHaveBeenCalledWith( updatedBlocks1, {
+			selectionEnd: {},
+			selectionStart: {},
+		} );
+
+		const newBlocks = [
+			{ clientId: 'b', innerBlocks: [], attributes: { foo: 1 } },
+		];
+
+		const onChange2 = jest.fn();
+
+		// Update the component to point at a "different entity" (e.g. different
+		// blocks and onChange handler.)
+		await act( async () => {
+			root.update(
+				<TestWrapper
+					setRegistry={ setRegistry }
+					value={ newBlocks }
+					onChange={ onChange2 }
+					onInput={ onInput }
+				/>
+			);
+		} );
+
+		// Create a persistent change.
+		registry
+			.dispatch( 'core/block-editor' )
+			.updateBlockAttributes( 'b', { foo: 3 } );
+
+		// The first callback should not be called with the new change.
+		expect( onChange1 ).toHaveBeenCalledWith( updatedBlocks1, {
+			selectionEnd: {},
+			selectionStart: {},
+		} );
+
+		// The second callback should be called with the new change.
+		expect( onChange2 ).toHaveBeenCalledWith(
+			[ { clientId: 'b', innerBlocks: [], attributes: { foo: 3 } } ],
+			{ selectionEnd: {}, selectionStart: {} }
+		);
+	} );
 } );

--- a/packages/block-editor/src/components/provider/test/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/test/use-block-sync.js
@@ -363,7 +363,7 @@ describe( 'useBlockSync hook', () => {
 		expect( onInput ).not.toHaveBeenCalled();
 	} );
 
-	it( 'should use fresh callbacks if onChange/onInput have been updated', async () => {
+	it( 'should use fresh callbacks if onChange/onInput have been updated when previous changes have been made', async () => {
 		const fakeBlocks = [
 			{ clientId: 'a', innerBlocks: [], attributes: { foo: 1 } },
 		];
@@ -430,6 +430,63 @@ describe( 'useBlockSync hook', () => {
 		expect( onChange1 ).not.toHaveBeenCalled();
 
 		// The second callback should be called with the new change.
+		expect( onChange2 ).toHaveBeenCalledWith(
+			[ { clientId: 'b', innerBlocks: [], attributes: { foo: 3 } } ],
+			{ selectionEnd: {}, selectionStart: {} }
+		);
+	} );
+
+	it( 'should use fresh callbacks when no previous changes have been made', async () => {
+		const fakeBlocks = [
+			{ clientId: 'a', innerBlocks: [], attributes: { foo: 1 } },
+		];
+		const onChange1 = jest.fn();
+		const onInput = jest.fn();
+
+		let registry;
+		const setRegistry = ( reg ) => {
+			registry = reg;
+		};
+		let root;
+		await act( async () => {
+			root = create(
+				<TestWrapper
+					setRegistry={ setRegistry }
+					value={ fakeBlocks }
+					onChange={ onChange1 }
+					onInput={ onInput }
+				/>
+			);
+		} );
+
+		const newBlocks = [
+			{ clientId: 'b', innerBlocks: [], attributes: { foo: 1 } },
+		];
+
+		const onChange2 = jest.fn();
+
+		// Update the component to point at a "different entity" (e.g. different
+		// blocks and onChange handler.)
+		await act( async () => {
+			root.update(
+				<TestWrapper
+					setRegistry={ setRegistry }
+					value={ newBlocks }
+					onChange={ onChange2 }
+					onInput={ onInput }
+				/>
+			);
+		} );
+
+		// Create a persistent change.
+		registry
+			.dispatch( 'core/block-editor' )
+			.updateBlockAttributes( 'b', { foo: 3 } );
+
+		// The first callback should never be called in this scenario.
+		expect( onChange1 ).not.toHaveBeenCalled();
+
+		// Only the new callback should be called.
 		expect( onChange2 ).toHaveBeenCalledWith(
 			[ { clientId: 'b', innerBlocks: [], attributes: { foo: 3 } } ],
 			{ selectionEnd: {}, selectionStart: {} }

--- a/packages/block-editor/src/components/provider/test/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/test/use-block-sync.js
@@ -404,6 +404,8 @@ describe( 'useBlockSync hook', () => {
 			{ clientId: 'b', innerBlocks: [], attributes: { foo: 1 } },
 		];
 
+		// Reset it so that we can test that it was not called after this point.
+		onChange1.mockReset();
 		const onChange2 = jest.fn();
 
 		// Update the component to point at a "different entity" (e.g. different
@@ -424,11 +426,8 @@ describe( 'useBlockSync hook', () => {
 			.dispatch( 'core/block-editor' )
 			.updateBlockAttributes( 'b', { foo: 3 } );
 
-		// The first callback should not be called with the new change.
-		expect( onChange1 ).toHaveBeenCalledWith( updatedBlocks1, {
-			selectionEnd: {},
-			selectionStart: {},
-		} );
+		// The first callback should not have been called.
+		expect( onChange1 ).not.toHaveBeenCalled();
 
 		// The second callback should be called with the new change.
 		expect( onChange2 ).toHaveBeenCalledWith(

--- a/packages/block-editor/src/components/provider/test/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/test/use-block-sync.js
@@ -436,7 +436,7 @@ describe( 'useBlockSync hook', () => {
 		);
 	} );
 
-	it( 'should use fresh callbacks when no previous changes have been made', async () => {
+	it( 'should use fresh callbacks if onChange/onInput have been updated when no previous changes have been made', async () => {
 		const fakeBlocks = [
 			{ clientId: 'a', innerBlocks: [], attributes: { foo: 1 } },
 		];

--- a/packages/block-editor/src/components/provider/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/use-block-sync.js
@@ -171,7 +171,9 @@ export default function useBlockSync( {
 
 				// Inform the controlling entity that changes have been made to
 				// the block-editor store they should be aware about.
-				const updateParent = isPersistent ? onChange : onInput;
+				const updateParent = isPersistent
+					? onChangeRef.current
+					: onInputRef.current;
 				updateParent( blocks, {
 					selectionStart: getSelectionStart(),
 					selectionEnd: getSelectionEnd(),


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
In the `useBlockSync` hook, if the `onChange` or `onInput` callbacks changed while the same component instance was being used, the old `onChange`/`onInput` callbacks were used instead of the updated ones.

For more context, in #23292, we started setting a ref with the latest onChange/onInput callbacks, but we unfortunately never consumed that ref. cc @youknowriad. This updates the block-editor subscription such that it uses the `onChange` and `onInput` refs. This way, it always uses the latest versions of the callbacks.

Specifically, this fixes #23967 (a result of the race condition).

## How has this been tested?
Locally, in edit-site.

## Screenshots <!-- if applicable -->
### Before:
![gif of before state](https://user-images.githubusercontent.com/28742426/87579765-71899680-c6a4-11ea-88a5-e68b5b0ce8de.gif)

### After:
![gif of after state](https://user-images.githubusercontent.com/6265975/87739236-38c8ea80-c794-11ea-91ca-4d59c50382b4.gif)

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
