### PR TITLE
Add alignment support to post content block

### DIFF
--- a/packages/block-library/src/post-content/block.json
+++ b/packages/block-library/src/post-content/block.json
@@ -7,6 +7,10 @@
 	],
 	"supports": {
 		"align": true,
-		"html": false
+		"html": false,
+		"__experimentalColor": {
+			"gradients": true,
+			"linkColor": true
+		}
 	}
 }

--- a/packages/block-library/src/post-content/block.json
+++ b/packages/block-library/src/post-content/block.json
@@ -7,10 +7,6 @@
 	],
 	"supports": {
 		"align": [ "wide", "full" ],
-		"html": false,
-		"__experimentalColor": {
-			"gradients": true,
-			"linkColor": true
-		}
+		"html": false
 	}
 }

--- a/packages/block-library/src/post-content/block.json
+++ b/packages/block-library/src/post-content/block.json
@@ -6,7 +6,7 @@
 		"postType"
 	],
 	"supports": {
-		"align": true,
+		"align": [ "wide", "full" ],
 		"html": false,
 		"__experimentalColor": {
 			"gradients": true,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Adds background & text color support to the post content block. It works well in the editor, but I think some front end stuff looks weird because of the theme.

Question: do we even want this? I feel like the same thing can be accomplished with a group block around post content.

I didn't add text size stuff since that can be handled inside the blocks. Should we support it in the post content block?

Let me know if anything else needs added to post content. It looks like alignment is working "ok".

## How has this been tested?
Locally in edit site

## Screenshots <!-- if applicable -->
<img width="1422" alt="Screen Shot 2020-07-16 at 7 25 25 PM" src="https://user-images.githubusercontent.com/6265975/87741747-1df97480-c79a-11ea-9215-1a7a10881198.png">

## Types of changes
Enhancement

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
