### PR TITLE
ReusableBlockConvertButton: use React hooks.

### DIFF
--- a/packages/editor/src/components/reusable-blocks-buttons/reusable-block-convert-button.js
+++ b/packages/editor/src/components/reusable-blocks-buttons/reusable-block-convert-button.js
@@ -1,24 +1,61 @@
 /**
- * External dependencies
- */
-import { every } from 'lodash';
-
-/**
  * WordPress dependencies
  */
-import { MenuItem } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
 import { hasBlockSupport, isReusableBlock } from '@wordpress/blocks';
-import { withSelect, withDispatch } from '@wordpress/data';
-import { compose } from '@wordpress/compose';
 import { BlockSettingsMenuControls } from '@wordpress/block-editor';
+import { MenuItem } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
 
-export function ReusableBlockConvertButton( {
-	isVisible,
-	isReusable,
-	onConvertToStatic,
-	onConvertToReusable,
-} ) {
+export default function ReusableBlockConvertButton( { clientIds } ) {
+	const { isReusable, isVisible } = useSelect(
+		( select ) => {
+			const { canUser } = select( 'core' );
+			const { getBlocksByClientId, canInsertBlockType } = select(
+				'core/block-editor'
+			);
+			const { __experimentalGetReusableBlock: getReusableBlock } = select(
+				'core/editor'
+			);
+
+			const blocks = getBlocksByClientId( clientIds );
+
+			const _isReusable =
+				blocks.length === 1 &&
+				blocks[ 0 ] &&
+				isReusableBlock( blocks[ 0 ] ) &&
+				!! getReusableBlock( blocks[ 0 ].attributes.ref );
+
+			// Show 'Convert to Regular Block' when selected block is a reusable block.
+			const _isVisible =
+				isReusable ||
+				// Hide 'Add to Reusable blocks' when reusable blocks are disabled.
+				( canInsertBlockType( 'core/block' ) &&
+					blocks?.every(
+						( block ) =>
+							// Guard against the case where a regular block has *just* been converted.
+							!! block &&
+							// Hide 'Add to Reusable blocks' on invalid blocks.
+							block.isValid &&
+							// Hide 'Add to Reusable blocks' when block doesn't support being made reusable.
+							hasBlockSupport( block.name, 'reusable', true )
+					) &&
+					// Hide 'Add to Reusable blocks' when current doesn't have permission to do that.
+					!! canUser( 'create', 'blocks' ) );
+
+			return {
+				isReusable: _isReusable,
+				isVisible: _isVisible,
+			};
+		},
+		[ clientIds ]
+	);
+
+	const {
+		__experimentalConvertBlockToReusable: convertBlockToReusable,
+		__experimentalConvertBlockToStatic: convertBlockToStatic,
+	} = useDispatch( 'core/editor' );
+
 	if ( ! isVisible ) {
 		return null;
 	}
@@ -30,7 +67,7 @@ export function ReusableBlockConvertButton( {
 					{ ! isReusable && (
 						<MenuItem
 							onClick={ () => {
-								onConvertToReusable();
+								convertBlockToReusable( clientIds );
 								onClose();
 							} }
 						>
@@ -40,7 +77,7 @@ export function ReusableBlockConvertButton( {
 					{ isReusable && (
 						<MenuItem
 							onClick={ () => {
-								onConvertToStatic();
+								convertBlockToStatic( clientIds[ 0 ] );
 								onClose();
 							} }
 						>
@@ -52,61 +89,3 @@ export function ReusableBlockConvertButton( {
 		</BlockSettingsMenuControls>
 	);
 }
-
-export default compose( [
-	withSelect( ( select, { clientIds } ) => {
-		const { getBlocksByClientId, canInsertBlockType } = select(
-			'core/block-editor'
-		);
-		const { __experimentalGetReusableBlock: getReusableBlock } = select(
-			'core/editor'
-		);
-		const { canUser } = select( 'core' );
-
-		const blocks = getBlocksByClientId( clientIds );
-
-		const isReusable =
-			blocks.length === 1 &&
-			blocks[ 0 ] &&
-			isReusableBlock( blocks[ 0 ] ) &&
-			!! getReusableBlock( blocks[ 0 ].attributes.ref );
-
-		// Show 'Convert to Regular Block' when selected block is a reusable block
-		const isVisible =
-			isReusable ||
-			// Hide 'Add to Reusable blocks' when reusable blocks are disabled
-			( canInsertBlockType( 'core/block' ) &&
-				every(
-					blocks,
-					( block ) =>
-						// Guard against the case where a regular block has *just* been converted
-						!! block &&
-						// Hide 'Add to Reusable blocks' on invalid blocks
-						block.isValid &&
-						// Hide 'Add to Reusable blocks' when block doesn't support being made reusable
-						hasBlockSupport( block.name, 'reusable', true )
-				) &&
-				// Hide 'Add to Reusable blocks' when current doesn't have permission to do that
-				!! canUser( 'create', 'blocks' ) );
-
-		return {
-			isReusable,
-			isVisible,
-		};
-	} ),
-	withDispatch( ( dispatch, { clientIds } ) => {
-		const {
-			__experimentalConvertBlockToReusable: convertBlockToReusable,
-			__experimentalConvertBlockToStatic: convertBlockToStatic,
-		} = dispatch( 'core/editor' );
-
-		return {
-			onConvertToStatic() {
-				convertBlockToStatic( clientIds[ 0 ] );
-			},
-			onConvertToReusable() {
-				convertBlockToReusable( clientIds );
-			},
-		};
-	} ),
-] )( ReusableBlockConvertButton );

--- a/packages/editor/src/components/reusable-blocks-buttons/reusable-block-convert-button.js
+++ b/packages/editor/src/components/reusable-blocks-buttons/reusable-block-convert-button.js
@@ -18,7 +18,7 @@ export default function ReusableBlockConvertButton( { clientIds } ) {
 				'core/editor'
 			);
 
-			const blocks = getBlocksByClientId( clientIds );
+			const blocks = getBlocksByClientId( clientIds ) ?? [];
 
 			const _isReusable =
 				blocks.length === 1 &&
@@ -28,10 +28,10 @@ export default function ReusableBlockConvertButton( { clientIds } ) {
 
 			// Show 'Convert to Regular Block' when selected block is a reusable block.
 			const _isVisible =
-				isReusable ||
+				_isReusable ||
 				// Hide 'Add to Reusable blocks' when reusable blocks are disabled.
 				( canInsertBlockType( 'core/block' ) &&
-					blocks?.every(
+					blocks.every(
 						( block ) =>
 							// Guard against the case where a regular block has *just* been converted.
 							!! block &&

--- a/packages/editor/src/components/reusable-blocks-buttons/reusable-block-convert-button.js
+++ b/packages/editor/src/components/reusable-blocks-buttons/reusable-block-convert-button.js
@@ -7,6 +7,14 @@ import { MenuItem } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Menu controls to convert block(s) to reusable block or vice-versa.
+ *
+ * @param {Object}   props           Component props.
+ * @param {string[]} props.clientIds Client ids of selected blocks.
+ *
+ * @return {import('@wordpress/element').WPComponent} The menu controls or null.
+ */
 export default function ReusableBlockConvertButton( { clientIds } ) {
 	const { isReusable, isVisible } = useSelect(
 		( select ) => {


### PR DESCRIPTION
## Description
This PR refactors ReusableBlockConvertButton to use the `useSelect` and `useDispatch` hooks, rather than the HOC equivalents. It also fixes some comment typos and removes an unnecessary Lodash dependency.

Side note: I'm working on a PR to [move the "Convert to Regular Block" button to the block toolbar](https://github.com/WordPress/gutenberg/issues/8403). This PR is intended to polish the code a bit before I make that change.

## How has this been tested?
I've tested to make sure the "Add to Reusable blocks" and "Convert to Reusable Block" options appear when they should and work as intended.

## Types of changes
Only refactoring + code quality changes. Everything should act the same as `master`.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
