### PR TITLE
Fix Copy block button focus loss and try to remove the visually hidden textarea

### DIFF
--- a/packages/compose/src/hooks/use-copy-on-click/index.js
+++ b/packages/compose/src/hooks/use-copy-on-click/index.js
@@ -32,11 +32,13 @@ export default function useCopyOnClick( ref, text, timeout = 4000 ) {
 			container: ref.current,
 		} );
 
-		clipboard.current.on( 'success', ( { clearSelection } ) => {
+		clipboard.current.on( 'success', ( { clearSelection, trigger } ) => {
 			// Clearing selection will move focus back to the triggering button,
 			// ensuring that it is not reset to the body, and further that it is
 			// kept within the rendered node.
 			clearSelection();
+			// Handle ClipboardJS focus bug, see https://github.com/zenorocha/clipboard.js/issues/680
+			trigger.focus();
 
 			if ( timeout ) {
 				setHasCopied( true );

--- a/packages/compose/src/hooks/use-copy-on-click/index.js
+++ b/packages/compose/src/hooks/use-copy-on-click/index.js
@@ -37,8 +37,11 @@ export default function useCopyOnClick( ref, text, timeout = 4000 ) {
 			// ensuring that it is not reset to the body, and further that it is
 			// kept within the rendered node.
 			clearSelection();
+
 			// Handle ClipboardJS focus bug, see https://github.com/zenorocha/clipboard.js/issues/680
-			trigger.focus();
+			if ( trigger ) {
+				trigger.focus();
+			}
 
 			if ( timeout ) {
 				setHasCopied( true );


### PR DESCRIPTION
closes #23994 

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

This PR seeks to solve two issues with the Clipboard.js-powered "Copy" block button.

1. Focus loss when pressing the button
2. The visually hidden textarea used by Clipboard.js is added within the button and stays there: thus, there's an additional, unexpected, tab stop and the textarea is announced by screen readers

For more details, please see the related issue https://github.com/WordPress/gutenberg/issues/23994

## Notes

These behaviors are Clipboard.js bugs (or "features") that produce a sub-optimal experience for keyboard users and assistive technology users.

While working on recent changes in WordPress core I stumbled upon the same issues. See:
https://core.trac.wordpress.org/changeset/48233
https://core.trac.wordpress.org/changeset/48232

I also reported these two issues upstream:
https://github.com/zenorocha/clipboard.js/issues/680
https://github.com/zenorocha/clipboard.js/issues/684

In the meantime, I guess they can be fixed in our implementation.

1
The focus loss is fixed by explicitly setting the focus back on the button. See also similar fixes used in the core changesets linked above.

2
I'd greatly appreciate some help to fix the second issue. 
Ideally, the visually hidden textarea should be removed on the copy action `success`. This is why I fixed it in core. Worth noting Clipboard.js re-adds the textarea at any click so removing it on success looks safe.

However, I couldn't find a nice way to use the fix used in core also in `useCopyOnClick`.

As far as I see, `clipboard.current.destroy();` is used in the `useEffect` cleanup but that's not enough.
It should be called on success. I couldn't find a way to make it work other than adding _one more timeout_ which I guess isn't ideal. Any help would be greatly appreciated.

