### PR TITLE
Support disabling core block patterns

### DIFF
--- a/lib/block-patterns.php
+++ b/lib/block-patterns.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Add support for block patterns and register default patterns.
+ *
+ * @package gutenberg
+ */
+
+add_theme_support( 'core-block-patterns' );
+
+/**
+ * Extends block editor settings to include a list of default patterns.
+ *
+ * @param array $settings Default editor settings.
+ *
+ * @return array Filtered editor settings.
+ */
+function gutenberg_extend_settings_block_patterns( $settings ) {
+	$settings['__experimentalBlockPatterns']          = WP_Block_Patterns_Registry::get_instance()->get_all_registered();
+	$settings['__experimentalBlockPatternCategories'] = WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered();
+
+	return $settings;
+}
+add_filter( 'block_editor_settings', 'gutenberg_extend_settings_block_patterns', 0 );
+
+
+/**
+ * Load a block pattern by name.
+ *
+ * @param string $name Block Pattern File name.
+ *
+ * @return array Block Pattern Array.
+ */
+function gutenberg_load_block_pattern( $name ) {
+	return require( __DIR__ . '/patterns/' . $name . '.php' );
+}
+
+/**
+ * Register default patterns and categories, potentially overriding ones that were already registered in Core.
+ *
+ * This can be removed when plugin support requires WordPress 5.5.0+, and patterns have been synced back to Core.
+ *
+ * @see https://core.trac.wordpress.org/ticket/50550
+ */
+function gutenberg_register_block_patterns() {
+	$should_register_core_patterns = get_theme_support( 'core-block-patterns' );
+
+	if ( $should_register_core_patterns ) {
+		register_block_pattern( 'core/text-two-columns', gutenberg_load_block_pattern( 'text-two-columns' ) );
+		register_block_pattern( 'core/two-buttons', gutenberg_load_block_pattern( 'two-buttons' ) );
+		register_block_pattern( 'core/two-images', gutenberg_load_block_pattern( 'two-images' ) );
+		register_block_pattern( 'core/text-two-columns-with-images', gutenberg_load_block_pattern( 'text-two-columns-with-images' ) );
+		register_block_pattern( 'core/text-three-columns-buttons', gutenberg_load_block_pattern( 'text-three-columns-buttons' ) );
+		register_block_pattern( 'core/large-header', gutenberg_load_block_pattern( 'large-header' ) );
+		register_block_pattern( 'core/large-header-paragraph', gutenberg_load_block_pattern( 'large-header-paragraph' ) );
+		register_block_pattern( 'core/three-buttons', gutenberg_load_block_pattern( 'three-buttons' ) );
+		register_block_pattern( 'core/quote', gutenberg_load_block_pattern( 'quote' ) );
+	}
+
+	register_block_pattern_category( 'buttons', array( 'label' => _x( 'Buttons', 'Block pattern category', 'gutenberg' ) ) );
+	register_block_pattern_category( 'columns', array( 'label' => _x( 'Columns', 'Block pattern category', 'gutenberg' ) ) );
+	register_block_pattern_category( 'gallery', array( 'label' => _x( 'Gallery', 'Block pattern category', 'gutenberg' ) ) );
+	register_block_pattern_category( 'header', array( 'label' => _x( 'Headers', 'Block pattern category', 'gutenberg' ) ) );
+	register_block_pattern_category( 'text', array( 'label' => _x( 'Text', 'Block pattern category', 'gutenberg' ) ) );
+}
+add_action( 'init', 'gutenberg_register_block_patterns' );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -622,32 +622,6 @@ function gutenberg_extend_block_editor_styles( $settings ) {
 add_filter( 'block_editor_settings', 'gutenberg_extend_block_editor_styles' );
 
 /**
- * Load a block pattern by name.
- *
- * @param string $name Block Pattern File name.
- *
- * @return array Block Pattern Array.
- */
-function gutenberg_load_block_pattern( $name ) {
-	return require( __DIR__ . '/patterns/' . $name . '.php' );
-}
-
-/**
- * Extends block editor settings to include a list of default patterns.
- *
- * @param array $settings Default editor settings.
- *
- * @return array Filtered editor settings.
- */
-function gutenberg_extend_settings_block_patterns( $settings ) {
-	$settings['__experimentalBlockPatterns']          = WP_Block_Patterns_Registry::get_instance()->get_all_registered();
-	$settings['__experimentalBlockPatternCategories'] = WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered();
-
-	return $settings;
-}
-add_filter( 'block_editor_settings', 'gutenberg_extend_settings_block_patterns', 0 );
-
-/**
  * Extends block editor settings to determine whether to use custom line height controls.
  *
  * @param array $settings Default editor settings.
@@ -702,40 +676,3 @@ function gutenberg_extend_settings_link_color( $settings ) {
 	return $settings;
 }
 add_filter( 'block_editor_settings', 'gutenberg_extend_settings_link_color' );
-
-/**
- * Register default patterns, potentially overriding ones that were already registered in Core.
- *
- * This can be removed when plugin support requires WordPress 5.5.0+, and patterns have been synced back to Core.
- *
- * @see https://core.trac.wordpress.org/ticket/50550
- */
-function gutenberg_register_block_patterns() {
-	if ( class_exists( 'WP_Block_Patterns_Registry' ) ) {
-		register_block_pattern( 'core/text-two-columns', gutenberg_load_block_pattern( 'text-two-columns' ) );
-		register_block_pattern( 'core/two-buttons', gutenberg_load_block_pattern( 'two-buttons' ) );
-		register_block_pattern( 'core/two-images', gutenberg_load_block_pattern( 'two-images' ) );
-		register_block_pattern( 'core/text-two-columns-with-images', gutenberg_load_block_pattern( 'text-two-columns-with-images' ) );
-		register_block_pattern( 'core/text-three-columns-buttons', gutenberg_load_block_pattern( 'text-three-columns-buttons' ) );
-		register_block_pattern( 'core/large-header', gutenberg_load_block_pattern( 'large-header' ) );
-		register_block_pattern( 'core/large-header-paragraph', gutenberg_load_block_pattern( 'large-header-paragraph' ) );
-		register_block_pattern( 'core/three-buttons', gutenberg_load_block_pattern( 'three-buttons' ) );
-		register_block_pattern( 'core/quote', gutenberg_load_block_pattern( 'quote' ) );
-	}
-}
-add_action( 'init', 'gutenberg_register_block_patterns' );
-
-/*
- * Register default pattern categories if not registered in Core already.
- *
- * This can be removed when plugin support requires WordPress 5.5.0+.
- *
- * @see https://core.trac.wordpress.org/ticket/50550
- */
-if ( class_exists( 'WP_Block_Pattern_Categories_Registry' ) ) {
-	register_block_pattern_category( 'buttons', array( 'label' => _x( 'Buttons', 'Block pattern category', 'gutenberg' ) ) );
-	register_block_pattern_category( 'columns', array( 'label' => _x( 'Columns', 'Block pattern category', 'gutenberg' ) ) );
-	register_block_pattern_category( 'gallery', array( 'label' => _x( 'Gallery', 'Block pattern category', 'gutenberg' ) ) );
-	register_block_pattern_category( 'header', array( 'label' => _x( 'Headers', 'Block pattern category', 'gutenberg' ) ) );
-	register_block_pattern_category( 'text', array( 'label' => _x( 'Text', 'Block pattern category', 'gutenberg' ) ) );
-}

--- a/lib/load.php
+++ b/lib/load.php
@@ -86,6 +86,7 @@ if ( ! class_exists( 'WP_Block_List' ) ) {
 require dirname( __FILE__ ) . '/compat.php';
 require dirname( __FILE__ ) . '/utils.php';
 
+require dirname( __FILE__ ) . '/block-patterns.php';
 require dirname( __FILE__ ) . '/blocks.php';
 require dirname( __FILE__ ) . '/templates.php';
 require dirname( __FILE__ ) . '/template-parts.php';


### PR DESCRIPTION
This PR refactors the block patterns code a little bit and adds the "core-block-patterns" theme support flag that already landed on Core. That way, users of WP 5.4 + plugin would also be able to disable the core block patterns.