### PR TITLE
Components: Fix Toolbar arrow key navigation in RTL contexts

### DIFF
--- a/packages/components/src/toolbar/toolbar-container.js
+++ b/packages/components/src/toolbar/toolbar-container.js
@@ -12,12 +12,17 @@ import { forwardRef } from '@wordpress/element';
  * Internal dependencies
  */
 import ToolbarContext from '../toolbar-context';
+import { getRTL } from '../utils/rtl';
 
 function ToolbarContainer( { accessibilityLabel, ...props }, ref ) {
 	// https://reakit.io/docs/basic-concepts/#state-hooks
 	// Passing baseId for server side rendering (which includes snapshots)
 	// If an id prop is passed to Toolbar, toolbar items will use it as a base for their ids
-	const toolbarState = useToolbarState( { loop: true, baseId: props.id } );
+	const toolbarState = useToolbarState( {
+		loop: true,
+		baseId: props.id,
+		rtl: getRTL(),
+	} );
 
 	return (
 		// This will provide state for `ToolbarButton`'s


### PR DESCRIPTION
This PR fixes https://github.com/WordPress/gutenberg/issues/23265#issuecomment-659410357.

**Before**:

![GIF showing the interaction on the block toolbar. Pressing arrow right moves focus to the toolbar item on the left, and pressing arrow left moves focus to the toolbar item on the right.](https://user-images.githubusercontent.com/3068563/87921507-0ac3fe80-ca51-11ea-9f5f-160506ef2f8c.gif)


**After:**

![GIF showing the interaction on the block toolbar. Pressing arrow right moves focus to the toolbar item on the right, and pressing arrow left moves focus to the toolbar item on the left.](https://user-images.githubusercontent.com/3068563/87921524-10214900-ca51-11ea-908b-4dbdf93bc4b9.gif)


## How to test

1. Set the site language to an RTL langauge, such as Arabic, in the settings.
2. Go to the block editor and interact with the block toolbar using arrow keys.
3. Make sure <kbd>ArrowLeft</kbd> moves focus to the left, and <kbd>ArrowRight</kbd> moves focus to the right.