### PR TITLE
Fix Inserter on the widgets screen

### DIFF
--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -136,6 +136,7 @@ class Inserter extends Component {
 				/>
 			);
 		}
+
 		return (
 			<InserterMenu
 				onSelect={ onClose }

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -153,9 +153,7 @@ function InserterMenu( {
 				</div>
 			</div>
 			{ showInserterHelpPanel && hoveredItem && (
-				<div className="block-editor-inserter__preview-container">
-					<InserterPreviewPanel item={ hoveredItem } />
-				</div>
+				<InserterPreviewPanel item={ hoveredItem } />
 			) }
 		</div>
 	);

--- a/packages/block-editor/src/components/inserter/preview-panel.js
+++ b/packages/block-editor/src/components/inserter/preview-panel.js
@@ -18,7 +18,7 @@ import BlockPreview from '../block-preview';
 function InserterPreviewPanel( { item } ) {
 	const hoveredItemBlockType = getBlockType( item.name );
 	return (
-		<div className="block-editor-inserter__menu-preview-panel">
+		<div className="block-editor-inserter__preview-container">
 			<div className="block-editor-inserter__preview">
 				{ isReusableBlock( item ) || hoveredItemBlockType.example ? (
 					<div className="block-editor-inserter__preview-content">

--- a/packages/block-editor/src/components/inserter/search-items.js
+++ b/packages/block-editor/src/components/inserter/search-items.js
@@ -110,7 +110,7 @@ export const searchBlockItems = (
  * @param {Object} config     Search Config.
  * @return {Array}            Filtered item list.
  */
-export const searchItems = ( items, searchTerm, config = {} ) => {
+export const searchItems = ( items = [], searchTerm = '', config = {} ) => {
 	const normalizedSearchTerms = normalizeSearchTerm( searchTerm );
 	if ( normalizedSearchTerms.length === 0 ) {
 		return items;

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -19,10 +19,6 @@ $block-inserter-tabs-height: 44px;
 .block-editor-inserter__popover .block-editor-inserter__menu {
 	margin: -$grid-unit-15;
 
-	.block-editor-inserter__search {
-		top: -$grid-unit-15;
-	}
-
 	.block-editor-inserter__tabs .components-tab-panel__tabs {
 		top: $grid-unit-10 + $grid-unit-20 + $grid-unit-60 - $grid-unit-15;
 	}
@@ -30,6 +26,10 @@ $block-inserter-tabs-height: 44px;
 	.block-editor-inserter__main-area {
 		overflow: visible;
 		height: auto;
+	}
+
+	.block-editor-inserter__preview-container {
+		display: none;
 	}
 }
 

--- a/packages/edit-widgets/src/components/header/index.js
+++ b/packages/edit-widgets/src/components/header/index.js
@@ -10,6 +10,7 @@ import {
 } from '@wordpress/block-editor';
 import { PinnedItems } from '@wordpress/interface';
 import { useViewportMatch } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -22,6 +23,13 @@ const inserterToggleProps = { isPrimary: true };
 
 function Header( { isCustomizer } ) {
 	const isLargeViewport = useViewportMatch( 'medium' );
+	const rootClientId = useSelect( ( select ) => {
+		const { getBlockRootClientId, getBlockSelectionEnd } = select(
+			'core/block-editor'
+		);
+		return getBlockRootClientId( getBlockSelectionEnd() );
+	}, [] );
+
 	return (
 		<>
 			<div className="edit-widgets-header">
@@ -30,6 +38,7 @@ function Header( { isCustomizer } ) {
 						position="bottom right"
 						showInserterHelpPanel
 						toggleProps={ inserterToggleProps }
+						rootClientId={ rootClientId }
 					/>
 					<UndoButton />
 					<RedoButton />


### PR DESCRIPTION
This PR fixes the inserter on the widgets screen but also fixes the global inserter when it's rendered on a popover. (This is a component in the public API)

**Testing instructions**

- Select a widget area.
- Open the inserter on the widgets screen.
- Make sure you can insert blocks there.