### PR TITLE
Prevent JavaScript error when using arrow navigation in URLInput

### DIFF
--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -64,10 +64,10 @@ class URLInput extends Component {
 		if (
 			showSuggestions &&
 			selectedSuggestion !== null &&
+			this.suggestionNodes[ selectedSuggestion ] &&
 			! this.scrollingIntoView
 		) {
 			this.scrollingIntoView = true;
-
 			scrollIntoView(
 				this.suggestionNodes[ selectedSuggestion ],
 				this.autocompleteRef.current,


### PR DESCRIPTION
closes #24037 

**Testing instructions**

 - Add a link
 - Navigate the link suggestions using arrow keys
 - No JS errors should be triggered.