### PR TITLE
Clarify custom link color documentation for themes

### DIFF
--- a/docs/designers-developers/developers/themes/theme-support.md
+++ b/docs/designers-developers/developers/themes/theme-support.md
@@ -372,4 +372,24 @@ Using the Gutenberg plugin (version 8.3 or later), link color control is availab
 add_theme_support('experimental-link-color');
 ```
 
-If a theme opts in, it should [define default link colors](https://developer.wordpress.org/block-editor/developers/themes/theme-json/#color-properties) in `experimental-theme.json` (or in its theme styles if no `experimental-theme.json` is present). The theme should also ensure that its link styles map to the `--wp--style--color--link` variable in both the editor and front-end stylesheets. 
+If a theme opts in, it should [define default link colors](https://developer.wordpress.org/block-editor/developers/themes/theme-json/#color-properties) in `experimental-theme.json` (or in its theme styles if no `experimental-theme.json` is present). For example:
+
+```css
+{ 
+    "global": {
+        "styles": {
+            "color": {
+                "link": "hotpink"
+            }
+        }
+    }
+}
+```
+
+If the theme styles the link color in its stylesheets (editor and front-end), it should ensure it maps to the `--wp--style--color--link` CSS variable:
+
+```css
+a {
+    color: var(--wp--style--color--link);
+}
+```

--- a/docs/designers-developers/developers/themes/theme-support.md
+++ b/docs/designers-developers/developers/themes/theme-support.md
@@ -371,3 +371,5 @@ Using the Gutenberg plugin (version 8.3 or later), link color control is availab
 ```php
 add_theme_support('experimental-link-color');
 ```
+
+If a theme opts in, it should [define default link colors](https://developer.wordpress.org/block-editor/developers/themes/theme-json/#color-properties) in `experimental-theme.json` (or in its theme styles if no `experimental-theme.json` is present). The theme should also ensure that its link styles map to the `--wp--style--color--link` variable in both the editor and front-end stylesheets. 


### PR DESCRIPTION
[Following up on](https://github.com/WordPress/gutenberg/pull/23590#issuecomment-658804519) #23590, this PR clarifies how themes can properly opt-in and support the experimental custom link color. 

@nosolosw, does this look about right to you?