### PR TITLE
Docs: Fix broken links in block-based themes tutorial

### DIFF
--- a/docs/designers-developers/developers/tutorials/block-based-themes/README.md
+++ b/docs/designers-developers/developers/tutorials/block-based-themes/README.md
@@ -15,7 +15,7 @@ Additional documentation for block-based themes is available at https://develope
  1. [What is needed to create a block-based theme?](/docs/designers-developers/developers/tutorials/block-based-themes/README.md#what-is-needed-to-create-a-block-based-theme)
  2. [Creating the theme](/docs/designers-developers/developers/tutorials/block-based-themes/README.md#creating-the-theme)
  3. [Creating the templates and template parts](/docs/designers-developers/developers/tutorials/block-based-themes/README.md#creating-the-templates-and-template-parts)
- 4. [Experimental-theme.json -Global styles](/docs/designers-developers/developers/tutorials/block-based-themes/README.md##experimental-themejson--global-styles)
+ 4. [Experimental-theme.json -Global styles](/docs/designers-developers/developers/tutorials/block-based-themes/README.md#experimental-themejson--global-styles)
  5. [Adding blocks](/docs/designers-developers/developers/tutorials/block-based-themes/block-based-themes-2-adding-blocks.md)
 
 ## What is needed to create a block-based theme?
@@ -390,4 +390,4 @@ Below are the presets and styles combined:
 }
 ```
 
-## [Adding blocks](docs/designers-developers/developers/tutorials/block-based-themes/block-based-themes-2-adding-blocks.md)
+## [Adding blocks](/docs/designers-developers/developers/tutorials/block-based-themes/block-based-themes-2-adding-blocks.md)


### PR DESCRIPTION
Minor followup from #23732. Two of the nav links weren't properly formatted and resulted in broken links. This PR fixes them. 👍 