### PR TITLE
(JS) Color Values: Rename brand to theme. Add fallback values.

### DIFF
--- a/packages/components/src/box-control/styles/box-control-visualizer-styles.js
+++ b/packages/components/src/box-control/styles/box-control-visualizer-styles.js
@@ -31,7 +31,8 @@ export const Container = styled.div`
 
 export const Side = styled.div`
 	box-sizing: border-box;
-	background: ${ color( 'ui.brand' ) };
+	background: ${ color( 'blue.wordpress.700' ) };
+	background: ${ color( 'ui.theme' ) };
 	filter: brightness( 1 );
 	opacity: 0;
 	position: absolute;

--- a/packages/components/src/focal-point-picker/styles/focal-point-style.js
+++ b/packages/components/src/focal-point-picker/styles/focal-point-style.js
@@ -45,5 +45,6 @@ export const PointerIconPathOutline = styled( Path )`
 `;
 
 export const PointerIconPathFill = styled( Path )`
-	fill: ${ color( 'ui.brand' ) };
+	fill: ${ color( 'blue.wordpress.700' ) };
+	fill: ${ color( 'ui.theme' ) };
 `;

--- a/packages/components/src/range-control/index.js
+++ b/packages/components/src/range-control/index.js
@@ -42,7 +42,7 @@ function RangeControl(
 		beforeIcon,
 		className,
 		currentInput,
-		color: colorProp = color( 'ui.brand' ),
+		color: colorProp = color( 'ui.theme' ),
 		disabled = false,
 		help,
 		initialPosition,

--- a/packages/components/src/range-control/stories/index.js
+++ b/packages/components/src/range-control/stories/index.js
@@ -32,7 +32,7 @@ const DefaultExample = () => {
 		afterIcon: text( 'afterIcon', '' ),
 		allowReset: boolean( 'allowReset', false ),
 		beforeIcon: text( 'beforeIcon', '' ),
-		color: text( 'color', color( 'ui.brand' ) ),
+		color: text( 'color', color( 'ui.theme' ) ),
 		disabled: boolean( 'disabled', false ),
 		help: text( 'help', '' ),
 		label: text( 'label', 'Range Label' ),

--- a/packages/components/src/range-control/styles/range-control-styles.js
+++ b/packages/components/src/range-control/styles/range-control-styles.js
@@ -33,6 +33,7 @@ const wrapperMargin = ( { marks } ) =>
 
 export const Wrapper = styled.span`
 	box-sizing: border-box;
+	color: ${ color( 'blue.medium.focus' ) };
 	display: block;
 	flex: 1;
 	padding-top: 15px;

--- a/packages/components/src/utils/colors-values.js
+++ b/packages/components/src/utils/colors-values.js
@@ -133,13 +133,18 @@ export const ALERT = {
 	green: '#4ab866',
 };
 
+export const ADMIN = {
+	theme: `var( --wp-admin-theme-color, ${ BLUE.wordpress[ 700 ] })`,
+	themeDark10: `var( --wp-admin-theme-color-darker-10, ${ BLUE.medium.focus })`,
+};
+
 // Namespaced values for raw colors hex codes
 export const UI = {
+	theme: ADMIN.theme,
 	background: BASE.white,
 	backgroundDisabled: LIGHT_GRAY[ 200 ],
-	brand: `var( --wp-admin-theme-color, ${ BLUE.wordpress[ 700 ] })`,
 	border: G2.darkGray.primary,
-	borderFocus: `var( --wp-admin-theme-color-darker-10, ${ BLUE.medium.focus })`,
+	borderFocus: ADMIN.themeDark10,
 	borderDisabled: DARK_GRAY[ 700 ],
 	borderLight: LIGHT_GRAY[ 600 ],
 	label: DARK_GRAY[ 500 ],
@@ -158,6 +163,7 @@ export const COLORS = {
 	lightGrayLight: LIGHT_OPACITY_LIGHT,
 	blue: merge( {}, BLUE, G2.blue ),
 	alert: ALERT,
+	admin: ADMIN,
 	ui: UI,
 };
 


### PR DESCRIPTION
<img width="436" alt="Screen Shot 2020-07-20 at 11 07 24 AM" src="https://user-images.githubusercontent.com/2322354/87953616-42df3780-ca79-11ea-8b04-0f41835a7888.png">

This PR is a follow up to https://github.com/WordPress/gutenberg/pull/23936

It fixes an IE11 regression for CSS variable support. It also renames the color `ui.brand` usage to `ui.theme`, which is feels more appropriate for this project.

## How has this been tested?

* Tested locally (Storybook + Gutenberg)
* Run `npm run dev`
* Add a Column block
* Ensure the slider renders correctly

## Types of changes

At the moment, we have to manually add fallbacks for any CSS `var()` usage (for CSS-in-JS generated styles). The Sass workflow offers automatic fallback generation thanks to it's PostCSS process. I recognize this isn't a great solution (especially at scale).

We'll need to look into a more automated solution for CSS variable fallbacks (as well as other features like RTL handling).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [n/a] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [n/a] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [n/a] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
