### PR TITLE
Fix Navigation Block submenu being overlapped by Cover block overlay

### DIFF
--- a/packages/block-library/src/navigation-link/style.scss
+++ b/packages/block-library/src/navigation-link/style.scss
@@ -37,7 +37,7 @@
 		left: 0;
 		top: 100%;
 		width: fit-content;
-		z-index: 1;
+		z-index: 2;
 		opacity: 0;
 		transition: opacity 0.1s linear;
 		visibility: hidden;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This PR increases the `z-index`, for the submenu flyout. Because currently the flyout is hidden behind the `wp-block-cover` as shown [in this issue](https://github.com/Automattic/wp-calypso/issues/41737). 

## How has this been tested?
I tested in FF and Chrome.

## Screenshots <!-- if applicable -->
Available in the issue.

## Types of changes
Minor CSS change.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->

Fixes: https://github.com/Automattic/wp-calypso/issues/41737
