### PR TITLE
Add check for button text before rendering Button block

### DIFF
--- a/packages/block-library/src/button/save.js
+++ b/packages/block-library/src/button/save.js
@@ -33,17 +33,21 @@ export default function save( { attributes } ) {
 	// A title will no longer be assigned for new or updated button block links.
 
 	return (
-		<div>
-			<RichText.Content
-				tagName="a"
-				className={ buttonClasses }
-				href={ url }
-				title={ title }
-				style={ buttonStyle }
-				value={ text }
-				target={ linkTarget }
-				rel={ rel }
-			/>
-		</div>
+		<>
+			{ text && (
+				<div>
+					<RichText.Content
+						tagName="a"
+						className={ buttonClasses }
+						href={ url }
+						title={ title }
+						style={ buttonStyle }
+						value={ text }
+						target={ linkTarget }
+						rel={ rel }
+					/>
+				</div>
+			) }
+		</>
 	);
 }


### PR DESCRIPTION
## Description
This PR adds a check for the `text` attribute before rendering the Button block on the front-end. This prevents an empty `<div class="wp-block-button"><a class="wp-block-button__link"></a></div>` from displaying on the front-end. 

Closes #17221

## How has this been tested?
Tested with WP 5.5 RC
Tested to see if we need a deprecation (_not needed_)


## Screenshots <!-- if applicable -->
### Before:
Editor:
<img width="884" alt="Screen Shot 2020-07-20 at 12 18 40 PM" src="https://user-images.githubusercontent.com/1813435/87961564-de75a580-ca83-11ea-9ed7-7d0779e4424b.png">
Front-end:
<img width="956" alt="Screen Shot 2020-07-20 at 12 25 29 PM" src="https://user-images.githubusercontent.com/1813435/87961711-1f6dba00-ca84-11ea-949c-daac990b6b43.png">


### After:
<img width="884" alt="Screen Shot 2020-07-20 at 12 18 40 PM" src="https://user-images.githubusercontent.com/1813435/87961564-de75a580-ca83-11ea-9ed7-7d0779e4424b.png">
<img width="908" alt="Screen Shot 2020-07-20 at 12 18 47 PM" src="https://user-images.githubusercontent.com/1813435/87961604-f4836600-ca83-11ea-8d13-24aeee2bf9ac.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
