### PR TITLE
Move "Convert to regular blocks" button to block toolbar.

### DIFF
--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -7,10 +7,17 @@ import { partial } from 'lodash';
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { Placeholder, Spinner, Disabled } from '@wordpress/components';
+import {
+	Placeholder,
+	Spinner,
+	Disabled,
+	ToolbarButton,
+	ToolbarGroup,
+} from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import {
+	BlockControls,
 	BlockEditorProvider,
 	BlockList,
 	WritingFlow,
@@ -105,6 +112,7 @@ class ReusableBlockEdit extends Component {
 
 	render() {
 		const {
+			convertToStatic,
 			isSelected,
 			reusableBlock,
 			isFetching,
@@ -148,21 +156,32 @@ class ReusableBlockEdit extends Component {
 		}
 
 		return (
-			<div className="block-library-block__reusable-block-container">
-				{ ( isSelected || isEditing ) && (
-					<ReusableBlockEditPanel
-						isEditing={ isEditing }
-						title={ title !== null ? title : reusableBlock.title }
-						isSaving={ isSaving && ! reusableBlock.isTemporary }
-						isEditDisabled={ ! canUpdateBlock }
-						onEdit={ this.startEditing }
-						onChangeTitle={ this.setTitle }
-						onSave={ this.save }
-						onCancel={ this.stopEditing }
-					/>
-				) }
-				{ element }
-			</div>
+			<>
+				<BlockControls>
+					<ToolbarGroup>
+						<ToolbarButton onClick={ convertToStatic }>
+							{ __( 'Convert to regular blocks' ) }
+						</ToolbarButton>
+					</ToolbarGroup>
+				</BlockControls>
+				<div className="block-library-block__reusable-block-container">
+					{ ( isSelected || isEditing ) && (
+						<ReusableBlockEditPanel
+							isEditing={ isEditing }
+							title={
+								title !== null ? title : reusableBlock.title
+							}
+							isSaving={ isSaving && ! reusableBlock.isTemporary }
+							isEditDisabled={ ! canUpdateBlock }
+							onEdit={ this.startEditing }
+							onChangeTitle={ this.setTitle }
+							onSave={ this.save }
+							onCancel={ this.stopEditing }
+						/>
+					) }
+					{ element }
+				</div>
+			</>
 		);
 	}
 }
@@ -197,6 +216,7 @@ export default compose( [
 	} ),
 	withDispatch( ( dispatch, ownProps ) => {
 		const {
+			__experimentalConvertBlockToStatic: convertBlockToStatic,
 			__experimentalFetchReusableBlocks: fetchReusableBlocks,
 			__experimentalUpdateReusableBlock: updateReusableBlock,
 			__experimentalSaveReusableBlock: saveReusableBlock,
@@ -207,6 +227,9 @@ export default compose( [
 			fetchReusableBlock: partial( fetchReusableBlocks, ref ),
 			onChange: partial( updateReusableBlock, ref ),
 			onSave: partial( saveReusableBlock, ref ),
+			convertToStatic() {
+				convertBlockToStatic( ownProps.clientId );
+			},
 		};
 	} ),
 ] )( ReusableBlockEdit );

--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -225,11 +225,7 @@ describe( 'Reusable blocks', () => {
 		await insertReusableBlock( 'Surprised greeting block' );
 
 		// Convert block to a regular block
-		await clickBlockToolbarButton( 'More options' );
-		const convertButton = await page.waitForXPath(
-			'//button[text()="Convert to Regular Block"]'
-		);
-		await convertButton.click();
+		await clickBlockToolbarButton( 'Convert to regular blocks', 'content' );
 
 		// Check that we have a paragraph block on the page
 		const block = await page.$(
@@ -331,11 +327,7 @@ describe( 'Reusable blocks', () => {
 		await insertReusableBlock( 'Multi-selection reusable block' );
 
 		// Convert block to a regular block
-		await clickBlockToolbarButton( 'More options' );
-		const convertButton = await page.waitForXPath(
-			'//button[text()="Convert to Regular Block"]'
-		);
-		await convertButton.click();
+		await clickBlockToolbarButton( 'Convert to regular blocks', 'content' );
 
 		// Check that we have two paragraph blocks on the page
 		expect( await getEditedPostContent() ).toMatchSnapshot();


### PR DESCRIPTION
## Description
Closes #8403.

This PR moves the option to convert an instance of a reusable block to just regular blocks. It moves it out of the block toolbar's "More options" menu to the top-level block toolbar. Since this action is specific to the "Reusable Block" block, it makes more sense to appear here rather than hidden in the menu, and it makes the button a lot more visible than before.

It also changes the wording of the button from "Convert to Regular Block" to "Convert to regular blocks", to be more consistent with other buttons that use sentence case.

## How has this been tested?
I tested to make sure that creating reusable blocks and converting instances of them back to regular blocks both still worked.

It's worth noting that the buggy behavior described in #22832 continues to exist, but this bug does not affect the behavior of the button, nor does it prevent it from appearing.

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/19592990/87975607-74fc9380-ca91-11ea-8c24-2ef473ab3e72.png)

### After
![image](https://user-images.githubusercontent.com/19592990/87976275-75495e80-ca92-11ea-81e8-c6ea989ee5e5.png)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
