### PR TITLE
Remove Link settings PanelBody from Button block

### DIFF
--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -12,8 +12,6 @@ import {
 	KeyboardShortcuts,
 	PanelBody,
 	RangeControl,
-	TextControl,
-	ToggleControl,
 	ToolbarButton,
 	ToolbarGroup,
 	Popover,
@@ -166,12 +164,6 @@ function ButtonEdit( props ) {
 		text,
 		url,
 	} = attributes;
-	const onSetLinkRel = useCallback(
-		( value ) => {
-			setAttributes( { rel: value } );
-		},
-		[ setAttributes ]
-	);
 
 	const onToggleOpenInNewTab = useCallback(
 		( value ) => {
@@ -240,18 +232,6 @@ function ButtonEdit( props ) {
 					borderRadius={ borderRadius }
 					setAttributes={ setAttributes }
 				/>
-				<PanelBody title={ __( 'Link settings' ) }>
-					<ToggleControl
-						label={ __( 'Open in new tab' ) }
-						onChange={ onToggleOpenInNewTab }
-						checked={ linkTarget === '_blank' }
-					/>
-					<TextControl
-						label={ __( 'Link rel' ) }
-						value={ rel || '' }
-						onChange={ onSetLinkRel }
-					/>
-				</PanelBody>
 			</InspectorControls>
 		</>
 	);


### PR DESCRIPTION
## Description
Closes #23768 by removing the duplicate Link Settings PanelBody, following the pattern of removing duplicate methods for the same actions, as seen in the Heading block #20246. 

One side-effect (that we'll need to address) is that the Link Settings PanelBody allowed for setting the `rel` attribute. I suggest that this is added to the [URLPicker](https://github.com/WordPress/gutenberg/blob/bdfdd73f4bd9295057b9bfa51fc996185dedb44f/packages/block-library/src/button/edit.js#L70) within the Button block. 

## How has this been tested?
WP 5.5 RC

## Screenshots <!-- if applicable -->
<img width="1234" alt="Screen Shot 2020-07-20 at 2 34 29 PM" src="https://user-images.githubusercontent.com/1813435/87973194-243b6980-ca96-11ea-8936-0d815640718b.png">

## Types of changes
Removing duplicate UI.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
