### PR TITLE
I18N: Fix missing plural forms for block related strings

### DIFF
--- a/packages/block-editor/src/components/block-draggable/draggable-chip.js
+++ b/packages/block-editor/src/components/block-draggable/draggable-chip.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { _n, sprintf } from '@wordpress/i18n';
 import { getBlockType } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 import { Flex, FlexItem } from '@wordpress/components';
@@ -43,8 +43,8 @@ export default function BlockDraggableChip( { clientIds } ) {
 							<BlockIcon icon={ icon } />
 						) : (
 							sprintf(
-								/* translators: %d: number of blocks. */
-								__( '%d blocks' ),
+								/* translators: %d: Number of blocks. */
+								_n( '%d block', '%d blocks', clientIds.length ),
 								clientIds.length
 							)
 						) }

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -8,7 +8,7 @@ import {
 	documentHasUncollapsedSelection,
 } from '@wordpress/dom';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -34,12 +34,12 @@ export function useNotifyCopy() {
 			notice =
 				eventType === 'copy'
 					? sprintf(
-							// Translators: Name of the block being copied, e.g. "Paragraph"
+							// Translators: Name of the block being copied, e.g. "Paragraph".
 							__( 'Copied "%s" to clipboard.' ),
 							title
 					  )
 					: sprintf(
-							// Translators: Name of the block being cut, e.g. "Paragraph"
+							// Translators: Name of the block being cut, e.g. "Paragraph".
 							__( 'Moved "%s" to clipboard.' ),
 							title
 					  );
@@ -47,13 +47,21 @@ export function useNotifyCopy() {
 			notice =
 				eventType === 'copy'
 					? sprintf(
-							// Translators: Number of blocks being copied
-							__( 'Copied %d blocks to clipboard.' ),
+							// Translators: %d: Number of blocks being copied.
+							_n(
+								'Copied %d block to clipboard.',
+								'Copied %d blocks to clipboard.',
+								selectedBlockClientIds.length
+							),
 							selectedBlockClientIds.length
 					  )
 					: sprintf(
-							// Translators: Number of blocks being cut
-							__( 'Moved %d blocks to clipboard.' ),
+							// Translators: %d: Number of blocks being cut.
+							_n(
+								'Moved %d block to clipboard.',
+								'Moved %d blocks to clipboard.',
+								selectedBlockClientIds.length
+							),
 							selectedBlockClientIds.length
 					  );
 		}

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -112,7 +112,7 @@ function useInsertionPoint( {
 			// translators: %d: the name of the block that has been added
 			const message = _n(
 				'%d block added.',
-				'%d blocks added',
+				'%d blocks added.',
 				blocks.length
 			);
 			speak( message );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This adds the missing `_n()` calls for strings with a placeholder for a block count.

## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
