### PR TITLE
Set Style sidebar panel initialOpen to false

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -67,7 +67,7 @@ const BlockInspector = ( {
 			<BlockCard blockType={ blockType } />
 			{ hasBlockStyles && (
 				<div>
-					<PanelBody title={ __( 'Styles' ) }>
+					<PanelBody title={ __( 'Styles' ) } initialOpen={ false }>
 						<BlockStyles clientId={ selectedBlockClientId } />
 						{ hasBlockSupport(
 							blockType.name,


### PR DESCRIPTION
## Description
This PR sets the initialOpen prop to false for the Styles PanelBody which will clean up the Settings Sidebar UI and lowering cognitive overload. Closes #24072.

## Screenshots <!-- if applicable -->
### Before:
<img width="1298" alt="Screen Shot 2020-07-20 at 2 52 16 PM" src="https://user-images.githubusercontent.com/1813435/87976082-84cca580-ca9a-11ea-913d-2606275f6f12.png">

### After:
<img width="1293" alt="Screen Shot 2020-07-20 at 2 43 45 PM" src="https://user-images.githubusercontent.com/1813435/87976091-872eff80-ca9a-11ea-821e-9050b40abe80.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
