### PR TITLE
Block Breadcrumb: Fix arrow direction in RTL

### DIFF
--- a/packages/block-editor/src/components/block-breadcrumb/style.scss
+++ b/packages/block-editor/src/components/block-breadcrumb/style.scss
@@ -8,7 +8,7 @@
 		margin: 0;
 
 		&:not(:last-child)::after {
-			content: "\2192"; // This becomes →.
+			content: "\2192" #{'/*rtl:"\2190"*/'}; // This becomes → for LTR and ← for RTL.
 		}
 	}
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes #24030.

Uses rtlcss' value directive to replace the unicode with the one for the leftwards arrow. See also https://rtlcss.com/learn/usage-guide/value-directives/#tip.

## How has this been tested?
Switch site language to a RTL language and select a block.

## Screenshots
![image](https://user-images.githubusercontent.com/617637/87979508-769a7b80-cad2-11ea-9028-915ab2f574b1.png)


## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
