### PR TITLE
REST API: Apply allowed_block_types filter to Block Types endpoint

### DIFF
--- a/lib/class-wp-rest-block-types-controller.php
+++ b/lib/class-wp-rest-block-types-controller.php
@@ -126,6 +126,9 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 		$data        = array();
 		$block_types = $this->block_registry->get_all_registered();
 
+		/** This filter is documented in wp-admin/edit-form-blocks.php */
+		$block_types = apply_filters( 'allowed_block_types', $block_types, $post );
+
 		// Retrieve the list of registered collection query parameters.
 		$registered = $this->get_collection_params();
 		$namespace  = '';


### PR DESCRIPTION
## Description

This is more of an RFC -- this code would currently produce an error.

In #21065, a new endpoint was introduced to return registered blocks:

> - `__experimental/block-types` List of all blocks
> - `__experimental/block-types/<namespace>/<block_type>` ie __experimental/block-types/core/post-author". Get details on a single block type
> - `__experimental/block-types/<namespace>` ie __experimental/block-types/core . Get all blocks in a single name space. 

By comparison, there's an [`allowed_block_types` hook](https://developer.wordpress.org/block-editor/developers/filters/block-filters/#hiding-blocks-from-the-inserter) in Core that's [applied](https://github.com/WordPress/wordpress-develop/blob/83e78d8cdd0282883d1b61d0b4d2820a9cadcebf/src/wp-admin/edit-form-blocks.php#L150) upon loading the Block Editor, allowing filtering of the blocks that are available to the user in the inserter.

I think it would make sense to apply that same filter to the `block-types` endpoint. However, that is not straight-forward, as the filter currently accepts a second argument: the current post object (which is, of course, readily available in a Block Editor context).

Somewhat related: https://github.com/WordPress/wordpress-develop/pull/419 

## Questions

- Do people agree that it makes sense to apply the filter to the endpoint?
- If yes, how do we get hold of a post ID? Do we mandate passing one to the endpoint? That'd mean a significant API change; but maybe it is arguable that a list of blocks _needs_ a post context? (Think e.g. Site Editor (`wp_template` CPTs) vs Post Editor.)

cc/ @spacedmonkey @TimothyBJacobs for opinions :slightly_smiling_face: 

## How has this been tested?
Hasn't yet :grimacing: 

## Types of changes
RFC

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
