### PR TITLE
Update FSE Blocks attribute name to use textAlign instead of align.

### DIFF
--- a/packages/block-library/src/post-author/block.json
+++ b/packages/block-library/src/post-author/block.json
@@ -2,7 +2,7 @@
 	"name": "core/post-author",
 	"category": "design",
 	"attributes": {
-		"align": {
+		"textAlign": {
 			"type": "string"
 		},
 		"avatarSize": {

--- a/packages/block-library/src/post-author/edit.js
+++ b/packages/block-library/src/post-author/edit.js
@@ -43,7 +43,7 @@ function PostAuthorEdit( { isSelected, context, attributes, setAttributes } ) {
 
 	const { editEntityRecord } = useDispatch( 'core' );
 
-	const { align, showAvatar, showBio, byline } = attributes;
+	const { textAlign, showAvatar, showBio, byline } = attributes;
 
 	const avatarSizes = [];
 	if ( authorDetails ) {
@@ -58,10 +58,10 @@ function PostAuthorEdit( { isSelected, context, attributes, setAttributes } ) {
 	const classNames = useMemo( () => {
 		return {
 			block: classnames( 'wp-block-post-author', {
-				[ `has-text-align-${ align }` ]: align,
+				[ `has-text-align-${ textAlign }` ]: textAlign,
 			} ),
 		};
-	}, [ align ] );
+	}, [ textAlign ] );
 
 	return (
 		<>
@@ -113,9 +113,9 @@ function PostAuthorEdit( { isSelected, context, attributes, setAttributes } ) {
 
 			<BlockControls>
 				<AlignmentToolbar
-					value={ align }
+					value={ textAlign }
 					onChange={ ( nextAlign ) => {
-						setAttributes( { align: nextAlign } );
+						setAttributes( { textAlign: nextAlign } );
 					} }
 				/>
 			</BlockControls>

--- a/packages/block-library/src/post-author/index.php
+++ b/packages/block-library/src/post-author/index.php
@@ -33,7 +33,7 @@ function render_block_core_post_author( $attributes, $content, $block ) {
 		array( 'wp-block-post-author' ),
 		isset( $attributes['className'] ) ? array( $attributes['className'] ) : array(),
 		isset( $attributes['itemsJustification'] ) ? array( 'items-justified-' . $attributes['itemsJustification'] ) : array(),
-		isset( $attributes['align'] ) ? array( 'has-text-align-' . $attributes['align'] ) : array()
+		isset( $attributes['textAlign'] ) ? array( 'has-text-align-' . $attributes['textAlign'] ) : array()
 	);
 
 	$class_attribute = sprintf( ' class="%s"', esc_attr( implode( ' ', $classes ) ) );

--- a/packages/block-library/src/post-date/block.json
+++ b/packages/block-library/src/post-date/block.json
@@ -2,7 +2,7 @@
 	"name": "core/post-date",
 	"category": "design",
 	"attributes": {
-		"align": {
+		"textAlign": {
 			"type": "string"
 		},
 		"format": {

--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -26,7 +26,7 @@ import {
 import { __ } from '@wordpress/i18n';
 
 export default function PostDateEdit( { attributes, context, setAttributes } ) {
-	const { align, format } = attributes;
+	const { textAlign, format } = attributes;
 	const { postId, postType } = context;
 
 	const [ siteFormat ] = useEntityProp( 'root', 'site', 'date_format' );
@@ -60,9 +60,9 @@ export default function PostDateEdit( { attributes, context, setAttributes } ) {
 		<>
 			<BlockControls>
 				<AlignmentToolbar
-					value={ align }
+					value={ textAlign }
 					onChange={ ( nextAlign ) => {
-						setAttributes( { align: nextAlign } );
+						setAttributes( { textAlign: nextAlign } );
 					} }
 				/>
 
@@ -101,7 +101,7 @@ export default function PostDateEdit( { attributes, context, setAttributes } ) {
 
 			<Block.div
 				className={ classnames( {
-					[ `has-text-align-${ align }` ]: align,
+					[ `has-text-align-${ textAlign }` ]: textAlign,
 				} ) }
 			>
 				{ date && (

--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -18,7 +18,7 @@ function render_block_core_post_date( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$align_class_name = empty( $attributes['align'] ) ? '' : ' ' . "has-text-align-{$attributes['align']}";
+	$align_class_name = empty( $attributes['textAlign'] ) ? '' : ' ' . "has-text-align-{$attributes['textAlign']}";
 
 	return sprintf(
 		'<div class="%1$s"><time datetime="%2$s">%3$s</time></div>',

--- a/packages/block-library/src/post-excerpt/block.json
+++ b/packages/block-library/src/post-excerpt/block.json
@@ -2,7 +2,7 @@
 	"name": "core/post-excerpt",
 	"category": "design",
 	"attributes": {
-		"align": {
+		"textAlign": {
 			"type": "string"
 		},
 		"wordCount": {

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -40,7 +40,7 @@ function usePostContentExcerpt( wordCount, postId, postType ) {
 }
 
 function PostExcerptEditor( {
-	attributes: { align, wordCount, moreText, showMoreOnNewLine },
+	attributes: { textAlign, wordCount, moreText, showMoreOnNewLine },
 	setAttributes,
 	isSelected,
 	context: { postId, postType },
@@ -60,9 +60,9 @@ function PostExcerptEditor( {
 		<>
 			<BlockControls>
 				<AlignmentToolbar
-					value={ align }
+					value={ textAlign }
 					onChange={ ( newAlign ) =>
-						setAttributes( { align: newAlign } )
+						setAttributes( { textAlign: newAlign } )
 					}
 				/>
 			</BlockControls>
@@ -92,7 +92,7 @@ function PostExcerptEditor( {
 			</InspectorControls>
 			<div
 				className={ classnames( 'wp-block-post-excerpt', {
-					[ `has-text-align-${ align }` ]: align,
+					[ `has-text-align-${ textAlign }` ]: textAlign,
 				} ) }
 			>
 				<RichText

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -29,8 +29,8 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	);
 
 	$classes = 'wp-block-post-excerpt';
-	if ( isset( $attributes['align'] ) ) {
-		$classes .= ' has-text-align-' . $attributes['align'];
+	if ( isset( $attributes['textAlign'] ) ) {
+		$classes .= ' has-text-align-' . $attributes['textAlign'];
 	}
 
 	$output = sprintf( '<div class="%1$s">', esc_attr( $classes ) ) . '<p class="wp-block-post-excerpt__excerpt">' . get_the_excerpt( $block->context['postId'] );

--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -6,7 +6,7 @@
 		"postType"
 	],
 	"attributes": {
-		"align": {
+		"textAlign": {
 			"type": "string"
 		},
 		"level": {

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -25,7 +25,7 @@ export default function PostTitleEdit( {
 	setAttributes,
 	context,
 } ) {
-	const { level, align } = attributes;
+	const { level, textAlign } = attributes;
 	const { postType, postId } = context;
 	const tagName = 0 === level ? 'p' : 'h' + level;
 
@@ -55,16 +55,16 @@ export default function PostTitleEdit( {
 					/>
 				</ToolbarGroup>
 				<AlignmentToolbar
-					value={ align }
+					value={ textAlign }
 					onChange={ ( nextAlign ) => {
-						setAttributes( { align: nextAlign } );
+						setAttributes( { textAlign: nextAlign } );
 					} }
 				/>
 			</BlockControls>
 			<Block
 				tagName={ tagName }
 				className={ classnames( {
-					[ `has-text-align-${ align }` ]: align,
+					[ `has-text-align-${ textAlign }` ]: textAlign,
 				} ) }
 			>
 				{ post.title || __( 'Post Title' ) }

--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -20,7 +20,7 @@ function render_block_core_post_title( $attributes, $content, $block ) {
 	}
 
 	$tag_name         = 'h2';
-	$align_class_name = empty( $attributes['align'] ) ? '' : ' ' . "has-text-align-{$attributes['align']}";
+	$align_class_name = empty( $attributes['textAlign'] ) ? '' : ' ' . "has-text-align-{$attributes['textAlign']}";
 
 	if ( isset( $attributes['level'] ) ) {
 		$tag_name = 0 === $attributes['level'] ? 'p' : 'h' . $attributes['level'];

--- a/packages/block-library/src/site-tagline/block.json
+++ b/packages/block-library/src/site-tagline/block.json
@@ -2,7 +2,7 @@
 	"name": "core/site-tagline",
 	"category": "design",
 	"attributes": {
-		"align": {
+		"textAlign": {
 			"type": "string"
 		}
 	},

--- a/packages/block-library/src/site-tagline/edit.js
+++ b/packages/block-library/src/site-tagline/edit.js
@@ -16,7 +16,7 @@ import {
 import { __ } from '@wordpress/i18n';
 
 export default function SiteTaglineEdit( { attributes, setAttributes } ) {
-	const { align } = attributes;
+	const { textAlign } = attributes;
 	const [ siteTagline, setSiteTagline ] = useEntityProp(
 		'root',
 		'site',
@@ -28,16 +28,16 @@ export default function SiteTaglineEdit( { attributes, setAttributes } ) {
 			<BlockControls>
 				<AlignmentToolbar
 					onChange={ ( newAlign ) =>
-						setAttributes( { align: newAlign } )
+						setAttributes( { textAlign: newAlign } )
 					}
-					value={ align }
+					value={ textAlign }
 				/>
 			</BlockControls>
 
 			<RichText
 				allowedFormats={ [] }
 				className={ classnames( {
-					[ `has-text-align-${ align }` ]: align,
+					[ `has-text-align-${ textAlign }` ]: textAlign,
 				} ) }
 				onChange={ setSiteTagline }
 				placeholder={ __( 'Site Tagline' ) }

--- a/packages/block-library/src/site-tagline/index.php
+++ b/packages/block-library/src/site-tagline/index.php
@@ -13,7 +13,7 @@
  * @return string The render.
  */
 function render_block_core_site_tagline( $attributes ) {
-	$align_class_name = empty( $attributes['align'] ) ? '' : ' ' . "has-text-align-{$attributes['align']}";
+	$align_class_name = empty( $attributes['textAlign'] ) ? '' : ' ' . "has-text-align-{$attributes['textAlign']}";
 
 	return sprintf(
 		'<p class="%1$s">%2$s</p>',

--- a/packages/block-library/src/site-title/block.json
+++ b/packages/block-library/src/site-title/block.json
@@ -6,7 +6,7 @@
 			"type": "number",
 			"default": 1
 		},
-		"align": {
+		"textAlign": {
 			"type": "string"
 		}
 	},

--- a/packages/block-library/src/site-title/edit.js
+++ b/packages/block-library/src/site-title/edit.js
@@ -16,7 +16,7 @@ import {
 } from '@wordpress/block-editor';
 
 export default function SiteTitleEdit( { attributes, setAttributes } ) {
-	const { level, align } = attributes;
+	const { level, textAlign } = attributes;
 	const [ title, setTitle ] = useEntityProp( 'root', 'site', 'title' );
 	const tagName = 0 === level ? 'p' : 'h' + level;
 
@@ -24,9 +24,9 @@ export default function SiteTitleEdit( { attributes, setAttributes } ) {
 		<>
 			<BlockControls>
 				<AlignmentToolbar
-					value={ align }
+					value={ textAlign }
 					onChange={ ( nextAlign ) => {
-						setAttributes( { align: nextAlign } );
+						setAttributes( { textAlign: nextAlign } );
 					} }
 				/>
 			</BlockControls>
@@ -37,7 +37,7 @@ export default function SiteTitleEdit( { attributes, setAttributes } ) {
 				value={ title }
 				onChange={ setTitle }
 				className={ classnames( {
-					[ `has-text-align-${ align }` ]: align,
+					[ `has-text-align-${ textAlign }` ]: textAlign,
 				} ) }
 				allowedFormats={ [] }
 				disableLineBreaks

--- a/packages/block-library/src/site-title/index.php
+++ b/packages/block-library/src/site-title/index.php
@@ -14,7 +14,7 @@
  */
 function render_block_core_site_title( $attributes ) {
 	$tag_name         = 'h1';
-	$align_class_name = empty( $attributes['align'] ) ? '' : ' ' . "has-text-align-{$attributes['align']}";
+	$align_class_name = empty( $attributes['textAlign'] ) ? '' : ' ' . "has-text-align-{$attributes['textAlign']}";
 
 	if ( isset( $attributes['level'] ) ) {
 		$tag_name = 0 === $attributes['level'] ? 'p' : 'h' . $attributes['level'];


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Changes the name of the `align` attribute to `textAlign` for FSE blocks.  Since `align` is used by the align hook for block alignment we should really be more specific in our attribute naming here.  Related convo - https://github.com/WordPress/gutenberg/pull/23945#discussion_r457590219

Updated the following blocks:
* Site Title
* Site Tagline
* Post Title
* Post Date
* Post Author
* Post Excerpt

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Tested on local docker environment.

Test text alignment settings for the listed blocks, verify they render as expected in the editor and on the front-end.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
