### PR TITLE
Polish editor PostFormat and PostFormatPanel components.

### DIFF
--- a/packages/editor/src/components/post-format/index.js
+++ b/packages/editor/src/components/post-format/index.js
@@ -1,22 +1,22 @@
 /**
  * External dependencies
  */
-import { find, get, includes, union } from 'lodash';
+import { union } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { Button, SelectControl } from '@wordpress/components';
-import { useDispatch, useSelect } from '@wordpress/data';
 import { useInstanceId } from '@wordpress/compose';
 import { store as coreStore } from '@wordpress/core-data';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import PostFormatCheck from './check';
 import { store as editorStore } from '../../store';
+import PostFormatCheck from './check';
 
 // All WP post formats, sorted alphabetically by translated name.
 export const POST_FORMATS = [
@@ -47,38 +47,51 @@ export default function PostFormat() {
 	const instanceId = useInstanceId( PostFormat );
 	const postFormatSelectorId = `post-format-selector-${ instanceId }`;
 
-	const { postFormat, suggestedFormat, supportedFormats } = useSelect(
+	const { currentFormatId, listedFormats, suggestedFormat } = useSelect(
 		( select ) => {
+			const supportedFormatIds =
+				select( coreStore ).getThemeSupports().formats ?? [];
 			const { getEditedPostAttribute, getSuggestedPostFormat } = select(
 				editorStore
 			);
-			const _postFormat = getEditedPostAttribute( 'format' );
-			const themeSupports = select( coreStore ).getThemeSupports();
+			const _currentFormatId =
+				getEditedPostAttribute( 'format' ) ?? 'standard';
+
+			const potentialSuggestedFormatId = getSuggestedPostFormat();
+
+			// If the suggested format isn't null, isn't already applied, and is
+			// supported by the theme, return it. Otherwise, return null.
+			const suggestionIsValid =
+				potentialSuggestedFormatId &&
+				potentialSuggestedFormatId !== _currentFormatId &&
+				supportedFormatIds.includes( potentialSuggestedFormatId );
+
+			// The current format may not be supported by the theme.
+			// Ensure it is always shown in the select control.
+			const currentOrSupportedFormatIds = union(
+				[ _currentFormatId ],
+				supportedFormatIds
+			);
+
 			return {
-				postFormat: _postFormat ?? 'standard',
-				suggestedFormat: getSuggestedPostFormat(),
-				// Ensure current format is always in the set.
-				// The current format may not be a format supported by the theme.
-				supportedFormats: union(
-					[ _postFormat ],
-					get( themeSupports, [ 'formats' ], [] )
+				currentFormatId: _currentFormatId,
+				// Filter out invalid formats not included in POST_FORMATS.
+				listedFormats: POST_FORMATS.filter( ( { id } ) =>
+					currentOrSupportedFormatIds.includes( id )
 				),
+				suggestedFormat: suggestionIsValid
+					? POST_FORMATS.find(
+							( { id } ) => id === potentialSuggestedFormatId
+					  )
+					: null,
 			};
 		},
 		[]
 	);
 
-	const formats = POST_FORMATS.filter( ( format ) =>
-		includes( supportedFormats, format.id )
-	);
-	const suggestion = find(
-		formats,
-		( format ) => format.id === suggestedFormat
-	);
-
 	const { editPost } = useDispatch( editorStore );
 
-	const onUpdatePostFormat = ( format ) => editPost( { format } );
+	const updatePostFormat = ( formatId ) => editPost( { format: formatId } );
 
 	return (
 		<PostFormatCheck>
@@ -88,26 +101,26 @@ export default function PostFormat() {
 						{ __( 'Post Format' ) }
 					</label>
 					<SelectControl
-						value={ postFormat }
-						onChange={ ( format ) => onUpdatePostFormat( format ) }
+						value={ currentFormatId }
+						onChange={ updatePostFormat }
 						id={ postFormatSelectorId }
-						options={ formats.map( ( format ) => ( {
+						options={ listedFormats.map( ( format ) => ( {
 							label: format.caption,
 							value: format.id,
 						} ) ) }
 					/>
 				</div>
 
-				{ suggestion && suggestion.id !== postFormat && (
+				{ suggestedFormat && (
 					<div className="editor-post-format__suggestion">
 						{ __( 'Suggestion:' ) }{ ' ' }
 						<Button
 							variant="link"
 							onClick={ () =>
-								onUpdatePostFormat( suggestion.id )
+								updatePostFormat( suggestedFormat.id )
 							}
 						>
-							{ suggestion.caption }
+							{ suggestedFormat.caption }
 						</Button>
 					</div>
 				) }

--- a/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
@@ -1,78 +1,64 @@
 /**
- * External dependencies
- */
-import { find, get, includes } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { Button, PanelBody } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
-import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
-import { POST_FORMATS } from '../post-format';
 import { store as editorStore } from '../../store';
+import { POST_FORMATS } from '../post-format';
 
-const getSuggestion = ( supportedFormats, suggestedPostFormat ) => {
-	const formats = POST_FORMATS.filter( ( format ) =>
-		includes( supportedFormats, format.id )
-	);
-	return find( formats, ( format ) => format.id === suggestedPostFormat );
-};
-
-const PostFormatSuggestion = ( {
-	suggestedPostFormat,
-	suggestionText,
-	onUpdatePostFormat,
-} ) => (
-	<Button
-		variant="link"
-		onClick={ () => onUpdatePostFormat( suggestedPostFormat ) }
-	>
+const PostFormatSuggestion = ( { onApplySuggestion, suggestionText } ) => (
+	<Button variant="link" onClick={ onApplySuggestion }>
 		{ suggestionText }
 	</Button>
 );
 
 export default function PostFormatPanel() {
-	const { currentPostFormat, suggestion } = useSelect( ( select ) => {
+	const suggestedFormat = useSelect( ( select ) => {
 		const { getEditedPostAttribute, getSuggestedPostFormat } = select(
 			editorStore
 		);
-		const supportedFormats = get(
-			select( coreStore ).getThemeSupports(),
-			[ 'formats' ],
-			[]
-		);
-		return {
-			currentPostFormat: getEditedPostAttribute( 'format' ),
-			suggestion: getSuggestion(
-				supportedFormats,
-				getSuggestedPostFormat()
-			),
-		};
+		const potentialSuggestedFormatId = getSuggestedPostFormat();
+
+		// If the suggested format isn't null, isn't already applied, and is
+		// supported by the theme, return it. Otherwise, return null.
+		if (
+			potentialSuggestedFormatId &&
+			potentialSuggestedFormatId !== getEditedPostAttribute( 'format' ) &&
+			( select( coreStore ).getThemeSupports().formats ?? [] ).includes(
+				potentialSuggestedFormatId
+			)
+		) {
+			return POST_FORMATS.find(
+				( { id } ) => id === potentialSuggestedFormatId
+			);
+		}
+		return null;
 	}, [] );
 
 	const { editPost } = useDispatch( editorStore );
 
-	const onUpdatePostFormat = ( format ) => editPost( { format } );
-
-	const panelBodyTitle = [
-		__( 'Suggestion:' ),
-		<span className="editor-post-publish-panel__link" key="label">
-			{ __( 'Use a post format' ) }
-		</span>,
-	];
-
-	if ( ! suggestion || suggestion.id === currentPostFormat ) {
+	if ( ! suggestedFormat ) {
 		return null;
 	}
 
 	return (
-		<PanelBody initialOpen={ false } title={ panelBodyTitle }>
+		<PanelBody
+			initialOpen={ false }
+			title={
+				<>
+					{ __( 'Suggestion:' ) }
+					<span className="editor-post-publish-panel__link">
+						{ __( 'Use a post format' ) }
+					</span>
+				</>
+			}
+		>
 			<p>
 				{ __(
 					'Your theme uses post formats to highlight different kinds of content, like images or videos. Apply a post format to see this special styling.'
@@ -80,12 +66,13 @@ export default function PostFormatPanel() {
 			</p>
 			<p>
 				<PostFormatSuggestion
-					onUpdatePostFormat={ onUpdatePostFormat }
-					suggestedPostFormat={ suggestion.id }
+					onApplySuggestion={ () => {
+						editPost( { format: suggestedFormat.id } );
+					} }
 					suggestionText={ sprintf(
 						/* translators: %s: post format */
 						__( 'Apply the "%1$s" format.' ),
-						suggestion.caption
+						suggestedFormat.caption
 					) }
 				/>
 			</p>


### PR DESCRIPTION
## Description
This PR refactors two components in the `editor` package: `PostFormat` and `PostFormatPanel`. The changes made are designed to simplify the code and make it easier to implement changes I want to make in #24024.

### List of changes
- I reduced Lodash usage, preferring more explicit defaulting for `undefined`/`null` handling using nullish coalescing and native JS array methods.
- I optimized `PostFormatPanel`'s `useSelect` callback to return only a single value.
- I optimized `PostFormatPanel`'s `PostFormatSuggestion` to take a single argument for the callback, rather than one for a callback and one for a value to pass to that callback.
- I simplified `PostFormatPanel`'s contained `PanelBody` to use a `Fragment` for its title element, rather than an array of elements with `key` props.
- I simplifed both `PostFormat` and `PostFormatPanel` to move a lot of the logic into the `useSelect` callbacks, to avoid unnecessarily running the same checks on every render.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
