### PR TITLE
Fix retrying of post-processing of edited images

### DIFF
--- a/lib/class-wp-rest-image-editor-controller.php
+++ b/lib/class-wp-rest-image-editor-controller.php
@@ -300,6 +300,12 @@ class WP_REST_Image_Editor_Controller extends WP_REST_Controller {
 			return $new_attachment_id;
 		}
 
+		if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+			// Set a custom header with the attachment_id.
+			// Used by the browser/client to resume creating image sub-sizes after a PHP fatal error.
+			header( 'X-WP-Upload-Attachment-ID: ' . $new_attachment_id );
+		}
+
 		// Generate image sub-sizes and meta.
 		$new_image_meta = wp_generate_attachment_metadata( $new_attachment_id, $saved['path'] );
 

--- a/packages/block-library/src/image/image-editor.js
+++ b/packages/block-library/src/image/image-editor.js
@@ -195,7 +195,7 @@ export default function ImageEditor( {
 		attrs.src = url;
 
 		apiFetch( {
-			path: `wp/v2/media/${ id }/edit`,
+			path: `/wp/v2/media/${ id }/edit`,
 			method: 'POST',
 			data: attrs,
 		} )


### PR DESCRIPTION
## Description
The path in apiFetch() in image-editor.js is `wp/v2/media/${ id }/edit` but seems it needs to be `/wp/v2/media/${ id }/edit` to match the expected path in the middleware https://github.com/WordPress/gutenberg/blob/master/packages/api-fetch/src/middlewares/media-upload.js#L24.

This will fix retrying of image post-processing when saving edited image if the server runs out of resources. 

- Fix typo in the apiFetch() path in image-editor.js
- Add the 'X-WP-Upload-Attachment-ID' HTTP header as back-compat to retry failed post-processing of edited images.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
