### PR TITLE
Post Tags: Fix bug where no tags are rendered

### DIFF
--- a/packages/block-library/src/post-tags/block.json
+++ b/packages/block-library/src/post-tags/block.json
@@ -2,7 +2,8 @@
 	"name": "core/post-tags",
 	"category": "design",
 	"usesContext": [
-		"postId"
+		"postId",
+		"postType"
 	],
 	"supports": {
 		"html": false

--- a/packages/block-library/src/post-tags/block.json
+++ b/packages/block-library/src/post-tags/block.json
@@ -1,11 +1,9 @@
 {
 	"name": "core/post-tags",
 	"category": "design",
-	"usesContext": [
-		"postId",
-		"postType"
-	],
+	"usesContext": [ "postId", "postType" ],
 	"supports": {
-		"html": false
+		"html": false,
+		"lightBlockWrapper": true
 	}
 }

--- a/packages/block-library/src/post-tags/edit.js
+++ b/packages/block-library/src/post-tags/edit.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useEntityProp } from '@wordpress/core-data';
-import { Warning } from '@wordpress/block-editor';
+import { Warning, __experimentalBlock as Block } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
@@ -32,6 +32,7 @@ function PostTagsDisplay( { context } ) {
 		},
 		[ tags ]
 	);
+
 	return (
 		tagLinks &&
 		( tagLinks.length === 0
@@ -41,8 +42,10 @@ function PostTagsDisplay( { context } ) {
 }
 
 export default function PostTagsEdit( { context } ) {
+	let display = <PostTagsDisplay context={ context } />;
+
 	if ( ! context.postType || ! context.postId ) {
-		return (
+		display = (
 			<Warning>
 				{ __( 'Post tags block: No post found for this block.' ) }
 			</Warning>
@@ -57,7 +60,7 @@ export default function PostTagsEdit( { context } ) {
 		 * post_tag taxonomy is registered for the current post type.
 		 */
 	} else if ( context.postType !== 'post' ) {
-		return (
+		display = (
 			<Warning>
 				{ __(
 					'Post tags block: Tags are not available for this post type.'
@@ -66,5 +69,5 @@ export default function PostTagsEdit( { context } ) {
 		);
 	}
 
-	return <PostTagsDisplay context={ context } />;
+	return <Block.div>{ display }</Block.div>;
 }

--- a/packages/block-library/src/post-tags/edit.js
+++ b/packages/block-library/src/post-tags/edit.js
@@ -6,7 +6,7 @@ import { Warning, __experimentalBlock as Block } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
-function PostTagsDisplay( { context } ) {
+export default function PostTagsEdit( { context } ) {
 	const [ tags ] = useEntityProp(
 		'postType',
 		context.postType,
@@ -42,16 +42,11 @@ function PostTagsDisplay( { context } ) {
 		[ tags ]
 	);
 
-	return (
+	let display =
 		tagLinks &&
 		( tagLinks.length === 0
 			? __( 'No tags.' )
-			: tagLinks.reduce( ( prev, curr ) => [ prev, ' | ', curr ] ) )
-	);
-}
-
-export default function PostTagsEdit( { context } ) {
-	let display = <PostTagsDisplay context={ context } />;
+			: tagLinks.reduce( ( prev, curr ) => [ prev, ' | ', curr ] ) );
 
 	if ( ! context.postType || ! context.postId ) {
 		display = (

--- a/packages/block-library/src/post-tags/edit.js
+++ b/packages/block-library/src/post-tags/edit.js
@@ -60,7 +60,7 @@ export default function PostTagsEdit( { context } ) {
 		return (
 			<Warning>
 				{ __(
-					'Post tags block: Tags are only available in posts. Please add this block to a post instead.'
+					'Post tags block: Tags are not available for this post type.'
 				) }
 			</Warning>
 		);

--- a/packages/block-library/src/post-tags/edit.js
+++ b/packages/block-library/src/post-tags/edit.js
@@ -47,6 +47,15 @@ export default function PostTagsEdit( { context } ) {
 				{ __( 'Post tags block: No post found for this block.' ) }
 			</Warning>
 		);
+
+		/**
+		 * Do not render the block when viewing a page (as opposed to a post)
+		 *
+		 * @todo By default, only posts can be grouped by tags. Therefore, without any configuration,
+		 * the post tags block will have no tags for pages. Plugins, however, can modify this behavior.
+		 * In the future, instead of only evaluating posts, we should check whether the
+		 * post_tag taxonomy is registered for the page post type.
+		 */
 	} else if ( context.postType !== 'post' ) {
 		return (
 			<Warning>

--- a/packages/block-library/src/post-tags/edit.js
+++ b/packages/block-library/src/post-tags/edit.js
@@ -17,17 +17,26 @@ function PostTagsDisplay( { context } ) {
 		( select ) => {
 			const { getEntityRecord } = select( 'core' );
 			let loaded = true;
-			const links = tags.map( ( tagId ) => {
-				const tag = getEntityRecord( 'taxonomy', 'post_tag', tagId );
-				if ( ! tag ) {
-					return ( loaded = false );
-				}
-				return (
-					<a key={ tagId } href={ tag.link }>
-						{ tag.name }
-					</a>
-				);
-			} );
+			let links;
+
+			if ( tags ) {
+				links = tags.map( ( tagId ) => {
+					const tag = getEntityRecord(
+						'taxonomy',
+						'post_tag',
+						tagId
+					);
+					if ( ! tag ) {
+						return ( loaded = false );
+					}
+					return (
+						<a key={ tagId } href={ tag.link }>
+							{ tag.name }
+						</a>
+					);
+				} );
+			}
+
 			return loaded && links;
 		},
 		[ tags ]

--- a/packages/block-library/src/post-tags/edit.js
+++ b/packages/block-library/src/post-tags/edit.js
@@ -54,7 +54,7 @@ export default function PostTagsEdit( { context } ) {
 		 * @todo By default, only posts can be grouped by tags. Therefore, without any configuration,
 		 * the post tags block will have no tags for pages. Plugins, however, can modify this behavior.
 		 * In the future, instead of only evaluating posts, we should check whether the
-		 * post_tag taxonomy is registered for the page post type.
+		 * post_tag taxonomy is registered for the current post type.
 		 */
 	} else if ( context.postType !== 'post' ) {
 		return (

--- a/packages/block-library/src/post-tags/edit.js
+++ b/packages/block-library/src/post-tags/edit.js
@@ -1,12 +1,18 @@
 /**
  * WordPress dependencies
  */
-import { useEntityProp, useEntityId } from '@wordpress/core-data';
+import { useEntityProp } from '@wordpress/core-data';
+import { Warning } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
-function PostTagsDisplay() {
-	const [ tags ] = useEntityProp( 'postType', 'post', 'tags' );
+function PostTagsDisplay( { context } ) {
+	const [ tags ] = useEntityProp(
+		'postType',
+		context.postType,
+		'tags',
+		context.postId
+	);
 	const tagLinks = useSelect(
 		( select ) => {
 			const { getEntityRecord } = select( 'core' );
@@ -34,9 +40,14 @@ function PostTagsDisplay() {
 	);
 }
 
-export default function PostTagsEdit() {
-	if ( ! useEntityId( 'postType', 'post' ) ) {
-		return __( 'Post Tags' );
+export default function PostTagsEdit( { context } ) {
+	if ( ! context.postType || ! context.postId ) {
+		return (
+			<Warning>
+				{ __( 'Post tags block: No post found for this block.' ) }
+			</Warning>
+		);
 	}
-	return <PostTagsDisplay />;
+
+	return <PostTagsDisplay context={ context } />;
 }

--- a/packages/block-library/src/post-tags/edit.js
+++ b/packages/block-library/src/post-tags/edit.js
@@ -17,25 +17,18 @@ export default function PostTagsEdit( { context } ) {
 		( select ) => {
 			const { getEntityRecord } = select( 'core' );
 			let loaded = true;
-			let links;
 
-			if ( tags ) {
-				links = tags.map( ( tagId ) => {
-					const tag = getEntityRecord(
-						'taxonomy',
-						'post_tag',
-						tagId
-					);
-					if ( ! tag ) {
-						return ( loaded = false );
-					}
-					return (
-						<a key={ tagId } href={ tag.link }>
-							{ tag.name }
-						</a>
-					);
-				} );
-			}
+			const links = tags?.map( ( tagId ) => {
+				const tag = getEntityRecord( 'taxonomy', 'post_tag', tagId );
+				if ( ! tag ) {
+					return ( loaded = false );
+				}
+				return (
+					<a key={ tagId } href={ tag.link }>
+						{ tag.name }
+					</a>
+				);
+			} );
 
 			return loaded && links;
 		},

--- a/packages/block-library/src/post-tags/edit.js
+++ b/packages/block-library/src/post-tags/edit.js
@@ -47,7 +47,7 @@ export default function PostTagsEdit( { context } ) {
 				{ __( 'Post tags block: No post found for this block.' ) }
 			</Warning>
 		);
-
+	} else if ( context.postType !== 'post' ) {
 		/**
 		 * Do not render the block when viewing a page (as opposed to a post)
 		 *
@@ -56,7 +56,6 @@ export default function PostTagsEdit( { context } ) {
 		 * In the future, instead of only evaluating posts, we should check whether the
 		 * post_tag taxonomy is registered for the current post type.
 		 */
-	} else if ( context.postType !== 'post' ) {
 		display = (
 			<Warning>
 				{ __(

--- a/packages/block-library/src/post-tags/edit.js
+++ b/packages/block-library/src/post-tags/edit.js
@@ -47,6 +47,14 @@ export default function PostTagsEdit( { context } ) {
 				{ __( 'Post tags block: No post found for this block.' ) }
 			</Warning>
 		);
+	} else if ( context.postType !== 'post' ) {
+		return (
+			<Warning>
+				{ __(
+					'Post tags block: Tags are only available in posts. Please add this block to a post instead.'
+				) }
+			</Warning>
+		);
 	}
 
 	return <PostTagsDisplay context={ context } />;

--- a/packages/block-library/src/post-tags/index.php
+++ b/packages/block-library/src/post-tags/index.php
@@ -20,17 +20,11 @@ function render_block_core_post_tags( $attributes, $content, $block ) {
 
 	$post_tags = get_the_tags( $block->context['postId'] );
 	if ( ! empty( $post_tags ) ) {
-		$output  = '';
-		$output .= '<div>';
-
+		$output = '';
 		foreach ( $post_tags as $tag ) {
 			$output .= '<a href="' . get_tag_link( $tag->term_id ) . '">' . $tag->name . '</a>' . ' | ';
 		}
-
-		$output  = trim( $output, ' | ' );
-		$output .= '</div>';
-
-		return $output;
+		return trim( $output, ' | ' );
 	}
 }
 

--- a/packages/block-library/src/post-tags/index.php
+++ b/packages/block-library/src/post-tags/index.php
@@ -20,8 +20,8 @@ function render_block_core_post_tags( $attributes, $content, $block ) {
 
 	$post_tags = get_the_tags( $block->context['postId'] );
 	if ( ! empty( $post_tags ) ) {
-		$output  = '';
-		$output .= '<div>';
+		$classes = 'wp-block-post-tags';
+		$output  = sprintf( '<div class="%1$s">', esc_attr( $classes ) );
 
 		foreach ( $post_tags as $tag ) {
 			$output .= '<a href="' . get_tag_link( $tag->term_id ) . '">' . $tag->name . '</a>' . ' | ';

--- a/packages/block-library/src/post-tags/index.php
+++ b/packages/block-library/src/post-tags/index.php
@@ -20,11 +20,17 @@ function render_block_core_post_tags( $attributes, $content, $block ) {
 
 	$post_tags = get_the_tags( $block->context['postId'] );
 	if ( ! empty( $post_tags ) ) {
-		$output = '';
+		$output  = '';
+		$output .= '<div>';
+
 		foreach ( $post_tags as $tag ) {
 			$output .= '<a href="' . get_tag_link( $tag->term_id ) . '">' . $tag->name . '</a>' . ' | ';
 		}
-		return trim( $output, ' | ' );
+
+		$output  = trim( $output, ' | ' );
+		$output .= '</div>';
+
+		return $output;
 	}
 }
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
This PR addresses a task in #21087 and is meant to add feature parity to FSE blocks. Previously, when the post tags block was added to a view, post tags **were not** being loaded. This PR implements a solution similar to what @Addison-Stavlo did for the post excerpt block in https://github.com/WordPress/gutenberg/pull/23945.

## Important Notes
- From my understanding, tags can only be applied to posts, **not** pages.
  - While viewing a page in the site editor (ex. static home page), and not a post, it seems like there are no tags to display. (Please let me know if this assumption is incorrect)
  - In the situation where post tags blocks are used on a page, I render a warning that informs the user that the post tags block on a page doesn't make sense.
  - An alternative might be to prevent the user from even inserting post tags blocks on pages.
- Adding a post tags block inside of a query loop block will add tags to _all_ posts 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Tested on local docker wp-env environment.

1. Create a post and add tags in the settings sidebar
2. Navigate to the site editor
3. In the template dropdown, navigate to the recently created post
4. Add the post tags block
5. Verify that the correct tags are applied

## Screenshots <!-- if applicable -->
### Query Loop Index
<img width="1547" alt="post-tags-query-loop" src="https://user-images.githubusercontent.com/5414230/88003745-71313700-caba-11ea-978d-6431ae60d5d1.png">

### Singular
<img width="1548" alt="post-tags-singular" src="https://user-images.githubusercontent.com/5414230/88003754-742c2780-caba-11ea-8598-d64b9eed395f.png">

### Static Home Page (Rendering post tags on pages doesn't seem to make sense. Instead I render a warning)
<img width="1548" alt="post-tags-static-home-page" src="https://user-images.githubusercontent.com/5414230/88003757-74c4be00-caba-11ea-9410-6b41f6b729fd.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->