### PR TITLE
Display children of inner block controllers in the block navigator

### DIFF
--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -94,10 +94,15 @@ then the nested template part's child blocks will not be returned. This way,
 the template block itself is considered part of the parent, but the children
 are not.
 
+You can override this behavior with the includeControlledInnerBlocks. So if
+you call `getBlock( TP, true )`, it will return all nested blocks, including
+all child inner block controllers and their children.
+
 _Parameters_
 
 -   _state_ `Object`: Editor state.
 -   _clientId_ `string`: Block client ID.
+-   _includeControlledInnerBlocks_ `?boolean`: If true, include controlleld inner block subtrees. The default behavior is to exclude controlled inner blocks (false).
 
 _Returns_
 
@@ -277,7 +282,8 @@ _Returns_
 
 Returns all block objects for the current post being edited as an array in
 the order they appear in the post. Note that this will exclude child blocks
-of nested inner block controllers.
+of nested inner block controllers unless the `includeControlledInnerBlocks`
+parameter is set to true.
 
 Note: It's important to memoize this selector to avoid return a new instance
 on each call. We use the block cache state for each top-level block of the
@@ -289,6 +295,7 @@ _Parameters_
 
 -   _state_ `Object`: Editor state.
 -   _rootClientId_ `?string`: Optional root client ID of block list.
+-   _includeControlledInnerBlocks_ `?boolean`: If true, include controlleld inner block subtrees. The default behavior is to exclude controlled inner blocks (false).
 
 _Returns_
 

--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -94,15 +94,15 @@ then the nested template part's child blocks will not be returned. This way,
 the template block itself is considered part of the parent, but the children
 are not.
 
-You can override this behavior with the includeControlledInnerBlocks. So if
-you call `getBlock( TP, true )`, it will return all nested blocks, including
-all child inner block controllers and their children.
+You can override this behavior with the includeControlledInnerBlocks setting.
+So if you call `getBlock( TP, { WPGetBlockSettings: true } )`, it will return
+all nested blocks, including all child inner block controllers and their children.
 
 _Parameters_
 
 -   _state_ `Object`: Editor state.
 -   _clientId_ `string`: Block client ID.
--   _includeControlledInnerBlocks_ `?boolean`: If true, include controlleld inner block subtrees. The default behavior is to exclude controlled inner blocks (false).
+-   _settings_ `?WPGetBlockSettings`: A settings object.
 
 _Returns_
 
@@ -283,7 +283,7 @@ _Returns_
 Returns all block objects for the current post being edited as an array in
 the order they appear in the post. Note that this will exclude child blocks
 of nested inner block controllers unless the `includeControlledInnerBlocks`
-parameter is set to true.
+setting is set to true.
 
 Note: It's important to memoize this selector to avoid return a new instance
 on each call. We use the block cache state for each top-level block of the
@@ -295,7 +295,7 @@ _Parameters_
 
 -   _state_ `Object`: Editor state.
 -   _rootClientId_ `?string`: Optional root client ID of block list.
--   _includeControlledInnerBlocks_ `?boolean`: If true, include controlleld inner block subtrees. The default behavior is to exclude controlled inner blocks (false).
+-   _settings_ `?WPGetBlockSettings`: A settings object.
 
 _Returns_
 

--- a/packages/block-editor/src/components/block-navigation/index.js
+++ b/packages/block-editor/src/components/block-navigation/index.js
@@ -67,11 +67,11 @@ export default compose(
 		} = select( 'core/block-editor' );
 		const selectedBlockClientId = getSelectedBlockClientId();
 		return {
-			rootBlocks: getBlocks( '', true ),
+			rootBlocks: getBlocks( '', { includeControlledInnerBlocks: true } ),
 			rootBlock: selectedBlockClientId
 				? getBlock(
 						getBlockHierarchyRootClientId( selectedBlockClientId ),
-						true
+						{ includeControlledInnerBlocks: true }
 				  )
 				: null,
 			selectedBlockClientId,

--- a/packages/block-editor/src/components/block-navigation/index.js
+++ b/packages/block-editor/src/components/block-navigation/index.js
@@ -67,10 +67,11 @@ export default compose(
 		} = select( 'core/block-editor' );
 		const selectedBlockClientId = getSelectedBlockClientId();
 		return {
-			rootBlocks: getBlocks(),
+			rootBlocks: getBlocks( '', true ),
 			rootBlock: selectedBlockClientId
 				? getBlock(
-						getBlockHierarchyRootClientId( selectedBlockClientId )
+						getBlockHierarchyRootClientId( selectedBlockClientId ),
+						true
 				  )
 				: null,
 			selectedBlockClientId,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -40,6 +40,16 @@ import { Platform } from '@wordpress/element';
  *                                 text value. See `wp.richText.create`.
  */
 
+/**
+ * Settings which can be passed to the getBlock or getBlocks selectors.
+ *
+ * @typedef {Object} WPGetBlockSettings
+ * @property {boolean} includeControlledInnerBlocks If true, include nested child
+ *                                                  blocks of inner block controllers.
+ *                                                  The default of false excludes
+ *                                                  nested blocks of inner block controllers.
+ */
+
 // Module constants
 const MILLISECONDS_PER_HOUR = 3600 * 1000;
 const MILLISECONDS_PER_DAY = 24 * 3600 * 1000;
@@ -133,21 +143,18 @@ export function getBlockAttributes( state, clientId ) {
  * the template block itself is considered part of the parent, but the children
  * are not.
  *
- * You can override this behavior with the includeControlledInnerBlocks. So if
- * you call `getBlock( TP, true )`, it will return all nested blocks, including
- * all child inner block controllers and their children.
+ * You can override this behavior with the includeControlledInnerBlocks setting.
+ * So if you call `getBlock( TP, { WPGetBlockSettings: true } )`, it will return
+ * all nested blocks, including all child inner block controllers and their children.
  *
- * @param {Object}   state                        Editor state.
- * @param {string}   clientId                     Block client ID.
- * @param {?boolean} includeControlledInnerBlocks If true, include controlleld
- *                                                inner block subtrees. The default
- *                                                behavior is to exclude controlled
- *                                                inner blocks (false).
+ * @param {Object}              state    Editor state.
+ * @param {string}              clientId Block client ID.
+ * @param {?WPGetBlockSettings} settings A settings object.
  *
  * @return {Object} Parsed block object.
  */
 export const getBlock = createSelector(
-	( state, clientId, includeControlledInnerBlocks = false ) => {
+	( state, clientId, { includeControlledInnerBlocks = false } = {} ) => {
 		const block = state.blocks.byClientId[ clientId ];
 		if ( ! block ) {
 			return null;
@@ -160,11 +167,9 @@ export const getBlock = createSelector(
 				! includeControlledInnerBlocks &&
 				areInnerBlocksControlled( state, clientId )
 					? EMPTY_ARRAY
-					: getBlocks(
-							state,
-							clientId,
-							includeControlledInnerBlocks
-					  ),
+					: getBlocks( state, clientId, {
+							includeControlledInnerBlocks,
+					  } ),
 		};
 	},
 	( state, clientId ) => [
@@ -199,7 +204,7 @@ export const __unstableGetBlockWithoutInnerBlocks = createSelector(
  * Returns all block objects for the current post being edited as an array in
  * the order they appear in the post. Note that this will exclude child blocks
  * of nested inner block controllers unless the `includeControlledInnerBlocks`
- * parameter is set to true.
+ * setting is set to true.
  *
  * Note: It's important to memoize this selector to avoid return a new instance
  * on each call. We use the block cache state for each top-level block of the
@@ -207,19 +212,16 @@ export const __unstableGetBlockWithoutInnerBlocks = createSelector(
  * associated with the given entity, and does not refresh when changes are made
  * to blocks which are part of different inner block controllers.
  *
- * @param {Object}   state                        Editor state.
- * @param {?string}  rootClientId                 Optional root client ID of block list.
- * @param {?boolean} includeControlledInnerBlocks If true, include controlleld
- *                                                inner block subtrees. The default
- *                                                behavior is to exclude controlled
- *                                                inner blocks (false).
+ * @param {Object}              state        Editor state.
+ * @param {?string}             rootClientId Optional root client ID of block list.
+ * @param {?WPGetBlockSettings} settings     A settings object.
  *
  * @return {Object[]} Post blocks.
  */
 export const getBlocks = createSelector(
-	( state, rootClientId, includeControlledInnerBlocks = false ) => {
+	( state, rootClientId, { includeControlledInnerBlocks = false } = {} ) => {
 		return map( getBlockOrder( state, rootClientId ), ( clientId ) =>
-			getBlock( state, clientId, includeControlledInnerBlocks )
+			getBlock( state, clientId, { includeControlledInnerBlocks } )
 		);
 	},
 	( state, rootClientId ) =>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes #23459. In #21368, all "controlled" inner blocks were excluded from `getBlock` and `getBlocks`. This works because much of the time, you only want to know whhat blocks are in the particular entity you are looking at. For example, when you call `getBlock` on a template part, you would not want to be aware of any children template parts. You only want to know which blocks are contained in that template part.

However, there are still some bits of the UI (like the block navigator) which depend on seeing a list of all the blocks rendered on the page -- it does not care which blocks belong to which entity. So this PR:

1. Adds a way to get all nested blocks via `getBlock` and `getBlocks`. Previously, those functions always excluded the children of nested inner block controllers. Now, these functions can include those nested children if a flag is set.
2. Use above flag in `BlockNavigation` to include all blocks, including nested inner block controller children. 

## How has this been tested?
Locally, in edit site.

## Screenshots <!-- if applicable -->
<img width="1337" alt="Screen Shot 2020-07-20 at 5 45 59 PM" src="https://user-images.githubusercontent.com/6265975/88000134-c3ba2580-cab1-11ea-912e-ff20a4542837.png">

## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
