### PR TITLE
Make the padding for the nav block inserter content the same for all sides

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -158,7 +158,7 @@ $block-inserter-tabs-height: 44px;
 }
 
 .block-editor-inserter__panel-content {
-	padding: 0 $grid-unit-20;
+	padding: $grid-unit-20;
 }
 
 .block-editor-inserter__panel-title {
@@ -175,7 +175,7 @@ $block-inserter-tabs-height: 44px;
 }
 
 .block-editor-inserter__popover .block-editor-block-types-list {
-	margin: 0 -8px;
+	margin: -8px;
 }
 
 .block-editor-inserter__reusable-blocks-panel {
@@ -281,12 +281,12 @@ $block-inserter-tabs-height: 44px;
 }
 
 .block-editor-inserter__quick-inserter .block-editor-inserter__panel-content {
-	padding: 0 $grid-unit-10;
+	padding: $grid-unit-10;
 }
 
 .block-editor-inserter__quick-inserter.has-search .block-editor-inserter__panel-content,
 .block-editor-inserter__quick-inserter.has-expand .block-editor-inserter__panel-content {
-	padding: 0 $grid-unit-20;
+	padding: $grid-unit-20;
 }
 
 .block-editor-inserter__quick-inserter-patterns {
@@ -310,7 +310,6 @@ $block-inserter-tabs-height: 44px;
 	width: 100%;
 	height: ($button-size + $grid-unit-10);
 	border-radius: 0;
-	margin-top: $grid-unit-20;
 
 	&:hover {
 		color: $white;


### PR DESCRIPTION
## Description
This pull request addressed #24078. The padding for the nav block inserter was updated to be the same for all sides.

## How has this been tested?
Observed on Ubuntu 20.04 with the following browsers
- Chromium Version 84.0.4147.89 (Official Build) snap (64-bit) 
- Firefox 78.0.2 (64-bit)

## Screenshots
**Original**
![image](https://user-images.githubusercontent.com/617986/87986025-6dd58580-ca91-11ea-94cb-b410b337e2b3.gif)

**Fixed**
![image](https://user-images.githubusercontent.com/4966719/88007977-c2e6bb00-cad4-11ea-81ff-bcbec60bf7aa.jpg)

## Types of changes
Bug fix