### PR TITLE
Set icon image width to 100% for consistency.

### DIFF
--- a/packages/block-directory/src/components/downloadable-block-icon/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-icon/style.scss
@@ -8,4 +8,8 @@
 		font-size: $button-size;
 		background-color: $gray-200;
 	}
+
+	> img {
+		width: 100%;
+	}
 }


### PR DESCRIPTION
## Description
This PR enforces `width: 100%` on the block directory icon.

Fixes: #24008 

This problem was only visible when editing full mode because a global style in the block editor was keeping it together:

```
.block-editor__container img {
    max-width: 100%;
    height: auto;
}
```

That style does not exist in full editor mode.

## How has this been tested?
Hand tested locally. :)

## Screenshots
![Screenshot](https://d.pr/i/n92Zja.png)

## Types of changes
CSS update.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
