### PR TITLE
Fix blurry borders in focus styles on 1x screens

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -117,13 +117,6 @@
  * Focus styles.
  */
 
-@mixin block-toolbar-button-style__focus() {
-	box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color), inset 0 0 0 4px $white;
-
-	// Windows High Contrast mode will show this outline, but not the box-shadow.
-	outline: 2px solid transparent;
-}
-
 // Tabs, Inputs, Square buttons.
 @mixin input-style__neutral() {
 	box-shadow: 0 0 0 transparent;
@@ -131,15 +124,6 @@
 	border-radius: $radius-block-ui;
 	border: $border-width solid $gray-700;
 	@include reduce-motion("transition");
-}
-
-
-@mixin input-style__focus() {
-	border-color: var(--wp-admin-theme-color);
-	box-shadow: 0 0 0 ($border-width-focus - $border-width) var(--wp-admin-theme-color);
-
-	// Windows High Contrast mode will show this outline, but not the box-shadow.
-	outline: 2px solid transparent;
 }
 
 
@@ -254,7 +238,11 @@
 	}
 
 	&:focus {
-		@include input-style__focus();
+		border-color: var(--wp-admin-theme-color);
+		box-shadow: 0 0 0 ($border-width-focus - $border-width) var(--wp-admin-theme-color);
+
+		// Windows High Contrast mode will show this outline, but not the box-shadow.
+		outline: 2px solid transparent;
 	}
 
 	// Use opacity to work in various editor styles.
@@ -372,7 +360,7 @@
 	}
 
 	&:focus {
-		box-shadow: 0 0 0 ($border-width * 2) $white, 0 0 0 ($border-width * 2 + $border-width-focus) var(--wp-admin-theme-color);
+		box-shadow: 0 0 0 ($border-width * 2) $white, 0 0 0 calc($border-width * 2 + var(--border-width-focus)) var(--wp-admin-theme-color);
 
 		// Only visible in Windows High Contrast mode.
 		outline: 2px solid transparent;

--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -17,6 +17,14 @@ $big-font-size: 18px;
 $mobile-text-min-font-size: 16px; // Any font size below 16px will cause Mobile Safari to "zoom in"
 $border-width: 1px;
 $border-width-focus: 1.5px;
+// Prevents bludrry borders on 1x screens
+:root {
+	--border-width-focus: 1.5px;
+
+	@media ( max-resolution: 96dpi ) {
+		--border-width-focus: 2px;
+	}
+}
 $border-width-tab: 4px;
 
 /**

--- a/packages/block-editor/src/components/block-breadcrumb/style.scss
+++ b/packages/block-editor/src/components/block-breadcrumb/style.scss
@@ -37,7 +37,7 @@
 		right: $border-width;
 		bottom: $border-width;
 		left: $border-width;
-		box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+		box-shadow: inset 0 0 0 var(--border-width-focus) var(--wp-admin-theme-color);
 	}
 }
 

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -64,12 +64,12 @@
 			right: $border-width;
 
 			// 2px outside.
-			box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+			box-shadow: 0 0 0 var(--border-width-focus) var(--wp-admin-theme-color);
 			border-radius: $radius-block-ui - $border-width; // Border is outset, so so subtract the width to achieve correct radius.
 
 			// Show a light color for dark themes.
 			.is-dark-theme & {
-				box-shadow: 0 0 0 $border-width-focus $dark-theme-focus;
+				box-shadow: 0 0 0 var(--border-width-focus) $dark-theme-focus;
 			}
 		}
 	}
@@ -142,7 +142,7 @@
 
 		&::after { // Everything else.
 			// 2px outside.
-			box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+			box-shadow: 0 0 0 var(--border-width-focus) var(--wp-admin-theme-color);
 			border-radius: $radius-block-ui - $border-width; // Border is outset, so so subtract the width to achieve correct radius.
 			transition: box-shadow 0.2s ease-out;
 			@include reduce-motion("transition");
@@ -152,7 +152,7 @@
 
 			// Show a lighter color for dark themes.
 			.is-dark-theme & {
-				box-shadow: 0 0 0 $border-width-focus $dark-theme-focus;
+				box-shadow: 0 0 0 var(--border-width-focus) $dark-theme-focus;
 			}
 		}
 
@@ -169,8 +169,8 @@
 	}
 
 	.is-block-moving-mode & .block-editor-block-list__block.has-child-selected {
-		box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color);
-		outline: $border-width-focus solid transparent;
+		box-shadow: 0 0 0 var(--border-width-focus) var(--wp-admin-theme-color);
+		outline: 2px solid transparent;
 	}
 
 	.is-block-moving-mode & .block-editor-block-list__block.is-selected {
@@ -230,7 +230,7 @@
 		bottom: 0;
 		left: 0;
 		border-radius: $radius-block-ui;
-		box-shadow: 0 0 0 $border-width-focus transparent;
+		box-shadow: 0 0 0 var(--border-width-focus) transparent;
 		transition: box-shadow 0.1s ease-in;
 		@include reduce-motion("transition");
 	}
@@ -370,7 +370,7 @@
 .block-editor-block-list__insertion-point-indicator {
 	position: absolute;
 	top: calc(50% - #{ $border-width });
-	height: $border-width-focus;
+	height: var(--border-width-focus);
 	left: 0;
 	right: 0;
 	background: var(--wp-admin-theme-color);
@@ -638,7 +638,7 @@
 
 		// When button is focused, it receives a box-shadow instead of the border.
 		&:focus {
-			box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+			box-shadow: 0 0 0 var(--border-width-focus) var(--wp-admin-theme-color);
 		}
 	}
 }

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -133,7 +133,10 @@ $tree-item-height: 36px;
 		}
 
 		&:focus::before {
-			@include block-toolbar-button-style__focus();
+			box-shadow: inset 0 0 0 var(--border-width-focus) var(--wp-admin-theme-color), inset 0 0 0 4px $white;
+
+			// Windows High Contrast mode will show this outline, but not the box-shadow.
+			outline: 2px solid transparent;
 		}
 
 		// Focus and toggle pseudo elements.

--- a/packages/block-editor/src/components/block-patterns-list/style.scss
+++ b/packages/block-editor/src/components/block-patterns-list/style.scss
@@ -12,7 +12,7 @@
 	}
 
 	&:focus {
-		box-shadow: inset 0 0 0 1px $white, 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+		box-shadow: inset 0 0 0 1px $white, 0 0 0 var(--border-width-focus) var(--wp-admin-theme-color);
 
 		// Windows High Contrast mode will show this outline, but not the box-shadow.
 		outline: 2px solid transparent;

--- a/packages/block-editor/src/components/block-styles/style.scss
+++ b/packages/block-editor/src/components/block-styles/style.scss
@@ -16,7 +16,7 @@
 	flex-direction: column;
 
 	&:focus {
-		box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+		box-shadow: 0 0 0 var(--border-width-focus) var(--wp-admin-theme-color);
 
 		// Windows High Contrast mode will show this outline, but not the box-shadow.
 		outline: 2px solid transparent;

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -95,7 +95,7 @@ $block-inserter-tabs-height: 44px;
 
 		&:focus {
 			background: $white;
-			box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+			box-shadow: 0 0 0 var(--border-width-focus) var(--wp-admin-theme-color);
 		}
 
 		&::placeholder {
@@ -317,6 +317,6 @@ $block-inserter-tabs-height: 44px;
 	}
 
 	&:focus:not(:disabled) {
-		box-shadow: inset 0 0 0 $border-width-focus $gray-900, inset 0 0 0 2px $white;
+		box-shadow: inset 0 0 0 var(--border-width-focus) $gray-900, inset 0 0 0 2px $white;
 	}
 }

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -127,7 +127,7 @@ $block-editor-link-control-number-of-actions: 1;
 
 	// The added specificity is needed to override.
 	&:focus:not(:disabled) {
-		box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color) inset;
+		box-shadow: 0 0 0 var(--border-width-focus) var(--wp-admin-theme-color) inset;
 	}
 
 	&.is-selected {

--- a/packages/block-editor/src/components/url-popover/style.scss
+++ b/packages/block-editor/src/components/url-popover/style.scss
@@ -35,7 +35,10 @@
 		box-shadow: none;
 
 		> svg {
-			@include block-toolbar-button-style__focus();
+			box-shadow: inset 0 0 0 var(--border-width-focus) var(--wp-admin-theme-color), inset 0 0 0 4px $white;
+
+			// Windows High Contrast mode will show this outline, but not the box-shadow.
+			outline: 2px solid transparent;
 		}
 	}
 }

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -26,7 +26,7 @@
 		}
 
 		&:focus {
-			box-shadow: inset 0 0 0 1px $white, 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+			box-shadow: inset 0 0 0 1px $white, 0 0 0 var(--border-width-focus) var(--wp-admin-theme-color);
 
 			// Windows High Contrast mode will show this outline, but not the box-shadow.
 			outline: 2px solid transparent;

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -29,7 +29,7 @@
 	// Focus.
 	// See https://github.com/WordPress/gutenberg/issues/13267 for more context on these selectors.
 	&:focus:not(:disabled) {
-		box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+		box-shadow: 0 0 0 var(--border-width-focus) var(--wp-admin-theme-color);
 
 		// Windows High Contrast mode will show this outline, but not the box-shadow.
 		outline: 1px solid transparent;
@@ -58,7 +58,7 @@
 		}
 
 		&:focus:not(:disabled) {
-			box-shadow: inset 0 0 0 1px $white, 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+			box-shadow: inset 0 0 0 1px $white, 0 0 0 var(--border-width-focus) var(--wp-admin-theme-color);
 
 			// Windows High Contrast mode will show this outline, but not the box-shadow.
 			outline: 1px solid transparent;
@@ -213,7 +213,7 @@
 			color: #124964;
 			box-shadow:
 				0 0 0 $border-width #5b9dd9,
-				0 0 $border-width-focus $border-width rgba(30, 140, 190, 0.8);
+				0 0 var(--border-width-focus) $border-width rgba(30, 140, 190, 0.8);
 		}
 
 		// Link buttons that are red to indicate destructive behavior.
@@ -300,7 +300,7 @@
 		background: $gray-900;
 
 		&:focus:not(:disabled) {
-			box-shadow: inset 0 0 0 1px $white, 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+			box-shadow: inset 0 0 0 1px $white, 0 0 0 var(--border-width-focus) var(--wp-admin-theme-color);
 
 			// Windows High Contrast mode will show this outline, but not the box-shadow.
 			outline: 2px solid transparent;

--- a/packages/components/src/checkbox-control/style.scss
+++ b/packages/components/src/checkbox-control/style.scss
@@ -27,7 +27,7 @@ $checkbox-input-size-sm: 24px; // Width & height for small viewports.
 	@include reduce-motion("transition");
 
 	&:focus {
-		box-shadow: 0 0 0 ($border-width * 2) $white, 0 0 0 ($border-width * 2 + $border-width-focus) var(--wp-admin-theme-color);
+		box-shadow: 0 0 0 ($border-width * 2) $white, 0 0 0 ($border-width * 2 + var(--border-width-focus)) var(--wp-admin-theme-color);
 
 		// Only visible in Windows High Contrast mode.
 		outline: 2px solid transparent;

--- a/packages/components/src/custom-select-control/style.scss
+++ b/packages/components/src/custom-select-control/style.scss
@@ -23,7 +23,7 @@
 
 	&:focus:not(:disabled) {
 		border-color: var(--wp-admin-theme-color);
-		box-shadow: 0 0 0 ($border-width-focus - $border-width) var(--wp-admin-theme-color);
+		box-shadow: 0 0 0 calc(var(--border-width-focus) - $border-width) var(--wp-admin-theme-color);
 	}
 
 	.components-custom-select-control__button-icon {

--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -72,7 +72,7 @@
 		text-align: center;
 
 		&:focus {
-			box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color), inset 0 0 0 #{ $border-width-focus + $border-width } $white;
+			box-shadow: inset 0 0 0 var(--border-width-focus) var(--wp-admin-theme-color), inset 0 0 0 calc(var(--border-width-focus) + $border-width) $white;
 			outline: 2px solid transparent; // Shown in Windows 10 high contrast mode.
 		}
 	}
@@ -95,7 +95,11 @@
 		top: 20px;
 
 		&:focus {
-			@include input-style__focus();
+			border-color: var(--wp-admin-theme-color);
+			box-shadow: 0 0 0 calc(var(--border-width-focus) - $border-width) var(--wp-admin-theme-color);
+
+			// Windows High Contrast mode will show this outline, but not the box-shadow.
+			outline: 2px solid transparent;
 		}
 	}
 

--- a/packages/components/src/form-toggle/style.scss
+++ b/packages/components/src/form-toggle/style.scss
@@ -44,7 +44,7 @@ $toggle-border-width: 1px;
 	}
 
 	.components-form-toggle__input:focus + .components-form-toggle__track {
-		box-shadow: 0 0 0 2px $white, 0 0 0 (2px + $border-width-focus) var(--wp-admin-theme-color);
+		box-shadow: 0 0 0 2px $white, 0 0 0 calc(2px + var(--border-width-focus)) var(--wp-admin-theme-color);
 
 		// Windows High Contrast mode will show this outline, but not the box-shadow.
 		outline: 2px solid transparent;

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -89,7 +89,7 @@
 	height: auto;
 
 	&:focus {
-		box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+		box-shadow: inset 0 0 0 var(--border-width-focus) var(--wp-admin-theme-color);
 		border-radius: 0;
 	}
 

--- a/packages/components/src/tab-panel/style.scss
+++ b/packages/components/src/tab-panel/style.scss
@@ -29,13 +29,13 @@
 	}
 
 	&:focus:not(:disabled) {
-		box-shadow: inset 0 $border-width-focus var(--wp-admin-theme-color);
+		box-shadow: inset 0 var(--border-width-focus) var(--wp-admin-theme-color);
 	}
 
 
 	&.is-active {
 		// The transparent shadow ensures no jumpiness when focus animates on an active tab.
-		box-shadow: inset 0 0 0 $border-width-focus transparent, inset 0 0 -$border-width-tab 0 0 var(--wp-admin-theme-color);
+		box-shadow: inset 0 0 0 var(--border-width-focus) transparent, inset 0 0 -$border-width-tab 0 0 var(--wp-admin-theme-color);
 		position: relative;
 
 		// This border appears in Windows High Contrast mode instead of the box-shadow.
@@ -51,10 +51,10 @@
 	}
 
 	&:focus {
-		box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+		box-shadow: inset 0 0 0 var(--border-width-focus) var(--wp-admin-theme-color);
 	}
 
 	&.is-active:focus {
-		box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color), inset 0 0 -$border-width-tab 0 0 var(--wp-admin-theme-color);
+		box-shadow: inset 0 0 0 var(--border-width-focus) var(--wp-admin-theme-color), inset 0 0 -$border-width-tab 0 0 var(--wp-admin-theme-color);
 	}
 }

--- a/packages/components/src/toolbar/style.scss
+++ b/packages/components/src/toolbar/style.scss
@@ -68,7 +68,10 @@
 
 		// Focus style.
 		&:focus::before {
-			@include block-toolbar-button-style__focus();
+			box-shadow: inset 0 0 0 var(--border-width-focus) var(--wp-admin-theme-color), inset 0 0 0 4px $white;
+
+			// Windows High Contrast mode will show this outline, but not the box-shadow.
+			outline: 2px solid transparent;
 		}
 
 		// Ensure the icon buttons remain square.

--- a/packages/edit-post/src/components/header/fullscreen-mode-close/style.scss
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/style.scss
@@ -23,7 +23,7 @@
 		}
 
 		&:focus {
-			box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color), inset 0 0 0 ($border-width-focus + 1px) $white;
+			box-shadow: inset 0 0 0 var(--border-width-focus) var(--wp-admin-theme-color), inset 0 0 0 calc(var(--border-width-focus) + 1px) $white;
 		}
 	}
 }

--- a/packages/edit-post/src/components/header/header-toolbar/style.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.scss
@@ -38,7 +38,7 @@
 		}
 
 		&:focus:not(:disabled) {
-			box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color), inset 0 0 0 $border-width $white;
+			box-shadow: 0 0 0 var(--border-width-focus) var(--wp-admin-theme-color), inset 0 0 0 $border-width $white;
 			outline: 1px solid transparent;
 		}
 

--- a/packages/edit-post/src/components/sidebar/settings-header/style.scss
+++ b/packages/edit-post/src/components/sidebar/settings-header/style.scss
@@ -25,7 +25,7 @@
 
 	&.is-active {
 		// The transparent shadow ensures no jumpiness when focus animates on an active tab.
-		box-shadow: inset 0 0 0 $border-width-focus transparent, inset 0 0 -$border-width-tab 0 0 var(--wp-admin-theme-color);
+		box-shadow: inset 0 0 0 var(--border-width-focus) transparent, inset 0 0 -$border-width-tab 0 0 var(--wp-admin-theme-color);
 		position: relative;
 		z-index: z-index(".edit-post-sidebar__panel-tab.is-active");
 
@@ -42,12 +42,12 @@
 	}
 
 	&:focus {
-		box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+		box-shadow: inset 0 0 0 var(--border-width-focus) var(--wp-admin-theme-color);
 		position: relative;
 		z-index: z-index(".edit-post-sidebar__panel-tab.is-active");
 	}
 
 	&.is-active:focus {
-		box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color), inset 0 0 -$border-width-tab 0 0 var(--wp-admin-theme-color);
+		box-shadow: inset 0 0 0 var(--border-width-focus) var(--wp-admin-theme-color), inset 0 0 -$border-width-tab 0 0 var(--wp-admin-theme-color);
 	}
 }

--- a/packages/edit-site/src/components/header/fullscreen-mode-close/style.scss
+++ b/packages/edit-site/src/components/header/fullscreen-mode-close/style.scss
@@ -22,7 +22,7 @@
 				color: $white;
 			}
 			&:focus {
-				box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color), inset 0 0 0 3px $white;
+				box-shadow: inset 0 0 0 var(--border-width-focus) var(--wp-admin-theme-color), inset 0 0 0 3px $white;
 			}
 		}
 	}

--- a/packages/edit-widgets/src/components/sidebar/style.scss
+++ b/packages/edit-widgets/src/components/sidebar/style.scss
@@ -49,7 +49,7 @@
 
 	&.is-active {
 		// The transparent shadow ensures no jumpiness when focus animates on an active tab.
-		box-shadow: inset 0 0 0 $border-width-focus transparent, inset 0 0 -$border-width-tab 0 0 var(--wp-admin-theme-color);
+		box-shadow: inset 0 0 0 var(--border-width-focus) transparent, inset 0 0 -$border-width-tab 0 0 var(--wp-admin-theme-color);
 		font-weight: 600;
 		position: relative;
 
@@ -66,11 +66,11 @@
 	}
 
 	&:focus {
-		box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+		box-shadow: inset 0 0 0 var(--border-width-focus) var(--wp-admin-theme-color);
 	}
 
 	&.is-active:focus {
-		box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color), inset 0 0 -$border-width-tab 0 0 var(--wp-admin-theme-color);
+		box-shadow: inset 0 0 0 var(--border-width-focus) var(--wp-admin-theme-color), inset 0 0 -$border-width-tab 0 0 var(--wp-admin-theme-color);
 	}
 }
 

--- a/packages/editor/src/components/document-outline/style.scss
+++ b/packages/editor/src/components/document-outline/style.scss
@@ -58,7 +58,7 @@
 	}
 
 	&:focus {
-		box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+		box-shadow: 0 0 0 var(--border-width-focus) var(--wp-admin-theme-color);
 
 		// Windows High Contrast mode will show this outline, but not the box-shadow.
 		outline: 2px solid transparent;

--- a/packages/editor/src/components/post-last-revision/style.scss
+++ b/packages/editor/src/components/post-last-revision/style.scss
@@ -17,7 +17,7 @@
 	}
 
 	&:focus {
-		box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+		box-shadow: inset 0 0 0 var(--border-width-focus) var(--wp-admin-theme-color);
 		border-radius: 0;
 	}
 }

--- a/packages/editor/src/components/table-of-contents/style.scss
+++ b/packages/editor/src/components/table-of-contents/style.scss
@@ -31,7 +31,7 @@
 	right: 0;
 	bottom: 0;
 	left: 0;
-	box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+	box-shadow: inset 0 0 0 var(--border-width-focus) var(--wp-admin-theme-color);
 }
 
 .table-of-contents__counts {


### PR DESCRIPTION
A second attempt,and a slightly simpler, implementation to fix blurry borders on 1x screens.

Many of the focus styles in Gutenberg are box shadows with a `1.5px` value. This is really nice looking on hidpi screens, but looks a bit rough on 1x screens. I thought I'd try a mixin that does a few things:

This idea was suggested by @jasmussen in https://github.com/WordPress/gutenberg/pull/23663 and looks like this:

```
:root {
	--border-width-focus: 1.5px;

	@media ( max-resolution: 96dpi ) {
		--border-width-focus: 2px;
	}
}
```

1. It does mean replacing the Sass variable with a CSS variable (custom property) which is why so many files are edited.
2. Safari (on either platform) does not yes support `max-resolution` so I defaulted to `1.5px`. Browsers that support the media query that are using a display with 1X resolution will see `2px` borders.
3. You'll see I removed a few mixins. They were hardly used. Might as well simplify.

**ISSUE** - Right now, there are two places in the mixins file that are throwing an error when I try to replace the Sass variable with a CSS custom property. I have tried a few things without success. Any suggestions are welcome.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->

