### PR TITLE
Revert "[Mobile] Reduce spacing between label and slider control"

### DIFF
--- a/packages/components/src/mobile/bottom-sheet/cellRowStyles.android.scss
+++ b/packages/components/src/mobile/bottom-sheet/cellRowStyles.android.scss
@@ -1,6 +1,0 @@
-.cellRowStyles {
-	min-height: 48px;
-	margin-bottom: -37px;
-	width: 100%;
-	justify-content: space-between;
-}

--- a/packages/components/src/mobile/bottom-sheet/cellRowStyles.ios.scss
+++ b/packages/components/src/mobile/bottom-sheet/cellRowStyles.ios.scss
@@ -1,6 +1,0 @@
-.cellRowStyles {
-	min-height: 48px;
-	margin-bottom: -27px;
-	width: 100%;
-	justify-content: space-between;
-}

--- a/packages/components/src/mobile/bottom-sheet/range-cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/range-cell.native.js
@@ -24,7 +24,6 @@ import { withPreferredColorScheme } from '@wordpress/compose';
  */
 import Cell from './cell';
 import styles from './range-cell.scss';
-import rowStyles from './cellRowStyles.scss';
 import borderStyles from './borderStyles.scss';
 
 class BottomSheetRangeCell extends Component {
@@ -180,7 +179,7 @@ class BottomSheetRangeCell extends Component {
 			<Cell
 				{ ...cellProps }
 				cellContainerStyle={ styles.cellContainerStyles }
-				cellRowContainerStyle={ rowStyles.cellRowStyles }
+				cellRowContainerStyle={ styles.cellRowStyles }
 				accessibilityRole={ 'none' }
 				value={ '' }
 				editable={ false }

--- a/packages/components/src/mobile/bottom-sheet/range-cell.native.scss
+++ b/packages/components/src/mobile/bottom-sheet/range-cell.native.scss
@@ -31,3 +31,10 @@
 	flex-direction: column;
 	align-items: flex-start;
 }
+
+.cellRowStyles {
+	min-height: 48px;
+	margin-bottom: -13px;
+	width: 100%;
+	justify-content: space-between;
+}


### PR DESCRIPTION
Reverts WordPress/gutenberg#23580

Fixes: https://github.com/wordpress-mobile/gutenberg-mobile/issues/2501

Note: Please note that even after reverting the issue exists. It’s just not obvious because the margin value does not cause an overlap.