### PR TITLE
Add missing prop in WPBlockVariation type definition

### DIFF
--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -93,6 +93,9 @@ import { DEPRECATED_ENTRY_KEYS } from './constants';
  * @property {WPBlockVariationScope[]} [scope] The list of scopes where the variation
  *                                             is applicable. When not provided, it
  *                                             assumes all available scopes.
+ * @property {string[]} [keywords]             An array of terms (which can be translated)
+ *                                             that help users discover the variation
+ *                                             while searching.
  */
 
 /**


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
This PR just adds the missing `keywords` property in `WPBlockVariation` type definition that was introduced here: https://github.com/WordPress/gutenberg/pull/24040.