### PR TITLE
Post Content Block: Disable when editing content (server-side approach)

### DIFF
--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -37,3 +37,21 @@ function register_block_core_post_content() {
 	);
 }
 add_action( 'init', 'register_block_core_post_content' );
+
+/**
+ * Only show the `core/post-content` block when editing templates and template parts.
+ * This is to prevent infinite recursions (post content containing a Post Content block
+ * that attempts to embed the post content it is part of).
+ *
+ * @param bool|array $allowed_block_types Array of block type slugs, or
+ *                                        boolean to enable/disable all.
+ * @param WP_Post    $post                The post resource data.
+ */
+function disallow_core_post_content_block_outside_templates( $allowed_block_types, $post ) {
+	if ( in_array( $post->post_type, array( 'wp_template', 'wp_template_part' ), true ) ) {
+		return $allowed_block_types;
+	}
+	return array_diff( $allowed_block_types, array( 'core/post-content' ) );
+}
+
+add_filter( 'allowed_block_types', 'disallow_core_post_content_block_outside_templates', 10, 2 );

--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -48,6 +48,14 @@ add_action( 'init', 'register_block_core_post_content' );
  * @param WP_Post    $post                The post resource data.
  */
 function disallow_core_post_content_block_outside_templates( $allowed_block_types, $post ) {
+	/**
+	 * The following if clause can be removed once Gutenberg requires a WordPress version
+	 * that includes https://github.com/WordPress/wordpress-develop/pull/419.
+	 */
+	if ( true === $allowed_block_types ) {
+		$allowed_block_types = WP_Block_Type_Registry::get_instance()->get_all_registered();
+	}
+
 	if ( in_array( $post->post_type, array( 'wp_template', 'wp_template_part' ), true ) ) {
 		return $allowed_block_types;
 	}


### PR DESCRIPTION
## Description

Tentative partial fix for #22080; alternative to #24006:  Remove the Post Content block when editing content, in order to prevent blockception (an infinite recursion of the Post Content block embedding the current post content, which includes itself, and so on).

## How has this been tested?
- Verify that in the Post Editor, the Post Content Block is no longer available from the block inserter.
- Verify that in the _Site_ Editor, the Post Content Block is still longer available from the block inserter.
- Verify that in the Template and Template Part Editors (found in the Appearance menu), the Post Block is still available from the inserter.
- Verify that the Post Content Block isn't available in the Widgets and Navigation Editors, and that no errors are thrown in the console. (Your have to enable those editors on the Gutenberg > Experiments wp-admin page first; this will enable the corresponding menu items in the Gutenberg menu.)

## Blockers

Can't `apply_filters( 'allowed_block_types', true, $post );` in `lib/edit-site-page.php` since no `$post` object is available :confused: (and if it was, it'd only represent the initially loaded template, not the ones that the user might switch to later). We'd need to query block types via the REST API (see #21065), and the filter would need to applied there (#24076).

## Screenshots <!-- if applicable -->
N/A

## Types of changes
Bug fix.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
