### PR TITLE
Wrap LinkControlSearchInput in forwardRef

### DIFF
--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -7,7 +7,7 @@ import { noop, omit } from 'lodash';
  * WordPress dependencies
  */
 import { useInstanceId } from '@wordpress/compose';
-import { useState } from '@wordpress/element';
+import { forwardRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -19,105 +19,115 @@ import { CREATE_TYPE } from './constants';
 import useSearchHandler from './use-search-handler';
 
 const noopSearchHandler = Promise.resolve( [] );
-const LinkControlSearchInput = ( {
-	value,
-	children,
-	currentLink = {},
-	className = null,
-	placeholder = null,
-	withCreateSuggestion = false,
-	onCreateSuggestion = noop,
-	onChange = noop,
-	onSelect = noop,
-	showSuggestions = true,
-	renderSuggestions = ( props ) => <LinkControlSearchResults { ...props } />,
-	fetchSuggestions = null,
-	allowDirectEntry = true,
-	showInitialSuggestions = false,
-} ) => {
-	const genericSearchHandler = useSearchHandler( allowDirectEntry );
-	const searchHandler = showSuggestions
-		? fetchSuggestions || genericSearchHandler
-		: noopSearchHandler;
+const LinkControlSearchInput = forwardRef(
+	(
+		{
+			value,
+			children,
+			currentLink = {},
+			className = null,
+			placeholder = null,
+			withCreateSuggestion = false,
+			onCreateSuggestion = noop,
+			onChange = noop,
+			onSelect = noop,
+			showSuggestions = true,
+			renderSuggestions = ( props ) => (
+				<LinkControlSearchResults { ...props } />
+			),
+			fetchSuggestions = null,
+			allowDirectEntry = true,
+			showInitialSuggestions = false,
+		},
+		ref
+	) => {
+		const genericSearchHandler = useSearchHandler( allowDirectEntry );
+		const searchHandler = showSuggestions
+			? fetchSuggestions || genericSearchHandler
+			: noopSearchHandler;
 
-	const instanceId = useInstanceId( LinkControlSearchInput );
-	const [ focusedSuggestion, setFocusedSuggestion ] = useState();
+		const instanceId = useInstanceId( LinkControlSearchInput );
+		const [ focusedSuggestion, setFocusedSuggestion ] = useState();
 
-	/**
-	 * Handles the user moving between different suggestions. Does not handle
-	 * choosing an individual item.
-	 *
-	 * @param {string} selection the url of the selected suggestion.
-	 * @param {Object} suggestion the suggestion object.
-	 */
-	const onInputChange = ( selection, suggestion ) => {
-		onChange( selection );
-		setFocusedSuggestion( suggestion );
-	};
+		/**
+		 * Handles the user moving between different suggestions. Does not handle
+		 * choosing an individual item.
+		 *
+		 * @param {string} selection the url of the selected suggestion.
+		 * @param {Object} suggestion the suggestion object.
+		 */
+		const onInputChange = ( selection, suggestion ) => {
+			onChange( selection );
+			setFocusedSuggestion( suggestion );
+		};
 
-	const onFormSubmit = ( event ) => {
-		event.preventDefault();
-		onSuggestionSelected( focusedSuggestion || { url: value } );
-	};
+		const onFormSubmit = ( event ) => {
+			event.preventDefault();
+			onSuggestionSelected( focusedSuggestion || { url: value } );
+		};
 
-	const handleRenderSuggestions = ( props ) =>
-		renderSuggestions( {
-			...props,
-			instanceId,
-			withCreateSuggestion,
-			currentInputValue: value,
-			handleSuggestionClick: ( suggestion ) => {
-				if ( props.handleSuggestionClick ) {
-					props.handleSuggestionClick( suggestion );
-				}
-				onSuggestionSelected( suggestion );
-			},
-		} );
+		const handleRenderSuggestions = ( props ) =>
+			renderSuggestions( {
+				...props,
+				instanceId,
+				withCreateSuggestion,
+				currentInputValue: value,
+				handleSuggestionClick: ( suggestion ) => {
+					if ( props.handleSuggestionClick ) {
+						props.handleSuggestionClick( suggestion );
+					}
+					onSuggestionSelected( suggestion );
+				},
+			} );
 
-	const onSuggestionSelected = async ( selectedSuggestion ) => {
-		let suggestion = selectedSuggestion;
-		if ( CREATE_TYPE === selectedSuggestion.type ) {
-			// Create a new page and call onSelect with the output from the onCreateSuggestion callback
-			try {
-				suggestion = await onCreateSuggestion(
-					selectedSuggestion.title
+		const onSuggestionSelected = async ( selectedSuggestion ) => {
+			let suggestion = selectedSuggestion;
+			if ( CREATE_TYPE === selectedSuggestion.type ) {
+				// Create a new page and call onSelect with the output from the onCreateSuggestion callback
+				try {
+					suggestion = await onCreateSuggestion(
+						selectedSuggestion.title
+					);
+					if ( suggestion?.url ) {
+						onSelect( suggestion );
+					}
+				} catch ( e ) {}
+				return;
+			}
+
+			if (
+				allowDirectEntry ||
+				( suggestion && Object.keys( suggestion ).length >= 1 )
+			) {
+				onSelect(
+					// Some direct entries don't have types or IDs, and we still need to clear the previous ones.
+					{ ...omit( currentLink, 'id', 'url' ), ...suggestion },
+					suggestion
 				);
-				if ( suggestion?.url ) {
-					onSelect( suggestion );
-				}
-			} catch ( e ) {}
-			return;
-		}
+			}
+		};
 
-		if (
-			allowDirectEntry ||
-			( suggestion && Object.keys( suggestion ).length >= 1 )
-		) {
-			onSelect(
-				// Some direct entries don't have types or IDs, and we still need to clear the previous ones.
-				{ ...omit( currentLink, 'id', 'url' ), ...suggestion },
-				suggestion
-			);
-		}
-	};
-
-	return (
-		<form onSubmit={ onFormSubmit }>
-			<URLInput
-				className={ className }
-				value={ value }
-				onChange={ onInputChange }
-				placeholder={ placeholder ?? __( 'Search or type url' ) }
-				__experimentalRenderSuggestions={
-					showSuggestions ? handleRenderSuggestions : null
-				}
-				__experimentalFetchLinkSuggestions={ searchHandler }
-				__experimentalHandleURLSuggestions={ true }
-				__experimentalShowInitialSuggestions={ showInitialSuggestions }
-			/>
-			{ children }
-		</form>
-	);
-};
+		return (
+			<form onSubmit={ onFormSubmit }>
+				<URLInput
+					className={ className }
+					value={ value }
+					onChange={ onInputChange }
+					placeholder={ placeholder ?? __( 'Search or type url' ) }
+					__experimentalRenderSuggestions={
+						showSuggestions ? handleRenderSuggestions : null
+					}
+					__experimentalFetchLinkSuggestions={ searchHandler }
+					__experimentalHandleURLSuggestions={ true }
+					__experimentalShowInitialSuggestions={
+						showInitialSuggestions
+					}
+					ref={ ref }
+				/>
+				{ children }
+			</form>
+		);
+	}
+);
 
 export default LinkControlSearchInput;


### PR DESCRIPTION
## Description
As in the title, `ref` needs to be supported in order to embed LinkControlSearchInput on block toolbar.

## How has this been tested?
Just eyeballing and passing tests should be enough. To be 110% sure, add a navigation block, edit a link, confirm the control looks the same as without this PR.

## Types of changes
Non-breaking changes

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
