### PR TITLE
Perf Tests: Set up branch only once for all test suites

### DIFF
--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -246,14 +246,14 @@ async function runPerformanceTests( branches, options ) {
 	/** @type {Record<string,Record<string, WPFormattedPerformanceResults>>} */
 	let results = {};
 	for ( const branch of branches ) {
-		for ( const testSuite of testSuites ) {
-			await setUpGitBranch( branch, environmentDirectory );
-			log(
-				'>> Running the test on the ' +
-					formats.success( branch ) +
-					' branch'
-			);
+		await setUpGitBranch( branch, environmentDirectory );
+		log(
+			'>> Running the test on the ' +
+				formats.success( branch ) +
+				' branch'
+		);
 
+		for ( const testSuite of testSuites ) {
 			results = {
 				...results,
 				[ testSuite ]: {

--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -246,18 +246,21 @@ async function runPerformanceTests( branches, options ) {
 	const testSuites = [ 'post-editor', 'site-editor' ];
 
 	/** @type {Record<string,Record<string, WPFormattedPerformanceResults>>} */
-	const results = {};
-	for ( const testSuite of testSuites ) {
-		results[ testSuite ] = {};
-		for ( const branch of branches ) {
-			results[ testSuite ][
-				branch
-			] = await getPerformanceResultsForBranch(
-				performanceTestDirectory,
-				environmentDirectory,
-				testSuite,
-				branch
-			);
+	let results = {};
+	for ( const branch of branches ) {
+		for ( const testSuite of testSuites ) {
+			results = {
+				...results,
+				[ testSuite ]: {
+					...results[ testSuite ],
+					[ branch ]: await getPerformanceResultsForBranch(
+						performanceTestDirectory,
+						environmentDirectory,
+						testSuite,
+						branch
+					),
+				},
+			};
 		}
 	}
 

--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -117,21 +117,12 @@ function curateResults( results ) {
 }
 
 /**
- * Runs the performance tests on a given branch.
+ * Set up the given branch for testing.
  *
- * @param {string} performanceTestDirectory Path to the performance tests' clone.
- * @param {string} environmentDirectory     Path to the plugin environment's clone.
- * @param {string} testSuite                Name of the tests set.
  * @param {string} branch                   Branch name.
- *
- * @return {Promise<WPFormattedPerformanceResults>} Performance results for the branch.
+ * @param {string} environmentDirectory     Path to the plugin environment's clone.
  */
-async function getPerformanceResultsForBranch(
-	performanceTestDirectory,
-	environmentDirectory,
-	testSuite,
-	branch
-) {
+async function setUpGitBranch( branch, environmentDirectory ) {
 	// Restore clean working directory (e.g. if `package-lock.json` has local
 	// changes after install).
 	await git.discardLocalChanges( environmentDirectory );
@@ -144,10 +135,17 @@ async function getPerformanceResultsForBranch(
 		'rm -rf node_modules && npm install && npm run build',
 		environmentDirectory
 	);
+}
 
-	log(
-		'>> Running the test on the ' + formats.success( branch ) + ' branch'
-	);
+/**
+ * Runs the performance tests on the current branch.
+ *
+ * @param {string} testSuite                Name of the tests set.
+ * @param {string} performanceTestDirectory Path to the performance tests' clone.
+ *
+ * @return {Promise<WPFormattedPerformanceResults>} Performance results for the branch.
+ */
+async function runTestSuite( testSuite, performanceTestDirectory ) {
 	const results = [];
 	for ( let i = 0; i < 3; i++ ) {
 		await runShellScript(
@@ -249,15 +247,20 @@ async function runPerformanceTests( branches, options ) {
 	let results = {};
 	for ( const branch of branches ) {
 		for ( const testSuite of testSuites ) {
+			await setUpGitBranch( branch, environmentDirectory );
+			log(
+				'>> Running the test on the ' +
+					formats.success( branch ) +
+					' branch'
+			);
+
 			results = {
 				...results,
 				[ testSuite ]: {
 					...results[ testSuite ],
-					[ branch ]: await getPerformanceResultsForBranch(
-						performanceTestDirectory,
-						environmentDirectory,
+					[ branch ]: await runTestSuite(
 						testSuite,
-						branch
+						performanceTestDirectory
 					),
 				},
 			};


### PR DESCRIPTION
## Description
@youknowriad notified me via DM that 

> we run first the post editor tests on both branches and then the site editor perf tests on both branches
> it seems  that we lose a lot of time building and installing deps when doing so instead it’d be better if we run both suites in a branch before switching branches

This is because my recent PR #23842 got the loop nesting order wrong. This PR fixes this issue.

## How has this been tested?
In the details for the Performance test GH Action on this PR, verify that a branch is only checked out once, and both test suites are run on it, before the next branch is checked out (cutting down overall running time of the Action). Verify that the results are still sane :+1: 

## Types of changes
Performance test performance improvement :grimacing: 

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
