### PR TITLE
Create Block: Enable loading translations for created blocks

### DIFF
--- a/docs/designers-developers/developers/tutorials/create-block/block-anatomy.md
+++ b/docs/designers-developers/developers/tutorials/create-block/block-anatomy.md
@@ -52,9 +52,9 @@ The results of the save function is what the editor will insert into the **post_
 If you look at the generated `src/index.js` file, the block title and description are wrapped in a function that looks like this:
 
 ```js
-__( 'Gutenpride', 'create-block' );
+__( 'Gutenpride', 'gutenpride' );
 ```
 
-This is an internationalization wrapper that allows for the string "Gutenpride" to be translated. The second parameter, "create_block" is called the text domain and gives context for where the string is from. The JavaScript internationalization, often abbreviated i18n, matches the core WordPress internationalization process. See the [I18n for WordPress documentation](https://codex.wordpress.org/I18n_for_WordPress_Developers) for more details.
+This is an internationalization wrapper that allows for the string "Gutenpride" to be translated. The second parameter, "gutenpride" is called the text domain and gives context for where the string is from. The JavaScript internationalization, often abbreviated i18n, matches the core WordPress internationalization process. See the [I18n for WordPress documentation](https://codex.wordpress.org/I18n_for_WordPress_Developers) for more details.
 
 Next Section: [Block Attributes](/docs/designers-developers/developers/tutorials/create-block/block-attributes.md)

--- a/docs/designers-developers/developers/tutorials/create-block/block-anatomy.md
+++ b/docs/designers-developers/developers/tutorials/create-block/block-anatomy.md
@@ -52,7 +52,7 @@ The results of the save function is what the editor will insert into the **post_
 If you look at the generated `src/index.js` file, the block title and description are wrapped in a function that looks like this:
 
 ```js
-__( 'Gutenpride', 'create_block' );
+__( 'Gutenpride', 'create-block' );
 ```
 
 This is an internationalization wrapper that allows for the string "Gutenpride" to be translated. The second parameter, "create_block" is called the text domain and gives context for where the string is from. The JavaScript internationalization, often abbreviated i18n, matches the core WordPress internationalization process. See the [I18n for WordPress documentation](https://codex.wordpress.org/I18n_for_WordPress_Developers) for more details.

--- a/docs/designers-developers/developers/tutorials/create-block/block-attributes.md
+++ b/docs/designers-developers/developers/tutorials/create-block/block-attributes.md
@@ -52,7 +52,7 @@ export default function Edit( { attributes, className, setAttributes } ) {
 	return (
 		<div className={ className }>
 			<TextControl
-				label={ __( 'Message', 'create-block' ) }
+				label={ __( 'Message', 'gutenpride' ) }
 				value={ attributes.message }
 				onChange={ ( val ) => setAttributes( { message: val } ) }
 			/>

--- a/docs/designers-developers/developers/tutorials/create-block/wp-plugin.md
+++ b/docs/designers-developers/developers/tutorials/create-block/wp-plugin.md
@@ -35,7 +35,7 @@ The main plugin file created is the PHP file `gutenpride.php`, at the top of thi
  * Author:          The WordPress Contributors
  * License:         GPL-2.0-or-later
  * License URI:     https://www.gnu.org/licenses/gpl-2.0.html
- * Text Domain:     create-block
+ * Text Domain:     gutenpride
  *
  * @package         create-block
  */

--- a/docs/designers-developers/developers/tutorials/create-block/wp-plugin.md
+++ b/docs/designers-developers/developers/tutorials/create-block/wp-plugin.md
@@ -108,6 +108,7 @@ function create_block_gutenpride_block_init() {
 		$script_asset['dependencies'],
 		$script_asset['version']
 	);
+	wp_set_script_translations( 'create-block-gutenpride-block-editor', 'create_block' );
 
 	$editor_css = 'editor.css';
 	wp_register_style(
@@ -137,6 +138,8 @@ add_action( 'init', 'create_block_gutenpride_block_init' );
 The build process creates a secondary asset file that contains the list of dependencies and a file version based on the timestamp, this is the `index.asset.php` file.
 
 The `wp_register_script` function registers a name, called the handle, and relates that name to the script file. The dependencies are used to specify if the script requires including other libraries. The version is specified so the browser will reload if the file changed.
+
+The `wp_set_script_translations` function tells WordPress to load translations for this script, if they exist. See more about [translations & internationalization.](/docs/designers-developers/developers/internationalization.md)
 
 The `register_block_type` function registers the block we are going to create and specifies the editor_script file handle registered. So now when the editor loads it will load this script.
 

--- a/docs/designers-developers/developers/tutorials/create-block/wp-plugin.md
+++ b/docs/designers-developers/developers/tutorials/create-block/wp-plugin.md
@@ -108,7 +108,7 @@ function create_block_gutenpride_block_init() {
 		$script_asset['dependencies'],
 		$script_asset['version']
 	);
-	wp_set_script_translations( 'create-block-gutenpride-block-editor', 'create-block' );
+	wp_set_script_translations( 'create-block-gutenpride-block-editor', 'gutenpride' );
 
 	$editor_css = 'editor.css';
 	wp_register_style(

--- a/docs/designers-developers/developers/tutorials/create-block/wp-plugin.md
+++ b/docs/designers-developers/developers/tutorials/create-block/wp-plugin.md
@@ -108,7 +108,7 @@ function create_block_gutenpride_block_init() {
 		$script_asset['dependencies'],
 		$script_asset['version']
 	);
-	wp_set_script_translations( 'create-block-gutenpride-block-editor', 'create_block' );
+	wp_set_script_translations( 'create-block-gutenpride-block-editor', 'create-block' );
 
 	$editor_css = 'editor.css';
 	wp_register_style(

--- a/packages/create-block/lib/scaffold.js
+++ b/packages/create-block/lib/scaffold.js
@@ -54,7 +54,7 @@ module.exports = async (
 		author,
 		license,
 		licenseURI,
-		textdomain: namespace,
+		textdomain: slug,
 		editorScript,
 		editorStyle,
 		style,

--- a/packages/create-block/lib/templates/es5/$slug.php.mustache
+++ b/packages/create-block/lib/templates/es5/$slug.php.mustache
@@ -39,6 +39,7 @@ function {{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init() {
 		),
 		filemtime( "$dir/$index_js" )
 	);
+	wp_set_script_translations( '{{namespace}}-{{slug}}-block-editor', '{{textdomain}}' );
 
 	$editor_css = 'editor.css';
 	wp_register_style(

--- a/packages/create-block/lib/templates/esnext/$slug.php.mustache
+++ b/packages/create-block/lib/templates/esnext/$slug.php.mustache
@@ -42,6 +42,7 @@ function {{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init() {
 		$script_asset['dependencies'],
 		$script_asset['version']
 	);
+	wp_set_script_translations( '{{namespace}}-{{slug}}-block-editor', '{{textdomain}}' );
 
 	$editor_css = 'build/index.css';
 	wp_register_style(


### PR DESCRIPTION
## Description
Currently, `create-block` creates a plugin using i18n, but it doesn't attach the translations to the script. This PR adds a call to `wp_set_script_translations` to both templates, to ensure that translations will be injected into the page.

I also added a note into the create-block tutorial, but since the next step explains what i18n is, I left it very basic.

## How has this been tested?
Ran the create-block script locally, and ensured that the `*-js-translations` script tag was output on the page.
