### PR TITLE
Fix PHP notices when block hasn't declared 'supports'.

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -234,7 +234,7 @@ function gutenberg_experimental_apply_classnames_and_styles( $block_content, $bl
 
 	$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
 	// If no render_callback, assume styles have been previously handled.
-	if ( ! $block_type || ! $block_type->render_callback ) {
+	if ( ! $block_type || ! $block_type->render_callback || empty( $block_type->supports ) ) {
 		return $block_content;
 	}
 	// Check what style features the block supports.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

I noticed this issue across all of the blocks we developed for Newspack shortly after the 8.6.0 release and traced the issue back to https://github.com/WordPress/gutenberg/commit/97fe260c953690fd7356e28fee22944ca529558a. In that feature, the code references `$block_type->supports` without first making sure the field is defined. This causes a bunch of notices like the following: 

```
Notice: Undefined property: WP_Block_Type::$supports in /xxxxxxx/wp-content/plugins/gutenberg/lib/blocks.php on line 242
```

My understanding of the feature is that server-side supports declarations for blocks are a brand new concept, so this error is likely present on tons of blocks all over the internet with Gutenberg 8.6.0, since nobody would have defined those declarations yet.

You can view a live test example at https://specified-wild.jurassic.ninja/, but it should be straightforward to reproduce the problem locally.

This PR adds an extra check to make sure that `$supports` is defined before doing stuff with it.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
This is a pretty straightforward hardening, so it shouldn't cause any issues. I did test with a variety of blocks to verify, though.

## Screenshots 

<img width="1255" alt="Screen Shot 2020-07-22 at 1 43 12 PM" src="https://user-images.githubusercontent.com/7317227/88226844-8ffe0d80-cc21-11ea-9bb4-985507770d6e.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
