### PR TITLE
Tweak to "wp-block-gallery" style, to be more efficient

### DIFF
--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -1,28 +1,34 @@
 .wp-block-gallery,
-.blocks-gallery-grid {
-	display: flex;
-	flex-wrap: wrap;
-	list-style-type: none;
-	padding: 0;
-	// Some themes give all <ul> default margin instead of padding.
+.blocks-gallery-grid,
+.blocks-gallery-image,
+.blocks-gallery-item {
 	margin: 0;
+	padding: 0;
+}
+
+.wp-block-gallery {
+	.blocks-gallery-grid {
+		display: flex;
+		flex-wrap: wrap;
+		list-style-type: none;
+
+		// Offset parent, by the amount of spacing for each thumbnail.
+		margin-left: -1 * $grid-unit-10;
+		margin-right: -1 * $grid-unit-10;
+	}
 
 	.blocks-gallery-image,
 	.blocks-gallery-item {
-		// Add space between thumbnails, and unset right most thumbnails later.
-		margin: 0 1em 1em 0;
+		// Add space between thumbnails.
+		padding-left: $grid-unit-10;
+		padding-right: $grid-unit-10;
+		padding-bottom: $grid-unit-20;
+
 		display: flex;
 		flex-grow: 1;
 		flex-direction: column;
 		justify-content: center;
 		position: relative;
-
-		// On mobile and responsive viewports, we allow only 1 or 2 columns at the most.
-		width: calc(50% - 1em);
-
-		&:nth-of-type(even) {
-			margin-right: 0;
-		}
 
 		figure {
 			margin: 0;
@@ -40,8 +46,10 @@
 			display: block;
 			max-width: 100%;
 			height: auto;
+		}
 
-			// IE doesn't handle cropping, so we need an explicit width here.
+		// IE doesn't handle cropping, so we need an explicit width here.
+		img {
 			width: 100%;
 
 			// IE11 doesn't read rules inside this query. They are applied only to modern browsers.
@@ -51,27 +59,28 @@
 		}
 
 		figcaption {
+			// Offset caption, by the amount of spacing for each thumbnail.
 			position: absolute;
-			bottom: 0;
-			width: 100%;
-			max-height: 100%;
+			left: $grid-unit-10;
+			right: $grid-unit-10;
+			bottom: $grid-unit-20;
+			max-height: calc(100% - #{ $grid-unit-20 });
+
+			margin: 0;
+			padding: 40px 10px 9px;
+
+			width: auto;
 			overflow: auto;
-			padding: 3em 0.77em 0.7em;
+
 			color: $white;
 			text-align: center;
-			font-size: 0.8em;
+			font-size: $default-font-size;
 			background: linear-gradient(0deg, rgba($color: $black, $alpha: 0.7) 0, rgba($color: $black, $alpha: 0.3) 70%, transparent);
-			box-sizing: border-box;
-			margin: 0;
 
 			img {
 				display: inline;
 			}
 		}
-	}
-
-	figcaption {
-		flex-grow: 1;
 	}
 
 	// Cropped
@@ -92,10 +101,15 @@
 		}
 	}
 
+	// On mobile and responsive viewports, we allow only 1 or 2 columns at the most.
+	.blocks-gallery-image,
+	.blocks-gallery-item {
+		width: 50%;
+	}
+
 	&.columns-1 .blocks-gallery-image,
 	&.columns-1 .blocks-gallery-item {
 		width: 100%;
-		margin-right: 0;
 	}
 
 	// Beyond mobile viewports, we allow up to 8 columns.
@@ -103,24 +117,9 @@
 		@for $i from 3 through 8 {
 			&.columns-#{ $i } .blocks-gallery-image,
 			&.columns-#{ $i } .blocks-gallery-item {
-				width: calc(#{ 100% / $i } - #{ 1em * ( $i - 1 ) / $i });
-				margin-right: 1em;
+				width: calc(100% / #{ $i });
 			}
 		}
-
-		// Unset the right margin on every rightmost gallery item to ensure center balance.
-		@for $column-count from 1 through 8 {
-			&.columns-#{ $column-count } .blocks-gallery-image:nth-of-type(#{ $column-count }n),
-			&.columns-#{ $column-count } .blocks-gallery-item:nth-of-type(#{ $column-count }n) {
-				margin-right: 0;
-			}
-		}
-	}
-
-	// Last item always needs margins reset.
-	.blocks-gallery-image:last-child,
-	.blocks-gallery-item:last-child {
-		margin-right: 0;
 	}
 
 	// Apply max-width to floated items that have no intrinsic width.

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -19,16 +19,19 @@
 
 	.blocks-gallery-image,
 	.blocks-gallery-item {
-		// Add space between thumbnails.
-		padding-left: $grid-unit-10;
-		padding-right: $grid-unit-10;
-		padding-bottom: $grid-unit-20;
-
 		display: flex;
 		flex-grow: 1;
 		flex-direction: column;
 		justify-content: center;
 		position: relative;
+
+		// On mobile and responsive viewports, we allow only 1 or 2 columns at the most.
+		width: 50%;
+
+		// Add space between thumbnails.
+		padding-left: $grid-unit-10;
+		padding-right: $grid-unit-10;
+		padding-bottom: $grid-unit-20;
 
 		figure {
 			margin: 0;
@@ -46,10 +49,8 @@
 			display: block;
 			max-width: 100%;
 			height: auto;
-		}
 
-		// IE doesn't handle cropping, so we need an explicit width here.
-		img {
+			// IE doesn't handle cropping, so we need an explicit width here.
 			width: 100%;
 
 			// IE11 doesn't read rules inside this query. They are applied only to modern browsers.
@@ -99,12 +100,6 @@
 				object-fit: cover;
 			}
 		}
-	}
-
-	// On mobile and responsive viewports, we allow only 1 or 2 columns at the most.
-	.blocks-gallery-image,
-	.blocks-gallery-item {
-		width: 50%;
 	}
 
 	&.columns-1 .blocks-gallery-image,

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -1,16 +1,29 @@
 .wp-block-gallery,
-.blocks-gallery-grid {
-	display: flex;
-	flex-wrap: wrap;
-	list-style-type: none;
-	padding: 0;
-	// Some themes give all <ul> default margin instead of padding.
+.blocks-gallery-grid,
+.blocks-gallery-image,
+.blocks-gallery-item {
 	margin: 0;
+	padding: 0;
+}
+
+.wp-block-gallery {
+	.blocks-gallery-grid {
+		display: flex;
+		flex-wrap: wrap;
+		list-style-type: none;
+
+		// Offset parent, by the amount of spacing for each thumbnail.
+		margin-left: -1 * $grid-unit-10;
+		margin-right: -1 * $grid-unit-10;
+	}
 
 	.blocks-gallery-image,
 	.blocks-gallery-item {
-		// Add space between thumbnails, and unset right most thumbnails later.
-		margin: 0 $grid-unit-20 $grid-unit-20 0;
+		// Add space between thumbnails.
+		padding-left: $grid-unit-10;
+		padding-right: $grid-unit-10;
+		padding-bottom: $grid-unit-20;
+
 		display: flex;
 		flex-grow: 1;
 		flex-direction: column;
@@ -46,12 +59,19 @@
 		}
 
 		figcaption {
+			// Offset caption, by the amount of spacing for each thumbnail.
 			position: absolute;
-			bottom: 0;
-			width: 100%;
-			max-height: 100%;
-			overflow: auto;
+			left: $grid-unit-10;
+			right: $grid-unit-10;
+			bottom: $grid-unit-20;
+			max-height: calc(100% - #{ $grid-unit-20 });
+
+			margin: 0;
 			padding: 40px 10px 9px;
+
+			width: auto;
+			overflow: auto;
+
 			color: $white;
 			text-align: center;
 			font-size: $default-font-size;
@@ -82,19 +102,14 @@
 	}
 
 	// On mobile and responsive viewports, we allow only 1 or 2 columns at the most.
-	& .blocks-gallery-image,
-	& .blocks-gallery-item {
-		width: calc(50% - #{ $grid-unit-20 });
-
-		&:nth-of-type(even) {
-			margin-right: 0;
-		}
+	.blocks-gallery-image,
+	.blocks-gallery-item {
+		width: 50%;
 	}
 
 	&.columns-1 .blocks-gallery-image,
 	&.columns-1 .blocks-gallery-item {
 		width: 100%;
-		margin-right: 0;
 	}
 
 	// Beyond mobile viewports, we allow up to 8 columns.
@@ -102,24 +117,9 @@
 		@for $i from 3 through 8 {
 			&.columns-#{ $i } .blocks-gallery-image,
 			&.columns-#{ $i } .blocks-gallery-item {
-				width: calc(#{ 100% / $i } - #{ $grid-unit-20 * ( $i - 1 ) / $i });
-				margin-right: $grid-unit-20;
+				width: calc(100% / #{ $i });
 			}
 		}
-
-		// Unset the right margin on every rightmost gallery item to ensure center balance.
-		@for $column-count from 1 through 8 {
-			&.columns-#{ $column-count } .blocks-gallery-image:nth-of-type(#{ $column-count }n),
-			&.columns-#{ $column-count } .blocks-gallery-item:nth-of-type(#{ $column-count }n) {
-				margin-right: 0;
-			}
-		}
-	}
-
-	// Last item always needs margins reset.
-	.blocks-gallery-image:last-child,
-	.blocks-gallery-item:last-child {
-		margin-right: 0;
 	}
 
 	// Apply max-width to floated items that have no intrinsic width.
@@ -136,4 +136,3 @@
 		}
 	}
 }
-


### PR DESCRIPTION
### NOTE

There are some failing tests that already existed in `master` when I cloned the repo.

That is beyond the scope of the file that I changed in this PR. Hopefully that is okay.

---

### Description

While looking through the CSS for `wp-block-gallery`, I noticed several aspects that could be simplified considerably.

Specifically, the way that "gutters" are created between gallery items. It currently uses `margin-right`, which necessitates a lot of tweaks based on the number of columns, and involves overrides to handle `:nth-of-type(…)` exceptions.

Instead, I ended up refactoring this code for our own usage (at my job), so that we can use WP generated markup in a stand-alone "headless" Gatsby context. My coworkers suggested that I submit a Trac ticket…

https://core.trac.wordpress.org/ticket/50690

…which eventually led me to create this PR.

I simply used interior `padding-left` and `padding-right` for each gallery item `<li>`. With a negative `margin-left` and `margin-right` offset applied to the parent `<ul>`.

---

### How has this been tested?

I visually tested this using a Vagrant setup, with the plugin code running locally via `npm run dev`.

Since this is a style change only, there were not unit tests that needed to be written and/or changed.

I did test on a number of browsers and breakpoints. This is also akin to code we have been using for our own in-house theme approach, and it has served us well so far.

---

### Screenshots

Here are screenshots at several breakpoints. Hopefully these will suffice. If need be, I can provide more.

| &nbsp; | **Chrome** | **Firefox** | **Safari** |
| --: | :-- | :-- | :-- |
| **small width** | ![chrome-small-width](https://user-images.githubusercontent.com/135995/88302027-f5f29f80-ccca-11ea-8193-16a65bf4549e.png) | ![firefox-small-width](https://user-images.githubusercontent.com/135995/88302063-0276f800-cccb-11ea-8fdc-1dec5eb83020.png) | ![safari-small-width](https://user-images.githubusercontent.com/135995/88302087-0acf3300-cccb-11ea-8ab5-f258f85d5082.png) |
| **medium width** | ![chrome-medium-width](https://user-images.githubusercontent.com/135995/88248455-e2155200-cc66-11ea-80ae-84b045bdc721.png) | ![firefox-medium-width](https://user-images.githubusercontent.com/135995/88248470-ea6d8d00-cc66-11ea-9ba2-a8ac51d07e1a.png) | ![safari-medium-width](https://user-images.githubusercontent.com/135995/88248483-f5282200-cc66-11ea-9bca-2182fe04a555.png) |
| **large width** | ![chrome-large-width](https://user-images.githubusercontent.com/135995/88248507-040ed480-cc67-11ea-9f62-2580a58e3857.png) | ![firefox-large-width](https://user-images.githubusercontent.com/135995/88248519-0f620000-cc67-11ea-9463-620acd8802c9.png) | ![safari-large-width](https://user-images.githubusercontent.com/135995/88248531-1a1c9500-cc67-11ea-8371-8992b79fc4c3.png) |

---

### Types of changes

This PR introduces styling changes only. The underlying markup remains untouched.

---

### Checklist

- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.
