### PR TITLE
Make sure we don't search the directory for child items.

### DIFF
--- a/packages/block-directory/src/plugins/inserter-menu-downloadable-blocks-panel/index.js
+++ b/packages/block-directory/src/plugins/inserter-menu-downloadable-blocks-panel/index.js
@@ -21,8 +21,14 @@ function InserterMenuDownloadableBlocksPanel() {
 
 	return (
 		<__experimentalInserterMenuExtension>
-			{ ( { onSelect, onHover, filterValue, hasItems } ) => {
-				if ( hasItems || ! filterValue ) {
+			{ ( {
+				onSelect,
+				onHover,
+				filterValue,
+				hasItems,
+				hasChildItems,
+			} ) => {
+				if ( hasItems || hasChildItems || ! filterValue ) {
 					return null;
 				}
 

--- a/packages/block-directory/src/plugins/inserter-menu-downloadable-blocks-panel/index.js
+++ b/packages/block-directory/src/plugins/inserter-menu-downloadable-blocks-panel/index.js
@@ -27,8 +27,14 @@ function InserterMenuDownloadableBlocksPanel() {
 				filterValue,
 				hasItems,
 				hasChildItems,
+				hasAllowedBlocks,
 			} ) => {
-				if ( hasItems || hasChildItems || ! filterValue ) {
+				if (
+					hasItems ||
+					hasChildItems ||
+					hasAllowedBlocks ||
+					! filterValue
+				) {
 					return null;
 				}
 

--- a/packages/block-editor/src/components/inserter/block-types-tab.js
+++ b/packages/block-editor/src/components/inserter/block-types-tab.js
@@ -119,7 +119,7 @@ export function BlockTypesTab( {
 		debouncedSpeak( resultsFoundMessage );
 	}, [ filterValue, debouncedSpeak ] );
 
-	const hasItems = ! isEmpty( filteredItems ) || hasChildItems;
+	const hasItems = ! isEmpty( filteredItems );
 
 	return (
 		<div>
@@ -216,6 +216,7 @@ export function BlockTypesTab( {
 					onHover,
 					filterValue,
 					hasItems,
+					hasChildItems,
 				} }
 			>
 				{ ( fills ) => {

--- a/packages/block-editor/src/components/inserter/block-types-tab.js
+++ b/packages/block-editor/src/components/inserter/block-types-tab.js
@@ -58,6 +58,13 @@ export function BlockTypesTab( {
 		[ rootClientId ]
 	);
 
+	const hasAllowedBlocks = useSelect( ( select ) => {
+		const { __experimentalGetAllowedBlocks } = select(
+			'core/block-editor'
+		);
+		return __experimentalGetAllowedBlocks( rootClientId ) !== undefined;
+	} );
+
 	const filteredItems = useMemo( () => {
 		return searchBlockItems( items, categories, collections, filterValue );
 	}, [ filterValue, items, categories, collections ] );
@@ -217,6 +224,7 @@ export function BlockTypesTab( {
 					filterValue,
 					hasItems,
 					hasChildItems,
+					hasAllowedBlocks,
 				} }
 			>
 				{ ( fills ) => {

--- a/packages/block-editor/src/components/inserter/block-types-tab.js
+++ b/packages/block-editor/src/components/inserter/block-types-tab.js
@@ -119,7 +119,7 @@ export function BlockTypesTab( {
 		debouncedSpeak( resultsFoundMessage );
 	}, [ filterValue, debouncedSpeak ] );
 
-	const hasItems = ! isEmpty( filteredItems );
+	const hasItems = ! isEmpty( filteredItems ) || hasChildItems;
 
 	return (
 		<div>

--- a/packages/e2e-tests/specs/editor/plugins/block-directory-add.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/block-directory-add.test.js
@@ -185,7 +185,7 @@ describe( 'adding blocks from block directory', () => {
 
 		// The block will auto select and get added, make sure we see it in the content
 		expect( await getEditedPostContent() ).toMatchSnapshot();
-    } );
+	} );
 
 	it( 'Should not see Block Directory results after install', async () => {
 		// Setup our mocks
@@ -208,6 +208,5 @@ describe( 'adding blocks from block directory', () => {
 		);
 
 		expect( hiddenBtn ).toBeNull();
-
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/plugins/block-directory-add.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/block-directory-add.test.js
@@ -186,27 +186,4 @@ describe( 'adding blocks from block directory', () => {
 		// The block will auto select and get added, make sure we see it in the content
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
-
-	it( 'Should not see Block Directory results after install', async () => {
-		// Setup our mocks
-		await setUpResponseMocking( MOCK_BLOCKS_RESPONSES );
-
-		// Search for the block via the inserter
-		await searchForBlock( MOCK_BLOCK1.title );
-
-		// Grab the first block in the list -> Needs to be the first one, the mock response expects it.
-		const addBtn = await page.waitForSelector(
-			'.block-directory-downloadable-blocks-list li:first-child button'
-		);
-
-		// Add the block
-		await addBtn.click();
-
-		const hiddenBtn = await page.waitForSelector(
-			'.block-directory-downloadable-blocks-list li:first-child button',
-			{ hidden: true }
-		);
-
-		expect( hiddenBtn ).toBeNull();
-	} );
 } );

--- a/packages/e2e-tests/specs/editor/plugins/block-directory-add.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/block-directory-add.test.js
@@ -185,5 +185,29 @@ describe( 'adding blocks from block directory', () => {
 
 		// The block will auto select and get added, make sure we see it in the content
 		expect( await getEditedPostContent() ).toMatchSnapshot();
+    } );
+
+	it( 'Should not see Block Directory results after install', async () => {
+		// Setup our mocks
+		await setUpResponseMocking( MOCK_BLOCKS_RESPONSES );
+
+		// Search for the block via the inserter
+		await searchForBlock( MOCK_BLOCK1.title );
+
+		// Grab the first block in the list -> Needs to be the first one, the mock response expects it.
+		const addBtn = await page.waitForSelector(
+			'.block-directory-downloadable-blocks-list li:first-child button'
+		);
+
+		// Add the block
+		await addBtn.click();
+
+		const hiddenBtn = await page.waitForSelector(
+			'.block-directory-downloadable-blocks-list li:first-child button',
+			{ hidden: true }
+		);
+
+		expect( hiddenBtn ).toBeNull();
+
 	} );
 } );


### PR DESCRIPTION
## Description
This PR makes sure that we don't search the block directory when we are displaying the child blocks otherwise the block inserter does not recognize that the block was already installed.

## How to replicate the issue?
1. Search for 'Cornell'
2. Install "Cornell Note" block
3. Notice that the block installs properly by the block directory result remains:

![screenshot of broken state](https://d.pr/i/GCcMB7.png)

## Why is this happening?
This problem occurs because the block enforces children blocks and this leads to 2 problems:
1. The `rootClientId` changes emptying `filteredItems` and therefore showing the block directory component.
2. The filter value doesn't match any child blocks and therefore they don't show up. 

## Types of changes
1. Pass `hasChildItems`& `hasAllowedBlocks` into the slot/fill and return `null` in the Block Directory package plugin component should either match.

## Question/Improvements
After the block installs, we move the focus into the block. Since the `filterValue` doesn't match the name of the child block, the user sees `no results` in the inserter. 

You can view the behaviour here (with the fix to stop searching the block directory): https://d.pr/v/QDVQ0p.

#### Should we clear the filter value for blocks with children blocks? 


## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
