### PR TITLE
Fix save shortcut in code editor

### DIFF
--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -254,6 +254,14 @@ _Returns_
 
 -   `Promise`: Promise resolving with a string containing the block title.
 
+<a name="getCurrentPostContent" href="#getCurrentPostContent">#</a> **getCurrentPostContent**
+
+Returns a promise which resolves with the current post content (HTML string).
+
+_Returns_
+
+-   `Promise`: Promise resolving with current post content markup.
+
 <a name="getEditedPostContent" href="#getEditedPostContent">#</a> **getEditedPostContent**
 
 Returns a promise which resolves with the edited post content (HTML string).

--- a/packages/e2e-test-utils/src/get-current-post-content.js
+++ b/packages/e2e-test-utils/src/get-current-post-content.js
@@ -1,0 +1,14 @@
+/**
+ * Internal dependencies
+ */
+import { wpDataSelect } from './wp-data-select';
+
+/**
+ * Returns a promise which resolves with the current post content (HTML string).
+ *
+ * @return {Promise} Promise resolving with current post content markup.
+ */
+export async function getCurrentPostContent() {
+	const post = await wpDataSelect( 'core/editor', 'getCurrentPost' );
+	return post.content;
+}

--- a/packages/e2e-test-utils/src/index.js
+++ b/packages/e2e-test-utils/src/index.js
@@ -21,6 +21,7 @@ export { getAllBlocks } from './get-all-blocks';
 export { getAvailableBlockTransforms } from './get-available-block-transforms';
 export { getBlockSetting } from './get-block-setting';
 export { getEditedPostContent } from './get-edited-post-content';
+export { getCurrentPostContent } from './get-current-post-content';
 export { hasBlockSwitcher } from './has-block-switcher';
 export { getPageError } from './get-page-error';
 export {

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/editor-modes.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/editor-modes.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Editing modes (visual/HTML) saves content when using the shortcut in the Code Editor 1`] = `
+"<!-- wp:paragraph -->
+<p>Hi world!</p>
+<!-- /wp:paragraph -->"
+`;

--- a/packages/editor/src/components/global-keyboard-shortcuts/save-shortcut.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/save-shortcut.js
@@ -5,7 +5,7 @@ import { useShortcut } from '@wordpress/keyboard-shortcuts';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { parse } from '@wordpress/blocks';
 
-function SaveShortcut( { persistOnSave } ) {
+function SaveShortcut( { resetBlocksOnSave } ) {
 	const { resetEditorBlocks, savePost } = useDispatch( 'core/editor' );
 	const { isEditedPostDirty, getPostEdits } = useSelect( ( select ) => {
 		const {
@@ -37,7 +37,7 @@ function SaveShortcut( { persistOnSave } ) {
 			// save to work correctly. Usually this happens when the textarea
 			// for the code editors blurs, but the shortcut can be used without
 			// blurring the textarea.
-			if ( persistOnSave ) {
+			if ( resetBlocksOnSave ) {
 				const postEdits = getPostEdits();
 				if ( postEdits.content ) {
 					const blocks = parse( postEdits.content );

--- a/packages/editor/src/components/global-keyboard-shortcuts/save-shortcut.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/save-shortcut.js
@@ -39,8 +39,10 @@ function SaveShortcut( { persistOnSave } ) {
 			// blurring the textarea.
 			if ( persistOnSave ) {
 				const postEdits = getPostEdits();
-				const blocks = parse( postEdits.content );
-				resetEditorBlocks( blocks );
+				if ( postEdits.content ) {
+					const blocks = parse( postEdits.content );
+					resetEditorBlocks( blocks );
+				}
 			}
 
 			savePost();

--- a/packages/editor/src/components/global-keyboard-shortcuts/save-shortcut.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/save-shortcut.js
@@ -39,7 +39,10 @@ function SaveShortcut( { resetBlocksOnSave } ) {
 			// blurring the textarea.
 			if ( resetBlocksOnSave ) {
 				const postEdits = getPostEdits();
-				if ( postEdits.content ) {
+				if (
+					postEdits.content &&
+					typeof postEdits.content === 'string'
+				) {
 					const blocks = parse( postEdits.content );
 					resetEditorBlocks( blocks );
 				}

--- a/packages/editor/src/components/global-keyboard-shortcuts/save-shortcut.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/save-shortcut.js
@@ -3,13 +3,21 @@
  */
 import { useShortcut } from '@wordpress/keyboard-shortcuts';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { parse } from '@wordpress/blocks';
 
-function SaveShortcut() {
-	const { savePost } = useDispatch( 'core/editor' );
-	const isEditedPostDirty = useSelect(
-		( select ) => select( 'core/editor' ).isEditedPostDirty,
-		[]
-	);
+function SaveShortcut( { persistOnSave } ) {
+	const { resetEditorBlocks, savePost } = useDispatch( 'core/editor' );
+	const { isEditedPostDirty, getPostEdits } = useSelect( ( select ) => {
+		const {
+			isEditedPostDirty: _isEditedPostDirty,
+			getPostEdits: _getPostEdits,
+		} = select( 'core/editor' );
+
+		return {
+			isEditedPostDirty: _isEditedPostDirty,
+			getPostEdits: _getPostEdits,
+		};
+	}, [] );
 
 	useShortcut(
 		'core/editor/save',
@@ -23,6 +31,16 @@ function SaveShortcut() {
 			// See: `isEditedPostSaveable`
 			if ( ! isEditedPostDirty() ) {
 				return;
+			}
+
+			// The text editor requires that editor blocks are updated for a
+			// save to work correctly. Usually this happens when the textarea
+			// for the code editors blurs, but the shortcut can be used without
+			// blurring the textarea.
+			if ( persistOnSave ) {
+				const postEdits = getPostEdits();
+				const blocks = parse( postEdits.content );
+				resetEditorBlocks( blocks );
 			}
 
 			savePost();

--- a/packages/editor/src/components/global-keyboard-shortcuts/text-editor-shortcuts.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/text-editor-shortcuts.js
@@ -4,5 +4,5 @@
 import SaveShortcut from './save-shortcut';
 
 export default function TextEditorGlobalKeyboardShortcuts() {
-	return <SaveShortcut />;
+	return <SaveShortcut persistOnSave />;
 }

--- a/packages/editor/src/components/global-keyboard-shortcuts/text-editor-shortcuts.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/text-editor-shortcuts.js
@@ -4,5 +4,5 @@
 import SaveShortcut from './save-shortcut';
 
 export default function TextEditorGlobalKeyboardShortcuts() {
-	return <SaveShortcut persistOnSave />;
+	return <SaveShortcut resetBlocksOnSave />;
 }

--- a/packages/editor/src/components/global-keyboard-shortcuts/visual-editor-shortcuts.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/visual-editor-shortcuts.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useShortcut } from '@wordpress/keyboard-shortcuts';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import deprecated from '@wordpress/deprecated';
 import { BlockEditorKeyboardShortcuts } from '@wordpress/block-editor';
 
@@ -12,11 +12,7 @@ import { BlockEditorKeyboardShortcuts } from '@wordpress/block-editor';
 import SaveShortcut from './save-shortcut';
 
 function VisualEditorGlobalKeyboardShortcuts() {
-	const { redo, undo, savePost } = useDispatch( 'core/editor' );
-	const isEditedPostDirty = useSelect(
-		( select ) => select( 'core/editor' ).isEditedPostDirty,
-		[]
-	);
+	const { redo, undo } = useDispatch( 'core/editor' );
 
 	useShortcut(
 		'core/editor/undo',
@@ -32,25 +28,6 @@ function VisualEditorGlobalKeyboardShortcuts() {
 		( event ) => {
 			redo();
 			event.preventDefault();
-		},
-		{ bindGlobal: true }
-	);
-
-	useShortcut(
-		'core/editor/save',
-		( event ) => {
-			event.preventDefault();
-
-			// TODO: This should be handled in the `savePost` effect in
-			// considering `isSaveable`. See note on `isEditedPostSaveable`
-			// selector about dirtiness and meta-boxes.
-			//
-			// See: `isEditedPostSaveable`
-			if ( ! isEditedPostDirty() ) {
-				return;
-			}
-
-			savePost();
 		},
 		{ bindGlobal: true }
 	);


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes #24054

Edits made in the code editor were not being saved when using the shortcut (Cmd+S or Ctrl+S).

The issue appears to be that edits are only persisted (`resetEditorBlocks` called) when the text area is blurred in the code editor:
https://github.com/WordPress/gutenberg/blob/master/packages/editor/src/components/post-text-editor/index.js#L82

When using the save shortcut, that blur event wouldn't be called, so the code editor changes wouldn't be saved.

This change makes the save shortcut for the code editor also call `resetEditorBlocks` with the relevant changes to ensure that the changes are prepared for saving.

This meant working with code I've not looked at for a while, so I'm open to suggestions on improvements.

Another bit of clean up is removing the duplicate registration of the save shortcut in the VisualEditorShortcuts component.

## How has this been tested?
Added e2e tests

1. Add three paragraphs with the text 'First paragraph' in the first, 'Second paragraph' in the second, 'Third paragraph' in the third ...
1. switch to Code editor via the keyboard shortcuts, on macOS: Shift+Alt+Cmd+M
1. manually edit the third paragraph text and change it to "Hello"
1. save as draft by pressing Cmd+S
1. switch back to Visual editor by pressing Shift+Alt+Cmd+M
1. observe the third paragraph content is now "Hello"
1. Previously it would still be 'Third paragraph'

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
