### PR TITLE
Fix Button block colors in the editor

### DIFF
--- a/packages/block-library/src/button/color-props.js
+++ b/packages/block-library/src/button/color-props.js
@@ -8,6 +8,7 @@ import classnames from 'classnames';
  */
 import {
 	getColorClassName,
+	getColorObjectByAttributeValues,
 	__experimentalGetGradientClass,
 } from '@wordpress/block-editor';
 
@@ -15,7 +16,11 @@ import {
 // The flag can't be used at the moment because of the extra wrapper around
 // the button block markup.
 
-export default function getColorAndStyleProps( attributes ) {
+export default function getColorAndStyleProps(
+	attributes,
+	colors,
+	isEdit = false
+) {
 	// I'd have prefered to avoid the "style" attribute usage here
 	const { backgroundColor, textColor, gradient, style } = attributes;
 
@@ -47,6 +52,28 @@ export default function getColorAndStyleProps( attributes ) {
 					color: style?.color?.text ? style.color.text : undefined,
 			  }
 			: {};
+
+	// This is needed only for themes that don't load their color stylesheets in the editor
+	// We force an inline style to apply the color.
+	if ( isEdit ) {
+		if ( backgroundColor ) {
+			const backgroundColorObject = getColorObjectByAttributeValues(
+				colors,
+				backgroundColor
+			);
+
+			styleProp.backgroundColor = backgroundColorObject.color;
+		}
+
+		if ( textColor ) {
+			const textColorObject = getColorObjectByAttributeValues(
+				colors,
+				textColor
+			);
+
+			styleProp.color = textColorObject.color;
+		}
+	}
 
 	return {
 		className: !! className ? className : undefined,

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -28,6 +28,7 @@ import {
 import { rawShortcut, displayShortcut } from '@wordpress/keycodes';
 import { link, linkOff } from '@wordpress/icons';
 import { createBlock } from '@wordpress/blocks';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -172,6 +173,9 @@ function ButtonEdit( props ) {
 		},
 		[ setAttributes ]
 	);
+	const { colors } = useSelect( ( select ) => {
+		return select( 'core/block-editor' ).getSettings();
+	}, [] );
 
 	const onToggleOpenInNewTab = useCallback(
 		( value ) => {
@@ -192,7 +196,7 @@ function ButtonEdit( props ) {
 		[ rel, setAttributes ]
 	);
 
-	const colorProps = getColorAndStyleProps( attributes );
+	const colorProps = getColorAndStyleProps( attributes, colors, true );
 
 	return (
 		<>


### PR DESCRIPTION
closes #23987

Color Palettes are not working properly in themes not loading their stylesheets in the editor. In #22356, we fixed the issue for the other blocks relying on __experimentalColor flag, but the Button block has a specific implementation for now, so it needs a specific fix.