### PR TITLE
Fix the gallery buttons focus style

### DIFF
--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -95,8 +95,10 @@ figure.wp-block-gallery {
 	}
 
 	.components-button.has-icon {
-		border: none;
-		box-shadow: none;
+		&:not(:focus) {
+			border: none;
+			box-shadow: none;
+		}
 
 		@include break-small() {
 			// Use smaller buttons to fit when there are many columns.


### PR DESCRIPTION
closes #24095 

This PR fixes a small regression where the focus styles of the Gallery buttons were being overridden. 

<img width="319" alt="Capture d’écran 2020-07-23 à 12 04 11 PM" src="https://user-images.githubusercontent.com/272444/88279853-a4531080-ccdc-11ea-8fde-956b033632fc.png">
