### PR TITLE
Post Comments Form: Add style attributes

### DIFF
--- a/packages/block-library/src/post-comments-form/block.json
+++ b/packages/block-library/src/post-comments-form/block.json
@@ -1,10 +1,23 @@
 {
 	"name": "core/post-comments-form",
 	"category": "design",
+	"attributes": {
+		"textAlign": {
+			"type": "string"
+		}
+	},
 	"usesContext": [
-		"postId"
+		"postId",
+		"postType"
 	],
 	"supports": {
-		"html": false
+		"html": false,
+		"lightBlockWrapper": true,
+		"__experimentalColor": {
+			"gradients": true,
+			"linkColor": true
+		},
+		"__experimentalFontSize": true,
+		"__experimentalLineHeight": true
 	}
 }

--- a/packages/block-library/src/post-comments-form/edit.js
+++ b/packages/block-library/src/post-comments-form/edit.js
@@ -1,8 +1,70 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
+import {
+	AlignmentToolbar,
+	BlockControls,
+	Warning,
+	__experimentalBlock as Block,
+} from '@wordpress/block-editor';
+import { useEntityProp } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 
-export default function PostCommentsFormEdit() {
-	return __( 'Post Comments Form' );
+export default function PostCommentsFormEdit( {
+	attributes,
+	context,
+	setAttributes,
+} ) {
+	const { textAlign } = attributes;
+	const { postId, postType } = context;
+	const [ commentStatus ] = useEntityProp(
+		'postType',
+		postType,
+		'comment_status',
+		postId
+	);
+
+	if ( ! commentStatus ) {
+		return (
+			<Warning>
+				{ __(
+					'Post Comments Form block: Comments are not enabled for this post type.'
+				) }
+			</Warning>
+		);
+	}
+	if ( 'open' !== commentStatus ) {
+		return (
+			<Warning>
+				{ __(
+					'Post Comments Form block: Comments to this post are not allowed.'
+				) }
+			</Warning>
+		);
+	}
+
+	return (
+		<>
+			<BlockControls>
+				<AlignmentToolbar
+					value={ textAlign }
+					onChange={ ( nextAlign ) => {
+						setAttributes( { textAlign: nextAlign } );
+					} }
+				/>
+			</BlockControls>
+			<Block.div
+				className={ classnames( {
+					[ `has-text-align-${ textAlign }` ]: textAlign,
+				} ) }
+			>
+				{ __( 'Post Comments Form' ) }
+			</Block.div>
+		</>
+	);
 }

--- a/packages/block-library/src/post-comments-form/edit.js
+++ b/packages/block-library/src/post-comments-form/edit.js
@@ -29,25 +29,6 @@ export default function PostCommentsFormEdit( {
 		postId
 	);
 
-	if ( ! commentStatus ) {
-		return (
-			<Warning>
-				{ __(
-					'Post Comments Form block: Comments are not enabled for this post type.'
-				) }
-			</Warning>
-		);
-	}
-	if ( 'open' !== commentStatus ) {
-		return (
-			<Warning>
-				{ __(
-					'Post Comments Form block: Comments to this post are not allowed.'
-				) }
-			</Warning>
-		);
-	}
-
 	return (
 		<>
 			<BlockControls>
@@ -63,7 +44,23 @@ export default function PostCommentsFormEdit( {
 					[ `has-text-align-${ textAlign }` ]: textAlign,
 				} ) }
 			>
-				{ __( 'Post Comments Form' ) }
+				{ ! commentStatus && (
+					<Warning>
+						{ __(
+							'Post Comments Form block: comments are not enabled for this post type.'
+						) }
+					</Warning>
+				) }
+
+				{ 'open' !== commentStatus && (
+					<Warning>
+						{ __(
+							'Post Comments Form block: comments to this post are not allowed.'
+						) }
+					</Warning>
+				) }
+
+				{ 'open' === commentStatus && __( 'Post Comments Form' ) }
 			</Block.div>
 		</>
 	);

--- a/packages/block-library/src/post-comments-form/index.php
+++ b/packages/block-library/src/post-comments-form/index.php
@@ -18,11 +18,16 @@ function render_block_core_post_comments_form( $attributes, $content, $block ) {
 		return '';
 	}
 
+	$classes = 'wp-block-post-comments-form';
+	if ( isset( $attributes['textAlign'] ) ) {
+		$classes .= ' has-text-align-' . $attributes['textAlign'];
+	}
+
 	ob_start();
 	comment_form( array(), $block->context['postId'] );
 	$form = ob_get_clean();
 
-	return $form;
+	return sprintf( '<div class="%1$s">%2$s</div>', esc_attr( $classes ), $form );
 }
 
 /**


### PR DESCRIPTION
## Description

Update the Post Comments Form block:

- Add support for colors, font size, line height, and text alignment.
- Convert the to light block wrapper.
- Render warnings if the comment status of the element in context is unknown, or if the comments are closed.

Note: the block is not much more than a placeholder.
It shows the whole `comment_form()` function in the front end, but in the editor it just renders "Post Comments Form".
I intentionally avoided to try to replicate `comment_form()` in the editor to avoid endlessly bloating this PR and get it stuck in a design feedback loop. 🙂 
Nevertheless, the style is applied to the front end — although in some cases the theme might prevail.
I don't find much value in fixing these cases right now, and I'd rather have a proper discussion about how to make the form consistent between editor and front end.

## How has this been tested?
Tested in Post, Page, and Site Editor, on Chrome 83 on macOS 10.15.5.
Tested on posts and pages, with comments allowed and otherwise.

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
