### PR TITLE
Post Comments Counts: Add style attributes

### DIFF
--- a/packages/block-library/src/post-comments-count/block.json
+++ b/packages/block-library/src/post-comments-count/block.json
@@ -1,10 +1,22 @@
 {
 	"name": "core/post-comments-count",
 	"category": "design",
+	"attributes": {
+		"textAlign": {
+			"type": "string"
+		}
+	},
 	"usesContext": [
 		"postId"
 	],
 	"supports": {
-		"html": false
+		"html": false,
+		"lightBlockWrapper": true,
+		"__experimentalColor": {
+			"gradients": true,
+			"linkColor": true
+		},
+		"__experimentalFontSize": true,
+		"__experimentalLineHeight": true
 	}
 }

--- a/packages/block-library/src/post-comments-count/block.json
+++ b/packages/block-library/src/post-comments-count/block.json
@@ -13,8 +13,7 @@
 		"html": false,
 		"lightBlockWrapper": true,
 		"__experimentalColor": {
-			"gradients": true,
-			"linkColor": true
+			"gradients": true
 		},
 		"__experimentalFontSize": true,
 		"__experimentalLineHeight": true

--- a/packages/block-library/src/post-comments-count/edit.js
+++ b/packages/block-library/src/post-comments-count/edit.js
@@ -1,16 +1,34 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
-import { useEntityId } from '@wordpress/core-data';
+import {
+	AlignmentToolbar,
+	BlockControls,
+	Warning,
+	__experimentalBlock as Block,
+} from '@wordpress/block-editor';
 import { useState, useEffect } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 import { __ } from '@wordpress/i18n';
 
-function PostCommentsCountDisplay( { className } ) {
-	const postId = useEntityId( 'postType', 'post' );
+export default function PostCommentsCountEdit( {
+	attributes,
+	context,
+	setAttributes,
+} ) {
+	const { textAlign } = attributes;
+	const { postId } = context;
 	const [ commentsCount, setCommentsCount ] = useState();
 	useEffect( () => {
+		if ( ! postId ) {
+			return;
+		}
 		const currentPostId = postId;
 		apiFetch( {
 			path: addQueryArgs( '/wp/v2/comments', {
@@ -24,16 +42,30 @@ function PostCommentsCountDisplay( { className } ) {
 			}
 		} );
 	}, [ postId ] );
-	return (
-		<span className={ className }>
-			{ commentsCount !== undefined && commentsCount }
-		</span>
-	);
-}
 
-export default function PostCommentsCountEdit( { className } ) {
-	if ( ! useEntityId( 'postType', 'post' ) ) {
-		return __( 'Post Comments Count' );
-	}
-	return <PostCommentsCountDisplay className={ className } />;
+	return (
+		<>
+			<BlockControls>
+				<AlignmentToolbar
+					value={ textAlign }
+					onChange={ ( nextAlign ) => {
+						setAttributes( { textAlign: nextAlign } );
+					} }
+				/>
+			</BlockControls>
+			<Block.div
+				className={ classnames( {
+					[ `has-text-align-${ textAlign }` ]: textAlign,
+				} ) }
+			>
+				{ postId && commentsCount !== undefined ? (
+					commentsCount
+				) : (
+					<Warning>
+						{ __( 'Post Comments Count block: post not found.' ) }
+					</Warning>
+				) }
+			</Block.div>
+		</>
+	);
 }

--- a/packages/block-library/src/post-comments-count/index.php
+++ b/packages/block-library/src/post-comments-count/index.php
@@ -18,14 +18,14 @@ function render_block_core_post_comments_count( $attributes, $content, $block ) 
 		return '';
 	}
 
-	$class = 'wp-block-post-comments-count';
-	if ( isset( $attributes['className'] ) ) {
-		$class .= ' ' . $attributes['className'];
+	$classes = 'wp-block-post-comments-count';
+	if ( isset( $attributes['textAlign'] ) ) {
+		$classes .= ' has-text-align-' . $attributes['textAlign'];
 	}
 
 	return sprintf(
-		'<span class="%1$s">%2$s</span>',
-		esc_attr( $class ),
+		'<div class="%1$s">%2$s</div>',
+		esc_attr( $classes ),
 		get_comments_number( $block->context['postId'] )
 	);
 }


### PR DESCRIPTION
## Description

Update the Post Comments Counts block:

- Add support for colors, font size, line height, and text alignment.
- Convert the to light block wrapper.
- Output a `div` instead of a `span`.

Note: the block simply outputs the number of comments, without labels.

## How has this been tested?
Tested in Post, Page, and Site Editor, on Chrome 83 on macOS 10.15.5.
Tested on posts and pages, with comments allowed and otherwise.

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
