### PR TITLE
i18n: Merge similar translation strings - tables

### DIFF
--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -83,17 +83,17 @@ const BACKGROUND_COLORS = [
 const ALIGNMENT_CONTROLS = [
 	{
 		icon: alignLeft,
-		title: __( 'Align Column Left' ),
+		title: __( 'Align column left' ),
 		align: 'left',
 	},
 	{
 		icon: alignCenter,
-		title: __( 'Align Column Center' ),
+		title: __( 'Align column center' ),
 		align: 'center',
 	},
 	{
 		icon: alignRight,
-		title: __( 'Align Column Right' ),
+		title: __( 'Align column right' ),
 		align: 'right',
 	},
 ];
@@ -435,37 +435,37 @@ export class TableEdit extends Component {
 		return [
 			{
 				icon: tableRowBefore,
-				title: __( 'Add Row Before' ),
+				title: __( 'Insert row before' ),
 				isDisabled: ! selectedCell,
 				onClick: this.onInsertRowBefore,
 			},
 			{
 				icon: tableRowAfter,
-				title: __( 'Add Row After' ),
+				title: __( 'Insert row after' ),
 				isDisabled: ! selectedCell,
 				onClick: this.onInsertRowAfter,
 			},
 			{
 				icon: tableRowDelete,
-				title: __( 'Delete Row' ),
+				title: __( 'Delete row' ),
 				isDisabled: ! selectedCell,
 				onClick: this.onDeleteRow,
 			},
 			{
 				icon: tableColumnBefore,
-				title: __( 'Add Column Before' ),
+				title: __( 'Insert column before' ),
 				isDisabled: ! selectedCell,
 				onClick: this.onInsertColumnBefore,
 			},
 			{
 				icon: tableColumnAfter,
-				title: __( 'Add Column After' ),
+				title: __( 'Insert column after' ),
 				isDisabled: ! selectedCell,
 				onClick: this.onInsertColumnAfter,
 			},
 			{
 				icon: tableColumnDelete,
-				title: __( 'Delete Column' ),
+				title: __( 'Delete column' ),
 				isDisabled: ! selectedCell,
 				onClick: this.onDeleteColumn,
 			},
@@ -580,7 +580,7 @@ export class TableEdit extends Component {
 					>
 						<TextControl
 							type="number"
-							label={ __( 'Column Count' ) }
+							label={ __( 'Column count' ) }
 							value={ initialColumnCount }
 							onChange={ this.onChangeInitialColumnCount }
 							min="1"
@@ -588,7 +588,7 @@ export class TableEdit extends Component {
 						/>
 						<TextControl
 							type="number"
-							label={ __( 'Row Count' ) }
+							label={ __( 'Row count' ) }
 							value={ initialRowCount }
 							onChange={ this.onChangeInitialRowCount }
 							min="1"

--- a/packages/e2e-tests/specs/editor/blocks/table.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/table.test.js
@@ -24,7 +24,7 @@ const createButtonLabel = 'Create Table';
  */
 async function changeCellAlignment( align ) {
 	await clickBlockToolbarButton( 'Change column alignment' );
-	await clickButton( `Align column ${ capitalize( align ) }` );
+	await clickButton( `Align column ${align}` );
 }
 
 describe( 'Table', () => {

--- a/packages/e2e-tests/specs/editor/blocks/table.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/table.test.js
@@ -24,7 +24,7 @@ const createButtonLabel = 'Create Table';
  */
 async function changeCellAlignment( align ) {
 	await clickBlockToolbarButton( 'Change column alignment' );
-	await clickButton( `Align Column ${ capitalize( align ) }` );
+	await clickButton( `Align column ${ capitalize( align ) }` );
 }
 
 describe( 'Table', () => {
@@ -37,7 +37,7 @@ describe( 'Table', () => {
 
 		// Check for existence of the column count field.
 		const columnCountLabel = await page.$x(
-			"//div[@data-type='core/table']//label[text()='Column Count']"
+			"//div[@data-type='core/table']//label[text()='Column count']"
 		);
 		expect( columnCountLabel ).toHaveLength( 1 );
 
@@ -52,7 +52,7 @@ describe( 'Table', () => {
 
 		// Check for existence of the row count field.
 		const rowCountLabel = await page.$x(
-			"//div[@data-type='core/table']//label[text()='Row Count']"
+			"//div[@data-type='core/table']//label[text()='Row count']"
 		);
 		expect( rowCountLabel ).toHaveLength( 1 );
 
@@ -165,7 +165,7 @@ describe( 'Table', () => {
 
 		// Add a column.
 		await clickBlockToolbarButton( 'Edit table' );
-		await clickButton( 'Add Column After' );
+		await clickButton( 'Insert column after' );
 
 		// Expect the table to have 3 columns across the header, body and footer.
 		expect( await getEditedPostContent() ).toMatchSnapshot();
@@ -174,7 +174,7 @@ describe( 'Table', () => {
 
 		// Delete a column.
 		await clickBlockToolbarButton( 'Edit table' );
-		await clickButton( 'Delete Column' );
+		await clickButton( 'Delete column' );
 
 		// Expect the table to have 2 columns across the header, body and footer.
 		expect( await getEditedPostContent() ).toMatchSnapshot();
@@ -184,7 +184,7 @@ describe( 'Table', () => {
 		await insertBlock( 'Table' );
 
 		const [ columnCountLabel ] = await page.$x(
-			"//div[@data-type='core/table']//label[text()='Column Count']"
+			"//div[@data-type='core/table']//label[text()='Column count']"
 		);
 		await columnCountLabel.click();
 		await page.keyboard.press( 'Backspace' );

--- a/packages/e2e-tests/specs/editor/blocks/table.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/table.test.js
@@ -19,7 +19,7 @@ const createButtonLabel = 'Create Table';
  */
 async function changeCellAlignment( align ) {
 	await clickBlockToolbarButton( 'Change column alignment' );
-	await clickButton( `Align column ${align.toLowerCase()}` );
+	await clickButton( `Align column ${ align.toLowerCase() }` );
 }
 
 describe( 'Table', () => {

--- a/packages/e2e-tests/specs/editor/blocks/table.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/table.test.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { capitalize } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import {
@@ -24,7 +19,7 @@ const createButtonLabel = 'Create Table';
  */
 async function changeCellAlignment( align ) {
 	await clickBlockToolbarButton( 'Change column alignment' );
-	await clickButton( `Align column ${align}` );
+	await clickButton( `Align column ${align.toLowerCase()}` );
 }
 
 describe( 'Table', () => {


### PR DESCRIPTION
## Description

This PR merges several similar translation strings to match them to existing strings we have in TinyMCE.

See trac ticket https://core.trac.wordpress.org/ticket/47259

The trac ticket fixes strings in WordPress core, this PR fixes Gutenberg strings.

## Screenshots

![47259a](https://user-images.githubusercontent.com/576623/88331059-0dff0900-cd35-11ea-8d72-b64d6a7b5b5c.png)
![47259b](https://user-images.githubusercontent.com/576623/88331062-0f303600-cd35-11ea-8023-2ca4cf8dad86.png)
![47259c](https://user-images.githubusercontent.com/576623/88331065-0fc8cc80-cd35-11ea-8d20-fc3aabd4b039.png)

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
