### PR TITLE
[Mobile] Disable Page Template picker if modal layout picker is available (Update for new capabilities mechanism)

### DIFF
--- a/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
+++ b/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
@@ -16,6 +16,7 @@ public struct MediaInfo {
 public enum Capabilities: String {
     case mentions
     case unsupportedBlockEditor
+    case modalLayoutPicker
 }
 
 /// Wrapper for single block data


### PR DESCRIPTION
Fixes: https://github.com/wordpress-mobile/gutenberg-mobile/issues/2419

Related PRs:
- `gutenberg-mobile`: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2505
- `WordPress-iOS`: https://github.com/wordpress-mobile/WordPress-iOS/pull/14501

## Description
This capability was originally tested as part of https://github.com/WordPress/gutenberg/pull/23872 this just serves as the update to migrate that strategy to be in line with recent changes.

Below is the description and testing steps from the original PR. 

____

## Description
This change enables the mobile editor to accept the capability `modalLayoutPicker` and based on that conditionally show or hide the Template Picker.

Android hasn't started Modal Layout Picker yet so this only needs to 

## How has this been tested?
To disable or enable the development version of Modal Layout Picker
- Open the app from the build https://github.com/wordpress-mobile/WordPress-iOS/pull/14456#issuecomment-656759183 or a local development build
    - By default, the modal layout picker will be enabled.
    - From the site page:
        - Click on your Gravatar.
        - Click on App Settings.
        - Click on Debug.
        - Toggle "Gutenberg Modal Layout Picker" to enable or disable the picker
            <details>
            <summary>To toggle: </summary>
            <img width=300 src="https://user-images.githubusercontent.com/3384451/87160515-106f5680-c291-11ea-9d49-fac5e6b7e66c.gif" />
            </details>


### On iOS using the build options mentioned above
- With Gutenberg Modal Layout Picker toggled on:
    - Select to create a new page
    - Expect to see the container for the new modal Layout Picker
    - Select "Create Blank Page"
    - Expect the current template picker to be hidden

- With Gutenberg Modal Layout Picker toggled on:
    - Select an existing page or draft without content (just a title)
    - You should not see the new Modal Layout Picker
    - Expect the current template picker to be hidden

- With Gutenberg Modal Layout Picker toggled off:
    - Select to create a new page
    - You should not see the new Modal Layout Picker
    - Expect the current template picker to be shown. 

- With Gutenberg Modal Layout Picker toggled off:
    - Select an existing page or draft without content (just a title)
    - You should not see the new Modal Layout Picker
    - Expect the current template picker to be shown

- With Gutenberg Modal Layout Picker toggled on or off:
    - Select an existing page or draft with content
    - Expect the current template picker to be hidden

### On Android running a metro server or generating a build

- Existing Blank Page
    - Select an existing page or draft without content (just a title)
    - Expect the current template picker to be shown
- New Page
    - Select to create a new page
    - Expect the current template picker to be shown. 
- Existing Page
    - Select an existing page or draft with content
    - Expect the current template picker to be hidden

## Types of changes
New feature
## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
