### PR TITLE
Block Directory: Decode entities in block title & description

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10953,6 +10953,7 @@
 				"@wordpress/data-controls": "file:packages/data-controls",
 				"@wordpress/edit-post": "file:packages/edit-post",
 				"@wordpress/element": "file:packages/element",
+				"@wordpress/html-entities": "file:packages/html-entities",
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/icons": "file:packages/icons",
 				"@wordpress/notices": "file:packages/notices",

--- a/packages/block-directory/package.json
+++ b/packages/block-directory/package.json
@@ -35,6 +35,7 @@
 		"@wordpress/data-controls": "file:../data-controls",
 		"@wordpress/edit-post": "file:../edit-post",
 		"@wordpress/element": "file:../element",
+		"@wordpress/html-entities": "file:../html-entities",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/notices": "file:../notices",

--- a/packages/block-directory/src/components/downloadable-block-header/index.js
+++ b/packages/block-directory/src/components/downloadable-block-header/index.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -25,7 +26,7 @@ function DownloadableBlockHeader( {
 
 			<div className="block-directory-downloadable-block-header__column">
 				<h2 className="block-directory-downloadable-block-header__title">
-					{ title }
+					{ decodeEntities( title ) }
 				</h2>
 				<BlockRatings rating={ rating } ratingCount={ ratingCount } />
 			</div>

--- a/packages/block-directory/src/components/downloadable-block-info/index.js
+++ b/packages/block-directory/src/components/downloadable-block-info/index.js
@@ -1,8 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { Fragment } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
+import { decodeEntities } from '@wordpress/html-entities';
+import { Fragment } from '@wordpress/element';
 import { Icon, update, chartLine } from '@wordpress/icons';
 
 function DownloadableBlockInfo( {
@@ -13,7 +14,7 @@ function DownloadableBlockInfo( {
 	return (
 		<Fragment>
 			<p className="block-directory-downloadable-block-info__content">
-				{ description }
+				{ decodeEntities( description ) }
 			</p>
 			<div className="block-directory-downloadable-block-info__meta">
 				<Icon


### PR DESCRIPTION
## Description

The block directory API returns encoded HTML entities in the description. This change decodes the entities so they're human-friendly. This also adds the same to the title, but I couldn't find any existing blocks that had encoded characters.

## Screenshots <!-- if applicable -->

Before:
<img width="343" alt="buybnb-_n3" src="https://user-images.githubusercontent.com/541093/88338943-2c4e1000-cd07-11ea-9bd5-a5cdc9ef3ac7.png">

After:
![Screen Shot 2020-07-23 at 5 06 42 PM](https://user-images.githubusercontent.com/541093/88338882-0b85ba80-cd07-11ea-84cf-628d9737e182.png)

