### PR TITLE
Load FSE php files only if experiment is enabled

### DIFF
--- a/lib/load.php
+++ b/lib/load.php
@@ -87,7 +87,7 @@ require dirname( __FILE__ ) . '/compat.php';
 require dirname( __FILE__ ) . '/utils.php';
 
 // Include FSE related files only if the experiment is enabled.
-if ( gutenberg_is_experiment_enabled( 'full-site-editing' ) ) {
+if ( gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' ) ) {
 	require dirname( __FILE__ ) . '/templates.php';
 	require dirname( __FILE__ ) . '/template-parts.php';
 	require dirname( __FILE__ ) . '/template-loader.php';

--- a/lib/load.php
+++ b/lib/load.php
@@ -86,11 +86,14 @@ if ( ! class_exists( 'WP_Block_List' ) ) {
 require dirname( __FILE__ ) . '/compat.php';
 require dirname( __FILE__ ) . '/utils.php';
 
+if ( gutenberg_is_experiment_enabled( 'full-site-editing' ) ) {
+	require dirname( __FILE__ ) . '/templates.php';
+	require dirname( __FILE__ ) . '/template-parts.php';
+	require dirname( __FILE__ ) . '/template-loader.php';
+}
+
 require dirname( __FILE__ ) . '/block-patterns.php';
 require dirname( __FILE__ ) . '/blocks.php';
-require dirname( __FILE__ ) . '/templates.php';
-require dirname( __FILE__ ) . '/template-parts.php';
-require dirname( __FILE__ ) . '/template-loader.php';
 require dirname( __FILE__ ) . '/client-assets.php';
 require dirname( __FILE__ ) . '/block-directory.php';
 require dirname( __FILE__ ) . '/demo.php';

--- a/lib/load.php
+++ b/lib/load.php
@@ -86,10 +86,13 @@ if ( ! class_exists( 'WP_Block_List' ) ) {
 require dirname( __FILE__ ) . '/compat.php';
 require dirname( __FILE__ ) . '/utils.php';
 
+// Include FSE related files only if the experiment is enabled.
 if ( gutenberg_is_experiment_enabled( 'full-site-editing' ) ) {
 	require dirname( __FILE__ ) . '/templates.php';
 	require dirname( __FILE__ ) . '/template-parts.php';
 	require dirname( __FILE__ ) . '/template-loader.php';
+	require dirname( __FILE__ ) . '/edit-site-page.php';
+	require dirname( __FILE__ ) . '/edit-site-export.php';
 }
 
 require dirname( __FILE__ ) . '/block-patterns.php';
@@ -102,8 +105,7 @@ require dirname( __FILE__ ) . '/widgets-page.php';
 require dirname( __FILE__ ) . '/navigation-page.php';
 require dirname( __FILE__ ) . '/experiments-page.php';
 require dirname( __FILE__ ) . '/customizer.php';
-require dirname( __FILE__ ) . '/edit-site-page.php';
-require dirname( __FILE__ ) . '/edit-site-export.php';
+require dirname( __FILE__ ) . '/editor-features.php';
 require dirname( __FILE__ ) . '/global-styles.php';
 require dirname( __FILE__ ) . '/block-supports/index.php';
 require dirname( __FILE__ ) . '/block-supports/align.php';

--- a/lib/load.php
+++ b/lib/load.php
@@ -105,7 +105,6 @@ require dirname( __FILE__ ) . '/widgets-page.php';
 require dirname( __FILE__ ) . '/navigation-page.php';
 require dirname( __FILE__ ) . '/experiments-page.php';
 require dirname( __FILE__ ) . '/customizer.php';
-require dirname( __FILE__ ) . '/editor-features.php';
 require dirname( __FILE__ ) . '/global-styles.php';
 require dirname( __FILE__ ) . '/block-supports/index.php';
 require dirname( __FILE__ ) . '/block-supports/align.php';

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -38,10 +38,6 @@ function get_template_types() {
  * Adds necessary filters to use 'wp_template' posts instead of theme template files.
  */
 function gutenberg_add_template_loader_filters() {
-	if ( ! post_type_exists( 'wp_template' ) ) {
-		return;
-	}
-
 	foreach ( get_template_types() as $template_type ) {
 		if ( 'embed' === $template_type ) { // Skip 'embed' for now because it is not a regular template type.
 			continue;
@@ -426,7 +422,7 @@ function gutenberg_strip_php_suffix( $template_file ) {
 function gutenberg_template_loader_filter_block_editor_settings( $settings ) {
 	global $post;
 
-	if ( ! $post || ! post_type_exists( 'wp_template' ) || ! post_type_exists( 'wp_template_part' ) ) {
+	if ( ! $post ) {
 		return $settings;
 	}
 

--- a/lib/template-parts.php
+++ b/lib/template-parts.php
@@ -9,10 +9,6 @@
  * Registers block editor 'wp_template_part' post type.
  */
 function gutenberg_register_template_part_post_type() {
-	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' ) ) {
-		return;
-	}
-
 	$labels = array(
 		'name'                  => __( 'Template Parts', 'gutenberg' ),
 		'singular_name'         => __( 'Template Part', 'gutenberg' ),

--- a/lib/templates.php
+++ b/lib/templates.php
@@ -9,10 +9,6 @@
  * Registers block editor 'wp_template' post type.
  */
 function gutenberg_register_template_post_type() {
-	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' ) ) {
-		return;
-	}
-
 	$labels = array(
 		'name'                  => __( 'Templates', 'gutenberg' ),
 		'singular_name'         => __( 'Template', 'gutenberg' ),

--- a/lib/widgets.php
+++ b/lib/widgets.php
@@ -21,7 +21,7 @@ function gutenberg_is_block_editor() {
 		(
 			$screen->is_block_editor() ||
 			'gutenberg_page_gutenberg-widgets' === $screen->id ||
-			gutenberg_is_edit_site_page( $screen->id )
+			( function_exists( 'gutenberg_is_edit_site_page' ) && gutenberg_is_edit_site_page( $screen->id ) )
 		);
 }
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Previously, any 3rd party who had the Gutenberg plugin installed could use `register_post_type( 'wp_template' )` to opt into block template resolution. Specifically, our template loader file is _always_ loaded and the filter is _always_ registered. When the filter runs, it is gated only by a check for the wp_template CPT. Obviously, anyone can register any CPT they like, so this means that folks can treat template resolution as a stable API simply by registering the CPT themselves. 

This is motivated by #24129, in which a user had created the wp_template CPT themselves without the experiment enabled, expecting template resolution to work correctly and to be a stable API.

There are some other examples of this (e.g. the edit-site exporter API is always registered if the plugin is installed).

What if we just avoid loading those files altogether if the experiment is disabled? (This is what I would have expected originally.)

My only concern is that this could be considered a breaking change. I know some others think it might not be a breaking change.

## How has this been tested?
Locally, in edit site. Tests should pass

## Screenshots <!-- if applicable -->

## Types of changes

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
