### PR TITLE
Fix dragging multiple blocks dowards resulted in blocks inserted in wrong position

### DIFF
--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -290,11 +290,13 @@ export default function useBlockDropZone( {
 				( sourceRootClientId === '' &&
 					targetRootClientId === undefined );
 
+			const draggedBlockCount = sourceClientIds.length;
+
 			// If the block is kept at the same level and moved downwards,
 			// subtract to account for blocks shifting upward to occupy its old position.
 			const insertIndex =
 				isAtSameLevel && sourceBlockIndex < targetBlockIndex
-					? targetBlockIndex - 1
+					? targetBlockIndex - draggedBlockCount
 					: targetBlockIndex;
 
 			moveBlocksToPosition(

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -293,7 +293,8 @@ export default function useBlockDropZone( {
 			const draggedBlockCount = sourceClientIds.length;
 
 			// If the block is kept at the same level and moved downwards,
-			// subtract to account for blocks shifting upward to occupy its old position.
+			// subtract to take into account that the blocks being dragged
+			// were removed from the block list.
 			const insertIndex =
 				isAtSameLevel && sourceBlockIndex < targetBlockIndex
 					? targetBlockIndex - draggedBlockCount


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes #24158.

When dragging and dropping blocks, if a block is dropped below where it originally was, the calculated insertion index has to take into that the dragged block was removed from the list above where we want to insert.

Previously, we did that by subtracting `1` from the insertion index, as only a single block could be dragged at a time. Now that multiple blocks can be dragged, we need to use the number of blocks being dragged, which this PR does.

## How has this been tested?
1. Insert multiple blocks into a post
2. Drag some of them to a position below.
3. The blocks should drop into the correct position.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
