### PR TITLE
Fix dropdown menu focus loss when using arrow keys with Safari and Voiceover

### DIFF
--- a/packages/components/src/navigable-container/container.js
+++ b/packages/components/src/navigable-container/container.js
@@ -9,6 +9,8 @@ import { omit, noop, isFunction } from 'lodash';
 import { Component, forwardRef } from '@wordpress/element';
 import { focus } from '@wordpress/dom';
 
+const MENU_ITEM_ROLES = [ 'menuitem', 'menuitemradio', 'menuitemcheckbox' ];
+
 function cycleValue( value, total, offset ) {
 	const nextValue = value + offset;
 	if ( nextValue < 0 ) {
@@ -96,8 +98,11 @@ class NavigableContainer extends Component {
 			event.stopImmediatePropagation();
 
 			// When navigating a collection of items, prevent scroll containers
-			// from scrolling.
-			if ( event.target.getAttribute( 'role' ) === 'menuitem' ) {
+			// from scrolling. The preventDefault also prevents Voiceover from
+			// 'handling' the event, as voiceover will try to use arrow keys
+			// for highlighting text.
+			const targetRole = event.target.getAttribute( 'role' );
+			if ( MENU_ITEM_ROLES.includes( targetRole ) ) {
 				event.preventDefault();
 			}
 		}

--- a/packages/components/src/navigable-container/menu.js
+++ b/packages/components/src/navigable-container/menu.js
@@ -38,6 +38,11 @@ export function NavigableMenu(
 			return 1;
 		} else if ( includes( previous, keyCode ) ) {
 			return -1;
+		} else if ( includes( [ DOWN, UP, LEFT, RIGHT ], keyCode ) ) {
+			// Key press should be handled, e.g. have event propagation and
+			// default behavior handled by NavigableContainer but not result
+			// in an offset.
+			return 0;
 		}
 	};
 

--- a/packages/components/src/navigable-container/test/menu.js
+++ b/packages/components/src/navigable-container/test/menu.js
@@ -94,8 +94,8 @@ describe( 'NavigableMenu', () => {
 		assertKeyDown( UP, 2, true );
 		assertKeyDown( UP, 1, true );
 		assertKeyDown( UP, 0, true );
-		assertKeyDown( LEFT, 0, false );
-		assertKeyDown( RIGHT, 0, false );
+		assertKeyDown( LEFT, 0, true );
+		assertKeyDown( RIGHT, 0, true );
 		assertKeyDown( SPACE, 0, false );
 	} );
 
@@ -146,8 +146,8 @@ describe( 'NavigableMenu', () => {
 		assertKeyDown( UP, 1, true );
 		assertKeyDown( UP, 0, true );
 		assertKeyDown( UP, 0, true );
-		assertKeyDown( LEFT, 0, false );
-		assertKeyDown( RIGHT, 0, false );
+		assertKeyDown( LEFT, 0, true );
+		assertKeyDown( RIGHT, 0, true );
 		assertKeyDown( SPACE, 0, false );
 	} );
 
@@ -204,8 +204,8 @@ describe( 'NavigableMenu', () => {
 		assertKeyDown( LEFT, 2, true );
 		assertKeyDown( LEFT, 1, true );
 		assertKeyDown( LEFT, 0, true );
-		assertKeyDown( UP, 0, false );
-		assertKeyDown( DOWN, 0, false );
+		assertKeyDown( UP, 0, true );
+		assertKeyDown( DOWN, 0, true );
 		assertKeyDown( SPACE, 0, false );
 	} );
 
@@ -256,8 +256,8 @@ describe( 'NavigableMenu', () => {
 		assertKeyDown( LEFT, 1, true );
 		assertKeyDown( LEFT, 0, true );
 		assertKeyDown( LEFT, 0, true );
-		assertKeyDown( DOWN, 0, false );
-		assertKeyDown( UP, 0, false );
+		assertKeyDown( DOWN, 0, true );
+		assertKeyDown( UP, 0, true );
 		assertKeyDown( SPACE, 0, false );
 	} );
 

--- a/packages/e2e-tests/specs/editor/various/dropdown-menu.test.js
+++ b/packages/e2e-tests/specs/editor/various/dropdown-menu.test.js
@@ -1,0 +1,144 @@
+/**
+ * WordPress dependencies
+ */
+import { createNewPost, pressKeyTimes } from '@wordpress/e2e-test-utils';
+
+const moreMenuButtonSelector =
+	'.components-button[aria-label="More tools & options"]';
+const moreMenuDropdownSelector =
+	'.components-dropdown-menu__menu[aria-label="More tools & options"]';
+const menuItemsSelector = [ 'menuitem', 'menuitemcheckbox', 'menuitemradio' ]
+	.map( ( role ) => `${ moreMenuDropdownSelector } [role="${ role }"]` )
+	.join( ',' );
+
+describe( 'Dropdown Menu', () => {
+	beforeEach( async () => {
+		await createNewPost();
+	} );
+
+	it( 'allows navigation through each item using arrow keys', async () => {
+		await page.click( moreMenuButtonSelector );
+		const menuItems = await page.$$( menuItemsSelector );
+
+		// Catch any issues with the selector, which could cause a false positive test result.
+		expect( menuItems.length ).toBeGreaterThan( 0 );
+
+		let activeElementText = await page.evaluate(
+			() => document.activeElement.textContent
+		);
+		const [ firstMenuItem ] = menuItems;
+		const firstMenuItemText = await firstMenuItem.evaluate(
+			( element ) => element.textContent
+		);
+
+		// Expect the first menu item to be focused.
+		expect( activeElementText ).toBeDefined();
+		expect( activeElementText ).toBe( firstMenuItemText );
+
+		// Arrow down to the last item.
+		await pressKeyTimes( 'ArrowDown', menuItems.length - 1 );
+
+		activeElementText = await page.evaluate(
+			() => document.activeElement.textContent
+		);
+
+		const [ lastMenuItem ] = menuItems.slice( -1 );
+		const lastMenuItemText = await lastMenuItem.evaluate(
+			( element ) => element.textContent
+		);
+
+		// Expect the last menu item to be focused.
+		expect( activeElementText ).toBeDefined();
+		expect( activeElementText ).toBe( lastMenuItemText );
+
+		// Arrow back up to the first item.
+		await pressKeyTimes( 'ArrowUp', menuItems.length - 1 );
+
+		activeElementText = await page.evaluate(
+			() => document.activeElement.textContent
+		);
+
+		// Expect the first menu item to be focused again.
+		expect( activeElementText ).toBeDefined();
+		expect( activeElementText ).toBe( firstMenuItemText );
+	} );
+
+	it( 'loops to the beginning and end when navigating past the boundaries of the menu', async () => {
+		await page.click( moreMenuButtonSelector );
+		const menuItems = await page.$$( menuItemsSelector );
+
+		// Catch any issues with the selector, which could cause a false positive test result.
+		expect( menuItems.length ).toBeGreaterThan( 0 );
+
+		let activeElementText = await page.evaluate(
+			() => document.activeElement.textContent
+		);
+		const [ firstMenuItem ] = menuItems;
+		const firstMenuItemText = await firstMenuItem.evaluate(
+			( element ) => element.textContent
+		);
+
+		// Expect the first menu item to be focused.
+		expect( activeElementText ).toBeDefined();
+		expect( activeElementText ).toBe( firstMenuItemText );
+
+		// Arrow up to the last item.
+		await page.keyboard.press( 'ArrowUp' );
+
+		activeElementText = await page.evaluate(
+			() => document.activeElement.textContent
+		);
+
+		const [ lastMenuItem ] = menuItems.slice( -1 );
+		const lastMenuItemText = await lastMenuItem.evaluate(
+			( element ) => element.textContent
+		);
+
+		// Expect the last menu item to be focused.
+		expect( activeElementText ).toBeDefined();
+		expect( activeElementText ).toBe( lastMenuItemText );
+
+		// Arrow back down to the first item.
+		await page.keyboard.press( 'ArrowDown' );
+
+		activeElementText = await page.evaluate(
+			() => document.activeElement.textContent
+		);
+
+		// Expect the first menu item to be focused again.
+		expect( activeElementText ).toBeDefined();
+		expect( activeElementText ).toBe( firstMenuItemText );
+	} );
+
+	it( 'ignores arrow key navigation that is orthogonal to the orientation of the menu, but stays open', async () => {
+		await page.click( moreMenuButtonSelector );
+		const menuItems = await page.$$( menuItemsSelector );
+
+		// Catch any issues with the selector, which could cause a false positive test result.
+		expect( menuItems.length ).toBeGreaterThan( 0 );
+
+		let activeElementText = await page.evaluate(
+			() => document.activeElement.textContent
+		);
+		const [ firstMenuItem ] = menuItems;
+		const firstMenuItemText = await firstMenuItem.evaluate(
+			( element ) => element.textContent
+		);
+
+		// Expect the first menu item to be focused.
+		expect( activeElementText ).toBeDefined();
+		expect( activeElementText ).toBe( firstMenuItemText );
+
+		// Press left and right keys an arbitrary (but > 1) number of times.
+		await pressKeyTimes( 'ArrowLeft', 5 );
+		await pressKeyTimes( 'ArrowRight', 5 );
+
+		activeElementText = await page.evaluate(
+			() => document.activeElement.textContent
+		);
+
+		// Expect the first menu item to still be focused.
+		expect( activeElementText ).toBeDefined();
+		expect( activeElementText ).toBe( firstMenuItemText );
+	} );
+} );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Resolves the issues with dropdown menus detailed on #18537.

The `NavigableContainer` component had some specific handling that called `preventedDefault` on key events. This function call seems to prevent Voiceover from initiating its own navigation from text content.

Unfortunately this code was only checking for elements with the role `menuitem`, while the More menu also contains `menuitemradio`s and could also contain `menuitemcheckbox` elements too.

This PR ensures the various kinds of menu items are handled.

The second part is that when pressing left or right arrow keys, Voiceover navigates through characters. This would result in a focus loss, since it Voiceover seems to move focus to the next bit of text outside the menu, and on focus loss the menu closes unexpectedly.

Left and right arrow key presses are now also prevented. This is debatable, perhaps left should only be prevented on the first menu item, and right on the last to prevent focus leaving the menu?

## How has this been tested?
Added e2e tests

1. Using Safari and Voiceover, start a new post
2. Open the more menu
3. Use up/down arrow keys
4. Expect each item in the menu receive focus one-by-one and that the menu stays open
5. Use left/right arrow keys
6. Expect that nothing happens, the menu stays open

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
