### PR TITLE
Fix missing focus outline in Add New Tag

### DIFF
--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -14,6 +14,10 @@
 		border-color: $light-gray-700;
 	}
 
+	&.is-active {
+		@include input-style__focus();
+	}
+
 	// Token input
 	input[type="text"].components-form-token-field__input {
 		display: inline-block;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Fixes: https://github.com/WordPress/gutenberg/issues/23990

If you focus on Add New Tag field there isn't outline styles for accessibility.

Screenshots are in the issue.