### PR TITLE
[Mobile] - Cover block: Hide media editing button for videos

### DIFF
--- a/packages/block-library/src/cover/edit.native.js
+++ b/packages/block-library/src/cover/edit.native.js
@@ -95,6 +95,7 @@ const Cover = ( {
 		customOverlayColor,
 	} = attributes;
 	const CONTAINER_HEIGHT = minHeight || COVER_DEFAULT_HEIGHT;
+	const isImage = backgroundType === MEDIA_TYPE_IMAGE;
 
 	const THEME_COLORS_COUNT = 4;
 	const coverDefaultPalette = {
@@ -160,7 +161,7 @@ const Cover = ( {
 			requestImageUploadCancelDialog( id );
 		} else if ( shouldShowFailure ) {
 			requestImageFailedRetryDialog( id );
-		} else if ( backgroundType === MEDIA_TYPE_IMAGE && url ) {
+		} else if ( isImage && url ) {
 			requestImageFullscreenPreview( url );
 		}
 	};
@@ -207,7 +208,8 @@ const Cover = ( {
 		},
 		// While we don't support theme colors we add a default bg color
 		! overlayColor.color && ! url ? backgroundColor : {},
-		isParentSelected &&
+		isImage &&
+			isParentSelected &&
 			! isUploadInProgress &&
 			! didUploadFail &&
 			styles.overlaySelected,
@@ -386,7 +388,8 @@ const Cover = ( {
 		<View style={ styles.backgroundContainer }>
 			{ controls }
 
-			{ url &&
+			{ isImage &&
+				url &&
 				openMediaOptionsRef.current &&
 				isParentSelected &&
 				! isUploadInProgress &&


### PR DESCRIPTION
`Gutenberg Mobile PR` -> https://github.com/wordpress-mobile/gutenberg-mobile/pull/2509

## Description
After merging [media editing](https://github.com/WordPress/gutenberg/pull/23280) support for Cover block it introduced a regression with videos, showing the media edit button when it shouldn't.

## How has this been tested?
<details><summary>Steps to test</summary>
---

**To test**

- Open the app with metro running (with a premium or self hosted site)
- Add a Cover block
- Upload a video
- **Expect** not to see the media editing button for videos.

</details>

## Screenshots <!-- if applicable -->
Before | After
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/88384111-18101e80-cdac-11ea-964f-829130b57b7a.png" width="250" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/88384117-1a727880-cdac-11ea-9589-0218e60cf5dc.png" width="250" /></kbd>

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
