### PR TITLE
Make shadow link color match text link color.

### DIFF
--- a/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -542,7 +542,9 @@ class RCTAztecView: Aztec.TextView {
 
     var linkTextColor: UIColor {
         set {
-            linkTextAttributes = [.foregroundColor: newValue, .underlineStyle: NSNumber(value: NSUnderlineStyle.single.rawValue)]
+            let shadow = NSShadow()
+            shadow.shadowColor = newValue
+            linkTextAttributes = [.foregroundColor: newValue, .underlineStyle: NSNumber(value: NSUnderlineStyle.single.rawValue), .shadow: shadow]
         }
         get {
             return linkTextAttributes[.foregroundColor] as? UIColor ?? UIColor.blue

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -14,6 +14,7 @@ For each user feature we should also add a importance categorization label  to i
 ## 1.34.0
 
 * [***] Media editing support in Cover block.
+* [*] Fixed a bug on the Heading block, where a heading with a link and string formatting showed a white shadow in dark mode.
 
 ## 1.33.0
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

Fixes #24191 

GB-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2511

## Description
<!-- Please describe what you have changed or added -->

Update the RCTAzteView code to make links shadow color match the links text color.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

<img src="https://user-images.githubusercontent.com/651601/88398763-c2447200-cdbd-11ea-9861-ebf2df6a85cf.png" width=300 />

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

1. Open the demo app
2. Add a header block
3. Write some text
4. Apply a link to a part of the text
5. Apply the Strong attributed to the link
6. Check if the Header looks correct.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
