### PR TITLE
Avoid rendering the clipboard textarea inside the button

### DIFF
--- a/packages/compose/src/hooks/use-copy-on-click/index.js
+++ b/packages/compose/src/hooks/use-copy-on-click/index.js
@@ -29,7 +29,6 @@ export default function useCopyOnClick( ref, text, timeout = 4000 ) {
 		// Clipboard listens to click events.
 		clipboard.current = new Clipboard( ref.current, {
 			text: () => ( typeof text === 'function' ? text() : text ),
-			container: ref.current,
 		} );
 
 		clipboard.current.on( 'success', ( { clearSelection, trigger } ) => {


### PR DESCRIPTION
closes #24063

It doesn't seem necessary anymore to render the textarea inside the button/popover to avoid the focus loss.

**Testing instructions**

- Click the  "Copy" button on the button settings dropdown
- the focus should stay on the button (dropdown don't close)