### PR TITLE
Avoid focusing the block selection button on each render

### DIFF
--- a/packages/block-editor/src/components/block-list/block-selection-button.js
+++ b/packages/block-editor/src/components/block-list/block-selection-button.js
@@ -63,7 +63,7 @@ function BlockSelectionButton( { clientId, rootClientId, ...props } ) {
 	// Focus the breadcrumb in navigation mode.
 	useEffect( () => {
 		ref.current.focus();
-	} );
+	}, [] );
 
 	function onKeyDown( event ) {
 		const { keyCode } = event;


### PR DESCRIPTION
closes #24190 

This is a bug that was present for a long time and it probably can be triggered in several ways. The block selection component was being refocused on each render.

**Testing  instructions**

 - Open the options modal$
 - click  "Contain text cursor inside active block"
 - The modal should stay open.
