### PR TITLE
Avoid focus style from being cut on the categories panel

### DIFF
--- a/packages/editor/src/components/post-taxonomies/style.scss
+++ b/packages/editor/src/components/post-taxonomies/style.scss
@@ -1,6 +1,5 @@
 .editor-post-taxonomies__hierarchical-terms-list {
 	max-height: 14em;
-	overflow: auto;
 
 	// Extra left padding prevents checkbox focus borders from being cut off.
 	padding-left: 2px;

--- a/packages/editor/src/components/post-taxonomies/style.scss
+++ b/packages/editor/src/components/post-taxonomies/style.scss
@@ -1,8 +1,12 @@
 .editor-post-taxonomies__hierarchical-terms-list {
 	max-height: 14em;
+	overflow: auto;
 
 	// Extra left padding prevents checkbox focus borders from being cut off.
-	padding-left: 2px;
+	margin-left: -$border-width * 4 - $border-width-focus;
+	padding-left: $border-width * 4 + $border-width-focus;
+	margin-top: -$border-width * 4 - $border-width-focus;
+	padding-top: $border-width * 4 + $border-width-focus;
 }
 
 .editor-post-taxonomies__hierarchical-terms-choice {


### PR DESCRIPTION
closes #23989

That overflow was not necessary.

**Testing instructions**

 - Add some categories to the categories panel
 - Focus the checkboxes
 - The focus style appears properly.