### PR TITLE
Docs: Update default values for Popover props 'noArrow' and 'position'

### DIFF
--- a/packages/components/src/popover/README.md
+++ b/packages/components/src/popover/README.md
@@ -70,7 +70,7 @@ The direction in which the popover should open relative to its parent node. Spec
 
 - Type: `String`
 - Required: No
-- Default: `"top center"`
+- Default: `"bottom right"`
 
 ### children
 
@@ -123,7 +123,7 @@ Opt-in prop to show popovers fullscreen on mobile, pass `false` in this prop to 
 
  - Type: `Boolean`
  - Required: No
- - Default: `false`
+ - Default: `true`
 
 ### anchorRect
 


### PR DESCRIPTION
## Description
This change reflects the new default values which were changed in https://github.com/WordPress/gutenberg/commit/ef73ed07bd59bdcbbe77cc1c537299d8e39167b1 and https://github.com/WordPress/gutenberg/commit/505e31049b7ca56aa1d343433308355fddbb449d.