### PR TITLE
Popover: Fix arrow color to match content border color

### DIFF
--- a/packages/components/src/popover/stories/index.js
+++ b/packages/components/src/popover/stories/index.js
@@ -30,12 +30,14 @@ export const _default = () => {
 		'firstElement'
 	);
 	const noArrow = boolean( 'noArrow', false );
+	const isAlternate = boolean( 'isAlternate', false );
 
 	const props = {
 		animate,
 		children,
 		focusOnMount,
 		noArrow,
+		isAlternate,
 	};
 
 	if ( ! show ) {

--- a/packages/components/src/popover/style.scss
+++ b/packages/components/src/popover/style.scss
@@ -29,7 +29,11 @@ $arrow-size: 8px;
 		margin-left: 2px;
 
 		&::before {
-			border: $arrow-size solid $gray-900;
+			border: $arrow-size solid $gray-400;
+		}
+
+		&.is-alternate::before {
+			border-color: $gray-900;
 		}
 
 		&::after {


### PR DESCRIPTION
## Description
The colors were changed in https://github.com/WordPress/gutenberg/commit/ef73ed07bd59bdcbbe77cc1c537299d8e39167b1 and https://github.com/WordPress/gutenberg/commit/505e31049b7ca56aa1d343433308355fddbb449d.

## How has this been tested?
See storybook: https://wordpress.github.io/gutenberg/?path=/story/components-popover--default

## Screenshots <!-- if applicable -->

Before:
![image](https://user-images.githubusercontent.com/617637/88478202-80930300-cf46-11ea-861a-fabb2537d23d.png)

After with default styling:
![image](https://user-images.githubusercontent.com/617637/88478216-9c96a480-cf46-11ea-8440-7b1d7e116853.png)

After with alternative styling:
![image](https://user-images.githubusercontent.com/617637/88478217-a0c2c200-cf46-11ea-8673-dfa05991e710.png)


## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
