### PR TITLE
Docs: Fix typo in block-code copy

### DIFF
--- a/docs/designers-developers/developers/tutorials/create-block/block-code.md
+++ b/docs/designers-developers/developers/tutorials/create-block/block-code.md
@@ -41,7 +41,7 @@ Note: the block classname is prefixed with `wp-block`. The `create-block/gutenpr
 }
 ```
 
-After updating, reload the post and refresh the brwoser. If you are using a browser that supports color fonts (Firefox) then you will see it styled.
+After updating, reload the post and refresh the browser. If you are using a browser that supports color fonts (Firefox) then you will see it styled.
 
 ## Use Sass for Style (optional)
 


### PR DESCRIPTION
## Description
Fixes a typo in the block-code copy where "browser" was spelt incorrectly.

## How has this been tested?
N/A Copy change in docs
