### PR TITLE
Replace the demo link of the Gutenberg Storybook in Docs

### DIFF
--- a/docs/architecture/folder-structure.md
+++ b/docs/architecture/folder-structure.md
@@ -116,7 +116,7 @@ The following snippet explains how the Gutenberg repository is structured omitti
     │   Unit tests for the PHP code of the Gutenberg plugin.
     │
     ├── storybook
-    │   Config of the [Gutenberg Storybook](http://wordpress.github.io).
+    │   Config of the [Gutenberg Storybook](https://wordpress.github.io/gutenberg/).
     │
     ├── test/integration
     │   Set of WordPress packages integration tests.


### PR DESCRIPTION
## Description

I've replaced the Gutenberg Storybook URL with the correct one. The current one resolves to 404.

## How has this been tested?

I've confirmed that the page is resolving properly and without a 404 error.

## Screenshots <!-- if applicable -->

## Types of changes

Url path change.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards. 
- [x] My code has proper inline documentation.
- [ ] I've included developer documentation if appropriate. 
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR.
