### PR TITLE
Fix gradient RGBA/HSLA inputs' width

### DIFF
--- a/packages/components/src/color-picker/inputs.js
+++ b/packages/components/src/color-picker/inputs.js
@@ -175,11 +175,12 @@ export class Inputs extends Component {
 				</div>
 			);
 		} else if ( this.state.view === 'rgb' ) {
+			const legend = disableAlpha
+				? __( 'Color value in RGB' )
+				: __( 'Color value in RGBA' );
 			return (
 				<fieldset>
-					<VisuallyHidden as="legend">
-						{ __( 'Color value in RGBA' ) }
-					</VisuallyHidden>
+					<VisuallyHidden as="legend">{ legend }</VisuallyHidden>
 					<div className="components-color-picker__inputs-fields">
 						<Input
 							source={ this.state.view }
@@ -228,11 +229,12 @@ export class Inputs extends Component {
 				</fieldset>
 			);
 		} else if ( this.state.view === 'hsl' ) {
+			const legend = disableAlpha
+				? __( 'Color value in HSL' )
+				: __( 'Color value in HSLA' );
 			return (
 				<fieldset>
-					<VisuallyHidden as="legend">
-						{ __( 'Color value in HSLA' ) }
-					</VisuallyHidden>
+					<VisuallyHidden as="legend">{ legend }</VisuallyHidden>
 					<div className="components-color-picker__inputs-fields">
 						<Input
 							source={ this.state.view }

--- a/packages/components/src/color-picker/inputs.js
+++ b/packages/components/src/color-picker/inputs.js
@@ -178,7 +178,7 @@ export class Inputs extends Component {
 			return (
 				<fieldset>
 					<VisuallyHidden as="legend">
-						{ __( 'Color value in RGB' ) }
+						{ __( 'Color value in RGBA' ) }
 					</VisuallyHidden>
 					<div className="components-color-picker__inputs-fields">
 						<Input
@@ -231,7 +231,7 @@ export class Inputs extends Component {
 			return (
 				<fieldset>
 					<VisuallyHidden as="legend">
-						{ __( 'Color value in HSL' ) }
+						{ __( 'Color value in HSLA' ) }
 					</VisuallyHidden>
 					<div className="components-color-picker__inputs-fields">
 						<Input

--- a/packages/components/src/color-picker/style.scss
+++ b/packages/components/src/color-picker/style.scss
@@ -227,6 +227,11 @@
 	padding-top: 16px;
 	display: flex;
 	align-items: flex-end;
+	min-width: 22em;
+
+	@include break-small() {
+		min-width: 25em;
+	}
 
 	fieldset {
 		flex: 1;
@@ -237,6 +242,7 @@
 
 	.components-color-picker__inputs-fields .components-text-control__input[type="number"] {
 		padding: 6px 8px;
+		margin: 0;
 	}
 }
 

--- a/packages/components/src/color-picker/style.scss
+++ b/packages/components/src/color-picker/style.scss
@@ -227,11 +227,7 @@
 	padding-top: 16px;
 	display: flex;
 	align-items: flex-end;
-	min-width: 260px;
-
-	@include break-small() {
-		min-width: 315px;
-	}
+	min-width: 255px;
 
 	fieldset {
 		flex: 1;
@@ -241,7 +237,7 @@
 	}
 
 	.components-color-picker__inputs-fields .components-text-control__input[type="number"] {
-		padding: 6px 8px;
+		padding: 6px 3px;
 		margin: 0;
 	}
 }
@@ -262,7 +258,7 @@
 	}
 
 	.components-base-control__field {
-		margin: 0 4px;
+		margin: 0 2px;
 	}
 }
 

--- a/packages/components/src/color-picker/style.scss
+++ b/packages/components/src/color-picker/style.scss
@@ -227,10 +227,10 @@
 	padding-top: 16px;
 	display: flex;
 	align-items: flex-end;
-	min-width: 22em;
+	min-width: 260px;
 
 	@include break-small() {
-		min-width: 25em;
+		min-width: 315px;
 	}
 
 	fieldset {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Fixes: https://github.com/WordPress/gutenberg/issues/24201

When adding a gradient with RGBA or HSLA color values to a block, the increment buttons of number inputs cover up the inputs' values.

Steps to reproduce and screenshots in the issue.
