### PR TITLE
Show the default style variation if none provided

### DIFF
--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -110,18 +110,21 @@ function BlockStyles( {
 		return null;
 	}
 
-	if ( ! type.styles && ! find( styles, 'isDefault' ) ) {
-		styles.unshift( {
-			name: 'default',
-			label: _x( 'Default', 'block style' ),
-			isDefault: true,
-		} );
-	}
+	const renderedStyles = find( styles, 'isDefault' )
+		? styles
+		: [
+				{
+					name: 'default',
+					label: _x( 'Default', 'block style' ),
+					isDefault: true,
+				},
+				...styles,
+		  ];
 
-	const activeStyle = getActiveStyle( styles, className );
+	const activeStyle = getActiveStyle( renderedStyles, className );
 	return (
 		<div className="block-editor-block-styles">
-			{ styles.map( ( style ) => {
+			{ renderedStyles.map( ( style ) => {
 				const styleClassName = replaceActiveStyle(
 					className,
 					activeStyle,


### PR DESCRIPTION
closes #24147 

The logic to add default style variations was only checking the "blockType.styles" property and not the registered styles.

**Testing instructions**

 - Add a style variations to the list block like so

```
wp.blocks.registerBlockStyle( 'core/list', {
	name: 'test',
	label: 'Test',
} );
```

 - The default style variation should be also  added to the block styles switcher.