### PR TITLE
Backport fixes to include on WordPress 5.5 beta 4

### DIFF
--- a/lib/block-patterns.php
+++ b/lib/block-patterns.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Add support for block patterns and register default patterns.
+ *
+ * @package gutenberg
+ */
+
+add_theme_support( 'core-block-patterns' );
+
+/**
+ * Extends block editor settings to include a list of default patterns.
+ *
+ * @param array $settings Default editor settings.
+ *
+ * @return array Filtered editor settings.
+ */
+function gutenberg_extend_settings_block_patterns( $settings ) {
+	$settings['__experimentalBlockPatterns']          = WP_Block_Patterns_Registry::get_instance()->get_all_registered();
+	$settings['__experimentalBlockPatternCategories'] = WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered();
+
+	return $settings;
+}
+add_filter( 'block_editor_settings', 'gutenberg_extend_settings_block_patterns', 0 );
+
+
+/**
+ * Load a block pattern by name.
+ *
+ * @param string $name Block Pattern File name.
+ *
+ * @return array Block Pattern Array.
+ */
+function gutenberg_load_block_pattern( $name ) {
+	return require( __DIR__ . '/patterns/' . $name . '.php' );
+}
+
+/**
+ * Register default patterns and categories, potentially overriding ones that were already registered in Core.
+ *
+ * This can be removed when plugin support requires WordPress 5.5.0+, and patterns have been synced back to Core.
+ *
+ * @see https://core.trac.wordpress.org/ticket/50550
+ */
+function gutenberg_register_block_patterns() {
+	$should_register_core_patterns = get_theme_support( 'core-block-patterns' );
+
+	if ( $should_register_core_patterns ) {
+		register_block_pattern( 'core/text-two-columns', gutenberg_load_block_pattern( 'text-two-columns' ) );
+		register_block_pattern( 'core/two-buttons', gutenberg_load_block_pattern( 'two-buttons' ) );
+		register_block_pattern( 'core/two-images', gutenberg_load_block_pattern( 'two-images' ) );
+		register_block_pattern( 'core/text-two-columns-with-images', gutenberg_load_block_pattern( 'text-two-columns-with-images' ) );
+		register_block_pattern( 'core/text-three-columns-buttons', gutenberg_load_block_pattern( 'text-three-columns-buttons' ) );
+		register_block_pattern( 'core/large-header', gutenberg_load_block_pattern( 'large-header' ) );
+		register_block_pattern( 'core/large-header-paragraph', gutenberg_load_block_pattern( 'large-header-paragraph' ) );
+		register_block_pattern( 'core/three-buttons', gutenberg_load_block_pattern( 'three-buttons' ) );
+		register_block_pattern( 'core/quote', gutenberg_load_block_pattern( 'quote' ) );
+	}
+
+	register_block_pattern_category( 'buttons', array( 'label' => _x( 'Buttons', 'Block pattern category', 'gutenberg' ) ) );
+	register_block_pattern_category( 'columns', array( 'label' => _x( 'Columns', 'Block pattern category', 'gutenberg' ) ) );
+	register_block_pattern_category( 'gallery', array( 'label' => _x( 'Gallery', 'Block pattern category', 'gutenberg' ) ) );
+	register_block_pattern_category( 'header', array( 'label' => _x( 'Headers', 'Block pattern category', 'gutenberg' ) ) );
+	register_block_pattern_category( 'text', array( 'label' => _x( 'Text', 'Block pattern category', 'gutenberg' ) ) );
+}
+add_action( 'init', 'gutenberg_register_block_patterns' );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -622,47 +622,6 @@ function gutenberg_extend_block_editor_styles( $settings ) {
 add_filter( 'block_editor_settings', 'gutenberg_extend_block_editor_styles' );
 
 /**
- * Load a block pattern by name.
- *
- * @param string $name Block Pattern File name.
- *
- * @return array Block Pattern Array.
- */
-function gutenberg_load_block_pattern( $name ) {
-	return require( __DIR__ . '/patterns/' . $name . '.php' );
-}
-
-/**
- * Extends block editor settings to include a list of default patterns.
- *
- * @param array $settings Default editor settings.
- *
- * @return array Filtered editor settings.
- */
-function gutenberg_extend_settings_block_patterns( $settings ) {
-	if ( empty( $settings['__experimentalBlockPatterns'] ) ) {
-		$settings['__experimentalBlockPatterns'] = array();
-	}
-
-	$settings['__experimentalBlockPatterns'] = array_merge(
-		WP_Block_Patterns_Registry::get_instance()->get_all_registered(),
-		$settings['__experimentalBlockPatterns']
-	);
-
-	if ( empty( $settings['__experimentalBlockPatternCategories'] ) ) {
-		$settings['__experimentalBlockPatternCategories'] = array();
-	}
-
-	$settings['__experimentalBlockPatternCategories'] = array_merge(
-		WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered(),
-		$settings['__experimentalBlockPatternCategories']
-	);
-
-	return $settings;
-}
-add_filter( 'block_editor_settings', 'gutenberg_extend_settings_block_patterns', 0 );
-
-/**
  * Extends block editor settings to determine whether to use custom line height controls.
  *
  * @param array $settings Default editor settings.
@@ -717,37 +676,3 @@ function gutenberg_extend_settings_link_color( $settings ) {
 	return $settings;
 }
 add_filter( 'block_editor_settings', 'gutenberg_extend_settings_link_color' );
-
-/*
- * Register default patterns if not registered in Core already.
- *
- * This can be removed when plugin support requires WordPress 5.5.0+.
- *
- * @see https://core.trac.wordpress.org/ticket/50550
- */
-if ( class_exists( 'WP_Block_Patterns_Registry' ) && ! WP_Block_Patterns_Registry::get_instance()->is_registered( 'text-two-columns' ) ) {
-	register_block_pattern( 'core/text-two-columns', gutenberg_load_block_pattern( 'text-two-columns' ) );
-	register_block_pattern( 'core/two-buttons', gutenberg_load_block_pattern( 'two-buttons' ) );
-	register_block_pattern( 'core/two-images', gutenberg_load_block_pattern( 'two-images' ) );
-	register_block_pattern( 'core/text-two-columns-with-images', gutenberg_load_block_pattern( 'text-two-columns-with-images' ) );
-	register_block_pattern( 'core/text-three-columns-buttons', gutenberg_load_block_pattern( 'text-three-columns-buttons' ) );
-	register_block_pattern( 'core/large-header', gutenberg_load_block_pattern( 'large-header' ) );
-	register_block_pattern( 'core/large-header-paragraph', gutenberg_load_block_pattern( 'large-header-paragraph' ) );
-	register_block_pattern( 'core/three-buttons', gutenberg_load_block_pattern( 'three-buttons' ) );
-	register_block_pattern( 'core/quote', gutenberg_load_block_pattern( 'quote' ) );
-}
-
-/*
- * Register default pattern categories if not registered in Core already.
- *
- * This can be removed when plugin support requires WordPress 5.5.0+.
- *
- * @see https://core.trac.wordpress.org/ticket/50550
- */
-if ( class_exists( 'WP_Block_Pattern_Categories_Registry' ) ) {
-	register_block_pattern_category( 'buttons', array( 'label' => _x( 'Buttons', 'Block pattern category', 'gutenberg' ) ) );
-	register_block_pattern_category( 'columns', array( 'label' => _x( 'Columns', 'Block pattern category', 'gutenberg' ) ) );
-	register_block_pattern_category( 'gallery', array( 'label' => _x( 'Gallery', 'Block pattern category', 'gutenberg' ) ) );
-	register_block_pattern_category( 'header', array( 'label' => _x( 'Headers', 'Block pattern category', 'gutenberg' ) ) );
-	register_block_pattern_category( 'text', array( 'label' => _x( 'Text', 'Block pattern category', 'gutenberg' ) ) );
-}

--- a/lib/load.php
+++ b/lib/load.php
@@ -86,6 +86,7 @@ if ( ! class_exists( 'WP_Block_List' ) ) {
 require dirname( __FILE__ ) . '/compat.php';
 require dirname( __FILE__ ) . '/utils.php';
 
+require dirname( __FILE__ ) . '/block-patterns.php';
 require dirname( __FILE__ ) . '/blocks.php';
 require dirname( __FILE__ ) . '/templates.php';
 require dirname( __FILE__ ) . '/template-parts.php';

--- a/packages/block-directory/src/store/actions.js
+++ b/packages/block-directory/src/store/actions.js
@@ -51,9 +51,6 @@ export function* installBlockType( block ) {
 	let success = false;
 	yield clearErrorNotice( id );
 	try {
-		if ( ! Array.isArray( assets ) || ! assets.length ) {
-			throw new Error( __( 'Block has no assets.' ) );
-		}
 		yield setIsInstalling( block.id, true );
 
 		// If we have a wp:plugin link, the plugin is installed but inactive.

--- a/packages/block-directory/src/store/controls.js
+++ b/packages/block-directory/src/store/controls.js
@@ -1,50 +1,49 @@
 /**
  * WordPress dependencies
  */
-import { getPath } from '@wordpress/url';
+import apiFetch from '@wordpress/api-fetch';
 
 /**
- * Loads a JavaScript file.
+ * Load an asset for a block.
  *
- * @param {string} asset The url for this file.
+ * This function returns a Promise that will resolve once the asset is loaded,
+ * or in the case of Stylesheets and Inline Javascript, will resolve immediately.
+ *
+ * @param {HTMLElement} el A HTML Element asset to inject.
  *
  * @return {Promise} Promise which will resolve when the asset is loaded.
  */
-export const loadScript = ( asset ) => {
-	if ( ! asset || ! /\.js$/.test( getPath( asset ) ) ) {
-		return Promise.reject( new Error( 'No script found.' ) );
-	}
+export const loadAsset = ( el ) => {
 	return new Promise( ( resolve, reject ) => {
-		const existing = document.querySelector( `script[src="${ asset }"]` );
-		if ( existing ) {
-			existing.parentNode.removeChild( existing );
-		}
-		const script = document.createElement( 'script' );
-		script.src = asset;
-		script.onload = () => resolve( true );
-		script.onerror = () => reject( new Error( 'Error loading script.' ) );
-		document.body.appendChild( script );
-	} );
-};
+		/*
+		 * Reconstruct the passed element, this is required as inserting the Node directly
+		 * won't always fire the required onload events, even if the asset wasn't already loaded.
+		 */
+		const newNode = document.createElement( el.nodeName );
 
-/**
- * Loads a CSS file.
- *
- * @param {string} asset The url for this file.
- *
- * @return {Promise} Promise which will resolve when the asset is added.
- */
-export const loadStyle = ( asset ) => {
-	if ( ! asset || ! /\.css$/.test( getPath( asset ) ) ) {
-		return Promise.reject( new Error( 'No style found.' ) );
-	}
-	return new Promise( ( resolve, reject ) => {
-		const link = document.createElement( 'link' );
-		link.rel = 'stylesheet';
-		link.href = asset;
-		link.onload = () => resolve( true );
-		link.onerror = () => reject( new Error( 'Error loading style.' ) );
-		document.body.appendChild( link );
+		[ 'id', 'rel', 'src', 'href', 'type' ].forEach( ( attr ) => {
+			if ( el[ attr ] ) {
+				newNode[ attr ] = el[ attr ];
+			}
+		} );
+
+		// Append inline <script> contents.
+		if ( el.innerHTML ) {
+			newNode.appendChild( document.createTextNode( el.innerHTML ) );
+		}
+
+		newNode.onload = () => resolve( true );
+		newNode.onerror = () => reject( new Error( 'Error loading asset.' ) );
+
+		document.body.appendChild( newNode );
+
+		// Resolve Stylesheets and Inline JavaScript immediately.
+		if (
+			'link' === newNode.nodeName.toLowerCase() ||
+			( 'script' === newNode.nodeName.toLowerCase() && ! newNode.src )
+		) {
+			resolve();
+		}
 	} );
 };
 
@@ -63,14 +62,47 @@ export function loadAssets( assets ) {
 }
 
 const controls = {
-	LOAD_ASSETS( { assets } ) {
-		const scripts = assets.map( ( asset ) =>
-			getPath( asset ).match( /\.js$/ ) !== null
-				? loadScript( asset )
-				: loadStyle( asset )
-		);
+	LOAD_ASSETS() {
+		/*
+		 * Fetch the current URL (post-new.php, or post.php?post=1&action=edit) and compare the
+		 * Javascript and CSS assets loaded between the pages. This imports the required assets
+		 * for the block into the current page while not requiring that we know them up-front.
+		 * In the future this can be improved by reliance upon block.json and/or a script-loader
+		 * dependancy API.
+		 */
+		return apiFetch( {
+			url: document.location.href,
+			parse: false,
+		} )
+			.then( ( response ) => response.text() )
+			.then( ( data ) => {
+				const doc = new window.DOMParser().parseFromString(
+					data,
+					'text/html'
+				);
 
-		return Promise.all( scripts );
+				const newAssets = Array.from(
+					doc.querySelectorAll( 'link[rel="stylesheet"],script' )
+				).filter(
+					( asset ) =>
+						asset.id && ! document.getElementById( asset.id )
+				);
+
+				return new Promise( async ( resolve, reject ) => {
+					for ( const i in newAssets ) {
+						try {
+							/*
+							 * Load each asset in order, as they may depend upon an earlier loaded script.
+							 * Stylesheets and Inline Scripts will resolve immediately upon insertion.
+							 */
+							await loadAsset( newAssets[ i ] );
+						} catch ( e ) {
+							reject( e );
+						}
+					}
+					resolve();
+				} );
+			} );
 	},
 };
 

--- a/packages/block-directory/src/store/test/actions.js
+++ b/packages/block-directory/src/store/test/actions.js
@@ -158,31 +158,6 @@ describe( 'actions', () => {
 			} );
 		} );
 
-		it( 'should set an error if the plugin has no assets', () => {
-			const generator = installBlockType( { ...block, assets: [] } );
-
-			expect( generator.next().value ).toEqual( {
-				type: 'CLEAR_ERROR_NOTICE',
-				blockId: block.id,
-			} );
-
-			expect( generator.next().value ).toMatchObject( {
-				type: 'SET_ERROR_NOTICE',
-				blockId: block.id,
-			} );
-
-			expect( generator.next().value ).toEqual( {
-				type: 'SET_INSTALLING_BLOCK',
-				blockId: block.id,
-				isInstalling: false,
-			} );
-
-			expect( generator.next() ).toEqual( {
-				value: false,
-				done: true,
-			} );
-		} );
-
 		it( "should set an error if the plugin can't install", () => {
 			const generator = installBlockType( block );
 

--- a/packages/block-directory/src/store/test/controls.js
+++ b/packages/block-directory/src/store/test/controls.js
@@ -1,45 +1,21 @@
 /**
  * Internal dependencies
  */
-import { loadScript, loadStyle } from '../controls';
+import { loadAsset } from '../controls';
 
 describe( 'controls', () => {
-	const scriptAsset = 'http://www.wordpress.org/plugins/fakeasset.js';
-	const styleAsset = 'http://www.wordpress.org/plugins/fakeasset.css';
+	describe( 'loadAsset', () => {
+		const script = document.createElement( 'script' );
+		const style = document.createElement( 'link' );
 
-	describe( 'loadScript', () => {
 		it( 'should return a Promise when loading a script', () => {
-			const result = loadScript( scriptAsset );
+			const result = loadAsset( script );
 			expect( typeof result.then ).toBe( 'function' );
 		} );
 
-		it( 'should reject when no script is given', async () => {
-			expect.assertions( 1 );
-			const result = loadScript( '' );
-			await expect( result ).rejects.toThrow( Error );
-		} );
-
-		it( 'should reject when a non-js file is given', async () => {
-			const result = loadScript( styleAsset );
-			await expect( result ).rejects.toThrow( Error );
-		} );
-	} );
-
-	describe( 'loadStyle', () => {
 		it( 'should return a Promise when loading a style', () => {
-			const result = loadStyle( styleAsset );
+			const result = loadAsset( style );
 			expect( typeof result.then ).toBe( 'function' );
-		} );
-
-		it( 'should reject when no style is given', async () => {
-			expect.assertions( 1 );
-			const result = loadStyle( '' );
-			await expect( result ).rejects.toThrow( Error );
-		} );
-
-		it( 'should reject when a non-css file is given', async () => {
-			const result = loadStyle( scriptAsset );
-			await expect( result ).rejects.toThrow( Error );
 		} );
 	} );
 } );

--- a/packages/block-editor/src/components/block-breadcrumb/style.scss
+++ b/packages/block-editor/src/components/block-breadcrumb/style.scss
@@ -8,7 +8,7 @@
 		margin: 0;
 
 		&:not(:last-child)::after {
-			content: "\2192"; // This becomes →.
+			content: "\2192" #{'/*rtl:"\2190"*/'}; // This becomes → for LTR and ← for RTL.
 		}
 	}
 }

--- a/packages/block-editor/src/components/block-draggable/draggable-chip.js
+++ b/packages/block-editor/src/components/block-draggable/draggable-chip.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { _n, sprintf } from '@wordpress/i18n';
 import { getBlockType } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 import { Flex, FlexItem } from '@wordpress/components';
@@ -43,8 +43,8 @@ export default function BlockDraggableChip( { clientIds } ) {
 							<BlockIcon icon={ icon } />
 						) : (
 							sprintf(
-								/* translators: %d: number of blocks. */
-								__( '%d blocks' ),
+								/* translators: %d: Number of blocks. */
+								_n( '%d block', '%d blocks', clientIds.length ),
 								clientIds.length
 							)
 						) }

--- a/packages/block-editor/src/components/block-list/block-selection-button.js
+++ b/packages/block-editor/src/components/block-list/block-selection-button.js
@@ -63,7 +63,7 @@ function BlockSelectionButton( { clientId, rootClientId, ...props } ) {
 	// Focus the breadcrumb in navigation mode.
 	useEffect( () => {
 		ref.current.focus();
-	} );
+	}, [] );
 
 	function onKeyDown( event ) {
 		const { keyCode } = event;

--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -45,7 +45,6 @@ const BlockComponent = forwardRef(
 			enableAnimation,
 			index,
 			className,
-			isLocked,
 			name,
 			mode,
 			blockTitle,
@@ -258,8 +257,8 @@ const BlockComponent = forwardRef(
 				data-block={ clientId }
 				data-type={ name }
 				data-title={ blockTitle }
-				// Only allow shortcuts when a blocks is selected and not locked.
-				onKeyDown={ isSelected && ! isLocked ? onKeyDown : undefined }
+				// Only allow shortcuts when a blocks is selected.
+				onKeyDown={ isSelected ? onKeyDown : undefined }
 				// Only allow selection to be started from a selected block.
 				onMouseLeave={ isSelected ? onMouseLeave : undefined }
 				// No need to have these listeners for hover class in edit mode.

--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -110,18 +110,21 @@ function BlockStyles( {
 		return null;
 	}
 
-	if ( ! type.styles && ! find( styles, 'isDefault' ) ) {
-		styles.unshift( {
-			name: 'default',
-			label: _x( 'Default', 'block style' ),
-			isDefault: true,
-		} );
-	}
+	const renderedStyles = find( styles, 'isDefault' )
+		? styles
+		: [
+				{
+					name: 'default',
+					label: _x( 'Default', 'block style' ),
+					isDefault: true,
+				},
+				...styles,
+		  ];
 
-	const activeStyle = getActiveStyle( styles, className );
+	const activeStyle = getActiveStyle( renderedStyles, className );
 	return (
 		<div className="block-editor-block-styles">
-			{ styles.map( ( style ) => {
+			{ renderedStyles.map( ( style ) => {
 				const styleClassName = replaceActiveStyle(
 					className,
 					activeStyle,

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -8,7 +8,7 @@ import {
 	documentHasUncollapsedSelection,
 } from '@wordpress/dom';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -34,12 +34,12 @@ export function useNotifyCopy() {
 			notice =
 				eventType === 'copy'
 					? sprintf(
-							// Translators: Name of the block being copied, e.g. "Paragraph"
+							// Translators: Name of the block being copied, e.g. "Paragraph".
 							__( 'Copied "%s" to clipboard.' ),
 							title
 					  )
 					: sprintf(
-							// Translators: Name of the block being cut, e.g. "Paragraph"
+							// Translators: Name of the block being cut, e.g. "Paragraph".
 							__( 'Moved "%s" to clipboard.' ),
 							title
 					  );
@@ -47,13 +47,21 @@ export function useNotifyCopy() {
 			notice =
 				eventType === 'copy'
 					? sprintf(
-							// Translators: Number of blocks being copied
-							__( 'Copied %d blocks to clipboard.' ),
+							// Translators: %d: Number of blocks being copied.
+							_n(
+								'Copied %d block to clipboard.',
+								'Copied %d blocks to clipboard.',
+								selectedBlockClientIds.length
+							),
 							selectedBlockClientIds.length
 					  )
 					: sprintf(
-							// Translators: Number of blocks being cut
-							__( 'Moved %d blocks to clipboard.' ),
+							// Translators: %d: Number of blocks being cut.
+							_n(
+								'Moved %d block to clipboard.',
+								'Moved %d blocks to clipboard.',
+								selectedBlockClientIds.length
+							),
 							selectedBlockClientIds.length
 					  );
 		}

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -111,7 +111,7 @@ function useInsertionPoint( {
 			// translators: %d: the name of the block that has been added
 			const message = _n(
 				'%d block added.',
-				'%d blocks added',
+				'%d blocks added.',
 				blocks.length
 			);
 			speak( message );

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -318,7 +318,7 @@ function LinkControl( {
 		// to the text value of the `<input>`. This is because `title` is used
 		// when creating the suggestion. Similarly `url` is used when using keyboard to select
 		// the suggestion (the <form> `onSubmit` handler falls-back to `url`).
-		return isURLLike( val )
+		return isURLLike( val ) || ! createSuggestion
 			? results
 			: results.concat( {
 					// the `id` prop is intentionally ommitted here because it

--- a/packages/block-editor/src/components/provider/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/use-block-sync.js
@@ -171,7 +171,9 @@ export default function useBlockSync( {
 
 				// Inform the controlling entity that changes have been made to
 				// the block-editor store they should be aware about.
-				const updateParent = isPersistent ? onChange : onInput;
+				const updateParent = isPersistent
+					? onChangeRef.current
+					: onInputRef.current;
 				updateParent( blocks, {
 					selectionStart: getSelectionStart(),
 					selectionEnd: getSelectionEnd(),

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -290,11 +290,14 @@ export default function useBlockDropZone( {
 				( sourceRootClientId === '' &&
 					targetRootClientId === undefined );
 
+			const draggedBlockCount = sourceClientIds.length;
+
 			// If the block is kept at the same level and moved downwards,
-			// subtract to account for blocks shifting upward to occupy its old position.
+			// subtract to take into account that the blocks being dragged
+			// were removed from the block list.
 			const insertIndex =
 				isAtSameLevel && sourceBlockIndex < targetBlockIndex
-					? targetBlockIndex - 1
+					? targetBlockIndex - draggedBlockCount
 					: targetBlockIndex;
 
 			moveBlocksToPosition(

--- a/packages/block-library/src/button/color-props.js
+++ b/packages/block-library/src/button/color-props.js
@@ -8,6 +8,7 @@ import classnames from 'classnames';
  */
 import {
 	getColorClassName,
+	getColorObjectByAttributeValues,
 	__experimentalGetGradientClass,
 } from '@wordpress/block-editor';
 
@@ -15,7 +16,11 @@ import {
 // The flag can't be used at the moment because of the extra wrapper around
 // the button block markup.
 
-export default function getColorAndStyleProps( attributes ) {
+export default function getColorAndStyleProps(
+	attributes,
+	colors,
+	isEdit = false
+) {
 	// I'd have prefered to avoid the "style" attribute usage here
 	const { backgroundColor, textColor, gradient, style } = attributes;
 
@@ -47,6 +52,28 @@ export default function getColorAndStyleProps( attributes ) {
 					color: style?.color?.text ? style.color.text : undefined,
 			  }
 			: {};
+
+	// This is needed only for themes that don't load their color stylesheets in the editor
+	// We force an inline style to apply the color.
+	if ( isEdit ) {
+		if ( backgroundColor ) {
+			const backgroundColorObject = getColorObjectByAttributeValues(
+				colors,
+				backgroundColor
+			);
+
+			styleProp.backgroundColor = backgroundColorObject.color;
+		}
+
+		if ( textColor ) {
+			const textColorObject = getColorObjectByAttributeValues(
+				colors,
+				textColor
+			);
+
+			styleProp.color = textColorObject.color;
+		}
+	}
 
 	return {
 		className: !! className ? className : undefined,

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -28,6 +28,7 @@ import {
 import { rawShortcut, displayShortcut } from '@wordpress/keycodes';
 import { link, linkOff } from '@wordpress/icons';
 import { createBlock } from '@wordpress/blocks';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -172,6 +173,9 @@ function ButtonEdit( props ) {
 		},
 		[ setAttributes ]
 	);
+	const { colors } = useSelect( ( select ) => {
+		return select( 'core/block-editor' ).getSettings();
+	}, [] );
 
 	const onToggleOpenInNewTab = useCallback(
 		( value ) => {
@@ -192,7 +196,7 @@ function ButtonEdit( props ) {
 		[ rel, setAttributes ]
 	);
 
-	const colorProps = getColorAndStyleProps( attributes );
+	const colorProps = getColorAndStyleProps( attributes, colors, true );
 
 	return (
 		<>

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -95,8 +95,10 @@ figure.wp-block-gallery {
 	}
 
 	.components-button.has-icon {
-		border: none;
-		box-shadow: none;
+		&:not(:focus) {
+			border: none;
+			box-shadow: none;
+		}
 
 		@include break-small() {
 			// Use smaller buttons to fit when there are many columns.

--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -55,7 +55,11 @@ function render_block_core_rss( $attributes ) {
 			$author = $item->get_author();
 			if ( is_object( $author ) ) {
 				$author = $author->get_name();
-				$author = '<span class="wp-block-rss__item-author">' . __( 'by' ) . ' ' . esc_html( strip_tags( $author ) ) . '</span>';
+				$author = '<span class="wp-block-rss__item-author">' . sprintf(
+					/* translators: %s: the author. */
+					__( 'by %s' ),
+					esc_html( strip_tags( $author ) )
+				) . '</span>';
 			}
 		}
 

--- a/packages/components/src/color-picker/inputs.js
+++ b/packages/components/src/color-picker/inputs.js
@@ -175,11 +175,12 @@ export class Inputs extends Component {
 				</div>
 			);
 		} else if ( this.state.view === 'rgb' ) {
+			const legend = disableAlpha
+				? __( 'Color value in RGB' )
+				: __( 'Color value in RGBA' );
 			return (
 				<fieldset>
-					<VisuallyHidden as="legend">
-						{ __( 'Color value in RGB' ) }
-					</VisuallyHidden>
+					<VisuallyHidden as="legend">{ legend }</VisuallyHidden>
 					<div className="components-color-picker__inputs-fields">
 						<Input
 							source={ this.state.view }
@@ -228,11 +229,12 @@ export class Inputs extends Component {
 				</fieldset>
 			);
 		} else if ( this.state.view === 'hsl' ) {
+			const legend = disableAlpha
+				? __( 'Color value in HSL' )
+				: __( 'Color value in HSLA' );
 			return (
 				<fieldset>
-					<VisuallyHidden as="legend">
-						{ __( 'Color value in HSL' ) }
-					</VisuallyHidden>
+					<VisuallyHidden as="legend">{ legend }</VisuallyHidden>
 					<div className="components-color-picker__inputs-fields">
 						<Input
 							source={ this.state.view }

--- a/packages/components/src/color-picker/style.scss
+++ b/packages/components/src/color-picker/style.scss
@@ -227,6 +227,7 @@
 	padding-top: 16px;
 	display: flex;
 	align-items: flex-end;
+	min-width: 255px;
 
 	fieldset {
 		flex: 1;
@@ -236,7 +237,8 @@
 	}
 
 	.components-color-picker__inputs-fields .components-text-control__input[type="number"] {
-		padding: 6px 8px;
+		padding: 6px 3px;
+		margin: 0;
 	}
 }
 
@@ -256,7 +258,7 @@
 	}
 
 	.components-base-control__field {
-		margin: 0 4px;
+		margin: 0 2px;
 	}
 }
 

--- a/packages/components/src/navigable-container/container.js
+++ b/packages/components/src/navigable-container/container.js
@@ -9,6 +9,8 @@ import { omit, noop, isFunction } from 'lodash';
 import { Component, forwardRef } from '@wordpress/element';
 import { focus } from '@wordpress/dom';
 
+const MENU_ITEM_ROLES = [ 'menuitem', 'menuitemradio', 'menuitemcheckbox' ];
+
 function cycleValue( value, total, offset ) {
 	const nextValue = value + offset;
 	if ( nextValue < 0 ) {
@@ -96,8 +98,11 @@ class NavigableContainer extends Component {
 			event.stopImmediatePropagation();
 
 			// When navigating a collection of items, prevent scroll containers
-			// from scrolling.
-			if ( event.target.getAttribute( 'role' ) === 'menuitem' ) {
+			// from scrolling. The preventDefault also prevents Voiceover from
+			// 'handling' the event, as voiceover will try to use arrow keys
+			// for highlighting text.
+			const targetRole = event.target.getAttribute( 'role' );
+			if ( MENU_ITEM_ROLES.includes( targetRole ) ) {
 				event.preventDefault();
 			}
 		}

--- a/packages/components/src/navigable-container/menu.js
+++ b/packages/components/src/navigable-container/menu.js
@@ -38,6 +38,11 @@ export function NavigableMenu(
 			return 1;
 		} else if ( includes( previous, keyCode ) ) {
 			return -1;
+		} else if ( includes( [ DOWN, UP, LEFT, RIGHT ], keyCode ) ) {
+			// Key press should be handled, e.g. have event propagation and
+			// default behavior handled by NavigableContainer but not result
+			// in an offset.
+			return 0;
 		}
 	};
 

--- a/packages/components/src/navigable-container/test/menu.js
+++ b/packages/components/src/navigable-container/test/menu.js
@@ -94,8 +94,8 @@ describe( 'NavigableMenu', () => {
 		assertKeyDown( UP, 2, true );
 		assertKeyDown( UP, 1, true );
 		assertKeyDown( UP, 0, true );
-		assertKeyDown( LEFT, 0, false );
-		assertKeyDown( RIGHT, 0, false );
+		assertKeyDown( LEFT, 0, true );
+		assertKeyDown( RIGHT, 0, true );
 		assertKeyDown( SPACE, 0, false );
 	} );
 
@@ -146,8 +146,8 @@ describe( 'NavigableMenu', () => {
 		assertKeyDown( UP, 1, true );
 		assertKeyDown( UP, 0, true );
 		assertKeyDown( UP, 0, true );
-		assertKeyDown( LEFT, 0, false );
-		assertKeyDown( RIGHT, 0, false );
+		assertKeyDown( LEFT, 0, true );
+		assertKeyDown( RIGHT, 0, true );
 		assertKeyDown( SPACE, 0, false );
 	} );
 
@@ -204,8 +204,8 @@ describe( 'NavigableMenu', () => {
 		assertKeyDown( LEFT, 2, true );
 		assertKeyDown( LEFT, 1, true );
 		assertKeyDown( LEFT, 0, true );
-		assertKeyDown( UP, 0, false );
-		assertKeyDown( DOWN, 0, false );
+		assertKeyDown( UP, 0, true );
+		assertKeyDown( DOWN, 0, true );
 		assertKeyDown( SPACE, 0, false );
 	} );
 
@@ -256,8 +256,8 @@ describe( 'NavigableMenu', () => {
 		assertKeyDown( LEFT, 1, true );
 		assertKeyDown( LEFT, 0, true );
 		assertKeyDown( LEFT, 0, true );
-		assertKeyDown( DOWN, 0, false );
-		assertKeyDown( UP, 0, false );
+		assertKeyDown( DOWN, 0, true );
+		assertKeyDown( UP, 0, true );
 		assertKeyDown( SPACE, 0, false );
 	} );
 

--- a/packages/components/src/popover/stories/index.js
+++ b/packages/components/src/popover/stories/index.js
@@ -30,12 +30,14 @@ export const _default = () => {
 		'firstElement'
 	);
 	const noArrow = boolean( 'noArrow', false );
+	const isAlternate = boolean( 'isAlternate', false );
 
 	const props = {
 		animate,
 		children,
 		focusOnMount,
 		noArrow,
+		isAlternate,
 	};
 
 	if ( ! show ) {

--- a/packages/components/src/popover/style.scss
+++ b/packages/components/src/popover/style.scss
@@ -29,7 +29,11 @@ $arrow-size: 8px;
 		margin-left: 2px;
 
 		&::before {
-			border: $arrow-size solid $gray-900;
+			border: $arrow-size solid $gray-400;
+		}
+
+		&.is-alternate::before {
+			border-color: $gray-900;
 		}
 
 		&::after {

--- a/packages/compose/src/hooks/use-copy-on-click/index.js
+++ b/packages/compose/src/hooks/use-copy-on-click/index.js
@@ -29,7 +29,6 @@ export default function useCopyOnClick( ref, text, timeout = 4000 ) {
 		// Clipboard listens to click events.
 		clipboard.current = new Clipboard( ref.current, {
 			text: () => ( typeof text === 'function' ? text() : text ),
-			container: ref.current,
 		} );
 
 		clipboard.current.on( 'success', ( { clearSelection, trigger } ) => {

--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -253,6 +253,14 @@ _Returns_
 
 -   `Promise`: Promise resolving with a string containing the block title.
 
+<a name="getCurrentPostContent" href="#getCurrentPostContent">#</a> **getCurrentPostContent**
+
+Returns a promise which resolves with the current post content (HTML string).
+
+_Returns_
+
+-   `Promise`: Promise resolving with current post content markup.
+
 <a name="getEditedPostContent" href="#getEditedPostContent">#</a> **getEditedPostContent**
 
 Returns a promise which resolves with the edited post content (HTML string).

--- a/packages/e2e-test-utils/src/get-current-post-content.js
+++ b/packages/e2e-test-utils/src/get-current-post-content.js
@@ -1,0 +1,14 @@
+/**
+ * Internal dependencies
+ */
+import { wpDataSelect } from './wp-data-select';
+
+/**
+ * Returns a promise which resolves with the current post content (HTML string).
+ *
+ * @return {Promise} Promise resolving with current post content markup.
+ */
+export async function getCurrentPostContent() {
+	const post = await wpDataSelect( 'core/editor', 'getCurrentPost' );
+	return post.content;
+}

--- a/packages/e2e-test-utils/src/index.js
+++ b/packages/e2e-test-utils/src/index.js
@@ -21,6 +21,7 @@ export { getAllBlocks } from './get-all-blocks';
 export { getAvailableBlockTransforms } from './get-available-block-transforms';
 export { getBlockSetting } from './get-block-setting';
 export { getEditedPostContent } from './get-edited-post-content';
+export { getCurrentPostContent } from './get-current-post-content';
 export { hasBlockSwitcher } from './has-block-switcher';
 export { getPageError } from './get-page-error';
 export {

--- a/packages/e2e-tests/specs/editor/plugins/__snapshots__/cpt-locking.test.js.snap
+++ b/packages/e2e-tests/specs/editor/plugins/__snapshots__/cpt-locking.test.js.snap
@@ -1,5 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`cpt locking template_lock all should insert line breaks when using enter and shift-enter 1`] = `
+"<!-- wp:image -->
+<figure class=\\"wp-block-image\\"><img alt=\\"\\"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {\\"placeholder\\":\\"Add a description\\"} -->
+<p>First line<br>Second line<br>Third line</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\"><p></p></blockquote>
+<!-- /wp:quote -->
+
+<!-- wp:columns -->
+<div class=\\"wp-block-columns\\"></div>
+<!-- /wp:columns -->"
+`;
+
 exports[`cpt locking template_lock all should not error when deleting the cotents of a paragraph 1`] = `
 "<!-- wp:image -->
 <figure class=\\"wp-block-image\\"><img alt=\\"\\"/></figure>

--- a/packages/e2e-tests/specs/editor/plugins/block-directory-add.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/block-directory-add.test.js
@@ -123,6 +123,14 @@ const MOCK_BLOCKS_RESPONSES = [
 			'application/javascript; charset=utf-8'
 		),
 	},
+	{
+		// Mock the post-new page as requested via apiFetch for determining new CSS/JS assets.
+		match: ( request ) => request.url().includes( '/post-new.php' ),
+		onRequestMatch: createResponse(
+			`<html><head><script id="mock-block-js" src="${ MOCK_BLOCK1.assets[ 0 ] }"></script></head><body/></html>`,
+			'text/html; charset=UTF-8'
+		),
+	},
 ];
 
 function getResponseObject( obj, contentType ) {
@@ -180,8 +188,7 @@ describe( 'adding blocks from block directory', () => {
 		// Add the block
 		await addBtn.click();
 
-		// Delay to let block script load
-		await new Promise( ( resolve ) => setTimeout( resolve, 100 ) );
+		await page.waitForSelector( `div[data-type="${ MOCK_BLOCK1.name }"]` );
 
 		// The block will auto select and get added, make sure we see it in the content
 		expect( await getEditedPostContent() ).toMatchSnapshot();

--- a/packages/e2e-tests/specs/editor/plugins/cpt-locking.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/cpt-locking.test.js
@@ -9,6 +9,7 @@ import {
 	getEditedPostContent,
 	insertBlock,
 	pressKeyTimes,
+	pressKeyWithModifier,
 	setPostContent,
 } from '@wordpress/e2e-test-utils';
 
@@ -82,6 +83,18 @@ describe( 'cpt locking', () => {
 			const textToType = 'Paragraph';
 			await page.keyboard.type( 'Paragraph' );
 			await pressKeyTimes( 'Backspace', textToType.length + 1 );
+			expect( await getEditedPostContent() ).toMatchSnapshot();
+		} );
+
+		it( 'should insert line breaks when using enter and shift-enter', async () => {
+			await page.click(
+				'.block-editor-block-list__block[data-type="core/paragraph"]'
+			);
+			await page.keyboard.type( 'First line' );
+			await pressKeyTimes( 'Enter', 1 );
+			await page.keyboard.type( 'Second line' );
+			await pressKeyWithModifier( 'shift', 'Enter' );
+			await page.keyboard.type( 'Third line' );
 			expect( await getEditedPostContent() ).toMatchSnapshot();
 		} );
 

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/editor-modes.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/editor-modes.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Editing modes (visual/HTML) saves content when using the shortcut in the Code Editor 1`] = `
+"<!-- wp:paragraph -->
+<p>Hi world!</p>
+<!-- /wp:paragraph -->"
+`;

--- a/packages/e2e-tests/specs/editor/various/dropdown-menu.test.js
+++ b/packages/e2e-tests/specs/editor/various/dropdown-menu.test.js
@@ -1,0 +1,144 @@
+/**
+ * WordPress dependencies
+ */
+import { createNewPost, pressKeyTimes } from '@wordpress/e2e-test-utils';
+
+const moreMenuButtonSelector =
+	'.components-button[aria-label="More tools & options"]';
+const moreMenuDropdownSelector =
+	'.components-dropdown-menu__menu[aria-label="More tools & options"]';
+const menuItemsSelector = [ 'menuitem', 'menuitemcheckbox', 'menuitemradio' ]
+	.map( ( role ) => `${ moreMenuDropdownSelector } [role="${ role }"]` )
+	.join( ',' );
+
+describe( 'Dropdown Menu', () => {
+	beforeEach( async () => {
+		await createNewPost();
+	} );
+
+	it( 'allows navigation through each item using arrow keys', async () => {
+		await page.click( moreMenuButtonSelector );
+		const menuItems = await page.$$( menuItemsSelector );
+
+		// Catch any issues with the selector, which could cause a false positive test result.
+		expect( menuItems.length ).toBeGreaterThan( 0 );
+
+		let activeElementText = await page.evaluate(
+			() => document.activeElement.textContent
+		);
+		const [ firstMenuItem ] = menuItems;
+		const firstMenuItemText = await firstMenuItem.evaluate(
+			( element ) => element.textContent
+		);
+
+		// Expect the first menu item to be focused.
+		expect( activeElementText ).toBeDefined();
+		expect( activeElementText ).toBe( firstMenuItemText );
+
+		// Arrow down to the last item.
+		await pressKeyTimes( 'ArrowDown', menuItems.length - 1 );
+
+		activeElementText = await page.evaluate(
+			() => document.activeElement.textContent
+		);
+
+		const [ lastMenuItem ] = menuItems.slice( -1 );
+		const lastMenuItemText = await lastMenuItem.evaluate(
+			( element ) => element.textContent
+		);
+
+		// Expect the last menu item to be focused.
+		expect( activeElementText ).toBeDefined();
+		expect( activeElementText ).toBe( lastMenuItemText );
+
+		// Arrow back up to the first item.
+		await pressKeyTimes( 'ArrowUp', menuItems.length - 1 );
+
+		activeElementText = await page.evaluate(
+			() => document.activeElement.textContent
+		);
+
+		// Expect the first menu item to be focused again.
+		expect( activeElementText ).toBeDefined();
+		expect( activeElementText ).toBe( firstMenuItemText );
+	} );
+
+	it( 'loops to the beginning and end when navigating past the boundaries of the menu', async () => {
+		await page.click( moreMenuButtonSelector );
+		const menuItems = await page.$$( menuItemsSelector );
+
+		// Catch any issues with the selector, which could cause a false positive test result.
+		expect( menuItems.length ).toBeGreaterThan( 0 );
+
+		let activeElementText = await page.evaluate(
+			() => document.activeElement.textContent
+		);
+		const [ firstMenuItem ] = menuItems;
+		const firstMenuItemText = await firstMenuItem.evaluate(
+			( element ) => element.textContent
+		);
+
+		// Expect the first menu item to be focused.
+		expect( activeElementText ).toBeDefined();
+		expect( activeElementText ).toBe( firstMenuItemText );
+
+		// Arrow up to the last item.
+		await page.keyboard.press( 'ArrowUp' );
+
+		activeElementText = await page.evaluate(
+			() => document.activeElement.textContent
+		);
+
+		const [ lastMenuItem ] = menuItems.slice( -1 );
+		const lastMenuItemText = await lastMenuItem.evaluate(
+			( element ) => element.textContent
+		);
+
+		// Expect the last menu item to be focused.
+		expect( activeElementText ).toBeDefined();
+		expect( activeElementText ).toBe( lastMenuItemText );
+
+		// Arrow back down to the first item.
+		await page.keyboard.press( 'ArrowDown' );
+
+		activeElementText = await page.evaluate(
+			() => document.activeElement.textContent
+		);
+
+		// Expect the first menu item to be focused again.
+		expect( activeElementText ).toBeDefined();
+		expect( activeElementText ).toBe( firstMenuItemText );
+	} );
+
+	it( 'ignores arrow key navigation that is orthogonal to the orientation of the menu, but stays open', async () => {
+		await page.click( moreMenuButtonSelector );
+		const menuItems = await page.$$( menuItemsSelector );
+
+		// Catch any issues with the selector, which could cause a false positive test result.
+		expect( menuItems.length ).toBeGreaterThan( 0 );
+
+		let activeElementText = await page.evaluate(
+			() => document.activeElement.textContent
+		);
+		const [ firstMenuItem ] = menuItems;
+		const firstMenuItemText = await firstMenuItem.evaluate(
+			( element ) => element.textContent
+		);
+
+		// Expect the first menu item to be focused.
+		expect( activeElementText ).toBeDefined();
+		expect( activeElementText ).toBe( firstMenuItemText );
+
+		// Press left and right keys an arbitrary (but > 1) number of times.
+		await pressKeyTimes( 'ArrowLeft', 5 );
+		await pressKeyTimes( 'ArrowRight', 5 );
+
+		activeElementText = await page.evaluate(
+			() => document.activeElement.textContent
+		);
+
+		// Expect the first menu item to still be focused.
+		expect( activeElementText ).toBeDefined();
+		expect( activeElementText ).toBe( firstMenuItemText );
+	} );
+} );

--- a/packages/e2e-tests/specs/experiments/navigation.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation.test.js
@@ -335,7 +335,7 @@ describe( 'Navigation', () => {
 			// Scope element selector to the Editor's "Content" region as otherwise it picks up on
 			// block previews.
 			const navBlockItemsLength = await page.$$eval(
-				'[aria-label="Content"][role="region"] li[aria-label="Block: Link"]',
+				'[aria-label="Editor content"][role="region"] li[aria-label="Block: Link"]',
 				( els ) => els.length
 			);
 
@@ -361,7 +361,7 @@ describe( 'Navigation', () => {
 			// Scope element selector to the "Editor content" as otherwise it picks up on
 			// Block Style live previews.
 			const navBlockItemsLength = await page.$$eval(
-				'[aria-label="Content"][role="region"] li[aria-label="Block: Link"]',
+				'[aria-label="Editor content"][role="region"] li[aria-label="Block: Link"]',
 				( els ) => els.length
 			);
 

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -52,7 +52,17 @@ import WelcomeGuide from '../welcome-guide';
 import ActionsPanel from './actions-panel';
 
 const interfaceLabels = {
-	leftSidebar: __( 'Block Library' ),
+	leftSidebar: __( 'Block library' ),
+	/* translators: accessibility text for the editor top bar landmark region. */
+	header: __( 'Editor top bar' ),
+	/* translators: accessibility text for the editor content landmark region. */
+	body: __( 'Editor content' ),
+	/* translators: accessibility text for the editor settings landmark region. */
+	sidebar: __( 'Editor settings' ),
+	/* translators: accessibility text for the editor publish landmark region. */
+	actions: __( 'Editor publish' ),
+	/* translators: accessibility text for the editor footer landmark region. */
+	footer: __( 'Editor footer' ),
 };
 
 function Layout() {

--- a/packages/editor/src/components/global-keyboard-shortcuts/text-editor-shortcuts.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/text-editor-shortcuts.js
@@ -4,5 +4,5 @@
 import SaveShortcut from './save-shortcut';
 
 export default function TextEditorGlobalKeyboardShortcuts() {
-	return <SaveShortcut />;
+	return <SaveShortcut resetBlocksOnSave />;
 }

--- a/packages/editor/src/components/global-keyboard-shortcuts/visual-editor-shortcuts.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/visual-editor-shortcuts.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useShortcut } from '@wordpress/keyboard-shortcuts';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import deprecated from '@wordpress/deprecated';
 import { BlockEditorKeyboardShortcuts } from '@wordpress/block-editor';
 
@@ -12,11 +12,7 @@ import { BlockEditorKeyboardShortcuts } from '@wordpress/block-editor';
 import SaveShortcut from './save-shortcut';
 
 function VisualEditorGlobalKeyboardShortcuts() {
-	const { redo, undo, savePost } = useDispatch( 'core/editor' );
-	const isEditedPostDirty = useSelect(
-		( select ) => select( 'core/editor' ).isEditedPostDirty,
-		[]
-	);
+	const { redo, undo } = useDispatch( 'core/editor' );
 
 	useShortcut(
 		'core/editor/undo',
@@ -32,25 +28,6 @@ function VisualEditorGlobalKeyboardShortcuts() {
 		( event ) => {
 			redo();
 			event.preventDefault();
-		},
-		{ bindGlobal: true }
-	);
-
-	useShortcut(
-		'core/editor/save',
-		( event ) => {
-			event.preventDefault();
-
-			// TODO: This should be handled in the `savePost` effect in
-			// considering `isSaveable`. See note on `isEditedPostSaveable`
-			// selector about dirtiness and meta-boxes.
-			//
-			// See: `isEditedPostSaveable`
-			if ( ! isEditedPostDirty() ) {
-				return;
-			}
-
-			savePost();
 		},
 		{ bindGlobal: true }
 	);

--- a/packages/editor/src/components/post-taxonomies/style.scss
+++ b/packages/editor/src/components/post-taxonomies/style.scss
@@ -3,7 +3,10 @@
 	overflow: auto;
 
 	// Extra left padding prevents checkbox focus borders from being cut off.
-	padding-left: 2px;
+	margin-left: -$border-width * 4 - $border-width-focus;
+	padding-left: $border-width * 4 + $border-width-focus;
+	margin-top: -$border-width * 4 - $border-width-focus;
+	padding-top: $border-width * 4 + $border-width-focus;
 }
 
 .editor-post-taxonomies__hierarchical-terms-choice {


### PR DESCRIPTION
Fixes included:

 - useBlockSync: Fix race condition when onChange callback changes #24012
 - I18N: Fix missing plural forms for block related strings #24071
 - Block Breadcrumb: Fix arrow direction in RTL #24074
 - Fix Button block colors in the editor #24153
 - Fix the gallery buttons focus style #24157
 - Fix dragging multiple blocks dowards resulted in blocks inserted in wrong position #24183
 - Block Directory: Use local assets with automatic asset detection #24117
 - Fix save shortcut in code editor #24151
 - Fix dropdown menu focus loss when using arrow keys with Safari and Voiceover #24186
 - Avoid rendering the clipboard textarea inside the button #24194
 - Avoid focusing the block selection button on each render #24195
 - Update the editor landmark regions #24196
 - Avoid focus style from being cut on the categories panel #24197
 - Popover: Fix arrow color to match content border color #24208
 - Fix gradient RGBA/HSLA inputs' width #24214
 - i18n: Merge similar translation strings in rss block #24159
 - Show the default style variation if none provided #24217
 - allow enter to insert line breaks even if template is locked #23330
 - Avoid adding the CREATE suggestion in the results of contexts that don't support it #24222