### PR TITLE
Avoid adding the CREATE suggestion in the results of contexts that don't support it

### DIFF
--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -41,7 +41,10 @@ const LinkControlSearchInput = forwardRef(
 		},
 		ref
 	) => {
-		const genericSearchHandler = useSearchHandler( allowDirectEntry );
+		const genericSearchHandler = useSearchHandler(
+			allowDirectEntry,
+			withCreateSuggestion
+		);
 		const searchHandler = showSuggestions
 			? fetchSuggestions || genericSearchHandler
 			: noopSearchHandler;

--- a/packages/block-editor/src/components/link-control/use-search-handler.js
+++ b/packages/block-editor/src/components/link-control/use-search-handler.js
@@ -49,7 +49,8 @@ export const handleEntitySearch = async (
 	val,
 	args,
 	fetchSearchSuggestions,
-	directEntryHandler
+	directEntryHandler,
+	withCreateSuggestion
 ) => {
 	let results = await Promise.all( [
 		fetchSearchSuggestions( val, {
@@ -87,7 +88,7 @@ export const handleEntitySearch = async (
 	// to the text value of the `<input>`. This is because `title` is used
 	// when creating the suggestion. Similarly `url` is used when using keyboard to select
 	// the suggestion (the <form> `onSubmit` handler falls-back to `url`).
-	return isURLLike( val )
+	return isURLLike( val ) || ! withCreateSuggestion
 		? results
 		: results.concat( {
 				// the `id` prop is intentionally ommitted here because it
@@ -99,7 +100,10 @@ export const handleEntitySearch = async (
 		  } );
 };
 
-export default function useSearchHandler( allowDirectEntry ) {
+export default function useSearchHandler(
+	allowDirectEntry,
+	withCreateSuggestion
+) {
 	const { fetchSearchSuggestions } = useSelect( ( select ) => {
 		const { getSettings } = select( 'core/block-editor' );
 		return {
@@ -120,9 +124,10 @@ export default function useSearchHandler( allowDirectEntry ) {
 						val,
 						args,
 						fetchSearchSuggestions,
-						directEntryHandler
+						directEntryHandler,
+						withCreateSuggestion
 				  );
 		},
-		[ directEntryHandler, fetchSearchSuggestions ]
+		[ directEntryHandler, fetchSearchSuggestions, withCreateSuggestion ]
 	);
 }


### PR DESCRIPTION
closes #24037 

In the Navigation block, a suggestion that allows creating pages is shown but it's hidden in other contexts. Instead of just hide it from the results, this PR removes it entirely from the results.
