### PR TITLE
Remove bottom margin of components dropdown menu item

### DIFF
--- a/packages/components/src/dropdown-menu/style.scss
+++ b/packages/components/src/dropdown-menu/style.scss
@@ -14,7 +14,6 @@
 		padding: 6px;
 		outline: none;
 		cursor: pointer;
-		margin-bottom: $grid-unit-05;
 
 		&.has-separator {
 			margin-top: 6px;


### PR DESCRIPTION
## Description
Currently, there's inconsistent spacing between menu items in the toolbar dropdown menus. This commit removes the unnecessary bottom margin of the menu items in the "more" dropdown to match the spacing of the others.

## How has this been tested?
Reviewed the changes on local in major browsers on MacOS and all were consistent.

## Screenshots
The target issue has screenshots of before and after: https://github.com/WordPress/gutenberg/issues/23907

### Before
<img width="350" alt="Screen Shot 2020-07-27 at 11 43 20 AM" src="https://user-images.githubusercontent.com/3665539/88562298-80eed500-cffe-11ea-94c9-4f96c8443c37.png">

### After
<img width="366" alt="Screen Shot 2020-07-27 at 11 41 07 AM" src="https://user-images.githubusercontent.com/3665539/88562321-89dfa680-cffe-11ea-8377-d5453bc027dd.png">

## Types of changes
CSS-only

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
