### PR TITLE
Block Placeholders: Changed placeholder borders to be dashed lines

### DIFF
--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -22,7 +22,7 @@
 	// Block UI appearance.
 	border-radius: $radius-block-ui;
 	background-color: $white;
-	box-shadow: inset 0 0 0 $border-width $gray-900;
+	border: $border-width dashed $gray-900;
 	outline: 1px solid transparent; // Shown for Windows 10 High Contrast mode.
 
 	.components-base-control__label {


### PR DESCRIPTION
## Description
Updated the Placeholder state to try dashed borders instead of solid. See #23124 

## How has this been tested?
Tested locally.

## Screenshots

![Screen Shot 2020-07-27 at 4 18 02 PM](https://user-images.githubusercontent.com/617986/88601455-975c5700-d025-11ea-93c5-d65261682b35.png)


## Types of changes
CSS only. Non-breaking changes.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
