### PR TITLE
Post Title Block: Add style attributes

### DIFF
--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -17,6 +17,11 @@
 	"supports": {
 		"html": false,
 		"lightBlockWrapper": true,
+		"__experimentalColor": {
+			"gradients": true
+		},
+		"__experimentalFontSize": true,
+		"__experimentalLineHeight": true,
 		"__experimentalSelector": {
 			"core/post-title/h1": "h1",
 			"core/post-title/h2": "h2",

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -43,6 +43,8 @@ export default function PostTitleEdit( {
 		return null;
 	}
 
+	const BlockWrapper = Block[ tagName ];
+
 	return (
 		<>
 			<BlockControls>
@@ -61,14 +63,13 @@ export default function PostTitleEdit( {
 					} }
 				/>
 			</BlockControls>
-			<Block
-				tagName={ tagName }
+			<BlockWrapper
 				className={ classnames( {
 					[ `has-text-align-${ textAlign }` ]: textAlign,
 				} ) }
 			>
 				{ post.title || __( 'Post Title' ) }
-			</Block>
+			</BlockWrapper>
 		</>
 	);
 }


### PR DESCRIPTION
Fixes #19491 
(last PR needed)

## Description

- Add support for text and background colors, line height, font size to the Post Title block.
- Fix an issue causing the `HeadingLevelDropdown` to move to the top of the page when changing the heading level.

#### More on the `HeadingLevelDropdown` issue

To reproduce, try changing the heading level of a Post Title block from its toolbar.
You'll notice that the block toolbar will disappear, while the heading dropdown remains visible but moved to the top of the screen; since the block is still technically selected, to make the toolbar show up again, you'll need to deselect and reselect it.

I'm not 100% sure about it, but I think it's caused by the re-render upon changing the light block wrapper tag.
I've simply tried copying the approach from [another block](https://github.com/WordPress/gutenberg/blob/131b21eade6ec3e722c8e2d5b4d6770f573440a0/packages/block-library/src/group/edit.js#L19), and it fixed the issue straight away.

## Types of changes
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
