### PR TITLE
Fix missing buttons example

### DIFF
--- a/packages/block-library/src/buttons/index.js
+++ b/packages/block-library/src/buttons/index.js
@@ -23,6 +23,7 @@ export const settings = {
 	),
 	icon,
 	keywords: [ __( 'link' ) ],
+	example: {},
 	transforms,
 	edit,
 	save,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

The buttons block is missing an example from the block inserter

[The button block has an example](https://github.com/WordPress/gutenberg/blob/11a3967416dec9e01a588350566cc7dfd2256a3b/packages/block-library/src/button/index.js#L26-L31), but it isn't used from the inserter

## How has this been tested?

I forked and `git clone`'d the repo, built the plugin locally and loaded on my local dev WP running 5.4.2 and no other plugins, default theme

## Screenshots <!-- if applicable -->

### Before

<img width="1501" alt="Screen Shot 2020-07-28 at 12 41 05 PM" src="https://user-images.githubusercontent.com/115911/88708258-9f250580-d0d0-11ea-9ae0-e1967cca5e6e.png">

### After

<img width="1497" alt="Screen Shot 2020-07-28 at 12 45 00 PM" src="https://user-images.githubusercontent.com/115911/88708276-a3e9b980-d0d0-11ea-840d-a377a4446002.png">

## Types of changes

Enhancement: This makes sure that the buttons block preview shows an example

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
