### PR TITLE
Cover: Fix padding controls showing null units

### DIFF
--- a/packages/components/src/box-control/index.js
+++ b/packages/components/src/box-control/index.js
@@ -52,7 +52,9 @@ export default function BoxControl( {
 	values: valuesProp,
 	units,
 } ) {
-	const [ values, setValues ] = useControlledState( valuesProp );
+	const [ values, setValues ] = useControlledState( valuesProp, {
+		fallback: DEFAULT_VALUES,
+	} );
 	const inputValues = values || DEFAULT_VALUES;
 	const hasInitialValue = isValuesDefined( valuesProp );
 

--- a/packages/components/src/box-control/test/index.js
+++ b/packages/components/src/box-control/test/index.js
@@ -1,0 +1,83 @@
+/**
+ * External dependencies
+ */
+import { render, fireEvent } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+import { ENTER } from '@wordpress/keycodes';
+
+/**
+ * Internal dependencies
+ */
+import BoxControl from '../';
+
+describe( 'BoxControl', () => {
+	describe( 'Basic rendering', () => {
+		it( 'should render', () => {
+			const { container } = render( <BoxControl /> );
+			const input = container.querySelector( 'input' );
+
+			expect( input ).toBeTruthy();
+		} );
+
+		it( 'should update values when interacting with input', () => {
+			const { container } = render( <BoxControl /> );
+			const input = container.querySelector( 'input' );
+			const unitSelect = container.querySelector( 'select' );
+
+			fireEvent.change( input, { target: { value: '100%' } } );
+			fireEvent.keyDown( input, { keyCode: ENTER } );
+
+			expect( input.value ).toBe( '100' );
+			expect( unitSelect.value ).toBe( '%' );
+		} );
+	} );
+
+	describe( 'Reset', () => {
+		it( 'should reset values when clicking Reset', () => {
+			const { container, getByText } = render( <BoxControl /> );
+			const input = container.querySelector( 'input' );
+			const unitSelect = container.querySelector( 'select' );
+
+			fireEvent.change( input, { target: { value: '100px' } } );
+			fireEvent.keyDown( input, { keyCode: ENTER } );
+
+			expect( input.value ).toBe( '100' );
+			expect( unitSelect.value ).toBe( 'px' );
+
+			fireEvent.click( getByText( /Reset/ ) );
+
+			expect( input.value ).toBe( '' );
+			expect( unitSelect.value ).toBe( 'px' );
+		} );
+
+		it( 'should reset values when clicking Reset, if controlled', () => {
+			const Example = () => {
+				const [ state, setState ] = useState();
+				return (
+					<BoxControl
+						value={ state }
+						onChange={ ( next ) => setState( next ) }
+					/>
+				);
+			};
+			const { container, getByText } = render( <Example /> );
+			const input = container.querySelector( 'input' );
+			const unitSelect = container.querySelector( 'select' );
+
+			fireEvent.change( input, { target: { value: '100px' } } );
+			fireEvent.keyDown( input, { keyCode: ENTER } );
+
+			expect( input.value ).toBe( '100' );
+			expect( unitSelect.value ).toBe( 'px' );
+
+			fireEvent.click( getByText( /Reset/ ) );
+
+			expect( input.value ).toBe( '' );
+			expect( unitSelect.value ).toBe( 'px' );
+		} );
+	} );
+} );

--- a/packages/components/src/box-control/test/index.js
+++ b/packages/components/src/box-control/test/index.js
@@ -57,10 +57,45 @@ describe( 'BoxControl', () => {
 		it( 'should reset values when clicking Reset, if controlled', () => {
 			const Example = () => {
 				const [ state, setState ] = useState();
+
 				return (
 					<BoxControl
-						value={ state }
+						values={ state }
 						onChange={ ( next ) => setState( next ) }
+					/>
+				);
+			};
+			const { container, getByText } = render( <Example /> );
+			const input = container.querySelector( 'input' );
+			const unitSelect = container.querySelector( 'select' );
+
+			fireEvent.change( input, { target: { value: '100px' } } );
+			fireEvent.keyDown( input, { keyCode: ENTER } );
+
+			expect( input.value ).toBe( '100' );
+			expect( unitSelect.value ).toBe( 'px' );
+
+			fireEvent.click( getByText( /Reset/ ) );
+
+			expect( input.value ).toBe( '' );
+			expect( unitSelect.value ).toBe( 'px' );
+		} );
+
+		it( 'should reset values when clicking Reset, if controlled <-> uncontrolled state changes', () => {
+			const Example = () => {
+				const [ state, setState ] = useState();
+
+				return (
+					<BoxControl
+						values={ state }
+						onChange={ ( next ) => {
+							if ( next.top ) {
+								setState( next );
+							} else {
+								// This reverts it to being uncontrolled
+								setState( undefined );
+							}
+						} }
 					/>
 				);
 			};

--- a/packages/components/src/unit-control/test/index.js
+++ b/packages/components/src/unit-control/test/index.js
@@ -387,5 +387,15 @@ describe( 'UnitControl', () => {
 
 			expect( select.value ).toBe( 'em' );
 		} );
+
+		it( 'should fallback to default unit if parsed unit is invalid', () => {
+			const { container: testContainer } = testRender(
+				<UnitControl value={ '10null' } />
+			);
+
+			const select = testContainer.querySelector( 'select' );
+
+			expect( select.value ).toBe( 'px' );
+		} );
 	} );
 } );

--- a/packages/components/src/unit-control/utils.js
+++ b/packages/components/src/unit-control/utils.js
@@ -63,6 +63,8 @@ export function parseUnit( initialValue, units = CSS_UNITS ) {
 	if ( hasUnits( units ) ) {
 		const match = units.find( ( item ) => item.value === unit );
 		unit = match?.value;
+	} else {
+		unit = DEFAULT_UNIT.value;
 	}
 
 	return [ num, unit ];

--- a/packages/components/src/utils/hooks/use-controlled-state.js
+++ b/packages/components/src/utils/hooks/use-controlled-state.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -45,6 +45,15 @@ function useControlledState( currentState, options = defaultOptions ) {
 
 	const [ internalState, setInternalState ] = useState( currentState );
 	const hasCurrentState = isValueDefined( currentState );
+
+	/*
+	 * Resets internal state if value every changes from uncontrolled <-> controlled.
+	 */
+	useEffect( () => {
+		if ( hasCurrentState && internalState ) {
+			setInternalState( undefined );
+		}
+	}, [ hasCurrentState, internalState ] );
 
 	const state = getDefinedValue(
 		[ currentState, internalState, initial ],


### PR DESCRIPTION
This update fixes the Padding controls that are available for the **Cover** block, specifically with the units not parsing correctly.

![box-control](https://user-images.githubusercontent.com/2322354/88713615-92f97200-d0e9-11ea-9d7f-b2eefa116f83.gif)

This happened if `add_theme_support( 'experimental-custom-spacing' );` was activated (to enable the padding controls), but `add_theme_support( 'custom-units' );` was not.

This was fixed by improving the invalid unit parsing in the logic of the `UnitControl` component.

Secondly, while testing this fix, I noticed that the **Reset** mechanism wasn't working correctly for padding controls.

This was resolved by improving state handling in the `useControlledState` hook used by the `BoxControl` component.

Unit tests have been written for the cases mentioned above.

Resolves: https://github.com/WordPress/gutenberg/issues/24245

cc'ing @jffng 

<3


## How has this been tested?

* Run `npm run dev`
* Add `add_theme_support( 'experimental-custom-spacing' );` to your theme's PHP file (`functions.php`)
* Add a Cover block
* Padding value should be empty, with a unit of `px`
* Change the value
* Cover padding should update
* Click reset
* Padding value should reset.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [n/a] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
