### PR TITLE
Edit Site: Add browse mode.

### DIFF
--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -833,6 +833,18 @@ _Returns_
 
 -   `boolean`: Whether block is selected and not the last in the selection.
 
+<a name="isBrowseMode" href="#isBrowseMode">#</a> **isBrowseMode**
+
+Returns whether the browse mode is enabled.
+
+_Parameters_
+
+-   _state_ `Object`: Editor state.
+
+_Returns_
+
+-   `boolean`: Is browse mode enabled.
+
 <a name="isCaretWithinFormattedText" href="#isCaretWithinFormattedText">#</a> **isCaretWithinFormattedText**
 
 Returns true if the caret is within formatted text, or false otherwise.
@@ -1293,6 +1305,14 @@ Generator that triggers an action used to enable or disable the block moving mod
 _Parameters_
 
 -   _hasBlockMovingClientId_ `(string|null)`: Enable/Disable block moving mode.
+
+<a name="setBrowseMode" href="#setBrowseMode">#</a> **setBrowseMode**
+
+Returns an action object used to enable or disable the browse mode.
+
+_Parameters_
+
+-   _isBrowseMode_ `string`: Enable/Disable browse mode.
 
 <a name="setHasControlledInnerBlocks" href="#setHasControlledInnerBlocks">#</a> **setHasControlledInnerBlocks**
 

--- a/packages/block-editor/src/components/tool-selector/index.js
+++ b/packages/block-editor/src/components/tool-selector/index.js
@@ -47,7 +47,7 @@ function ToolSelector( props, ref ) {
 
 	const onSwitchMode = ( mode ) => {
 		setNavigationMode( mode === 'edit' ? false : true );
-		setBrowseMode( mode === 'browse' ? false : true );
+		setBrowseMode( mode === 'browse' );
 		setTool( mode );
 	};
 	return (

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -915,6 +915,18 @@ export function* setNavigationMode( isNavigationMode = true ) {
 }
 
 /**
+ * Returns an action object used to enable or disable the browse mode.
+ *
+ * @param {string} isBrowseMode Enable/Disable browse mode.
+ */
+export function* setBrowseMode( isBrowseMode = true ) {
+	return {
+		type: 'SET_BROWSE_MODE',
+		isBrowseMode,
+	};
+}
+
+/**
  * Generator that triggers an action used to enable or disable the block moving mode.
  *
  * @param {string|null} hasBlockMovingClientId Enable/Disable block moving mode.

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1536,6 +1536,21 @@ export function isNavigationMode( state = false, action ) {
 }
 
 /**
+ * Reducer returning whether the browse mode is enabled or not.
+ *
+ * @param {string} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {string} Updated state.
+ */
+export function isBrowseMode( state = false, action ) {
+	if ( action.type === 'SET_BROWSE_MODE' ) {
+		return action.isBrowseMode;
+	}
+	return state;
+}
+
+/**
  * Reducer returning whether the block moving mode is enabled or not.
  *
  * @param {string|null} state  Current state.
@@ -1661,6 +1676,7 @@ export default combineReducers( {
 	preferences,
 	lastBlockAttributesChange,
 	isNavigationMode,
+	isBrowseMode,
 	hasBlockMovingClientId,
 	automaticChangeStatus,
 	highlightedBlock,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1591,6 +1591,17 @@ export function isNavigationMode( state ) {
 }
 
 /**
+ * Returns whether the browse mode is enabled.
+ *
+ * @param {Object} state Editor state.
+ *
+ * @return {boolean} Is browse mode enabled.
+ */
+export function isBrowseMode( state ) {
+	return state.isBrowseMode;
+}
+
+/**
  * Returns whether block moving mode is enabled.
  *
  * @param {Object} state Editor state.

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -17,6 +17,7 @@ import {
 /**
  * Internal dependencies
  */
+import BrowseModeNavigation from '../browse-mode-navigation';
 import NavigateToLink from '../navigate-to-link';
 import { SidebarInspectorFill } from '../sidebar';
 
@@ -48,6 +49,7 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 			onChange={ onChange }
 			useSubRegistry={ false }
 		>
+			<BrowseModeNavigation />
 			<BlockEditorKeyboardShortcuts />
 			<__experimentalLinkControl.ViewerFill>
 				{ useCallback(

--- a/packages/edit-site/src/components/browse-mode-navigation/index.js
+++ b/packages/edit-site/src/components/browse-mode-navigation/index.js
@@ -1,0 +1,56 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+import { getPathAndQueryString } from '@wordpress/url';
+import { useRegistry, useSelect, useDispatch } from '@wordpress/data';
+
+function useBrowseModeNavigation( isBrowseMode, registry, setPage ) {
+	useEffect( () => {
+		const listener = async ( event ) => {
+			if ( ! event.target.dataset.type || ! event.target.dataset.id )
+				return;
+
+			const entity = await registry
+				.__experimentalResolveSelect( 'core' )
+				.getEntityRecord(
+					'postType',
+					event.target.dataset.type,
+					event.target.dataset.id
+				);
+
+			setPage( {
+				type: entity.type,
+				slug: entity.slug,
+				path: getPathAndQueryString( entity.link || entity.url ),
+				context: { postType: entity.type, postId: entity.id },
+			} );
+		};
+
+		const unsubscribe = () =>
+			document
+				.getElementsByClassName( 'editor-styles-wrapper' )?.[ 0 ]
+				?.removeEventListener( 'click', listener, true );
+
+		if ( ! isBrowseMode ) unsubscribe();
+		else
+			return (
+				document
+					.getElementsByClassName( 'editor-styles-wrapper' )?.[ 0 ]
+					?.addEventListener( 'click', listener, true ) && unsubscribe
+			);
+	}, [ isBrowseMode ] );
+}
+
+export default function BrowseModeNavigation() {
+	const registry = useRegistry();
+	useBrowseModeNavigation(
+		useSelect(
+			( select ) => select( 'core/block-editor' ).isBrowseMode(),
+			[]
+		),
+		registry,
+		useDispatch( 'core/edit-site' ).setPage
+	);
+	return null;
+}


### PR DESCRIPTION
## Description

Closes #23328.

This PR implements browse mode navigation from #23328.

## Screenshots

![ezgif-4-14f75a598c64](https://user-images.githubusercontent.com/19157096/88718261-8fa8bb00-d0d6-11ea-919e-b8e307e093e9.gif)

## Checklist:

- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
