### PR TITLE
Make "Attempt Block Recovery" the default option of block invalidation

### DIFF
--- a/docs/designers-developers/developers/block-api/block-edit-save.md
+++ b/docs/designers-developers/developers/block-api/block-edit-save.md
@@ -399,8 +399,8 @@ Clicking the "3-dot" menu on the side of the block displays three options:
 - **Resolve**: Open Resolve Block dialog box with two buttons:
   - **Convert to HTML**: Protects the original markup from the saved post content and convert the block from its original type to the HTML block type, enabling the user to modify the HTML markup directly.
   - **Convert to Blocks**: Protects the original markup from the saved post content and convert the block from its original type to the validated block type.
+- **Convert to HTML**: Protects the original markup from the saved post content and convert the block from its original type to the HTML block type, enabling the user to modify the HTML markup directly.
 - **Convert to Classic Block**: Protects the original markup from the saved post content as correct. Since the block will be converted from its original type to the Classic block type, it will no longer be possible to edit the content using controls available for the original block type.
-- **Attempt Block Recovery**: Attempts recovery action as much as possible.
 
 ### Validation FAQ
 

--- a/docs/designers-developers/developers/block-api/block-edit-save.md
+++ b/docs/designers-developers/developers/block-api/block-edit-save.md
@@ -390,15 +390,15 @@ When the editor loads, all blocks within post content are validated to determine
 
 If a block is detected to be invalid, the user will be prompted to choose how to handle the invalidation:
 
-![Invalid block prompt](https://user-images.githubusercontent.com/8876600/87853743-bb45db80-c947-11ea-8e61-93d948d2ba84.png)
+![Invalid block prompt](https://user-images.githubusercontent.com/7753001/88754471-4cf7e900-d191-11ea-9123-3cee20719d10.png)
 
-Clicking Resolve button will open Resolve Block dialog box with two buttons:
+Clicking **Attempt Block Recovery** button will attempt recovery action as much as possible.
 
-- **Convert to HTML**: Protects the original markup from the saved post content and convert the block from its original type to the HTML block type, enabling the user to modify the HTML markup directly.
-- **Convert to Blocks**: Protects the original markup from the saved post content and convert the block from its original type to the validated block type.
+Clicking the "3-dot" menu on the side of the block displays three options:
 
-Clicking the "3-dot" menu on the side of the block displays two options:
-
+- **Resolve**: Open Resolve Block dialog box with two buttons:
+  - **Convert to HTML**: Protects the original markup from the saved post content and convert the block from its original type to the HTML block type, enabling the user to modify the HTML markup directly.
+  - **Convert to Blocks**: Protects the original markup from the saved post content and convert the block from its original type to the validated block type.
 - **Convert to Classic Block**: Protects the original markup from the saved post content as correct. Since the block will be converted from its original type to the Classic block type, it will no longer be possible to edit the content using controls available for the original block type.
 - **Attempt Block Recovery**: Attempts recovery action as much as possible.
 

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -111,6 +111,7 @@ $z-layers: (
 	".components-popover.edit-post-more-menu__content": 99998,
 	".components-popover.edit-site-more-menu__content": 99998,
 	".components-popover.block-editor-rich-text__inline-format-toolbar": 99998,
+	".components-popover.block-editor-warning__dropdown": 99998,
 
 	".components-autocomplete__results": 1000000,
 

--- a/packages/block-editor/src/components/block-list/block-invalid-warning.js
+++ b/packages/block-editor/src/components/block-list/block-invalid-warning.js
@@ -43,39 +43,31 @@ export class BlockInvalidWarning extends Component {
 		const { compare } = this.state;
 		const hiddenActions = [
 			{
+				// translators: Button to fix block content
+				title: _x( 'Resolve', 'imperative verb' ),
+				onClick: this.onCompare,
+			},
+			hasHTMLBlock && {
+				title: __( 'Convert to HTML' ),
+				onClick: convertToHTML,
+			},
+			{
 				title: __( 'Convert to Classic Block' ),
 				onClick: convertToClassic,
 			},
-			{
-				title: __( 'Attempt Block Recovery' ),
-				onClick: attemptBlockRecovery,
-			},
-		];
+		].filter( Boolean );
 
 		return (
 			<>
 				<Warning
 					actions={ [
 						<Button
-							key="convert"
-							onClick={ this.onCompare }
-							isSecondary={ hasHTMLBlock }
-							isPrimary={ ! hasHTMLBlock }
+							key="recover"
+							onClick={ attemptBlockRecovery }
+							isPrimary
 						>
-							{
-								// translators: Button to fix block content
-								_x( 'Resolve', 'imperative verb' )
-							}
+							{ __( 'Attempt Block Recovery' ) }
 						</Button>,
-						hasHTMLBlock && (
-							<Button
-								key="edit"
-								onClick={ convertToHTML }
-								isPrimary
-							>
-								{ __( 'Convert to HTML' ) }
-							</Button>
-						),
 					] }
 					secondaryActions={ hiddenActions }
 				>

--- a/packages/block-editor/src/components/warning/index.js
+++ b/packages/block-editor/src/components/warning/index.js
@@ -31,6 +31,7 @@ function Warning( { className, actions, children, secondaryActions } ) {
 						{ secondaryActions && (
 							<Dropdown
 								className="block-editor-warning__secondary"
+								contentClassName="block-editor-warning__dropdown"
 								position="bottom left"
 								renderToggle={ ( { isOpen, onToggle } ) => (
 									<Button

--- a/packages/block-editor/src/components/warning/style.scss
+++ b/packages/block-editor/src/components/warning/style.scss
@@ -45,3 +45,9 @@
 .block-editor-warning__secondary {
 	margin: auto 0 auto $grid-unit-10;
 }
+
+.components-popover.block-editor-warning__dropdown {
+	// Set z-index as if it's displayed on the bottom, otherwise the modal
+	// dialog popover might overlap if displayed on the bottom.
+	z-index: z-index(".components-popover.block-editor-warning__dropdown");
+}

--- a/packages/e2e-tests/specs/editor/various/invalid-block.test.js
+++ b/packages/e2e-tests/specs/editor/various/invalid-block.test.js
@@ -36,8 +36,14 @@ describe( 'invalid blocks', () => {
 		expect( console ).toHaveErrored();
 		expect( console ).toHaveWarned();
 
-		// Click on the 'resolve' button
-		await page.click( '.block-editor-warning__actions button' );
+		// Click on the 'three-dots' menu toggle
+		await page.click(
+			'.block-editor-warning__actions button[aria-label="More options"]'
+		);
+
+		// Click on the 'Resolve' button
+		const [ resolveButton ] = await page.$x( '//button[text()="Resolve"]' );
+		await resolveButton.click();
 
 		// Check we get the resolve modal with the appropriate contents
 		const htmlBlockContent = await page.$eval(


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fix #16425.

As stated in the original issue:

> "Attempt block recovery" should be prominently displayed where "Resolve" and "Convert to HTML" currently are. And those options can be moved behind the three dot menu.

This PR makes **Attempt Block Recovery** the default option of block invalidation.

## How has this been tested?
1. Set up development environment for this project.
2. Edit a sample post [here](http://localhost:8888/wp-admin/post.php?post=5&action=edit)
3. Switch to **Code Editor**.
4. Change the heading tag below from `h2` to `h3`
	```diff
	<!-- wp:heading -->
    - <h2>The <em>Inserter</em> Tool</h2>
	+ <h3>The <em>Inserter</em> Tool</h3>
	<!-- /wp:heading -->
	```
5. Exit **Code Editor**.
6. The editor should display the invalidation warning like shown in the screenshot below.
7. All the buttons works the same.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
![Screen Shot 2020-07-29 at 2 45 14 PM](https://user-images.githubusercontent.com/7753001/88766158-23978700-d1aa-11ea-8eb0-ad1b97458d3b.png)

## Caveat

When opening the resolve dialog from the sub-menu of the "3-dots" menu icon, the modal dialog will be below the sub-menu itself, which looks like a bug.

![Screen Shot 2020-07-29 at 3 00 35 PM](https://user-images.githubusercontent.com/7753001/88767523-55a9e880-d1ac-11ea-9101-a037f6f244dc.png)

I think we have 2 options to solve it:

1. Increase `z-index` of the modal dialog, but the sub-menu will still be open
2. Close the sub-menu when the dialog is opened, which seems to be controlled by this line: https://github.com/WordPress/gutenberg/blob/a260cda069b1899399795062935f6e53555cf855/packages/components/src/dropdown/index.js#L58-L72

(1) doesn't really solve the problem but can be a hacky temporary solution. I believe we should go with (2) is possible. However, I think this is outside of this PR's scope, and I'm not sure what changes should be make?

**In the end, we chose to go with (1). Since it looks like we cannot do (2) because of an [accessibility issue](https://github.com/WordPress/gutenberg/issues/15321).**

The solution is to decrease the `z-index` value for all the dropdowns under the `<Warning>` component. As shown below.

![image](https://user-images.githubusercontent.com/7753001/88774942-a45c8000-d1b6-11ea-8b18-577f420e41ab.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
