### PR TITLE
Make the list of widgets excluded from the legacy widget block extensible via a filter

### DIFF
--- a/lib/widgets.php
+++ b/lib/widgets.php
@@ -105,11 +105,6 @@ add_action( 'admin_footer-widgets.php', 'gutenberg_print_save_widgets_nonce' );
  */
 function gutenberg_get_legacy_widget_settings() {
 	$settings = array();
-	/**
-	 * TODO: The hardcoded array should be replaced with a mechanism to allow
-	 * core and third party blocks to specify they already have equivalent
-	 * blocks, and maybe even allow them to have a migration function.
-	 */
 	$core_widgets = array(
 		'WP_Widget_Pages',
 		'WP_Widget_Calendar',

--- a/lib/widgets.php
+++ b/lib/widgets.php
@@ -115,25 +115,28 @@ function gutenberg_get_legacy_widget_settings() {
 	 *
 	 * @since 5.6.0
 	 */
-	$widgets_to_exclude_from_legacy_widget_block = apply_filters( 'widgets_to_exclude_from_legacy_widget_block', array(
-		'WP_Widget_Pages',
-		'WP_Widget_Calendar',
-		'WP_Widget_Archives',
-		'WP_Widget_Media_Audio',
-		'WP_Widget_Media_Image',
-		'WP_Widget_Media_Gallery',
-		'WP_Widget_Media_Video',
-		'WP_Widget_Meta',
-		'WP_Widget_Search',
-		'WP_Widget_Text',
-		'WP_Widget_Categories',
-		'WP_Widget_Recent_Posts',
-		'WP_Widget_Recent_Comments',
-		'WP_Widget_RSS',
-		'WP_Widget_Tag_Cloud',
-		'WP_Nav_Menu_Widget',
-		'WP_Widget_Custom_HTML',
-	) );
+	$widgets_to_exclude_from_legacy_widget_block = apply_filters(
+		'widgets_to_exclude_from_legacy_widget_block',
+		array(
+			'WP_Widget_Pages',
+			'WP_Widget_Calendar',
+			'WP_Widget_Archives',
+			'WP_Widget_Media_Audio',
+			'WP_Widget_Media_Image',
+			'WP_Widget_Media_Gallery',
+			'WP_Widget_Media_Video',
+			'WP_Widget_Meta',
+			'WP_Widget_Search',
+			'WP_Widget_Text',
+			'WP_Widget_Categories',
+			'WP_Widget_Recent_Posts',
+			'WP_Widget_Recent_Comments',
+			'WP_Widget_RSS',
+			'WP_Widget_Tag_Cloud',
+			'WP_Nav_Menu_Widget',
+			'WP_Widget_Custom_HTML',
+		)
+	);
 
 	$has_permissions_to_manage_widgets = current_user_can( 'edit_theme_options' );
 	$available_legacy_widgets          = array();

--- a/lib/widgets.php
+++ b/lib/widgets.php
@@ -105,7 +105,17 @@ add_action( 'admin_footer-widgets.php', 'gutenberg_print_save_widgets_nonce' );
  */
 function gutenberg_get_legacy_widget_settings() {
 	$settings = array();
-	$core_widgets = array(
+
+	/**
+	 * Filters the list of widget classes that should **not** be offered by the legacy widget block.
+	 *
+	 * Returning an empty array will make all the widgets available.
+	 *
+	 * @param array $widgets An array of excluded widgets classnames.
+	 *
+	 * @since 5.6.0
+	 */
+	$widgets_to_exclude_from_legacy_widget_block = apply_filters( 'widgets_to_exclude_from_legacy_widget_block', array(
 		'WP_Widget_Pages',
 		'WP_Widget_Calendar',
 		'WP_Widget_Archives',
@@ -123,7 +133,7 @@ function gutenberg_get_legacy_widget_settings() {
 		'WP_Widget_Tag_Cloud',
 		'WP_Nav_Menu_Widget',
 		'WP_Widget_Custom_HTML',
-	);
+	) );
 
 	$has_permissions_to_manage_widgets = current_user_can( 'edit_theme_options' );
 	$available_legacy_widgets          = array();
@@ -139,7 +149,7 @@ function gutenberg_get_legacy_widget_settings() {
 					html_entity_decode( $widget_obj->widget_options['description'] ) :
 					null,
 				'isReferenceWidget' => false,
-				'isHidden'          => in_array( $class, $core_widgets, true ),
+				'isHidden'          => in_array( $class, $widgets_to_exclude_from_legacy_widget_block, true ),
 			);
 		}
 	}

--- a/packages/block-library/src/legacy-widget/transforms.js
+++ b/packages/block-library/src/legacy-widget/transforms.js
@@ -187,7 +187,7 @@ let legacyWidgetTransforms = [
 } );
 
 legacyWidgetTransforms = applyFilters(
-	'blocks.legacyWidgetTransforms',
+	'blocks.legacyWidget.transforms',
 	legacyWidgetTransforms
 );
 

--- a/packages/block-library/src/legacy-widget/transforms.js
+++ b/packages/block-library/src/legacy-widget/transforms.js
@@ -4,7 +4,7 @@
 import { createBlock } from '@wordpress/blocks';
 import { applyFilters } from '@wordpress/hooks';
 
-let legacyWidgetTransforms = [
+const legacyWidgetTransforms = [
 	{
 		block: 'core/calendar',
 		widget: 'WP_Widget_Calendar',
@@ -186,13 +186,13 @@ let legacyWidgetTransforms = [
 	};
 } );
 
-legacyWidgetTransforms = applyFilters(
-	'blocks.legacyWidget.transforms',
-	legacyWidgetTransforms
-);
-
 const transforms = {
-	to: legacyWidgetTransforms,
+	get to() {
+		return applyFilters(
+			'blocks.legacyWidget.transforms',
+			legacyWidgetTransforms
+		);
+	},
 };
 
 export default transforms;

--- a/packages/block-library/src/legacy-widget/transforms.js
+++ b/packages/block-library/src/legacy-widget/transforms.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { createBlock } from '@wordpress/blocks';
-import { applyFilters } from '@wordpress/hooks';
 
 const legacyWidgetTransforms = [
 	{
@@ -187,12 +186,7 @@ const legacyWidgetTransforms = [
 } );
 
 const transforms = {
-	get to() {
-		return applyFilters(
-			'blocks.legacyWidget.transforms',
-			legacyWidgetTransforms
-		);
-	},
+	to: legacyWidgetTransforms,
 };
 
 export default transforms;

--- a/packages/block-library/src/legacy-widget/transforms.js
+++ b/packages/block-library/src/legacy-widget/transforms.js
@@ -2,8 +2,9 @@
  * WordPress dependencies
  */
 import { createBlock } from '@wordpress/blocks';
+import { applyFilters } from '@wordpress/hooks';
 
-const legacyWidgetTransforms = [
+let legacyWidgetTransforms = [
 	{
 		block: 'core/calendar',
 		widget: 'WP_Widget_Calendar',
@@ -184,6 +185,11 @@ const legacyWidgetTransforms = [
 		},
 	};
 } );
+
+legacyWidgetTransforms = applyFilters(
+	'blocks.legacyWidgetTransforms',
+	legacyWidgetTransforms
+);
 
 const transforms = {
 	to: legacyWidgetTransforms,


### PR DESCRIPTION
## Description
This PR adds the `widgets_to_exclude_from_legacy_widget_block` filter to enable plugins and themes to add/remove their own widgets from the legacy widget block:

<img width="712" alt="Zrzut ekranu 2020-07-29 o 16 29 47" src="https://user-images.githubusercontent.com/205419/88817154-7464ab00-d1bd-11ea-9396-2b19eb0519bc.png">

It also removes a misleading @TODO comment from lib/widgets.php. The feature described in that comment can be achieved by using the transform API that already exists:

```js
{
	transforms: {
		from: [
			{
				type: 'block',
				blocks: [ 'core/legacy-widget' ],
				isMatch: ( { widgetClass } ) => {
					return widgetClass === 'WP_Widget_Custom_HTML';
				},
				transform: ( {} ) => {
					return createBlock( 'core/navigation', {}, [] );
				},
			},
		],
	},
}
```

