### PR TITLE
correct bad condition

### DIFF
--- a/packages/editor/src/components/page-attributes/check.js
+++ b/packages/editor/src/components/page-attributes/check.js
@@ -20,7 +20,7 @@ export function PageAttributesCheck( {
 	);
 
 	// Only render fields if post type supports page attributes or available templates exist.
-	if ( ! supportsPageAttributes && isEmpty( availableTemplates ) ) {
+	if ( ! supportsPageAttributes || isEmpty( availableTemplates ) ) {
 		return null;
 	}
 


### PR DESCRIPTION
## Description
The Page attributes still displayed even when the post type does not support it, bad condition was found and corrected.

## How has this been tested?
**To reproduce**
Remove support for page-attributes and it will still displayed

code example to remove support of page-attributes from page post type :

1. Add this code  to your theme's PHP file (functions.php) ⬇️ :  

`function remove_page_attributes_support() {`
`remove_post_type_support( 'page', 'page-attributes' );`
`}`
`add_action( 'admin_init', 'remove_page_attributes_support' );`

2. Go to Pages
3. Select a Page
4. Scroll down


## Types of changes
Correct bad condition

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. 
-  My code follows the accessibility standards.
- [x] My code has proper inline documentation.
-  I've included developer documentation if appropriate. 
-  I've updated all React Native files affected by any refactorings/renamings in this PR.
