### PR TITLE
Convert <BlockInvalidWarning> to function component with hooks

### DIFF
--- a/packages/block-editor/src/components/block-list/block-invalid-warning.js
+++ b/packages/block-editor/src/components/block-list/block-invalid-warning.js
@@ -27,6 +27,7 @@ export function BlockInvalidWarning( {
 	const onCompare = useCallback( () => setCompare( true ), [] );
 	const onCompareClose = useCallback( () => setCompare( false ), [] );
 
+	// We memo the array here to prevent the children components from being updated unexpectedly
 	const hiddenActions = useMemo(
 		() =>
 			[

--- a/packages/block-editor/src/components/block-list/block-invalid-warning.js
+++ b/packages/block-editor/src/components/block-list/block-invalid-warning.js
@@ -3,7 +3,7 @@
  */
 import { __, _x } from '@wordpress/i18n';
 import { Button, Modal } from '@wordpress/components';
-import { Component } from '@wordpress/element';
+import { useState, useCallback, useMemo } from '@wordpress/element';
 import { getBlockType, createBlock, rawHandler } from '@wordpress/blocks';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
@@ -14,88 +14,75 @@ import { withDispatch, withSelect } from '@wordpress/data';
 import Warning from '../warning';
 import BlockCompare from '../block-compare';
 
-export class BlockInvalidWarning extends Component {
-	constructor( props ) {
-		super( props );
+export function BlockInvalidWarning( {
+	convertToHTML,
+	convertToBlocks,
+	convertToClassic,
+	attemptBlockRecovery,
+	block,
+} ) {
+	const hasHTMLBlock = !! getBlockType( 'core/html' );
+	const [ compare, setCompare ] = useState( false );
 
-		this.state = { compare: false };
-		this.onCompare = this.onCompare.bind( this );
-		this.onCompareClose = this.onCompareClose.bind( this );
-	}
+	const onCompare = useCallback( () => setCompare( true ), [] );
+	const onCompareClose = useCallback( () => setCompare( false ), [] );
 
-	onCompare() {
-		this.setState( { compare: true } );
-	}
+	const hiddenActions = useMemo(
+		() =>
+			[
+				{
+					// translators: Button to fix block content
+					title: _x( 'Resolve', 'imperative verb' ),
+					onClick: onCompare,
+				},
+				hasHTMLBlock && {
+					title: __( 'Convert to HTML' ),
+					onClick: convertToHTML,
+				},
+				{
+					title: __( 'Convert to Classic Block' ),
+					onClick: convertToClassic,
+				},
+			].filter( Boolean ),
+		[ onCompare, convertToHTML, convertToClassic ]
+	);
 
-	onCompareClose() {
-		this.setState( { compare: false } );
-	}
-
-	render() {
-		const {
-			convertToHTML,
-			convertToBlocks,
-			convertToClassic,
-			attemptBlockRecovery,
-			block,
-		} = this.props;
-		const hasHTMLBlock = !! getBlockType( 'core/html' );
-		const { compare } = this.state;
-		const hiddenActions = [
-			{
-				// translators: Button to fix block content
-				title: _x( 'Resolve', 'imperative verb' ),
-				onClick: this.onCompare,
-			},
-			hasHTMLBlock && {
-				title: __( 'Convert to HTML' ),
-				onClick: convertToHTML,
-			},
-			{
-				title: __( 'Convert to Classic Block' ),
-				onClick: convertToClassic,
-			},
-		].filter( Boolean );
-
-		return (
-			<>
-				<Warning
-					actions={ [
-						<Button
-							key="recover"
-							onClick={ attemptBlockRecovery }
-							isPrimary
-						>
-							{ __( 'Attempt Block Recovery' ) }
-						</Button>,
-					] }
-					secondaryActions={ hiddenActions }
-				>
-					{ __(
-						'This block contains unexpected or invalid content.'
-					) }
-				</Warning>
-				{ compare && (
-					<Modal
-						title={
-							// translators: Dialog title to fix block content
-							__( 'Resolve Block' )
-						}
-						onRequestClose={ this.onCompareClose }
-						className="block-editor-block-compare"
+	return (
+		<>
+			<Warning
+				actions={ [
+					<Button
+						key="recover"
+						onClick={ attemptBlockRecovery }
+						isPrimary
 					>
-						<BlockCompare
-							block={ block }
-							onKeep={ convertToHTML }
-							onConvert={ convertToBlocks }
-							convertor={ blockToBlocks }
-							convertButtonText={ __( 'Convert to Blocks' ) }
-						/>
-					</Modal>
-				) }
-			</>
-		);
-	}
+						{ __( 'Attempt Block Recovery' ) }
+					</Button>,
+				] }
+				secondaryActions={ hiddenActions }
+			>
+				{ __( 'This block contains unexpected or invalid content.' ) }
+			</Warning>
+			{ compare && (
+				<Modal
+					title={
+						// translators: Dialog title to fix block content
+						__( 'Resolve Block' )
+					}
+					onRequestClose={ onCompareClose }
+					className="block-editor-block-compare"
+				>
+					<BlockCompare
+						block={ block }
+						onKeep={ convertToHTML }
+						onConvert={ convertToBlocks }
+						convertor={ blockToBlocks }
+						convertButtonText={ __( 'Convert to Blocks' ) }
+					/>
+				</Modal>
+			) }
+		</>
+	);
 }
 
 const blockToClassic = ( block ) =>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Related to #22890.

Convert the `<BlockInvalidWarning>` component to function component with hooks.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Choose an existing block and select "Edit as HTML".
2. Append `<p>Invalid` to the end of the HTML to make the block invalid.
3. Click outside the block, the block should now display the `<BlockInvalidWarning>`
4. The component works the same.

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/7753001/88896147-0206d000-d27c-11ea-8f9a-6df1baafc37a.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
