### PR TITLE
Fix block insertion place after clicking Browse All in the inline inserter

### DIFF
--- a/packages/block-editor/src/components/inserter/quick-inserter.js
+++ b/packages/block-editor/src/components/inserter/quick-inserter.js
@@ -163,18 +163,10 @@ function QuickInserter( {
 		[]
 	);
 
-	const clientIdFromInserter = useSelect(
-		( select ) => {
-			const { getBlockIndex, getBlockOrder } = select(
-				'core/block-editor'
-			);
-			// We have to select the previous block because the menu inserter
-			// inserts block after the selected
-			return getBlockOrder( destinationRootClientId )[
-				getBlockIndex( clientId, destinationRootClientId ) - 1
-			];
-		},
-		[ clientId, destinationRootClientId ]
+	const previousBlockClientId = useSelect(
+		( select ) =>
+			select( 'core/block-editor' ).getPreviousBlockClientId( clientId ),
+		[ clientId ]
 	);
 
 	useEffect( () => {
@@ -202,7 +194,9 @@ function QuickInserter( {
 	// When clicking Browse All select the appropriate block so as
 	// the insertion point can work as expected
 	const onBrowseAll = () => {
-		selectBlock( clientIdFromInserter );
+		// We have to select the previous block because the menu inserter
+		// inserts the new block after the selected one.
+		selectBlock( previousBlockClientId );
 		setInserterIsOpened( true );
 	};
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Fixes: https://github.com/WordPress/gutenberg/issues/24262

When you click `Browse All` button from inline inserter and then select a block, it inserts it after the previously selected block.


## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
