### PR TITLE
Consider any user changes to global styles as publishable

### DIFF
--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -101,7 +101,7 @@ function gutenberg_experimental_global_styles_get_from_file( $file_path ) {
  */
 function gutenberg_experimental_global_styles_get_user() {
 	$config   = array();
-	$user_cpt = gutenberg_experimental_global_styles_get_user_cpt( array( 'publish' ) );
+	$user_cpt = gutenberg_experimental_global_styles_get_user_cpt();
 	if ( array_key_exists( 'post_content', $user_cpt ) ) {
 		$decoded_data = json_decode( $user_cpt['post_content'], true );
 
@@ -125,13 +125,13 @@ function gutenberg_experimental_global_styles_get_user() {
  *
  * It can also create and return a new draft CPT.
  *
+ * @param bool  $should_create_cpt Whether a new CPT should be created if no one was found.
+ *                                   False by default.
  * @param array $post_status_filter  Filter CPT by post status.
  *                                   ['publish'] by default, so it only fetches published posts.
- * @param bool  $should_create_draft Whether a new draft should be created if no CPT was found.
- *                                   False by default.
  * @return array Custom Post Type for the user's origin config.
  */
-function gutenberg_experimental_global_styles_get_user_cpt( $post_status_filter = array( 'publish' ), $should_create_draft = false ) {
+function gutenberg_experimental_global_styles_get_user_cpt( $should_create_cpt = false, $post_status_filter = array( 'publish' ) ) {
 	$user_cpt         = array();
 	$post_type_filter = 'wp_global_styles';
 	$post_name_filter = 'wp-global-styles-' . strtolower( wp_get_theme()->get( 'TextDomain' ) );
@@ -148,11 +148,11 @@ function gutenberg_experimental_global_styles_get_user_cpt( $post_status_filter 
 
 	if ( is_array( $recent_posts ) && ( count( $recent_posts ) === 1 ) ) {
 		$user_cpt = $recent_posts[0];
-	} elseif ( $should_create_draft ) {
+	} elseif ( $should_create_cpt ) {
 		$cpt_post_id = wp_insert_post(
 			array(
 				'post_content' => '{}',
-				'post_status'  => 'draft',
+				'post_status'  => 'publish',
 				'post_type'    => $post_type_filter,
 				'post_name'    => $post_name_filter,
 			),
@@ -171,7 +171,7 @@ function gutenberg_experimental_global_styles_get_user_cpt( $post_status_filter 
  */
 function gutenberg_experimental_global_styles_get_user_cpt_id() {
 	$user_cpt_id = null;
-	$user_cpt    = gutenberg_experimental_global_styles_get_user_cpt( array( 'publish', 'draft' ), true );
+	$user_cpt    = gutenberg_experimental_global_styles_get_user_cpt( true );
 	if ( array_key_exists( 'ID', $user_cpt ) ) {
 		$user_cpt_id = $user_cpt['ID'];
 	}


### PR DESCRIPTION
Extracted from https://github.com/WordPress/gutenberg/pull/24250

This PR makes any stored user changes ready to use in the front-end, as we don't have yet the notion of "draft user changes" for global styles.
