### PR TITLE
Fix merge algorithm for global styles

### DIFF
--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -502,7 +502,7 @@ function gutenberg_experimental_global_styles_merge_trees( $core, $theme, $user 
 				$user[ $block_name ][ $subtree ]
 			);
 		}
-		foreach ( array( 'typography', 'color' ) as $subtree ) {
+		foreach ( array_keys( $core[ $block_name ]['styles'] ) as $subtree ) {
 			$result[ $block_name ]['styles'][ $subtree ] = array_merge(
 				$core[ $block_name ]['styles'][ $subtree ],
 				$theme[ $block_name ]['styles'][ $subtree ],

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -495,11 +495,18 @@ function gutenberg_experimental_global_styles_merge_trees( $core, $theme, $user 
 	$result = gutenberg_experimental_global_styles_normalize_schema( array() );
 
 	foreach ( array_keys( $core ) as $block_name ) {
-		foreach ( array( 'presets', 'styles', 'features' ) as $subtree ) {
+		foreach ( array( 'presets', 'features' ) as $subtree ) {
 			$result[ $block_name ][ $subtree ] = array_merge(
 				$core[ $block_name ][ $subtree ],
 				$theme[ $block_name ][ $subtree ],
 				$user[ $block_name ][ $subtree ]
+			);
+		}
+		foreach ( array( 'typography', 'color' ) as $subtree ) {
+			$result[ $block_name ]['styles'][ $subtree ] = array_merge(
+				$core[ $block_name ]['styles'][ $subtree ],
+				$theme[ $block_name ]['styles'][ $subtree ],
+				$user[ $block_name ]['styles'][ $subtree ]
 			);
 		}
 	}
@@ -516,7 +523,10 @@ function gutenberg_experimental_global_styles_merge_trees( $core, $theme, $user 
  */
 function gutenberg_experimental_global_styles_normalize_schema( $tree ) {
 	$block_schema = array(
-		'styles'   => array(),
+		'styles'   => array(
+			'typography' => array(),
+			'color'      => array(),
+		),
 		'features' => array(),
 		'presets'  => array(),
 	);


### PR DESCRIPTION
Extracted from https://github.com/WordPress/gutenberg/pull/24250

This fixes the merge algorithm for global styles.

Before:

```
$result = array_merge(
    [
        'typography' => [ 
            'font-family' => 'first',
            'line-height' => 'first'
        ]
    ],
    [
        'typography' => [
            'font-family' => 'second'
        ]
    ]
);

var_dump( $result );
// array(1) {
//  ["typography"]=>
//  array(1) {
//    ["font-family"]=>
//    string(6) "second"
//  }
//}
```

After:

```
$result['typography'] = array_merge(
    [
        'font-family' => 'first',
        'line-height' => 'first'
    ],
    [
        'font-family' => 'second'
    ]
);

var_dump( $result );
// array(1) {
//  ["typography"]=>
//  array(2) {
//    ["font-family"]=>
//    string(6) "second"
//    ["line-height"]=>
//    string(5) "first"
//  }
//}
```
