### PR TITLE
Fix link color style property name in global styles

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -320,7 +320,7 @@ function gutenberg_experimental_build_css_colors( $attributes, $block_attributes
 	}
 
 	// Link Colors.
-	if ( in_array( 'link-color', $supports, true ) ) {
+	if ( in_array( '--wp--style--color--link', $supports, true ) ) {
 		$has_link_color = isset( $block_attributes['style']['color']['link'] );
 		// Apply required class and style.
 		if ( $has_link_color ) {

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -270,13 +270,13 @@ function gutenberg_experimental_global_styles_get_theme() {
  */
 function gutenberg_experimental_global_styles_get_supported_styles( $supports ) {
 	$style_features = array(
-		'color'            => array( '__experimentalColor' ),
-		'background-color' => array( '__experimentalColor' ),
-		'background'       => array( '__experimentalColor', 'gradients' ),
-		'link-color'       => array( '__experimentalColor', 'linkColor' ),
-		'line-height'      => array( '__experimentalLineHeight' ),
-		'font-size'        => array( '__experimentalFontSize' ),
-		'block-align'      => array( 'align' ),
+		'--wp--style--color--link' => array( '__experimentalColor', 'linkColor' ),
+		'background-color'         => array( '__experimentalColor' ),
+		'background'               => array( '__experimentalColor', 'gradients' ),
+		'block-align'              => array( 'align' ),
+		'color'                    => array( '__experimentalColor' ),
+		'font-size'                => array( '__experimentalFontSize' ),
+		'line-height'              => array( '__experimentalLineHeight' ),
 	);
 
 	$supported_features = array();


### PR DESCRIPTION
Extracted from https://github.com/WordPress/gutenberg/pull/24250

This fixes the name of the style property for link color + sorts them alphabetically.
