### PR TITLE
Group block: Updated the block description

### DIFF
--- a/packages/block-library/src/group/index.js
+++ b/packages/block-library/src/group/index.js
@@ -20,7 +20,7 @@ export { metadata, name };
 export const settings = {
 	title: __( 'Group' ),
 	icon,
-	description: __( 'A block that groups other blocks.' ),
+	description: __( 'Combine blocks into a group.' ),
 	keywords: [
 		__( 'container' ),
 		__( 'wrapper' ),


### PR DESCRIPTION
## Description
The block description wasn't following the pattern of other block descriptions as outlined here: https://github.com/WordPress/gutenberg/pull/16002#issuecomment-499831853. The PR updating this change went stale and included some bigger issues, so I created this PR to move it forward.

I've left out the description change for the ellipses dropdown actions because "Group" and "Ungroup" are reasonable enough.

There was consensus to keep the word "group" in the description because it's still a great word that describes exactly what is happening.

Replaces: https://github.com/WordPress/gutenberg/pull/16002

cc @paaljoachim @kjellr 

## How has this been tested?
Tested locally.

## Screenshots

![Screen Shot 2020-07-30 at 10 05 44 AM](https://user-images.githubusercontent.com/617986/88952406-411d2d00-d24c-11ea-9f3f-33959a8d353e.png)


## Types of changes
Non-breaking text changes.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
