### PR TITLE
Add support for more style properties in the global context

### DIFF
--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -298,7 +298,7 @@ function gutenberg_experimental_global_styles_get_block_data() {
 	$block_data = array(
 		'global' => array(
 			'selector' => ':root',
-			'supports' => array( 'background-color' ),
+			'supports' => array( '--wp--style--color--link', 'background-color', 'font-size' ),
 		),
 	);
 

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -312,9 +312,9 @@ function gutenberg_experimental_global_styles_get_block_data() {
 							'gradients' => true,
 						),
 					),
-				),
+				)
 			),
-		),
+		)
 	);
 	foreach ( $blocks as $block_name => $block_type ) {
 		if ( empty( $block_type->supports ) || ! is_array( $block_type->supports ) ) {

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -308,7 +308,8 @@ function gutenberg_experimental_global_styles_get_block_data() {
 						'__experimentalSelector' => ':root',
 						'__experimentalFontSize' => true,
 						'__experimentalColor' => array(
-							'linkColor' => true
+							'linkColor' => true,
+							'gradients' => true,
 						)
 					)
 				)

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -298,7 +298,7 @@ function gutenberg_experimental_global_styles_get_block_data() {
 	$block_data = array();
 
 	$registry = WP_Block_Type_Registry::get_instance();
-	$blocks = array_merge(
+	$blocks   = array_merge(
 		$registry->get_all_registered(),
 		array(
 			'global' => new WP_Block_Type(
@@ -307,14 +307,14 @@ function gutenberg_experimental_global_styles_get_block_data() {
 					'supports' => array(
 						'__experimentalSelector' => ':root',
 						'__experimentalFontSize' => true,
-						'__experimentalColor' => array(
+						'__experimentalColor'    => array(
 							'linkColor' => true,
 							'gradients' => true,
-						)
-					)
-				)
-			)
-		)
+						),
+					),
+				),
+			),
+		),
 	);
 	foreach ( $blocks as $block_name => $block_type ) {
 		if ( empty( $block_type->supports ) || ! is_array( $block_type->supports ) ) {

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -295,15 +295,27 @@ function gutenberg_experimental_global_styles_get_supported_styles( $supports ) 
  * @return array
  */
 function gutenberg_experimental_global_styles_get_block_data() {
-	$block_data = array(
-		'global' => array(
-			'selector' => ':root',
-			'supports' => array( '--wp--style--color--link', 'background-color', 'font-size' ),
-		),
-	);
+	$block_data = array();
 
 	$registry = WP_Block_Type_Registry::get_instance();
-	foreach ( $registry->get_all_registered() as $block_name => $block_type ) {
+	$blocks = array_merge(
+		$registry->get_all_registered(),
+		array(
+			'global' => new WP_Block_Type(
+				'global',
+				array(
+					'supports' => array(
+						'__experimentalSelector' => ':root',
+						'__experimentalFontSize' => true,
+						'__experimentalColor' => array(
+							'linkColor' => true
+						)
+					)
+				)
+			)
+		)
+	);
+	foreach ( $blocks as $block_name => $block_type ) {
 		if ( empty( $block_type->supports ) || ! is_array( $block_type->supports ) ) {
 			continue;
 		}


### PR DESCRIPTION
Extracted from https://github.com/WordPress/gutenberg/pull/24250

This PR adds support for more style properties in the global context.

## Testing instructions

- Install & activate a theme with support for global styles ([demo theme](https://github.com/nosolosw/global-styles-theme/)).
- Edit the gutenberg file `lib/experimental-theme.json`:

```
{
    "global": {
        "styles": {
            "typography": {
                "fontSize": 12,
                "lineHeight": 2.3
            },
            "color": {
                "text": "red",
                "link": "blue",
                "background": "yellow",
                "gradient": ""gradient": "var(--wp--preset--gradient--blush-bordeaux)"
            }
        }
    }
}
```

- Go to the front-end and verify that there is an inlined stylesheet named `global-styles-inline-css` that contains a style rule with the `:root` selector. For that style rule, verify that:
  => does have the properties `font-size`, `background-color`, `background`, `--wp--style--color--link`
  => does **not** have the properties `line-height`, `color`
