### PR TITLE
Announce block selection changes manually on windows

### DIFF
--- a/packages/block-editor/src/components/block-list/block-selection-button.js
+++ b/packages/block-editor/src/components/block-list/block-selection-button.js
@@ -14,11 +14,21 @@ import {
 	getBlockType,
 	__experimentalGetAccessibleBlockLabel as getAccessibleBlockLabel,
 } from '@wordpress/blocks';
+import { speak } from '@wordpress/a11y';
 
 /**
  * Internal dependencies
  */
 import BlockTitle from '../block-title';
+
+/**
+ * Returns true if the user is using windows.
+ *
+ * @return {boolean} Whether the user is using Windows.
+ */
+function isWindows() {
+	return window.navigator.platform.indexOf( 'Win' ) > -1;
+}
 
 /**
  * Block selection button component, displaying the label of the block. If the block
@@ -63,6 +73,13 @@ function BlockSelectionButton( { clientId, rootClientId, ...props } ) {
 	// Focus the breadcrumb in navigation mode.
 	useEffect( () => {
 		ref.current.focus();
+
+		// NVDA on windows suffers from a bug where focus changes are not announced properly
+		// See WordPress/gutenberg#24121 and nvaccess/nvda#5825 for more details
+		// To solve it we announce the focus change manually.
+		if ( isWindows() ) {
+			speak( label );
+		}
 	}, [] );
 
 	function onKeyDown( event ) {


### PR DESCRIPTION
refs #24121 

In NVDA on Windows, the block selection changes are not announced properly on Navigation Mode (Gutenberg's navigation mode).

As discussed on the issue, this solves the issue by announcing the blocks manually.