### PR TITLE
Full Site Editing: Fix Site Title Save Bug

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -117,10 +117,12 @@ function Editor() {
 				const { getEditedEntityRecord } = select( 'core' );
 				entitiesToSave.forEach( ( { kind, name, key } ) => {
 					const record = getEditedEntityRecord( kind, name, key );
-					editEntityRecord( kind, name, key, {
-						status: 'publish',
-						title: record.slug,
-					} );
+
+					const edits = record.slug
+						? { status: 'publish', title: record.slug }
+						: { status: 'publish' };
+
+					editEntityRecord( kind, name, key, edits );
 				} );
 			}
 			setIsEntitiesSavedStatesOpen( false );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->
Fixes https://github.com/WordPress/gutenberg/issues/24003

## Description
<!-- Please describe what you have changed or added -->
Users could not save updates to the Site Title block in Full Site Editing.

There were changes introduced in a previous PR https://github.com/WordPress/gutenberg/pull/22876 that aimed to avoid dirtying un-customized templates on first load. The modifications introduced metadata to be evaluated before saving block editor updates. These included record `title` and record `status` as seen [here](https://github.com/WordPress/gutenberg/pull/22876/files#diff-641afe1a0152b0e5136c8b46edb84b33R112-R115).

Unfortunately, Site Title also uses the `title` attribute, which, inadvertently, was being overridden by the record `title`.

```javascript
// When the save button is clicked, the stack trace eventually leads here
// packages/core-data/src/actions.js:234

// the edits param looks like { status: 'publish', title: record.slug }
// it was introduced in #22876
// when saving a site title, record.slug will be undefined (there is no "slug" attribute for the site settings record)
Object.keys( edits ).reduce( ( acc, key ) => {
	const recordValue = record[ key ];
        
        // editedRecord looks like { title: 'My brand spanking new site title', ...rest }
	const editedRecordValue = editedRecord[ key ];
        
        // Where the record title overrides the site title
	const value = mergedEdits[ key ]
		? { ...editedRecordValue, ...edits[ key ] }
		: edits[ key ];
	acc[ key ] = isEqual( recordValue, value ) ? undefined : value;
	return acc;
}, {} ),
```

More context can be seen [here](https://github.com/WordPress/gutenberg/blob/master/packages/core-data/src/actions.js#L237-L239) in the `core/data` library.

## Solution
**Note**: I am going to lean on the expertise of others because I may be missing some context, and my solution may not be ideal. 

The fix ensures that, if the record slug does not exist, then an undefined title is **not** included as metadata. This prevents the undefined title from overriding updates to site title. 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Navigate to the full site editor
2. Modify any instance of the site title block
3. Click on the "Update Design" button
4. Click on the "Save" button
5. Refresh the page to ensure that the Site Title has been persisted
6. Navigate to a separate page or post and add the Site Title block. Ensure that it reflects the updated site title.

## Screenshots <!-- if applicable -->
![site title bug](https://user-images.githubusercontent.com/5414230/88989856-6d0ed180-d291-11ea-8dc4-fc8b790e1908.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
