### PR TITLE
Fix not truncating at minutes the first time in <TimePicker>

### DIFF
--- a/packages/components/src/date-time/test/time.js
+++ b/packages/components/src/date-time/test/time.js
@@ -200,4 +200,23 @@ describe( 'TimePicker', () => {
 		pmButton.simulate( 'click' );
 		expect( onChangeSpy ).toHaveBeenCalledWith( '1986-10-18T11:00:00' );
 	} );
+
+	it( 'should truncate at the minutes on change', () => {
+		const onChangeSpy = jest.fn();
+
+		const wrapper = shallow(
+			<TimePicker
+				currentTime="1986-10-18T23:12:35"
+				onChange={ onChangeSpy }
+				is12Hour
+			/>
+		);
+
+		const minuteInput = wrapper.find( 'input[aria-label="Minutes"]' );
+
+		minuteInput.simulate( 'change', { target: { value: '22' } } );
+		minuteInput.simulate( 'blur' );
+
+		expect( onChangeSpy ).toHaveBeenCalledWith( '1986-10-18T23:22:00' );
+	} );
 } );

--- a/packages/components/src/date-time/time.js
+++ b/packages/components/src/date-time/time.js
@@ -73,7 +73,9 @@ class TimePicker extends Component {
 	changeDate( newDate ) {
 		const dateWithStartOfMinutes = newDate.clone().startOf( 'minute' );
 		this.setState( { date: dateWithStartOfMinutes } );
-		this.props.onChange( newDate.format( TIMEZONELESS_FORMAT ) );
+		this.props.onChange(
+			dateWithStartOfMinutes.format( TIMEZONELESS_FORMAT )
+		);
 	}
 
 	getMaxHours() {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Continued from #15495.

Seems like that PR only fixes truncating at minutes the second time and beyond. When first calling `changeDate`, the truncated date is saved in the Component's internal state, but not passed as a argument of `onChange`.

The detailed steps are as follow:

1. `<TimePicker>` initializes the date with `currentTime` or now. which contains seconds like `2020-07-31T06:45:35`.
2. User updates the time, e.g. updating minutes from `45` to `46`, and `blur` the input.
3. `changeDate` updates state with zeroed seconds (`2020-07-31T06:46:00`)
4. **However, `onChange` is triggered with non-zeroed seconds (`2020-07-31T06:46:35`)**
5. `<TimePicker>` re-renders using the new state as the new date
6. User updates the time again, e.g. updating hours from `06` to `07`.
7. `changeDate` triggered, and because state was updated with zeroed seconds, `newDate` now also has zeroed seconds (`2020-07-31T07:46:00`)

Note the 4th step, the component will temporary have a non-zeroed second in the date value.

It's likely that users tend to not only update the time once, normally they would update it multiple times, that's why we didn't notice the bug before 🤔 ?

I'm also trying to refactor this component into [function component](https://github.com/WordPress/gutenberg/issues/22890#issuecomment-666224667). The updated implementation should not have this bug, but figured to open a bug fix PR first to get it landed. Will open another PR for the refactor.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Added unit test in `test/time.js`. 

Also can tested in the `<PostSchedule>` component. Create a new post and change the schedule time in the settings, and observe the value in devtools or React devtools.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
