### PR TITLE
Improve rootClientId comparison in useBlockDropZone

### DIFF
--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -173,7 +173,7 @@ export default function useBlockDropZone( {
 	element,
 	// An undefined value represents a top-level block. Default to an empty
 	// string for this so that `targetRootClientId` can be easily compared to
-	// values return by the `getRootBlockClientId` selector, which also uses
+	// values returned by the `getRootBlockClientId` selector, which also uses
 	// an empty string to represent top-level blocks.
 	rootClientId: targetRootClientId = '',
 } ) {

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -171,7 +171,11 @@ function parseDropEvent( event ) {
  */
 export default function useBlockDropZone( {
 	element,
-	rootClientId: targetRootClientId,
+	// An undefined value represents a top-level block. Default to an empty
+	// string for this so that `targetRootClientId` can be easily compared to
+	// values return by the `getRootBlockClientId` selector, which also uses
+	// an empty string to represent top-level blocks.
+	rootClientId: targetRootClientId = '',
 } ) {
 	const [ targetBlockIndex, setTargetBlockIndex ] = useState( null );
 
@@ -285,16 +289,11 @@ export default function useBlockDropZone( {
 				return;
 			}
 
-			const isAtSameLevel =
-				sourceRootClientId === targetRootClientId ||
-				( sourceRootClientId === '' &&
-					targetRootClientId === undefined );
-
-			const draggedBlockCount = sourceClientIds.length;
-
 			// If the block is kept at the same level and moved downwards,
 			// subtract to take into account that the blocks being dragged
 			// were removed from the block list.
+			const isAtSameLevel = sourceRootClientId === targetRootClientId;
+			const draggedBlockCount = sourceClientIds.length;
 			const insertIndex =
 				isAtSameLevel && sourceBlockIndex < targetBlockIndex
 					? targetBlockIndex - draggedBlockCount


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Addreses https://github.com/WordPress/gutenberg/pull/23020#discussion_r460088463

There's a slight discrepancy between values for `rootClientId` that represent top-level blocks.

- `getBlockRootClientId` returns an empty string for a top level block.
- `BlockList` components tend to use `undefined` because the prop for `rootClientId` is omitted for the top level block list.

`useBlockDropZone` performs a comparison between rootClientIds that originate from these two separate places.

This PR smooths over the inconsistency in that hook by defaulting `targetRootClientId` (which is sourced from `BlockList`) to an empty string.

## How has this been tested?
Dragging and dropping top-level blocks should continue to work. Specifically dragging a block downwards should result in the block being inserted in the correct place.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
Non-breaking code quality improvement
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
