### PR TITLE
Improve margin within the media replace popover

### DIFF
--- a/packages/block-editor/src/components/media-replace-flow/style.scss
+++ b/packages/block-editor/src/components/media-replace-flow/style.scss
@@ -15,11 +15,8 @@
 	margin-left: 4px;
 }
 
-.block-editor-media-replace-flow__media-upload-menu {
-	margin-bottom: $grid-unit-20;
-}
-
 .block-editor-media-flow__url-input {
+	margin-top: $grid-unit-20;
 
 	.block-editor-media-replace-flow__image-url-label {
 		top: $grid-unit-20;


### PR DESCRIPTION
## Description
Currently, there is a bottom margin placed on the replace media menu to create space between menu items and the "Current media URL" container. When the "Current media URL" container is not shown, the bottom margin of the menu persists, causing there to be excessive space at the bottom of the popover.

This commit moves the margin from the bottom of the media replace menu to the top of the media replace url input so that the popover spacing stays consistent when the media replace URL input is not shown (the Cover block instance, for example)

## How has this been tested?
Tested the change with the following browser on MacOS:
- Chrome 83.0.4103.116
- Firefox 79
- Safari 13.1.1

## Screenshots <!-- if applicable -->
### Before
<img width="474" alt="Screen Shot 2020-07-31 at 8 43 44 AM" src="https://user-images.githubusercontent.com/3665539/89036565-e4cd1280-d30a-11ea-8fbd-55d9932d67a6.png">

### After
<img width="473" alt="Screen Shot 2020-07-31 at 8 44 16 AM" src="https://user-images.githubusercontent.com/3665539/89036574-e991c680-d30a-11ea-907e-682f3b564e0c.png">

## Types of changes
Style/CSS adjustment

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
