### PR TITLE
Use same mappings for the style properties everywhere

### DIFF
--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -6,6 +6,44 @@
  */
 
 /**
+ * Returns the paths to get the information about a particular
+ * style property from the block.json or the theme.json.
+ */
+function gutenberg_experimental_global_styles_get_mappings() {
+	$mappings = array(
+		'line-height'              => array(
+			'theme_json' => array( 'typography', 'lineHeight' ),
+			'block_json' => array( '__experimentalLineHeight' ),
+		),
+		'font-size'                => array(
+			'block_json' => array( '__experimentalFontSize' ),
+			'theme_json' => array( 'typography', 'fontSize' ),
+		),
+		'background'               => array(
+			'block_json' => array( '__experimentalColor', 'gradients' ),
+			'theme_json' => array( 'color', 'gradient' ),
+		),
+		'background-color'         => array(
+			'block_json' => array( '__experimentalColor' ),
+			'theme_json' => array( 'color', 'background' ),
+		),
+		'color'                    => array(
+			'block_json' => array( '__experimentalColor' ),
+			'theme_json' => array( 'color', 'text' ),
+		),
+		'--wp--style--color--link' => array(
+			'block_json' => array( '__experimentalColor', 'linkColor' ),
+			'theme_json' => array( 'color', 'link' ),
+		),
+		'block-align'      => array(
+			'block_json' => array( 'align' ),
+		),
+	);
+
+	return $mappings;
+}
+
+/**
  * Whether the current theme has a theme.json file.
  *
  * @return boolean
@@ -269,19 +307,11 @@ function gutenberg_experimental_global_styles_get_theme() {
  * @return array Style features supported by the block.
  */
 function gutenberg_experimental_global_styles_get_supported_styles( $supports ) {
-	$style_features = array(
-		'--wp--style--color--link' => array( '__experimentalColor', 'linkColor' ),
-		'background-color'         => array( '__experimentalColor' ),
-		'background'               => array( '__experimentalColor', 'gradients' ),
-		'block-align'              => array( 'align' ),
-		'color'                    => array( '__experimentalColor' ),
-		'font-size'                => array( '__experimentalFontSize' ),
-		'line-height'              => array( '__experimentalLineHeight' ),
-	);
+	$mappings = gutenberg_experimental_global_styles_get_mappings();
 
 	$supported_features = array();
-	foreach ( $style_features as $style_feature => $path ) {
-		if ( gutenberg_experimental_get( $supports, $path ) ) {
+	foreach ( $mappings as $style_feature => $path ) {
+		if ( gutenberg_experimental_get( $supports, $path['block_json'] ) ) {
 			$supported_features[] = $style_feature;
 		}
 	}
@@ -370,19 +400,12 @@ function gutenberg_experimental_global_styles_get_block_data() {
  * @return array Containing a set of css rules.
  */
 function gutenberg_experimental_global_styles_flatten_styles_tree( $styles ) {
-	$mappings = array(
-		'line-height'              => array( 'typography', 'lineHeight' ),
-		'font-size'                => array( 'typography', 'fontSize' ),
-		'background'               => array( 'color', 'gradient' ),
-		'background-color'         => array( 'color', 'background' ),
-		'color'                    => array( 'color', 'text' ),
-		'--wp--style--color--link' => array( 'color', 'link' ),
-	);
+	$mappings = gutenberg_experimental_global_styles_get_mappings();
 
 	$result = array();
 
 	foreach ( $mappings as $key => $path ) {
-		$value = gutenberg_experimental_get( $styles, $path, null );
+		$value = gutenberg_experimental_get( $styles, $path['theme_json'], null );
 		if ( null !== $value ) {
 			$result[ $key ] = $value;
 		}

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -10,37 +10,14 @@
  * style property from the block.json or the theme.json.
  */
 function gutenberg_experimental_global_styles_get_mappings() {
-	$mappings = array(
-		'line-height'              => array(
-			'theme_json' => array( 'typography', 'lineHeight' ),
-			'block_json' => array( '__experimentalLineHeight' ),
-		),
-		'font-size'                => array(
-			'block_json' => array( '__experimentalFontSize' ),
-			'theme_json' => array( 'typography', 'fontSize' ),
-		),
-		'background'               => array(
-			'block_json' => array( '__experimentalColor', 'gradients' ),
-			'theme_json' => array( 'color', 'gradient' ),
-		),
-		'background-color'         => array(
-			'block_json' => array( '__experimentalColor' ),
-			'theme_json' => array( 'color', 'background' ),
-		),
-		'color'                    => array(
-			'block_json' => array( '__experimentalColor' ),
-			'theme_json' => array( 'color', 'text' ),
-		),
-		'--wp--style--color--link' => array(
-			'block_json' => array( '__experimentalColor', 'linkColor' ),
-			'theme_json' => array( 'color', 'link' ),
-		),
-		'block-align'      => array(
-			'block_json' => array( 'align' ),
-		),
+	return array(
+		'line-height'              => array( 'typography', 'lineHeight' ),
+		'font-size'                => array( 'typography', 'fontSize' ),
+		'background'               => array( 'color', 'gradient' ),
+		'background-color'         => array( 'color', 'background' ),
+		'color'                    => array( 'color', 'text' ),
+		'--wp--style--color--link' => array( 'color', 'link' )
 	);
-
-	return $mappings;
 }
 
 /**
@@ -307,11 +284,20 @@ function gutenberg_experimental_global_styles_get_theme() {
  * @return array Style features supported by the block.
  */
 function gutenberg_experimental_global_styles_get_supported_styles( $supports ) {
-	$mappings = gutenberg_experimental_global_styles_get_mappings();
+	$mappings = array_merge(
+		gutenberg_experimental_global_styles_get_mappings(),
+		// TODO: remove from here and access directly from lib/blocks.php
+		array(
+			'block-align' => array( 'align' )
+		)
+	);
 
 	$supported_features = array();
 	foreach ( $mappings as $style_feature => $path ) {
-		if ( gutenberg_experimental_get( $supports, $path['block_json'] ) ) {
+		if ( gutenberg_experimental_get(
+				$supports,
+				array_merge( array( '__experimentalStyles' ) , $path )
+		) ) {
 			$supported_features[] = $style_feature;
 		}
 	}
@@ -405,7 +391,7 @@ function gutenberg_experimental_global_styles_flatten_styles_tree( $styles ) {
 	$result = array();
 
 	foreach ( $mappings as $key => $path ) {
-		$value = gutenberg_experimental_get( $styles, $path['theme_json'], null );
+		$value = gutenberg_experimental_get( $styles, $path, null );
 		if ( null !== $value ) {
 			$result[ $key ] = $value;
 		}

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -16,7 +16,7 @@ function gutenberg_experimental_global_styles_get_mappings() {
 		'background'               => array( 'color', 'gradient' ),
 		'background-color'         => array( 'color', 'background' ),
 		'color'                    => array( 'color', 'text' ),
-		'--wp--style--color--link' => array( 'color', 'link' )
+		'--wp--style--color--link' => array( 'color', 'link' ),
 	);
 }
 
@@ -286,18 +286,15 @@ function gutenberg_experimental_global_styles_get_theme() {
 function gutenberg_experimental_global_styles_get_supported_styles( $supports ) {
 	$mappings = array_merge(
 		gutenberg_experimental_global_styles_get_mappings(),
-		// TODO: remove from here and access directly from lib/blocks.php
+		// TODO: remove from here and access directly from lib/blocks.php.
 		array(
-			'block-align' => array( 'align' )
+			'block-align' => array( 'align' ),
 		)
 	);
 
 	$supported_features = array();
 	foreach ( $mappings as $style_feature => $path ) {
-		if ( gutenberg_experimental_get(
-				$supports,
-				array_merge( array( '__experimentalStyles' ) , $path )
-		) ) {
+		if ( gutenberg_experimental_get( $supports, array_merge( array( '__experimentalStyles' ), $path ) ) ) {
 			$supported_features[] = $style_feature;
 		}
 	}

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -30,7 +30,7 @@ import {
 import { cleanEmptyObject } from './utils';
 import ColorPanel from './color-panel';
 
-export const COLOR_SUPPORT_KEY = '__experimentalColor';
+export const COLOR_SUPPORT_KEY = '__experimentalStyles.color';
 
 const hasColorSupport = ( blockType ) =>
 	Platform.OS === 'web' && hasBlockSupport( blockType, COLOR_SUPPORT_KEY );
@@ -42,7 +42,7 @@ const hasLinkColorSupport = ( blockType ) => {
 
 	const colorSupport = getBlockSupport( blockType, COLOR_SUPPORT_KEY );
 
-	return isObject( colorSupport ) && !! colorSupport.linkColor;
+	return isObject( colorSupport ) && !! colorSupport.link;
 };
 
 const hasGradientSupport = ( blockType ) => {
@@ -52,7 +52,7 @@ const hasGradientSupport = ( blockType ) => {
 
 	const colorSupport = getBlockSupport( blockType, COLOR_SUPPORT_KEY );
 
-	return isObject( colorSupport ) && !! colorSupport.gradients;
+	return isObject( colorSupport ) && !! colorSupport.gradient;
 };
 
 /**

--- a/packages/block-editor/src/hooks/font-size.js
+++ b/packages/block-editor/src/hooks/font-size.js
@@ -18,7 +18,7 @@ import {
 import { cleanEmptyObject } from './utils';
 import { createHigherOrderComponent } from '@wordpress/compose';
 
-export const FONT_SIZE_SUPPORT_KEY = '__experimentalFontSize';
+export const FONT_SIZE_SUPPORT_KEY = '__experimentalStyles.typography.fontSize';
 
 /**
  * Filters registered block settings, extending attributes to include

--- a/packages/block-editor/src/hooks/line-height.js
+++ b/packages/block-editor/src/hooks/line-height.js
@@ -10,7 +10,8 @@ import { useSelect } from '@wordpress/data';
 import LineHeightControl from '../components/line-height-control';
 import { cleanEmptyObject } from './utils';
 
-export const LINE_HEIGHT_SUPPORT_KEY = '__experimentalLineHeight';
+export const LINE_HEIGHT_SUPPORT_KEY =
+	'__experimentalStyles.typography.lineHeight';
 
 /**
  * Inspector control panel containing the line height related configuration

--- a/packages/block-library/src/columns/block.json
+++ b/packages/block-library/src/columns/block.json
@@ -17,6 +17,14 @@
 		"__experimentalColor": {
 			"gradients": true,
 			"linkColor": true
+		},
+		"__experimentalStyles": {
+			"color": {
+				"background": true,
+				"gradient": true,
+				"link": true,
+				"text": true
+			}
 		}
 	}
 }

--- a/packages/block-library/src/columns/block.json
+++ b/packages/block-library/src/columns/block.json
@@ -14,10 +14,6 @@
 		],
 		"html": false,
 		"lightBlockWrapper": true,
-		"__experimentalColor": {
-			"gradients": true,
-			"linkColor": true
-		},
 		"__experimentalStyles": {
 			"color": {
 				"background": true,

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -18,6 +18,14 @@
 		"__experimentalColor": {
 			"gradients": true,
 			"linkColor": true
+		},
+		"__experimentalStyles": {
+			"color": {
+				"background": true,
+				"gradient": true,
+				"link": true,
+				"text": true
+			}
 		}
 	}
 }

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -15,10 +15,6 @@
 		"anchor": true,
 		"html": false,
 		"lightBlockWrapper": true,
-		"__experimentalColor": {
-			"gradients": true,
-			"linkColor": true
-		},
 		"__experimentalStyles": {
 			"color": {
 				"background": true,

--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -36,6 +36,17 @@
 			"core/heading/h5": "h5",
 			"core/heading/h6": "h6"
 		},
+		"__experimentalStyles": {
+			"color": {
+				"background": true,
+				"link": true,
+				"text": true
+			},
+			"typography": {
+				"fontSize": true,
+				"lineHeight": true
+			}
+		},
 		"__unstablePasteTextInline": true
 	}
 }

--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -23,11 +23,6 @@
 		"anchor": true,
 		"className": false,
 		"lightBlockWrapper": true,
-		"__experimentalColor": {
-			"linkColor": true
-		},
-		"__experimentalFontSize": true,
-		"__experimentalLineHeight": true,
 		"__experimentalSelector": {
 			"core/heading/h1": "h1",
 			"core/heading/h2": "h2",

--- a/packages/block-library/src/media-text/block.json
+++ b/packages/block-library/src/media-text/block.json
@@ -85,10 +85,6 @@
 		],
 		"html": false,
 		"lightBlockWrapper": true,
-		"__experimentalColor": {
-			"gradients": true,
-			"linkColor": true
-		},
 		"__experimentalStyles": {
 			"color": {
 				"background": true,

--- a/packages/block-library/src/media-text/block.json
+++ b/packages/block-library/src/media-text/block.json
@@ -88,6 +88,14 @@
 		"__experimentalColor": {
 			"gradients": true,
 			"linkColor": true
+		},
+		"__experimentalStyles": {
+			"color": {
+				"background": true,
+				"gradient": true,
+				"link": true,
+				"text": true
+			}
 		}
 	}
 }

--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -30,11 +30,6 @@
 		"anchor": true,
 		"className": false,
 		"lightBlockWrapper": true,
-		"__experimentalColor": {
-			"linkColor": true
-		},
-		"__experimentalFontSize": true,
-		"__experimentalLineHeight": true,
 		"__experimentalFeatures": {
 			"typography": {
 				"dropCap": true

--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -41,6 +41,17 @@
 			}
 		},
 		"__experimentalSelector": "p",
+		"__experimentalStyles": {
+			"color": {
+				"background": true,
+				"link": true,
+				"text": true
+			},
+			"typography": {
+				"fontSize": true,
+				"lineHeight": true
+			}
+		},
 		"__unstablePasteTextInline": true
 	}
 }

--- a/packages/block-library/src/post-author/block.json
+++ b/packages/block-library/src/post-author/block.json
@@ -32,6 +32,18 @@
 			"gradients": true,
 			"linkColor": true
 		},
-		"__experimentalLineHeight": true
+		"__experimentalLineHeight": true,
+		"__experimentalStyles": {
+			"color": {
+				"background": true,
+				"gradient": true,
+				"link": true,
+				"text": true
+			},
+			"typography": {
+				"fontSize": true,
+				"lineHeight": true
+			}
+		}
 	}
 }

--- a/packages/block-library/src/post-author/block.json
+++ b/packages/block-library/src/post-author/block.json
@@ -27,12 +27,6 @@
 	"supports": {
 		"html": false,
 		"lightBlockWrapper": true,
-		"__experimentalFontSize": true,
-		"__experimentalColor": {
-			"gradients": true,
-			"linkColor": true
-		},
-		"__experimentalLineHeight": true,
 		"__experimentalStyles": {
 			"color": {
 				"background": true,

--- a/packages/block-library/src/post-comments-count/block.json
+++ b/packages/block-library/src/post-comments-count/block.json
@@ -12,11 +12,6 @@
 	"supports": {
 		"html": false,
 		"lightBlockWrapper": true,
-		"__experimentalColor": {
-			"gradients": true
-		},
-		"__experimentalFontSize": true,
-		"__experimentalLineHeight": true,
 		"__experimentalStyles": {
 			"color": {
 				"background": true,

--- a/packages/block-library/src/post-comments-count/block.json
+++ b/packages/block-library/src/post-comments-count/block.json
@@ -16,6 +16,17 @@
 			"gradients": true
 		},
 		"__experimentalFontSize": true,
-		"__experimentalLineHeight": true
+		"__experimentalLineHeight": true,
+		"__experimentalStyles": {
+			"color": {
+				"background": true,
+				"gradient": true,
+				"text": true
+			},
+			"typography": {
+				"fontSize": true,
+				"lineHeight": true
+			}
+		}
 	}
 }

--- a/packages/block-library/src/post-comments-form/block.json
+++ b/packages/block-library/src/post-comments-form/block.json
@@ -18,6 +18,18 @@
 			"linkColor": true
 		},
 		"__experimentalFontSize": true,
-		"__experimentalLineHeight": true
+		"__experimentalLineHeight": true,
+		"__experimentalStyles": {
+			"color": {
+				"background": true,
+				"gradient": true,
+				"link": true,
+				"text": true
+			},
+			"typography": {
+				"fontSize": true,
+				"lineHeight": true
+			}
+		}
 	}
 }

--- a/packages/block-library/src/post-comments-form/block.json
+++ b/packages/block-library/src/post-comments-form/block.json
@@ -13,12 +13,6 @@
 	"supports": {
 		"html": false,
 		"lightBlockWrapper": true,
-		"__experimentalColor": {
-			"gradients": true,
-			"linkColor": true
-		},
-		"__experimentalFontSize": true,
-		"__experimentalLineHeight": true,
 		"__experimentalStyles": {
 			"color": {
 				"background": true,

--- a/packages/block-library/src/post-comments/block.json
+++ b/packages/block-library/src/post-comments/block.json
@@ -17,12 +17,6 @@
 			"wide",
 			"full"
 		],
-		"__experimentalFontSize": true,
-		"__experimentalColor": {
-			"gradients": true,
-			"linkColor": true
-		},
-		"__experimentalLineHeight": true,
 		"__experimentalStyles": {
 			"color": {
 				"background": true,

--- a/packages/block-library/src/post-comments/block.json
+++ b/packages/block-library/src/post-comments/block.json
@@ -22,6 +22,18 @@
 			"gradients": true,
 			"linkColor": true
 		},
-		"__experimentalLineHeight": true
+		"__experimentalLineHeight": true,
+		"__experimentalStyles": {
+			"color": {
+				"background": true,
+				"gradient": true,
+				"link": true,
+				"text": true
+			},
+			"typography": {
+				"fontSize": true,
+				"lineHeight": true
+			}
+		}
 	}
 }

--- a/packages/block-library/src/post-date/block.json
+++ b/packages/block-library/src/post-date/block.json
@@ -20,6 +20,17 @@
 			"gradients": true
 		},
 		"__experimentalFontSize": true,
-		"__experimentalLineHeight": true
+		"__experimentalLineHeight": true,
+		"__experimentalStyles": {
+			"color": {
+				"background": true,
+				"gradient": true,
+				"text": true
+			},
+			"typography": {
+				"fontSize": true,
+				"lineHeight": true
+			}
+		}
 	}
 }

--- a/packages/block-library/src/post-date/block.json
+++ b/packages/block-library/src/post-date/block.json
@@ -16,11 +16,6 @@
 	"supports": {
 		"html": false,
 		"lightBlockWrapper": true,
-		"__experimentalColor": {
-			"gradients": true
-		},
-		"__experimentalFontSize": true,
-		"__experimentalLineHeight": true,
 		"__experimentalStyles": {
 			"color": {
 				"background": true,

--- a/packages/block-library/src/post-excerpt/block.json
+++ b/packages/block-library/src/post-excerpt/block.json
@@ -24,12 +24,6 @@
 	"supports": {
 		"html": false,
 		"lightBlockWrapper": true,
-		"__experimentalFontSize": true,
-		"__experimentalColor": {
-			"gradients": true,
-			"linkColor": true
-		},
-		"__experimentalLineHeight": true,
 		"__experimentalStyles": {
 			"color": {
 				"background": true,

--- a/packages/block-library/src/post-excerpt/block.json
+++ b/packages/block-library/src/post-excerpt/block.json
@@ -29,6 +29,18 @@
 			"gradients": true,
 			"linkColor": true
 		},
-		"__experimentalLineHeight": true
+		"__experimentalLineHeight": true,
+		"__experimentalStyles": {
+			"color": {
+				"background": true,
+				"gradient": true,
+				"link": true,
+				"text": true
+			},
+			"typography": {
+				"fontSize": true,
+				"lineHeight": true
+			}
+		}
 	}
 }

--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -17,11 +17,6 @@
 	"supports": {
 		"html": false,
 		"lightBlockWrapper": true,
-		"__experimentalColor": {
-			"gradients": true
-		},
-		"__experimentalFontSize": true,
-		"__experimentalLineHeight": true,
 		"__experimentalSelector": {
 			"core/post-title/h1": "h1",
 			"core/post-title/h2": "h2",

--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -30,6 +30,17 @@
 			"core/post-title/h5": "h5",
 			"core/post-title/h6": "h6",
 			"core/post-title/p": "p"
+		},
+		"__experimentalStyles": {
+			"color": {
+				"background": true,
+				"gradient": true,
+				"text": true
+			},
+			"typography": {
+				"fontSize": true,
+				"lineHeight": true
+			}
 		}
 	}
 }

--- a/packages/block-library/src/site-tagline/block.json
+++ b/packages/block-library/src/site-tagline/block.json
@@ -9,11 +9,6 @@
 	"supports": {
 		"html": false,
 		"lightBlockWrapper": true,
-		"__experimentalColor": {
-			"gradients": true
-		},
-		"__experimentalFontSize": true,
-		"__experimentalLineHeight": true,
 		"__experimentalStyles": {
 			"color": {
 				"background": true,

--- a/packages/block-library/src/site-tagline/block.json
+++ b/packages/block-library/src/site-tagline/block.json
@@ -13,6 +13,17 @@
 			"gradients": true
 		},
 		"__experimentalFontSize": true,
-		"__experimentalLineHeight": true
+		"__experimentalLineHeight": true,
+		"__experimentalStyles": {
+			"color": {
+				"background": true,
+				"gradient": true,
+				"text": true
+			},
+			"typography": {
+				"fontSize": true,
+				"lineHeight": true
+			}
+		}
 	}
 }

--- a/packages/block-library/src/site-title/block.json
+++ b/packages/block-library/src/site-title/block.json
@@ -13,11 +13,6 @@
 	"supports": {
 		"html": false,
 		"lightBlockWrapper": true,
-		"__experimentalColor": {
-			"gradients": true
-		},
-		"__experimentalFontSize": true,
-		"__experimentalLineHeight": true,
 		"__experimentalStyles": {
 			"color": {
 				"background": true,

--- a/packages/block-library/src/site-title/block.json
+++ b/packages/block-library/src/site-title/block.json
@@ -17,6 +17,17 @@
 			"gradients": true
 		},
 		"__experimentalFontSize": true,
-		"__experimentalLineHeight": true
+		"__experimentalLineHeight": true,
+		"__experimentalStyles": {
+			"color": {
+				"background": true,
+				"gradient": true,
+				"text": true
+			},
+			"typography": {
+				"fontSize": true,
+				"lineHeight": true
+			}
+		}
 	}
 }

--- a/phpunit/class-block-supported-styles-test.php
+++ b/phpunit/class-block-supported-styles-test.php
@@ -99,7 +99,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 					'color' => array(
 						'background' => true,
 						'text'       => true,
-					)
+					),
 				),
 			),
 			'render_callback' => true,
@@ -136,7 +136,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 					'color' => array(
 						'background' => true,
 						'text'       => true,
-					)
+					),
 				),
 			),
 			'render_callback' => true,
@@ -179,7 +179,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 						'background' => true,
 						'link'       => true,
 						'text'       => true,
-					)
+					),
 				),
 			),
 			'render_callback' => true,
@@ -214,7 +214,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 						'background' => true,
 						'link'       => true,
 						'text'       => true,
-					)
+					),
 				),
 			),
 			'render_callback' => true,
@@ -249,7 +249,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 						'background' => true,
 						'gradient'   => true,
 						'text'       => true,
-					)
+					),
 				),
 			),
 			'render_callback' => true,
@@ -284,7 +284,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 						'background' => true,
 						'gradient'   => true,
 						'text'       => true,
-					)
+					),
 				),
 			),
 			'render_callback' => true,
@@ -352,7 +352,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 			'supports'        => array(
 				'__experimentalStyles' => array(
 					'typography' => array(
-						'fontSize' => true
+						'fontSize' => true,
 					),
 				),
 			),
@@ -385,7 +385,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 			'supports'        => array(
 				'__experimentalStyles' => array(
 					'typography' => array(
-						'fontSize' => true
+						'fontSize' => true,
 					),
 				),
 			),
@@ -446,7 +446,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 			'supports'        => array(
 				'__experimentalStyles' => array(
 					'typography' => array(
-						'lineHeight' => true
+						'lineHeight' => true,
 					),
 				),
 			),
@@ -563,14 +563,14 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 				'__experimentalStyles' => array(
 					'color'      => array(
 						'gradient' => true,
-						'link' => true,
+						'link'     => true,
 					),
 					'typography' => array(
 						'fontSize'   => true,
 						'lineHeight' => true,
 					),
 				),
-				'align'                    => true,
+				'align'                => true,
 			),
 			'render_callback' => true,
 		);
@@ -614,7 +614,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 			'supports'        => array(
 				'__experimentalStyles' => array(
 					'typography' => array(
-						'fontSize' => true
+						'fontSize' => true,
 					),
 				),
 			),
@@ -657,7 +657,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$block_type_settings = array(
 			'attributes' => array(),
 			'supports'   => array(
-				'align'                    => true,
+				'align'                => true,
 				'__experimentalStyles' => array(
 					'color'      => array(
 						'gradient' => true,

--- a/phpunit/class-block-supported-styles-test.php
+++ b/phpunit/class-block-supported-styles-test.php
@@ -95,7 +95,12 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$block_type_settings = array(
 			'attributes'      => array(),
 			'supports'        => array(
-				'__experimentalColor' => true,
+				'__experimentalStyles' => array(
+					'color' => array(
+						'background' => true,
+						'text'       => true,
+					)
+				),
 			),
 			'render_callback' => true,
 		);
@@ -127,7 +132,12 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$block_type_settings = array(
 			'attributes'      => array(),
 			'supports'        => array(
-				'__experimentalColor' => true,
+				'__experimentalStyles' => array(
+					'color' => array(
+						'background' => true,
+						'text'       => true,
+					)
+				),
 			),
 			'render_callback' => true,
 		);
@@ -164,8 +174,12 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$block_type_settings = array(
 			'attributes'      => array(),
 			'supports'        => array(
-				'__experimentalColor' => array(
-					'linkColor' => true,
+				'__experimentalStyles' => array(
+					'color' => array(
+						'background' => true,
+						'link'       => true,
+						'text'       => true,
+					)
 				),
 			),
 			'render_callback' => true,
@@ -195,8 +209,12 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$block_type_settings = array(
 			'attributes'      => array(),
 			'supports'        => array(
-				'__experimentalColor' => array(
-					'linkColor' => true,
+				'__experimentalStyles' => array(
+					'color' => array(
+						'background' => true,
+						'link'       => true,
+						'text'       => true,
+					)
 				),
 			),
 			'render_callback' => true,
@@ -226,8 +244,12 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$block_type_settings = array(
 			'attributes'      => array(),
 			'supports'        => array(
-				'__experimentalColor' => array(
-					'gradients' => true,
+				'__experimentalStyles' => array(
+					'color' => array(
+						'background' => true,
+						'gradient'   => true,
+						'text'       => true,
+					)
 				),
 			),
 			'render_callback' => true,
@@ -257,8 +279,12 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$block_type_settings = array(
 			'attributes'      => array(),
 			'supports'        => array(
-				'__experimentalColor' => array(
-					'gradients' => true,
+				'__experimentalStyles' => array(
+					'color' => array(
+						'background' => true,
+						'gradient'   => true,
+						'text'       => true,
+					)
 				),
 			),
 			'render_callback' => true,
@@ -324,7 +350,11 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$block_type_settings = array(
 			'attributes'      => array(),
 			'supports'        => array(
-				'__experimentalFontSize' => true,
+				'__experimentalStyles' => array(
+					'typography' => array(
+						'fontSize' => true
+					),
+				),
 			),
 			'render_callback' => true,
 		);
@@ -353,7 +383,11 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$block_type_settings = array(
 			'attributes'      => array(),
 			'supports'        => array(
-				'__experimentalFontSize' => true,
+				'__experimentalStyles' => array(
+					'typography' => array(
+						'fontSize' => true
+					),
+				),
 			),
 			'render_callback' => true,
 		);
@@ -410,7 +444,11 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$block_type_settings = array(
 			'attributes'      => array(),
 			'supports'        => array(
-				'__experimentalLineHeight' => true,
+				'__experimentalStyles' => array(
+					'typography' => array(
+						'lineHeight' => true
+					),
+				),
 			),
 			'render_callback' => true,
 		);
@@ -522,12 +560,16 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$block_type_settings = array(
 			'attributes'      => array(),
 			'supports'        => array(
-				'__experimentalColor'      => array(
-					'gradients' => true,
-					'linkColor' => true,
+				'__experimentalStyles' => array(
+					'color'      => array(
+						'gradient' => true,
+						'link' => true,
+					),
+					'typography' => array(
+						'fontSize'   => true,
+						'lineHeight' => true,
+					),
 				),
-				'__experimentalFontSize'   => true,
-				'__experimentalLineHeight' => true,
 				'align'                    => true,
 			),
 			'render_callback' => true,
@@ -570,7 +612,11 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$block_type_settings = array(
 			'attributes'      => array(),
 			'supports'        => array(
-				'__experimentalFontSize' => true,
+				'__experimentalStyles' => array(
+					'typography' => array(
+						'fontSize' => true
+					),
+				),
 			),
 			'render_callback' => true,
 		);
@@ -612,12 +658,16 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 			'attributes' => array(),
 			'supports'   => array(
 				'align'                    => true,
-				'__experimentalColor'      => array(
-					'gradients' => true,
-					'linkColor' => true,
+				'__experimentalStyles' => array(
+					'color'      => array(
+						'gradient' => true,
+						'link'     => true,
+					),
+					'typography' => array(
+						'fontSize'   => true,
+						'lineHeight' => true,
+					),
 				),
-				'__experimentalFontSize'   => true,
-				'__experimentalLineHeight' => true,
 			),
 		);
 		$this->register_block_type( 'core/example', $block_type_settings );


### PR DESCRIPTION
Follow-up to this conversation https://github.com/WordPress/gutenberg/pull/24298#discussion_r463160267

The way we declared the style properties within block.json's supports key was inconsistent with how the properties were stored in the theme.json and the block attributes, which followed [the theme.json specification](https://developer.wordpress.org/block-editor/developers/themes/theme-json/).
