### PR TITLE
Button Block: Use relative instead of absolute units

### DIFF
--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -1,4 +1,4 @@
-$blocks-button__height: 56px;
+$blocks-button__height: 3.1em;
 
 // Prefer the link selector instead of the regular button classname
 // to support the previous markup in addition to the new one.
@@ -10,8 +10,8 @@ $blocks-button__height: 56px;
 	box-shadow: none;
 	cursor: pointer;
 	display: inline-block;
-	font-size: $big-font-size;
-	padding: 12px 24px;
+	font-size: 1.125em;
+	padding: 0.67em 1.33em;
 	text-align: center;
 	text-decoration: none;
 	overflow-wrap: break-word;


### PR DESCRIPTION
Right now, the button block has these styles:

```css
.wp-block-button__link {
	border-radius: 28px;
	font-size: 18px;
	padding: 12px 24px;
}
```

These styles don't scale to their surrounding text or theme by default.
I propose we change these to use relative units. The result will be buttons that can auto-scale to automatically use sizes relative to their location and context.

Default browser font-size is `16px` so all calculations here were done using that as a base.

