### PR TITLE
Docs: Indicate custom-fields support is required for registering meta

### DIFF
--- a/docs/designers-developers/developers/tutorials/metabox/meta-block-2-register-meta.md
+++ b/docs/designers-developers/developers/tutorials/metabox/meta-block-2-register-meta.md
@@ -35,3 +35,4 @@ register_post_meta( 'post', '_myguten_protected_key', array(
 	}
 ) );
 ```
+**Note:** Your post type needs to support `custom-fields` for `register_post_meta` function to work.

--- a/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-3-register-meta.md
+++ b/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-3-register-meta.md
@@ -19,3 +19,5 @@ wp.data.select( 'core/editor' ).getCurrentPost().meta;
 ```
 
 Before adding the `register_post_meta` function to the plugin, this code returns a void array, because WordPress hasn't been told to load any meta field yet. After registering the field, the same code will return an object containing the registered meta field you registered.
+
+If the code returns `undefined` make sure your post type supports `custom-fields`. Either when [registering the post](https://developer.wordpress.org/reference/functions/register_post_type/#supports) or with [add_post_type_support function](https://developer.wordpress.org/reference/functions/add_post_type_support/).


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Added documentation to explicitly indicate that `custom-fields` support is required to use `register_post_meta`.

## How has this been tested?
Looked at the rendering on markdown.

## Screenshots <!-- if applicable -->

## Types of changes
Added some footnotes in markdown.

## Checklist:
- [x] My code is tested.
- [x] ~My code follows the WordPress code style.~ <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] ~My code follows the accessibility standards.~ <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] ~My code has proper inline documentation.~ <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] ~I've updated all React Native files affected by any refactorings/renamings in this PR.~ <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
