### PR TITLE
Paragraph block: Use relative instead of absolute units

### DIFF
--- a/packages/block-library/src/paragraph/style.scss
+++ b/packages/block-library/src/paragraph/style.scss
@@ -1,17 +1,17 @@
 .is-small-text {
-	font-size: 14px;
+	font-size: 0.875rem;
 }
 
 .is-regular-text {
-	font-size: 16px;
+	font-size: 1rem;
 }
 
 .is-large-text {
-	font-size: 36px;
+	font-size: 2.25rem;
 }
 
 .is-larger-text {
-	font-size: 48px;
+	font-size: 3rem;
 }
 
 // Don't show the drop cap when editing the paragraph's content. It causes a
@@ -29,7 +29,7 @@
 }
 
 p.has-background {
-	padding: $block-bg-padding--v $block-bg-padding--h;
+	padding: 1.25em 2.375em;
 }
 
 p.has-text-color a {


### PR DESCRIPTION
This PR converts the paragraph block to use `rem` values instead of `px`.
This will provide better compatibility with themes that use a different base font-size, as lately we're seeing a tendency to use a base font-size of 20px+.
With these changes in place, themes won't need to rewrite all CSS and can just use what's provided by core.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] ~My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->~  (Not applicable)
- [x] ~I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->~  (Not applicable)
- [x] ~I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->~  (Not applicable)