### PR TITLE
Add arrow navigation to Warning dropdown menu

### DIFF
--- a/packages/block-editor/src/components/warning/index.js
+++ b/packages/block-editor/src/components/warning/index.js
@@ -7,9 +7,14 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { Children } from '@wordpress/element';
-import { Dropdown, Button, MenuGroup, MenuItem } from '@wordpress/components';
+import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { moreHorizontal } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import BlockIcon from '../block-icon';
 
 function Warning( { className, actions, children, secondaryActions } ) {
 	return (
@@ -29,19 +34,16 @@ function Warning( { className, actions, children, secondaryActions } ) {
 								</span>
 							) ) }
 						{ secondaryActions && (
-							<Dropdown
+							<DropdownMenu
 								className="block-editor-warning__secondary"
-								contentClassName="block-editor-warning__dropdown"
-								position="bottom left"
-								renderToggle={ ( { isOpen, onToggle } ) => (
-									<Button
-										icon={ moreHorizontal }
-										label={ __( 'More options' ) }
-										onClick={ onToggle }
-										aria-expanded={ isOpen }
-									/>
-								) }
-								renderContent={ () => (
+								icon={ <BlockIcon icon={ moreHorizontal } /> }
+								label={ __( 'More options' ) }
+								popoverProps={ {
+									position: 'bottom left',
+									className: 'block-editor-warning__dropdown',
+								} }
+							>
+								{ () => (
 									<MenuGroup>
 										{ secondaryActions.map(
 											( item, pos ) => (
@@ -55,7 +57,7 @@ function Warning( { className, actions, children, secondaryActions } ) {
 										) }
 									</MenuGroup>
 								) }
-							/>
+							</DropdownMenu>
 						) }
 					</div>
 				) }

--- a/packages/block-editor/src/components/warning/index.js
+++ b/packages/block-editor/src/components/warning/index.js
@@ -11,11 +11,6 @@ import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { moreHorizontal } from '@wordpress/icons';
 
-/**
- * Internal dependencies
- */
-import BlockIcon from '../block-icon';
-
 function Warning( { className, actions, children, secondaryActions } ) {
 	return (
 		<div className={ classnames( className, 'block-editor-warning' ) }>
@@ -36,7 +31,7 @@ function Warning( { className, actions, children, secondaryActions } ) {
 						{ secondaryActions && (
 							<DropdownMenu
 								className="block-editor-warning__secondary"
-								icon={ <BlockIcon icon={ moreHorizontal } /> }
+								icon={ moreHorizontal }
 								label={ __( 'More options' ) }
 								popoverProps={ {
 									position: 'bottom left',

--- a/packages/block-editor/src/components/warning/index.js
+++ b/packages/block-editor/src/components/warning/index.js
@@ -37,6 +37,7 @@ function Warning( { className, actions, children, secondaryActions } ) {
 									position: 'bottom left',
 									className: 'block-editor-warning__dropdown',
 								} }
+								noIcons
 							>
 								{ () => (
 									<MenuGroup>

--- a/packages/block-editor/src/components/warning/style.scss
+++ b/packages/block-editor/src/components/warning/style.scss
@@ -50,4 +50,7 @@
 	// Set z-index as if it's displayed on the bottom, otherwise the modal
 	// dialog popover might overlap if displayed on the bottom.
 	z-index: z-index(".components-popover.block-editor-warning__dropdown");
+	.components-menu-item__button {
+		padding: 6px 12px;
+	}
 }

--- a/packages/block-editor/src/components/warning/style.scss
+++ b/packages/block-editor/src/components/warning/style.scss
@@ -50,7 +50,4 @@
 	// Set z-index as if it's displayed on the bottom, otherwise the modal
 	// dialog popover might overlap if displayed on the bottom.
 	z-index: z-index(".components-popover.block-editor-warning__dropdown");
-	.components-menu-item__button {
-		padding: 6px 12px;
-	}
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Fixes: https://github.com/WordPress/gutenberg/issues/24303

This PR refactors `Warning` component to use `DropdownMenu` instead of `Dropdown` to enable arrow navigation in its secondary menu.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
