### PR TITLE
[RNMobile] E2E Android - Use swipe gesture to scroll inserter menu

### DIFF
--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -446,10 +446,19 @@ const swipeUp = async ( driver, element = undefined ) => {
 	const endX = startX;
 	const endY = startY + startY * -1 * 0.5;
 
+	await swipeFromTo( driver, { x: startX, y: startY }, { x: endX, y: endY } );
+};
+
+const defaultCoordinates = { x: 0, y: 0 };
+const swipeFromTo = async (
+	driver,
+	from = defaultCoordinates,
+	to = defaultCoordinates
+) => {
 	const action = await new wd.TouchAction( driver );
-	action.press( { x: startX, y: startY } );
+	action.press( from );
 	action.wait( 3000 );
-	action.moveTo( { x: endX, y: endY } );
+	action.moveTo( to );
 	action.release();
 	await action.perform();
 };
@@ -464,12 +473,7 @@ const swipeDown = async ( driver ) => {
 	const endX = startX;
 	const endY = startY - startY * -1 * 0.5;
 
-	const action = await new wd.TouchAction( driver );
-	action.press( { x: startX, y: startY } );
-	action.wait( 3000 );
-	action.moveTo( { x: endX, y: endY } );
-	action.release();
-	await action.perform();
+	await swipeFromTo( driver, { x: startX, y: startY }, { x: endX, y: endY } );
 };
 
 const toggleHtmlMode = async ( driver, toggleOn ) => {
@@ -526,6 +530,7 @@ module.exports = {
 	tapPasteAboveElement,
 	swipeDown,
 	swipeUp,
+	swipeFromTo,
 	stopDriver,
 	toggleHtmlMode,
 	toggleOrientation,

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -7,6 +7,7 @@ import {
 	swipeDown,
 	typeString,
 	toggleHtmlMode,
+	swipeFromTo,
 } from '../helpers/utils';
 
 export default class EditorPage {
@@ -197,11 +198,17 @@ export default class EditorPage {
 	// Attempts to find the given block button in the block inserter control.
 	async findBlockButton( blockName ) {
 		if ( isAndroid() ) {
+			const size = await this.driver.getWindowSize();
+			const x = size.width / 2;
 			// Checks if the Block Button is available, and if not will scroll to the second half of the available buttons.
 			while (
 				! ( await this.driver.hasElementByAccessibilityId( blockName ) )
 			) {
-				await this.driver.pressKeycode( 20 ); // Press the Down arrow to force a scroll.
+				swipeFromTo(
+					this.driver,
+					{ x, y: size.height - 100 },
+					{ x, y: size.height - 450 }
+				);
 			}
 
 			return await this.driver.elementByAccessibilityId( blockName );


### PR DESCRIPTION
## Description
Gutenberg-mobile PR https://github.com/wordpress-mobile/gutenberg-mobile/pull/2527
Fixes Failing CI e2e test on `gutenberg-mobile` repo. Android e2e tests started failing after removing the scroll view from the inserter menu. I couldn't reproduce it on my side but I could fix that by using swipe gesture instead of sending the keycode 20 (arrow down).
I created the same Simulator as on Sauce Labs, used the same version of Appium and tests were passing on my side. I also tried to send locally keyevent by  `adb shell input keyevent 20` and that also works. However, I used the mechanism from here https://github.com/WordPress/gutenberg/pull/24338/files#diff-34060c7868e5c5d05b0a7f37b80fd440R453 that simulates the swipe gesture and tests pass. 

## How has this been tested?
- Green e2e tests locally
- Green CI tests here (https://github.com/wordpress-mobile/gutenberg-mobile/pull/2527/commits/71838fafda79da6a5095bf6ac172630045724534) - I removed the canary test pattern for a while just to test

## Types of changes
Use swipe gestures in e2e tests to scroll the inserter menu.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
