### PR TITLE
Spacer block: Reduce minimum height to 5px

### DIFF
--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -13,7 +13,7 @@ import { compose, withInstanceId } from '@wordpress/compose';
 import { withDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 
-const MIN_SPACER_HEIGHT = 20;
+const MIN_SPACER_HEIGHT = 5;
 const MAX_SPACER_HEIGHT = 500;
 
 const SpacerEdit = ( {


### PR DESCRIPTION
## Description
Fixes #18906 
This PR reduces the minimum height of the Spacer block to 5px instead of 20px. 

There's been some feedback that a minimum height of 20px was too big and felt much like a bug. I agree it doesn't allow for the precise adjustments a user might like when building their layout. For this reason, I've created this PR to fiddle with and see if a minimum of 5px feels better. It is still selectable with the mouse albeit the click space is much smaller now. And it no longer aligns with the height of the Separator block either. But dang, I like being able to go smaller with this block! 😉 

cc @designsimply 

## How has this been tested?
Tested locally.

## Screenshots 

![spacer](https://user-images.githubusercontent.com/617986/89231961-43102480-d59b-11ea-9a6a-a041e8d300e7.gif)


## Types of changes
Non-breaking changes.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
