### PR TITLE
Image Editing: Fix alignment of aspect-ratio button

### DIFF
--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -107,7 +107,6 @@ figure.wp-block-image:not(.wp-block) {
 
 .wp-block-image__aspect-ratio {
 	height: $grid-unit-60 - $border-width - $border-width;
-	margin-top: -$grid-unit-10;
 	margin-bottom: -$grid-unit-10;
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
## Description
The "aspect ratio" button in the inline image editing toolbar is misaligned. This fixes the alignment by removing the negative top margin.

## How has this been tested?
Browser tested in chrome & firefox, used browserstack to check on Edge.

## Screenshots <!-- if applicable -->

| Before | After |
|--------|-------|
| ![Screen Shot 2020-08-03 at 6 05 44 PM](https://user-images.githubusercontent.com/541093/89232591-c0489300-d5b5-11ea-8d90-30816c16d664.png) | ![Screen Shot 2020-08-03 at 6 19 57 PM](https://user-images.githubusercontent.com/541093/89232689-f128c800-d5b5-11ea-872f-028b1ff24e1f.png) |
| ![Screen Shot 2020-08-03 at 6 07 10 PM](https://user-images.githubusercontent.com/541093/89232650-de15f800-d5b5-11ea-974c-b9c572c9b724.png) | ![Screen Shot 2020-08-03 at 6 07 27 PM](https://user-images.githubusercontent.com/541093/89232636-d9514400-d5b5-11ea-81f2-b67d4706a411.png)

## Types of changes
Bug fix (non-breaking change which fixes an issue)
