### PR TITLE
Fix block movers overlapping

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -572,11 +572,13 @@
 		.components-button.has-icon.block-editor-block-mover-button.block-editor-block-mover-button {
 			min-width: $button-size;
 			width: $button-size;
+			overflow: hidden;
 		}
 
 		&.is-horizontal .components-button.has-icon.block-editor-block-mover-button.block-editor-block-mover-button {
 			min-width: $block-toolbar-height/2;
 			width: $block-toolbar-height/2;
+			overflow: hidden;
 		}
 	}
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes: https://github.com/WordPress/gutenberg/issues/23983
<!-- Please describe what you have changed or added -->
More often than not, when attempting to move a block up by clicking on the Up arrow it moves the other way.

This is caused by overlapping `move icons` svg and is fixed in this PR.

Before:
<img width="413" alt="Screenshot 2020-08-04 at 11 50 51 AM" src="https://user-images.githubusercontent.com/16275880/89275310-c8064700-d64a-11ea-819e-07ede9fbcb38.png">

After:
<img width="413" alt="Screenshot 2020-08-04 at 11 52 07 AM" src="https://user-images.githubusercontent.com/16275880/89275272-b755d100-d64a-11ea-974a-434774e507bc.png">


## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
