### PR TITLE
Set autosaveInterval to 1 on mobile

### DIFF
--- a/packages/editor/src/store/reducer.native.js
+++ b/packages/editor/src/store/reducer.native.js
@@ -26,7 +26,7 @@ import {
 
 import { EDITOR_SETTINGS_DEFAULTS } from './defaults.js';
 
-EDITOR_SETTINGS_DEFAULTS.autosaveInterval = 0; // This is a way to override default behavior on mobile, and make it ping the native save at each keystroke
+EDITOR_SETTINGS_DEFAULTS.autosaveInterval = 1; // This is a way to override default behavior on mobile, and make it ping the native save every second as long as something changed
 
 export * from './reducer.js';
 


### PR DESCRIPTION
#23962 changed the way AutosaveMonitor works, which combined with the `0` override in react native config caused a high CPU usage in mobile apps. This PR changes the native autosaveInterval to `1` which closely mimics the old behavior.
