### PR TITLE
Try: contenteditable background highlight.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -50,8 +50,7 @@
 	// Navigate mode & Focused wrapper.
 	// We're using a pseudo element to overflow placeholder borders
 	// and any border inside the block itself.
-	&:not([contenteditable]):focus {
-		outline: none;
+	&:not([contenteditable]) {
 
 		&::after {
 			position: absolute;
@@ -63,13 +62,67 @@
 			left: $border-width;
 			right: $border-width;
 
-			// 2px outside.
+			// Animate.
+			opacity: 0;
+			transition: opacity 0.2s ease-out;
+			@include reduce-motion("transition");
+
+			// Show border outside.
 			box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color);
 			border-radius: $radius-block-ui - $border-width; // Border is outset, so so subtract the width to achieve correct radius.
 
 			// Show a light color for dark themes.
 			.is-dark-theme & {
 				box-shadow: 0 0 0 $border-width-focus $dark-theme-focus;
+			}
+		}
+
+		&:focus {
+			outline: none;
+
+			&::after {
+				opacity: 1;
+			}
+		}
+	}
+
+	// Use "before" to not conflict with the selected block indication.
+	&[contenteditable]:not(.is-typing):not(.is-highlighted) {
+		&::before {
+			position: absolute;
+			z-index: 1;
+			pointer-events: none;
+			content: "";
+
+			// Animate.
+			opacity: 0;
+			transition: all 0.2s ease-out;
+			@include reduce-motion("transition");
+
+			// Position the element.
+			top: 0;
+			bottom: 0;
+			left: 0;
+			right: 0;
+
+			// Draw the corners using a gradient.
+			background-color: rgba($black, 0.05);
+			border-radius: $radius-block-ui;
+
+			// Show a light color for dark themes.
+			.is-dark-theme & {
+				background-color: rgba($white, 0.2);
+			}
+
+			// Windows High Contrast mode.
+			outline: 1px solid transparent;
+		}
+
+		&:focus {
+			outline: none;
+
+			&::before {
+				opacity: 1;
 			}
 		}
 	}
@@ -127,7 +180,6 @@
 	.is-navigate-mode & .block-editor-block-list__block.is-hovered,
 	.block-editor-block-list__block.is-highlighted,
 	.block-editor-block-list__block.is-multi-selected {
-
 		// Show selection borders around every non-nested block's actual footprint.
 		&::after {
 			position: absolute;
@@ -138,6 +190,7 @@
 			bottom: $border-width;
 			left: $border-width;
 			right: $border-width;
+			opacity: 1;
 		}
 
 		&::after { // Everything else.

--- a/packages/block-editor/src/components/default-block-appender/style.scss
+++ b/packages/block-editor/src/components/default-block-appender/style.scss
@@ -57,6 +57,8 @@
 	position: absolute;
 	top: 0;
 	height: $button-size-small + $grid-unit-10;
+	display: flex;
+	align-items: center;
 
 	.block-editor-inserter__toggle {
 		margin-right: 0;

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -9,7 +9,7 @@ $block-inserter-tabs-height: 44px;
 	padding: 0;
 	font-family: $default-font;
 	font-size: $default-font-size;
-	line-height: $default-line-height;
+	line-height: 0;
 
 	@include break-medium {
 		position: relative;


### PR DESCRIPTION
This PR adds a background color to a contenteditable text block (such as Paragraph or Heading) to indicate focus. This is separate from the selection indication (press Escape to select at the block level).

GIFs after this, but please also try out this branch, as the GIF compression do not correctly capture the colors. 

In light themes (default):

![light themes](https://user-images.githubusercontent.com/1204802/89304540-d6b22580-d66d-11ea-938f-75ee5ebaa518.gif)

In [dark themes](https://developer.wordpress.org/block-editor/developers/themes/theme-support/#dark-backgrounds): 

![dark themes](https://user-images.githubusercontent.com/1204802/89304627-f0ec0380-d66d-11ea-9e62-0be07d728bb1.gif)
