### PR TITLE
Docs: Add instructions for disabling the Block Directory

### DIFF
--- a/docs/designers-developers/developers/filters/editor-filters.md
+++ b/docs/designers-developers/developers/filters/editor-filters.md
@@ -50,3 +50,17 @@ It is set by default to the return value of the [`user_can_richedit`](https://de
 Default `true`. Indicates whether the user can access the code editor **in addition** to the visual editor.
 
 If set to false the user will not be able to switch between visual and code editor. The option in the settings menu will not be available and the keyboard shortcut for switching editor types will not fire.  
+
+### Block Directory
+
+The Block Directory enables installing new block plugins from [WordPress.org.](https://wordpress.org/plugins/browse/block/) It can be disabled by removing the actions that enqueue it. In WordPress core, the function is `wp_enqueue_editor_block_directory_assets`, and Gutenberg uses `gutenberg_enqueue_block_editor_assets_block_directory`. To remove the feature, use [`remove_action`,](https://developer.wordpress.org/reference/functions/remove_action/) like this:
+
+```php
+add_action(
+	'plugins_loaded',
+	function() {
+		remove_action( 'enqueue_block_editor_assets', 'wp_enqueue_editor_block_directory_assets' );
+		remove_action( 'enqueue_block_editor_assets', 'gutenberg_enqueue_block_editor_assets_block_directory' );
+	}
+);
+```


### PR DESCRIPTION
## Description
Now that we have a way to disable the Block Directory, we should document it. See https://github.com/WordPress/gutenberg/issues/23961#issuecomment-667915712 This PR adds a section into the Editor Filters section, with example code to remove the Block Directory. Looking at other docs, this _seems_ to be the best place for it, but I'm open to moving it if there's somewhere better.

Closes https://github.com/WordPress/gutenberg/issues/23961

## How has this been tested?
View the documentation at [docs/designers-developers/developers/filters/editor-filters.md](https://github.com/WordPress/gutenberg/blob/6ddbcbdb0383ccc13d17ae4f72f933a9bccce069/docs/designers-developers/developers/filters/editor-filters.md#block-directory)

## Types of changes
Documentation
