### PR TITLE
WIP: Show sibling inserter on hover

### DIFF
--- a/packages/block-editor/src/components/block-list/insertion-point.js
+++ b/packages/block-editor/src/components/block-list/insertion-point.js
@@ -135,73 +135,92 @@ export default function InsertionPoint( { children, containerRef } ) {
 	const [ isInserterShown, setIsInserterShown ] = useState( false );
 	const [ isInserterForced, setIsInserterForced ] = useState( false );
 	const [ inserterClientId, setInserterClientId ] = useState( null );
-	const { isMultiSelecting, isInserterVisible, selectedClientId } = useSelect(
-		( select ) => {
-			const {
-				isMultiSelecting: _isMultiSelecting,
-				isBlockInsertionPointVisible,
-				getBlockInsertionPoint,
-				getBlockOrder,
-			} = select( 'core/block-editor' );
+	const {
+		isMultiSelecting,
+		isInserterVisible,
+		selectedClientId,
+		blockOrder,
+	} = useSelect( ( select ) => {
+		const {
+			isMultiSelecting: _isMultiSelecting,
+			isBlockInsertionPointVisible,
+			getBlockInsertionPoint,
+			getBlockOrder,
+		} = select( 'core/block-editor' );
 
-			const insertionPoint = getBlockInsertionPoint();
-			const order = getBlockOrder( insertionPoint.rootClientId );
+		const insertionPoint = getBlockInsertionPoint();
+		const order = getBlockOrder( insertionPoint.rootClientId );
 
-			return {
-				isMultiSelecting: _isMultiSelecting(),
-				isInserterVisible: isBlockInsertionPointVisible(),
-				selectedClientId: order[ insertionPoint.index ],
-			};
-		},
-		[]
-	);
+		return {
+			isMultiSelecting: _isMultiSelecting(),
+			isInserterVisible: isBlockInsertionPointVisible(),
+			selectedClientId: order[ insertionPoint.index ],
+			blockOrder: order,
+		};
+	}, [] );
+
+	// function onMouseMove( event ) {
+	// 	if (
+	// 		! event.target.classList.contains(
+	// 			'block-editor-block-list__layout'
+	// 		)
+	// 	) {
+	// 		if ( isInserterShown ) {
+	// 			setIsInserterShown( false );
+	// 		}
+	// 		return;
+	// 	}
+	//
+	// 	const rect = event.target.getBoundingClientRect();
+	// 	const offset = event.clientY - rect.top;
+	// 	const element = Array.from( event.target.children ).find(
+	// 		( blockEl ) => {
+	// 			return blockEl.offsetTop > offset;
+	// 		}
+	// 	);
+	//
+	// 	if ( ! element ) {
+	// 		return;
+	// 	}
+	//
+	// 	const clientId = element.id.slice( 'block-'.length );
+	//
+	// 	if ( ! clientId ) {
+	// 		return;
+	// 	}
+	//
+	// 	const elementRect = element.getBoundingClientRect();
+	//
+	// 	if (
+	// 		event.clientX > elementRect.right ||
+	// 		event.clientX < elementRect.left
+	// 	) {
+	// 		if ( isInserterShown ) {
+	// 			setIsInserterShown( false );
+	// 		}
+	// 		return;
+	// 	}
+	//
+	// 	setIsInserterShown( true );
+	// 	setInserterClientId( clientId );
+	// }
 
 	function onMouseMove( event ) {
-		if (
-			! event.target.classList.contains(
-				'block-editor-block-list__layout'
-			)
-		) {
-			if ( isInserterShown ) {
-				setIsInserterShown( false );
-			}
+		const clientId = event.target.id.slice( 'block-'.length );
+		const index = blockOrder.findIndex( ( id ) => id === clientId );
+
+		// when there is no match return
+		if ( index === -1 ) {
+			setIsInserterShown( false );
 			return;
 		}
 
-		const rect = event.target.getBoundingClientRect();
-		const offset = event.clientY - rect.top;
-		const element = Array.from( event.target.children ).find(
-			( blockEl ) => {
-				return blockEl.offsetTop > offset;
-			}
-		);
-
-		if ( ! element ) {
-			return;
+		// first element should show only bottom inserter
+		if ( index >= 0 ) {
+			setIsInserterShown( true );
+			setInserterClientId( clientId );
 		}
-
-		const clientId = element.id.slice( 'block-'.length );
-
-		if ( ! clientId ) {
-			return;
-		}
-
-		const elementRect = element.getBoundingClientRect();
-
-		if (
-			event.clientX > elementRect.right ||
-			event.clientX < elementRect.left
-		) {
-			if ( isInserterShown ) {
-				setIsInserterShown( false );
-			}
-			return;
-		}
-
-		setIsInserterShown( true );
-		setInserterClientId( clientId );
 	}
-
 	const isVisible = isInserterShown || isInserterForced || isInserterVisible;
 
 	return (
@@ -218,15 +237,7 @@ export default function InsertionPoint( { children, containerRef } ) {
 					showInsertionPoint={ isInserterVisible }
 				/>
 			) }
-			<div
-				onMouseMove={
-					! isInserterForced && ! isMultiSelecting
-						? onMouseMove
-						: undefined
-				}
-			>
-				{ children }
-			</div>
+			<div onMouseMove={ onMouseMove }> { children } </div>
 		</>
 	);
 }

--- a/packages/block-editor/src/components/block-list/insertion-point.js
+++ b/packages/block-editor/src/components/block-list/insertion-point.js
@@ -99,12 +99,11 @@ function InsertionPointPopover( {
 	setIsInserterForced,
 	containerRef,
 } ) {
-	return clientId.map( ( id, index ) => {
-		const element = getBlockDOMNode( id );
+	const element = getBlockDOMNode( clientId );
 
-		return (
+	return (
+		<>
 			<Popover
-				key={ `${ index }${ id }` }
 				noArrow
 				animate={ false }
 				anchorRef={ element }
@@ -127,14 +126,37 @@ function InsertionPointPopover( {
 					) }
 				</div>
 			</Popover>
-		);
-	} );
+			<Popover
+				noArrow
+				animate={ false }
+				anchorRef={ element }
+				position="bottom right left"
+				focusOnMount={ false }
+				className="block-editor-block-list__insertion-point-popover"
+				__unstableSlotName="block-toolbar"
+			>
+				<div
+					className="block-editor-block-list__insertion-point"
+					style={ { width: element?.offsetWidth } }
+				>
+					<div className="block-editor-block-list__insertion-point-indicator" />
+					{ ( isInserterShown || isInserterForced ) && (
+						<InsertionPointInserter
+							clientId={ clientId }
+							setIsInserterForced={ setIsInserterForced }
+							containerRef={ containerRef }
+						/>
+					) }
+				</div>
+			</Popover>
+		</>
+	);
 }
 
 export default function InsertionPoint( { children, containerRef } ) {
 	const [ isInserterShown, setIsInserterShown ] = useState( false );
 	const [ isInserterForced, setIsInserterForced ] = useState( false );
-	const [ inserterClientId, setInserterClientId ] = useState( [] );
+	const [ inserterClientId, setInserterClientId ] = useState( null );
 	const { isMultiSelecting, isInserterVisible, blockOrder } = useSelect(
 		( select ) => {
 			const {
@@ -167,25 +189,7 @@ export default function InsertionPoint( { children, containerRef } ) {
 		}
 
 		setIsInserterShown( true );
-
-		// first element should have only bottom inserter
-		if ( index === 0 ) {
-			// eslint-disable-next-line no-unused-vars
-			const [ firstTop, firstBottom, ...rest ] = blockOrder;
-			setInserterClientId( [ firstBottom ] );
-			return;
-		}
-
-		// last element should have only top inserter
-		if ( index === blockOrder.length ) {
-			const lastTop = blockOrder.slice( -1 );
-			setInserterClientId( [ lastTop ] );
-			return;
-		}
-
-		const top = blockOrder[ index ];
-		const bottom = blockOrder[ index + 1 ];
-		setInserterClientId( [ top, bottom ] );
+		setInserterClientId( clientId );
 	}
 	const isVisible = isInserterShown || isInserterForced || isInserterVisible;
 

--- a/packages/block-editor/src/components/block-list/insertion-point.js
+++ b/packages/block-editor/src/components/block-list/insertion-point.js
@@ -98,43 +98,43 @@ function InsertionPointPopover( {
 	isInserterForced,
 	setIsInserterForced,
 	containerRef,
-	showInsertionPoint,
 } ) {
-	const element = getBlockDOMNode( clientId );
+	return clientId.map( ( id, index ) => {
+		const element = getBlockDOMNode( id );
 
-	return (
-		<Popover
-			noArrow
-			animate={ false }
-			anchorRef={ element }
-			position="top right left"
-			focusOnMount={ false }
-			className="block-editor-block-list__insertion-point-popover"
-			__unstableSlotName="block-toolbar"
-		>
-			<div
-				className="block-editor-block-list__insertion-point"
-				style={ { width: element?.offsetWidth } }
+		return (
+			<Popover
+				key={ `${ index }${ id }` }
+				noArrow
+				animate={ false }
+				anchorRef={ element }
+				position="top right left"
+				focusOnMount={ false }
+				className="block-editor-block-list__insertion-point-popover"
+				__unstableSlotName="block-toolbar"
 			>
-				{ showInsertionPoint && (
+				<div
+					className="block-editor-block-list__insertion-point"
+					style={ { width: element?.offsetWidth } }
+				>
 					<div className="block-editor-block-list__insertion-point-indicator" />
-				) }
-				{ ( isInserterShown || isInserterForced ) && (
-					<InsertionPointInserter
-						clientId={ clientId }
-						setIsInserterForced={ setIsInserterForced }
-						containerRef={ containerRef }
-					/>
-				) }
-			</div>
-		</Popover>
-	);
+					{ ( isInserterShown || isInserterForced ) && (
+						<InsertionPointInserter
+							clientId={ clientId }
+							setIsInserterForced={ setIsInserterForced }
+							containerRef={ containerRef }
+						/>
+					) }
+				</div>
+			</Popover>
+		);
+	} );
 }
 
 export default function InsertionPoint( { children, containerRef } ) {
 	const [ isInserterShown, setIsInserterShown ] = useState( false );
 	const [ isInserterForced, setIsInserterForced ] = useState( false );
-	const [ inserterClientId, setInserterClientId ] = useState( null );
+	const [ inserterClientId, setInserterClientId ] = useState( [] );
 	const {
 		isMultiSelecting,
 		isInserterVisible,
@@ -211,15 +211,27 @@ export default function InsertionPoint( { children, containerRef } ) {
 
 		// when there is no match return
 		if ( index === -1 ) {
+			setInserterClientId( [] );
 			setIsInserterShown( false );
 			return;
 		}
 
-		// first element should show only bottom inserter
-		if ( index >= 0 ) {
-			setIsInserterShown( true );
-			setInserterClientId( clientId );
+		setIsInserterShown( true );
+
+		if ( index === 0 ) {
+			// eslint-disable-next-line no-unused-vars
+			const [ _, first, ...rest ] = blockOrder;
+			setInserterClientId( [ first ] );
+			return;
 		}
+
+		if ( index === blockOrder.length ) {
+			const lastElement = blockOrder.slice( -1 );
+			setInserterClientId( [ lastElement ] );
+			return;
+		}
+
+		setInserterClientId( [ blockOrder[ index ], blockOrder[ index + 1 ] ] );
 	}
 	const isVisible = isInserterShown || isInserterForced || isInserterVisible;
 
@@ -227,9 +239,7 @@ export default function InsertionPoint( { children, containerRef } ) {
 		<>
 			{ ! isMultiSelecting && isVisible && (
 				<InsertionPointPopover
-					clientId={
-						isInserterVisible ? selectedClientId : inserterClientId
-					}
+					clientId={ inserterClientId }
 					isInserterShown={ isInserterShown }
 					isInserterForced={ isInserterForced }
 					setIsInserterForced={ setIsInserterForced }

--- a/packages/block-editor/src/components/block-list/insertion-point.js
+++ b/packages/block-editor/src/components/block-list/insertion-point.js
@@ -135,75 +135,26 @@ export default function InsertionPoint( { children, containerRef } ) {
 	const [ isInserterShown, setIsInserterShown ] = useState( false );
 	const [ isInserterForced, setIsInserterForced ] = useState( false );
 	const [ inserterClientId, setInserterClientId ] = useState( [] );
-	const {
-		isMultiSelecting,
-		isInserterVisible,
-		selectedClientId,
-		blockOrder,
-	} = useSelect( ( select ) => {
-		const {
-			isMultiSelecting: _isMultiSelecting,
-			isBlockInsertionPointVisible,
-			getBlockInsertionPoint,
-			getBlockOrder,
-		} = select( 'core/block-editor' );
+	const { isMultiSelecting, isInserterVisible, blockOrder } = useSelect(
+		( select ) => {
+			const {
+				isMultiSelecting: _isMultiSelecting,
+				isBlockInsertionPointVisible,
+				getBlockInsertionPoint,
+				getBlockOrder,
+			} = select( 'core/block-editor' );
 
-		const insertionPoint = getBlockInsertionPoint();
-		const order = getBlockOrder( insertionPoint.rootClientId );
+			const insertionPoint = getBlockInsertionPoint();
+			const order = getBlockOrder( insertionPoint.rootClientId );
 
-		return {
-			isMultiSelecting: _isMultiSelecting(),
-			isInserterVisible: isBlockInsertionPointVisible(),
-			selectedClientId: order[ insertionPoint.index ],
-			blockOrder: order,
-		};
-	}, [] );
-
-	// function onMouseMove( event ) {
-	// 	if (
-	// 		! event.target.classList.contains(
-	// 			'block-editor-block-list__layout'
-	// 		)
-	// 	) {
-	// 		if ( isInserterShown ) {
-	// 			setIsInserterShown( false );
-	// 		}
-	// 		return;
-	// 	}
-	//
-	// 	const rect = event.target.getBoundingClientRect();
-	// 	const offset = event.clientY - rect.top;
-	// 	const element = Array.from( event.target.children ).find(
-	// 		( blockEl ) => {
-	// 			return blockEl.offsetTop > offset;
-	// 		}
-	// 	);
-	//
-	// 	if ( ! element ) {
-	// 		return;
-	// 	}
-	//
-	// 	const clientId = element.id.slice( 'block-'.length );
-	//
-	// 	if ( ! clientId ) {
-	// 		return;
-	// 	}
-	//
-	// 	const elementRect = element.getBoundingClientRect();
-	//
-	// 	if (
-	// 		event.clientX > elementRect.right ||
-	// 		event.clientX < elementRect.left
-	// 	) {
-	// 		if ( isInserterShown ) {
-	// 			setIsInserterShown( false );
-	// 		}
-	// 		return;
-	// 	}
-	//
-	// 	setIsInserterShown( true );
-	// 	setInserterClientId( clientId );
-	// }
+			return {
+				isMultiSelecting: _isMultiSelecting(),
+				isInserterVisible: isBlockInsertionPointVisible(),
+				blockOrder: order,
+			};
+		},
+		[]
+	);
 
 	function onMouseMove( event ) {
 		const clientId = event.target.id.slice( 'block-'.length );
@@ -218,20 +169,24 @@ export default function InsertionPoint( { children, containerRef } ) {
 
 		setIsInserterShown( true );
 
+		// first element should have only bottom inserter
 		if ( index === 0 ) {
 			// eslint-disable-next-line no-unused-vars
-			const [ _, first, ...rest ] = blockOrder;
-			setInserterClientId( [ first ] );
+			const [ firstTop, firstBottom, ...rest ] = blockOrder;
+			setInserterClientId( [ firstBottom ] );
 			return;
 		}
 
+		// last element should have only top inserter
 		if ( index === blockOrder.length ) {
-			const lastElement = blockOrder.slice( -1 );
-			setInserterClientId( [ lastElement ] );
+			const lastTop = blockOrder.slice( -1 );
+			setInserterClientId( [ lastTop ] );
 			return;
 		}
 
-		setInserterClientId( [ blockOrder[ index ], blockOrder[ index + 1 ] ] );
+		const top = blockOrder[ index ];
+		const bottom = blockOrder[ index + 1 ];
+		setInserterClientId( [ top, bottom ] );
 	}
 	const isVisible = isInserterShown || isInserterForced || isInserterVisible;
 

--- a/packages/block-editor/src/components/block-list/insertion-point.js
+++ b/packages/block-editor/src/components/block-list/insertion-point.js
@@ -162,7 +162,6 @@ export default function InsertionPoint( { children, containerRef } ) {
 
 		// when there is no match return
 		if ( index === -1 ) {
-			setInserterClientId( [] );
 			setIsInserterShown( false );
 			return;
 		}
@@ -202,7 +201,9 @@ export default function InsertionPoint( { children, containerRef } ) {
 					showInsertionPoint={ isInserterVisible }
 				/>
 			) }
-			<div onMouseMove={ onMouseMove }> { children } </div>
+			<div onMouseMove={ ! isInserterForced ? onMouseMove : undefined }>
+				{ children }
+			</div>
 		</>
 	);
 }

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -428,7 +428,6 @@
 	}
 }
 
-
 .block-editor-block-list__insertion-point-inserter,
 .block-editor-block-list__block-popover-inserter {
 	.block-editor-inserter__toggle.components-button {
@@ -438,6 +437,13 @@
 		@include reduce-motion("animation");
 	}
 }
+
+.block-editor-block-list__insertion-point-indicator {
+	animation: block-editor-inserter__toggle__fade-in-animation-delayed 0.3s ease;
+	animation-fill-mode: forwards;
+	@include reduce-motion("animation");
+}
+
 
 @keyframes block-editor-inserter__toggle__fade-in-animation-delayed {
 	0% {

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -428,21 +428,21 @@
 	}
 }
 
-.block-editor-block-list__insertion-point-inserter,
-.block-editor-block-list__block-popover-inserter {
-	.block-editor-inserter__toggle.components-button {
-		// Fade it in after a delay.
-		animation: block-editor-inserter__toggle__fade-in-animation-delayed 0.3s ease;
-		animation-fill-mode: forwards;
-		@include reduce-motion("animation");
-	}
-}
-
-.block-editor-block-list__insertion-point-indicator {
-	animation: block-editor-inserter__toggle__fade-in-animation-delayed 0.3s ease;
-	animation-fill-mode: forwards;
-	@include reduce-motion("animation");
-}
+//.block-editor-block-list__insertion-point-inserter,
+//.block-editor-block-list__block-popover-inserter {
+//	.block-editor-inserter__toggle.components-button {
+//		// Fade it in after a delay.
+//		animation: block-editor-inserter__toggle__fade-in-animation-delayed 0.3s ease;
+//		animation-fill-mode: forwards;
+//		@include reduce-motion("animation");
+//	}
+//}
+//
+//.block-editor-block-list__insertion-point-indicator {
+//	animation: block-editor-inserter__toggle__fade-in-animation-delayed 0.3s ease;
+//	animation-fill-mode: forwards;
+//	@include reduce-motion("animation");
+//}
 
 
 @keyframes block-editor-inserter__toggle__fade-in-animation-delayed {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Addresses: #22867

What I'm trying to do is detect over which block-id the mouse is hovering, find its index and then show two sibling inserters on the bottom and top respectively. I'm stuck however on handling blocks that have nested blocks in them. In such cases the event.target is the innermost element and I haven't found an elegant solution to the problem. :( 

![Screen-Recording-2020-07-31-at-1](https://user-images.githubusercontent.com/17088041/89408086-8d72dc00-d728-11ea-94dc-9c15a15371a8.gif)


<!-- Please describe what you have changed or added -->

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
