### PR TITLE
Show updated permalink on status bar.

### DIFF
--- a/packages/edit-post/src/components/sidebar/post-link/index.js
+++ b/packages/edit-post/src/components/sidebar/post-link/index.js
@@ -31,7 +31,7 @@ function PostLink( {
 	postSlug,
 	postTypeLabel,
 } ) {
-	let prefixElement, postNameElement, suffixElement;
+	let prefixElement, postNameElement, suffixElement, permalink;
 	if ( isEditable ) {
 		prefixElement = permalinkPrefix && (
 			<span className="edit-post-post-link__link-prefix">
@@ -48,6 +48,9 @@ function PostLink( {
 				{ permalinkSuffix }
 			</span>
 		);
+
+		// Using array join prevents undefined/null values
+		permalink = [ permalinkPrefix, postSlug, permalinkSuffix ].join( '' );
 	}
 
 	return (
@@ -104,8 +107,18 @@ function PostLink( {
 			<div className="edit-post-post-link__preview-link-container">
 				<ExternalLink
 					className="edit-post-post-link__link"
-					href={ postLink }
+					href={ isEditable ? permalink : postLink }
 					target="_blank"
+					onClick={ ( event ) => {
+						// This shows the permalink in the status bar,
+						// while uses the postLink to open in a new window.
+						event.preventDefault();
+						window.open(
+							postLink,
+							'_blank',
+							'noreferrer,noopener'
+						);
+					} }
 				>
 					{ isEditable ? (
 						<>


### PR DESCRIPTION
## Description

When hovering over the permalink in the document sidebar on the block editor, the status bar should show the updated permalink.

When clicking on the permalink, it should still be able to open the post in a new window (by using the postLink) even though the permalink hasn't been created yet.

See https://github.com/Automattic/wp-calypso/issues/41948 for more details.

## How has this been tested?

Tested this in my local wp-env with permalink enabled on settings page.

## Screenshots

![image](https://user-images.githubusercontent.com/1287077/89429554-fd3f9180-d73d-11ea-996f-d7724eece672.png)

![image](https://user-images.githubusercontent.com/1287077/89429561-ffa1eb80-d73d-11ea-9b73-ddc828da4b28.png)

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
