### PR TITLE
Remove "experimental" from title of editor filters

### DIFF
--- a/docs/designers-developers/developers/filters/editor-filters.md
+++ b/docs/designers-developers/developers/filters/editor-filters.md
@@ -1,4 +1,5 @@
-# Editor Filters (Experimental)
+# Editor Filters
+
 To modify the behavior of the editor experience, the following Filters are exposed:
 
 ### `editor.PostFeaturedImage.imageSize`
@@ -36,7 +37,7 @@ This is a PHP filter which is applied before sending settings to the WordPress b
 
 You may find details about this filter [on its WordPress Code Reference page](https://developer.wordpress.org/reference/hooks/block_editor_settings/).
 
-The filter will send any setting to the initialized Editor, which means any editor setting that is used to configure the editor at initialisation can be filtered by a PHP WordPress plugin before being sent. 
+The filter will send any setting to the initialized Editor, which means any editor setting that is used to configure the editor at initialisation can be filtered by a PHP WordPress plugin before being sent.
 
 ### Available default editor settings
 
@@ -49,7 +50,7 @@ It is set by default to the return value of the [`user_can_richedit`](https://de
 #### `codeEditingEnabled`
 Default `true`. Indicates whether the user can access the code editor **in addition** to the visual editor.
 
-If set to false the user will not be able to switch between visual and code editor. The option in the settings menu will not be available and the keyboard shortcut for switching editor types will not fire.  
+If set to false the user will not be able to switch between visual and code editor. The option in the settings menu will not be available and the keyboard shortcut for switching editor types will not fire.
 
 ### Block Directory
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -156,7 +156,7 @@
 		"parent": "filters"
 	},
 	{
-		"title": "Editor Filters (Experimental)",
+		"title": "Editor Filters",
 		"slug": "editor-filters",
 		"markdown_source": "../docs/designers-developers/developers/filters/editor-filters.md",
 		"parent": "filters"


### PR DESCRIPTION

## Description

Per #24357 the experimental in the title for editor filters is no longer needed.


## Types of changes

Document title change.

