### PR TITLE
Revert "[RNMobile] Fix jumping toolbar"

### DIFF
--- a/packages/block-library/src/button/edit.native.js
+++ b/packages/block-library/src/button/edit.native.js
@@ -372,6 +372,7 @@ class ButtonEdit extends Component {
 						__unstableMobileNoFocusOnMount={ ! isSelected }
 						selectionColor={ textColor }
 						onBlur={ () => {
+							this.onToggleButtonFocus( false );
 							this.onSetMaxWidth();
 						} }
 						onReplace={ onReplace }

--- a/packages/components/src/mobile/keyboard-avoiding-view/index.ios.js
+++ b/packages/components/src/mobile/keyboard-avoiding-view/index.ios.js
@@ -3,76 +3,18 @@
  */
 import {
 	KeyboardAvoidingView as IOSKeyboardAvoidingView,
-	Animated,
-	Keyboard,
 	Dimensions,
 } from 'react-native';
 
-/**
- * WordPress dependencies
- */
-import { useState, useEffect, useRef } from '@wordpress/element';
-
-const AnimatedKeyboardAvoidingView = Animated.createAnimatedComponent(
-	IOSKeyboardAvoidingView
-);
-
-const MIN_HEIGHT = 44;
-
-export const KeyboardAvoidingView = ( {
-	parentHeight,
-	style,
-	withAnimatedHeight = false,
-	...otherProps
-} ) => {
-	const [ keyboardHeight, setKeyboardHeight ] = useState( 0 );
-	const animatedHeight = useRef( new Animated.Value( MIN_HEIGHT ) ).current;
-
+export const KeyboardAvoidingView = ( { parentHeight, ...otherProps } ) => {
 	const { height: fullHeight } = Dimensions.get( 'window' );
 	const keyboardVerticalOffset = fullHeight - parentHeight;
 
-	useEffect( () => {
-		Keyboard.addListener( 'keyboardWillShow', onKeyboardWillShow );
-		Keyboard.addListener( 'keyboardWillHide', onKeyboardWillHide );
-		return () => {
-			Keyboard.removeListener( 'keyboardWillShow', onKeyboardWillShow );
-			Keyboard.removeListener( 'keyboardWillHide', onKeyboardWillHide );
-		};
-	}, [] );
-
-	useEffect( () => {
-		animate();
-	}, [ keyboardHeight ] );
-
-	function onKeyboardWillShow( { endCoordinates } ) {
-		setKeyboardHeight( endCoordinates.height );
-	}
-
-	function onKeyboardWillHide() {
-		setKeyboardHeight( 0 );
-	}
-
-	const paddedKeyboardHeight =
-		keyboardHeight + MIN_HEIGHT - ( style.bottom || 0 );
-
-	function animate() {
-		Animated.timing( animatedHeight, {
-			toValue: keyboardHeight ? paddedKeyboardHeight : MIN_HEIGHT,
-			duration: keyboardHeight ? 0 : 150,
-			useNativeDriver: false,
-		} ).start();
-	}
-
 	return (
-		<AnimatedKeyboardAvoidingView
+		<IOSKeyboardAvoidingView
 			{ ...otherProps }
 			behavior="padding"
 			keyboardVerticalOffset={ keyboardVerticalOffset }
-			style={
-				withAnimatedHeight
-					? [ style, { height: animatedHeight } ]
-					: style
-			}
 		/>
 	);
 };

--- a/packages/edit-post/src/components/layout/index.native.js
+++ b/packages/edit-post/src/components/layout/index.native.js
@@ -153,7 +153,6 @@ class Layout extends Component {
 					<KeyboardAvoidingView
 						parentHeight={ this.state.rootViewHeight }
 						style={ toolbarKeyboardAvoidingViewStyle }
-						withAnimatedHeight
 					>
 						{ isTemplatePickerAvailable && (
 							<__experimentalPageTemplatePicker


### PR DESCRIPTION
Reverts WordPress/gutenberg#23684

This PR reverts the changes in WordPress/gutenberg#23684 due to an error that was being generated while trying to layout the Starter Page Template buttons and the bottom bar.

<img width="474" alt="Screen Shot 2020-08-05 at 11 05 52 AM" src="https://user-images.githubusercontent.com/3384451/89429701-e2ecc000-d70b-11ea-805a-ed1b93df3696.png">

### After Revert:

<img width="436" alt="Screen Shot 2020-08-05 at 1 38 58 PM" src="https://user-images.githubusercontent.com/3384451/89445390-171eab80-d721-11ea-9777-7dd19c260753.png">

