### PR TITLE
FSE: Move settings registration to init, remove API name param

### DIFF
--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -222,9 +222,7 @@ function register_site_editor_homepage_settings() {
 		'general',
 		'show_on_front',
 		array(
-			'show_in_rest' => array(
-				'name' => 'show_on_front',
-			),
+			'show_in_rest' => true,
 			'type'         => 'string',
 			'description'  => __( 'What to show on the front page', 'gutenberg' ),
 		)
@@ -234,12 +232,10 @@ function register_site_editor_homepage_settings() {
 		'general',
 		'page_on_front',
 		array(
-			'show_in_rest' => array(
-				'name' => 'page_on_front',
-			),
+			'show_in_rest' => true,
 			'type'         => 'number',
 			'description'  => __( 'The ID of the page that should be displayed on the front page', 'gutenberg' ),
 		)
 	);
 }
-add_action( 'rest_api_init', 'register_site_editor_homepage_settings', 10 );
+add_action( 'init', 'register_site_editor_homepage_settings', 10 );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Follow up from https://github.com/WordPress/gutenberg/pull/23775#discussion_r465975969.

- Use init so that the setting is always registered
- the name is redundant in this scenario

## How has this been tested?
Locally in edit site, e2e's should pass. (if these changes don't work the site editor will not load any page at start)

## Screenshots <!-- if applicable -->
n/a

## Types of changes
Code quality improvements

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
