### PR TITLE
Cover Block: Fix min height input stuck on single digit after entering & clearing value.

### DIFF
--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -91,7 +91,8 @@ function CoverHeightInput( {
 	const inputId = `block-cover-height-input-${ instanceId }`;
 	const isPx = unit === 'px';
 
-	const handleOnChange = ( unprocessedValue ) => {
+	const handleOnInput = ( e ) => {
+		const unprocessedValue = e.target.value;
 		const inputValue =
 			unprocessedValue !== ''
 				? parseInt( unprocessedValue, 10 )
@@ -121,7 +122,7 @@ function CoverHeightInput( {
 				isResetValueOnUnitChange
 				min={ min }
 				onBlur={ handleOnBlur }
-				onChange={ handleOnChange }
+				onInput={ handleOnInput }
 				onUnitChange={ onUnitChange }
 				step="1"
 				style={ { maxWidth: 80 } }


### PR DESCRIPTION
## Description

This PR fixes min height input stuck on single digit after entering a value and clearing it using backspace.

The reason this is happening is because the `onChange` input fires the last known valid value when the input field is empty. The `onChange` event by `UnitControl` is actually a modified version of the `onChange` event which has a different behaviour than the native `onChange` event.

The solution is to use `onInput` which ensures the event handler always executes when input value has changed.

More detail of this issue here: https://github.com/Automattic/wp-calypso/issues/43961

## How has this been tested?
1. Create a cover block.
2. Enter a value, e.g. 400.
3. Press backspace until input is cleared.
4. Enter any single digit value (0-9), you'll always get 4.

## Screenshots <!-- if applicable -->

See gif video at https://github.com/Automattic/wp-calypso/issues/43961

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
