### PR TITLE
FSE: Use navigation mode as the default

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -57,6 +57,7 @@ function Editor() {
 		page,
 		template,
 		select,
+		hasSelectedBlock,
 	} = useSelect( ( _select ) => {
 		const {
 			isFeatureActive,
@@ -96,6 +97,9 @@ function Editor() {
 				: null,
 			select: _select,
 			entityId: _entityId,
+			hasSelectedBlock: !! _select(
+				'core/block-editor'
+			).getSelectedBlock(),
 		};
 	}, [] );
 	const { editEntityRecord } = useDispatch( 'core' );
@@ -103,10 +107,12 @@ function Editor() {
 
 	const { setNavigationMode } = useDispatch( 'core/block-editor' );
 
-	// Set editor to navigation mode on component mount.
+	// Set editor to navigation mode whenever no blocks are selected.
 	useEffect( () => {
-		setNavigationMode( true );
-	}, [ true ] );
+		if ( ! hasSelectedBlock ) {
+			setNavigationMode( true );
+		}
+	}, [ hasSelectedBlock ] );
 
 	const inlineStyles = useResizeCanvas( deviceType );
 

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useState, useMemo, useCallback } from '@wordpress/element';
+import { useState, useMemo, useCallback, useEffect } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	SlotFillProvider,
@@ -100,6 +100,13 @@ function Editor() {
 	}, [] );
 	const { editEntityRecord } = useDispatch( 'core' );
 	const { setPage } = useDispatch( 'core/edit-site' );
+
+	const { setNavigationMode } = useDispatch( 'core/block-editor' );
+
+	// Set editor to navigation mode on component mount.
+	useEffect( () => {
+		setNavigationMode( true );
+	}, [ true ] );
 
 	const inlineStyles = useResizeCanvas( deviceType );
 

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -57,7 +57,7 @@ function Editor() {
 		page,
 		template,
 		select,
-		hasSelectedBlock,
+		hasBlockSelection,
 	} = useSelect( ( _select ) => {
 		const {
 			isFeatureActive,
@@ -97,9 +97,8 @@ function Editor() {
 				: null,
 			select: _select,
 			entityId: _entityId,
-			hasSelectedBlock: !! _select(
-				'core/block-editor'
-			).getSelectedBlock(),
+			hasBlockSelection:
+				_select( 'core/block-editor' ).getSelectedBlockCount() > 0,
 		};
 	}, [] );
 	const { editEntityRecord } = useDispatch( 'core' );
@@ -109,10 +108,10 @@ function Editor() {
 
 	// Set editor to navigation mode whenever no blocks are selected.
 	useEffect( () => {
-		if ( ! hasSelectedBlock ) {
+		if ( ! hasBlockSelection ) {
 			setNavigationMode( true );
 		}
-	}, [ hasSelectedBlock ] );
+	}, [ hasBlockSelection ] );
 
 	const inlineStyles = useResizeCanvas( deviceType );
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
- Set the block editor to navigation mode whenever no blocks are selected.

This partially iterates towards #22064, and helps solve the problem of "what am I editing" when first entering the site editor. This is an important question to answer for the user, because there are many different entities available to edit (unlike the normal post editor.)

To do:
- [ ] I bet e2e tests need updated with this change
- [ ] Is there a better way to set this as default? Should we move the editing mode state to "settings" so that we can set them via BlockEditorProvider?
- [ ] Should we activate this mode more frequently? e.g. when switching templates or pages, go back to nav mode?

## How has this been tested?
Locally, in edit site.

## Screenshots <!-- if applicable -->
![2020-08-05 17 01 54](https://user-images.githubusercontent.com/6265975/89477202-80aeb200-d741-11ea-8ba5-6d7369a25995.gif)

## Types of changes
UX

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
