### PR TITLE
Prevent <a> tag from being focusable (via tabbing) when inside <Disabled> component.

### DIFF
--- a/packages/components/src/disabled/index.js
+++ b/packages/components/src/disabled/index.js
@@ -47,6 +47,10 @@ function Disabled( { className, children, ...props } ) {
 				focusable.setAttribute( 'disabled', '' );
 			}
 
+			if ( focusable.nodeName=='A' ) {
+				focusable.setAttribute( 'tabindex', -1 );
+			}
+
 			if ( focusable.hasAttribute( 'tabindex' ) ) {
 				focusable.removeAttribute( 'tabindex' );
 			}

--- a/packages/components/src/disabled/index.js
+++ b/packages/components/src/disabled/index.js
@@ -47,7 +47,7 @@ function Disabled( { className, children, ...props } ) {
 				focusable.setAttribute( 'disabled', '' );
 			}
 
-			if ( focusable.nodeName=='A' ) {
+			if ( focusable.nodeName === 'A' ) {
 				focusable.setAttribute( 'tabindex', -1 );
 			}
 


### PR DESCRIPTION
When `<a>` tag is inside the `<Disabled>`, it is focusable via tabbing, therefore causing unintended consequences. 

One such example is when the `<a>` tag presents itself inside block previews on block pattern list on the block inserter menu, it causes the `<a>` to receive focus, and activates the block toolbar unintentionally.

See more detail of this issue at: https://github.com/Automattic/wp-calypso/issues/44042

## Description

Set `tabindex=-1` specifically on `<a>` nodes when inside `<Disabled>` component.

## How has this been tested?

1. Tab through the block pattern list.
2. It should not activate the block toolbar.

## Screenshots

See https://github.com/Automattic/wp-calypso/issues/44042

## Types of changes

Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
