### PR TITLE
fix: Error notice is displayed when uploading images exceeding the size limit

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -17,7 +17,7 @@ import {
 	MediaPlaceholder,
 	__experimentalBlock as Block,
 } from '@wordpress/block-editor';
-import { useEffect, useRef } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { image as icon } from '@wordpress/icons';
 
@@ -100,6 +100,7 @@ export function ImageEdit( {
 	}, [ caption ] );
 
 	const ref = useRef();
+	const [ state, setState ] = useState( { hasError: false } );
 	const mediaUpload = useSelect( ( select ) => {
 		const { getSettings } = select( 'core/block-editor' );
 		return getSettings().mediaUpload;
@@ -168,6 +169,7 @@ export function ImageEdit( {
 			...mediaAttributes,
 			...additionalAttributes,
 		} );
+		setState( { hasError: false } );
 	}
 
 	function onSelectURL( newURL ) {
@@ -209,6 +211,7 @@ export function ImageEdit( {
 				allowedTypes: ALLOWED_MEDIA_TYPES,
 				onError: ( message ) => {
 					noticeOperations.createErrorNotice( message );
+					setState( { hasError: true } );
 				},
 			} );
 		}
@@ -270,6 +273,20 @@ export function ImageEdit( {
 	// Focussing the image caption after inserting an image relies on the
 	// component remounting. This needs to be fixed.
 	const key = !! url;
+
+	if ( state.hasError ) {
+		return (
+			<Block.figure ref={ ref } className={ classes } key={ key }>
+				<MediaPlaceholder
+					icon={ <BlockIcon icon={ icon } /> }
+					onSelect={ onSelectImage }
+					notices={ noticeUI }
+					onError={ onUploadError }
+					accept="image/*"
+				/>
+			</Block.figure>
+		);
+	}
 
 	return (
 		<>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes: #21559
Similar to how errors are handled when uploading files I added state property to the component which if true returns a `MediaPlaceholder`.
https://github.com/WordPress/gutenberg/blob/3ef584960be7672959766521d7e9cea29340db6e/packages/block-library/src/file/edit.js#L153-L169
<!-- Please describe what you have changed or added -->

## How has this been tested?
Manually tested uploading an image that exceeds the size limit and then uploading an image under the limit.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/17088041/89509942-9e7b2600-d7d8-11ea-8601-7996aed39b1e.png)


## Types of changes
Bugfix, non-breaking change that fixes uploading files exceeding the size limit.
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
