### PR TITLE
Register the block attributes server-side for blocks with support flags

### DIFF
--- a/lib/block-supports/align.php
+++ b/lib/block-supports/align.php
@@ -6,7 +6,7 @@
  */
 
 /**
- * Registers the attributes block attribute for block types that support it.
+ * Registers the align block attribute for block types that support it.
  *
  * @param  array $block_type Block Type.
  */
@@ -17,10 +17,12 @@ function gutenberg_register_alignment_support( $block_type ) {
 			$block_type->attributes = array();
 		}
 
-		$block_type->attributes['align'] = array(
-			'type' => 'string',
-			'enum' => array( 'left', 'center', 'right', 'wide', 'full', '' ),
-		);
+		if ( ! array_key_exists( 'align', $block_type->attributes ) ) {
+			$block_type->attributes['align'] = array(
+				'type' => 'string',
+				'enum' => array( 'left', 'center', 'right', 'wide', 'full', '' ),
+			);
+		}
 	}
 }
 

--- a/lib/block-supports/colors.php
+++ b/lib/block-supports/colors.php
@@ -6,6 +6,47 @@
  */
 
 /**
+ * Registers the style and colors block attributes for block types that support it.
+ *
+ * @param  array $block_type Block Type.
+ */
+function gutenberg_register_colors_support( $block_type ) {
+	$color_support                 = gutenberg_experimental_get( $block_type->supports, array( '__experimentalColor' ), false );
+	$has_text_colors_support       = is_array( $color_support ) || $color_support;
+	$has_background_colors_support = $has_text_colors_support;
+	$has_gradients_support         = $has_text_colors_support && gutenberg_experimental_get( $color_support, array( 'gradients' ), false );
+
+	if ( ! $block_type->attributes ) {
+		$block_type->attributes = array();
+	}
+
+	if ( $has_text_colors_support && ! array_key_exists( 'style', $block_type->attributes ) ) {
+		$block_type->attributes['style'] = array(
+			'type' => 'object',
+		);
+	}
+
+	if ( $has_background_colors_support && ! array_key_exists( 'backgroundColor', $block_type->attributes ) ) {
+		$block_type->attributes['backgroundColor'] = array(
+			'type' => 'string',
+		);
+	}
+
+	if ( $has_text_colors_support && ! array_key_exists( 'textColor', $block_type->attributes ) ) {
+		$block_type->attributes['textColor'] = array(
+			'type' => 'string',
+		);
+	}
+
+	if ( $has_gradients_support && ! array_key_exists( 'gradient', $block_type->attributes ) ) {
+		$block_type->attributes['gradient'] = array(
+			'type' => 'string',
+		);
+	}
+}
+
+
+/**
  * Add CSS classes and inline styles for colors to the incoming attributes array.
  * This will be applied to the block markup in the front-end.
  *

--- a/lib/block-supports/index.php
+++ b/lib/block-supports/index.php
@@ -15,6 +15,8 @@ function gutenberg_register_block_supports() {
 	// instead of mutating the block type.
 	foreach ( $registered_block_types as $block_type ) {
 		gutenberg_register_alignment_support( $block_type );
+		gutenberg_register_colors_support( $block_type );
+		gutenberg_register_typography_support( $block_type );
 	}
 }
 

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -6,6 +6,32 @@
  */
 
 /**
+ * Registers the style and typography block attributes for block types that support it.
+ *
+ * @param  array $block_type Block Type.
+ */
+function gutenberg_register_typography_support( $block_type ) {
+	$has_font_size_support   = gutenberg_experimental_get( $block_type->supports, array( '__experimentalFontSize' ), false );
+	$has_line_height_support = gutenberg_experimental_get( $block_type->supports, array( '__experimentalLineHeight' ), false );
+
+	if ( ! $block_type->attributes ) {
+		$block_type->attributes = array();
+	}
+
+	if ( ( $has_font_size_support || $has_line_height_support ) && ! array_key_exists( 'style', $block_type->attributes ) ) {
+		$block_type->attributes['style'] = array(
+			'type' => 'object',
+		);
+	}
+
+	if ( $has_font_size_support && ! array_key_exists( 'fontSize', $block_type->attributes ) ) {
+		$block_type->attributes['fontSize'] = array(
+			'type' => 'string',
+		);
+	}
+}
+
+/**
  * Add CSS classes and inline styles for font sizes to the incoming attributes array.
  * This will be applied to the block markup in the front-end.
  *


### PR DESCRIPTION
This PR continues on top of #24351 to register the missing attributes for the colors and typography support flags.
This doesn't have any impact on Core blocks because Core blocks with these flags don't use `ServerSideRender`.  Nonetheless, it is important to register those attributes for third-party blocks and for consistency.