### PR TITLE
Text Columns: Prefer relative units instead of absolute

### DIFF
--- a/packages/block-library/src/text-columns/style.scss
+++ b/packages/block-library/src/text-columns/style.scss
@@ -6,7 +6,7 @@
 	}
 
 	.wp-block-column {
-		margin: 0 16px;
+		margin: 0 1rem;
 		padding: 0;
 
 		&:first-child {


### PR DESCRIPTION
This PR changes the margin of text-columns to use `rem` instead of `px` values.
This will allow themes to have columns proportionally scale depending on the selected font-size.