### PR TITLE
Quote block: Prefer relative units

### DIFF
--- a/packages/block-library/src/quote/style.scss
+++ b/packages/block-library/src/quote/style.scss
@@ -1,18 +1,18 @@
 .wp-block-quote {
 	&.is-style-large,
 	&.is-large {
-		margin: 0 0 16px;
+		margin: 0 0 1rem;
 		padding: 0 1em;
 
 		p {
-			font-size: 24px;
+			font-size: 1.5rem;
 			font-style: italic;
 			line-height: 1.6;
 		}
 
 		cite,
 		footer {
-			font-size: 18px;
+			font-size: 1.125rem;
 			text-align: right;
 		}
 	}


### PR DESCRIPTION
Modern themes use a base font-size of 20px+.
With the current quote block styles, themes have to rewrite everything in order to have things work the way they were meant to.
Changing the dimensions from `px` to `rem` values here will allow theme authors to use the core styles as-is without being forced to rewrite the core styles.