### PR TITLE
Pullquote block: Prefer relative units

### DIFF
--- a/packages/block-library/src/pullquote/blockquote.native.scss
+++ b/packages/block-library/src/pullquote/blockquote.native.scss
@@ -1,8 +1,8 @@
 .quote {
-	font-size: 18px;
+	font-size: 1.125rem;
 }
 
 .citation {
-	font-size: 14px;
-	margin-top: 12px;
+	font-size: 0.875rem;
+	margin-top: 0.75rem;
 }

--- a/packages/block-library/src/pullquote/figure.native.scss
+++ b/packages/block-library/src/pullquote/figure.native.scss
@@ -1,6 +1,6 @@
 %shared {
 	border-width: 3px 0;
-	padding: 21px 16px;
+	padding: 1.3125rem 1rem;
 }
 
 .light {

--- a/packages/block-library/src/pullquote/style.scss
+++ b/packages/block-library/src/pullquote/style.scss
@@ -9,12 +9,12 @@
 		max-width: $content-width / 2;
 
 		p {
-			font-size: 20px;
+			font-size: 1.25rem;
 		}
 	}
 
 	p {
-		font-size: 28px;
+		font-size: 1.75rem;
 		line-height: 1.6;
 	}
 
@@ -43,7 +43,7 @@
 		p {
 			margin-top: 0;
 			margin-bottom: 0;
-			font-size: 32px;
+			font-size: 2rem;
 		}
 
 		cite {


### PR DESCRIPTION
Companion to #24405, this time for the pullquote block.

The intention of this PR is to make life easier for theme developers by allowing them to change the root font-size of their document without being forced to rewrite styles for the pullquote block.