### PR TITLE
Try: Fix admin-theme colors in the canvas.

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -677,9 +677,3 @@
 	}
 	/* stylelint-enable function-comma-space-after */
 }
-
-// It is important to include these styles in all built stylesheets.
-// This allows to CSS variables post CSS plugin to generate fallbacks.
-:root {
-	@include admin-scheme(#007cba);
-}

--- a/packages/postcss-plugins-preset/lib/index.js
+++ b/packages/postcss-plugins-preset/lib/index.js
@@ -1,4 +1,14 @@
 module.exports = [
-	require( 'postcss-custom-properties' )(),
+	require( 'postcss-custom-properties' )( {
+		importFrom: [
+			{
+				customProperties: {
+					'--wp-admin-theme-color': '#007cba',
+					'--wp-admin-theme-color-darker-10': '#006ba1',
+					'--wp-admin-theme-color-darker-20': '#005a87',
+				},
+			},
+		],
+	} ),
 	require( 'autoprefixer' )( { grid: true } ),
 ];


### PR DESCRIPTION
The globally set CSS variables for the WP-admin color scheme were overridden, just inside the editing canvas. 

Before:

<img width="1245" alt="Screenshot 2020-08-06 at 13 55 51" src="https://user-images.githubusercontent.com/1204802/89529267-b8beff00-d7ec-11ea-9048-4fc81d194235.png">

After:

<img width="1245" alt="Screenshot 2020-08-06 at 13 53 46" src="https://user-images.githubusercontent.com/1204802/89529273-bbb9ef80-d7ec-11ea-92b6-ac5174e0e02e.png">

This is a draft PR because based on the code comment, it looks like the rule removed was necessary. I'd appreciate advice on where to move it. 