### PR TITLE
Recent Comments block: remove hardcoded color

### DIFF
--- a/packages/block-library/src/latest-comments/style.scss
+++ b/packages/block-library/src/latest-comments/style.scss
@@ -27,7 +27,6 @@
 }
 
 .wp-block-latest-comments__comment-date {
-	color: $dark-gray-100;
 	display: block;
 	font-size: 12px;
 }


### PR DESCRIPTION
This will remove the hardcoded color from `.wp-block-latest-comments__comment-date`.
If a theme uses a dark background or anything other than white, a hardcoded text-color will not work and themes will be forced to add custom styles and override the defaults.
By removing the custom color definition, the comment-date will use the current text color, therefore avoiding any implications and overrides associated with hardcoded color values.
That selector is already smaller in size, making it lighter in color will only make it harder to read.
If we absolutely need it to have a different color, we could instead use something like `opacity:0.9;`. This will keep using the currently defined text-color so it will be OK both for light and dark themes.

Also related: https://github.com/WordPress/gutenberg/pull/24409 which is a companion to this PR and deals with using relative instead of absolute units for the block.