### PR TITLE
Use relative units for social-icons block

### DIFF
--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -17,18 +17,23 @@
 
 .wp-social-link {
 	display: block;
-	width: 36px;
-	height: 36px;
-	border-radius: 36px; // This makes it pill-shaped instead of oval, in cases where the image fed is not perfectly sized.
-	margin-right: 8px;
+	width: 2.25rem;
+	height: 2.25rem;
+	border-radius: 2.25rem; // This makes it pill-shaped instead of oval, in cases where the image fed is not perfectly sized.
+	margin-right: 0.5rem;
 	transition: transform 0.1s ease;
 	@include reduce-motion("transition");
 
 	a {
-		padding: 6px;
+		padding: 0.375rem;
 		display: block;
 		line-height: 0;
 		transition: transform 0.1s ease;
+
+		svg {
+			width: 1.5rem;
+			height: 1.5rem;
+		}
 	}
 
 	a,
@@ -65,10 +70,10 @@
 		background: none;
 
 		// Make these bigger.
-		padding: 4px;
+		padding: 0.25rem;
 		svg {
-			width: 28px;
-			height: 28px;
+			width: 1.75rem;
+			height: 1.75rem;
 		}
 	}
 


### PR DESCRIPTION
Currently thiis block uses absolute units (`px`) for everything.
As a result, it looks a bit funky when the theme tweaks the base font-size.

This PR changes all units to relative (`rem`) so icons can scale depending on the theme's defined font-size.

## Before:

### Theme using a large font-size
![Screenshot_2020-08-06 test – lemon(7)](https://user-images.githubusercontent.com/588688/89535354-02b0e080-d7ff-11ea-8142-390ac5558f18.png)
### Theme using a small font-size
![Screenshot_2020-08-06 test – lemon(6)](https://user-images.githubusercontent.com/588688/89535359-03497700-d7ff-11ea-857f-0ce8710cf031.png)

## After:

### Theme using a large font-size
![Screenshot_2020-08-06 test – lemon(8)](https://user-images.githubusercontent.com/588688/89535875-b6b26b80-d7ff-11ea-9521-308e56bc49a7.png)
### Theme using a small font-size
![Screenshot_2020-08-06 test – lemon(9)](https://user-images.githubusercontent.com/588688/89535848-ab5f4000-d7ff-11ea-805a-2e2226ccec39.png)