### PR TITLE
[RNMobile] Turn off autosave interval for mobile

### DIFF
--- a/packages/edit-post/src/components/layout/index.native.js
+++ b/packages/edit-post/src/components/layout/index.native.js
@@ -129,7 +129,7 @@ class Layout extends Component {
 				) }
 				onLayout={ this.onRootViewLayout }
 			>
-				<AutosaveMonitor />
+				<AutosaveMonitor disableIntervalChecks />
 				<View
 					style={ getStylesFromColorScheme(
 						styles.background,

--- a/packages/editor/src/components/autosave-monitor/index.js
+++ b/packages/editor/src/components/autosave-monitor/index.js
@@ -12,10 +12,20 @@ export class AutosaveMonitor extends Component {
 	}
 
 	componentDidMount() {
-		this.setAutosaveTimer();
+		if ( ! this.props.disableIntervalChecks ) {
+			this.setAutosaveTimer();
+		}
 	}
 
 	componentDidUpdate( prevProps ) {
+		if (
+			this.props.disableIntervalChecks &&
+			this.props.editsReference !== prevProps.editsReference
+		) {
+			this.props.autosave();
+			return;
+		}
+
 		if ( ! this.props.isDirty && prevProps.isDirty ) {
 			this.needsAutosave = false;
 			return;


### PR DESCRIPTION
## Description
The Autosave mechanism was changed recently and sets the interval to check if there are new changes to save. It works well for the web but introduced some issues on mobile. we used to call `autosave` after each change and the native part has an own throttle mechanism to handle that in a performant way.

In this PR I added a prop called `disableIntervalChecks` that determines if the interval should be set. I set this to true for mobile autosave in the layout component.

## How has this been tested?
1. The autosave should work the same for web

2. The autosave is called after each change on mobile
- Type really fast in Android client app and close the editor w/o any pause.
- The correct data should be saved

## Types of changes
Remove unnecessary interval on mobile.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
