### PR TITLE
useEditorFeature: take block context into account

### DIFF
--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -600,7 +600,7 @@ function gutenberg_experimental_global_styles_get_editor_features( $config ) {
 	foreach ( array_keys( $config ) as $context ) {
 		if (
 			empty( $config[ $context ]['features'] ) ||
-			! is_array( $config[ $context ]['features'])
+			! is_array( $config[ $context ]['features'] )
 		) {
 			$features[ $context ] = array();
 		} else {

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -596,22 +596,27 @@ function gutenberg_experimental_global_styles_enqueue_assets() {
  * @return array Default features config for the editor.
  */
 function gutenberg_experimental_global_styles_get_editor_features( $config ) {
-	if (
-		empty( $config['global']['features'] ) ||
-		! is_array( $config['global']['features'] )
-	) {
-		$config['global']['features'] = array();
+	$features = array();
+	foreach ( array_keys( $config ) as $context ) {
+		if (
+			empty( $config[ $context ]['features'] ) ||
+			! is_array( $config[ $context ]['features'])
+		) {
+			$features[ $context ] = array();
+		} else {
+			$features[ $context ] = $config[ $context ]['features'];
+		}
 	}
 
 	// Deprecated theme supports.
 	if ( get_theme_support( 'disable-custom-colors' ) ) {
-		if ( ! isset( $config['global']['features']['color'] ) ) {
-			$config['global']['features']['color'] = array();
+		if ( ! isset( $features['global']['color'] ) ) {
+			$features['global']['color'] = array();
 		}
-		$config['global']['features']['color']['custom'] = false;
+		$features['global']['color']['custom'] = false;
 	}
 
-	return $config['global']['features'];
+	return $features;
 }
 
 /**

--- a/packages/block-editor/src/components/use-editor-feature/index.js
+++ b/packages/block-editor/src/components/use-editor-feature/index.js
@@ -38,8 +38,6 @@ export default function useEditorFeature( featurePath ) {
 
 	const setting = useSelect(
 		( select ) => {
-			const path = `__experimentalFeatures.${ featurePath }`;
-
 			// 1 - Use deprecated settings, if available.
 			const settings = select( 'core/block-editor' ).getSettings();
 			const deprecatedSettingsValue = deprecatedFlags[ featurePath ]
@@ -49,8 +47,14 @@ export default function useEditorFeature( featurePath ) {
 				return deprecatedSettingsValue;
 			}
 
-			// 2 - Use global __experimentalFeatures otherwise.
-			return get( settings, path );
+			// 2 - Use __experimental features otherwise.
+			// We cascade to the global value if the block one is not available.
+			//
+			// TODO: make it work for blocks that define multiple selectors
+			// such as core/heading or core/post-title.
+			const globalPath = `__experimentalFeatures.global.${ featurePath }`;
+			const blockPath = `__experimentalFeatures.${ blockName }.${ featurePath }`;
+			return get( settings, blockPath ) ?? get( settings, globalPath );
 		},
 		[ blockName, featurePath ]
 	);


### PR DESCRIPTION
Related https://github.com/WordPress/gutenberg/issues/20588
Follows-up https://github.com/WordPress/gutenberg/pull/24275
Partially fixes https://github.com/WordPress/gutenberg/issues/22657

This PR makes `useEditorFeature` to take into account the block context data to decide whether a feature should be enabled or not.

This is the current algorithm to decide what value to take:

1. Is it defined in the corresponding block section (ex: `core/paragraph`) of the theme's config? If so, take this value.
2. Is it defined in the corresponding block section (ex: `core/paragraph`) of the core's config? If so, take this value.
3. Is it defined in the `global` section of the theme's config? If so, take this value.
4. Is it defined in the `global` section of the core's config? If so, take this value.

## Test

Using a theme that supports global styles:

- test that a feature can be disabled globally
- test that a feature can be disabled globally but enabled per block
- test that a feature can be enabled globally but disabled per block

You can use the demo theme at https://github.com/nosolosw/global-styles-theme/pull/12 as a testbed. The expected result is that custom colors are disabled for every block except paragraph.

## Follow-up tasks:

- Make it work for blocks that define many contexts: core/heading (core/heading/h1, */h2, etc), core/post-title, etc.
