### PR TITLE
Fix text wrapping in table headers

### DIFF
--- a/packages/block-library/src/table/style.scss
+++ b/packages/block-library/src/table/style.scss
@@ -15,8 +15,7 @@
 		table-layout: fixed;
 		width: 100%;
 
-		td,
-		th {
+		td {
 			word-break: break-word;
 		}
 	}
@@ -32,8 +31,7 @@
 		// width as auto.
 		width: auto;
 
-		td,
-		th {
+		td {
 			word-break: break-word;
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/24393

Can we just keep normal word-break with table headers?  I can think of cases where folks might paste a long URL in a table cell, and would need to wrap that. But I would think most people would just name the table header differently if it were too long to fit.  As it stands, this arbitrary break points truly are arbitrary, and it's turning out some strange results. Normal word breaks will break with spaces and hyphens automatically.

## Description
Removed th from places where we specified break-word

## How has this been tested?
See comments below

## Screenshots <!-- if applicable -->
See https://github.com/WordPress/gutenberg/issues/24393

## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested  (I don't have a good testing environment for the SCSS, but I have tested this by removing that style locally)
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [na] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [na] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [na] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
