### PR TITLE
Update Preview, Save and Switch to Draft button labels blue

### DIFF
--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -79,13 +79,6 @@
 		}
 	}
 
-	.components-button.editor-post-save-draft,
-	.components-button.editor-post-switch-to-draft,
-	.components-button.editor-post-preview,
-	.components-button.block-editor-post-preview__button-toggle {
-		color: $gray-900;
-	}
-
 	.components-button.block-editor-post-preview__dropdown,
 	.components-button.editor-post-publish-button,
 	.components-button.editor-post-publish-panel__toggle {


### PR DESCRIPTION
Fixes #23890.

This PR aims to help resolve some issues around the Switch to Draft, Save, and Preview buttons in the editor's top toolbar, which were updated in #21192. In #23890 there are some concerns that these buttons now look like plain text. One [suggestion brought up by the accessibility team](https://wordpress.slack.com/archives/C02RP4X03/p1596556270336300) was to switch the color to blue, and that's what this PR does.

Here's how they look in `master` today:

<img width="347" alt="image" src="https://user-images.githubusercontent.com/191598/89556298-26fcc500-d7df-11ea-8019-f362435e387d.png">

And here's how they look in this PR:

<img width="367" alt="image" src="https://user-images.githubusercontent.com/191598/89555896-9cb46100-d7de-11ea-9452-b8d2ddc12976.png">

<img width="330" alt="image" src="https://user-images.githubusercontent.com/191598/89555934-a938b980-d7de-11ea-9f6d-73bbc9e0d96a.png">

