### PR TITLE
Try new syntax for dynamic selectors

### DIFF
--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -29,12 +29,9 @@
 		"__experimentalFontSize": true,
 		"__experimentalLineHeight": true,
 		"__experimentalSelector": {
-			"core/heading/h1": "h1",
-			"core/heading/h2": "h2",
-			"core/heading/h3": "h3",
-			"core/heading/h4": "h4",
-			"core/heading/h5": "h5",
-			"core/heading/h6": "h6"
+			"attribute": "level",
+			"expression": "h${attribute}",
+			"range": ["h1", "h2", "h3", "h4", "h5", "h6"]
 		},
 		"__unstablePasteTextInline": true
 	}

--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -23,13 +23,9 @@
 		"__experimentalFontSize": true,
 		"__experimentalLineHeight": true,
 		"__experimentalSelector": {
-			"core/post-title/h1": "h1",
-			"core/post-title/h2": "h2",
-			"core/post-title/h3": "h3",
-			"core/post-title/h4": "h4",
-			"core/post-title/h5": "h5",
-			"core/post-title/h6": "h6",
-			"core/post-title/p": "p"
+			"attribute": "level",
+			"expression": "h${attribute}",
+			"range": ["h1", "h2", "h3", "h4", "h5", "h6"]
 		}
 	}
 }


### PR DESCRIPTION
Related:

- [theme.json spec](https://developer.wordpress.org/block-editor/developers/themes/theme-json/)
- try encoding dynamic selectors as block variations https://github.com/WordPress/gutenberg/pull/22805
- https://github.com/WordPress/gutenberg/pull/22518#discussion_r429180157
- https://github.com/WordPress/gutenberg/pull/22698#issuecomment-635352451

Blocks that support the Global Styles system need a way to be converted to a CSS selector. At the moment, the way we do it is by using this algorithm:

1. If the block doesn't define a `__experimentalSelector` within its block.json, the selector is built based on its name: `.wp-block-${ blockName }`.Example: `core/group` maps to `.wp-block-group`.

2. If the block does define a `__experimentalSelector` key within its block.json and it is a string, the selector is the value of `__experimentalSelector`. Example: `core/paragraph` maps to `p` because it declares support by `"__experimentalSelector": "p"`.

3. If the block does define a `__experimentalSelector` key within its block.json and it is an object, the block has as many selectors as object entries. Example: `core/heading` can be `core/heading/h1`, `core/heading/h2`, ..., `core/heading/h6` and each one has its own selector that is defined this way:

```
"__experimentalSelector": {
    "core/heading/h1": "h1",
    "core/heading/h2": "h2",
    "core/heading/h3": "h3",
    "core/heading/h4": "h4",
    "core/heading/h5": "h5",
    "core/heading/h6": "h6"
}
```

This works fine for the static nature of server-side global styles (it doesn't use the block values, only its description). However, for the dynamic nature of the client-side (particularly [feature detection](https://github.com/WordPress/gutenberg/pull/24416)) we need a way to map the specific instance of a block to a particular selector. Example: the core/heading block when its level is 3 should be detected as `core/heading/h3`, while it should be detected as `core/heading/h2` when its level is 2.

This PR proposes a new syntax for dynamic selectors:

```
"__experimentalSelector": {
    "attribute": "level",
    "expression": "h${attribute}",
    "range": ["h1", "h2", "h3", "h4", "h5", "h6"]
}
```

The `attribute` and `expression` would be used client-side (or in mobile) to construct the selector based on dynamic data (the value of the `level` attribute). The `range` would be used server-side to process the block.

Note that I haven't implemented the change yet because I want to gather thoughts first.