### PR TITLE
Block Toolbar More Menu: Switch back to the vertical ellipsis icon

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -14,7 +14,7 @@ import {
 	ClipboardButton,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { moreHorizontal } from '@wordpress/icons';
+import { moreVertical } from '@wordpress/icons';
 
 import { Children, cloneElement, useCallback } from '@wordpress/element';
 import { serialize } from '@wordpress/blocks';
@@ -92,7 +92,7 @@ export function BlockSettingsDropdown( {
 				blocks,
 			} ) => (
 				<DropdownMenu
-					icon={ moreHorizontal }
+					icon={ moreVertical }
 					label={ __( 'More options' ) }
 					className="block-editor-block-settings-menu"
 					popoverProps={ POPOVER_PROPS }


### PR DESCRIPTION
Fixes #23889

<img width="361" alt="image" src="https://user-images.githubusercontent.com/191598/89580991-3d694780-d804-11ea-8cc1-359ff610c97c.png">

