### PR TITLE
Preview menu: Remove redundant "opens in a new tab" hidden text

### DIFF
--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -207,7 +207,17 @@ export class PostPreviewButton extends Component {
 			>
 				{ this.props.textContent
 					? this.props.textContent
-					: _x( 'Preview', 'imperative verb' ) }
+					: 
+					<>
+						{ _x( 'Preview', 'imperative verb' ) }
+						<VisuallyHidden as="span">
+						{
+							/* translators: accessibility text */
+							__( '(opens in a new tab)' )
+						}
+						</VisuallyHidden>
+					</>
+					}
 			</Button>
 		);
 	}

--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -208,12 +208,6 @@ export class PostPreviewButton extends Component {
 				{ this.props.textContent
 					? this.props.textContent
 					: _x( 'Preview', 'imperative verb' ) }
-				<VisuallyHidden as="span">
-					{
-						/* translators: accessibility text */
-						__( '(opens in a new tab)' )
-					}
-				</VisuallyHidden>
 			</Button>
 		);
 	}

--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -205,19 +205,19 @@ export class PostPreviewButton extends Component {
 				ref={ this.buttonRef }
 				role={ role }
 			>
-				{ this.props.textContent
-					? this.props.textContent
-					: 
+				{ this.props.textContent ? (
+					this.props.textContent
+				) : (
 					<>
 						{ _x( 'Preview', 'imperative verb' ) }
 						<VisuallyHidden as="span">
-						{
-							/* translators: accessibility text */
-							__( '(opens in a new tab)' )
-						}
+							{
+								/* translators: accessibility text */
+								__( '(opens in a new tab)' )
+							}
 						</VisuallyHidden>
 					</>
-					}
+				) }
 			</Button>
 		);
 	}

--- a/packages/editor/src/components/post-preview-button/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-preview-button/test/__snapshots__/index.js.snap
@@ -10,11 +10,6 @@ exports[`PostPreviewButton render() should render currentPostLink otherwise 1`] 
   target="wp-preview-1"
 >
   Preview
-  <VisuallyHidden
-    as="span"
-  >
-    (opens in a new tab)
-  </VisuallyHidden>
 </ForwardRef(Button)>
 `;
 
@@ -28,10 +23,5 @@ exports[`PostPreviewButton render() should render previewLink if provided 1`] = 
   target="wp-preview-1"
 >
   Preview
-  <VisuallyHidden
-    as="span"
-  >
-    (opens in a new tab)
-  </VisuallyHidden>
 </ForwardRef(Button)>
 `;

--- a/packages/editor/src/components/post-preview-button/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-preview-button/test/__snapshots__/index.js.snap
@@ -10,6 +10,11 @@ exports[`PostPreviewButton render() should render currentPostLink otherwise 1`] 
   target="wp-preview-1"
 >
   Preview
+  <VisuallyHidden
+    as="span"
+  >
+    (opens in a new tab)
+  </VisuallyHidden>
 </ForwardRef(Button)>
 `;
 
@@ -23,5 +28,10 @@ exports[`PostPreviewButton render() should render previewLink if provided 1`] = 
   target="wp-preview-1"
 >
   Preview
+  <VisuallyHidden
+    as="span"
+  >
+    (opens in a new tab)
+  </VisuallyHidden>
 </ForwardRef(Button)>
 `;


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/24386 

Text link already states that the link will open in a new tab, so this PR removes the visually hidden "(opens in a new tab)" text. (And yes, I realize this very description is redundant if you've read the title)