### PR TITLE
React Native: Fix @-mentions UI to allow @ character in posts

### DIFF
--- a/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -306,9 +306,11 @@ class RCTAztecView: Aztec.TextView {
     // MARK: - Edits
 
     open override func insertText(_ text: String) {
-        guard !interceptEnter(text), !interceptTriggersKeyCodes(text) else {
+        guard !interceptEnter(text) else {
             return
         }
+
+        interceptTriggersKeyCodes(text)
 
         super.insertText(text)
         updatePlaceholderVisibility()
@@ -374,13 +376,13 @@ class RCTAztecView: Aztec.TextView {
         return true
     }
 
-    private func interceptTriggersKeyCodes(_ text: String) -> Bool {
+    private func interceptTriggersKeyCodes(_ text: String) {
         guard let keyCodes = triggerKeyCodes,
             keyCodes.count > 0,
             let onKeyDown = onKeyDown,
             text.count == 1
         else {
-            return false
+            return
         }
         for value in keyCodes {
             guard let keyString = value as? String,
@@ -393,9 +395,8 @@ class RCTAztecView: Aztec.TextView {
             var eventData = [AnyHashable:Any]()
             eventData = add(keyCode: keyCode, to: eventData)
             onKeyDown(eventData)
-            return true
+            return
         }
-        return false;
     }
 
     private func isNewLineBeforeSelectionAndNotEndOfContent() -> Bool {

--- a/packages/react-native-editor/RELEASE-NOTES.txt
+++ b/packages/react-native-editor/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+1.33.1
+------
+* Fixed a bug in the @-mentions feature where dismissing the @-mentions UI removed the @ character from the post.
+
 1.33.0
 ------
 * [***] Media editing support in Media & Text block.


### PR DESCRIPTION
## Description

Addresses https://github.com/WordPress/gutenberg/issues/24425

This address a bug with the @-mention feature that made entering the standalone @ character difficult because of the @-mention UI getting in the way.
The fix here is to allow the @ character to be intercepted without being consumed by the key event logic. This addresses one aspect of proposed fix for the issue linked above:

> tap backspace after adding a @ character, which should dismiss the mentions UI and leave the @ character in the post


## How has this been tested?

- [x] Download the demo build from https://github.com/wordpress-mobile/WordPress-iOS/pull/14596#issuecomment-670239929
- [x] Perform the test cases found [here](https://github.com/wordpress-mobile/test-cases/blob/d0ffb4b25fa270435c1d4bcc0d2c3155a0d3185b/test-cases/gutenberg/mentions.md) (please note that this will be merged soon via https://github.com/wordpress-mobile/test-cases/pull/52).

## Screenshots <!-- if applicable -->

<img width="250" src="https://user-images.githubusercontent.com/1898325/89591256-bd4cdd00-d817-11ea-927e-f1dcde4469d3.gif">

## Types of changes
- Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
