### PR TITLE
Refactored BlockSwitcher to functional components using hooks

### DIFF
--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { castArray, filter, mapKeys, orderBy, uniq, map } from 'lodash';
+import { castArray, mapKeys, orderBy, uniq } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -22,9 +22,8 @@ import {
 	cloneBlock,
 	getBlockFromExample,
 } from '@wordpress/blocks';
-import { Component } from '@wordpress/element';
-import { withSelect, withDispatch } from '@wordpress/data';
-import { compose } from '@wordpress/compose';
+import { useState } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { stack } from '@wordpress/icons';
 
 /**
@@ -75,188 +74,171 @@ function PreviewBlockPopover( { hoveredBlock, hoveredClassName } ) {
 	);
 }
 
-export class BlockSwitcher extends Component {
-	constructor() {
-		super( ...arguments );
-		this.state = {
-			hoveredClassName: null,
-		};
-		this.onHoverClassName = this.onHoverClassName.bind( this );
-	}
+export default function BlockSwitcher( { clientIds } ) {
+	const [ hoveredClassName, setHoveredClassName ] = useState();
 
-	onHoverClassName( className ) {
-		this.setState( { hoveredClassName: className } );
-	}
+	const { blocks, inserterItems, hasBlockStyles } = useSelect(
+		( select ) => {
+			const {
+				getBlocksByClientId,
+				getBlockRootClientId,
+				getInserterItems,
+			} = select( 'core/block-editor' );
 
-	render() {
-		const {
-			blocks,
-			onTransform,
-			inserterItems,
-			hasBlockStyles,
-		} = this.props;
-		const { hoveredClassName } = this.state;
-
-		if ( ! Array.isArray( blocks ) || ! blocks.length ) {
-			return null;
-		}
-
-		const [ hoveredBlock ] = blocks;
-		const itemsByName = mapKeys( inserterItems, ( { name } ) => name );
-		const possibleBlockTransformations = orderBy(
-			filter(
-				getPossibleBlockTransformations( blocks ),
-				( block ) => block && !! itemsByName[ block.name ]
-			),
-			( block ) => itemsByName[ block.name ].frecency,
-			'desc'
-		);
-
-		// When selection consists of blocks of multiple types, display an
-		// appropriate icon to communicate the non-uniformity.
-		const isSelectionOfSameType =
-			uniq( map( blocks, 'name' ) ).length === 1;
-
-		let icon;
-		if ( isSelectionOfSameType ) {
-			const sourceBlockName = hoveredBlock.name;
-			const blockType = getBlockType( sourceBlockName );
-			icon = blockType.icon;
-		} else {
-			icon = stack;
-		}
-
-		const hasPossibleBlockTransformations = !! possibleBlockTransformations.length;
-
-		if ( ! hasBlockStyles && ! hasPossibleBlockTransformations ) {
-			return (
-				<ToolbarGroup>
-					<ToolbarButton
-						disabled
-						className="block-editor-block-switcher__no-switcher-icon"
-						title={ __( 'Block icon' ) }
-						icon={ <BlockIcon icon={ icon } showColors /> }
-					/>
-				</ToolbarGroup>
+			const { getBlockStyles } = select( 'core/blocks' );
+			const rootClientId = getBlockRootClientId(
+				castArray( clientIds )[ 0 ]
 			);
-		}
 
-		const blockSwitcherLabel =
-			1 === blocks.length
-				? __( 'Change block type or style' )
-				: sprintf(
-						/* translators: %s: number of blocks. */
-						_n(
-							'Change type of %d block',
-							'Change type of %d blocks',
-							blocks.length
-						),
-						blocks.length
-				  );
+			const selectedBlocks = getBlocksByClientId( clientIds );
+			const firstBlock =
+				selectedBlocks && selectedBlocks.length === 1
+					? selectedBlocks[ 0 ]
+					: null;
+			const styles = firstBlock && getBlockStyles( firstBlock.name );
 
+			return {
+				blocks: selectedBlocks,
+				inserterItems: getInserterItems( rootClientId ),
+				hasBlockStyles: styles && styles.length > 0,
+			};
+		},
+		[ clientIds ]
+	);
+
+	const { replaceBlocks } = useDispatch( 'core/block-editor' );
+
+	const onTransform = ( name ) => {
+		replaceBlocks( clientIds, switchToBlockType( blocks, name ) );
+	};
+
+	if ( ! Array.isArray( blocks ) || ! blocks.length ) {
+		return null;
+	}
+
+	const [ hoveredBlock ] = blocks;
+	const itemsByName = mapKeys( inserterItems, ( { name } ) => name );
+	const possibleBlockTransformations = orderBy(
+		getPossibleBlockTransformations( blocks ).filter(
+			( block ) => block && !! itemsByName[ block.name ]
+		),
+		( block ) => itemsByName[ block.name ].frecency,
+		'desc'
+	);
+
+	// When selection consists of blocks of multiple types, display an
+	// appropriate icon to communicate the non-uniformity.
+	const isSelectionOfSameType =
+		uniq( blocks.map( ( block ) => block.name ) ).length === 1;
+
+	let icon;
+	if ( isSelectionOfSameType ) {
+		const sourceBlockName = hoveredBlock.name;
+		const blockType = getBlockType( sourceBlockName );
+		icon = blockType.icon;
+	} else {
+		icon = stack;
+	}
+
+	const hasPossibleBlockTransformations = !! possibleBlockTransformations.length;
+
+	if ( ! hasBlockStyles && ! hasPossibleBlockTransformations ) {
 		return (
 			<ToolbarGroup>
-				<ToolbarItem>
-					{ ( toggleProps ) => (
-						<DropdownMenu
-							className="block-editor-block-switcher"
-							label={ blockSwitcherLabel }
-							popoverProps={ {
-								position: 'bottom right',
-								isAlternate: true,
-								className:
-									'block-editor-block-switcher__popover',
-							} }
-							icon={
-								<BlockIcon
-									icon={ icon }
-									className="block-editor-block-switcher__toggle"
-									showColors
-								/>
-							}
-							toggleProps={ toggleProps }
-							menuProps={ { orientation: 'both' } }
-						>
-							{ ( { onClose } ) =>
-								( hasBlockStyles ||
-									hasPossibleBlockTransformations ) && (
-									<div className="block-editor-block-switcher__container">
-										{ hasPossibleBlockTransformations && (
-											<BlockTransformationsMenu
-												className="block-editor-block-switcher__transforms__menugroup"
-												possibleBlockTransformations={
-													possibleBlockTransformations
-												}
-												onSelect={ ( name ) => {
-													onTransform( blocks, name );
-													onClose();
-												} }
-											/>
-										) }
-										{ hasBlockStyles && (
-											<MenuGroup
-												label={ __( 'Styles' ) }
-												className="block-editor-block-switcher__styles__menugroup"
-											>
-												{ hoveredClassName !== null && (
-													<PreviewBlockPopover
-														hoveredBlock={
-															hoveredBlock
-														}
-														hoveredClassName={
-															hoveredClassName
-														}
-													/>
-												) }
-												<BlockStyles
-													clientId={
-														hoveredBlock.clientId
-													}
-													onSwitch={ onClose }
-													onHoverClassName={
-														this.onHoverClassName
-													}
-													itemRole="menuitem"
-												/>
-											</MenuGroup>
-										) }
-									</div>
-								)
-							}
-						</DropdownMenu>
-					) }
-				</ToolbarItem>
+				<ToolbarButton
+					disabled
+					className="block-editor-block-switcher__no-switcher-icon"
+					title={ __( 'Block icon' ) }
+					icon={ <BlockIcon icon={ icon } showColors /> }
+				/>
 			</ToolbarGroup>
 		);
 	}
-}
 
-export default compose(
-	withSelect( ( select, { clientIds } ) => {
-		const {
-			getBlocksByClientId,
-			getBlockRootClientId,
-			getInserterItems,
-		} = select( 'core/block-editor' );
-		const { getBlockStyles } = select( 'core/blocks' );
-		const rootClientId = getBlockRootClientId(
-			castArray( clientIds )[ 0 ]
-		);
-		const blocks = getBlocksByClientId( clientIds );
-		const firstBlock = blocks && blocks.length === 1 ? blocks[ 0 ] : null;
-		const styles = firstBlock && getBlockStyles( firstBlock.name );
-		return {
-			blocks,
-			inserterItems: getInserterItems( rootClientId ),
-			hasBlockStyles: styles && styles.length > 0,
-		};
-	} ),
-	withDispatch( ( dispatch, ownProps ) => ( {
-		onTransform( blocks, name ) {
-			dispatch( 'core/block-editor' ).replaceBlocks(
-				ownProps.clientIds,
-				switchToBlockType( blocks, name )
-			);
-		},
-	} ) )
-)( BlockSwitcher );
+	const blockSwitcherLabel =
+		1 === blocks.length
+			? __( 'Change block type or style' )
+			: sprintf(
+					/* translators: %s: number of blocks. */
+					_n(
+						'Change type of %d block',
+						'Change type of %d blocks',
+						blocks.length
+					),
+					blocks.length
+			  );
+
+	return (
+		<ToolbarGroup>
+			<ToolbarItem>
+				{ ( toggleProps ) => (
+					<DropdownMenu
+						className="block-editor-block-switcher"
+						label={ blockSwitcherLabel }
+						popoverProps={ {
+							position: 'bottom right',
+							isAlternate: true,
+							className: 'block-editor-block-switcher__popover',
+						} }
+						icon={
+							<BlockIcon
+								icon={ icon }
+								className="block-editor-block-switcher__toggle"
+								showColors
+							/>
+						}
+						toggleProps={ toggleProps }
+						menuProps={ { orientation: 'both' } }
+					>
+						{ ( { onClose } ) =>
+							( hasBlockStyles ||
+								hasPossibleBlockTransformations ) && (
+								<div className="block-editor-block-switcher__container">
+									{ hasPossibleBlockTransformations && (
+										<BlockTransformationsMenu
+											className="block-editor-block-switcher__transforms__menugroup"
+											possibleBlockTransformations={
+												possibleBlockTransformations
+											}
+											onSelect={ ( name ) => {
+												onTransform( name );
+												onClose();
+											} }
+										/>
+									) }
+									{ hasBlockStyles && (
+										<MenuGroup
+											label={ __( 'Styles' ) }
+											className="block-editor-block-switcher__styles__menugroup"
+										>
+											{ hoveredClassName !== null && (
+												<PreviewBlockPopover
+													hoveredBlock={
+														hoveredBlock
+													}
+													hoveredClassName={
+														hoveredClassName
+													}
+												/>
+											) }
+											<BlockStyles
+												clientId={
+													hoveredBlock.clientId
+												}
+												onSwitch={ onClose }
+												onHoverClassName={
+													setHoveredClassName
+												}
+												itemRole="menuitem"
+											/>
+										</MenuGroup>
+									) }
+								</div>
+							)
+						}
+					</DropdownMenu>
+				) }
+			</ToolbarItem>
+		</ToolbarGroup>
+	);
+}

--- a/packages/block-editor/src/components/block-switcher/test/index.js
+++ b/packages/block-editor/src/components/block-switcher/test/index.js
@@ -6,6 +6,7 @@ import { shallow, mount } from 'enzyme';
 /**
  * WordPress dependencies
  */
+import { useSelect } from '@wordpress/data';
 import { registerBlockType, unregisterBlockType } from '@wordpress/blocks';
 import { DOWN } from '@wordpress/keycodes';
 import { Button } from '@wordpress/components';
@@ -13,7 +14,12 @@ import { Button } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { BlockSwitcher } from '../';
+import BlockSwitcher from '../';
+
+jest.mock( '@wordpress/data/src/components/use-select', () => {
+	// This allows us to tweak the returned value on each test
+	return jest.fn();
+} );
 
 describe( 'BlockSwitcher', () => {
 	const headingBlock1 = {
@@ -94,73 +100,90 @@ describe( 'BlockSwitcher', () => {
 	} );
 
 	test( 'should not render block switcher without blocks', () => {
+		useSelect.mockImplementation( () => {
+			return {
+				blocks: [],
+				inserterItems: [],
+				hasBlockStyles: false,
+			};
+		} );
+
 		const wrapper = shallow( <BlockSwitcher /> );
 
 		expect( wrapper.html() ).toBeNull();
 	} );
 
 	test( 'should render switcher with blocks', () => {
-		const blocks = [ headingBlock1 ];
-		const inserterItems = [
-			{ name: 'core/heading', frecency: 1 },
-			{ name: 'core/paragraph', frecency: 1 },
-		];
+		useSelect.mockImplementation( () => {
+			return {
+				blocks: [ headingBlock1 ],
+				inserterItems: [
+					{ name: 'core/heading', frecency: 1 },
+					{ name: 'core/paragraph', frecency: 1 },
+				],
+				hasBlockStyles: true,
+			};
+		} );
 
-		const wrapper = shallow(
-			<BlockSwitcher blocks={ blocks } inserterItems={ inserterItems } />
-		);
+		const wrapper = shallow( <BlockSwitcher /> );
 
 		expect( wrapper ).toMatchSnapshot();
 	} );
 
 	test( 'should render disabled block switcher with multi block of different types when no transforms', () => {
-		const blocks = [ headingBlock1, textBlock ];
-		const inserterItems = [
-			{ name: 'core/heading', frecency: 1 },
-			{ name: 'core/paragraph', frecency: 1 },
-		];
+		useSelect.mockImplementation( () => {
+			return {
+				blocks: [ headingBlock1, textBlock ],
+				inserterItems: [
+					{ name: 'core/heading', frecency: 1 },
+					{ name: 'core/paragraph', frecency: 1 },
+				],
+				hasBlockStyles: false,
+			};
+		} );
 
-		const wrapper = shallow(
-			<BlockSwitcher blocks={ blocks } inserterItems={ inserterItems } />
-		);
+		const wrapper = shallow( <BlockSwitcher /> );
 
 		expect( wrapper ).toMatchSnapshot();
 	} );
 
 	test( 'should render enabled block switcher with multi block when transforms exist', () => {
-		const blocks = [ headingBlock1, headingBlock2 ];
-		const inserterItems = [
-			{ name: 'core/heading', frecency: 1 },
-			{ name: 'core/paragraph', frecency: 1 },
-		];
+		useSelect.mockImplementation( () => {
+			return {
+				blocks: [ headingBlock1, headingBlock2 ],
+				inserterItems: [
+					{ name: 'core/heading', frecency: 1 },
+					{ name: 'core/paragraph', frecency: 1 },
+				],
+				hasBlockStyles: true,
+			};
+		} );
 
-		const wrapper = shallow(
-			<BlockSwitcher blocks={ blocks } inserterItems={ inserterItems } />
-		);
+		const wrapper = shallow( <BlockSwitcher /> );
 
 		expect( wrapper ).toMatchSnapshot();
 	} );
 
 	describe( 'Dropdown', () => {
-		const blocks = [ headingBlock1 ];
+		beforeEach( () => {
+			useSelect.mockImplementation( () => {
+				return {
+					blocks: [ headingBlock1 ],
+					inserterItems: [
+						{ name: 'core/quote', frecency: 1 },
+						{ name: 'core/cover-image', frecency: 2 },
+						{ name: 'core/paragraph', frecency: 3 },
+						{ name: 'core/heading', frecency: 4 },
+						{ name: 'core/text', frecency: 5 },
+					],
+					hasBlockStyles: true,
+				};
+			} );
+		} );
 
-		const inserterItems = [
-			{ name: 'core/quote', frecency: 1 },
-			{ name: 'core/cover-image', frecency: 2 },
-			{ name: 'core/paragraph', frecency: 3 },
-			{ name: 'core/heading', frecency: 4 },
-			{ name: 'core/text', frecency: 5 },
-		];
-
-		const onTransformStub = jest.fn();
 		const getDropdown = () => {
-			const blockSwitcher = mount(
-				<BlockSwitcher
-					blocks={ blocks }
-					onTransform={ onTransformStub }
-					inserterItems={ inserterItems }
-				/>
-			);
+			const blockSwitcher = mount( <BlockSwitcher /> );
+
 			return blockSwitcher.find( 'Dropdown' );
 		};
 


### PR DESCRIPTION
## Description
Related to #22890.

Refactored BlockSwitcher to use React Hooks.

## How has this been tested?
Tested using existing unit tests for BlockSwitcher.
Tested by running `npm run test`.
Observed that I was able to switch blocks using Gutenberg block editor.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [ ] My code follows the accessibility standards.
- [ ] My code has proper inline documentation.
- [ ] I've included developer documentation if appropriate.
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR.