### PR TITLE
Avoid using `$default-block-margin` for front-facing styles

### DIFF
--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -1,6 +1,6 @@
 .wp-block-columns {
 	display: flex;
-	margin-bottom: $default-block-margin;
+	margin-bottom: 1.75rem;
 
 	// Responsiveness: Allow wrapping on mobile.
 	flex-wrap: wrap;

--- a/packages/block-library/src/pullquote/theme.scss
+++ b/packages/block-library/src/pullquote/theme.scss
@@ -1,7 +1,7 @@
 .wp-block-pullquote {
 	border-top: 4px solid $dark-gray-500;
 	border-bottom: 4px solid $dark-gray-500;
-	margin-bottom: $default-block-margin;
+	margin-bottom: 1.75rem;
 	color: $dark-gray-600;
 
 	cite,

--- a/packages/block-library/src/quote/theme.scss
+++ b/packages/block-library/src/quote/theme.scss
@@ -1,6 +1,6 @@
 .wp-block-quote {
 	border-left: 4px solid $black;
-	margin: 0 0 $default-block-margin 0;
+	margin: 0 0 1.75rem 0;
 	padding-left: 1em;
 
 	cite,


### PR DESCRIPTION
Same as https://github.com/WordPress/gutenberg/pull/24432, but this time for the `$default-block-margin` var.
That variable was added for editor styles and should not be used for front-facing styles.
This PR fixes that issue and at the same time converts the value to `rem` units for easier theming.