### PR TITLE
Add an example to the buttons block to avoid focus loss issue

### DIFF
--- a/packages/block-library/src/buttons/index.js
+++ b/packages/block-library/src/buttons/index.js
@@ -23,7 +23,18 @@ export const settings = {
 	),
 	icon,
 	keywords: [ __( 'link' ) ],
-	example: {},
+	example: {
+		innerBlocks: [
+			{
+				name: 'core/button',
+				attributes: { text: __( 'Find out more' ) },
+			},
+			{
+				name: 'core/button',
+				attributes: { text: __( 'Contact us' ) },
+			},
+		],
+	},
 	transforms,
 	edit,
 	save,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes #24430

It looks like the preview is causing a focus loss (perhaps some kind of autofocus? Possibly the block inserter in the preview). This solves the issue by adding an example with inner blocks, but it'd be good to look into the underlying issue of why focus was being taken by the preview. This issue might still be affecting third party blocks.

A designer may also want to improve the example. 😀

## How has this been tested?
1. Start a new post
2. Open the inserter
3. Try tabbing through block categories
4. When focus lands on the Buttons block in the inserter focus should not be lost

## Screenshots <!-- if applicable -->
<img width="673" alt="Screenshot 2020-08-07 at 5 20 16 pm" src="https://user-images.githubusercontent.com/677833/89630677-49233f80-d8d2-11ea-8dc0-2cad3aafddf1.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
