### PR TITLE
Remove` --wp-admin-theme-color` reference from front-facing styles

### DIFF
--- a/packages/block-library/src/calendar/style.scss
+++ b/packages/block-library/src/calendar/style.scss
@@ -26,10 +26,6 @@
 		text-decoration: underline;
 	}
 
-	tfoot a {
-		color: var(--wp-admin-theme-color);
-	}
-
 	table tbody,
 	table caption {
 		color: $dark-gray-600;


### PR DESCRIPTION
The title says it all :laughing: 

We recently introduced a new `--wp-admin-theme-color` CSS-variable.
That somehow stayed in the calendar block, so this PR removes it and the link can keep inheriting the theme's link styles.