### PR TITLE
[Android] Dialog to replace image with gallery for multiple images

### DIFF
--- a/packages/editor/src/components/provider/index.native.js
+++ b/packages/editor/src/components/provider/index.native.js
@@ -93,20 +93,36 @@ class NativeEditorProvider extends Component {
 		);
 
 		this.subscriptionParentMediaAppend = subscribeMediaAppend(
-			( payload ) => {
-				const blockName = 'core/' + payload.mediaType;
-				const newBlock = createBlock( blockName, {
-					id: payload.mediaId,
-					[ payload.mediaType === 'image'
-						? 'url'
-						: 'src' ]: payload.mediaUrl,
-				} );
+			( { mediaType, mediaId, mediaUrl, images } ) => {
+				const {
+					selectedBlockClientId,
+					selectedBlockIndex,
+					blockCount,
+					insertBlock,
+					replaceBlock,
+				} = this.props;
 
-				const indexAfterSelected = this.props.selectedBlockIndex + 1;
-				const insertionIndex =
-					indexAfterSelected || this.props.blockCount;
+				const blockName = 'core/' + mediaType;
 
-				this.props.insertBlock( newBlock, insertionIndex );
+				let attributes, isReplacing;
+				if ( mediaType === 'gallery' ) {
+					attributes = { images };
+					isReplacing = true;
+				} else {
+					attributes = {
+						id: mediaId,
+						[ mediaType === 'image' ? 'url' : 'src' ]: mediaUrl,
+					};
+				}
+
+				const newBlock = createBlock( blockName, attributes );
+
+				if ( isReplacing ) {
+					replaceBlock( selectedBlockClientId, newBlock );
+				} else {
+					const insertionIndex = selectedBlockIndex + 1 || blockCount;
+					insertBlock( newBlock, insertionIndex );
+				}
 			}
 		);
 
@@ -264,6 +280,7 @@ export default compose( [
 			blocks: getEditorBlocks(),
 			title: getEditedPostAttribute( 'title' ),
 			getEditedPostContent,
+			selectedBlockClientId,
 			selectedBlockIndex: getBlockIndex( selectedBlockClientId ),
 			blockCount: getGlobalBlockCount(),
 			paragraphCount: getGlobalBlockCount( 'core/paragraph' ),

--- a/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
+++ b/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
@@ -19,10 +19,12 @@ import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 
 import org.wordpress.mobile.ReactNativeGutenbergBridge.GutenbergBridgeJS2Parent.GutenbergUserEvent;
+import org.wordpress.mobile.ReactNativeGutenbergBridge.GutenbergBridgeJS2Parent.MediaSelectedCallback;
 import org.wordpress.mobile.ReactNativeGutenbergBridge.GutenbergBridgeJS2Parent.MediaType;
 import org.wordpress.mobile.ReactNativeGutenbergBridge.GutenbergBridgeJS2Parent.OtherMediaOptionsReceivedCallback;
 import org.wordpress.mobile.ReactNativeGutenbergBridge.GutenbergBridgeJS2Parent.StarterPageTemplatesTooltipShownCallback;
 import org.wordpress.mobile.WPAndroidGlue.DeferredEventEmitter;
+import org.wordpress.mobile.WPAndroidGlue.Media;
 import org.wordpress.mobile.WPAndroidGlue.MediaOption;
 
 import java.io.Serializable;

--- a/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
+++ b/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
@@ -170,14 +170,16 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
     @ReactMethod
     public void requestMediaPickFrom(String mediaSource, ReadableArray filter, Boolean allowMultipleSelection, final Callback onMediaSelected) {
         MediaType mediaType = getMediaTypeFromFilter(filter);
+        MediaSelectedCallback mediaSelectedCallback = getNewMediaSelectedCallback(allowMultipleSelection, onMediaSelected);
+
         if (mediaSource.equals(MEDIA_SOURCE_MEDIA_LIBRARY)) {
-            mGutenbergBridgeJS2Parent.requestMediaPickFromMediaLibrary(getNewMediaSelectedCallback(allowMultipleSelection, onMediaSelected), allowMultipleSelection, mediaType);
+            mGutenbergBridgeJS2Parent.requestMediaPickFromMediaLibrary(mediaSelectedCallback, allowMultipleSelection, mediaType);
         } else if (mediaSource.equals(MEDIA_SOURCE_DEVICE_LIBRARY)) {
-            mGutenbergBridgeJS2Parent.requestMediaPickFromDeviceLibrary(getNewMediaSelectedCallback(allowMultipleSelection, onMediaSelected), allowMultipleSelection, mediaType);
+            mGutenbergBridgeJS2Parent.requestMediaPickFromDeviceLibrary(mediaSelectedCallback, allowMultipleSelection, mediaType);
         } else if (mediaSource.equals(MEDIA_SOURCE_DEVICE_CAMERA)) {
-            mGutenbergBridgeJS2Parent.requestMediaPickerFromDeviceCamera(getNewMediaSelectedCallback(allowMultipleSelection, onMediaSelected), mediaType);
+            mGutenbergBridgeJS2Parent.requestMediaPickerFromDeviceCamera(mediaSelectedCallback, mediaType);
         } else {
-            mGutenbergBridgeJS2Parent.requestMediaPickFrom(mediaSource, getNewMediaSelectedCallback(allowMultipleSelection, onMediaSelected), allowMultipleSelection);
+            mGutenbergBridgeJS2Parent.requestMediaPickFrom(mediaSource, mediaSelectedCallback, allowMultipleSelection);
         }
     }
 

--- a/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
+++ b/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
@@ -120,6 +120,17 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
         emitToJS(EVENT_NAME_MEDIA_APPEND, writableMap);
     }
 
+    public void appendNewGalleryBlock(List<Media> images) {
+        WritableMap writableMap = new WritableNativeMap();
+        WritableArray writableArray = new WritableNativeArray();
+        for (RNMedia image : images) {
+            writableArray.pushMap(image.toMap());
+        }
+        writableMap.putString(MAP_KEY_MEDIA_FILE_UPLOAD_MEDIA_TYPE, "gallery");
+        writableMap.putArray("images", writableArray);
+        emitToJS(EVENT_NAME_MEDIA_APPEND, writableMap);
+    }
+
     public void setPreferredColorScheme(boolean isDarkMode) {
         WritableMap writableMap = new WritableNativeMap();
         writableMap.putBoolean(MAP_KEY_IS_PREFERRED_COLOR_SCHEME_DARK, isDarkMode);

--- a/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
+++ b/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
@@ -227,7 +227,7 @@ public class WPAndroidGlueCode {
                 mAppendsMultipleSelectedToSiblingBlocks = mediaType == MediaType.IMAGE && !allowMultipleSelection;
                 mMediaSelectedCallback = mediaSelectedCallback;
                 if (mediaType == MediaType.IMAGE) {
-                    mOnMediaLibraryButtonListener.onUploadPhotoButtonClicked(true);
+                    mOnMediaLibraryButtonListener.onUploadPhotoButtonClicked(allowMultipleSelection);
                 } else if (mediaType == MediaType.VIDEO) {
                     mOnMediaLibraryButtonListener.onUploadVideoButtonClicked(allowMultipleSelection);
                 } else if (mediaType == MediaType.MEDIA) {

--- a/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
+++ b/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
@@ -558,6 +558,16 @@ public class WPAndroidGlueCode {
                                             .appendNewMediaBlock(mediaId, mediaUri, mediaType);
     }
 
+    public void appendNewGalleryBlock(ArrayList<Media> images) {
+        if (isMediaSelectedCallbackRegistered() && mMediaPickedByUserOnBlock) {
+            mMediaPickedByUserOnBlock = false;
+            mAppendsMultipleSelectedToSiblingBlocks = false;
+            // we still must invoke callback, so we use an empty array
+            mMediaSelectedCallback.onMediaFileSelected(new ArrayList<>());
+            mRnReactNativeGutenbergBridgePackage.getRNReactNativeGutenbergBridgeModule().appendNewGalleryBlock(images);
+        }
+    }
+
     public void setPreferredColorScheme(boolean isDarkMode) {
         if (mIsDarkMode != isDarkMode) {
             mIsDarkMode = isDarkMode;

--- a/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
+++ b/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/WPAndroidGlueCode.java
@@ -223,10 +223,11 @@ public class WPAndroidGlueCode {
             @Override
             public void requestMediaPickFromDeviceLibrary(MediaSelectedCallback mediaSelectedCallback, Boolean allowMultipleSelection, MediaType mediaType) {
                 mMediaPickedByUserOnBlock = true;
-                mAppendsMultipleSelectedToSiblingBlocks = false;
+                // image blocks do not respect the multiple selection flag, so we set the append as siblings flag instead
+                mAppendsMultipleSelectedToSiblingBlocks = mediaType == MediaType.IMAGE && !allowMultipleSelection;
                 mMediaSelectedCallback = mediaSelectedCallback;
                 if (mediaType == MediaType.IMAGE) {
-                    mOnMediaLibraryButtonListener.onUploadPhotoButtonClicked(allowMultipleSelection);
+                    mOnMediaLibraryButtonListener.onUploadPhotoButtonClicked(true);
                 } else if (mediaType == MediaType.VIDEO) {
                     mOnMediaLibraryButtonListener.onUploadVideoButtonClicked(allowMultipleSelection);
                 } else if (mediaType == MediaType.MEDIA) {


### PR DESCRIPTION
### Related PRs:

`gutenberg-mobile`: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2539
`WordPress-Android`: https://github.com/wordpress-mobile/WordPress-Android/pull/12618

## Description
This PR is another step towards resolving this issue: https://github.com/wordpress-mobile/gutenberg-mobile/issues/2255

## How has this been tested?
tbd

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
