### PR TITLE
Block Supports: Add missing UTF-8 conversion

### DIFF
--- a/lib/block-supports/index.php
+++ b/lib/block-supports/index.php
@@ -84,6 +84,6 @@ function gutenberg_apply_block_supports( $block_content, $block ) {
 		$block_root->setAttribute( 'style', $new_styles );
 	}
 
-	return $dom->saveHtml();
+	return mb_convert_encoding( $dom->saveHtml(), 'UTF-8', 'HTML-ENTITIES' );
 }
 add_filter( 'render_block', 'gutenberg_apply_block_supports', 10, 2 );

--- a/lib/block-supports/index.php
+++ b/lib/block-supports/index.php
@@ -51,7 +51,7 @@ function gutenberg_apply_block_supports( $block_content, $block ) {
 
 	// Suppress warnings from this method from polluting the front-end.
 	// @codingStandardsIgnoreStart
-	if ( ! @$dom->loadHTML( $block_content, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD | LIBXML_COMPACT ) ) {
+	if ( ! @$dom->loadHTML( mb_convert_encoding( $block_content, 'HTML-ENTITIES', 'UTF-8' ), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD | LIBXML_COMPACT ) ) {
 	// @codingStandardsIgnoreEnd
 		return $block_content;
 	}

--- a/phpunit/class-block-supported-styles-test.php
+++ b/phpunit/class-block-supported-styles-test.php
@@ -66,6 +66,19 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Retrieves block content from the rendered block string
+	 * (i.e. what's wrapped by the block wrapper `<div />`).
+	 *
+	 * @param string $block String of rendered block to check.
+	 */
+	private function get_content_from_block( $block ) {
+		$start_index = strpos( $block, '>' ) + 1;
+		$split_arr   = substr( $block, $start_index );
+		$end_index   = strpos( $split_arr, '<' );
+		return substr( $split_arr, 0, $end_index );
+	}
+
+	/**
 	 * Runs assertions that the rendered output has expected class/style attrs.
 	 *
 	 * @param array  $block Block to render.
@@ -73,7 +86,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 * @param string $expected_styles Expected output styles attr string.
 	 */
 	private function assert_styles_and_classes_match( $block, $expected_classes, $expected_styles ) {
-		$styled_block = apply_filters( 'render_block', $this->block_content, $block );
+		$styled_block = apply_filters( 'render_block', self::BLOCK_MARKUP, $block );
 		$class_list   = $this->get_attribute_from_block( 'class', $styled_block );
 		$style_list   = $this->get_attribute_from_block( 'style', $styled_block );
 
@@ -82,11 +95,36 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Example block content to test with.
+	 * Runs assertions that the rendered output has expected content and class/style attrs.
+	 *
+	 * @param array  $block Block to render.
+	 * @param string $expected_classes Expected output class attr string.
+	 * @param string $expected_styles Expected output styles attr string.
+	 */
+	private function assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles ) {
+		$styled_block = apply_filters( 'render_block', self::BLOCK_MARKUP, $block );
+		$content      = $this->get_content_from_block( $styled_block );
+		$class_list   = $this->get_attribute_from_block( 'class', $styled_block );
+		$style_list   = $this->get_attribute_from_block( 'style', $styled_block );
+
+		$this->assertEquals( self::BLOCK_CONTENT, $content );
+		$this->assertEquals( $expected_classes, $class_list );
+		$this->assertEquals( $expected_styles, $style_list );
+	}
+
+	/**
+	 * Block content to test with (i.e. what's wrapped by the block wrapper `<div />`).
 	 *
 	 * @var string
 	 */
-	private $block_content = '<div class="wp-block-example foo-bar-class" style="test:style;">So say we all.</div>';
+	const BLOCK_CONTENT = 'Some non-Latin chärs to make sure DOM öperations don\'t mess them up: こんにちは';
+
+	/**
+	 * Example block markup string to test with.
+	 *
+	 * @var string
+	 */
+	const BLOCK_MARKUP = '<div class="wp-block-example foo-bar-class" style="test:style;">' . self::BLOCK_CONTENT . '</div>';
 
 	/**
 	 * Tests color support for named color support for named colors.
@@ -117,7 +155,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$expected_classes = 'wp-block-example foo-bar-class has-text-color has-red-color has-background has-black-background-color';
 		$expected_styles  = 'test:style; ';
 
-		$this->assert_styles_and_classes_match( $block, $expected_classes, $expected_styles );
+		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
 	}
 
 	/**
@@ -154,7 +192,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$expected_styles  = 'test:style; color: #000; background-color: #fff;';
 		$expected_classes = 'wp-block-example foo-bar-class has-text-color has-background';
 
-		$this->assert_styles_and_classes_match( $block, $expected_classes, $expected_styles );
+		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
 	}
 
 	/**
@@ -185,7 +223,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$expected_classes = 'wp-block-example foo-bar-class has-link-color';
 		$expected_styles  = 'test:style; --wp--style--color--link:var(--wp--preset--color--red);';
 
-		$this->assert_styles_and_classes_match( $block, $expected_classes, $expected_styles );
+		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
 	}
 
 	/**
@@ -216,7 +254,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$expected_classes = 'wp-block-example foo-bar-class has-link-color';
 		$expected_styles  = 'test:style; --wp--style--color--link: #fff;';
 
-		$this->assert_styles_and_classes_match( $block, $expected_classes, $expected_styles );
+		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
 	}
 
 	/**
@@ -247,7 +285,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$expected_classes = 'wp-block-example foo-bar-class has-background has-red-gradient-background';
 		$expected_styles  = 'test:style; ';
 
-		$this->assert_styles_and_classes_match( $block, $expected_classes, $expected_styles );
+		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
 	}
 
 	/**
@@ -278,7 +316,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$expected_classes = 'wp-block-example foo-bar-class has-background';
 		$expected_styles  = 'test:style; background: some-gradient-style;';
 
-		$this->assert_styles_and_classes_match( $block, $expected_classes, $expected_styles );
+		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
 	}
 
 	/**
@@ -314,7 +352,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$expected_classes = 'wp-block-example foo-bar-class';
 		$expected_styles  = 'test:style;';
 
-		$this->assert_styles_and_classes_match( $block, $expected_classes, $expected_styles );
+		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
 	}
 
 	/**
@@ -343,7 +381,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$expected_classes = 'wp-block-example foo-bar-class has-large-font-size';
 		$expected_styles  = 'test:style; ';
 
-		$this->assert_styles_and_classes_match( $block, $expected_classes, $expected_styles );
+		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
 	}
 
 	/**
@@ -372,7 +410,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$expected_classes = 'wp-block-example foo-bar-class ';
 		$expected_styles  = 'test:style; font-size: 10px;';
 
-		$this->assert_styles_and_classes_match( $block, $expected_classes, $expected_styles );
+		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
 	}
 
 	/**
@@ -400,7 +438,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$expected_classes = 'wp-block-example foo-bar-class';
 		$expected_styles  = 'test:style;';
 
-		$this->assert_styles_and_classes_match( $block, $expected_classes, $expected_styles );
+		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
 	}
 
 	/**
@@ -429,7 +467,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$expected_classes = 'wp-block-example foo-bar-class ';
 		$expected_styles  = 'test:style; line-height: 10;';
 
-		$this->assert_styles_and_classes_match( $block, $expected_classes, $expected_styles );
+		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
 	}
 
 	/**
@@ -456,7 +494,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$expected_classes = 'wp-block-example foo-bar-class';
 		$expected_styles  = 'test:style;';
 
-		$this->assert_styles_and_classes_match( $block, $expected_classes, $expected_styles );
+		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
 	}
 
 	/**
@@ -485,7 +523,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$expected_classes = 'wp-block-example foo-bar-class alignwide';
 		$expected_styles  = 'test:style; ';
 
-		$this->assert_styles_and_classes_match( $block, $expected_classes, $expected_styles );
+		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
 	}
 
 	/**
@@ -512,7 +550,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$expected_classes = 'wp-block-example foo-bar-class';
 		$expected_styles  = 'test:style;';
 
-		$this->assert_styles_and_classes_match( $block, $expected_classes, $expected_styles );
+		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
 	}
 
 	/**
@@ -559,7 +597,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$expected_classes = 'wp-block-example foo-bar-class has-text-color has-background alignwide';
 		$expected_styles  = 'test:style; color: #000; background-color: #fff; background: some-gradient; font-size: 10px; line-height: 20;';
 
-		$this->assert_styles_and_classes_match( $block, $expected_classes, $expected_styles );
+		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
 	}
 
 	/**
@@ -601,7 +639,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$expected_classes = 'wp-block-example foo-bar-class ';
 		$expected_styles  = 'test:style; font-size: 10px;';
 
-		$this->assert_styles_and_classes_match( $block, $expected_classes, $expected_styles );
+		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
 	}
 
 	/**
@@ -647,6 +685,6 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$expected_classes = 'wp-block-example foo-bar-class';
 		$expected_styles  = 'test:style;';
 
-		$this->assert_styles_and_classes_match( $block, $expected_classes, $expected_styles );
+		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
 	}
 }


### PR DESCRIPTION
## Description
Fixes https://github.com/WordPress/gutenberg/issues/24445.

This should probably be backported to 8.7 (and potentially further back if needed).

## How has this been tested?
See #24445 for instructions on how to reproduce the issue. Verify that this PR fixes it.

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->

props @akirk @sirreal @simison for finding the fix