### PR TITLE
Template Part: Move "title" to block toolbar

### DIFF
--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -3,6 +3,7 @@
  */
 import { useRef, useEffect } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { BlockControls } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -16,7 +17,6 @@ export default function TemplatePartEdit( {
 	attributes: { postId: _postId, slug, theme },
 	setAttributes,
 	clientId,
-	isSelected,
 } ) {
 	const initialPostId = useRef( _postId );
 	const initialSlug = useRef( slug );
@@ -29,18 +29,11 @@ export default function TemplatePartEdit( {
 	// but wait until the third inner blocks change,
 	// because the first 2 are just the template part
 	// content loading.
-	const { innerBlocks, hasSelectedInnerBlock } = useSelect(
+	const { innerBlocks } = useSelect(
 		( select ) => {
-			const {
-				getBlocks,
-				hasSelectedInnerBlock: getHasSelectedInnerBlock,
-			} = select( 'core/block-editor' );
+			const { getBlocks } = select( 'core/block-editor' );
 			return {
 				innerBlocks: getBlocks( clientId ),
-				hasSelectedInnerBlock: getHasSelectedInnerBlock(
-					clientId,
-					true
-				),
 			};
 		},
 		[ clientId ]
@@ -68,12 +61,12 @@ export default function TemplatePartEdit( {
 		// Part of a template file, post ID already resolved.
 		return (
 			<>
-				{ ( isSelected || hasSelectedInnerBlock ) && (
+				<BlockControls>
 					<TemplatePartNamePanel
 						postId={ postId }
 						setAttributes={ setAttributes }
 					/>
-				) }
+				</BlockControls>
 				<TemplatePartInnerBlocks
 					postId={ postId }
 					hasInnerBlocks={ innerBlocks.length > 0 }

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -61,10 +61,9 @@
 
 .wp-block-template-part__name-panel {
 	background-color: $white;
-	border-radius: $radius-block-ui;
 	box-shadow: 0 0 0 $border-width $gray-900;
 	outline: 1px solid transparent;
-	padding: ($grid-unit-10 - $border-width - $border-width) $grid-unit-15;
+	padding: $grid-unit-10 $grid-unit-15;
 
 	.components-base-control__field {
 		align-items: center;

--- a/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
@@ -62,7 +62,7 @@ const createTemplatePart = async (
 			? '.wp-block[data-type="core/template-part"] .wp-block[data-type="core/template-part"] .block-editor-inner-blocks'
 			: '.wp-block[data-type="core/template-part"] .block-editor-inner-blocks'
 	);
-	await page.keyboard.press( 'Tab' );
+	await page.focus( '.wp-block-template-part__name-panel input' );
 	await page.keyboard.type( templatePartName );
 };
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Moves the title input to the block toolbar for consistency. Work towards #23871.

_Note: This is not supposed to be a super fancy, polished design or implementation. It's just a foundation from which we can improve the interaction. _

This is part of our work towards the editing interactions with the different entity-related blocks in the editor, like the template parts.

# How has this been tested?
Locally, in edit site.

## Screenshots <!-- if applicable -->
<img width="456" alt="Screen Shot 2020-08-07 at 4 17 13 PM" src="https://user-images.githubusercontent.com/6265975/89695609-7ae3d880-d8c9-11ea-9eb4-e97799a14bc7.png">

<img width="1996" alt="Screen Shot 2020-08-07 at 4 15 32 PM" src="https://user-images.githubusercontent.com/6265975/89695560-4a9c3a00-d8c9-11ea-9870-a6e4fb247dd2.png">

## Types of changes
Enhancement

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
