### PR TITLE
Fix the unicode character used to represent the macOS Control key

### DIFF
--- a/packages/keycodes/src/index.js
+++ b/packages/keycodes/src/index.js
@@ -156,7 +156,7 @@ export const displayShortcutList = mapValues( modifiers, ( modifier ) => {
 		const isApple = _isApple();
 		const replacementKeyMap = {
 			[ ALT ]: isApple ? '⌥' : 'Alt',
-			[ CTRL ]: isApple ? '^' : 'Ctrl',
+			[ CTRL ]: isApple ? '⌃' : 'Ctrl', // Make sure ⌃ is the U+2303 UP ARROWHEAD unicode character and not the caret character.
 			[ COMMAND ]: '⌘',
 			[ SHIFT ]: isApple ? '⇧' : 'Shift',
 		};

--- a/packages/keycodes/src/test/index.js
+++ b/packages/keycodes/src/test/index.js
@@ -91,9 +91,9 @@ describe( 'displayShortcutList', () => {
 			expect( shortcut ).toEqual( [ 'Shift', '+', 'Alt', '+', 'M' ] );
 		} );
 
-		it( 'should output [^, ⌥, M ] on MacOS', () => {
+		it( 'should output [⌃, ⌥, M ] on MacOS', () => {
 			const shortcut = displayShortcutList.access( 'm', isAppleOSTrue );
-			expect( shortcut ).toEqual( [ '^', '⌥', 'M' ] );
+			expect( shortcut ).toEqual( [ '⌃', '⌥', 'M' ] );
 		} );
 	} );
 } );
@@ -159,7 +159,7 @@ describe( 'displayShortcut', () => {
 
 		it( 'should output control+option symbols on MacOS', () => {
 			const shortcut = displayShortcut.access( 'm', isAppleOSTrue );
-			expect( shortcut ).toEqual( '^⌥M' );
+			expect( shortcut ).toEqual( '⌃⌥M' );
 		} );
 	} );
 } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Changes the character used to represent the macOS Control key from "U+005E CIRCUMFLEX ACCENT" to "U+2303 UP ARROWHEAD"

## How has this been tested?
- on master, follow the steps described on the issue #24451 
- observe that Safari and VoiceOver announce the Remove Block menu item as "Remove Block caret option z"
- open the keyboard shortcuts modal dialog
- observe the single characters `^` are announced as "caret"
- switch to this branch and build
- repeat the steps above
- observe that Safari and VoiceOver announce the Remove Block menu item as "Remove Block control option z"
- observe the single characters `⌃` within the keyboard shortcuts modal dialog are announced as "Control"

## Screenshots <!-- if applicable -->

<img width="987" alt="control" src="https://user-images.githubusercontent.com/1682452/89730328-e6e74d80-da3d-11ea-8678-a7e121480d0d.png">

<img width="1013" alt="control 2" src="https://user-images.githubusercontent.com/1682452/89730329-ea7ad480-da3d-11ea-8951-f4896f2979d9.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->

Fixes #24451 