### PR TITLE
Rename block patterns in translations strings

### DIFF
--- a/lib/class-wp-block-patterns-registry.php
+++ b/lib/class-wp-block-patterns-registry.php
@@ -37,19 +37,19 @@ final class WP_Block_Patterns_Registry {
 	 */
 	public function register( $pattern_name, $pattern_properties ) {
 		if ( ! isset( $pattern_name ) || ! is_string( $pattern_name ) ) {
-			$message = __( 'Pattern name must be a string.', 'gutenberg' );
+			$message = __( 'Block pattern name must be a string.', 'gutenberg' );
 			_doing_it_wrong( __METHOD__, $message, '7.8.0' );
 			return false;
 		}
 
 		if ( ! isset( $pattern_properties['title'] ) || ! is_string( $pattern_properties['title'] ) ) {
-			$message = __( 'Pattern title must be a string.', 'gutenberg' );
+			$message = __( 'Block pattern title must be a string.', 'gutenberg' );
 			_doing_it_wrong( __METHOD__, $message, '8.5.0' );
 			return false;
 		}
 
 		if ( ! isset( $pattern_properties['content'] ) || ! is_string( $pattern_properties['content'] ) ) {
-			$message = __( 'Pattern content must be a string.', 'gutenberg' );
+			$message = __( 'Block pattern content must be a string.', 'gutenberg' );
 			_doing_it_wrong( __METHOD__, $message, '8.5.0' );
 			return false;
 		}
@@ -71,7 +71,7 @@ final class WP_Block_Patterns_Registry {
 	public function unregister( $pattern_name ) {
 		if ( ! $this->is_registered( $pattern_name ) ) {
 			/* translators: 1: Pattern name. */
-			$message = sprintf( __( 'Pattern "%1$s" not found.', 'gutenberg' ), $pattern_name );
+			$message = sprintf( __( 'Block pattern "%1$s" not found.', 'gutenberg' ), $pattern_name );
 			_doing_it_wrong( __METHOD__, $message, '7.8.0' );
 			return false;
 		}

--- a/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
@@ -35,7 +35,7 @@ const usePatternsState = ( onInsert ) => {
 		createSuccessNotice(
 			sprintf(
 				/* translators: %s: block pattern title. */
-				__( 'Pattern "%s" inserted.' ),
+				__( 'Block pattern "%s" inserted.' ),
 				pattern.title
 			),
 			{


### PR DESCRIPTION
## Description
We have `Block Patterns`,  `Block Patterns Category` and other `Patterns` like in Rest API. Users and translators should know what kind of patterns are we talking about.

## Screenshots
Different kind of "patterns":
![77777-patterns](https://user-images.githubusercontent.com/576623/89745098-218ecb80-daba-11ea-97de-3f2d52cc19db.png)

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
