### PR TITLE
Remove hardcoded colors from nav block

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -1,11 +1,6 @@
-// Default background and font color
-.wp-block-navigation:not(.has-background) .wp-block-navigation__container {
-	.wp-block-navigation-link:not(.has-text-color) {
-		color: $gray-900;
-	}
-	.wp-block-navigation__container {
-		background-color: $white;
-	}
+// Default text color.
+.wp-block-navigation-link:not(.has-text-color) {
+	color: currentColor;
 }
 
 // Justification.
@@ -20,4 +15,3 @@
 .items-justified-right > ul {
 	justify-content: flex-end;
 }
-


### PR DESCRIPTION
Currently we have these styles for the nav block:

```css
.wp-block-navigation:not(.has-background) .wp-block-navigation__container .wp-block-navigation-link:not(.has-text-color) {
  color: #1e1e1e; 
}

.wp-block-navigation:not(.has-background) .wp-block-navigation__container .wp-block-navigation__container {
  background-color: #fff; 
}
```

what these styles do is change the background-color of the nav block to white if no background-color is defined in the block, and then change the text-color of nav-links if there is no background color AND no text-color defined.

This PR changes the above styles to this:

```css
.wp-block-navigation-link:not(.has-text-color) {
  color: currentColor;
}
```

With this change, the background of nav blocks is not hardcoded to white, and links just use the default text-color if one is not defined.
This will make the block not stand out and appear as if it's separate, since it will inherit the theme styles.
The problem with current styles is that they look out of place if used in a theme with a dark background and light text for example, or even on  a theme that has light - but not white - background.