### PR TITLE
Add arrow navigation in Preview menu

### DIFF
--- a/packages/block-editor/src/components/preview-options/index.js
+++ b/packages/block-editor/src/components/preview-options/index.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Button, Dropdown, MenuGroup, MenuItem } from '@wordpress/components';
+import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { check } from '@wordpress/icons';
 
@@ -17,27 +17,27 @@ export default function PreviewOptions( {
 	deviceType,
 	setDeviceType,
 } ) {
+	const popoverProps = {
+		className: classnames(
+			className,
+			'block-editor-post-preview__dropdown-content'
+		),
+		position: 'bottom left',
+	};
+	const toggleProps = {
+		isTertiary: true,
+		className: 'block-editor-post-preview__button-toggle',
+		disabled: ! isEnabled,
+		children: __( 'Preview' ),
+	};
 	return (
-		<Dropdown
+		<DropdownMenu
 			className="block-editor-post-preview__dropdown"
-			contentClassName={ classnames(
-				className,
-				'block-editor-post-preview__dropdown-content'
-			) }
-			popoverProps={ { role: 'menu' } }
-			position="bottom left"
-			renderToggle={ ( { isOpen, onToggle } ) => (
-				<Button
-					isTertiary
-					onClick={ onToggle }
-					className="block-editor-post-preview__button-toggle"
-					aria-expanded={ isOpen }
-					disabled={ ! isEnabled }
-				>
-					{ __( 'Preview' ) }
-				</Button>
-			) }
-			renderContent={ () => (
+			popoverProps={ popoverProps }
+			toggleProps={ toggleProps }
+			icon={ null }
+		>
+			{ () => (
 				<>
 					<MenuGroup>
 						<MenuItem
@@ -65,6 +65,6 @@ export default function PreviewOptions( {
 					{ children }
 				</>
 			) }
-		/>
+		</DropdownMenu>
 	);
 }

--- a/packages/block-editor/src/components/preview-options/style.scss
+++ b/packages/block-editor/src/components/preview-options/style.scss
@@ -16,9 +16,16 @@
 	.components-popover__content {
 		overflow-y: visible;
 	}
+	.components-menu-group {
+		&:first-child {
+			padding-bottom: $grid-unit-10;
+		}
+		&:last-child {
+			margin-bottom: 0;
+		}
+	}
 
 	.components-menu-group + .components-menu-group {
-		border-top: $border-width solid $gray-400;
 		padding: $grid-unit-10 $grid-unit-15;
 		margin-left: -$grid-unit-15;
 		margin-right: -$grid-unit-15;

--- a/packages/block-editor/src/components/preview-options/style.scss
+++ b/packages/block-editor/src/components/preview-options/style.scss
@@ -16,12 +16,15 @@
 	.components-popover__content {
 		overflow-y: visible;
 	}
-	.components-menu-group {
-		&:first-child {
-			padding-bottom: $grid-unit-10;
-		}
-		&:last-child {
-			margin-bottom: 0;
+
+	&.edit-post-post-preview-dropdown {
+		.components-menu-group {
+			&:first-child {
+				padding-bottom: $grid-unit-10;
+			}
+			&:last-child {
+				margin-bottom: 0;
+			}
 		}
 	}
 

--- a/packages/edit-post/src/components/device-preview/index.js
+++ b/packages/edit-post/src/components/device-preview/index.js
@@ -42,6 +42,7 @@ export default function DevicePreview() {
 						className={
 							'edit-post-header-preview__button-external'
 						}
+						role="menuitem"
 						forceIsAutosaveable={ hasActiveMetaboxes }
 						forcePreviewLink={ isSaving ? null : undefined }
 						textContent={

--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -180,7 +180,7 @@ export class PostPreviewButton extends Component {
 	}
 
 	render() {
-		const { previewLink, currentPostLink, isSaveable } = this.props;
+		const { previewLink, currentPostLink, isSaveable, role } = this.props;
 
 		// Link to the `?preview=true` URL if we have it, since this lets us see
 		// changes that were autosaved since the post was last published. Otherwise,
@@ -203,6 +203,7 @@ export class PostPreviewButton extends Component {
 				disabled={ ! isSaveable }
 				onClick={ this.openPreviewWindow }
 				ref={ this.buttonRef }
+				role={ role }
 			>
 				{ this.props.textContent
 					? this.props.textContent


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Resolves: https://github.com/WordPress/gutenberg/issues/24453

This PR adds arrow navigation support for Preview menu and prevents scroll containers from scrolling, when navigating.
<!-- Please describe what you have changed or added -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
