### PR TITLE
Fixing duplicated wp-block classes in block-list

### DIFF
--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -79,7 +79,6 @@ const BlockComponent = forwardRef(
 			'core/block-editor'
 		);
 		const fallbackRef = useRef();
-		const isAligned = wrapperProps && !! wrapperProps[ 'data-align' ];
 		wrapper = wrapper || fallbackRef;
 
 		const [ isHovered, setHovered ] = useState( false );
@@ -251,7 +250,6 @@ const BlockComponent = forwardRef(
 					wrapperProps && wrapperProps.className,
 					{
 						'is-hovered': isHovered,
-						'wp-block': ! isAligned,
 					}
 				) }
 				data-block={ clientId }


### PR DESCRIPTION

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Note: This is my first PR.

Fixes issue #24367


<!-- Please describe what you have changed or added -->
I removed the isAlign check for block-wrapper.js of block-list in block-editor. This check is already done in block.js. Doing it again causes the wp-block class to show up twice in the block-list.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
I tested it on Firefox in Ubuntu to see if anything was broken. 

I added some blocks in the editor. I couldn't find anything that was misaligned or didn't show up.  All the blocks in the block-list had one `wp-block` class. No more duplicated `wp-block` classes.

Then, I ran the `npm run test` script. I didn't get any errors.

## Types of changes
<!-- What types of changes does your code introduce?  -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
