### PR TITLE
Fix: Media Text: Always show images on top on mobile.

### DIFF
--- a/packages/block-library/src/media-text/style.scss
+++ b/packages/block-library/src/media-text/style.scss
@@ -108,15 +108,4 @@
 			grid-row: 2;
 		}
 	}
-
-	.wp-block-media-text.is-stacked-on-mobile.has-media-on-the-right {
-		.wp-block-media-text__media {
-			grid-column: 1;
-			grid-row: 2;
-		}
-		.wp-block-media-text__content {
-			grid-column: 1;
-			grid-row: 1;
-		}
-	}
 }


### PR DESCRIPTION
Fix: https://github.com/WordPress/gutenberg/issues/14283

In https://github.com/WordPress/gutenberg/issues/14283, it seems we arrived at a consensus that on mobile the media & text images should appear on top (and the display image on left/right option should be ignored).

This PR applies that change to the block.
 

## How has this been tested?
I two added the media & text block.
In one I made the images appear on the right and it the other on the left (default).
I resized the window to a mobile view (650px) I verified that in both editor and frontend and for both blocks the images appear on the top.
