### PR TITLE
Fix: Custom gradient picker unable to change predefined gradients with hex colors

### DIFF
--- a/packages/components/src/custom-gradient-picker/serializer.js
+++ b/packages/components/src/custom-gradient-picker/serializer.js
@@ -4,8 +4,11 @@
 import { compact, get } from 'lodash';
 
 export function serializeGradientColor( { type, value } ) {
-	if ( type === 'literal' || type === 'hex' ) {
+	if ( type === 'literal' ) {
 		return value;
+	}
+	if ( type === 'hex' ) {
+		return `#${ value }`;
 	}
 	return `${ type }(${ value.join( ',' ) })`;
 }

--- a/packages/components/src/custom-gradient-picker/test/serializer.js
+++ b/packages/components/src/custom-gradient-picker/test/serializer.js
@@ -113,6 +113,24 @@ describe( 'It should serialize a gradient', () => {
 		expect(
 			serializeGradient( {
 				type: 'linear-gradient',
+				colorStops: [
+					{
+						type: 'hex',
+						value: '000',
+						length: { type: '%', value: 70 },
+					},
+					{
+						type: 'hex',
+						value: 'fff',
+						length: { type: '%', value: 40 },
+					},
+				],
+			} )
+		).toBe( 'linear-gradient(#fff 40%,#000 70%)' );
+
+		expect(
+			serializeGradient( {
+				type: 'linear-gradient',
 				orientation: { type: 'angular', value: 0 },
 				colorStops: [
 					{


### PR DESCRIPTION
This PR makes the custom gradient picker able to change predefined gradients with colors defined in hexadecimal format.


Continues the work started on https://github.com/WordPress/gutenberg/pull/23363.

## Description
I added this code block to the functions.php file of the current enabled theme:
```
add_theme_support(
	'editor-gradient-presets',
	array(
		array(
			'name'     => __( 'Hex gradient', 'themeslug'  ),
			'gradient' => 'linear-gradient(to bottom, #000000 0%, #fff 100%)',
			'slug'     => 'hex-gradient',
		),
	)
);
```

I added a group block. I set the background of the group to the predefined gradient, and I verified I was able to change the gradient correctly with the custom gradient picker (on master it reverts to the default gradient). The predefined gradient will not preview accurately on the block unless the gradient class is added to the theme.