### PR TITLE
Fix: Image Block: Alt and caption written during image upload are discarded

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -88,6 +88,17 @@ export function ImageEdit( {
 		height,
 		sizeSlug,
 	} = attributes;
+
+	const altRef = useRef();
+	useEffect( () => {
+		altRef.current = alt;
+	}, [ alt ] );
+
+	const captionRef = useRef();
+	useEffect( () => {
+		captionRef.current = caption;
+	}, [ caption ] );
+
 	const ref = useRef();
 	const mediaUpload = useSelect( ( select ) => {
 		const { getSettings } = select( 'core/block-editor' );
@@ -116,14 +127,14 @@ export function ImageEdit( {
 		// If the current image is temporary but an alt text was meanwhile
 		// written by the user, make sure the text is not overwritten.
 		if ( isTemporaryImage( id, url ) ) {
-			if ( alt ) {
+			if ( altRef.current ) {
 				mediaAttributes = omit( mediaAttributes, [ 'alt' ] );
 			}
 		}
 
 		// If a caption text was meanwhile written by the user,
 		// make sure the text is not overwritten by empty captions.
-		if ( caption && ! get( mediaAttributes, [ 'caption' ] ) ) {
+		if ( captionRef.current && ! get( mediaAttributes, [ 'caption' ] ) ) {
 			mediaAttributes = omit( mediaAttributes, [ 'caption' ] );
 		}
 


### PR DESCRIPTION
This issue was already fixed in the past at https://github.com/WordPress/gutenberg/pull/16051.
But meanwhile, the component was refactored from a class component to a functional hook based component. The refactoring made the logic not to work as expected.

A function onSelectImage is passed as a callback to the media upload function before the user writes any. If after uploading an image but before the process is completed the user writes a caption and an alt tag the attributes get the new values, but the function still references the empty fields (because when the function was passed to media upload they were empty). This PR solves the issue by using references and hooks to update the references.


## Description
I added an image block.
On chrome dev tools I created a network profile with 5 seconds latency and enabled it.
I uploaded an image to the image block.
While the image was uploading (takes 5seconds) I wrote a caption and an alt.
I verified after the upload is complete the attributes I wrote are kept (on master they are ignored).
