### PR TITLE
Remove Embeds for Facebook and Instagram

### DIFF
--- a/packages/block-library/src/embed/variations.js
+++ b/packages/block-library/src/embed/variations.js
@@ -73,7 +73,7 @@ const variations = [
 	},
 	{
 		// Deprecate Instagram per FB policy
-		// See: https://developers.facebook.com/docs/plugins/oembed-legacy
+		// See: https://developers.facebook.com/docs/instagram/oembed-legacy
 		name: 'instagram',
 		title: 'Instagram',
 		icon: embedInstagramIcon,

--- a/packages/block-library/src/embed/variations.js
+++ b/packages/block-library/src/embed/variations.js
@@ -56,12 +56,15 @@ const variations = [
 		attributes: { providerNameSlug: 'youtube', responsive: true },
 	},
 	{
+		// Deprecate Facebook Embed per FB policy
+		// See: https://developers.facebook.com/docs/plugins/oembed-legacy
 		name: 'facebook',
 		title: 'Facebook',
 		icon: embedFacebookIcon,
 		keywords: [ __( 'social' ) ],
 		description: __( 'Embed a Facebook post.' ),
-		patterns: [ /^https?:\/\/www\.facebook.com\/.+/i ],
+		scope: [ 'block' ],
+		patterns: [],
 		attributes: {
 			providerNameSlug: 'facebook',
 			previewable: false,
@@ -69,12 +72,15 @@ const variations = [
 		},
 	},
 	{
+		// Deprecate Instagram per FB policy
+		// See: https://developers.facebook.com/docs/plugins/oembed-legacy
 		name: 'instagram',
 		title: 'Instagram',
 		icon: embedInstagramIcon,
 		keywords: [ __( 'image' ), __( 'social' ) ],
 		description: __( 'Embed an Instagram post.' ),
-		patterns: [ /^https?:\/\/(www\.)?instagr(\.am|am\.com)\/.+/i ],
+		scope: [ 'block' ],
+		patterns: [],
 		attributes: { providerNameSlug: 'instagram', responsive: true },
 	},
 	{


### PR DESCRIPTION
## Description

This PR removes the Facebook & Instagram blocks from the inserter. Per Facebook, the [embed APIs are going to require an authentication token](https://developers.facebook.com/docs/plugins/oembed-legacy) so will remove from Gutenberg embeds.

As done with the deprecated CollegeHumor embed, I removed the pattern regular expression, and added the `scope: [ 'block' ]` that removes them from the inserter.

Fixes #24389 

Deadline: October 24, 2020

Core will remove API in WP 5.6

Related: https://core.trac.wordpress.org/ticket/50861


## Types of changes

Move Facebook and Instagram embeds to `others` section in embeds and add `support: { inserter: false }`

We will probably want to update support documentation.


