### PR TITLE
Fix tiny editor preview when using Mobile or Tablet options with metaboxes enabled

### DIFF
--- a/packages/block-editor/src/components/use-resize-canvas/index.js
+++ b/packages/block-editor/src/components/use-resize-canvas/index.js
@@ -51,6 +51,7 @@ export default function useResizeCanvas( deviceType ) {
 	const marginValue = () => ( window.innerHeight < 800 ? 36 : 72 );
 
 	const contentInlineStyles = ( device ) => {
+		const height = device === 'Mobile' ? '768px' : '1024px';
 		switch ( device ) {
 			case 'Tablet':
 			case 'Mobile':
@@ -58,7 +59,9 @@ export default function useResizeCanvas( deviceType ) {
 					width: getCanvasWidth( device ),
 					margin: marginValue() + 'px auto',
 					flexGrow: 0,
-					maxHeight: device === 'Mobile' ? '768px' : '1024px',
+					height,
+					minHeight: height,
+					maxHeight: height,
 					overflowY: 'auto',
 				};
 			default:


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes #23404.

The issue was caused by `overflow-y: auto` being applied to the editor area, but no `min-height` being set which caused the area to collapse.

I've fixed this by making the preview area generally try to have the right dimensions for the desired devices (min-height of 768px for the mobile option, and 1024px for the Tablet option).

This does result in the metabox options being pushed down the page a bit, but I think this is ok, the user can still scroll down, and generally has to do that anyway outside of preview. When a user selects one of those preview options, they generally want to be able to see the content at the right size first and foremost.

## How has this been tested?
1. Install a plugin with lots of metaboxes (i.e. Yoast)
2. Start a new post.
3. Select the 'Mobile' preview option.
4. Observe the editor should be displayed at the correct size
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
