### PR TITLE
Support drag-and-drop for submenus of navigation blocks

### DIFF
--- a/packages/block-editor/src/components/block-draggable/style.scss
+++ b/packages/block-editor/src/components/block-draggable/style.scss
@@ -32,7 +32,6 @@
 
 // This hides the block being dragged.
 // The effect is that the block being dragged appears to be "lifted".
-.is-dragging.is-selected,
-.is-dragging.is-multi-selected {
+.is-dragging {
 	display: none !important;
 }

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -149,7 +149,8 @@ function BlockListBlock( {
 		{
 			'wp-block': ! isAligned,
 			'has-warning': ! isValid || !! hasError || isUnregisteredBlock,
-			'is-selected': isSelected,
+			// Don't select the item while dragging
+			'is-selected': isSelected && ! isDragging,
 			'is-highlighted': isHighlighted,
 			'is-multi-selected': isMultiSelected,
 			'is-reusable': isReusableBlock( blockType ),
@@ -159,7 +160,8 @@ function BlockListBlock( {
 			'is-focused':
 				isFocusMode && ( isSelected || isAncestorOfSelectedBlock ),
 			'is-focus-mode': isFocusMode,
-			'has-child-selected': isAncestorOfSelectedBlock,
+			// Don't select child while dragging
+			'has-child-selected': isAncestorOfSelectedBlock && ! isDragging,
 		},
 		className
 	);

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -149,7 +149,7 @@ function BlockListBlock( {
 		{
 			'wp-block': ! isAligned,
 			'has-warning': ! isValid || !! hasError || isUnregisteredBlock,
-			// Don't select the item while dragging
+			// Don't select the item while dragging.
 			'is-selected': isSelected && ! isDragging,
 			'is-highlighted': isHighlighted,
 			'is-multi-selected': isMultiSelected,
@@ -160,7 +160,7 @@ function BlockListBlock( {
 			'is-focused':
 				isFocusMode && ( isSelected || isAncestorOfSelectedBlock ),
 			'is-focus-mode': isFocusMode,
-			// Don't select child while dragging
+			// Don't select child while dragging.
 			'has-child-selected': isAncestorOfSelectedBlock && ! isDragging,
 		},
 		className

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -628,6 +628,15 @@
 	}
 }
 
+// Hide the popover block editor list while dragging.
+// Using a hacky animation to delay hiding the element so that dragging can still work
+@keyframes hide-during-dragging {
+	to {
+		position: fixed;
+		transform: translate(9999px, 9999px);
+	}
+}
+
 .components-popover.block-editor-block-list__block-popover {
 	z-index: z-index(".block-editor-block-list__block-popover");
 	position: absolute;
@@ -657,6 +666,8 @@
 
 	.is-dragging-components-draggable & {
 		opacity: 0;
+		// Use a minimal duration to delay hiding the element, see hide-during-dragging animation for more details
+		animation: hide-during-dragging 1ms linear forwards;
 	}
 }
 

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -629,7 +629,7 @@
 }
 
 // Hide the popover block editor list while dragging.
-// Using a hacky animation to delay hiding the element so that dragging can still work
+// Using a hacky animation to delay hiding the element so that dragging can still work.
 @keyframes hide-during-dragging {
 	to {
 		position: fixed;
@@ -666,7 +666,7 @@
 
 	.is-dragging-components-draggable & {
 		opacity: 0;
-		// Use a minimal duration to delay hiding the element, see hide-during-dragging animation for more details
+		// Use a minimal duration to delay hiding the element, see hide-during-dragging animation for more details.
 		animation: hide-during-dragging 1ms linear forwards;
 	}
 }

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -44,12 +44,21 @@ import { link as linkIcon } from '@wordpress/icons';
  */
 import { ToolbarSubmenuIcon, ItemSubmenuIcon } from './icons';
 
+/**
+ * A React hook to determine if it's dragging within the target element.
+ *
+ * @typedef {import('@wordpress/element').RefObject} RefObject
+ *
+ * @param {RefObject<HTMLElement>} elementRef The target elementRef object.
+ *
+ * @return {boolean} Is dragging within the target element.
+ */
 const useIsDraggingWithin = ( elementRef ) => {
 	const [ isDraggingWithin, setIsDraggingWithin ] = useState( false );
 
 	useEffect( () => {
 		function handleDragStart( event ) {
-			// Check the first time when the dragging starts
+			// Check the first time when the dragging starts.
 			handleDragEnter( event );
 		}
 
@@ -59,7 +68,7 @@ const useIsDraggingWithin = ( elementRef ) => {
 		}
 
 		function handleDragEnter( event ) {
-			// Check if the current target is inside the item element
+			// Check if the current target is inside the item element.
 			if ( elementRef.current.contains( event.target ) ) {
 				setIsDraggingWithin( true );
 			} else {
@@ -236,9 +245,9 @@ function NavigationLinkEdit( {
 				className={ classnames( {
 					'is-editing':
 						( isSelected || isParentOfSelectedBlock ) &&
-						// Don't show the element as editing while dragging
+						// Don't show the element as editing while dragging.
 						! isDraggingBlocks,
-					// Don't select the element while dragging
+					// Don't select the element while dragging.
 					'is-selected': isSelected && ! isDraggingBlocks,
 					'is-dragging-within': isDraggingWithin,
 					'has-link': !! url,
@@ -340,7 +349,7 @@ function NavigationLinkEdit( {
 						( isSelected && hasDescendants ) ||
 						( isImmediateParentOfSelectedBlock &&
 							! selectedBlockHasDescendants ) ||
-						// Show the appender while dragging to allow inserting element between item and the appender
+						// Show the appender while dragging to allow inserting element between item and the appender.
 						( isDraggingBlocks && hasDescendants )
 							? InnerBlocks.DefaultAppender
 							: false
@@ -353,7 +362,7 @@ function NavigationLinkEdit( {
 							{
 								'is-parent-of-selected-block':
 									isParentOfSelectedBlock &&
-									// Don't select as parent of selected block while dragging
+									// Don't select as parent of selected block while dragging.
 									! isDraggingBlocks,
 							}
 						),

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -65,6 +65,8 @@ function NavigationLinkEdit( {
 	};
 	const { saveEntityRecord } = useDispatch( 'core' );
 	const [ isLinkOpen, setIsLinkOpen ] = useState( false );
+	const [ isDragEnter, setIsDragEnter ] = useState( false );
+	const listItemRef = useRef( null );
 	const itemLabelPlaceholder = __( 'Add link…' );
 	const ref = useRef();
 
@@ -104,6 +106,29 @@ function NavigationLinkEdit( {
 			}
 		}
 	}, [ url ] );
+
+	// Set isDragEnter to false whenever the user cancel the drag event by either releasing the mouse or press Escape.
+	useEffect( () => {
+		function handleDragEnd() {
+			setIsDragEnter( false );
+		}
+
+		function handleDragEnter( e ) {
+			if ( listItemRef.current.contains( e.target ) ) {
+				setIsDragEnter( true );
+			} else {
+				setIsDragEnter( false );
+			}
+		}
+
+		document.addEventListener( 'dragend', handleDragEnd );
+		document.addEventListener( 'dragenter', handleDragEnter );
+
+		return () => {
+			document.removeEventListener( 'dragend', handleDragEnd );
+			document.removeEventListener( 'dragenter', handleDragEnter );
+		};
+	}, [] );
 
 	/**
 	 * Focus the Link label text and select it.
@@ -185,6 +210,7 @@ function NavigationLinkEdit( {
 				className={ classnames( {
 					'is-editing': isSelected || isParentOfSelectedBlock,
 					'is-selected': isSelected,
+					'is-drag-enter': isDragEnter,
 					'has-link': !! url,
 					'has-child': hasDescendants,
 					'has-text-color': rgbTextColor,
@@ -196,6 +222,7 @@ function NavigationLinkEdit( {
 					color: rgbTextColor,
 					backgroundColor: rgbBackgroundColor,
 				} }
+				ref={ listItemRef }
 			>
 				<div className="wp-block-navigation-link__content">
 					<RichText

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -49,7 +49,7 @@ $navigation-item-height: 46px;
 	&.is-selected,
 	&.has-child-selected,
 	// Show the submenu list when is dragging and drag enter the list item
-	body.is-dragging-components-draggable &.is-drag-enter {
+	body.is-dragging-components-draggable &.is-dragging-within {
 		> .wp-block-navigation__container {
 			opacity: 1;
 			visibility: visible;

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -48,11 +48,23 @@ $navigation-item-height: 46px;
 
 	&.is-selected,
 	&.has-child-selected,
+	// Show the submenu list when is dragging and drag enter the list item
 	body.is-dragging-components-draggable &.is-drag-enter {
 		> .wp-block-navigation__container {
 			opacity: 1;
 			visibility: visible;
 		}
+	}
+}
+
+body.is-dragging-components-draggable .wp-block-navigation-link > .wp-block-navigation__container {
+	// Set opacity to 1 to still be able to show the draggable chip
+	opacity: 1;
+	visibility: hidden;
+
+	// Show the chip but hide the submenu list
+	.block-editor-block-draggable-chip-wrapper {
+		visibility: visible;
 	}
 }
 
@@ -96,7 +108,7 @@ $colors-selector-size: 22px;
 		min-width: $colors-selector-size;
 		height: $colors-selector-size;
 		min-height: $colors-selector-size;
-		line-height: ($colors-selector-size - 2);
+		line-height: ( $colors-selector-size - 2 );
 		padding: 2px;
 
 		> svg {
@@ -146,7 +158,6 @@ $color-control-label-height: 20px;
 }
 
 .wp-block-navigation-placeholder {
-
 	.components-spinner {
 		margin-top: -4px;
 		margin-left: 4px;
@@ -166,7 +177,6 @@ $color-control-label-height: 20px;
 
 	// Styles for when there are Menus present in the dropdown.
 	.components-custom-select-control.has-menus .components-custom-select-control__item {
-
 		// Creates a faux divider between the menu options if present
 		&.is-create-empty-option {
 			position: relative; // positioning context for pseudo
@@ -196,7 +206,6 @@ $color-control-label-height: 20px;
 		font-family: $default-font;
 		font-size: $default-font-size;
 	}
-
 }
 
 .wp-block-navigation .block-editor-button-block-appender {

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -48,7 +48,7 @@ $navigation-item-height: 46px;
 
 	&.is-selected,
 	&.has-child-selected,
-	// Show the submenu list when is dragging and drag enter the list item
+	// Show the submenu list when is dragging and drag enter the list item.
 	body.is-dragging-components-draggable &.is-dragging-within {
 		> .wp-block-navigation__container {
 			opacity: 1;
@@ -58,11 +58,11 @@ $navigation-item-height: 46px;
 }
 
 body.is-dragging-components-draggable .wp-block-navigation-link > .wp-block-navigation__container {
-	// Set opacity to 1 to still be able to show the draggable chip
+	// Set opacity to 1 to still be able to show the draggable chip.
 	opacity: 1;
 	visibility: hidden;
 
-	// Show the chip but hide the submenu list
+	// Show the chip but hide the submenu list.
 	.block-editor-block-draggable-chip-wrapper {
 		visibility: visible;
 	}

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -47,7 +47,8 @@ $navigation-item-height: 46px;
 	}
 
 	&.is-selected,
-	&.has-child-selected {
+	&.has-child-selected,
+	body.is-dragging-components-draggable &.is-drag-enter {
 		> .wp-block-navigation__container {
 			opacity: 1;
 			visibility: visible;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Close #23874, enable drag-and-drop for submenus in navigation block.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Create a new post with navigation blocks
2. Add a few links with submenus
3. Drag and drop a few links/submenus around

Currently only manually testing are available.

## Screenshots <!-- if applicable -->
![Drag and drop GIF](https://user-images.githubusercontent.com/7753001/89878954-d4634480-dbf4-11ea-99eb-ef65b769aee0.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
