### PR TITLE
Fill quick inserter results with available variations if limit is set and items are less.

### DIFF
--- a/packages/block-editor/src/components/inserter/test/fixtures/index.js
+++ b/packages/block-editor/src/components/inserter/test/fixtures/index.js
@@ -40,6 +40,21 @@ export const withSingleVariationItem = {
 	],
 };
 
+export const withDefaultVariationItem = {
+	id: 'core/block-with-default-variation',
+	name: 'core/block-with-default-variation',
+	description: 'core description',
+	initialAttributes: {},
+	category: 'text',
+	variations: [
+		{
+			name: 'special',
+			title: 'Special',
+			isDefault: true,
+		},
+	],
+};
+
 export const withVariationsItem = {
 	id: 'core/block-with-variations',
 	name: 'core/block-with-variations',

--- a/packages/block-editor/src/components/inserter/test/utils.js
+++ b/packages/block-editor/src/components/inserter/test/utils.js
@@ -7,11 +7,33 @@ import {
 	someOtherItem,
 	withVariationsItem,
 	withSingleVariationItem,
+	withDefaultVariationItem,
 } from './fixtures';
 import { includeVariationsInInserterItems } from '../utils';
 
 describe( 'inserter utils', () => {
 	describe( 'includeVariationsInInserterItems', () => {
+		it( 'should let a block type be replaced with the default variation', () => {
+			// The base block type is replaced with the default variation
+			expect(
+				includeVariationsInInserterItems( [ withDefaultVariationItem ] )
+			).toEqual( [
+				expect.objectContaining( {
+					id: 'core/block-with-default-variation-special',
+				} ),
+			] );
+			// The base block type is supplemented by non-default variations
+			expect(
+				includeVariationsInInserterItems( [ withSingleVariationItem ] )
+			).toEqual( [
+				expect.objectContaining( {
+					id: 'core/embed',
+				} ),
+				expect.objectContaining( {
+					id: 'core/embed-youtube',
+				} ),
+			] );
+		} );
 		it( 'should return items if limit is equal to items length', () => {
 			const items = [ moreItem, paragraphItem, someOtherItem ];
 			const res = includeVariationsInInserterItems( items, 3 );

--- a/packages/block-editor/src/components/inserter/test/utils.js
+++ b/packages/block-editor/src/components/inserter/test/utils.js
@@ -27,6 +27,28 @@ describe( 'inserter utils', () => {
 			const res = includeVariationsInInserterItems( items, 2 );
 			expect( res ).toEqual( [ moreItem, paragraphItem ] );
 		} );
+		it( 'should fill the items with variations, if limit is set and items are fewer than limit and variations exist', () => {
+			const items = [ moreItem, paragraphItem, withVariationsItem ];
+			const res = includeVariationsInInserterItems( items, 5 );
+			expect( res.length ).toEqual( 5 );
+			expect( res ).toEqual( [
+				...items,
+				expect.objectContaining( {
+					id: 'core/block-with-variations-variation-one',
+					title: 'Variation One',
+				} ),
+				expect.objectContaining( {
+					id: 'core/block-with-variations-variation-two',
+					title: 'Variation Two',
+				} ),
+			] );
+		} );
+		it( 'should return the items, if limit is set and items are fewer than limit and variations do NOT exist', () => {
+			const items = [ moreItem, paragraphItem, someOtherItem ];
+			const res = includeVariationsInInserterItems( items, 4 );
+			expect( res.length ).toEqual( 3 );
+			expect( res ).toEqual( items );
+		} );
 		it( 'should return proper result if no limit provided and block variations do NOT exist', () => {
 			const items = [ moreItem, paragraphItem, someOtherItem ];
 			const res = includeVariationsInInserterItems( items );

--- a/packages/block-editor/src/components/inserter/utils.js
+++ b/packages/block-editor/src/components/inserter/utils.js
@@ -29,11 +29,6 @@ const getItemFromVariation = ( item ) => ( variation ) => ( {
  * @return {Array} Normalized inserter items.
  */
 export function includeVariationsInInserterItems( items, limit = Infinity ) {
-	if ( items.length >= limit ) {
-		// No need to iterate for variations
-		return items.slice( 0, limit );
-	}
-
 	// Exclude any block type item that is to be replaced by a default
 	// variation.
 	const filteredItems = items.filter(

--- a/packages/block-editor/src/components/inserter/utils.js
+++ b/packages/block-editor/src/components/inserter/utils.js
@@ -29,6 +29,11 @@ const getItemFromVariation = ( item ) => ( variation ) => ( {
  * @return {Array} Normalized inserter items.
  */
 export function includeVariationsInInserterItems( items, limit = Infinity ) {
+	if ( items.length >= limit ) {
+		// No need to iterate for variations
+		return items.slice( 0, limit );
+	}
+
 	// Exclude any block type item that is to be replaced by a default
 	// variation.
 	const filteredItems = items.filter(

--- a/packages/block-editor/src/components/inserter/utils.js
+++ b/packages/block-editor/src/components/inserter/utils.js
@@ -29,10 +29,33 @@ const getItemFromVariation = ( item ) => ( variation ) => ( {
  * @return {Array} Normalized inserter items.
  */
 export function includeVariationsInInserterItems( items, limit = Infinity ) {
-	if ( items.length >= limit ) {
+	const itemsLength = items.length;
+	if ( itemsLength >= limit ) {
 		// No need to iterate for variations
 		return items.slice( 0, limit );
 	}
+
+	// If there is a limit set but the items are fewer than the limit,
+	// add the variations to fill the limit with order of blocks.
+	// It should be handled better when decided how to choose the variations to fill.
+	if ( Number.isFinite( limit ) ) {
+		let itemsToAdd = limit - itemsLength;
+		let variationsToAdd = [];
+		for ( const item of items ) {
+			const { variations = [] } = item;
+			const variationsLength = variations.length;
+			if ( variationsLength ) {
+				const variationMapper = getItemFromVariation( item );
+				variationsToAdd = variationsToAdd.concat(
+					variations.slice( 0, itemsToAdd ).map( variationMapper )
+				);
+				itemsToAdd -= variationsLength;
+				if ( itemsToAdd < 1 ) break;
+			}
+		}
+		return items.concat( variationsToAdd );
+	}
+
 	// Show all available blocks with variations
 	return items.reduce( ( result, item ) => {
 		const { variations = [] } = item;

--- a/packages/block-editor/src/components/inserter/utils.js
+++ b/packages/block-editor/src/components/inserter/utils.js
@@ -29,51 +29,30 @@ const getItemFromVariation = ( item ) => ( variation ) => ( {
  * @return {Array} Normalized inserter items.
  */
 export function includeVariationsInInserterItems( items, limit = Infinity ) {
-	const itemsLength = items.length;
-	if ( itemsLength >= limit ) {
-		// No need to iterate for variations
-		return items.slice( 0, limit );
-	}
+	// Exclude any block type item that is to be replaced by a default
+	// variation.
+	const filteredItems = items.filter(
+		( { variations = [] } ) =>
+			! variations.some( ( { isDefault } ) => isDefault )
+	);
 
-	// If there is a limit set but the items are fewer than the limit,
-	// add the variations to fill the limit with order of blocks.
-	// It should be handled better when decided how to choose the variations to fill.
-	if ( Number.isFinite( limit ) ) {
-		let itemsToAdd = limit - itemsLength;
-		let variationsToAdd = [];
+	// Fill `variationsToAdd` until there are as many items in total as
+	// `limit`.
+	const variationsToAdd = [];
+	if ( filteredItems.length < limit ) {
+		// Show all available blocks with variations
 		for ( const item of items ) {
+			if ( filteredItems.length + variationsToAdd.length >= limit ) {
+				break;
+			}
+
 			const { variations = [] } = item;
-			const variationsLength = variations.length;
-			if ( variationsLength ) {
+			if ( variations.length ) {
 				const variationMapper = getItemFromVariation( item );
-				variationsToAdd = variationsToAdd.concat(
-					variations.slice( 0, itemsToAdd ).map( variationMapper )
-				);
-				itemsToAdd -= variationsLength;
-				if ( itemsToAdd < 1 ) break;
+				variationsToAdd.push( ...variations.map( variationMapper ) );
 			}
 		}
-		return items.concat( variationsToAdd );
 	}
 
-	// Show all available blocks with variations
-	return items.reduce( ( result, item ) => {
-		const { variations = [] } = item;
-		const hasDefaultVariation = variations.some(
-			( { isDefault } ) => isDefault
-		);
-
-		// If there is no default inserter variation provided,
-		// then default block type is displayed.
-		if ( ! hasDefaultVariation ) {
-			result.push( item );
-		}
-
-		if ( variations.length ) {
-			const variationMapper = getItemFromVariation( item );
-			result.push( ...variations.map( variationMapper ) );
-		}
-
-		return result;
-	}, [] );
+	return [ ...filteredItems, ...variationsToAdd ].slice( 0, limit );
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
There was a refactoring (https://github.com/WordPress/gutenberg/pull/24090)  in `embed block` that made it a single block with lots of `block variations`. That surfaced a problem with quick Inserter and the main Inserter when suggesting items with a limit (currently six).

A small fix was there to handle the cases where the `limit was set` and `the items where NOT fewer` than the limit.

I saw now that when you're searching for items and the filtered results are for example four, it continues to add all the available variations.

This PR handles this case ( `limit is set and bigger than items` ) and fills the Block list with available variations, if they exist, until it reaches the provided limit.

The addition now happens by taking account only the order of variations and there is not a sophisticated handling of which variations to choose. It could/should be handled better when we decide how to handle block variations better. 
<!-- Please describe what you have changed or added -->

## Steps to reproduce
1. Go to edit a post/page
2. Clock on the quick Inserter ( plus button )
3. Type in search `em`
4. You can see that the results are way more than the current limit ( 6 )
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->



## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
