### PR TITLE
Implement the custom classname support hook in the server

### DIFF
--- a/lib/block-supports/custom-classname.php
+++ b/lib/block-supports/custom-classname.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Custom classname block support flag.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Registers the custom classname block attribute for block types that support it.
+ *
+ * @param  array $block_type Block Type.
+ */
+function gutenberg_register_custom_classname_support( $block_type ) {
+	$has_custom_classname_support = gutenberg_experimental_get( $block_type->supports, array( 'customClassName' ), true );
+	if ( $has_custom_classname_support ) {
+		if ( ! $block_type->attributes ) {
+			$block_type->attributes = array();
+		}
+
+		if ( ! array_key_exists( 'className', $block_type->attributes ) ) {
+			$block_type->attributes['className'] = array(
+				'type' => 'string',
+			);
+		}
+	}
+}
+
+/**
+ * Add the custom classnames to the output.
+ *
+ * @param  array $attributes comprehensive list of attributes to be applied.
+ * @param  array $block_attributes block attributes.
+ * @param  array $block_type Block Type.
+ * @return array Block CSS classes and inline styles.
+ */
+function gutenberg_apply_custom_classname_support( $attributes, $block_attributes, $block_type ) {
+	$has_custom_classname_support = gutenberg_experimental_get( $block_type->supports, array( 'customClassName' ), true );
+	if ( $has_custom_classname_support ) {
+		$has_custom_classnames = array_key_exists( 'className', $block_attributes );
+
+		if ( $has_custom_classnames ) {
+			$attributes['css_classes'][] = $block_attributes['className'];
+		}
+	}
+
+	return $attributes;
+}

--- a/lib/block-supports/index.php
+++ b/lib/block-supports/index.php
@@ -17,6 +17,7 @@ function gutenberg_register_block_supports() {
 		gutenberg_register_alignment_support( $block_type );
 		gutenberg_register_colors_support( $block_type );
 		gutenberg_register_typography_support( $block_type );
+		gutenberg_register_custom_classname_support( $block_type );
 	}
 }
 
@@ -44,6 +45,7 @@ function gutenberg_apply_block_supports( $block_content, $block ) {
 	$attributes = gutenberg_apply_colors_support( $attributes, $block['attrs'], $block_type );
 	$attributes = gutenberg_apply_typography_support( $attributes, $block['attrs'], $block_type );
 	$attributes = gutenberg_apply_alignment_support( $attributes, $block['attrs'], $block_type );
+	$attributes = gutenberg_apply_custom_classname_support( $attributes, $block['attrs'], $block_type );
 
 	if ( ! count( $attributes ) ) {
 		return $block_content;

--- a/lib/load.php
+++ b/lib/load.php
@@ -110,3 +110,4 @@ require dirname( __FILE__ ) . '/block-supports/index.php';
 require dirname( __FILE__ ) . '/block-supports/align.php';
 require dirname( __FILE__ ) . '/block-supports/colors.php';
 require dirname( __FILE__ ) . '/block-supports/typography.php';
+require dirname( __FILE__ ) . '/block-supports/custom-classname.php';

--- a/lib/utils.php
+++ b/lib/utils.php
@@ -24,7 +24,7 @@ function gutenberg_experimental_get( $array, $path, $default = array() ) {
 
 	$path_length = count( $path );
 	for ( $i = 0; $i < $path_length; ++$i ) {
-		if ( empty( $array[ $path[ $i ] ] ) ) {
+		if ( ! isset( $array[ $path[ $i ] ] ) ) {
 			return $default;
 		}
 		$array = $array[ $path[ $i ] ];

--- a/packages/block-library/src/archives/block.json
+++ b/packages/block-library/src/archives/block.json
@@ -2,9 +2,6 @@
 	"name": "core/archives",
 	"category": "widgets",
 	"attributes": {
-		"className": {
-			"type": "string"
-		},
 		"displayAsDropdown": {
 			"type": "boolean",
 			"default": false

--- a/packages/block-library/src/archives/index.php
+++ b/packages/block-library/src/archives/index.php
@@ -19,10 +19,6 @@ function render_block_core_archives( $attributes ) {
 
 	$class = 'wp-block-archives';
 
-	if ( isset( $attributes['className'] ) ) {
-		$class .= " {$attributes['className']}";
-	}
-
 	if ( ! empty( $attributes['displayAsDropdown'] ) ) {
 
 		$class .= ' wp-block-archives-dropdown';

--- a/packages/block-library/src/calendar/block.json
+++ b/packages/block-library/src/calendar/block.json
@@ -2,9 +2,6 @@
 	"name": "core/calendar",
 	"category": "widgets",
 	"attributes": {
-		"className": {
-			"type": "string"
-		},
 		"month": {
 			"type": "integer"
 		},

--- a/packages/block-library/src/calendar/index.php
+++ b/packages/block-library/src/calendar/index.php
@@ -31,11 +31,9 @@ function render_block_core_calendar( $attributes ) {
 		}
 	}
 
-	$custom_class_name = empty( $attributes['className'] ) ? '' : ' ' . $attributes['className'];
-
 	$output = sprintf(
 		'<div class="%1$s">%2$s</div>',
-		esc_attr( 'wp-block-calendar' . $custom_class_name ),
+		esc_attr( 'wp-block-calendar' ),
 		get_calendar( true, false )
 	);
 

--- a/packages/block-library/src/categories/block.json
+++ b/packages/block-library/src/categories/block.json
@@ -2,9 +2,6 @@
 	"name": "core/categories",
 	"category": "widgets",
 	"attributes": {
-		"className": {
-			"type": "string"
-		},
 		"displayAsDropdown": {
 			"type": "boolean",
 			"default": false

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -43,10 +43,6 @@ function render_block_core_categories( $attributes ) {
 
 	$class = "wp-block-categories wp-block-categories-{$type}";
 
-	if ( isset( $attributes['className'] ) ) {
-		$class .= " {$attributes['className']}";
-	}
-
 	return sprintf(
 		$wrapper_markup,
 		esc_attr( $class ),

--- a/packages/block-library/src/latest-comments/block.json
+++ b/packages/block-library/src/latest-comments/block.json
@@ -2,9 +2,6 @@
 	"name": "core/latest-comments",
 	"category": "widgets",
 	"attributes": {
-		"className": {
-			"type": "string"
-		},
 		"commentsToShow": {
 			"type": "number",
 			"default": 5,

--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -117,9 +117,6 @@ function render_block_core_latest_comments( $attributes = array() ) {
 	}
 
 	$class = 'wp-block-latest-comments';
-	if ( ! empty( $attributes['className'] ) ) {
-		$class .= ' ' . $attributes['className'];
-	}
 	if ( $attributes['displayAvatar'] ) {
 		$class .= ' has-avatars';
 	}

--- a/packages/block-library/src/latest-posts/block.json
+++ b/packages/block-library/src/latest-posts/block.json
@@ -2,9 +2,6 @@
 	"name": "core/latest-posts",
 	"category": "widgets",
 	"attributes": {
-		"className": {
-			"type": "string"
-		},
 		"categories": {
 			"type": "array",
 			"items": {

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -162,10 +162,6 @@ function render_block_core_latest_posts( $attributes ) {
 		$class .= ' has-author';
 	}
 
-	if ( isset( $attributes['className'] ) ) {
-		$class .= ' ' . $attributes['className'];
-	}
-
 	return sprintf(
 		'<ul class="%1$s">%2$s</ul>',
 		esc_attr( $class ),

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -5,9 +5,6 @@
 		"orientation": {
 			"type": "string"
 		},
-		"className": {
-			"type": "string"
-		},
 		"textColor": {
 			"type": "string"
 		},

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -131,7 +131,6 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 		$colors['css_classes'],
 		$font_sizes['css_classes'],
 		array( 'wp-block-navigation' ),
-		isset( $attributes['className'] ) ? array( $attributes['className'] ) : array(),
 		( isset( $attributes['orientation'] ) && 'vertical' === $attributes['orientation'] ) ? array( 'is-vertical' ) : array(),
 		isset( $attributes['itemsJustification'] ) ? array( 'items-justified-' . $attributes['itemsJustification'] ) : array()
 	);

--- a/packages/block-library/src/rss/block.json
+++ b/packages/block-library/src/rss/block.json
@@ -2,9 +2,6 @@
 	"name": "core/rss",
 	"category": "widgets",
 	"attributes": {
-		"className": {
-			"type": "string"
-		},
 		"columns": {
 			"type": "number",
 			"default": 2

--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -88,10 +88,6 @@ function render_block_core_rss( $attributes ) {
 		$class .= ' columns-' . $attributes['columns'];
 	}
 
-	if ( isset( $attributes['className'] ) ) {
-		$class .= ' ' . $attributes['className'];
-	}
-
 	return sprintf( '<ul class="%s">%s</ul>', esc_attr( $class ), $list_items );
 }
 

--- a/packages/block-library/src/search/block.json
+++ b/packages/block-library/src/search/block.json
@@ -2,9 +2,6 @@
 	"name": "core/search",
 	"category": "widgets",
 	"attributes": {
-		"className": {
-			"type": "string"
-		},
 		"label": {
 			"type": "string"
 		},

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -60,9 +60,6 @@ function render_block_core_search( $attributes ) {
 	}
 
 	$class = 'wp-block-search';
-	if ( isset( $attributes['className'] ) ) {
-		$class .= ' ' . $attributes['className'];
-	}
 
 	return sprintf(
 		'<form class="%s" role="search" method="get" action="%s">%s</form>',

--- a/packages/block-library/src/tag-cloud/block.json
+++ b/packages/block-library/src/tag-cloud/block.json
@@ -2,9 +2,6 @@
 	"name": "core/tag-cloud",
 	"category": "widgets",
 	"attributes": {
-		"className": {
-			"type": "string"
-		},
 		"taxonomy": {
 			"type": "string",
 			"default": "post_tag"

--- a/packages/block-library/src/tag-cloud/index.php
+++ b/packages/block-library/src/tag-cloud/index.php
@@ -14,11 +14,6 @@
  */
 function render_block_core_tag_cloud( $attributes ) {
 	$class = 'wp-block-tag-cloud';
-
-	if ( isset( $attributes['className'] ) ) {
-		$class .= ' ' . $attributes['className'];
-	}
-
 	$args = array(
 		'echo'       => false,
 		'taxonomy'   => $attributes['taxonomy'],

--- a/packages/block-library/src/tag-cloud/index.php
+++ b/packages/block-library/src/tag-cloud/index.php
@@ -14,7 +14,7 @@
  */
 function render_block_core_tag_cloud( $attributes ) {
 	$class = 'wp-block-tag-cloud';
-	$args = array(
+	$args  = array(
 		'echo'       => false,
 		'taxonomy'   => $attributes['taxonomy'],
 		'show_count' => $attributes['showTagCounts'],

--- a/phpunit/class-block-supported-styles-test.php
+++ b/phpunit/class-block-supported-styles-test.php
@@ -687,4 +687,60 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 
 		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
 	}
+
+	/**
+	 * Tests custom classname server-side block support.
+	 */
+	function test_custom_classnames_support() {
+		$block_type_settings = array(
+			'attributes'      => array(),
+			'supports'        => array(),
+			'render_callback' => true,
+		);
+		$this->register_block_type( 'core/example', $block_type_settings );
+
+		$block = array(
+			'blockName'    => 'core/example',
+			'attrs'        => array(
+				'className' => 'my-custom-classname',
+			),
+			'innerBlock'   => array(),
+			'innerContent' => array(),
+			'innerHTML'    => array(),
+		);
+
+		$expected_styles  = 'test:style; ';
+		$expected_classes = 'wp-block-example foo-bar-class my-custom-classname';
+
+		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
+	}
+
+	/**
+	 * Tests custom classname server-side block support opt-out.
+	 */
+	function test_custom_classnames_support_opt_out() {
+		$block_type_settings = array(
+			'attributes'      => array(),
+			'supports'        => array(
+				'customClassName' => false
+			),
+			'render_callback' => true,
+		);
+		$this->register_block_type( 'core/example', $block_type_settings );
+
+		$block = array(
+			'blockName'    => 'core/example',
+			'attrs'        => array(
+				'className' => 'my-custom-classname',
+			),
+			'innerBlock'   => array(),
+			'innerContent' => array(),
+			'innerHTML'    => array(),
+		);
+
+		$expected_styles  = 'test:style;';
+		$expected_classes = 'wp-block-example foo-bar-class';
+
+		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
+	}
 }

--- a/phpunit/class-block-supported-styles-test.php
+++ b/phpunit/class-block-supported-styles-test.php
@@ -722,7 +722,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$block_type_settings = array(
 			'attributes'      => array(),
 			'supports'        => array(
-				'customClassName' => false
+				'customClassName' => false,
 			),
 			'render_callback' => true,
 		);


### PR DESCRIPTION
In different dynamic blocks, we support custom class names in the server in an Adhoc way and now that we have the block-supports handling on the server as well, this PR implements it automatically for all these blocks.

There are still other hooks that could benefit from a similar approach: anchor, generated classname.

**Testing instructions**

Check that custom classnames work for these blocks (editor and frontend)

 - archives, calendar,  tag-cloud, categories, latest comments, latest posts, navigation, rss, and search.