### PR TITLE
Server Styles - fix deduplication of style rules.

### DIFF
--- a/lib/block-supports/index.php
+++ b/lib/block-supports/index.php
@@ -65,6 +65,7 @@ function gutenberg_apply_block_supports( $block_content, $block ) {
 		return $block_content;
 	}
 
+	// Merge and dedupe new and existing classes and styles.
 	$current_classes = explode( ' ', trim( $block_root->getAttribute( 'class' ) ) );
 	$classes_to_add  = array_key_exists( 'css_classes', $attributes ) ? $attributes['css_classes'] : array();
 	$new_classes     = array_unique( array_filter( array_merge( $current_classes, $classes_to_add ) ) );

--- a/lib/block-supports/index.php
+++ b/lib/block-supports/index.php
@@ -75,7 +75,20 @@ function gutenberg_apply_block_supports( $block_content, $block ) {
 	$classes_to_add = esc_attr( implode( ' ', array_key_exists( 'css_classes', $attributes ) ? $attributes['css_classes'] : array() ) );
 	$styles_to_add  = esc_attr( implode( ' ', array_key_exists( 'inline_styles', $attributes ) ? $attributes['inline_styles'] : array() ) );
 	$new_classes    = implode( ' ', array_unique( explode( ' ', ltrim( $block_root->getAttribute( 'class' ) . ' ' ) . $classes_to_add ) ) );
-	$new_styles     = implode( ' ', array_unique( explode( ' ', $current_styles . ' ' . $styles_to_add ) ) );
+	// Normalize styles for dedupe.
+	$all_styles        = explode( ';', $current_styles . $styles_to_add );
+	$normalized_styles = array();
+	foreach ( $all_styles as $style ) {
+		if ( '' === $style ) {
+			continue;
+		}
+		// Split key and value of style.
+		$split_style = explode( ':', $style );
+		// Trim whitespace and recombine the style in a consistent form.
+		$style               = trim( $split_style[0] ) . ': ' . trim( $split_style[1] ) . ';';
+		$normalized_styles[] = $style;
+	}
+	$new_styles = implode( ' ', array_unique( $normalized_styles ) );
 
 	// Apply new styles and classes.
 	if ( ! empty( $new_classes ) ) {

--- a/phpunit/class-block-supported-styles-test.php
+++ b/phpunit/class-block-supported-styles-test.php
@@ -153,7 +153,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		);
 
 		$expected_classes = 'wp-block-example foo-bar-class has-text-color has-red-color has-background has-black-background-color';
-		$expected_styles  = 'test:style; ';
+		$expected_styles  = 'test: style;';
 
 		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
 	}
@@ -189,7 +189,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 			'innerHTML'    => array(),
 		);
 
-		$expected_styles  = 'test:style; color: #000; background-color: #fff;';
+		$expected_styles  = 'test: style; color: #000; background-color: #fff;';
 		$expected_classes = 'wp-block-example foo-bar-class has-text-color has-background';
 
 		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
@@ -221,7 +221,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		);
 
 		$expected_classes = 'wp-block-example foo-bar-class has-link-color';
-		$expected_styles  = 'test:style; --wp--style--color--link:var(--wp--preset--color--red);';
+		$expected_styles  = 'test: style; --wp--style--color--link: var(--wp--preset--color--red);';
 
 		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
 	}
@@ -252,7 +252,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		);
 
 		$expected_classes = 'wp-block-example foo-bar-class has-link-color';
-		$expected_styles  = 'test:style; --wp--style--color--link: #fff;';
+		$expected_styles  = 'test: style; --wp--style--color--link: #fff;';
 
 		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
 	}
@@ -283,7 +283,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		);
 
 		$expected_classes = 'wp-block-example foo-bar-class has-background has-red-gradient-background';
-		$expected_styles  = 'test:style; ';
+		$expected_styles  = 'test: style;';
 
 		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
 	}
@@ -314,7 +314,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		);
 
 		$expected_classes = 'wp-block-example foo-bar-class has-background';
-		$expected_styles  = 'test:style; background: some-gradient-style;';
+		$expected_styles  = 'test: style; background: some-gradient-style;';
 
 		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
 	}
@@ -379,7 +379,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		);
 
 		$expected_classes = 'wp-block-example foo-bar-class has-large-font-size';
-		$expected_styles  = 'test:style; ';
+		$expected_styles  = 'test: style;';
 
 		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
 	}
@@ -408,7 +408,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		);
 
 		$expected_classes = 'wp-block-example foo-bar-class ';
-		$expected_styles  = 'test:style; font-size: 10px;';
+		$expected_styles  = 'test: style; font-size: 10px;';
 
 		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
 	}
@@ -465,7 +465,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		);
 
 		$expected_classes = 'wp-block-example foo-bar-class ';
-		$expected_styles  = 'test:style; line-height: 10;';
+		$expected_styles  = 'test: style; line-height: 10;';
 
 		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
 	}
@@ -521,7 +521,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		);
 
 		$expected_classes = 'wp-block-example foo-bar-class alignwide';
-		$expected_styles  = 'test:style; ';
+		$expected_styles  = 'test: style;';
 
 		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
 	}
@@ -595,7 +595,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		);
 
 		$expected_classes = 'wp-block-example foo-bar-class has-text-color has-background alignwide';
-		$expected_styles  = 'test:style; color: #000; background-color: #fff; background: some-gradient; font-size: 10px; line-height: 20;';
+		$expected_styles  = 'test: style; color: #000; background-color: #fff; background: some-gradient; font-size: 10px; line-height: 20;';
 
 		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
 	}
@@ -637,7 +637,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		);
 
 		$expected_classes = 'wp-block-example foo-bar-class ';
-		$expected_styles  = 'test:style; font-size: 10px;';
+		$expected_styles  = 'test: style; font-size: 10px;';
 
 		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
 	}

--- a/phpunit/class-block-supported-styles-test.php
+++ b/phpunit/class-block-supported-styles-test.php
@@ -407,7 +407,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 			'innerHTML'    => array(),
 		);
 
-		$expected_classes = 'wp-block-example foo-bar-class ';
+		$expected_classes = 'wp-block-example foo-bar-class';
 		$expected_styles  = 'test: style; font-size: 10px;';
 
 		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
@@ -464,7 +464,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 			'innerHTML'    => array(),
 		);
 
-		$expected_classes = 'wp-block-example foo-bar-class ';
+		$expected_classes = 'wp-block-example foo-bar-class';
 		$expected_styles  = 'test: style; line-height: 10;';
 
 		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
@@ -636,7 +636,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 			'innerHTML'    => array(),
 		);
 
-		$expected_classes = 'wp-block-example foo-bar-class ';
+		$expected_classes = 'wp-block-example foo-bar-class';
 		$expected_styles  = 'test: style; font-size: 10px;';
 
 		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
This PR fixes style rule deduplication by adding an extra step to normalize style rules to follow the same format.  (Thanks @mcsf for pointing this out https://github.com/WordPress/gutenberg/pull/23007#discussion_r467952556)

Currently in server styles there are some issues with deduplication:
https://github.com/WordPress/gutenberg/blob/5fdd5b780bf945925823c8ccc435dec5fc9a5fbf/lib/block-supports/index.php#L78

At this point in the process, `$current_styles` and `$styles_to_add` may or may not have different formats in spacing convention. ex: 
`$current_styles` may be of the form `one:thing;another:thing;`.
`$styles_to_add` may be of the form `one: thing; another: thing;`.  

The line above acting on these inputs would output: `"one:thing;another:thing; one: thing; another:"`

This happens because when these are then `explode`d by `' '`, style keys in the second string are split from their values while the first string is not split at all.  Additionally, since the convention in spacing is different inside the values themselves, even if these were split properly the dedupe would not work as `'one:thing'` !== `'one: thing'`.

This PR introduces an extra step in the process to normalize the values so dedupe works as intended, and the final output of `$new_styles` would be properly deduped and of the form `one: thing; another: thing;`

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
