### PR TITLE
Fix: Post preview button only appears on small screens

### DIFF
--- a/packages/block-editor/src/components/preview-options/style.scss
+++ b/packages/block-editor/src/components/preview-options/style.scss
@@ -34,13 +34,3 @@
 		margin-right: -$grid-unit-15;
 	}
 }
-
-@include break-small() {
-	.editor-post-preview {
-		display: none;
-	}
-
-	.block-editor-post-preview__dropdown {
-		display: flex;
-	}
-}

--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -57,6 +57,14 @@
 
 	@include break-small () {
 		padding-right: $grid-unit-20;
+
+		.editor-post-preview {
+			display: none;
+		}
+
+		.block-editor-post-preview__dropdown {
+			display: flex;
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/24381

We have a rule that on non-small screens hides the preview button (on the header at the side of the publish button) and instead displays a component that allows simulating a specific device size.
That rule was to generic and hided every use case of the PostPreviewButton component causing bug https://github.com/WordPress/gutenberg/issues/24381.


This PR makes sure the rule only applies inside the header section making other post preview buttons work normally.



## How has this been tested?
Repeated the steps from https://github.com/WordPress/gutenberg/issues/24381 and verified the issue does not happen anymore.

Verified the behavior of the preview functionality still works as expected on desktop and mobile.