### PR TITLE
Fix: Cover block: Impossible to reset the minimum height value

### DIFF
--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -103,6 +103,9 @@ function CoverHeightInput( {
 		}
 		setTemporaryInput( null );
 		onChange( inputValue );
+		if ( inputValue === undefined ) {
+			onUnitChange();
+		}
 	};
 
 	const handleOnBlur = () => {

--- a/packages/components/src/unit-control/index.js
+++ b/packages/components/src/unit-control/index.js
@@ -51,6 +51,10 @@ function UnitControl(
 	const classes = classnames( 'components-unit-control', className );
 
 	const handleOnChange = ( next, changeProps ) => {
+		if ( next === '' ) {
+			onChange( '', changeProps );
+			return;
+		}
 		/**
 		 * Customizing the onChange callback.
 		 * This allows as to broadcast a combined value+unit to onChange.


### PR DESCRIPTION
Fix: https://github.com/WordPress/gutenberg/issues/23988


This PR changes the UnitControl component to pass via the onChange cases where the input is made empty.

On the cover block, it resets the units in the cases where there is no value so the value of minimum height is totally reset when the user cleans the field.
