### PR TITLE
Docs: Fix missing quote in Prettier config code sample

### DIFF
--- a/packages/prettier-config/README.md
+++ b/packages/prettier-config/README.md
@@ -15,7 +15,7 @@ $ npm install @wordpress/prettier-config --save-dev
 Add this to your `package.json` file:
 
 ```json
-prettier": "@wordpress/prettier-config"
+"prettier": "@wordpress/prettier-config"
 ```
 
 Alternatively, add this to `.prettierrc` file:


### PR DESCRIPTION
## Description
Fixes the missing quote in the `"prettier"` key in the package.json example, which causes an error if someone simply copies and pastes the line into their file.

## How has this been tested?
No tests for docs.


## Types of changes
Text change in code sample in [prettier-config package docs](https://developer.wordpress.org/block-editor/packages/packages-prettier-config/) in the Block Editor Handbook.

## Checklist:
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
