### PR TITLE
Fix: has-huge-font-size smaller than on editor when using default styling

### DIFF
--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -120,7 +120,7 @@ export const SETTINGS_DEFAULTS = {
 		},
 		{
 			name: _x( 'Huge', 'font size name' ),
-			size: 48,
+			size: 42,
 			slug: 'huge',
 		},
 	],


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/24023

We made the huge font size value class be 42px:
.has-huge-font-size {
	font-size: 42px;
}

But on the editor settings, we specified the default value for the huge font size as 48px. This made the editor not show the true value of the font size.

This PR just corrects the default font size value setting.
