### PR TITLE
Adding a maximum height to the preview of the long blocks

### DIFF
--- a/packages/block-editor/src/components/block-styles/style.scss
+++ b/packages/block-editor/src/components/block-styles/style.scss
@@ -48,6 +48,7 @@
 	align-items: center;
 	flex-grow: 1;
 	min-height: 80px;
+	max-height: 160px;
 }
 
 .block-editor-block-switcher__styles__menugroup {

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -224,7 +224,7 @@ $block-inserter-tabs-height: 44px;
 	position: absolute;
 	top: $grid-unit-20;
 	left: calc(100% + #{$grid-unit-20});
-	max-height: 700px;
+	max-height: calc(100% - #{$grid-unit-40});
 	overflow-y: hidden;
 
 	@include break-medium {

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -224,6 +224,8 @@ $block-inserter-tabs-height: 44px;
 	position: absolute;
 	top: $grid-unit-20;
 	left: calc(100% + #{$grid-unit-20});
+	max-height: 700px;
+	overflow-y: hidden;
 
 	@include break-medium {
 		display: block;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Closes #24484 
<!-- Please describe what you have changed or added -->
- The preview of large blocks exceeds the whole page. 
## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
- I created a table block with 200 rows and checked the preview.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
- ~~I added a maximum height of 700px to the preview of the blocks~~
- Fix: It now uses the height of the inserter minus the top position.
- The overflowing part of the tall block is hidden.

![download](https://user-images.githubusercontent.com/12985956/89957604-82e0a700-dc40-11ea-964c-66faf55b5b91.png)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
