### PR TITLE
Only update state if we have a valid reference

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/utils.js
+++ b/packages/block-editor/src/components/block-toolbar/utils.js
@@ -31,7 +31,10 @@ export function useDebouncedShowMovers( {
 	const timeoutRef = useRef();
 
 	const handleOnChange = ( nextIsFocused ) => {
-		setShowMovers( nextIsFocused );
+		if ( ref?.current ) {
+			setShowMovers( nextIsFocused );
+		}
+
 		onChange( nextIsFocused );
 	};
 


### PR DESCRIPTION
Description
This should resolve #24495. 

If a block is a child of a group block, it will have a parent selector that is shown when we hover over the block switcher and hidden when we move from it. The function to hide this is called in a setTimeout callback. If the block is unmounted, we still attempt to hide the parent selector via the setTimeout callback. By the time the callback gets executed, it is possible that the component would have already been unmounted. 

## How has this been tested?
 - Ensure that the existing unit tests were passing
 - Manually test and observed in the browser

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code follows the accessibility standards.
- [ ] My code has proper inline documentation. 
- [ ] I've included developer documentation if appropriate.
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR.