### PR TITLE
Template Part block - add border states in editor.

### DIFF
--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -110,7 +110,11 @@
 
 	&.has-child-selected {
 		&::after {
-			box-shadow: 0 0 0 $border-width $gray-600;
+			box-shadow: 0 0 0 $border-width $gray-200;
+
+			.is-dark-theme & {
+				box-shadow: 0 0 0 $border-width-focus $gray-700;
+			}
 		}
 	}
 }

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -110,10 +110,10 @@
 
 	&.has-child-selected {
 		&::after {
-			box-shadow: 0 0 0 $border-width-focus $gray-700;
+			box-shadow: 0 0 0 $border-width $gray-600;
 			// Show a light color for dark themes.
 			.is-dark-theme & {
-				box-shadow: 0 0 0 $border-width-focus $gray-200;
+				box-shadow: 0 0 0 $border-width $gray-200;
 			}
 		}
 	}

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -84,3 +84,43 @@
 		box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color);
 	}
 }
+
+.block-editor-block-list__block[data-type="core/template-part"] {
+	&.is-selected,
+	&.has-child-selected,
+	&:hover {
+		&::after {
+			top: $border-width;
+			bottom: $border-width;
+			left: $border-width;
+			right: $border-width;
+			border-radius: $radius-block-ui - $border-width; // Border is outset, so so subtract the width to achieve correct radius.
+		}
+	}
+
+	&.is-selected {
+		&::after {
+			// 2px outside.
+			box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+			// Show a light color for dark themes.
+			.is-dark-theme & {
+				box-shadow: 0 0 0 $border-width-focus $dark-theme-focus;
+			}
+		}
+	}
+
+	&.has-child-selected,
+	&:hover:not(.is-selected) {
+		&::after {
+			box-shadow: 0 0 0 $border-width-focus $gray-700;
+			// Show a light color for dark themes.
+			.is-dark-theme & {
+				box-shadow: 0 0 0 $border-width-focus $gray-200;
+			}
+		}
+	}
+
+	&:hover:not(.is-selected):not(.has-child-selected) {
+		cursor: pointer;
+	}
+}

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -123,6 +123,7 @@
 	&:hover:not(.is-selected):not(.has-child-selected) {
 		cursor: pointer;
 
+		// Disable pointer events on children, prevents inserter from capturing hover state etc.
 		* {
 			pointer-events: none;
 		}

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -122,5 +122,9 @@
 
 	&:hover:not(.is-selected):not(.has-child-selected) {
 		cursor: pointer;
+
+		* {
+			pointer-events: none;
+		}
 	}
 }

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -87,8 +87,7 @@
 
 .block-editor-block-list__block[data-type="core/template-part"] {
 	&.is-selected,
-	&.has-child-selected,
-	&:hover {
+	&.has-child-selected {
 		&::after {
 			top: $border-width;
 			bottom: $border-width;
@@ -109,23 +108,13 @@
 		}
 	}
 
-	&.has-child-selected,
-	&:hover:not(.is-selected) {
+	&.has-child-selected {
 		&::after {
 			box-shadow: 0 0 0 $border-width-focus $gray-700;
 			// Show a light color for dark themes.
 			.is-dark-theme & {
 				box-shadow: 0 0 0 $border-width-focus $gray-200;
 			}
-		}
-	}
-
-	&:hover:not(.is-selected):not(.has-child-selected) {
-		cursor: pointer;
-
-		// Disable pointer events on children, prevents inserter from capturing hover state etc.
-		* {
-			pointer-events: none;
 		}
 	}
 }

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -111,10 +111,6 @@
 	&.has-child-selected {
 		&::after {
 			box-shadow: 0 0 0 $border-width $gray-600;
-			// Show a light color for dark themes.
-			.is-dark-theme & {
-				box-shadow: 0 0 0 $border-width $gray-200;
-			}
 		}
 	}
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Adding is-selected, has-child-selected, and hover border states to the template part block in the editor. (as requested in https://github.com/WordPress/gutenberg/issues/22064)

These borders styles have been intentionally matched visually to fit the style added on the focus state by the block-list component, and change the color appropriately for each state:
https://github.com/WordPress/gutenberg/blob/5597947dadeba0b788269ae50676812c80eeb8f0/packages/block-editor/src/components/block-list/style.scss#L56-L74


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
