### PR TITLE
Fix Template Part renaming error.

### DIFF
--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -23,11 +23,10 @@ export default function TemplatePartEdit( {
 	const initialTheme = useRef( theme );
 
 	// Resolve the post ID if not set, and load its post.
-	const postId = useTemplatePartPost(
-		_postId,
-		initialSlug.current,
-		initialTheme.current
-	);
+	const postId = useTemplatePartPost( _postId, slug, theme );
+	useEffect( () => {
+		setAttributes( { postId } );
+	}, [ postId ] );
 
 	// Set the post ID, once found, so that edits persist,
 	// but wait until the third inner blocks change,

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -24,9 +24,6 @@ export default function TemplatePartEdit( {
 
 	// Resolve the post ID if not set, and load its post.
 	const postId = useTemplatePartPost( _postId, slug, theme );
-	useEffect( () => {
-		setAttributes( { postId } );
-	}, [ postId ] );
 
 	// Set the post ID, once found, so that edits persist,
 	// but wait until the third inner blocks change,

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -23,7 +23,11 @@ export default function TemplatePartEdit( {
 	const initialTheme = useRef( theme );
 
 	// Resolve the post ID if not set, and load its post.
-	const postId = useTemplatePartPost( _postId, slug, theme );
+	const postId = useTemplatePartPost(
+		_postId,
+		initialSlug.current,
+		initialTheme.current
+	);
 
 	// Set the post ID, once found, so that edits persist,
 	// but wait until the third inner blocks change,

--- a/packages/block-library/src/template-part/edit/name-panel.js
+++ b/packages/block-library/src/template-part/edit/name-panel.js
@@ -28,7 +28,7 @@ export default function TemplatePartNamePanel( { postId, setAttributes } ) {
 					setTitle( value );
 					const newSlug = cleanForSlug( value );
 					setSlug( newSlug );
-					setAttributes( { slug: newSlug } );
+					setAttributes( { slug: newSlug, postId } );
 				} }
 				onFocus={ ( event ) => event.target.select() }
 			/>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Fixes #24000 by using ensuring the `postId` attribute is set on the block when we update the `slug`.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Load a fresh template part supplied by the theme and attempt to rename it.  
Verify it does not disappear from the screen.
Verify saving works as expected.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
