### PR TITLE
[RNMobile - iOS] Fix empty rich-text with no height on RTL layout

### DIFF
--- a/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -134,7 +134,7 @@ class RCTAztecView: Aztec.TextView {
         delegate = self
         textContainerInset = .zero
         contentInset = .zero
-        textContainer.lineFragmentPadding = 0        
+        textContainer.lineFragmentPadding = 0
         addPlaceholder()
         textDragInteraction?.isEnabled = false
         storage.htmlConverter.characterToReplaceLastEmptyLine = Character(.zeroWidthSpace)
@@ -195,6 +195,14 @@ class RCTAztecView: Aztec.TextView {
             // This fixes the position of the label after "fixing" (partially) the constraints.
             placeholderHorizontalConstraint.constant = leftTextInsetInRTLLayout
         }
+    }
+
+    override func sizeThatFits(_ size: CGSize) -> CGSize {
+        // Set the Placeholder height as the minimum TextView height.
+        let minimumHeight = placeholderLabel.frame.height
+        let fittingSize = super.sizeThatFits(size)
+        let height = max(fittingSize.height, minimumHeight)
+        return CGSize(width: fittingSize.width, height: height)
     }
 
     func updateContentSizeInRN() {

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -13,6 +13,7 @@ For each user feature we should also add a importance categorization label  to i
 
 ## 1.35.0
 
+* [***] Fixed empty text fields on RTL layout. Now they are selectable and placeholders are visible.
 * [**] Add settings to allow changing column widths
 * [**] Media editing support in Gallery block.
 


### PR DESCRIPTION
This PR fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/14477

gutenberg-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2544
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14630

By testing I noticed that `let newSize = sizeThatFits(frame.size)` was returning 0 height on RTL while it was returning a proper value (around 20 ~ 30) for LTR layout.

This is the value used by gutenberg to size the Aztec parent View and give RNAztec its height.

I'm not sure of why or how this stopped working. I tested an older iOS version and has the same problem (12.4).


![RTL](https://user-images.githubusercontent.com/9772967/89987364-403dbf80-dc7e-11ea-9e12-c0efa5f9331c.png)

### To test:
- Run the project from https://github.com/wordpress-mobile/WordPress-iOS/pull/14630.
- Set the Application Language to a RTL language (Hebrew - Arabic) on the Run Options on Xcode.
- Open a new empty post.
  - Check that the Title and inserter placeholders are visible.
  - Check that the fields are selectable and you can type on them.
  - Check that longer text makes the text area increase in height as expected.
- Make the same checks from ⬆️ on a LTR language.


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
