### PR TITLE
Add `editor.PanelBody.children` filter

### DIFF
--- a/packages/components/src/panel/body.js
+++ b/packages/components/src/panel/body.js
@@ -11,6 +11,7 @@ import mergeRefs from 'react-merge-refs';
 import { useReducedMotion } from '@wordpress/compose';
 import { forwardRef, useRef } from '@wordpress/element';
 import { chevronUp, chevronDown } from '@wordpress/icons';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -38,6 +39,13 @@ export function PanelBody(
 		setIsOpened( next );
 		onToggle( next );
 	};
+
+	children = applyFilters(
+		'editor.PanelBody.children',
+		children,
+		className,
+		isOpened
+	);
 
 	// Runs after initial render
 	useUpdateEffect( () => {


### PR DESCRIPTION
This is a simple change, adding a new `editor.PanelBody.children` filter.
This will allow plugin & theme developers to modify controls that were already added from somewhere else (core or 3rd parties), add their own, and generally be allowed to tweak things properly without resorting to hacky, hardcoded solutions.

An example scenario: Recently in a theme I was building I wanted to add a simple switch in the colors panel to allow auto-calculating the text-color for maximum readability depending on the selected background-color. It was impossible to do because a filter was not present.

There are many scenarios I can think of that would benefit from something like this, both in plugins and themes :+1: 