### PR TITLE
Fix canInsertBlockType selector returning true for blocks that don't allow inner blocks

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1164,6 +1164,13 @@ const canInsertBlockTypeUnmemoized = (
 	}
 
 	const parentBlockListSettings = getBlockListSettings( state, rootClientId );
+
+	// The parent block doesn't have settings indicating it doesn't support
+	// inner blocks, return false.
+	if ( rootClientId && parentBlockListSettings === undefined ) {
+		return false;
+	}
+
 	const parentAllowedBlocks = get( parentBlockListSettings, [
 		'allowedBlocks',
 	] );

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -2160,7 +2160,7 @@ describe( 'selectors', () => {
 			).toBe( false );
 		} );
 
-		it( 'should allow blocks that restrict parent to be inserted into an allowed parent', () => {
+		it( 'should allow blocks to be inserted into an allowed parent', () => {
 			const state = {
 				blocks: {
 					byClientId: {
@@ -2170,7 +2170,29 @@ describe( 'selectors', () => {
 						block1: {},
 					},
 				},
-				blockListSettings: {},
+				blockListSettings: {
+					block1: {},
+				},
+				settings: {},
+			};
+			expect(
+				canInsertBlockType( state, 'core/test-block-c', 'block1' )
+			).toBe( true );
+		} );
+
+		it( 'should deny blocks from being inserted into a block that does not allow inner blocks', () => {
+			const state = {
+				blocks: {
+					byClientId: {
+						block1: { name: 'core/test-block-b' },
+					},
+					attributes: {
+						block1: {},
+					},
+				},
+				blockListSettings: {
+					block1: {},
+				},
 				settings: {},
 			};
 			expect(
@@ -2441,12 +2463,16 @@ describe( 'selectors', () => {
 				preferences: {
 					insertUsage: {},
 				},
-				blockListSettings: {},
+				blockListSettings: {
+					block3: {},
+					block4: {},
+				},
 			};
 
 			const stateSecondBlockRestricted = {
 				...state,
 				blockListSettings: {
+					...state.blockListSettings,
 					block4: {
 						allowedBlocks: [ 'core/test-block-b' ],
 					},
@@ -2472,6 +2498,7 @@ describe( 'selectors', () => {
 				stateSecondBlockRestricted,
 				'block4'
 			);
+			expect( secondBlockFirstCall ).not.toBe( secondBlockSecondCall );
 			expect( secondBlockFirstCall.map( ( item ) => item.id ) ).toEqual( [
 				'core/test-block-a',
 				'core/test-block-b',


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
While working on #23952, I noticed `canInsertBlockType` will return `true` for block types that don't support inner blocks.

For example, running `canInsertBlockType` with `core/paragraph` as the first argument and the client id of another paragraph as the second argument returns `true`, indicating a paragraph can be nested under a paragraph.

I think this hasn't ever been a problem because this selector wouldn't have been used on a paragraph. It's perhaps only used within the `InnerBlocks` component.

For List View, the blocks in the list don't render `InnerBlocks`, so I needed to be able to determine if a block like a paragraph could support inner blocks outside of that context.

## Code changes

When a block supports Inner Blocks, an object is added to `blockListSettings` for its clientId. This PR uses that implementation detail to determine if a blocks supports inner blocks. If that value is `undefined`, `false` is returned.

This meant updating a few tests that made the assumption no value would be stored in `blockListSettings` for a block that supports inner blocks.

## How has this been tested?
1. Add a paragraph to a post
2. Grab the clientId by inspecting the HTML for the paragraph and copying the value for the data-block attribute.
3. In the console run the following, pasing the clientId copied in step 2 in place of `_clientId_`:
```js
wp.data.select( 'core/block-editor').canInsertBlockType( 'core/paragraph', '_clientId_' );
```

e.g.:
```js
wp.data.select( 'core/block-editor').canInsertBlockType( 'core/paragraph', 'c8fc7238-e82f-43f7-b79b-d45cbd56ec90' );
```
4. Observe that `false` is returned.
5. Insert some other blocks that support inner blocks (group, buttons, navigation).
6. Open the inserter for those blocks and observe the correct blocks are still displayed.

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
