### PR TITLE
Fix regression bug for category select in QueryControls component 

### DIFF
--- a/packages/components/src/query-controls/index.js
+++ b/packages/components/src/query-controls/index.js
@@ -76,6 +76,7 @@ export default function QueryControls( {
 				label={ __( 'Category' ) }
 				noOptionLabel={ __( 'All' ) }
 				selectedCategoryId={ selectedCategoryId }
+				onChange={ onCategoryChange }
 			/>
 		),
 		categorySuggestions && onCategoryChange && (


### PR DESCRIPTION
## Description

In #23419, backwards compatibility with `<QueryControls>` was fixed. However, the `<CategorySelect>` still misses the `onChange` property, causing an error when a category is selected from the dropdown:

```
Uncaught TypeError: onChange is not a function
```

## How has this been tested?

I manually tested the fix and I ran `npm run test` locally.

## Types of changes

Bug fix.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
