### PR TITLE
Site Editor: Export Editor component

### DIFF
--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -64,4 +64,5 @@ export function initialize( id, settings ) {
 	render( <Editor />, document.getElementById( id ) );
 }
 
+export { Editor };
 export { default as __experimentalFullscreenModeClose } from './components/header/fullscreen-mode-close';


### PR DESCRIPTION
## Description
Export the Editor component from the `@wordpress/edit-site` package. This will allow us to embed that component in different JS apps.

## How has this been tested?
Doesn't really need testing.

## Types of changes
New export.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
