### PR TITLE
Add experimental font size attribute to Navigation block

### DIFF
--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -50,13 +50,11 @@
 		"showSubmenuIcon": "showSubmenuIcon"
 	},
 	"supports": {
-		"align": [
-			"wide",
-			"full"
-		],
+		"align": [ "wide", "full" ],
 		"anchor": true,
 		"html": false,
 		"inserter": true,
-		"lightBlockWrapper": true
+		"lightBlockWrapper": true,
+		"__experimentalFontSize": true
 	}
 }

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -26,12 +26,6 @@
 		"rgbBackgroundColor": {
 			"type": "string"
 		},
-		"fontSize": {
-			"type": "string"
-		},
-		"customFontSize": {
-			"type": "number"
-		},
 		"itemsJustification": {
 			"type": "string"
 		},

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -12,8 +12,6 @@ import {
 	InnerBlocks,
 	InspectorControls,
 	BlockControls,
-	FontSizePicker,
-	withFontSizes,
 	__experimentalUseColors,
 	__experimentalBlock as Block,
 } from '@wordpress/block-editor';
@@ -39,12 +37,10 @@ function Navigation( {
 	selectedBlockHasDescendants,
 	attributes,
 	clientId,
-	fontSize,
 	hasExistingNavItems,
 	isImmediateParentOfSelectedBlock,
 	isSelected,
 	setAttributes,
-	setFontSize,
 	updateInnerBlocks,
 	className,
 } ) {
@@ -52,7 +48,6 @@ function Navigation( {
 	// HOOKS
 	//
 	const ref = useRef();
-
 	const { selectBlock } = useDispatch( 'core/block-editor' );
 	const { TextColor, BackgroundColor, ColorPanel } = __experimentalUseColors(
 		[
@@ -64,15 +59,13 @@ function Navigation( {
 				{
 					backgroundColor: true,
 					textColor: true,
-					fontSize: fontSize.size,
 				},
 			],
 			colorDetector: { targetRef: ref },
 			colorPanelProps: {
 				initialOpen: true,
 			},
-		},
-		[ fontSize.size ]
+		}
 	);
 
 	const { navigatorToolbarButton, navigatorModal } = useBlockNavigator(
@@ -109,13 +102,8 @@ function Navigation( {
 		);
 	}
 
-	const blockInlineStyles = {
-		fontSize: fontSize.size ? fontSize.size + 'px' : undefined,
-	};
-
 	const blockClassNames = classnames( className, {
 		[ `items-justified-${ attributes.itemsJustification }` ]: attributes.itemsJustification,
-		[ fontSize.class ]: fontSize.class,
 		'is-vertical': attributes.orientation === 'vertical',
 	} );
 
@@ -167,14 +155,6 @@ function Navigation( {
 			</BlockControls>
 			{ navigatorModal }
 			<InspectorControls>
-				<PanelBody title={ __( 'Text settings' ) }>
-					<FontSizePicker
-						value={ fontSize.size }
-						onChange={ setFontSize }
-					/>
-				</PanelBody>
-			</InspectorControls>
-			<InspectorControls>
 				<PanelBody title={ __( 'Display settings' ) }>
 					<ToggleControl
 						checked={ attributes.showSubmenuIcon }
@@ -187,10 +167,7 @@ function Navigation( {
 			</InspectorControls>
 			<TextColor>
 				<BackgroundColor>
-					<Block.nav
-						className={ blockClassNames }
-						style={ blockInlineStyles }
-					>
+					<Block.nav className={ blockClassNames }>
 						<InnerBlocks
 							ref={ ref }
 							allowedBlocks={ [
@@ -227,7 +204,6 @@ function Navigation( {
 }
 
 export default compose( [
-	withFontSizes( 'fontSize' ),
 	withSelect( ( select, { clientId } ) => {
 		const innerBlocks = select( 'core/block-editor' ).getBlocks( clientId );
 		const {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

Replaces the current font size sidebar control with the new font size attribute on the Navigation block. 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Tested in browser.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
