### PR TITLE
Fix incorrect aria description in List View

### DIFF
--- a/packages/block-editor/src/components/block-navigation/block-contents.js
+++ b/packages/block-editor/src/components/block-navigation/block-contents.js
@@ -12,7 +12,15 @@ import BlockNavigationBlockSelectButton from './block-select-button';
 
 const BlockNavigationBlockContents = forwardRef(
 	(
-		{ onClick, block, isSelected, position, siblingCount, level, ...props },
+		{
+			onClick,
+			block,
+			isSelected,
+			position,
+			siblingBlockCount,
+			level,
+			...props
+		},
 		ref
 	) => {
 		const {
@@ -27,7 +35,7 @@ const BlockNavigationBlockContents = forwardRef(
 				onClick={ onClick }
 				isSelected={ isSelected }
 				position={ position }
-				siblingCount={ siblingCount }
+				siblingBlockCount={ siblingBlockCount }
 				level={ level }
 				{ ...props }
 			/>
@@ -39,7 +47,7 @@ const BlockNavigationBlockContents = forwardRef(
 				onClick={ onClick }
 				isSelected={ isSelected }
 				position={ position }
-				siblingCount={ siblingCount }
+				siblingBlockCount={ siblingBlockCount }
 				level={ level }
 				{ ...props }
 			/>

--- a/packages/block-editor/src/components/block-navigation/block-select-button.js
+++ b/packages/block-editor/src/components/block-navigation/block-select-button.js
@@ -28,7 +28,7 @@ function BlockNavigationBlockSelectButton(
 		isSelected,
 		onClick,
 		position,
-		siblingCount,
+		siblingBlockCount,
 		level,
 		tabIndex,
 		onFocus,
@@ -43,7 +43,7 @@ function BlockNavigationBlockSelectButton(
 	const descriptionId = `block-navigation-block-select-button__${ instanceId }`;
 	const blockPositionDescription = getBlockPositionDescription(
 		position,
-		siblingCount,
+		siblingBlockCount,
 		level
 	);
 

--- a/packages/block-editor/src/components/block-navigation/block-slot.js
+++ b/packages/block-editor/src/components/block-navigation/block-slot.js
@@ -48,7 +48,7 @@ function BlockNavigationBlockSlot( props, ref ) {
 					block,
 					isSelected,
 					position,
-					siblingCount,
+					siblingBlockCount,
 					level,
 					tabIndex,
 					onFocus,
@@ -59,7 +59,7 @@ function BlockNavigationBlockSlot( props, ref ) {
 				const descriptionId = `block-navigation-block-slot__${ instanceId }`;
 				const blockPositionDescription = getBlockPositionDescription(
 					position,
-					siblingCount,
+					siblingBlockCount,
 					level
 				);
 

--- a/packages/block-editor/src/components/block-navigation/block.js
+++ b/packages/block-editor/src/components/block-navigation/block.js
@@ -50,7 +50,6 @@ export default function BlockNavigationBlock( {
 	);
 	const { clientId } = block;
 
-	// Subtract 1 from rowCount, as it includes the block appender.
 	const hasSiblings = siblingBlockCount > 0;
 	const hasRenderedMovers = showBlockMovers && hasSiblings;
 	const hasVisibleMovers = isHovered || isFocused;

--- a/packages/block-editor/src/components/block-navigation/block.js
+++ b/packages/block-editor/src/components/block-navigation/block.js
@@ -37,6 +37,7 @@ export default function BlockNavigationBlock( {
 	position,
 	level,
 	rowCount,
+	siblingBlockCount,
 	showBlockMovers,
 	terminatedLevels,
 	path,
@@ -50,8 +51,7 @@ export default function BlockNavigationBlock( {
 	const { clientId } = block;
 
 	// Subtract 1 from rowCount, as it includes the block appender.
-	const siblingCount = rowCount - 1;
-	const hasSiblings = siblingCount > 0;
+	const hasSiblings = siblingBlockCount > 0;
 	const hasRenderedMovers = showBlockMovers && hasSiblings;
 	const hasVisibleMovers = isHovered || isFocused;
 	const moverCellClassName = classnames(
@@ -102,7 +102,7 @@ export default function BlockNavigationBlock( {
 							onClick={ () => onClick( block.clientId ) }
 							isSelected={ isSelected }
 							position={ position }
-							siblingCount={ siblingCount }
+							siblingBlockCount={ siblingBlockCount }
 							level={ level }
 							ref={ ref }
 							tabIndex={ tabIndex }

--- a/packages/block-editor/src/components/block-navigation/branch.js
+++ b/packages/block-editor/src/components/block-navigation/branch.js
@@ -36,9 +36,8 @@ export default function BlockNavigationBranch( props ) {
 		selectedBlockClientId === parentClientId;
 	const hasAppender = itemHasAppender( parentBlockClientId );
 	// Add +1 to the rowCount to take the block appender into account.
-	const rowCount = hasAppender
-		? filteredBlocks.length + 1
-		: filteredBlocks.length;
+	const blockCount = filteredBlocks.length;
+	const rowCount = hasAppender ? blockCount + 1 : blockCount;
 	const appenderPosition = rowCount;
 
 	return (
@@ -64,6 +63,7 @@ export default function BlockNavigationBranch( props ) {
 							level={ level }
 							position={ position }
 							rowCount={ rowCount }
+							siblingBlockCount={ blockCount }
 							showBlockMovers={ showBlockMovers }
 							terminatedLevels={ terminatedLevels }
 							path={ updatedPath }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Blocks in list view have an aria-description that helps screenreader users know the position they're at within the tree grid. A description like 'Block 1 of 1, level 1' is read.

Currently, there's a bug where the indexing is off by 1 resulting in the possibility of a message like 'Block 1 of 0, level 1', which doesn't make sense. I think this happened because there was a change to optionally showing the appender within the treegrid, but didn't update the row count to coexist with this logic.

This fixes the issue, the indexes should now be correct.

## How has this been tested?
1. Add several blocks to a post with various levels of nesting
2. Using the keyboard and a screenreader, navigate around the List View.
3. Observe or hear that the aria description for each block is now correct.

## Screenshots <!-- if applicable -->
Before:
<img width="252" alt="Screenshot 2020-08-13 at 3 39 13 pm" src="https://user-images.githubusercontent.com/677833/90107289-2afa8b00-dd7b-11ea-88a1-2085312ff010.png">

After:
<img width="251" alt="Screenshot 2020-08-13 at 3 36 29 pm" src="https://user-images.githubusercontent.com/677833/90107007-cd663e80-dd7a-11ea-891d-81d362438c8b.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
