### PR TITLE
Hide Preview menu on small viewports and fix regression for FSE preview

### DIFF
--- a/packages/block-editor/src/components/preview-options/index.js
+++ b/packages/block-editor/src/components/preview-options/index.js
@@ -6,6 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
+import { useViewportMatch } from '@wordpress/compose';
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { check } from '@wordpress/icons';
@@ -17,6 +18,9 @@ export default function PreviewOptions( {
 	deviceType,
 	setDeviceType,
 } ) {
+	const isMobile = useViewportMatch( 'small', '<' );
+	if ( isMobile ) return null;
+
 	const popoverProps = {
 		className: classnames(
 			className,

--- a/packages/block-editor/src/components/preview-options/style.scss
+++ b/packages/block-editor/src/components/preview-options/style.scss
@@ -1,5 +1,4 @@
 .block-editor-post-preview__dropdown {
-	display: none;
 	margin-right: $grid-unit-15;
 	padding: 0;
 }
@@ -13,7 +12,6 @@
 }
 
 .block-editor-post-preview__dropdown-content {
-	display: none;
 	.components-popover__content {
 		overflow-y: visible;
 	}
@@ -42,15 +40,5 @@
 		.editor-post-preview {
 			display: none;
 		}
-
-		.block-editor-post-preview__dropdown {
-			display: flex;
-		}
-	}
-}
-
-@include break-small () {
-	.block-editor-post-preview__dropdown-content {
-		display: block;
 	}
 }

--- a/packages/block-editor/src/components/preview-options/style.scss
+++ b/packages/block-editor/src/components/preview-options/style.scss
@@ -13,6 +13,7 @@
 }
 
 .block-editor-post-preview__dropdown-content {
+	display: none;
 	.components-popover__content {
 		overflow-y: visible;
 	}
@@ -32,5 +33,24 @@
 		padding: $grid-unit-10 $grid-unit-15;
 		margin-left: -$grid-unit-15;
 		margin-right: -$grid-unit-15;
+	}
+}
+
+.edit-post-header__settings,
+.edit-site-header__actions {
+	@include break-small () {
+		.editor-post-preview {
+			display: none;
+		}
+
+		.block-editor-post-preview__dropdown {
+			display: flex;
+		}
+	}
+}
+
+@include break-small () {
+	.block-editor-post-preview__dropdown-content {
+		display: block;
 	}
 }

--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -57,14 +57,6 @@
 
 	@include break-small () {
 		padding-right: $grid-unit-20;
-
-		.editor-post-preview {
-			display: none;
-		}
-
-		.block-editor-post-preview__dropdown {
-			display: flex;
-		}
 	}
 }
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Resolves: https://github.com/WordPress/gutenberg/issues/24385

Also fixes a small regression from this PR: https://github.com/WordPress/gutenberg/pull/24487, that hid the `Preview` component in `FSE`.
