### PR TITLE
Safari Bugfix: Caption jumps when hovering resize handles

### DIFF
--- a/packages/components/src/resizable-box/style.scss
+++ b/packages/components/src/resizable-box/style.scss
@@ -108,6 +108,26 @@ $resize-handler-container-size: $resize-handler-size + ($grid-unit-05 * 2); // M
 	@include reduce-motion("animation");
 }
 
+/* This CSS is shown only to Safari, which has a bug with table-caption making it jumpy.
+See https://bugs.webkit.org/show_bug.cgi?id=187903. */
+@media not all and (min-resolution: 0.001dpcm) {
+	@supports (-webkit-appearance:none) {
+		.components-resizable-box__side-handle.components-resizable-box__handle-top:hover::before,
+		.components-resizable-box__side-handle.components-resizable-box__handle-bottom:hover::before,
+		.components-resizable-box__side-handle.components-resizable-box__handle-top:active::before,
+		.components-resizable-box__side-handle.components-resizable-box__handle-bottom:active::before {
+			animation: none;
+		}
+
+		.components-resizable-box__side-handle.components-resizable-box__handle-left:hover::before,
+		.components-resizable-box__side-handle.components-resizable-box__handle-right:hover::before,
+		.components-resizable-box__side-handle.components-resizable-box__handle-left:active::before,
+		.components-resizable-box__side-handle.components-resizable-box__handle-right:active::before {
+			animation: none;
+		}
+	}
+}
+
 @keyframes components-resizable-box__top-bottom-animation {
 	from {
 		transform: scaleX(0);


### PR DESCRIPTION
Fixes #15924.

There's a frustrating bug in Safari, [not fixed in v14](https://github.com/WordPress/gutenberg/issues/15924#issuecomment-672063256), which is tracked here: https://bugs.webkit.org/show_bug.cgi?id=187903

When you hover the resize handle of an image with a caption, the caption travels down the page:

![safari before](https://user-images.githubusercontent.com/1204802/90114632-481b6380-dd53-11ea-9ea5-d13079640034.gif)

The precise cause is a little elusive, but it appears to be related to the `table-caption` property used for the image caption, combined with the image itself reiving an `animation` and/or a `transform`. 

This PR takes the smallest route I could think of, to improve the situation: it simplpy disables the animation in Safari using a hack documented with a comment. Safari after:

![safari after](https://user-images.githubusercontent.com/1204802/90114777-7ef17980-dd53-11ea-905c-229060b208b6.gif)

Chrome and other blink browsers are unchanged, same with Firefox. Here's Chrome:

![chrome before and after](https://user-images.githubusercontent.com/1204802/90114806-8b75d200-dd53-11ea-8aa6-63666755d48d.gif)

I wish there was a better and still small fix, but I was unable to find one. Ideally this gets fixed in Safar 15, and we can remove the hack. An alternate approach is to revisit the Image block and how captions are treated, but that is a nontrivial project. 