### PR TITLE
Docs: Updated Create a Block Tutorial

### DIFF
--- a/docs/designers-developers/developers/tutorials/create-block/attributes.md
+++ b/docs/designers-developers/developers/tutorials/create-block/attributes.md
@@ -36,7 +36,7 @@ export default function Edit( { attributes, setAttributes } ) {
 
 For our example block, the component we are going to use is the **TextControl** component, it is similar to an HTML text input field. You can see [documentation for TextControl component](/packages/components/src/text-control/README.md). You can browse an [interactive set of components in this Storybook](https://wordpress.github.io/gutenberg/).
 
-The component is added similar to an HTML tag, setting a label, the `value` is set to the `attributes.message` and the `onChange` function uses the `setAttributes` to update the url attribute value.
+The component is added similar to an HTML tag, setting a label, the `value` is set to the `attributes.message` and the `onChange` function uses the `setAttributes` to update the message attribute value.
 
 The save function will simply write the `attributes.message` as a div tag since that is how we defined it to be parsed.
 

--- a/docs/designers-developers/developers/tutorials/create-block/author-experience.md
+++ b/docs/designers-developers/developers/tutorials/create-block/author-experience.md
@@ -56,6 +56,7 @@ This can be used inside a block to control what shows when a parameter is set or
 					/>
 				</div>
 			}
+		</div>
 	);
 ```
 

--- a/docs/designers-developers/developers/tutorials/create-block/block-anatomy.md
+++ b/docs/designers-developers/developers/tutorials/create-block/block-anatomy.md
@@ -55,6 +55,6 @@ If you look at the generated `src/index.js` file, the block title and descriptio
 __( 'Gutenpride', 'gutenpride' );
 ```
 
-This is an internationalization wrapper that allows for the string "Gutenpride" to be translated. The second parameter, "gutenpride" is called the text domain and gives context for where the string is from. The JavaScript internationalization, often abbreviated i18n, matches the core WordPress internationalization process. See the [I18n for WordPress documentation](https://codex.wordpress.org/I18n_for_WordPress_Developers) for more details.
+This is an internationalization wrapper that allows for the string "Gutenpride" to be translated. The second parameter, "gutenpride" is called the text domain and gives context for where the string is from. The JavaScript internationalization, often abbreviated i18n, matches the core WordPress internationalization process. See the [Internationalization in Plugin Developer Handbook](https://developer.wordpress.org/plugins/internationalization/) for more details.
 
 Next Section: [Block Attributes](/docs/designers-developers/developers/tutorials/create-block/attributes.md)

--- a/docs/designers-developers/developers/tutorials/create-block/finishing.md
+++ b/docs/designers-developers/developers/tutorials/create-block/finishing.md
@@ -6,7 +6,7 @@ This tutorial covers general concepts and structure for creating basic blocks.
 
 The block editor provides a [components package](/packages/components/README.md) which contains numerous prebuilt components you can use to build your block.
 
-You can visually browse the components and what their implementation looks like using the Storybook tool published at [https://wordpress.github.io/gutenberg].
+You can visually browse the components and what their implementation looks like using the Storybook tool published at https://wordpress.github.io/gutenberg.
 
 ## Additional Tutorials
 

--- a/docs/designers-developers/developers/tutorials/create-block/wp-plugin.md
+++ b/docs/designers-developers/developers/tutorials/create-block/wp-plugin.md
@@ -55,7 +55,7 @@ Let's confirm the plugin is loaded and working.
 wp-env start
 ```
 
-This will start your local WordPress site and use the current directory as your plugin directory. In your browser, go to [https://localhost:8888/wp-admin/] and login, the default username is "admin" and password is "password", no quotes.
+This will start your local WordPress site and use the current directory as your plugin directory. In your browser, go to https://localhost:8888/wp-admin/ and login, the default username is "admin" and password is "password", no quotes.
 
 ### Confirm Plugin Installed
 
@@ -67,7 +67,7 @@ For more on creating a WordPress plugin see [Plugin Basics](https://developer.wo
 
 The `package.json` file defines the JavaScript properties for your project. This is a standard file used by NPM for defining properties and scripts it can run, the file and process is not specific to WordPress.
 
-A `package.json` file was created with the create script, this defines the dependecies and scripts needed. you can install dependencies. The only initial dependency is the `@wordpress/scripts` package that bundles the tools and configurations needed to build blocks.
+A `package.json` file was created with the create script, this defines the dependecies and scripts needed. You can install dependencies. The only initial dependency is the `@wordpress/scripts` package that bundles the tools and configurations needed to build blocks.
 
 In `package.json`, there is a `scripts` property that defines what command to run when using `npm run (cmd)`. In our generated `package.json` file, the two main scripts point to the commands in the `wp-scripts` package:
 
@@ -143,7 +143,7 @@ The `wp_set_script_translations` function tells WordPress to load translations f
 
 The `register_block_type` function registers the block we are going to create and specifies the editor_script file handle registered. So now when the editor loads it will load this script.
 
-With the above in place, create a new post to load the editor and check the you can add the block in the inserter. You can use `/` to search, or click the box with the [+] and search for "Gutenpride" to find the block.
+With the above in place, create a new post to load the editor and check your plugin is in the inserter. You can use `/` to search, or click the box with the [+] and search for "Gutenpride" to find the block.
 
 ## Troubleshooting
 
@@ -153,7 +153,7 @@ To open the developer tools in Firefox, use the menu selecting Web Developer : T
 
 Try running `npm run start` that will start the watch process for automatic rebuilds. If you then make an update to `src/index.js` file, you will see the build run, and if you reload the WordPress editor you'll see the change.
 
-For more info, see the build section of the [Getting Started with JavaScript tutorial](/docs/designers-developers/developers/tutorials/javascript/js-build-setup.md) in the WordPress Handbook.
+For more info, see the build section of the [Getting Started with JavaScript tutorial](/docs/designers-developers/developers/tutorials/javascript/js-build-setup.md) in the Block Editor Handbook.
 
 ## Summary
 


### PR DESCRIPTION
@mkaz 
This PR fixes some issues in Create a Block Tutorial.
Changes other than typo are as followings:

## wp-plugins.md
- wrong link format: `[https://localhost:8888/wp-admin/] -> https://localhost:8888/wp-admin/` 
- wrong description:
With the above in place, create a new post to load the editor and check the you can add the block in the inserter. -> ... and check your block is in the inserter.

## block-anatomy.md
- update link from Codex to developer resources
`[I18n for WordPress documentation](https://codex.wordpress.org/I18n_for_WordPress_Developers)
-> [Internationalization in Plugin Developer Handbook](https://developer.wordpress.org/plugins/internationalization/)`

## attributes.md
- fix: the url attribute -> the message attribute

## block-code.md
- fix: The `style` CSS loads -> The `style` loads CSS

## author-experience.md
- fix: missing `</div>`

## finishing.md
- wrong link format: `[https://wordpress.github.io/gutenberg] -> https://wordpress.github.io/gutenberg`

