### PR TITLE
Add generated block classname to dynamic blocks

### DIFF
--- a/lib/block-supports/generated-classname.php
+++ b/lib/block-supports/generated-classname.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Generated classname block support flag.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Get the generated classname from a given block name.
+ *
+ * @param  string $block_name Block Name.
+ * @return string Generated classname.
+ */
+function gutenberg_get_block_default_classname( $block_name ) {
+	// Generated HTML classes for blocks follow the `wp-block-{name}` nomenclature.
+	// Blocks provided by WordPress drop the prefixes 'core/' or 'core-' (historically used in 'core-embed/').
+	$classname = 'wp-block-' . preg_replace(
+		'/^core-/',
+		'',
+		str_replace( '/', '-', $block_name )
+	);
+
+	/**
+	 * Filters the default block className for server rendered blocks.
+	 *
+	 * @param string     $class_name The current applied classname.
+	 * @param string     $block_name The block name.
+	 */
+	$classname = apply_filters( 'block_default_classname', $classname, $block_name );
+
+	return $classname;
+}
+
+/**
+ * Add the generated classnames to the output.
+ *
+ * @param  array $attributes comprehensive list of attributes to be applied.
+ * @param  array $block_attributes block attributes.
+ * @param  array $block_type Block Type.
+ * @return array Block CSS classes and inline styles.
+ */
+function gutenberg_apply_generated_classname_support( $attributes, $block_attributes, $block_type ) {
+	$has_generated_classname_support = gutenberg_experimental_get( $block_type->supports, array( 'className' ), true );
+	if ( $has_generated_classname_support ) {
+		$block_classname = gutenberg_get_block_default_classname( $block_type->name );
+
+		if ( $block_classname ) {
+			$attributes['css_classes'][] = $block_classname;
+		}
+	}
+
+	return $attributes;
+}

--- a/lib/block-supports/index.php
+++ b/lib/block-supports/index.php
@@ -42,6 +42,7 @@ function gutenberg_apply_block_supports( $block_content, $block ) {
 	}
 
 	$attributes = array();
+	$attributes = gutenberg_apply_generated_classname_support( $attributes, $block['attrs'], $block_type );
 	$attributes = gutenberg_apply_colors_support( $attributes, $block['attrs'], $block_type );
 	$attributes = gutenberg_apply_typography_support( $attributes, $block['attrs'], $block_type );
 	$attributes = gutenberg_apply_alignment_support( $attributes, $block['attrs'], $block_type );

--- a/lib/load.php
+++ b/lib/load.php
@@ -117,3 +117,4 @@ require dirname( __FILE__ ) . '/block-supports/align.php';
 require dirname( __FILE__ ) . '/block-supports/colors.php';
 require dirname( __FILE__ ) . '/block-supports/typography.php';
 require dirname( __FILE__ ) . '/block-supports/custom-classname.php';
+require dirname( __FILE__ ) . '/block-supports/generated-classname.php';

--- a/packages/block-library/src/archives/index.php
+++ b/packages/block-library/src/archives/index.php
@@ -17,7 +17,7 @@
 function render_block_core_archives( $attributes ) {
 	$show_post_count = ! empty( $attributes['showPostCounts'] );
 
-	$class = 'wp-block-archives';
+	$class = '';
 
 	if ( ! empty( $attributes['displayAsDropdown'] ) ) {
 

--- a/packages/block-library/src/calendar/index.php
+++ b/packages/block-library/src/calendar/index.php
@@ -32,8 +32,7 @@ function render_block_core_calendar( $attributes ) {
 	}
 
 	$output = sprintf(
-		'<div class="%1$s">%2$s</div>',
-		esc_attr( 'wp-block-calendar' ),
+		'<div>%1$s</div>',
 		get_calendar( true, false )
 	);
 

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -41,7 +41,7 @@ function render_block_core_categories( $attributes ) {
 		$type           = 'list';
 	}
 
-	$class = "wp-block-categories wp-block-categories-{$type}";
+	$class = "wp-block-categories-{$type}";
 
 	return sprintf(
 		$wrapper_markup,

--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -116,28 +116,28 @@ function render_block_core_latest_comments( $attributes = array() ) {
 		}
 	}
 
-	$class = 'wp-block-latest-comments';
+	$classnames = array();
 	if ( $attributes['displayAvatar'] ) {
-		$class .= ' has-avatars';
+		$classnames[] = 'has-avatars';
 	}
 	if ( $attributes['displayDate'] ) {
-		$class .= ' has-dates';
+		$classnames[] = 'has-dates';
 	}
 	if ( $attributes['displayExcerpt'] ) {
-		$class .= ' has-excerpts';
+		$classnames[] = 'has-excerpts';
 	}
 	if ( empty( $comments ) ) {
-		$class .= ' no-comments';
+		$classnames[] = 'no-comments';
 	}
-	$classnames = esc_attr( $class );
+	$class = esc_attr( implode( ' ', $classnames ) );
 
 	return ! empty( $comments ) ? sprintf(
 		'<ol class="%1$s">%2$s</ol>',
-		$classnames,
+		$class,
 		$list_items_markup
 	) : sprintf(
 		'<div class="%1$s">%2$s</div>',
-		$classnames,
+		$class,
 		__( 'No comments to show.' )
 	);
 }

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -144,7 +144,7 @@ function render_block_core_latest_posts( $attributes ) {
 
 	remove_filter( 'excerpt_length', 'block_core_latest_posts_get_excerpt_length', 20 );
 
-	$class = 'wp-block-latest-posts wp-block-latest-posts__list';
+	$class = 'wp-block-latest-posts__list';
 
 	if ( isset( $attributes['postLayout'] ) && 'grid' === $attributes['postLayout'] ) {
 		$class .= ' is-grid';

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -115,7 +115,6 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 		$colors['css_classes'],
 		$font_sizes['css_classes']
 	);
-	$classes[]       = 'wp-block-navigation-link';
 	$style_attribute = ( $colors['inline_styles'] || $font_sizes['inline_styles'] );
 
 	$css_classes = trim( implode( ' ', $classes ) );

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -130,7 +130,6 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	$classes         = array_merge(
 		$colors['css_classes'],
 		$font_sizes['css_classes'],
-		array( 'wp-block-navigation' ),
 		( isset( $attributes['orientation'] ) && 'vertical' === $attributes['orientation'] ) ? array( 'is-vertical' ) : array(),
 		isset( $attributes['itemsJustification'] ) ? array( 'items-justified-' . $attributes['itemsJustification'] ) : array()
 	);

--- a/packages/block-library/src/post-author/index.php
+++ b/packages/block-library/src/post-author/index.php
@@ -30,7 +30,6 @@ function render_block_core_post_author( $attributes, $content, $block ) {
 
 	$byline  = ! empty( $attributes['byline'] ) ? $attributes['byline'] : false;
 	$classes = array_merge(
-		array( 'wp-block-post-author' ),
 		isset( $attributes['className'] ) ? array( $attributes['className'] ) : array(),
 		isset( $attributes['itemsJustification'] ) ? array( 'items-justified-' . $attributes['itemsJustification'] ) : array(),
 		isset( $attributes['textAlign'] ) ? array( 'has-text-align-' . $attributes['textAlign'] ) : array()

--- a/packages/block-library/src/post-comments-count/index.php
+++ b/packages/block-library/src/post-comments-count/index.php
@@ -18,9 +18,9 @@ function render_block_core_post_comments_count( $attributes, $content, $block ) 
 		return '';
 	}
 
-	$classes = 'wp-block-post-comments-count';
+	$classes = '';
 	if ( isset( $attributes['textAlign'] ) ) {
-		$classes .= ' has-text-align-' . $attributes['textAlign'];
+		$classes .= 'has-text-align-' . $attributes['textAlign'];
 	}
 
 	return sprintf(

--- a/packages/block-library/src/post-comments-form/index.php
+++ b/packages/block-library/src/post-comments-form/index.php
@@ -18,9 +18,9 @@ function render_block_core_post_comments_form( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$classes = 'wp-block-post-comments-form';
+	$classes = '';
 	if ( isset( $attributes['textAlign'] ) ) {
-		$classes .= ' has-text-align-' . $attributes['textAlign'];
+		$classes .= 'has-text-align-' . $attributes['textAlign'];
 	}
 
 	ob_start();

--- a/packages/block-library/src/post-comments/index.php
+++ b/packages/block-library/src/post-comments/index.php
@@ -31,9 +31,9 @@ function render_block_core_post_comments( $attributes, $content, $block ) {
 	comments_template();
 	$post = $post_before;
 
-	$classes = 'wp-block-post-comments';
+	$classes = '';
 	if ( isset( $attributes['textAlign'] ) ) {
-		$classes .= ' has-text-align-' . $attributes['textAlign'];
+		$classes .= 'has-text-align-' . $attributes['textAlign'];
 	}
 
 	$output = sprintf( '<div class="%1$s">', esc_attr( $classes ) ) . ob_get_clean() . '</div>';

--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -18,11 +18,11 @@ function render_block_core_post_date( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$align_class_name = empty( $attributes['textAlign'] ) ? '' : ' ' . "has-text-align-{$attributes['textAlign']}";
+	$align_class_name = empty( $attributes['textAlign'] ) ? '' : "has-text-align-{$attributes['textAlign']}";
 
 	return sprintf(
 		'<div class="%1$s"><time datetime="%2$s">%3$s</time></div>',
-		'wp-block-post-date' . esc_attr( $align_class_name ),
+		esc_attr( $align_class_name ),
 		get_the_date( 'c', $block->context['postId'] ),
 		get_the_date( isset( $attributes['format'] ) ? $attributes['format'] : '', $block->context['postId'] )
 	);

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -28,9 +28,9 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 		$filter_excerpt_length
 	);
 
-	$classes = 'wp-block-post-excerpt';
+	$classes = '';
 	if ( isset( $attributes['textAlign'] ) ) {
-		$classes .= ' has-text-align-' . $attributes['textAlign'];
+		$classes .= 'has-text-align-' . $attributes['textAlign'];
 	}
 
 	$output = sprintf( '<div class="%1$s">', esc_attr( $classes ) ) . '<p class="wp-block-post-excerpt__excerpt">' . get_the_excerpt( $block->context['postId'] );

--- a/packages/block-library/src/post-tags/index.php
+++ b/packages/block-library/src/post-tags/index.php
@@ -20,9 +20,9 @@ function render_block_core_post_tags( $attributes, $content, $block ) {
 
 	$post_tags = get_the_tags( $block->context['postId'] );
 	if ( ! empty( $post_tags ) ) {
-		$classes = 'wp-block-post-tags';
+		$classes = '';
 		if ( isset( $attributes['textAlign'] ) ) {
-			$classes .= ' has-text-align-' . $attributes['textAlign'];
+			$classes .= 'has-text-align-' . $attributes['textAlign'];
 		}
 
 		$output = sprintf( '<div class="%1$s">', esc_attr( $classes ) );

--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -20,7 +20,7 @@ function render_block_core_post_title( $attributes, $content, $block ) {
 	}
 
 	$tag_name         = 'h2';
-	$align_class_name = empty( $attributes['textAlign'] ) ? '' : ' ' . "has-text-align-{$attributes['textAlign']}";
+	$align_class_name = empty( $attributes['textAlign'] ) ? '' : "has-text-align-{$attributes['textAlign']}";
 
 	if ( isset( $attributes['level'] ) ) {
 		$tag_name = 0 === $attributes['level'] ? 'p' : 'h' . $attributes['level'];
@@ -29,7 +29,7 @@ function render_block_core_post_title( $attributes, $content, $block ) {
 	return sprintf(
 		'<%1$s class="%2$s">%3$s</%1$s>',
 		$tag_name,
-		'wp-block-post-title' . esc_attr( $align_class_name ),
+		esc_attr( $align_class_name ),
 		get_the_title( $block->context['postId'] )
 	);
 }

--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -79,16 +79,16 @@ function render_block_core_rss( $attributes ) {
 		$list_items .= "<li class='wp-block-rss__item'>{$title}{$date}{$author}{$excerpt}</li>";
 	}
 
-	$class = 'wp-block-rss';
+	$classnames = array();
 	if ( isset( $attributes['blockLayout'] ) && 'grid' === $attributes['blockLayout'] ) {
-		$class .= ' is-grid';
+		$classnames[] = 'is-grid';
 	}
 
 	if ( isset( $attributes['columns'] ) && 'grid' === $attributes['blockLayout'] ) {
-		$class .= ' columns-' . $attributes['columns'];
+		$classnames[] = 'columns-' . $attributes['columns'];
 	}
 
-	return sprintf( '<ul class="%s">%s</ul>', esc_attr( $class ), $list_items );
+	return sprintf( '<ul class="%s">%s</ul>', esc_attr( implode( ' ', $classnames ) ), $list_items );
 }
 
 /**

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -59,11 +59,8 @@ function render_block_core_search( $attributes ) {
 		);
 	}
 
-	$class = 'wp-block-search';
-
 	return sprintf(
-		'<form class="%s" role="search" method="get" action="%s">%s</form>',
-		esc_attr( $class ),
+		'<form role="search" method="get" action="%s">%s</form>',
 		esc_url( home_url( '/' ) ),
 		$label_markup . $input_markup . $button_markup
 	);

--- a/packages/block-library/src/site-logo/index.php
+++ b/packages/block-library/src/site-logo/index.php
@@ -23,16 +23,17 @@ function render_block_core_site_logo( $attributes ) {
 
 	add_filter( 'wp_get_attachment_image_src', $adjust_width_height_filter );
 	$custom_logo = get_custom_logo();
-	$class_name  = 'wp-block-site-logo';
+	$classnames  = array();
 	if ( ! empty( $attributes['className'] ) ) {
-		$class_name .= " {$attributes['className']}";
+		$classnames[] = $attributes['className'];
 	}
 
 	if ( ! empty( $attributes['align'] ) && in_array( $attributes['align'], array( 'center', 'left', 'right' ), true ) ) {
-		$class_name .= " align{$attributes['align']}";
+		$classnames[] = "align{$attributes['align']}";
 	}
 
-	$html = sprintf( '<div class="%s"><a href="' . get_bloginfo( 'url' ) . '" rel="home" title="' . get_bloginfo( 'name' ) . '">%s</a></div>', $class_name, $custom_logo );
+	$class_name = implode( ' ', $classnames );
+	$html       = sprintf( '<div class="%s"><a href="' . get_bloginfo( 'url' ) . '" rel="home" title="' . get_bloginfo( 'name' ) . '">%s</a></div>', $class_name, $custom_logo );
 	remove_filter( 'wp_get_attachment_image_src', $adjust_width_height_filter );
 	return $html;
 }

--- a/packages/block-library/src/site-tagline/index.php
+++ b/packages/block-library/src/site-tagline/index.php
@@ -13,11 +13,11 @@
  * @return string The render.
  */
 function render_block_core_site_tagline( $attributes ) {
-	$align_class_name = empty( $attributes['textAlign'] ) ? '' : ' ' . "has-text-align-{$attributes['textAlign']}";
+	$align_class_name = empty( $attributes['textAlign'] ) ? '' : "has-text-align-{$attributes['textAlign']}";
 
 	return sprintf(
 		'<p class="%1$s">%2$s</p>',
-		'wp-block-site-tagline' . esc_attr( $align_class_name ),
+		esc_attr( $align_class_name ),
 		get_bloginfo( 'description' )
 	);
 }

--- a/packages/block-library/src/site-title/index.php
+++ b/packages/block-library/src/site-title/index.php
@@ -14,7 +14,7 @@
  */
 function render_block_core_site_title( $attributes ) {
 	$tag_name         = 'h1';
-	$align_class_name = empty( $attributes['textAlign'] ) ? '' : ' ' . "has-text-align-{$attributes['textAlign']}";
+	$align_class_name = empty( $attributes['textAlign'] ) ? '' : "has-text-align-{$attributes['textAlign']}";
 
 	if ( isset( $attributes['level'] ) ) {
 		$tag_name = 0 === $attributes['level'] ? 'p' : 'h' . $attributes['level'];
@@ -23,7 +23,7 @@ function render_block_core_site_title( $attributes ) {
 	return sprintf(
 		'<%1$s class="%2$s">%3$s</%1$s>',
 		$tag_name,
-		'wp-block-site-title' . esc_attr( $align_class_name ),
+		esc_attr( $align_class_name ),
 		get_bloginfo( 'name' )
 	);
 }

--- a/packages/block-library/src/tag-cloud/index.php
+++ b/packages/block-library/src/tag-cloud/index.php
@@ -13,13 +13,11 @@
  * @return string Returns the tag cloud for selected taxonomy.
  */
 function render_block_core_tag_cloud( $attributes ) {
-	$class = 'wp-block-tag-cloud';
-	$args  = array(
+	$args      = array(
 		'echo'       => false,
 		'taxonomy'   => $attributes['taxonomy'],
 		'show_count' => $attributes['showTagCounts'],
 	);
-
 	$tag_cloud = wp_tag_cloud( $args );
 
 	if ( ! $tag_cloud ) {
@@ -34,8 +32,7 @@ function render_block_core_tag_cloud( $attributes ) {
 	}
 
 	return sprintf(
-		'<p class="%1$s">%2$s</p>',
-		esc_attr( $class ),
+		'<p>%1$s</p>',
 		$tag_cloud
 	);
 }

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -63,7 +63,7 @@ function render_block_core_template_part( $attributes ) {
 	}
 	$content = do_shortcode( $content );
 
-	return '<div class="wp-block-template-part">' . str_replace( ']]>', ']]&gt;', $content ) . '</div>';
+	return '<div>' . str_replace( ']]>', ']]&gt;', $content ) . '</div>';
 }
 
 /**

--- a/phpunit/class-block-supported-styles-test.php
+++ b/phpunit/class-block-supported-styles-test.php
@@ -124,7 +124,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 *
 	 * @var string
 	 */
-	const BLOCK_MARKUP = '<div class="wp-block-example foo-bar-class" style="test:style;">' . self::BLOCK_CONTENT . '</div>';
+	const BLOCK_MARKUP = '<div class="foo-bar-class" style="test:style;">' . self::BLOCK_CONTENT . '</div>';
 
 	/**
 	 * Tests color support for named color support for named colors.
@@ -152,7 +152,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 			'innerHTML'    => array(),
 		);
 
-		$expected_classes = 'wp-block-example foo-bar-class has-text-color has-red-color has-background has-black-background-color';
+		$expected_classes = 'foo-bar-class wp-block-example has-text-color has-red-color has-background has-black-background-color';
 		$expected_styles  = 'test: style;';
 
 		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
@@ -190,7 +190,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		);
 
 		$expected_styles  = 'test: style; color: #000; background-color: #fff;';
-		$expected_classes = 'wp-block-example foo-bar-class has-text-color has-background';
+		$expected_classes = 'foo-bar-class wp-block-example has-text-color has-background';
 
 		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
 	}
@@ -220,7 +220,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 			'innerHTML'    => array(),
 		);
 
-		$expected_classes = 'wp-block-example foo-bar-class has-link-color';
+		$expected_classes = 'foo-bar-class wp-block-example has-link-color';
 		$expected_styles  = 'test: style; --wp--style--color--link: var(--wp--preset--color--red);';
 
 		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
@@ -251,7 +251,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 			'innerHTML'    => array(),
 		);
 
-		$expected_classes = 'wp-block-example foo-bar-class has-link-color';
+		$expected_classes = 'foo-bar-class wp-block-example has-link-color';
 		$expected_styles  = 'test: style; --wp--style--color--link: #fff;';
 
 		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
@@ -282,7 +282,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 			'innerHTML'    => array(),
 		);
 
-		$expected_classes = 'wp-block-example foo-bar-class has-background has-red-gradient-background';
+		$expected_classes = 'foo-bar-class wp-block-example has-background has-red-gradient-background';
 		$expected_styles  = 'test: style;';
 
 		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
@@ -313,7 +313,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 			'innerHTML'    => array(),
 		);
 
-		$expected_classes = 'wp-block-example foo-bar-class has-background';
+		$expected_classes = 'foo-bar-class wp-block-example has-background';
 		$expected_styles  = 'test: style; background: some-gradient-style;';
 
 		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
@@ -349,8 +349,8 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 			'innerHTML'    => array(),
 		);
 
-		$expected_classes = 'wp-block-example foo-bar-class';
-		$expected_styles  = 'test:style;';
+		$expected_classes = 'foo-bar-class wp-block-example';
+		$expected_styles  = 'test: style;';
 
 		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
 	}
@@ -378,7 +378,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 			'innerHTML'    => array(),
 		);
 
-		$expected_classes = 'wp-block-example foo-bar-class has-large-font-size';
+		$expected_classes = 'foo-bar-class wp-block-example has-large-font-size';
 		$expected_styles  = 'test: style;';
 
 		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
@@ -407,7 +407,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 			'innerHTML'    => array(),
 		);
 
-		$expected_classes = 'wp-block-example foo-bar-class';
+		$expected_classes = 'foo-bar-class wp-block-example';
 		$expected_styles  = 'test: style; font-size: 10px;';
 
 		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
@@ -435,8 +435,8 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 			'innerHTML'    => array(),
 		);
 
-		$expected_classes = 'wp-block-example foo-bar-class';
-		$expected_styles  = 'test:style;';
+		$expected_classes = 'foo-bar-class wp-block-example';
+		$expected_styles  = 'test: style;';
 
 		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
 	}
@@ -464,7 +464,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 			'innerHTML'    => array(),
 		);
 
-		$expected_classes = 'wp-block-example foo-bar-class';
+		$expected_classes = 'foo-bar-class wp-block-example';
 		$expected_styles  = 'test: style; line-height: 10;';
 
 		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
@@ -491,8 +491,8 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 			'innerHTML'    => array(),
 		);
 
-		$expected_classes = 'wp-block-example foo-bar-class';
-		$expected_styles  = 'test:style;';
+		$expected_classes = 'foo-bar-class wp-block-example';
+		$expected_styles  = 'test: style;';
 
 		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
 	}
@@ -520,7 +520,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 			'innerHTML'    => array(),
 		);
 
-		$expected_classes = 'wp-block-example foo-bar-class alignwide';
+		$expected_classes = 'foo-bar-class wp-block-example alignwide';
 		$expected_styles  = 'test: style;';
 
 		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
@@ -547,8 +547,8 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 			'innerHTML'    => array(),
 		);
 
-		$expected_classes = 'wp-block-example foo-bar-class';
-		$expected_styles  = 'test:style;';
+		$expected_classes = 'foo-bar-class wp-block-example';
+		$expected_styles  = 'test: style;';
 
 		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
 	}
@@ -594,7 +594,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 			'innerHTML'    => array(),
 		);
 
-		$expected_classes = 'wp-block-example foo-bar-class has-text-color has-background alignwide';
+		$expected_classes = 'foo-bar-class wp-block-example has-text-color has-background alignwide';
 		$expected_styles  = 'test: style; color: #000; background-color: #fff; background: some-gradient; font-size: 10px; line-height: 20;';
 
 		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
@@ -636,7 +636,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 			'innerHTML'    => array(),
 		);
 
-		$expected_classes = 'wp-block-example foo-bar-class';
+		$expected_classes = 'foo-bar-class wp-block-example';
 		$expected_styles  = 'test: style; font-size: 10px;';
 
 		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
@@ -682,7 +682,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 			'innerHTML'    => array(),
 		);
 
-		$expected_classes = 'wp-block-example foo-bar-class';
+		$expected_classes = 'foo-bar-class';
 		$expected_styles  = 'test:style;';
 
 		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
@@ -709,8 +709,8 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 			'innerHTML'    => array(),
 		);
 
-		$expected_styles  = 'test:style; ';
-		$expected_classes = 'wp-block-example foo-bar-class my-custom-classname';
+		$expected_styles  = 'test: style;';
+		$expected_classes = 'foo-bar-class wp-block-example my-custom-classname';
 
 		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
 	}
@@ -738,8 +738,35 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 			'innerHTML'    => array(),
 		);
 
+		$expected_styles  = 'test: style;';
+		$expected_classes = 'foo-bar-class wp-block-example';
+
+		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
+	}
+
+	/**
+	 * Tests generated classname server-side block support opt-out.
+	 */
+	function test_generatted_classnames_support_opt_out() {
+		$block_type_settings = array(
+			'attributes'      => array(),
+			'supports'        => array(
+				'className' => false,
+			),
+			'render_callback' => true,
+		);
+		$this->register_block_type( 'core/example', $block_type_settings );
+
+		$block = array(
+			'blockName'    => 'core/example',
+			'attrs'        => array(),
+			'innerBlock'   => array(),
+			'innerContent' => array(),
+			'innerHTML'    => array(),
+		);
+
 		$expected_styles  = 'test:style;';
-		$expected_classes = 'wp-block-example foo-bar-class';
+		$expected_classes = 'foo-bar-class';
 
 		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
 	}


### PR DESCRIPTION
Follow up to #24483  

In different dynamic blocks, we support block default class names in the server in an Adhoc way and now that we have the block-supports handling on the server as well, this PR implements it automatically for all these blocks.

the remaining hook after this PR will be "anchor".

**Testing instructions**

Check that dynamic blocks render the default block class names `wp-block-*` on the frontend.