### PR TITLE
Block Variations: Center-align the variation buttons

### DIFF
--- a/packages/block-editor/src/components/block-variation-picker/style.scss
+++ b/packages/block-editor/src/components/block-variation-picker/style.scss
@@ -26,13 +26,13 @@
 	margin: $grid-unit-20 0;
 	padding: 0;
 	list-style: none;
-	text-align: center;
 
 	> li {
 		list-style: none;
 		margin: $grid-unit-10 ( $grid-unit-10 + $grid-unit-15 ) 0 0;
 		flex-shrink: 1;
 		max-width: 100px;
+		text-align: center;
 
 		button {
 			display: inline-flex;

--- a/packages/block-editor/src/components/block-variation-picker/style.scss
+++ b/packages/block-editor/src/components/block-variation-picker/style.scss
@@ -26,15 +26,17 @@
 	margin: $grid-unit-20 0;
 	padding: 0;
 	list-style: none;
+	text-align: center;
 
 	> li {
 		list-style: none;
-		margin: $grid-unit-10 $grid-unit-10 0 0;
+		margin: $grid-unit-10 ( $grid-unit-10 + $grid-unit-15 ) 0 0;
 		flex-shrink: 1;
 		max-width: 100px;
 
 		button {
-			display: flex;
+			display: inline-flex;
+			margin-right: 0;
 		}
 	}
 
@@ -46,8 +48,6 @@
 		font-family: $default-font;
 		font-size: 12px;
 		display: block;
-		margin-right: $grid-unit-15;
-		text-align: center;
 	}
 }
 


### PR DESCRIPTION
## Description

The variation button is left-aligned, while its label is centered.
When the label is wider than the button, it appears misaligned.

This PR centers the button as well, and moves the margins from button and label to the list item itself in order to retain the same spacing between variations.

## How has this been tested?

Tested with the Columns block, by manually replacing the variations names with their descriptions.

## Screenshots

| Before | After |
| - | - |
| <img width="620" alt="Screenshot 2020-08-13 at 12 16 53" src="https://user-images.githubusercontent.com/2070010/90129395-7d7a7e00-dd60-11ea-951f-7e09a2e6ffb1.png"> | <img width="617" alt="Screenshot 2020-08-13 at 12 20 37" src="https://user-images.githubusercontent.com/2070010/90129404-810e0500-dd60-11ea-92a1-803b71767286.png"> |
| <img width="617" alt="Screenshot 2020-08-13 at 12 11 36" src="https://user-images.githubusercontent.com/2070010/90129415-853a2280-dd60-11ea-92d6-af9f4c4fda82.png"> | <img width="618" alt="Screenshot 2020-08-13 at 12 15 56" src="https://user-images.githubusercontent.com/2070010/90129429-89664000-dd60-11ea-96dc-174c2de4786e.png"> |

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
