### PR TITLE
Add option for adding link in featured image [ Latest Posts block ]

### DIFF
--- a/packages/block-library/src/latest-posts/block.json
+++ b/packages/block-library/src/latest-posts/block.json
@@ -74,6 +74,10 @@
 		"featuredImageSizeHeight": {
 			"type": "number",
 			"default": null
+		},
+		"addLinkToFeaturedImage": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -122,6 +122,7 @@ class LatestPostsEdit extends Component {
 			featuredImageSizeSlug,
 			featuredImageSizeWidth,
 			featuredImageSizeHeight,
+			addLinkToFeaturedImage,
 		} = attributes;
 		const categorySuggestions = categoriesList.reduce(
 			( accumulator, category ) => ( {
@@ -264,6 +265,15 @@ class LatestPostsEdit extends Component {
 									isCollapsed={ false }
 								/>
 							</BaseControl>
+							<ToggleControl
+								label={ __( 'Add link to featured image' ) }
+								checked={ addLinkToFeaturedImage }
+								onChange={ ( value ) =>
+									setAttributes( {
+										addLinkToFeaturedImage: value,
+									} )
+								}
+							/>
 						</>
 					) }
 				</PanelBody>
@@ -391,11 +401,22 @@ class LatestPostsEdit extends Component {
 							'';
 
 						const imageSourceUrl = post.featuredImageSourceUrl;
-
 						const imageClasses = classnames( {
 							'wp-block-latest-posts__featured-image': true,
 							[ `align${ featuredImageAlign }` ]: !! featuredImageAlign,
 						} );
+						const showFeaturedImage =
+							displayFeaturedImage && imageSourceUrl;
+						const featuredImage = showFeaturedImage && (
+							<img
+								src={ imageSourceUrl }
+								alt=""
+								style={ {
+									maxWidth: featuredImageSizeWidth,
+									maxHeight: featuredImageSizeHeight,
+								} }
+							/>
+						);
 
 						const needsReadMore =
 							excerptLength <
@@ -424,17 +445,18 @@ class LatestPostsEdit extends Component {
 
 						return (
 							<li key={ i }>
-								{ displayFeaturedImage && (
+								{ showFeaturedImage && (
 									<div className={ imageClasses }>
-										{ imageSourceUrl && (
-											<img
-												src={ imageSourceUrl }
-												alt=""
-												style={ {
-													maxWidth: featuredImageSizeWidth,
-													maxHeight: featuredImageSizeHeight,
-												} }
-											/>
+										{ addLinkToFeaturedImage ? (
+											<a
+												href={ post.link }
+												target="_blank"
+												rel="noreferrer noopener"
+											>
+												{ featuredImage }
+											</a>
+										) : (
+											featuredImage
 										) }
 									</div>
 								) }

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -405,9 +405,9 @@ class LatestPostsEdit extends Component {
 							'wp-block-latest-posts__featured-image': true,
 							[ `align${ featuredImageAlign }` ]: !! featuredImageAlign,
 						} );
-						const showFeaturedImage =
+						const renderFeaturedImage =
 							displayFeaturedImage && imageSourceUrl;
-						const featuredImage = showFeaturedImage && (
+						const featuredImage = renderFeaturedImage && (
 							<img
 								src={ imageSourceUrl }
 								alt=""
@@ -445,7 +445,7 @@ class LatestPostsEdit extends Component {
 
 						return (
 							<li key={ i }>
-								{ showFeaturedImage && (
+								{ renderFeaturedImage && (
 									<div className={ imageClasses }>
 										{ addLinkToFeaturedImage ? (
 											<a

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -400,7 +400,12 @@ class LatestPostsEdit extends Component {
 							excerptElement.innerText ||
 							'';
 
-						const imageSourceUrl = post.featuredImageSourceUrl;
+						const {
+							featuredImageInfo: {
+								url: imageSourceUrl,
+								alt: featuredImageAlt,
+							} = {},
+						} = post;
 						const imageClasses = classnames( {
 							'wp-block-latest-posts__featured-image': true,
 							[ `align${ featuredImageAlign }` ]: !! featuredImageAlign,
@@ -410,7 +415,7 @@ class LatestPostsEdit extends Component {
 						const featuredImage = renderFeaturedImage && (
 							<img
 								src={ imageSourceUrl }
-								alt=""
+								alt={ featuredImageAlt }
 								style={ {
 									maxWidth: featuredImageSizeWidth,
 									maxHeight: featuredImageSizeHeight,
@@ -564,24 +569,28 @@ export default withSelect( ( select, props ) => {
 		latestPosts: ! Array.isArray( posts )
 			? posts
 			: posts.map( ( post ) => {
-					if ( post.featured_media ) {
-						const image = getMedia( post.featured_media );
-						let url = get(
-							image,
-							[
-								'media_details',
-								'sizes',
-								featuredImageSizeSlug,
-								'source_url',
-							],
-							null
-						);
-						if ( ! url ) {
-							url = get( image, 'source_url', null );
-						}
-						return { ...post, featuredImageSourceUrl: url };
+					if ( ! post.featured_media ) return post;
+
+					const image = getMedia( post.featured_media );
+					let url = get(
+						image,
+						[
+							'media_details',
+							'sizes',
+							featuredImageSizeSlug,
+							'source_url',
+						],
+						null
+					);
+					if ( ! url ) {
+						url = get( image, 'source_url', null );
 					}
-					return post;
+					const featuredImageInfo = {
+						url,
+						// eslint-disable-next-line camelcase
+						alt: image?.alt_text,
+					};
+					return { ...post, featuredImageInfo };
 			  } ),
 	};
 } )( LatestPostsEdit );

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -58,7 +58,7 @@ function render_block_core_latest_posts( $attributes ) {
 	$list_items_markup = '';
 
 	foreach ( $recent_posts as $post ) {
-
+		$post_link = esc_url( get_permalink( $post ) );
 		$list_items_markup .= '<li>';
 
 		if ( $attributes['displayFeaturedImage'] && has_post_thumbnail( $post ) ) {
@@ -75,16 +75,25 @@ function render_block_core_latest_posts( $attributes ) {
 				$image_classes .= ' align' . $attributes['featuredImageAlign'];
 			}
 
+			$featured_image = get_the_post_thumbnail(
+				$post,
+				$attributes['featuredImageSizeSlug'],
+				array(
+					'style' => $image_style,
+				)
+			);
+			$addLinkToFeaturedImage = $attributes['addLinkToFeaturedImage'];
+			if ( $addLinkToFeaturedImage ) {
+				$featured_image = sprintf(
+					'<a href="%1$s">%2$s</a>',
+					$post_link,
+					$featured_image
+				);
+			}
 			$list_items_markup .= sprintf(
 				'<div class="%1$s">%2$s</div>',
 				$image_classes,
-				get_the_post_thumbnail(
-					$post,
-					$attributes['featuredImageSizeSlug'],
-					array(
-						'style' => $image_style,
-					)
-				)
+				$featured_image
 			);
 		}
 
@@ -94,7 +103,7 @@ function render_block_core_latest_posts( $attributes ) {
 		}
 		$list_items_markup .= sprintf(
 			'<a href="%1$s">%2$s</a>',
-			esc_url( get_permalink( $post ) ),
+			$post_link,
 			$title
 		);
 

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -59,6 +59,7 @@ function render_block_core_latest_posts( $attributes ) {
 
 	foreach ( $recent_posts as $post ) {
 		$post_link = esc_url( get_permalink( $post ) );
+
 		$list_items_markup .= '<li>';
 
 		if ( $attributes['displayFeaturedImage'] && has_post_thumbnail( $post ) ) {
@@ -82,8 +83,7 @@ function render_block_core_latest_posts( $attributes ) {
 					'style' => $image_style,
 				)
 			);
-			$addLinkToFeaturedImage = $attributes['addLinkToFeaturedImage'];
-			if ( $addLinkToFeaturedImage ) {
+			if ( $attributes['addLinkToFeaturedImage'] ) {
 				$featured_image = sprintf(
 					'<a href="%1$s">%2$s</a>',
 					$post_link,

--- a/packages/block-library/src/latest-posts/style.scss
+++ b/packages/block-library/src/latest-posts/style.scss
@@ -47,6 +47,9 @@
 }
 
 .wp-block-latest-posts__featured-image {
+	a {
+		display: inline-block;
+	}
 	img {
 		height: auto;
 		width: auto;

--- a/packages/e2e-tests/fixtures/blocks/core__latest-posts.json
+++ b/packages/e2e-tests/fixtures/blocks/core__latest-posts.json
@@ -17,7 +17,8 @@
             "displayFeaturedImage": false,
             "featuredImageSizeSlug": "thumbnail",
             "featuredImageSizeWidth": null,
-            "featuredImageSizeHeight": null
+            "featuredImageSizeHeight": null,
+			"addLinkToFeaturedImage": false
         },
         "innerBlocks": [],
         "originalContent": ""

--- a/packages/e2e-tests/fixtures/blocks/core__latest-posts.json
+++ b/packages/e2e-tests/fixtures/blocks/core__latest-posts.json
@@ -1,26 +1,26 @@
 [
-    {
-        "clientId": "_clientId_0",
-        "name": "core/latest-posts",
-        "isValid": true,
-        "attributes": {
-            "postsToShow": 5,
-            "displayPostContent": false,
-            "displayPostContentRadio": "excerpt",
-            "excerptLength": 55,
-            "displayAuthor": false,
-            "displayPostDate": false,
-            "postLayout": "list",
-            "columns": 3,
-            "order": "desc",
-            "orderBy": "date",
-            "displayFeaturedImage": false,
-            "featuredImageSizeSlug": "thumbnail",
-            "featuredImageSizeWidth": null,
-            "featuredImageSizeHeight": null,
+	{
+		"clientId": "_clientId_0",
+		"name": "core/latest-posts",
+		"isValid": true,
+		"attributes": {
+			"postsToShow": 5,
+			"displayPostContent": false,
+			"displayPostContentRadio": "excerpt",
+			"excerptLength": 55,
+			"displayAuthor": false,
+			"displayPostDate": false,
+			"postLayout": "list",
+			"columns": 3,
+			"order": "desc",
+			"orderBy": "date",
+			"displayFeaturedImage": false,
+			"featuredImageSizeSlug": "thumbnail",
+			"featuredImageSizeWidth": null,
+			"featuredImageSizeHeight": null,
 			"addLinkToFeaturedImage": false
-        },
-        "innerBlocks": [],
-        "originalContent": ""
-    }
+		},
+		"innerBlocks": [],
+		"originalContent": ""
+	}
 ]

--- a/packages/e2e-tests/fixtures/blocks/core__latest-posts__displayPostDate.json
+++ b/packages/e2e-tests/fixtures/blocks/core__latest-posts__displayPostDate.json
@@ -17,7 +17,8 @@
             "displayFeaturedImage": false,
             "featuredImageSizeSlug": "thumbnail",
             "featuredImageSizeWidth": null,
-            "featuredImageSizeHeight": null
+			"featuredImageSizeHeight": null,
+			"addLinkToFeaturedImage": false
         },
         "innerBlocks": [],
         "originalContent": ""

--- a/packages/e2e-tests/fixtures/blocks/core__latest-posts__displayPostDate.json
+++ b/packages/e2e-tests/fixtures/blocks/core__latest-posts__displayPostDate.json
@@ -1,26 +1,26 @@
 [
-    {
-        "clientId": "_clientId_0",
-        "name": "core/latest-posts",
-        "isValid": true,
-        "attributes": {
-            "postsToShow": 5,
-            "displayPostContent": false,
-            "displayPostContentRadio": "excerpt",
-            "excerptLength": 55,
-            "displayAuthor": false,
-            "displayPostDate": true,
-            "postLayout": "list",
-            "columns": 3,
-            "order": "desc",
-            "orderBy": "date",
-            "displayFeaturedImage": false,
-            "featuredImageSizeSlug": "thumbnail",
-            "featuredImageSizeWidth": null,
+	{
+		"clientId": "_clientId_0",
+		"name": "core/latest-posts",
+		"isValid": true,
+		"attributes": {
+			"postsToShow": 5,
+			"displayPostContent": false,
+			"displayPostContentRadio": "excerpt",
+			"excerptLength": 55,
+			"displayAuthor": false,
+			"displayPostDate": true,
+			"postLayout": "list",
+			"columns": 3,
+			"order": "desc",
+			"orderBy": "date",
+			"displayFeaturedImage": false,
+			"featuredImageSizeSlug": "thumbnail",
+			"featuredImageSizeWidth": null,
 			"featuredImageSizeHeight": null,
 			"addLinkToFeaturedImage": false
-        },
-        "innerBlocks": [],
-        "originalContent": ""
-    }
+		},
+		"innerBlocks": [],
+		"originalContent": ""
+	}
 ]


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Resolves: https://github.com/WordPress/gutenberg/issues/21530

This PR adds an option to `Latest Posts` block to add a link of the post to `featured image`.

This is part of https://github.com/WordPress/gutenberg/issues/20046 and ultimately the direction is to implement the `LatestPosts` block as a variation of the `Query` block, as described here:  https://github.com/WordPress/gutenberg/issues/24521.
<!-- Please describe what you have changed or added -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
