### PR TITLE
Fix inserter expecting experimental settings to exist in the context

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -499,6 +499,8 @@ _Properties_
 -   _\_\_experimentalBlockDirectory_ `boolean`: Whether the user has enabled the Block Directory
 -   _\_\_experimentalEnableFullSiteEditing_ `boolean`: Whether the user has enabled Full Site Editing
 -   _\_\_experimentalEnableFullSiteEditingDemo_ `boolean`: Whether the user has enabled Full Site Editing Demo Templates
+-   _\_\_experimentalBlockPatterns_ `Array`: Array of objects representing the block patterns
+-   _\_\_experimentalBlockPatternCategories_ `Array`: Array of objects representing the block pattern categories
 
 <a name="SkipToSelectedBlock" href="#SkipToSelectedBlock">#</a> **SkipToSelectedBlock**
 

--- a/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
@@ -21,8 +21,8 @@ import { __, sprintf } from '@wordpress/i18n';
 const usePatternsState = ( onInsert ) => {
 	const { patternCategories, patterns } = useSelect( ( select ) => {
 		const {
-			__experimentalBlockPatterns,
-			__experimentalBlockPatternCategories,
+			__experimentalBlockPatterns = [],
+			__experimentalBlockPatternCategories = [],
 		} = select( 'core/block-editor' ).getSettings();
 		return {
 			patterns: __experimentalBlockPatterns,

--- a/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
@@ -21,8 +21,8 @@ import { __, sprintf } from '@wordpress/i18n';
 const usePatternsState = ( onInsert ) => {
 	const { patternCategories, patterns } = useSelect( ( select ) => {
 		const {
-			__experimentalBlockPatterns = [],
-			__experimentalBlockPatternCategories = [],
+			__experimentalBlockPatterns,
+			__experimentalBlockPatternCategories,
 		} = select( 'core/block-editor' ).getSettings();
 		return {
 			patterns: __experimentalBlockPatterns,

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -35,6 +35,8 @@ export const PREFERENCES_DEFAULTS = {
  * @property {boolean} __experimentalBlockDirectory Whether the user has enabled the Block Directory
  * @property {boolean} __experimentalEnableFullSiteEditing Whether the user has enabled Full Site Editing
  * @property {boolean} __experimentalEnableFullSiteEditingDemo Whether the user has enabled Full Site Editing Demo Templates
+ * @property {Array} __experimentalBlockPatterns Array of objects representing the block patterns
+ * @property {Array} __experimentalBlockPatternCategories Array of objects representing the block pattern categories
  */
 export const SETTINGS_DEFAULTS = {
 	alignWide: false,
@@ -156,6 +158,9 @@ export const SETTINGS_DEFAULTS = {
 	__experimentalEnableFullSiteEditing: false,
 	__experimentalEnableFullSiteEditingDemo: false,
 	__mobileEnablePageTemplates: false,
+	__experimentalBlockPatterns: [],
+	__experimentalBlockPatternCategories: [],
+
 	gradients: [
 		{
 			name: __( 'Vivid cyan blue to vivid purple' ),


### PR DESCRIPTION
closes #24051  

While reviewing [this PR](https://github.com/Automattic/wp-calypso/pull/44801#discussion_r470064423) that's trying to integrate the block editor directly in WP Calypso, I noticed that the inserter is expecting these experimental settings to exist in the context: `__experimentalBlockPatterns` and `__experimentalBlockPatternCategories`. Which doesn't seem correct, especially since they're experimental.

This PR changes it so they use empty arrays by default. But please let me know if there's a better way to handle this. :)