### PR TITLE
Remove references to `$default-font` from front-facing styles

### DIFF
--- a/packages/block-library/src/calendar/style.scss
+++ b/packages/block-library/src/calendar/style.scss
@@ -14,7 +14,6 @@
 	table {
 		width: 100%;
 		border-collapse: collapse;
-		font-family: $default-font;
 	}
 
 	table th {

--- a/packages/block-library/src/navigation-link/style.scss
+++ b/packages/block-library/src/navigation-link/style.scss
@@ -116,8 +116,6 @@
 }
 
 .wp-block-navigation-link__label {
-	font-family: $default-font;
-
 	word-break: normal;
 	overflow-wrap: break-word;
 }


### PR DESCRIPTION
Currently we're defining the editorr's default font-family on a couple of frontend styles:
In calendars we apply it to tables, and we also add it to navigation link labels.

This PR removes these 2 rules so the theme's font-family can be used instead.