### PR TITLE
[RNMobile] Content is in the `content` attr for the classic block

### DIFF
--- a/packages/block-library/src/missing/edit.native.js
+++ b/packages/block-library/src/missing/edit.native.js
@@ -122,8 +122,13 @@ export class UnsupportedBlockEdit extends Component {
 						// On iOS, onModalHide is called when the controller is still part of the hierarchy.
 						// A small delay will ensure that the controller has already been removed.
 						this.timeout = setTimeout( () => {
+							// for the Classic block, the content is kept in the `content` attribute
+							const content =
+								blockName === 'core/freeform'
+									? attributes.content
+									: attributes.originalContent;
 							requestUnsupportedBlockFallback(
-								attributes.originalContent,
+								content,
 								clientId,
 								blockName,
 								blockTitle


### PR DESCRIPTION
Fixes #24563 

This PR includes a fix for the native mobile Unsupported Blocks Fallback editor, to better support the Classic block. The fix consists of one change: to use the `content` attribute of the block for accessing the block content, instead of the `.original_content` that is for the rest of the blocks.

Note: this PR is based on v1.33.1 of the native block editor with the goal of landing the fix on a 1.33.2 version to then land on WPAndroid **v15.4*. There's a accompanying [GB PR](https://github.com/WordPress/gutenberg/pull/24571) based on v1.32 of gb-mobile to land on a v1.32.1 and then land on WPiOS **v15.3**. Notice the difference in WP Apps and versions.

## How has this been tested?
0. Using the [gb-mobile PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/2550)
1. Run metro (`npm run start:reset`)
2. Run the Android demo app (`npm run core android`)
3. Switch to html mode and write some text in-between two blocks, making sure the text is not inside the block delimiters
4. Switch back to visual mode
5. There should be an unsupported block displayed between the blocks the text was inserted
6. Use the "?" button of the unsupported block and then "Edit block in web browser" to launch the Unsupported Block editor
7. Notice the text being displayed inside a "Classic" block without an error 🎉
8. Make some changes to the text and hit the "✔️" icon in the upper right to commit the changes
9. Switch to html mode again and notice that the text includes the changes made inside the Unsupported Block editor 🎉

## Types of changes
When launching the Unsupported Block editor, provide the Classic block context available in the `content` attribute instead of the `original_content` attribute.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
