### PR TITLE
Add custom nav link props to Navigation component

### DIFF
--- a/packages/components/src/navigation/menu-item.js
+++ b/packages/components/src/navigation/menu-item.js
@@ -41,36 +41,22 @@ const NavigationMenuItem = ( props ) => {
 		onClick( props );
 	};
 
-	const linkContents = (
-		<>
-			<Text variant="body.small">
-				<span>{ title }</span>
-			</Text>
-			{ badge && <BadgeUI>{ badge }</BadgeUI> }
-			{ hasChildren ? <Icon icon={ chevronRight } /> : null }
-		</>
-	);
+	const LinkComponentTag = LinkComponent ? LinkComponent : Button;
 
 	return (
 		<MenuItemUI className={ classes }>
-			{ LinkComponent ? (
-				<LinkComponent
-					className={ classes }
-					onClick={ handleClick }
-					{ ...linkProps }
-				>
-					{ linkContents }
-				</LinkComponent>
-			) : (
-				<Button
-					className={ classes }
-					href={ href }
-					onClick={ handleClick }
-					{ ...linkProps }
-				>
-					{ linkContents }
-				</Button>
-			) }
+			<LinkComponentTag
+				className={ classes }
+				href={ href }
+				onClick={ handleClick }
+				{ ...linkProps }
+			>
+				<Text variant="body.small">
+					<span>{ title }</span>
+				</Text>
+				{ badge && <BadgeUI>{ badge }</BadgeUI> }
+				{ hasChildren ? <Icon icon={ chevronRight } /> : null }
+			</LinkComponentTag>
 		</MenuItemUI>
 	);
 };

--- a/packages/components/src/navigation/menu-item.js
+++ b/packages/components/src/navigation/menu-item.js
@@ -20,8 +20,11 @@ const NavigationMenuItem = ( props ) => {
 		badge,
 		children,
 		hasChildren,
+		href,
 		id,
 		isActive,
+		linkTag,
+		linkTagProps,
 		onClick,
 		setActiveLevel,
 		title,
@@ -38,15 +41,22 @@ const NavigationMenuItem = ( props ) => {
 		onClick( props );
 	};
 
+	const LinkTagName = linkTag || Button;
+
 	return (
 		<MenuItemUI className={ classes }>
-			<Button className={ classes } onClick={ handleClick }>
+			<LinkTagName
+				className={ classes }
+				href={ href }
+				onClick={ handleClick }
+				{ ...linkTagProps }
+			>
 				<Text variant="body.small">
 					<span>{ title }</span>
 				</Text>
 				{ badge && <BadgeUI>{ badge }</BadgeUI> }
 				{ hasChildren ? <Icon icon={ chevronRight } /> : null }
-			</Button>
+			</LinkTagName>
 		</MenuItemUI>
 	);
 };

--- a/packages/components/src/navigation/menu-item.js
+++ b/packages/components/src/navigation/menu-item.js
@@ -23,8 +23,8 @@ const NavigationMenuItem = ( props ) => {
 		href,
 		id,
 		isActive,
-		linkTag,
-		linkTagProps,
+		LinkComponent,
+		linkProps,
 		onClick,
 		setActiveLevel,
 		title,
@@ -41,22 +41,36 @@ const NavigationMenuItem = ( props ) => {
 		onClick( props );
 	};
 
-	const LinkTagName = linkTag || Button;
+	const linkContents = (
+		<>
+			<Text variant="body.small">
+				<span>{ title }</span>
+			</Text>
+			{ badge && <BadgeUI>{ badge }</BadgeUI> }
+			{ hasChildren ? <Icon icon={ chevronRight } /> : null }
+		</>
+	);
 
 	return (
 		<MenuItemUI className={ classes }>
-			<LinkTagName
-				className={ classes }
-				href={ href }
-				onClick={ handleClick }
-				{ ...linkTagProps }
-			>
-				<Text variant="body.small">
-					<span>{ title }</span>
-				</Text>
-				{ badge && <BadgeUI>{ badge }</BadgeUI> }
-				{ hasChildren ? <Icon icon={ chevronRight } /> : null }
-			</LinkTagName>
+			{ LinkComponent ? (
+				<LinkComponent
+					className={ classes }
+					onClick={ handleClick }
+					{ ...linkProps }
+				>
+					{ linkContents }
+				</LinkComponent>
+			) : (
+				<Button
+					className={ classes }
+					href={ href }
+					onClick={ handleClick }
+					{ ...linkProps }
+				>
+					{ linkContents }
+				</Button>
+			) }
 		</MenuItemUI>
 	);
 };

--- a/packages/components/src/navigation/stories/index.js
+++ b/packages/components/src/navigation/stories/index.js
@@ -16,6 +16,13 @@ export default {
 	component: Navigation,
 };
 
+// Example Link component from a router such as React Router
+const CustomRouterLink = ( { children, onClick } ) => {
+	// Here I'm passing the onClick prop for simplicity, but behavior can be
+	// anything here.
+	return <Button onClick={ onClick }>{ children }</Button>;
+};
+
 const data = [
 	{
 		title: 'Item 1',
@@ -42,13 +49,17 @@ const data = [
 		parent: 'item-3',
 	},
 	{
-		title: 'Custom link',
+		title: 'External link',
 		id: 'item-4',
-		linkTag: 'a',
 		href: 'https://wordpress.com',
-		linkTagProps: {
+		linkProps: {
 			target: '_blank',
 		},
+	},
+	{
+		title: 'Internal link',
+		id: 'item-5',
+		LinkComponent: CustomRouterLink,
 	},
 ];
 

--- a/packages/components/src/navigation/stories/index.js
+++ b/packages/components/src/navigation/stories/index.js
@@ -41,6 +41,15 @@ const data = [
 		id: 'child-2',
 		parent: 'item-3',
 	},
+	{
+		title: 'Custom link',
+		id: 'item-4',
+		linkTag: 'a',
+		href: 'https://wordpress.com',
+		linkTagProps: {
+			target: '_blank',
+		},
+	},
 ];
 
 function Example() {


### PR DESCRIPTION
## Description

NOTE: Branched from `add/nav-badges` and will need a rebase pending its merge.

Allows passing the link tag name as well as additional props to this component.  Allows consumers to bring their own routing components and link tags.

## Screenshots <!-- if applicable -->
<img width="278" alt="Screen Shot 2020-08-14 at 7 10 18 AM" src="https://user-images.githubusercontent.com/10561050/90244016-9eae9d80-de38-11ea-881c-0a6d12b56d7b.png">


## Testing

1. Run `npm run storybook:dev`.
1. Visit the Navigation component.
1. Check that the newly added "Custom link" works by opening a new browser tab.