### PR TITLE
Revert "[RNMobile] another approach to fix jumping toolbar"

### DIFF
--- a/packages/block-library/src/button/edit.native.js
+++ b/packages/block-library/src/button/edit.native.js
@@ -372,6 +372,7 @@ class ButtonEdit extends Component {
 						__unstableMobileNoFocusOnMount={ ! isSelected }
 						selectionColor={ textColor }
 						onBlur={ () => {
+							this.onToggleButtonFocus( false );
 							this.onSetMaxWidth();
 						} }
 						onReplace={ onReplace }

--- a/packages/components/src/mobile/keyboard-avoiding-view/index.ios.js
+++ b/packages/components/src/mobile/keyboard-avoiding-view/index.ios.js
@@ -3,95 +3,19 @@
  */
 import {
 	KeyboardAvoidingView as IOSKeyboardAvoidingView,
-	Animated,
-	Keyboard,
 	Dimensions,
-	View,
 } from 'react-native';
-import SafeArea from 'react-native-safe-area';
 
-/**
- * WordPress dependencies
- */
-import { useEffect, useRef } from '@wordpress/element';
-import { useResizeObserver } from '@wordpress/compose';
-
-/**
- * Internal dependencies
- */
-import styles from './styles.scss';
-
-const AnimatedKeyboardAvoidingView = Animated.createAnimatedComponent(
-	IOSKeyboardAvoidingView
-);
-
-const MIN_HEIGHT = 44;
-
-export const KeyboardAvoidingView = ( {
-	parentHeight,
-	style,
-	withAnimatedHeight = false,
-	...otherProps
-} ) => {
-	const [ resizeObserver, sizes ] = useResizeObserver();
-	const { height = 0 } = sizes || {};
-
-	const animatedHeight = useRef( new Animated.Value( MIN_HEIGHT ) ).current;
-
+export const KeyboardAvoidingView = ( { parentHeight, ...otherProps } ) => {
 	const { height: fullHeight } = Dimensions.get( 'window' );
 	const keyboardVerticalOffset = fullHeight - parentHeight;
 
-	useEffect( () => {
-		Keyboard.addListener( 'keyboardWillShow', onKeyboardWillShow );
-		Keyboard.addListener( 'keyboardWillHide', onKeyboardWillHide );
-		return () => {
-			Keyboard.removeListener( 'keyboardWillShow', onKeyboardWillShow );
-			Keyboard.removeListener( 'keyboardWillHide', onKeyboardWillHide );
-		};
-	}, [] );
-
-	function onKeyboardWillShow( { endCoordinates } ) {
-		SafeArea.getSafeAreaInsetsForRootView().then( ( result ) => {
-			animatedHeight.setValue(
-				endCoordinates.height +
-					MIN_HEIGHT -
-					result.safeAreaInsets.bottom
-			);
-		} );
-	}
-
-	function onKeyboardWillHide( { duration } ) {
-		Animated.timing( animatedHeight, {
-			toValue: MIN_HEIGHT,
-			duration,
-			useNativeDriver: false,
-		} ).start();
-	}
-
 	return (
-		<AnimatedKeyboardAvoidingView
+		<IOSKeyboardAvoidingView
 			{ ...otherProps }
 			behavior="padding"
 			keyboardVerticalOffset={ keyboardVerticalOffset }
-			style={
-				withAnimatedHeight
-					? [ style, { height: animatedHeight } ]
-					: style
-			}
-		>
-			<View
-				style={ [
-					{
-						top: -height + MIN_HEIGHT,
-					},
-					styles.animatedChildStyle,
-					! withAnimatedHeight && styles.defaultChildStyle,
-				] }
-			>
-				{ resizeObserver }
-				{ otherProps.children }
-			</View>
-		</AnimatedKeyboardAvoidingView>
+		/>
 	);
 };
 

--- a/packages/components/src/mobile/keyboard-avoiding-view/styles.native.scss
+++ b/packages/components/src/mobile/keyboard-avoiding-view/styles.native.scss
@@ -1,9 +1,0 @@
-.animatedChildStyle {
-	position: absolute;
-	width: 100%;
-}
-
-.defaultChildStyle {
-	height: 100%;
-	top: 0;
-}

--- a/packages/edit-post/src/components/layout/index.native.js
+++ b/packages/edit-post/src/components/layout/index.native.js
@@ -153,7 +153,6 @@ class Layout extends Component {
 					<KeyboardAvoidingView
 						parentHeight={ this.state.rootViewHeight }
 						style={ toolbarKeyboardAvoidingViewStyle }
-						withAnimatedHeight
 					>
 						{ isTemplatePickerAvailable && (
 							<__experimentalPageTemplatePicker


### PR DESCRIPTION
Reverts WordPress/gutenberg#24414

I've noticed that toolbar is hanging in case when user is adding a new block from previously focused Paragraph. These changes has to be reverted. I will be working on a fix in https://github.com/WordPress/gutenberg/pull/24573