### PR TITLE
Fix support for SVG in rich text

### DIFF
--- a/packages/rich-text/src/test/to-dom.js
+++ b/packages/rich-text/src/test/to-dom.js
@@ -109,3 +109,32 @@ describe( 'applyValue', () => {
 		} );
 	} );
 } );
+
+describe( 'toDom-SVG', () => {
+	let body;
+	beforeAll( () => {
+		const svg = { type: 'svg' };
+		const use = { type: 'use', attributes: { 'xlink:href': '#logo' } };
+		body = toDom( {
+			value: {
+				start: 0,
+				end: 1,
+				formats: [ [ svg ] ],
+				replacements: [ use ],
+				text: '\ufffc',
+			},
+		} ).body;
+	} );
+
+	it( 'should create nodes with svg namespace', () => {
+		const target = body.firstElementChild;
+		expect( target.namespaceURI ).toEqual( 'http://www.w3.org/2000/svg' );
+	} );
+
+	it( 'should create attribute xlink:href with xlink namespace', () => {
+		const target = body
+			.querySelector( 'use' )
+			.getAttributeNode( 'xlink:href' );
+		expect( target.namespaceURI ).toEqual( 'http://www.w3.org/1999/xlink' );
+	} );
+} );

--- a/packages/rich-text/src/to-dom.js
+++ b/packages/rich-text/src/to-dom.js
@@ -7,6 +7,9 @@ import { createElement } from './create-element';
 
 /** @typedef {import('./create').RichTextValue} RichTextValue */
 
+const NS_SVG = 'http://www.w3.org/2000/svg';
+const NS_XLINK = 'http://www.w3.org/1999/xlink';
+
 /**
  * Creates a path as an array of indices from the given root node to the given
  * node.
@@ -59,18 +62,36 @@ function append( element, child ) {
 	if ( typeof child === 'string' ) {
 		child = element.ownerDocument.createTextNode( child );
 	}
-
-	const { type, attributes } = child;
-
-	if ( type ) {
-		child = element.ownerDocument.createElement( type );
-
-		for ( const key in attributes ) {
-			child.setAttribute( key, attributes[ key ] );
-		}
+	if ( 'type' in child ) {
+		child = contextuallyCreate( element, child );
 	}
 
 	return element.appendChild( child );
+}
+
+function contextuallyCreate( element, child ) {
+	const { ownerDocument: doc, namespaceURI } = element;
+	const { type, attributes } = child;
+	const [ childNode, addAttribute ] =
+		type === 'svg' || namespaceURI === NS_SVG
+			? [
+					doc.createElementNS( NS_SVG, type ),
+					( node, key, value ) => {
+						if ( key === 'xlink:href' ) {
+							node.setAttributeNS( NS_XLINK, key, value );
+						} else {
+							node.setAttribute( key, value );
+						}
+					},
+			  ]
+			: [
+					doc.createElement( type ),
+					( node, key, value ) => node.setAttribute( key, value ),
+			  ];
+	for ( const key in attributes ) {
+		addAttribute( childNode, key, attributes[ key ] );
+	}
+	return childNode;
 }
 
 function appendText( node, text ) {


### PR DESCRIPTION
## Description
Fixes support for SVG in `RichText` by adding simple logic to element/attribute creation for the use of `createElementNS` and `setAttributeNS` where appropriate. Adds a couple of test cases to cover expected behavior. Changes were made intending to do the simplest thing that could work for most use cases and not to fully support all SVG markup. 

## Why
To enable SVG icons in rich text. Presently, adding SVG markup is possible and it will display properly on the frontend, but in the block editor, it does not display due to the elements being created without namespacing. 

## Demonstration
I've made [a gist](https://gist.github.com/stokesman/4961fa04cdd601a08e3124cb1a305834) of a plugin that allows easy reproduction of the issue (also works to just run the JS in the console while on an editor screen). It adds a button to the rich text toolbar for inserting sample SVG markup.

## How has this been tested?
Ran unit tests. Ran e2e tests with WordPress 5.4.2. Rich text related tests all passed.

## Types of changes
Bugfix and added tests

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
