### PR TITLE
Upgrade eslint-plugin-jsdoc to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11577,7 +11577,7 @@
 				"babel-eslint": "^10.1.0",
 				"eslint-config-prettier": "^6.10.1",
 				"eslint-plugin-jest": "^23.8.2",
-				"eslint-plugin-jsdoc": "^26.0.0",
+				"eslint-plugin-jsdoc": "^30.2.2",
 				"eslint-plugin-jsx-a11y": "^6.2.3",
 				"eslint-plugin-prettier": "^3.1.2",
 				"eslint-plugin-react": "^7.20.0",
@@ -22951,9 +22951,9 @@
 			"dev": true
 		},
 		"comment-parser": {
-			"version": "0.7.5",
-			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.7.5.tgz",
-			"integrity": "sha512-iH9YA35ccw94nx5244GVkpyC9eVTsL71jZz6iz5w6RIf79JLF2AsXHXq9p6Oaohyl3sx5qSMnGsWUDFIAfWL4w==",
+			"version": "0.7.6",
+			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.7.6.tgz",
+			"integrity": "sha512-GKNxVA7/iuTnAqGADlTWX4tkhzxZKXp5fLJqKTlQLHkE65XDUKutZ3BHaJC5IGcper2tT3QRD1xr4o3jNpgXXg==",
 			"dev": true
 		},
 		"commondir": {
@@ -26979,17 +26979,17 @@
 			}
 		},
 		"eslint-plugin-jsdoc": {
-			"version": "26.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-26.0.0.tgz",
-			"integrity": "sha512-/oEywHPBn6eVDExTgDTwdwyQlVIuJziovXOPXBROW8yW93vk6/IGezW5jbzmA2pX4tVRCQc/jz5/mZea+FCmfw==",
+			"version": "30.2.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-30.2.2.tgz",
+			"integrity": "sha512-588zVyRy+g7s8VU3D0AL75r7xBYN0UX6tZEwP5EQ4JvpVavwu2iPJRaBxwuG3QAj99WZkUBlrLU16p4qST6vSw==",
 			"dev": true,
 			"requires": {
-				"comment-parser": "^0.7.4",
+				"comment-parser": "^0.7.5",
 				"debug": "^4.1.1",
-				"jsdoctypeparser": "^6.1.0",
-				"lodash": "^4.17.15",
+				"jsdoctypeparser": "^9.0.0",
+				"lodash": "^4.17.19",
 				"regextras": "^0.7.1",
-				"semver": "^6.3.0",
+				"semver": "^7.3.2",
 				"spdx-expression-parse": "^3.0.1"
 			},
 			"dependencies": {
@@ -27006,12 +27006,6 @@
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 					"dev": true
 				},
 				"spdx-expression-parse": {
@@ -37123,9 +37117,9 @@
 			}
 		},
 		"jsdoctypeparser": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-6.1.0.tgz",
-			"integrity": "sha512-UCQBZ3xCUBv/PLfwKAJhp6jmGOSLFNKzrotXGNgbKhWvz27wPsCsVeP7gIcHPElQw2agBmynAitXqhxR58XAmA==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-9.0.0.tgz",
+			"integrity": "sha512-jrTA2jJIL6/DAEILBEh2/w9QxCuwmvNXIry39Ay/HVfhE3o2yVV0U44blYkqdHA/OKloJEqvJy0xU+GSdE2SIw==",
 			"dev": true
 		},
 		"jsdom": {

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -50,14 +50,12 @@ import { ViewerFill } from './viewer-slot';
  * @property {string} title Human-readable label to show in user interface.
  */
 
-/* eslint-disable jsdoc/valid-types */
 /**
  * Properties associated with a link control value, composed as a union of the
  * default properties and any custom settings values.
  *
  * @typedef {WPLinkControlDefaultValue&WPLinkControlSettingsValue} WPLinkControlValue
  */
-/* eslint-enable */
 
 /** @typedef {(nextValue:WPLinkControlValue)=>void} WPLinkControlOnChangeProp */
 

--- a/packages/element/src/raw-html.js
+++ b/packages/element/src/raw-html.js
@@ -4,9 +4,7 @@
 import { createElement } from './react';
 
 // Disable reason: JSDoc linter doesn't seem to parse the union (`&`) correctly.
-/* eslint-disable jsdoc/valid-types */
 /** @typedef {{children: string} & import('react').ComponentPropsWithoutRef<'div'>} RawHTMLProps */
-/* eslint-enable jsdoc/valid-types */
 
 /**
  * Component used as equivalent of Fragment with unescaped HTML, in cases where

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   The bundled `eslint-plugin-jsdoc` dependency has been updated from requiring `^26.0.0` to requiring `^30.2.2`.
+
 ## 7.1.0-rc.0 (2020-06-24)
 
 ### Enhancements

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -31,7 +31,7 @@
 		"babel-eslint": "^10.1.0",
 		"eslint-config-prettier": "^6.10.1",
 		"eslint-plugin-jest": "^23.8.2",
-		"eslint-plugin-jsdoc": "^26.0.0",
+		"eslint-plugin-jsdoc": "^30.2.2",
 		"eslint-plugin-jsx-a11y": "^6.2.3",
 		"eslint-plugin-prettier": "^3.1.2",
 		"eslint-plugin-react": "^7.20.0",

--- a/packages/icons/src/icon/index.js
+++ b/packages/icons/src/icon/index.js
@@ -4,9 +4,7 @@
 import { cloneElement } from '@wordpress/element';
 
 // Disable reason: JSDoc linter doesn't seem to parse the union (`&`) correctly.
-/* eslint-disable jsdoc/valid-types */
 /** @typedef {{icon: JSX.Element, size?: number} & import('react').ComponentPropsWithoutRef<'SVG'>} IconProps */
-/* eslint-enable jsdoc/valid-types */
 
 /**
  * Return an SVG icon.

--- a/packages/is-shallow-equal/.eslintrc.json
+++ b/packages/is-shallow-equal/.eslintrc.json
@@ -6,6 +6,11 @@
 	"env": {
 		"node": true
 	},
+	"settings": {
+		"jsdoc": {
+			"mode": "typescript"
+		}
+	},
 	"overrides": [
 		{
 			"files": [ "@(test|benchmark)/*.js" ],

--- a/packages/prettier-config/lib/index.js
+++ b/packages/prettier-config/lib/index.js
@@ -9,9 +9,7 @@
 // Disable reason: The current JSDoc tooling does not yet understand TypeScript
 // union types.
 
-/* eslint-disable jsdoc/valid-types */
 /** @type {PrettierOptions & WPPrettierOptions} */
-/* eslint-enable jsdoc/valid-types */
 const config = {
 	useTabs: true,
 	tabWidth: 4,

--- a/packages/primitives/src/svg/index.js
+++ b/packages/primitives/src/svg/index.js
@@ -8,10 +8,7 @@ import classnames from 'classnames';
  */
 import { createElement } from '@wordpress/element';
 
-// Disable reason: JSDoc linter doesn't seem to parse the union (`&`) correctly.
-/* eslint-disable jsdoc/valid-types */
 /** @typedef {{isPressed?: boolean} & import('react').ComponentPropsWithoutRef<'svg'>} SVGProps */
-/* eslint-enable jsdoc/valid-types */
 
 /**
  * @param {import('react').ComponentPropsWithoutRef<'circle'>} props

--- a/packages/priority-queue/src/index.js
+++ b/packages/priority-queue/src/index.js
@@ -74,14 +74,12 @@ export const createQueue = () => {
 
 	let isRunning = false;
 
-	/* eslint-disable jsdoc/valid-types */
 	/**
 	 * Callback to process as much queue as time permits.
 	 *
 	 * @param {IdleDeadline|number} deadline Idle callback deadline object, or
 	 *                                       animation frame timestamp.
 	 */
-	/* eslint-enable */
 	const runWaitingList = ( deadline ) => {
 		const hasTimeRemaining =
 			typeof deadline === 'number'


### PR DESCRIPTION
This pull request seeks to upgrade the `eslint-plugin-jsdoc` dependency of `@wordpress/eslint-plugin` to the latest version, from `26.0.0` to `30.2.2`. Newer versions of the plugin include improved support for TypeScript syntax, notably with type intersections. Previously, these were flagged as invalid syntax, and it was frequently required to disable the rule via inline configuration.

There is still some unsupported syntax after this upgrade. The upstream issues https://github.com/jsdoctypeparser/jsdoctypeparser/issues/50 and https://github.com/gajus/eslint-plugin-jsdoc/issues/145 serve as tracking resources.

**Testing Instructions:**

Verify lint passes:

```
npm run lint-js
```