### PR TITLE
Allow local Prettier configuration to take precedence in recommended ESLint configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11575,6 +11575,7 @@
 			"requires": {
 				"@wordpress/prettier-config": "file:packages/prettier-config",
 				"babel-eslint": "^10.1.0",
+				"cosmiconfig": "^7.0.0",
 				"eslint-config-prettier": "^6.10.1",
 				"eslint-plugin-jest": "^23.8.2",
 				"eslint-plugin-jsdoc": "^30.2.2",
@@ -11585,6 +11586,61 @@
 				"globals": "^12.0.0",
 				"prettier": "npm:wp-prettier@2.0.5",
 				"requireindex": "^1.2.0"
+			},
+			"dependencies": {
+				"cosmiconfig": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
+					"integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
+					"dev": true,
+					"requires": {
+						"@types/parse-json": "^4.0.0",
+						"import-fresh": "^3.2.1",
+						"parse-json": "^5.0.0",
+						"path-type": "^4.0.0",
+						"yaml": "^1.10.0"
+					}
+				},
+				"import-fresh": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+					"integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+					"dev": true,
+					"requires": {
+						"parent-module": "^1.0.0",
+						"resolve-from": "^4.0.0"
+					}
+				},
+				"parse-json": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.1.tgz",
+					"integrity": "sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1",
+						"lines-and-columns": "^1.1.6"
+					}
+				},
+				"path-type": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+					"dev": true
+				},
+				"resolve-from": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+					"dev": true
+				},
+				"yaml": {
+					"version": "1.10.0",
+					"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
+					"integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
+					"dev": true
+				}
 			}
 		},
 		"@wordpress/format-library": {

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   The bundled `eslint-plugin-jsdoc` dependency has been updated from requiring `^26.0.0` to requiring `^30.2.2`.
 
+### Bug Fixes
+
+-   The recommended configuration will now respect local Prettier configuration. These are merged to the default WordPress configuration.
+
 ## 7.1.0-rc.0 (2020-06-24)
 
 ### Enhancements

--- a/packages/eslint-plugin/configs/recommended.js
+++ b/packages/eslint-plugin/configs/recommended.js
@@ -1,7 +1,15 @@
 /**
+ * External dependencies
+ */
+const { cosmiconfigSync } = require( 'cosmiconfig' );
+
+/**
  * WordPress dependencies
  */
 const defaultPrettierConfig = require( '@wordpress/prettier-config' );
+
+const { config: localPrettierConfig } = cosmiconfigSync( 'prettier' ).search();
+const prettierConfig = { ...defaultPrettierConfig, ...localPrettierConfig };
 
 module.exports = {
 	extends: [
@@ -10,6 +18,6 @@ module.exports = {
 		'prettier/react',
 	],
 	rules: {
-		'prettier/prettier': [ 'error', defaultPrettierConfig ],
+		'prettier/prettier': [ 'error', prettierConfig ],
 	},
 };

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -29,6 +29,7 @@
 	"dependencies": {
 		"@wordpress/prettier-config": "file:../prettier-config",
 		"babel-eslint": "^10.1.0",
+		"cosmiconfig": "^7.0.0",
 		"eslint-config-prettier": "^6.10.1",
 		"eslint-plugin-jest": "^23.8.2",
 		"eslint-plugin-jsdoc": "^30.2.2",


### PR DESCRIPTION
Fixes #24589

This pull request seeks to allow local project Prettier configuration to take precedence over WordPress default configuration, when present.

**Implementation notes:**

`cosmiconfig` was chosen intentionally because it's the same as what Prettier uses internally:

>Prettier uses cosmiconfig for configuration file support.

https://prettier.io/docs/en/configuration.html

**Testing Instructions:**

Modify Gutenberg's root `.prettierrc.js` with values which override the default:

```diff
diff --git a/.prettierrc.js b/.prettierrc.js
index 51b8aeb415..72ab00293b 100644
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,3 +1,3 @@
 // Import the default config file and expose it in the project root.
 // Useful for editor integrations.
-module.exports = require( '@wordpress/prettier-config' );
+module.exports = { ...require( '@wordpress/prettier-config' ), printWidth: 100 };
```

Run `npm run lint-js .prettierrc.js`

There should be no errors reported.

In `master`, this will report an error because, despite the fact that `printWidth` is overridden to `100`, the default `80` will always be enforced, and the line length in the diff (82) will violate.