### PR TITLE
Fix specificity for buttons with outline style and background colors

### DIFF
--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -47,7 +47,7 @@ $blocks-button__height: 56px;
 	border-radius: 0 !important;
 }
 
-.wp-block-button.is-style-outline .wp-block-button__link,
+.is-style-outline .wp-block-button__link,
 .wp-block-button__link.is-style-outline {
 	color: $dark-gray-700;
 	background-color: transparent;

--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -41,15 +41,19 @@ $blocks-button__height: 56px;
 
 
 // the first selector is required for old buttons markup
-
 .wp-block-button.no-border-radius,
 .wp-block-button__link.no-border-radius {
 	border-radius: 0 !important;
 }
 
-.is-style-outline .wp-block-button__link,
+.wp-block-button.is-style-outline,
 .wp-block-button__link.is-style-outline {
 	color: $dark-gray-700;
 	background-color: transparent;
+
+}
+
+.wp-block-button__link.is-style-outline,
+.wp-block-button.is-style-outline .wp-block-button__link {
 	border: 2px solid;
 }

--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -41,19 +41,15 @@ $blocks-button__height: 56px;
 
 
 // the first selector is required for old buttons markup
+
 .wp-block-button.no-border-radius,
 .wp-block-button__link.no-border-radius {
 	border-radius: 0 !important;
 }
 
-.wp-block-button.is-style-outline,
+.is-style-outline .wp-block-button__link,
 .wp-block-button__link.is-style-outline {
 	color: $dark-gray-700;
 	background-color: transparent;
-
-}
-
-.wp-block-button__link.is-style-outline,
-.wp-block-button.is-style-outline .wp-block-button__link {
 	border: 2px solid;
 }


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/pull/21816/files#r471447642
Related: [forum thread](https://wordpress.org/support/topic/issue-with-wp-buttons-having-a-transparent-background-post-5-5-update/#post-13268135)

This fixes a regression for the button block when the outline style is applied: unlike WordPress 5.4, the background color wasn't applied in this scenario.

## Test

1. Add a button.
2. Select a background color.
3. Set the style to outline (the background color should still be applied).
4. Publish the post.

The expected result is that the button has the background color selected, both in the editor and in the front. Tested with the themes TwentyTwenty, TwentyNineteen, TwentySeventeen. This was the behavior in 5.4 that we regressed in 5.5.
