### PR TITLE
Fix Pullquote text color after unsetting main color 

### DIFF
--- a/packages/block-library/src/pullquote/edit.js
+++ b/packages/block-library/src/pullquote/edit.js
@@ -54,8 +54,7 @@ class PullQuoteEdit extends Component {
 		const isSolidColorStyle = includes( className, SOLID_COLOR_CLASS );
 		const needTextColor =
 			! textColor.color || this.wasTextColorAutomaticallyComputed;
-		const shouldSetTextColor =
-			isSolidColorStyle && needTextColor && colorValue;
+		const shouldSetTextColor = isSolidColorStyle && needTextColor;
 
 		if ( isSolidColorStyle ) {
 			// If we use the solid color style, set the color using the normal mechanism.
@@ -67,8 +66,14 @@ class PullQuoteEdit extends Component {
 		}
 
 		if ( shouldSetTextColor ) {
-			this.wasTextColorAutomaticallyComputed = true;
-			setTextColor( colorUtils.getMostReadableColor( colorValue ) );
+			if ( ! colorValue && this.wasTextColorAutomaticallyComputed ) {
+				// We have to unset our previously computed text color on unsetting the main color.
+				this.wasTextColorAutomaticallyComputed = false;
+				setTextColor();
+			} else {
+				this.wasTextColorAutomaticallyComputed = true;
+				setTextColor( colorUtils.getMostReadableColor( colorValue ) );
+			}
 		}
 	}
 

--- a/packages/block-library/src/pullquote/edit.js
+++ b/packages/block-library/src/pullquote/edit.js
@@ -66,13 +66,13 @@ class PullQuoteEdit extends Component {
 		}
 
 		if ( shouldSetTextColor ) {
-			if ( ! colorValue && this.wasTextColorAutomaticallyComputed ) {
+			if ( colorValue ) {
+				this.wasTextColorAutomaticallyComputed = true;
+				setTextColor( colorUtils.getMostReadableColor( colorValue ) );
+			} else if ( this.wasTextColorAutomaticallyComputed ) {
 				// We have to unset our previously computed text color on unsetting the main color.
 				this.wasTextColorAutomaticallyComputed = false;
 				setTextColor();
-			} else {
-				this.wasTextColorAutomaticallyComputed = true;
-				setTextColor( colorUtils.getMostReadableColor( colorValue ) );
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes: https://github.com/WordPress/gutenberg/issues/24440

Currently in a `Solid color` `Pullquote` if you change the main color and a text color is automatically computed ( for example main color black ), and then you unset the main color, the text color remains set and that can lead to `invisible` text (same color with background).

In this PR if we unset the main color and the text color was previously automatically computed, we unset the text color as well.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
