### PR TITLE
Inserter: Test to make sure the Inserter menu is closed.

### DIFF
--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -302,6 +302,16 @@ _Parameters_
 
 -   _searchTerm_ `string`: The text to search the inserter for.
 
+<a name="insertBlockDirectoryBlock" href="#insertBlockDirectoryBlock">#</a> **insertBlockDirectoryBlock**
+
+Opens the inserter, searches for the given block, then selects the
+first result that appears from the block directory. It then waits briefly for the block list to
+update.
+
+_Parameters_
+
+-   _searchTerm_ `string`: The text to search the inserter for.
+
 <a name="insertPattern" href="#insertPattern">#</a> **insertPattern**
 
 Opens the inserter, searches for the given pattern, then selects the first

--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -301,7 +301,6 @@ result that appears. It then waits briefly for the block list to update.
 _Parameters_
 
 -   _searchTerm_ `string`: The text to search the inserter for.
--   _xPath_ `[string]`: The xPath to the button.
 
 <a name="insertPattern" href="#insertPattern">#</a> **insertPattern**
 

--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -301,6 +301,7 @@ result that appears. It then waits briefly for the block list to update.
 _Parameters_
 
 -   _searchTerm_ `string`: The text to search the inserter for.
+-   _xPath_ `[string]`: The xPath to the button.
 
 <a name="insertPattern" href="#insertPattern">#</a> **insertPattern**
 

--- a/packages/e2e-test-utils/src/index.js
+++ b/packages/e2e-test-utils/src/index.js
@@ -31,6 +31,7 @@ export {
 	searchForBlock,
 	searchForPattern,
 	searchForReusableBlock,
+	insertBlockDirectoryBlock,
 	openGlobalBlockInserter,
 	closeGlobalBlockInserter,
 } from './inserter';

--- a/packages/e2e-test-utils/src/inserter.js
+++ b/packages/e2e-test-utils/src/inserter.js
@@ -52,6 +52,17 @@ async function toggleGlobalBlockInserter() {
 }
 
 /**
+ * Retrieves the document container by css class and checks to make sure the document's active element is within it
+ */
+async function waitForInserterCloseAndContentFocus() {
+	await page.waitForFunction( () =>
+		document.body
+			.querySelector( '.block-editor-block-list__layout' )
+			.contains( document.activeElement )
+	);
+}
+
+/**
  * Search for block in the global inserter
  *
  * @param {string} searchTerm The text to search the inserter for.
@@ -121,11 +132,7 @@ export async function insertBlock( searchTerm ) {
 	 )[ 0 ];
 	await insertButton.click();
 	// We should wait until the inserter closes and the focus moves to the content.
-	await page.waitForFunction( () =>
-		document.body
-			.querySelector( '.block-editor-block-list__layout' )
-			.contains( document.activeElement )
-	);
+	await waitForInserterCloseAndContentFocus();
 }
 
 /**
@@ -143,11 +150,7 @@ export async function insertPattern( searchTerm ) {
 	 )[ 0 ];
 	await insertButton.click();
 	// We should wait until the inserter closes and the focus moves to the content.
-	await page.waitForFunction( () =>
-		document.body
-			.querySelector( '.block-editor-block-list__layout' )
-			.contains( document.activeElement )
-	);
+	await waitForInserterCloseAndContentFocus();
 }
 
 /**
@@ -164,9 +167,24 @@ export async function insertReusableBlock( searchTerm ) {
 	 )[ 0 ];
 	await insertButton.click();
 	// We should wait until the inserter closes and the focus moves to the content.
-	await page.waitForFunction( () =>
-		document.body
-			.querySelector( '.block-editor-block-list__layout' )
-			.contains( document.activeElement )
+	await waitForInserterCloseAndContentFocus();
+}
+
+/**
+ * Opens the inserter, searches for the given block, then selects the
+ * first result that appears from the block directory. It then waits briefly for the block list to
+ * update.
+ *
+ * @param {string} searchTerm The text to search the inserter for.
+ */
+export async function insertBlockDirectoryBlock( searchTerm ) {
+	await searchForBlock( searchTerm );
+
+	// Grab the first block in the list
+	const insertButton = await page.waitForSelector(
+		'.block-directory-downloadable-blocks-list li:first-child button'
 	);
+	await insertButton.click();
+	// We should wait until the inserter closes and the focus moves to the content.
+	await waitForInserterCloseAndContentFocus();
 }

--- a/packages/e2e-test-utils/src/inserter.js
+++ b/packages/e2e-test-utils/src/inserter.js
@@ -113,21 +113,14 @@ export async function searchForReusableBlock( searchTerm ) {
  * result that appears. It then waits briefly for the block list to update.
  *
  * @param {string} searchTerm The text to search the inserter for.
- * @param {string} [xPath] The xPath to the button.
  */
-export async function insertBlock( searchTerm, xPath = undefined ) {
+export async function insertBlock( searchTerm ) {
 	await searchForBlock( searchTerm );
-	const insertButton = await page.waitForXPath(
-		xPath || `//button//span[contains(text(), '${ searchTerm }')]`
-	);
+	const insertButton = (
+		await page.$x( `//button//span[contains(text(), '${ searchTerm }')]` )
+	 )[ 0 ];
 	await insertButton.click();
-
-	// We should wait until the inserter closes
-	await page.waitForSelector( '.block-editor-inserter__menu', {
-		hidden: true,
-	} );
-
-	// We should wait until the focus moves to the content.
+	// We should wait until the inserter closes and the focus moves to the content.
 	await page.waitForFunction( () =>
 		document.body
 			.querySelector( '.block-editor-block-list__layout' )

--- a/packages/e2e-test-utils/src/inserter.js
+++ b/packages/e2e-test-utils/src/inserter.js
@@ -113,14 +113,21 @@ export async function searchForReusableBlock( searchTerm ) {
  * result that appears. It then waits briefly for the block list to update.
  *
  * @param {string} searchTerm The text to search the inserter for.
+ * @param {string} [xPath] The xPath to the button.
  */
-export async function insertBlock( searchTerm ) {
+export async function insertBlock( searchTerm, xPath = undefined ) {
 	await searchForBlock( searchTerm );
-	const insertButton = (
-		await page.$x( `//button//span[contains(text(), '${ searchTerm }')]` )
-	 )[ 0 ];
+	const insertButton = await page.waitForXPath(
+		xPath || `//button//span[contains(text(), '${ searchTerm }')]`
+	);
 	await insertButton.click();
-	// We should wait until the inserter closes and the focus moves to the content.
+
+	// We should wait until the inserter closes
+	await page.waitForSelector( '.block-editor-inserter__menu', {
+		hidden: true,
+	} );
+
+	// We should wait until the focus moves to the content.
 	await page.waitForFunction( () =>
 		document.body
 			.querySelector( '.block-editor-block-list__layout' )

--- a/packages/e2e-tests/specs/editor/plugins/block-directory-add.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/block-directory-add.test.js
@@ -4,6 +4,7 @@
 import {
 	createNewPost,
 	searchForBlock,
+	insertBlockDirectoryBlock,
 	setUpResponseMocking,
 	getEditedPostContent,
 	createJSONResponse,
@@ -178,15 +179,7 @@ describe( 'adding blocks from block directory', () => {
 		await setUpResponseMocking( MOCK_BLOCKS_RESPONSES );
 
 		// Search for the block via the inserter
-		await searchForBlock( MOCK_BLOCK1.title );
-
-		// Grab the first block in the list -> Needs to be the first one, the mock response expects it.
-		const addBtn = await page.waitForSelector(
-			'.block-directory-downloadable-blocks-list li:first-child button'
-		);
-
-		// Add the block
-		await addBtn.click();
+		await insertBlockDirectoryBlock( MOCK_BLOCK1.title );
 
 		await page.waitForSelector( `div[data-type="${ MOCK_BLOCK1.name }"]` );
 

--- a/packages/e2e-tests/specs/editor/plugins/block-directory-add.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/block-directory-add.test.js
@@ -7,7 +7,6 @@ import {
 	setUpResponseMocking,
 	getEditedPostContent,
 	createJSONResponse,
-	insertBlock,
 } from '@wordpress/e2e-test-utils';
 
 // Urls to mock
@@ -178,10 +177,16 @@ describe( 'adding blocks from block directory', () => {
 		// Setup our mocks
 		await setUpResponseMocking( MOCK_BLOCKS_RESPONSES );
 
-		await insertBlock(
-			MOCK_BLOCK1.title,
-			`//ul[@class="block-directory-downloadable-blocks-list"]//button[text()="Add block"]`
+		// Search for the block via the inserter
+		await searchForBlock( MOCK_BLOCK1.title );
+
+		// Grab the first block in the list -> Needs to be the first one, the mock response expects it.
+		const addBtn = await page.waitForSelector(
+			'.block-directory-downloadable-blocks-list li:first-child button'
 		);
+
+		// Add the block
+		await addBtn.click();
 
 		await page.waitForSelector( `div[data-type="${ MOCK_BLOCK1.name }"]` );
 

--- a/packages/e2e-tests/specs/editor/plugins/block-directory-add.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/block-directory-add.test.js
@@ -7,6 +7,7 @@ import {
 	setUpResponseMocking,
 	getEditedPostContent,
 	createJSONResponse,
+	insertBlock,
 } from '@wordpress/e2e-test-utils';
 
 // Urls to mock
@@ -177,16 +178,10 @@ describe( 'adding blocks from block directory', () => {
 		// Setup our mocks
 		await setUpResponseMocking( MOCK_BLOCKS_RESPONSES );
 
-		// Search for the block via the inserter
-		await searchForBlock( MOCK_BLOCK1.title );
-
-		// Grab the first block in the list -> Needs to be the first one, the mock response expects it.
-		const addBtn = await page.waitForSelector(
-			'.block-directory-downloadable-blocks-list li:first-child button'
+		await insertBlock(
+			MOCK_BLOCK1.title,
+			`//ul[@class="block-directory-downloadable-blocks-list"]//button[text()="Add block"]`
 		);
-
-		// Add the block
-		await addBtn.click();
 
 		await page.waitForSelector( `div[data-type="${ MOCK_BLOCK1.name }"]` );
 


### PR DESCRIPTION
## Description
This is an experimental PR to start addressing #24606. 

## The Problem
The block directory package is bundled in Gutenberg but its E2E tests are separate and therefore changes to the `Inserter` and its related components can break Block Directory functionality. This is because the Block Directory package makes use of the slot/fill component in the inserter.

## A Potential Solution
This PR includes updates to the `insertBlock` function so it can be used by the block directory end to end tests since its markup differs from the default markup view. This PR allows developers to pass an optional `xPath` to the button that eventually inserts a block (the block directory installs first). Up until now, the block directory e2e tests reimplemented a Block Directory specific "insertBlock" sequence that was not sufficiently bubbling up errors introduced with `Inserter` changes.

While it is most likely not a good approach to continually abstract the `insertBlock` function and make it super configurable, this will at least ensure that all items in the inserter that insert blocks behave consistently and share a common code base.

I have also added the following:
\
`await page.waitForSelector( '.block-editor-inserter__menu', {
		hidden: true,
	} );
`
\
since the current test doesn't actually test whether the inserter has closed, even though the comment suggests it has. By adding this block, the bug defined in #24606, is exposed.


## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
