### PR TITLE
Fix inserter z-index

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -105,7 +105,7 @@ $z-layers: (
 	".components-popover": 1000000,
 
 	// ...Except for popovers immediately beneath wp-admin menu on large breakpoints
-	".components-popover.block-editor-inserter__popover": 99998,
+	".components-popover.block-editor-inserter__popover": 99999,
 	".components-popover.table-of-contents__popover": 99998,
 	".components-popover.block-editor-block-navigation__popover": 99998,
 	".components-popover.edit-post-more-menu__content": 99998,


### PR DESCRIPTION
Tentatively fixes #24507.

It simply bumps the z-index. However there's this comment in context of this rule:

`// ...Except for popovers immediately beneath wp-admin menu on large breakpoints`

I wonder if changing this z-index is causing a regression elsewhere? It seems awfully specific to choose a level that's 1 lower than the adminbar. 

GIF:

![z index](https://user-images.githubusercontent.com/1204802/90489146-306e2180-e13d-11ea-9952-ed749ece3455.gif)
