### PR TITLE
fix: inline text-color regex in edge-case when color slug ends with '-color'

### DIFF
--- a/packages/format-library/src/text-color/inline.js
+++ b/packages/format-library/src/text-color/inline.js
@@ -34,7 +34,10 @@ export function getActiveColor( formatName, formatValue, colors ) {
 	}
 	const currentClass = activeColorFormat.attributes.class;
 	if ( currentClass ) {
-		const colorSlug = currentClass.replace( /.*has-(.*?)-color$/, '$1' );
+		const colorSlug = currentClass.replace(
+			/.*has-([^\s]*)-color.*/,
+			'$1'
+		);
 		return getColorObjectByAttributeValues( colors, colorSlug ).color;
 	}
 }

--- a/packages/format-library/src/text-color/inline.js
+++ b/packages/format-library/src/text-color/inline.js
@@ -34,7 +34,7 @@ export function getActiveColor( formatName, formatValue, colors ) {
 	}
 	const currentClass = activeColorFormat.attributes.class;
 	if ( currentClass ) {
-		const colorSlug = currentClass.replace( /.*has-(.*?)-color.*/, '$1' );
+		const colorSlug = currentClass.replace( /.*has-(.*?)-color$/, '$1' );
 		return getColorObjectByAttributeValues( colors, colorSlug ).color;
 	}
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Changes regex used to match active color slug in the inline text-color library. Attempts to fix #24620.
<!-- Please describe what you have changed or added -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
