### PR TITLE
fix issue 24539, show external icon on help button

### DIFF
--- a/packages/edit-post/src/plugins/index.js
+++ b/packages/edit-post/src/plugins/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { MenuItem } from '@wordpress/components';
+import { MenuItem, VisuallyHidden } from '@wordpress/components';
 import { external } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
@@ -47,6 +47,12 @@ registerPlugin( 'edit-post', {
 								rel="noopener noreferrer"
 							>
 								{ __( 'Help' ) }
+								<VisuallyHidden as="span">
+									{
+										/* translators: accessibility text */
+										__( '(opens in a new tab)' )
+									}
+								</VisuallyHidden>
 							</MenuItem>
 						</>
 					) }

--- a/packages/edit-post/src/plugins/index.js
+++ b/packages/edit-post/src/plugins/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { MenuItem } from '@wordpress/components';
+import { external } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
 import { addQueryArgs } from '@wordpress/url';
@@ -38,6 +39,7 @@ registerPlugin( 'edit-post', {
 							<CopyContentMenuItem />
 							<MenuItem
 								role="menuitem"
+								icon={ external }
 								href={ __(
 									'https://wordpress.org/support/article/wordpress-editor/'
 								) }

--- a/packages/edit-site/src/plugins/index.js
+++ b/packages/edit-site/src/plugins/index.js
@@ -6,7 +6,7 @@ import downloadjs from 'downloadjs';
 /**
  * WordPress dependencies
  */
-import { MenuItem } from '@wordpress/components';
+import { MenuItem, VisuallyHidden } from '@wordpress/components';
 import { external } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
@@ -65,6 +65,12 @@ registerPlugin( 'edit-site', {
 						rel="noopener noreferrer"
 					>
 						{ __( 'Help' ) }
+						<VisuallyHidden as="span">
+							{
+								/* translators: accessibility text */
+								__( '(opens in a new tab)' )
+							}
+						</VisuallyHidden>
 					</MenuItem>
 				</ToolsMoreMenuGroup>
 			</>

--- a/packages/edit-site/src/plugins/index.js
+++ b/packages/edit-site/src/plugins/index.js
@@ -7,12 +7,11 @@ import downloadjs from 'downloadjs';
  * WordPress dependencies
  */
 import { MenuItem, VisuallyHidden } from '@wordpress/components';
-import { external } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
 import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
-import { download } from '@wordpress/icons';
+import { download, external } from '@wordpress/icons';
 
 /**
  * Internal dependencies

--- a/packages/edit-site/src/plugins/index.js
+++ b/packages/edit-site/src/plugins/index.js
@@ -7,6 +7,7 @@ import downloadjs from 'downloadjs';
  * WordPress dependencies
  */
 import { MenuItem } from '@wordpress/components';
+import { external } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
 import { addQueryArgs } from '@wordpress/url';
@@ -56,6 +57,7 @@ registerPlugin( 'edit-site', {
 					</MenuItem>
 					<MenuItem
 						role="menuitem"
+						icon={ external }
 						href={ __(
 							'https://wordpress.org/support/article/wordpress-editor/'
 						) }


### PR DESCRIPTION
## Description
I have added the external icon (`icon={ external }`) to the Help MenuItem for edit-post and edit-site plugin. Adding as an svg was important because when i referenced it only as a string (`icon="external"`) it creates a Dashicon, which is 20x20 pixel big, it would break the padding of the text. The default icon size is 24x24 pixel and fits perfect into the more option menu.

## How has this been tested?
Open gutenberg editor for a page.
Open the "more option" menu and check/click the help button.

## Screenshots
![help-with-external-icon](https://user-images.githubusercontent.com/5269059/90518674-61fbe280-e167-11ea-8d31-d50afa6d118a.png)

## Types of changes
Bug fix for #24539 with non-breaking change

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.
- [x] I've included developer documentation if appropriate.
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR.
