### PR TITLE
Fix: Double border on metabox panel

### DIFF
--- a/packages/edit-post/src/components/meta-boxes/meta-boxes-area/style.scss
+++ b/packages/edit-post/src/components/meta-boxes/meta-boxes-area/style.scss
@@ -30,7 +30,6 @@
 	#poststuff h3.hndle,
 	#poststuff .stuffbox > h3,
 	#poststuff h2.hndle { /* WordPress selectors yolo */
-		border-bottom: $border-width solid $gray-200;
 		box-sizing: border-box;
 		color: inherit;
 		font-weight: 600;


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/24612

This PR fixes a visual issue where two borders appear on the meta boxes panel

## How has this been tested?
I installed yoast, and simple CSS plugin (both have a metabox).
I verified in the meta boxes panels there were no double borders.
