### PR TITLE
Fix: Crash after undo with top toolbar on

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu-controls/index.js
+++ b/packages/block-editor/src/components/block-settings-menu-controls/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, map } from 'lodash';
+import { compact, isEmpty, map } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -21,7 +21,10 @@ const BlockSettingsMenuControlsSlot = ( { fillProps, clientIds = null } ) => {
 			);
 			const ids =
 				clientIds !== null ? clientIds : getSelectedBlockClientIds();
-			return map( getBlocksByClientId( ids ), ( block ) => block.name );
+			return map(
+				compact( getBlocksByClientId( ids ) ),
+				( block ) => block.name
+			);
 		},
 		[ clientIds ]
 	);


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/24515


## How has this been tested?
I repeated the steps described in https://github.com/WordPress/gutenberg/issues/24515 and verified there was no crash anymore.
