### PR TITLE
Improve focus state of the form token remove button

### DIFF
--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -57,7 +57,7 @@
 	display: flex;
 	margin: 2px 4px 2px 0;
 	color: $dark-gray-700;
-	overflow: hidden;
+	max-width: 100%;
 
 	&.is-success {
 		.components-form-token-field__token-text,


### PR DESCRIPTION
This change allows the form tokens to maintain truncation, while allowing the proper state when focusing the remove button.

Resolves: #23992 

## How has this been tested?
Tested the solution on MacOS in:
- Chrome 84.0.4147.105
- Firefox 79
- 13.1.1

## Screenshots

### Before
<img width="299" alt="Screen Shot 2020-08-18 at 4 09 42 PM" src="https://user-images.githubusercontent.com/3665539/90560748-94a8d980-e16d-11ea-8f57-66e57f18493f.png">

### After
<img width="302" alt="Screen Shot 2020-08-18 at 4 09 22 PM" src="https://user-images.githubusercontent.com/3665539/90560770-9bcfe780-e16d-11ea-95b7-c225237100bc.png">

## Types of changes
This is a CSS change to fix a minor bug

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
