### PR TITLE
Add ToggleControl at related components section in FormToggle documentation

### DIFF
--- a/packages/components/src/form-toggle/README.md
+++ b/packages/components/src/form-toggle/README.md
@@ -90,4 +90,5 @@ A function that receives the checked state (boolean) as input.
 
 - To select one option from a set, and you want to show them all the available options at once, use the `Radio` component.
 - To select one or more items from a set, use the `CheckboxControl` component.
+- To display a toggle with label and help text, use the `ToggleControl` component.
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

I was trying to find a way to display the FormToggle component with a label and help text and found out much later of the existence of the ToggleControl component. I think that this addition can help other developers in a similar situation.
