### PR TITLE
Navigation: Fix invalid textarea markup

### DIFF
--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -336,7 +336,7 @@ function gutenberg_output_block_menu_item_custom_fields( $item_id, $item ) {
 		<p class="field-content description description-wide">
 			<label for="edit-menu-item-content-<?php echo $item_id; ?>">
 				<?php _e( 'Content', 'gutenberg' ); ?><br />
-				<textarea readonly name="menu-item-content[<?php echo $item_id; ?>]"><?php echo esc_textarea( trim( $item->content ) ); ?></textarea>
+				<textarea id="edit-menu-item-content-<?php echo $item_id; ?>" class="widefat" rows="3" cols="20" name="menu-item-content[<?php echo $item_id; ?>]" readonly><?php echo esc_textarea( trim( $item->content ) ); ?></textarea>
 			</label>
 		</p>
 		<?php
@@ -367,11 +367,6 @@ function gutenberg_add_block_menu_item_styles_to_nav_menus( $hook ) {
 			 */
 			.menu-item-block .description:not(.field-content) {
 				display: none;
-			}
-
-			.menu-item-block textarea {
-				width: 100%;
-				min-height: 100px;
 			}
 CSS;
 		wp_add_inline_style( 'nav-menus', $css );


### PR DESCRIPTION
Follows https://github.com/WordPress/gutenberg/pull/24503.

Fixes a few small issues with the markup added to `nav-menus.php`:

- Adds `rows` and `cols` to the `textarea` which is required.
- Adds `id` to the `textarea` which is required because of the `label`'s `for`.
- Uses existing `widefat` class instead of our own custom CSS.