### PR TITLE
Avoid lossy html entities encoding by setting charset

### DIFF
--- a/lib/block-supports/index.php
+++ b/lib/block-supports/index.php
@@ -53,7 +53,7 @@ function gutenberg_apply_block_supports( $block_content, $block ) {
 	}
 
 	// We need to wrap the block in order to handle UTF-8 properly.
-	$wrapper_left = '<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head><body>';
+	$wrapper_left  = '<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head><body>';
 	$wrapper_right = '</body></html>';
 
 	$dom = new DOMDocument( '1.0', 'utf-8' );

--- a/lib/block-supports/index.php
+++ b/lib/block-supports/index.php
@@ -56,13 +56,13 @@ function gutenberg_apply_block_supports( $block_content, $block ) {
 
 	// Suppress warnings from this method from polluting the front-end.
 	// @codingStandardsIgnoreStart
-	if ( ! @$dom->loadHTML( mb_convert_encoding( $block_content, 'HTML-ENTITIES', 'UTF-8' ), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD | LIBXML_COMPACT ) ) {
+	if ( ! @$dom->loadHTML( '<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head><body>' . $block_content . '</body></html>', LIBXML_HTML_NODEFDTD | LIBXML_COMPACT ) ) {
 	// @codingStandardsIgnoreEnd
 		return $block_content;
 	}
 
 	$xpath      = new DOMXPath( $dom );
-	$block_root = $xpath->query( '/*' )[0];
+	$block_root = $xpath->query( '/html/body/*' )[0];
 
 	if ( empty( $block_root ) ) {
 		return $block_content;
@@ -86,7 +86,7 @@ function gutenberg_apply_block_supports( $block_content, $block ) {
 		$block_root->setAttribute( 'style', esc_attr( implode( '; ', $new_styles ) . ';' ) );
 	}
 
-	return mb_convert_encoding( $dom->saveHtml(), 'UTF-8', 'HTML-ENTITIES' );
+	return preg_replace( array( '/^<html><head><meta http-equiv="Content-Type" content="text\/html; charset=utf-8"><\/head><body>/', '/<\/body><\/html>$/' ), '', $dom->saveHtml() );
 }
 add_filter( 'render_block', 'gutenberg_apply_block_supports', 10, 2 );
 

--- a/lib/block-supports/index.php
+++ b/lib/block-supports/index.php
@@ -52,11 +52,15 @@ function gutenberg_apply_block_supports( $block_content, $block ) {
 		return $block_content;
 	}
 
+	// We need to wrap the block in order to handle UTF-8 properly.
+	$wrapper_left = '<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head><body>';
+	$wrapper_right = '</body></html>';
+
 	$dom = new DOMDocument( '1.0', 'utf-8' );
 
 	// Suppress warnings from this method from polluting the front-end.
 	// @codingStandardsIgnoreStart
-	if ( ! @$dom->loadHTML( '<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head><body>' . $block_content . '</body></html>', LIBXML_HTML_NODEFDTD | LIBXML_COMPACT ) ) {
+	if ( ! @$dom->loadHTML( $wrapper_left . $block_content . $wrapper_right , LIBXML_HTML_NODEFDTD | LIBXML_COMPACT ) ) {
 	// @codingStandardsIgnoreEnd
 		return $block_content;
 	}
@@ -86,7 +90,7 @@ function gutenberg_apply_block_supports( $block_content, $block ) {
 		$block_root->setAttribute( 'style', esc_attr( implode( '; ', $new_styles ) . ';' ) );
 	}
 
-	return preg_replace( array( '/^<html><head><meta http-equiv="Content-Type" content="text\/html; charset=utf-8"><\/head><body>/', '/<\/body><\/html>$/' ), '', $dom->saveHtml() );
+	return str_replace( array( $wrapper_left, $wrapper_right ), '', $dom->saveHtml() );
 }
 add_filter( 'render_block', 'gutenberg_apply_block_supports', 10, 2 );
 

--- a/phpunit/class-block-supported-styles-test.php
+++ b/phpunit/class-block-supported-styles-test.php
@@ -72,9 +72,9 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 * @param string $block String of rendered block to check.
 	 */
 	private function get_content_from_block( $block ) {
-		$start_index = strpos( $block, '>' ) + 1; // First occurrence of '<'
+		$start_index = strpos( $block, '>' ) + 1; // First occurrence of '>'
 		$split_arr   = substr( $block, $start_index );
-		$end_index   = strrpos( $split_arr, '<' ); // Last occurrence of '>'
+		$end_index   = strrpos( $split_arr, '<' ); // Last occurrence of '<'
 		return substr( $split_arr, 0, $end_index ); // String between first '>' and last '<'
 	}
 

--- a/phpunit/class-block-supported-styles-test.php
+++ b/phpunit/class-block-supported-styles-test.php
@@ -74,7 +74,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	private function get_content_from_block( $block ) {
 		$start_index = strpos( $block, '>' ) + 1;
 		$split_arr   = substr( $block, $start_index );
-		$end_index   = strpos( $split_arr, '<' );
+		$end_index   = strrpos( $split_arr, '<' );
 		return substr( $split_arr, 0, $end_index );
 	}
 

--- a/phpunit/class-block-supported-styles-test.php
+++ b/phpunit/class-block-supported-styles-test.php
@@ -72,10 +72,10 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 * @param string $block String of rendered block to check.
 	 */
 	private function get_content_from_block( $block ) {
-		$start_index = strpos( $block, '>' ) + 1;
+		$start_index = strpos( $block, '>' ) + 1; // First occurrence of '<'
 		$split_arr   = substr( $block, $start_index );
-		$end_index   = strrpos( $split_arr, '<' );
-		return substr( $split_arr, 0, $end_index );
+		$end_index   = strrpos( $split_arr, '<' ); // Last occurrence of '>'
+		return substr( $split_arr, 0, $end_index ); // String between first '>' and last '<'
 	}
 
 	/**

--- a/phpunit/class-block-supported-styles-test.php
+++ b/phpunit/class-block-supported-styles-test.php
@@ -117,7 +117,13 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 *
 	 * @var string
 	 */
-	const BLOCK_CONTENT = 'Some non-Latin chärs to make sure DOM öperations don\'t mess them up: こんにちは';
+	const BLOCK_CONTENT = '
+		<p data-image-description="&lt;p&gt;Test!&lt;/p&gt;">Test</p>
+		<p>äöü</p>
+		<p>ß</p>
+		<p>系の家庭に</p>
+		<p>Example &lt;p&gt;Test!&lt;/p&gt;</p>
+	';
 
 	/**
 	 * Example block markup string to test with.

--- a/phpunit/class-block-supported-styles-test.php
+++ b/phpunit/class-block-supported-styles-test.php
@@ -72,10 +72,10 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 * @param string $block String of rendered block to check.
 	 */
 	private function get_content_from_block( $block ) {
-		$start_index = strpos( $block, '>' ) + 1; // First occurrence of '>'
+		$start_index = strpos( $block, '>' ) + 1; // First occurrence of '>'.
 		$split_arr   = substr( $block, $start_index );
-		$end_index   = strrpos( $split_arr, '<' ); // Last occurrence of '<'
-		return substr( $split_arr, 0, $end_index ); // String between first '>' and last '<'
+		$end_index   = strrpos( $split_arr, '<' ); // Last occurrence of '<'.
+		return substr( $split_arr, 0, $end_index ); // String between first '>' and last '<'.
 	}
 
 	/**


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This change specifies the content type and charset of the html passed into `DomDocument` as `utf-8`.

Replaces the `mb_convert_encoding` call which encodes `UTF-8` as `HTML-ENTITIES` before handing off to `DomDocument`.

This change avoids the need to later revert the encoding back to `UTF-8` afterwards using `mb_convert_encoding`. This secondary `mb_convert_encoding` call was converting not only the `UTF-8` characters that were converted earlier but also any pre-existing entity encoded html stored inside block content.

This issue was originally raised here: https://github.com/Automattic/wp-calypso/issues/44897 as I wasn't sure of the root cause at the time, originally thinking it may be because of the way [Jetpack is injecting](https://github.com/Automattic/jetpack/blob/dcfa5ca8bdfc31aacec107aec27bb24357d6cdac/modules/carousel/jetpack-carousel.php#L434) html into the [`data-image-description` attributes](https://github.com/Automattic/jetpack/blob/dcfa5ca8bdfc31aacec107aec27bb24357d6cdac/modules/carousel/jetpack-carousel.php#L485). 

There are more situations where this can be a problem such as encoded html entities existing inside block content then being decoded breaking html validation.

## How has this been tested?
- The `npm run test-php` unittests cover this somewhat, will add more soon.
- https://3v4l.org/EaZv9 contains illustrates a comparison of the different approaches available

## Screenshots <!-- if applicable -->
Before
<img src="https://user-images.githubusercontent.com/811776/90636644-44657080-e26e-11ea-8442-fb6a0271dd92.png" width=300/>

After
<img src="https://user-images.githubusercontent.com/811776/90636663-4af3e800-e26e-11ea-8e2b-7fcee0ea2e63.png" width=300/>

## Types of changes
- Bug fix
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->

(re)Fixes https://github.com/WordPress/gutenberg/issues/24445 (Mostly maintaining the same behavior introduced in https://github.com/WordPress/gutenberg/pull/24447)