### PR TITLE
make sure the template-part exists before using it

### DIFF
--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -15,8 +15,8 @@
 function render_block_core_template_part( $attributes ) {
 	$content = null;
 
-	if ( ! empty( $attributes['postId'] ) ) {
-		// If we have a post ID, which means this template part
+	if ( ! empty( $attributes['postId'] ) && is_string( get_post_status( $attributes['postId'] ) ) ) {
+		// If we have a post ID and the post exists, which means this template part
 		// is user-customized, render the corresponding post content.
 		$content = get_post( $attributes['postId'] )->post_content;
 	} elseif ( isset( $attributes['theme'] ) && wp_get_theme()->get( 'TextDomain' ) === $attributes['theme'] ) {

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -15,7 +15,7 @@
 function render_block_core_template_part( $attributes ) {
 	$content = null;
 
-	if ( ! empty( $attributes['postId'] ) && is_string( get_post_status( $attributes['postId'] ) ) ) {
+	if ( ! empty( $attributes['postId'] ) && get_post_status( $attributes['postId'] ) ) {
 		// If we have a post ID and the post exists, which means this template part
 		// is user-customized, render the corresponding post content.
 		$content = get_post( $attributes['postId'] )->post_content;


### PR DESCRIPTION
While exploring FSE themes today I came across a weird issue.
Installed & activated [an FSE theme](https://github.com/WebDevStudios/wds-block-based-theme) to test. When visiting the frontend saw these errors:
```
PHP Notice:  Trying to get property 'post_content' of non-object in /wp-content/plugins/gutenberg/build/block-library/blocks/template-part.php on line 21
PHP Stack trace:
PHP   1. {main}() /index.php:0
PHP   2. require() /index.php:17
PHP   3. require_once() /wp-blog-header.php:19
PHP   4. include() /wp-includes/template-loader.php:106
PHP   5. gutenberg_render_the_template() /wp-content/plugins/gutenberg/lib/template-canvas.php:19
PHP   6. do_blocks() /wp-content/plugins/gutenberg/lib/template-loader.php:378
PHP   7. render_block() /wp-includes/blocks.php:758
PHP   8. apply_filters() /wp-includes/blocks.php:670
PHP   9. WP_Hook->apply_filters() /wp-includes/plugin.php:206
PHP  10. gutenberg_render_block_with_assigned_block_context() /wp-includes/class-wp-hook.php:287
PHP  11. WP_Block->render() /wp-content/plugins/gutenberg/lib/compat.php:531
PHP  12. gutenberg_render_block_core_template_part() /wp-includes/class-wp-block.php:217
```

This PR adds an additional check to make sure the post exists before querying it.