### PR TITLE
Inline docs: `$block_type` is an object, not an array

### DIFF
--- a/lib/block-supports/align.php
+++ b/lib/block-supports/align.php
@@ -8,7 +8,7 @@
 /**
  * Registers the align block attribute for block types that support it.
  *
- * @param  array $block_type Block Type.
+ * @param WP_Block_Type $block_type Block Type.
  */
 function gutenberg_register_alignment_support( $block_type ) {
 	$has_align_support = gutenberg_experimental_get( $block_type->supports, array( 'align' ), false );
@@ -30,9 +30,10 @@ function gutenberg_register_alignment_support( $block_type ) {
  * Add CSS classes for block alignment to the incoming attributes array.
  * This will be applied to the block markup in the front-end.
  *
- * @param  array $attributes comprehensive list of attributes to be applied.
- * @param  array $block_attributes block attributes.
- * @param  array $block_type Block Type.
+ * @param array         $attributes       Comprehensive list of attributes to be applied.
+ * @param array         $block_attributes Block attributes.
+ * @param WP_Block_Type $block_type       Block Type.
+ *
  * @return array Block alignment CSS classes and inline styles.
  */
 function gutenberg_apply_alignment_support( $attributes, $block_attributes, $block_type ) {

--- a/lib/block-supports/colors.php
+++ b/lib/block-supports/colors.php
@@ -8,7 +8,7 @@
 /**
  * Registers the style and colors block attributes for block types that support it.
  *
- * @param  array $block_type Block Type.
+ * @param WP_Block_Type $block_type Block Type.
  */
 function gutenberg_register_colors_support( $block_type ) {
 	$color_support                 = gutenberg_experimental_get( $block_type->supports, array( '__experimentalColor' ), false );
@@ -50,9 +50,10 @@ function gutenberg_register_colors_support( $block_type ) {
  * Add CSS classes and inline styles for colors to the incoming attributes array.
  * This will be applied to the block markup in the front-end.
  *
- * @param  array $attributes comprehensive list of attributes to be applied.
- * @param  array $block_attributes block attributes.
- * @param  array $block_type Block type.
+ * @param  array         $attributes       Comprehensive list of attributes to be applied.
+ * @param  array         $block_attributes Block attributes.
+ * @param  WP_Block_Type $block_type       Block type.
+ *
  * @return array Colors CSS classes and inline styles.
  */
 function gutenberg_apply_colors_support( $attributes, $block_attributes, $block_type ) {

--- a/lib/block-supports/custom-classname.php
+++ b/lib/block-supports/custom-classname.php
@@ -8,7 +8,7 @@
 /**
  * Registers the custom classname block attribute for block types that support it.
  *
- * @param  array $block_type Block Type.
+ * @param WP_Block_Type $block_type Block Type.
  */
 function gutenberg_register_custom_classname_support( $block_type ) {
 	$has_custom_classname_support = gutenberg_experimental_get( $block_type->supports, array( 'customClassName' ), true );
@@ -28,9 +28,10 @@ function gutenberg_register_custom_classname_support( $block_type ) {
 /**
  * Add the custom classnames to the output.
  *
- * @param  array $attributes comprehensive list of attributes to be applied.
- * @param  array $block_attributes block attributes.
- * @param  array $block_type Block Type.
+ * @param  array         $attributes       Comprehensive list of attributes to be applied.
+ * @param  array         $block_attributes Block attributes.
+ * @param  WP_Block_Type $block_type       Block Type.
+ *
  * @return array Block CSS classes and inline styles.
  */
 function gutenberg_apply_custom_classname_support( $attributes, $block_attributes, $block_type ) {

--- a/lib/block-supports/generated-classname.php
+++ b/lib/block-supports/generated-classname.php
@@ -34,9 +34,10 @@ function gutenberg_get_block_default_classname( $block_name ) {
 /**
  * Add the generated classnames to the output.
  *
- * @param  array $attributes comprehensive list of attributes to be applied.
- * @param  array $block_attributes block attributes.
- * @param  array $block_type Block Type.
+ * @param  array         $attributes       Comprehensive list of attributes to be applied.
+ * @param  array         $block_attributes Block attributes.
+ * @param  WP_Block_Type $block_type       Block Type.
+ *
  * @return array Block CSS classes and inline styles.
  */
 function gutenberg_apply_generated_classname_support( $attributes, $block_attributes, $block_type ) {

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -8,7 +8,7 @@
 /**
  * Registers the style and typography block attributes for block types that support it.
  *
- * @param  array $block_type Block Type.
+ * @param WP_Block_Type $block_type Block Type.
  */
 function gutenberg_register_typography_support( $block_type ) {
 	$has_font_size_support   = gutenberg_experimental_get( $block_type->supports, array( '__experimentalFontSize' ), false );
@@ -35,9 +35,10 @@ function gutenberg_register_typography_support( $block_type ) {
  * Add CSS classes and inline styles for font sizes to the incoming attributes array.
  * This will be applied to the block markup in the front-end.
  *
- * @param  array $attributes comprehensive list of attributes to be applied.
- * @param  array $block_attributes block attributes.
- * @param  array $block_type block type.
+ * @param  array         $attributes       Comprehensive list of attributes to be applied.
+ * @param  array         $block_attributes Block attributes.
+ * @param  WP_Block_Type $block_type       Block type.
+ *
  * @return array Font size CSS classes and inline styles.
  */
 function gutenberg_apply_typography_support( $attributes, $block_attributes, $block_type ) {


### PR DESCRIPTION
Simple fix, changing some docblock to properly document that `$block_type` is a `WP_Block_Type` and not an `array`.