### PR TITLE
Fix styling of  image alignment controls in Latest posts block

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -250,7 +250,7 @@ class LatestPostsEdit extends Component {
 									} )
 								}
 							/>
-							<BaseControl>
+							<BaseControl className="block-editor-image-alignment-control__row">
 								<BaseControl.VisualLabel>
 									{ __( 'Image alignment' ) }
 								</BaseControl.VisualLabel>

--- a/packages/block-library/src/latest-posts/style.scss
+++ b/packages/block-library/src/latest-posts/style.scss
@@ -67,3 +67,15 @@
 		text-align: center;
 	}
 }
+
+.block-editor-image-alignment-control__row {
+	.components-base-control__field {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+
+		.components-base-control__label {
+			margin-bottom: 0;
+		}
+	}
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This just styles a bit better the image alignment controls in Latest posts block.
<!-- Please describe what you have changed or added -->


## How has this been tested?
1. insert a `Latest posts` block
2. inspect block settings the `image alignment` controls
3. observe the styling issue

## Screenshots <!-- if applicable -->
before:
![before](https://user-images.githubusercontent.com/16275880/90635274-a653b500-e231-11ea-9546-2cc63c2ab8b3.png)

after:
![after](https://user-images.githubusercontent.com/16275880/90635277-a784e200-e231-11ea-9991-64b18e46fbbd.png)
