### PR TITLE
[RNMobile] Fix for vertical alignment in column that is added from the inserter menu.

### DIFF
--- a/packages/block-library/src/column/edit.native.js
+++ b/packages/block-library/src/column/edit.native.js
@@ -8,6 +8,7 @@ import { View } from 'react-native';
  */
 import { withSelect } from '@wordpress/data';
 import { compose, withPreferredColorScheme } from '@wordpress/compose';
+import { useEffect } from '@wordpress/element';
 import {
 	InnerBlocks,
 	BlockControls,
@@ -38,12 +39,19 @@ function ColumnEdit( {
 	columns,
 	columnCount,
 	selectedColumnIndex,
+	parentAlignment,
 } ) {
 	const { verticalAlignment } = attributes;
 
 	const updateAlignment = ( alignment ) => {
 		setAttributes( { verticalAlignment: alignment } );
 	};
+
+	useEffect( () => {
+		if ( ! verticalAlignment && parentAlignment ) {
+			updateAlignment( parentAlignment );
+		}
+	}, [] );
 
 	const onWidthChange = ( width ) => {
 		setAttributes( {
@@ -146,6 +154,7 @@ export default compose( [
 			getSelectedBlockClientId,
 			getBlocks,
 			getBlockOrder,
+			getBlockAttributes,
 		} = select( 'core/block-editor' );
 
 		const selectedBlockClientId = getSelectedBlockClientId();
@@ -162,6 +171,9 @@ export default compose( [
 		const columnCount = getBlockCount( parentId );
 		const columns = getBlocks( parentId );
 
+		const parentAlignment = getBlockAttributes( parentId )
+			?.verticalAlignment;
+
 		return {
 			hasChildren,
 			isParentSelected,
@@ -169,6 +181,7 @@ export default compose( [
 			selectedColumnIndex,
 			columns,
 			columnCount,
+			parentAlignment,
 		};
 	} ),
 	withPreferredColorScheme,


### PR DESCRIPTION
## Description
Fixes: https://github.com/wordpress-mobile/WordPress-Android/pull/12709#issuecomment-675616041
GB-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2560

When the column block is added by the appender then we set the alignment while creating a new `column` block (https://github.com/WordPress/gutenberg/blob/master/packages/block-library/src/columns/edit.native.js#L326). Unfortunately the alignment is not set when we add the column from inserter menu.

In this PR I set the alignment from the parent (`columns`) if no alignment is set in the block (`column`).

I added a `useEffect` with no dependencies to do it only after the component is mounted and the `verticalAlignment` is not set in the column block.

## How has this been tested?
- Add a Columns block
- Select a verticalAlignment such as middle
- Select a column
- Add a new Column using the block inserter
- The verticalAlignment on the new Column should be set to the same as for Columns.

## Screenshots <!-- if applicable -->
Before | After
--- | ---
![AlignmentSettingNotPassed 2020-08-18 13_41_17](https://user-images.githubusercontent.com/3384451/90546907-b9df1d00-e158-11ea-9835-58c546a9300a.gif) | ![AlignmentSettingNotPassed 2020-08-18 13_41_17](https://user-images.githubusercontent.com/16336501/90636270-a7351880-e22a-11ea-8965-8cd1a586251b.gif)



## Types of changes
Fix for vertical alignment in the column that is added from the inserter menu.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
