### PR TITLE
Search Block: Add button, label, and width options

### DIFF
--- a/packages/block-library/src/search/block.json
+++ b/packages/block-library/src/search/block.json
@@ -5,16 +5,29 @@
 		"label": {
 			"type": "string"
 		},
+		"showLabel": {
+			"type": "bool",
+			"default": false
+		},
 		"placeholder": {
 			"type": "string",
 			"default": ""
 		},
 		"buttonText": {
 			"type": "string"
+		},
+		"buttonPosition": {
+			"type": "string",
+			"default": "button-outside"
+		},
+		"buttonUseIcon": {
+			"type": "bool",
+			"default": false
 		}
 	},
 	"supports": {
 		"align": true,
-		"html": false
+		"html": false,
+		"lightBlockWrapper": true
 	}
 }

--- a/packages/block-library/src/search/block.json
+++ b/packages/block-library/src/search/block.json
@@ -13,6 +13,10 @@
 			"type": "string",
 			"default": ""
 		},
+		"width": {
+			"type": "number",
+			"default": 250
+		},
 		"buttonText": {
 			"type": "string"
 		},
@@ -26,7 +30,7 @@
 		}
 	},
 	"supports": {
-		"align": true,
+		"align": [ "left", "center", "right" ],
 		"html": false,
 		"lightBlockWrapper": true
 	}

--- a/packages/block-library/src/search/block.json
+++ b/packages/block-library/src/search/block.json
@@ -7,7 +7,7 @@
 		},
 		"showLabel": {
 			"type": "bool",
-			"default": false
+			"default": true
 		},
 		"placeholder": {
 			"type": "string",
@@ -15,7 +15,7 @@
 		},
 		"width": {
 			"type": "number",
-			"default": 250
+			"default": 460
 		},
 		"buttonText": {
 			"type": "string"

--- a/packages/block-library/src/search/block.json
+++ b/packages/block-library/src/search/block.json
@@ -14,6 +14,9 @@
 			"default": ""
 		},
 		"width": {
+			"type": "number"
+		},
+		"widthUnit": {
 			"type": "string"
 		},
 		"buttonText": {

--- a/packages/block-library/src/search/block.json
+++ b/packages/block-library/src/search/block.json
@@ -14,8 +14,7 @@
 			"default": ""
 		},
 		"width": {
-			"type": "number",
-			"default": 460
+			"type": "string"
 		},
 		"buttonText": {
 			"type": "string"

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -234,7 +234,9 @@ export default function SearchEdit( {
 									buttonUseIcon: ! buttonUseIcon,
 								} );
 							} }
-							className={ buttonUseIcon ? 'is-pressed' : undefined }
+							className={
+								buttonUseIcon ? 'is-pressed' : undefined
+							}
 						/>
 					) }
 				</ToolbarGroup>
@@ -242,7 +244,10 @@ export default function SearchEdit( {
 
 			<InspectorControls>
 				<PanelBody title={ __( 'Display Settings' ) }>
-					<BaseControl label={ __( 'Width' ) } id={ unitControlInputId }>
+					<BaseControl
+						label={ __( 'Width' ) }
+						id={ unitControlInputId }
+					>
 						<UnitControl
 							id={ unitControlInputId }
 							min={ MIN_WIDTH }

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -45,6 +45,7 @@ export default function SearchEdit( {
 	attributes,
 	setAttributes,
 	toggleSelection,
+	isSelected,
 } ) {
 	const {
 		label,
@@ -286,15 +287,16 @@ export default function SearchEdit( {
 				minWidth={ MIN_WIDTH }
 				bounds={ align === undefined ? 'parent' : 'window' }
 				enable={ getResizableSides() }
+				onResizeStart={ () => {
+					toggleSelection( false );
+				} }
 				onResizeStop={ ( event, direction, elt, delta ) => {
 					setAttributes( {
 						width: parseInt( width + delta.width, 10 ),
 					} );
 					toggleSelection( true );
 				} }
-				onResizeStart={ () => {
-					toggleSelection( false );
-				} }
+				showHandle={ isSelected }
 			>
 				{ ( 'button-inside' === buttonPosition ||
 					'button-outside' === buttonPosition ) && (

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -1,22 +1,63 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
-import { RichText } from '@wordpress/block-editor';
+import {
+	__experimentalBlock as Block,
+	BlockControls,
+	RichText,
+} from '@wordpress/block-editor';
+import {
+	DropdownMenu,
+	MenuGroup,
+	MenuItem,
+	ToolbarGroup,
+	Button,
+	ToolbarButton,
+} from '@wordpress/components';
+import { button } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
 export default function SearchEdit( { className, attributes, setAttributes } ) {
-	const { label, placeholder, buttonText } = attributes;
+	const {
+		label,
+		showLabel,
+		placeholder,
+		buttonText,
+		buttonPosition,
+		buttonUseIcon,
+	} = attributes;
 
-	return (
-		<div className={ className }>
-			<RichText
-				className="wp-block-search__label"
-				aria-label={ __( 'Label text' ) }
-				placeholder={ __( 'Add label…' ) }
-				withoutInteractiveFormatting
-				value={ label }
-				onChange={ ( html ) => setAttributes( { label: html } ) }
-			/>
+	const getBlockClassNames = () => {
+		return classnames(
+			className,
+			'button-inside' === buttonPosition
+				? 'wp-block-search__button-inside'
+				: undefined,
+			'button-outside' === buttonPosition
+				? 'wp-block-search__button-outside'
+				: undefined,
+			'no-button' === buttonPosition
+				? 'wp-block-search__no-button'
+				: undefined,
+			'button-only' === buttonPosition
+				? 'wp-block-search__button-only'
+				: undefined,
+			buttonUseIcon && 'no-button' !== buttonPosition
+				? 'wp-block-search__text-button'
+				: undefined,
+			! buttonUseIcon && 'no-button' !== buttonPosition
+				? 'wp-block-search__icon-button'
+				: undefined
+		);
+	};
+
+	const renderTextField = () => {
+		return (
 			<input
 				className="wp-block-search__input"
 				aria-label={ __( 'Optional placeholder text' ) }
@@ -31,14 +72,134 @@ export default function SearchEdit( { className, attributes, setAttributes } ) {
 					setAttributes( { placeholder: event.target.value } )
 				}
 			/>
-			<RichText
-				className="wp-block-search__button"
-				aria-label={ __( 'Button text' ) }
-				placeholder={ __( 'Add button text…' ) }
-				withoutInteractiveFormatting
-				value={ buttonText }
-				onChange={ ( html ) => setAttributes( { buttonText: html } ) }
-			/>
-		</div>
+		);
+	};
+
+	const renderButton = () => {
+		return (
+			<>
+				{ buttonUseIcon && (
+					<Button icon="search" className="wp-block-search__button" />
+				) }
+
+				{ ! buttonUseIcon && (
+					<RichText
+						className="wp-block-search__button"
+						aria-label={ __( 'Button text' ) }
+						placeholder={ __( 'Add button text…' ) }
+						withoutInteractiveFormatting
+						value={ buttonText }
+						onChange={ ( html ) =>
+							setAttributes( { buttonText: html } )
+						}
+					/>
+				) }
+			</>
+		);
+	};
+
+	return (
+		<Block.div className={ getBlockClassNames() }>
+			<BlockControls>
+				<ToolbarGroup>
+					<DropdownMenu
+						icon={ button }
+						label={ __( 'Change Button Position' ) }
+					>
+						{ ( { onClose } ) => (
+							<MenuGroup className="wp-block-search__button-position-menu">
+								<MenuItem
+									icon={ button }
+									onClick={ () => {
+										setAttributes( {
+											buttonPosition: 'no-button',
+										} );
+										onClose();
+									} }
+								>
+									{ __( 'No Button' ) }
+								</MenuItem>
+								<MenuItem
+									icon={ button }
+									onClick={ () => {
+										setAttributes( {
+											buttonPosition: 'button-inside',
+										} );
+										onClose();
+									} }
+								>
+									{ __( 'Button Inside' ) }
+								</MenuItem>
+								<MenuItem
+									icon={ button }
+									onClick={ () => {
+										setAttributes( {
+											buttonPosition: 'button-outside',
+										} );
+										onClose();
+									} }
+								>
+									{ __( 'Button Outside' ) }
+								</MenuItem>
+								<MenuItem
+									icon={ button }
+									onClick={ () => {
+										setAttributes( {
+											buttonPosition: 'button-only',
+										} );
+										onClose();
+									} }
+								>
+									{ __( 'Button Only' ) }
+								</MenuItem>
+							</MenuGroup>
+						) }
+					</DropdownMenu>
+
+					{ 'no-button' !== buttonPosition && (
+						<ToolbarButton
+							title={ __( 'Use Icon Button' ) }
+							icon={ button }
+							onClick={ () => {
+								setAttributes( {
+									buttonUseIcon: ! buttonUseIcon,
+								} );
+							} }
+							className={
+								buttonUseIcon ? 'is-pressed' : undefined
+							}
+						/>
+					) }
+				</ToolbarGroup>
+			</BlockControls>
+
+			{ showLabel && (
+				<RichText
+					className="wp-block-search__label"
+					aria-label={ __( 'Label text' ) }
+					placeholder={ __( 'Add label…' ) }
+					withoutInteractiveFormatting
+					value={ label }
+					onChange={ ( html ) => setAttributes( { label: html } ) }
+				/>
+			) }
+
+			{ 'button-outside' === buttonPosition && (
+				<>
+					{ renderTextField() }
+					{ renderButton() }
+				</>
+			) }
+
+			{ 'button-inside' === buttonPosition && (
+				<div className="wp-block-search__inside-wrapper">
+					{ renderTextField() }
+					{ renderButton() }
+				</div>
+			) }
+
+			{ 'button-only' === buttonPosition && renderButton() }
+			{ 'no-button' === buttonPosition && renderTextField() }
+		</Block.div>
 	);
 }

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -19,7 +19,7 @@ import {
 	Button,
 	ToolbarButton,
 } from '@wordpress/components';
-import { button } from '@wordpress/icons';
+import { button, title, search } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
 export default function SearchEdit( { className, attributes, setAttributes } ) {
@@ -79,7 +79,7 @@ export default function SearchEdit( { className, attributes, setAttributes } ) {
 		return (
 			<>
 				{ buttonUseIcon && (
-					<Button icon="search" className="wp-block-search__button" />
+					<Button icon={ search } className="wp-block-search__button" />
 				) }
 
 				{ ! buttonUseIcon && (
@@ -101,6 +101,21 @@ export default function SearchEdit( { className, attributes, setAttributes } ) {
 	return (
 		<Block.div className={ getBlockClassNames() }>
 			<BlockControls>
+				<ToolbarGroup>
+					<ToolbarButton
+						title={ __( 'Toggle Label' ) }
+						icon={ title }
+						onClick={ () => {
+							setAttributes( {
+								showLabel: ! showLabel,
+							} );
+						} }
+						className={
+							showLabel ? 'is-pressed' : undefined
+						}
+					/>
+				</ToolbarGroup>
+
 				<ToolbarGroup>
 					<DropdownMenu
 						icon={ button }

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -19,8 +19,20 @@ import {
 	Button,
 	ToolbarButton,
 } from '@wordpress/components';
-import { button, title, search } from '@wordpress/icons';
+import { search } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import {
+	buttonOnly,
+	buttonOutside,
+	buttonInside,
+	noButton,
+	buttonWithIcon,
+	toggleLabel,
+} from './icons';
 
 export default function SearchEdit( { className, attributes, setAttributes } ) {
 	const {
@@ -56,6 +68,19 @@ export default function SearchEdit( { className, attributes, setAttributes } ) {
 		);
 	};
 
+	const getButtonPositionIcon = () => {
+		switch ( buttonPosition ) {
+			case 'button-inside':
+				return buttonInside;
+			case 'button-outside':
+				return buttonOutside;
+			case 'no-button':
+				return noButton;
+			case 'button-only':
+				return buttonOnly;
+		}
+	};
+
 	const renderTextField = () => {
 		return (
 			<input
@@ -79,7 +104,10 @@ export default function SearchEdit( { className, attributes, setAttributes } ) {
 		return (
 			<>
 				{ buttonUseIcon && (
-					<Button icon={ search } className="wp-block-search__button" />
+					<Button
+						icon={ search }
+						className="wp-block-search__button"
+					/>
 				) }
 
 				{ ! buttonUseIcon && (
@@ -103,28 +131,26 @@ export default function SearchEdit( { className, attributes, setAttributes } ) {
 			<BlockControls>
 				<ToolbarGroup>
 					<ToolbarButton
-						title={ __( 'Toggle Label' ) }
-						icon={ title }
+						title={ __( 'Toggle Search Label' ) }
+						icon={ toggleLabel }
 						onClick={ () => {
 							setAttributes( {
 								showLabel: ! showLabel,
 							} );
 						} }
-						className={
-							showLabel ? 'is-pressed' : undefined
-						}
+						className={ showLabel ? 'is-pressed' : undefined }
 					/>
 				</ToolbarGroup>
 
 				<ToolbarGroup>
 					<DropdownMenu
-						icon={ button }
+						icon={ getButtonPositionIcon() }
 						label={ __( 'Change Button Position' ) }
 					>
 						{ ( { onClose } ) => (
 							<MenuGroup className="wp-block-search__button-position-menu">
 								<MenuItem
-									icon={ button }
+									icon={ noButton }
 									onClick={ () => {
 										setAttributes( {
 											buttonPosition: 'no-button',
@@ -135,18 +161,7 @@ export default function SearchEdit( { className, attributes, setAttributes } ) {
 									{ __( 'No Button' ) }
 								</MenuItem>
 								<MenuItem
-									icon={ button }
-									onClick={ () => {
-										setAttributes( {
-											buttonPosition: 'button-inside',
-										} );
-										onClose();
-									} }
-								>
-									{ __( 'Button Inside' ) }
-								</MenuItem>
-								<MenuItem
-									icon={ button }
+									icon={ buttonOutside }
 									onClick={ () => {
 										setAttributes( {
 											buttonPosition: 'button-outside',
@@ -157,7 +172,18 @@ export default function SearchEdit( { className, attributes, setAttributes } ) {
 									{ __( 'Button Outside' ) }
 								</MenuItem>
 								<MenuItem
-									icon={ button }
+									icon={ buttonInside }
+									onClick={ () => {
+										setAttributes( {
+											buttonPosition: 'button-inside',
+										} );
+										onClose();
+									} }
+								>
+									{ __( 'Button Inside' ) }
+								</MenuItem>
+								<MenuItem
+									icon={ buttonOnly }
 									onClick={ () => {
 										setAttributes( {
 											buttonPosition: 'button-only',
@@ -173,8 +199,8 @@ export default function SearchEdit( { className, attributes, setAttributes } ) {
 
 					{ 'no-button' !== buttonPosition && (
 						<ToolbarButton
-							title={ __( 'Use Icon Button' ) }
-							icon={ button }
+							title={ __( 'Use Button with Icon' ) }
+							icon={ buttonWithIcon }
 							onClick={ () => {
 								setAttributes( {
 									buttonUseIcon: ! buttonUseIcon,

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -9,7 +9,9 @@ import classnames from 'classnames';
 import {
 	__experimentalBlock as Block,
 	BlockControls,
+	InspectorControls,
 	RichText,
+	__experimentalUnitControl as UnitControl,
 } from '@wordpress/block-editor';
 import {
 	DropdownMenu,
@@ -19,7 +21,10 @@ import {
 	Button,
 	ToolbarButton,
 	ResizableBox,
+	PanelBody,
+	BaseControl,
 } from '@wordpress/components';
+import { useInstanceId } from '@wordpress/compose';
 import { search } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
@@ -53,6 +58,8 @@ export default function SearchEdit( {
 	} = attributes;
 
 	const MIN_WIDTH = 120;
+	const unitControlInstanceId = useInstanceId( UnitControl );
+	const unitControlInputId = `wp-block-search__width-${ unitControlInstanceId }`;
 
 	const getBlockClassNames = () => {
 		return classnames(
@@ -148,89 +155,107 @@ export default function SearchEdit( {
 	};
 
 	const controls = (
-		<BlockControls>
-			<ToolbarGroup>
-				<ToolbarButton
-					title={ __( 'Toggle Search Label' ) }
-					icon={ toggleLabel }
-					onClick={ () => {
-						setAttributes( {
-							showLabel: ! showLabel,
-						} );
-					} }
-					className={ showLabel ? 'is-pressed' : undefined }
-				/>
-			</ToolbarGroup>
-
-			<ToolbarGroup>
-				<DropdownMenu
-					icon={ getButtonPositionIcon() }
-					label={ __( 'Change Button Position' ) }
-				>
-					{ ( { onClose } ) => (
-						<MenuGroup className="wp-block-search__button-position-menu">
-							<MenuItem
-								icon={ noButton }
-								onClick={ () => {
-									setAttributes( {
-										buttonPosition: 'no-button',
-									} );
-									onClose();
-								} }
-							>
-								{ __( 'No Button' ) }
-							</MenuItem>
-							<MenuItem
-								icon={ buttonOutside }
-								onClick={ () => {
-									setAttributes( {
-										buttonPosition: 'button-outside',
-									} );
-									onClose();
-								} }
-							>
-								{ __( 'Button Outside' ) }
-							</MenuItem>
-							<MenuItem
-								icon={ buttonInside }
-								onClick={ () => {
-									setAttributes( {
-										buttonPosition: 'button-inside',
-									} );
-									onClose();
-								} }
-							>
-								{ __( 'Button Inside' ) }
-							</MenuItem>
-							<MenuItem
-								icon={ buttonOnly }
-								onClick={ () => {
-									setAttributes( {
-										buttonPosition: 'button-only',
-									} );
-									onClose();
-								} }
-							>
-								{ __( 'Button Only' ) }
-							</MenuItem>
-						</MenuGroup>
-					) }
-				</DropdownMenu>
-
-				{ 'no-button' !== buttonPosition && (
+		<>
+			<BlockControls>
+				<ToolbarGroup>
 					<ToolbarButton
-						title={ __( 'Use Button with Icon' ) }
-						icon={ buttonWithIcon }
+						title={ __( 'Toggle Search Label' ) }
+						icon={ toggleLabel }
 						onClick={ () => {
 							setAttributes( {
-								buttonUseIcon: ! buttonUseIcon,
+								showLabel: ! showLabel,
 							} );
 						} }
-						className={ buttonUseIcon ? 'is-pressed' : undefined }
+						className={ showLabel ? 'is-pressed' : undefined }
 					/>
-				) }
-			</ToolbarGroup>
-		</BlockControls>
+				</ToolbarGroup>
+
+				<ToolbarGroup>
+					<DropdownMenu
+						icon={ getButtonPositionIcon() }
+						label={ __( 'Change Button Position' ) }
+					>
+						{ ( { onClose } ) => (
+							<MenuGroup className="wp-block-search__button-position-menu">
+								<MenuItem
+									icon={ noButton }
+									onClick={ () => {
+										setAttributes( {
+											buttonPosition: 'no-button',
+										} );
+										onClose();
+									} }
+								>
+									{ __( 'No Button' ) }
+								</MenuItem>
+								<MenuItem
+									icon={ buttonOutside }
+									onClick={ () => {
+										setAttributes( {
+											buttonPosition: 'button-outside',
+										} );
+										onClose();
+									} }
+								>
+									{ __( 'Button Outside' ) }
+								</MenuItem>
+								<MenuItem
+									icon={ buttonInside }
+									onClick={ () => {
+										setAttributes( {
+											buttonPosition: 'button-inside',
+										} );
+										onClose();
+									} }
+								>
+									{ __( 'Button Inside' ) }
+								</MenuItem>
+								<MenuItem
+									icon={ buttonOnly }
+									onClick={ () => {
+										setAttributes( {
+											buttonPosition: 'button-only',
+										} );
+										onClose();
+									} }
+								>
+									{ __( 'Button Only' ) }
+								</MenuItem>
+							</MenuGroup>
+						) }
+					</DropdownMenu>
+
+					{ 'no-button' !== buttonPosition && (
+						<ToolbarButton
+							title={ __( 'Use Button with Icon' ) }
+							icon={ buttonWithIcon }
+							onClick={ () => {
+								setAttributes( {
+									buttonUseIcon: ! buttonUseIcon,
+								} );
+							} }
+							className={ buttonUseIcon ? 'is-pressed' : undefined }
+						/>
+					) }
+				</ToolbarGroup>
+			</BlockControls>
+
+			<InspectorControls>
+				<PanelBody title={ __( 'Display Settings' ) }>
+					<BaseControl label={ __( 'Width' ) } id={ unitControlInputId }>
+						<UnitControl
+							id={ unitControlInputId }
+							min={ MIN_WIDTH }
+							onChange={ ( newWidth ) =>
+								setAttributes( { width: newWidth } )
+							}
+							style={ { maxWidth: 80 } }
+							value={ width }
+						/>
+					</BaseControl>
+				</PanelBody>
+			</InspectorControls>
+		</>
 	);
 
 	return (

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -58,7 +58,7 @@ export default function SearchEdit( {
 		buttonUseIcon,
 	} = attributes;
 
-	const MIN_WIDTH = 120;
+	const MIN_WIDTH = 220;
 	const unitControlInstanceId = useInstanceId( UnitControl );
 	const unitControlInputId = `wp-block-search__width-${ unitControlInstanceId }`;
 
@@ -285,7 +285,6 @@ export default function SearchEdit( {
 				} }
 				className="wp-block-search__inside-wrapper"
 				minWidth={ MIN_WIDTH }
-				bounds={ align === undefined ? 'parent' : 'window' }
 				enable={ getResizableSides() }
 				onResizeStart={ () => {
 					toggleSelection( false );

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -263,8 +263,14 @@ export default function SearchEdit( {
 							id={ unitControlInputId }
 							min={ `${ MIN_WIDTH }${ MIN_WIDTH_UNIT }` }
 							onChange={ ( newWidth ) => {
+								const filteredWidth =
+									widthUnit === '%' &&
+									parseInt( newWidth, 10 ) > 100
+										? 100
+										: newWidth;
+
 								setAttributes( {
-									width: parseInt( newWidth, 10 ),
+									width: parseInt( filteredWidth, 10 ),
 								} );
 							} }
 							onUnitChange={ ( newUnit ) => {

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -173,7 +173,7 @@ export default function SearchEdit( {
 			<BlockControls>
 				<ToolbarGroup>
 					<ToolbarButton
-						title={ __( 'Toggle Search Label' ) }
+						title={ __( 'Toggle search label' ) }
 						icon={ toggleLabel }
 						onClick={ () => {
 							setAttributes( {
@@ -184,7 +184,7 @@ export default function SearchEdit( {
 					/>
 					<DropdownMenu
 						icon={ getButtonPositionIcon() }
-						label={ __( 'Change Button Position' ) }
+						label={ __( 'Change button position' ) }
 					>
 						{ ( { onClose } ) => (
 							<MenuGroup className="wp-block-search__button-position-menu">
@@ -238,7 +238,7 @@ export default function SearchEdit( {
 
 					{ 'no-button' !== buttonPosition && (
 						<ToolbarButton
-							title={ __( 'Use Button with Icon' ) }
+							title={ __( 'Use button with icon' ) }
 							icon={ buttonWithIcon }
 							onClick={ () => {
 								setAttributes( {

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -19,6 +19,7 @@ import {
 	MenuItem,
 	ToolbarGroup,
 	Button,
+	ButtonGroup,
 	ToolbarButton,
 	ResizableBox,
 	PanelBody,
@@ -40,6 +41,18 @@ import {
 	toggleLabel,
 } from './icons';
 
+/**
+ * Constants
+ */
+const MIN_WIDTH = 220;
+const MIN_WIDTH_UNIT = 'px';
+const PC_WIDTH_DEFAULT = 50;
+const PX_WIDTH_DEFAULT = 350;
+const CSS_UNITS = [
+	{ value: '%', label: '%', default: PC_WIDTH_DEFAULT },
+	{ value: 'px', label: 'px', default: PX_WIDTH_DEFAULT },
+];
+
 export default function SearchEdit( {
 	className,
 	attributes,
@@ -52,13 +65,13 @@ export default function SearchEdit( {
 		showLabel,
 		placeholder,
 		width,
+		widthUnit,
 		align,
 		buttonText,
 		buttonPosition,
 		buttonUseIcon,
 	} = attributes;
 
-	const MIN_WIDTH = 220;
 	const unitControlInstanceId = useInstanceId( UnitControl );
 	const unitControlInputId = `wp-block-search__width-${ unitControlInstanceId }`;
 
@@ -248,13 +261,52 @@ export default function SearchEdit( {
 					>
 						<UnitControl
 							id={ unitControlInputId }
-							min={ MIN_WIDTH }
-							onChange={ ( newWidth ) =>
-								setAttributes( { width: newWidth } )
-							}
+							min={ `${ MIN_WIDTH }${ MIN_WIDTH_UNIT }` }
+							onChange={ ( newWidth ) => {
+								setAttributes( {
+									width: parseInt( newWidth, 10 ),
+								} );
+							} }
+							onUnitChange={ ( newUnit ) => {
+								setAttributes( {
+									width:
+										'%' === newUnit
+											? PC_WIDTH_DEFAULT
+											: PX_WIDTH_DEFAULT,
+									widthUnit: newUnit,
+								} );
+							} }
 							style={ { maxWidth: 80 } }
-							value={ width }
+							value={ `${ width }${ widthUnit }` }
+							unit={ widthUnit }
+							units={ CSS_UNITS }
 						/>
+
+						<ButtonGroup
+							className="wp-block-search__components-button-group"
+							aria-label={ __( 'Percentage Width' ) }
+						>
+							{ [ 25, 50, 75, 100 ].map( ( widthValue ) => {
+								return (
+									<Button
+										key={ widthValue }
+										isSmall
+										isPrimary={
+											`${ widthValue }%` ===
+											`${ width }${ widthUnit }`
+										}
+										onClick={ () =>
+											setAttributes( {
+												width: widthValue,
+												widthUnit: '%',
+											} )
+										}
+									>
+										{ widthValue }%
+									</Button>
+								);
+							} ) }
+						</ButtonGroup>
 					</BaseControl>
 				</PanelBody>
 			</InspectorControls>
@@ -278,12 +330,17 @@ export default function SearchEdit( {
 
 			<ResizableBox
 				size={ {
-					width,
+					width: `${ width }${ widthUnit }`,
 				} }
 				className="wp-block-search__inside-wrapper"
+				isResetValueOnUnitChange
 				minWidth={ MIN_WIDTH }
 				enable={ getResizableSides() }
-				onResizeStart={ () => {
+				onResizeStart={ ( event, direction, elt ) => {
+					setAttributes( {
+						width: parseInt( elt.offsetWidth, 10 ),
+						widthUnit: 'px',
+					} );
 					toggleSelection( false );
 				} }
 				onResizeStop={ ( event, direction, elt, delta ) => {

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -169,9 +169,6 @@ export default function SearchEdit( {
 						} }
 						className={ showLabel ? 'is-pressed' : undefined }
 					/>
-				</ToolbarGroup>
-
-				<ToolbarGroup>
 					<DropdownMenu
 						icon={ getButtonPositionIcon() }
 						label={ __( 'Change Button Position' ) }

--- a/packages/block-library/src/search/editor.scss
+++ b/packages/block-library/src/search/editor.scss
@@ -1,6 +1,6 @@
 .wp-block-search {
 	&__input,
-	&__inside-wrapper {
+	&.wp-block-search__button-inside .wp-block-search__inside-wrapper {
 		border-radius: $radius-block-ui;
 		border: 1px solid $dark-gray-200;
 		color: $dark-gray-placeholder;
@@ -25,9 +25,13 @@
 		color: $dark-gray-700;
 	}
 
-	&__inside-wrapper {
+	.wp-block-search__inside-wrapper {
 		display: flex;
 		flex: auto;
+		flex-wrap: nowrap;
+	}
+
+	&.wp-block-search__button-inside .wp-block-search__inside-wrapper {
 		padding: $grid-unit-05;
 
 		.wp-block-search__input {

--- a/packages/block-library/src/search/editor.scss
+++ b/packages/block-library/src/search/editor.scss
@@ -1,5 +1,6 @@
 .wp-block-search {
-	&__input {
+	&__input,
+	&__inside-wrapper {
 		border-radius: $radius-block-ui;
 		border: 1px solid $dark-gray-200;
 		color: $dark-gray-placeholder;
@@ -20,5 +21,22 @@
 		font-family: $default-font;
 		font-size: $default-font-size;
 		padding: 6px 10px;
+		color: $dark-gray-700;
+	}
+
+	&__inside-wrapper {
+		display: flex;
+		flex: auto;
+		padding: $grid-unit-05;
+
+		.wp-block-search__input {
+			border-radius: 0;
+			border: none;
+			padding: 0 0 0 4px;
+		}
+
+		.wp-block-search__button {
+			padding: 2px 8px;
+		}
 	}
 }

--- a/packages/block-library/src/search/editor.scss
+++ b/packages/block-library/src/search/editor.scss
@@ -25,12 +25,6 @@
 		color: $dark-gray-700;
 	}
 
-	.wp-block-search__inside-wrapper {
-		display: flex;
-		flex: auto;
-		flex-wrap: nowrap;
-	}
-
 	&.wp-block-search__button-inside .wp-block-search__inside-wrapper {
 		padding: $grid-unit-05;
 

--- a/packages/block-library/src/search/editor.scss
+++ b/packages/block-library/src/search/editor.scss
@@ -1,5 +1,5 @@
 .wp-block-search {
-	&__input,
+	.wp-block-search__input,
 	&.wp-block-search__button-inside .wp-block-search__inside-wrapper {
 		border-radius: $radius-block-ui;
 		border: 1px solid $dark-gray-200;
@@ -14,7 +14,7 @@
 		}
 	}
 
-	&__button {
+	.wp-block-search__button {
 		background: #f7f7f7;
 		border-radius: $radius-block-ui;
 		border: 1px solid #ccc;

--- a/packages/block-library/src/search/editor.scss
+++ b/packages/block-library/src/search/editor.scss
@@ -1,4 +1,12 @@
 .wp-block-search {
+	.wp-block-search__input {
+		padding: $grid-unit-10;
+	}
+
+	&.wp-block-search__button-inside .wp-block-search__inside-wrapper {
+		padding: $grid-unit-05;
+	}
+
 	.wp-block-search__input,
 	&.wp-block-search__button-inside .wp-block-search__inside-wrapper {
 		border-radius: $radius-block-ui;
@@ -6,7 +14,6 @@
 		color: $dark-gray-placeholder;
 		font-family: $default-font;
 		font-size: $default-font-size;
-		padding: $grid-unit-10;
 		background-color: $white;
 
 		&:focus {
@@ -23,19 +30,5 @@
 		font-size: $default-font-size;
 		padding: 6px 10px;
 		color: $dark-gray-700;
-	}
-
-	&.wp-block-search__button-inside .wp-block-search__inside-wrapper {
-		padding: $grid-unit-05;
-
-		.wp-block-search__input {
-			border-radius: 0;
-			border: none;
-			padding: 0 0 0 4px;
-		}
-
-		.wp-block-search__button {
-			padding: 2px 8px;
-		}
 	}
 }

--- a/packages/block-library/src/search/editor.scss
+++ b/packages/block-library/src/search/editor.scss
@@ -7,6 +7,7 @@
 		font-family: $default-font;
 		font-size: $default-font-size;
 		padding: $grid-unit-10;
+		background-color: $white;
 
 		&:focus {
 			outline: none;

--- a/packages/block-library/src/search/editor.scss
+++ b/packages/block-library/src/search/editor.scss
@@ -31,4 +31,8 @@
 		padding: 6px 10px;
 		color: $dark-gray-700;
 	}
+
+	&__components-button-group {
+		margin-top: 10px;
+	}
 }

--- a/packages/block-library/src/search/icons.js
+++ b/packages/block-library/src/search/icons.js
@@ -1,0 +1,54 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, SVG, Rect, Circle } from '@wordpress/components';
+
+export const buttonOnly = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Rect x="8" y="10" width="8" height="4" rx="1" />
+	</SVG>
+);
+
+export const buttonOutside = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Circle cx="19" cy="12" r="2" />
+		<Path d="M9.32263 7.50024H12.0001C13.6569 7.50024 15.0001 8.84339 15.0001 10.5002V13.3891C15.0001 15.046 13.6569 16.3891 12.0001 16.3891H9.32263" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" fill="none" />
+		<Path d="M9.67743 16.3889L7.00001 16.3889C5.34316 16.3889 4.00001 15.0458 4.00001 13.3889L4.00001 10.5C4.00001 8.84317 5.34316 7.50003 7.00001 7.50003L9.67743 7.50003" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" fill="none" />
+	</SVG>
+);
+
+export const buttonInside = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Circle cx="16" cy="12" r="2" />
+		<Path d="M15 7.50024H17.3333C18.9902 7.50024 20.3333 8.84339 20.3333 10.5002V13.3891C20.3333 15.046 18.9902 16.3891 17.3333 16.3891H15" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" fill="none" />
+		<Path d="M9.33331 16.3889L6.99998 16.3889C5.34313 16.3889 3.99998 15.0458 3.99998 13.3889L3.99998 10.5C3.99998 8.84317 5.34312 7.50003 6.99998 7.50003L9.33331 7.50003" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" fill="none" />
+		<Rect x="9" y="6.75" width="6" height="1.5" />
+		<Rect x="9" y="15.65" width="6" height="1.5" />
+	</SVG>
+);
+
+export const noButton = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path d="M15 7.50024H17.3333C18.9902 7.50024 20.3333 8.84339 20.3333 10.5002V13.3891C20.3333 15.046 18.9902 16.3891 17.3333 16.3891H15" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" fill="none"/>
+		<Path d="M9.33337 16.3889L7.00004 16.3889C5.34319 16.3889 4.00004 15.0458 4.00004 13.3889L4.00004 10.5C4.00004 8.84317 5.34319 7.50003 7.00004 7.50003L9.33337 7.50003" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" fill="none" />
+		<Rect x="9" y="6.75" width="6" height="1.5" />
+		<Rect x="9" y="15.65" width="6" height="1.5" />
+	</SVG>
+);
+
+export const buttonWithIcon = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path d="M8 7.75H16C16.6904 7.75 17.25 8.30964 17.25 9V16C17.25 16.6904 16.6904 17.25 16 17.25H8C7.30964 17.25 6.75 16.6904 6.75 16V9C6.75 8.30964 7.30964 7.75 8 7.75Z" stroke="currentColor" stroke-width="1.5" fill="none" />
+		<Path fill-rule="evenodd" clip-rule="evenodd" d="M14 12.5C14 13.3284 13.3284 14 12.5 14H11.5C10.6716 14 10 13.3284 10 12.5C10 11.6716 10.6716 11 11.5 11H12.5C13.3284 11 14 11.6716 14 12.5Z" fill="currentColor" />
+	</SVG>
+);
+
+export const toggleLabel = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path d="M15 9.50024H17.3333C18.9902 9.50024 20.3333 10.8434 20.3333 12.5002V15.3891C20.3333 17.046 18.9902 18.3891 17.3333 18.3891H15" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" fill="none" />
+		<Path d="M9.33333 18.3889L7 18.3889C5.34315 18.3889 4 17.0458 4 15.3889L4 12.5C4 10.8432 5.34315 9.50003 7 9.50003L9.33333 9.50003" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" fill="none" />
+		<Rect x="9" y="8.75" width="6" height="1.5" />
+		<Rect x="4" y="5" width="11" height="1.5" />
+		<Rect x="9" y="17.65" width="6" height="1.5" />
+	</SVG>
+);

--- a/packages/block-library/src/search/icons.js
+++ b/packages/block-library/src/search/icons.js
@@ -1,54 +1,89 @@
 /**
  * WordPress dependencies
  */
-import { Path, SVG, Rect, Circle } from '@wordpress/components';
+import { SVG, Rect } from '@wordpress/components';
 
 export const buttonOnly = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-		<Rect x="8" y="10" width="8" height="4" rx="1" />
+		<Rect x="7" y="10" width="10" height="4" rx="1" fill="currentColor" />
 	</SVG>
 );
 
 export const buttonOutside = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-		<Circle cx="19" cy="12" r="2" />
-		<Path d="M9.32263 7.50024H12.0001C13.6569 7.50024 15.0001 8.84339 15.0001 10.5002V13.3891C15.0001 15.046 13.6569 16.3891 12.0001 16.3891H9.32263" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" fill="none" />
-		<Path d="M9.67743 16.3889L7.00001 16.3889C5.34316 16.3889 4.00001 15.0458 4.00001 13.3889L4.00001 10.5C4.00001 8.84317 5.34316 7.50003 7.00001 7.50003L9.67743 7.50003" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" fill="none" />
+		<Rect
+			x="4.75"
+			y="15.25"
+			width="6.5"
+			height="9.5"
+			transform="rotate(-90 4.75 15.25)"
+			stroke="currentColor"
+			stroke-width="1.5"
+			fill="none"
+		/>
+		<Rect x="16" y="10" width="4" height="4" rx="1" fill="currentColor" />
 	</SVG>
 );
 
 export const buttonInside = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-		<Circle cx="16" cy="12" r="2" />
-		<Path d="M15 7.50024H17.3333C18.9902 7.50024 20.3333 8.84339 20.3333 10.5002V13.3891C20.3333 15.046 18.9902 16.3891 17.3333 16.3891H15" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" fill="none" />
-		<Path d="M9.33331 16.3889L6.99998 16.3889C5.34313 16.3889 3.99998 15.0458 3.99998 13.3889L3.99998 10.5C3.99998 8.84317 5.34312 7.50003 6.99998 7.50003L9.33331 7.50003" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" fill="none" />
-		<Rect x="9" y="6.75" width="6" height="1.5" />
-		<Rect x="9" y="15.65" width="6" height="1.5" />
+		<Rect
+			x="4.75"
+			y="15.25"
+			width="6.5"
+			height="14.5"
+			transform="rotate(-90 4.75 15.25)"
+			stroke="currentColor"
+			stroke-width="1.5"
+			fill="none"
+		/>
+		<Rect x="14" y="10" width="4" height="4" rx="1" fill="currentColor" />
 	</SVG>
 );
 
 export const noButton = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-		<Path d="M15 7.50024H17.3333C18.9902 7.50024 20.3333 8.84339 20.3333 10.5002V13.3891C20.3333 15.046 18.9902 16.3891 17.3333 16.3891H15" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" fill="none"/>
-		<Path d="M9.33337 16.3889L7.00004 16.3889C5.34319 16.3889 4.00004 15.0458 4.00004 13.3889L4.00004 10.5C4.00004 8.84317 5.34319 7.50003 7.00004 7.50003L9.33337 7.50003" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" fill="none" />
-		<Rect x="9" y="6.75" width="6" height="1.5" />
-		<Rect x="9" y="15.65" width="6" height="1.5" />
+		<Rect
+			x="4.75"
+			y="15.25"
+			width="6.5"
+			height="14.5"
+			transform="rotate(-90 4.75 15.25)"
+			stroke="currentColor"
+			fill="none"
+			stroke-width="1.5"
+		/>
 	</SVG>
 );
 
 export const buttonWithIcon = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-		<Path d="M8 7.75H16C16.6904 7.75 17.25 8.30964 17.25 9V16C17.25 16.6904 16.6904 17.25 16 17.25H8C7.30964 17.25 6.75 16.6904 6.75 16V9C6.75 8.30964 7.30964 7.75 8 7.75Z" stroke="currentColor" stroke-width="1.5" fill="none" />
-		<Path fill-rule="evenodd" clip-rule="evenodd" d="M14 12.5C14 13.3284 13.3284 14 12.5 14H11.5C10.6716 14 10 13.3284 10 12.5C10 11.6716 10.6716 11 11.5 11H12.5C13.3284 11 14 11.6716 14 12.5Z" fill="currentColor" />
+		<Rect
+			x="4.75"
+			y="7.75"
+			width="14.5"
+			height="8.5"
+			rx="1.25"
+			stroke="currentColor"
+			fill="none"
+			stroke-width="1.5"
+		/>
+		<Rect x="8" y="11" width="8" height="2" fill="currentColor" />
 	</SVG>
 );
 
 export const toggleLabel = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-		<Path d="M15 9.50024H17.3333C18.9902 9.50024 20.3333 10.8434 20.3333 12.5002V15.3891C20.3333 17.046 18.9902 18.3891 17.3333 18.3891H15" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" fill="none" />
-		<Path d="M9.33333 18.3889L7 18.3889C5.34315 18.3889 4 17.0458 4 15.3889L4 12.5C4 10.8432 5.34315 9.50003 7 9.50003L9.33333 9.50003" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" fill="none" />
-		<Rect x="9" y="8.75" width="6" height="1.5" />
-		<Rect x="4" y="5" width="11" height="1.5" />
-		<Rect x="9" y="17.65" width="6" height="1.5" />
+		<Rect
+			x="4.75"
+			y="17.25"
+			width="5.5"
+			height="14.5"
+			transform="rotate(-90 4.75 17.25)"
+			stroke="currentColor"
+			fill="none"
+			stroke-width="1.5"
+		/>
+		<Rect x="4" y="7" width="10" height="2" fill="currentColor" />
 	</SVG>
 );

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -28,12 +28,19 @@ function render_block_core_search( $attributes ) {
 	);
 
 	$input_id       = 'wp-block-search__input-' . ++$instance_id;
+	$classnames     = classnames_for_block_core_search( $attributes );
+
+	$show_label	     = ( isset( $attributes['showLabel'] ) && ! $attributes['showLabel'] ) ? false : true;
+	$show_input		 = ( isset( $attributes['buttonPosition'] ) && 'button-only' == $attributes['buttonPosition'] ) ? false : true;
+	$show_button	 = ( isset( $attributes['buttonPosition'] ) && 'no-button' == $attributes['buttonPosition'] ) ? false : true;
+	$use_icon_button = ( isset( $attributes['buttonUseIcon'] ) && ! $attributes['buttonUseIcon'] ) ? false : true;
+
 	$label_markup   = '';
 	$input_markup	= '';
 	$button_markup  = '';
 	$width_styles   = '';
 
-	if ( ! empty( $attributes['showLabel'] ) ) {
+	if ( $show_label ) {
 		if ( ! empty( $attributes['label'] ) ) {
 			$label_markup = sprintf(
 				'<label for="%s" class="wp-block-search__label">%s</label>',
@@ -49,7 +56,7 @@ function render_block_core_search( $attributes ) {
 		}
 	}
 
-	if ( ! empty( $attributes['buttonPosition'] ) && 'button-only' !== $attributes['buttonPosition'] ) {
+	if ( $show_input ) {
 		$input_markup = sprintf(
 			'<input type="search" id="%s" class="wp-block-search__input" name="s" value="%s" placeholder="%s" required />',
 			$input_id,
@@ -58,10 +65,23 @@ function render_block_core_search( $attributes ) {
 		);
 	}
 
-	if ( ! empty( $attributes['buttonText'] ) ) {
+	if ( $show_button ) {
+		$button_internal_markup = '';
+
+		if ( ! $use_icon_button ) {
+			if ( ! empty( $attributes['buttonText'] ) ) {
+				$button_internal_markup = $attributes['buttonText'];
+			}
+		} else {
+			$button_internal_markup =
+				'<svg id="search-icon" class="search-icon" viewBox="0 0 24 24">
+			        <path d="M13.5 6C10.5 6 8 8.5 8 11.5c0 1.1.3 2.1.9 3l-3.4 3 1 1.1 3.4-2.9c1 .9 2.2 1.4 3.6 1.4 3 0 5.5-2.5 5.5-5.5C19 8.5 16.5 6 13.5 6zm0 9.5c-2.2 0-4-1.8-4-4s1.8-4 4-4 4 1.8 4 4-1.8 4-4 4z"></path>
+			    </svg>';
+		}
+
 		$button_markup = sprintf(
 			'<button type="submit" class="wp-block-search__button">%s</button>',
-			$attributes['buttonText']
+			$button_internal_markup
 		);
 	}
 
@@ -78,8 +98,9 @@ function render_block_core_search( $attributes ) {
 	);
 
 	return sprintf(
-		'<form role="search" method="get" action="%s">%s</form>',
+		'<form role="search" method="get" action="%s" class="%s">%s</form>',
 		esc_url( home_url( '/' ) ),
+		$classnames,
 		$label_markup . $field_markup
 	);
 }
@@ -96,3 +117,40 @@ function register_block_core_search() {
 	);
 }
 add_action( 'init', 'register_block_core_search' );
+
+/**
+ * Builds the correct top level classnames for the 'core/search' block.
+ */
+function classnames_for_block_core_search( $attributes ) {
+	$classnames = [];
+
+	if ( ! empty( $attributes['buttonPosition'] ) ) {
+		if ( 'button-inside' == $attributes['buttonPosition'] ) {
+			$classnames[] = 'wp-block-search__button-inside';
+		}
+
+		if ( 'button-outside' == $attributes['buttonPosition'] ) {
+			$classnames[] = 'wp-block-search__button-outside';
+		}
+
+		if ( 'no-button' == $attributes['buttonPosition'] ) {
+			$classnames[] = 'wp-block-search__no-button';
+		}
+
+		if ( 'button-only' == $attributes['buttonPosition'] ) {
+			$classnames[] = 'wp-block-search__button-only';
+		}
+	}
+
+	if ( isset( $attributes['buttonUseIcon'] ) ) {
+		if ( ! empty( $attributes['buttonPosition'] ) && 'no-button' !== $attributes['buttonPosition'] ) {
+			if ( $attributes['buttonUseIcon'] ) {
+				$classnames[] = 'wp-block-search__icon-button';
+			} else {
+				$classnames[] = 'wp-block-search__text-button';
+			}
+		}
+	}
+
+	return implode( ' ', $classnames );
+}

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -30,10 +30,10 @@ function render_block_core_search( $attributes ) {
 	$input_id       = 'wp-block-search__input-' . ++$instance_id;
 	$classnames     = classnames_for_block_core_search( $attributes );
 
-	$show_label	     = ( isset( $attributes['showLabel'] ) && ! $attributes['showLabel'] ) ? false : true;
-	$show_input		 = ( isset( $attributes['buttonPosition'] ) && 'button-only' == $attributes['buttonPosition'] ) ? false : true;
-	$show_button	 = ( isset( $attributes['buttonPosition'] ) && 'no-button' == $attributes['buttonPosition'] ) ? false : true;
-	$use_icon_button = ( isset( $attributes['buttonUseIcon'] ) && ! $attributes['buttonUseIcon'] ) ? false : true;
+	$show_label	     = ( ! empty( $attributes['showLabel'] ) ) ? true : false;
+	$use_icon_button = ( ! empty( $attributes['buttonUseIcon'] ) ) ? true : false;
+	$show_input		 = ( ! empty( $attributes['buttonPosition'] ) && 'button-only' == $attributes['buttonPosition'] ) ? false : true;
+	$show_button	 = ( ! empty( $attributes['buttonPosition'] ) && 'no-button' == $attributes['buttonPosition'] ) ? false : true;
 
 	$label_markup   = '';
 	$input_markup	= '';

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -27,30 +27,36 @@ function render_block_core_search( $attributes ) {
 		)
 	);
 
-	$input_id      = 'wp-block-search__input-' . ++$instance_id;
-	$label_markup  = '';
-	$button_markup = '';
+	$input_id       = 'wp-block-search__input-' . ++$instance_id;
+	$label_markup   = '';
+	$input_markup	= '';
+	$button_markup  = '';
+	$width_styles   = '';
 
-	if ( ! empty( $attributes['label'] ) ) {
-		$label_markup = sprintf(
-			'<label for="%s" class="wp-block-search__label">%s</label>',
-			$input_id,
-			$attributes['label']
-		);
-	} else {
-		$label_markup = sprintf(
-			'<label for="%s" class="wp-block-search__label screen-reader-text">%s</label>',
-			$input_id,
-			__( 'Search' )
-		);
+	if ( ! empty( $attributes['showLabel'] ) ) {
+		if ( ! empty( $attributes['label'] ) ) {
+			$label_markup = sprintf(
+				'<label for="%s" class="wp-block-search__label">%s</label>',
+				$input_id,
+				$attributes['label']
+			);
+		} else {
+			$label_markup = sprintf(
+				'<label for="%s" class="wp-block-search__label screen-reader-text">%s</label>',
+				$input_id,
+				__( 'Search' )
+			);
+		}
 	}
 
-	$input_markup = sprintf(
-		'<input type="search" id="%s" class="wp-block-search__input" name="s" value="%s" placeholder="%s" required />',
-		$input_id,
-		esc_attr( get_search_query() ),
-		esc_attr( $attributes['placeholder'] )
-	);
+	if ( ! empty( $attributes['buttonPosition'] ) && 'button-only' !== $attributes['buttonPosition'] ) {
+		$input_markup = sprintf(
+			'<input type="search" id="%s" class="wp-block-search__input" name="s" value="%s" placeholder="%s" required />',
+			$input_id,
+			esc_attr( get_search_query() ),
+			esc_attr( $attributes['placeholder'] )
+		);
+	}
 
 	if ( ! empty( $attributes['buttonText'] ) ) {
 		$button_markup = sprintf(
@@ -59,10 +65,22 @@ function render_block_core_search( $attributes ) {
 		);
 	}
 
+	if ( ! empty( $attributes['width'] ) ) {
+		if ( ! empty( $attributes['buttonPosition'] ) && 'button-only' !== $attributes['buttonPosition'] ) {
+			$width_styles = ' style="width: ' . $attributes['width'] . 'px;"';
+		}
+	}
+
+	$field_markup = sprintf(
+		'<div class="wp-block-search__inside-wrapper"%s>%s</div>',
+		$width_styles,
+		$input_markup . $button_markup
+	);
+
 	return sprintf(
 		'<form role="search" method="get" action="%s">%s</form>',
 		esc_url( home_url( '/' ) ),
-		$label_markup . $input_markup . $button_markup
+		$label_markup . $field_markup
 	);
 }
 

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -85,9 +85,9 @@ function render_block_core_search( $attributes ) {
 		);
 	}
 
-	if ( ! empty( $attributes['width'] ) ) {
+	if ( ! empty( $attributes['width'] ) && ! empty( $attributes['widthUnit'] ) ) {
 		if ( ! empty( $attributes['buttonPosition'] ) && 'button-only' !== $attributes['buttonPosition'] ) {
-			$width_styles = ' style="width: ' . $attributes['width'] . 'px;"';
+			$width_styles = ' style="width: ' . $attributes['width'] . $attributes['widthUnit'] . ';"';
 		}
 	}
 

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -29,7 +29,7 @@ function render_block_core_search( $attributes ) {
 
 	$input_id        = 'wp-block-search__input-' . ++$instance_id;
 	$classnames      = classnames_for_block_core_search( $attributes );
-	$show_label	     = ( ! empty( $attributes['showLabel'] ) ) ? true : false;
+	$show_label      = ( ! empty( $attributes['showLabel'] ) ) ? true : false;
 	$use_icon_button = ( ! empty( $attributes['buttonUseIcon'] ) ) ? true : false;
 	$show_input      = ( ! empty( $attributes['buttonPosition'] ) && 'button-only' === $attributes['buttonPosition'] ) ? false : true;
 	$show_button     = ( ! empty( $attributes['buttonPosition'] ) && 'no-button' === $attributes['buttonPosition'] ) ? false : true;

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -27,18 +27,16 @@ function render_block_core_search( $attributes ) {
 		)
 	);
 
-	$input_id       = 'wp-block-search__input-' . ++$instance_id;
-	$classnames     = classnames_for_block_core_search( $attributes );
-
+	$input_id        = 'wp-block-search__input-' . ++$instance_id;
+	$classnames      = classnames_for_block_core_search( $attributes );
 	$show_label	     = ( ! empty( $attributes['showLabel'] ) ) ? true : false;
 	$use_icon_button = ( ! empty( $attributes['buttonUseIcon'] ) ) ? true : false;
-	$show_input		 = ( ! empty( $attributes['buttonPosition'] ) && 'button-only' == $attributes['buttonPosition'] ) ? false : true;
-	$show_button	 = ( ! empty( $attributes['buttonPosition'] ) && 'no-button' == $attributes['buttonPosition'] ) ? false : true;
-
-	$label_markup   = '';
-	$input_markup	= '';
-	$button_markup  = '';
-	$width_styles   = '';
+	$show_input      = ( ! empty( $attributes['buttonPosition'] ) && 'button-only' === $attributes['buttonPosition'] ) ? false : true;
+	$show_button     = ( ! empty( $attributes['buttonPosition'] ) && 'no-button' === $attributes['buttonPosition'] ) ? false : true;
+	$label_markup    = '';
+	$input_markup    = '';
+	$button_markup   = '';
+	$width_styles    = '';
 
 	if ( $show_label ) {
 		if ( ! empty( $attributes['label'] ) ) {
@@ -120,24 +118,28 @@ add_action( 'init', 'register_block_core_search' );
 
 /**
  * Builds the correct top level classnames for the 'core/search' block.
+ *
+ * @param array $attributes The block attributes.
+ *
+ * @return string The classnames used in the block.
  */
 function classnames_for_block_core_search( $attributes ) {
-	$classnames = [];
+	$classnames = array();
 
 	if ( ! empty( $attributes['buttonPosition'] ) ) {
-		if ( 'button-inside' == $attributes['buttonPosition'] ) {
+		if ( 'button-inside' === $attributes['buttonPosition'] ) {
 			$classnames[] = 'wp-block-search__button-inside';
 		}
 
-		if ( 'button-outside' == $attributes['buttonPosition'] ) {
+		if ( 'button-outside' === $attributes['buttonPosition'] ) {
 			$classnames[] = 'wp-block-search__button-outside';
 		}
 
-		if ( 'no-button' == $attributes['buttonPosition'] ) {
+		if ( 'no-button' === $attributes['buttonPosition'] ) {
 			$classnames[] = 'wp-block-search__no-button';
 		}
 
-		if ( 'button-only' == $attributes['buttonPosition'] ) {
+		if ( 'button-only' === $attributes['buttonPosition'] ) {
 			$classnames[] = 'wp-block-search__button-only';
 		}
 	}

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -1,4 +1,10 @@
 .wp-block-search {
+	.wp-block-search__inside-wrapper {
+		display: flex;
+		flex: auto;
+		flex-wrap: nowrap;
+	}
+
 	.wp-block-search__label {
 		width: 100%;
 	}

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -1,13 +1,11 @@
 .wp-block-search {
-	display: flex;
-	flex-wrap: wrap;
-
 	.wp-block-search__label {
 		width: 100%;
 	}
 
 	.wp-block-search__input {
 		flex-grow: 1;
+		min-width: 50px;
 	}
 
 	.wp-block-search__button {

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -3,6 +3,7 @@
 		display: flex;
 		flex: auto;
 		flex-wrap: nowrap;
+		max-width: 100%;
 	}
 
 	.wp-block-search__label {

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -12,14 +12,16 @@
 	.wp-block-search__input {
 		flex-grow: 1;
 		min-width: 50px;
+		border: 1px solid $dark-gray-200;
 	}
 
 	.wp-block-search__button {
 		margin-left: 0.625em;
+		word-break: normal;
 
 		svg {
-			width: 25px;
-			height: 25px;
+			min-width: 25px;
+			min-height: 25px;
 		}
 	}
 
@@ -28,4 +30,24 @@
 			margin-left: 0;
 		}
 	}
+
+	&.wp-block-search__button-inside .wp-block-search__inside-wrapper {
+		padding: $grid-unit-05;
+		border: 1px solid $dark-gray-200;
+
+		.wp-block-search__input {
+			border-radius: 0;
+			border: none;
+			padding: 0 0 0 4px;
+
+			&:focus {
+				outline: none;
+			}
+		}
+
+		.wp-block-search__button {
+			padding: 2px 8px;
+		}
+	}
 }
+

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -12,7 +12,7 @@
 
 	.wp-block-search__input {
 		flex-grow: 1;
-		min-width: 50px;
+		min-width: 3em;
 		border: 1px solid $dark-gray-200;
 	}
 
@@ -21,8 +21,8 @@
 		word-break: normal;
 
 		svg {
-			min-width: 25px;
-			min-height: 25px;
+			min-width: 1.5em;
+			min-height: 1.5em;
 		}
 	}
 
@@ -47,7 +47,7 @@
 		}
 
 		.wp-block-search__button {
-			padding: 2px 8px;
+			padding: 0.125em 0.5em;
 		}
 	}
 }

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -39,7 +39,7 @@
 		.wp-block-search__input {
 			border-radius: 0;
 			border: none;
-			padding: 0 0 0 4px;
+			padding: 0 0 0 0.25em;
 
 			&:focus {
 				outline: none;

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -16,6 +16,11 @@
 
 	.wp-block-search__button {
 		margin-left: 0.625em;
+
+		svg {
+			width: 25px;
+			height: 25px;
+		}
 	}
 
 	&.wp-block-search__button-only {

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -8,10 +8,15 @@
 
 	.wp-block-search__input {
 		flex-grow: 1;
-		max-width: 22.5em;
 	}
 
 	.wp-block-search__button {
 		margin-left: 0.625em;
+	}
+
+	&.wp-block-search__button-only {
+		.wp-block-search__button {
+			margin-left: 0;
+		}
 	}
 }

--- a/packages/e2e-tests/fixtures/blocks/core__search.json
+++ b/packages/e2e-tests/fixtures/blocks/core__search.json
@@ -4,7 +4,10 @@
         "name": "core/search",
         "isValid": true,
         "attributes": {
-            "placeholder": ""
+            "buttonPosition": "button-outside",
+            "buttonUseIcon": false,
+            "placeholder": "",
+            "showLabel": true
         },
         "innerBlocks": [],
         "originalContent": ""

--- a/packages/e2e-tests/fixtures/blocks/core__search__custom-text.json
+++ b/packages/e2e-tests/fixtures/blocks/core__search__custom-text.json
@@ -4,9 +4,12 @@
         "name": "core/search",
         "isValid": true,
         "attributes": {
+            "buttonPosition": "button-outside",
             "label": "Custom label",
             "placeholder": "Custom placeholder",
-            "buttonText": "Custom button text"
+            "buttonText": "Custom button text",
+            "buttonUseIcon": false,
+            "showLabel": true
         },
         "innerBlocks": [],
         "originalContent": ""


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

Fixes #22071 (partially)
Closes #24643

## Description
Update the search block to support:

* Hiding the search label.
* Switching between a button with text, or an icon.
* Changing the position of the button (outside, inside, button only, no button)
* Resizing the width of the search field.

## How has this been tested?
Tested locally, all e2e tests passed.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

![2020-09-02 11 19 19](https://user-images.githubusercontent.com/1464705/92021211-4ae3f580-ed0e-11ea-81e3-9282c460164b.gif)


## Types of changes
New feature. I have tested upgrading from the previous version of the block, and all settings and visuals remain consistent.

## Testing Instructions
* Insert a search block into a post or page
* Adjust the settings for the block using the block toolbar
* Confirm these settings are saved, and the search block is rendered correctly on the front end.
* Try adding a search block using master, and then switch to this branch and confirm the block still works and looks correct.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
