### PR TITLE
Fix JS error when selecting a category in the QueryControls component

### DIFF
--- a/packages/components/src/query-controls/index.js
+++ b/packages/components/src/query-controls/index.js
@@ -76,6 +76,7 @@ export default function QueryControls( {
 				label={ __( 'Category' ) }
 				noOptionLabel={ __( 'All' ) }
 				selectedCategoryId={ selectedCategoryId }
+				onChange={ onCategoryChange }
 			/>
 		),
 		categorySuggestions && onCategoryChange && (


### PR DESCRIPTION
CategorySelect requires the onChange attribute for avoiding throwing an error message that says: "Uncaught TypeError: onChange is not a function".

## Description
I have added the `onChange` attribute to the `CategorySelected` component used in the `QueryControls` component.

## How has this been tested?
I have changed the definition of the `QueryControls` component on my local environment and used it in the Advanced Gutenberg plugin "Recent Posts" block for testing. The error message is not there anymore when I select categories in the the block settings.

## Types of changes
Bug fix for https://github.com/WordPress/gutenberg/issues/24667, adding the missed `onChange` attribute to the `CategorySelect` component.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
