### PR TITLE
Add block inspector to nav screen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11390,6 +11390,7 @@
 				"@wordpress/hooks": "file:packages/hooks",
 				"@wordpress/html-entities": "file:packages/html-entities",
 				"@wordpress/i18n": "file:packages/i18n",
+				"@wordpress/icons": "file:packages/icons",
 				"@wordpress/keyboard-shortcuts": "file:packages/keyboard-shortcuts",
 				"@wordpress/media-utils": "file:packages/media-utils",
 				"@wordpress/notices": "file:packages/notices",

--- a/packages/edit-navigation/package.json
+++ b/packages/edit-navigation/package.json
@@ -43,6 +43,7 @@
 		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/html-entities": "file:../html-entities",
 		"@wordpress/i18n": "file:../i18n",
+		"@wordpress/icons": "file:../icons",
 		"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
 		"@wordpress/media-utils": "file:../media-utils",
 		"@wordpress/notices": "file:../notices",

--- a/packages/edit-navigation/src/components/navigation-editor/block-editor-area.js
+++ b/packages/edit-navigation/src/components/navigation-editor/block-editor-area.js
@@ -12,6 +12,7 @@ import {
 	NavigableToolbar,
 	ObserveTyping,
 	WritingFlow,
+	BlockInspector,
 } from '@wordpress/block-editor';
 import { useEffect, useState } from '@wordpress/element';
 import {
@@ -21,10 +22,12 @@ import {
 	CardBody,
 	CardFooter,
 	CheckboxControl,
+	Dropdown,
 	Popover,
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { cog } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -96,6 +99,19 @@ export default function BlockEditorArea( {
 				<Button isPrimary onClick={ saveBlocks }>
 					{ __( 'Save navigation' ) }
 				</Button>
+				<Dropdown
+					className="edit-navigation-block-inspector"
+					position="bottom right"
+					renderToggle={ ( { isOpen, onToggle } ) => (
+						<Button
+							icon={ cog }
+							onClick={ onToggle }
+							aria-expanded={ isOpen }
+							label="Block inspector"
+						/>
+					) }
+					renderContent={ () => <BlockInspector /> }
+				/>
 			</CardHeader>
 			<CardBody>
 				<NavigableToolbar

--- a/packages/edit-navigation/src/components/navigation-editor/block-editor-area.js
+++ b/packages/edit-navigation/src/components/navigation-editor/block-editor-area.js
@@ -100,7 +100,7 @@ export default function BlockEditorArea( {
 					{ __( 'Save navigation' ) }
 				</Button>
 				<Dropdown
-					className="edit-navigation-block-inspector"
+					className="edit-navigation-editor__block-inspector"
 					position="bottom right"
 					renderToggle={ ( { isOpen, onToggle } ) => (
 						<Button

--- a/packages/edit-navigation/src/components/navigation-editor/style.scss
+++ b/packages/edit-navigation/src/components/navigation-editor/style.scss
@@ -111,7 +111,7 @@
 	border-top: 1px solid $gray-200;
 }
 
-.edit-navigation-block-inspector {
+.edit-navigation-editor__block-inspector {
 	.components-button {
 		margin-left: $grid-unit-20;
 

--- a/packages/edit-navigation/src/components/navigation-editor/style.scss
+++ b/packages/edit-navigation/src/components/navigation-editor/style.scss
@@ -110,3 +110,14 @@
 	text-align: left;
 	border-top: 1px solid $gray-200;
 }
+
+.edit-navigation-block-inspector {
+	.components-button {
+		margin-left: $grid-unit-20;
+
+		&[aria-expanded="true"] {
+			color: $white;
+			background-color: $gray-900;
+		}
+	}
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

Closes #23934 

Adds block inspector to Navigation screen, inside a dropdown.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Tested in browser and checked keyboard navigation.

## Screenshots <!-- if applicable -->

<img width="753" alt="Screen Shot 2020-08-20 at 11 48 46 am" src="https://user-images.githubusercontent.com/8096000/90707548-2f72f680-e2db-11ea-8946-aa93f35a5ac1.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
