### PR TITLE
Navigation: Add Post, Page, Category and Tag variations to Link

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -76,19 +76,21 @@ import { ViewerFill } from './viewer-slot';
 /**
  * @typedef WPLinkControlProps
  *
- * @property {(WPLinkControlSetting[])=}            settings               An array of settings objects. Each object will used to
- *                                                                         render a `ToggleControl` for that setting.
- * @property {boolean=}                             forceIsEditingLink     If passed as either `true` or `false`, controls the
- *                                                                         internal editing state of the component to respective
- *                                                                         show or not show the URL input field.
- * @property {WPLinkControlValue=}                  value                  Current link value.
- * @property {WPLinkControlOnChangeProp=}           onChange               Value change handler, called with the updated value if
- *                                                                         the user selects a new link or updates settings.
- * @property {boolean=}                             noDirectEntry          Whether to disable direct entries or not.
- * @property {boolean=}                             showSuggestions        Whether to present suggestions when typing the URL.
- * @property {boolean=}                             showInitialSuggestions Whether to present initial suggestions immediately.
- * @property {boolean=}                             withCreateSuggestion   Whether to allow creation of link value from suggestion.
- * @property {Object=}                              suggestionsQuery       Query parameters to pass along to wp.blockEditor.__experimentalFetchLinkSuggestions.
+ * @property {(WPLinkControlSetting[])=}  settings                   An array of settings objects. Each object will used to
+ *                                                                   render a `ToggleControl` for that setting.
+ * @property {boolean=}                   forceIsEditingLink         If passed as either `true` or `false`, controls the
+ *                                                                   internal editing state of the component to respective
+ *                                                                   show or not show the URL input field.
+ * @property {WPLinkControlValue=}        value                      Current link value.
+ * @property {WPLinkControlOnChangeProp=} onChange                   Value change handler, called with the updated value if
+ *                                                                   the user selects a new link or updates settings.
+ * @property {boolean=}                   noDirectEntry              Whether to disable direct entries or not.
+ * @property {boolean=}                   showSuggestions            Whether to present suggestions when typing the URL.
+ * @property {boolean=}                   showInitialSuggestions     Whether to present initial suggestions immediately.
+ * @property {boolean=}                   withCreateSuggestion       Whether to allow creation of link value from suggestion.
+ * @property {Object=}                    suggestionsQuery           Query parameters to pass along to wp.blockEditor.__experimentalFetchLinkSuggestions.
+ * @property {boolean=}                   noURLSuggestion            Whether to disable suggesting the search query as a URL.
+ * @property {string|Function|undefined}  createSuggestionButtonText Text to use in the button that creates a suggestion.
  */
 
 /**
@@ -111,6 +113,8 @@ function LinkControl( {
 	withCreateSuggestion,
 	inputValue: propInputValue = '',
 	suggestionsQuery = {},
+	noURLSuggestion = false,
+	createSuggestionButtonText,
 } ) {
 	if ( withCreateSuggestion === undefined && createSuggestion ) {
 		withCreateSuggestion = true;
@@ -212,6 +216,10 @@ function LinkControl( {
 							allowDirectEntry={ ! noDirectEntry }
 							showSuggestions={ showSuggestions }
 							suggestionsQuery={ suggestionsQuery }
+							withURLSuggestion={ ! noURLSuggestion }
+							createSuggestionButtonText={
+								createSuggestionButtonText
+							}
 						>
 							<div className="block-editor-link-control__search-actions">
 								<Button

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -84,13 +84,13 @@ import { ViewerFill } from './viewer-slot';
  * @property {WPLinkControlValue=}        value                      Current link value.
  * @property {WPLinkControlOnChangeProp=} onChange                   Value change handler, called with the updated value if
  *                                                                   the user selects a new link or updates settings.
- * @property {boolean=}                   noDirectEntry              Whether to disable direct entries or not.
+ * @property {boolean=}                   noDirectEntry              Whether to allow turning a URL-like search query directly into a link.
  * @property {boolean=}                   showSuggestions            Whether to present suggestions when typing the URL.
  * @property {boolean=}                   showInitialSuggestions     Whether to present initial suggestions immediately.
  * @property {boolean=}                   withCreateSuggestion       Whether to allow creation of link value from suggestion.
  * @property {Object=}                    suggestionsQuery           Query parameters to pass along to wp.blockEditor.__experimentalFetchLinkSuggestions.
- * @property {boolean=}                   noURLSuggestion            Whether to disable suggesting the search query as a URL.
- * @property {string|Function|undefined}  createSuggestionButtonText Text to use in the button that creates a suggestion.
+ * @property {boolean=}                   noURLSuggestion            Whether to add a fallback suggestion which treats the search query as a URL.
+ * @property {string|Function|undefined}  createSuggestionButtonText The text to use in the button that calls createSuggestion.
  */
 
 /**

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -88,6 +88,7 @@ import { ViewerFill } from './viewer-slot';
  * @property {boolean=}                             showSuggestions        Whether to present suggestions when typing the URL.
  * @property {boolean=}                             showInitialSuggestions Whether to present initial suggestions immediately.
  * @property {boolean=}                             withCreateSuggestion   Whether to allow creation of link value from suggestion.
+ * @property {Object=}                              suggestionsQuery       Query parameters to pass along to wp.blockEditor.__experimentalFetchLinkSuggestions.
  */
 
 /**
@@ -109,6 +110,7 @@ function LinkControl( {
 	createSuggestion,
 	withCreateSuggestion,
 	inputValue: propInputValue = '',
+	suggestionsQuery = {},
 } ) {
 	if ( withCreateSuggestion === undefined && createSuggestion ) {
 		withCreateSuggestion = true;
@@ -209,6 +211,7 @@ function LinkControl( {
 							showInitialSuggestions={ showInitialSuggestions }
 							allowDirectEntry={ ! noDirectEntry }
 							showSuggestions={ showSuggestions }
+							suggestionsQuery={ suggestionsQuery }
 						>
 							<div className="block-editor-link-control__search-actions">
 								<Button

--- a/packages/block-editor/src/components/link-control/search-create-button.js
+++ b/packages/block-editor/src/components/link-control/search-create-button.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { isFunction } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -15,9 +16,24 @@ export const LinkControlSearchCreate = ( {
 	onClick,
 	itemProps,
 	isSelected,
+	buttonText,
 } ) => {
 	if ( ! searchTerm ) {
 		return null;
+	}
+
+	let text;
+	if ( buttonText ) {
+		text = isFunction( buttonText ) ? buttonText( searchTerm ) : buttonText;
+	} else {
+		text = createInterpolateElement(
+			sprintf(
+				/* translators: %s: search term. */
+				__( 'Create: <mark>%s</mark>' ),
+				searchTerm
+			),
+			{ mark: <mark /> }
+		);
 	}
 
 	return (
@@ -38,14 +54,7 @@ export const LinkControlSearchCreate = ( {
 
 			<span className="block-editor-link-control__search-item-header">
 				<span className="block-editor-link-control__search-item-title">
-					{ createInterpolateElement(
-						sprintf(
-							/* translators: %s: search term. */
-							__( 'New page: <mark>%s</mark>' ),
-							searchTerm
-						),
-						{ mark: <mark /> }
-					) }
+					{ text }
 				</span>
 			</span>
 		</Button>

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -38,10 +38,12 @@ const LinkControlSearchInput = forwardRef(
 			fetchSuggestions = null,
 			allowDirectEntry = true,
 			showInitialSuggestions = false,
+			suggestionsQuery = {},
 		},
 		ref
 	) => {
 		const genericSearchHandler = useSearchHandler(
+			suggestionsQuery,
 			allowDirectEntry,
 			withCreateSuggestion
 		);

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -39,13 +39,16 @@ const LinkControlSearchInput = forwardRef(
 			allowDirectEntry = true,
 			showInitialSuggestions = false,
 			suggestionsQuery = {},
+			withURLSuggestion = true,
+			createSuggestionButtonText,
 		},
 		ref
 	) => {
 		const genericSearchHandler = useSearchHandler(
 			suggestionsQuery,
 			allowDirectEntry,
-			withCreateSuggestion
+			withCreateSuggestion,
+			withURLSuggestion
 		);
 		const searchHandler = showSuggestions
 			? fetchSuggestions || genericSearchHandler
@@ -77,6 +80,7 @@ const LinkControlSearchInput = forwardRef(
 				instanceId,
 				withCreateSuggestion,
 				currentInputValue: value,
+				createSuggestionButtonText,
 				handleSuggestionClick: ( suggestion ) => {
 					if ( props.handleSuggestionClick ) {
 						props.handleSuggestionClick( suggestion );

--- a/packages/block-editor/src/components/link-control/search-item.js
+++ b/packages/block-editor/src/components/link-control/search-item.js
@@ -56,7 +56,8 @@ export const LinkControlSearchItem = ( {
 			</span>
 			{ suggestion.type && (
 				<span className="block-editor-link-control__search-item-type">
-					{ suggestion.type }
+					{ /* Rename 'post_tag' to 'tag'. Ideally, the API would return the localised CPT or taxonomy label. */ }
+					{ suggestion.type === 'post_tag' ? 'tag' : suggestion.type }
 				</span>
 			) }
 		</Button>

--- a/packages/block-editor/src/components/link-control/search-results.js
+++ b/packages/block-editor/src/components/link-control/search-results.js
@@ -28,6 +28,7 @@ export default function LinkControlSearchResults( {
 	selectedSuggestion,
 	isLoading,
 	isInitialSuggestions,
+	createSuggestionButtonText,
 } ) {
 	const resultsListClasses = classnames(
 		'block-editor-link-control__search-results',
@@ -87,6 +88,7 @@ export default function LinkControlSearchResults( {
 						return (
 							<LinkControlSearchCreate
 								searchTerm={ currentInputValue }
+								buttonText={ createSuggestionButtonText }
 								onClick={ () =>
 									handleSuggestionClick( suggestion )
 								}

--- a/packages/block-editor/src/components/link-control/test/fixtures/index.js
+++ b/packages/block-editor/src/components/link-control/test/fixtures/index.js
@@ -38,10 +38,10 @@ export const fauxEntitySuggestions = [
 /* eslint-disable no-unused-vars */
 export const fetchFauxEntitySuggestions = (
 	val = '',
-	{ perPage = null } = {}
+	{ isInitialSuggestions } = {}
 ) => {
-	const suggestions = perPage
-		? take( fauxEntitySuggestions, perPage )
+	const suggestions = isInitialSuggestions
+		? take( fauxEntitySuggestions, 3 )
 		: fauxEntitySuggestions;
 	return Promise.resolve( suggestions );
 };

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -725,7 +725,7 @@ describe( 'Creating Entities (eg: Posts, Pages)', () => {
 
 			const createButton = first(
 				Array.from( searchResultElements ).filter( ( result ) =>
-					result.innerHTML.includes( 'New page' )
+					result.innerHTML.includes( 'Create:' )
 				)
 			);
 
@@ -822,7 +822,7 @@ describe( 'Creating Entities (eg: Posts, Pages)', () => {
 
 		const createButton = first(
 			Array.from( searchResultElements ).filter( ( result ) =>
-				result.innerHTML.includes( 'New page' )
+				result.innerHTML.includes( 'Create:' )
 			)
 		);
 
@@ -895,7 +895,7 @@ describe( 'Creating Entities (eg: Posts, Pages)', () => {
 		const form = container.querySelector( 'form' );
 		const createButton = first(
 			Array.from( searchResultElements ).filter( ( result ) =>
-				result.innerHTML.includes( 'New page' )
+				result.innerHTML.includes( 'Create:' )
 			)
 		);
 
@@ -949,7 +949,7 @@ describe( 'Creating Entities (eg: Posts, Pages)', () => {
 				);
 				const createButton = first(
 					Array.from( searchResultElements ).filter( ( result ) =>
-						result.innerHTML.includes( 'New page' )
+						result.innerHTML.includes( 'Create:' )
 					)
 				);
 
@@ -1074,7 +1074,7 @@ describe( 'Creating Entities (eg: Posts, Pages)', () => {
 			);
 			let createButton = first(
 				Array.from( searchResultElements ).filter( ( result ) =>
-					result.innerHTML.includes( 'New page' )
+					result.innerHTML.includes( 'Create:' )
 				)
 			);
 

--- a/packages/block-editor/src/components/link-control/use-search-handler.js
+++ b/packages/block-editor/src/components/link-control/use-search-handler.js
@@ -50,8 +50,11 @@ const handleEntitySearch = async (
 	suggestionsQuery,
 	fetchSearchSuggestions,
 	directEntryHandler,
-	withCreateSuggestion
+	withCreateSuggestion,
+	withURLSuggestion
 ) => {
+	const { isInitialSuggestions } = suggestionsQuery;
+
 	let results = await Promise.all( [
 		fetchSearchSuggestions( val, suggestionsQuery ),
 		directEntryHandler( val ),
@@ -62,13 +65,14 @@ const handleEntitySearch = async (
 	// If it's potentially a URL search then concat on a URL search suggestion
 	// just for good measure. That way once the actual results run out we always
 	// have a URL option to fallback on.
-	results =
-		couldBeURL && ! suggestionsQuery.isInitialSuggestions
-			? results[ 0 ].concat( results[ 1 ] )
-			: results[ 0 ];
+	if ( couldBeURL && withURLSuggestion && ! isInitialSuggestions ) {
+		results = results[ 0 ].concat( results[ 1 ] );
+	} else {
+		results = results[ 0 ];
+	}
 
 	// If displaying initial suggestions just return plain results.
-	if ( suggestionsQuery.isInitialSuggestions ) {
+	if ( isInitialSuggestions ) {
 		return results;
 	}
 
@@ -101,7 +105,8 @@ const handleEntitySearch = async (
 export default function useSearchHandler(
 	suggestionsQuery,
 	allowDirectEntry,
-	withCreateSuggestion
+	withCreateSuggestion,
+	withURLSuggestion
 ) {
 	const { fetchSearchSuggestions } = useSelect( ( select ) => {
 		const { getSettings } = select( 'core/block-editor' );
@@ -124,7 +129,8 @@ export default function useSearchHandler(
 						{ ...suggestionsQuery, isInitialSuggestions },
 						fetchSearchSuggestions,
 						directEntryHandler,
-						withCreateSuggestion
+						withCreateSuggestion,
+						withURLSuggestion
 				  );
 		},
 		[ directEntryHandler, fetchSearchSuggestions, withCreateSuggestion ]

--- a/packages/block-editor/src/components/link-control/use-search-handler.js
+++ b/packages/block-editor/src/components/link-control/use-search-handler.js
@@ -45,17 +45,15 @@ export const handleDirectEntry = ( val ) => {
 	] );
 };
 
-export const handleEntitySearch = async (
+const handleEntitySearch = async (
 	val,
-	args,
+	suggestionsQuery,
 	fetchSearchSuggestions,
 	directEntryHandler,
 	withCreateSuggestion
 ) => {
 	let results = await Promise.all( [
-		fetchSearchSuggestions( val, {
-			...( args.isInitialSuggestions ? { perPage: 3 } : {} ),
-		} ),
+		fetchSearchSuggestions( val, suggestionsQuery ),
 		directEntryHandler( val ),
 	] );
 
@@ -65,12 +63,12 @@ export const handleEntitySearch = async (
 	// just for good measure. That way once the actual results run out we always
 	// have a URL option to fallback on.
 	results =
-		couldBeURL && ! args.isInitialSuggestions
+		couldBeURL && ! suggestionsQuery.isInitialSuggestions
 			? results[ 0 ].concat( results[ 1 ] )
 			: results[ 0 ];
 
 	// If displaying initial suggestions just return plain results.
-	if ( args.isInitialSuggestions ) {
+	if ( suggestionsQuery.isInitialSuggestions ) {
 		return results;
 	}
 
@@ -101,6 +99,7 @@ export const handleEntitySearch = async (
 };
 
 export default function useSearchHandler(
+	suggestionsQuery,
 	allowDirectEntry,
 	withCreateSuggestion
 ) {
@@ -117,12 +116,12 @@ export default function useSearchHandler(
 		: handleNoop;
 
 	return useCallback(
-		( val, args ) => {
+		( val, { isInitialSuggestions } ) => {
 			return isURLLike( val )
-				? directEntryHandler( val, args )
+				? directEntryHandler( val, { isInitialSuggestions } )
 				: handleEntitySearch(
 						val,
-						args,
+						{ ...suggestionsQuery, isInitialSuggestions },
 						fetchSearchSuggestions,
 						directEntryHandler,
 						withCreateSuggestion

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -92,6 +92,27 @@ const useIsDraggingWithin = ( elementRef ) => {
 	return isDraggingWithin;
 };
 
+/**
+ * Given the Link block's type attribute, return the query params to give to
+ * /wp/v2/search.
+ *
+ * @param {string} type Link block's type attribute.
+ * @return {{ type?: string, subtype?: string }} Search query params.
+ */
+function getSuggestionsQuery( type ) {
+	switch ( type ) {
+		case 'post':
+		case 'page':
+			return { type: 'post', subtype: type };
+		case 'category':
+			return { type: 'term', subtype: 'category' };
+		case 'tag':
+			return { type: 'term', subtype: 'post_tag' };
+		default:
+			return {};
+	}
+}
+
 function NavigationLinkEdit( {
 	attributes,
 	hasDescendants,
@@ -111,7 +132,7 @@ function NavigationLinkEdit( {
 	mergeBlocks,
 	onReplace,
 } ) {
-	const { label, opensInNewTab, url, description, rel } = attributes;
+	const { label, type, opensInNewTab, url, description, rel } = attributes;
 	const link = {
 		url,
 		opensInNewTab,
@@ -179,8 +200,7 @@ function NavigationLinkEdit( {
 	}
 
 	async function handleCreatePage( pageTitle ) {
-		const type = 'page';
-		const page = await saveEntityRecord( 'postType', type, {
+		const page = await saveEntityRecord( 'postType', 'page', {
 			title: pageTitle,
 			status: 'publish',
 		} );
@@ -300,6 +320,7 @@ function NavigationLinkEdit( {
 								showInitialSuggestions={ true }
 								withCreateSuggestion={ userCanCreatePages }
 								createSuggestion={ handleCreatePage }
+								suggestionsQuery={ getSuggestionsQuery( type ) }
 								onChange={ ( {
 									title: newTitle = '',
 									url: newURL = '',

--- a/packages/block-library/src/navigation-link/index.js
+++ b/packages/block-library/src/navigation-link/index.js
@@ -18,16 +18,56 @@ export { metadata, name };
 
 export const settings = {
 	title: __( 'Link' ),
+
 	icon,
+
 	description: __( 'Add a page, link, or another item to your navigation.' ),
+
+	variations: [
+		{
+			name: 'link',
+			isDefault: true,
+			title: __( 'Link' ),
+			description: __( 'A link to a URL.' ),
+			attributes: {},
+		},
+		{
+			name: 'post',
+			title: __( 'Post' ),
+			description: __( 'A link to a post.' ),
+			attributes: { type: 'post' },
+		},
+		{
+			name: 'page',
+			title: __( 'Page' ),
+			description: __( 'A link to a page.' ),
+			attributes: { type: 'page' },
+		},
+		{
+			name: 'category',
+			title: __( 'Category' ),
+			description: __( 'A link to a category.' ),
+			attributes: { type: 'category' },
+		},
+		{
+			name: 'tag',
+			title: __( 'Tag' ),
+			description: __( 'A link to a tag.' ),
+			attributes: { type: 'tag' },
+		},
+	],
+
 	__experimentalLabel: ( { label } ) => label,
+
 	merge( leftAttributes, { label: rightLabel = '' } ) {
 		return {
 			...leftAttributes,
 			label: leftAttributes.label + rightLabel,
 		};
 	},
+
 	edit,
+
 	save,
 
 	deprecated: [

--- a/packages/block-library/src/navigation-link/index.js
+++ b/packages/block-library/src/navigation-link/index.js
@@ -2,7 +2,13 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { mapMarker as icon } from '@wordpress/icons';
+import {
+	category as categoryIcon,
+	mapMarker as linkIcon,
+	page as pageIcon,
+	postTitle as postIcon,
+	tag as tagIcon,
+} from '@wordpress/icons';
 import { InnerBlocks } from '@wordpress/block-editor';
 
 /**
@@ -19,7 +25,7 @@ export { metadata, name };
 export const settings = {
 	title: __( 'Link' ),
 
-	icon,
+	icon: linkIcon,
 
 	description: __( 'Add a page, link, or another item to your navigation.' ),
 
@@ -33,25 +39,29 @@ export const settings = {
 		},
 		{
 			name: 'post',
-			title: __( 'Post' ),
+			icon: postIcon,
+			title: __( 'Post Link' ),
 			description: __( 'A link to a post.' ),
 			attributes: { type: 'post' },
 		},
 		{
 			name: 'page',
-			title: __( 'Page' ),
+			icon: pageIcon,
+			title: __( 'Page Link' ),
 			description: __( 'A link to a page.' ),
 			attributes: { type: 'page' },
 		},
 		{
 			name: 'category',
-			title: __( 'Category' ),
+			icon: categoryIcon,
+			title: __( 'Category Link' ),
 			description: __( 'A link to a category.' ),
 			attributes: { type: 'category' },
 		},
 		{
 			name: 'tag',
-			title: __( 'Tag' ),
+			icon: tagIcon,
+			title: __( 'Tag Link' ),
 			description: __( 'A link to a tag.' ),
 			attributes: { type: 'tag' },
 		},

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useRef } from '@wordpress/element';
+import { useRef, useState } from '@wordpress/element';
 import {
 	InnerBlocks,
 	InspectorControls,
@@ -48,7 +48,13 @@ function Navigation( {
 	// HOOKS
 	//
 	const ref = useRef();
+
+	const [ isPlaceholderShown, setIsPlaceholderShown ] = useState(
+		! hasExistingNavItems
+	);
+
 	const { selectBlock } = useDispatch( 'core/block-editor' );
+
 	const { TextColor, BackgroundColor, ColorPanel } = __experimentalUseColors(
 		[
 			{ name: 'textColor', property: 'color' },
@@ -85,13 +91,17 @@ function Navigation( {
 		};
 	}
 
-	// If we don't have existing items then show the Placeholder
-	if ( ! hasExistingNavItems ) {
+	//
+	// RENDER
+	//
+
+	if ( isPlaceholderShown ) {
 		return (
 			<Block.div>
 				<NavigationPlaceholder
 					ref={ ref }
 					onCreate={ ( blocks, selectNavigationBlock ) => {
+						setIsPlaceholderShown( false );
 						updateInnerBlocks( blocks );
 						if ( selectNavigationBlock ) {
 							selectBlock( clientId );
@@ -107,7 +117,6 @@ function Navigation( {
 		'is-vertical': attributes.orientation === 'vertical',
 	} );
 
-	// UI State: rendered Block UI
 	return (
 		<>
 			<BlockControls>

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -28,6 +28,11 @@ $navigation-item-height: 46px;
 	padding: $grid-unit-20;
 }
 
+// Ensure that an empty block has space around the appender.
+.wp-block-navigation__container {
+	min-height: $navigation-item-height;
+}
+
 // Ensure sub-menus stay open and visible when a nested block is selected.
 .wp-block-navigation__container.is-parent-of-selected-block {
 	visibility: visible;

--- a/packages/block-library/src/navigation/placeholder.js
+++ b/packages/block-library/src/navigation/placeholder.js
@@ -245,8 +245,7 @@ function NavigationPlaceholder( { onCreate }, ref ) {
 	const createFromMenu = useCallback( () => {
 		// If an empty menu was selected, create an empty block.
 		if ( ! menuItems.length ) {
-			const blocks = [ createBlock( 'core/navigation-link' ) ];
-			onCreate( blocks );
+			onCreate( [] );
 			return;
 		}
 
@@ -263,8 +262,7 @@ function NavigationPlaceholder( { onCreate }, ref ) {
 		const { key } = selectedCreateOption;
 		switch ( key ) {
 			case CREATE_EMPTY_OPTION_VALUE: {
-				const blocks = [ createBlock( 'core/navigation-link' ) ];
-				onCreate( blocks );
+				onCreate( [] );
 				return;
 			}
 

--- a/packages/e2e-tests/specs/experiments/__snapshots__/navigation.test.js.snap
+++ b/packages/e2e-tests/specs/experiments/__snapshots__/navigation.test.js.snap
@@ -36,11 +36,7 @@ exports[`Navigation Creating from existing Menus allows a navigation block to be
 <!-- /wp:navigation -->"
 `;
 
-exports[`Navigation Creating from existing Menus creates an empty navigation block when the selected existing menu is also empty 1`] = `
-"<!-- wp:navigation {\\"orientation\\":\\"horizontal\\"} -->
-<!-- wp:navigation-link /-->
-<!-- /wp:navigation -->"
-`;
+exports[`Navigation Creating from existing Menus creates an empty navigation block when the selected existing menu is also empty 1`] = `"<!-- wp:navigation {\\"orientation\\":\\"horizontal\\"} /-->"`;
 
 exports[`Navigation Creating from existing Menus does not display option to create from existing menus if there are no menus 1`] = `"<!-- wp:navigation {\\"orientation\\":\\"horizontal\\"} /-->"`;
 

--- a/packages/e2e-tests/specs/experiments/navigation.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation.test.js
@@ -249,6 +249,17 @@ async function createEmptyNavBlock() {
 	await clickCreateButton();
 }
 
+async function addLinkBlock() {
+	// Using 'click' here checks for regressions of https://github.com/WordPress/gutenberg/issues/18329,
+	// an issue where the block appender requires two clicks.
+	await page.click( '.wp-block-navigation .block-list-appender' );
+
+	const [ linkButton ] = await page.$x(
+		"//*[contains(@class, 'block-editor-inserter__quick-inserter')]//*[text()='Link']"
+	);
+	await linkButton.click();
+}
+
 beforeEach( async () => {
 	await createNewPost();
 } );
@@ -364,8 +375,7 @@ describe( 'Navigation', () => {
 			);
 
 			// Assert an empty Nav Block is created.
-			// We expect 1 here because a "placeholder" Nav Item Block is automatically inserted
-			expect( navBlockItemsLength ).toEqual( 1 );
+			expect( navBlockItemsLength ).toEqual( 0 );
 
 			// Snapshot should contain the mocked menu items.
 			expect( await getEditedPostContent() ).toMatchSnapshot();
@@ -410,7 +420,9 @@ describe( 'Navigation', () => {
 
 		await createEmptyNavBlock();
 
-		// Add a link to the default Link block.
+		await addLinkBlock();
+
+		// Add a link to the Link block.
 		await updateActiveNavigationLink( {
 			url: 'https://wordpress.org',
 			label: 'WP',
@@ -419,16 +431,7 @@ describe( 'Navigation', () => {
 
 		await showBlockToolbar();
 
-		// Add another block.
-		// Using 'click' here checks for regressions of https://github.com/WordPress/gutenberg/issues/18329,
-		// an issue where the block appender requires two clicks.
-		await page.click( '.wp-block-navigation .block-list-appender' );
-
-		// Select a Link block.
-		const [ linkButton ] = await page.$x(
-			"//*[contains(@class, 'block-editor-inserter__quick-inserter')]//*[text()='Link']"
-		);
-		await linkButton.click();
+		await addLinkBlock();
 
 		// After adding a new block, search input should be shown immediately.
 		// Verify that Escape would close the popover.
@@ -495,6 +498,8 @@ describe( 'Navigation', () => {
 
 		// Create an empty nav block.
 		await createEmptyNavBlock();
+
+		await addLinkBlock();
 
 		// Wait for URL input to be focused
 		await page.waitForSelector(

--- a/packages/edit-navigation/src/index.js
+++ b/packages/edit-navigation/src/index.js
@@ -34,53 +34,69 @@ function disableInsertingNonNavigationBlocks( settings, name ) {
 /**
  * Fetches link suggestions from the API. This function is an exact copy of a function found at:
  *
- * wordpress/editor/src/components/provider/index.js
+ * packages/editor/src/components/provider/index.js
  *
  * It seems like there is no suitable package to import this from. Ideally it would be either part of core-data.
  * Until we refactor it, just copying the code is the simplest solution.
  *
  * @param {string} search
  * @param {Object} [searchArguments]
- * @param {number} [searchArguments.perPage=20]
+ * @param {number} [searchArguments.isInitialSuggestions]
+ * @param {number} [searchArguments.type]
+ * @param {number} [searchArguments.subtype]
  * @param {Object} [editorSettings]
  * @param {boolean} [editorSettings.disablePostFormats=false]
  * @return {Promise<Object[]>} List of suggestions
  */
 const fetchLinkSuggestions = (
 	search,
-	{ perPage = 20 } = {},
+	{ isInitialSuggestions, type, subtype } = {},
 	{ disablePostFormats = false } = {}
 ) => {
-	const posts = apiFetch( {
-		path: addQueryArgs( '/wp/v2/search', {
-			search,
-			per_page: perPage,
-			type: 'post',
-		} ),
-	} );
+	const perPage = isInitialSuggestions ? 3 : 20;
 
-	const terms = apiFetch( {
-		path: addQueryArgs( '/wp/v2/search', {
-			search,
-			per_page: perPage,
-			type: 'term',
-		} ),
-	} );
+	const queries = [];
 
-	let formats;
-	if ( disablePostFormats ) {
-		formats = Promise.resolve( [] );
-	} else {
-		formats = apiFetch( {
-			path: addQueryArgs( '/wp/v2/search', {
-				search,
-				per_page: perPage,
-				type: 'post-format',
-			} ),
-		} );
+	if ( ! type || type === 'post' ) {
+		queries.push(
+			apiFetch( {
+				path: addQueryArgs( '/wp/v2/search', {
+					search,
+					per_page: perPage,
+					type: 'post',
+					subtype,
+				} ),
+			} )
+		);
 	}
 
-	return Promise.all( [ posts, terms, formats ] ).then( ( results ) => {
+	if ( ! type || type === 'term' ) {
+		queries.push(
+			apiFetch( {
+				path: addQueryArgs( '/wp/v2/search', {
+					search,
+					per_page: perPage,
+					type: 'term',
+					subtype,
+				} ),
+			} )
+		);
+	}
+
+	if ( ! disablePostFormats && ( ! type || type === 'post-format' ) ) {
+		queries.push(
+			apiFetch( {
+				path: addQueryArgs( '/wp/v2/search', {
+					search,
+					per_page: perPage,
+					type: 'post-format',
+					subtype,
+				} ),
+			} )
+		);
+	}
+
+	return Promise.all( queries ).then( ( results ) => {
 		return map( flatten( results ).slice( 0, perPage ), ( result ) => ( {
 			id: result.id,
 			url: result.url,

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -32,53 +32,69 @@ import ConvertToGroupButtons from '../convert-to-group-buttons';
 /**
  * Fetches link suggestions from the API. This function is an exact copy of a function found at:
  *
- * wordpress/editor/src/components/provider/index.js
+ * packages/edit-navigation/src/index.js
  *
  * It seems like there is no suitable package to import this from. Ideally it would be either part of core-data.
  * Until we refactor it, just copying the code is the simplest solution.
  *
  * @param {string} search
  * @param {Object} [searchArguments]
- * @param {number} [searchArguments.perPage=20]
+ * @param {number} [searchArguments.isInitialSuggestions]
+ * @param {number} [searchArguments.type]
+ * @param {number} [searchArguments.subtype]
  * @param {Object} [editorSettings]
  * @param {boolean} [editorSettings.disablePostFormats=false]
  * @return {Promise<Object[]>} List of suggestions
  */
 const fetchLinkSuggestions = (
 	search,
-	{ perPage = 20 } = {},
+	{ isInitialSuggestions, type, subtype } = {},
 	{ disablePostFormats = false } = {}
 ) => {
-	const posts = apiFetch( {
-		path: addQueryArgs( '/wp/v2/search', {
-			search,
-			per_page: perPage,
-			type: 'post',
-		} ),
-	} );
+	const perPage = isInitialSuggestions ? 3 : 20;
 
-	const terms = apiFetch( {
-		path: addQueryArgs( '/wp/v2/search', {
-			search,
-			per_page: perPage,
-			type: 'term',
-		} ),
-	} );
+	const queries = [];
 
-	let formats;
-	if ( disablePostFormats ) {
-		formats = Promise.resolve( [] );
-	} else {
-		formats = apiFetch( {
-			path: addQueryArgs( '/wp/v2/search', {
-				search,
-				per_page: perPage,
-				type: 'post-format',
-			} ),
-		} );
+	if ( ! type || type === 'post' ) {
+		queries.push(
+			apiFetch( {
+				path: addQueryArgs( '/wp/v2/search', {
+					search,
+					per_page: perPage,
+					type: 'post',
+					subtype,
+				} ),
+			} )
+		);
 	}
 
-	return Promise.all( [ posts, terms, formats ] ).then( ( results ) => {
+	if ( ! type || type === 'term' ) {
+		queries.push(
+			apiFetch( {
+				path: addQueryArgs( '/wp/v2/search', {
+					search,
+					per_page: perPage,
+					type: 'term',
+					subtype,
+				} ),
+			} )
+		);
+	}
+
+	if ( ! disablePostFormats && ( ! type || type === 'post-format' ) ) {
+		queries.push(
+			apiFetch( {
+				path: addQueryArgs( '/wp/v2/search', {
+					search,
+					per_page: perPage,
+					type: 'post-format',
+					subtype,
+				} ),
+			} )
+		);
+	}
+
+	return Promise.all( queries ).then( ( results ) => {
 		return map( flatten( results ).slice( 0, perPage ), ( result ) => ( {
 			id: result.id,
 			url: result.url,


### PR DESCRIPTION
Closes #22919. ~Requires #22600.~ Split out from #24613.

![nav-variations](https://user-images.githubusercontent.com/612155/90710862-a19b0980-e2e2-11ea-9442-f6a0714bc7b3.gif)

Adds Post, Page, Category and Tag variations to the Navigation Link block. Each variation sets the `type` attribute which in turn causes `LinkControl` to filter its results using the `/wp/v2/search` endpoint's `type` and `subtype` params.

~This PR requires #22600 which adds the ability to search for categories and triages using the search endpoint. Do not merge this PR until #22600 is merged and this PR's base is updated.~

### How to test

1. Ensure that your site has some posts, pages, categories and tags.
1. Create a Navigation block.
1. Add a Link block. You should be able to search for posts, pages, categories and tags.
1. Add a Page block. You should only be able to search for posts.
1. ...and so on for Post, Category and Tag.