### PR TITLE
Navigation: Fix creating Navigation from pages or menu with HTML in title

### DIFF
--- a/lib/class-wp-rest-menu-items-controller.php
+++ b/lib/class-wp-rest-menu-items-controller.php
@@ -569,9 +569,15 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 		if ( in_array( 'title', $fields, true ) ) {
 			add_filter( 'protected_title_format', array( $this, 'protected_title_format' ) );
 
+			/** This filter is documented in wp-includes/post-template.php */
+			$title = apply_filters( 'the_title', $menu_item->title, $menu_item->ID );
+
+			/** This filter is documented in wp-includes/class-walker-nav-menu.php */
+			$title = apply_filters( 'nav_menu_item_title', $title, $menu_item, null, 0 );
+
 			$data['title'] = array(
-				'raw'      => $menu_item->post_title,
-				'rendered' => $menu_item->title,
+				'raw'      => $menu_item->title,
+				'rendered' => $title,
 			);
 
 			remove_filter( 'protected_title_format', array( $this, 'protected_title_format' ) );

--- a/packages/block-library/src/navigation/placeholder.js
+++ b/packages/block-library/src/navigation/placeholder.js
@@ -1,8 +1,6 @@
 /**
  * External dependencies
  */
-
-import { escape } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -93,9 +91,7 @@ function mapMenuItemsToBlocks( nodes ) {
 				type,
 				id,
 				url,
-				label: ! title.rendered
-					? __( '(no title)' )
-					: escape( title.rendered ),
+				label: ! title.rendered ? __( '(no title)' ) : title.rendered,
 				opensInNewTab: false,
 			},
 			innerBlocks
@@ -136,9 +132,7 @@ function convertPagesToBlocks( pages ) {
 			type,
 			id,
 			url,
-			label: ! title.rendered
-				? __( '(no title)' )
-				: escape( title.rendered ),
+			label: ! title.rendered ? __( '(no title)' ) : title.rendered,
 			opensInNewTab: false,
 		} )
 	);

--- a/phpunit/class-rest-nav-menu-items-controller-test.php
+++ b/phpunit/class-rest-nav-menu-items-controller-test.php
@@ -210,13 +210,29 @@ class REST_Nav_Menu_Items_Controller_Test extends WP_Test_REST_Post_Type_Control
 
 		$response = rest_get_server()->dispatch( $request );
 
-		$this->assertEquals(
-			array(
-				'rendered' => '<strong>Foo</strong> &#038; bar',
-				'raw'      => '<strong>Foo</strong> & bar',
-			),
-			$response->get_data()['title']
-		);
+		if ( ! MULTISITE ) {
+			// Check that title.raw is the unescaped title and that
+			// title.rendered has been run through the_title.
+			$this->assertEquals(
+				array(
+					'rendered' => '<strong>Foo</strong> &#038; bar',
+					'raw'      => '<strong>Foo</strong> & bar',
+				),
+				$response->get_data()['title']
+			);
+		} else {
+			// In a multisite, administrators do not have unfiltered_html and
+			// post_title is ran through wp_kses before being saved in the
+			// database. Running the title through the_title does nothing in
+			// this case.
+			$this->assertEquals(
+				array(
+					'rendered' => '<strong>Foo</strong> &amp; bar',
+					'raw'      => '<strong>Foo</strong> &amp; bar',
+				),
+				$response->get_data()['title']
+			);
+		}
 
 		wp_delete_post( $menu_item_id );
 	}

--- a/phpunit/class-rest-nav-menu-items-controller-test.php
+++ b/phpunit/class-rest-nav-menu-items-controller-test.php
@@ -210,7 +210,7 @@ class REST_Nav_Menu_Items_Controller_Test extends WP_Test_REST_Post_Type_Control
 
 		$response = rest_get_server()->dispatch( $request );
 
-		if ( ! MULTISITE ) {
+		if ( ! is_multisite() ) {
 			// Check that title.raw is the unescaped title and that
 			// title.rendered has been run through the_title.
 			$this->assertEquals(

--- a/phpunit/class-rest-nav-menu-items-controller-test.php
+++ b/phpunit/class-rest-nav-menu-items-controller-test.php
@@ -178,6 +178,50 @@ class REST_Nav_Menu_Items_Controller_Test extends WP_Test_REST_Post_Type_Control
 	}
 
 	/**
+	 * Test that title.raw contains the verbatim title and that title.rendered
+	 * has been passed through the_title which escapes & characters.
+	 *
+	 * @see https://github.com/WordPress/gutenberg/pull/24673
+	 */
+	public function test_get_item_escapes_title() {
+		wp_set_current_user( self::$admin_id );
+
+		$menu_item_id = wp_update_nav_menu_item(
+			$this->menu_id,
+			0,
+			array(
+				'menu-item-type'      => 'taxonomy',
+				'menu-item-object'    => 'post_tag',
+				'menu-item-object-id' => $this->tag_id,
+				'menu-item-status'    => 'publish',
+				'menu-item-title'     => '<strong>Foo</strong> & bar',
+			)
+		);
+
+		$request = new WP_REST_Request(
+			'GET',
+			"/__experimental/menu-items/$menu_item_id"
+		);
+		$request->set_query_params(
+			array(
+				'context' => 'edit',
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertEquals(
+			array(
+				'rendered' => '<strong>Foo</strong> &#038; bar',
+				'raw'      => '<strong>Foo</strong> & bar',
+			),
+			$response->get_data()['title']
+		);
+
+		wp_delete_post( $menu_item_id );
+	}
+
+	/**
 	 *
 	 */
 	public function test_create_item() {
@@ -726,7 +770,7 @@ class REST_Nav_Menu_Items_Controller_Test extends WP_Test_REST_Post_Type_Control
 			$this->assertEquals( $post->title, $data['title']['rendered'] );
 			remove_filter( 'protected_title_format', array( $this, 'protected_title_format' ) );
 			if ( 'edit' === $context ) {
-				$this->assertEquals( $post->post_title, $data['title']['raw'] );
+				$this->assertEquals( $post->title, $data['title']['raw'] );
 			} else {
 				$this->assertFalse( isset( $data['title']['raw'] ) );
 			}


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/23919.

Pages and menu items in WordPress allow HTML in the title. We should therefore not escape the menu item title when creating a Navigation block from top-level pages or an existing menu.

Additionally, the menu items REST API endpoint was setting `title.raw` to the menu item CPT's `post_title` (`$menu_item->post_title`) and `title.rendered` to the referenced object's `post_title` (`get_post( $menu_item->object_id )->post_title)`). Both `title.raw` and `title.rendered` should be set to the menu item's `title` (`$menu_item->title`), which [is properly set by `wp_setup_nav_menu_item()`](https://github.com/WordPress/wordpress-develop/blob/master/src/wp-includes/nav-menu.php#L836-L853).

The only difference is that `title.rendered` should be passed through `the_title`, [which escapes `&` characters](https://github.com/WordPress/wordpress-develop/blob/ca5c4cebefe9f493e42eba9ec909b433373bf3be/src/wp-includes/default-filters.php#L168-L170), and `nav_menu_item_title`, which provides plugins a chance to customise menu item titles before display. This matches [what `Walker_Nav_Menu` does](https://github.com/WordPress/wordpress-develop/blob/ca5c4cebefe9f493e42eba9ec909b433373bf3be/src/wp-includes/class-walker-nav-menu.php#L212-L225).

### How to test

1. Create a menu which has a menu item with the title: `<strong>Menu item</strong> & foo`
1. Create a page with the title: `<strong>Page</strong> & foo`.
1. Insert a Navigation block, select the menu you just created, and click _Create_.
1. Insert another Navigation  block, select _Create from all top-level pages_, and click _Create_.

Both blocks should have bold text and a `&` in one of the links.