### PR TITLE
Use internal libxml errors instead of @suppression

### DIFF
--- a/lib/block-supports/index.php
+++ b/lib/block-supports/index.php
@@ -58,10 +58,16 @@ function gutenberg_apply_block_supports( $block_content, $block ) {
 
 	$dom = new DOMDocument( '1.0', 'utf-8' );
 
-	// Suppress warnings from this method from polluting the front-end.
-	// @codingStandardsIgnoreStart
-	if ( ! @$dom->loadHTML( $wrapper_left . $block_content . $wrapper_right , LIBXML_HTML_NODEFDTD | LIBXML_COMPACT ) ) {
-	// @codingStandardsIgnoreEnd
+	// Suppress DOMDocument::loadHTML warnings from polluting the front-end.
+	$previous = libxml_use_internal_errors( true );
+
+	$success = $dom->loadHTML( $wrapper_left . $block_content . $wrapper_right, LIBXML_HTML_NODEFDTD | LIBXML_COMPACT );
+
+	// Clear errors and reset the use_errors setting.
+	libxml_clear_errors();
+	libxml_use_internal_errors( $previous );
+
+	if ( ! $success ) {
 		return $block_content;
 	}
 

--- a/phpunit/class-block-supported-styles-test.php
+++ b/phpunit/class-block-supported-styles-test.php
@@ -805,7 +805,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 			}
 		);
 
-		// HTML5 elemetns like <time> are not supported by the DOMDocument parser used by the block supports feature.
+		// HTML5 elements like <time> are not supported by the DOMDocument parser used by the block supports feature.
 		// This specific example is emitted by the "Display post date" setting in the latest-posts block.
 		apply_filters( 'render_block', '<div><time datetime="2020-06-18T04:01:43+10:00" class="wp-block-latest-posts__post-date">June 18, 2020</time></div>', $block );
 

--- a/phpunit/class-block-supported-styles-test.php
+++ b/phpunit/class-block-supported-styles-test.php
@@ -776,4 +776,41 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 
 		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
 	}
+
+	/**
+	 * Ensures libxml_internal_errors is being used instead of @ warning suppression
+	 */
+	public function test_render_block_suppresses_warnings_without_at_suppression() {
+		$block_type_settings = array(
+			'attributes'      => array(),
+			'supports'        => array(),
+			'render_callback' => true,
+		);
+		$this->register_block_type( 'core/example', $block_type_settings );
+
+		$block = array(
+			'blockName'    => 'core/example',
+			'attrs'        => array(),
+			'innerBlock'   => array(),
+			'innerContent' => array(),
+			'innerHTML'    => array(),
+		);
+
+		// Custom error handler's see Warnings even if they are suppressed by the @ symbol.
+		$errors = array();
+		set_error_handler(
+			function ( $errno = 0, $errstr = '' ) use ( &$errors ) {
+				$errors[] = $errstr;
+				return false;
+			}
+		);
+
+		// HTML5 elemetns like <time> are not supported by the DOMDocument parser used by the block supports feature.
+		// This specific example is emitted by the "Display post date" setting in the latest-posts block.
+		apply_filters( 'render_block', '<div><time datetime="2020-06-18T04:01:43+10:00" class="wp-block-latest-posts__post-date">June 18, 2020</time></div>', $block );
+
+		restore_error_handler();
+
+		$this->assertEmpty( $errors, 'Libxml errors should be dropped.' );
+	}
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Instead of using `@` to suppress errors during `DOMDocument::loadHTML`
use `libxml_use_internal_errors` to capture and suppress the errors
instead.

If there is a custom `set_error_handler` set for your installation it
will continue to receive warnings and html validation errors from this
`loadHTML` call. If the goal is to suppress these errors we should try
to capture and drop these without polluting customized error logs.


## How has this been tested?
- Added a unit test to capture errors that would be missed by `@` suppression
- Removed the change and confirmed the test fails
- Watched the php error log of a test site using the latest posts block with the block setting of "Show post date" toggled on.

## Types of changes
Bug fix, there shouldn't be any breaking changes although some people may see less errors for broken block html or html5 features passing through this code.

<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
