### PR TITLE
Fix: Warning on text color formatter

### DIFF
--- a/packages/format-library/src/text-color/index.js
+++ b/packages/format-library/src/text-color/index.js
@@ -90,7 +90,6 @@ function TextColorEdit( { value, onChange, isActive, activeAttributes } ) {
 					name={ name }
 					addingColor={ isAddingColor }
 					onClose={ disableIsAddingColor }
-					isActive={ isActive }
 					activeAttributes={ activeAttributes }
 					value={ value }
 					onChange={ onChange }

--- a/packages/format-library/src/text-color/inline.js
+++ b/packages/format-library/src/text-color/inline.js
@@ -116,18 +116,10 @@ const ColorPicker = ( { name, value, onChange } ) => {
 	return <ColorPalette value={ activeColor } onChange={ onColorChange } />;
 };
 
-const InlineColorUI = ( {
-	name,
-	value,
-	onChange,
-	onClose,
-	isActive,
-	addingColor,
-} ) => {
+const InlineColorUI = ( { name, value, onChange, onClose, addingColor } ) => {
 	return (
 		<ColorPopoverAtLink
 			value={ value }
-			isActive={ isActive }
 			addingColor={ addingColor }
 			onClose={ onClose }
 			className="components-inline-color-popover"


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/24543

The text color formatter was passing down an isActive prop that was not used at all and causing a warning. This  PR removes this unused prop.

## How has this been tested?
I checked the text color formatter still works well.
I verified there were no warnings when I used the formatter.