### PR TITLE
Code block: allow HTML editing & rich text

### DIFF
--- a/packages/block-library/src/code/block.json
+++ b/packages/block-library/src/code/block.json
@@ -10,7 +10,6 @@
 	},
 	"supports": {
 		"anchor": true,
-		"html": false,
 		"lightBlockWrapper": true
 	}
 }

--- a/packages/block-library/src/code/block.json
+++ b/packages/block-library/src/code/block.json
@@ -4,7 +4,7 @@
 	"attributes": {
 		"content": {
 			"type": "string",
-			"source": "text",
+			"source": "html",
 			"selector": "code"
 		}
 	},

--- a/packages/block-library/src/code/edit.js
+++ b/packages/block-library/src/code/edit.js
@@ -2,12 +2,8 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-
-/**
- * Internal dependencies
- */
 import {
-	PlainText,
+	RichText,
 	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 } from '@wordpress/block-editor';
 
@@ -15,8 +11,7 @@ export default function CodeEdit( { attributes, setAttributes } ) {
 	const blockWrapperProps = useBlockWrapperProps();
 	return (
 		<pre { ...blockWrapperProps }>
-			<PlainText
-				__experimentalVersion={ 2 }
+			<RichText
 				tagName="code"
 				value={ attributes.content }
 				onChange={ ( content ) => setAttributes( { content } ) }

--- a/packages/block-library/src/code/save.js
+++ b/packages/block-library/src/code/save.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { RichText } from '@wordpress/block-editor';
+
+/**
  * Internal dependencies
  */
 import { escape } from './utils';
@@ -6,7 +11,10 @@ import { escape } from './utils';
 export default function save( { attributes } ) {
 	return (
 		<pre>
-			<code>{ escape( attributes.content ) }</code>
+			<RichText.Content
+				tagName="code"
+				value={ escape( attributes.content ) }
+			/>
 		</pre>
 	);
 }

--- a/packages/block-library/src/code/utils.js
+++ b/packages/block-library/src/code/utils.js
@@ -4,11 +4,6 @@
 import { flow } from 'lodash';
 
 /**
- * WordPress dependencies
- */
-import { escapeEditableHTML } from '@wordpress/escape-html';
-
-/**
  * Escapes ampersands, shortcodes, and links.
  *
  * @param {string} content The content of a code block.
@@ -16,7 +11,6 @@ import { escapeEditableHTML } from '@wordpress/escape-html';
  */
 export function escape( content ) {
 	return flow(
-		escapeEditableHTML,
 		escapeOpeningSquareBrackets,
 		escapeProtocolInIsolatedUrls
 	)( content || '' );

--- a/packages/e2e-tests/fixtures/blocks/core__code.json
+++ b/packages/e2e-tests/fixtures/blocks/core__code.json
@@ -4,7 +4,7 @@
         "name": "core/code",
         "isValid": true,
         "attributes": {
-            "content": "export default function MyButton() {\n\treturn <Button>Click Me!</Button>;\n}"
+            "content": "export default function MyButton() {\n\treturn &lt;Button&gt;Click Me!&lt;/Button&gt;;\n}"
         },
         "innerBlocks": [],
         "originalContent": "<pre class=\"wp-block-code\"><code>export default function MyButton() {\n\treturn &lt;Button&gt;Click Me!&lt;/Button&gt;;\n}</code></pre>"

--- a/packages/e2e-tests/fixtures/blocks/core__code.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__code.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:code -->
 <pre class="wp-block-code"><code>export default function MyButton() {
-	return &lt;Button>Click Me!&lt;/Button>;
+	return &lt;Button&gt;Click Me!&lt;/Button&gt;;
 }</code></pre>
 <!-- /wp:code -->


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

Fixes #6672.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
