### PR TITLE
Make image block resize undoable

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -103,7 +103,10 @@ export default function Image( {
 			'mediaUpload',
 		] );
 	} );
-	const { toggleSelection } = useDispatch( 'core/block-editor' );
+	const {
+		toggleSelection,
+		__unstableMarkLastChangeAsPersistent,
+	} = useDispatch( 'core/block-editor' );
 	const { createErrorNotice, createSuccessNotice } = useDispatch(
 		'core/notices'
 	);
@@ -473,6 +476,7 @@ export default function Image( {
 						width: parseInt( currentWidth + delta.width, 10 ),
 						height: parseInt( currentHeight + delta.height, 10 ),
 					} );
+					__unstableMarkLastChangeAsPersistent();
 				} }
 			>
 				{ img }

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -476,7 +476,7 @@ export default function Image( {
 						width: parseInt( currentWidth + delta.width, 10 ),
 						height: parseInt( currentHeight + delta.height, 10 ),
 					} );
-					__unstableMarkLastChangeAsPersistent();
+					markLastChangeAsPersistent();
 				} }
 			>
 				{ img }

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -105,7 +105,7 @@ export default function Image( {
 	} );
 	const {
 		toggleSelection,
-		__unstableMarkLastChangeAsPersistent,
+		__unstableMarkLastChangeAsPersistent: markLastChangeAsPersistent,
 	} = useDispatch( 'core/block-editor' );
 	const { createErrorNotice, createSuccessNotice } = useDispatch(
 		'core/notices'


### PR DESCRIPTION
## Description
Fixes https://github.com/WordPress/gutenberg/issues/24199
Resizing an image block should create a new undo. If we resize an image, press undo, then it reverts back to the very first change. It would be better UX to be able to undo every resize change.

## How has this been tested?
1. Add image block
2. Resize it multiple times
3. Clicking on undo will resize the image to the previous state rather than the original state

## Screenshots
Before:
![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/2256104/90785599-c99a6500-e302-11ea-980f-dc5875668ae7.gif)

After:
![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/2256104/90785367-8b04aa80-e302-11ea-9662-21a645d513a0.gif)

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
