### PR TITLE
Inserter: Update the search form placeholder text when changing tabs

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -114,13 +114,15 @@ function InserterMenu( {
 	);
 
 	const searchFormPlaceholder = () => {
-		if ( activeTab === 'blocks' ) {
-			return __( 'Search for a block' );
-		} else if ( activeTab === 'patterns' ) {
+		if ( activeTab === 'reusable' ) {
+			return __( 'Search for a reusable block' );
+		}
+
+		if ( activeTab === 'patterns' ) {
 			return __( 'Search for a pattern' );
 		}
 
-		return __( 'Search for a reusable block' );
+		return __( 'Search for a block' );
 	};
 
 	// Disable reason (no-autofocus): The inserter menu is a modal display, not one which

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -30,6 +30,7 @@ function InserterMenu( {
 	showInserterHelpPanel,
 	showMostUsedBlocks,
 } ) {
+	const [ activeTab, setActiveTab ] = useState( 'blocks' );
 	const [ filterValue, setFilterValue ] = useState( '' );
 	const [ hoveredItem, setHoveredItem ] = useState( null );
 	const [
@@ -112,6 +113,16 @@ function InserterMenu( {
 		/>
 	);
 
+	const searchFormPlaceholder = () => {
+		if ( activeTab === 'blocks' ) {
+			return __( 'Search for a block' );
+		} else if ( activeTab === 'patterns' ) {
+			return __( 'Search for a pattern' );
+		}
+
+		return __( 'Search for a reusable block' );
+	};
+
 	// Disable reason (no-autofocus): The inserter menu is a modal display, not one which
 	// is always visible, and one which already incurs this behavior of autoFocus via
 	// Popover's focusOnMount.
@@ -133,11 +144,13 @@ function InserterMenu( {
 							setFilterValue( value );
 						} }
 						value={ filterValue }
+						placeholder={ searchFormPlaceholder() }
 					/>
 					{ ( showPatterns || hasReusableBlocks ) && (
 						<InserterTabs
 							showPatterns={ showPatterns }
 							showReusableBlocks={ hasReusableBlocks }
+							onSelect={ setActiveTab }
 						>
 							{ ( tab ) => {
 								if ( tab.name === 'blocks' ) {

--- a/packages/block-editor/src/components/inserter/search-form.js
+++ b/packages/block-editor/src/components/inserter/search-form.js
@@ -12,7 +12,7 @@ import { VisuallyHidden, Button } from '@wordpress/components';
 import { Icon, search, closeSmall } from '@wordpress/icons';
 import { useRef } from '@wordpress/element';
 
-function InserterSearchForm( { className, onChange, value } ) {
+function InserterSearchForm( { className, onChange, value, placeholder } ) {
 	const instanceId = useInstanceId( InserterSearchForm );
 	const searchInput = useRef();
 
@@ -31,14 +31,14 @@ function InserterSearchForm( { className, onChange, value } ) {
 				as="label"
 				htmlFor={ `block-editor-inserter__search-${ instanceId }` }
 			>
-				{ __( 'Search for a block' ) }
+				{ placeholder }
 			</VisuallyHidden>
 			<input
 				ref={ searchInput }
 				className="block-editor-inserter__search-input"
 				id={ `block-editor-inserter__search-${ instanceId }` }
 				type="search"
-				placeholder={ __( 'Search for a block' ) }
+				placeholder={ placeholder }
 				autoFocus
 				onChange={ ( event ) => onChange( event.target.value ) }
 				autoComplete="off"

--- a/packages/block-editor/src/components/inserter/tabs.js
+++ b/packages/block-editor/src/components/inserter/tabs.js
@@ -24,6 +24,7 @@ function InserterTabs( {
 	children,
 	showPatterns = false,
 	showReusableBlocks = false,
+	onSelect,
 } ) {
 	const tabs = [ blocksTab ];
 
@@ -35,7 +36,11 @@ function InserterTabs( {
 	}
 
 	return (
-		<TabPanel className="block-editor-inserter__tabs" tabs={ tabs }>
+		<TabPanel
+			className="block-editor-inserter__tabs"
+			tabs={ tabs }
+			onSelect={ onSelect }
+		>
 			{ children }
 		</TabPanel>
 	);


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
When changing tabs between: "Blocks | Patterns | Reusable", the search form does not change its placeholder text. This means when looking at the Patterns or Reusable tabs, it still says "Search for a block".

This PR makes sure that the placeholder in the search input field changes depending on the tab you have selected.

## How has this been tested?
Tested locally and all tests run and passed.

## Screenshots <!-- if applicable -->

![2020-08-20 11 52 44](https://user-images.githubusercontent.com/1464705/90812957-bfb13b80-e2db-11ea-96f2-5db66648325b.gif)

## Types of changes
Bug fix, non breaking change.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
