### PR TITLE
fix: block selection if block is aligned left or right

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -311,8 +311,11 @@
 	&[data-align="right"] {
 		width: 100%;
 
-		// When images are floated, the block itself should collapse to zero height.
-		height: 0;
+		&::after {
+			content: "";
+			clear: both;
+			display: table;
+		}
 
 		&::before {
 			content: none;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Fixes: #24653 
Currently there is the problem with many blocks, as soon as they are positioned left or right, that you can no longer select them in gutenberg. This is caused by a floating that is written to the block (data attribute) when the block is positioned with the GUI. I have now added a "clearfix" to the whole thing. This is the most common and modern way to solve the float problem.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
I inserted several blocks in Gutenberg and then positioned them. I repeated this in several browsers.

## Screenshots <!-- if applicable -->
<img width="1274" alt="Bildschirmfoto 2020-08-20 um 23 30 49" src="https://user-images.githubusercontent.com/52854338/90827828-3d596380-e33d-11ea-9c85-28ec76a6ee23.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
