### PR TITLE
Navigation Component: Remove setActiveLevel child function arg

### DIFF
--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -7,6 +7,7 @@ import { useEffect, useState } from '@wordpress/element';
  * Internal dependencies
  */
 import { Root } from './styles/navigation-styles';
+import Button from '../button';
 
 const Navigation = ( { activeItemId, children, data, rootTitle } ) => {
 	const [ activeLevel, setActiveLevel ] = useState( 'root' );
@@ -20,6 +21,7 @@ const Navigation = ( { activeItemId, children, data, rootTitle } ) => {
 				parent: item.parent || 'root',
 				isActive: item.id === activeItemId,
 				hasChildren: itemChildren.length > 0,
+				setActiveLevel,
 			};
 		} );
 	};
@@ -39,13 +41,24 @@ const Navigation = ( { activeItemId, children, data, rootTitle } ) => {
 		}
 	}, [] );
 
+	const NavigationBack = ( { children: backButtonChildren } ) => {
+		return (
+			<Button
+				isPrimary
+				onClick={ () => setActiveLevel( parentLevel.id ) }
+			>
+				{ backButtonChildren }
+			</Button>
+		);
+	};
+
 	return (
 		<Root className="components-navigation">
 			{ children( {
 				level,
 				levelItems,
 				parentLevel,
-				setActiveLevel,
+				NavigationBack,
 			} ) }
 		</Root>
 	);

--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -41,7 +41,7 @@ const Navigation = ( { activeItemId, children, data, rootTitle } ) => {
 		}
 	}, [] );
 
-	const NavigationBack = ( { children: backButtonChildren } ) => {
+	const NavigationBackButton = ( { children: backButtonChildren } ) => {
 		return (
 			<Button
 				isPrimary
@@ -58,7 +58,7 @@ const Navigation = ( { activeItemId, children, data, rootTitle } ) => {
 				level,
 				levelItems,
 				parentLevel,
-				NavigationBack,
+				NavigationBackButton,
 			} ) }
 		</Root>
 	);

--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -42,6 +42,10 @@ const Navigation = ( { activeItemId, children, data, rootTitle } ) => {
 	}, [] );
 
 	const NavigationBackButton = ( { children: backButtonChildren } ) => {
+		if ( ! parentLevel ) {
+			return null;
+		}
+
 		return (
 			<Button
 				isPrimary

--- a/packages/components/src/navigation/stories/index.js
+++ b/packages/components/src/navigation/stories/index.js
@@ -3,6 +3,7 @@
  */
 import { Button } from '@wordpress/components';
 import { useState } from '@wordpress/element';
+import { Icon, arrowLeft } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -49,6 +50,21 @@ const data = [
 		parent: 'item-3',
 	},
 	{
+		title: 'Nested Category',
+		id: 'child-3',
+		parent: 'item-3',
+	},
+	{
+		title: 'Sub Child 1',
+		id: 'sub-child-1',
+		parent: 'child-3',
+	},
+	{
+		title: 'Sub Child 2',
+		id: 'sub-child-2',
+		parent: 'child-3',
+	},
+	{
 		title: 'External link',
 		id: 'item-4',
 		href: 'https://wordpress.com',
@@ -68,18 +84,14 @@ function Example() {
 
 	return (
 		<Navigation activeItemId={ active } data={ data } rootTitle="Home">
-			{ ( { level, levelItems, parentLevel, setActiveLevel } ) => {
+			{ ( { level, levelItems, parentLevel, NavigationBack } ) => {
 				return (
 					<>
 						{ parentLevel && (
-							<Button
-								isPrimary
-								onClick={ () =>
-									setActiveLevel( parentLevel.id )
-								}
-							>
-								Back
-							</Button>
+							<NavigationBack>
+								<Icon icon={ arrowLeft } />
+								{ parentLevel.title }
+							</NavigationBack>
 						) }
 						<h1>{ level.title }</h1>
 						<NavigationMenu>
@@ -91,7 +103,6 @@ function Example() {
 										onClick={ ( selected ) =>
 											setActive( selected.id )
 										}
-										setActiveLevel={ setActiveLevel }
 									/>
 								);
 							} ) }

--- a/packages/components/src/navigation/stories/index.js
+++ b/packages/components/src/navigation/stories/index.js
@@ -84,14 +84,14 @@ function Example() {
 
 	return (
 		<Navigation activeItemId={ active } data={ data } rootTitle="Home">
-			{ ( { level, levelItems, parentLevel, NavigationBack } ) => {
+			{ ( { level, levelItems, parentLevel, NavigationBackButton } ) => {
 				return (
 					<>
 						{ parentLevel && (
-							<NavigationBack>
+							<NavigationBackButton>
 								<Icon icon={ arrowLeft } />
 								{ parentLevel.title }
-							</NavigationBack>
+							</NavigationBackButton>
 						) }
 						<h1>{ level.title }</h1>
 						<NavigationMenu>


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/24671

## Description

Remove `setActiveLevel` from `Navigation` child function arguments. `setActiveLevel` exposes the internal mechanism for keeping track of waterfall state, or in other words where the user is as they navigate the tree. The consuming app doesn't need to use it and exposing it only causes confusion.

Its functionality is useful for the "Back" button but allowing the consuming app to compose the contents as they choose requires its use. This PR seeks a middle ground by passing down a component called `NavigationBack` as a child function argument.

Its use now encapsulates `setActiveLevel` while allowing maximum composition.

## How has this been tested?

1. Run `npm run storybook:dev` to see the Navigation component function.
2. See the "back" button work as expected.

## Screenshots 

![Screen Shot 2020-08-21 at 12 20 36 PM](https://user-images.githubusercontent.com/1922453/90838337-c22d9700-e3a8-11ea-9473-0da8597577eb.png)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
