### PR TITLE
Navigation Component: Expose __experimentalNavigation component

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Introduce `Navigation` component as `__experimentalNavigation` for displahing a heirarchy of items.
+
 ## 10.0.0 (2020-07-07)
 
 ### Breaking Change

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Introduce `Navigation` component as `__experimentalNavigation` for displahing a heirarchy of items.
+- Introduce `Navigation` component as `__experimentalNavigation` for displaying a heirarchy of items.
 
 ## 10.0.0 (2020-07-07)
 

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -67,6 +67,7 @@ export { default as MenuItemsChoice } from './menu-items-choice';
 export { default as Modal } from './modal';
 export { default as ScrollLock } from './scroll-lock';
 export { NavigableMenu, TabbableContainer } from './navigable-container';
+export { default as __experimentalNavigation } from './navigation';
 export { default as Notice } from './notice';
 export { default as __experimentalNumberControl } from './number-control';
 export { default as NoticeList } from './notice/list';

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -67,7 +67,11 @@ export { default as MenuItemsChoice } from './menu-items-choice';
 export { default as Modal } from './modal';
 export { default as ScrollLock } from './scroll-lock';
 export { NavigableMenu, TabbableContainer } from './navigable-container';
-export { default as __experimentalNavigation } from './navigation';
+export {
+	default as __experimentalNavigation,
+	NavigationMenu as __experimentalNavigationMenu,
+	NavigationMenuItem as __experimentalNavigationMenuItem,
+} from './navigation';
 export { default as Notice } from './notice';
 export { default as __experimentalNumberControl } from './number-control';
 export { default as NoticeList } from './notice/list';

--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -52,3 +52,5 @@ const Navigation = ( { activeItemId, children, data, rootTitle } ) => {
 };
 
 export default Navigation;
+export { default as NavigationMenu } from './menu';
+export { default as NavigationMenuItem } from './menu-item';


### PR DESCRIPTION
## Description

This PR introduces the `Navigation` component as `__experimentalNavigation` and exposes it in the components package for inclusion:

```js
import { __experimentalNavigation as Navigation } from '@wordpress/components';
```

## Testing

1. Visit a page with Gutenberg.
2. See `wp.components. __experimentalNavigation` exist in the console.

Note: Documentation to be updated as part of https://github.com/WordPress/gutenberg/issues/24700.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
