### PR TITLE
Don't use an offset when dragging using draggable chip

### DIFF
--- a/packages/block-editor/src/components/block-draggable/style.scss
+++ b/packages/block-editor/src/components/block-draggable/style.scss
@@ -2,8 +2,8 @@
 	position: absolute;
 	// Offset position by half the height of the draggable chip
 	// so that the cursor is centered over the left part of the chip.
-	top: -$grid-unit-30;
-	left: -$grid-unit-30;
+	top: -#{$block-toolbar-height / 2};
+	left: -#{$block-toolbar-height / 2};
 }
 
 .block-editor-block-draggable-chip {

--- a/packages/block-editor/src/components/block-draggable/style.scss
+++ b/packages/block-editor/src/components/block-draggable/style.scss
@@ -1,6 +1,9 @@
 .block-editor-block-draggable-chip-wrapper {
 	position: absolute;
-	top: -$block-toolbar-height - $grid-unit-15;
+	// Offset position by half the height of the draggable chip
+	// so that the cursor is centered over the left part of the chip.
+	top: -$grid-unit-30;
+	left: -$grid-unit-30;
 }
 
 .block-editor-block-draggable-chip {

--- a/packages/components/src/draggable/index.js
+++ b/packages/components/src/draggable/index.js
@@ -131,13 +131,9 @@ class Draggable extends Component {
 		// If a dragComponent is defined, the following logic will clone the
 		// HTML node and inject it into the cloneWrapper.
 		if ( this.dragComponentRef.current ) {
-			// Position clone right over the original element (20px padding).
-			this.cloneWrapper.style.top = `${
-				elementTopOffset - clonePadding
-			}px`;
-			this.cloneWrapper.style.left = `${
-				elementLeftOffset - clonePadding
-			}px`;
+			// Position clone right over the cursor (24px padding).
+			this.cloneWrapper.style.top = `${ event.clientY + 24 }px`;
+			this.cloneWrapper.style.left = `${ event.clientX - 24 }px`;
 
 			const clonedDragComponent = document.createElement( 'div' );
 			clonedDragComponent.innerHTML = this.dragComponentRef.current.innerHTML;

--- a/packages/components/src/draggable/index.js
+++ b/packages/components/src/draggable/index.js
@@ -131,7 +131,7 @@ class Draggable extends Component {
 		// If a dragComponent is defined, the following logic will clone the
 		// HTML node and inject it into the cloneWrapper.
 		if ( this.dragComponentRef.current ) {
-			// Position clone right over the cursor (24px padding).
+			// Position dragComponent at the same position as the cursor.
 			this.cloneWrapper.style.top = `${ event.clientY }px`;
 			this.cloneWrapper.style.left = `${ event.clientX }px`;
 

--- a/packages/components/src/draggable/index.js
+++ b/packages/components/src/draggable/index.js
@@ -132,8 +132,8 @@ class Draggable extends Component {
 		// HTML node and inject it into the cloneWrapper.
 		if ( this.dragComponentRef.current ) {
 			// Position clone right over the cursor (24px padding).
-			this.cloneWrapper.style.top = `${ event.clientY + 24 }px`;
-			this.cloneWrapper.style.left = `${ event.clientX - 24 }px`;
+			this.cloneWrapper.style.top = `${ event.clientY }px`;
+			this.cloneWrapper.style.left = `${ event.clientX }px`;
 
 			const clonedDragComponent = document.createElement( 'div' );
 			clonedDragComponent.innerHTML = this.dragComponentRef.current.innerHTML;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Addresses part of #23581

When dragging a block that uses the `captureToolbar` option, the `DraggableChip` representing the block can be offset from the cursor by quite a distance.

This is most noticeable in the Navigation block where a user might drag a block that's far away from the toolbar, resulting in this:
![dragchipbefore](https://user-images.githubusercontent.com/677833/90850459-46c9e680-e3a4-11ea-85c4-948745d8aa72.gif)

This PR changes the Draggable component so that when a component like `DraggableChip` is used instead of a clone of the actual content, the draggable chip is always placed under the cursor:
![dragchipafter](https://user-images.githubusercontent.com/677833/90850535-80025680-e3a4-11ea-9cff-392afd1a056c.gif)

While I still don't think it's perfect that the user has to drag something far away from the content, it's a step improvement over the current behavior, and I think the right behavior for something like `DraggableChip`, which you wouldn't expect to be offset from the cursor.

For an example of this kind of behavior in the wild, try dragging a file in Google Drive—the 'chip' always snaps to the position of the cursor.

## How has this been tested?
1. Add a navigation block with a number of submenu items
2. Try dragging the last item in a submenu
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
