### PR TITLE
Block Directory: Explicitly close the inserter on block add.

### DIFF
--- a/packages/block-directory/src/components/downloadable-blocks-list/index.js
+++ b/packages/block-directory/src/components/downloadable-blocks-list/index.js
@@ -15,6 +15,7 @@ import DownloadableBlockListItem from '../downloadable-block-list-item';
 
 function DownloadableBlocksList( { items, onHover = noop, onSelect } ) {
 	const { installBlockType } = useDispatch( 'core/block-directory' );
+	const { setIsInserterOpened } = useDispatch( 'core/edit-post' );
 
 	if ( ! items.length ) {
 		return null;
@@ -35,6 +36,7 @@ function DownloadableBlocksList( { items, onHover = noop, onSelect } ) {
 							installBlockType( item ).then( ( success ) => {
 								if ( success ) {
 									onSelect( item );
+									setIsInserterOpened( false );
 								}
 							} );
 							onHover( null );


### PR DESCRIPTION
## Description
This PR explicitly closes the `Inserter` after a block is successfully installed from the Block Directory.

Ideally, we would want the default inserter behaviour to determine whether the inserter should close or not. At the moment of this PR, the inserter closes when a block is added. 

However, it appears like the async calls that are triggered when a user clicks "Install" on a block directory block do not trigger the same code paths/timings as regular blocks. 

In order to solve #24606, there appear to be 2 choices:

1. Modify [popover-wrapper.js](https://github.com/WordPress/gutenberg/blob/master/packages/edit-post/src/components/layout/popover-wrapper.js) & [with-focus-outside](https://github.com/WordPress/gutenberg/blob/master/packages/components/src/higher-order/with-focus-outside/index.js)
    - There is logic that is preventing the triggering of the `onClose` function that closes the inserter.
2. Explicitly close the inserter in the block directory package. (implemented here)

## How has this been tested?
1. Search for "p5"
2. Click to install the block
3. Notice the block is inserted and the inserter closes.


## Drawbacks
As mentioned above if the main inserter goes back to not closing on block add, this will fall out of sync.


## Types of changes
- When the block is inserted successfully, trigger `setIsInserterOpened` and close the inserter

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
