### PR TITLE
enhance menu-item with externalLink prop to show links with icon and …

### DIFF
--- a/packages/components/src/button/index.js
+++ b/packages/components/src/button/index.js
@@ -9,12 +9,14 @@ import { isArray } from 'lodash';
  */
 import deprecated from '@wordpress/deprecated';
 import { forwardRef } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import Tooltip from '../tooltip';
 import Icon from '../icon';
+import VisuallyHidden from '../visually-hidden';
 
 const disabledEventsOnDisabledButton = [ 'onMouseDown', 'onClick' ];
 
@@ -39,6 +41,7 @@ export function Button( props, ref ) {
 		tooltipPosition,
 		shortcut,
 		label,
+		externalLink,
 		children,
 		__experimentalIsFocusable: isFocusable,
 		...additionalProps
@@ -112,6 +115,11 @@ export function Button( props, ref ) {
 		>
 			{ icon && <Icon icon={ icon } size={ iconSize } /> }
 			{ children }
+			{ externalLink && (
+				<VisuallyHidden as="span">
+					{ __( '(opens in a new tab)' ) }
+				</VisuallyHidden>
+			) }
 		</Tag>
 	);
 

--- a/packages/components/src/menu-item/index.js
+++ b/packages/components/src/menu-item/index.js
@@ -8,6 +8,7 @@ import { isString } from 'lodash';
  * WordPress dependencies
  */
 import { cloneElement, forwardRef } from '@wordpress/element';
+import { external } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -25,6 +26,7 @@ import Button from '../button';
  * @param {WPIcon}        props.icon              Button's `icon` prop.
  * @param {string|Object} props.shortcut          Shortcut's `shortcut` prop.
  * @param {boolean}       props.isSelected        Whether or not the menu item is currently selected.
+ * @param {boolean}       props.externalLink      If the menuitem displays an external link, with icon and hidden text
  * @param {string}        [props.role="menuitem"] ARIA role of the menu item.
  * @param {Object}        ref                     React Element ref.
  *
@@ -38,6 +40,7 @@ export function MenuItem(
 		icon,
 		shortcut,
 		isSelected,
+		externalLink,
 		role = 'menuitem',
 		...props
 	},
@@ -60,6 +63,12 @@ export function MenuItem(
 		} );
 	}
 
+	if ( externalLink ) {
+		icon = cloneElement( external, {
+			className: 'components-menu-items__item-icon',
+		} );
+	}
+
 	return (
 		<Button
 			ref={ ref }
@@ -71,6 +80,7 @@ export function MenuItem(
 					: undefined
 			}
 			role={ role }
+			externalLink={ externalLink }
 			className={ className }
 			{ ...props }
 		>

--- a/packages/edit-post/src/plugins/index.js
+++ b/packages/edit-post/src/plugins/index.js
@@ -38,6 +38,7 @@ registerPlugin( 'edit-post', {
 							<CopyContentMenuItem />
 							<MenuItem
 								role="menuitem"
+								externalLink={ true }
 								href={ __(
 									'https://wordpress.org/support/article/wordpress-editor/'
 								) }

--- a/packages/edit-site/src/plugins/index.js
+++ b/packages/edit-site/src/plugins/index.js
@@ -55,6 +55,7 @@ registerPlugin( 'edit-site', {
 					</MenuItem>
 					<MenuItem
 						role="menuitem"
+						externalLink={ true }
 						href={ __(
 							'https://wordpress.org/support/article/wordpress-editor/'
 						) }


### PR DESCRIPTION
## Description
I introduced a new prop for the menu-item and the button, called externalLink. It is an indicator if the menu-item/button is used as an external link which needs to have a icon (external) and a visually hidden text for screenreader users.
If the prop is set to true, the menu-item clones the external icon which is imported to the current icon, because there should be only one icon displayed and gives the new icon and externalLink prop to the button. The button displays now the the external icon and the visually hidden text, on an a or button tag.
This is an alternative proposal for issue #24539 

## How has this been tested?
Open gutenberg editor for a page and the new FSE-Editor.
Open the "more option" menu and check/click the help button.

## Screenshots <!-- if applicable -->
![help-with-external-icon](https://user-images.githubusercontent.com/5269059/90862729-28f18700-e38e-11ea-9c9e-a49c8a8e3ed6.png)

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.
- [x] I've included developer documentation if appropriate.
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR.
