### PR TITLE
Unify UnsavedChangesWarning's isDirty check

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -86,7 +86,6 @@ function Layout() {
 		hasBlockSelected,
 		showMostUsedBlocks,
 		isInserterOpened,
-		isEditedPostDirty,
 	} = useSelect( ( select ) => {
 		return {
 			hasFixedToolbar: select( 'core/edit-post' ).isFeatureActive(
@@ -116,7 +115,6 @@ function Layout() {
 			nextShortcut: select(
 				'core/keyboard-shortcuts'
 			).getAllShortcutRawKeyCombinations( 'core/edit-post/next-region' ),
-			isEditedPostDirty: select( 'core/editor' ).isEditedPostDirty,
 		};
 	}, [] );
 	const className = classnames( 'edit-post-layout', 'is-mode-' + mode, {
@@ -161,7 +159,7 @@ function Layout() {
 		<>
 			<FullscreenMode isActive={ isFullscreenActive } />
 			<BrowserURL />
-			<UnsavedChangesWarning isDirty={ isEditedPostDirty } />
+			<UnsavedChangesWarning />
 			<AutosaveMonitor />
 			<LocalAutosaveMonitor />
 			<EditPostKeyboardShortcuts />

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -57,9 +57,7 @@ function Editor() {
 		page,
 		template,
 		select,
-		hasDirtyEntityRecords,
 	} = useSelect( ( _select ) => {
-		const { __experimentalGetDirtyEntityRecords } = _select( 'core' );
 		const {
 			isFeatureActive,
 			__experimentalGetPreviewDeviceType,
@@ -98,8 +96,6 @@ function Editor() {
 				: null,
 			select: _select,
 			entityId: _entityId,
-			hasDirtyEntityRecords: () =>
-				__experimentalGetDirtyEntityRecords().length > 0,
 		};
 	}, [] );
 	const { editEntityRecord } = useDispatch( 'core' );
@@ -163,7 +159,7 @@ function Editor() {
 		<>
 			<EditorStyles styles={ settings.styles } />
 			<FullscreenMode isActive={ isFullscreenActive } />
-			<UnsavedChangesWarning isDirty={ hasDirtyEntityRecords } />
+			<UnsavedChangesWarning />
 			<SlotFillProvider>
 				<DropZoneProvider>
 					<EntityProvider kind="root" type="site">

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Unreleased
 
-### Breaking Change
+### Enhancement
 
-- The `UnsavedChangesWarning` component now accepts a required `isDirty` prop. Making it less tightly coupled so we can reuse it for site editing.
+- The `UnsavedChangesWarning` component is now using `__experimentalGetDirtyEntityRecords` to determine if there were changes.
 
 ## 9.4.0 (2019-06-12)
 

--- a/packages/editor/src/components/unsaved-changes-warning/index.js
+++ b/packages/editor/src/components/unsaved-changes-warning/index.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
+import { withSelect } from '@wordpress/data';
 
 class UnsavedChangesWarning extends Component {
 	constructor() {
@@ -28,10 +29,6 @@ class UnsavedChangesWarning extends Component {
 	warnIfUnsavedChanges( event ) {
 		const { isDirty } = this.props;
 
-		// We need to call the selector directly in the listener to avoid race
-		// conditions with `BrowserURL` where `componentDidUpdate` gets the
-		// new value of `isEditedPostDirty` before this component does,
-		// causing this component to incorrectly think a trashed post is still dirty.
 		if ( isDirty() ) {
 			event.returnValue = __(
 				'You have unsaved changes. If you proceed, they will be lost.'
@@ -45,4 +42,14 @@ class UnsavedChangesWarning extends Component {
 	}
 }
 
-export default UnsavedChangesWarning;
+export default withSelect( ( select ) => ( {
+	// We need to call the selector directly in the listener to avoid race
+	// conditions with `BrowserURL` where `componentDidUpdate` gets the
+	// new value of `isEditedPostDirty` before this component does,
+	// causing this component to incorrectly think a trashed post is still dirty.
+	isDirty: () => {
+		const { __experimentalGetDirtyEntityRecords } = select( 'core' );
+		const dirtyEntityRecords = __experimentalGetDirtyEntityRecords();
+		return dirtyEntityRecords.length > 0;
+	},
+} ) )( UnsavedChangesWarning );


### PR DESCRIPTION
## Description
According to the discussion in this PR: https://github.com/WordPress/gutenberg/pull/24659
We bundle the check into the component. Instead of `isEditedPostDirty` we use `__experimentalGetDirtyEntityRecords` to determine if there were any changes in the editor. Since we are using `__experimentalGetDirtyEntityRecords`, this component will work fine in both Post and Site editor.

## How has this been tested?
1. Open post editor
2. Make changes
3. Try to navigate away (like Settings or All posts)
4. Should show an alert

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
