### PR TITLE
Make Site-Title a link

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-### Breaking Change
+### Enhancement
 
 - Site title is now a link.
 

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Change
+
+- Site title is now a link.
+
 ### New Features
 
 - Add heading level controls to Site Title block.

--- a/packages/block-library/src/site-title/index.php
+++ b/packages/block-library/src/site-title/index.php
@@ -20,11 +20,13 @@ function render_block_core_site_title( $attributes ) {
 		$tag_name = 0 === $attributes['level'] ? 'p' : 'h' . $attributes['level'];
 	}
 
+	$link = sprintf( '<a href="%1$s" rel="home">%2$s</a>', get_bloginfo( 'url' ), get_bloginfo( 'name' ) );
+
 	return sprintf(
 		'<%1$s class="%2$s">%3$s</%1$s>',
 		$tag_name,
 		esc_attr( $align_class_name ),
-		get_bloginfo( 'name' )
+		$link
 	);
 }
 


### PR DESCRIPTION
## Description
Closes https://github.com/WordPress/gutenberg/issues/24716
Turns Site Title into a link on the frontend.

## Caveats
Site Title is not a link in the editor. I tried multiple ways to solve it, but none of them worked properly. 
1. If I'm using an **a** tag as `tagName` for `RichText` Block then it gives a warning about using an inline element
2. Using a custom element as a `tagName` (`a` element wrapped in the `tagName`) caused usability issues. The `a` element hijacked content editing. No matter where I clicked in the text, it always put the caret at the start of the text. If I used `pointerEvents: 'none'` then it ignored the hover style.

Looking forward to suggestions.

## How has this been tested?
1. Add Site Title block
2. Save
3. Site Title should point to the homepage on the frontend

## Types of changes
Breaking change? (It breaks styling by adding a new element)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
