### PR TITLE
Fix block directory author average rating formatted as intereg

### DIFF
--- a/packages/block-directory/src/components/downloadable-block-author-info/index.js
+++ b/packages/block-directory/src/components/downloadable-block-author-info/index.js
@@ -23,8 +23,8 @@ function DownloadableBlockAuthorInfo( {
 					? sprintf(
 							/* translators: 1: number of blocks. 2: average rating. */
 							_n(
-								'This author has %1$d block, with an average rating of %2$f.',
-								'This author has %1$d blocks, with an average rating of %2$f.',
+								'This author has %1$d block, with an average rating of %2$.1f.',
+								'This author has %1$d blocks, with an average rating of %2$.1f.',
 								authorBlockCount
 							),
 							authorBlockCount,

--- a/packages/block-directory/src/components/downloadable-block-author-info/index.js
+++ b/packages/block-directory/src/components/downloadable-block-author-info/index.js
@@ -23,8 +23,8 @@ function DownloadableBlockAuthorInfo( {
 					? sprintf(
 							/* translators: 1: number of blocks. 2: average rating. */
 							_n(
-								'This author has %1$d block, with an average rating of %2$d.',
-								'This author has %1$d blocks, with an average rating of %2$d.',
+								'This author has %1$d block, with an average rating of %2$f.',
+								'This author has %1$d blocks, with an average rating of %2$f.',
 								authorBlockCount
 							),
 							authorBlockCount,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

Fixes #24731 

Uses `f` in favor of `d` to format the rating as a `float` in favor of an `int`.

## How has this been tested?

+ Manually tested against the recreation steps I noted in the related issue.
+ Locally ran `npm run test` to ensure this change didn't break any existing tests.

```
Test Suites: 408 passed, 408 total
Tests:       4376 passed, 4376 total
Snapshots:   198 passed, 198 total
Time:        39.582s
Ran all test suites.
```

+ I don't see any tests that specifically touch this particular area and I'm not sure what the best practice for creating a brand new test are so I haven't endeavored to write new tests. I'll be happy to update the PR if a regular contributor or reviewer would give me the go ahead to write new tests for the affected component. I've never written a test with snapshots before but I can figure it out.

## Screenshots <!-- if applicable -->

Compare to initial screenshot submitted in bug report

![Screenshot_2020-08-21_15-16-56](https://user-images.githubusercontent.com/1290739/90939748-73d8c200-e3c1-11ea-8d3d-e4c53edf67ac.png)


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
