### PR TITLE
Fixed style flickering caused by the border

### DIFF
--- a/packages/block-editor/src/components/block-styles/style.scss
+++ b/packages/block-editor/src/components/block-styles/style.scss
@@ -32,7 +32,7 @@
 		}
 
 		.block-editor-block-styles__item-preview {
-			border: 2px solid $gray-900;
+			outline: 2px solid $gray-900;
 		}
 	}
 }
@@ -48,7 +48,6 @@
 	align-items: center;
 	flex-grow: 1;
 	min-height: 80px;
-	border: 2px solid transparent;
 }
 
 .block-editor-block-switcher__styles__menugroup {

--- a/packages/block-editor/src/components/block-styles/style.scss
+++ b/packages/block-editor/src/components/block-styles/style.scss
@@ -32,7 +32,7 @@
 		}
 
 		.block-editor-block-styles__item-preview {
-			padding: 0;
+			margin: 0;
 			border: 2px solid $gray-900;
 		}
 	}
@@ -41,7 +41,8 @@
 // Show a little preview thumbnail for style variations.
 .block-editor-block-styles__item-preview {
 	outline: $border-width solid transparent; // Shown in Windows High Contrast mode.
-	padding: 2px;
+	padding: 0;
+	margin: 2px;
 	border-radius: $radius-block-ui;
 	display: flex;
 	overflow: hidden;

--- a/packages/block-editor/src/components/block-styles/style.scss
+++ b/packages/block-editor/src/components/block-styles/style.scss
@@ -48,6 +48,7 @@
 	align-items: center;
 	flex-grow: 1;
 	min-height: 80px;
+	border: 2px solid transparent;
 }
 
 .block-editor-block-switcher__styles__menugroup {

--- a/packages/block-editor/src/components/block-styles/style.scss
+++ b/packages/block-editor/src/components/block-styles/style.scss
@@ -32,7 +32,8 @@
 		}
 
 		.block-editor-block-styles__item-preview {
-			outline: 2px solid $gray-900;
+			padding: 0;
+			border: 2px solid $gray-900;
 		}
 	}
 }
@@ -40,7 +41,7 @@
 // Show a little preview thumbnail for style variations.
 .block-editor-block-styles__item-preview {
 	outline: $border-width solid transparent; // Shown in Windows High Contrast mode.
-	padding: 0;
+	padding: 2px;
 	border-radius: $radius-block-ui;
 	display: flex;
 	overflow: hidden;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
In block-preview, when a style is selected, the style gets a 2px wide border, which causes a small flickering effect. This PR adds a transparent 2px border so that the style doesn't flicker with the new `is-active` border.
Closes #24740
## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Tested it on ubuntu firefox.
1- Add an image
2- Click in between styles

## Screenshots <!-- if applicable -->
Before:
![before](https://user-images.githubusercontent.com/12985956/90969434-354a2100-e501-11ea-9d9b-64f8466072bf.gif)

After:
![working](https://user-images.githubusercontent.com/12985956/90969398-c40a6e00-e500-11ea-964b-c443319e0c5a.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Added a new line of style for the border.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
