### PR TITLE
Add picture keyword in Image block

### DIFF
--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -24,6 +24,7 @@ export const settings = {
 	keywords: [
 		'img', // "img" is not translated as it is intended to reflect the HTML <img> tag.
 		__( 'photo' ),
+		__( 'picture' ),
 	],
 	example: {
 		attributes: {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Resolves: https://github.com/WordPress/gutenberg/issues/24754
<!-- Please describe what you have changed or added -->
This PR just adds `picture` keyword in `Image` block.
