### PR TITLE
Add CSS variables for `textColor` & `backgroundColor`

### DIFF
--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -362,6 +362,12 @@ export const withColorPaletteStyles = createHigherOrderComponent(
 				? getColorObjectByAttributeValues( colors, backgroundColor )
 						?.color
 				: undefined,
+			'--wp--style--color--text': textColor
+				? `var(--wp--preset--color--${ textColor })`
+				: undefined,
+			'--wp--style--color--background': backgroundColor
+				? `var(--wp--preset--color--${ backgroundColor })`
+				: undefined,
 		};
 
 		let wrapperProps = props.wrapperProps;

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -59,6 +59,8 @@ export function getInlineStyles( styles = {} ) {
 		background: [ 'color', 'gradient' ],
 		backgroundColor: [ 'color', 'background' ],
 		color: [ 'color', 'text' ],
+		'--wp--style--color--text': [ 'color', 'text' ],
+		'--wp--style--color--background': [ 'color', 'background' ],
 		'--wp--style--color--link': [ 'color', 'link' ],
 	};
 


### PR DESCRIPTION
This PR adds 2 new CSS variables: `--wp--style--color--text` & `--wp--style--color--background`.
The naming of these is similar to the `--wp--style--color--link` we already have, and the logic is the same.
This increases consistency for controls since now all color controls (text/background/link) will add their corresponding CSS variables, and at the same time it will allow us to get rid of a lot of hardcoded text & background colors we have in our CSS.
This is also the 1st step to fix a regression that was introduced in #24462, see comment here for details and the discussion related to that: https://github.com/WordPress/gutenberg/pull/24462#issuecomment-678048725


cc @talldan 