### PR TITLE
Migrate existing theme supports to configure the editor to theme.json configs

### DIFF
--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -128,7 +128,6 @@ function gutenberg_edit_site_init( $hook ) {
 
 	$settings = array(
 		'alignWide'              => get_theme_support( 'align-wide' ),
-		'disableCustomColors'    => get_theme_support( 'disable-custom-colors' ),
 		'disableCustomFontSizes' => get_theme_support( 'disable-custom-font-sizes' ),
 		'imageSizes'             => $available_image_sizes,
 		'isRTL'                  => is_rtl(),
@@ -144,6 +143,7 @@ function gutenberg_edit_site_init( $hook ) {
 		$settings['fontSizes'] = $font_sizes;
 	}
 	$settings['styles'] = gutenberg_get_editor_styles();
+	$settings = gutenberg_experimental_global_styles_settings( $settings );
 
 	// This is so other parts of the code can hook their own settings.
 	// Example: Global Styles.

--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -143,7 +143,7 @@ function gutenberg_edit_site_init( $hook ) {
 		$settings['fontSizes'] = $font_sizes;
 	}
 	$settings['styles'] = gutenberg_get_editor_styles();
-	$settings = gutenberg_experimental_global_styles_settings( $settings );
+	$settings           = gutenberg_experimental_global_styles_settings( $settings );
 
 	// This is so other parts of the code can hook their own settings.
 	// Example: Global Styles.

--- a/lib/experimental-default-theme.json
+++ b/lib/experimental-default-theme.json
@@ -127,6 +127,9 @@
 		"features": {
 			"typography": {
 				"dropCap": false
+			},
+			"colors": {
+				"allowCustom": true
 			}
 		}
 	}

--- a/lib/experimental-default-theme.json
+++ b/lib/experimental-default-theme.json
@@ -129,7 +129,7 @@
 				"dropCap": false
 			},
 			"colors": {
-				"allowCustom": true
+				"custom": true
 			}
 		}
 	}

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -604,11 +604,11 @@ function gutenberg_experimental_global_styles_get_editor_features( $config ) {
 	}
 
 	// Deprecated theme supports.
-	if ( null !== get_theme_support( 'disable-custom-colors' ) ) {
+	if ( get_theme_support( 'disable-custom-colors' ) ) {
 		if ( ! isset( $config['global']['features']['colors'] ) ) {
 			$config['global']['features']['colors'] = array();
 		}
-		$config['global']['features']['colors']['custom'] = ! get_theme_support( 'disable-custom-colors' );
+		$config['global']['features']['colors']['custom'] = false;
 	}
 
 	return $config['global']['features'];
@@ -641,6 +641,8 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 	$settings['styles'][] = array( 'css' => $stylesheet );
 
 	$settings['__experimentalFeatures'] = gutenberg_experimental_global_styles_get_editor_features( $merged );
+	// Unsetting deprecated settings defined by Core.
+	unset( $settings['disableCustomColors'] );
 
 	return $settings;
 }

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -600,11 +600,14 @@ function gutenberg_experimental_global_styles_get_editor_features( $config ) {
 		empty( $config['global']['features'] ) ||
 		! is_array( $config['global']['features'] )
 	) {
-		return array();
+		$config['global']['features'] = array();
 	}
 
 	// Deprecated theme supports.
 	if ( null !== get_theme_support( 'disable-custom-colors' ) ) {
+		if ( ! isset( $config['global']['features']['colors'] ) ) {
+			$config['global']['features']['colors'] = array();
+		}
 		$config['global']['features']['colors']['custom'] = ! get_theme_support( 'disable-custom-colors' );
 	}
 

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -603,6 +603,11 @@ function gutenberg_experimental_global_styles_get_editor_features( $config ) {
 		return array();
 	}
 
+	// Deprecated theme supports
+	if ( null !== get_theme_support( 'disable-custom-colors' ) ) {
+		$config['global']['features']['colors']['allowCustom'] = ! get_theme_support( 'disable-custom-colors' );
+	}
+
 	return $config['global']['features'];
 }
 

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -605,7 +605,7 @@ function gutenberg_experimental_global_styles_get_editor_features( $config ) {
 
 	// Deprecated theme supports.
 	if ( null !== get_theme_support( 'disable-custom-colors' ) ) {
-		$config['global']['features']['colors']['allowCustom'] = ! get_theme_support( 'disable-custom-colors' );
+		$config['global']['features']['colors']['custom'] = ! get_theme_support( 'disable-custom-colors' );
 	}
 
 	return $config['global']['features'];

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -603,7 +603,7 @@ function gutenberg_experimental_global_styles_get_editor_features( $config ) {
 		return array();
 	}
 
-	// Deprecated theme supports
+	// Deprecated theme supports.
 	if ( null !== get_theme_support( 'disable-custom-colors' ) ) {
 		$config['global']['features']['colors']['allowCustom'] = ! get_theme_support( 'disable-custom-colors' );
 	}

--- a/lib/navigation-page.php
+++ b/lib/navigation-page.php
@@ -75,7 +75,7 @@ function gutenberg_navigation_init( $hook ) {
 	if ( false !== $font_sizes ) {
 		$settings['fontSizes'] = $font_sizes;
 	}
-	
+
 	$settings = gutenberg_experimental_global_styles_settings( $settings );
 
 	wp_add_inline_script(

--- a/lib/navigation-page.php
+++ b/lib/navigation-page.php
@@ -58,7 +58,6 @@ function gutenberg_navigation_init( $hook ) {
 	}
 
 	$settings = array(
-		'disableCustomColors'    => get_theme_support( 'disable-custom-colors' ),
 		'disableCustomFontSizes' => get_theme_support( 'disable-custom-font-sizes' ),
 		'imageSizes'             => $available_image_sizes,
 		'isRTL'                  => is_rtl(),
@@ -76,6 +75,8 @@ function gutenberg_navigation_init( $hook ) {
 	if ( false !== $font_sizes ) {
 		$settings['fontSizes'] = $font_sizes;
 	}
+	
+	$settings = gutenberg_experimental_global_styles_settings( $settings );
 
 	wp_add_inline_script(
 		'wp-edit-navigation',

--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -71,7 +71,6 @@ function gutenberg_widgets_init( $hook ) {
 
 	$settings = array_merge(
 		array(
-			'disableCustomColors'    => get_theme_support( 'disable-custom-colors' ),
 			'disableCustomFontSizes' => get_theme_support( 'disable-custom-font-sizes' ),
 			'imageSizes'             => $available_image_sizes,
 			'isRTL'                  => is_rtl(),
@@ -90,6 +89,7 @@ function gutenberg_widgets_init( $hook ) {
 	if ( false !== $font_sizes ) {
 		$settings['fontSizes'] = $font_sizes;
 	}
+	$settings = gutenberg_experimental_global_styles_settings( $settings );
 
 	wp_add_inline_script(
 		'wp-edit-widgets',

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -478,7 +478,6 @@ _Properties_
 -   _alignWide_ `boolean`: Enable/Disable Wide/Full Alignments
 -   _availableLegacyWidgets_ `Array`: Array of objects representing the legacy widgets available.
 -   _colors_ `Array`: Palette colors
--   _disableCustomColors_ `boolean`: Whether or not the custom colors are disabled
 -   _fontSizes_ `Array`: Available font sizes
 -   _disableCustomFontSizes_ `boolean`: Whether or not the custom font sizes are disabled
 -   _imageEditing_ `boolean`: Image Editing settings set to false to disable.

--- a/packages/block-editor/src/components/color-palette/with-color-context.js
+++ b/packages/block-editor/src/components/color-palette/with-color-context.js
@@ -6,24 +6,50 @@ import { isEmpty } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { createHigherOrderComponent } from '@wordpress/compose';
+import { createHigherOrderComponent, compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 
-export default createHigherOrderComponent(
-	withSelect( ( select, ownProps ) => {
-		const settings = select( 'core/block-editor' ).getSettings();
-		const colors =
-			ownProps.colors === undefined ? settings.colors : ownProps.colors;
+/**
+ * Internal dependencies
+ */
+import useEditorFeature from '../use-editor-feature';
 
-		const disableCustomColors =
-			ownProps.disableCustomColors === undefined
-				? settings.disableCustomColors
-				: ownProps.disableCustomColors;
-		return {
-			colors,
-			disableCustomColors,
-			hasColorsToChoose: ! isEmpty( colors ) || ! disableCustomColors,
+const withDisableCustomColors = createHigherOrderComponent(
+	( WrappedComponent ) => {
+		return ( props ) => {
+			const disableCustomColors = ! useEditorFeature(
+				'colors.allowCustom'
+			);
+
+			return (
+				<WrappedComponent
+					{ ...props }
+					disableCustomColors={
+						props.disableCustomColors || disableCustomColors
+					}
+				/>
+			);
 		};
-	} ),
+	},
+	'withDisableCustomColors'
+);
+
+export default createHigherOrderComponent(
+	compose(
+		withDisableCustomColors,
+		withSelect( ( select, ownProps ) => {
+			const settings = select( 'core/block-editor' ).getSettings();
+			const colors =
+				ownProps.colors === undefined
+					? settings.colors
+					: ownProps.colors;
+
+			return {
+				colors,
+				hasColorsToChoose:
+					! isEmpty( colors ) || ! ownProps.disableCustomColors,
+			};
+		} )
+	),
 	'withColorContext'
 );

--- a/packages/block-editor/src/components/color-palette/with-color-context.js
+++ b/packages/block-editor/src/components/color-palette/with-color-context.js
@@ -17,9 +17,7 @@ import useEditorFeature from '../use-editor-feature';
 const withDisableCustomColors = createHigherOrderComponent(
 	( WrappedComponent ) => {
 		return ( props ) => {
-			const disableCustomColors = ! useEditorFeature(
-				'colors.allowCustom'
-			);
+			const disableCustomColors = ! useEditorFeature( 'colors.custom' );
 
 			return (
 				<WrappedComponent

--- a/packages/block-editor/src/components/colors-gradients/control.js
+++ b/packages/block-editor/src/components/colors-gradients/control.js
@@ -24,6 +24,7 @@ import { useSelect } from '@wordpress/data';
  */
 import { getColorObjectByColorValue } from '../colors';
 import { __experimentalGetGradientObjectByGradientValue } from '../gradients';
+import useEditorFeature from '../use-editor-feature';
 
 // translators: first %s: the color name or value (e.g. red or #ff0000)
 const colorIndicatorAriaLabel = __( '(Color: %s)' );
@@ -177,6 +178,10 @@ function ColorGradientControlSelect( props ) {
 		const settings = select( 'core/block-editor' ).getSettings();
 		return pick( settings, colorsAndGradientKeys );
 	} );
+	colorGradientSettings.disableCustomColors = ! useEditorFeature(
+		'colors.allowCustom'
+	);
+
 	return (
 		<ColorGradientControlInner
 			{ ...{ ...colorGradientSettings, ...props } }

--- a/packages/block-editor/src/components/colors-gradients/control.js
+++ b/packages/block-editor/src/components/colors-gradients/control.js
@@ -179,7 +179,7 @@ function ColorGradientControlSelect( props ) {
 		return pick( settings, colorsAndGradientKeys );
 	} );
 	colorGradientSettings.disableCustomColors = ! useEditorFeature(
-		'colors.allowCustom'
+		'colors.custom'
 	);
 
 	return (

--- a/packages/block-editor/src/components/colors-gradients/panel-color-gradient-settings.js
+++ b/packages/block-editor/src/components/colors-gradients/panel-color-gradient-settings.js
@@ -153,7 +153,7 @@ const PanelColorGradientSettingsSelect = ( props ) => {
 		return pick( settings, colorsAndGradientKeys );
 	} );
 	colorGradientSettings.disableCustomColors = ! useEditorFeature(
-		'colors.allowCustom'
+		'colors.custom'
 	);
 	return (
 		<PanelColorGradientSettingsInner

--- a/packages/block-editor/src/components/colors-gradients/panel-color-gradient-settings.js
+++ b/packages/block-editor/src/components/colors-gradients/panel-color-gradient-settings.js
@@ -17,6 +17,7 @@ import { useSelect } from '@wordpress/data';
 import ColorGradientControl from './control';
 import { getColorObjectByColorValue } from '../colors';
 import { __experimentalGetGradientObjectByGradientValue } from '../gradients';
+import useEditorFeature from '../use-editor-feature';
 
 // translators: first %s: The type of color or gradient (e.g. background, overlay...), second %s: the color name or value (e.g. red or #ff0000)
 const colorIndicatorAriaLabel = __( '(%s: color %s)' );
@@ -151,6 +152,9 @@ const PanelColorGradientSettingsSelect = ( props ) => {
 		const settings = select( 'core/block-editor' ).getSettings();
 		return pick( settings, colorsAndGradientKeys );
 	} );
+	colorGradientSettings.disableCustomColors = ! useEditorFeature(
+		'colors.allowCustom'
+	);
 	return (
 		<PanelColorGradientSettingsInner
 			{ ...{ ...colorGradientSettings, ...props } }

--- a/packages/block-editor/src/components/use-editor-feature/index.js
+++ b/packages/block-editor/src/components/use-editor-feature/index.js
@@ -13,6 +13,13 @@ import { useSelect } from '@wordpress/data';
  */
 import { useBlockEditContext } from '../block-edit';
 
+const deprecatedFlags = {
+	'colors.allowCustom': ( settings ) =>
+		settings.disableCustomColors === undefined
+			? undefined
+			: ! settings.disableCustomColors,
+};
+
 /**
  * Hook that retrieves the setting for the given editor feature.
  * It works with nested objects using by finding the value at path.
@@ -28,22 +35,23 @@ import { useBlockEditContext } from '../block-edit';
  */
 export default function useEditorFeature( featurePath ) {
 	const { name: blockName } = useBlockEditContext();
-	const path = `__experimentalFeatures.${ featurePath }`;
 
 	const setting = useSelect(
 		( select ) => {
-			const { getBlockSupport } = select( 'core/blocks' );
-
-			const blockSupportValue = getBlockSupport( blockName, path );
-			if ( blockSupportValue !== undefined ) {
-				return blockSupportValue;
-			}
-
+			const path = `__experimentalFeatures.${ featurePath }`;
 			const { getSettings } = select( 'core/block-editor' );
+			const settings = getSettings();
 
-			return get( getSettings(), path );
+			const deprecatedSettingsValue = deprecatedFlags[ featurePath ]
+				? deprecatedFlags[ featurePath ]( settings )
+				: undefined;
+
+			if ( deprecatedSettingsValue !== undefined ) {
+				return deprecatedSettingsValue;
+			}
+			return get( settings, path );
 		},
-		[ blockName, path ]
+		[ blockName, featurePath ]
 	);
 
 	return setting;

--- a/packages/block-editor/src/components/use-editor-feature/index.js
+++ b/packages/block-editor/src/components/use-editor-feature/index.js
@@ -14,7 +14,7 @@ import { useSelect } from '@wordpress/data';
 import { useBlockEditContext } from '../block-edit';
 
 const deprecatedFlags = {
-	'colors.allowCustom': ( settings ) =>
+	'colors.custom': ( settings ) =>
 		settings.disableCustomColors === undefined
 			? undefined
 			: ! settings.disableCustomColors,

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -14,7 +14,6 @@ export const PREFERENCES_DEFAULTS = {
  * @property {boolean} alignWide Enable/Disable Wide/Full Alignments
  * @property {Array} availableLegacyWidgets Array of objects representing the legacy widgets available.
  * @property {Array} colors Palette colors
- * @property {boolean} disableCustomColors Whether or not the custom colors are disabled
  * @property {Array} fontSizes Available font sizes
  * @property {boolean} disableCustomFontSizes Whether or not the custom font sizes are disabled
  * @property {boolean} imageEditing Image Editing settings set to false to disable.

--- a/packages/format-library/src/text-color/index.js
+++ b/packages/format-library/src/text-color/index.js
@@ -9,7 +9,10 @@ import { get, isEmpty } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { useCallback, useMemo, useState } from '@wordpress/element';
-import { RichTextToolbarButton } from '@wordpress/block-editor';
+import {
+	RichTextToolbarButton,
+	__experimentalUseEditorFeature as useEditorFeature,
+} from '@wordpress/block-editor';
 import { Icon, textColor as textColorIcon } from '@wordpress/icons';
 import { removeFormat } from '@wordpress/rich-text';
 
@@ -24,7 +27,8 @@ const title = __( 'Text Color' );
 const EMPTY_ARRAY = [];
 
 function TextColorEdit( { value, onChange, isActive, activeAttributes } ) {
-	const { colors, disableCustomColors } = useSelect( ( select ) => {
+	const allowCustomControl = useEditorFeature( 'colors.allowCustom' );
+	const { colors } = useSelect( ( select ) => {
 		const blockEditorSelect = select( 'core/block-editor' );
 		let settings;
 		if ( blockEditorSelect && blockEditorSelect.getSettings ) {
@@ -34,7 +38,6 @@ function TextColorEdit( { value, onChange, isActive, activeAttributes } ) {
 		}
 		return {
 			colors: get( settings, [ 'colors' ], EMPTY_ARRAY ),
-			disableCustomColors: settings.disableCustomColors,
 		};
 	} );
 	const [ isAddingColor, setIsAddingColor ] = useState( false );
@@ -54,8 +57,7 @@ function TextColorEdit( { value, onChange, isActive, activeAttributes } ) {
 		};
 	}, [ value, colors ] );
 
-	const hasColorsToChoose =
-		! isEmpty( colors ) || disableCustomColors !== true;
+	const hasColorsToChoose = ! isEmpty( colors ) || ! allowCustomControl;
 	if ( ! hasColorsToChoose && ! isActive ) {
 		return null;
 	}

--- a/packages/format-library/src/text-color/index.js
+++ b/packages/format-library/src/text-color/index.js
@@ -27,7 +27,7 @@ const title = __( 'Text Color' );
 const EMPTY_ARRAY = [];
 
 function TextColorEdit( { value, onChange, isActive, activeAttributes } ) {
-	const allowCustomControl = useEditorFeature( 'colors.allowCustom' );
+	const allowCustomControl = useEditorFeature( 'colors.custom' );
 	const { colors } = useSelect( ( select ) => {
 		const blockEditorSelect = select( 'core/block-editor' );
 		let settings;


### PR DESCRIPTION
Related #20588 

The idea of this PR is that there's a lot of existing theme supports like `disable-custom-colors`... that can be used to control Gutenberg and we want to consolidate all of these in a unique "features" key that can be provided by `theme.json` or `block-editor-settings` filter.

This PR explores how we can do so while still retaining backward compatibility for existing theme supports the block editor settings. It explores doing so for the `disableCustomColors` setting. It is now transformed to a feature with the following path: `colors.allowCustom`.

Also to do so, it adds the global styles settings to the new screens (navigation, widgets, edit-site).

**Testing instructions**

 - Check that you can enable/disable custom colors support using the existing theme support flag `disable-custom-colors`
 - Check that you can enable/disable custom colors support using the theme.json `colors.allowCustom` path.