### PR TITLE
Fix navigation block styles regression

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -1,6 +1,11 @@
-// Default text color.
-.wp-block-navigation-link:not(.has-text-color) {
-	color: currentColor;
+// Default background and font color
+.wp-block-navigation:not(.has-background) .wp-block-navigation__container {
+	.wp-block-navigation-link:not(.has-text-color) {
+		color: $gray-900;
+	}
+	.wp-block-navigation__container {
+		background-color: $white;
+	}
 }
 
 // Justification.


### PR DESCRIPTION
Reverts https://github.com/WordPress/gutenberg/pull/24462.
See discussion in https://github.com/WordPress/gutenberg/pull/24462#issuecomment-678048725 and also the discussion on https://github.com/WordPress/gutenberg/pull/24757 for details.

TLDR: #24462 did not take into account submenu backgrounds if the nav block doesn't have a background defined. The regression is that in that case, submenus are transparent - and that will obviously cause issues.