### PR TITLE
Add animations to navigation component

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Introduce `Navigation` component as `__experimentalNavigation` for displaying a heirarchy of items.
+
 ## 10.0.0 (2020-07-07)
 
 ### Breaking Change

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -67,6 +67,11 @@ export { default as MenuItemsChoice } from './menu-items-choice';
 export { default as Modal } from './modal';
 export { default as ScrollLock } from './scroll-lock';
 export { NavigableMenu, TabbableContainer } from './navigable-container';
+export {
+	default as __experimentalNavigation,
+	NavigationMenu as __experimentalNavigationMenu,
+	NavigationMenuItem as __experimentalNavigationMenuItem,
+} from './navigation';
 export { default as Notice } from './notice';
 export { default as __experimentalNumberControl } from './number-control';
 export { default as NoticeList } from './notice/list';

--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -69,3 +69,5 @@ const Navigation = ( { activeItemId, children, data, rootTitle } ) => {
 };
 
 export default Navigation;
+export { default as NavigationMenu } from './menu';
+export { default as NavigationMenuItem } from './menu-item';

--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -7,6 +7,7 @@ import { useEffect, useState } from '@wordpress/element';
  * Internal dependencies
  */
 import { Root } from './styles/navigation-styles';
+import Button from '../button';
 
 const Navigation = ( { activeItemId, children, data, rootTitle } ) => {
 	const [ activeLevel, setActiveLevel ] = useState( 'root' );
@@ -20,6 +21,7 @@ const Navigation = ( { activeItemId, children, data, rootTitle } ) => {
 				parent: item.parent || 'root',
 				isActive: item.id === activeItemId,
 				hasChildren: itemChildren.length > 0,
+				setActiveLevel,
 			};
 		} );
 	};
@@ -39,13 +41,28 @@ const Navigation = ( { activeItemId, children, data, rootTitle } ) => {
 		}
 	}, [] );
 
+	const NavigationBackButton = ( { children: backButtonChildren } ) => {
+		if ( ! parentLevel ) {
+			return null;
+		}
+
+		return (
+			<Button
+				isPrimary
+				onClick={ () => setActiveLevel( parentLevel.id ) }
+			>
+				{ backButtonChildren }
+			</Button>
+		);
+	};
+
 	return (
 		<Root className="components-navigation">
 			{ children( {
 				level,
 				levelItems,
 				parentLevel,
-				setActiveLevel,
+				NavigationBackButton,
 			} ) }
 		</Root>
 	);

--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -49,10 +49,10 @@ const Navigation = ( { activeItemId, children, data, rootTitle } ) => {
 	};
 
 	const items = mapItems( data );
-	const parentLevel = items.get( level.parent );
 	const activeItem = items.get( activeItemId );
 	const previousActiveLevelId = usePrevious( activeLevelId );
 	const level = items.get( activeLevelId );
+	const parentLevel = level && items.get( level.parent );
 	const isNavigatingBack =
 		previousActiveLevelId &&
 		items.get( previousActiveLevelId ).parent === activeLevelId;

--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect, useMemo, useState } from '@wordpress/element';
 import { usePrevious } from '@wordpress/compose';
 
 /**
@@ -48,7 +48,11 @@ const Navigation = ( { activeItemId, children, data, rootTitle } ) => {
 		return items;
 	};
 
-	const items = mapItems( data );
+	const items = useMemo( () => mapItems( data ), [
+		data,
+		activeItemId,
+		rootTitle,
+	] );
 	const activeItem = items.get( activeItemId );
 	const previousActiveLevelId = usePrevious( activeLevelId );
 	const level = items.get( activeLevelId );

--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -85,7 +85,6 @@ const Navigation = ( { activeItemId, children, data, rootTitle } ) => {
 				options={ {
 					origin: isNavigatingBack ? 'right' : 'left',
 				} }
-				key={ level.id }
 			>
 				{ ( { className: animateClassName } ) => (
 					<div

--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -81,6 +81,7 @@ const Navigation = ( { activeItemId, children, data, rootTitle } ) => {
 	return (
 		<Root className="components-navigation">
 			<Animate
+				key={ level.id }
 				type="slide-in"
 				options={ {
 					origin: isNavigatingBack ? 'right' : 'left',

--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { useEffect, useState } from '@wordpress/element';
@@ -6,6 +11,7 @@ import { useEffect, useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import Animate from '../animate';
 import { Root } from './styles/navigation-styles';
 import Button from '../button';
 
@@ -25,15 +31,23 @@ const Navigation = ( { activeItemId, children, data, rootTitle } ) => {
 			};
 		} );
 	};
-	const items = [ { id: 'root', title: rootTitle }, ...mapItemData( data ) ];
 
+	const getRootItem = ( items ) => {
+		const itemChildren = items.filter( ( i ) => i.parent === 'root' );
+		return {
+			id: 'root',
+			parent: null,
+			title: rootTitle,
+			children: itemChildren,
+			isActive: false,
+			hasChildren: itemChildren.length > 0,
+		};
+	};
+
+	const mappedItems = mapItemData( data );
+	const items = [ getRootItem( mappedItems ), ...mappedItems ];
+	const levels = items.filter( ( item ) => item.hasChildren );
 	const activeItem = items.find( ( item ) => item.id === activeItemId );
-	const level = items.find( ( item ) => item.id === activeLevel );
-	const levelItems = items.filter( ( item ) => item.parent === level.id );
-	const parentLevel =
-		level.id === 'root'
-			? null
-			: items.find( ( item ) => item.id === level.parent );
 
 	useEffect( () => {
 		if ( activeItem ) {
@@ -58,12 +72,32 @@ const Navigation = ( { activeItemId, children, data, rootTitle } ) => {
 
 	return (
 		<Root className="components-navigation">
-			{ children( {
-				level,
-				levelItems,
-				parentLevel,
-				NavigationBackButton,
-			} ) }
+			{ levels.map(
+				( level ) =>
+					activeLevel === level.id && (
+						<Animate type="slide-in" key={ level.id }>
+							{ ( { className: animateClassName } ) => (
+								<div
+									className={ classnames(
+										'components-navigation__level',
+										animateClassName
+									) }
+								>
+									{ children( {
+										level,
+										levelItems: items.filter(
+											( i ) => i.parent === level.id
+										),
+										NavigationBackButton,
+										parentLevel: items.find(
+											( i ) => i.id === level.parent
+										),
+									} ) }
+								</div>
+							) }
+						</Animate>
+					)
+			) }
 		</Root>
 	);
 };

--- a/packages/components/src/navigation/menu-item.js
+++ b/packages/components/src/navigation/menu-item.js
@@ -26,7 +26,7 @@ const NavigationMenuItem = ( props ) => {
 		LinkComponent,
 		linkProps,
 		onClick,
-		setActiveLevel,
+		setActiveLevelId,
 		title,
 	} = props;
 	const classes = classnames( 'components-navigation__menu-item', {
@@ -35,7 +35,7 @@ const NavigationMenuItem = ( props ) => {
 
 	const handleClick = () => {
 		if ( children.length ) {
-			setActiveLevel( id );
+			setActiveLevelId( id );
 			return;
 		}
 		onClick( props );

--- a/packages/components/src/navigation/stories/index.js
+++ b/packages/components/src/navigation/stories/index.js
@@ -3,6 +3,7 @@
  */
 import { Button } from '@wordpress/components';
 import { useState } from '@wordpress/element';
+import { Icon, arrowLeft } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -49,6 +50,21 @@ const data = [
 		parent: 'item-3',
 	},
 	{
+		title: 'Nested Category',
+		id: 'child-3',
+		parent: 'item-3',
+	},
+	{
+		title: 'Sub Child 1',
+		id: 'sub-child-1',
+		parent: 'child-3',
+	},
+	{
+		title: 'Sub Child 2',
+		id: 'sub-child-2',
+		parent: 'child-3',
+	},
+	{
 		title: 'External link',
 		id: 'item-4',
 		href: 'https://wordpress.com',
@@ -68,18 +84,14 @@ function Example() {
 
 	return (
 		<Navigation activeItemId={ active } data={ data } rootTitle="Home">
-			{ ( { level, levelItems, parentLevel, setActiveLevel } ) => {
+			{ ( { level, levelItems, parentLevel, NavigationBackButton } ) => {
 				return (
 					<>
 						{ parentLevel && (
-							<Button
-								isPrimary
-								onClick={ () =>
-									setActiveLevel( parentLevel.id )
-								}
-							>
-								Back
-							</Button>
+							<NavigationBackButton>
+								<Icon icon={ arrowLeft } />
+								{ parentLevel.title }
+							</NavigationBackButton>
 						) }
 						<h1>{ level.title }</h1>
 						<NavigationMenu>
@@ -91,7 +103,6 @@ function Example() {
 										onClick={ ( selected ) =>
 											setActive( selected.id )
 										}
-										setActiveLevel={ setActiveLevel }
 									/>
 								);
 							} ) }

--- a/packages/components/src/navigation/stories/index.js
+++ b/packages/components/src/navigation/stories/index.js
@@ -84,7 +84,7 @@ function Example() {
 
 	return (
 		<Navigation activeItemId={ active } data={ data } rootTitle="Home">
-			{ ( { level, levelItems, parentLevel, NavigationBackButton } ) => {
+			{ ( { level, parentLevel, NavigationBackButton } ) => {
 				return (
 					<>
 						{ parentLevel && (
@@ -95,7 +95,7 @@ function Example() {
 						) }
 						<h1>{ level.title }</h1>
 						<NavigationMenu>
-							{ levelItems.map( ( item ) => {
+							{ level.children.map( ( item ) => {
 								return (
 									<NavigationMenuItem
 										{ ...item }


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/24258

## Description
* Adds left and right sliding animations for navigation levels.
* Refactors the item mapping to be significantly more performant.

## Testing

1. Make sure the navigation component items and children still work as expected.
1. Make sure that navigation down in items or up (using the back button) results in the expected animation.
1. Optionally, add more levels of depth in the story to see this continue working.
