### PR TITLE
env: Update docker volumes during wp-env start

### DIFF
--- a/packages/env/lib/commands/start.js
+++ b/packages/env/lib/commands/start.js
@@ -12,6 +12,7 @@ const inquirer = require( 'inquirer' );
  */
 const sleep = util.promisify( setTimeout );
 const rimraf = util.promisify( require( 'rimraf' ) );
+const exec = util.promisify( require( 'child_process' ).exec );
 
 /**
  * Internal dependencies
@@ -65,6 +66,11 @@ module.exports = async function start( { spinner, debug, update } ) {
 			workDirectoryPath,
 		} ) );
 
+	const dockerComposeConfig = {
+		config: config.dockerComposeConfigPath,
+		log: config.debug,
+	};
+
 	/**
 	 * If the Docker image is already running and the `wp-env` files have been
 	 * deleted, the start command will not complete successfully. Stopping
@@ -78,13 +84,39 @@ module.exports = async function start( { spinner, debug, update } ) {
 	 */
 	if ( shouldConfigureWp ) {
 		await stop( { spinner, debug } );
+		// Update the images before starting the services again.
+		spinner.text = 'Updating docker images.';
+
+		const directoryHash = path.basename( workDirectoryPath );
+
+		// Note: when the base docker image is updated, we want that operation to
+		// also update WordPress. Since we store wordpress/tests-wordpress files
+		// as docker volumes, simply updating the image will not change those
+		// files. Thus, we need to remove those volumes in order for the files
+		// to be updated when pulling the new images.
+		const volumesToRemove = `${ directoryHash }_wordpress ${ directoryHash }_tests-wordpress`;
+
+		try {
+			if ( config.debug ) {
+				spinner.text = `Removing the WordPress volumes: ${ volumesToRemove }`;
+			}
+			await exec( `docker volume rm ${ volumesToRemove }` );
+		} catch {
+			// Note: we do not care about this error condition because it will
+			// mostly happen when the volume already exists. This error would not
+			// stop wp-env from working correctlyl.
+		}
+
+		await dockerCompose.pullAll( dockerComposeConfig );
 		spinner.text = 'Downloading sources.';
 	}
 
 	await Promise.all( [
 		dockerCompose.upOne( 'mysql', {
-			config: config.dockerComposeConfigPath,
-			log: config.debug,
+			...dockerComposeConfig,
+			commandOptions: shouldConfigureWp
+				? [ '--build', '--force-recreate' ]
+				: [],
 		} ),
 		shouldConfigureWp && downloadSources( config, spinner ),
 	] );
@@ -96,8 +128,10 @@ module.exports = async function start( { spinner, debug, update } ) {
 	spinner.text = 'Starting WordPress.';
 
 	await dockerCompose.upMany( [ 'wordpress', 'tests-wordpress' ], {
-		config: config.dockerComposeConfigPath,
-		log: config.debug,
+		...dockerComposeConfig,
+		commandOptions: shouldConfigureWp
+			? [ '--build', '--force-recreate' ]
+			: [],
 	} );
 
 	// Only run WordPress install/configuration when config has changed.

--- a/packages/env/lib/commands/start.js
+++ b/packages/env/lib/commands/start.js
@@ -104,7 +104,7 @@ module.exports = async function start( { spinner, debug, update } ) {
 		} catch {
 			// Note: we do not care about this error condition because it will
 			// mostly happen when the volume already exists. This error would not
-			// stop wp-env from working correctlyl.
+			// stop wp-env from working correctly.
 		}
 
 		await dockerCompose.pullAll( dockerComposeConfig );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Since WordPress 5.5 was recently released, I noticed that some of my 3rd party plugins which rely on the base WordPress image were not updating to the latest version. Even after pulling the image updates, WordPress did not update.

This adds two things to the `wp-env start --update` process:
1. Remove the `$hash_wordpress` and `$hash_tests-wordpress` volumes. These cache the wordpress files, so these volumes need to be removed for the next step.
2. Run docker-compose pull to get the latest image updates.

Step 1 is necessary because without it, the container will not see that any wordpress files have changed even after pulling and rebuilding the images.

## How has this been tested?
Locally in wp-env with a 3rd party plugin which was out of date.

## Screenshots <!-- if applicable -->

## Types of changes
Enhancement

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
