### PR TITLE
UnsavedChangesWarning: Turn into functional component

### DIFF
--- a/packages/editor/src/components/unsaved-changes-warning/index.js
+++ b/packages/editor/src/components/unsaved-changes-warning/index.js
@@ -2,22 +2,23 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component } from '@wordpress/element';
-import { withSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 
-class UnsavedChangesWarning extends Component {
-	constructor() {
-		super( ...arguments );
-		this.warnIfUnsavedChanges = this.warnIfUnsavedChanges.bind( this );
-	}
-
-	componentDidMount() {
-		window.addEventListener( 'beforeunload', this.warnIfUnsavedChanges );
-	}
-
-	componentWillUnmount() {
-		window.removeEventListener( 'beforeunload', this.warnIfUnsavedChanges );
-	}
+/**
+ * Warns the user if there are unsaved changes before leaving the editor.
+ * Compatible with Post Editor and Site Editor.
+ *
+ * @return {WPComponent} The component.
+ */
+export default function UnsavedChangesWarning() {
+	const isDirty = useSelect( ( select ) => {
+		return () => {
+			const { __experimentalGetDirtyEntityRecords } = select( 'core' );
+			const dirtyEntityRecords = __experimentalGetDirtyEntityRecords();
+			return dirtyEntityRecords.length > 0;
+		};
+	}, [] );
 
 	/**
 	 * Warns the user if there are unsaved changes before leaving the editor.
@@ -26,30 +27,26 @@ class UnsavedChangesWarning extends Component {
 	 *
 	 * @return {?string} Warning prompt message, if unsaved changes exist.
 	 */
-	warnIfUnsavedChanges( event ) {
-		const { isDirty } = this.props;
-
+	const warnIfUnsavedChanges = ( event ) => {
+		// We need to call the selector directly in the listener to avoid race
+		// conditions with `BrowserURL` where `componentDidUpdate` gets the
+		// new value of `isEditedPostDirty` before this component does,
+		// causing this component to incorrectly think a trashed post is still dirty.
 		if ( isDirty() ) {
 			event.returnValue = __(
 				'You have unsaved changes. If you proceed, they will be lost.'
 			);
 			return event.returnValue;
 		}
-	}
+	};
 
-	render() {
-		return null;
-	}
+	useEffect( () => {
+		window.addEventListener( 'beforeunload', warnIfUnsavedChanges );
+
+		return () => {
+			window.removeEventListener( 'beforeunload', warnIfUnsavedChanges );
+		};
+	}, [] );
+
+	return null;
 }
-
-export default withSelect( ( select ) => ( {
-	// We need to call the selector directly in the listener to avoid race
-	// conditions with `BrowserURL` where `componentDidUpdate` gets the
-	// new value of `isEditedPostDirty` before this component does,
-	// causing this component to incorrectly think a trashed post is still dirty.
-	isDirty: () => {
-		const { __experimentalGetDirtyEntityRecords } = select( 'core' );
-		const dirtyEntityRecords = __experimentalGetDirtyEntityRecords();
-		return dirtyEntityRecords.length > 0;
-	},
-} ) )( UnsavedChangesWarning );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Closes: https://github.com/WordPress/gutenberg/issues/24767
Turn UnsavedChangesWarning into a functional component.

## Types of changes
Internal

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
