### PR TITLE
[Sidebars endpoint] Add permissions PHPUnit tests 

### DIFF
--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -70,8 +70,15 @@ function fail_if_died( $message ) {
 }
 tests_add_filter( 'wp_die_handler', 'fail_if_died' );
 
+$GLOBALS['wp_tests_options'] = array(
+	'gutenberg-experiments' => array(
+		'gutenberg-widget-experiments' => '1',
+	),
+);
+
 // Start up the WP testing environment.
 require $_tests_dir . '/includes/bootstrap.php';
 
 // Use existing behavior for wp_die during actual test execution.
 remove_filter( 'wp_die_handler', 'fail_if_died' );
+

--- a/phpunit/class-rest-sidebars-controller-test.php
+++ b/phpunit/class-rest-sidebars-controller-test.php
@@ -148,13 +148,33 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	}
 
 	/**
-	 * @dataProvider users_without_permissions
+	 *
 	 */
-	public function test_get_items_permission( $user_id ) {
-		wp_set_current_user( $user_id );
+	public function test_get_items_no_permission() {
+		wp_set_current_user( 0 );
 		$request  = new WP_REST_Request( 'GET', '/__experimental/sidebars' );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertErrorResponse( 'widgets_cannot_access', $response, 401 );
+	}
+
+	/**
+	 *
+	 */
+	public function test_get_items_wrong_permission_author() {
+		wp_set_current_user( self::$author_id );
+		$request  = new WP_REST_Request( 'GET', '/__experimental/sidebars' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'widgets_cannot_access', $response, 403 );
+	}
+
+	/**
+	 *
+	 */
+	public function test_get_items_wrong_permission_subscriber() {
+		wp_set_current_user( self::$subscriber_id );
+		$request  = new WP_REST_Request( 'GET', '/__experimental/sidebars' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'widgets_cannot_access', $response, 403 );
 	}
 
 	/**
@@ -280,10 +300,44 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	}
 
 	/**
-	 * @dataProvider users_without_permissions
+	 *
 	 */
-	public function test_get_item_permission( $user_id ) {
-		wp_set_current_user( $user_id );
+	public function test_get_item_no_permission() {
+		wp_set_current_user( 0 );
+		$this->setup_sidebar(
+			'sidebar-1',
+			array(
+				'name' => 'Test sidebar',
+			)
+		);
+
+		$request  = new WP_REST_Request( 'GET', '/__experimental/sidebars/sidebar-1' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'widgets_cannot_access', $response, 401 );
+	}
+
+	/**
+	 *
+	 */
+	public function test_get_item_wrong_permission_author() {
+		wp_set_current_user( self::$author_id );
+		$this->setup_sidebar(
+			'sidebar-1',
+			array(
+				'name' => 'Test sidebar',
+			)
+		);
+
+		$request  = new WP_REST_Request( 'GET', '/__experimental/sidebars/sidebar-1' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'widgets_cannot_access', $response, 403 );
+	}
+
+	/**
+	 *
+	 */
+	public function test_get_item_wrong_permission_subscriber() {
+		wp_set_current_user( self::$subscriber_id );
 		$this->setup_sidebar(
 			'sidebar-1',
 			array(
@@ -401,10 +455,42 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	}
 
 	/**
-	 * @dataProvider users_without_permissions
+	 *
 	 */
-	public function test_update_item_permission( $user_id ) {
-		wp_set_current_user( $user_id );
+	public function test_update_item_no_permission() {
+		wp_set_current_user( 0 );
+
+		$request = new WP_REST_Request( 'POST', '/__experimental/sidebars/sidebar-1' );
+		$request->set_body_params(
+			array(
+				'widgets' => array(),
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'widgets_cannot_access', $response, 401 );
+	}
+
+	/**
+	 *
+	 */
+	public function test_update_item_wrong_permission_author() {
+		wp_set_current_user( self::$author_id );
+
+		$request = new WP_REST_Request( 'POST', '/__experimental/sidebars/sidebar-1' );
+		$request->set_body_params(
+			array(
+				'widgets' => array(),
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'widgets_cannot_access', $response, 403 );
+	}
+
+	/**
+	 *
+	 */
+	public function test_update_item_wrong_permission_subscriber() {
+		wp_set_current_user( self::$subscriber_id );
 
 		$request = new WP_REST_Request( 'POST', '/__experimental/sidebars/sidebar-1' );
 		$request->set_body_params(
@@ -446,10 +532,4 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( 'widgets', $properties );
 	}
 
-	public function users_without_permissions() {
-		return array(
-			array( self::$subscriber_id ),
-			array( self::$author_id ),
-		);
-	}
 }

--- a/phpunit/class-rest-sidebars-controller-test.php
+++ b/phpunit/class-rest-sidebars-controller-test.php
@@ -302,7 +302,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 
 		$request  = new WP_REST_Request( 'GET', '/__experimental/sidebars/sidebar-1' );
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( 'widgets_cannot_access', $response, 401 );
+		$this->assertErrorResponse( 'widgets_cannot_access', $response, 403 );
 	}
 
 	/**

--- a/phpunit/class-rest-sidebars-controller-test.php
+++ b/phpunit/class-rest-sidebars-controller-test.php
@@ -422,7 +422,6 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			)
 		);
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertEquals( 401, $response->get_status() );
 		$this->assertErrorResponse( 'widgets_cannot_access', $response, 401 );
 	}
 

--- a/phpunit/class-rest-sidebars-controller-test.php
+++ b/phpunit/class-rest-sidebars-controller-test.php
@@ -6,15 +6,6 @@
  * @subpackage REST_API
  */
 
-require_once dirname( __FILE__ ) . '/../lib/class-wp-rest-sidebars-controller.php';
-add_filter(
-	'rest_api_init',
-	function () {
-		$sidebars = new WP_REST_Sidebars_Controller();
-		$sidebars->register_routes();
-	}
-);
-
 /**
  * Tests for REST API for Menus.
  *

--- a/phpunit/class-rest-sidebars-controller-test.php
+++ b/phpunit/class-rest-sidebars-controller-test.php
@@ -421,7 +421,8 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request->set_body_params(
 			array(
 				'widgets' => array(),
-			) );
+			)
+		);
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertEquals( 401, $response->get_status() );
 		$this->assertErrorResponse( 'widgets_cannot_access', $response, 401 );

--- a/phpunit/class-rest-sidebars-controller-test.php
+++ b/phpunit/class-rest-sidebars-controller-test.php
@@ -163,7 +163,6 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		wp_set_current_user( $user_id );
 		$request  = new WP_REST_Request( 'GET', '/__experimental/sidebars' );
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertEquals( 401, $response->get_status() );
 		$this->assertErrorResponse( 'widgets_cannot_access', $response, 401 );
 	}
 

--- a/phpunit/class-rest-sidebars-controller-test.php
+++ b/phpunit/class-rest-sidebars-controller-test.php
@@ -302,7 +302,6 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 
 		$request  = new WP_REST_Request( 'GET', '/__experimental/sidebars/sidebar-1' );
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertEquals( 401, $response->get_status() );
 		$this->assertErrorResponse( 'widgets_cannot_access', $response, 401 );
 	}
 

--- a/phpunit/class-rest-sidebars-controller-test.php
+++ b/phpunit/class-rest-sidebars-controller-test.php
@@ -422,7 +422,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			)
 		);
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( 'widgets_cannot_access', $response, 401 );
+		$this->assertErrorResponse( 'widgets_cannot_access', $response, 403 );
 	}
 
 	/**


### PR DESCRIPTION
## Description
This PR adds coverage for when the user is logged out or has insufficient permissions as per https://github.com/WordPress/gutenberg/pull/24290#pullrequestreview-464724722.

## How has this been tested?
Confirm all checks pass on this PR.

## Types of changes
Non-breaking change

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
