### PR TITLE
[Sitebars endpoint] Add tests for slashing behavior

### DIFF
--- a/phpunit/class-rest-sidebars-controller-test.php
+++ b/phpunit/class-rest-sidebars-controller-test.php
@@ -716,7 +716,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 					array(
 						'id'           => 'text-1',
 						'settings'     => array(
-							'text'   => 'Updated \\" \\\' > text test',
+							'text'   => 'Updated \\" \\\' &gt; text test',
 							'title'  => '',
 							'filter' => false,
 						),
@@ -725,7 +725,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 						'name'         => 'Text',
 						'description'  => 'Arbitrary text.',
 						'number'       => 1,
-						'rendered'     => '			<div class="textwidget">Updated \\" \\\' > text test</div>' . "\n		",
+						'rendered'     => '			<div class="textwidget">Updated \\" \\\' &gt; text test</div>' . "\n		",
 					),
 				),
 			),

--- a/phpunit/class-rest-sidebars-controller-test.php
+++ b/phpunit/class-rest-sidebars-controller-test.php
@@ -680,7 +680,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	}
 
 	/**
-	 *
+	 * Tests if the endpoint correctly handles "slashable" characters such as " or '.
 	 */
 	public function test_update_item_slashing() {
 		$this->setup_widget( 'widget_text', 1, array( 'text' => 'Custom text test' ) );
@@ -716,7 +716,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 					array(
 						'id'           => 'text-1',
 						'settings'     => array(
-							'text'   => 'Updated \\" \\\' &gt; text test',
+							'text'   => 'Updated \\" \\\' > text test',
 							'title'  => '',
 							'filter' => false,
 						),
@@ -725,7 +725,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 						'name'         => 'Text',
 						'description'  => 'Arbitrary text.',
 						'number'       => 1,
-						'rendered'     => '			<div class="textwidget">Updated \\" \\\' &gt; text test</div>' . "\n		",
+						'rendered'     => '<div class="textwidget">Updated \\" \\\' > text test</div>',
 					),
 				),
 			),

--- a/phpunit/class-rest-sidebars-controller-test.php
+++ b/phpunit/class-rest-sidebars-controller-test.php
@@ -693,7 +693,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 					array(
 						'id'           => 'text-1',
 						'settings'     => array(
-							'text' => 'Updated \\" \\\' > text test',
+							'text' => 'Updated \\" \\\' text test',
 						),
 						'id_base'      => 'text',
 						'widget_class' => 'WP_Widget_Text',
@@ -716,7 +716,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 					array(
 						'id'           => 'text-1',
 						'settings'     => array(
-							'text'   => 'Updated \\" \\\' &gt; text test',
+							'text'   => 'Updated \\" \\\' text test',
 							'title'  => '',
 							'filter' => false,
 						),
@@ -725,7 +725,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 						'name'         => 'Text',
 						'description'  => 'Arbitrary text.',
 						'number'       => 1,
-						'rendered'     => '<div class="textwidget">Updated \\" \\\' &gt; text test</div>',
+						'rendered'     => '<div class="textwidget">Updated \\" \\\' text test</div>',
 					),
 				),
 			),

--- a/phpunit/class-rest-sidebars-controller-test.php
+++ b/phpunit/class-rest-sidebars-controller-test.php
@@ -716,7 +716,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 					array(
 						'id'           => 'text-1',
 						'settings'     => array(
-							'text'   => 'Updated \\" \\\' > text test',
+							'text'   => 'Updated \\" \\\' &gt; text test',
 							'title'  => '',
 							'filter' => false,
 						),
@@ -725,7 +725,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 						'name'         => 'Text',
 						'description'  => 'Arbitrary text.',
 						'number'       => 1,
-						'rendered'     => '<div class="textwidget">Updated \\" \\\' > text test</div>',
+						'rendered'     => '<div class="textwidget">Updated \\" \\\' &gt; text test</div>',
 					),
 				),
 			),

--- a/phpunit/class-rest-sidebars-controller-test.php
+++ b/phpunit/class-rest-sidebars-controller-test.php
@@ -683,8 +683,8 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	 *
 	 */
 	public function test_update_item_slashing() {
-		$this->setup_widget( 'widget_text', 1, array( 'text' => 'Custom text test', ) );
-		$this->setup_sidebar( 'sidebar-1', array( 'name' => 'Test sidebar', ), array( 'text-1', 'rss-1' ) );
+		$this->setup_widget( 'widget_text', 1, array( 'text' => 'Custom text test' ) );
+		$this->setup_sidebar( 'sidebar-1', array( 'name' => 'Test sidebar' ), array( 'text-1', 'rss-1' ) );
 
 		$request = new WP_REST_Request( 'POST', '/__experimental/sidebars/sidebar-1' );
 		$request->set_body_params(

--- a/phpunit/class-rest-sidebars-controller-test.php
+++ b/phpunit/class-rest-sidebars-controller-test.php
@@ -680,6 +680,60 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	}
 
 	/**
+	 *
+	 */
+	public function test_update_item_slashing() {
+		$this->setup_widget( 'widget_text', 1, array( 'text' => 'Custom text test', ) );
+		$this->setup_sidebar( 'sidebar-1', array( 'name' => 'Test sidebar', ), array( 'text-1', 'rss-1' ) );
+
+		$request = new WP_REST_Request( 'POST', '/__experimental/sidebars/sidebar-1' );
+		$request->set_body_params(
+			array(
+				'widgets' => array(
+					array(
+						'id'           => 'text-1',
+						'settings'     => array(
+							'text' => 'Updated \\" \\\' > text test',
+						),
+						'id_base'      => 'text',
+						'widget_class' => 'WP_Widget_Text',
+						'name'         => 'Text',
+						'description'  => 'Arbitrary text.',
+						'number'       => 1,
+					),
+				),
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		$this->assertEquals(
+			array(
+				'id'          => 'sidebar-1',
+				'name'        => 'Test sidebar',
+				'description' => '',
+				'status'      => 'active',
+				'widgets'     => array(
+					array(
+						'id'           => 'text-1',
+						'settings'     => array(
+							'text'   => 'Updated \\" \\\' > text test',
+							'title'  => '',
+							'filter' => false,
+						),
+						'id_base'      => 'text',
+						'widget_class' => 'WP_Widget_Text',
+						'name'         => 'Text',
+						'description'  => 'Arbitrary text.',
+						'number'       => 1,
+						'rendered'     => '			<div class="textwidget">Updated \\" \\\' > text test</div>' . "\n		",
+					),
+				),
+			),
+			$data
+		);
+	}
+
+	/**
 	 * The test_delete_item() method does not exist for sidebar.
 	 */
 	public function test_delete_item() {
@@ -708,5 +762,4 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( 'status', $properties );
 		$this->assertArrayHasKey( 'widgets', $properties );
 	}
-
 }


### PR DESCRIPTION
## Description
This PR adds coverage for the correct usage of `wp_slash` in `update_item` method as per  https://github.com/WordPress/gutenberg/pull/24290#pullrequestreview-464724722.

## How has this been tested?
Confirm all checks pass on this PR.

## Types of changes
Non-breaking change

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
