### PR TITLE
[RNMobile] Add fullHeight prop to navigation-screen in bottom-sheet

### DIFF
--- a/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/navigation-container.native.js
+++ b/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/navigation-container.native.js
@@ -63,6 +63,7 @@ function BottomSheetNavigationContainer( { children, animate, main, theme } ) {
 	const [ currentHeight, setCurrentHeight ] = useState(
 		context.currentHeight || 1
 	);
+	const [ isFullScreen, setIsFullScreen ] = useState( false );
 
 	const backgroundStyle = usePreferredColorSchemeStyle(
 		styles.background,
@@ -90,6 +91,13 @@ function BottomSheetNavigationContainer( { children, animate, main, theme } ) {
 		}
 	};
 
+	const setNavigationFullScreen = ( isFull ) => {
+		if ( isFull !== isFullScreen ) {
+			performLayoutAnimation( ANIMATION_DURATION );
+			setIsFullScreen( isFull );
+		}
+	};
+
 	const screens = useMemo( () => {
 		return Children.map( children, ( child ) => {
 			const { name, ...otherProps } = child.props;
@@ -105,9 +113,17 @@ function BottomSheetNavigationContainer( { children, animate, main, theme } ) {
 
 	return useMemo( () => {
 		return (
-			<View style={ { height: currentHeight } }>
+			<View
+				style={ {
+					height: isFullScreen ? '100%' : currentHeight,
+				} }
+			>
 				<BottomSheetNavigationProvider
-					value={ { setHeight, currentHeight } }
+					value={ {
+						setHeight,
+						currentHeight,
+						setNavigationFullScreen,
+					} }
 				>
 					{ main ? (
 						<NavigationContainer theme={ _theme }>
@@ -123,7 +139,7 @@ function BottomSheetNavigationContainer( { children, animate, main, theme } ) {
 				</BottomSheetNavigationProvider>
 			</View>
 		);
-	}, [ currentHeight ] );
+	}, [ currentHeight, isFullScreen ] );
 }
 
 export default BottomSheetNavigationContainer;

--- a/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/navigation-screen.native.js
+++ b/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/navigation-screen.native.js
@@ -40,7 +40,7 @@ const BottomSheetNavigationScreen = ( { children, fullScreen } ) => {
 			setHeight( height, true );
 			setNavigationFullScreen( false );
 		}, 10 ),
-		[ setNavigationFullScreen ]
+		[ setNavigationFullScreen, setHeight ]
 	);
 
 	const setFullHeight = useCallback(

--- a/packages/components/src/mobile/bottom-sheet/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet/index.native.js
@@ -50,6 +50,8 @@ class BottomSheet extends Component {
 			this
 		);
 
+		this.setIsFullScreen = this.setIsFullScreen.bind( this );
+
 		this.onDimensionsChange = this.onDimensionsChange.bind( this );
 		this.onCloseBottomSheet = this.onCloseBottomSheet.bind( this );
 		this.onHandleClosingBottomSheet = this.onHandleClosingBottomSheet.bind(
@@ -72,6 +74,7 @@ class BottomSheet extends Component {
 			handleClosingBottomSheet: null,
 			handleHardwareButtonPress: null,
 			isMaxHeightSet: true,
+			isFullScreen: this.props.isFullScreen || false,
 		};
 
 		SafeArea.getSafeAreaInsetsForRootView().then(
@@ -231,6 +234,16 @@ class BottomSheet extends Component {
 		this.onShouldSetBottomSheetMaxHeight( true );
 	}
 
+	setIsFullScreen( isFullScreen ) {
+		if ( isFullScreen !== this.state.isFullScreen ) {
+			if ( isFullScreen ) {
+				this.setState( { isFullScreen, isMaxHeightSet: false } );
+			} else {
+				this.setState( { isFullScreen, isMaxHeightSet: true } );
+			}
+		}
+	}
+
 	onHardwareButtonPress() {
 		const { onClose } = this.props;
 		const { handleHardwareButtonPress } = this.state;
@@ -275,6 +288,7 @@ class BottomSheet extends Component {
 			isScrolling,
 			scrollEnabled,
 			isMaxHeightSet,
+			isFullScreen,
 		} = this.state;
 
 		const panResponder = PanResponder.create( {
@@ -303,6 +317,12 @@ class BottomSheet extends Component {
 			styles.bottomSheetHeaderTitleDark
 		);
 
+		let listStyle = {};
+		if ( isFullScreen ) {
+			listStyle = { flexGrow: 1 };
+		} else if ( isMaxHeightSet ) {
+			listStyle = { maxHeight };
+		}
 		const listProps = {
 			disableScrollViewPanResponder: true,
 			bounces,
@@ -316,8 +336,9 @@ class BottomSheet extends Component {
 				contentStyle,
 				isChildrenScrollable && this.getContentStyle(),
 				contentStyle,
+				isFullScreen && { flexGrow: 1 },
 			],
-			style: isMaxHeightSet ? { maxHeight } : {},
+			style: listStyle,
 			scrollEnabled,
 			automaticallyAdjustContentInsets: false,
 		};
@@ -373,6 +394,7 @@ class BottomSheet extends Component {
 					style={ {
 						...backgroundStyle,
 						borderColor: 'rgba(0, 0, 0, 0.1)',
+						flex: isFullScreen ? 1 : undefined,
 						...style,
 					} }
 					keyboardVerticalOffset={ -safeAreaBottomInset }
@@ -396,6 +418,7 @@ class BottomSheet extends Component {
 								onHandleHardwareButtonPress: this
 									.onHandleHardwareButtonPress,
 								listProps,
+								setIsFullScreen: this.setIsFullScreen,
 							} }
 						>
 							<TouchableHighlight accessible={ false }>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
In this PR i added a `fullScreen` prop to the `BottomSheet.NavigationScreen` which allows us to determine which screen is a full height one.

## How has this been tested?
This can be tested in this PR https://github.com/wordpress-mobile/gutenberg-mobile/pull/2484 since currently, we do not have any fullHeight modal 

## Screenshots <!-- if applicable -->

## Types of changes
Introduce a new prop : `fullScreen` to the `BottomSheet.NavigationScreen`

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
