### PR TITLE
Remove WP_Widget_Block from the legacy dropdown list

### DIFF
--- a/lib/widgets.php
+++ b/lib/widgets.php
@@ -118,6 +118,7 @@ function gutenberg_get_legacy_widget_settings() {
 	$widgets_to_exclude_from_legacy_widget_block = apply_filters(
 		'widgets_to_exclude_from_legacy_widget_block',
 		array(
+			'WP_Widget_Block',
 			'WP_Widget_Pages',
 			'WP_Widget_Calendar',
 			'WP_Widget_Archives',


### PR DESCRIPTION
## Description

As mentioned in https://github.com/WordPress/gutenberg/pull/24290#discussion_r468765681, this is what happens when you add a legacy widget on the experimental management screen:

**Before:**
<img width="721" alt="Zrzut ekranu 2020-08-25 o 12 32 23" src="https://user-images.githubusercontent.com/205419/91164388-3af56180-e6cf-11ea-8397-066180a9a365.png">

This is undesired, the Block widget shouldn't be visible to the user, it's just an implementation detail to ensure interoperability. This PR removes it from that dropdown like this:

**After:**
<img width="729" alt="Zrzut ekranu 2020-08-25 o 12 32 41" src="https://user-images.githubusercontent.com/205419/91164397-3df05200-e6cf-11ea-9702-d590b52c0fa7.png">

## How has this been tested?

* Apply the patch
* Go to experimental Widgets screen
* Add Legacy widget block
* Open the dropdown
* Confirm it's consistent with the **After** screenshot.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
