### PR TITLE
[edit-widgets] Fix isSavingWidgetAreas selector

### DIFF
--- a/packages/edit-widgets/src/components/save-button/index.js
+++ b/packages/edit-widgets/src/components/save-button/index.js
@@ -30,7 +30,7 @@ function SaveButton() {
 			onClick={ isSaving ? undefined : saveEditedWidgetAreas }
 			disabled={ ! hasEditedWidgetAreaIds }
 		>
-			{ __( 'Update' ) }
+			{ isSaving ? __( 'Saving…' ) : __( 'Update' ) }
 		</Button>
 	);
 }

--- a/packages/edit-widgets/src/store/selectors.js
+++ b/packages/edit-widgets/src/store/selectors.js
@@ -75,7 +75,10 @@ export const isSavingWidgetAreas = createRegistrySelector(
 				.getWidgetAreas()
 				?.map( ( { id } ) => id );
 		}
-		for ( const id in ids ) {
+		if ( ! ids ) {
+			return false;
+		}
+		for ( const id of ids ) {
 			const isSaving = select( 'core' ).isSavingEntityRecord(
 				KIND,
 				WIDGET_AREA_ENTITY_TYPE,


### PR DESCRIPTION
## Description
As mentioned in https://github.com/WordPress/gutenberg/pull/24290#pullrequestreview-464691675, the widgets management screen should indicate progress when the Block Area screen's Update button is clicked.

It turns out the code was in there, but `isSavingWidgetAreas` selector wasn't working properly. This PR fixes that selector and improves the interaction with the button.

**Before**
<img width="146" alt="Zrzut ekranu 2020-08-25 o 12 46 51" src="https://user-images.githubusercontent.com/205419/91165585-2dd97200-e6d1-11ea-9710-0ec1df695a37.png">

**After**
<img width="141" alt="Zrzut ekranu 2020-08-25 o 12 47 16" src="https://user-images.githubusercontent.com/205419/91165583-2d40db80-e6d1-11ea-9346-852561142830.png">

## How has this been tested?
1. Go to the experimental widgets screen
1. Change something
1. Click "Update"
1. Confirm the button looks like on the **After** screenshot.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
