### PR TITLE
[edit-widgets] Trim whitespace from rendered widgets

### DIFF
--- a/lib/class-wp-rest-sidebars-controller.php
+++ b/lib/class-wp-rest-sidebars-controller.php
@@ -321,7 +321,7 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 
 						call_user_func_array( $widget['callback'], $widget_parameters );
 
-						$widget['rendered'] = ob_get_clean();
+						$widget['rendered'] = trim( ob_get_clean() );
 					}
 
 					if ( is_array( $widget['callback'] ) && isset( $widget['callback'][0] ) ) {

--- a/phpunit/class-rest-sidebars-controller-test.php
+++ b/phpunit/class-rest-sidebars-controller-test.php
@@ -227,7 +227,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 							'name'         => 'Text',
 							'description'  => 'Arbitrary text.',
 							'number'       => 1,
-							'rendered'     => '			<div class="textwidget">Custom text test</div>' . "\n		",
+							'rendered'     => '<div class="textwidget">Custom text test</div>',
 						),
 						array(
 							'id'           => 'rss-1',
@@ -356,7 +356,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 						'name'         => 'Text',
 						'description'  => 'Arbitrary text.',
 						'number'       => 1,
-						'rendered'     => '			<div class="textwidget">Updated text test</div>' . "\n		",
+						'rendered'     => '<div class="textwidget">Updated text test</div>',
 					),
 					array(
 						'id'           => 'text-2',
@@ -370,7 +370,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 						'name'         => 'Text',
 						'description'  => 'Arbitrary text.',
 						'number'       => 2,
-						'rendered'     => '			<div class="textwidget">Another text widget</div>' . "\n		",
+						'rendered'     => '<div class="textwidget">Another text widget</div>',
 					),
 				),
 			),


### PR DESCRIPTION
## Description

There is some whitespace around `rendered` widgets coming from the sidebars API endpoints. As mentioned in this comment, it could be a good idea to trim it: https://github.com/WordPress/gutenberg/pull/24290#discussion_r468305723

This PR does just that.

## How has this been tested?
Make sure all checks pass on this PR

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
