### PR TITLE
[edit-widgets] Improve the UX of wp_inactive_widgets on the experimental screen

### DIFF
--- a/lib/class-wp-rest-sidebars-controller.php
+++ b/lib/class-wp-rest-sidebars-controller.php
@@ -290,8 +290,9 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 
 		$widgets          = array();
 		$sidebars_widgets = (array) wp_get_sidebars_widgets();
+		$is_registered_sidebar = $sidebar_id === 'wp_inactive_widgets' || isset( $wp_registered_sidebars[ $sidebar_id ] );
 
-		if ( isset( $wp_registered_sidebars[ $sidebar_id ] ) && isset( $sidebars_widgets[ $sidebar_id ] ) ) {
+		if ( $is_registered_sidebar && isset( $sidebars_widgets[ $sidebar_id ] ) ) {
 			foreach ( $sidebars_widgets[ $sidebar_id ] as $widget_id ) {
 				// Just to be sure.
 				if ( isset( $wp_registered_widgets[ $widget_id ] ) ) {
@@ -381,6 +382,10 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 			$sidebar['description'] = isset( $registered_sidebar['description'] ) ? $registered_sidebar['description'] : '';
 		} else {
 			$sidebar['status'] = 'inactive';
+		}
+
+		if ( $sidebar['id'] === 'wp_inactive_widgets' && empty( $sidebar['name'] ) ) {
+			$sidebar['name'] = __( 'Inactive widgets', 'gutenberg' );
 		}
 
 		$fields = $this->get_fields_for_response( $request );

--- a/lib/class-wp-rest-sidebars-controller.php
+++ b/lib/class-wp-rest-sidebars-controller.php
@@ -288,11 +288,13 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 	public static function get_widgets( $sidebar_id ) {
 		global $wp_registered_widgets, $wp_registered_sidebars;
 
-		$widgets               = array();
-		$sidebars_widgets      = (array) wp_get_sidebars_widgets();
-		$is_registered_sidebar = 'wp_inactive_widgets' === $sidebar_id || isset( $wp_registered_sidebars[ $sidebar_id ] );
+		$widgets            = array();
+		$sidebars_widgets   = (array) wp_get_sidebars_widgets();
+		$registered_sidebar = isset( $wp_registered_sidebars[ $sidebar_id ] ) ? $wp_registered_sidebars[ $sidebar_id ] : (
+			'wp_inactive_widgets' === $sidebar_id ? array() : null
+		);
 
-		if ( $is_registered_sidebar && isset( $sidebars_widgets[ $sidebar_id ] ) ) {
+		if ( null !== $registered_sidebar && isset( $sidebars_widgets[ $sidebar_id ] ) ) {
 			foreach ( $sidebars_widgets[ $sidebar_id ] as $widget_id ) {
 				// Just to be sure.
 				if ( isset( $wp_registered_widgets[ $widget_id ] ) ) {
@@ -304,7 +306,7 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 						$widget_parameters = array_merge(
 							array(
 								array_merge(
-									$wp_registered_sidebars[ $sidebar_id ],
+									$registered_sidebar,
 									array(
 										'widget_id'   => $widget_id,
 										'widget_name' => $widget['name'],
@@ -342,7 +344,7 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 						$instance               = $widget['callback'][0];
 						$widget['widget_class'] = get_class( $instance );
 						$widget['settings']     = static::get_sidebar_widget_instance(
-							$wp_registered_sidebars[ $sidebar_id ],
+							$registered_sidebar,
 							$widget_id
 						);
 						$widget['number']       = (int) $widget['params'][0]['number'];

--- a/lib/class-wp-rest-sidebars-controller.php
+++ b/lib/class-wp-rest-sidebars-controller.php
@@ -288,9 +288,9 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 	public static function get_widgets( $sidebar_id ) {
 		global $wp_registered_widgets, $wp_registered_sidebars;
 
-		$widgets          = array();
-		$sidebars_widgets = (array) wp_get_sidebars_widgets();
-		$is_registered_sidebar = $sidebar_id === 'wp_inactive_widgets' || isset( $wp_registered_sidebars[ $sidebar_id ] );
+		$widgets               = array();
+		$sidebars_widgets      = (array) wp_get_sidebars_widgets();
+		$is_registered_sidebar = 'wp_inactive_widgets' === $sidebar_id || isset( $wp_registered_sidebars[ $sidebar_id ] );
 
 		if ( $is_registered_sidebar && isset( $sidebars_widgets[ $sidebar_id ] ) ) {
 			foreach ( $sidebars_widgets[ $sidebar_id ] as $widget_id ) {
@@ -384,7 +384,7 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 			$sidebar['status'] = 'inactive';
 		}
 
-		if ( $sidebar['id'] === 'wp_inactive_widgets' && empty( $sidebar['name'] ) ) {
+		if ( 'wp_inactive_widgets' === $sidebar['id'] && empty( $sidebar['name'] ) ) {
 			$sidebar['name'] = __( 'Inactive widgets', 'gutenberg' );
 		}
 

--- a/packages/edit-widgets/src/store/resolvers.js
+++ b/packages/edit-widgets/src/store/resolvers.js
@@ -30,7 +30,16 @@ export function* getWidgetAreas() {
 
 	const widgetAreaBlocks = [];
 	const widgetIdToClientId = {};
-	for ( const widgetArea of widgetAreas ) {
+	const sortedWidgetAreas = widgetAreas.sort( ( a, b ) => {
+		if ( a.id === 'wp_inactive_widgets' ) {
+			return 1;
+		}
+		if ( b.id === 'wp_inactive_widgets' ) {
+			return -1;
+		}
+		return 0;
+	} );
+	for ( const widgetArea of sortedWidgetAreas ) {
 		const widgetBlocks = [];
 		for ( const widget of widgetArea.widgets ) {
 			const block = transformWidgetToBlock( widget );

--- a/packages/edit-widgets/src/store/resolvers.js
+++ b/packages/edit-widgets/src/store/resolvers.js
@@ -44,10 +44,6 @@ export function* getWidgetAreas() {
 			widgetBlocks
 		);
 
-		if ( widgetArea.id === 'wp_inactive_widgets' ) {
-			continue;
-		}
-
 		widgetAreaBlocks.push(
 			createBlock( 'core/widget-area', {
 				id: widgetArea.id,

--- a/packages/edit-widgets/src/store/resolvers.js
+++ b/packages/edit-widgets/src/store/resolvers.js
@@ -44,6 +44,10 @@ export function* getWidgetAreas() {
 			widgetBlocks
 		);
 
+		if ( widgetArea.id === 'wp_inactive_widgets' ) {
+			continue;
+		}
+
 		widgetAreaBlocks.push(
 			createBlock( 'core/widget-area', {
 				id: widgetArea.id,

--- a/packages/edit-widgets/src/store/selectors.js
+++ b/packages/edit-widgets/src/store/selectors.js
@@ -34,9 +34,11 @@ export const getWidgetAreas = createRegistrySelector( ( select ) => () => {
 	}
 
 	const query = buildWidgetAreasQuery();
-	return select( 'core' )
-		.getEntityRecords( KIND, WIDGET_AREA_ENTITY_TYPE, query )
-		.filter( ( { id } ) => id !== 'wp_inactive_widgets' );
+	return select( 'core' ).getEntityRecords(
+		KIND,
+		WIDGET_AREA_ENTITY_TYPE,
+		query
+	);
 } );
 
 export const getEditedWidgetAreas = createRegistrySelector(

--- a/phpunit/class-rest-sidebars-controller-test.php
+++ b/phpunit/class-rest-sidebars-controller-test.php
@@ -471,6 +471,91 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	}
 
 	/**
+	 *
+	 */
+	public function test_get_items_inactive_widgets() {
+		$this->setup_widget(
+			'widget_rss',
+			1,
+			array(
+				'title' => 'RSS test',
+			)
+		);
+		$this->setup_widget(
+			'widget_text',
+			1,
+			array(
+				'text' => 'Custom text test',
+			)
+		);
+		$this->setup_sidebar(
+			'sidebar-1',
+			array(
+				'name' => 'Test sidebar',
+			),
+			array( 'text-1' )
+		);
+		update_option(
+			'sidebars_widgets',
+			array_merge(
+				get_option( 'sidebars_widgets' ),
+				array(
+					'wp_inactive_widgets' => array( 'rss-1', 'rss' ),
+				)
+			)
+		);
+
+		$request  = new WP_REST_Request( 'GET', '/__experimental/sidebars' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		$this->assertEquals(
+			array(
+				array(
+					'id'          => 'sidebar-1',
+					'name'        => 'Test sidebar',
+					'description' => '',
+					'status'      => 'active',
+					'widgets'     => array(
+						array(
+							'id'           => 'text-1',
+							'settings'     => array(
+								'text' => 'Custom text test',
+							),
+							'id_base'      => 'text',
+							'widget_class' => 'WP_Widget_Text',
+							'name'         => 'Text',
+							'description'  => 'Arbitrary text.',
+							'number'       => 1,
+							'rendered'     => '			<div class="textwidget">Custom text test</div>' . "\n		",
+						),
+					),
+				),
+				array(
+					'id'          => 'wp_inactive_widgets',
+					'name'        => 'Inactive widgets',
+					'description' => '',
+					'status'      => 'inactive',
+					'widgets'     => array(
+						array(
+							'id'           => 'rss-1',
+							'settings'     => array(
+								'title' => 'RSS test',
+							),
+							'id_base'      => 'rss',
+							'widget_class' => 'WP_Widget_RSS',
+							'name'         => 'RSS',
+							'description'  => 'Entries from any RSS or Atom feed.',
+							'number'       => 1,
+							'rendered'     => '',
+						),
+					),
+				),
+			),
+			$data
+		);
+	}
+
+	/**
 	 * The test_delete_item() method does not exist for sidebar.
 	 */
 	public function test_delete_item() {

--- a/phpunit/class-rest-sidebars-controller-test.php
+++ b/phpunit/class-rest-sidebars-controller-test.php
@@ -526,7 +526,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 							'name'         => 'Text',
 							'description'  => 'Arbitrary text.',
 							'number'       => 1,
-							'rendered'     => '			<div class="textwidget">Custom text test</div>' . "\n		",
+							'rendered'     => '<div class="textwidget">Custom text test</div>',
 						),
 					),
 				),


### PR DESCRIPTION
## Description
At the moment, there is an empty area at the top of the Block Areas screen which has no title. It is the inactive widgets area. Widgets in that area are not being correctly stored/returned by the API and they are lost after leaving the page. After applying this PR, the interaction in question works properly:

**Before:**
<img width="731" alt="Zrzut ekranu 2020-08-25 o 13 24 26" src="https://user-images.githubusercontent.com/205419/91168670-5021be80-e6d6-11ea-9b57-c9bea3f62670.png">

**After:**
<img width="734" alt="Zrzut ekranu 2020-08-25 o 13 24 09" src="https://user-images.githubusercontent.com/205419/91168656-48fab080-e6d6-11ea-9489-e01e0e82cc43.png">

Related comment: https://github.com/WordPress/gutenberg/pull/24290#pullrequestreview-464691675

## How has this been tested?
1. Go to the experimental widgets management screen.
1. Add a few widgets to the inactive widgets area.
1. Click save.
1. Refresh the page.
1. Confirm the widgets you just added are still there.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
