### PR TITLE
Fix PHP errors in the query loop.

### DIFF
--- a/packages/block-library/src/query-loop/index.php
+++ b/packages/block-library/src/query-loop/index.php
@@ -19,12 +19,20 @@ function render_block_core_query_loop( $attributes, $content, $block ) {
 	$page     = empty( $_GET[ $page_key ] ) ? 1 : filter_var( $_GET[ $page_key ], FILTER_VALIDATE_INT );
 
 	$query = array(
-		'post_type'    => 'post',
-		'offset'       => isset( $block->context['query']['perPage'] ) ? ( $block->context['query']['perPage'] * ( $page - 1 ) + $block->context['query']['offset'] ) : 0,
-		'category__in' => $block->context['query']['categoryIds'],
+		'post_type' => 'post',
 	);
-	if ( isset( $block->context['query']['perPage'] ) ) {
-		$query['posts_per_page'] = $block->context['query']['perPage'];
+
+	if ( isset( $block->context['query'] ) ) {
+		$query['offset'] = isset( $block->context['query']['perPage'] )
+			? ( $block->context['query']['perPage'] * ( $page - 1 ) + $block->context['query']['offset'] )
+			: 0;
+
+		if ( isset( $block->context['query']['categoryIds'] ) ) {
+			$query['category__in'] = $block->context['query']['categoryIds'];
+		}
+		if ( isset( $block->context['query']['perPage'] ) ) {
+			$query['posts_per_page'] = $block->context['query']['perPage'];
+		}
 	}
 	$posts = get_posts( $query );
 

--- a/packages/block-library/src/query-loop/index.php
+++ b/packages/block-library/src/query-loop/index.php
@@ -23,10 +23,10 @@ function render_block_core_query_loop( $attributes, $content, $block ) {
 	);
 
 	if ( isset( $block->context['query'] ) ) {
-		$query['offset'] = isset( $block->context['query']['perPage'] )
-			? ( $block->context['query']['perPage'] * ( $page - 1 ) + $block->context['query']['offset'] )
-			: 0;
-
+		$query['offset'] = 0;
+		if ( isset( $block->context['query']['perPage'] ) ) {
+			$query['offset'] = ( $block->context['query']['perPage'] * ( $page - 1 ) ) + $block->context['query']['offset'];
+		}
 		if ( isset( $block->context['query']['categoryIds'] ) ) {
 			$query['category__in'] = $block->context['query']['categoryIds'];
 		}

--- a/packages/block-library/src/query-loop/index.php
+++ b/packages/block-library/src/query-loop/index.php
@@ -20,10 +20,10 @@ function render_block_core_query_loop( $attributes, $content, $block ) {
 
 	$query = array(
 		'post_type' => 'post',
+		'offset'    => 0,
 	);
 
 	if ( isset( $block->context['query'] ) ) {
-		$query['offset'] = 0;
 		if ( isset( $block->context['query']['perPage'] ) ) {
 			$query['offset'] = ( $block->context['query']['perPage'] * ( $page - 1 ) ) + $block->context['query']['offset'];
 		}


### PR DESCRIPTION
Got an error log full of these today while working on FSE:

```
PHP Notice:  Undefined index: query in wp-content/plugins/gutenberg/build/block-library/blocks/query-loop.php on line 24
PHP Stack trace:
PHP   1. {main}() index.php:0
PHP   2. require() index.php:17
PHP   3. require_once() wp-blog-header.php:19
PHP   4. include() wp-includes/template-loader.php:106
PHP   5. gutenberg_render_the_template() wp-content/plugins/gutenberg/lib/template-canvas.php:19
PHP   6. do_blocks() wp-content/plugins/gutenberg/lib/template-loader.php:378
PHP   7. render_block() wp-includes/blocks.php:758
PHP   8. apply_filters() wp-includes/blocks.php:670
PHP   9. WP_Hook->apply_filters() wp-includes/plugin.php:206
PHP  10. gutenberg_render_block_with_assigned_block_context() wp-includes/class-wp-hook.php:287
PHP  11. WP_Block->render() wp-content/plugins/gutenberg/lib/compat.php:431
PHP  12. WP_Block->render() wp-includes/class-wp-block.php:211
PHP  13. gutenberg_render_block_core_query_loop() wp-includes/class-wp-block.php:217
```

This PR adds some additional checks to ensure that `$block->context['query']` is set before using it.

## How has this been tested?

PHP notices no longer occur after the commit.

## Types of changes

Bug fix: Added an `isset()` check to wrap parts of the query that use the previously undefined properties.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] ~~My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] ~~My code has proper inline documentation.~~ ( Not applicable) <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] ~~I've included developer documentation if appropriate.~~ ( Not applicable) <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] ~~I've updated all React Native files affected by any refactorings/renamings in this PR.~~ ( Not applicable) <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
