### PR TITLE
[Sidebars endpoint] Save function-based widgets 

### DIFF
--- a/lib/class-wp-rest-sidebars-controller.php
+++ b/lib/class-wp-rest-sidebars-controller.php
@@ -176,11 +176,23 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 						$wp_registered_widgets[ $input_widget['id'] ]['callback'][0] = $new_object;
 					}
 				}
-			} elseif ( $wp_registered_widget_updates[ $input_widget['id'] ] ) {
-				// Old-style widget.
-				$update_control = $wp_registered_widget_updates[ $input_widget['id'] ];
-				$_POST          = wp_slash( $input_widget['settings'] );
-				call_user_func( $update_control['callback'] );
+			} else {
+				$registered_widget_id = null;
+				if ( isset( $wp_registered_widget_updates[ $input_widget['id'] ] ) ) {
+					$registered_widget_id = $input_widget['id'];
+				} else {
+					$numberless_id = substr( $input_widget['id'], 0, strrpos( $input_widget['id'], '-' ) );
+					if ( isset( $wp_registered_widget_updates[ $numberless_id ] ) ) {
+						$registered_widget_id = $numberless_id;
+					}
+				}
+
+				if ( $registered_widget_id ) {
+					// Old-style widget.
+					$update_control = $wp_registered_widget_updates[ $registered_widget_id ];
+					$_POST          = wp_slash( $input_widget['settings'] );
+					call_user_func( $update_control['callback'] );
+				}
 			}
 			ob_end_clean();
 
@@ -213,6 +225,7 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 
 			$data[] = $this->prepare_item_for_response( $sidebar, $request )->get_data();
 		}
+
 		return rest_ensure_response( $data );
 	}
 
@@ -349,8 +362,8 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 	/**
 	 * Prepare a single sidebar output for response
 	 *
-	 * @param array           $raw_sidebar Sidebar instance.
-	 * @param WP_REST_Request $request     Request object.
+	 * @param array $raw_sidebar Sidebar instance.
+	 * @param WP_REST_Request $request Request object.
 	 *
 	 * @return WP_REST_Response $data
 	 */
@@ -522,7 +535,7 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 	/**
 	 * Retrieves a widget instance.
 	 *
-	 * @param array  $sidebar sidebar data available at $wp_registered_sidebars.
+	 * @param array $sidebar sidebar data available at $wp_registered_sidebars.
 	 * @param string $id Identifier of the widget instance.
 	 *
 	 * @return array Array containing the widget instance.

--- a/lib/class-wp-rest-sidebars-controller.php
+++ b/lib/class-wp-rest-sidebars-controller.php
@@ -142,7 +142,7 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 		$sidebar_widgets_ids = array();
 		foreach ( $input_widgets as $input_widget ) {
 			ob_start();
-			if ( isset( $wp_registered_widget_updates[ $input_widget['id_base'] ] ) ) {
+			if ( isset( $input_widget['id_base'] ) && isset( $wp_registered_widget_updates[ $input_widget['id_base'] ] ) ) {
 				// Class-based widget.
 				$update_control = $wp_registered_widget_updates[ $input_widget['id_base'] ];
 				if ( ! isset( $input_widget['id'] ) ) {
@@ -362,7 +362,7 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 	/**
 	 * Prepare a single sidebar output for response
 	 *
-	 * @param array $raw_sidebar Sidebar instance.
+	 * @param array           $raw_sidebar Sidebar instance.
 	 * @param WP_REST_Request $request Request object.
 	 *
 	 * @return WP_REST_Response $data
@@ -403,7 +403,7 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 			foreach ( $schema['properties']['widgets']['items']['properties'] as $property_id => $property ) {
 				if ( isset( $widget[ $property_id ] ) && gettype( $widget[ $property_id ] ) === $property['type'] ) {
 					$widget_data[ $property_id ] = $widget[ $property_id ];
-				} elseif ( 'settings' === $property_id && 'array' === gettype( $widget[ $property_id ] ) ) {
+				} elseif ( 'settings' === $property_id && isset( $widget[ $property_id ] ) && 'array' === gettype( $widget[ $property_id ] ) ) {
 					$widget_data[ $property_id ] = $widget['settings'];
 				} elseif ( isset( $property['default'] ) ) {
 					$widget_data[ $property_id ] = $property['default'];
@@ -535,7 +535,7 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 	/**
 	 * Retrieves a widget instance.
 	 *
-	 * @param array $sidebar sidebar data available at $wp_registered_sidebars.
+	 * @param array  $sidebar sidebar data available at $wp_registered_sidebars.
 	 * @param string $id Identifier of the widget instance.
 	 *
 	 * @return array Array containing the widget instance.


### PR DESCRIPTION
##  Description
As @jorgefilipecosta noticed in https://github.com/WordPress/gutenberg/pull/24290/files#r468740440:

> Right now the non-class based widgets seem to not be saved.
> I tested with this simple widget https://themes.trac.wordpress.org/browser/silesia/1.0.6/include/widgets/feedburner.php
(pasted it on functions.php)
> And I verified the values on the form never get saved.

The root cause is the API endpoint getting confused about widget IDs like `feedburner-1` vs `feedburner`. Function-based widgets may be registered following either pattern and the API needs to account for that. This PR solves this problem.

## How has this been tested?

1. Add the feedburner widget mentioned above to your local WP.
1. Go to the experimental widget management screen.
1. Add a legacy widget and set it to Feedburner.
1. Update title and feedburner ID.
1. Click save.
1. Refresh the page.
1. Confirm the widget is rendered with the settings you provided earlier.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
