### PR TITLE
[edit-widgets] Simplify gutenberg_widgets_init when $hook === 'widgets.php'

### DIFF
--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -38,6 +38,7 @@ function the_gutenberg_widgets( $page = 'gutenberg_page_gutenberg-widgets' ) {
 function gutenberg_widgets_init( $hook ) {
 	if ( $hook === 'widgets.php' ) {
 		wp_enqueue_style( 'wp-block-library' );
+		wp_enqueue_style( 'wp-block-library-theme' );
 		return;
 	}
 	if ( ! in_array( $hook, array( 'gutenberg_page_gutenberg-widgets', 'gutenberg_customizer', ), true ) ) {

--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -36,12 +36,12 @@ function the_gutenberg_widgets( $page = 'gutenberg_page_gutenberg-widgets' ) {
  * @param string $hook Page.
  */
 function gutenberg_widgets_init( $hook ) {
-	if ( $hook === 'widgets.php' ) {
+	if ( 'widgets.php' === $hook ) {
 		wp_enqueue_style( 'wp-block-library' );
 		wp_enqueue_style( 'wp-block-library-theme' );
 		return;
 	}
-	if ( ! in_array( $hook, array( 'gutenberg_page_gutenberg-widgets', 'gutenberg_customizer', ), true ) ) {
+	if ( ! in_array( $hook, array( 'gutenberg_page_gutenberg-widgets', 'gutenberg_customizer' ), true ) ) {
 		return;
 	}
 

--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -36,7 +36,11 @@ function the_gutenberg_widgets( $page = 'gutenberg_page_gutenberg-widgets' ) {
  * @param string $hook Page.
  */
 function gutenberg_widgets_init( $hook ) {
-	if ( ! in_array( $hook, array( 'gutenberg_page_gutenberg-widgets', 'gutenberg_customizer', 'widgets.php' ), true ) ) {
+	if ( $hook === 'widgets.php' ) {
+		wp_enqueue_style( 'wp-block-library' );
+		return;
+	}
+	if ( ! in_array( $hook, array( 'gutenberg_page_gutenberg-widgets', 'gutenberg_customizer', ), true ) ) {
 		return;
 	}
 


### PR DESCRIPTION
## Description
As @noisysocks noted in https://github.com/WordPress/gutenberg/pull/24290#discussion_r468945880:

> We don't need to run all of this function in widgets.php, just wp_enqueue_style( 'wp-block-library' );

This PR fixes that. A nice side-effect is that it also fixes [a JS error on the old widgets screen](https://github.com/WordPress/gutenberg/pull/24290#pullrequestreview-465272414).

## How has this been tested?

1. Go to the experimental widget management screen.
1. Add a few block widgets and save.
1. Go to legacy widgets screen (/widgets.php).
1. Confirm your block widgets are rendering properly and have appropriate CSS applied, for example a quote should look like on the screenshot:

<img width="438" alt="Zrzut ekranu 2020-08-25 o 14 55 59" src="https://user-images.githubusercontent.com/205419/91176867-2b801380-e6e3-11ea-926d-5735db7eeb84.png">

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
