### PR TITLE
Add "read more" keyword to the `more` block

### DIFF
--- a/packages/block-library/src/more/index.js
+++ b/packages/block-library/src/more/index.js
@@ -21,6 +21,7 @@ export const settings = {
 	description: __(
 		'Content before this block will be shown in the excerpt on your archives page.'
 	),
+	keywords: [ __( 'read more' ) ],
 	icon,
 	example: {},
 	__experimentalLabel( attributes, { context } ) {

--- a/packages/block-library/src/more/index.js
+++ b/packages/block-library/src/more/index.js
@@ -21,7 +21,7 @@ export const settings = {
 	description: __(
 		'Content before this block will be shown in the excerpt on your archives page.'
 	),
-	keywords: [ __( 'read' ) ], // Show in search results when looking for "Read More".
+	keywords: [ __( 'read more' ) ],
 	icon,
 	example: {},
 	__experimentalLabel( attributes, { context } ) {

--- a/packages/block-library/src/more/index.js
+++ b/packages/block-library/src/more/index.js
@@ -21,7 +21,7 @@ export const settings = {
 	description: __(
 		'Content before this block will be shown in the excerpt on your archives page.'
 	),
-	keywords: [ __( 'read more' ) ],
+	keywords: [ __( 'read' ) ], // Show in search results when looking for "Read More".
 	icon,
 	example: {},
 	__experimentalLabel( attributes, { context } ) {


### PR DESCRIPTION
Fixes #24779 

This PR adds a `read more` keyword to the `more` block so it's easier to find when searching for it.

## How has this been tested?
Searching for `read` now brings up the block.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
