### PR TITLE
Add Image Size dropdown for Media & Text block

### DIFF
--- a/packages/block-library/src/media-text/block.json
+++ b/packages/block-library/src/media-text/block.json
@@ -63,6 +63,10 @@
 			"type": "number",
 			"default": 50
 		},
+		"mediaSizeSlug": {
+			"type": "string",
+			"default": "full"
+		},
 		"isStackedOnMobile": {
 			"type": "boolean",
 			"default": true

--- a/packages/block-library/src/media-text/block.json
+++ b/packages/block-library/src/media-text/block.json
@@ -79,10 +79,7 @@
 	},
 	"supports": {
 		"anchor": true,
-		"align": [
-			"wide",
-			"full"
-		],
+		"align": [ "wide", "full" ],
 		"html": false,
 		"lightBlockWrapper": true,
 		"__experimentalColor": {

--- a/packages/block-library/src/media-text/block.json
+++ b/packages/block-library/src/media-text/block.json
@@ -64,8 +64,7 @@
 			"default": 50
 		},
 		"mediaSizeSlug": {
-			"type": "string",
-			"default": "full"
+			"type": "string"
 		},
 		"isStackedOnMobile": {
 			"type": "boolean",

--- a/packages/block-library/src/media-text/constants.js
+++ b/packages/block-library/src/media-text/constants.js
@@ -1,0 +1,1 @@
+export const DEFAULT_MEDIA_SIZE_SLUG = 'full';

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -33,6 +33,7 @@ import { pullLeft, pullRight } from '@wordpress/icons';
  * Internal dependencies
  */
 import MediaContainer from './media-container';
+import { DEFAULT_MEDIA_SIZE_SLUG } from './constants';
 
 /**
  * Constants
@@ -125,10 +126,10 @@ function MediaTextEdit( { attributes, isSelected, setAttributes } ) {
 		mediaType,
 		mediaUrl,
 		mediaWidth,
-		mediaSizeSlug,
 		rel,
 		verticalAlignment,
 	} = attributes;
+	const mediaSizeSlug = attributes.mediaSizeSlug || DEFAULT_MEDIA_SIZE_SLUG;
 
 	const image = useSelect(
 		( select ) =>

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { pick, get, map, filter } from 'lodash';
+import { map, filter } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -57,6 +57,11 @@ const applyWidthConstraints = ( width ) =>
 
 const LINK_DESTINATION_MEDIA = 'media';
 const LINK_DESTINATION_ATTACHMENT = 'attachment';
+
+function getImageSourceUrlBySizeSlug( image, slug ) {
+	// eslint-disable-next-line camelcase
+	return image?.media_details?.sizes?.[ slug ]?.source_url;
+}
 
 function attributesFromMedia( {
 	attributes: { linkDestination, href },
@@ -192,23 +197,18 @@ function MediaTextEdit( { attributes, isSelected, setAttributes } ) {
 		setAttributes( { verticalAlignment: alignment } );
 	};
 
-	const { imageSizes } = useSelect( ( select ) => {
-		const { getSettings } = select( 'core/block-editor' );
-		return pick( getSettings(), [ 'imageSizes' ] );
+	const imageSizes = useSelect( ( select ) => {
+		const settings = select( 'core/block-editor' ).getSettings();
+		return settings?.imageSizes;
 	} );
 	const imageSizeOptions = map(
 		filter( imageSizes, ( { slug } ) =>
-			get( image, [ 'media_details', 'sizes', slug, 'source_url' ] )
+			getImageSourceUrlBySizeSlug( image, slug )
 		),
 		( { name, slug } ) => ( { value: slug, label: name } )
 	);
 	const updateImage = ( newMediaSizeSlug ) => {
-		const newUrl = get( image, [
-			'media_details',
-			'sizes',
-			newMediaSizeSlug,
-			'source_url',
-		] );
+		const newUrl = getImageSourceUrlBySizeSlug( image, newMediaSizeSlug );
 
 		if ( ! newUrl ) {
 			return null;

--- a/packages/block-library/src/media-text/save.js
+++ b/packages/block-library/src/media-text/save.js
@@ -24,6 +24,7 @@ export default function save( { attributes } ) {
 		mediaType,
 		mediaUrl,
 		mediaWidth,
+		mediaSizeSlug,
 		mediaId,
 		verticalAlignment,
 		imageFill,
@@ -35,17 +36,12 @@ export default function save( { attributes } ) {
 	} = attributes;
 	const newRel = isEmpty( rel ) ? undefined : rel;
 
-	let image = (
-		<img
-			src={ mediaUrl }
-			alt={ mediaAlt }
-			className={
-				mediaId && mediaType === 'image'
-					? `wp-image-${ mediaId }`
-					: null
-			}
-		/>
-	);
+	const classes = classnames( {
+		[ `wp-image-${ mediaId }` ]: mediaId && mediaType === 'image',
+		[ `size-${ mediaSizeSlug }` ]: mediaId && mediaType === 'image',
+	} );
+
+	let image = <img src={ mediaUrl } alt={ mediaAlt } className={ classes } />;
 
 	if ( href ) {
 		image = (

--- a/packages/block-library/src/media-text/save.js
+++ b/packages/block-library/src/media-text/save.js
@@ -36,12 +36,15 @@ export default function save( { attributes } ) {
 	} = attributes;
 	const newRel = isEmpty( rel ) ? undefined : rel;
 
-	const classes = classnames( {
+	const imageClasses = classnames( {
 		[ `wp-image-${ mediaId }` ]: mediaId && mediaType === 'image',
 		[ `size-${ mediaSizeSlug }` ]: mediaId && mediaType === 'image',
 	} );
+	const imageClassName = imageClasses === '' ? null : imageClasses;
 
-	let image = <img src={ mediaUrl } alt={ mediaAlt } className={ classes } />;
+	let image = (
+		<img src={ mediaUrl } alt={ mediaAlt } className={ imageClassName } />
+	);
 
 	if ( href ) {
 		image = (

--- a/packages/block-library/src/media-text/save.js
+++ b/packages/block-library/src/media-text/save.js
@@ -13,6 +13,7 @@ import { InnerBlocks } from '@wordpress/block-editor';
  * Internal dependencies
  */
 import { imageFillStyles } from './media-container';
+import { DEFAULT_MEDIA_SIZE_SLUG } from './constants';
 
 const DEFAULT_MEDIA_WIDTH = 50;
 
@@ -24,7 +25,6 @@ export default function save( { attributes } ) {
 		mediaType,
 		mediaUrl,
 		mediaWidth,
-		mediaSizeSlug,
 		mediaId,
 		verticalAlignment,
 		imageFill,
@@ -34,6 +34,7 @@ export default function save( { attributes } ) {
 		linkTarget,
 		rel,
 	} = attributes;
+	const mediaSizeSlug = attributes.mediaSizeSlug || DEFAULT_MEDIA_SIZE_SLUG;
 	const newRel = isEmpty( rel ) ? undefined : rel;
 
 	const imageClasses = classnames( {

--- a/packages/block-library/src/media-text/save.js
+++ b/packages/block-library/src/media-text/save.js
@@ -41,10 +41,13 @@ export default function save( { attributes } ) {
 		[ `wp-image-${ mediaId }` ]: mediaId && mediaType === 'image',
 		[ `size-${ mediaSizeSlug }` ]: mediaId && mediaType === 'image',
 	} );
-	const imageClassName = imageClasses === '' ? null : imageClasses;
 
 	let image = (
-		<img src={ mediaUrl } alt={ mediaAlt } className={ imageClassName } />
+		<img
+			src={ mediaUrl }
+			alt={ mediaAlt }
+			className={ imageClasses || null }
+		/>
 	);
 
 	if ( href ) {


### PR DESCRIPTION
Closes: https://github.com/WordPress/gutenberg/issues/24688

## Description
Add an Image Size dropdown for Media & Text block. We can change the size of the image for the Image block, but we didn't have the option to do the same for Media & Text block. Which caused the Media & Text block to always render the full-size image.

**NOTE:** Default value for Image Size is **Full**. I think Large would be better in general, but that would break existing posts.

## How has this been tested?
1. Open Editor
2. Add Media & Text Block
3. Select an **image** from the media library
4. Make sure Media & Text Block is in focus
5. You should see an Image Size dropdown in the right sidebar

## Screenshots
![image](https://user-images.githubusercontent.com/2256104/91188129-3cd01c80-e6f1-11ea-92bd-ca4dbed8da11.png)

## Types of changes
New feature (non-breaking change which adds functionality) 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
