### PR TITLE
Inserter: Add missing placeholder to Quick Inserter

### DIFF
--- a/packages/block-editor/src/components/inserter/quick-inserter.js
+++ b/packages/block-editor/src/components/inserter/quick-inserter.js
@@ -226,6 +226,7 @@ function QuickInserter( {
 					onChange={ ( value ) => {
 						setFilterValue( value );
 					} }
+					placeholder={ __( 'Search for a block' ) }
 				/>
 			) }
 


### PR DESCRIPTION
## Description
In #24697 the placeholder for the search input now changes to adapt to the currently active tab. This change affected the quick inserter, where the placeholder text is currently missing. This PR adds the placeholder text back into the quick inserter search input.

## How has this been tested?
Locally, all tests passed.

## Screenshots <!-- if applicable -->

| Before             | After     |
| :------------- | :----------: |
|  <img width="395" alt="Screen Shot 2020-08-25 at 9 58 29 AM" src="https://user-images.githubusercontent.com/1464705/91205051-ce239c80-e6b9-11ea-8e52-845e489f2055.png"> | <img width="412" alt="Screen Shot 2020-08-25 at 9 58 16 AM" src="https://user-images.githubusercontent.com/1464705/91205059-cfed6000-e6b9-11ea-93a7-a19bc3d9017d.png">   |

## Types of changes
Bug fix, non breaking.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
