### PR TITLE
Add text-color to tag cloud links

### DIFF
--- a/packages/block-library/src/group/editor.scss
+++ b/packages/block-library/src/group/editor.scss
@@ -34,6 +34,12 @@
 		// note: also duplicated below for full width Groups
 		width: calc(100% + 60px);
 	}
+
+	&.has-text-color {
+		a {
+			color: inherit;
+		}
+	}
 }
 
 /**

--- a/packages/block-library/src/tag-cloud/editor.scss
+++ b/packages/block-library/src/tag-cloud/editor.scss
@@ -2,6 +2,7 @@
 	a {
 		display: inline-block;
 		margin-right: 5px;
+		color: inherit;
 	}
 
 	span {

--- a/packages/block-library/src/tag-cloud/editor.scss
+++ b/packages/block-library/src/tag-cloud/editor.scss
@@ -2,7 +2,6 @@
 	a {
 		display: inline-block;
 		margin-right: 5px;
-		color: inherit;
 	}
 
 	span {


### PR DESCRIPTION
# Description
This PR fixes #24568.

## How has this been tested?
I have tested it locally on WordPress 5.5 with TwentyTwenty Theme. Also, I tested that it didn't break colors in other situations like convert paragraph block into a group block and gave color to it and it will work just fine.
 
## Screenshots <!-- if applicable -->
![screenshot-gutenberg local-2020 08 25-23_57_10](https://user-images.githubusercontent.com/25550562/91213323-0addab00-e72f-11ea-84e5-53c47f7d57f8.png)


## Types of changes
I have add a single CSS property to style link
It will not affect on other blocks styles

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
