### PR TITLE
Fix typo in removeNotice

### DIFF
--- a/packages/block-editor/src/components/media-replace-flow/README.md
+++ b/packages/block-editor/src/components/media-replace-flow/README.md
@@ -70,7 +70,7 @@ Creates a media replace notice.
 - Type: `func`
 - Required: No
 
-### remvovedNotice
+### removeNotice
 
 Removes a media replace notice.
 


### PR DESCRIPTION
Fixes minor typo `remvovedNotice ` should be `removeNotice`