### PR TITLE
Update package lock file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44768,9 +44768,9 @@
 					"dev": true
 				},
 				"bl": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
-					"integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
+					"integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
 					"dev": true,
 					"requires": {
 						"buffer": "^5.5.0",


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
In #24681, we're seeing a diff in the package-lock.json, which is causing CI to fail.

It seems this is just a dependency change as we sometimes have to (previously https://github.com/WordPress/gutenberg/pull/23747)