### PR TITLE
[Experimental widgets screen] Remove "id" attribute of the legacy-widget block

### DIFF
--- a/packages/block-library/src/legacy-widget/block.json
+++ b/packages/block-library/src/legacy-widget/block.json
@@ -5,9 +5,6 @@
 		"widgetClass": {
 			"type": "string"
 		},
-		"id": {
-			"type": "string"
-		},
 		"idBase": {
 			"type": "string"
 		},

--- a/packages/block-library/src/legacy-widget/edit/index.js
+++ b/packages/block-library/src/legacy-widget/edit/index.js
@@ -39,14 +39,15 @@ class LegacyWidgetEdit extends Component {
 			hasPermissionsToManageWidgets,
 			isSelected,
 			setAttributes,
+			widgetId,
 		} = this.props;
 		const { isPreview, hasEditForm } = this.state;
-		const { id, widgetClass } = attributes;
+		const { widgetClass } = attributes;
 		const widgetObject =
-			( id && availableLegacyWidgets[ id ] ) ||
+			( widgetId && availableLegacyWidgets[ widgetId ] ) ||
 			( widgetClass && availableLegacyWidgets[ widgetClass ] );
 
-		if ( ! id && ! widgetClass ) {
+		if ( ! widgetId && ! widgetClass ) {
 			return (
 				<LegacyWidgetPlaceholder
 					availableLegacyWidgets={ availableLegacyWidgets }
@@ -123,8 +124,8 @@ class LegacyWidgetEdit extends Component {
 					<LegacyWidgetEditHandler
 						isSelected={ isSelected }
 						isVisible={ ! isPreview }
-						id={ id }
-						idBase={ attributes.idBase || attributes.id }
+						id={ widgetId }
+						idBase={ attributes.idBase || widgetId }
 						number={ attributes.number }
 						widgetName={ get( widgetObject, [ 'name' ] ) }
 						widgetClass={ attributes.widgetClass }
@@ -180,7 +181,10 @@ class LegacyWidgetEdit extends Component {
 	}
 }
 
-export default withSelect( ( select ) => {
+export default withSelect( ( select, { clientId } ) => {
+	const widgetId = select( 'core/edit-widgets' ).getWidgetIdForClientId(
+		clientId
+	);
 	const editorSettings = select( 'core/block-editor' ).getSettings();
 	const {
 		availableLegacyWidgets,
@@ -189,5 +193,6 @@ export default withSelect( ( select ) => {
 	return {
 		hasPermissionsToManageWidgets,
 		availableLegacyWidgets,
+		widgetId,
 	};
 } )( LegacyWidgetEdit );

--- a/packages/edit-widgets/src/store/selectors.js
+++ b/packages/edit-widgets/src/store/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { keyBy } from 'lodash';
+import { invert, keyBy } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -38,6 +38,12 @@ export const getWidgetAreas = createRegistrySelector( ( select ) => () => {
 		.getEntityRecords( KIND, WIDGET_AREA_ENTITY_TYPE, query )
 		.filter( ( { id } ) => id !== 'wp_inactive_widgets' );
 } );
+
+export const getWidgetIdForClientId = ( state, clientId ) => {
+	const widgetIdToClientId = state.mapping;
+	const clientIdToWidgetId = invert( widgetIdToClientId );
+	return clientIdToWidgetId[ clientId ];
+};
 
 export const getEditedWidgetAreas = createRegistrySelector(
 	( select ) => ( state, ids ) => {

--- a/packages/edit-widgets/src/store/transformers.js
+++ b/packages/edit-widgets/src/store/transformers.js
@@ -32,7 +32,6 @@ export function transformBlockToWidget( block, relatedWidget = {} ) {
 	if ( name === 'core/legacy-widget' ) {
 		const widget = {
 			...relatedWidget,
-			id: attributes.id,
 			widget_class: attributes.widgetClass,
 			number: attributes.number,
 			id_base: attributes.idBase,

--- a/packages/edit-widgets/src/store/transformers.js
+++ b/packages/edit-widgets/src/store/transformers.js
@@ -17,7 +17,6 @@ export function transformWidgetToBlock( widget ) {
 		{
 			rendered: widget.rendered,
 			form: widget.form,
-			id: widget.id,
 			widgetClass: widget.widget_class,
 			instance: widget.settings,
 			idBase: widget.id_base,
@@ -33,7 +32,6 @@ export function transformBlockToWidget( block, relatedWidget = {} ) {
 		const widget = {
 			...relatedWidget,
 			widget_class: attributes.widgetClass,
-			number: attributes.number,
 			id_base: attributes.idBase,
 			settings: attributes.instance,
 		};


### PR DESCRIPTION
## Description
As @noisysocks mentioned in [his comment](https://github.com/WordPress/gutenberg/pull/24290#pullrequestreview-464691675):

> If you duplicate a Legacy Widget block and then make edits to the duplicate, those changes are saved to both the original and the duplicate widget

The culprit is that widgets are saved using data from their attributes. ID is one such attribute, and once the block is duplicated there are two blocks with the same ID. This PR removes the ID attribute entirely, replacing it with pulling the widget ID correlated with the block ID from  the data store. It also removes the dependency of the save function on the `number` block attribute. Note that the `number` attribute could potentially be removed entirely in a subsequent PR.

## How has this been tested?
1. Go to widgets.php and add a RSS widget.
1. Go to the experimental widgets screen.
1. Duplicate that RSS widget, set the title and URL to something different than in the original one.
1. Save and refresh the page.
1. Confirm the changes were correctly saved.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
