### PR TITLE
Use 2-pass terser compression

### DIFF
--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -84,6 +84,9 @@ const config = {
 					output: {
 						comments: /translators:/i,
 					},
+					compress: {
+						passes: 2,
+					},
 				},
 				extractComments: false,
 			} ),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -55,6 +55,9 @@ module.exports = {
 					output: {
 						comments: /translators:/i,
 					},
+					compress: {
+						passes: 2,
+					},
 				},
 				extractComments: false,
 			} ),


### PR DESCRIPTION
## Description
Terser supports multi-pass compression, which is slower at build time, but produces smaller output. This PR switches from the default 1-pass compression to 2-pass compression.

I measured a few small gains locally, but am curious to see what the bundle size bot reports.

## How has this been tested?
Ad-hoc smoke testing of local build.

## Types of changes
Build configuration changes only.

## Checklist:
- [X] My code is tested.