### PR TITLE
Add character count to info panel

### DIFF
--- a/packages/editor/src/components/character-count/index.js
+++ b/packages/editor/src/components/character-count/index.js
@@ -1,0 +1,15 @@
+/**
+ * WordPress dependencies
+ */
+import { withSelect } from '@wordpress/data';
+import { count as characterCount } from '@wordpress/wordcount';
+
+function CharacterCount( { content } ) {
+	return characterCount( content, 'characters_including_spaces' );
+}
+
+export default withSelect( ( select ) => {
+	return {
+		content: select( 'core/editor' ).getEditedPostAttribute( 'content' ),
+	};
+} )( CharacterCount );

--- a/packages/editor/src/components/character-count/index.js
+++ b/packages/editor/src/components/character-count/index.js
@@ -1,15 +1,13 @@
 /**
  * WordPress dependencies
  */
-import { withSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { count as characterCount } from '@wordpress/wordcount';
 
-function CharacterCount( { content } ) {
+export default function CharacterCount() {
+	const content = useSelect( ( select ) =>
+		select( 'core/editor' ).getEditedPostAttribute( 'content' )
+	);
+
 	return characterCount( content, 'characters_including_spaces' );
 }
-
-export default withSelect( ( select ) => {
-	return {
-		content: select( 'core/editor' ).getEditedPostAttribute( 'content' ),
-	};
-} )( CharacterCount );

--- a/packages/editor/src/components/table-of-contents/panel.js
+++ b/packages/editor/src/components/table-of-contents/panel.js
@@ -9,6 +9,7 @@ import { useSelect } from '@wordpress/data';
  */
 import WordCount from '../word-count';
 import DocumentOutline from '../document-outline';
+import CharacterCount from '../character-count';
 
 function TableOfContentsPanel( { hasOutlineItemsDisabled, onRequestClose } ) {
 	const { headingCount, paragraphCount, numberOfBlocks } = useSelect(
@@ -36,6 +37,12 @@ function TableOfContentsPanel( { hasOutlineItemsDisabled, onRequestClose } ) {
 				tabIndex="0"
 			>
 				<ul role="list" className="table-of-contents__counts">
+					<li className="table-of-contents__count">
+						{ __( 'Characters' ) }
+						<span className="table-of-contents__number">
+							<CharacterCount />
+						</span>
+					</li>
 					<li className="table-of-contents__count">
 						{ __( 'Words' ) }
 						<WordCount />

--- a/packages/editor/src/components/table-of-contents/style.scss
+++ b/packages/editor/src/components/table-of-contents/style.scss
@@ -38,6 +38,7 @@
 	display: flex;
 	flex-wrap: wrap;
 	margin: 0;
+	margin-top: -$grid-unit-10;
 }
 
 .table-of-contents__count {
@@ -48,8 +49,9 @@
 	color: $dark-gray-300;
 	padding-right: $grid-unit-10;
 	margin-bottom: 0;
+	margin-top: $grid-unit-10;
 
-	&:last-child {
+	&:nth-child(4n) {
 		padding-right: 0;
 	}
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Closes: https://github.com/WordPress/gutenberg/issues/24538
Adds "Characters" count to the document information panel.

## How has this been tested?
1. Edit an existing post or create a new one
2. Type a few words
3. Click on the (i) icon
4. See "Characters" count

## Screenshots
![image](https://user-images.githubusercontent.com/2256104/91315891-7f106100-e7b8-11ea-8772-9c7a5181213d.png)

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
