### PR TITLE
Add "Post Comment Author" block

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -75,8 +75,8 @@ function gutenberg_reregister_core_block_types() {
 			array(
 				'post-author.php'             => 'core/post-author',
 				'post-comment.php'            => 'core/post-comment',
-				'post-comment-content.php'    => 'core/post-comment-content',
 				'post-comment-author.php'     => 'core/post-comment-author',
+				'post-comment-content.php'    => 'core/post-comment-content',
 				'post-comment-date.php'       => 'core/post-comment-date',
 				'post-comments.php'           => 'core/post-comments',
 				'post-comments-count.php'     => 'core/post-comments-count',

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -76,6 +76,7 @@ function gutenberg_reregister_core_block_types() {
 				'post-author.php'             => 'core/post-author',
 				'post-comment.php'            => 'core/post-comment',
 				'post-comment-content.php'    => 'core/post-comment-content',
+				'post-comment-author.php'     => 'core/post-comment-author',
 				'post-comments.php'           => 'core/post-comments',
 				'post-comments-count.php'     => 'core/post-comments-count',
 				'post-comments-form.php'      => 'core/post-comments-form',

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -77,6 +77,7 @@ import * as postContent from './post-content';
 import * as postAuthor from './post-author';
 import * as postComment from './post-comment';
 import * as postCommentContent from './post-comment-content';
+import * as postCommentAuthor from './post-comment-author';
 import * as postComments from './post-comments';
 import * as postCommentsCount from './post-comments-count';
 import * as postCommentsForm from './post-comments-form';
@@ -213,6 +214,7 @@ export const __experimentalRegisterExperimentalCoreBlocks =
 								postAuthor,
 								postComment,
 								postCommentContent,
+								postCommentAuthor,
 								postComments,
 								postCommentsCount,
 								postCommentsForm,

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -76,8 +76,8 @@ import * as postTitle from './post-title';
 import * as postContent from './post-content';
 import * as postAuthor from './post-author';
 import * as postComment from './post-comment';
-import * as postCommentContent from './post-comment-content';
 import * as postCommentAuthor from './post-comment-author';
+import * as postCommentContent from './post-comment-content';
 import * as postCommentDate from './post-comment-date';
 import * as postComments from './post-comments';
 import * as postCommentsCount from './post-comments-count';
@@ -214,8 +214,8 @@ export const __experimentalRegisterExperimentalCoreBlocks =
 								postContent,
 								postAuthor,
 								postComment,
-								postCommentContent,
 								postCommentAuthor,
+								postCommentContent,
 								postCommentDate,
 								postComments,
 								postCommentsCount,

--- a/packages/block-library/src/post-comment-author/block.json
+++ b/packages/block-library/src/post-comment-author/block.json
@@ -1,0 +1,8 @@
+{
+	"name": "core/post-comment-author",
+	"category": "design",
+	"usesContext": [ "commentId" ],
+	"supports": {
+		"html": false
+	}
+}

--- a/packages/block-library/src/post-comment-author/edit.js
+++ b/packages/block-library/src/post-comment-author/edit.js
@@ -14,15 +14,10 @@ export default function Edit( { attributes, context } ) {
 		const comment = getEntityRecord( 'root', 'comment', commentId );
 		if ( comment && ! comment.authorName ) {
 			const user = getEntityRecord( 'root', 'user', comment.author );
-
-			if ( ! user || ! user.name ) {
-				return __( 'Anonymous' );
-			}
-
-			return user.name;
+			return user?.name ?? __( 'Anonymous' );
 		}
 
-		return comment ? comment.authorName : '';
+		return comment?.authorName ?? '';
 	} );
 
 	return <p className={ className }>{ displayName }</p>;

--- a/packages/block-library/src/post-comment-author/edit.js
+++ b/packages/block-library/src/post-comment-author/edit.js
@@ -1,19 +1,30 @@
 /**
  * WordPress dependencies
  */
-import ServerSideRender from '@wordpress/server-side-render';
+import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
 
 // TODO: JSDOC types
 export default function Edit( { attributes, context } ) {
 	const { className } = attributes;
 	const { commentId } = context;
 
-	return (
-		<p className={ className }>
-			<ServerSideRender
-				block="core/post-comment-author"
-				attributes={ { commentId } }
-			/>
-		</p>
-	);
+	const displayName = useSelect( ( select ) => {
+		const { getEntityRecord } = select( 'core' );
+
+		const comment = getEntityRecord( 'root', 'comment', commentId );
+		if ( comment && ! comment.authorName ) {
+			const user = getEntityRecord( 'root', 'user', comment.author );
+
+			if ( ! user || ! user.name ) {
+				return __( 'Anonymous' );
+			}
+
+			return user.name;
+		}
+
+		return comment ? comment.authorName : '';
+	} );
+
+	return <p className={ className }>{ displayName }</p>;
 }

--- a/packages/block-library/src/post-comment-author/edit.js
+++ b/packages/block-library/src/post-comment-author/edit.js
@@ -1,0 +1,19 @@
+/**
+ * WordPress dependencies
+ */
+import ServerSideRender from '@wordpress/server-side-render';
+
+// TODO: JSDOC types
+export default function Edit( { attributes, context } ) {
+	const { className } = attributes;
+	const { commentId } = context;
+
+	return (
+		<p className={ className }>
+			<ServerSideRender
+				block="core/post-comment-author"
+				attributes={ { commentId } }
+			/>
+		</p>
+	);
+}

--- a/packages/block-library/src/post-comment-author/edit.js
+++ b/packages/block-library/src/post-comment-author/edit.js
@@ -12,12 +12,14 @@ export default function Edit( { attributes, context } ) {
 		const { getEntityRecord } = select( 'core' );
 
 		const comment = getEntityRecord( 'root', 'comment', commentId );
-		if ( comment && ! comment.authorName ) {
+		const authorName = comment?.author_name; // eslint-disable-line camelcase
+
+		if ( comment && ! authorName ) {
 			const user = getEntityRecord( 'root', 'user', comment.author );
 			return user?.name ?? __( 'Anonymous' );
 		}
 
-		return comment?.authorName ?? '';
+		return authorName ?? '';
 	} );
 
 	return <p className={ className }>{ displayName }</p>;

--- a/packages/block-library/src/post-comment-author/edit.js
+++ b/packages/block-library/src/post-comment-author/edit.js
@@ -4,7 +4,6 @@
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 
-// TODO: JSDOC types
 export default function Edit( { attributes, context } ) {
 	const { className } = attributes;
 	const { commentId } = context;

--- a/packages/block-library/src/post-comment-author/icon.js
+++ b/packages/block-library/src/post-comment-author/icon.js
@@ -1,0 +1,10 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, SVG } from '@wordpress/components';
+
+export default (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path d="M5.8 11c0-.7.6-1.2 1.2-1.2h4c.7 0 1.2.6 1.2 1.2v1h1.5v-1c0-1.5-1.2-2.8-2.8-2.8H7c-1.5 0-2.8 1.2-2.8 2.8v1h1.5v-1zM4 20h9v-1.5H4V20zm0-5.5V16h16v-1.5H4zM9 7c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2z" />
+	</SVG>
+);

--- a/packages/block-library/src/post-comment-author/index.js
+++ b/packages/block-library/src/post-comment-author/index.js
@@ -1,0 +1,22 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import edit from './edit';
+import icon from './icon';
+
+const { name } = metadata;
+export { metadata, name };
+
+export const settings = {
+	title: __( 'Post Comment Author' ),
+	description: __( 'Post Comment Author' ),
+	icon,
+	edit,
+	parent: [ 'core/post-comment' ],
+};

--- a/packages/block-library/src/post-comment-author/index.php
+++ b/packages/block-library/src/post-comment-author/index.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Server-side rendering of the `core/post-comment-author` block.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Renders the `core/post-comment-author` block on the server.
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ * @return string Return the post comment's content.
+ */
+function render_block_core_post_comment_author( $attributes, $content, $block ) {
+	$commentId = null;
+
+	if ( ! empty( $block->context['commentId'] ) ) {
+		$commentId = $block->context['commentId'];
+	}
+
+	if ( ! empty( $attributes['commentId'] ) ) {
+		$commentId = $attributes['commentId'];
+	}
+
+	if ( ! $commentId ) {
+		return '';
+	}
+
+	return sprintf( '<div>%1$s</div>', get_comment_author( $commentId ) );
+}
+
+/**
+ * Registers the `core/post-comment-author` block on the server.
+ */
+function register_block_core_post_comment_author() {
+	register_block_type_from_metadata(
+		__DIR__ . '/post-comment-author',
+		array(
+			'attributes' => [
+				'commentId' => 'number'
+			],
+			'render_callback' => 'render_block_core_post_comment_author',
+		)
+	);
+}
+add_action( 'init', 'register_block_core_post_comment_author' );

--- a/packages/block-library/src/post-comment-author/index.php
+++ b/packages/block-library/src/post-comment-author/index.php
@@ -14,21 +14,21 @@
  * @return string Return the post comment's content.
  */
 function render_block_core_post_comment_author( $attributes, $content, $block ) {
-	$commentId = null;
+	$comment_id = null;
 
 	if ( ! empty( $block->context['commentId'] ) ) {
-		$commentId = $block->context['commentId'];
+		$comment_id = $block->context['commentId'];
 	}
 
 	if ( ! empty( $attributes['commentId'] ) ) {
-		$commentId = $attributes['commentId'];
+		$comment_id = $attributes['commentId'];
 	}
 
-	if ( ! $commentId ) {
+	if ( ! $comment_id ) {
 		return '';
 	}
 
-	return sprintf( '<div>%1$s</div>', get_comment_author( $commentId ) );
+	return sprintf( '<div>%1$s</div>', get_comment_author( $comment_id ) );
 }
 
 /**

--- a/packages/block-library/src/post-comment-author/index.php
+++ b/packages/block-library/src/post-comment-author/index.php
@@ -14,21 +14,11 @@
  * @return string Return the post comment's content.
  */
 function render_block_core_post_comment_author( $attributes, $content, $block ) {
-	$comment_id = null;
-
-	if ( ! empty( $block->context['commentId'] ) ) {
-		$comment_id = $block->context['commentId'];
-	}
-
-	if ( ! empty( $attributes['commentId'] ) ) {
-		$comment_id = $attributes['commentId'];
-	}
-
-	if ( ! $comment_id ) {
+	if ( ! isset( $block->context['commentId'] ) ) {
 		return '';
 	}
 
-	return sprintf( '<div>%1$s</div>', get_comment_author( $comment_id ) );
+	return sprintf( '<div>%1$s</div>', get_comment_author( $block->context['commentId'] ) );
 }
 
 /**
@@ -38,9 +28,6 @@ function register_block_core_post_comment_author() {
 	register_block_type_from_metadata(
 		__DIR__ . '/post-comment-author',
 		array(
-			'attributes' => [
-				'commentId' => 'number'
-			],
 			'render_callback' => 'render_block_core_post_comment_author',
 		)
 	);

--- a/packages/block-library/src/post-comment/edit.js
+++ b/packages/block-library/src/post-comment/edit.js
@@ -7,7 +7,10 @@ import { useState } from '@wordpress/element';
 import { blockDefault } from '@wordpress/icons';
 import { InnerBlocks } from '@wordpress/block-editor';
 
-const ALLOWED_BLOCKS = [ [ 'core/post-comment-content' ] ];
+const ALLOWED_BLOCKS = [
+	'core/post-comment-content',
+	'core/post-comment-author',
+];
 
 // TODO: JSDOC types
 export default function Edit( { className, attributes, setAttributes } ) {

--- a/packages/e2e-tests/fixtures/blocks/core__post-comment-author.html
+++ b/packages/e2e-tests/fixtures/blocks/core__post-comment-author.html
@@ -1,0 +1,1 @@
+<!-- wp:post-comment-author /-->

--- a/packages/e2e-tests/fixtures/blocks/core__post-comment-author.json
+++ b/packages/e2e-tests/fixtures/blocks/core__post-comment-author.json
@@ -1,0 +1,10 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "core/post-comment-author",
+        "isValid": true,
+        "attributes": {},
+        "innerBlocks": [],
+        "originalContent": ""
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__post-comment-author.parsed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__post-comment-author.parsed.json
@@ -1,0 +1,18 @@
+[
+    {
+        "blockName": "core/post-comment-author",
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "",
+        "innerContent": []
+    },
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n",
+        "innerContent": [
+            "\n"
+        ]
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__post-comment-author.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__post-comment-author.serialized.html
@@ -1,0 +1,1 @@
+<!-- wp:post-comment-author /-->


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Adds a new inner block called Post Comment Author. It can be inserted into the Post Comment block.

## How has this been tested?
1. Insert Post Comment block
2. Insert nested block: Post Comment Author
3. Comment author's name should appear

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
