### PR TITLE
WordPress 5.5.1 Backports

### DIFF
--- a/packages/block-editor/src/components/block-navigation/block-contents.js
+++ b/packages/block-editor/src/components/block-navigation/block-contents.js
@@ -12,7 +12,15 @@ import BlockNavigationBlockSelectButton from './block-select-button';
 
 const BlockNavigationBlockContents = forwardRef(
 	(
-		{ onClick, block, isSelected, position, siblingCount, level, ...props },
+		{
+			onClick,
+			block,
+			isSelected,
+			position,
+			siblingBlockCount,
+			level,
+			...props
+		},
 		ref
 	) => {
 		const {
@@ -27,7 +35,7 @@ const BlockNavigationBlockContents = forwardRef(
 				onClick={ onClick }
 				isSelected={ isSelected }
 				position={ position }
-				siblingCount={ siblingCount }
+				siblingBlockCount={ siblingBlockCount }
 				level={ level }
 				{ ...props }
 			/>
@@ -39,7 +47,7 @@ const BlockNavigationBlockContents = forwardRef(
 				onClick={ onClick }
 				isSelected={ isSelected }
 				position={ position }
-				siblingCount={ siblingCount }
+				siblingBlockCount={ siblingBlockCount }
 				level={ level }
 				{ ...props }
 			/>

--- a/packages/block-editor/src/components/block-navigation/block-select-button.js
+++ b/packages/block-editor/src/components/block-navigation/block-select-button.js
@@ -28,7 +28,7 @@ function BlockNavigationBlockSelectButton(
 		isSelected,
 		onClick,
 		position,
-		siblingCount,
+		siblingBlockCount,
 		level,
 		tabIndex,
 		onFocus,
@@ -43,7 +43,7 @@ function BlockNavigationBlockSelectButton(
 	const descriptionId = `block-navigation-block-select-button__${ instanceId }`;
 	const blockPositionDescription = getBlockPositionDescription(
 		position,
-		siblingCount,
+		siblingBlockCount,
 		level
 	);
 

--- a/packages/block-editor/src/components/block-navigation/block-slot.js
+++ b/packages/block-editor/src/components/block-navigation/block-slot.js
@@ -48,7 +48,7 @@ function BlockNavigationBlockSlot( props, ref ) {
 					block,
 					isSelected,
 					position,
-					siblingCount,
+					siblingBlockCount,
 					level,
 					tabIndex,
 					onFocus,
@@ -59,7 +59,7 @@ function BlockNavigationBlockSlot( props, ref ) {
 				const descriptionId = `block-navigation-block-slot__${ instanceId }`;
 				const blockPositionDescription = getBlockPositionDescription(
 					position,
-					siblingCount,
+					siblingBlockCount,
 					level
 				);
 

--- a/packages/block-editor/src/components/block-navigation/block.js
+++ b/packages/block-editor/src/components/block-navigation/block.js
@@ -37,6 +37,7 @@ export default function BlockNavigationBlock( {
 	position,
 	level,
 	rowCount,
+	siblingBlockCount,
 	showBlockMovers,
 	terminatedLevels,
 	path,
@@ -49,9 +50,7 @@ export default function BlockNavigationBlock( {
 	);
 	const { clientId } = block;
 
-	// Subtract 1 from rowCount, as it includes the block appender.
-	const siblingCount = rowCount - 1;
-	const hasSiblings = siblingCount > 1;
+	const hasSiblings = siblingBlockCount > 0;
 	const hasRenderedMovers = showBlockMovers && hasSiblings;
 	const hasVisibleMovers = isHovered || isFocused;
 	const moverCellClassName = classnames(
@@ -102,7 +101,7 @@ export default function BlockNavigationBlock( {
 							onClick={ () => onClick( block.clientId ) }
 							isSelected={ isSelected }
 							position={ position }
-							siblingCount={ siblingCount }
+							siblingBlockCount={ siblingBlockCount }
 							level={ level }
 							ref={ ref }
 							tabIndex={ tabIndex }

--- a/packages/block-editor/src/components/block-navigation/branch.js
+++ b/packages/block-editor/src/components/block-navigation/branch.js
@@ -36,9 +36,8 @@ export default function BlockNavigationBranch( props ) {
 		selectedBlockClientId === parentClientId;
 	const hasAppender = itemHasAppender( parentBlockClientId );
 	// Add +1 to the rowCount to take the block appender into account.
-	const rowCount = hasAppender
-		? filteredBlocks.length + 1
-		: filteredBlocks.length;
+	const blockCount = filteredBlocks.length;
+	const rowCount = hasAppender ? blockCount + 1 : blockCount;
 	const appenderPosition = rowCount;
 
 	return (
@@ -64,6 +63,7 @@ export default function BlockNavigationBranch( props ) {
 							level={ level }
 							position={ position }
 							rowCount={ rowCount }
+							siblingBlockCount={ blockCount }
 							showBlockMovers={ showBlockMovers }
 							terminatedLevels={ terminatedLevels }
 							path={ updatedPath }

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -56,6 +56,14 @@ $tree-item-height: 36px;
 		margin-right: 6px;
 	}
 
+	&.is-selected .block-editor-block-icon svg,
+	&.is-selected:focus .block-editor-block-icon svg {
+		color: $white;
+		background: $gray-900;
+		box-shadow: 0 0 0 $border-width $gray-900;
+		border-radius: $border-width;
+	}
+
 	.block-editor-block-navigation-block__menu-cell,
 	.block-editor-block-navigation-block__mover-cell,
 	.block-editor-block-navigation-block__contents-cell {

--- a/packages/block-editor/src/components/use-resize-canvas/index.js
+++ b/packages/block-editor/src/components/use-resize-canvas/index.js
@@ -51,6 +51,7 @@ export default function useResizeCanvas( deviceType ) {
 	const marginValue = () => ( window.innerHeight < 800 ? 36 : 72 );
 
 	const contentInlineStyles = ( device ) => {
+		const height = device === 'Mobile' ? '768px' : '1024px';
 		switch ( device ) {
 			case 'Tablet':
 			case 'Mobile':
@@ -58,7 +59,9 @@ export default function useResizeCanvas( deviceType ) {
 					width: getCanvasWidth( device ),
 					margin: marginValue() + 'px auto',
 					flexGrow: 0,
-					maxHeight: device === 'Mobile' ? '768px' : '1024px',
+					height,
+					minHeight: height,
+					maxHeight: height,
 					overflowY: 'auto',
 				};
 			default:

--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -47,7 +47,7 @@ $blocks-button__height: 56px;
 	border-radius: 0 !important;
 }
 
-.wp-block-button.is-style-outline .wp-block-button__link,
+.is-style-outline .wp-block-button__link,
 .wp-block-button__link.is-style-outline {
 	color: $dark-gray-700;
 	background-color: transparent;

--- a/packages/components/src/query-controls/index.js
+++ b/packages/components/src/query-controls/index.js
@@ -76,6 +76,7 @@ export default function QueryControls( {
 				label={ __( 'Category' ) }
 				noOptionLabel={ __( 'All' ) }
 				selectedCategoryId={ selectedCategoryId }
+				onChange={ onCategoryChange }
 			/>
 		),
 		categorySuggestions && onCategoryChange && (

--- a/packages/edit-navigation/src/components/navigation-editor/style.scss
+++ b/packages/edit-navigation/src/components/navigation-editor/style.scss
@@ -56,6 +56,13 @@
 	> :first-child button {
 		padding-left: 0;
 	}
+
+	&.is-selected .block-editor-block-icon svg,
+	&.is-selected:focus .block-editor-block-icon svg {
+		color: $dark-gray-600;
+		background: transparent;
+		box-shadow: none;
+	}
 }
 
 .edit-navigation-editor__navigation-structure-panel {


### PR DESCRIPTION
Backports the following PR's to be part of WordPress 5.5.1

<table>

<tr><td>PR</td><td>Author</td><td>Action For cherry pick</td></tr>
<tr><td><a href="https://github.com/WordPress/gutenberg/pull/24609">Fix missing selected block highlighting in list view</a></td><td>@talldan</td><td>-</td></tr>
<tr><td><a href="https://github.com/WordPress/gutenberg/pull/24599">Fix specificity for buttons with outline style and background colors</a></td><td>@nosolosw</td><td>-</td></tr>
<tr><td><a href="https://github.com/WordPress/gutenberg/pull/24533">Fix incorrect aria description in List View</a></td><td>@talldan</td><td>Conflict on packages/block-editor/src/components/block-navigation/block.js. The resolution was accept incoming changes.</td></tr>
<tr><td><a href="https://github.com/WordPress/gutenberg/pull/24516">Fix regression bug for category select in QueryControls component </a></td><td>@gchtr</td><td>-</td></tr>
<tr><td><a href="https://github.com/WordPress/gutenberg/pull/24478">Fix tiny editor preview when using Mobile or Tablet options with metaboxes enabled</a></td><td>@talldan</td><td>-</td></tr>

</table>
