### PR TITLE
Remove extra slash from `$block_json_file`

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -100,7 +100,7 @@ function gutenberg_reregister_core_block_types() {
 	$registry = WP_Block_Type_Registry::get_instance();
 
 	foreach ( $block_folders as $folder_name ) {
-		$block_json_file = $blocks_dir . '/' . $folder_name . '/block.json';
+		$block_json_file = $blocks_dir . $folder_name . '/block.json';
 		if ( ! file_exists( $block_json_file ) ) {
 			return;
 		}


### PR DESCRIPTION
Paths are wrong and have a double slash.
We define the `$blocks_dir` var like this:
```php
$blocks_dir = dirname( __FILE__ ) . '/../build/block-library/blocks/';
```
then when we build the path for the block JSON file we do it like this:
```php
$block_json_file = $blocks_dir . '/' . $folder_name . '/block.json';
```
Doing an `error_log( $block_json_file )` shows that paths are formed like this:
```
wp-content/plugins/gutenberg/lib/../build/block-library/blocks//column/block.json
```
`$blocks_dir` already has a trailing slash, so the extra slash between `$blocks_dir` and `$folder_name` should be removed.
