### PR TITLE
Create unstable selectors for getting all controlled inner blocks

### DIFF
--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -94,15 +94,10 @@ then the nested template part's child blocks will not be returned. This way,
 the template block itself is considered part of the parent, but the children
 are not.
 
-You can override this behavior with the includeControlledInnerBlocks setting.
-So if you call `getBlock( TP, { WPGetBlockSettings: true } )`, it will return
-all nested blocks, including all child inner block controllers and their children.
-
 _Parameters_
 
 -   _state_ `Object`: Editor state.
 -   _clientId_ `string`: Block client ID.
--   _settings_ `?WPGetBlockSettings`: A settings object.
 
 _Returns_
 
@@ -282,8 +277,7 @@ _Returns_
 
 Returns all block objects for the current post being edited as an array in
 the order they appear in the post. Note that this will exclude child blocks
-of nested inner block controllers unless the `includeControlledInnerBlocks`
-setting is set to true.
+of nested inner block controllers.
 
 Note: It's important to memoize this selector to avoid return a new instance
 on each call. We use the block cache state for each top-level block of the
@@ -295,7 +289,6 @@ _Parameters_
 
 -   _state_ `Object`: Editor state.
 -   _rootClientId_ `?string`: Optional root client ID of block list.
--   _settings_ `?WPGetBlockSettings`: A settings object.
 
 _Returns_
 

--- a/packages/block-editor/src/components/block-navigation/index.js
+++ b/packages/block-editor/src/components/block-navigation/index.js
@@ -62,16 +62,15 @@ export default compose(
 		const {
 			getSelectedBlockClientId,
 			getBlockHierarchyRootClientId,
-			getBlock,
-			getBlocks,
+			__unstableGetBlockWithControlledInnerBlocks,
+			__unstableGetBlocksWithControlledInnerBlocks,
 		} = select( 'core/block-editor' );
 		const selectedBlockClientId = getSelectedBlockClientId();
 		return {
-			rootBlocks: getBlocks( '', { includeControlledInnerBlocks: true } ),
+			rootBlocks: __unstableGetBlocksWithControlledInnerBlocks( '' ),
 			rootBlock: selectedBlockClientId
-				? getBlock(
-						getBlockHierarchyRootClientId( selectedBlockClientId ),
-						{ includeControlledInnerBlocks: true }
+				? __unstableGetBlockWithControlledInnerBlocks(
+						getBlockHierarchyRootClientId( selectedBlockClientId )
 				  )
 				: null,
 			selectedBlockClientId,

--- a/packages/block-editor/src/components/block-navigation/index.js
+++ b/packages/block-editor/src/components/block-navigation/index.js
@@ -62,14 +62,14 @@ export default compose(
 		const {
 			getSelectedBlockClientId,
 			getBlockHierarchyRootClientId,
-			__unstableGetBlockWithControlledInnerBlocks,
-			__unstableGetBlocksWithControlledInnerBlocks,
+			__unstableGetBlockWithBlockTree,
+			__unstableGetBlockTree,
 		} = select( 'core/block-editor' );
 		const selectedBlockClientId = getSelectedBlockClientId();
 		return {
-			rootBlocks: __unstableGetBlocksWithControlledInnerBlocks( '' ),
+			rootBlocks: __unstableGetBlockTree( '' ),
 			rootBlock: selectedBlockClientId
-				? __unstableGetBlockWithControlledInnerBlocks(
+				? __unstableGetBlockWithBlockTree(
 						getBlockHierarchyRootClientId( selectedBlockClientId )
 				  )
 				: null,

--- a/packages/block-editor/src/components/block-navigation/index.js
+++ b/packages/block-editor/src/components/block-navigation/index.js
@@ -67,7 +67,7 @@ export default compose(
 		} = select( 'core/block-editor' );
 		const selectedBlockClientId = getSelectedBlockClientId();
 		return {
-			rootBlocks: __unstableGetBlockTree( '' ),
+			rootBlocks: __unstableGetBlockTree(),
 			rootBlock: selectedBlockClientId
 				? __unstableGetBlockWithBlockTree(
 						getBlockHierarchyRootClientId( selectedBlockClientId )

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -211,15 +211,16 @@ export const getBlocks = createSelector(
 );
 
 /**
- * Same as getBlock, except it will include controlled inner blocks which would
- * normally be excluded.
+ * Similar to getBlock, except it will include the entire nested block tree as
+ * inner blocks. The normal getBlock selector will exclude sections of the block
+ * tree which belong to different entities.
  *
  * @param {Object} state    Editor state.
  * @param {string} clientId Client ID of the block to get.
  *
- * @return {Object} The block.
+ * @return {Object} The block with all
  */
-export const __unstableGetBlockWithControlledInnerBlocks = createSelector(
+export const __unstableGetBlockWithBlockTree = createSelector(
 	( state, clientId ) => {
 		const block = state.blocks.byClientId[ clientId ];
 		if ( ! block ) {
@@ -229,28 +230,26 @@ export const __unstableGetBlockWithControlledInnerBlocks = createSelector(
 		return {
 			...block,
 			attributes: getBlockAttributes( state, clientId ),
-			innerBlocks: __unstableGetBlocksWithControlledInnerBlocks(
-				state,
-				clientId
-			),
+			innerBlocks: __unstableGetBlockTree( state, clientId ),
 		};
 	},
 	( state, clientId ) => [ state.blocks.cache[ clientId ] ]
 );
 
 /**
- * Same as getBlocks, except it will include controlled inner blocks which would
- * normally be excluded.
+ * Similar to getBlocks, except this selector returns the entire block tree
+ * represented in the block-editor store from the given root regardless of any
+ * inner block controllers.
  *
  * @param {Object}  state        Editor state.
  * @param {?string} rootClientId Optional root client ID of block list.
  *
  * @return {Object[]} Post blocks.
  */
-export const __unstableGetBlocksWithControlledInnerBlocks = createSelector(
-	( state, rootClientId ) =>
+export const __unstableGetBlockTree = createSelector(
+	( state, rootClientId = '' ) =>
 		map( getBlockOrder( state, rootClientId ), ( clientId ) =>
-			__unstableGetBlockWithControlledInnerBlocks( state, clientId )
+			__unstableGetBlockWithBlockTree( state, clientId )
 		),
 	( state ) => [
 		state.blocks.byClientId,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -233,7 +233,11 @@ export const __unstableGetBlockWithBlockTree = createSelector(
 			innerBlocks: __unstableGetBlockTree( state, clientId ),
 		};
 	},
-	( state, clientId ) => [ state.blocks.cache[ clientId ] ]
+	( state ) => [
+		state.blocks.byClientId,
+		state.blocks.order,
+		state.blocks.attributes,
+	]
 );
 
 /**


### PR DESCRIPTION
closes #24690 

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Based on discussion [here](https://github.com/WordPress/gutenberg/pull/24083#discussion_r476576982) and in slack, this PR moves the code which gets blocks including controlled inner blocks to separate unstable selectors. Previously, this behaviour was accessible via parameters to the normal getBlock/getBlocks selectors.

This changes nothing functionally, just cleans up the API for getBlock/getBlocks.

## How has this been tested?
locally, in edit site.

## Screenshots <!-- if applicable -->
behaviour of block navigation is the same:
![image](https://user-images.githubusercontent.com/6265975/91368382-c1886c80-e7bd-11ea-923c-ebbd20b24d73.png)

## Types of changes
Code quality.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
