### PR TITLE
Block Editor: Fix Multiple Trailing Inserters for Nested Inner Blocks

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/index.js
+++ b/packages/block-editor/src/components/block-list-appender/index.js
@@ -27,9 +27,14 @@ function BlockListAppender( {
 	isLocked,
 	renderAppender: CustomAppender,
 	className,
+	selectedBlockClientId,
 	tagName: TagName = 'div',
 } ) {
-	if ( isLocked || CustomAppender === false ) {
+	const hasSiblingsSelected =
+		selectedBlockClientId &&
+		blockClientIds.includes( selectedBlockClientId );
+
+	if ( isLocked || CustomAppender === false || ! hasSiblingsSelected ) {
 		return null;
 	}
 
@@ -79,9 +84,12 @@ function BlockListAppender( {
 }
 
 export default withSelect( ( select, { rootClientId } ) => {
-	const { getBlockOrder, canInsertBlockType, getTemplateLock } = select(
-		'core/block-editor'
-	);
+	const {
+		getBlockOrder,
+		canInsertBlockType,
+		getTemplateLock,
+		getSelectedBlockClientId,
+	} = select( 'core/block-editor' );
 
 	return {
 		isLocked: !! getTemplateLock( rootClientId ),
@@ -90,5 +98,6 @@ export default withSelect( ( select, { rootClientId } ) => {
 			getDefaultBlockName(),
 			rootClientId
 		),
+		selectedBlockClientId: getSelectedBlockClientId(),
 	};
 } )( BlockListAppender );

--- a/packages/block-editor/src/components/block-list-appender/index.js
+++ b/packages/block-editor/src/components/block-list-appender/index.js
@@ -30,11 +30,7 @@ function BlockListAppender( {
 	selectedBlockClientId,
 	tagName: TagName = 'div',
 } ) {
-	const hasSiblingsSelected =
-		selectedBlockClientId &&
-		blockClientIds.includes( selectedBlockClientId );
-
-	if ( isLocked || CustomAppender === false || ! hasSiblingsSelected ) {
+	if ( isLocked || CustomAppender === false ) {
 		return null;
 	}
 
@@ -45,6 +41,14 @@ function BlockListAppender( {
 	} else if ( canInsertDefaultBlock ) {
 		// Render the default block appender when renderAppender has not been
 		// provided and the context supports use of the default appender.
+		const isDocumentAppender = ! rootClientId;
+		const isAnotherDefaultAppenderAlreadyDisplayed =
+			selectedBlockClientId &&
+			! blockClientIds.includes( selectedBlockClientId );
+
+		if ( ! isDocumentAppender && isAnotherDefaultAppenderAlreadyDisplayed )
+			return null;
+
 		appender = (
 			<DefaultBlockAppender
 				rootClientId={ rootClientId }

--- a/packages/block-editor/src/components/block-list-appender/index.js
+++ b/packages/block-editor/src/components/block-list-appender/index.js
@@ -42,7 +42,7 @@ function BlockListAppender( {
 		// Render the default block appender when renderAppender has not been
 		// provided and the context supports use of the default appender.
 		const isDocumentAppender = ! rootClientId;
-		const isParentSelected = selectedBlockClientId !== rootClientId;
+		const isParentSelected = selectedBlockClientId === rootClientId;
 		const isAnotherDefaultAppenderAlreadyDisplayed =
 			selectedBlockClientId &&
 			! blockClientIds.includes( selectedBlockClientId );

--- a/packages/block-editor/src/components/block-list-appender/index.js
+++ b/packages/block-editor/src/components/block-list-appender/index.js
@@ -42,12 +42,18 @@ function BlockListAppender( {
 		// Render the default block appender when renderAppender has not been
 		// provided and the context supports use of the default appender.
 		const isDocumentAppender = ! rootClientId;
+		const isParentSelected = selectedBlockClientId !== rootClientId;
 		const isAnotherDefaultAppenderAlreadyDisplayed =
 			selectedBlockClientId &&
 			! blockClientIds.includes( selectedBlockClientId );
 
-		if ( ! isDocumentAppender && isAnotherDefaultAppenderAlreadyDisplayed )
+		if (
+			! isDocumentAppender &&
+			! isParentSelected &&
+			isAnotherDefaultAppenderAlreadyDisplayed
+		) {
 			return null;
+		}
 
 		appender = (
 			<DefaultBlockAppender


### PR DESCRIPTION
## Note:
This is a _potential_ fix. It seems like this issue has been discussed in the past, and there might be UX reasoning behind why we want to show duplicate trialing inserters. I think it's worthwhile to discuss, but for now, I drafted a PR to frame our conversation in something concrete. I will be posting a quick summary of alternative ways we can proceed here https://github.com/WordPress/gutenberg/issues/24360

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Blocks, like the group or query loop block, render what are called [inner blocks](https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/inner-blocks/index.js). These inner blocks use block list blocks to display ordered content. The trailing inserter is included as the last item in block lists.

When blocks with inner blocks are **nested** in other inner blocks, the trailing inserter is rendered multiple times. For example, if a query loop block is placed **within** a group block, both will render their own set of inner blocks, which subsequently display two trailing inserters.

One potential solution is to display a single trailing inserter at any given time. We determine which inserter to show by evaluating the currently selected block and ensuring that the trailing inserter is a sibling (that way we're certain they're children of the same inner block)

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Enable site editing locally
2. Navigate to the site editor
3. Click on a child of a set of inner blocks, where inner blocks are the content for group blocks, query loop blocks, etc.)
4. Verify that multiple **trailing** inserters are not displayed at any given time
5. Verify the same behavior in the post editor

## Screenshots <!-- if applicable -->
### Before
![Bad Trailing Inserter](https://user-images.githubusercontent.com/5414230/91368390-c9481100-e7bd-11ea-80fc-70e838c6f4e3.gif)

### After
![Trailing Inserter](https://user-images.githubusercontent.com/5414230/91368199-5048b980-e7bd-11ea-89ed-fb10f249e132.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Potential bug fix for https://github.com/WordPress/gutenberg/issues/24360

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
