### PR TITLE
Widgets: Always enable Legacy Widget block and Widget REST APIs

### DIFF
--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -120,7 +120,6 @@ function gutenberg_display_experiment_section() {
  */
 function gutenberg_experiments_editor_settings( $settings ) {
 	$experiments_settings = array(
-		'__experimentalEnableLegacyWidgetBlock'   => get_theme_support( 'widgets-block-editor' ),
 		'__experimentalEnableFullSiteEditing'     => gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' ),
 		'__experimentalEnableFullSiteEditingDemo' => gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing-demo' ),
 	);

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -136,10 +136,8 @@ add_filter( 'rest_prepare_theme', 'gutenberg_filter_rest_prepare_theme', 10, 3 )
  * @since 5.0.0
  */
 function gutenberg_register_rest_widget_updater_routes() {
-	if ( get_theme_support( 'widgets-block-editor' ) ) {
-		$widget_forms = new WP_REST_Widget_Utils_Controller();
-		$widget_forms->register_routes();
-	}
+	$widget_forms = new WP_REST_Widget_Utils_Controller();
+	$widget_forms->register_routes();
 }
 add_action( 'rest_api_init', 'gutenberg_register_rest_widget_updater_routes' );
 
@@ -194,10 +192,8 @@ add_action( 'rest_api_init', 'gutenberg_register_plugins_endpoint' );
  * Registers the Sidebars REST API routes.
  */
 function gutenberg_register_sidebars_endpoint() {
-	if ( get_theme_support( 'widgets-block-editor' ) ) {
-		$sidebars = new WP_REST_Sidebars_Controller();
-		$sidebars->register_routes();
-	}
+	$sidebars = new WP_REST_Sidebars_Controller();
+	$sidebars->register_routes();
 }
 add_action( 'rest_api_init', 'gutenberg_register_sidebars_endpoint' );
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -495,7 +495,6 @@ _Properties_
 -   _titlePlaceholder_ `string`: Empty title placeholder
 -   _codeEditingEnabled_ `boolean`: Whether or not the user can switch to the code editor
 -   _\_\_experimentalCanUserUseUnfilteredHTML_ `boolean`: Whether the user should be able to use unfiltered HTML or the HTML should be filtered e.g., to remove elements considered insecure like iframes.
--   _\_\_experimentalEnableLegacyWidgetBlock_ `boolean`: Whether the user has enabled the Legacy Widget Block
 -   _\_\_experimentalBlockDirectory_ `boolean`: Whether the user has enabled the Block Directory
 -   _\_\_experimentalEnableFullSiteEditing_ `boolean`: Whether the user has enabled Full Site Editing
 -   _\_\_experimentalEnableFullSiteEditingDemo_ `boolean`: Whether the user has enabled Full Site Editing Demo Templates

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -31,7 +31,6 @@ export const PREFERENCES_DEFAULTS = {
  * @property {string} titlePlaceholder Empty title placeholder
  * @property {boolean} codeEditingEnabled Whether or not the user can switch to the code editor
  * @property {boolean} __experimentalCanUserUseUnfilteredHTML Whether the user should be able to use unfiltered HTML or the HTML should be filtered e.g., to remove elements considered insecure like iframes.
- * @property {boolean} __experimentalEnableLegacyWidgetBlock Whether the user has enabled the Legacy Widget Block
  * @property {boolean} __experimentalBlockDirectory Whether the user has enabled the Block Directory
  * @property {boolean} __experimentalEnableFullSiteEditing Whether the user has enabled Full Site Editing
  * @property {boolean} __experimentalEnableFullSiteEditingDemo Whether the user has enabled Full Site Editing Demo Templates
@@ -153,7 +152,6 @@ export const SETTINGS_DEFAULTS = {
 	availableLegacyWidgets: {},
 	hasPermissionsToManageWidgets: false,
 	__experimentalCanUserUseUnfilteredHTML: false,
-	__experimentalEnableLegacyWidgetBlock: false,
 	__experimentalBlockDirectory: false,
 	__experimentalEnableFullSiteEditing: false,
 	__experimentalEnableFullSiteEditingDemo: false,

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -187,14 +187,11 @@ export const registerCoreBlocks = () => {
 export const __experimentalRegisterExperimentalCoreBlocks =
 	process.env.GUTENBERG_PHASE === 2
 		? ( settings ) => {
-				const {
-					__experimentalEnableLegacyWidgetBlock,
-					__experimentalEnableFullSiteEditing,
-				} = settings;
+				const { __experimentalEnableFullSiteEditing } = settings;
 
 				[
 					widgetArea,
-					__experimentalEnableLegacyWidgetBlock ? legacyWidget : null,
+					legacyWidget,
 					navigation,
 					navigationLink,
 

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -161,7 +161,6 @@ class EditorProvider extends Component {
 				'__experimentalBlockPatterns',
 				'__experimentalBlockPatternCategories',
 				'__experimentalEnableCustomSpacing',
-				'__experimentalEnableLegacyWidgetBlock',
 				'__experimentalEnableLinkColor',
 				'__experimentalEnableFullSiteEditing',
 				'__experimentalEnableFullSiteEditingDemo',

--- a/test/integration/full-content/full-content.test.js
+++ b/test/integration/full-content/full-content.test.js
@@ -66,7 +66,6 @@ describe( 'full post content fixture', () => {
 		);
 		unstable__bootstrapServerSideBlockDefinitions( blockDefinitions );
 		const settings = {
-			__experimentalEnableLegacyWidgetBlock: true,
 			__experimentalEnableFullSiteEditing: true,
 		};
 		// Load all hooks that modify blocks


### PR DESCRIPTION
Fixes phpunit test failures introduced by https://github.com/WordPress/gutenberg/pull/24087.

Some features related to the new widgets screen should always be enabled regardless of whether or not the current theme has support for `widgets-block-editor`:

- The Legacy Widget block. This block is useful in other contexts such as FSE and posts.
- The `/__experimental/sidebars` REST API. This is a new API to be introduced to Core and is useful for third parties.
- The `/__experimental/widget-utils` REST API. This is a new API to be introduced to Core, is used by the Legacy Widget block, and is useful for third parties.

To test:

1. Check that navigating to Appearance > Widgets opens the new widgets screen and that it works.
1. Check that you can insert a Legacy Widget block into a post.
1. Turn off the new widgets functionality by commenting out the `add_theme_support( 'widgets-block-editor' );` at the end of `gutenberg.php`.
1. Check that navigating to Appearance > Widgets opens the old widgets screen.
1. Check that you can insert a Legacy Widget block into a post.