### PR TITLE
Revert "Replace the widgets screen experiment with a theme support"

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -45,23 +45,17 @@ function gutenberg_menu() {
 		'gutenberg'
 	);
 
-	if ( get_theme_support( 'widgets-block-editor' ) ) {
-		add_theme_page(
-			__( 'Widgets', 'gutenberg' ),
-			__( 'Widgets', 'gutenberg' ),
-			'edit_theme_options',
-			'gutenberg-widgets',
-			'the_gutenberg_widgets'
-		);
-		$submenu['themes.php'] = array_filter(
-			$submenu['themes.php'],
-			function( $current_menu_item ) {
-				return isset( $current_menu_item[2] ) && 'widgets.php' !== $current_menu_item[2];
-			}
-		);
-	}
-
 	if ( get_option( 'gutenberg-experiments' ) ) {
+		if ( array_key_exists( 'gutenberg-widget-experiments', get_option( 'gutenberg-experiments' ) ) ) {
+			add_submenu_page(
+				'gutenberg',
+				__( 'Widgets (beta)', 'gutenberg' ),
+				__( 'Widgets (beta)', 'gutenberg' ),
+				'edit_theme_options',
+				'gutenberg-widgets',
+				'the_gutenberg_widgets'
+			);
+		}
 		if ( array_key_exists( 'gutenberg-navigation', get_option( 'gutenberg-experiments' ) ) ) {
 			add_submenu_page(
 				'gutenberg',
@@ -107,7 +101,7 @@ function gutenberg_menu() {
 		'the_gutenberg_experiments'
 	);
 }
-add_action( 'admin_menu', 'gutenberg_menu', 9 );
+add_action( 'admin_menu', 'gutenberg_menu' );
 
 /**
  * Display a version notice and deactivate the Gutenberg plugin.
@@ -188,4 +182,13 @@ function register_site_icon_url( $response ) {
 
 add_filter( 'rest_index', 'register_site_icon_url' );
 
-add_theme_support( 'widgets-block-editor' );
+/**
+ * Registers the WP_Widget_Block widget
+ */
+function gutenberg_register_widgets() {
+	if ( gutenberg_is_experiment_enabled( 'gutenberg-widget-experiments' ) ) {
+		register_widget( 'WP_Widget_Block' );
+	}
+}
+
+add_action( 'widgets_init', 'gutenberg_register_widgets' );

--- a/lib/customizer.php
+++ b/lib/customizer.php
@@ -55,10 +55,10 @@ function gutenberg_customize_register( $wp_customize ) {
 			'sanitize_callback' => 'gutenberg_customize_sanitize',
 		)
 	);
-	if ( get_theme_support( 'widgets-block-editor' ) ) {
+	if ( gutenberg_is_experiment_enabled( 'gutenberg-widget-experiments' ) ) {
 		$wp_customize->add_section(
 			'gutenberg_widget_blocks',
-			array( 'title' => __( 'Widget Blocks', 'gutenberg' ) )
+			array( 'title' => __( 'Widget Blocks (Experimental)', 'gutenberg' ) )
 		);
 		$wp_customize->add_control(
 			new WP_Customize_Widget_Blocks_Control(
@@ -73,25 +73,6 @@ function gutenberg_customize_register( $wp_customize ) {
 	}
 }
 add_action( 'customize_register', 'gutenberg_customize_register' );
-
-/**
- * Removes the core 'Widgets' panel from the Customizer if block based widgets are enabled.
- *
- * @param array $components Core Customizer components list.
- * @return array (Maybe) modified components list.
- */
-function gutenberg_remove_widgets_panel( $components ) {
-	if ( ! get_theme_support( 'widgets-block-editor' ) ) {
-		return $components;
-	}
-
-	$i = array_search( 'widgets', $components, true );
-	if ( false !== $i ) {
-		unset( $components[ $i ] );
-	}
-	return $components;
-}
-add_filter( 'customize_loaded_components', 'gutenberg_remove_widgets_panel' );
 
 /**
  * Filters the Customizer widget settings arguments.

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -41,6 +41,17 @@ function gutenberg_initialize_experiments_settings() {
 		'gutenberg-experiments'
 	);
 	add_settings_field(
+		'gutenberg-widget-experiments',
+		__( 'Widgets', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Enable Widgets screen and Legacy Widgets block', 'gutenberg' ),
+			'id'    => 'gutenberg-widget-experiments',
+		)
+	);
+	add_settings_field(
 		'gutenberg-navigation',
 		__( 'Navigation', 'gutenberg' ),
 		'gutenberg_display_experiment_field',
@@ -120,7 +131,7 @@ function gutenberg_display_experiment_section() {
  */
 function gutenberg_experiments_editor_settings( $settings ) {
 	$experiments_settings = array(
-		'__experimentalEnableLegacyWidgetBlock'   => get_theme_support( 'widgets-block-editor' ),
+		'__experimentalEnableLegacyWidgetBlock'   => gutenberg_is_experiment_enabled( 'gutenberg-widget-experiments' ),
 		'__experimentalEnableFullSiteEditing'     => gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' ),
 		'__experimentalEnableFullSiteEditingDemo' => gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing-demo' ),
 	);

--- a/lib/load.php
+++ b/lib/load.php
@@ -29,11 +29,13 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	/**
 	* Start: Include for phase 2
 	*/
-	if ( ! class_exists( 'WP_REST_Widget_Utils_Controller' ) ) {
-		require dirname( __FILE__ ) . '/class-wp-rest-widget-utils-controller.php';
-	}
-	if ( ! class_exists( 'WP_REST_Sidebars_Controller' ) ) {
-		require_once dirname( __FILE__ ) . '/class-wp-rest-sidebars-controller.php';
+	if ( gutenberg_is_experiment_enabled( 'gutenberg-widget-experiments' ) ) {
+		if ( ! class_exists( 'WP_REST_Widget_Utils_Controller' ) ) {
+			require dirname( __FILE__ ) . '/class-wp-rest-widget-utils-controller.php';
+		}
+		if ( ! class_exists( 'WP_REST_Sidebars_Controller' ) ) {
+			require_once dirname( __FILE__ ) . '/class-wp-rest-sidebars-controller.php';
+		}
 	}
 	if ( ! class_exists( 'WP_REST_Block_Directory_Controller' ) ) {
 		require dirname( __FILE__ ) . '/class-wp-rest-block-directory-controller.php';
@@ -87,10 +89,12 @@ if ( ! class_exists( 'WP_Block' ) ) {
 if ( ! class_exists( 'WP_Block_List' ) ) {
 	require dirname( __FILE__ ) . '/class-wp-block-list.php';
 }
-if ( ! class_exists( 'WP_Widget_Block' ) ) {
-	require_once dirname( __FILE__ ) . '/class-wp-widget-block.php';
+if ( gutenberg_is_experiment_enabled( 'gutenberg-widget-experiments' ) ) {
+	if ( ! class_exists( 'WP_Widget_Block' ) ) {
+		require_once dirname( __FILE__ ) . '/class-wp-widget-block.php';
+	}
+	require_once dirname( __FILE__ ) . '/widgets-page.php';
 }
-require_once dirname( __FILE__ ) . '/widgets-page.php';
 
 require dirname( __FILE__ ) . '/compat.php';
 require dirname( __FILE__ ) . '/utils.php';

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -136,7 +136,7 @@ add_filter( 'rest_prepare_theme', 'gutenberg_filter_rest_prepare_theme', 10, 3 )
  * @since 5.0.0
  */
 function gutenberg_register_rest_widget_updater_routes() {
-	if ( get_theme_support( 'widgets-block-editor' ) ) {
+	if ( gutenberg_is_experiment_enabled( 'gutenberg-widget-experiments' ) ) {
 		$widget_forms = new WP_REST_Widget_Utils_Controller();
 		$widget_forms->register_routes();
 	}
@@ -194,7 +194,7 @@ add_action( 'rest_api_init', 'gutenberg_register_plugins_endpoint' );
  * Registers the Sidebars REST API routes.
  */
 function gutenberg_register_sidebars_endpoint() {
-	if ( get_theme_support( 'widgets-block-editor' ) ) {
+	if ( gutenberg_is_experiment_enabled( 'gutenberg-widget-experiments' ) ) {
 		$sidebars = new WP_REST_Sidebars_Controller();
 		$sidebars->register_routes();
 	}

--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -12,7 +12,7 @@
  *
  * @param string $page The page name the function is being called for, `'gutenberg_customizer'` for the Customizer.
  */
-function the_gutenberg_widgets( $page = 'appearance_page_gutenberg-widgets' ) {
+function the_gutenberg_widgets( $page = 'gutenberg_page_gutenberg-widgets' ) {
 	?>
 	<div
 		id="widgets-editor"
@@ -41,11 +41,11 @@ function gutenberg_widgets_init( $hook ) {
 		wp_enqueue_style( 'wp-block-library-theme' );
 		return;
 	}
-	if ( ! in_array( $hook, array( 'appearance_page_gutenberg-widgets', 'gutenberg_customizer' ), true ) ) {
+	if ( ! in_array( $hook, array( 'gutenberg_page_gutenberg-widgets', 'gutenberg_customizer' ), true ) ) {
 		return;
 	}
 
-	$initializer_name = 'appearance_page_gutenberg-widgets' === $hook
+	$initializer_name = 'gutenberg_page_gutenberg-widgets' === $hook
 		? 'initialize'
 		: 'customizerInitialize';
 

--- a/lib/widgets.php
+++ b/lib/widgets.php
@@ -20,7 +20,7 @@ function gutenberg_is_block_editor() {
 	return ! empty( $screen ) &&
 		(
 			$screen->is_block_editor() ||
-			'appearance_page_gutenberg-widgets' === $screen->id ||
+			'gutenberg_page_gutenberg-widgets' === $screen->id ||
 			( function_exists( 'gutenberg_is_edit_site_page' ) && gutenberg_is_edit_site_page( $screen->id ) )
 		);
 }
@@ -261,14 +261,3 @@ function gutenberg_enqueue_widget_scripts() {
 }
 
 add_action( 'enqueue_block_editor_assets', 'gutenberg_enqueue_widget_scripts' );
-
-/**
- * Registers the WP_Widget_Block widget
- */
-function gutenberg_register_widgets() {
-	if ( get_theme_support( 'widgets-block-editor' ) ) {
-		register_widget( 'WP_Widget_Block' );
-	}
-}
-
-add_action( 'widgets_init', 'gutenberg_register_widgets' );

--- a/packages/edit-widgets/src/components/header/index.js
+++ b/packages/edit-widgets/src/components/header/index.js
@@ -46,7 +46,7 @@ function Header( { isCustomizer } ) {
 				</NavigableMenu>
 				{ ! isCustomizer && (
 					<h1 className="edit-widgets-header__title">
-						{ __( 'Block Areas' ) }
+						{ __( 'Block Areas' ) } { __( '(experimental)' ) }
 					</h1>
 				) }
 				<div className="edit-widgets-header__actions">

--- a/packages/edit-widgets/src/style.scss
+++ b/packages/edit-widgets/src/style.scss
@@ -11,7 +11,7 @@ html.wp-toolbar {
 	background: $white;
 }
 
-body.appearance_page_gutenberg-widgets {
+body.gutenberg_page_gutenberg-widgets {
 	@include wp-admin-reset( ".blocks-widgets-container" );
 }
 


### PR DESCRIPTION
Reverts WordPress/gutenberg#24087.

WordPress/gutenberg#24087 effectively ships the experimental `/__experimental/sidebars` REST API endpoint to production websites that are running the Gutenberg plugin. We cannot do this until https://github.com/WordPress/gutenberg/issues/24530 is closed as there is a potential XSS issue that needs to be confirmed.

This also fixes phpunit test failures on master which were introduced by #24087.