### PR TITLE
Navigation: Handle block menu items

### DIFF
--- a/packages/e2e-tests/specs/experiments/__snapshots__/navigation.test.js.snap
+++ b/packages/e2e-tests/specs/experiments/__snapshots__/navigation.test.js.snap
@@ -2,36 +2,36 @@
 
 exports[`Navigation Creating from existing Menus allows a navigation block to be created from existing menus 1`] = `
 "<!-- wp:navigation {\\"orientation\\":\\"horizontal\\"} -->
-<!-- wp:navigation-link {\\"label\\":\\"Home\\",\\"type\\":\\"custom\\",\\"id\\":94} /-->
+<!-- wp:navigation-link {\\"label\\":\\"Home\\",\\"url\\":\\"http://localhost:8889/\\"} /-->
 
-<!-- wp:navigation-link {\\"label\\":\\"Accusamus quo repellat illum magnam quas\\",\\"type\\":\\"post_type\\",\\"id\\":95} -->
-<!-- wp:navigation-link {\\"label\\":\\"Debitis cum consequatur sit doloremque\\",\\"type\\":\\"post_type\\",\\"id\\":96} /-->
+<!-- wp:navigation-link {\\"label\\":\\"Accusamus quo repellat illum magnam quas\\",\\"url\\":\\"http://localhost:8889/?page_id=41\\"} -->
+<!-- wp:navigation-link {\\"label\\":\\"Debitis cum consequatur sit doloremque\\",\\"url\\":\\"http://localhost:8889/?page_id=51\\"} /-->
 <!-- /wp:navigation-link -->
 
-<!-- wp:navigation-link {\\"label\\":\\"Est ea vero non nihil officiis in\\",\\"type\\":\\"post_type\\",\\"id\\":97} -->
-<!-- wp:navigation-link {\\"label\\":\\"Fuga odio quis tempora\\",\\"type\\":\\"post_type\\",\\"id\\":98} -->
-<!-- wp:navigation-link {\\"label\\":\\"In consectetur repellendus eveniet maiores aperiam\\",\\"type\\":\\"post_type\\",\\"id\\":99} -->
-<!-- wp:navigation-link {\\"label\\":\\"Mollitia maiores consequatur ea dolorem blanditiis\\",\\"type\\":\\"post_type\\",\\"id\\":100} -->
-<!-- wp:navigation-link {\\"label\\":\\"Necessitatibus nisi qui qui necessitatibus quaerat possimus\\",\\"type\\":\\"post_type\\",\\"id\\":101} /-->
+<!-- wp:navigation-link {\\"label\\":\\"Est ea vero non nihil officiis in\\",\\"url\\":\\"http://localhost:8889/?page_id=53\\"} -->
+<!-- wp:navigation-link {\\"label\\":\\"Fuga odio quis tempora\\",\\"url\\":\\"http://localhost:8889/?page_id=56\\"} -->
+<!-- wp:navigation-link {\\"label\\":\\"In consectetur repellendus eveniet maiores aperiam\\",\\"url\\":\\"http://localhost:8889/?page_id=15\\"} -->
+<!-- wp:navigation-link {\\"label\\":\\"Mollitia maiores consequatur ea dolorem blanditiis\\",\\"url\\":\\"http://localhost:8889/?page_id=45\\"} -->
+<!-- wp:navigation-link {\\"label\\":\\"Necessitatibus nisi qui qui necessitatibus quaerat possimus\\",\\"url\\":\\"http://localhost:8889/?page_id=27\\"} /-->
 <!-- /wp:navigation-link -->
-<!-- /wp:navigation-link -->
-<!-- /wp:navigation-link -->
-<!-- /wp:navigation-link -->
-
-<!-- wp:navigation-link {\\"label\\":\\"Nulla omnis autem dolores eligendi\\",\\"type\\":\\"post_type\\",\\"id\\":102} /-->
-
-<!-- wp:navigation-link {\\"label\\":\\"Sample Page\\",\\"type\\":\\"post_type\\",\\"id\\":103} /-->
-
-<!-- wp:navigation-link {\\"label\\":\\"Beatae qui labore voluptas eveniet officia quia voluptas qui porro sequi et aut est\\",\\"type\\":\\"taxonomy\\",\\"id\\":104} -->
-<!-- wp:navigation-link {\\"label\\":\\"Et minus itaque velit tempore hic quisquam saepe quas asperiores\\",\\"type\\":\\"taxonomy\\",\\"id\\":105} -->
-<!-- wp:navigation-link {\\"label\\":\\"Et quas a et mollitia et voluptas optio voluptate quia quo unde aut in nostrum iste impedit quisquam id aut\\",\\"type\\":\\"taxonomy\\",\\"id\\":106} -->
-<!-- wp:navigation-link {\\"label\\":\\"Illo quis sit impedit itaque expedita earum deserunt magni doloremque velit eum id error\\",\\"type\\":\\"taxonomy\\",\\"id\\":107} /-->
 <!-- /wp:navigation-link -->
 <!-- /wp:navigation-link -->
 <!-- /wp:navigation-link -->
 
-<!-- wp:navigation-link {\\"label\\":\\"WordPress.org\\",\\"type\\":\\"custom\\",\\"id\\":108} -->
-<!-- wp:navigation-link {\\"label\\":\\"Google\\",\\"type\\":\\"custom\\",\\"id\\":109} /-->
+<!-- wp:navigation-link {\\"label\\":\\"Nulla omnis autem dolores eligendi\\",\\"url\\":\\"http://localhost:8889/?page_id=43\\"} /-->
+
+<!-- wp:navigation-link {\\"label\\":\\"Sample Page\\",\\"url\\":\\"http://localhost:8889/?page_id=2\\"} /-->
+
+<!-- wp:navigation-link {\\"label\\":\\"Beatae qui labore voluptas eveniet officia quia voluptas qui porro sequi et aut est\\",\\"description\\":\\"Ratione nemo ut aut ullam sed assumenda quis est exercitationem\\",\\"url\\":\\"http://localhost:8889/?cat=7\\"} -->
+<!-- wp:navigation-link {\\"label\\":\\"Et minus itaque velit tempore hic quisquam saepe quas asperiores\\",\\"description\\":\\"Vel fuga enim rerum perspiciatis sapiente mollitia magni ut molestiae labore quae quia quia libero perspiciatis voluptatem quidem deleniti eveniet laboriosam doloribus dolor laborum accusantium modi ducimus itaque rerum cum nostrum\\",\\"url\\":\\"http://localhost:8889/?cat=19\\"} -->
+<!-- wp:navigation-link {\\"label\\":\\"Et quas a et mollitia et voluptas optio voluptate quia quo unde aut in nostrum iste impedit quisquam id aut\\",\\"description\\":\\"Quas sit labore earum omnis eos sint iste est possimus harum aut soluta sint optio quos distinctio inventore voluptate non ut aliquam ad ut voluptates fugiat numquam magnam modi repellendus modi laudantium et debitis officia est voluptatum quidem unde molestiae animi vero fuga accusamus nam\\",\\"url\\":\\"http://localhost:8889/?cat=6\\"} -->
+<!-- wp:navigation-link {\\"label\\":\\"Illo quis sit impedit itaque expedita earum deserunt magni doloremque velit eum id error\\",\\"description\\":\\"Doloremque vero sunt officiis iste voluptatibus voluptas molestiae sint asperiores recusandae amet praesentium et explicabo nesciunt similique voluptatum laudantium amet officiis quas distinctio quis enim nihil tempora\\",\\"url\\":\\"http://localhost:8889/?cat=16\\"} /-->
+<!-- /wp:navigation-link -->
+<!-- /wp:navigation-link -->
+<!-- /wp:navigation-link -->
+
+<!-- wp:navigation-link {\\"label\\":\\"WordPress.org\\",\\"url\\":\\"https://wordpress.org\\"} -->
+<!-- wp:navigation-link {\\"label\\":\\"Google\\",\\"url\\":\\"https://google.com\\"} /-->
 <!-- /wp:navigation-link -->
 <!-- /wp:navigation -->"
 `;


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/24675. Fixes https://github.com/WordPress/gutenberg/issues/25087.

![block-menu-items](https://user-images.githubusercontent.com/612155/91407920-58b8f700-e886-11ea-96ac-41374e978dc3.gif)

Updates the Navigation block to properly convert menu items with `type = 'block'` when creating a Navigation block from an existing menu.

I also made it pull the `description`, `rel` and `className` over from the menu item.

### How to test

1. Patch your current theme to support block navigation. Here's how that looks for Twenty Twenty:

```diff
Index: src/wp-content/themes/twentytwenty/functions.php
===================================================================
--- src/wp-content/themes/twentytwenty/functions.php	(revision 48655)
+++ src/wp-content/themes/twentytwenty/functions.php	(working copy)
@@ -142,6 +142,7 @@
 	$loader = new TwentyTwenty_Script_Loader();
 	add_filter( 'script_loader_tag', array( $loader, 'filter_script_loader_tag' ), 10, 2 );
 
+	add_theme_support( 'block-nav-menus' );
 }
 
 add_action( 'after_setup_theme', 'twentytwenty_theme_support' );
Index: src/wp-content/themes/twentytwenty/header.php
===================================================================
--- src/wp-content/themes/twentytwenty/header.php	(revision 48655)
+++ src/wp-content/themes/twentytwenty/header.php	(working copy)
@@ -83,25 +83,25 @@
 
 					<?php
 					if ( has_nav_menu( 'primary' ) || ! has_nav_menu( 'expanded' ) ) {
-						?>
 
-							<nav class="primary-menu-wrapper" aria-label="<?php esc_attr_e( 'Horizontal', 'twentytwenty' ); ?>" role="navigation">
+						if ( has_nav_menu( 'primary' ) ) {
 
-								<ul class="primary-menu reset-list-style">
+							wp_nav_menu(
+								array(
+									'container'      => '',
+									'items_wrap'     => '%3$s',
+									'theme_location' => 'primary',
+								)
+							);
 
-								<?php
-								if ( has_nav_menu( 'primary' ) ) {
+						} elseif ( ! has_nav_menu( 'expanded' ) ) {
+							?>
 
-									wp_nav_menu(
-										array(
-											'container'  => '',
-											'items_wrap' => '%3$s',
-											'theme_location' => 'primary',
-										)
-									);
+							<nav class="primary-menu-wrapper" aria-label="<?php esc_attr_e( 'Horizontal', 'twentytwenty' ); ?>" role="navigation">
 
-								} elseif ( ! has_nav_menu( 'expanded' ) ) {
+								<ul class="primary-menu reset-list-style">
 
+									<?php
 									wp_list_pages(
 										array(
 											'match_menu_classes' => true,
@@ -110,15 +110,14 @@
 											'walker'   => new TwentyTwenty_Walker_Page(),
 										)
 									);
+									?>
 
-								}
-								?>
-
 								</ul>
 
 							</nav><!-- .primary-menu-wrapper -->
 
-						<?php
+							<?php
+						}
 					}
 
 					if ( true === $enable_header_search || has_nav_menu( 'expanded' ) ) {
```

2. Add a Search block to a menu using the Navigation screen. See https://github.com/WordPress/gutenberg/pull/24503 for instructions.

3. Save the menu.

4. Go to a post and insert a Navigation block.

5. Select the menu and click _Create_.

6. Note that the Search block is properly added.