### PR TITLE
Navigation screen: Select Navigation block when user clicks away

### DIFF
--- a/packages/edit-navigation/src/components/navigation-editor/block-editor-area.js
+++ b/packages/edit-navigation/src/components/navigation-editor/block-editor-area.js
@@ -81,12 +81,33 @@ export default function BlockEditorArea( {
 		}
 	}, [ menuId ] );
 
-	// Select the navigation block when it becomes available
+	// Select the navigation block when it becomes available or when user clicks
+	// away from the navigation area.
 	const { selectBlock } = useDispatch( 'core/block-editor' );
 	useEffect( () => {
-		if ( rootBlockId ) {
-			selectBlock( rootBlockId );
-		}
+		const selectNavigation = () => {
+			if ( rootBlockId ) {
+				selectBlock( rootBlockId );
+			}
+		};
+
+		const detectClickOutside = ( event ) => {
+			const navigationContainer = document.querySelector(
+				'.wp-block-navigation'
+			);
+			if (
+				navigationContainer &&
+				! navigationContainer.contains( event.target )
+			) {
+				selectNavigation();
+			}
+		};
+
+		selectNavigation();
+
+		document.addEventListener( 'click', detectClickOutside );
+		return () =>
+			document.removeEventListener( 'click', detectClickOutside );
 	}, [ rootBlockId ] );
 
 	return (


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/24808.

![click-outside](https://user-images.githubusercontent.com/612155/91411365-8fddd700-e88b-11ea-898a-6f62e2f4f250.gif)

When a submenu is open in the Navigation screen, clicking outside the Navigation block should close the submenu.

This is done by selecting the Navigation block when a `click` event didn't originate from within the Navigation block.