### PR TITLE
Turn `WordCount` into a functional component

### DIFF
--- a/packages/editor/src/components/word-count/index.js
+++ b/packages/editor/src/components/word-count/index.js
@@ -1,11 +1,15 @@
 /**
  * WordPress dependencies
  */
-import { withSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { _x } from '@wordpress/i18n';
 import { count as wordCount } from '@wordpress/wordcount';
 
-function WordCount( { content } ) {
+export default function WordCount() {
+	const content = useSelect( ( select ) =>
+		select( 'core/editor' ).getEditedPostAttribute( 'content' )
+	);
+
 	/*
 	 * translators: If your word count is based on single characters (e.g. East Asian characters),
 	 * enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'.
@@ -19,9 +23,3 @@ function WordCount( { content } ) {
 		</span>
 	);
 }
-
-export default withSelect( ( select ) => {
-	return {
-		content: select( 'core/editor' ).getEditedPostAttribute( 'content' ),
-	};
-} )( WordCount );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Replace `withSelect` HOC with `useSelect` hook to turn `WordCount` into a truly functional component.

## Types of changes
Internal / Code quality

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
