### PR TITLE
Add Post Comment Date block

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -76,6 +76,7 @@ function gutenberg_reregister_core_block_types() {
 				'post-author.php'             => 'core/post-author',
 				'post-comment.php'            => 'core/post-comment',
 				'post-comment-content.php'    => 'core/post-comment-content',
+				'post-comment-date.php'       => 'core/post-comment-date',
 				'post-comments.php'           => 'core/post-comments',
 				'post-comments-count.php'     => 'core/post-comments-count',
 				'post-comments-form.php'      => 'core/post-comments-form',

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -77,6 +77,7 @@ import * as postContent from './post-content';
 import * as postAuthor from './post-author';
 import * as postComment from './post-comment';
 import * as postCommentContent from './post-comment-content';
+import * as postCommentDate from './post-comment-date';
 import * as postComments from './post-comments';
 import * as postCommentsCount from './post-comments-count';
 import * as postCommentsForm from './post-comments-form';
@@ -213,6 +214,7 @@ export const __experimentalRegisterExperimentalCoreBlocks =
 								postAuthor,
 								postComment,
 								postCommentContent,
+								postCommentDate,
 								postComments,
 								postCommentsCount,
 								postCommentsForm,

--- a/packages/block-library/src/post-comment-date/block.json
+++ b/packages/block-library/src/post-comment-date/block.json
@@ -1,6 +1,11 @@
 {
 	"name": "core/post-comment-date",
 	"category": "design",
+	"attributes": {
+		"format": {
+			"type": "string"
+		}
+	},
 	"usesContext": [ "commentId" ],
 	"supports": {
 		"html": false

--- a/packages/block-library/src/post-comment-date/block.json
+++ b/packages/block-library/src/post-comment-date/block.json
@@ -1,0 +1,8 @@
+{
+	"name": "core/post-comment-date",
+	"category": "design",
+	"usesContext": [ "commentId" ],
+	"supports": {
+		"html": false
+	}
+}

--- a/packages/block-library/src/post-comment-date/edit.js
+++ b/packages/block-library/src/post-comment-date/edit.js
@@ -2,20 +2,55 @@
  * WordPress dependencies
  */
 import { useEntityProp } from '@wordpress/core-data';
-import { dateI18n } from '@wordpress/date';
+import { __experimentalGetSettings, dateI18n } from '@wordpress/date';
+import {
+	InspectorControls,
+	__experimentalBlock as Block,
+} from '@wordpress/block-editor';
+import { PanelBody, CustomSelectControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
-export default function Edit( { attributes, context } ) {
-	const { className } = attributes;
+export default function Edit( { attributes, context, setAttributes } ) {
+	const { className, format } = attributes;
 	const { commentId } = context;
 
+	const settings = __experimentalGetSettings();
 	const [ siteDateFormat ] = useEntityProp( 'root', 'site', 'date_format' );
 	const [ date ] = useEntityProp( 'root', 'comment', 'date', commentId );
 
+	const formatOptions = Object.values( settings.formats ).map(
+		( formatOption ) => ( {
+			key: formatOption,
+			name: dateI18n( formatOption, date ),
+		} )
+	);
+	const resolvedFormat = format || siteDateFormat || settings.formats.date;
+
 	return (
-		<div className={ className }>
-			<time dateTime={ dateI18n( 'c', date ) }>
-				{ dateI18n( siteDateFormat, date ) }
-			</time>
-		</div>
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Format settings' ) }>
+					<CustomSelectControl
+						hideLabelFromVision
+						label={ __( 'Date Format' ) }
+						options={ formatOptions }
+						onChange={ ( { selectedItem } ) =>
+							setAttributes( {
+								format: selectedItem.key,
+							} )
+						}
+						value={ formatOptions.find(
+							( option ) => option.key === resolvedFormat
+						) }
+					/>
+				</PanelBody>
+			</InspectorControls>
+
+			<Block.div className={ className }>
+				<time dateTime={ dateI18n( 'c', date ) }>
+					{ dateI18n( resolvedFormat, date ) }
+				</time>
+			</Block.div>
+		</>
 	);
 }

--- a/packages/block-library/src/post-comment-date/edit.js
+++ b/packages/block-library/src/post-comment-date/edit.js
@@ -1,0 +1,21 @@
+/**
+ * WordPress dependencies
+ */
+import { useEntityProp } from '@wordpress/core-data';
+import { dateI18n } from '@wordpress/date';
+
+export default function Edit( { attributes, context } ) {
+	const { className } = attributes;
+	const { commentId } = context;
+
+	const [ siteDateFormat ] = useEntityProp( 'root', 'site', 'date_format' );
+	const [ date ] = useEntityProp( 'root', 'comment', 'date', commentId );
+
+	return (
+		<div className={ className }>
+			<time dateTime={ dateI18n( 'c', date ) }>
+				{ dateI18n( siteDateFormat, date ) }
+			</time>
+		</div>
+	);
+}

--- a/packages/block-library/src/post-comment-date/index.js
+++ b/packages/block-library/src/post-comment-date/index.js
@@ -1,0 +1,22 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { postDate as icon } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import edit from './edit';
+
+const { name } = metadata;
+export { metadata, name };
+
+export const settings = {
+	title: __( 'Post Comment Date' ),
+	description: __( 'Post Comment Date' ),
+	icon,
+	edit,
+	parent: [ 'core/post-comment' ],
+};

--- a/packages/block-library/src/post-comment-date/index.php
+++ b/packages/block-library/src/post-comment-date/index.php
@@ -18,7 +18,14 @@ function render_block_core_post_comment_date( $attributes, $content, $block ) {
 		return '';
 	}
 
-	return sprintf( '<div><time datetime="%1$s">%2$s</time></div>', get_comment_date( 'c', $block->context['commentId'] ), get_comment_date( '', $block->context['commentId'] ) );
+	return sprintf(
+		'<div><time datetime="%1$s">%2$s</time></div>',
+		get_comment_date( 'c', $block->context['commentId'] ),
+		get_comment_date(
+			isset( $attributes['format'] ) ? $attributes['format'] : '',
+			$block->context['commentId']
+		)
+	);
 }
 
 /**

--- a/packages/block-library/src/post-comment-date/index.php
+++ b/packages/block-library/src/post-comment-date/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Server-side rendering of the `core/post-comment-date` block.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Renders the `core/post-comment-date` block on the server.
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ * @return string Return the post comment's date.
+ */
+function render_block_core_post_comment_date( $attributes, $content, $block ) {
+	if ( ! isset( $block->context['commentId'] ) ) {
+		return '';
+	}
+
+	return sprintf( '<div><time datetime="%1$s">%2$s</time></div>', get_comment_date( 'c', $block->context['commentId'] ), get_comment_date( '', $block->context['commentId'] ) );
+}
+
+/**
+ * Registers the `core/post-comment-date` block on the server.
+ */
+function register_block_core_post_comment_date() {
+	register_block_type_from_metadata(
+		__DIR__ . '/post-comment-date',
+		array(
+			'render_callback' => 'render_block_core_post_comment_date',
+		)
+	);
+}
+add_action( 'init', 'register_block_core_post_comment_date' );

--- a/packages/e2e-tests/fixtures/blocks/core__post-comment-date.html
+++ b/packages/e2e-tests/fixtures/blocks/core__post-comment-date.html
@@ -1,0 +1,1 @@
+<!-- wp:post-comment-date /-->

--- a/packages/e2e-tests/fixtures/blocks/core__post-comment-date.json
+++ b/packages/e2e-tests/fixtures/blocks/core__post-comment-date.json
@@ -1,0 +1,10 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "core/post-comment-date",
+        "isValid": true,
+        "attributes": {},
+        "innerBlocks": [],
+        "originalContent": ""
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__post-comment-date.parsed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__post-comment-date.parsed.json
@@ -1,0 +1,18 @@
+[
+    {
+        "blockName": "core/post-comment-date",
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "",
+        "innerContent": []
+    },
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n",
+        "innerContent": [
+            "\n"
+        ]
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__post-comment-date.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__post-comment-date.serialized.html
@@ -1,0 +1,1 @@
+<!-- wp:post-comment-date /-->


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Add a new inner block called Post Comment Date. It can be inserted into the Post Comment block.

## How has this been tested?
1. Insert Post Comment block
2. Insert nested block: Post Comment Date
3. Comment's date should appear in the selected format

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/2256104/91434872-b8eb7100-e865-11ea-937b-6a2dd9e7358d.png)


## Types of changes
New feature (non-breaking change which adds functionality) 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
