### PR TITLE
[edit-widgets beta] Preload widgets

### DIFF
--- a/lib/class-wp-rest-sidebars-controller.php
+++ b/lib/class-wp-rest-sidebars-controller.php
@@ -280,6 +280,7 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 	 * Returns a list of widgets for the given sidebar id
 	 *
 	 * @param string $sidebar_id ID of the sidebar.
+	 * @param WP_REST_Request $request Request object.
 	 *
 	 * @return array
 	 * @global array $wp_registered_widgets
@@ -351,7 +352,7 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 						$widget['id_base']      = $instance->id_base;
 					}
 
-					if ( $request['context'] === 'edit' && isset( $wp_registered_widget_controls[ $widget_id ]['callback'] ) ) {
+					if ( 'edit' === $request['context'] && isset( $wp_registered_widget_controls[ $widget_id ]['callback'] ) ) {
 						$control   = $wp_registered_widget_controls[ $widget_id ];
 						$arguments = array();
 						if ( ! empty( $widget['number'] ) ) {

--- a/lib/class-wp-rest-sidebars-controller.php
+++ b/lib/class-wp-rest-sidebars-controller.php
@@ -279,8 +279,8 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 	/**
 	 * Returns a list of widgets for the given sidebar id
 	 *
-	 * @param string $sidebar_id ID of the sidebar.
-	 * @param WP_REST_Request $request Request object.
+	 * @param string          $sidebar_id ID of the sidebar.
+	 * @param WP_REST_Request $request    Request object.
 	 *
 	 * @return array
 	 * @global array $wp_registered_widgets

--- a/lib/class-wp-rest-sidebars-controller.php
+++ b/lib/class-wp-rest-sidebars-controller.php
@@ -286,13 +286,15 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 	 * @global array $wp_registered_sidebars
 	 */
 	public static function get_widgets( $sidebar_id ) {
-		global $wp_registered_widgets, $wp_registered_sidebars;
+		global $wp_registered_widgets, $wp_registered_sidebars, $wp_registered_widget_controls;
 
 		$widgets            = array();
 		$sidebars_widgets   = (array) wp_get_sidebars_widgets();
-		$registered_sidebar = isset( $wp_registered_sidebars[ $sidebar_id ] ) ? $wp_registered_sidebars[ $sidebar_id ] : (
+		$registered_sidebar = isset( $wp_registered_sidebars[ $sidebar_id ] )
+			? $wp_registered_sidebars[ $sidebar_id ]
+			: (
 			'wp_inactive_widgets' === $sidebar_id ? array() : null
-		);
+			);
 
 		if ( null !== $registered_sidebar && isset( $sidebars_widgets[ $sidebar_id ] ) ) {
 			foreach ( $sidebars_widgets[ $sidebar_id ] as $widget_id ) {
@@ -334,9 +336,7 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 						}
 
 						ob_start();
-
 						call_user_func_array( $widget['callback'], $widget_parameters );
-
 						$widget['rendered'] = trim( ob_get_clean() );
 					}
 
@@ -349,6 +349,17 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 						);
 						$widget['number']       = (int) $widget['params'][0]['number'];
 						$widget['id_base']      = $instance->id_base;
+					}
+
+					if ( isset( $wp_registered_widget_controls[ $widget_id ]['callback'] ) ) {
+						$control   = $wp_registered_widget_controls[ $widget_id ];
+						$arguments = array();
+						if ( ! empty( $widget['number'] ) ) {
+							$arguments[0] = array( 'number' => $widget['number'] );
+						}
+						ob_start();
+						call_user_func_array( $control['callback'], $arguments );
+						$widget['rendered_form'] = trim( ob_get_clean() );
 					}
 
 					unset( $widget['params'] );
@@ -484,43 +495,49 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 					'items'       => array(
 						'type'       => 'object',
 						'properties' => array(
-							'id'           => array(
+							'id'            => array(
 								'description' => __( 'Unique identifier for the widget.', 'gutenberg' ),
 								'type'        => 'string',
 								'context'     => array( 'view', 'edit', 'embed' ),
 							),
-							'id_base'      => array(
+							'id_base'       => array(
 								'description' => __( 'Type of widget for the object.', 'gutenberg' ),
 								'type'        => 'string',
 								'context'     => array( 'view', 'edit', 'embed' ),
 							),
-							'widget_class' => array(
+							'widget_class'  => array(
 								'description' => __( 'Class name of the widget implementation.', 'gutenberg' ),
 								'type'        => 'string',
 								'context'     => array( 'view', 'edit', 'embed' ),
 							),
-							'name'         => array(
+							'name'          => array(
 								'description' => __( 'Name of the widget.', 'gutenberg' ),
 								'type'        => 'string',
 								'context'     => array( 'view', 'edit', 'embed' ),
 							),
-							'description'  => array(
+							'description'   => array(
 								'description' => __( 'Description of the widget.', 'gutenberg' ),
 								'type'        => 'string',
 								'context'     => array( 'view', 'edit', 'embed' ),
 							),
-							'number'       => array(
+							'number'        => array(
 								'description' => __( 'Number of the widget.', 'gutenberg' ),
 								'type'        => 'integer',
 								'context'     => array( 'view', 'edit', 'embed' ),
 							),
-							'rendered'     => array(
+							'rendered'      => array(
 								'description' => __( 'HTML representation of the widget.', 'gutenberg' ),
 								'type'        => 'string',
-								'context'     => array( 'view', 'edit', 'embed' ),
+								'context'     => array( 'view', 'embed' ),
 								'readonly'    => true,
 							),
-							'settings'     => array(
+							'rendered_form' => array(
+								'description' => __( 'HTML representation of the widget admin form.', 'gutenberg' ),
+								'type'        => 'string',
+								'context'     => array( 'edit' ),
+								'readonly'    => true,
+							),
+							'settings'      => array(
 								'description' => __( 'Settings of the widget.', 'gutenberg' ),
 								'type'        => 'object',
 								'context'     => array( 'view', 'edit', 'embed' ),

--- a/lib/class-wp-rest-sidebars-controller.php
+++ b/lib/class-wp-rest-sidebars-controller.php
@@ -285,7 +285,7 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 	 * @global array $wp_registered_widgets
 	 * @global array $wp_registered_sidebars
 	 */
-	public static function get_widgets( $sidebar_id ) {
+	public static function get_widgets( $sidebar_id, $request ) {
 		global $wp_registered_widgets, $wp_registered_sidebars, $wp_registered_widget_controls;
 
 		$widgets            = array();
@@ -351,7 +351,7 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 						$widget['id_base']      = $instance->id_base;
 					}
 
-					if ( isset( $wp_registered_widget_controls[ $widget_id ]['callback'] ) ) {
+					if ( $request['context'] === 'edit' && isset( $wp_registered_widget_controls[ $widget_id ]['callback'] ) ) {
 						$control   = $wp_registered_widget_controls[ $widget_id ];
 						$arguments = array();
 						if ( ! empty( $widget['number'] ) ) {
@@ -403,7 +403,7 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 
 		$fields = $this->get_fields_for_response( $request );
 		if ( rest_is_field_included( 'widgets', $fields ) ) {
-			$sidebar['widgets'] = self::get_widgets( $sidebar['id'] );
+			$sidebar['widgets'] = self::get_widgets( $sidebar['id'], $request );
 		}
 
 		$schema = $this->get_item_schema();

--- a/packages/block-library/src/legacy-widget/edit/handler.js
+++ b/packages/block-library/src/legacy-widget/edit/handler.js
@@ -18,10 +18,10 @@ import LegacyWidgetEditDomManager from './dom-manager';
 const { XMLHttpRequest, FormData } = window;
 
 class LegacyWidgetEditHandler extends Component {
-	constructor() {
+	constructor( props ) {
 		super( ...arguments );
 		this.state = {
-			form: null,
+			form: props.prerenderedEditForm,
 		};
 		this.widgetNonce = null;
 		this.instanceUpdating = null;
@@ -32,9 +32,11 @@ class LegacyWidgetEditHandler extends Component {
 	componentDidMount() {
 		this.isStillMounted = true;
 		this.trySetNonce();
-		this.requestWidgetForm( undefined, ( response ) => {
-			this.props.onInstanceChange( null, !! response.form );
-		} );
+		if ( ! this.props.prerenderedEditForm ) {
+			this.requestWidgetForm( undefined, ( response ) => {
+				this.props.onInstanceChange( null, !! response.form );
+			} );
+		}
 	}
 
 	componentDidUpdate( prevProps ) {

--- a/packages/block-library/src/legacy-widget/edit/index.js
+++ b/packages/block-library/src/legacy-widget/edit/index.js
@@ -38,6 +38,7 @@ class LegacyWidgetEdit extends Component {
 			availableLegacyWidgets,
 			hasPermissionsToManageWidgets,
 			isSelected,
+			prerenderedEditForm,
 			setAttributes,
 			widgetId,
 		} = this.props;
@@ -127,6 +128,7 @@ class LegacyWidgetEdit extends Component {
 						id={ widgetId }
 						idBase={ attributes.idBase || widgetId }
 						number={ attributes.number }
+						prerenderedEditForm={ prerenderedEditForm }
 						widgetName={ get( widgetObject, [ 'name' ] ) }
 						widgetClass={ attributes.widgetClass }
 						instance={ attributes.instance }

--- a/packages/block-library/src/legacy-widget/edit/index.js
+++ b/packages/block-library/src/legacy-widget/edit/index.js
@@ -187,6 +187,7 @@ export default withSelect( ( select, { clientId } ) => {
 	const widgetId = select( 'core/edit-widgets' ).getWidgetIdForClientId(
 		clientId
 	);
+	const widget = select( 'core/edit-widgets' ).getWidget( widgetId );
 	const editorSettings = select( 'core/block-editor' ).getSettings();
 	const {
 		availableLegacyWidgets,
@@ -196,5 +197,6 @@ export default withSelect( ( select, { clientId } ) => {
 		hasPermissionsToManageWidgets,
 		availableLegacyWidgets,
 		widgetId,
+		prerenderedEditForm: widget.rendered_form,
 	};
 } )( LegacyWidgetEdit );

--- a/packages/edit-widgets/src/store/selectors.js
+++ b/packages/edit-widgets/src/store/selectors.js
@@ -28,6 +28,13 @@ export const getWidgets = createRegistrySelector( ( select ) => () => {
 	);
 } );
 
+export const getWidget = createRegistrySelector(
+	( select ) => ( state, id ) => {
+		const widgets = select( 'core/edit-widgets' ).getWidgets();
+		return widgets[ id ];
+	}
+);
+
 export const getWidgetAreas = createRegistrySelector( ( select ) => () => {
 	if ( ! hasResolvedWidgetAreas( query ) ) {
 		return null;

--- a/packages/edit-widgets/src/store/transformers.js
+++ b/packages/edit-widgets/src/store/transformers.js
@@ -15,7 +15,6 @@ export function transformWidgetToBlock( widget ) {
 	return createBlock(
 		'core/legacy-widget',
 		{
-			rendered: widget.rendered,
 			form: widget.form,
 			widgetClass: widget.widget_class,
 			instance: widget.settings,

--- a/phpunit/class-rest-sidebars-controller-test.php
+++ b/phpunit/class-rest-sidebars-controller-test.php
@@ -276,6 +276,60 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	/**
 	 *
 	 */
+	public function test_get_items_active_sidebar_with_widgets_edit_context() {
+		$this->setup_widget(
+			'widget_text',
+			1,
+			array(
+				'text' => 'Custom text test',
+			)
+		);
+		$this->setup_sidebar(
+			'sidebar-1',
+			array(
+				'name' => 'Test sidebar',
+			),
+			array( 'text-1' )
+		);
+
+		$request            = new WP_REST_Request( 'GET', '/__experimental/sidebars' );
+		$request['context'] = 'edit';
+		$response           = rest_get_server()->dispatch( $request );
+		$data               = $response->get_data();
+		$this->assertEquals(
+			array(
+				array(
+					'id'          => 'sidebar-1',
+					'name'        => 'Test sidebar',
+					'description' => '',
+					'status'      => 'active',
+					'widgets'     => array(
+						array(
+							'id'            => 'text-1',
+							'settings'      => array(
+								'text' => 'Custom text test',
+							),
+							'id_base'       => 'text',
+							'widget_class'  => 'WP_Widget_Text',
+							'name'          => 'Text',
+							'description'   => 'Arbitrary text.',
+							'number'        => 1,
+							'rendered'      => '<div class="textwidget">Custom text test</div>',
+							'rendered_form' => '<input id="widget-text-1-title" name="widget-text[1][title]" class="title sync-input" type="hidden" value="">' . "\n" .
+																							'			<textarea id="widget-text-1-text" name="widget-text[1][text]" class="text sync-input" hidden>Custom text test</textarea>' . "\n" .
+																							'			<input id="widget-text-1-filter" name="widget-text[1][filter]" class="filter sync-input" type="hidden" value="on">' . "\n" .
+																							'			<input id="widget-text-1-visual" name="widget-text[1][visual]" class="visual sync-input" type="hidden" value="on">',
+						),
+					),
+				),
+			),
+			$data
+		);
+	}
+
+	/**
+	 *
+	 */
 	public function test_get_item() {
 		$this->setup_sidebar(
 			'sidebar-1',
@@ -581,7 +635,8 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			)
 		);
 
-		$request  = new WP_REST_Request( 'GET', '/__experimental/sidebars' );
+		$request = new WP_REST_Request( 'GET', '/__experimental/sidebars' );
+		$request->set_param( 'context', 'view' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 		$this->assertEquals(


### PR DESCRIPTION
## Description
This PR updates the experimental widgets screen so that it's pre-populated with legacy widgets on the initial load.

*Before*: (flash of blank state, issuing multiple XHRs)

<img width="769" alt="Zrzut ekranu 2020-08-27 o 13 32 10" src="https://user-images.githubusercontent.com/205419/91437186-c7d42280-e869-11ea-8b73-c28f2eac02a9.png">

*After*: (all forms loaded from the very beginning)

<img width="835" alt="Zrzut ekranu 2020-08-27 o 13 31 23" src="https://user-images.githubusercontent.com/205419/91437124-a8d59080-e869-11ea-8150-923a7b6a1db3.png">

## How has this been tested?
1. Add a bunch of widgets on `/widgets.php`.
1. Go to the beta widgets management screen.
1. Confirm it was loaded right away.
1. Make some changes, save them, confirm everything worked as expected.

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
