### PR TITLE
Add navigation component tests

### DIFF
--- a/packages/components/src/navigation/menu-item.js
+++ b/packages/components/src/navigation/menu-item.js
@@ -50,7 +50,7 @@ const NavigationMenuItem = ( props ) => {
 		<MenuItemUI className={ classes }>
 			<LinkComponentTag
 				className={ classes }
-				href={ ! children.length ? href : null }
+				href={ ! children.length ? href : undefined }
 				onClick={ handleClick }
 				{ ...linkProps }
 			>

--- a/packages/components/src/navigation/test/index.js
+++ b/packages/components/src/navigation/test/index.js
@@ -10,6 +10,10 @@ import Navigation from '../';
 import NavigationMenu from '../menu';
 import NavigationMenuItem from '../menu-item';
 
+const CustomComponent = ( { onClick } ) => {
+	return <button onClick={ onClick }>customize me</button>;
+};
+
 const sampleData = [
 	{
 		title: 'Item 1',
@@ -18,10 +22,19 @@ const sampleData = [
 	{
 		title: 'Item 2',
 		id: 'item-2',
+		href: 'http://example.com',
+		linkProps: {
+			target: '_blank',
+		},
 	},
 	{
 		title: 'Category',
 		id: 'category',
+	},
+	{
+		title: 'Item 3',
+		id: 'item-3',
+		LinkComponent: CustomComponent,
 	},
 	{
 		title: 'Child 1',
@@ -59,14 +72,42 @@ describe( 'Navigation', () => {
 
 		const menuItems = screen.getAllByRole( 'listitem' );
 
-		expect( menuItems.length ).toBe( 3 );
+		expect( menuItems.length ).toBe( 4 );
 		expect( menuItems[ 0 ].textContent ).toBe( 'Item 1' );
 		expect( menuItems[ 1 ].textContent ).toBe( 'Item 2' );
 		expect( menuItems[ 2 ].textContent ).toBe( 'Category' );
+		expect( menuItems[ 3 ].textContent ).toBe( 'customize me' );
 		expect( menuItems[ 0 ].classList.contains( 'is-active' ) ).toBe(
 			false
 		);
 		expect( menuItems[ 1 ].classList.contains( 'is-active' ) ).toBe( true );
+	} );
+
+	it( 'should render anchor links when menu item supplies an href', async () => {
+		render(
+			<Navigation activeItemId={ 'item-2' } data={ sampleData }>
+				{ renderPane() }
+			</Navigation>
+		);
+
+		const linkItem = screen.getByRole( 'link', { name: 'Item 2' } );
+
+		expect( linkItem ).toBeDefined();
+		expect( linkItem.target ).toBe( '_blank' );
+	} );
+
+	it( 'should render a custom component when menu item supplies one', async () => {
+		render(
+			<Navigation activeItemId={ 'item-2' } data={ sampleData }>
+				{ renderPane() }
+			</Navigation>
+		);
+
+		const customItem = screen.getByRole( 'button', {
+			name: 'customize me',
+		} );
+
+		expect( customItem ).toBeDefined();
 	} );
 
 	it( 'should set an active category on click', async () => {

--- a/packages/components/src/navigation/test/index.js
+++ b/packages/components/src/navigation/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -51,15 +51,13 @@ const renderPane = () => ( { level, NavigationBackButton } ) => {
 
 describe( 'Navigation', () => {
 	it( 'should render the panes and active item', async () => {
-		const { container } = render(
+		render(
 			<Navigation activeItemId={ 'item-2' } data={ sampleData }>
 				{ renderPane() }
 			</Navigation>
 		);
 
-		const menuItems = container.querySelectorAll(
-			'.components-navigation__menu-item'
-		);
+		const menuItems = screen.getAllByRole( 'listitem' );
 
 		expect( menuItems.length ).toBe( 3 );
 		expect( menuItems[ 0 ].textContent ).toBe( 'Item 1' );
@@ -72,15 +70,12 @@ describe( 'Navigation', () => {
 	} );
 
 	it( 'should set an active category on click', async () => {
-		const { container, getByText } = render(
-			<Navigation data={ sampleData }>{ renderPane() }</Navigation>
-		);
+		render( <Navigation data={ sampleData }>{ renderPane() }</Navigation> );
 
-		fireEvent.click( getByText( 'Category' ) );
-		const categoryTitle = container.querySelector( 'h2' );
-		const menuItems = container.querySelectorAll(
-			'.components-navigation__menu-item'
-		);
+		fireEvent.click( screen.getByRole( 'button', { name: 'Category' } ) );
+		const categoryTitle = screen.getByRole( 'heading' );
+		const menuItems = screen.getAllByRole( 'listitem' );
+
 		expect( categoryTitle.textContent ).toBe( 'Category' );
 		expect( menuItems.length ).toBe( 2 );
 		expect( menuItems[ 0 ].textContent ).toBe( 'Child 1' );
@@ -88,11 +83,11 @@ describe( 'Navigation', () => {
 	} );
 
 	it( 'should render the root title', async () => {
-		const { container, rerender } = render(
+		const { rerender } = render(
 			<Navigation data={ sampleData }>{ renderPane() }</Navigation>
 		);
 
-		const emptyTitle = container.querySelector( 'h2' );
+		const emptyTitle = screen.getByRole( 'heading' );
 		expect( emptyTitle.textContent ).toBe( '' );
 
 		rerender(
@@ -101,12 +96,12 @@ describe( 'Navigation', () => {
 			</Navigation>
 		);
 
-		const rootTitle = container.querySelector( 'h2' );
+		const rootTitle = screen.getByRole( 'heading' );
 		expect( rootTitle.textContent ).toBe( 'Home' );
 	} );
 
 	it( 'should render badges', async () => {
-		const { container } = render(
+		render(
 			<Navigation
 				data={ [ { id: 'item-1', title: 'Item 1', badge: 21 } ] }
 			>
@@ -114,24 +109,22 @@ describe( 'Navigation', () => {
 			</Navigation>
 		);
 
-		const menuItem = container.querySelector(
-			'.components-navigation__menu-item'
-		);
+		const menuItem = screen.getByRole( 'listitem' );
 		expect( menuItem.textContent ).toBe( 'Item 1' + '21' );
 	} );
 
 	it( 'should navigate up a level when clicking the back button', async () => {
-		const { container, getByText } = render(
+		render(
 			<Navigation data={ sampleData } rootTitle="Home">
 				{ renderPane() }
 			</Navigation>
 		);
 
-		fireEvent.click( getByText( 'Category' ) );
-		let levelTitle = container.querySelector( 'h2' );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Category' } ) );
+		let levelTitle = screen.getByRole( 'heading' );
 		expect( levelTitle.textContent ).toBe( 'Category' );
-		fireEvent.click( getByText( 'Back' ) );
-		levelTitle = container.querySelector( 'h2' );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Back' } ) );
+		levelTitle = screen.getByRole( 'heading' );
 		expect( levelTitle.textContent ).toBe( 'Home' );
 	} );
 } );

--- a/packages/components/src/navigation/test/index.js
+++ b/packages/components/src/navigation/test/index.js
@@ -1,0 +1,137 @@
+/**
+ * External dependencies
+ */
+import { render, fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import Navigation from '../';
+import NavigationMenu from '../menu';
+import NavigationMenuItem from '../menu-item';
+
+const sampleData = [
+	{
+		title: 'Item 1',
+		id: 'item-1',
+	},
+	{
+		title: 'Item 2',
+		id: 'item-2',
+	},
+	{
+		title: 'Category',
+		id: 'category',
+	},
+	{
+		title: 'Child 1',
+		id: 'child-1',
+		parent: 'category',
+	},
+	{
+		title: 'Child 2',
+		id: 'child-2',
+		parent: 'category',
+	},
+];
+
+const renderPane = () => ( { level, NavigationBackButton } ) => {
+	return (
+		<>
+			<h2>{ level.title }</h2>
+			<NavigationBackButton>Back</NavigationBackButton>
+			<NavigationMenu>
+				{ level.children.map( ( item ) => {
+					return <NavigationMenuItem { ...item } key={ item.id } />;
+				} ) }
+			</NavigationMenu>
+		</>
+	);
+};
+
+describe( 'Navigation', () => {
+	it( 'should render the panes and active item', async () => {
+		const { container } = render(
+			<Navigation activeItemId={ 'item-2' } data={ sampleData }>
+				{ renderPane() }
+			</Navigation>
+		);
+
+		const menuItems = container.querySelectorAll(
+			'.components-navigation__menu-item'
+		);
+
+		expect( menuItems.length ).toBe( 3 );
+		expect( menuItems[ 0 ].textContent ).toBe( 'Item 1' );
+		expect( menuItems[ 1 ].textContent ).toBe( 'Item 2' );
+		expect( menuItems[ 2 ].textContent ).toBe( 'Category' );
+		expect( menuItems[ 0 ].classList.contains( 'is-active' ) ).toBe(
+			false
+		);
+		expect( menuItems[ 1 ].classList.contains( 'is-active' ) ).toBe( true );
+	} );
+
+	it( 'should set an active category on click', async () => {
+		const { container, getByText } = render(
+			<Navigation data={ sampleData }>{ renderPane() }</Navigation>
+		);
+
+		fireEvent.click( getByText( 'Category' ) );
+		const categoryTitle = container.querySelector( 'h2' );
+		const menuItems = container.querySelectorAll(
+			'.components-navigation__menu-item'
+		);
+		expect( categoryTitle.textContent ).toBe( 'Category' );
+		expect( menuItems.length ).toBe( 2 );
+		expect( menuItems[ 0 ].textContent ).toBe( 'Child 1' );
+		expect( menuItems[ 1 ].textContent ).toBe( 'Child 2' );
+	} );
+
+	it( 'should render the root title', async () => {
+		const { container, rerender } = render(
+			<Navigation data={ sampleData }>{ renderPane() }</Navigation>
+		);
+
+		const emptyTitle = container.querySelector( 'h2' );
+		expect( emptyTitle.textContent ).toBe( '' );
+
+		rerender(
+			<Navigation rootTitle="Home" data={ sampleData }>
+				{ renderPane() }
+			</Navigation>
+		);
+
+		const rootTitle = container.querySelector( 'h2' );
+		expect( rootTitle.textContent ).toBe( 'Home' );
+	} );
+
+	it( 'should render badges', async () => {
+		const { container } = render(
+			<Navigation
+				data={ [ { id: 'item-1', title: 'Item 1', badge: 21 } ] }
+			>
+				{ renderPane() }
+			</Navigation>
+		);
+
+		const menuItem = container.querySelector(
+			'.components-navigation__menu-item'
+		);
+		expect( menuItem.textContent ).toBe( 'Item 1' + '21' );
+	} );
+
+	it( 'should navigate up a level when clicking the back button', async () => {
+		const { container, getByText } = render(
+			<Navigation data={ sampleData } rootTitle="Home">
+				{ renderPane() }
+			</Navigation>
+		);
+
+		fireEvent.click( getByText( 'Category' ) );
+		let levelTitle = container.querySelector( 'h2' );
+		expect( levelTitle.textContent ).toBe( 'Category' );
+		fireEvent.click( getByText( 'Back' ) );
+		levelTitle = container.querySelector( 'h2' );
+		expect( levelTitle.textContent ).toBe( 'Home' );
+	} );
+} );


### PR DESCRIPTION
## Description
Adds the navigation component tests.

## How has this been tested?
Through...tests.

## Testing

1. Run `npm run test-unit packages/components/src/navigation`
1. Make sure all tests pass.
1. Make sure test coverage is adequate.
