### PR TITLE
Fix invalid HTML structure on the widgets screen

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -198,7 +198,7 @@ function gutenberg_register_widgets() {
 			if($arg[0]['widget_name'] === 'Block'){
 				$arg[0]['before_form'] = '';
 				$arg[0]['before_widget_content'] = '<div class="widget-content">';
-				$arg[0]['after_widget_content'] = '</div><form>';
+				$arg[0]['after_widget_content'] = '</div><form class="block-widget-form">';
 				$arg[0]['after_form'] = '</form>';
 			}
 			return $arg;

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -186,23 +186,32 @@ add_filter( 'rest_index', 'register_site_icon_url' );
  * Registers the WP_Widget_Block widget
  */
 function gutenberg_register_widgets() {
-	if ( gutenberg_is_experiment_enabled( 'gutenberg-widget-experiments' ) ) {
-		register_widget( 'WP_Widget_Block' );
-		// By default every widget on widgets.php is wrapped with a <form>.
-		// This means that you can sometimes end up with invalid HTML, e.g. when
-		// one of the widgets is a Search block.
-		//
-		// To fix the problem, let's add a filter that moves the form below the actual
-		// widget content.
-		add_filter( 'dynamic_sidebar_params', function($arg) {
-			if($arg[0]['widget_name'] === 'Block'){
-				$arg[0]['before_form'] = '';
-				$arg[0]['before_widget_content'] = '<div class="widget-content">';
-				$arg[0]['after_widget_content'] = '</div><form class="block-widget-form">';
-				$arg[0]['after_form'] = '</form>';
+	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-widget-experiments' ) ) {
+		return;
+	}
+
+	register_widget( 'WP_Widget_Block' );
+	// By default every widget on widgets.php is wrapped with a <form>.
+	// This means that you can sometimes end up with invalid HTML, e.g. when
+	// one of the widgets is a Search block.
+	//
+	// To fix the problem, let's add a filter that moves the form below the actual
+	// widget content.
+	global $pagenow;
+	if ( 'widgets.php' === $pagenow ) {
+		add_filter(
+			'dynamic_sidebar_params',
+			function ( $arg ) {
+				if ( 'Block' === $arg[0]['widget_name'] ) {
+					$arg[0]['before_form']           = '';
+					$arg[0]['before_widget_content'] = '<div class="widget-content">';
+					$arg[0]['after_widget_content']  = '</div><form class="block-widget-form">';
+					$arg[0]['after_form']            = '</form>';
+				}
+
+				return $arg;
 			}
-			return $arg;
-		} );
+		);
 	}
 }
 

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -201,18 +201,20 @@ function gutenberg_register_widgets() {
 	if ( 'widgets.php' === $pagenow ) {
 		add_filter(
 			'dynamic_sidebar_params',
-			function ( $arg ) {
-				if ( 'Block' === $arg[0]['widget_name'] ) {
-					$arg[0]['before_form']           = '';
-					$arg[0]['before_widget_content'] = '<div class="widget-content">';
-					$arg[0]['after_widget_content']  = '</div><form class="block-widget-form">';
-					$arg[0]['after_form']            = '</form>';
-				}
-
-				return $arg;
-			}
+			'gutenberg_override_sidebar_params_for_block_widget'
 		);
 	}
+}
+
+function gutenberg_override_sidebar_params_for_block_widget( $arg ) {
+	if ( 'Block' === $arg[0]['widget_name'] ) {
+		$arg[0]['before_form']           = '';
+		$arg[0]['before_widget_content'] = '<div class="widget-content">';
+		$arg[0]['after_widget_content']  = '</div><form class="block-widget-form">';
+		$arg[0]['after_form']            = '</form>';
+	}
+
+	return $arg;
 }
 
 add_action( 'widgets_init', 'gutenberg_register_widgets' );

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -206,6 +206,12 @@ function gutenberg_register_widgets() {
 	}
 }
 
+/**
+ * Overrides dynamic_sidebar_params to make sure Blocks are not wrapped in <form> tag.
+ *
+ * @param  array $arg Dynamic sidebar params.
+ * @return array Updated dynamic sidebar params.
+ */
 function gutenberg_override_sidebar_params_for_block_widget( $arg ) {
 	if ( 'Block' === $arg[0]['widget_name'] ) {
 		$arg[0]['before_form']           = '';

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -188,6 +188,21 @@ add_filter( 'rest_index', 'register_site_icon_url' );
 function gutenberg_register_widgets() {
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-widget-experiments' ) ) {
 		register_widget( 'WP_Widget_Block' );
+		// By default every widget on widgets.php is wrapped with a <form>.
+		// This means that you can sometimes end up with invalid HTML, e.g. when
+		// one of the widgets is a Search block.
+		//
+		// To fix the problem, let's add a filter that moves the form below the actual
+		// widget content.
+		add_filter( 'dynamic_sidebar_params', function($arg) {
+			if($arg[0]['widget_name'] === 'Block'){
+				$arg[0]['before_form'] = '';
+				$arg[0]['before_widget_content'] = '<div class="widget-content">';
+				$arg[0]['after_widget_content'] = '</div><form>';
+				$arg[0]['after_form'] = '</form>';
+			}
+			return $arg;
+		} );
 	}
 }
 

--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -36,13 +36,11 @@ function the_gutenberg_widgets( $page = 'gutenberg_page_gutenberg-widgets' ) {
  * @param string $hook Page.
  */
 function gutenberg_widgets_init( $hook ) {
+	$inline_css = '.block-widget-form .widget-control-save { display: none; }';
 	if ( 'widgets.php' === $hook ) {
 		wp_enqueue_style( 'wp-block-library' );
 		wp_enqueue_style( 'wp-block-library-theme' );
-		wp_add_inline_style(
-			'wp-block-library-theme',
-			'.block-widget-form .widget-control-save { display: none; }'
-		);
+		wp_add_inline_style( 'wp-block-library-theme', $inline_css );
 		return;
 	}
 	if ( ! in_array( $hook, array( 'gutenberg_page_gutenberg-widgets', 'gutenberg_customizer' ), true ) ) {
@@ -122,5 +120,6 @@ function gutenberg_widgets_init( $hook ) {
 	wp_enqueue_script( 'wp-format-library' );
 	wp_enqueue_style( 'wp-edit-widgets' );
 	wp_enqueue_style( 'wp-format-library' );
+	wp_add_inline_style( 'wp-format-library', $inline_css );
 }
 add_action( 'admin_enqueue_scripts', 'gutenberg_widgets_init' );

--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -39,6 +39,10 @@ function gutenberg_widgets_init( $hook ) {
 	if ( 'widgets.php' === $hook ) {
 		wp_enqueue_style( 'wp-block-library' );
 		wp_enqueue_style( 'wp-block-library-theme' );
+		wp_add_inline_style(
+			'wp-block-library-theme',
+			'.block-widget-form .widget-control-save { display: none; }'
+		);
 		return;
 	}
 	if ( ! in_array( $hook, array( 'gutenberg_page_gutenberg-widgets', 'gutenberg_customizer' ), true ) ) {

--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -36,11 +36,13 @@ function the_gutenberg_widgets( $page = 'gutenberg_page_gutenberg-widgets' ) {
  * @param string $hook Page.
  */
 function gutenberg_widgets_init( $hook ) {
-	$inline_css = '.block-widget-form .widget-control-save { display: none; }';
 	if ( 'widgets.php' === $hook ) {
 		wp_enqueue_style( 'wp-block-library' );
 		wp_enqueue_style( 'wp-block-library-theme' );
-		wp_add_inline_style( 'wp-block-library-theme', $inline_css );
+		wp_add_inline_style(
+			'wp-block-library-theme',
+			'.block-widget-form .widget-control-save { display: none; }'
+		);
 		return;
 	}
 	if ( ! in_array( $hook, array( 'gutenberg_page_gutenberg-widgets', 'gutenberg_customizer' ), true ) ) {
@@ -120,6 +122,5 @@ function gutenberg_widgets_init( $hook ) {
 	wp_enqueue_script( 'wp-format-library' );
 	wp_enqueue_style( 'wp-edit-widgets' );
 	wp_enqueue_style( 'wp-format-library' );
-	wp_add_inline_style( 'wp-format-library', $inline_css );
 }
 add_action( 'admin_enqueue_scripts', 'gutenberg_widgets_init' );


### PR DESCRIPTION
## Description
By default every widget on the legacy screen is wrapped with a `<form>`.

https://github.com/WordPress/wordpress-develop/blob/master/src/wp-admin/includes/widgets.php#L205

This means that you can sometimes end up with invalid HTML.

1. Navigate to Widgets (beta) and add a Search block to one of the block areas.
1. Navigate to Widgets (the old screen).
1. View the page source and search for wp-block-search.
1. You'll see that there's a `<form>` inside a `<form>`. Firefox helpfully highlights the invalid HTML.

<img width="1440" alt="91242962-190de480-e78c-11ea-9214-4f7b9dff7edc" src="https://user-images.githubusercontent.com/205419/91455329-391fcf80-e882-11ea-84c2-a07caa038411.png">

Courtesy of @noisysocks https://github.com/WordPress/gutenberg/pull/24290#discussion_r476936838

This solution is not awesome, but it's okay. I believe that's what this filter and dynamic options were invented for anyway. Since there is no real form when the widget is also a block, this PR also hides the save button for such widgets.

## How has this been tested?

1. Navigate to Widgets (beta) and add a Search block to one of the block areas.
1. Navigate to Widgets (the old screen).
1. View the page source and search for wp-block-search.
1. Confirm there's no `form` inside a `form`.
1. Confirm everything works as expected.
1. Repeat in customizer.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
