### PR TITLE
Theme Support: Enable custom units by default

### DIFF
--- a/docs/designers-developers/developers/themes/theme-support.md
+++ b/docs/designers-developers/developers/themes/theme-support.md
@@ -280,16 +280,18 @@ add_theme_support( 'custom-line-height' );
 
 ### Support custom units
 
-In addition to pixels, users can use other units to define sizes, paddings... The available units are: px, em, rem, vh, vw. Themes can enable support for this feature with the following code:
-
-```php
-add_theme_support( 'custom-units' );
-```
+In addition to pixels, users can use other units to define sizes, paddings... The available units are: px, em, rem, vh, vw.
 
 Themes can also filter the available custom units.
 
 ```php
 add_theme_support( 'custom-units', 'rem', 'em' );
+```
+
+Custom units are available by default. However, themes can disable support for this feature with the following code:
+
+```php
+add_theme_support( 'custom-units', false );
 ```
 
 ### Disabling the default block patterns.

--- a/packages/block-editor/src/components/unit-control/index.js
+++ b/packages/block-editor/src/components/unit-control/index.js
@@ -37,7 +37,14 @@ export function useCustomUnits( unitsProp ) {
 			select( 'core/block-editor' ).getSettings().enableCustomUnits,
 		[]
 	);
-	const isDisabled = ! settings;
+	const hasConfigs = Array.isArray( settings );
+
+	let isDisabled = false;
+
+	if ( hasConfigs ) {
+		const [ enabledFlag ] = settings;
+		isDisabled = enabledFlag === false;
+	}
 
 	// Adjust units based on add_theme_support( 'custom-units' );
 	let units;
@@ -51,7 +58,7 @@ export function useCustomUnits( unitsProp ) {
 	 * Note: If there are unit argument (e.g. 'em'), these units are enabled
 	 * within the control.
 	 */
-	if ( Array.isArray( settings ) ) {
+	if ( hasConfigs ) {
 		units = filterUnitsWithSettings( settings, unitsProp );
 	} else {
 		units = isDisabled ? false : unitsProp;


### PR DESCRIPTION
This update enables custom units by **default**. Custom units can be disabled using `add_theme_support( 'custom-unit' )` and setting it to `false`, like so:

```php
add_theme_support( 'custom-unit', false )
```

A quick enhancement for this: https://github.com/WordPress/gutenberg/pull/23964#issuecomment-682082482

### Thinking behind this approach

Since the `experimental` flag was removed from `custom-unit`, I felt hesitant changing that filter key. Unlike some of the other design tool filters, this one acts as more than just a `boolean` value.

For instance, themers can filter certain units by doing the following:

```php
add_theme_support( 'custom-unit', 'em, 'px'  );
```

(The above would use only `em` and `px`).

Instead of adding something like `add_theme_support( 'disable-custom-unit' )`... I preserved the `custom-unit` theme support key, but adjusted the way it could be used to disable + filter units.

**Default**: Custom units on

```php
// This does nothing now.
add_theme_support( 'custom-unit' );
```

**Disable**: Custom units off

```php
add_theme_support( 'custom-unit', false );
```

**Filtering**: Custom units on, but filtered

```php
add_theme_support( 'custom-unit', 'em', 'rem' );
```

---

### Working with (global) custom units

At the moment, Cover appears to be the only core block that uses `UnitControl`, specifically for height and padding.

For the units to respect the `add_theme_support`, the component (or hook) must come from:

```
packages/block-editor/src/components/unit-control/index.js
```

This will have the theme-configured units pre-bound:

```js
import { __experimentalUnitControl as UnitControl } from '@wordpress/block-editor';

const Example = () => <UnitControl />
```

When working within `block-editor`, you can use the hook to receive pre-filtered units:

```js
import { useCustomUnits } from '../components/unit-control';

const Example = () => {
  const units = useCustomUnits();
  return <UnitControl units={units}  />
}
```

---

## Working with `UnitControl`

The recommended implementation of `<UnitControl />` would be this setup:

```jsx
// myValue = 45%
<UnitControl value={myValue} onChange={handleOnChange} isPressEnterToChange />
```

The unit value (`string`) contains both the value and the unit. `isPressEnterToChange` is important as it allows users to type in custom values, e.g. `12345px`. The change only applies on `ENTER` press (or blur).

This is how it's setup with Cover's padding controls (via `BoxControl`).

An older (initial) implementation looked like this (Cover's height controls):

```jsx
<UnitControl value={myValue} unit={myUnit} onChange={handleOnChange} onUnitChange={handleOnUnitChange}  />
```

Notice how the `value` and `unit` is tracked separately. Also, there isn't `isPressEnterToChange`, therefore the changes are applied immediately.

### Adding custom units

If you need to add custom units to your control (e.g. `vmin`, `%`, etc...), you can do so like this:

```jsx
const customUnits = [
	{ value: 'px', label: 'px', default: 430 },
	{ value: '%', label: '%', default: 20 },
	{ value: 'rem', label: 'rem', default: 20 },
];

<UnitControl units={customUnits} />
```

This will allow you to adjust unit values based on different design contexts.

An example of this can be seen in Cover:
https://github.com/WordPress/gutenberg/blob/master/packages/block-library/src/cover/shared.js#L21


## How has this been tested?

* Tested locally in Gutenberg
* Add Cover block
* Ensure that the Height control has custom units (presented in a dropdown)


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [n/a] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [n/a] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
