### PR TITLE
Fix prop error and missing classes in Navigation component

### DIFF
--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -74,6 +74,7 @@ const Navigation = ( { activeItemId, children, data, rootTitle } ) => {
 
 		return (
 			<Button
+				className="components-navigation__back-button"
 				isPrimary
 				onClick={ () => setActiveLevelId( parentLevel.id ) }
 			>

--- a/packages/components/src/navigation/menu-item.js
+++ b/packages/components/src/navigation/menu-item.js
@@ -50,14 +50,22 @@ const NavigationMenuItem = ( props ) => {
 		<MenuItemUI className={ classes }>
 			<LinkComponentTag
 				className={ classes }
-				href={ href }
+				href={ ! children.length ? href : null }
 				onClick={ handleClick }
 				{ ...linkProps }
 			>
-				<Text variant="body.small">
-					<span>{ title }</span>
+				<Text
+					className="components-navigation__menu-item-title"
+					variant="body.small"
+					as="span"
+				>
+					{ title }
 				</Text>
-				{ badge && <BadgeUI>{ badge }</BadgeUI> }
+				{ badge && (
+					<BadgeUI className="components-navigation__menu-item-badge">
+						{ badge }
+					</BadgeUI>
+				) }
 				{ hasChildren ? <Icon icon={ chevronRight } /> : null }
 			</LinkComponentTag>
 		</MenuItemUI>

--- a/packages/components/src/navigation/menu-item.js
+++ b/packages/components/src/navigation/menu-item.js
@@ -38,6 +38,9 @@ const NavigationMenuItem = ( props ) => {
 			setActiveLevelId( id );
 			return;
 		}
+		if ( ! onClick ) {
+			return;
+		}
 		onClick( props );
 	};
 

--- a/packages/components/src/navigation/stories/index.js
+++ b/packages/components/src/navigation/stories/index.js
@@ -100,8 +100,11 @@ function Example() {
 									<NavigationMenuItem
 										{ ...item }
 										key={ item.id }
-										onClick={ ( selected ) =>
-											setActive( selected.id )
+										onClick={
+											! item.href
+												? ( selected ) =>
+														setActive( selected.id )
+												: null
 										}
 									/>
 								);


### PR DESCRIPTION
## Description
Doesn't trigger the `onClick` prop if not passed in favor of just using the `href` prop and doesn't trigger `href` if children exist.

Also adds some missing classes for easier styling by the consumer.

## Testing

1. Run `npm run storybook:dev`
1. Go to Components->Navigation.
1. Check that all links work as expected (especially the "External link").
1. Check that no console errors occur.