### PR TITLE
Navigation Component: Update docs

### DIFF
--- a/packages/components/src/navigation/README.md
+++ b/packages/components/src/navigation/README.md
@@ -1,26 +1,74 @@
 # Navigation
 
-Navigation is a component which renders a component which renders a heirarchy of menu items.
+Render a heirarchy of menu items into a waterfall style navigation.
 
 ## Usage
 
 ```jsx
-import { MenuItem } from '@wordpress/components';
-import { withState } from '@wordpress/compose';
+import Navigation from '@wordpress/components';
+import NavigationMenu from '@wordpress/components';
+import NavigationMenuItem from '@wordpress/components';
+import { useState } from '@wordpress/compose';
 
 const data = [
-    { title: 'My Navigation', slug: 'root', back: 'Back' },
-    { title: 'Home', slug: 'home', parent: 'root', menu: 'primary' },
-    { title: 'Option one', slug: 'option_one', parent: 'root', menu: 'primary' },
-    { title: 'Option two', slug: 'option_two', parent: 'root', menu: 'primary' },
-    { title: 'Option three', slug: 'option_three', parent: 'root', menu: 'secondary' },
-    { title: 'Child one', slug: 'child_one', parent: 'option_three', menu: 'primary' },
-    { title: 'Child two', slug: 'child_two', parent: 'option_three', menu: 'primary' },
-    { title: 'Child three', slug: 'child_three', parent: 'option_three', menu: 'primary' },
+    {
+		title: 'Item 1',
+		id: 'item-1',
+	},
+	{
+		title: 'Item 2',
+		id: 'item-2',
+	},
+	{
+		title: 'Category',
+		id: 'item-3',
+		badge: '2',
+	},
+	{
+		title: 'Child 1',
+		id: 'child-1',
+		parent: 'item-3',
+		badge: '1',
+	},
+	{
+		title: 'Child 2',
+		id: 'child-2',
+		parent: 'item-3',
+	},
 ];
 
 const MyNavigation = () => {
-    return <Navigation data={ data } initial="home" />;
+    const [ active, setActive ] = useState( 'item-1' );
+
+	return (
+		<Navigation activeItemId={ active } data={ data } rootTitle="Home">
+			{ ( { level, parentLevel, NavigationBackButton } ) => {
+				return (
+					<>
+						{ parentLevel && (
+							<NavigationBackButton>
+								<Icon icon={ arrowLeft } />
+								{ parentLevel.title }
+							</NavigationBackButton>
+						) }
+						<h1>{ level.title }</h1>
+						<NavigationMenu>
+							{ level.children.map( ( item ) => {
+								return (
+									<NavigationMenuItem
+										{ ...item }
+										key={ item.id }
+										onClick={ ( selected ) =>
+											setActive( selected.id )
+										}
+									/>
+								);
+							} ) }
+						</NavigationMenu>
+					</>
+				);
+			} }
+		</Navigation>
 };
 ```
 
@@ -30,14 +78,21 @@ Navigation supports the following props.
 
 ### `data`
 
-- Type: `array`
-- Required: Yes
+-   Type: `array`
+-   Required: Yes
 
 An array of config objects for each menu item.
 
-### `initial`
+### `activeItemId`
 
-- Type: `string`
-- Required: Yes
+-   Type: `string`
+-   Required: Yes
 
-The active slug.
+The active screen id.
+
+### `rootTitle`
+
+-   Type: `string`
+-   Required: No
+
+A top level title.

--- a/packages/components/src/navigation/README.md
+++ b/packages/components/src/navigation/README.md
@@ -5,7 +5,11 @@ Render a flat array of menu items into a waterfall style hierarchy navigation.
 ## Usage
 
 ```jsx
-import Navigation from '@wordpress/components';
+import {
+	__experimentalNavigation as Navigation,
+	__experimentalNavigationMenu as NavigationMenu,
+	__experimentalNavigationMenuItem as NavigationMenuItem,
+} from '@wordpress/components';
 import NavigationMenu from '@wordpress/components';
 import NavigationMenuItem from '@wordpress/components';
 import { useState } from '@wordpress/compose';

--- a/packages/components/src/navigation/README.md
+++ b/packages/components/src/navigation/README.md
@@ -106,7 +106,7 @@ A menu item's id.
 -   Type: `string|Number`
 -   Required: No
 
-Specify a menu item's parent id.
+Specify a menu item's parent id. Defaults to the menu item's parent if none is provided.
 
 #### `config.href`
 

--- a/packages/components/src/navigation/README.md
+++ b/packages/components/src/navigation/README.md
@@ -1,6 +1,6 @@
 # Navigation
 
-Render a heirarchy of menu items into a waterfall style navigation.
+Render a flat array of menu items into a waterfall style hierarchy navigation.
 
 ## Usage
 

--- a/packages/components/src/navigation/README.md
+++ b/packages/components/src/navigation/README.md
@@ -120,7 +120,7 @@ Turn a menu item into a link by supplying a url.
 -   Type: `object`
 -   Required: No
 
-Supply an properties passed to the menu-item.
+Supply properties passed to the menu-item.
 
 #### `config.LinkComponent`
 

--- a/packages/components/src/navigation/README.md
+++ b/packages/components/src/navigation/README.md
@@ -10,8 +10,6 @@ import {
 	__experimentalNavigationMenu as NavigationMenu,
 	__experimentalNavigationMenuItem as NavigationMenuItem,
 } from '@wordpress/components';
-import NavigationMenu from '@wordpress/components';
-import NavigationMenuItem from '@wordpress/components';
 import { useState } from '@wordpress/compose';
 
 const data = [

--- a/packages/components/src/navigation/README.md
+++ b/packages/components/src/navigation/README.md
@@ -83,6 +83,50 @@ Navigation supports the following props.
 
 An array of config objects for each menu item.
 
+Config objects can be represented
+
+#### `config.title`
+
+-   Type: `string`
+-   Required: Yes
+
+A menu item's title.
+
+#### `config.id`
+
+-   Type: `string|Number`
+-   Required: Yes
+
+A menu item's id.
+
+#### `config.parent`
+
+-   Type: `string|Number`
+-   Required: No
+
+Specify a menu item's parent id.
+
+#### `config.href`
+
+-   Type: `string`
+-   Required: No
+
+Turn a menu item into a link by supplying a url.
+
+#### `config.linkProps`
+
+-   Type: `object`
+-   Required: No
+
+Supply an properties passed to the menu-item.
+
+#### `config.LinkComponent`
+
+-   Type: `Node`
+-   Required: No
+
+Supply a React component to render as the menu item. This is useful for router link components for internal navigation.
+
 ### `activeItemId`
 
 -   Type: `string`

--- a/packages/components/src/navigation/README.md
+++ b/packages/components/src/navigation/README.md
@@ -74,7 +74,7 @@ const MyNavigation = () => {
 };
 ```
 
-## Props
+## Navigation Props
 
 Navigation supports the following props.
 
@@ -142,3 +142,14 @@ The active screen id.
 -   Required: No
 
 A top level title.
+
+## NavigationMenuItem Props
+
+NavigationMenuItem supports the following props.
+
+### `onClick`
+
+-   Type: `function`
+-   Required: No
+
+A callback to handle selection of a menu item.


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/24700

## Description

Update the navigation component's README and other docs.