### PR TITLE
Add/block navigation component readme

### DIFF
--- a/packages/block-editor/src/components/block-navigation/README.md
+++ b/packages/block-editor/src/components/block-navigation/README.md
@@ -1,0 +1,30 @@
+# Block navigation
+
+The BlockNavigation component provides an overview of the hierarchical structure of all blocks in the editor. The blocks are presented vertically one below the other.
+
+Blocks that have child blocks (such as group or column blocks) are presented with the parent at the top and the nested children below.
+
+In addition to presenting the structure of the blocks in the editor, the BlockNavigation component lets users navigate to each block by clicking on its line in the hierarchy tree.
+
+![Block navigation](https://make.wordpress.org/core/files/2020/08/block-navigation.png)
+![View of a group block navigation](https://make.wordpress.org/core/files/2020/08/view-of-group-block-navigation.png)
+
+
+## Table of contents
+
+1. [Development guidelines](#development-guidelines)
+2. [Related components](#related-components)
+
+## Development guidelines
+
+### Usage
+
+Renders a block navigation with default syles.
+
+```jsx
+
+```
+
+### Props
+
+## Related components

--- a/packages/block-editor/src/components/block-navigation/README.md
+++ b/packages/block-editor/src/components/block-navigation/README.md
@@ -23,10 +23,10 @@ Renders a block navigation with default syles.
 ```jsx
 import { BlockNavigation } from '@wordpress/block-editor';
 
-<BlockNavigation
+const MyNavigation = () => <BlockNavigation
 	onSelect={ onClose }
 	__experimentalFeatures={ __experimentalFeatures }
-/>
+/>;
 ```
 
 ## Related components

--- a/packages/block-editor/src/components/block-navigation/README.md
+++ b/packages/block-editor/src/components/block-navigation/README.md
@@ -9,7 +9,6 @@ In addition to presenting the structure of the blocks in the editor, the BlockNa
 ![Block navigation](https://make.wordpress.org/core/files/2020/08/block-navigation.png)
 ![View of a group block navigation](https://make.wordpress.org/core/files/2020/08/view-of-group-block-navigation.png)
 
-
 ## Table of contents
 
 1. [Development guidelines](#development-guidelines)
@@ -22,9 +21,14 @@ In addition to presenting the structure of the blocks in the editor, the BlockNa
 Renders a block navigation with default syles.
 
 ```jsx
+import { BlockNavigation } from '@wordpress/block-editor';
 
+<BlockNavigation
+	onSelect={ onClose }
+	__experimentalFeatures={ __experimentalFeatures }
+/>
 ```
 
-### Props
-
 ## Related components
+
+Block Editor components are components that can be used to compose the UI of your block editor. Thus, they can only be used under a [BlockEditorProvider](https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/provider/README.md) in the components tree.

--- a/packages/block-editor/src/components/block-navigation/README.md
+++ b/packages/block-editor/src/components/block-navigation/README.md
@@ -25,7 +25,6 @@ import { BlockNavigation } from '@wordpress/block-editor';
 
 const MyNavigation = () => <BlockNavigation
 	onSelect={ onClose }
-	__experimentalFeatures={ __experimentalFeatures }
 />;
 ```
 


### PR DESCRIPTION
## Description
Added documentation for the block navigation component (see #22891)

## How has this been tested?
N/A, documentation only

## Types of changes
Documentation

## Checklist:
- [n/a] My code is tested.
- [n/a] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [n/a] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
