### PR TITLE
Fix wp-env start for non-english core sources

### DIFF
--- a/packages/env/lib/wordpress.js
+++ b/packages/env/lib/wordpress.js
@@ -83,7 +83,7 @@ async function configureWordPress( environment, config, spinner ) {
 		// Add quotes around string values to work with multi-word strings better.
 		value = typeof value === 'string' ? `"${ value }"` : value;
 		setupCommands.push(
-			`wp config set ${ key } ${ value }${
+			`wp config set ${ key } ${ value } --anchor="define( 'WP_DEBUG',"${
 				typeof value !== 'string' ? ' --raw' : ''
 			}`
 		);


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
To specify the `anchor` parameter of `wp config set` to `define( 'WP_DEBUG',` in `configureWordPress()` instead of using the default `/* That’s all, stop editing!`, because non-English WordPress core doesn't have that line in `wp-config-sample.php` and will return errors. This will fix #22938.

By the way, I also tested `--anchor="define( 'WP_DEBUG', true );" --placement=after`, `--anchor="define( 'WP_DEBUG', false );" --placement=after`, etc. It inserts values properly to the `wp-config.php`, but the CLI still returns `Error: Could not process the 'wp-config.php' transformation. Reason: Unable to locate placement anchor.`.

I know this might not be the best solution, but it's better to make wp-env work in all environments first.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
- `npx wp-env start` with the default `.wp-env.json`
- `npx wp-env start` with `"core": "https://ja.wordpress.org/latest-ja.zip"` in `.wp-env.json`
- `npm run test`

All of these returned no warnings and errors, and the front page of WordPress was displayed at http://localhost:8888.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
