### PR TITLE
[edit-widgets] Test for storing raw html in widgets

### DIFF
--- a/phpunit/class-rest-sidebars-controller-test.php
+++ b/phpunit/class-rest-sidebars-controller-test.php
@@ -9,7 +9,6 @@
 /**
  * Tests for REST API for Menus.
  *
- * @group failing
  * @see WP_Test_REST_Controller_Testcase
  */
 class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {

--- a/phpunit/class-rest-sidebars-controller-test.php
+++ b/phpunit/class-rest-sidebars-controller-test.php
@@ -30,6 +30,11 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	/**
 	 * @var int
 	 */
+	protected static $admin_id_without_unfiltered_html;
+
+	/**
+	 * @var int
+	 */
 	protected static $editor_id;
 
 	/**
@@ -62,11 +67,17 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		if ( is_multisite() ) {
 			update_site_option( 'site_admins', array( 'superadmin' ) );
 		}
-		self::$admin_id      = $factory->user->create(
+		self::$admin_id                         = $factory->user->create(
 			array(
 				'role' => 'administrator',
 			)
 		);
+		self::$admin_id_without_unfiltered_html = $factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+		get_user_by( 'id', self::$admin_id_without_unfiltered_html )->remove_cap( 'unfiltered_html' );
 		self::$editor_id     = $factory->user->create(
 			array(
 				'role' => 'editor',
@@ -534,6 +545,11 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		} else {
 			$this->assertEquals(
 				'<div class="textwidget"><script>alert(1)</script></div>',
+				$this->update_text_widget_with_raw_html( '<script>alert(1)</script>' )
+			);
+			wp_set_current_user( self::$admin_id_without_unfiltered_html );
+			$this->assertEquals(
+				'<div class="textwidget">alert(1)</div>',
 				$this->update_text_widget_with_raw_html( '<script>alert(1)</script>' )
 			);
 		}

--- a/phpunit/class-rest-sidebars-controller-test.php
+++ b/phpunit/class-rest-sidebars-controller-test.php
@@ -68,7 +68,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		if ( is_multisite() ) {
 			update_site_option( 'site_admins', array( 'superadmin' ) );
 		}
-		self::$admin_id                         = $factory->user->create(
+		self::$admin_id      = $factory->user->create(
 			array(
 				'role' => 'administrator',
 			)

--- a/phpunit/class-rest-sidebars-controller-test.php
+++ b/phpunit/class-rest-sidebars-controller-test.php
@@ -9,6 +9,7 @@
 /**
  * Tests for REST API for Menus.
  *
+ * @group failing
  * @see WP_Test_REST_Controller_Testcase
  */
 class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
@@ -72,12 +73,6 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 				'role' => 'administrator',
 			)
 		);
-		self::$admin_id_without_unfiltered_html = $factory->user->create(
-			array(
-				'role' => 'administrator',
-			)
-		);
-		get_user_by( 'id', self::$admin_id_without_unfiltered_html )->remove_cap( 'unfiltered_html' );
 		self::$editor_id     = $factory->user->create(
 			array(
 				'role' => 'editor',
@@ -545,11 +540,6 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		} else {
 			$this->assertEquals(
 				'<div class="textwidget"><script>alert(1)</script></div>',
-				$this->update_text_widget_with_raw_html( '<script>alert(1)</script>' )
-			);
-			wp_set_current_user( self::$admin_id_without_unfiltered_html );
-			$this->assertEquals(
-				'<div class="textwidget">alert(1)</div>',
 				$this->update_text_widget_with_raw_html( '<script>alert(1)</script>' )
 			);
 		}

--- a/phpunit/class-rest-sidebars-controller-test.php
+++ b/phpunit/class-rest-sidebars-controller-test.php
@@ -59,6 +59,9 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 				'user_login' => 'superadmin',
 			)
 		);
+		if ( is_multisite() ) {
+			update_site_option( 'site_admins', array( 'superadmin' ) );
+		}
 		self::$admin_id      = $factory->user->create(
 			array(
 				'role' => 'administrator',
@@ -543,7 +546,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		wp_set_current_user( self::$superadmin_id );
 		if ( is_multisite() ) {
 			$this->assertEquals(
-				'<div class="textwidget">alert(1)</div>',
+				'<div class="textwidget"><script>alert(1)</script></div>',
 				$this->update_text_widget_with_raw_html( '<script>alert(1)</script>' )
 			);
 		} else {

--- a/phpunit/class-rest-sidebars-controller-test.php
+++ b/phpunit/class-rest-sidebars-controller-test.php
@@ -53,7 +53,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	 * @param WP_UnitTest_Factory $factory Helper that lets us create fake data.
 	 */
 	public static function wpSetUpBeforeClass( $factory ) {
-		self::$superadmin_id  = $factory->user->create(
+		self::$superadmin_id = $factory->user->create(
 			array(
 				'role'       => 'administrator',
 				'user_login' => 'superadmin',
@@ -567,7 +567,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			array(
 				'name' => 'Test sidebar',
 			),
-			array( 'text-1', )
+			array( 'text-1' )
 		);
 
 		$request = new WP_REST_Request( 'POST', '/__experimental/sidebars/sidebar-1' );
@@ -589,7 +589,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			)
 		);
 		$response = rest_get_server()->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 		return $data['widgets'][0]['rendered'];
 	}
 

--- a/phpunit/class-rest-sidebars-controller-test.php
+++ b/phpunit/class-rest-sidebars-controller-test.php
@@ -525,7 +525,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	public function test_store_html_as_admin() {
 		if ( is_multisite() ) {
 			$this->assertEquals(
-				'<div class="textwidget">&lt;script&gt;alert(1)&lt;/script&gt;</div>',
+				'<div class="textwidget">alert(1)</div>',
 				$this->update_text_widget_with_raw_html( '<script>alert(1)</script>' )
 			);
 		} else {

--- a/phpunit/class-rest-sidebars-controller-test.php
+++ b/phpunit/class-rest-sidebars-controller-test.php
@@ -543,7 +543,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		wp_set_current_user( self::$superadmin_id );
 		if ( is_multisite() ) {
 			$this->assertEquals(
-				'<div class="textwidget"><script>alert(1)</script></div>',
+				'<div class="textwidget">alert(1)</div>',
 				$this->update_text_widget_with_raw_html( '<script>alert(1)</script>' )
 			);
 		} else {


### PR DESCRIPTION
## Description

This PR adds more test to ensure that only superadmin is universally able to store HTML in widgets using the new API endpoint. Admins should only be able to do so on regular sites (not multisites).

This PR tests based on roles, it would be much nicer to test based on capabilities - I didn't quite figure it yet and I'll be away for the next two weeks, but follow-up PRs are welcome!