### PR TITLE
Keep the default CSS variables for npm consumers 

### DIFF
--- a/bin/packages/build-worker.js
+++ b/bin/packages/build-worker.js
@@ -96,7 +96,6 @@ const BUILD_TASK_BY_EXTENSION = {
 			makeDir( path.dirname( outputFile ) ),
 			readFile( file, 'utf8' ),
 		] );
-
 		const builtSass = await renderSass( {
 			file,
 			includePaths: [ path.join( PACKAGES_DIR, 'base-styles' ) ],
@@ -109,6 +108,12 @@ const BUILD_TASK_BY_EXTENSION = {
 					'animations',
 					'z-index',
 				]
+					// Editor styles should be excluded from the default CSS vars output.
+					.concat(
+						file.includes( 'editor-styles.scss' )
+							? []
+							: [ 'default-custom-properties' ]
+					)
 					.map( ( imported ) => `@import "${ imported }";` )
 					.join( ' ' ) + contents,
 		} );

--- a/packages/base-styles/_default-custom-properties.scss
+++ b/packages/base-styles/_default-custom-properties.scss
@@ -1,0 +1,7 @@
+
+// It is important to include these styles in all built stylesheets.
+// This allows to CSS variables post CSS plugin to generate fallbacks.
+// It also provides default CSS variables for npm package consumers.
+:root {
+	@include admin-scheme(#007cba);
+}

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -677,9 +677,3 @@
 	}
 	/* stylelint-enable function-comma-space-after */
 }
-
-// It is important to include these styles in all built stylesheets.
-// This allows to CSS variables post CSS plugin to generate fallbacks.
-:root {
-	@include admin-scheme(#007cba);
-}

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -677,3 +677,9 @@
 	}
 	/* stylelint-enable function-comma-space-after */
 }
+
+// It is important to include these styles in all built stylesheets.
+// This allows to CSS variables post CSS plugin to generate fallbacks.
+:root {
+	@include admin-scheme(#007cba);
+}

--- a/packages/postcss-plugins-preset/lib/index.js
+++ b/packages/postcss-plugins-preset/lib/index.js
@@ -1,14 +1,4 @@
 module.exports = [
-	require( 'postcss-custom-properties' )( {
-		importFrom: [
-			{
-				customProperties: {
-					'--wp-admin-theme-color': '#007cba',
-					'--wp-admin-theme-color-darker-10': '#006ba1',
-					'--wp-admin-theme-color-darker-20': '#005a87',
-				},
-			},
-		],
-	} ),
+	require( 'postcss-custom-properties' )(),
 	require( 'autoprefixer' )( { grid: true } ),
 ];


### PR DESCRIPTION
Alternative to #24408

This is basically a revert to #24408 + a fix to the canvas not receiving the right variables by excluding the "editor styles" from receiving the default CSS variables.

The result should be the same but now npm consumers are not forced to define the CSS variables in order to get a decent default result.