### PR TITLE
Upgrade TypeScript to v4

### DIFF
--- a/bin/tsconfig.json
+++ b/bin/tsconfig.json
@@ -7,7 +7,7 @@
 		"lib": [ "ES6", "ES2020.string" ],
 		"rootDir": ".",
 
-		// These script are unpublished and packages do not depend on them.
+		// These scripts aren't published and packages don't depend on them.
 		// Don't generate types, this is strictly for validation.
 		"incremental": true,
 		"declarationMap": false,

--- a/bin/tsconfig.json
+++ b/bin/tsconfig.json
@@ -6,11 +6,13 @@
 		"target": "ES6",
 		"lib": [ "ES6", "ES2020.string" ],
 		"rootDir": ".",
-		"declarationMap": false,
 
-		// We're not interested in the output, but we must generate
-		// something as part of a composite project. Use the
-		// ignored `.cache` file to hide tsbuildinfo and d.ts files.
+		// These script are unpublished and packages do not depend on them.
+		// Don't generate types, this is strictly for validation.
+		"incremental": true,
+		"declarationMap": false,
+		"emitDeclarationOnly": false,
+		"noEmit": true,
 		"outDir": ".cache"
 	},
 	"files": [
@@ -24,6 +26,6 @@
 		"./plugin/lib/logger.js",
 		"./plugin/lib/utils.js",
 		"./plugin/lib/git.js",
-		"./validate-package-lock.js",
+		"./validate-package-lock.js"
 	]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -59943,9 +59943,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.8.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
+			"integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
 			"dev": true
 		},
 		"ua-parser-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -59943,9 +59943,9 @@
 			}
 		},
 		"typescript": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
-			"integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
+			"integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
 			"dev": true
 		},
 		"ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -195,7 +195,7 @@
 		"style-loader": "1.0.0",
 		"stylelint-config-wordpress": "17.0.0",
 		"terser-webpack-plugin": "3.0.3",
-		"typescript": "4.0.2",
+		"typescript": "4.0.3",
 		"uuid": "7.0.2",
 		"wd": "1.12.1",
 		"webpack": "4.42.0",

--- a/package.json
+++ b/package.json
@@ -195,7 +195,7 @@
 		"style-loader": "1.0.0",
 		"stylelint-config-wordpress": "17.0.0",
 		"terser-webpack-plugin": "3.0.3",
-		"typescript": "3.8.3",
+		"typescript": "4.0.2",
 		"uuid": "7.0.2",
 		"wd": "1.12.1",
 		"webpack": "4.42.0",


### PR DESCRIPTION
## Description
Upgrade TypeScript dependency to version 4.

Read the announcement [here](https://devblogs.microsoft.com/typescript/announcing-typescript-4-0/).

Applies a new feature [`noEmit` with `incremental`](https://devblogs.microsoft.com/typescript/announcing-typescript-4-0/#noemit-and-incremental) to the `bin/` directory typings. These typings were discarded before, this change prevents them from being produced at all.

## How has this been tested?

Types continue to be generated as expected. The following completes without issues:

```sh
npm run clean:package-types
npm run build:package-types
npm run build:package-types
```

Types are generated as expected, e.g. `packages/warning/build-types/index.d.ts`:

```ts
/**
 * Shows a warning with `message` if environment is not `production`.
 *
 * @param {string} message Message to show in the warning.
 *
 * @example
 * ```js
 * import warning from '@wordpress/warning';
 *
 * function MyComponent( props ) {
 *   if ( ! props.title ) {
 *     warning( '`props.title` was not passed' );
 *   }
 *   ...
 * }
 * ```
 */
export default function warning(message: string): void;
//# sourceMappingURL=index.d.ts.map
```


## Types of changes

Internal.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
