### PR TITLE
Add audible messages to confirm the "move block" actions

### DIFF
--- a/packages/block-editor/src/components/block-mover/button.js
+++ b/packages/block-editor/src/components/block-mover/button.js
@@ -121,7 +121,7 @@ const BlockMoverButton = forwardRef(
 			direction === 'up' ? moveBlocksUp : moveBlocksDown;
 
 		const onClick = ( event ) => {
-			moverFunction( clientIds, rootClientId );
+			moverFunction( clientIds, rootClientId, orientation );
 			if ( props.onClick ) {
 				props.onClick( event );
 			}

--- a/packages/block-editor/src/components/keyboard-shortcuts/index.js
+++ b/packages/block-editor/src/components/keyboard-shortcuts/index.js
@@ -12,23 +12,31 @@ import { __ } from '@wordpress/i18n';
 
 function KeyboardShortcuts() {
 	// Shortcuts Logic
-	const { clientIds, rootBlocksClientIds, rootClientId } = useSelect(
-		( select ) => {
-			const {
-				getSelectedBlockClientIds,
-				getBlockOrder,
-				getBlockRootClientId,
-			} = select( 'core/block-editor' );
-			const selectedClientIds = getSelectedBlockClientIds();
-			const [ firstClientId ] = selectedClientIds;
-			return {
-				clientIds: selectedClientIds,
-				rootBlocksClientIds: getBlockOrder(),
-				rootClientId: getBlockRootClientId( firstClientId ),
-			};
-		},
-		[]
-	);
+	const {
+		clientIds,
+		rootBlocksClientIds,
+		rootClientId,
+		orientation,
+	} = useSelect( ( select ) => {
+		const {
+			getSelectedBlockClientIds,
+			getBlockOrder,
+			getBlockRootClientId,
+			getBlockListSettings,
+		} = select( 'core/block-editor' );
+		const selectedClientIds = getSelectedBlockClientIds();
+		const [ firstClientId ] = selectedClientIds;
+		const blockRootClientId = getBlockRootClientId( firstClientId );
+		const { orientation: blockListOrientation } =
+			getBlockListSettings( blockRootClientId ) || {};
+
+		return {
+			clientIds: selectedClientIds,
+			rootBlocksClientIds: getBlockOrder(),
+			rootClientId: blockRootClientId,
+			orientation: blockListOrientation || 'vertical',
+		};
+	}, [] );
 
 	const {
 		duplicateBlocks,
@@ -47,7 +55,7 @@ function KeyboardShortcuts() {
 		useCallback(
 			( event ) => {
 				event.preventDefault();
-				moveBlocksUp( clientIds, rootClientId );
+				moveBlocksUp( clientIds, rootClientId, orientation );
 			},
 			[ clientIds, moveBlocksUp ]
 		),
@@ -60,7 +68,7 @@ function KeyboardShortcuts() {
 		useCallback(
 			( event ) => {
 				event.preventDefault();
-				moveBlocksDown( clientIds, rootClientId );
+				moveBlocksDown( clientIds, rootClientId, orientation );
 			},
 			[ clientIds, moveBlocksDown ]
 		),

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -356,11 +356,12 @@ export function replaceBlock( clientId, block ) {
  * @return {Function} Action creator.
  */
 function createOnMove( type ) {
-	return ( clientIds, rootClientId ) => {
+	return ( clientIds, rootClientId, orientation ) => {
 		return {
 			clientIds: castArray( clientIds ),
 			type,
 			rootClientId,
+			orientation,
 		};
 	};
 }

--- a/packages/block-editor/src/store/effects.js
+++ b/packages/block-editor/src/store/effects.js
@@ -35,6 +35,7 @@ import {
 	getTemplate,
 	isValidTemplate,
 	getSelectionStart,
+	getSettings,
 } from './selectors';
 
 /**
@@ -64,6 +65,57 @@ export function validateBlocksToTemplate( action, store ) {
 	if ( isBlocksValidToTemplate !== isValidTemplate( state ) ) {
 		return setTemplateValidity( isBlocksValidToTemplate );
 	}
+}
+
+/**
+ * Announces when a block is moved.
+ *
+ * @param {Object} state The current state.
+ * @param {string} direction The direction the block was moved in.
+ */
+export function announceBlockMoved( state, direction ) {
+	const blockCount = getSelectedBlockCount( state );
+	let message;
+
+	switch ( direction ) {
+		case 'up':
+			/* translators: %s: number of selected blocks */
+			message = _n(
+				'%s block moved up.',
+				'%s blocks moved up.',
+				blockCount
+			);
+			break;
+		case 'down':
+			/* translators: %s: number of selected blocks */
+			message = _n(
+				'%s block moved down.',
+				'%s blocks moved down.',
+				blockCount
+			);
+			break;
+		case 'left':
+			/* translators: %s: number of selected blocks */
+			message = _n(
+				'%s block moved left.',
+				'%s blocks moved left.',
+				blockCount
+			);
+			break;
+		case 'right':
+			/* translators: %s: number of selected blocks */
+			message = _n(
+				'%s block moved right.',
+				'%s blocks moved right.',
+				blockCount
+			);
+			break;
+		default:
+			/* translators: %s: number of selected blocks */
+			message = _n( '%s block moved.', '%s blocks moved.', blockCount );
+	}
+
+	speak( sprintf( message, blockCount, direction ), 'assertive' );
 }
 
 export default {
@@ -218,6 +270,30 @@ export default {
 				]
 			)
 		);
+	},
+	MOVE_BLOCKS_DOWN: ( action, { getState } ) => {
+		const state = getState();
+		const settings = getSettings( state );
+
+		let direction = 'down';
+
+		if ( action.orientation === 'horizontal' ) {
+			direction = settings.isRTL ? 'left' : 'right';
+		}
+
+		announceBlockMoved( state, direction );
+	},
+	MOVE_BLOCKS_UP: ( action, { getState } ) => {
+		const state = getState();
+		const settings = getSettings( state );
+
+		let direction = 'up';
+
+		if ( action.orientation === 'horizontal' ) {
+			direction = settings.isRTL ? 'right' : 'left';
+		}
+
+		announceBlockMoved( state, direction );
 	},
 	RESET_BLOCKS: [ validateBlocksToTemplate ],
 	MULTI_SELECT: ( action, { getState } ) => {


### PR DESCRIPTION
Fixes #23995.

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Added audible messages to `aria-live="assertive"` region to confirm the "move" action to the screen reader users.
The messages check for orientation and RTL to make sure they are consistent with the label of the button used to perform the action.

_This PR has been created during the Yoast Contributor Day.
The people who worked on it are  @jcomack, @afercia, @enricobattocchi._

## How has this been tested?

1. edit a (new) post with a screen reader active
2. add a number of blocks, plus a button list (which has a `horizontal` orientation)
3. move the blocks using the buttons or the keyboard shortcuts and check that the actions are confirmed by the audible messages. Notice that button can be moved left or right and the messages change accordingly.
4. Try also to select multiple blocks and move them together to hear a message telling the correct number of blocks moved.
5. Switch to a RTL environment and see that the "move up" action becomes "move right" for the buttons, and the audible messages are correct.
6. You can also the content of the `<div id="a11y-speak-assertive">` to read the messages without a screen reader active.

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
