### PR TITLE
Try a white style variant for gallery caption backgrounds

### DIFF
--- a/packages/block-library/src/gallery/index.js
+++ b/packages/block-library/src/gallery/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { gallery as icon } from '@wordpress/icons';
 
 /**
@@ -22,6 +22,17 @@ export const settings = {
 	description: __( 'Display multiple images in a rich gallery.' ),
 	icon,
 	keywords: [ __( 'images' ), __( 'photos' ) ],
+	styles: [
+		{
+			name: 'default',
+			label: _x( 'Default', 'block style' ),
+			isDefault: true,
+		},
+		{
+			name: 'white-caption-background',
+			label: _x( 'White caption background', 'block style' ),
+		},
+	],
 	example: {
 		attributes: {
 			columns: 2,

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -57,6 +57,12 @@
 			font-size: $default-font-size;
 			background: linear-gradient(0deg, rgba($color: $black, $alpha: 0.7) 0, rgba($color: $black, $alpha: 0.3) 70%, transparent);
 
+			// White background variation
+			.is-style-white-caption-background & {
+				color: inherit;
+				background: linear-gradient(0deg, rgba($color: $white, $alpha: 0.7) 0, rgba($color: $white, $alpha: 0.3) 70%, rgba($color: $white, $alpha: 0));
+			}
+
 			img {
 				display: inline;
 			}


### PR DESCRIPTION
Addresses https://github.com/WordPress/gutenberg/issues/24896 by adding a white gradient background variant for gallery captions.

Potential concerns: 

- I'm not sure what to call this variant. "White caption background works", but it's long. 
- Since there's no caption in the block preview, there's no visual difference between the two block style previews. 

**Screenshot:** 

<img width="979" alt="Screen Shot 2020-08-28 at 11 41 00 AM" src="https://user-images.githubusercontent.com/1202812/91587750-32966400-e925-11ea-881f-5bf2e126a758.png">


