### PR TITLE
[widgets.php] Use textarea for editing block widgets

### DIFF
--- a/lib/class-wp-widget-block.php
+++ b/lib/class-wp-widget-block.php
@@ -175,20 +175,8 @@ class WP_Widget_Block extends WP_Widget {
 	 */
 	public function form( $instance ) {
 		$instance = wp_parse_args( (array) $instance, $this->default_instance );
-		echo do_blocks( $instance['content'] );
-		$textarea_id = $this->get_field_id( 'content' );
 		?>
-		<br/>
-		<textarea id="<?php echo $textarea_id; ?>" name="<?php echo $this->get_field_name( 'content' ); ?>"
-				class="content sync-input" hidden><?php echo esc_textarea( $instance['content'] ); ?></textarea>
-		<script>
-			(function() {
-				var link = "<?php echo esc_js( admin_url( 'themes.php?page=gutenberg-widgets' ) ); ?>";
-				var container = jQuery('#<?php echo $textarea_id; ?>').closest(".form").find('.widget-control-actions .alignleft');
-				container.prepend(jQuery('<span> |</span>'));
-				container.prepend(jQuery('<a href="'+link+'" class="button-link">Edit</a>'));
-			})();
-		</script>
+		<textarea id="<?php echo $this->get_field_id( 'content' ); ?>" name="<?php echo $this->get_field_name( 'content' ); ?>" class="widefat text wp-block-textarea"><?php echo esc_textarea( $instance['content'] ); ?></textarea>
 		<?php
 	}
 

--- a/lib/class-wp-widget-block.php
+++ b/lib/class-wp-widget-block.php
@@ -176,7 +176,7 @@ class WP_Widget_Block extends WP_Widget {
 	public function form( $instance ) {
 		$instance = wp_parse_args( (array) $instance, $this->default_instance );
 		?>
-		<textarea id="<?php echo $this->get_field_id( 'content' ); ?>" name="<?php echo $this->get_field_name( 'content' ); ?>" rows="6" cols="50" class="widefat text wp-block-textarea"><?php echo esc_textarea( $instance['content'] ); ?></textarea>
+		<textarea id="<?php echo $this->get_field_id( 'content' ); ?>" name="<?php echo $this->get_field_name( 'content' ); ?>" rows="6" cols="50" class="widefat text wp-block-widget-textarea"><?php echo esc_textarea( $instance['content'] ); ?></textarea>
 		<?php
 	}
 

--- a/lib/class-wp-widget-block.php
+++ b/lib/class-wp-widget-block.php
@@ -176,7 +176,7 @@ class WP_Widget_Block extends WP_Widget {
 	public function form( $instance ) {
 		$instance = wp_parse_args( (array) $instance, $this->default_instance );
 		?>
-		<textarea id="<?php echo $this->get_field_id( 'content' ); ?>" name="<?php echo $this->get_field_name( 'content' ); ?>" class="widefat text wp-block-textarea"><?php echo esc_textarea( $instance['content'] ); ?></textarea>
+		<textarea id="<?php echo $this->get_field_id( 'content' ); ?>" name="<?php echo $this->get_field_name( 'content' ); ?>" rows="6" cols="50" class="widefat text wp-block-textarea"><?php echo esc_textarea( $instance['content'] ); ?></textarea>
 		<?php
 	}
 

--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -33,7 +33,7 @@ function gutenberg_widgets_init( $hook ) {
 		wp_enqueue_style( 'wp-block-library-theme' );
 		wp_add_inline_style(
 			'wp-block-library-theme',
-			'.block-widget-form .widget-control-save { display: none; }'
+			'.wp-block-textarea { width: 100%; min-height: 5em; margin: 8px 0 16px 0; }'
 		);
 		return;
 	}

--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -33,7 +33,7 @@ function gutenberg_widgets_init( $hook ) {
 		wp_enqueue_style( 'wp-block-library-theme' );
 		wp_add_inline_style(
 			'wp-block-library-theme',
-			'.wp-block-textarea { width: 100%; min-height: 5em; margin: 8px 0 16px 0; }'
+			'.wp-block-widget-textarea { width: 100%; min-height: 5em; margin: 8px 0 16px 0; }'
 		);
 		return;
 	}


### PR DESCRIPTION
## Description
As @noisysocks noted [here](https://github.com/WordPress/gutenberg/pull/24866#issuecomment-682273940):

> Does it make sense to output the rendered Search block at all? What does submitting the Search form do?
> More generally, does it make sense to render any block on widgets.php? The semantics of this page are that there is a widget control for each widget. It's not possible to preview a widget on widgets.php. It's not WYSIWYG.

This PR updates the Widget Block to use a textarea as it's edit form instead of rendering the block.

## How has this been tested?

1. Navigate to Widgets (beta) and add a Search block to one of the block areas.
1. Navigate to Widgets (the old screen).
1. Confirm the search block is rendered as a textarea with it's gutenberg contents inside.
1. Update the textarea and hit save.
1. Refresh the page and confirm your changes were saved.

## Types of changes
Non-breaking change

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
