### PR TITLE
[edit-widgets] Make global inserter usable by passing correct rootClientId to it

### DIFF
--- a/packages/edit-widgets/src/components/header/index.js
+++ b/packages/edit-widgets/src/components/header/index.js
@@ -11,40 +11,20 @@ import {
 } from '@wordpress/block-editor';
 import { PinnedItems } from '@wordpress/interface';
 import { useViewportMatch } from '@wordpress/compose';
-import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import SaveButton from '../save-button';
+import useLastSelectedRootId from '../../hooks/use-last-selected-root-id';
 import UndoButton from './undo-redo/undo';
 import RedoButton from './undo-redo/redo';
-import { buildWidgetAreasPostId, KIND, POST_TYPE } from '../../store/utils';
 
 const inserterToggleProps = { isPrimary: true };
 
 function Header( { isCustomizer } ) {
 	const isLargeViewport = useViewportMatch( 'medium' );
-	const rootClientId = useSelect( ( select ) => {
-		const { getBlockRootClientId, getBlockSelectionEnd } = select(
-			'core/block-editor'
-		);
-		const selectedRootId = getBlockRootClientId( getBlockSelectionEnd() );
-		if ( selectedRootId ) {
-			return selectedRootId;
-		}
-
-		// Default to the first widget area
-		const { getEntityRecord } = select( 'core' );
-		const widgetAreasPost = getEntityRecord(
-			KIND,
-			POST_TYPE,
-			buildWidgetAreasPostId()
-		);
-		if ( widgetAreasPost ) {
-			return widgetAreasPost?.blocks[ 0 ]?.clientId;
-		}
-	}, [] );
+	const rootClientId = useLastSelectedRootId();
 
 	return (
 		<>

--- a/packages/edit-widgets/src/components/header/index.js
+++ b/packages/edit-widgets/src/components/header/index.js
@@ -19,6 +19,7 @@ import { useSelect } from '@wordpress/data';
 import SaveButton from '../save-button';
 import UndoButton from './undo-redo/undo';
 import RedoButton from './undo-redo/redo';
+import { buildWidgetAreasPostId, KIND, POST_TYPE } from '../../store/utils';
 
 const inserterToggleProps = { isPrimary: true };
 
@@ -28,7 +29,21 @@ function Header( { isCustomizer } ) {
 		const { getBlockRootClientId, getBlockSelectionEnd } = select(
 			'core/block-editor'
 		);
-		return getBlockRootClientId( getBlockSelectionEnd() );
+		const selectedRootId = getBlockRootClientId( getBlockSelectionEnd() );
+		if ( selectedRootId ) {
+			return selectedRootId;
+		}
+
+		// Default to the first widget area
+		const { getEntityRecord } = select( 'core' );
+		const widgetAreasPost = getEntityRecord(
+			KIND,
+			POST_TYPE,
+			buildWidgetAreasPostId()
+		);
+		if ( widgetAreasPost ) {
+			return widgetAreasPost?.blocks[ 0 ]?.clientId;
+		}
 	}, [] );
 
 	return (

--- a/packages/edit-widgets/src/hooks/use-last-selected-root-id.js
+++ b/packages/edit-widgets/src/hooks/use-last-selected-root-id.js
@@ -1,0 +1,45 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { useRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { buildWidgetAreasPostId, KIND, POST_TYPE } from '../store/utils';
+
+const useLastSelectedRootId = () => {
+	const firstRootId = useSelect( ( select ) => {
+		// Default to the first widget area
+		const { getEntityRecord } = select( 'core' );
+		const widgetAreasPost = getEntityRecord(
+			KIND,
+			POST_TYPE,
+			buildWidgetAreasPostId()
+		);
+		if ( widgetAreasPost ) {
+			return widgetAreasPost?.blocks[ 0 ]?.clientId;
+		}
+	}, [] );
+
+	const lastSelectedRootIdRef = useRef();
+	if ( ! lastSelectedRootIdRef.current && firstRootId ) {
+		lastSelectedRootIdRef.current = firstRootId;
+	}
+
+	const selectedRootId = useSelect( ( select ) => {
+		const { getBlockRootClientId, getBlockSelectionEnd } = select(
+			'core/block-editor'
+		);
+		return getBlockRootClientId( getBlockSelectionEnd() );
+	}, [] );
+
+	if ( selectedRootId ) {
+		lastSelectedRootIdRef.current = selectedRootId;
+	}
+
+	return lastSelectedRootIdRef.current;
+};
+
+export default useLastSelectedRootId;


### PR DESCRIPTION
## Description

Global inserter is always inactive because it's receiving an incorrect `rootClientId`. That's related to the somewhat novel way in which blocks in the widgets editor are set up. This PR ensures the correct value is passed.

**Before**

<img width="219" alt="Zrzut ekranu 2020-08-28 o 22 21 26" src="https://user-images.githubusercontent.com/205419/91612054-dd863c80-e97c-11ea-8c56-418c57fed18b.png">

**After**

<img width="376" alt="Zrzut ekranu 2020-08-28 o 22 21 31" src="https://user-images.githubusercontent.com/205419/91612051-dc550f80-e97c-11ea-8914-7ef118d12169.png">

## How has this been tested?
1. Go to the widgets editor.
1. Confirm the global inserter works.

## Screenshots <!-- if applicable -->

## Types of changes
Non-breaking change

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
