### PR TITLE
Add default attribute values on server side.

### DIFF
--- a/lib/block-supports/index.php
+++ b/lib/block-supports/index.php
@@ -118,7 +118,7 @@ function gutenberg_normalize_css_rule( $css_rule_string ) {
 function gutenberg_apply_default_block_attribute_values( $block ) {
 	$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
 	// If no render_callback, assume default values have been previously handled.
-	if ( ! $block_type || ! $block_type->render_callback ) {
+	if ( ! $block_type || ! $block_type->render_callback || ! $block_type->attributes ) {
 		return $block;
 	}
 

--- a/lib/block-supports/index.php
+++ b/lib/block-supports/index.php
@@ -35,6 +35,8 @@ function gutenberg_apply_block_supports( $block_content, $block ) {
 		return $block_content;
 	}
 
+	$block = gutenberg_apply_default_block_attribute_values( $block );
+
 	$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
 	// If no render_callback, assume styles have been previously handled.
 	if ( ! $block_type || ! $block_type->render_callback ) {
@@ -105,4 +107,26 @@ add_filter( 'render_block', 'gutenberg_apply_block_supports', 10, 2 );
  */
 function gutenberg_normalize_css_rule( $css_rule_string ) {
 	return trim( implode( ': ', preg_split( '/\s*:\s*/', $css_rule_string, 2 ) ), ';' );
+}
+
+/**
+ * Applies default values to block attributes if no values are set.
+ *
+ * @param  object $block The block to apply default values to.
+ * @return object The block with default values applied to its attributes.
+ */
+function gutenberg_apply_default_block_attribute_values( $block ) {
+	$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
+	// If no render_callback, assume default values have been previously handled.
+	if ( ! $block_type || ! $block_type->render_callback ) {
+		return $block;
+	}
+
+	foreach ( $block_type->attributes as $attribute_name => $attribute_value ) {
+		if ( ! isset( $block['attrs'][ $attribute_name ] ) && isset( $attribute_value['default'] ) ) {
+			$block['attrs'][ $attribute_name ] = $attribute_value['default'];
+		}
+	}
+
+	return $block;
 }

--- a/phpunit/class-block-supported-styles-test.php
+++ b/phpunit/class-block-supported-styles-test.php
@@ -614,13 +614,13 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 			'attributes'      => array(
 				'textColor'       => array( 'default' => 'red' ),
 				'backgroundColor' => array( 'default' => 'black' ),
-				'style' => array(
+				'style'           => array(
 					'default' => array(
-						'color' => array(
+						'color'      => array(
 							'link' => 'var:preset|color|red',
 						),
 						'typography' => array(
-							'fontSize' => '10',
+							'fontSize'   => '10',
 							'lineHeight' => '10',
 						),
 					),

--- a/phpunit/class-block-supported-styles-test.php
+++ b/phpunit/class-block-supported-styles-test.php
@@ -607,6 +607,53 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that default values are applied if none are saved.
+	 */
+	function test_default_values_applied() {
+		$block_type_settings = array(
+			'attributes'      => array(
+				'textColor'       => array( 'default' => 'red' ),
+				'backgroundColor' => array( 'default' => 'black' ),
+				'style' => array(
+					'default' => array(
+						'color' => array(
+							'link' => 'var:preset|color|red',
+						),
+						'typography' => array(
+							'fontSize' => '10',
+							'lineHeight' => '10',
+						),
+					),
+				),
+			),
+			'supports'        => array(
+				'__experimentalColor'      => array(
+					'gradients' => true,
+					'linkColor' => true,
+				),
+				'__experimentalFontSize'   => true,
+				'__experimentalLineHeight' => true,
+				'align'                    => true,
+			),
+			'render_callback' => true,
+		);
+		$this->register_block_type( 'core/example', $block_type_settings );
+
+		$block = array(
+			'blockName'    => 'core/example',
+			'attrs'        => array(),
+			'innerBlock'   => array(),
+			'innerContent' => array(),
+			'innerHTML'    => array(),
+		);
+
+		$expected_classes = 'foo-bar-class wp-block-example has-text-color has-red-color has-link-color has-background has-black-background-color';
+		$expected_styles  = 'test: style; --wp--style--color--link: var(--wp--preset--color--red); font-size: 10px; line-height: 10;';
+
+		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
+	}
+
+	/**
 	 * Tests that only styles for the supported flag are added.
 	 * Verify one support enabled does not imply multiple supports enabled.
 	 */


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Alternative approach to #24300:  Following up on the style support added for server side blocks in #23007 - I noticed these default values are already picked up by the corresponding hooks in the editor, but in the case of server side blocks are never applied on the front end.

This PR adds a function that can be used to apply default attribute values to a block array.   This function is to be called before the attributes are used, and is currently called as a first step in `gutenberg_apply_block_supports`.

<hr/>

@mcsf / @youknowriad - We talked about running a function like this on the render_block filter higher up in the chain than where we apply the styles.  But I am noticing that filter only filters the content string and not the block object itself.  So it seems changes applied to the block object passed in that filter are not persistent to the next step in the filter (unless there is a way to do this I may be missing?).  

So for now we are just calling this function as a first step in the apply_styles function to filter the block and apply the default values where necessary.  Perhaps this generic function could be available for use by developers when default attributes need to be applied for dynamic blocks. 🤔 

A few questions:
* Is there a way to do this with the render_block filter (or is there a more appropriate filter that exists for the block object) so we don't have to call this function everywhere it is needed?

If we go with this approach:
* should this type of reusable function live elsewhere (and should it be documented)?

if not:
* Are there other ideas for an approach?

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
There are not currently any server side blocks in Gutenberg that define defaults for these values. In my testing I have added default values (and their corresponding support flags if necessary) to current blocks (such as Post Author). After verifying all default value styles are applied as expected to the front-end, I added a test in class-block-supported-styles-test.php to make this easier to see.

**To test this manually for a server side block, you can add default values (and their corresponding support flags) to its `block.json` file under attributes. (see below)**

For named default values you can add the following attributes (note - backgroundColor and gradient to be added and tested separately since they are both for the background):
```
"textColor": {
	"type": "string",
	"default": "secondary"
},
"backgroundColor": {
	"type": "string",
	"default": "foreground"
},
"gradient": {
	"type": "string",
	"default": "diagonal"
},
"fontSize": {
	"type": "string",
	"default": "large"
},
"align": {
	"type": "string",
	"default": "wide"
}
```
For custom default values you can add the following to attributes (same note with background and gradient to be tested separately):
```
"style": {
	"type": "object",
	"default": {
		"color": {
			"background": "#00F",
			"gradient": "linear-gradient(90deg, rgba(2,0,36,1) 0%, rgba(0,212,255,1) 100%)",
			"text": "#0F0",
			"link": "#F00"
		},
		"typography": {
			"fontSize": "33",
			"lineHeight": "2.0"
		}
	}
}
```
also, be sure the required flags are added under `supports` in block.json:
```
"__experimentalFontSize": true,
"__experimentalColor": {
	"gradients": true,
	"linkColor": true
},
"__experimentalLineHeight": true,
"align": true
```
Add the block to a post in the editor, save, and view it on the front-end.  You should see the styles visually applied, and their corresponding classes and/or inline styles present on the wrapping element.

## Screenshots <!-- if applicable -->
**Before** - A server side block with hook style support with default values defined but not applied:
![Screen Shot 2020-07-30 at 6 45 07 PM](https://user-images.githubusercontent.com/28742426/88981927-0e4b5700-d295-11ea-8bc6-f8904edb30f0.png)
**After** - Default values applied as expected:
![Screen Shot 2020-07-30 at 6 41 39 PM](https://user-images.githubusercontent.com/28742426/88981937-16a39200-d295-11ea-9e35-41743140eaaf.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)

(Kind of both of the above.  It is a known 'bug' or shortcoming in the current implementation.)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
