### PR TITLE
Button block: reduce chance of style conflicts.

### DIFF
--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -47,7 +47,7 @@ $blocks-button__height: 3.1em;
 	border-radius: 0 !important;
 }
 
-.is-style-outline .wp-block-button__link,
+.is-style-outline > .wp-block-button__link,
 .wp-block-button__link.is-style-outline {
 	color: $dark-gray-700;
 	background-color: transparent;


### PR DESCRIPTION
## Description
Follow up to #24599. [See this discussion for context.](https://github.com/WordPress/gutenberg/pull/24599/files#r472348869)

Using the [child combinator](https://developer.mozilla.org/en-US/docs/Web/CSS/Child_combinator) (instead of the descendant combinator) narrows the selector without increasing its specificity. This should help reduce the likelihood of a style issue occurring when a parent element has an `is-style-outline` CSS class. Technically, a conflict is still possible, but it's much less likely now.