### PR TITLE
Enhancement: Disable tools while code editor mode is enable

### DIFF
--- a/packages/block-editor/src/components/tool-selector/index.js
+++ b/packages/block-editor/src/components/tool-selector/index.js
@@ -26,29 +26,10 @@ const selectIcon = (
 );
 
 function ToolSelector( props, ref ) {
-	const {
-		isInserterEnabled,
-		isNavigationTool
-	} = useSelect( ( select ) => {
-		const {
-			hasInserterItems,
-			getBlockRootClientId,
-			getBlockSelectionEnd,
-			isNavigationMode,
-		} = select( 'core/block-editor' );
-		return {
-			// This setting (richEditingEnabled) should not live in the block editor's setting.
-			isInserterEnabled:
-				select( 'core/edit-post' ).getEditorMode() === 'visual' &&
-				select( 'core/editor' ).getEditorSettings()
-					.richEditingEnabled &&
-				hasInserterItems(
-					getBlockRootClientId( getBlockSelectionEnd() )
-				),
-			isNavigationMode,
-		};
-	}, [] );
-
+	const isNavigationTool = useSelect(
+		( select ) => select( 'core/block-editor' ).isNavigationMode(),
+		[]
+	);
 	const { setNavigationMode } = useDispatch( 'core/block-editor' );
 
 	const onSwitchMode = ( mode ) => {
@@ -65,7 +46,6 @@ function ToolSelector( props, ref ) {
 					aria-expanded={ isOpen }
 					onClick={ onToggle }
 					label={ __( 'Tools' ) }
-					disabled={ ! isInserterEnabled }
 				/>
 			) }
 			position="bottom right"

--- a/packages/block-editor/src/components/tool-selector/index.js
+++ b/packages/block-editor/src/components/tool-selector/index.js
@@ -26,10 +26,29 @@ const selectIcon = (
 );
 
 function ToolSelector( props, ref ) {
-	const isNavigationTool = useSelect(
-		( select ) => select( 'core/block-editor' ).isNavigationMode(),
-		[]
-	);
+	const {
+		isInserterEnabled,
+		isNavigationTool
+	} = useSelect( ( select ) => {
+		const {
+			hasInserterItems,
+			getBlockRootClientId,
+			getBlockSelectionEnd,
+			isNavigationMode,
+		} = select( 'core/block-editor' );
+		return {
+			// This setting (richEditingEnabled) should not live in the block editor's setting.
+			isInserterEnabled:
+				select( 'core/edit-post' ).getEditorMode() === 'visual' &&
+				select( 'core/editor' ).getEditorSettings()
+					.richEditingEnabled &&
+				hasInserterItems(
+					getBlockRootClientId( getBlockSelectionEnd() )
+				),
+			isNavigationMode,
+		};
+	}, [] );
+
 	const { setNavigationMode } = useDispatch( 'core/block-editor' );
 
 	const onSwitchMode = ( mode ) => {
@@ -46,6 +65,7 @@ function ToolSelector( props, ref ) {
 					aria-expanded={ isOpen }
 					onClick={ onToggle }
 					label={ __( 'Tools' ) }
+					disabled={ ! isInserterEnabled }
 				/>
 			) }
 			position="bottom right"

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -94,7 +94,12 @@ function HeaderToolbar() {
 					'Generic label for block inserter button'
 				) }
 			/>
-			{ isLargeViewport && <ToolbarItem as={ ToolSelector } disabled={ ! isInserterEnabled } /> }
+			{ isLargeViewport && (
+				<ToolbarItem
+					as={ ToolSelector }
+					disabled={ ! isTextModeEnabled }
+				/>
+			) }
 			<ToolbarItem as={ EditorHistoryUndo } />
 			<ToolbarItem as={ EditorHistoryRedo } />
 			<ToolbarItem

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -94,7 +94,7 @@ function HeaderToolbar() {
 					'Generic label for block inserter button'
 				) }
 			/>
-			{ isLargeViewport && <ToolbarItem as={ ToolSelector } /> }
+			{ isLargeViewport && <ToolbarItem as={ ToolSelector } disabled={ ! isInserterEnabled } /> }
 			<ToolbarItem as={ EditorHistoryUndo } />
 			<ToolbarItem as={ EditorHistoryRedo } />
 			<ToolbarItem

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -97,7 +97,7 @@ function HeaderToolbar() {
 			{ isLargeViewport && (
 				<ToolbarItem
 					as={ ToolSelector }
-					disabled={ ! isTextModeEnabled }
+					disabled={ isTextModeEnabled }
 				/>
 			) }
 			<ToolbarItem as={ EditorHistoryUndo } />


### PR DESCRIPTION
closes #24917 

## Description
<!-- Please describe what you have changed or added -->
I have one property to check whether the code editor mode is enabled or not.

## How has this been tested?
- I have tested changes with Wordpress5.5 
- The code is only for that particular component won't affect other components.

## Screenshots <!-- if applicable -->
![screenshot-gutenberg local-2020 08 31-12_32_34](https://user-images.githubusercontent.com/25550562/91692018-4ee50b80-eb86-11ea-9f3c-ba63aa7269cc.png)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
