### PR TITLE
Enable back dropCap for paragraph

### DIFF
--- a/packages/block-editor/src/components/use-editor-feature/index.js
+++ b/packages/block-editor/src/components/use-editor-feature/index.js
@@ -39,16 +39,24 @@ export default function useEditorFeature( featurePath ) {
 	const setting = useSelect(
 		( select ) => {
 			const path = `__experimentalFeatures.${ featurePath }`;
-			const { getSettings } = select( 'core/block-editor' );
-			const settings = getSettings();
 
+			// 1 - Use block.json, if available.
+			const { getBlockSupport } = select( 'core/blocks' );
+			const blockSupportValue = getBlockSupport( blockName, path );
+			if ( blockSupportValue !== undefined ) {
+				return blockSupportValue;
+			}
+
+			// 2 - Use deprecated settings, if available.
+			const settings = select( 'core/block-editor' ).getSettings();
 			const deprecatedSettingsValue = deprecatedFlags[ featurePath ]
 				? deprecatedFlags[ featurePath ]( settings )
 				: undefined;
-
 			if ( deprecatedSettingsValue !== undefined ) {
 				return deprecatedSettingsValue;
 			}
+
+			// 3 - Use global __experimentalFeatures otherwise.
 			return get( settings, path );
 		},
 		[ blockName, featurePath ]


### PR DESCRIPTION
This fixes a regression introduced at https://github.com/WordPress/gutenberg/pull/24761 by which the paragraph block lost the dropCap control.