### PR TITLE
Enable back dropCap for paragraph

### DIFF
--- a/lib/experimental-default-theme.json
+++ b/lib/experimental-default-theme.json
@@ -126,7 +126,7 @@
 		},
 		"features": {
 			"typography": {
-				"dropCap": false
+				"dropCap": true
 			},
 			"colors": {
 				"custom": true

--- a/packages/block-editor/src/components/use-editor-feature/index.js
+++ b/packages/block-editor/src/components/use-editor-feature/index.js
@@ -40,14 +40,7 @@ export default function useEditorFeature( featurePath ) {
 		( select ) => {
 			const path = `__experimentalFeatures.${ featurePath }`;
 
-			// 1 - Use block.json, if available.
-			const { getBlockSupport } = select( 'core/blocks' );
-			const blockSupportValue = getBlockSupport( blockName, path );
-			if ( blockSupportValue !== undefined ) {
-				return blockSupportValue;
-			}
-
-			// 2 - Use deprecated settings, if available.
+			// 1 - Use deprecated settings, if available.
 			const settings = select( 'core/block-editor' ).getSettings();
 			const deprecatedSettingsValue = deprecatedFlags[ featurePath ]
 				? deprecatedFlags[ featurePath ]( settings )
@@ -56,7 +49,7 @@ export default function useEditorFeature( featurePath ) {
 				return deprecatedSettingsValue;
 			}
 
-			// 3 - Use global __experimentalFeatures otherwise.
+			// 2 - Use global __experimentalFeatures otherwise.
 			return get( settings, path );
 		},
 		[ blockName, featurePath ]

--- a/packages/block-editor/src/components/use-editor-feature/index.js
+++ b/packages/block-editor/src/components/use-editor-feature/index.js
@@ -39,16 +39,24 @@ export default function useEditorFeature( featurePath ) {
 	const setting = useSelect(
 		( select ) => {
 			const path = `__experimentalFeatures.${ featurePath }`;
-			const { getSettings } = select( 'core/block-editor' );
-			const settings = getSettings();
 
+			// 1 - Use block.json, if available.
+			const { getBlockSupport } = select( 'core/blocks' );
+			const blockSupportValue = getBlockSupport( blockName, path );
+			if ( blockSupportValue !== undefined ) {
+				return blockSupportValue;
+			}
+
+			// 2 - Use deprecated settings, if available.
+			const settings = select( 'core/block-editor' ).getSettings();
 			const deprecatedSettingsValue = deprecatedFlags[ featurePath ]
 				? deprecatedFlags[ featurePath ]( settings )
 				: undefined;
-
 			if ( deprecatedSettingsValue !== undefined ) {
 				return deprecatedSettingsValue;
 			}
+
+			// 3 - Use global __experimentalFeatures otherwise.
 			return get( settings, path );
 		},
 		[ blockName, featurePath ]

--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -35,11 +35,6 @@
 		},
 		"__experimentalFontSize": true,
 		"__experimentalLineHeight": true,
-		"__experimentalFeatures": {
-			"typography": {
-				"dropCap": true
-			}
-		},
 		"__experimentalSelector": "p",
 		"__unstablePasteTextInline": true
 	}


### PR DESCRIPTION
Alternative to https://github.com/WordPress/gutenberg/pull/24930

This fixes a regression introduced at #24761 by which the paragraph block lost the dropCap control.