### PR TITLE
Rename features.colors to features.color

### DIFF
--- a/lib/experimental-default-theme.json
+++ b/lib/experimental-default-theme.json
@@ -128,7 +128,7 @@
 			"typography": {
 				"dropCap": false
 			},
-			"colors": {
+			"color": {
 				"custom": true
 			}
 		}

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -605,10 +605,10 @@ function gutenberg_experimental_global_styles_get_editor_features( $config ) {
 
 	// Deprecated theme supports.
 	if ( get_theme_support( 'disable-custom-colors' ) ) {
-		if ( ! isset( $config['global']['features']['colors'] ) ) {
-			$config['global']['features']['colors'] = array();
+		if ( ! isset( $config['global']['features']['color'] ) ) {
+			$config['global']['features']['color'] = array();
 		}
-		$config['global']['features']['colors']['custom'] = false;
+		$config['global']['features']['color']['custom'] = false;
 	}
 
 	return $config['global']['features'];

--- a/packages/block-editor/src/components/color-palette/with-color-context.js
+++ b/packages/block-editor/src/components/color-palette/with-color-context.js
@@ -17,7 +17,7 @@ import useEditorFeature from '../use-editor-feature';
 const withDisableCustomColors = createHigherOrderComponent(
 	( WrappedComponent ) => {
 		return ( props ) => {
-			const disableCustomColors = ! useEditorFeature( 'colors.custom' );
+			const disableCustomColors = ! useEditorFeature( 'color.custom' );
 
 			return (
 				<WrappedComponent

--- a/packages/block-editor/src/components/colors-gradients/control.js
+++ b/packages/block-editor/src/components/colors-gradients/control.js
@@ -179,7 +179,7 @@ function ColorGradientControlSelect( props ) {
 		return pick( settings, colorsAndGradientKeys );
 	} );
 	colorGradientSettings.disableCustomColors = ! useEditorFeature(
-		'colors.custom'
+		'color.custom'
 	);
 
 	return (

--- a/packages/block-editor/src/components/colors-gradients/panel-color-gradient-settings.js
+++ b/packages/block-editor/src/components/colors-gradients/panel-color-gradient-settings.js
@@ -153,7 +153,7 @@ const PanelColorGradientSettingsSelect = ( props ) => {
 		return pick( settings, colorsAndGradientKeys );
 	} );
 	colorGradientSettings.disableCustomColors = ! useEditorFeature(
-		'colors.custom'
+		'color.custom'
 	);
 	return (
 		<PanelColorGradientSettingsInner

--- a/packages/block-editor/src/components/use-editor-feature/index.js
+++ b/packages/block-editor/src/components/use-editor-feature/index.js
@@ -14,7 +14,7 @@ import { useSelect } from '@wordpress/data';
 import { useBlockEditContext } from '../block-edit';
 
 const deprecatedFlags = {
-	'colors.custom': ( settings ) =>
+	'color.custom': ( settings ) =>
 		settings.disableCustomColors === undefined
 			? undefined
 			: ! settings.disableCustomColors,

--- a/packages/format-library/src/text-color/index.js
+++ b/packages/format-library/src/text-color/index.js
@@ -27,7 +27,7 @@ const title = __( 'Text Color' );
 const EMPTY_ARRAY = [];
 
 function TextColorEdit( { value, onChange, isActive, activeAttributes } ) {
-	const allowCustomControl = useEditorFeature( 'colors.custom' );
+	const allowCustomControl = useEditorFeature( 'color.custom' );
 	const { colors } = useSelect( ( select ) => {
 		const blockEditorSelect = select( 'core/block-editor' );
 		let settings;


### PR DESCRIPTION
This renames `features.colors` to `features.color` for coherence.