### PR TITLE
Fix Disabled component infinite loop for `a` elements

### DIFF
--- a/packages/components/src/disabled/index.js
+++ b/packages/components/src/disabled/index.js
@@ -49,9 +49,7 @@ function Disabled( { className, children, ...props } ) {
 
 			if ( focusable.nodeName === 'A' ) {
 				focusable.setAttribute( 'tabindex', -1 );
-			}
-
-			if ( focusable.hasAttribute( 'tabindex' ) ) {
+			} else if ( focusable.hasAttribute( 'tabindex' ) ) {
 				focusable.removeAttribute( 'tabindex' );
 			}
 

--- a/packages/components/src/disabled/index.js
+++ b/packages/components/src/disabled/index.js
@@ -49,7 +49,10 @@ function Disabled( { className, children, ...props } ) {
 
 			if ( focusable.nodeName === 'A' ) {
 				focusable.setAttribute( 'tabindex', -1 );
-			} else if ( focusable.hasAttribute( 'tabindex' ) ) {
+			}
+
+			const tabIndex = focusable.getAttribute( 'tabindex' );
+			if ( tabIndex !== null && tabIndex !== '-1' ) {
 				focusable.removeAttribute( 'tabindex' );
 			}
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This PR here: https://github.com/WordPress/gutenberg/pull/24397 not long ago, introduced a change the Disabled Component to disable hyperlink focusing. The change causes "infinite loop". Since we add `tabindex` to `a` elements, but then we remove it immediately.

This PR fixes it by adding an else-if to avoid the inifinite loop. 

## How has this been tested?
1. Open Block Editor
2. Open inserter (top-left plus button with black background)
3. Click on Patterns
4. Keep pressing tab

## Screenshots <!-- if applicable -->
Before: (Notice `a` element keeps changing)
![ezgif com-video-to-gif (3)](https://user-images.githubusercontent.com/2256104/91718682-27953b00-eb94-11ea-9809-00983bd1e468.gif)

After:
![image](https://user-images.githubusercontent.com/2256104/91718342-75f60a00-eb93-11ea-893d-a93589d4060d.png)

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
