### PR TITLE
[Mobile] - Fix Pullquote block styles

### DIFF
--- a/packages/block-library/src/pullquote/blockquote.native.scss
+++ b/packages/block-library/src/pullquote/blockquote.native.scss
@@ -1,8 +1,8 @@
 .quote {
-	font-size: 1.125em;
+	font-size: 18px;
 }
 
 .citation {
-	font-size: 0.875em;
-	margin-top: 0.85em;
+	font-size: 14px;
+	margin-top: 14px;
 }

--- a/packages/block-library/src/pullquote/figure.native.scss
+++ b/packages/block-library/src/pullquote/figure.native.scss
@@ -1,6 +1,6 @@
 %shared {
 	border-width: 3px 0;
-	padding: 1.3125em 1em;
+	padding: 21px 16px;
 }
 
 .light {


### PR DESCRIPTION
## Description
This PR addresses a regression from this [PR](https://github.com/WordPress/gutenberg/pull/24523/files).

It adds back the previous values since `em` is not supported on mobile.

## How has this been tested?
- Open the app with metro running
- Add a `Pullquote` block (Only on iOS)
- **Expect** the block to be rendered correctly without any crashes

## Screenshots <!-- if applicable -->
<kbd><img src="https://user-images.githubusercontent.com/4885740/91726583-cd4ea700-eba0-11ea-960f-84d9dba092ce.png" width="300" /></kbd>

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
