### PR TITLE
Navigation Component: Apply effect on activeItem change

### DIFF
--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -65,7 +65,7 @@ const Navigation = ( { activeItemId, children, data, rootTitle } ) => {
 		if ( activeItem ) {
 			setActiveLevelId( activeItem.parent );
 		}
-	}, [] );
+	}, [ activeItem ] );
 
 	const NavigationBackButton = ( { children: backButtonChildren } ) => {
 		if ( ! parentLevel ) {

--- a/packages/components/src/navigation/stories/index.js
+++ b/packages/components/src/navigation/stories/index.js
@@ -83,37 +83,49 @@ function Example() {
 	const [ active, setActive ] = useState( 'item-1' );
 
 	return (
-		<Navigation activeItemId={ active } data={ data } rootTitle="Home">
-			{ ( { level, parentLevel, NavigationBackButton } ) => {
-				return (
-					<>
-						{ parentLevel && (
-							<NavigationBackButton>
-								<Icon icon={ arrowLeft } />
-								{ parentLevel.title }
-							</NavigationBackButton>
-						) }
-						<h1>{ level.title }</h1>
-						<NavigationMenu>
-							{ level.children.map( ( item ) => {
-								return (
-									<NavigationMenuItem
-										{ ...item }
-										key={ item.id }
-										onClick={
-											! item.href
-												? ( selected ) =>
-														setActive( selected.id )
-												: null
-										}
-									/>
-								);
-							} ) }
-						</NavigationMenu>
-					</>
-				);
-			} }
-		</Navigation>
+		<>
+			{ active !== 'child-2' ? (
+				<Button
+					style={ { position: 'absolute', bottom: 0 } }
+					onClick={ () => setActive( 'child-2' ) }
+				>
+					Direct link to Child 2
+				</Button>
+			) : null }
+			<Navigation activeItemId={ active } data={ data } rootTitle="Home">
+				{ ( { level, parentLevel, NavigationBackButton } ) => {
+					return (
+						<>
+							{ parentLevel && (
+								<NavigationBackButton>
+									<Icon icon={ arrowLeft } />
+									{ parentLevel.title }
+								</NavigationBackButton>
+							) }
+							<h1>{ level.title }</h1>
+							<NavigationMenu>
+								{ level.children.map( ( item ) => {
+									return (
+										<NavigationMenuItem
+											{ ...item }
+											key={ item.id }
+											onClick={
+												! item.href
+													? ( selected ) =>
+															setActive(
+																selected.id
+															)
+													: null
+											}
+										/>
+									);
+								} ) }
+							</NavigationMenu>
+						</>
+					);
+				} }
+			</Navigation>
+		</>
 	);
 }
 

--- a/packages/components/src/navigation/stories/index.js
+++ b/packages/components/src/navigation/stories/index.js
@@ -89,7 +89,7 @@ function Example() {
 					style={ { position: 'absolute', bottom: 0 } }
 					onClick={ () => setActive( 'child-2' ) }
 				>
-					Direct link to Child 2
+					Non-navigation link to Child 2
 				</Button>
 			) : null }
 			<Navigation activeItemId={ active } data={ data } rootTitle="Home">


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

Ensure that direct manipulation of `activeItem` from outside results in a navigation. This PR changes the `useEffect` function to react to changes of `activeItem`. To test, a button simulating a link to mimic outside navigation was added to the Story.

## How has this been tested?

1. `npm run storybook:dev`
2. Components > Navigation.
3. Test the new "direct link to Child 2" button to make sure it behaves as expected, especially in regards to animation.

## Screenshots <!-- if applicable -->

![Screen Shot 2020-09-01 at 1 33 52 PM](https://user-images.githubusercontent.com/1922453/91784772-d5b5e900-ec57-11ea-9a99-4929e7396169.png)
