### PR TITLE
Navigation Component: Avoid animation on mounting

### DIFF
--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useEffect, useMemo, useState } from '@wordpress/element';
+import { useEffect, useMemo, useState, useRef } from '@wordpress/element';
 import { usePrevious } from '@wordpress/compose';
 
 /**
@@ -67,10 +67,12 @@ const Navigation = ( { activeItemId, children, data, rootTitle } ) => {
 		}
 	}, [ activeItem ] );
 
-	let onMount = false;
+	const isMounted = useRef( true );
 
 	useEffect( () => {
-		onMount = true;
+		if ( isMounted.current ) {
+			isMounted.current = false;
+		}
 	}, [] );
 
 	const NavigationBackButton = ( { children: backButtonChildren } ) => {
@@ -89,36 +91,34 @@ const Navigation = ( { activeItemId, children, data, rootTitle } ) => {
 		);
 	};
 
-	const render = ( { className: animateClassName } ) => (
-		<div
-			className={ classnames(
-				'components-navigation__level',
-				animateClassName
-			) }
-		>
-			{ children( {
-				level,
-				NavigationBackButton,
-				parentLevel,
-			} ) }
-		</div>
-	);
-
 	return (
 		<Root className="components-navigation">
-			{ onMount ? (
-				render( {} )
-			) : (
-				<Animate
-					key={ level.id }
-					type="slide-in"
-					options={ {
-						origin: isNavigatingBack ? 'right' : 'left',
-					} }
-				>
-					{ render }
-				</Animate>
-			) }
+			<Animate
+				key={ level.id }
+				type="slide-in"
+				options={ {
+					origin: isNavigatingBack ? 'right' : 'left',
+				} }
+			>
+				{ ( { className: animateClassName } ) => {
+					return (
+						<div
+							className={ classnames(
+								'components-navigation__level',
+								{
+									[ animateClassName ]: ! isMounted.current,
+								}
+							) }
+						>
+							{ children( {
+								level,
+								NavigationBackButton,
+								parentLevel,
+							} ) }
+						</div>
+					);
+				} }
+			</Animate>
 		</Root>
 	);
 };

--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -67,11 +67,11 @@ const Navigation = ( { activeItemId, children, data, rootTitle } ) => {
 		}
 	}, [ activeItem ] );
 
-	const isMounted = useRef( true );
+	const isMounted = useRef( false );
 
 	useEffect( () => {
-		if ( isMounted.current ) {
-			isMounted.current = false;
+		if ( ! isMounted.current ) {
+			isMounted.current = true;
 		}
 	}, [] );
 
@@ -105,7 +105,7 @@ const Navigation = ( { activeItemId, children, data, rootTitle } ) => {
 						className={ classnames(
 							'components-navigation__level',
 							{
-								[ animateClassName ]: ! isMounted.current,
+								[ animateClassName ]: isMounted.current,
 							}
 						) }
 					>

--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -100,24 +100,22 @@ const Navigation = ( { activeItemId, children, data, rootTitle } ) => {
 					origin: isNavigatingBack ? 'right' : 'left',
 				} }
 			>
-				{ ( { className: animateClassName } ) => {
-					return (
-						<div
-							className={ classnames(
-								'components-navigation__level',
-								{
-									[ animateClassName ]: ! isMounted.current,
-								}
-							) }
-						>
-							{ children( {
-								level,
-								NavigationBackButton,
-								parentLevel,
-							} ) }
-						</div>
-					);
-				} }
+				{ ( { className: animateClassName } ) => (
+					<div
+						className={ classnames(
+							'components-navigation__level',
+							{
+								[ animateClassName ]: ! isMounted.current,
+							}
+						) }
+					>
+						{ children( {
+							level,
+							NavigationBackButton,
+							parentLevel,
+						} ) }
+					</div>
+				) }
 			</Animate>
 		</Root>
 	);

--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -67,6 +67,12 @@ const Navigation = ( { activeItemId, children, data, rootTitle } ) => {
 		}
 	}, [ activeItem ] );
 
+	let onMount = false;
+
+	useEffect( () => {
+		onMount = true;
+	}, [] );
+
 	const NavigationBackButton = ( { children: backButtonChildren } ) => {
 		if ( ! parentLevel ) {
 			return null;
@@ -83,30 +89,36 @@ const Navigation = ( { activeItemId, children, data, rootTitle } ) => {
 		);
 	};
 
+	const render = ( { className: animateClassName } ) => (
+		<div
+			className={ classnames(
+				'components-navigation__level',
+				animateClassName
+			) }
+		>
+			{ children( {
+				level,
+				NavigationBackButton,
+				parentLevel,
+			} ) }
+		</div>
+	);
+
 	return (
 		<Root className="components-navigation">
-			<Animate
-				key={ level.id }
-				type="slide-in"
-				options={ {
-					origin: isNavigatingBack ? 'right' : 'left',
-				} }
-			>
-				{ ( { className: animateClassName } ) => (
-					<div
-						className={ classnames(
-							'components-navigation__level',
-							animateClassName
-						) }
-					>
-						{ children( {
-							level,
-							NavigationBackButton,
-							parentLevel,
-						} ) }
-					</div>
-				) }
-			</Animate>
+			{ onMount ? (
+				render( {} )
+			) : (
+				<Animate
+					key={ level.id }
+					type="slide-in"
+					options={ {
+						origin: isNavigatingBack ? 'right' : 'left',
+					} }
+				>
+					{ render }
+				</Animate>
+			) }
 		</Root>
 	);
 };


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/24951

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

The navigation component animates on navigation, but when the page loads it should not. This PR adds a check to see if the component is mounting and avoids the animation if thats the case.

## How has this been tested?

1. `npm run storybook:dev`
2. Components > Navigation.
3. Test the animation and refresh the screen. It should not animate on the first render.

