### PR TITLE
Add block parent selector component readme

### DIFF
--- a/packages/block-editor/src/components/block-parent-selector/README.md
+++ b/packages/block-editor/src/components/block-parent-selector/README.md
@@ -1,0 +1,41 @@
+# Block Parent Selector
+
+Block parent selector component displays the hierarchy of the current block selection as a single icon to "go up" a level. The parent selector icon appears when hovering over the icon of the selected block. In addition, it appears only if the selected block in question has a parent.
+
+A click on the selector triggers the selection of the parent block.
+
+In practice the BlockParentSelector component renders a <ToolbarButton /> component that contains the parent selector icon.
+
+![Block parent selector test](https://make.wordpress.org/core/files/2020/09/block-parent-selector-test.gif)
+
+
+## Table of contents
+
+1. [Development guidelines](#development-guidelines)
+2. [Related components](#related-components)
+
+## Development guidelines
+
+### Usage
+
+Renders block parent selector icon in a <ToolbarButton /> component.
+
+```jsx
+import { Button } from '@wordpress/components';
+
+const MyBlockParentSelector = () => (
+	<BlockParentSelector clientIds={ blockClientId } />
+);
+```
+
+### Props
+
+#### clientIds
+
+Blocks IDs
+
+-   Type: `Array`
+
+## Related components
+
+Block Editor components are components that can be used to compose the UI of your block editor. Thus, they can only be used under a [BlockEditorProvider](https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/provider/README.md) in the components tree.

--- a/packages/block-editor/src/components/block-parent-selector/README.md
+++ b/packages/block-editor/src/components/block-parent-selector/README.md
@@ -24,7 +24,7 @@ Renders block parent selector icon in a <ToolbarButton /> component.
 import { Button } from '@wordpress/components';
 
 const MyBlockParentSelector = () => (
-	<BlockParentSelector clientIds={ blockClientId } />
+	<BlockParentSelector clientIds={ blockClientIds } />
 );
 ```
 


### PR DESCRIPTION
## Description
Added documentation for the block parent selector component (see #22891)

## How has this been tested?
N/A, documentation only

## Types of changes
Documentation

## Checklist:
- [n/a] My code is tested.
- [n/a] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [n/a] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
