### PR TITLE
Update Storybook URL from text to a real link

### DIFF
--- a/docs/designers-developers/developers/tutorials/create-block/finishing.md
+++ b/docs/designers-developers/developers/tutorials/create-block/finishing.md
@@ -6,7 +6,7 @@ This tutorial covers general concepts and structure for creating basic blocks.
 
 The block editor provides a [components package](/packages/components/README.md) which contains numerous prebuilt components you can use to build your block.
 
-You can visually browse the components and what their implementation looks like using the Storybook tool published at https://wordpress.github.io/gutenberg.
+You can visually browse the components and what their implementation looks like using the Storybook tool published at [https://wordpress.github.io/gutenberg](https://wordpress.github.io/gutenberg).
 
 ## Additional Tutorials
 


### PR DESCRIPTION
## Description
The PR updates the URL that points to the Gutenberg Storybook from simple text to a normal link.

## How has this been tested?
The change has been tested with a markdown preview tool.

## Types of changes
Documentation