### PR TITLE
Transform multiple heading blocks to list or paragraphs

### DIFF
--- a/packages/block-library/src/heading/transforms.js
+++ b/packages/block-library/src/heading/transforms.js
@@ -13,13 +13,15 @@ const transforms = {
 	from: [
 		{
 			type: 'block',
+			isMultiBlock: true,
 			blocks: [ 'core/paragraph' ],
-			transform: ( { content, anchor } ) => {
-				return createBlock( name, {
-					content,
-					anchor,
-				} );
-			},
+			transform: ( attributes ) =>
+				attributes.map( ( { content, anchor } ) =>
+					createBlock( name, {
+						content,
+						anchor,
+					} )
+				),
 		},
 		{
 			type: 'raw',
@@ -69,13 +71,15 @@ const transforms = {
 	to: [
 		{
 			type: 'block',
+			isMultiBlock: true,
 			blocks: [ 'core/paragraph' ],
-			transform: ( { content, anchor } ) => {
-				return createBlock( 'core/paragraph', {
-					content,
-					anchor,
-				} );
-			},
+			transform: ( attributes ) =>
+				attributes.map( ( { content, anchor } ) =>
+					createBlock( 'core/paragraph', {
+						content,
+						anchor,
+					} )
+				),
 		},
 	],
 };

--- a/packages/block-library/src/list/transforms.js
+++ b/packages/block-library/src/list/transforms.js
@@ -37,7 +37,7 @@ const transforms = {
 		{
 			type: 'block',
 			isMultiBlock: true,
-			blocks: [ 'core/paragraph' ],
+			blocks: [ 'core/paragraph', 'core/heading' ],
 			transform: ( blockAttributes ) => {
 				return createBlock( 'core/list', {
 					values: toHTMLString( {
@@ -153,6 +153,23 @@ const transforms = {
 					__UNSTABLE_LINE_SEPARATOR
 				).map( ( piece ) =>
 					createBlock( 'core/paragraph', {
+						content: toHTMLString( { value: piece } ),
+					} )
+				),
+		},
+		{
+			type: 'block',
+			blocks: [ 'core/heading' ],
+			transform: ( { values } ) =>
+				split(
+					create( {
+						html: values,
+						multilineTag: 'li',
+						multilineWrapperTags: [ 'ul', 'ol' ],
+					} ),
+					__UNSTABLE_LINE_SEPARATOR
+				).map( ( piece ) =>
+					createBlock( 'core/heading', {
 						content: toHTMLString( { value: piece } ),
 					} )
 				),

--- a/packages/e2e-tests/specs/editor/various/block-switcher.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-switcher.test.js
@@ -24,12 +24,15 @@ describe( 'Block Switcher', () => {
 		expect( await hasBlockSwitcher() ).toBeTruthy();
 
 		// Verify the correct block transforms appear.
-		expect( await getAvailableBlockTransforms() ).toEqual( [
-			'Group',
-			'Paragraph',
-			'Quote',
-			'Pullquote',
-		] );
+		expect( await getAvailableBlockTransforms() ).toEqual(
+			expect.arrayContaining( [
+				'Group',
+				'Paragraph',
+				'Quote',
+				'Heading',
+				'Pullquote',
+			] )
+		);
 	} );
 
 	it( 'Should show the expected block transforms on the list block when the quote block is removed', async () => {
@@ -47,11 +50,14 @@ describe( 'Block Switcher', () => {
 		expect( await hasBlockSwitcher() ).toBeTruthy();
 
 		// Verify the correct block transforms appear.
-		expect( await getAvailableBlockTransforms() ).toEqual( [
-			'Group',
-			'Paragraph',
-			'Pullquote',
-		] );
+		expect( await getAvailableBlockTransforms() ).toEqual(
+			expect.arrayContaining( [
+				'Group',
+				'Paragraph',
+				'Pullquote',
+				'Heading',
+			] )
+		);
 	} );
 
 	it( 'Should not show the block switcher if all the blocks the list block transforms into are removed', async () => {
@@ -62,6 +68,7 @@ describe( 'Block Switcher', () => {
 				'core/pullquote',
 				'core/paragraph',
 				'core/group',
+				'core/heading',
 			].map( ( block ) => wp.blocks.unregisterBlockType( block ) );
 		} );
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Resolves: https://github.com/WordPress/gutenberg/issues/24969

This PR adds the ability to transform multiple `heading` blocks to a `list` or `paragraphs` and vice versa.
<!-- Please describe what you have changed or added -->
