### PR TITLE
Add font weight picking mechanism

### DIFF
--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -69,6 +69,11 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 		$has_font_family_support = gutenberg_experimental_get( $block_type->supports, array( '__experimentalFontFamily' ), false );
 	}
 
+	$has_font_weight_support = false;
+	if ( property_exists( $block_type, 'supports' ) ) {
+		$has_font_weight_support = gutenberg_experimental_get( $block_type->supports, array( '__experimentalFontWeight' ), false );
+	}
+
 	// Font Size.
 	if ( $has_font_size_support ) {
 		$has_named_font_size  = array_key_exists( 'fontSize', $block_attributes );
@@ -96,6 +101,16 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 			} else {
 				$styles[] = sprintf( 'font-family: %s;', $block_attributes['style']['color']['fontFamily'] );
 			}
+		}
+	}
+
+	// Font weight.
+	if ( $has_font_weight_support ) {
+		$has_font_weight = isset( $block_attributes['style']['typography']['fontWeight'] );
+		// Apply required class and style.
+		if ( $has_font_weight ) {
+			// Add the style (no classes for line-height).
+			$styles[] = sprintf( 'font-weight: %s;', $block_attributes['style']['typography']['fontWeight'] );
 		}
 	}
 

--- a/lib/experimental-default-theme.json
+++ b/lib/experimental-default-theme.json
@@ -174,7 +174,7 @@
 						"name": "Ab",
 						"slug": "capitalize"
 					}
-				]
+				],
 				"fontWeight": true
 			},
 			"spacing": {

--- a/lib/experimental-default-theme.json
+++ b/lib/experimental-default-theme.json
@@ -175,6 +175,7 @@
 						"slug": "capitalize"
 					}
 				]
+				"fontWeight": true
 			},
 			"spacing": {
 				"customPadding": false,

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -399,6 +399,8 @@ function gutenberg_experimental_global_styles_get_css_property( $style_property 
 			return 'font-family';
 		case 'textTransform':
 			return 'text-transform';
+		case 'fontWeight':
+			return 'font-weight';
 		default:
 			return $style_property;
 	}
@@ -418,6 +420,7 @@ function gutenberg_experimental_global_styles_get_style_property() {
 		'fontSize'                 => array( 'typography', 'fontSize' ),
 		'fontFamily'               => array( 'typography', 'fontFamily' ),
 		'lineHeight'               => array( 'typography', 'lineHeight' ),
+		'fontWeight'               => array( 'typography', 'fontWeight' ),
 		'textTransform'            => array( 'typography', 'textTransform' ),
 	);
 }
@@ -437,6 +440,7 @@ function gutenberg_experimental_global_styles_get_support_keys() {
 		'lineHeight'               => array( 'lineHeight' ),
 		'fontFamily'               => array( '__experimentalFontFamily' ),
 		'textTransform'            => array( '__experimentalTextTransform' ),
+		'fontWeight'               => array( '__experimentalFontWeight' ),
 	);
 }
 

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -511,6 +511,7 @@ function gutenberg_experimental_global_styles_get_block_data() {
 					'supports' => array(
 						'__experimentalSelector'      => ':root',
 						'__experimentalFontFamily'    => true,
+						'__experimentalFontWeight'    => true,
 						'fontSize'                    => true,
 						'__experimentalTextTransform' => true,
 						'color'                       => array(

--- a/packages/block-editor/src/components/font-weight/index.js
+++ b/packages/block-editor/src/components/font-weight/index.js
@@ -1,0 +1,34 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { SelectControl } from '@wordpress/components';
+
+const FONT_WEIGHT_OPTIONS = [
+	{ value: '', label: __( 'Default' ) },
+	{ value: 'normal', label: __( 'Normal' ) },
+	{ value: 'bold', label: __( 'Bold' ) },
+	{ value: 'lighter', label: __( 'Lighter' ) },
+	{ value: 'bolder', label: __( 'Bolder' ) },
+	...[ ...Array( 9 ).keys() ]
+		.map( ( i ) => ( i + 1 ) * 100 )
+		.map( ( weight ) => ( { value: weight, label: weight } ) ),
+	{ value: 'initial', label: __( 'Initial' ) },
+	{ value: 'inherit', label: __( 'Inherit' ) },
+];
+
+export default function FontWeightControl( {
+	value = '',
+	onChange,
+	...props
+} ) {
+	return (
+		<SelectControl
+			label={ __( 'Font weight' ) }
+			options={ FONT_WEIGHT_OPTIONS }
+			value={ value }
+			onChange={ onChange }
+			{ ...props }
+		/>
+	);
+}

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -30,6 +30,7 @@ export { default as __experimentalGradientPicker } from './gradient-picker';
 export { default as __experimentalGradientPickerControl } from './gradient-picker/control';
 export { default as __experimentalGradientPickerPanel } from './gradient-picker/panel';
 export { default as __experimentalFontFamilyControl } from './font-family';
+export { default as __experimentalFontWeightControl } from './font-weight';
 export { default as __experimentalColorGradientControl } from './colors-gradients/control';
 export { default as __experimentalPanelColorGradientSettings } from './colors-gradients/panel-color-gradient-settings';
 export { default as __experimentalImageSizeControl } from './image-size-control';

--- a/packages/block-editor/src/hooks/font-weight.js
+++ b/packages/block-editor/src/hooks/font-weight.js
@@ -1,0 +1,89 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { hasBlockSupport } from '@wordpress/blocks';
+import { useSelect } from '@wordpress/data';
+import { SelectControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { cleanEmptyObject } from './utils';
+
+export const FONT_WEIGHT_SUPPORT_KEY = '__experimentalFontWeight';
+
+const FONT_WEIGHT_OPTIONS = [
+	{ value: '', label: __( 'Default' ) },
+	{ value: 'normal', label: __( 'Normal' ) },
+	{ value: 'bold', label: __( 'Bold' ) },
+	{ value: 'lighter', label: __( 'Lighter' ) },
+	{ value: 'bolder', label: __( 'Bolder' ) },
+	...[ ...Array( 9 ).keys() ]
+		.map( ( i ) => ( i + 1 ) * 100 )
+		.map( ( weight ) => ( { value: weight, label: weight } ) ),
+	{ value: 'initial', label: __( 'Initial' ) },
+	{ value: 'inherit', label: __( 'Inherit' ) },
+];
+
+function FontWeightControl( { value = '', onChange, ...props } ) {
+	return (
+		<SelectControl
+			label={ __( 'Font weight' ) }
+			options={ FONT_WEIGHT_OPTIONS }
+			value={ value }
+			onChange={ onChange }
+			{ ...props }
+		/>
+	);
+}
+
+export function FontWeightEdit( {
+	name,
+	setAttributes,
+	attributes: { style = {} },
+} ) {
+	const isDisable = useIsFontWeightDisabled( { name } );
+
+	if ( isDisable ) {
+		return null;
+	}
+
+	const fontWeight = style.typography?.fontWeight || '';
+
+	function onChange( newValue ) {
+		setAttributes( {
+			style: cleanEmptyObject( {
+				...style,
+				typography: {
+					...( style.typography || {} ),
+					fontWeight: newValue || undefined,
+				},
+			} ),
+		} );
+	}
+
+	return (
+		<FontWeightControl
+			className="block-editor-hooks-font-weight-control"
+			value={ fontWeight }
+			onChange={ onChange }
+		/>
+	);
+}
+
+/**
+ * Custom hook that checks if font-family functionality is disabled.
+ *
+ * @param {string} name The name of the block.
+ * @return {boolean} Whether setting is disabled.
+ */
+export function useIsFontWeightDisabled( { name } ) {
+	return (
+		useSelect( ( select ) => {
+			const editorSettings = select( 'core/block-editor' ).getSettings();
+			return !! editorSettings.__experimentalGlobalStylesBase?.global
+				.features?.typography?.fontWeight;
+		} ) || ! hasBlockSupport( name, FONT_WEIGHT_SUPPORT_KEY )
+	);
+}

--- a/packages/block-editor/src/hooks/font-weight.js
+++ b/packages/block-editor/src/hooks/font-weight.js
@@ -1,42 +1,16 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { hasBlockSupport } from '@wordpress/blocks';
-import { useSelect } from '@wordpress/data';
-import { SelectControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import { cleanEmptyObject } from './utils';
+import FontWeightControl from '../components/font-weight';
+import useEditorFeature from '../components/use-editor-feature';
 
 export const FONT_WEIGHT_SUPPORT_KEY = '__experimentalFontWeight';
-
-const FONT_WEIGHT_OPTIONS = [
-	{ value: '', label: __( 'Default' ) },
-	{ value: 'normal', label: __( 'Normal' ) },
-	{ value: 'bold', label: __( 'Bold' ) },
-	{ value: 'lighter', label: __( 'Lighter' ) },
-	{ value: 'bolder', label: __( 'Bolder' ) },
-	...[ ...Array( 9 ).keys() ]
-		.map( ( i ) => ( i + 1 ) * 100 )
-		.map( ( weight ) => ( { value: weight, label: weight } ) ),
-	{ value: 'initial', label: __( 'Initial' ) },
-	{ value: 'inherit', label: __( 'Inherit' ) },
-];
-
-function FontWeightControl( { value = '', onChange, ...props } ) {
-	return (
-		<SelectControl
-			label={ __( 'Font weight' ) }
-			options={ FONT_WEIGHT_OPTIONS }
-			value={ value }
-			onChange={ onChange }
-			{ ...props }
-		/>
-	);
-}
 
 export function FontWeightEdit( {
 	name,
@@ -80,10 +54,7 @@ export function FontWeightEdit( {
  */
 export function useIsFontWeightDisabled( { name } ) {
 	return (
-		useSelect( ( select ) => {
-			const editorSettings = select( 'core/block-editor' ).getSettings();
-			return !! editorSettings.__experimentalGlobalStylesBase?.global
-				.features?.typography?.fontWeight;
-		} ) || ! hasBlockSupport( name, FONT_WEIGHT_SUPPORT_KEY )
+		! useEditorFeature( 'typography.fontWeight' ) ||
+		! hasBlockSupport( name, FONT_WEIGHT_SUPPORT_KEY )
 	);
 }

--- a/packages/block-editor/src/hooks/font-weight.scss
+++ b/packages/block-editor/src/hooks/font-weight.scss
@@ -1,0 +1,3 @@
+.block-editor-hooks-font-weight-control.components-select-control {
+	display: block;
+}

--- a/packages/block-editor/src/hooks/typography.js
+++ b/packages/block-editor/src/hooks/typography.js
@@ -31,12 +31,18 @@ import {
 	TEXT_TRANSFORM_SUPPORT_KEY,
 	useIsTextTransformDisabled,
 } from './text-transform';
+import {
+	FONT_WEIGHT_SUPPORT_KEY,
+	FontWeightEdit,
+	useIsFontWeightDisabled,
+} from './font-weight';
 
 export const TYPOGRAPHY_SUPPORT_KEYS = [
 	LINE_HEIGHT_SUPPORT_KEY,
 	FONT_SIZE_SUPPORT_KEY,
 	FONT_FAMILY_SUPPORT_KEY,
 	TEXT_TRANSFORM_SUPPORT_KEY,
+	FONT_WEIGHT_SUPPORT_KEY,
 ];
 
 export function TypographyPanel( props ) {
@@ -49,6 +55,7 @@ export function TypographyPanel( props ) {
 		<InspectorControls>
 			<PanelBody title={ __( 'Typography' ) }>
 				<FontFamilyEdit { ...props } />
+				<FontWeightEdit { ...props } />
 				<FontSizeEdit { ...props } />
 				<LineHeightEdit { ...props } />
 				<TextDecorationAndTransformEdit { ...props } />
@@ -72,6 +79,7 @@ function useIsTypographyDisabled( props = {} ) {
 		useIsLineHeightDisabled( props ),
 		useIsFontFamilyDisabled( props ),
 		useIsTextTransformDisabled( props ),
+		useIsFontWeightDisabled( props ),
 	];
 
 	return configs.filter( Boolean ).length === configs.length;

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -51,6 +51,7 @@
 @import "./components/warning/style.scss";
 @import "./components/writing-flow/style.scss";
 @import "./hooks/anchor.scss";
+@import "./hooks/font-weight.scss";
 
 // This tag marks the end of the styles that apply to editing canvas contents and need to be manipulated when we resize the editor.
 #end-resizable-editor-section {

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -55,6 +55,7 @@
 			"textColor": true,
 			"backgroundColor": true
 		},
-		"__experimentalFontFamily": true
+		"__experimentalFontFamily": true,
+		"__experimentalFontWeight": true
 	}
 }

--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -36,6 +36,7 @@
 		"fontSize": true,
 		"lineHeight": true,
 		"__experimentalSelector": "p",
-		"__unstablePasteTextInline": true
+		"__unstablePasteTextInline": true,
+		"__experimentalFontWeight": true
 	}
 }

--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -36,6 +36,7 @@
 		"fontSize": true,
 		"lineHeight": true,
 		"__experimentalFontFamily": true,
+		"__experimentalFontWeight": true,
 		"__experimentalSelector": {
 			"core/post-title/h1": "h1",
 			"core/post-title/h2": "h2",

--- a/packages/block-library/src/site-tagline/block.json
+++ b/packages/block-library/src/site-tagline/block.json
@@ -14,6 +14,7 @@
 		},
 		"fontSize": true,
 		"lineHeight": true,
-		"__experimentalFontFamily": true
+		"__experimentalFontFamily": true,
+		"__experimentalFontWeight": true
 	}
 }

--- a/packages/block-library/src/site-title/block.json
+++ b/packages/block-library/src/site-title/block.json
@@ -18,6 +18,7 @@
 		},
 		"fontSize": true,
 		"lineHeight": true,
-		"__experimentalFontFamily": true
+		"__experimentalFontFamily": true,
+		"__experimentalFontWeight": true
 	}
 }

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -25,4 +25,5 @@ export const __EXPERIMENTAL_STYLE_PROPERTY = {
 	paddingRight: [ 'spacing', 'padding', 'right' ],
 	paddingTop: [ 'spacing', 'padding', 'top' ],
 	fontFamily: [ 'typography', 'fontFamily' ],
+	fontWeight: [ 'typography', 'fontWeight' ],
 };

--- a/packages/edit-site/src/components/sidebar/typography-panel.js
+++ b/packages/edit-site/src/components/sidebar/typography-panel.js
@@ -4,6 +4,7 @@
 import {
 	LineHeightControl,
 	__experimentalFontFamilyControl as FontFamilyControl,
+	__experimentalFontWeightControl as FontWeightControl,
 } from '@wordpress/block-editor';
 import { PanelBody, FontSizePicker } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -13,8 +14,19 @@ import { __ } from '@wordpress/i18n';
  */
 import { useEditorFeature } from '../editor/utils';
 
-export function useHasTypographyPanel( { supports } ) {
-	return supports.includes( 'fontSize' ) || supports.includes( 'lineHeight' );
+function useHasFontWeight( { supports, name } ) {
+	return (
+		useEditorFeature( 'typography.fontWeight', name ) &&
+		supports.includes( 'fontWeight' )
+	);
+}
+
+export function useHasTypographyPanel( { supports, name } ) {
+	return (
+		useHasFontWeight( { supports, name } ) ||
+		supports.includes( 'fontSize' ) ||
+		supports.includes( 'lineHeight' )
+	);
 }
 
 export default function TypographyPanel( {
@@ -28,6 +40,7 @@ export default function TypographyPanel( {
 		name
 	);
 	const fontFamilies = useEditorFeature( 'typography.fontFamilies', name );
+	const hasFontWeightEnabled = useHasFontWeight( { supports, name } );
 
 	return (
 		<PanelBody title={ __( 'Typography' ) } initialOpen={ true }>
@@ -36,6 +49,14 @@ export default function TypographyPanel( {
 					value={ getStyleProperty( name, 'fontFamily' ) }
 					onChange={ ( value ) =>
 						setStyleProperty( name, 'fontFamily', value )
+					}
+				/>
+			) }
+			{ hasFontWeightEnabled && (
+				<FontWeightControl
+					value={ getStyleProperty( name, 'fontWeight' ) }
+					onChange={ ( value ) =>
+						setStyleProperty( name, 'fontWeight', value )
 					}
 				/>
 			) }


### PR DESCRIPTION
This PR adds a font-weight picking mechanism.

The mechanism is very simple and allows to use all valid CSS values for font-weight. Themes can disable font-weight picking via theme.json or set default values there.

Question: Should themes be able to restrict what font weights are available? If yes, should the restriction be dependent on a font family?


## Screenshots <!-- if applicable -->

![image](https://user-images.githubusercontent.com/11271197/91875112-f475a900-ec72-11ea-93dc-a9de72916f4e.png)

![image](https://user-images.githubusercontent.com/11271197/91875132-f93a5d00-ec72-11ea-9189-075e0cd05c5a.png)

