### PR TITLE
Try: Use route detection to set active state of links

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -55,7 +55,6 @@
 		"react-dates": "^17.1.1",
 		"react-merge-refs": "^1.0.0",
 		"react-resize-aware": "^3.0.1",
-		"react-router-dom": "^5.1.2",
 		"react-spring": "^8.0.20",
 		"react-use-gesture": "^7.0.15",
 		"reakit": "^1.1.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -55,6 +55,7 @@
 		"react-dates": "^17.1.1",
 		"react-merge-refs": "^1.0.0",
 		"react-resize-aware": "^3.0.1",
+		"react-router-dom": "^5.1.2",
 		"react-spring": "^8.0.20",
 		"react-use-gesture": "^7.0.15",
 		"reakit": "^1.1.0",

--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -17,8 +17,9 @@ import { Root } from './styles/navigation-styles';
 import Button from '../button';
 import { isMatchingUrl, addHistoryListener } from './utils';
 
-const Navigation = ( { activeItemId, children, data, rootTitle } ) => {
+const Navigation = ( { children, data, rootTitle } ) => {
 	const [ activeLevelId, setActiveLevelId ] = useState( 'root' );
+	const [ activeItem, setActiveItem ] = useState( null );
 	const [ location, setLocation ] = useState( window.location );
 
 	useEffect( () => {
@@ -53,20 +54,19 @@ const Navigation = ( { activeItemId, children, data, rootTitle } ) => {
 				parentItem.children.push( item );
 				parentItem.hasChildren = true;
 			}
+			if ( item.isActive ) {
+				setActiveItem( item );
+			}
 		} );
-
-		// @todo Store active Item ID so we can retrieve below.
 
 		return items;
 	};
 
 	const items = useMemo( () => mapItems( data ), [
-		activeItemId,
 		data,
 		location,
 		rootTitle,
 	] );
-	const activeItem = items.get( activeItemId );
 	const previousActiveLevelId = usePrevious( activeLevelId );
 	const level = items.get( activeLevelId );
 	const parentLevel = level && items.get( level.parent );

--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { matchPath, useLocation } from 'react-router-dom';
 
 /**
  * WordPress dependencies
@@ -18,13 +19,20 @@ import Button from '../button';
 
 const Navigation = ( { activeItemId, children, data, rootTitle } ) => {
 	const [ activeLevelId, setActiveLevelId ] = useState( 'root' );
+	const location = useLocation();
 
 	const appendItemData = ( item ) => {
+		const match = matchPath( location, {
+			path: item.href,
+			exact: true,
+			strict: false,
+		} );
+
 		return {
 			...item,
 			children: [],
 			parent: item.id === 'root' ? null : item.parent || 'root',
-			isActive: item.id === activeItemId,
+			isActive: !! match,
 			setActiveLevelId,
 		};
 	};
@@ -45,12 +53,15 @@ const Navigation = ( { activeItemId, children, data, rootTitle } ) => {
 			}
 		} );
 
+		// @todo Store active Item ID so we can retrieve below.
+
 		return items;
 	};
 
 	const items = useMemo( () => mapItems( data ), [
-		data,
 		activeItemId,
+		data,
+		location,
 		rootTitle,
 	] );
 	const activeItem = items.get( activeItemId );

--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { matchPath, useLocation } from 'react-router-dom';
 
 /**
  * WordPress dependencies
@@ -16,23 +15,26 @@ import { usePrevious } from '@wordpress/compose';
 import Animate from '../animate';
 import { Root } from './styles/navigation-styles';
 import Button from '../button';
+import { isMatchingUrl, addHistoryListener } from './utils';
 
 const Navigation = ( { activeItemId, children, data, rootTitle } ) => {
 	const [ activeLevelId, setActiveLevelId ] = useState( 'root' );
-	const location = useLocation();
+	const [ location, setLocation ] = useState( window.location );
 
-	const appendItemData = ( item ) => {
-		const match = matchPath( location, {
-			path: item.href,
-			exact: true,
-			strict: false,
+	useEffect( () => {
+		const removeListener = addHistoryListener( () => {
+			setTimeout( () => setLocation( { ...window.location } ), 1 );
 		} );
 
+		return removeListener;
+	}, [] );
+
+	const appendItemData = ( item ) => {
 		return {
 			...item,
 			children: [],
 			parent: item.id === 'root' ? null : item.parent || 'root',
-			isActive: !! match,
+			isActive: isMatchingUrl( location, item.href, true ),
 			setActiveLevelId,
 		};
 	};

--- a/packages/components/src/navigation/menu-item.js
+++ b/packages/components/src/navigation/menu-item.js
@@ -33,7 +33,7 @@ const NavigationMenuItem = ( props ) => {
 		'is-active': isActive,
 	} );
 
-	const handleClick = () => {
+	const handleClick = ( event ) => {
 		if ( children.length ) {
 			setActiveLevelId( id );
 			return;
@@ -41,7 +41,7 @@ const NavigationMenuItem = ( props ) => {
 		if ( ! onClick ) {
 			return;
 		}
-		onClick( props );
+		onClick( event, props );
 	};
 
 	const LinkComponentTag = LinkComponent ? LinkComponent : Button;

--- a/packages/components/src/navigation/stories/index.js
+++ b/packages/components/src/navigation/stories/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { Button } from '@wordpress/components';
-import { useState } from '@wordpress/element';
 import { Icon, arrowLeft } from '@wordpress/icons';
 
 /**
@@ -24,14 +23,25 @@ const CustomRouterLink = ( { children, onClick } ) => {
 	return <Button onClick={ onClick }>{ children }</Button>;
 };
 
+// This is a custom click handler to mimic a page change,
+// but this would typically be handle by the router.
+const onClick = ( e, props ) => {
+	e.preventDefault();
+	window.history.pushState( {}, null, props.href );
+};
+
 const data = [
 	{
 		title: 'Item 1',
 		id: 'item-1',
+		href: '#item-1',
+		onClick,
 	},
 	{
 		title: 'Item 2',
 		id: 'item-2',
+		href: '#item-2',
+		onClick,
 	},
 	{
 		title: 'Category',
@@ -43,26 +53,36 @@ const data = [
 		id: 'child-1',
 		parent: 'item-3',
 		badge: '1',
+		href: '#child-1',
+		onClick,
 	},
 	{
 		title: 'Child 2',
 		id: 'child-2',
 		parent: 'item-3',
+		href: '#child-2',
+		onClick,
 	},
 	{
 		title: 'Nested Category',
 		id: 'child-3',
 		parent: 'item-3',
+		href: '#child-3',
+		onClick,
 	},
 	{
 		title: 'Sub Child 1',
 		id: 'sub-child-1',
 		parent: 'child-3',
+		href: '#sub-child-1',
+		onClick,
 	},
 	{
 		title: 'Sub Child 2',
 		id: 'sub-child-2',
 		parent: 'child-3',
+		href: '#sub-child-2',
+		onClick,
 	},
 	{
 		title: 'External link',
@@ -76,23 +96,25 @@ const data = [
 		title: 'Internal link',
 		id: 'item-5',
 		LinkComponent: CustomRouterLink,
+		href: '#internal',
+		onClick,
 	},
 ];
 
 function Example() {
-	const [ active, setActive ] = useState( 'item-1' );
-
 	return (
 		<>
-			{ active !== 'child-2' ? (
+			{ window.location.pathname !== '/child-2' ? (
 				<Button
 					style={ { position: 'absolute', bottom: 0 } }
-					onClick={ () => setActive( 'child-2' ) }
+					onClick={ () =>
+						window.history.pushState( {}, null, '#child-2' )
+					}
 				>
 					Non-navigation link to Child 2
 				</Button>
 			) : null }
-			<Navigation activeItemId={ active } data={ data } rootTitle="Home">
+			<Navigation data={ data } rootTitle="Home">
 				{ ( { level, parentLevel, NavigationBackButton } ) => {
 					return (
 						<>
@@ -109,14 +131,6 @@ function Example() {
 										<NavigationMenuItem
 											{ ...item }
 											key={ item.id }
-											onClick={
-												! item.href
-													? ( selected ) =>
-															setActive(
-																selected.id
-															)
-													: null
-											}
 										/>
 									);
 								} ) }

--- a/packages/components/src/navigation/utils.js
+++ b/packages/components/src/navigation/utils.js
@@ -1,0 +1,101 @@
+/**
+ * Get the params from a location as a key/value pair object.
+ *
+ * @param {Object} location Window location
+ * @return {Object} Params
+ */
+const getParams = ( location ) => {
+	const params = {};
+	if ( location.search ) {
+		location.search.substr( 1 ).split`&`.forEach( ( item ) => {
+			const [ key, value ] = item.split( '=' );
+			params[ key ] = decodeURIComponent( value );
+		} );
+	}
+	return params;
+};
+
+/**
+ * Get the full URL if a relative path is passed.
+ *
+ * @param {string} url URL
+ * @return {string} Full URL
+ */
+const getFullUrl = ( url ) => {
+	const { origin, pathname, search } = window.location;
+
+	if ( url.indexOf( '#' ) === 0 ) {
+		return origin + pathname + search + url;
+	}
+
+	if ( url.indexOf( 'http' ) === 0 ) {
+		return url;
+	}
+
+	return origin + url;
+};
+
+/**
+ * Check to see if a URL matches a given window location.
+ *
+ * @param {Object} location Window location
+ * @param {string} url URL to compare
+ * @param {boolean} exact Exact match or loose matching with search args
+ * @return {boolean} Matching or not
+ */
+export const isMatchingUrl = ( location, url, exact ) => {
+	if ( ! url ) {
+		return;
+	}
+
+	const fullUrl = getFullUrl( url );
+	const domain = new URL( fullUrl ).origin;
+	const isHash = url.indexOf( '#' ) === 0;
+	const { hash, pathname, search } = location;
+	const { origin } = window.location;
+
+	if ( exact || isHash ) {
+		return origin + pathname + search + hash === fullUrl;
+	}
+
+	const urlParams = getParams( location );
+	const locationParams = getParams( window.location );
+	let hasMatchingParams = true;
+
+	Object.keys( urlParams ).forEach( ( key ) => {
+		if ( urlParams[ key ] !== locationParams[ key ] ) {
+			hasMatchingParams = false;
+		}
+	} );
+
+	return origin === domain && hasMatchingParams;
+};
+
+/**
+ * Adds a listener that runs on history change.
+ *
+ * @param {Function} listener Listener to add on history change.
+ * @return {Function} Function to remove listeners.
+ */
+export const addHistoryListener = ( listener ) => {
+	// Monkey path pushState to allow trigger the pushstate event listener.
+	( ( history ) => {
+		const pushState = history.pushState;
+		history.pushState = function ( state ) {
+			/* global CustomEvent */
+			const pushStateEvent = new CustomEvent( 'pushstate', {
+				state,
+			} );
+			window.dispatchEvent( pushStateEvent );
+			return pushState.apply( history, arguments );
+		};
+	} )( window.history );
+
+	window.addEventListener( 'popstate', listener );
+	window.addEventListener( 'pushstate', listener );
+
+	return () => {
+		window.removeEventListener( 'popstate', listener );
+		window.removeEventListener( 'pushstate', listener );
+	};
+};


### PR DESCRIPTION
## Description

This is an attempt to set the active state based on the current route.  It works by watching history changes and updating the active link based on routes that match.

If we go this route, there's probably some follow-ups needed:
* Allowing exact/non-exact matching URLs (just need a prop for this).
* Allowing a consumer to directly override with `isActive` on an item.
* Testing for new utils

## Testing
1. Run `npm run storybook:dev`.
1. Go to the "Navigation" component.
1. Check that navigating through the links works as expected.
1. Use back/forward in your browser
1. Optionally, navigate to `http://localhost:50240/iframe.html?id=components-navigation--default&viewMode=story` (to avoid the constraints of the iframe in storybook).
1. Manually manipulate the history in your console.  E.g., `history.pushState({fdsfds: 'bfdssla'}, 'New Title', '#item-1');` and note the active item is updated.