### PR TITLE
Update nav styles to match core designs

### DIFF
--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -14,8 +14,7 @@ import { usePrevious } from '@wordpress/compose';
  * Internal dependencies
  */
 import Animate from '../animate';
-import { Root } from './styles/navigation-styles';
-import Button from '../button';
+import { BackButtonUi, Root } from './styles/navigation-styles';
 
 const Navigation = ( { activeItemId, children, data, rootTitle } ) => {
 	const [ activeLevelId, setActiveLevelId ] = useState( 'root' );
@@ -82,14 +81,14 @@ const Navigation = ( { activeItemId, children, data, rootTitle } ) => {
 		}
 
 		return (
-			<Button
+			<BackButtonUi
 				className="components-navigation__back-button"
 				isTertiary
 				onClick={ () => setActiveLevelId( parentLevel.id ) }
 			>
 				<Icon icon={ chevronLeft } />
 				{ backButtonChildren }
-			</Button>
+			</BackButtonUi>
 		);
 	};
 

--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -14,7 +14,7 @@ import { usePrevious } from '@wordpress/compose';
  * Internal dependencies
  */
 import Animate from '../animate';
-import { BackButtonUi, Root } from './styles/navigation-styles';
+import { BackButtonUI, Root } from './styles/navigation-styles';
 
 const Navigation = ( { activeItemId, children, data, rootTitle } ) => {
 	const [ activeLevelId, setActiveLevelId ] = useState( 'root' );
@@ -81,14 +81,14 @@ const Navigation = ( { activeItemId, children, data, rootTitle } ) => {
 		}
 
 		return (
-			<BackButtonUi
+			<BackButtonUI
 				className="components-navigation__back-button"
 				isTertiary
 				onClick={ () => setActiveLevelId( parentLevel.id ) }
 			>
 				<Icon icon={ chevronLeft } />
 				{ backButtonChildren }
-			</BackButtonUi>
+			</BackButtonUI>
 		);
 	};
 

--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -6,6 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
+import { Icon, chevronLeft } from '@wordpress/icons';
 import { useEffect, useMemo, useState, useRef } from '@wordpress/element';
 import { usePrevious } from '@wordpress/compose';
 
@@ -83,9 +84,10 @@ const Navigation = ( { activeItemId, children, data, rootTitle } ) => {
 		return (
 			<Button
 				className="components-navigation__back-button"
-				isPrimary
+				isTertiary
 				onClick={ () => setActiveLevelId( parentLevel.id ) }
 			>
+				<Icon icon={ chevronLeft } />
 				{ backButtonChildren }
 			</Button>
 		);

--- a/packages/components/src/navigation/menu-item.js
+++ b/packages/components/src/navigation/menu-item.js
@@ -12,8 +12,11 @@ import { Icon, chevronRight } from '@wordpress/icons';
  * Internal dependencies
  */
 import Button from '../button';
-import { MenuItemUI, BadgeUI } from './styles/navigation-styles';
-import Text from '../text';
+import {
+	MenuItemUI,
+	MenuItemTitleUI,
+	BadgeUI,
+} from './styles/navigation-styles';
 
 const NavigationMenuItem = ( props ) => {
 	const {
@@ -54,13 +57,13 @@ const NavigationMenuItem = ( props ) => {
 				onClick={ handleClick }
 				{ ...linkProps }
 			>
-				<Text
+				<MenuItemTitleUI
 					className="components-navigation__menu-item-title"
 					variant="body.small"
 					as="span"
 				>
 					{ title }
-				</Text>
+				</MenuItemTitleUI>
 				{ badge && (
 					<BadgeUI className="components-navigation__menu-item-badge">
 						{ badge }

--- a/packages/components/src/navigation/menu.js
+++ b/packages/components/src/navigation/menu.js
@@ -4,6 +4,10 @@
 import { MenuUI, MenuTitleUI } from './styles/navigation-styles';
 
 const NavigationMenu = ( { children, title } ) => {
+	if ( ! children.length ) {
+		return null;
+	}
+
 	return (
 		<MenuUI className="components-navigation__menu">
 			{ title && (

--- a/packages/components/src/navigation/menu.js
+++ b/packages/components/src/navigation/menu.js
@@ -1,11 +1,21 @@
 /**
  * Internal dependencies
  */
-import { MenuUI } from './styles/navigation-styles';
+import { MenuUI, MenuTitleUI } from './styles/navigation-styles';
 
-const NavigationMenu = ( { children } ) => {
+const NavigationMenu = ( { children, title } ) => {
 	return (
-		<MenuUI className="components-navigation__menu">{ children }</MenuUI>
+		<MenuUI className="components-navigation__menu">
+			{ title && (
+				<MenuTitleUI
+					variant="subtitle"
+					className="components-navigation__menu-title"
+				>
+					{ title }
+				</MenuTitleUI>
+			) }
+			<ul>{ children }</ul>
+		</MenuUI>
 	);
 };
 

--- a/packages/components/src/navigation/stories/index.js
+++ b/packages/components/src/navigation/stories/index.js
@@ -3,7 +3,11 @@
  */
 import { Button } from '@wordpress/components';
 import { useState } from '@wordpress/element';
-import { Icon, arrowLeft } from '@wordpress/icons';
+
+/**
+ * External dependencies
+ */
+import styled from '@emotion/styled';
 
 /**
  * Internal dependencies
@@ -92,42 +96,51 @@ function Example() {
 					Non-navigation link to Child 2
 				</Button>
 			) : null }
-			<Navigation activeItemId={ active } data={ data } rootTitle="Home">
-				{ ( { level, parentLevel, NavigationBackButton } ) => {
-					return (
-						<>
-							{ parentLevel && (
-								<NavigationBackButton>
-									<Icon icon={ arrowLeft } />
-									{ parentLevel.title }
-								</NavigationBackButton>
-							) }
-							<h1>{ level.title }</h1>
-							<NavigationMenu>
-								{ level.children.map( ( item ) => {
-									return (
-										<NavigationMenuItem
-											{ ...item }
-											key={ item.id }
-											onClick={
-												! item.href
-													? ( selected ) =>
-															setActive(
-																selected.id
-															)
-													: null
-											}
-										/>
-									);
-								} ) }
-							</NavigationMenu>
-						</>
-					);
-				} }
-			</Navigation>
+			<Container>
+				<Navigation
+					activeItemId={ active }
+					data={ data }
+					rootTitle="Home"
+				>
+					{ ( { level, parentLevel, NavigationBackButton } ) => {
+						return (
+							<>
+								{ parentLevel && (
+									<NavigationBackButton>
+										{ parentLevel.title }
+									</NavigationBackButton>
+								) }
+								<h1>{ level.title }</h1>
+								<NavigationMenu>
+									{ level.children.map( ( item ) => {
+										return (
+											<NavigationMenuItem
+												{ ...item }
+												key={ item.id }
+												onClick={
+													! item.href
+														? ( selected ) =>
+																setActive(
+																	selected.id
+																)
+														: null
+												}
+											/>
+										);
+									} ) }
+								</NavigationMenu>
+							</>
+						);
+					} }
+				</Navigation>
+			</Container>
 		</>
 	);
 }
+
+const Container = styled.div`
+	max-width: 246px;
+`;
 
 export const _default = () => {
 	return <Example />;

--- a/packages/components/src/navigation/stories/index.js
+++ b/packages/components/src/navigation/stories/index.js
@@ -81,10 +81,42 @@ const data = [
 		id: 'item-5',
 		LinkComponent: CustomRouterLink,
 	},
+	{
+		title: 'Secondary Item 1',
+		id: 'secondary-item-1',
+		isSecondary: true,
+	},
+	{
+		title: 'Secondary Item 2',
+		id: 'secondary-item-2',
+		isSecondary: true,
+	},
+	{
+		title: 'Secondary Child 1',
+		id: 'secondary-child-1',
+		parent: 'secondary-item-1',
+		isSecondary: true,
+	},
+	{
+		title: 'Secondary Child 2',
+		id: 'secondary-child-2',
+		parent: 'secondary-item-1',
+		isSecondary: true,
+	},
 ];
 
 function Example() {
 	const [ active, setActive ] = useState( 'item-1' );
+
+	const renderMenuItem = ( item ) => (
+		<NavigationMenuItem
+			{ ...item }
+			key={ item.id }
+			onClick={
+				! item.href ? ( selected ) => setActive( selected.id ) : null
+			}
+		/>
+	);
 
 	return (
 		<>
@@ -111,22 +143,26 @@ function Example() {
 									</NavigationBackButton>
 								) }
 								<NavigationMenu title={ level.title }>
-									{ level.children.map( ( item ) => {
-										return (
-											<NavigationMenuItem
-												{ ...item }
-												key={ item.id }
-												onClick={
-													! item.href
-														? ( selected ) =>
-																setActive(
-																	selected.id
-																)
-														: null
-												}
-											/>
-										);
-									} ) }
+									{ level.children
+										.filter(
+											( item ) => ! item.isSecondary
+										)
+										.map( ( item ) =>
+											renderMenuItem( item )
+										) }
+								</NavigationMenu>
+								<NavigationMenu
+									title={
+										level.id === 'root'
+											? 'Secondary Menu'
+											: level.title
+									}
+								>
+									{ level.children
+										.filter( ( item ) => item.isSecondary )
+										.map( ( item ) =>
+											renderMenuItem( item )
+										) }
 								</NavigationMenu>
 							</>
 						);

--- a/packages/components/src/navigation/stories/index.js
+++ b/packages/components/src/navigation/stories/index.js
@@ -110,8 +110,7 @@ function Example() {
 										{ parentLevel.title }
 									</NavigationBackButton>
 								) }
-								<h1>{ level.title }</h1>
-								<NavigationMenu title="Menu">
+								<NavigationMenu title={ level.title }>
 									{ level.children.map( ( item ) => {
 										return (
 											<NavigationMenuItem

--- a/packages/components/src/navigation/stories/index.js
+++ b/packages/components/src/navigation/stories/index.js
@@ -111,7 +111,7 @@ function Example() {
 									</NavigationBackButton>
 								) }
 								<h1>{ level.title }</h1>
-								<NavigationMenu>
+								<NavigationMenu title="Menu">
 									{ level.children.map( ( item ) => {
 										return (
 											<NavigationMenuItem

--- a/packages/components/src/navigation/styles/navigation-styles.js
+++ b/packages/components/src/navigation/styles/navigation-styles.js
@@ -13,15 +13,27 @@ export const Root = styled.div`
 	width: 100%;
 `;
 
-export const MenuUI = styled.ul`
-	padding: 0;
-	margin: 0 0 32px 0;
+export const MenuUI = styled.div`
+	margin-top: 24px;
 	display: flex;
 	flex-direction: column;
+	ul {
+		padding: 0;
+		margin: 0;
+		list-style: none;
+	}
+`;
+
+export const MenuTitleUI = styled( Text )`
+	padding: 4px 0 4px 16px;
+	margin-bottom: 8px;
 `;
 
 export const MenuItemUI = styled.li`
-	button {
+	button,
+	a {
+		padding-left: 16px;
+		padding-right: 16px;
 		width: 100%;
 	}
 	&.is-active {

--- a/packages/components/src/navigation/styles/navigation-styles.js
+++ b/packages/components/src/navigation/styles/navigation-styles.js
@@ -68,7 +68,7 @@ export const MenuItemUI = styled.li`
 	}
 `;
 
-export const BackButtonUi = styled( Button )`
+export const BackButtonUI = styled( Button )`
 	&.is-tertiary {
 		color: ${ G2.lightGray.ui };
 

--- a/packages/components/src/navigation/styles/navigation-styles.js
+++ b/packages/components/src/navigation/styles/navigation-styles.js
@@ -6,15 +6,21 @@ import styled from '@emotion/styled';
 /**
  * Internal dependencies
  */
-import { LIGHT_GRAY } from '../../utils/colors-values';
+import { BASE, G2 } from '../../utils/colors-values';
+import Button from '../../button';
 import Text from '../../text';
 
 export const Root = styled.div`
 	width: 100%;
+	background-color: ${ G2.darkGray.primary };
+	color: #f0f0f0;
+	padding: 8px;
+	overflow: hidden;
 `;
 
 export const MenuUI = styled.div`
 	margin-top: 24px;
+	margin-bottom: 24px;
 	display: flex;
 	flex-direction: column;
 	ul {
@@ -30,14 +36,51 @@ export const MenuTitleUI = styled( Text )`
 `;
 
 export const MenuItemUI = styled.li`
+	border-radius: 2px;
+	color: ${ G2.lightGray.ui };
+
 	button,
 	a {
 		padding-left: 16px;
 		padding-right: 16px;
 		width: 100%;
+		color: ${ G2.lightGray.ui };
+
+		&:hover,
+		&:focus:not( [aria-disabled='true'] ):active,
+		&:active:not( [aria-disabled='true'] ):active {
+			color: #ddd;
+		}
 	}
+
 	&.is-active {
-		background-color: ${ LIGHT_GRAY[ 300 ] };
+		background-color: ${ BASE.black };
+		color: ${ G2.lightGray.secondary };
+
+		button,
+		a {
+			color: ${ G2.lightGray.secondary };
+		}
+	}
+
+	svg path {
+		color: ${ G2.lightGray.ui };
+	}
+`;
+
+export const BackButtonUi = styled( Button )`
+	&.is-tertiary {
+		color: ${ G2.lightGray.ui };
+
+		&:hover:not( :disabled ) {
+			color: #ddd;
+			box-shadow: none;
+		}
+
+		&:active:not( :disabled ) {
+			background: transparent;
+			color: #ddd;
+		}
 	}
 `;
 

--- a/packages/components/src/navigation/styles/navigation-styles.js
+++ b/packages/components/src/navigation/styles/navigation-styles.js
@@ -7,6 +7,7 @@ import styled from '@emotion/styled';
  * Internal dependencies
  */
 import { LIGHT_GRAY } from '../../utils/colors-values';
+import Text from '../../text';
 
 export const Root = styled.div`
 	width: 100%;
@@ -23,9 +24,13 @@ export const MenuItemUI = styled.li`
 	button {
 		width: 100%;
 	}
-	&.is-active span {
-		border-bottom: 2px solid var( --wp-admin-theme-color );
+	&.is-active {
+		background-color: ${ LIGHT_GRAY[ 300 ] };
 	}
+`;
+
+export const MenuItemTitleUI = styled( Text )`
+	margin-right: auto;
 `;
 
 export const BadgeUI = styled.span`
@@ -33,5 +38,4 @@ export const BadgeUI = styled.span`
 	display: inline-flex;
 	padding: 4px 12px;
 	border-radius: 2px;
-	background-color: ${ LIGHT_GRAY[ 300 ] };
 `;

--- a/packages/components/src/navigation/test/index.js
+++ b/packages/components/src/navigation/test/index.js
@@ -53,7 +53,7 @@ const renderPane = () => ( { level, NavigationBackButton } ) => {
 		<>
 			<h2>{ level.title }</h2>
 			<NavigationBackButton>Back</NavigationBackButton>
-			<NavigationMenu>
+			<NavigationMenu title="Menu title">
 				{ level.children.map( ( item ) => {
 					return <NavigationMenuItem { ...item } key={ item.id } />;
 				} ) }
@@ -152,6 +152,22 @@ describe( 'Navigation', () => {
 
 		const menuItem = screen.getByRole( 'listitem' );
 		expect( menuItem.textContent ).toBe( 'Item 1' + '21' );
+	} );
+
+	it( 'should render menu titles when items exist', async () => {
+		const { rerender } = render(
+			<Navigation data={ [] }>{ renderPane() }</Navigation>
+		);
+
+		const emptyMenu = screen.queryByText( 'Menu title' );
+		expect( emptyMenu ).toBeNull();
+
+		rerender(
+			<Navigation data={ sampleData }>{ renderPane() }</Navigation>
+		);
+
+		const menuTitle = screen.queryByText( 'Menu title' );
+		expect( menuTitle ).not.toBeNull();
 	} );
 
 	it( 'should navigate up a level when clicking the back button', async () => {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Related to https://github.com/woocommerce/navigation/pull/68 - this PR updates to the latest design exploration for the nav component ( https://www.figma.com/file/e4tLacmlPuZV47l7901FEs/WordPress-Design-Library?node-id=1456%3A72 ).

## Screenshots <!-- if applicable -->

<img width="306" alt="Screen Shot 2020-09-02 at 10 09 59 AM" src="https://user-images.githubusercontent.com/10561050/92013638-bbaf0000-ed56-11ea-8a1d-e79ae88791e3.png">


