### PR TITLE
Updating Versions in WordPress doc to include 5.5.1

### DIFF
--- a/docs/contributors/versions-in-wordpress.md
+++ b/docs/contributors/versions-in-wordpress.md
@@ -1,11 +1,12 @@
 # Versions in WordPress
 
-With each WordPress release cycle, various versions of Gutenberg are included. This has created confusion over time as people try to figure out how best to debug problems and report bugs appropriately. To make this easier for everyone to keep track of, this document serves as a canonical list of the Gutenberg versions integrated into each WordPress release. Of note, during the beta period for WordPress releases, additional bug fixes from later Gutenberg releases than those noted are cherry-picked into the WordPress release as necessary.
+With each major release of WordPress a new version of Gutenberg is included. This has caused confusion over time as people have tried to figure out how to best debug problems and report bugs appropriately. To make this easier we have made this document to serve as a canonical list of the Gutenberg versions integrated into each major WordPress release. Of note, during the beta period of a WordPress release, additional bug fixes from later Gutenberg releases than those noted are added into the WordPress release where it is needed.
 
 If anything looks incorrect here, please bring it up in #core-editor in [WordPress.org slack](https://make.wordpress.org/chat/).
 
 | Gutenberg Versions | WordPress Version |
 | ------------------ | ----------------- |
+| 7.6-8.5            | 5.5.1             |
 | 7.6-8.5            | 5.5               |
 | 6.6-7.5            | 5.4.2             |
 | 6.6-7.5            | 5.4.0             |


### PR DESCRIPTION
With 5.5.1 being released, this is just an update to take care of the newest release. I also included an update to the language in the intro post as proposed by @paaljoachim in https://github.com/WordPress/gutenberg/issues/23344#issuecomment-658620351.