### PR TITLE
Add block inspector virtual bubbling option

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -36,11 +36,7 @@ const BlockInspector = ( {
 		return (
 			<div className="block-editor-block-inspector">
 				<MultiSelectionInspector />
-				{ bubblesVirtually ? (
-					<InspectorControls.Slot bubblesVirtually />
-				) : (
-					<InspectorControls.Slot />
-				) }
+				<InspectorControls.Slot bubblesVirtually={ bubblesVirtually } />
 			</div>
 		);
 	}
@@ -84,11 +80,7 @@ const BlockInspector = ( {
 					</PanelBody>
 				</div>
 			) }
-			{ bubblesVirtually ? (
-				<InspectorControls.Slot bubblesVirtually />
-			) : (
-				<InspectorControls.Slot />
-			) }
+			<InspectorControls.Slot bubblesVirtually={ bubblesVirtually } />
 			<div>
 				<AdvancedControls
 					slotName={ InspectorAdvancedControls.slotName }
@@ -114,11 +106,9 @@ const AdvancedControls = ( { slotName, bubblesVirtually } ) => {
 			title={ __( 'Advanced' ) }
 			initialOpen={ false }
 		>
-			{ bubblesVirtually ? (
-				<InspectorAdvancedControls.Slot bubblesVirtually />
-			) : (
-				<InspectorAdvancedControls.Slot />
-			) }
+			<InspectorAdvancedControls.Slot
+				bubblesVirtually={ bubblesVirtually }
+			/>
 		</PanelBody>
 	);
 };

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -30,12 +30,17 @@ const BlockInspector = ( {
 	selectedBlockClientId,
 	selectedBlockName,
 	showNoBlockSelectedMessage = true,
+	bubblesVirtually = true,
 } ) => {
 	if ( count > 1 ) {
 		return (
 			<div className="block-editor-block-inspector">
 				<MultiSelectionInspector />
-				<InspectorControls.Slot bubblesVirtually />
+				{ bubblesVirtually ? (
+					<InspectorControls.Slot bubblesVirtually />
+				) : (
+					<InspectorControls.Slot />
+				) }
 			</div>
 		);
 	}
@@ -79,10 +84,15 @@ const BlockInspector = ( {
 					</PanelBody>
 				</div>
 			) }
-			<InspectorControls.Slot bubblesVirtually />
+			{ bubblesVirtually ? (
+				<InspectorControls.Slot bubblesVirtually />
+			) : (
+				<InspectorControls.Slot />
+			) }
 			<div>
 				<AdvancedControls
 					slotName={ InspectorAdvancedControls.slotName }
+					bubblesVirtually={ bubblesVirtually }
 				/>
 			</div>
 			<SkipToSelectedBlock key="back" />
@@ -90,7 +100,7 @@ const BlockInspector = ( {
 	);
 };
 
-const AdvancedControls = ( { slotName } ) => {
+const AdvancedControls = ( { slotName, bubblesVirtually } ) => {
 	const slot = useSlot( slotName );
 	const hasFills = Boolean( slot.fills && slot.fills.length );
 
@@ -104,7 +114,11 @@ const AdvancedControls = ( { slotName } ) => {
 			title={ __( 'Advanced' ) }
 			initialOpen={ false }
 		>
-			<InspectorAdvancedControls.Slot bubblesVirtually />
+			{ bubblesVirtually ? (
+				<InspectorAdvancedControls.Slot bubblesVirtually />
+			) : (
+				<InspectorAdvancedControls.Slot />
+			) }
 		</PanelBody>
 	);
 };

--- a/packages/edit-navigation/src/components/navigation-editor/block-editor-area.js
+++ b/packages/edit-navigation/src/components/navigation-editor/block-editor-area.js
@@ -110,7 +110,9 @@ export default function BlockEditorArea( {
 							label="Block inspector"
 						/>
 					) }
-					renderContent={ () => <BlockInspector /> }
+					renderContent={ () => (
+						<BlockInspector bubblesVirtually={ false } />
+					) }
 				/>
 			</CardHeader>
 			<CardBody>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

Fixes #24809 

The block inspector in the Navigation screen is inside a Dropdown, and its default `bubblesVirtually` causes Dropdown's `withFocusOutside` wrapper to not receive focus/blur events correctly. This PR adds a `bubblesVirtually` prop to `BlockInspector`, defaulting to `true`, so that it can be set to `false` whenever the inspector needs to be used inside a dropdown or popover.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Tested in browser, checked keyboard navigation follows the correct sequence.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
