### PR TITLE
Add/block variation picker component readme

### DIFF
--- a/packages/block-editor/src/components/block-variation-picker/README.md
+++ b/packages/block-editor/src/components/block-variation-picker/README.md
@@ -1,0 +1,50 @@
+# Block Variation Picker
+
+The `BlockVariationPicker` component allows to display for certain types of blocks their different variations, and to choose one of them.
+
+This component is currently used by the "Columns" block to display and choose the number and structure of columns. It is also used by the "Post Hierarchical Terms Block" block.
+
+![Columns block variations](https://make.wordpress.org/core/files/2020/09/colums-block-variations.png)
+
+## Table of contents
+
+1. [Development guidelines](#development-guidelines)
+2. [Related components](#related-components)
+
+## Development guidelines
+
+### Usage
+
+Renders the variations of a block.
+
+```jsx
+import { Button } from '@wordpress/components';
+
+const MyButton = () => <Button isSecondary>Click me!</Button>;
+```
+
+### Props
+
+#### icon
+
+The icons for each variation of the block.
+
+#### label
+
+The label of each variation of the block.
+
+-   Type: `String`
+
+#### instructions
+
+The instructions to choose a block variation.
+
+-   Type: `String`
+
+#### variations
+
+The different variations of the block.
+
+## Related components
+
+Block Editor components are components that can be used to compose the UI of your block editor. Thus, they can only be used under a [BlockEditorProvider](https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/provider/README.md) in the components tree. 

--- a/packages/block-editor/src/components/block-variation-picker/README.md
+++ b/packages/block-editor/src/components/block-variation-picker/README.md
@@ -18,7 +18,7 @@ This component is currently used by the "Columns" block to display and choose th
 Renders the variations of a block.
 
 ```jsx
-import { Button } from '@wordpress/components';
+import { BlockVariationPicker } from '@wordpress/block-editor';
 
 const MyBlockVariationPicker = () => (
 	<BlockVariationPicker

--- a/packages/block-editor/src/components/block-variation-picker/README.md
+++ b/packages/block-editor/src/components/block-variation-picker/README.md
@@ -29,10 +29,6 @@ const MyBlockVariationPicker = () => (
 
 ### Props
 
-#### icon
-
-The icons for each variation of the block.
-
 #### label
 
 The label of each variation of the block.
@@ -46,6 +42,8 @@ The instructions to choose a block variation.
 -   Type: `String`
 
 #### variations
+
+-   Type: `Array`
 
 The different variations of the block.
 

--- a/packages/block-editor/src/components/block-variation-picker/README.md
+++ b/packages/block-editor/src/components/block-variation-picker/README.md
@@ -20,7 +20,11 @@ Renders the variations of a block.
 ```jsx
 import { Button } from '@wordpress/components';
 
-const MyButton = () => <Button isSecondary>Click me!</Button>;
+const MyBlockVariationPicker = () => (
+	<BlockVariationPicker
+		variations={ variations }
+	/>
+);
 ```
 
 ### Props
@@ -47,4 +51,4 @@ The different variations of the block.
 
 ## Related components
 
-Block Editor components are components that can be used to compose the UI of your block editor. Thus, they can only be used under a [BlockEditorProvider](https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/provider/README.md) in the components tree. 
+Block Editor components are components that can be used to compose the UI of your block editor. Thus, they can only be used under a [BlockEditorProvider](https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/provider/README.md) in the components tree.


### PR DESCRIPTION
## Description
Added documentation for the block variations picker component (see #22891)

## How has this been tested?
N/A, documentation only

## Types of changes
Documentation

## Checklist:
- [n/a] My code is tested.
- [n/a] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [n/a] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
