### PR TITLE
Resolve Warning 2 : Fix Console error when trying to open the aspect-ratio tool for images

### DIFF
--- a/packages/block-library/src/image/image-editor.js
+++ b/packages/block-library/src/image/image-editor.js
@@ -45,7 +45,7 @@ function AspectGroup( { aspectRatios, isDisabled, label, onClick, value } ) {
 			{ aspectRatios.map( ( { title, aspect } ) => (
 				<MenuItem
 					key={ aspect }
-					isDisabled={ isDisabled }
+					disabled={ isDisabled }
 					onClick={ () => {
 						onClick( aspect );
 					} }


### PR DESCRIPTION
Fixed Issue: #24971 

## Description
I have changed the one invalid attribute of the component. Which was creating a console error.
Resolved 2nd warning from the issue.

## How has this been tested?
I have tested it by defining `define( 'SCRIPT_DEBUG', true );` in my wp-config.php and tested.

## Types of changes
Validate invalid property with the valid one.
It a non-breaking change to component.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
