### PR TITLE
Fix/block parent selector component readme

### DIFF
--- a/packages/block-editor/src/components/block-parent-selector/README.md
+++ b/packages/block-editor/src/components/block-parent-selector/README.md
@@ -21,7 +21,7 @@ In practice the BlockParentSelector component renders a <ToolbarButton /> compon
 Renders block parent selector icon in a <ToolbarButton /> component.
 
 ```jsx
-import { BlockParentSelector } from '@wordpress/components';
+import { BlockParentSelector } from '@wordpress/block-editor';
 
 const MyBlockParentSelector = () => (
 	<BlockParentSelector clientIds={ blockClientIds } />

--- a/packages/block-editor/src/components/block-parent-selector/README.md
+++ b/packages/block-editor/src/components/block-parent-selector/README.md
@@ -21,7 +21,7 @@ In practice the BlockParentSelector component renders a <ToolbarButton /> compon
 Renders block parent selector icon in a <ToolbarButton /> component.
 
 ```jsx
-import { Button } from '@wordpress/components';
+import { BlockParentSelector } from '@wordpress/components';
 
 const MyBlockParentSelector = () => (
 	<BlockParentSelector clientIds={ blockClientIds } />


### PR DESCRIPTION
## Description
This PR fixed a mistake introduced in https://github.com/WordPress/gutenberg/pull/24962 which has been merged earlier.
The imported component was `Button` instead of `BlockParentSelector`. And was imported from `@wordpress/components` instead of `@wordpress/block-editor`.

## How has this been tested?
N/A, documentation only

## Types of changes
Documentation

## Checklist:
- [n/a] My code is tested.
- [n/a] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [n/a] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
