### PR TITLE
Update block inspector component readme

### DIFF
--- a/packages/block-editor/src/components/block-inspector/README.md
+++ b/packages/block-editor/src/components/block-inspector/README.md
@@ -15,7 +15,7 @@ The Block inspector is one of the panels that is displayed in the editor; it is 
 Render the block inspector component.
 
 ```jsx
-import { BlockInspector } from '@wordpress/components';
+import { BlockInspector } from '@wordpress/block-editor';
 
 const MyBlockInspector = () => <BlockInspector />
 ```


### PR DESCRIPTION
## Description
This PR fixed a mistake introduced in https://github.com/WordPress/gutenberg/pull/24929  which has been merged earlier.
In the JSX code example, the component was imported from `@wordpress/components` instead of `@wordpress/block-editor`.

## How has this been tested?
N/A, documentation only

## Types of changes
Documentation

## Checklist:
- [n/a] My code is tested.
- [n/a] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [n/a] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
