### PR TITLE
api-fetch: simplify the code that executes the handlers

### DIFF
--- a/packages/api-fetch/src/index.js
+++ b/packages/api-fetch/src/index.js
@@ -132,24 +132,19 @@ function apiFetch( options ) {
 		return step( workingOptions, next );
 	};
 
-	return new Promise( ( resolve, reject ) => {
-		createRunStep( 0 )( options )
-			.then( resolve )
-			.catch( ( error ) => {
-				if ( error.code !== 'rest_cookie_invalid_nonce' ) {
-					return reject( error );
-				}
+	return createRunStep( 0 )( options ).catch( ( error ) => {
+		if ( error.code !== 'rest_cookie_invalid_nonce' ) {
+			return Promise.reject( error );
+		}
 
-				// If the nonce is invalid, refresh it and try again.
-				window
-					.fetch( apiFetch.nonceEndpoint )
-					.then( checkStatus )
-					.then( ( data ) => data.text() )
-					.then( ( text ) => {
-						apiFetch.nonceMiddleware.nonce = text;
-						apiFetch( options ).then( resolve ).catch( reject );
-					} )
-					.catch( reject );
+		// If the nonce is invalid, refresh it and try again.
+		return window
+			.fetch( apiFetch.nonceEndpoint )
+			.then( checkStatus )
+			.then( ( data ) => data.text() )
+			.then( ( text ) => {
+				apiFetch.nonceMiddleware.nonce = text;
+				return apiFetch( options );
 			} );
 	} );
 }

--- a/packages/api-fetch/src/index.js
+++ b/packages/api-fetch/src/index.js
@@ -120,19 +120,16 @@ function setFetchHandler( newFetchHandler ) {
 }
 
 function apiFetch( options ) {
-	const steps = [ ...middlewares, fetchHandler ];
+	// creates a nested function chain that calls all middlewares and finally the `fetchHandler`,
+	// converting `middlewares = [ m1, m2, m3 ]` into:
+	// ```
+	// opts1 => m1( opts1, opts2 => m2( opts2, opts3 => m3( opts3, fetchHandler ) ) );
+	// ```
+	const enhancedHandler = middlewares.reduceRight( ( next, middleware ) => {
+		return ( workingOptions ) => middleware( workingOptions, next );
+	}, fetchHandler );
 
-	const createRunStep = ( index ) => ( workingOptions ) => {
-		const step = steps[ index ];
-		if ( index === steps.length - 1 ) {
-			return step( workingOptions );
-		}
-
-		const next = createRunStep( index + 1 );
-		return step( workingOptions, next );
-	};
-
-	return createRunStep( 0 )( options ).catch( ( error ) => {
+	return enhancedHandler( options ).catch( ( error ) => {
 		if ( error.code !== 'rest_cookie_invalid_nonce' ) {
 			return Promise.reject( error );
 		}


### PR DESCRIPTION
This PR is a refactoring of the `apiFetch` function that leverages some JS language features to make the code simpler/smaller.

The first commit removes the `new Promise( resolve, reject )` wrapper and uses the `Promise` chaining rules properly. The behavior of the code is:
1. If the handler (`createRunStep[ 0 ]` or `enhancedHandler`) executes successfully, we return the resolved Promise right away.
2. If the handler fails and `error.code !== 'rest_cookie_invalid_nonce'`, we return the rejected Promise with that error unchanged.
3. In case of `rest_cookie_invalid_nonce`, we call the `apiFetch.nonceEndpoint` endpoint. If it fails in any way, the rejected Promise is returned from `apiFetch`.
4. If fetching the new nonce succeeds, we call `apiFetch` recursively again and return the Promise it returns, as is. (It's a case of tail recursion)

The second commits composes the `middleware` and `fetchHandler` functions using `reduceRight`. It's a perfect use case for that helper function.

**How to test:**
- verify that unit tests for `api-fetch` package continue to pass
- in a local environment, verify that `apiFetch` requests continue to work as before
