### PR TITLE
Fix unlinked padding controls JS error

### DIFF
--- a/packages/components/src/unit-control/index.js
+++ b/packages/components/src/unit-control/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
+import { noop, omit } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -172,7 +172,7 @@ function UnitControl(
 			<ValueInput
 				aria-label={ label }
 				type={ isPressEnterToChange ? 'text' : 'number' }
-				{ ...props }
+				{ ...omit( props, [ 'children' ] ) }
 				autoComplete={ autoComplete }
 				className={ classes }
 				disabled={ disabled }


### PR DESCRIPTION
It seems that the `styled` HoC can add extra empty `children` props? At last that's what my debugging suggests.
So I'm omitting this from spreading to children components.
This is one of the reasons I don't like prop spreading in UI components. We should probably move away from this at some point and be more specific about what props we allow.

**Testing instructions**

 - Check that you can "unlink" the padding controls when using the Cover block.