### PR TITLE
api-fetch: remove redundant next parameter from middleware calls

### DIFF
--- a/packages/api-fetch/src/middlewares/http-v1.js
+++ b/packages/api-fetch/src/middlewares/http-v1.js
@@ -40,7 +40,7 @@ function httpV1Middleware( options, next ) {
 		};
 	}
 
-	return next( options, next );
+	return next( options );
 }
 
 export default httpV1Middleware;

--- a/packages/api-fetch/src/middlewares/user-locale.js
+++ b/packages/api-fetch/src/middlewares/user-locale.js
@@ -18,7 +18,7 @@ function userLocaleMiddleware( options, next ) {
 		options.path = addQueryArgs( options.path, { _locale: 'user' } );
 	}
 
-	return next( options, next );
+	return next( options );
 }
 
 export default userLocaleMiddleware;


### PR DESCRIPTION
In the middleware API, the `next` function has only one parameter: `options`. The codebase has a few middlewares that call `next( options, next )`, where the second parameter is redundant (although completely harmless). This patch removes these.
