### PR TITLE
Add tags support in Query block

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -418,6 +418,23 @@ function gutenberg_render_block_with_assigned_block_context( $pre_render, $parse
 		}
 	}
 
+	if ( isset( $wp_query->tax_query->queried_terms['post_tag'] ) ) {
+		$context['query'] = array( 'tagIds' => array() );
+
+		foreach ( $wp_query->tax_query->queried_terms['post_tag']['terms'] as $tag_slug_or_id ) {
+			$tag_ID = $tag_slug_or_id;
+
+			if ( 'slug' === $wp_query->tax_query->queried_terms['post_tag']['field'] ) {
+				$tag = get_term_by( 'slug', $tag_slug_or_id, 'post_tag' );
+
+				if ( $tag ) {
+					$tag_ID = $tag->term_id;
+				}
+			}
+			$context['query']['tagIds'][] = $tag_ID;
+		}
+	}
+
 	/**
 	 * Filters the default context provided to a rendered block.
 	 *

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -419,7 +419,11 @@ function gutenberg_render_block_with_assigned_block_context( $pre_render, $parse
 	}
 
 	if ( isset( $wp_query->tax_query->queried_terms['post_tag'] ) ) {
-		$context['query'] = array( 'tagIds' => array() );
+		if ( isset( $context['query'] ) ) {
+			$context['query']['tagIds'] = array();
+		} else {
+			$context['query'] = array( 'tagIds' => array() );
+		}
 
 		foreach ( $wp_query->tax_query->queried_terms['post_tag']['terms'] as $tag_slug_or_id ) {
 			$tag_ID = $tag_slug_or_id;

--- a/packages/block-library/src/query-loop/edit.js
+++ b/packages/block-library/src/query-loop/edit.js
@@ -19,7 +19,14 @@ const TEMPLATE = [ [ 'core/post-title' ], [ 'core/post-content' ] ];
 export default function QueryLoopEdit( {
 	clientId,
 	context: {
-		query: { perPage, offset, categoryIds, order, orderBy } = {},
+		query: {
+			perPage,
+			offset,
+			categoryIds,
+			tagIds = [],
+			order,
+			orderBy,
+		} = {},
 		queryContext,
 	},
 } ) {
@@ -31,6 +38,7 @@ export default function QueryLoopEdit( {
 			const query = {
 				offset: perPage ? perPage * ( page - 1 ) + offset : 0,
 				categories: categoryIds,
+				tags: tagIds,
 				order,
 				orderby: orderBy,
 			};
@@ -46,7 +54,7 @@ export default function QueryLoopEdit( {
 				blocks: select( 'core/block-editor' ).getBlocks( clientId ),
 			};
 		},
-		[ perPage, page, offset, categoryIds, order, orderBy, clientId ]
+		[ perPage, page, offset, categoryIds, tagIds, order, orderBy, clientId ]
 	);
 
 	const blockContexts = useMemo(

--- a/packages/block-library/src/query-loop/index.php
+++ b/packages/block-library/src/query-loop/index.php
@@ -32,6 +32,9 @@ function render_block_core_query_loop( $attributes, $content, $block ) {
 		if ( isset( $block->context['query']['categoryIds'] ) ) {
 			$query['category__in'] = $block->context['query']['categoryIds'];
 		}
+		if ( isset( $block->context['query']['tagIds'] ) ) {
+			$query['tag__in'] = $block->context['query']['tagIds'];
+		}
 		if ( isset( $block->context['query']['order'] ) ) {
 			$query['order'] = strtoupper( $block->context['query']['order'] );
 		}
@@ -42,6 +45,7 @@ function render_block_core_query_loop( $attributes, $content, $block ) {
 			$query['posts_per_page'] = $block->context['query']['perPage'];
 		}
 	}
+
 	$posts = get_posts( $query );
 
 	$content = '';

--- a/packages/block-library/src/query/block.json
+++ b/packages/block-library/src/query/block.json
@@ -12,6 +12,7 @@
 				"pages": 1,
 				"offset": 0,
 				"categoryIds": [],
+				"tagIds": [],
 				"order": "desc",
 				"orderBy": "date"
 			}

--- a/packages/block-library/src/query/constants.js
+++ b/packages/block-library/src/query/constants.js
@@ -1,0 +1,5 @@
+export const MAX_FETCHED_TERMS = 100;
+
+export default {
+	MAX_FETCHED_TERMS,
+};

--- a/packages/block-library/src/query/edit/query-toolbar.js
+++ b/packages/block-library/src/query/edit/query-toolbar.js
@@ -15,7 +15,7 @@ import { postList } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import { getTaxonomyInfo } from '../utils';
+import { getTermsInfo } from '../utils';
 
 export default function QueryToolbar( { query, setQuery } ) {
 	const { categories, tags } = useSelect( ( select ) => {
@@ -23,10 +23,22 @@ export default function QueryToolbar( { query, setQuery } ) {
 		const _categories = getEntityRecords( 'taxonomy', 'category' );
 		const _tags = getEntityRecords( 'taxonomy', 'post_tag' );
 		return {
-			categories: getTaxonomyInfo( _categories ),
-			tags: getTaxonomyInfo( _tags ),
+			categories: getTermsInfo( _categories ),
+			tags: getTermsInfo( _tags ),
 		};
 	}, [] );
+
+	// Handles categories and tags changes.
+	const onTermsChange = ( terms, queryProperty ) => ( newTermNames ) => {
+		const termIds = newTermNames.map(
+			( name ) => terms.mapByName[ name ]?.id
+		);
+		if ( termIds.includes( undefined ) ) return;
+		setQuery( { [ queryProperty ]: termIds } );
+	};
+	const onCategoriesChange = onTermsChange( categories, 'categoryIds' );
+	const onTagsChange = onTermsChange( tags, 'tagIds' );
+
 	return (
 		<Toolbar>
 			<Dropdown
@@ -77,19 +89,8 @@ export default function QueryToolbar( { query, setQuery } ) {
 												.name,
 									} )
 								) }
-								suggestions={ categories.terms.map(
-									( { name } ) => name
-								) }
-								onChange={ ( newCategoryNames ) => {
-									const categoryIds = newCategoryNames.map(
-										( categoryName ) =>
-											categories.mapByName[ categoryName ]
-												?.id
-									);
-									if ( categoryIds.includes( undefined ) )
-										return;
-									setQuery( { categoryIds } );
-								} }
+								suggestions={ categories.names }
+								onChange={ onCategoriesChange }
 							/>
 						) }
 						{ tags?.terms && (
@@ -101,17 +102,8 @@ export default function QueryToolbar( { query, setQuery } ) {
 										value: tags.mapById[ tagId ].name,
 									} )
 								) }
-								suggestions={ tags.terms.map(
-									( { name } ) => name
-								) }
-								onChange={ ( newTagNames ) => {
-									const tagIds = newTagNames.map(
-										( tagName ) =>
-											tags.mapByName[ tagName ]?.id
-									);
-									if ( tagIds.includes( undefined ) ) return;
-									setQuery( { tagIds } );
-								} }
+								suggestions={ tags.names }
+								onChange={ onTagsChange }
 							/>
 						) }
 					</>

--- a/packages/block-library/src/query/edit/query-toolbar.js
+++ b/packages/block-library/src/query/edit/query-toolbar.js
@@ -35,11 +35,12 @@ export default function QueryToolbar( { query, setQuery } ) {
 	}, [] );
 
 	// Handles categories and tags changes.
-	const onTermsChange = ( terms, queryProperty ) => ( newTermNames ) => {
-		const termIds = newTermNames.map(
-			( name ) => terms.mapByName[ name ]?.id
-		);
-		if ( termIds.includes( undefined ) ) return;
+	const onTermsChange = ( terms, queryProperty ) => ( newTermValues ) => {
+		const termIds = newTermValues.reduce( ( accumulator, termValue ) => {
+			const termId = termValue?.id || terms.mapByName[ termValue ]?.id;
+			if ( termId ) accumulator.push( termId );
+			return accumulator;
+		}, [] );
 		setQuery( { [ queryProperty ]: termIds } );
 	};
 	const onCategoriesChange = onTermsChange( categories, 'categoryIds' );

--- a/packages/block-library/src/query/edit/query-toolbar.js
+++ b/packages/block-library/src/query/edit/query-toolbar.js
@@ -16,12 +16,18 @@ import { postList } from '@wordpress/icons';
  * Internal dependencies
  */
 import { getTermsInfo } from '../utils';
+import { MAX_FETCHED_TERMS } from '../constants';
 
 export default function QueryToolbar( { query, setQuery } ) {
 	const { categories, tags } = useSelect( ( select ) => {
 		const { getEntityRecords } = select( 'core' );
-		const _categories = getEntityRecords( 'taxonomy', 'category' );
-		const _tags = getEntityRecords( 'taxonomy', 'post_tag' );
+		const termsQuery = { per_page: MAX_FETCHED_TERMS };
+		const _categories = getEntityRecords(
+			'taxonomy',
+			'category',
+			termsQuery
+		);
+		const _tags = getEntityRecords( 'taxonomy', 'post_tag', termsQuery );
 		return {
 			categories: getTermsInfo( _categories ),
 			tags: getTermsInfo( _tags ),

--- a/packages/block-library/src/query/test/fixtures/index.js
+++ b/packages/block-library/src/query/test/fixtures/index.js
@@ -1,0 +1,21 @@
+export const terms = [
+	{
+		count: 2,
+		id: 4,
+		meta: [],
+		name: 'nba',
+		parent: 0,
+		slug: 'nba',
+		taxonomy: 'category',
+	},
+	{
+		count: 0,
+		id: 11,
+		link: 'http://localhost:8888/?tag=featured',
+		name: 'featured',
+		slug: 'featured',
+		taxonomy: 'post_tag',
+	},
+];
+
+export default { terms };

--- a/packages/block-library/src/query/test/utils.js
+++ b/packages/block-library/src/query/test/utils.js
@@ -1,0 +1,30 @@
+/**
+ * Internal dependencies
+ */
+import { terms } from './fixtures';
+import { getTermsInfo } from '../utils';
+
+describe( 'Query block utils', () => {
+	describe( 'getTermsInfo', () => {
+		it( 'should return an empty object when no terms provided', () => {
+			expect( getTermsInfo() ).toEqual( { terms: undefined } );
+		} );
+		it( 'should return proper terms info object', () => {
+			expect( getTermsInfo( terms ) ).toEqual(
+				expect.objectContaining( {
+					mapById: expect.objectContaining( {
+						'4': expect.objectContaining( { name: 'nba' } ),
+						'11': expect.objectContaining( {
+							name: 'featured',
+						} ),
+					} ),
+					mapByName: expect.objectContaining( {
+						nba: expect.objectContaining( { id: 4 } ),
+						featured: expect.objectContaining( { id: 11 } ),
+					} ),
+					names: expect.arrayContaining( [ 'nba', 'featured' ] ),
+				} )
+			);
+		} );
+	} );
+} );

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -1,17 +1,14 @@
 // TODO jsdoc and tests
-export const getTaxonomyInfo = ( terms ) => ( {
+export const getTermsInfo = ( terms ) => ( {
 	terms,
 	...terms?.reduce(
-		( acc, term ) => ( {
-			mapById: {
-				...acc.mapById,
-				[ term.id ]: term,
-			},
-			mapByName: {
-				...acc.mapByName,
-				[ term.name ]: term,
-			},
-		} ),
-		{ mapById: {}, mapByName: {} }
+		( accumulator, term ) => {
+			const { mapById, mapByName, names } = accumulator;
+			mapById[ term.id ] = term;
+			mapByName[ term.name ] = term;
+			names.push( term.name );
+			return accumulator;
+		},
+		{ mapById: {}, mapByName: {}, names: [] }
 	),
 } );

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -1,0 +1,17 @@
+// TODO jsdoc and tests
+export const getTaxonomyInfo = ( terms ) => ( {
+	terms,
+	...terms?.reduce(
+		( acc, term ) => ( {
+			mapById: {
+				...acc.mapById,
+				[ term.id ]: term,
+			},
+			mapByName: {
+				...acc.mapByName,
+				[ term.name ]: term,
+			},
+		} ),
+		{ mapById: {}, mapByName: {} }
+	),
+} );

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -1,4 +1,37 @@
-// TODO jsdoc and tests
+/**
+ * WordPress term object from REST API.
+ * Categories ref: https://developer.wordpress.org/rest-api/reference/categories/
+ * Tags ref: https://developer.wordpress.org/rest-api/reference/tags/
+ *
+ * @typedef {Object} WPTerm
+ * @property {number} id Unique identifier for the term.
+ * @property {number} count Number of published posts for the term.
+ * @property {string} description HTML description of the term.
+ * @property {string} link URL of the term.
+ * @property {string} name HTML title for the term.
+ * @property {string} slug An alphanumeric identifier for the term unique to its type.
+ * @property {string} taxonomy Type attribution for the term.
+ * @property {Object} meta Meta fields
+ * @property {number} [parent] The parent term ID.
+ */
+
+/**
+ * The object used in Query block that contains info and helper mappings
+ * from an array of WPTerm.
+ *
+ * @typedef {Object} QueryTermsInfo
+ * @property {WPTerm[]} terms The array of terms.
+ * @property {Object<string, WPTerm>} mapById Object mapping with the term id as key and the term as value.
+ * @property {Object<string, WPTerm>} mapByName Object mapping with the term name as key and the term as value.
+ * @property {string[]} names Array with the terms' names.
+ */
+
+/**
+ * Returns a helper object with mapping from WPTerms.
+ *
+ * @param {WPTerm[]} terms The terms to extract of helper object.
+ * @return {QueryTermsInfo} The object with the terms information.
+ */
 export const getTermsInfo = ( terms ) => ( {
 	terms,
 	...terms?.reduce(

--- a/packages/e2e-tests/fixtures/blocks/core__query.json
+++ b/packages/e2e-tests/fixtures/blocks/core__query.json
@@ -9,6 +9,7 @@
 				"pages": 1,
 				"offset": 0,
 				"categoryIds": [],
+				"tagIds": [],
 				"order": "desc",
 				"orderBy": "date"
 			}

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -136,7 +136,7 @@ function Editor() {
 	const blockContext = useMemo(
 		() => ( {
 			...page?.context,
-			query: page?.context.query || { categoryIds: [] },
+			query: page?.context.query || { categoryIds: [], tagIds: [] },
 			queryContext: [
 				page?.context.queryContext || { page: 1 },
 				( newQueryContext ) =>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This PR will add `tags` support in `Query` block and is part of https://github.com/WordPress/gutenberg/issues/24934 and FSE milestone 5.

There still needs to be a decision about the final design of `Query` block, but that also depends on how many things we will include eventually and where ( toolbar, inspector controls etc..).

For now I've added the `tags` controls in the `toolbar` like the previously existed `categories`. To me though this could be a better fit for inspector controls (maybe a follow up PR?). IMO since it's easy to move the functionality between the toolbar and the inspector controls, this enhances the functionality of `Query` block and could be merged even without the finalized design.

Also note that for now if you select both `tags` and `categories` it defaults to `AND` query for those. Maybe we should consider `tax relation` in the future to allow the `OR` option.

Finally this PR fixes a previous bug which didn't allow the selection of multiple categories in `Query` block. The multiple terms are with `OR` relationship. That means if we have two categories [a, b] and one tag [tagLabel], it would fetch `a+tagLabel OR b+tagLabel`.
Fixes: https://github.com/WordPress/gutenberg/issues/25047
<!-- Please describe what you have changed or added -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
