### PR TITLE
Save DOMDocument node instead of root + str_replace

### DIFF
--- a/lib/block-supports/index.php
+++ b/lib/block-supports/index.php
@@ -96,7 +96,7 @@ function gutenberg_apply_block_supports( $block_content, $block ) {
 		$block_root->setAttribute( 'style', esc_attr( implode( '; ', $new_styles ) . ';' ) );
 	}
 
-	return str_replace( array( $wrapper_left, $wrapper_right ), '', $dom->saveHtml() );
+	return $dom->saveHtml( $block_root );
 }
 add_filter( 'render_block', 'gutenberg_apply_block_supports', 10, 2 );
 

--- a/phpunit/class-block-supported-styles-test.php
+++ b/phpunit/class-block-supported-styles-test.php
@@ -104,12 +104,12 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	private function assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles ) {
 		$styled_block = apply_filters( 'render_block', self::BLOCK_MARKUP, $block );
 
-		// Ensure blocks to not add extra whitespace
+		// Ensure blocks to not add extra whitespace.
 		$this->assertEquals( $styled_block, trim( $styled_block ) );
 
-		$content      = $this->get_content_from_block( $styled_block );
-		$class_list   = $this->get_attribute_from_block( 'class', $styled_block );
-		$style_list   = $this->get_attribute_from_block( 'style', $styled_block );
+		$content    = $this->get_content_from_block( $styled_block );
+		$class_list = $this->get_attribute_from_block( 'class', $styled_block );
+		$style_list = $this->get_attribute_from_block( 'style', $styled_block );
 
 		$this->assertEquals( self::BLOCK_CONTENT, $content );
 		$this->assertEquals( $expected_classes, $class_list );

--- a/phpunit/class-block-supported-styles-test.php
+++ b/phpunit/class-block-supported-styles-test.php
@@ -103,6 +103,10 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	private function assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles ) {
 		$styled_block = apply_filters( 'render_block', self::BLOCK_MARKUP, $block );
+
+		// Ensure blocks to not add extra whitespace
+		$this->assertEquals( $styled_block, trim( $styled_block ) );
+
 		$content      = $this->get_content_from_block( $styled_block );
 		$class_list   = $this->get_attribute_from_block( 'class', $styled_block );
 		$style_list   = $this->get_attribute_from_block( 'style', $styled_block );


### PR DESCRIPTION
## Description

We wrapped block HTML in some tags to ensure the DOMDocument parses it
correctly, then unwrapped it again with str_replace after using
`saveHTML`.

The `saveHTML` method accepts an optional argument that is the dom node
to output a subset of the document:
https://www.php.net/manual/en/domdocument.savehtml.php

Rather than calling `str_replace` on the entire document to get the
unwrapped block HTML, invoke `saveHTML` on the block root to get the
unwrapped HTML.

This prevents some additional newlines from being appended to the
output which was observed when running core block tests with Gutenberg
activated.



## How has this been tested?

Manual and automated testing of some dynamic blocks.

## Types of changes
Internal.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
