### PR TITLE
Fix injection of script in Categories block when dropdown displayed

### DIFF
--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -33,7 +33,13 @@ function render_block_core_categories( $attributes ) {
 		$type                     = 'dropdown';
 
 		if ( ! is_admin() ) {
-			$wrapper_markup .= build_dropdown_script_block_core_categories( $id );
+			// Inject the dropdown script immediately after the select dropdown.
+			$items_markup = preg_replace(
+				'#(?<=</select>)#',
+				build_dropdown_script_block_core_categories( $id ),
+				$items_markup,
+				1
+			);
 		}
 	} else {
 		$wrapper_markup = '<ul class="%1$s">%2$s</ul>';


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

Unit tests for the AMP plugin started failing once Guenberg v8.9.0: https://github.com/ampproject/amp-wp/pull/5319#issuecomment-685932561. The issue was traced back to https://github.com/WordPress/gutenberg/commit/7fbdda269f9ec2164c211df2215b36c790f09248 as part of #25020. 

Currently, when a Categories block is added and the "Display as dropdown" option is enabled, selecting a category in the dropdown has no effect. This is because the script constructed by `build_dropdown_script_block_core_categories()` is no longer making it into the page. The reason is that `gutenberg_render_block_core_categories()` is _appending_ the script to the `$wrapper_markup` so it is _outside_ of the block wrapper, but after 7fbdda269f9ec2164c211df2215b36c790f09248 only the block wrapper (`$block_root`) is returned by `gutenberg_apply_block_supports()`.

This PR fixes that problem by ensuring that `<script>` returned by `build_dropdown_script_block_core_categories()` is inserted immediately after the `</select>` closing tag and is placed on the _inside_ of the `$items_markup` rather than being inserted after the `$wrapper_markup`. 

This should also prevent the `sprintf()` call from failing if someone has a category containing string formats.

## How has this been tested?

Add a Categories block to the content and enable the "Display as dropdown" option. Before this PR, no `<script>` is  added with the block. With this PR, a `<script>` is added and selecting a category causes navigation to the category.

## Screenshots <!-- if applicable -->

### Before

```html
<div class="wp-block-categories-dropdown wp-block-categories">
	<select name="cat" id="wp-block-categories-1" class="postform">
		<option value="-1">Select Category</option>
		<option class="level-0" value="3">aciform</option>
		<!-- ... -->
	</select>
</div>
```

### After

```html
<div class="wp-block-categories-dropdown wp-block-categories">
	<select name="cat" id="wp-block-categories-1" class="postform">
		<option value="-1">Select Category</option>
		<option class="level-0" value="3">aciform</option>
		<!-- ... -->
	</select>
	<script type="text/javascript">
	/* <![CDATA[ */
	( function() {
		var dropdown = document.getElementById( 'wp-block-categories-1' );
		function onCatChange() {
			if ( dropdown.options[ dropdown.selectedIndex ].value > 0 ) {
				location.href = "https://wordpressdev.lndo.site/?cat=" + dropdown.options[ dropdown.selectedIndex ].value;
			}
		}
		dropdown.onchange = onCatChange;
	})();
	/* ]]&gt; */
	</script>
</div>
```

## Types of changes

Bug fix (a regression)

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
