### PR TITLE
Block supports: Restore root DOMDocument save

### DIFF
--- a/lib/block-supports/index.php
+++ b/lib/block-supports/index.php
@@ -52,16 +52,22 @@ function gutenberg_apply_block_supports( $block_content, $block ) {
 		return $block_content;
 	}
 
-	// We need to wrap the block in order to handle UTF-8 properly.
-	$wrapper_left  = '<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head><body>';
-	$wrapper_right = '</body></html>';
-
 	$dom = new DOMDocument( '1.0', 'utf-8' );
 
 	// Suppress DOMDocument::loadHTML warnings from polluting the front-end.
 	$previous = libxml_use_internal_errors( true );
 
-	$success = $dom->loadHTML( $wrapper_left . $block_content . $wrapper_right, LIBXML_HTML_NODEFDTD | LIBXML_COMPACT );
+	$body_id = '__BLOCK_SUPPORTS_INJECTED_BODY_ID__';
+
+	// We need to wrap the block in order to handle UTF-8 properly.
+	$wrapped_block_html =
+		'<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head><body id="'
+		. $body_id
+		. '">'
+		. $block_content
+		. '</body></html>';
+
+	$success = $dom->loadHTML( $wrapped_block_html, LIBXML_HTML_NODEFDTD | LIBXML_COMPACT );
 
 	// Clear errors and reset the use_errors setting.
 	libxml_clear_errors();
@@ -71,7 +77,7 @@ function gutenberg_apply_block_supports( $block_content, $block ) {
 		return $block_content;
 	}
 
-	$body_element = $dom->getElementsByTagName( 'body' )[0];
+	$body_element = $dom->getElementByID( $body_id );
 	$block_root   = $body_element->childNodes[0]; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
 	if ( empty( $block_root ) ) {

--- a/lib/block-supports/index.php
+++ b/lib/block-supports/index.php
@@ -98,7 +98,7 @@ function gutenberg_apply_block_supports( $block_content, $block ) {
 		$block_root->setAttribute( 'style', implode( '; ', $new_styles ) . ';' );
 	}
 
-	return $dom->saveHtml( $block_root );
+	return str_replace( array( $wrapper_left, $wrapper_right ), '', $dom->saveHtml() );
 }
 add_filter( 'render_block', 'gutenberg_apply_block_supports', 10, 2 );
 

--- a/lib/block-supports/index.php
+++ b/lib/block-supports/index.php
@@ -71,8 +71,8 @@ function gutenberg_apply_block_supports( $block_content, $block ) {
 		return $block_content;
 	}
 
-	$xpath      = new DOMXPath( $dom );
-	$block_root = $xpath->query( '/html/body/*' )[0];
+	$body_element = $dom->getElementsByTagName( 'body' )[0];
+	$block_root   = $body_element->childNodes[0]; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
 	if ( empty( $block_root ) ) {
 		return $block_content;
@@ -98,7 +98,12 @@ function gutenberg_apply_block_supports( $block_content, $block ) {
 		$block_root->setAttribute( 'style', implode( '; ', $new_styles ) . ';' );
 	}
 
-	return trim( str_replace( array( $wrapper_left, $wrapper_right ), '', $dom->saveHtml() ) );
+	$result = '';
+	// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+	foreach ( $body_element->childNodes as $child_node ) {
+		$result .= $dom->saveHtml( $child_node );
+	}
+	return $result;
 }
 add_filter( 'render_block', 'gutenberg_apply_block_supports', 10, 2 );
 

--- a/lib/block-supports/index.php
+++ b/lib/block-supports/index.php
@@ -98,7 +98,7 @@ function gutenberg_apply_block_supports( $block_content, $block ) {
 		$block_root->setAttribute( 'style', implode( '; ', $new_styles ) . ';' );
 	}
 
-	return str_replace( array( $wrapper_left, $wrapper_right ), '', $dom->saveHtml() );
+	return trim( str_replace( array( $wrapper_left, $wrapper_right ), '', $dom->saveHtml() ) );
 }
 add_filter( 'render_block', 'gutenberg_apply_block_supports', 10, 2 );
 

--- a/lib/block-supports/index.php
+++ b/lib/block-supports/index.php
@@ -77,7 +77,8 @@ function gutenberg_apply_block_supports( $block_content, $block ) {
 	$body_element = $dom->documentElement->lastChild; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 	$block_root   = $body_element->childNodes[0]; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
-	if ( empty( $block_root ) ) {
+	// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+	if ( empty( $block_root ) || XML_ELEMENT_NODE !== $block_root->nodeType ) {
 		return $block_content;
 	}
 

--- a/lib/block-supports/index.php
+++ b/lib/block-supports/index.php
@@ -57,13 +57,9 @@ function gutenberg_apply_block_supports( $block_content, $block ) {
 	// Suppress DOMDocument::loadHTML warnings from polluting the front-end.
 	$previous = libxml_use_internal_errors( true );
 
-	$body_id = '__BLOCK_SUPPORTS_INJECTED_BODY_ID__';
-
 	// We need to wrap the block in order to handle UTF-8 properly.
 	$wrapped_block_html =
-		'<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head><body id="'
-		. $body_id
-		. '">'
+		'<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head><body>'
 		. $block_content
 		. '</body></html>';
 
@@ -77,7 +73,8 @@ function gutenberg_apply_block_supports( $block_content, $block ) {
 		return $block_content;
 	}
 
-	$body_element = $dom->getElementByID( $body_id );
+	// Structure is like `<html><head/><body/></html>`, so body is the `lastChild` of our document.
+	$body_element = $dom->documentElement->lastChild; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 	$block_root   = $body_element->childNodes[0]; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
 	if ( empty( $block_root ) ) {

--- a/lib/block-supports/index.php
+++ b/lib/block-supports/index.php
@@ -75,10 +75,12 @@ function gutenberg_apply_block_supports( $block_content, $block ) {
 
 	// Structure is like `<html><head/><body/></html>`, so body is the `lastChild` of our document.
 	$body_element = $dom->documentElement->lastChild; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-	$block_root   = $body_element->childNodes[0]; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+
+	$xpath      = new DOMXPath( $dom );
+	$block_root = $xpath->query( './*', $body_element )[0];
 
 	// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-	if ( empty( $block_root ) || XML_ELEMENT_NODE !== $block_root->nodeType ) {
+	if ( empty( $block_root ) ) {
 		return $block_content;
 	}
 

--- a/phpunit/class-block-supported-styles-test.php
+++ b/phpunit/class-block-supported-styles-test.php
@@ -861,4 +861,22 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 			$this->assertEquals( $expected, $result );
 		}
 	}
+
+	/**
+	 * Ensure that HTML appended to the block content is preserved.
+	 */
+	public function test_render_block_includes_appended_html() {
+		$this->register_block_type(
+			'core/example',
+			array(
+				'render_callback' => function( $attributes, $content ) {
+					return $content . '<div>Appended</div>';
+				},
+			)
+		);
+
+		$result = do_blocks( '<!-- wp:core/example --><p>Hello from the block content!</p><!-- /wp:core/example -->' );
+
+		$this->assertEquals( '<p class="wp-block-example">Hello from the block content!</p><div>Appended</div>', $result );
+	}
 }

--- a/phpunit/class-block-supported-styles-test.php
+++ b/phpunit/class-block-supported-styles-test.php
@@ -103,9 +103,13 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	private function assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles ) {
 		$styled_block = apply_filters( 'render_block', self::BLOCK_MARKUP, $block );
-		$content      = $this->get_content_from_block( $styled_block );
-		$class_list   = $this->get_attribute_from_block( 'class', $styled_block );
-		$style_list   = $this->get_attribute_from_block( 'style', $styled_block );
+
+		// Ensure blocks to not add extra whitespace.
+		$this->assertEquals( $styled_block, trim( $styled_block ) );
+
+		$content    = $this->get_content_from_block( $styled_block );
+		$class_list = $this->get_attribute_from_block( 'class', $styled_block );
+		$style_list = $this->get_attribute_from_block( 'style', $styled_block );
 
 		$this->assertEquals( self::BLOCK_CONTENT, $content );
 		$this->assertEquals( $expected_classes, $class_list );

--- a/phpunit/class-block-supported-styles-test.php
+++ b/phpunit/class-block-supported-styles-test.php
@@ -103,13 +103,9 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	private function assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles ) {
 		$styled_block = apply_filters( 'render_block', self::BLOCK_MARKUP, $block );
-
-		// Ensure blocks to not add extra whitespace.
-		$this->assertEquals( $styled_block, trim( $styled_block ) );
-
-		$content    = $this->get_content_from_block( $styled_block );
-		$class_list = $this->get_attribute_from_block( 'class', $styled_block );
-		$style_list = $this->get_attribute_from_block( 'style', $styled_block );
+		$content      = $this->get_content_from_block( $styled_block );
+		$class_list   = $this->get_attribute_from_block( 'class', $styled_block );
+		$style_list   = $this->get_attribute_from_block( 'style', $styled_block );
 
 		$this->assertEquals( self::BLOCK_CONTENT, $content );
 		$this->assertEquals( $expected_classes, $class_list );

--- a/phpunit/class-block-supported-styles-test.php
+++ b/phpunit/class-block-supported-styles-test.php
@@ -879,4 +879,22 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( '<p class="wp-block-example">Hello from the block content!</p><div>Appended</div>', $result );
 	}
+
+	/**
+	 * Should not error when the rendered block is text only.
+	 */
+	public function test_render_block_rendered_text_node() {
+		$this->register_block_type(
+			'core/example',
+			array(
+				'render_callback' => function() {
+					return 'This is rendered as just text.';
+				},
+			)
+		);
+
+		$result = do_blocks( '<!-- wp:core/example /-->' );
+
+		$this->assertEquals( 'This is rendered as just text.', $result );
+	}
 }


### PR DESCRIPTION
Fix a regression from WordPress/gutenberg#25020 which was found to remove anything outside of the block root that may have been appended or prepended. This fix is achieved by concatenating all the childNodes in the DOMDocument body. See https://github.com/WordPress/gutenberg/pull/25026 for additional details on the regression.

Add a test to ensure that appended HTML is preserved.

The regression from #25020 exposes an issue I'll raise in another PR with some failing tests. HTML _appended_ to the block content works well. However, if additional output comes before the block content then then `gutenberg_apply_block_supports` will misbehave because it expects the block content to be the first element in the constructed DOM body:
https://github.com/WordPress/gutenberg/blob/7ee00ad4c5dc64a2b971cebe1d6ee4789eff7157/lib/block-supports/index.php#L75

See https://github.com/WordPress/gutenberg/pull/25053 for discussion around the expected behavior of `gutenberg_apply_block_supports`.

Fixes #25117