### PR TITLE
Use cleaned slug to query for template part post

### DIFF
--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -148,7 +148,7 @@ function create_auto_draft_for_template_part_block( $block ) {
 				array(
 					'post_type'      => 'wp_template_part',
 					'post_status'    => array( 'publish', 'auto-draft' ),
-					'name'           => $block['attrs']['slug'],
+					'title'          => $block['attrs']['slug'],
 					'meta_key'       => 'theme',
 					'meta_value'     => $block['attrs']['theme'],
 					'posts_per_page' => 1,

--- a/packages/block-library/src/template-part/edit/use-template-part-post.js
+++ b/packages/block-library/src/template-part/edit/use-template-part-post.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
+import { cleanForSlug } from '@wordpress/url';
 
 export default function useTemplatePartPost( postId, slug, theme ) {
 	return useSelect(
@@ -22,18 +23,19 @@ export default function useTemplatePartPost( postId, slug, theme ) {
 			// load the auto-draft created from the
 			// relevant file.
 			if ( slug && theme ) {
+				const cleanedSlug = cleanForSlug( slug );
 				const posts = select( 'core' ).getEntityRecords(
 					'postType',
 					'wp_template_part',
 					{
 						status: [ 'publish', 'auto-draft' ],
-						slug,
+						slug: cleanedSlug,
 						theme,
 					}
 				);
 				const foundPosts = posts?.filter(
 					( post ) =>
-						post.slug === slug &&
+						post.slug === cleanedSlug &&
 						post.meta &&
 						post.meta.theme === theme
 				);


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes #20375. Apparently, WordPress changes the title of the template part CPT to remove a character like `/` and replace it with `-`, which is obviously problematic for paths. We "clean for slug" in several other places in the template part, so I'm just adding that here. That said....

What other code could be problematic because of this? Do we need to support the character `/` more directly? I wonder if this code could be problematic when trying to figure out if we need to create a new template part autodraft:

https://github.com/WordPress/gutenberg/blob/73c234a9f9a7f1ae72f98412e6a1143e5066cece/lib/template-loader.php#L147-L157

it might not be able to find existing autodrafts because it does not convert the slug.

## How has this been tested?
Locally in edit site. To test, you should do the following:
1. delete all existing template and template part CPTs.
2. In an existing block-based theme mapped to your WordPress instance, create a new subdirectory under `block-template-parts` called `template-part-subdir`
3. In that subdirectory, create a new file called `new-template-part.html`. Copy/paste some block markup into that file and make sure you can identify what the content is by changing some paragraph content or something like that.
4. From an existing template (e.g. index or singular), update one of the template parts slugs to say `template-part-subdir/new-template-part`. (e.g. change the slug from `header` to essentially the path to the new template part under the subdirectory)
5. Open that template in the site editor and make sure that the template part loads from the subdirectory.

## Screenshots <!-- if applicable -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
