### PR TITLE
[Try] Navigation Component: Internal groupings

### DIFF
--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -30,18 +30,42 @@ const Navigation = ( { activeItemId, children, data, rootTitle } ) => {
 	};
 
 	const mapItems = ( itemData ) => {
+		const groupings = [];
 		const items = new Map(
-			[
-				{ id: 'root', parent: null, title: rootTitle },
-				...itemData,
-			].map( ( item ) => [ item.id, appendItemData( item ) ] )
+			[ { id: 'root', parent: null, title: rootTitle }, ...itemData ]
+				.filter( ( item ) => {
+					if ( item.type === 'grouping' ) {
+						item.children = [];
+						groupings.push( item );
+						return false;
+					}
+					return true;
+				} )
+				.map( ( item ) => [ item.id, appendItemData( item ) ] )
 		);
 
 		items.forEach( ( item ) => {
 			const parentItem = items.get( item.parent );
 			if ( parentItem ) {
-				parentItem.children.push( item );
-				parentItem.hasChildren = true;
+				if ( item.group ) {
+					const grouping = groupings.find(
+						( group ) => group.id === item.group
+					);
+					if ( grouping ) {
+						grouping.children.push( item );
+					}
+				} else {
+					parentItem.children.push( item );
+					parentItem.hasChildren = true;
+				}
+			}
+		} );
+
+		groupings.forEach( ( grouping ) => {
+			const parentItem = items.get( grouping.parent );
+			if ( parentItem ) {
+				parentItem.groupings = parentItem.groupings || [];
+				parentItem.groupings.push( grouping );
 			}
 		} );
 

--- a/packages/components/src/navigation/stories/index.js
+++ b/packages/components/src/navigation/stories/index.js
@@ -53,6 +53,13 @@ const data = [
 		title: 'Nested Category',
 		id: 'child-3',
 		parent: 'item-3',
+		group: 'grouping-1',
+	},
+	{
+		title: 'Child 4',
+		id: 'child-4',
+		parent: 'item-3',
+		group: 'grouping-1',
 	},
 	{
 		title: 'Sub Child 1',
@@ -78,6 +85,37 @@ const data = [
 		LinkComponent: CustomRouterLink,
 	},
 ];
+
+const tryThis = ( { level, setActive } ) => (
+	<NavigationMenu>
+		{ level.children.map( ( item ) => {
+			if ( item.type === 'grouping' ) {
+				return item.groupings.map( ( groupItem ) => (
+					<NavigationMenuItem
+						{ ...groupItem }
+						key={ groupItem.id }
+						onClick={
+							! groupItem.href
+								? ( selected ) => setActive( selected.id )
+								: null
+						}
+					/>
+				) );
+			}
+			return (
+				<NavigationMenuItem
+					{ ...item }
+					key={ item.id }
+					onClick={
+						! item.href
+							? ( selected ) => setActive( selected.id )
+							: null
+					}
+				/>
+			);
+		} ) }
+	</NavigationMenu>
+);
 
 function Example() {
 	const [ active, setActive ] = useState( 'item-1' );

--- a/packages/components/src/navigation/stories/index.js
+++ b/packages/components/src/navigation/stories/index.js
@@ -50,6 +50,12 @@ const data = [
 		parent: 'item-3',
 	},
 	{
+		title: 'Secondary Menu',
+		id: 'grouping-1',
+		parent: 'item-3',
+		type: 'grouping',
+	},
+	{
 		title: 'Nested Category',
 		id: 'child-3',
 		parent: 'item-3',
@@ -86,39 +92,18 @@ const data = [
 	},
 ];
 
-const tryThis = ( { level, setActive } ) => (
-	<NavigationMenu>
-		{ level.children.map( ( item ) => {
-			if ( item.type === 'grouping' ) {
-				return item.groupings.map( ( groupItem ) => (
-					<NavigationMenuItem
-						{ ...groupItem }
-						key={ groupItem.id }
-						onClick={
-							! groupItem.href
-								? ( selected ) => setActive( selected.id )
-								: null
-						}
-					/>
-				) );
-			}
-			return (
-				<NavigationMenuItem
-					{ ...item }
-					key={ item.id }
-					onClick={
-						! item.href
-							? ( selected ) => setActive( selected.id )
-							: null
-					}
-				/>
-			);
-		} ) }
-	</NavigationMenu>
-);
-
 function Example() {
 	const [ active, setActive ] = useState( 'item-1' );
+
+	const renderItem = ( item ) => (
+		<NavigationMenuItem
+			{ ...item }
+			key={ item.id }
+			onClick={
+				! item.href ? ( selected ) => setActive( selected.id ) : null
+			}
+		/>
+	);
 
 	return (
 		<>
@@ -142,22 +127,22 @@ function Example() {
 							) }
 							<h1>{ level.title }</h1>
 							<NavigationMenu>
-								{ level.children.map( ( item ) => {
-									return (
-										<NavigationMenuItem
-											{ ...item }
-											key={ item.id }
-											onClick={
-												! item.href
-													? ( selected ) =>
-															setActive(
-																selected.id
-															)
-													: null
-											}
-										/>
-									);
-								} ) }
+								{ level.children.map( renderItem ) }
+								{ level.groupings
+									? level.groupings.map( ( grouping ) => (
+											<>
+												<h2>{ grouping.title }</h2>
+												<NavigationMenu
+													key={ grouping.id }
+													title={ grouping.title }
+												>
+													{ grouping.children.map(
+														renderItem
+													) }
+												</NavigationMenu>
+											</>
+									  ) )
+									: null }
 							</NavigationMenu>
 						</>
 					);


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/24992

cc @joshuatf @Copons. This is rough try at groupings and would need a fair amount of cleanup. I'm open to suggestions and am not married to any of the naming. Thanks!

## Description

The idea behind this branch is to allow the consumer to supply a data object for a grouping that looks like this:

```
	{
		title: 'Secondary Menu',
		id: 'grouping-1',
		parent: 'item-3',
		type: 'grouping',
	},
```

The data is then prepared such that a `level` can not only have `children` but `groupings` as well. `groupings` would be an array of groups, each with their own children. 

The consumer renders the child items as well as each grouping's child items. The result is an ability to render groups at any portion of the waterfall without having to know anything about the details of the group

<img width="549" alt="image" src="https://user-images.githubusercontent.com/191598/91755038-78a72e00-eb98-11ea-800c-2075e314b85c.png">

## How has this been tested?

1. `npm run storybook:dev`
2. Navigate to "Category"

<img width="197" alt="Screen Shot 2020-09-03 at 7 28 00 PM" src="https://user-images.githubusercontent.com/1922453/92084546-a8b23380-ee1b-11ea-96ea-95e5b4114ac8.png">


