### PR TITLE
Polish horizontal movers.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -539,9 +539,37 @@
 	.block-editor-block-mover.is-horizontal .block-editor-block-mover-button.block-editor-block-mover-button {
 		min-width: $block-toolbar-height/2;
 		width: $block-toolbar-height/2;
+
+		// Animate buttons on hover.
+		&.is-up-button {
+			svg {
+				transition: ease-in-out transform 0.1s;
+				@include reduce-motion("transition");
+			}
+			&:focus,
+			&:hover {
+				svg {
+					transform: translateX(-2px);
+				}
+			}
+		}
+
+		&.is-down-button {
+			svg {
+				transition: ease-in-out transform 0.1s;
+				@include reduce-motion("transition");
+			}
+			&:focus,
+			&:hover {
+				svg {
+					transform: translateX(2px);
+				}
+			}
+		}
 	}
 
 	.block-editor-block-mover:not(.is-horizontal) {
+		// Position SVGs. Animate buttons on hover.
 		.block-editor-block-mover-button {
 			&.is-up-button {
 				svg {

--- a/packages/block-editor/src/components/block-mover/style.scss
+++ b/packages/block-editor/src/components/block-mover/style.scss
@@ -38,7 +38,6 @@
 			width: $block-toolbar-height - $grid-unit-15 / 2;
 			padding-right: $grid-unit-15 - $border-width !important;
 			padding-left: $grid-unit-15 / 2 !important;
-			min-width: $block-toolbar-height - $grid-unit-15 / 2 !important;
 		}
 
 		// Focus style.
@@ -105,8 +104,8 @@
 
 			// Focus style.
 			&::before {
-				top: 0;
-				bottom: 0;
+				top: $border-width;
+				bottom: $border-width;
 				min-width: 0;
 				width: auto;
 				height: auto;


### PR DESCRIPTION
As part of the mover refactor, the spacing was not perfect for horizontal movers. This PR addresses that. Before:

<img width="592" alt="Screenshot 2020-09-03 at 10 20 55" src="https://user-images.githubusercontent.com/1204802/92091323-e3db4500-edd0-11ea-8cdd-b53bf95d25f8.png">

After:

<img width="520" alt="Screenshot 2020-09-03 at 10 29 52" src="https://user-images.githubusercontent.com/1204802/92091332-e6d63580-edd0-11ea-94ea-e98f514c2fd8.png">

This also adds the same animation the vertical ones have.