### PR TITLE
[WIP] loginout link block

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -60,6 +60,7 @@ function gutenberg_reregister_core_block_types() {
 		'latest-comments.php' => 'core/latest-comments',
 		'latest-posts.php'    => 'core/latest-posts',
 		'legacy-widget.php'   => 'core/legacy-widget',
+		'loginout.php'        => 'core/loginout',
 		'navigation.php'      => 'core/navigation',
 		'navigation-link.php' => 'core/navigation-link',
 		'rss.php'             => 'core/rss',

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -41,6 +41,7 @@ import * as latestComments from './latest-comments';
 import * as latestPosts from './latest-posts';
 import * as legacyWidget from './legacy-widget';
 import * as list from './list';
+import * as loginout from './loginout';
 import * as missing from './missing';
 import * as more from './more';
 import * as nextpage from './nextpage';
@@ -146,6 +147,7 @@ export const registerCoreBlocks = () => {
 		mediaText,
 		latestComments,
 		latestPosts,
+		loginout,
 		missing,
 		more,
 		nextpage,

--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -41,6 +41,7 @@ import * as mediaText from './media-text';
 import * as latestComments from './latest-comments';
 import * as latestPosts from './latest-posts';
 import * as list from './list';
+import * as loginout from './loginout';
 import * as missing from './missing';
 import * as more from './more';
 import * as nextpage from './nextpage';
@@ -91,6 +92,7 @@ export const coreBlocks = [
 	mediaText,
 	latestComments,
 	latestPosts,
+	loginout,
 	missing,
 	more,
 	nextpage,

--- a/packages/block-library/src/loginout/block.json
+++ b/packages/block-library/src/loginout/block.json
@@ -1,0 +1,20 @@
+{
+	"name": "core/loginout",
+	"category": "design",
+	"attributes": {
+		"logInText": {
+			"type": "string"
+		},
+		"logOutText": {
+			"type": "string"
+		}
+	},
+	"supports": {
+		"html": false,
+		"lightBlockWrapper": true,
+		"__experimentalFontSize": true,
+		"__experimentalColor": {
+			"linkColor": true
+		}
+	}
+}

--- a/packages/block-library/src/loginout/edit.js
+++ b/packages/block-library/src/loginout/edit.js
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	InspectorControls,
+	__experimentalBlock as Block,
+} from '@wordpress/block-editor';
+import { PanelBody, TextControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+function LoginOutEdit( {
+	attributes: { logInText, logOutText },
+	setAttributes,
+} ) {
+	logInText = logInText || __( 'Log In' );
+	logOutText = logOutText || __( 'Log Out' );
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Link Text' ) }>
+					<TextControl
+						label={ __( 'Login Text' ) }
+						value={ logInText }
+						default={ __( 'Log In' ) }
+						onChange={ ( value ) => {
+							setAttributes( { logInText: value } );
+						} }
+					/>
+					<TextControl
+						label={ __( 'Logout Text' ) }
+						value={ logOutText }
+						default={ __( 'Log In' ) }
+						onChange={ ( value ) => {
+							setAttributes( { logOutText: value } );
+						} }
+					/>
+				</PanelBody>
+			</InspectorControls>
+
+			<Block.div className={ classnames() }>
+				<span className="wp-block-loginout">{ logOutText }</span>
+			</Block.div>
+		</>
+	);
+}
+
+export default LoginOutEdit;

--- a/packages/block-library/src/loginout/index.js
+++ b/packages/block-library/src/loginout/index.js
@@ -1,0 +1,19 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import edit from './edit';
+
+const { name } = metadata;
+export { metadata, name };
+
+export const settings = {
+	title: __( 'Login/Logout Link' ),
+	description: __( 'Add a login/logout link.' ),
+	edit,
+};

--- a/packages/block-library/src/loginout/index.php
+++ b/packages/block-library/src/loginout/index.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Server-side rendering of the `core/post-author` block.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Renders the `core/post-author` block on the server.
+ *
+ * @param  array    $attributes Block attributes.
+ * @param  string   $content    Block default content.
+ * @param  WP_Block $block      Block instance.
+ * @return string Returns the rendered author block.
+ */
+function render_block_core_loginout( $attributes, $content, $block ) {
+	if ( ! is_user_logged_in() ) {
+		$log_in_text = ( isset( $attributes['logInText'] ) && $attributes['logInText'] )
+			? $attributes['logInText']
+			: __( 'Log In' );
+
+        /** This filter is documented in wp-includes/general-template.php */
+		return apply_filters( 'loginout', '<a class="wp-block-loginout" href="' . esc_url( wp_login_url() ) . '">' . $log_in_text . '</a>' );
+	}
+
+	$log_out_text = ( isset( $attributes['logOutText'] ) && $attributes['logOutText'] )
+		? $attributes['logOutText']
+		: __( 'Log Out' );
+
+	/** This filter is documented in wp-includes/general-template.php */
+	return apply_filters( 'loginout', '<a class="wp-block-loginout" href="' . esc_url( wp_logout_url() ) . '">' . $log_out_text . '</a>' );
+}
+
+/**
+ * Registers the `core/post-author` block on the server.
+ */
+function register_block_core_post_author() {
+	register_block_type_from_metadata(
+		__DIR__ . '/loginout',
+		array(
+			'render_callback' => 'render_block_core_loginout',
+		)
+	);
+}
+add_action( 'init', 'register_block_core_post_author' );


### PR DESCRIPTION
Came up in https://github.com/WordPress/gutenberg/issues/22724#issuecomment-685858166 during a block-based themes meeting that having a login-logout link would be useful for FSE.
This PR adds a loginout block which will be usable in nav menus or footers etc when building templates.

Right now the login/logout text are customizable, but we could very well just remove these options and in the callback just use `wp_loginout` instead of what I added.

This is a draft we can iterate on and investigate the logic a bit.