### PR TITLE
Fix settings name

### DIFF
--- a/packages/block-editor/src/components/colors-gradients/control.js
+++ b/packages/block-editor/src/components/colors-gradients/control.js
@@ -182,7 +182,7 @@ function ColorGradientControlSelect( props ) {
 		'color.custom'
 	);
 	colorGradientSettings.disableCustomGradients = ! useEditorFeature(
-		'gradients.custom'
+		'gradient.custom'
 	);
 
 	return (


### PR DESCRIPTION
This fixes the setting name introduced at https://github.com/WordPress/gutenberg/pull/24964

This is a bug I couldn't reproduce, so I'm going to call it a _dormant bug_. What happens is that the `ColorGradientControl` pulls the data from the store if their ancestors don't pass it as props. I could check that this never happens in practice. These are the two ancestors that use the control:

- `PanelColorGradientSettingsInner` => retrieves on its own the settings from the store and pass them to `ColorGradientControl`.
- `ColorPaletteControl` => I haven't found this component in use anywhere.

A related question is whether it should be the `ColorGradientControl` responsibility to pull this data or let their ancestors configure it via props, as they already do the same. However, that's a separate discussion, so I think we should just fix this at the moment.