### PR TITLE
Fix Template Part auto-drafting to support sub-directories.

### DIFF
--- a/lib/template-parts.php
+++ b/lib/template-parts.php
@@ -212,7 +212,8 @@ function filter_rest_wp_template_part_query( $args, $request ) {
 		// Ensure auto-drafts of all theme supplied template parts are created.
 		if ( wp_get_theme()->get( 'TextDomain' ) === $request['theme'] ) {
 			// Get file paths for all theme supplied template parts.
-			function get_template_part_paths( $base_directory, $path_list = array() ) {
+			function get_template_part_paths( $base_directory ) {
+				$path_list = array();
 				if ( file_exists( $base_directory . '/block-template-parts' ) ) {
 					$nested_files      = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $base_directory . '/block-template-parts' ) );
 					$nested_html_files = new RegexIterator( $nested_files, '/^.+\.html$/i', RecursiveRegexIterator::GET_MATCH );
@@ -225,7 +226,7 @@ function filter_rest_wp_template_part_query( $args, $request ) {
 
 			$template_part_files = get_template_part_paths( get_stylesheet_directory() );
 			if ( is_child_theme() ) {
-				$template_part_files = get_template_part_paths( get_template_directory(), $template_part_files );
+				$template_part_files = array_merge( $template_part_files, get_template_part_paths( get_template_directory() ) );
 			}
 			// Build and save each template part.
 			foreach ( $template_part_files as $template_part_file ) {

--- a/lib/template-parts.php
+++ b/lib/template-parts.php
@@ -212,12 +212,20 @@ function filter_rest_wp_template_part_query( $args, $request ) {
 		// Ensure auto-drafts of all theme supplied template parts are created.
 		if ( wp_get_theme()->get( 'TextDomain' ) === $request['theme'] ) {
 			// Get file paths for all theme supplied template parts.
-			$template_part_files = glob( get_stylesheet_directory() . '/block-template-parts/*.html' );
-			$template_part_files = is_array( $template_part_files ) ? $template_part_files : array();
+			function get_template_part_paths( $base_directory, $path_list = array() ) {
+				if ( file_exists( $base_directory . '/block-template-parts' ) ) {
+					$nested_files      = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $base_directory . '/block-template-parts' ) );
+					$nested_html_files = new RegexIterator( $nested_files, '/^.+\.html$/i', RecursiveRegexIterator::GET_MATCH );
+					foreach ( $nested_html_files as $path => $file ) {
+						$path_list[] = $path;
+					}
+				}
+				return $path_list;
+			}
+
+			$template_part_files = get_template_part_paths( get_stylesheet_directory() );
 			if ( is_child_theme() ) {
-				$child_template_part_files = glob( get_template_directory() . '/block-template-parts/*.html' );
-				$child_template_part_files = is_array( $child_template_part_files ) ? $child_template_part_files : array();
-				$template_part_files       = array_merge( $template_part_files, $child_template_part_files );
+				$template_part_files = get_template_part_paths( get_template_directory(), $template_part_files );
 			}
 			// Build and save each template part.
 			foreach ( $template_part_files as $template_part_file ) {

--- a/lib/template-parts.php
+++ b/lib/template-parts.php
@@ -211,7 +211,12 @@ function filter_rest_wp_template_part_query( $args, $request ) {
 
 		// Ensure auto-drafts of all theme supplied template parts are created.
 		if ( wp_get_theme()->get( 'TextDomain' ) === $request['theme'] ) {
-			// Get file paths for all theme supplied template parts.
+			/**
+			 * Finds all nested template part file paths in a theme's directory.
+			 *
+			 * @param string $base_directory The theme's file path.
+			 * @return array $path_list A list of paths to all template part files.
+			 */
 			function get_template_part_paths( $base_directory ) {
 				$path_list = array();
 				if ( file_exists( $base_directory . '/block-template-parts' ) ) {
@@ -224,6 +229,7 @@ function filter_rest_wp_template_part_query( $args, $request ) {
 				return $path_list;
 			}
 
+			// Get file paths for all theme supplied template parts.
 			$template_part_files = get_template_part_paths( get_stylesheet_directory() );
 			if ( is_child_theme() ) {
 				$template_part_files = array_merge( $template_part_files, get_template_part_paths( get_template_directory() ) );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Currently, template part auto-drafting is only done for template parts directly in the block-template-parts directory of a theme.  This change updates this to handle template parts included in subdirectories of block-template-parts.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
In your themes block-template-parts folder, create a new template part .html file in a sub-directory.  Load the editor, and verify the auto draft for this new template part is found in the template part placeholder's selection/preview popover.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
