### PR TITLE
Prevent TypeError for projects without a local Prettier configuration

### DIFF
--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Fix TypeError for projects without a local Prettier configuration.
+
+## 7.2.0 (2020-09-03)
+
 ### Enhancements
 
 -   The bundled `eslint-plugin-jsdoc` dependency has been updated from requiring `^26.0.0` to requiring `^30.2.2`.

--- a/packages/eslint-plugin/configs/recommended.js
+++ b/packages/eslint-plugin/configs/recommended.js
@@ -8,7 +8,8 @@ const { cosmiconfigSync } = require( 'cosmiconfig' );
  */
 const defaultPrettierConfig = require( '@wordpress/prettier-config' );
 
-const { config: localPrettierConfig } = cosmiconfigSync( 'prettier' ).search();
+const { config: localPrettierConfig } =
+	cosmiconfigSync( 'prettier' ).search() || {};
 const prettierConfig = { ...defaultPrettierConfig, ...localPrettierConfig };
 
 module.exports = {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes #25048.
See #24590.

`cosmiconfigSync()` returns `null` if no config is found which can't be destructured.

## How has this been tested?
Using the configs from https://github.com/WordPress/gutenberg/issues/25048#issuecomment-686962023 in an example project.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
