### PR TITLE
Fix PHP error when users don't have access to the Appearance menu

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -45,7 +45,7 @@ function gutenberg_menu() {
 		'gutenberg'
 	);
 
-	if ( gutenberg_use_widgets_block_editor() ) {
+	if ( gutenberg_use_widgets_block_editor() && isset( $submenu['themes.php'] ) ) {
 		add_theme_page(
 			__( 'Widgets', 'gutenberg' ),
 			__( 'Widgets', 'gutenberg' ),


### PR DESCRIPTION
Fixes #25054 

When a user doesn't have access to the "Appearance" admin menu (`themes.php`) they get PHP errors because there's a check missing and we're trying to add submenus to an item that doesn't exist.

## Types of changes
Added an extra `isset()` check to make sure the menu-item exists before we add a submenu to it.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] ~~My code follows the accessibility standards.~~ <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] ~~My code has proper inline documentation.~~ <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] ~~I've included developer documentation if appropriate.~~ <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] ~~I've updated all React Native files affected by any refactorings/renamings in this PR.~~ <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
