### PR TITLE
Feature/18066 add plugin area to widgets screen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11503,6 +11503,7 @@
 				"@wordpress/keycodes": "file:packages/keycodes",
 				"@wordpress/media-utils": "file:packages/media-utils",
 				"@wordpress/notices": "file:packages/notices",
+				"@wordpress/plugins": "file:packages/plugins",
 				"classnames": "^2.2.5",
 				"lodash": "^4.17.19",
 				"rememo": "^3.0.0"

--- a/packages/edit-widgets/package.json
+++ b/packages/edit-widgets/package.json
@@ -46,6 +46,7 @@
 		"@wordpress/keycodes": "file:../keycodes",
 		"@wordpress/media-utils": "file:../media-utils",
 		"@wordpress/notices": "file:../notices",
+		"@wordpress/plugins": "file:../plugins",
 		"classnames": "^2.2.5",
 		"lodash": "^4.17.19",
 		"rememo": "^3.0.0"

--- a/packages/edit-widgets/src/components/layout/index.js
+++ b/packages/edit-widgets/src/components/layout/index.js
@@ -4,6 +4,7 @@
 import { Popover } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { InterfaceSkeleton, ComplementaryArea } from '@wordpress/interface';
+import { PluginArea } from '@wordpress/plugins';
 
 /**
  * Internal dependencies
@@ -39,6 +40,7 @@ function Layout( { blockEditorSettings } ) {
 			/>
 			<Sidebar />
 			<Popover.Slot />
+			<PluginArea />
 		</WidgetAreasBlockEditorProvider>
 	);
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This PR adds the PluginArea to the WidgetAreasBlockEditorProvider component and replaces #18067. 

This is the first step for #18068

Closes #18066

## How has this been tested?
Tested locally to ensure no visual changes occur.

## Screenshots <!-- if applicable -->

## Types of changes
Introduces the `<PluginArea/>` component. No visual changes.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
