### PR TITLE
Allow inserting an h1 using # + space

### DIFF
--- a/packages/block-library/src/heading/transforms.js
+++ b/packages/block-library/src/heading/transforms.js
@@ -57,7 +57,7 @@ const transforms = {
 				return createBlock( name, attributes );
 			},
 		},
-		...[ 2, 3, 4, 5, 6 ].map( ( level ) => ( {
+		...[ 1, 2, 3, 4, 5, 6 ].map( ( level ) => ( {
 			type: 'prefix',
 			prefix: Array( level + 1 ).join( '#' ),
 			transform( content ) {


### PR DESCRIPTION
## Description
Fixes #24747 

## How has this been tested?
I can now insert an `h1` header using `#` + `space`.

## Types of changes
tweak in transforms.js

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] ~~My code has proper inline documentation.~~ <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] ~~I've included developer documentation if appropriate.~~ <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] ~~I've updated all React Native files affected by any refactorings/renamings in this PR.~~ <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
