### PR TITLE
Block supports: Fix block attribute (style and class) double-encoding

### DIFF
--- a/lib/block-supports/index.php
+++ b/lib/block-supports/index.php
@@ -89,11 +89,11 @@ function gutenberg_apply_block_supports( $block_content, $block ) {
 
 	// Apply new styles and classes.
 	if ( ! empty( $new_classes ) ) {
-		$block_root->setAttribute( 'class', esc_attr( implode( ' ', $new_classes ) ) );
+		$block_root->setAttribute( 'class', implode( ' ', $new_classes ) );
 	}
 
 	if ( ! empty( $new_styles ) ) {
-		$block_root->setAttribute( 'style', esc_attr( implode( '; ', $new_styles ) . ';' ) );
+		$block_root->setAttribute( 'style', implode( '; ', $new_styles ) . ';' );
 	}
 
 	return $dom->saveHtml( $block_root );

--- a/lib/block-supports/index.php
+++ b/lib/block-supports/index.php
@@ -89,10 +89,12 @@ function gutenberg_apply_block_supports( $block_content, $block ) {
 
 	// Apply new styles and classes.
 	if ( ! empty( $new_classes ) ) {
+		// `DOMElement::setAttribute` handles attribute value escaping.
 		$block_root->setAttribute( 'class', implode( ' ', $new_classes ) );
 	}
 
 	if ( ! empty( $new_styles ) ) {
+		// `DOMElement::setAttribute` handles attribute value escaping.
 		$block_root->setAttribute( 'style', implode( '; ', $new_styles ) . ';' );
 	}
 

--- a/phpunit/class-block-supported-styles-test.php
+++ b/phpunit/class-block-supported-styles-test.php
@@ -817,4 +817,48 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 
 		$this->assertEmpty( $errors, 'Libxml errors should be dropped.' );
 	}
+
+	/**
+	 * Ensures block attributes are output correctly.
+	 *
+	 * Some blocks saved with valid attributes were broken after the block was rendered. Ensure that
+	 * block attributes are escaped correctly and safely.
+	 */
+	public function test_render_block_attribute() {
+		$this->register_block_type( 'core/example', array( 'render_callback' => true ) );
+
+		$block = array(
+			'blockName' => 'core/example',
+			'attrs'     => array(),
+		);
+
+		// Tests of shape [ [ $input, $expected_result ], … ].
+		$tests = array(
+
+			// Valid single quotes in double-quoted attribute.
+			array(
+				'<div style="background-image:url(\'https://example.com/image.png?example=query&amp;args\')"></div>',
+				'<div style="background-image: url(\'https://example.com/image.png?example=query&amp;args\');" class="wp-block-example"></div>',
+			),
+
+			// Valid double quotes in single-quoted attribute.
+			array(
+				'<div style=\'background-image:url("https://example.com/image.png?example=query&amp;args")\'></div>',
+				'<div style=\'background-image: url("https://example.com/image.png?example=query&amp;args");\' class="wp-block-example"></div>',
+			),
+
+			// Encode attributes.
+			array(
+				'<div style="&quot;><script>alert(1)</script>"></div>',
+				'<div style=\'"&gt;&lt;script&gt;alert(1)&lt;/script&gt;;\' class="wp-block-example"></div>',
+			),
+		);
+
+		foreach ( $tests as $test ) {
+			$input = $test[0];
+			$expected = $test[1];
+			$result = apply_filters( 'render_block', $input, $block );
+			$this->assertEquals( $expected, $result );
+		}
+	}
 }

--- a/phpunit/class-block-supported-styles-test.php
+++ b/phpunit/class-block-supported-styles-test.php
@@ -855,9 +855,9 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		);
 
 		foreach ( $tests as $test ) {
-			$input = $test[0];
+			$input    = $test[0];
 			$expected = $test[1];
-			$result = apply_filters( 'render_block', $input, $block );
+			$result   = apply_filters( 'render_block', $input, $block );
 			$this->assertEquals( $expected, $result );
 		}
 	}


### PR DESCRIPTION
## Description

Remove double encoding of class and style attributes in block supports.

Dynamic blocks rendered by block-supports double encode html which may produce broken results. For example, if we start with valid HTML including a single quote (apostrophe) in a double-quoted attribute, the single quote will be encoded by `esc_attr` to the unicode HTML entity `&#039;`. [`DOMElement::setAttribute`](https://www.php.net/manual/en/domelement.setattribute.php) will then encode this result to `&amp;#039;`. This single entity is now doubly encoded and will be interpreted by the browser as `&#039;`. A full example:

```html
<!-- Saved block content: -->
<div style="background-image:url('https://example.com/image.png');"></div>

<!-- with esc_attr we would get this (also seems to be valid) -->
<div style="background-image:url(&#039;https://example.com/image.png&#039;);"></div>

<!-- setAttribute escapes the escaped attribute, this is now broken -->
<div style="background-image:url(&amp;#039;https://example.com/image.png&amp;#039;);"></div>
```

When this finally reaches the browser, it makes a request for the background image to the relative path `&` because the unescaped url is interpreted as `&#039;https://example.com/image.png&#039;`.

I've added unit tests which attempt to clarify and verify the expected behavior, we can observe the double encoding in the [failed unit tests on the first commit of this PR](https://github.com/WordPress/gutenberg/runs/1072976504).

This behavior was introduced in https://github.com/WordPress/gutenberg/pull/24486.

## How has this been tested?
Unit tests.
Manual testing.

## Types of changes
Bug fix: Fix double-encoding of dynamic block classes and styles.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
