### PR TITLE
Core Data: Bring back support for nested `_fields` values

### DIFF
--- a/packages/core-data/src/queried-data/selectors.js
+++ b/packages/core-data/src/queried-data/selectors.js
@@ -77,12 +77,12 @@ function getQueriedItemsUncached( state, query ) {
 				// This accounts for the fact that queried items are stored by
 				// stable key without an associated fields query. Other requests
 				// may have included fewer fields properties.
-				const field = fields[ f ];
+				const field = fields[ f ].split( '.' );
 				if ( ! has( item, field ) ) {
 					return null;
 				}
-
-				set( filteredItem, field, get( item, field ) );
+				const value = get( item, field );
+				set( filteredItem, field, value );
 			}
 		} else {
 			// If expecting a complete item, validate that completeness, or

--- a/packages/core-data/src/queried-data/selectors.js
+++ b/packages/core-data/src/queried-data/selectors.js
@@ -3,6 +3,7 @@
  */
 import createSelector from 'rememo';
 import EquivalentKeyMap from 'equivalent-key-map';
+import { get, has, set } from 'lodash';
 
 /**
  * Internal dependencies
@@ -77,11 +78,11 @@ function getQueriedItemsUncached( state, query ) {
 				// stable key without an associated fields query. Other requests
 				// may have included fewer fields properties.
 				const field = fields[ f ];
-				if ( ! item.hasOwnProperty( field ) ) {
+				if ( ! has( item, field ) ) {
 					return null;
 				}
 
-				filteredItem[ field ] = item[ field ];
+				set( filteredItem, field, get( item, field ) );
 			}
 		} else {
 			// If expecting a complete item, validate that completeness, or

--- a/packages/core-data/src/queried-data/test/selectors.js
+++ b/packages/core-data/src/queried-data/test/selectors.js
@@ -106,6 +106,47 @@ describe( 'getQueriedItems', () => {
 		] );
 	} );
 
+	it( 'should dynamically construct fields-filtered item from available data with nested fields', () => {
+		const state = {
+			items: {
+				1: {
+					id: 1,
+					content: 'chicken',
+					author: 'bob',
+					meta: {
+						template: 'single',
+						_private: 'unused',
+					},
+				},
+				2: {
+					id: 2,
+					content: 'ribs',
+					author: 'sally',
+					meta: {
+						template: 'single',
+						_private: 'unused',
+					},
+				},
+			},
+			itemIsComplete: {
+				1: true,
+				2: true,
+			},
+			queries: {
+				'': [ 1, 2 ],
+			},
+		};
+
+		const result = getQueriedItems( state, {
+			_fields: [ 'content', 'meta.template' ],
+		} );
+
+		expect( result ).toEqual( [
+			{ content: 'chicken', meta: { template: 'single' } },
+			{ content: 'ribs', meta: { template: 'single' } },
+		] );
+	} );
+
 	it( 'should return null if attempting to filter by yet-unknown fields', () => {
 		const state = {
 			items: {


### PR DESCRIPTION
## Description
Fixes #25078 — The change to `getEntityRecords`'s use of _fields has broken nested meta field requests. In the API, you can pass nested fields for meta, ex: `wp-json/wp/v2/posts?_fields=title,meta.demo,id`, and this used to work for the getEntityRecords request.

It seems the change in #19498 introduced this:

https://github.com/WordPress/gutenberg/blob/8ba0a42e7d461722129c2c21b77b2625a1f8a255/packages/core-data/src/queried-data/selectors.js#L80-L82

Which is returning null, because it's testing for `item['meta.key']`, rather than `item.meta.key`. This PR switches to using the lodash functions `has`, `get`, and `set`, which support string keys like that. I've seen some moves away from lodash, but it seems like the most straightforward fix here.

## How has this been tested?
There's a new test case introduced in `packages/core-data/src/queried-data/test/selectors.js` which catches this case.

You can also test with the code snippet in #25078

## Types of changes
Bug fix (non-breaking change which fixes an issue)
