### PR TITLE
Mirror WordPress plugin install text for blocks

### DIFF
--- a/packages/block-directory/src/components/downloadable-block-info/index.js
+++ b/packages/block-directory/src/components/downloadable-block-info/index.js
@@ -1,16 +1,34 @@
 /**
  * WordPress dependencies
  */
-import { __, _n, sprintf } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 import { Fragment } from '@wordpress/element';
 import { Icon, update, chartLine } from '@wordpress/icons';
 
 function DownloadableBlockInfo( {
-	description,
 	activeInstalls,
+	description,
 	humanizedUpdated,
 } ) {
+	let activeInstallsString;
+
+	if ( activeInstalls > 1000000 ) {
+		activeInstallsString = sprintf(
+			/* translators: %d: number of active installations. */
+			__( '%d+ Million active installations' ),
+			Math.floor( activeInstalls / 1000000 )
+		);
+	} else if ( 0 === activeInstalls ) {
+		activeInstallsString = __( 'Less than 10 active installations' );
+	} else {
+		activeInstallsString = sprintf(
+			/* translators: %d: number of active installations. */
+			__( '%d+ active installations' ),
+			activeInstalls
+		);
+	}
+
 	return (
 		<Fragment>
 			<p className="block-directory-downloadable-block-info__content">
@@ -21,15 +39,7 @@ function DownloadableBlockInfo( {
 					className="block-directory-downloadable-block-info__icon"
 					icon={ chartLine }
 				/>
-				{ sprintf(
-					/* translators: %s: number of active installations. */
-					_n(
-						'%d active installation',
-						'%d active installations',
-						activeInstalls
-					),
-					activeInstalls
-				) }
+				{ activeInstallsString }
 			</div>
 			<div className="block-directory-downloadable-block-info__meta">
 				<Icon

--- a/packages/block-directory/src/components/downloadable-block-info/test/index.js
+++ b/packages/block-directory/src/components/downloadable-block-info/test/index.js
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import DownloadableBlockInfo from '../index';
+
+describe( 'DownloadableBlockInfo', () => {
+	const metaSelector = '.block-directory-downloadable-block-info__meta';
+	describe( 'Active Installs Count', () => {
+		it( 'should display the correct count for over a million installs', () => {
+			const wrapper = shallow(
+				<DownloadableBlockInfo activeInstalls={ 10000000 } />
+			);
+
+			const count = wrapper.find( metaSelector ).first().text();
+
+			expect( count ).toContain( '10+ Million' );
+		} );
+
+		it( 'should display the correct count for 0 installs', () => {
+			const wrapper = shallow(
+				<DownloadableBlockInfo activeInstalls={ 0 } />
+			);
+
+			const count = wrapper.find( metaSelector ).first().text();
+
+			expect( count ).toContain( 'Less than 10 active installations' );
+		} );
+
+		it( 'should display the correct count for 10+ and less than a Million installs', () => {
+			const wrapper = shallow(
+				<DownloadableBlockInfo activeInstalls={ 100 } />
+			);
+
+			const count = wrapper.find( metaSelector ).first().text();
+
+			expect( count ).toContain( '100+ active installations' );
+		} );
+	} );
+} );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Related to https://github.com/WordPress/gutenberg/issues/24842 —I've modified the text to mirror the implementation of the [plugin installations count text from WordPress](https://core.trac.wordpress.org/browser/trunk/src/wp-admin/includes/plugin-install.php#L685). 

Something to consider is that `number_format_i18n` is not implemented yet for Gutenberg.(https://github.com/WordPress/gutenberg/issues/22628)

## How has this been tested?
Added tests for each variation.

## Screenshots <!-- if applicable -->

<img width="352" alt="image" src="https://user-images.githubusercontent.com/1157901/92272755-288ddb80-eeb8-11ea-94d5-55fa7de528ba.png">
<img width="351" alt="image" src="https://user-images.githubusercontent.com/1157901/92273344-2bd59700-eeb9-11ea-97f5-33428fee3ea1.png">


## Types of changes

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
