### PR TITLE
Element: Add and upgrade @types/{react,react-dom} dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10341,12 +10341,19 @@
 			}
 		},
 		"@types/react": {
-			"version": "16.9.18",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.18.tgz",
-			"integrity": "sha512-MvjiKX/kUE8o49ipppg49RDZ97p4XfW1WWksp/UlTUSJpisyhzd62pZAMXxAscFLoxfYOflkGANAnGkSeHTFQg==",
+			"version": "16.9.49",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.49.tgz",
+			"integrity": "sha512-DtLFjSj0OYAdVLBbyjhuV9CdGVHCkHn2R+xr3XkBvK2rS1Y1tkc14XSGjYgm5Fjjr90AxH9tiSzc1pCFMGO06g==",
 			"requires": {
 				"@types/prop-types": "*",
-				"csstype": "^2.2.0"
+				"csstype": "^3.0.2"
+			},
+			"dependencies": {
+				"csstype": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.3.tgz",
+					"integrity": "sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag=="
+				}
 			}
 		},
 		"@types/react-color": {
@@ -10359,10 +10366,9 @@
 			}
 		},
 		"@types/react-dom": {
-			"version": "16.9.5",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.5.tgz",
-			"integrity": "sha512-BX6RQ8s9D+2/gDhxrj8OW+YD4R+8hj7FEM/OJHGNR0KipE1h1mSsf39YeyC81qafkq+N3rU3h3RFbLSwE5VqUg==",
-			"dev": true,
+			"version": "16.9.8",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.8.tgz",
+			"integrity": "sha512-ykkPQ+5nFknnlU6lDd947WbQ6TE3NNzbQAkInC2EKY1qeYdTKp7onFusmYZb+ityzx2YviqT6BXSu+LyWWJwcA==",
 			"requires": {
 				"@types/react": "*"
 			}
@@ -11552,6 +11558,8 @@
 			"version": "file:packages/element",
 			"requires": {
 				"@babel/runtime": "^7.9.2",
+				"@types/react": "^16.9.0",
+				"@types/react-dom": "^16.9.0",
 				"@wordpress/escape-html": "file:packages/escape-html",
 				"lodash": "^4.17.19",
 				"react": "^16.13.1",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
 		"@types/npm-package-arg": "6.1.0",
 		"@types/prettier": "1.19.0",
 		"@types/qs": "6.9.1",
-		"@types/react-dom": "16.9.5",
 		"@types/requestidlecallback": "0.3.1",
 		"@types/semver": "7.2.0",
 		"@types/sprintf-js": "1.1.2",

--- a/packages/element/CHANGELOG.md
+++ b/packages/element/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Bug fix
+
+- Declare @types/react and @types/react-dom dependencies which could cause type errors when using
+  this package with TypeScript ([#25086](https://github.com/WordPress/gutenberg/pull/25086))
+
 ## 2.14.0 (2020-05-14)
 
 ### New Feature

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -4,12 +4,7 @@
 	"description": "Element React module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
-	"keywords": [
-		"wordpress",
-		"gutenberg",
-		"element",
-		"react"
-	],
+	"keywords": [ "wordpress", "gutenberg", "element", "react" ],
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/element/README.md",
 	"repository": {
 		"type": "git",
@@ -26,6 +21,8 @@
 	"sideEffects": false,
 	"dependencies": {
 		"@babel/runtime": "^7.9.2",
+		"@types/react": "^16.9.0",
+		"@types/react-dom": "^16.9.0",
 		"@wordpress/escape-html": "file:../escape-html",
 		"lodash": "^4.17.19",
 		"react": "^16.13.1",


### PR DESCRIPTION
## Description
https://github.com/WordPress/gutenberg/issues/23130 describes a reproducible issue where the output types from `@wordpress/element` reference types that may not exist when installed as a dependency.

Include `@types/react` and `@types/react-dom` dependencies of `@wordpress/element` package.

This also upgrades them to their latest version in the lockfile.

Fixes #23130.

## How has this been tested?
Type build works without errors.

## Types of changes

Internal.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
