### PR TITLE
fixed z-index issue between media-modal and popover component

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -102,7 +102,7 @@ $z-layers: (
 
 	// Show popovers above wp-admin menus and submenus and sidebar:
 	// #adminmenuwrap { z-index: 9990 }
-	".components-popover": 1000000,
+	".components-popover": 100000,
 
 	// ...Except for popovers immediately beneath wp-admin menu on large breakpoints
 	".components-popover.block-editor-inserter__popover": 99999,


### PR DESCRIPTION
## Description
While the media-modal and popover component is open, z-index issue occur.
I've explored this issue a[t coblocks](https://github.com/godaddy-wordpress/coblocks/issues/1580#issue-662363245) plugin issues tab. I just deleted just one 0 from the popover z-index value. It was too hight.

Please find the details [here](https://github.com/godaddy-wordpress/coblocks/issues/1580#issue-662363245).

## How has this been tested?
This can be tested by[ Coblocks ](https://wordpress.org/plugins/coblocks/)plugin's Hero block.

## Screenshots <!-- if applicable -->
https://user-images.githubusercontent.com/1781226/87995326-070d9780-caa4-11ea-8cff-db1af7428b1f.png

## Types of changes
minor z-index value changes

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
