### PR TITLE
Widgets screen: Add labels for settings button and close button

### DIFF
--- a/packages/edit-widgets/src/components/sidebar/index.js
+++ b/packages/edit-widgets/src/components/sidebar/index.js
@@ -133,6 +133,9 @@ export default function Sidebar() {
 				/>
 			}
 			headerClassName="edit-widgets-sidebar__panel-tabs"
+			/* translators: button label text should, if possible, be under 16 characters. */
+			title={ __( 'Settings' ) }
+			closeLabel={ __( 'Close settings' ) }
 			scope="core/edit-widgets"
 			identifier={ currentArea }
 			icon={ cog }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Fix #24943.

Add title `Settings` to the settings button in Widgets screen, and also change the label of the close button from `Close plugin` to `Close settings`.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Go to the Widgets screen (Enable via experiments in Gutenberg)
2. Hover over the settings button
3. Observe the tooltip
4. Hover over the close button
5. Observe the tooltip

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/7753001/92345921-bc9cb480-f0fd-11ea-8e8b-a654aaccbc2d.png)

![image](https://user-images.githubusercontent.com/7753001/92345844-80695400-f0fd-11ea-8be1-b4ba6983e8d7.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
