### PR TITLE
Data: add a comment about why we normalize resolvers to objects with fulfill method

### DIFF
--- a/packages/data/src/namespace-store/index.js
+++ b/packages/data/src/namespace-store/index.js
@@ -252,13 +252,21 @@ function mapActions( actions, store ) {
  * @param {Object} resolvers      Resolvers to register.
  * @param {Object} selectors      The current selectors to be modified.
  * @param {Object} store          The redux store to which the resolvers should be mapped.
- * @param {Object} queue          Resolvers async queue.
  * @param {Object} resolversCache Resolvers Cache.
  */
 function mapResolvers( resolvers, selectors, store, resolversCache ) {
+	// The `resolver` can be either a function that does the resolution, or, in more advanced
+	// cases, an object with a `fullfill` method and other optional methods like `isFulfilled`.
+	// Here we normalize the `resolver` function to an object with `fulfill` method.
 	const mappedResolvers = mapValues( resolvers, ( resolver ) => {
-		const { fulfill: resolverFulfill = resolver } = resolver;
-		return { ...resolver, fulfill: resolverFulfill };
+		if ( resolver.fulfill ) {
+			return resolver;
+		}
+
+		return {
+			...resolver, // copy the enumerable properties of the resolver function
+			fulfill: resolver, // add the fulfill method
+		};
 	} );
 
 	const mapSelector = ( selector, selectorName ) => {


### PR DESCRIPTION
I was not sure why we normalize resolver functions to a `{ fulfill }` object, so I did a bit of research and added a comment to the code.

It seems to me that the `isFulfilled` method, introduced in #6084, is not used anywhere in the Gutenberg code base and I'm not sure if it was _ever_ used. These days, the selector/resolver state is stored in the store's `metadata` and there is a `ifNotResolved` helper in `core-data` that uses a metadata selector. @youknowriad is `isFulfilled` indeed a candidate for deprecation, or is it still useful?

The patch also refactors the code to remove destructuring that seems a bit too smart to me, and removes a stale JSDoc comment about the `query` param that was added during some back-and-forth in #21289.
