### PR TITLE
Fix cover width regression.

### DIFF
--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -92,7 +92,6 @@
 	}
 
 	.wp-block-cover__inner-container {
-		width: calc(100% - 4.375em);
 		z-index: z-index(".wp-block-cover__inner-container");
 		color: $white;
 	}


### PR DESCRIPTION
This issue seems to have been made more visible by #24523, but did not seem to be the result of it.

Basically, the Cover block has an inner container, called `wp-block-cover__inner-container`. This had a max-width of `calc(100% - 70px)`. Since that rule was written for the UI that shipped with 5.4, I'm assuming those 70px were to accommodate for the side UI that was present (movers, etc). 

Since that side UI is no longer needed, that rule can be removed. Which in turn makes the editor consistent with the frontend:

<img width="1294" alt="Screenshot 2020-09-07 at 10 32 37" src="https://user-images.githubusercontent.com/1204802/92366914-0ed9d780-f0f6-11ea-802b-de8d8d825c1e.png">

<img width="1017" alt="Screenshot 2020-09-07 at 10 32 46" src="https://user-images.githubusercontent.com/1204802/92366918-100b0480-f0f6-11ea-88b1-29f8ac99cb39.png">

Here's before:

<img width="1296" alt="Screenshot 2020-09-07 at 10 37 22" src="https://user-images.githubusercontent.com/1204802/92366987-2913b580-f0f6-11ea-8914-f10d3148dd0b.png">
