### PR TITLE
Add/preview options component readme

### DIFF
--- a/packages/block-editor/src/components/preview-options/README.md
+++ b/packages/block-editor/src/components/preview-options/README.md
@@ -37,6 +37,7 @@ const MyPreviewOptions = () => (
 The CSS classes added to the component.
 
 -   Type: `String`
+-   Required: no
 
 #### isEnabled
 
@@ -44,6 +45,7 @@ Wheter or not the preview options are enabled for the current post.
 And example of when the preview options are not enabled is when the current post is not savable.
 
 -   Type: `boolean`
+-   Required: no
 -   Default: true
 
 #### deviceType
@@ -51,12 +53,14 @@ And example of when the preview options are not enabled is when the current post
 The device type in the preview options. It can be either Desktop or Tablet or Mobile among others.
 
 -   Type: `String`
+-   Required: yes
 
 #### setDeviceType
 
 Used to set the device type that will be used to display the preview inside the editor.
 
 -   Type: `func`
+-   Required: yes
 
 ## Related components
 

--- a/packages/block-editor/src/components/preview-options/README.md
+++ b/packages/block-editor/src/components/preview-options/README.md
@@ -36,7 +36,7 @@ const MyPreviewOptions = () => (
 
 The CSS classes added to the component.
 
--   Type: any
+-   Type: `String`
 
 #### isEnabled
 
@@ -50,13 +50,13 @@ And example of when the preview options are not enabled is when the current post
 
 The device type in the preview options. It can be either Desktop or Tablet or Mobile among others.
 
--   Type: `any`
+-   Type: `String`
 
 #### setDeviceType
 
 Used to set the device type that will be used to display the preview inside the editor.
 
--   Type: `any`
+-   Type: `func`
 
 ## Related components
 

--- a/packages/block-editor/src/components/preview-options/README.md
+++ b/packages/block-editor/src/components/preview-options/README.md
@@ -18,7 +18,7 @@ It returns a [`DropdownMenu`](https://github.com/WordPress/gutenberg/tree/master
 Renders the previews options of the editor in a dropdown menu.
 
 ```jsx
-import { PreviewOptions } from '@wordpress/block-editor';
+import { __experimentalPreviewOptions as PreviewOptions } from '@wordpress/block-editor';
 
 const MyPreviewOptions = () => (
     <PreviewOptions

--- a/packages/block-editor/src/components/preview-options/README.md
+++ b/packages/block-editor/src/components/preview-options/README.md
@@ -18,6 +18,8 @@ It returns a [`DropdownMenu`](https://github.com/WordPress/gutenberg/tree/master
 Renders the previews options of the editor in a dropdown menu.
 
 ```jsx
+import { Icon, MenuGroup } from '@wordpress/components';
+import { PostPreviewButton } from '@wordpress/editor';
 import { __experimentalPreviewOptions as PreviewOptions } from '@wordpress/block-editor';
 
 const MyPreviewOptions = () => (
@@ -26,6 +28,25 @@ const MyPreviewOptions = () => (
         className="edit-post-post-preview-dropdown"
         deviceType={ deviceType }
         setDeviceType={ setPreviewDeviceType }
+        >
+        <MenuGroup>
+            <div className="edit-post-header-preview__grouping-external">
+                <PostPreviewButton
+                    className={
+                        'edit-post-header-preview__button-external'
+                    }
+                    role="menuitem"
+                    forceIsAutosaveable={ hasActiveMetaboxes }
+                    forcePreviewLink={ isSaving ? null : undefined }
+                    textContent={
+                        <>
+                            { __( 'Preview in new tab' ) }
+                            <Icon icon={ external } />
+                        </>
+                    }
+                />
+            </div>
+		</MenuGroup>
     >
 );
 ```

--- a/packages/block-editor/src/components/preview-options/README.md
+++ b/packages/block-editor/src/components/preview-options/README.md
@@ -23,31 +23,29 @@ import { PostPreviewButton } from '@wordpress/editor';
 import { __experimentalPreviewOptions as PreviewOptions } from '@wordpress/block-editor';
 
 const MyPreviewOptions = () => (
-    <PreviewOptions
-        isEnabled={ true }
-        className="edit-post-post-preview-dropdown"
-        deviceType={ deviceType }
-        setDeviceType={ setPreviewDeviceType }
-        >
-        <MenuGroup>
-            <div className="edit-post-header-preview__grouping-external">
-                <PostPreviewButton
-                    className={
-                        'edit-post-header-preview__button-external'
-                    }
-                    role="menuitem"
-                    forceIsAutosaveable={ hasActiveMetaboxes }
-                    forcePreviewLink={ isSaving ? null : undefined }
-                    textContent={
-                        <>
-                            { __( 'Preview in new tab' ) }
-                            <Icon icon={ external } />
-                        </>
-                    }
-                />
-            </div>
+	<PreviewOptions
+		isEnabled={ true }
+		className="edit-post-post-preview-dropdown"
+		deviceType={ deviceType }
+		setDeviceType={ setPreviewDeviceType }
+	>
+		<MenuGroup>
+			<div className="edit-post-header-preview__grouping-external">
+				<PostPreviewButton
+					className={ 'edit-post-header-preview__button-external' }
+					role="menuitem"
+					forceIsAutosaveable={ hasActiveMetaboxes }
+					forcePreviewLink={ isSaving ? null : undefined }
+					textContent={
+						<>
+							{ __( 'Preview in new tab' ) }
+							<Icon icon={ external } />
+						</>
+					}
+				/>
+			</div>
 		</MenuGroup>
-    </PreviewOptions>
+	</PreviewOptions>
 );
 ```
 

--- a/packages/block-editor/src/components/preview-options/README.md
+++ b/packages/block-editor/src/components/preview-options/README.md
@@ -1,0 +1,63 @@
+# Preview Options
+
+The `PreviewOptions` component displays the list of different preview options available in the editor.
+
+It returns a [`DropdownMenu`](https://github.com/WordPress/gutenberg/tree/master/packages/components/src/dropdown-menu) component with these different options. The options currently available in the editor are Desktop, Mobile, Tablet and "Preview in new tab".
+
+![Preview options dropdown menu](https://make.wordpress.org/core/files/2020/09/preview-options-dropdown-menu.png)
+
+## Table of contents
+
+1. [Development guidelines](#development-guidelines)
+2. [Related components](#related-components)
+
+## Development guidelines
+
+### Usage
+
+Renders the previews options of the editor in a dropdown menu.
+
+```jsx
+import { PreviewOptions } from '@wordpress/block-editor';
+
+const MyPreviewOptions = () => (
+    <PreviewOptions
+        isEnabled={ true }
+        className="edit-post-post-preview-dropdown"
+        deviceType={ deviceType }
+        setDeviceType={ setPreviewDeviceType }
+    >
+);
+```
+
+### Props
+
+#### className
+
+The CSS classes added to the component.
+
+-   Type: any
+
+#### isEnabled
+
+Wheter or not the preview options are enabled for the current post.
+And example of when the preview options are not enabled is when the current post is not savable.
+
+-   Type: `boolean`
+-   Default: true
+
+#### deviceType
+
+The device type in the preview options. It can be either Desktop or Tablet or Mobile among others.
+
+-   Type: `any`
+
+#### setDeviceType
+
+Used to set the device type that will be used to display the preview inside the editor.
+
+-   Type: `any`
+
+## Related components
+
+Block Editor components are components that can be used to compose the UI of your block editor. Thus, they can only be used under a [`BlockEditorProvider`](https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/provider/README.md) in the components tree.

--- a/packages/block-editor/src/components/preview-options/README.md
+++ b/packages/block-editor/src/components/preview-options/README.md
@@ -47,7 +47,7 @@ const MyPreviewOptions = () => (
                 />
             </div>
 		</MenuGroup>
-    >
+    </PreviewOptions>
 );
 ```
 


### PR DESCRIPTION
## Description
Added documentation for the preview options component (see #22891)

## How has this been tested?
N/A, documentation only

## Types of changes
Documentation

## Checklist:
- [n/a] My code is tested.
- [n/a] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [n/a] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
