### PR TITLE
Improve the block and patterns search algorithm

### DIFF
--- a/packages/block-editor/src/components/inserter/search-items.js
+++ b/packages/block-editor/src/components/inserter/search-items.js
@@ -181,7 +181,7 @@ export function getItemSearchRank( item, searchTerm, config = {} ) {
 	// name, keywords, categories, collection, variations match come later.
 	if ( normalizedSearchInput === normalizedTitle ) {
 		rank += 30;
-	} else if ( normalizedTitle.indexOf( normalizedSearchInput ) === 0 ) {
+	} else if ( normalizedTitle.startsWith( normalizedSearchInput ) ) {
 		rank += 20;
 	} else {
 		const terms = [
@@ -204,7 +204,7 @@ export function getItemSearchRank( item, searchTerm, config = {} ) {
 	}
 
 	// Give a better rank to "core" namespaced items.
-	if ( rank !== 0 && name.indexOf( 'core/' ) === 0 ) {
+	if ( rank !== 0 && name.startsWith( 'core/' ) ) {
 		rank++;
 	}
 

--- a/packages/block-editor/src/components/inserter/search-items.js
+++ b/packages/block-editor/src/components/inserter/search-items.js
@@ -185,6 +185,7 @@ export function getItemSearchRank( item, searchTerm, config = {} ) {
 		rank += 20;
 	} else {
 		const terms = [
+			name,
 			title,
 			...keywords,
 			category,

--- a/packages/block-editor/src/components/inserter/search-items.js
+++ b/packages/block-editor/src/components/inserter/search-items.js
@@ -139,7 +139,7 @@ export const searchItems = ( items = [], searchTerm = '', config = {} ) => {
 
 /**
  * Get the search rank for a given item and a specific search term.
- * The higher is higher for items with the best match.
+ * The better the match, the higher the rank.
  * If the rank equals 0, it should be excluded from the results.
  *
  * @param {Object} item       Item to filter.

--- a/packages/block-editor/src/components/inserter/search-items.js
+++ b/packages/block-editor/src/components/inserter/search-items.js
@@ -138,7 +138,7 @@ export const searchItems = ( items = [], searchTerm = '', config = {} ) => {
 };
 
 /**
- * Get the search rank for a given iotem and a specific search term.
+ * Get the search rank for a given item and a specific search term.
  * The higher is higher for items with the best match.
  * If the rank equals 0, it should be excluded from the results.
  *

--- a/packages/block-editor/src/components/inserter/search-items.js
+++ b/packages/block-editor/src/components/inserter/search-items.js
@@ -176,9 +176,9 @@ export function getItemSearchRank( item, searchTerm, config = {} ) {
 
 	let rank = 0;
 
-	// Prefers exact matchs
+	// Prefers exact matches
 	// Then prefers if the beginning of the title matches the search term
-	// Keywords, categories, collection, variations match come later.
+	// name, keywords, categories, collection, variations match come later.
 	if ( sanitizedSearchTerm === sanitizedTitle ) {
 		rank += 30;
 	} else if ( sanitizedTitle.indexOf( sanitizedSearchTerm ) === 0 ) {

--- a/packages/block-editor/src/components/inserter/search-items.js
+++ b/packages/block-editor/src/components/inserter/search-items.js
@@ -10,6 +10,14 @@ import {
 	words,
 } from 'lodash';
 
+// Default search helpers
+const defaultGetName = ( item ) => item.name || '';
+const defaultGetTitle = ( item ) => item.title;
+const defaultGetKeywords = ( item ) => item.keywords || [];
+const defaultGetCategory = ( item ) => item.category;
+const defaultGetCollection = () => null;
+const defaultGetVariations = () => [];
+
 /**
  * Sanitizes the search input string.
  *
@@ -148,13 +156,6 @@ export const searchItems = ( items = [], searchInput = '', config = {} ) => {
  * @return {number}           Search Rank.
  */
 export function getItemSearchRank( item, searchTerm, config = {} ) {
-	const defaultGetName = ( it ) => it.name || '';
-	const defaultGetTitle = ( it ) => it.title;
-	const defaultGetKeywords = ( it ) => it.keywords || [];
-	const defaultGetCategory = ( it ) => it.category;
-	const defaultGetCollection = () => null;
-	const defaultGetVariations = () => [];
-
 	const {
 		getName = defaultGetName,
 		getTitle = defaultGetTitle,

--- a/packages/block-editor/src/components/inserter/test/search-items.js
+++ b/packages/block-editor/src/components/inserter/test/search-items.js
@@ -10,7 +10,11 @@ import items, {
 	youtubeItem,
 	paragraphEmbedItem,
 } from './fixtures';
-import { normalizeSearchTerm, searchBlockItems } from '../search-items';
+import {
+	normalizeSearchTerm,
+	searchBlockItems,
+	getItemSearchRank,
+} from '../search-items';
 
 describe( 'normalizeSearchTerm', () => {
 	it( 'should return an empty array when no words detected', () => {
@@ -33,6 +37,38 @@ describe( 'normalizeSearchTerm', () => {
 		expect(
 			normalizeSearchTerm( '  Média  &   Text Tag-Cloud > 123' )
 		).toEqual( [ 'media', 'text', 'tag', 'cloud', '123' ] );
+	} );
+} );
+
+describe( 'getItemSearchRank', () => {
+	it( 'should return the highest rank for exact matches', () => {
+		expect( getItemSearchRank( { title: 'Button' }, 'button' ) ).toEqual(
+			30
+		);
+	} );
+
+	it( 'should return a high rank if the start of title matches the search term', () => {
+		expect(
+			getItemSearchRank( { title: 'Button Advanced' }, 'button' )
+		).toEqual( 20 );
+	} );
+
+	it( 'should add a bonus point to items with core namespaces', () => {
+		expect(
+			getItemSearchRank(
+				{ name: 'core/button', title: 'Button' },
+				'button'
+			)
+		).toEqual( 31 );
+	} );
+
+	it( 'should have a small rank if it matches keywords, category...', () => {
+		expect(
+			getItemSearchRank(
+				{ title: 'link', keywords: [ 'button' ] },
+				'button'
+			)
+		).toEqual( 10 );
 	} );
 } );
 

--- a/packages/block-editor/src/components/inserter/test/search-items.js
+++ b/packages/block-editor/src/components/inserter/test/search-items.js
@@ -93,6 +93,16 @@ describe( 'searchBlockItems', () => {
 		] );
 	} );
 
+	it( 'should use the ranking algorithm to order the blocks', () => {
+		expect(
+			searchBlockItems( items, categories, collections, 'a para' )
+		).toEqual( [
+			paragraphEmbedItem,
+			paragraphItem,
+			advancedParagraphItem,
+		] );
+	} );
+
 	it( 'should search items using the keywords and partial terms', () => {
 		expect(
 			searchBlockItems( items, categories, collections, 'GOOGL' )

--- a/packages/block-editor/src/components/inserter/test/search-items.js
+++ b/packages/block-editor/src/components/inserter/test/search-items.js
@@ -11,31 +11,35 @@ import items, {
 	paragraphEmbedItem,
 } from './fixtures';
 import {
-	normalizeSearchTerm,
+	getNormalizedSearchTerms,
 	searchBlockItems,
 	getItemSearchRank,
 } from '../search-items';
 
-describe( 'normalizeSearchTerm', () => {
+describe( 'getNormalizedSearchTerms', () => {
 	it( 'should return an empty array when no words detected', () => {
-		expect( normalizeSearchTerm( ' - !? *** ' ) ).toEqual( [] );
+		expect( getNormalizedSearchTerms( ' - !? *** ' ) ).toEqual( [] );
 	} );
 
 	it( 'should remove diacritics', () => {
-		expect( normalizeSearchTerm( 'média' ) ).toEqual( [ 'media' ] );
+		expect( getNormalizedSearchTerms( 'média' ) ).toEqual( [ 'media' ] );
 	} );
 
 	it( 'should trim whitespace', () => {
-		expect( normalizeSearchTerm( '  média  ' ) ).toEqual( [ 'media' ] );
+		expect( getNormalizedSearchTerms( '  média  ' ) ).toEqual( [
+			'media',
+		] );
 	} );
 
 	it( 'should convert to lowercase', () => {
-		expect( normalizeSearchTerm( '  Média  ' ) ).toEqual( [ 'media' ] );
+		expect( getNormalizedSearchTerms( '  Média  ' ) ).toEqual( [
+			'media',
+		] );
 	} );
 
 	it( 'should extract only words', () => {
 		expect(
-			normalizeSearchTerm( '  Média  &   Text Tag-Cloud > 123' )
+			getNormalizedSearchTerms( '  Média  &   Text Tag-Cloud > 123' )
 		).toEqual( [ 'media', 'text', 'tag', 'cloud', '123' ] );
 	} );
 } );


### PR DESCRIPTION
closes #14868 
closes #24651  

This PR improves the search algorithm for blocks and patterns by implementing a rank-based search:

The blocks are ordered as follows:

 - Search term matches the title
 - Search term matches the start of the title
 - Other matches (keywords, category, collection)

Also, if the block is a "core" block, it has a bonus point.

Note that the search algorithm doesn't work properly for block variations, the issue there is not from the search algorithm but more from the inserter where we consider the variations and the blocks as a single "item". A separate refactoring should be done to improve that. 
