### PR TITLE
Fix issue with single block.

### DIFF
--- a/packages/block-editor/src/components/block-switcher/style.scss
+++ b/packages/block-editor/src/components/block-switcher/style.scss
@@ -51,8 +51,6 @@
 .block-editor-block-toolbar .components-toolbar .components-button.block-editor-block-switcher__no-switcher-icon.has-icon.has-icon,
 .block-editor-block-toolbar .components-toolbar-group .components-button.block-editor-block-switcher__toggle.has-icon.has-icon,
 .block-editor-block-toolbar .components-toolbar .components-button.block-editor-block-switcher__toggle.has-icon.has-icon {
-	padding: 0;
-
 	.block-editor-block-icon {
 		height: 100%;
 		position: relative;

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -53,11 +53,6 @@
 	// Switcher.
 	.block-editor-block-switcher .components-dropdown-menu__toggle,
 	.block-editor-block-switcher__no-switcher-icon {
-		min-width: $block-toolbar-height - $grid-unit-15 / 2 !important;
-		width: $block-toolbar-height - $grid-unit-15 / 2 !important;
-		padding-left: $grid-unit-15 - $border-width !important;
-		padding-right: $grid-unit-15 / 2 !important;
-
 		.block-editor-block-icon {
 			width: $button-size-small !important;
 			margin: 0 !important;
@@ -66,6 +61,11 @@
 		&:focus::before {
 			right: $grid-unit-05 !important;
 		}
+	}
+
+	// Compensate for width of block switcher.
+	.block-editor-block-mover {
+		margin-left: -$grid-unit-15 / 2;
 	}
 }
 


### PR DESCRIPTION
Per the recent drag handle improvements, there was an issue with the situation where a block cannot be moved (i.e. you have only one). This PR fixes that, and also removes a bunch of !importants.

Before:

<img width="656" alt="Screenshot 2020-09-07 at 11 37 06" src="https://user-images.githubusercontent.com/1204802/92374952-c378f680-f100-11ea-982c-79347a29ab85.png">

After:

<img width="421" alt="Screenshot 2020-09-07 at 11 47 16" src="https://user-images.githubusercontent.com/1204802/92374964-c70c7d80-f100-11ea-80b8-2aa12048087f.png">

To test, verify a visually unchanged look for the block toolbar in top level, nested, and by selecting a group (which does not have a transform option). Also test a lone block.