### PR TITLE
Fix inline Block Inserter unwanted horizontal scrollbar in FF 79

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -271,6 +271,10 @@ $block-inserter-tabs-height: 44px;
 .block-editor-inserter__quick-inserter {
 	width: 100%;
 
+	// Constrain to container. Avoids overflow bug on FF 79
+	// see https://github.com/WordPress/gutenberg/issues/24529.
+	max-width: 100%;
+
 	@include break-medium {
 		width: $block-inserter-width;
 	}


### PR DESCRIPTION
This fixes Issue with horizontal scrollbar showing up in the Block Inserter on a specific resolution on Firefox 79 on Windows 10.

See https://github.com/WordPress/gutenberg/issues/24529

## Description
Added CSS rule to constrain the width of the inserter when displayed within the popover which has a fixed width.

## How has this been tested?

### Master branch
* On FF79 on Windows (I used Browserstack) use the latest Gutenberg `master` branch + WordPres 5.5 / 5.6.
* Resize browser to `1366x768`
* Create a new Post.
* Click in the "inline" plus icon to bring up the Block Inserter.
* See hoz scrollbars as per screenshot below.

### this PR branch

* Checkout this PRs branch locally.
* Build with `npm run dev`.
* Ensure the Gutenberg Plugin you just built is active.
* On FF79 on Windows (I used Browserstack) use the latest Gutenberg `master` branch + WordPres 5.5 / 5.6.
* Resize browser to `1366x768`
* Create a new Post.
* Click in the "inline" plus icon to bring up the Block Inserter.
* See no hoz scrollbars as per screenshot below.

## Screenshots <!-- if applicable -->

| Before | After
| ---- | -------- 
| ![Screen Shot 2020-09-07 at 11 48 54](https://user-images.githubusercontent.com/444434/92380275-cffd4f00-f100-11ea-911a-2ecb1cb43f27.png) | <img width="2158" alt="Screen Shot 2020-09-07 at 11 48 18" src="https://user-images.githubusercontent.com/444434/92380292-d7bcf380-f100-11ea-9903-704737d98dbb.png">

## Types of changes
Bug fix (non-breaking change which fixes an issue.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
