### PR TITLE
Convert the toolbar in Widgets screen to ARIA toolbar

### DIFF
--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -28,7 +28,7 @@ const defaultRenderToggle = ( {
 	isOpen,
 	blockTitle,
 	hasSingleBlockType,
-	toggleProps,
+	toggleProps = {},
 } ) => {
 	let label;
 	if ( hasSingleBlockType ) {
@@ -40,17 +40,30 @@ const defaultRenderToggle = ( {
 	} else {
 		label = _x( 'Add block', 'Generic label for block inserter button' );
 	}
+
+	const { onClick, ...rest } = toggleProps;
+
+	// Handle both onClick functions from the toggle and the parent component
+	function handleClick( event ) {
+		if ( onToggle ) {
+			onToggle( event );
+		}
+		if ( onClick ) {
+			onClick( event );
+		}
+	}
+
 	return (
 		<Button
 			icon={ plus }
 			label={ label }
 			tooltipPosition="bottom"
-			onClick={ onToggle }
+			onClick={ handleClick }
 			className="block-editor-inserter__toggle"
 			aria-haspopup={ ! hasSingleBlockType ? 'true' : false }
 			aria-expanded={ ! hasSingleBlockType ? isOpen : false }
 			disabled={ disabled }
-			{ ...toggleProps }
+			{ ...rest }
 		/>
 	);
 };

--- a/packages/edit-widgets/src/components/header/index.js
+++ b/packages/edit-widgets/src/components/header/index.js
@@ -2,11 +2,12 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { NavigableMenu } from '@wordpress/components';
+import { ToolbarItem } from '@wordpress/components';
 import {
 	BlockNavigationDropdown,
 	BlockToolbar,
 	Inserter,
+	NavigableToolbar,
 } from '@wordpress/block-editor';
 import { PinnedItems } from '@wordpress/interface';
 import { useViewportMatch } from '@wordpress/compose';
@@ -33,17 +34,27 @@ function Header( { isCustomizer } ) {
 	return (
 		<>
 			<div className="edit-widgets-header">
-				<NavigableMenu>
-					<Inserter
-						position="bottom right"
-						showInserterHelpPanel
-						toggleProps={ inserterToggleProps }
-						rootClientId={ rootClientId }
-					/>
-					<UndoButton />
-					<RedoButton />
-					<BlockNavigationDropdown />
-				</NavigableMenu>
+				<NavigableToolbar
+					className="edit-widgets-header-toolbar"
+					aria-label={ __( 'Document tools' ) }
+				>
+					<ToolbarItem>
+						{ ( toolbarItemProps ) => (
+							<Inserter
+								position="bottom right"
+								showInserterHelpPanel
+								toggleProps={ {
+									...inserterToggleProps,
+									...toolbarItemProps,
+								} }
+								rootClientId={ rootClientId }
+							/>
+						) }
+					</ToolbarItem>
+					<ToolbarItem as={ UndoButton } />
+					<ToolbarItem as={ RedoButton } />
+					<ToolbarItem as={ BlockNavigationDropdown } />
+				</NavigableToolbar>
 				{ ! isCustomizer && (
 					<h1 className="edit-widgets-header__title">
 						{ __( 'Block Areas' ) }

--- a/packages/edit-widgets/src/components/header/style.scss
+++ b/packages/edit-widgets/src/components/header/style.scss
@@ -6,6 +6,36 @@
 	padding: 0 $grid-unit-20;
 }
 
+.edit-widgets-header-toolbar {
+	display: inline-flex;
+	align-items: center;
+	border: none;
+
+	// The Toolbar component adds different styles to buttons, so we reset them
+	// here to the original button styles
+	> .components-button.has-icon,
+	> .components-dropdown > .components-button.has-icon {
+		height: $button-size;
+		min-width: $button-size;
+		padding: 6px;
+
+		&.is-pressed {
+			background: $gray-900;
+		}
+
+		&:focus:not(:disabled) {
+			box-shadow:
+				0 0 0 $border-width-focus var(--wp-admin-theme-color),
+				inset 0 0 0 $border-width $white;
+			outline: 1px solid transparent;
+		}
+
+		&::before {
+			display: none;
+		}
+	}
+}
+
 .edit-widgets-header__title {
 	font-size: 16px;
 	padding: 0 20px;

--- a/packages/edit-widgets/src/components/header/style.scss
+++ b/packages/edit-widgets/src/components/header/style.scss
@@ -7,8 +7,6 @@
 }
 
 .edit-widgets-header-toolbar {
-	display: inline-flex;
-	align-items: center;
 	border: none;
 
 	// The Toolbar component adds different styles to buttons, so we reset them
@@ -19,19 +17,11 @@
 		min-width: $button-size;
 		padding: 6px;
 
-		&.is-pressed {
-			background: $gray-900;
-		}
-
 		&:focus:not(:disabled) {
 			box-shadow:
 				0 0 0 $border-width-focus var(--wp-admin-theme-color),
 				inset 0 0 0 $border-width $white;
 			outline: 1px solid transparent;
-		}
-
-		&::before {
-			display: none;
 		}
 	}
 }

--- a/packages/edit-widgets/src/components/header/undo-redo/redo.js
+++ b/packages/edit-widgets/src/components/header/undo-redo/redo.js
@@ -1,13 +1,14 @@
 /**
  * WordPress dependencies
  */
+import { forwardRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { redo as redoIcon } from '@wordpress/icons';
 import { displayShortcut } from '@wordpress/keycodes';
 
-export default function RedoButton() {
+function RedoButton( props, ref ) {
 	const hasRedo = useSelect( ( select ) => select( 'core' ).hasRedo() );
 	const { redo } = useDispatch( 'core' );
 	return (
@@ -20,6 +21,10 @@ export default function RedoButton() {
 			// See: https://github.com/WordPress/gutenberg/issues/3486
 			aria-disabled={ ! hasRedo }
 			onClick={ hasRedo ? redo : undefined }
+			ref={ ref }
+			{ ...props }
 		/>
 	);
 }
+
+export default forwardRef( RedoButton );

--- a/packages/edit-widgets/src/components/header/undo-redo/undo.js
+++ b/packages/edit-widgets/src/components/header/undo-redo/undo.js
@@ -1,13 +1,14 @@
 /**
  * WordPress dependencies
  */
+import { forwardRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { undo as undoIcon } from '@wordpress/icons';
 import { displayShortcut } from '@wordpress/keycodes';
 
-export default function UndoButton() {
+function UndoButton( props, ref ) {
 	const hasUndo = useSelect( ( select ) => select( 'core' ).hasUndo() );
 	const { undo } = useDispatch( 'core' );
 	return (
@@ -20,6 +21,10 @@ export default function UndoButton() {
 			// See: https://github.com/WordPress/gutenberg/issues/3486
 			aria-disabled={ ! hasUndo }
 			onClick={ hasUndo ? undo : undefined }
+			ref={ ref }
+			{ ...props }
 		/>
 	);
 }
+
+export default forwardRef( UndoButton );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Fix #24938.

Convert the toolbar in Widgets screen from menu to toolbar, and make them accessible.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Go to Widgets screen (Enable via experiments in Gutenberg)
2. Play with the toolbar on the top left corner
3. It should be accessible, and functionally the same as before.

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/7753001/92383401-d57a8980-f140-11ea-81c7-1325fe1d266d.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
