### PR TITLE
Scripts: Ensure chromium is installed for test-e2e

### DIFF
--- a/packages/scripts/scripts/test-e2e.js
+++ b/packages/scripts/scripts/test-e2e.js
@@ -29,6 +29,11 @@ const {
 } = require( '../utils' );
 
 const result = spawn( 'node', [ require.resolve( 'puppeteer/install' ) ], {
+	env: {
+		...process.env,
+		PUPPETEER_SKIP_DOWNLOAD: '',
+		PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: '',
+	},
 	stdio: 'inherit',
 } );
 


### PR DESCRIPTION
## Description

The environment variables `PUPPETEER_SKIP_DOWNLOAD` and
`PUPPETEER_SKIP_CHROMIUM_DOWNLOAD` can be used to control whether
puppeteer downloads Chromium binaries when installed.

The `test-e2e` script invokes puppeteer's install script in order to
install Chromium, but these environment variables which may be present
on any given system will disable the installation. When `test-e2e` is
invoked, it will not work without Chromium, and it makes sense to
override the environment variables in this case.


## How has this been tested?

Run the `test-e2e` script in some way where `PUPPETEER_SKIP_DOWNLOAD` and/or `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD` environment variables are set.

```sh
export PUPPETEER_SKIP_DOWNLOAD=true
export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
npm ci

# The following would fail because Chromium isn't installed. Fixed in this PR.
node_modules/.bin/wp-scripts test-e2e --config ./packages/e2e-tests/jest.config.js
```

## Types of changes
Bug fix: Ensure Chromium is installed to run e2e tests.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
