### PR TITLE
Limit the block slash inserter to 9 items and show most used by default

### DIFF
--- a/packages/block-editor/src/autocompleters/block.js
+++ b/packages/block-editor/src/autocompleters/block.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { noop, map } from 'lodash';
+import { noop, map, orderBy } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -17,6 +17,8 @@ import { searchBlockItems } from '../components/inserter/search-items';
 import useBlockTypesState from '../components/inserter/hooks/use-block-types-state';
 import { includeVariationsInInserterItems } from '../components/inserter/utils';
 import BlockIcon from '../components/block-icon';
+
+const SHOWN_BLOCK_TYPES = 6;
 
 const createBlocksFromInnerBlocksTemplate = ( innerBlocksTemplate ) => {
 	return map(
@@ -74,12 +76,18 @@ function createBlockCompleter() {
 			);
 
 			const filteredItems = useMemo( () => {
-				return searchBlockItems(
-					items,
-					categories,
-					collections,
-					filterValue
-				).filter( ( item ) => item.name !== selectedBlockName );
+				const initialFilteredItems = !! filterValue.trim()
+					? searchBlockItems(
+							items,
+							categories,
+							collections,
+							filterValue
+					  )
+					: orderBy( items, [ 'frecency' ], [ 'desc' ] );
+
+				return initialFilteredItems
+					.filter( ( item ) => item.name !== selectedBlockName )
+					.slice( 0, SHOWN_BLOCK_TYPES );
 			}, [
 				filterValue,
 				selectedBlockName,

--- a/packages/block-editor/src/autocompleters/block.js
+++ b/packages/block-editor/src/autocompleters/block.js
@@ -98,26 +98,27 @@ function createBlockCompleter() {
 
 			const options = useMemo(
 				() =>
-					includeVariationsInInserterItems( filteredItems, SHOWN_BLOCK_TYPES ).map(
-						( blockItem ) => {
-							const { title, icon, isDisabled } = blockItem;
-							return {
-								key: `block-${ blockItem.id }`,
-								value: blockItem,
-								label: (
-									<>
-										<BlockIcon
-											key="icon"
-											icon={ icon }
-											showColors
-										/>
-										{ title }
-									</>
-								),
-								isDisabled,
-							};
-						}
-					),
+					includeVariationsInInserterItems(
+						filteredItems,
+						SHOWN_BLOCK_TYPES
+					).map( ( blockItem ) => {
+						const { title, icon, isDisabled } = blockItem;
+						return {
+							key: `block-${ blockItem.id }`,
+							value: blockItem,
+							label: (
+								<>
+									<BlockIcon
+										key="icon"
+										icon={ icon }
+										showColors
+									/>
+									{ title }
+								</>
+							),
+							isDisabled,
+						};
+					} ),
 				[ filteredItems ]
 			);
 

--- a/packages/block-editor/src/autocompleters/block.js
+++ b/packages/block-editor/src/autocompleters/block.js
@@ -98,7 +98,7 @@ function createBlockCompleter() {
 
 			const options = useMemo(
 				() =>
-					includeVariationsInInserterItems( filteredItems ).map(
+					includeVariationsInInserterItems( filteredItems, SHOWN_BLOCK_TYPES ).map(
 						( blockItem ) => {
 							const { title, icon, isDisabled } = blockItem;
 							return {

--- a/packages/block-editor/src/autocompleters/block.js
+++ b/packages/block-editor/src/autocompleters/block.js
@@ -18,7 +18,7 @@ import useBlockTypesState from '../components/inserter/hooks/use-block-types-sta
 import { includeVariationsInInserterItems } from '../components/inserter/utils';
 import BlockIcon from '../components/block-icon';
 
-const SHOWN_BLOCK_TYPES = 6;
+const SHOWN_BLOCK_TYPES = 9;
 
 const createBlocksFromInnerBlocksTemplate = ( innerBlocksTemplate ) => {
 	return map(


### PR DESCRIPTION
This PR limits the block autocompleter to 6 items and default to the most used blocks by default.
