### PR TITLE
Cover block: Update the box-sizing attribute

### DIFF
--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -10,6 +10,7 @@
 	justify-content: center;
 	align-items: center;
 	padding: 1em;
+	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
 
 	&.has-parallax {

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -10,6 +10,7 @@
 	justify-content: center;
 	align-items: center;
 	padding: 1em;
+	box-sizing: border-box;
 
 	&.has-parallax {
 		background-attachment: fixed;

--- a/packages/block-library/src/group/style.scss
+++ b/packages/block-library/src/group/style.scss
@@ -1,0 +1,4 @@
+.wp-block-group {
+	// This block has customizable padding, border-box makes that more predictable.
+	box-sizing: border-box;
+}

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -13,6 +13,7 @@
 @import "./embed/style.scss";
 @import "./file/style.scss";
 @import "./gallery/style.scss";
+@import "./group/style.scss";
 @import "./heading/style.scss";
 @import "./image/style.scss";
 @import "./latest-comments/style.scss";


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
I think we should add `box-sizing: border-box;` to the cover block. In themes with a fixed post width, the combination of a cover block with 100% width and 16px padding means that the cover block extends outside the bounds of the post content:

<img width="922" alt="Screenshot 2020-09-07 at 13 34 51" src="https://user-images.githubusercontent.com/275961/92388268-ead6c000-f10e-11ea-8812-554b28c5dfec.png">

Adding `box-sizing: border-box;` tells that block to count the padding as part of the 100% width, and prevents it bleeding out:

<img width="925" alt="Screenshot 2020-09-07 at 13 36 12" src="https://user-images.githubusercontent.com/275961/92388392-1bb6f500-f10f-11ea-847e-a69915fcedb5.png">


In the other themes I tested this doesn't change anything.

## How has this been tested?
Tested with TwentyTwenty and Seedlet thems

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
