### PR TITLE
Decode HTML entities created by block parser matcher reliance on innerHTML

### DIFF
--- a/packages/blocks/src/api/matchers.js
+++ b/packages/blocks/src/api/matchers.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { decodeEntities } from '@wordpress/html-entities';
+
+/**
  * External dependencies
  */
 export { attr, prop, text, query } from 'hpq';
@@ -38,6 +43,6 @@ export function html( selector, multilineTag ) {
 			return value;
 		}
 
-		return match.innerHTML;
+		return decodeEntities( match.innerHTML );
 	};
 }

--- a/packages/blocks/src/api/matchers.js
+++ b/packages/blocks/src/api/matchers.js
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-import { decodeEntities } from '@wordpress/html-entities';
-
-/**
  * External dependencies
  */
 export { attr, prop, text, query } from 'hpq';
@@ -13,6 +8,20 @@ export { attr, prop, text, query } from 'hpq';
  */
 export { matcher as node } from './node';
 export { matcher as children } from './children';
+
+function replaceInnerHTMLEntities( innerHTML ) {
+	const entityRegEx = /&(amp|lt|gt);/g;
+
+	// This subset of chars are returned as HTML entities from Element.innerHTML
+	const lookUp = {
+		amp: '&',
+		lt: '<',
+		gt: '>',
+	};
+
+	// Replace entity with text equivalent.
+	return innerHTML.replace( entityRegEx, ( match, p1 ) => lookUp[ p1 ] );
+}
 
 export function html( selector, multilineTag ) {
 	return ( domNode ) => {
@@ -43,6 +52,6 @@ export function html( selector, multilineTag ) {
 			return value;
 		}
 
-		return decodeEntities( match.innerHTML );
+		return replaceInnerHTMLEntities( match.innerHTML );
 	};
 }


### PR DESCRIPTION
This PR fixes an issue with Block parsing as evidenced by https://github.com/WordPress/gutenberg/issues/24282 whereby `<` characters are converted into the HTML entity equivalent `&lt;` thus causing a **block validation error** in the HTML block.

In addition it fixes the issue whereby `&` and `>` characters in the HTML block are converted into their entity forms.

See also https://github.com/WordPress/gutenberg/issues/23509.

## Description

Essentially on `trunk` right now, if you have a HTML block which contains the literal `<` character then it will cause a block validation error when the block is parsed.

Try it now...

1. New Post.
2. Add HTML block.
3. Add content `3 < 4`.
4. Save Draft.
5. Reload the editor.
6. See validation error.

```
Block validation: Block validation failed for `core/html` ({name: "core/html", icon: {…}, keywords: Array(1), attributes: {…}, providesContext: {…}, …}).

Content generated by `save` function:

3 &lt; 4

Content retrieved from post body:

3 < 4
```

https://user-images.githubusercontent.com/444434/133300973-e97845af-dcbe-4b2c-9a5b-55470d7844c2.mov

## Why does this happen?

It's complex...but the TL;DR is

*  validation errors occur because the _parsed_ version of the block's `save` content is different from that in the post body.
    - saved post content - `3 < 4` (correct)    
    - _parsed_ block content - `3 &lt; 4` (does not match!)
* the _parsed_ content is different because it contains the HTML entity version of `<` which is `&lt;`.
* it contains this entity because [the `html` matcher](https://github.com/WordPress/gutenberg/blob/8714f668dde8120068028f0975adac5fdaa8f30e/packages/blocks/src/api/matchers.js#L41) which is used to parse block's identified as containing HTML utilises `.innerHTML` to read the content from the match. 
* Unfortunately, [`Element.innerHTML` returns the following characters as HTML entities](https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML?retiredLocale=it): `&`, `<`, or `>`. 
* Therefore if the HTML block contains any of those characters they will be parsed as their HTML entity equivalents.

## So why does the validation error only happen for `<`?

A good question!

The reason appears to be that 

* the `isEquivalentHTML()` method used to determine whether blocks are valid utilises `getHTMLTokens()` which relies on `Tokenizer` from the `npm` package `'simple-html-tokenizer'. 
* it appears that it will "see" the `<` from `3 < 4` as being an opening tag. See tildeio/simple-html-tokenizer#20 for more details.
* as a result the comparison function `isEquivalentHTML` will return `false`.
* as this only happens for the `<` character the other two characters (`&` and `>`) do not cause validation errors.

## What bugs do & and > cause?

`&` and `>` are still converted to their entity forms there is an inconsistency in the HTML block as the original content `&` becomes `&amp;` and `>` becomes `&gt;`. This is not what the user wants nor expects.

https://user-images.githubusercontent.com/444434/133300734-c495775c-92ef-4095-960a-f37e0e88b32e.mp4




<img width="670" alt="Screen Shot 2021-09-14 at 17 48 55" src="https://user-images.githubusercontent.com/444434/133299971-2b9824b5-13ea-49cf-b65e-8774d6ac832b.png">

## Solution - how does this PR solve these issues?

We need to ensure that `&`, `<` and `>` are converted into their string form. However, we do not want to convert _all_ HTML entities as this would cause things such as `&nbsp;` to be unintentionally converted.

Therefore our fix acts in a limited way and only transforms those characters that are specifically returned as HTML entities from `Element.innerHTML`.

Because the chars are converted at the base "matcher" level of the block parsers all the block validation issues are resolved. Moreover, the content the user entered is preserved (ie: not converted into entity form).

## How has this been tested?

#### On Master

* Create HTML block
* Insert content `3 < 4`.
* Save the draft. 
* Reload the browser.
* See validation error in browser console.

```
Block validation: Block validation failed for `core/html` ({name: "core/html", icon: {…}, keywords: Array(1), attributes: {…}, providesContext: {…}, …}).

Content generated by `save` function:

3 &lt; 4

Content retrieved from post body:

3 < 4
```

#### This PR

* Checkout this PR
* Create HTML block
* Insert content `3 < 4`.
* Save the draft. 
* Reload the browser.
* See no validation errors.
* See content displayed in editor without any entities



## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->

------
------
------

# Original Issue Content

Essentially if you have a HTML block which contains `3 < 4` it will cause validation errors because the parsed version of the block's `save` content is different from that in the post body.

* _parsed_ save content `3 &lt; 4`
* post body content 
```html
<!-- wp:html -->
3 < 4
<!-- /wp:html -->
```

The serialized block content is actually `3 < 4`. It is only when this content is parsed that it is converted into a string containing HTML entities.

Note I believe this occurs because the [`html()` matcher](https://github.com/WordPress/gutenberg/blob/2dd0fb4415bbc7dd0cae96f09504cd9bae0c5eef/packages/blocks/src/api/matchers.js#L12) passed to `hpqParse` [relies on using `.innerHTML` to retrieve the content of the parsed HTML](https://github.com/WordPress/gutenberg/blob/2dd0fb4415bbc7dd0cae96f09504cd9bae0c5eef/packages/blocks/src/api/matchers.js#L41). 

For the `match` (DOM node) which is passed into `html`, some light debugging reveals:

* `match.innerHTML` => `3 &lt; 4`
* `match.innerText` => `3 < 4`

I understand this difference is due to the way `innerHTML` works - indeed [the MDN reference for `innerHTML`](https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML) says:

> Note: If a `<div>`, `<span>`, or `<noembed>` node has a child text node that includes the characters (&), (<), or (>), innerHTML returns these characters as the HTML entities "&amp;", "&lt;" and "&gt;" respectively. Use Node.textContent to get a raw copy of these text nodes' contents.

I believe this is why the `<` gets encoded to `&lt;`.

However, [in the matcher implementation `match.innerHTML` is returned](https://github.com/WordPress/gutenberg/blob/2dd0fb4415bbc7dd0cae96f09504cd9bae0c5eef/packages/blocks/src/api/matchers.js#L41) which means the string **with encoded entities** is returned.

Wrapping this string in `@wordpess/html-entities`'s `decodeEntities()` ensures that any entities are converted _back_ to their string form.

Note for @ellatrix: I could be _way_ off on this one. I just narrowed down the cause of the _specific_ issue but that doesn't mean it doesn't have lots of knock-on effects. I'm hopeful that as we're just fixing the `innerHTML` returned it should be ok, but this will needs lots of testing with content variations.

## Detailed Explanation

The block parser works roughly as follows:

* [`createBlockWithFallback`](https://github.com/WordPress/gutenberg/blob/0d2771b807c2654c6694f7c8036d2796c1e136c4/packages/blocks/src/api/parser.js#L404) is called with the block node in question. In our use case it looks like this:

```js
{
  "blockName": "core/html",
  "attrs": {},
  "innerBlocks": [],
  "innerHTML": "3 < 4",
  "innerContent": [
    "3 < 4"
  ]
}
```

Notice how `innerHTML` and `innerContent` are correct as `3 < 4` but the block attributes have yet to be parsed.

* Within `createBlockWithFallback` the `createBlock` function is called 

https://github.com/WordPress/gutenberg/blob/0d2771b807c2654c6694f7c8036d2796c1e136c4/packages/blocks/src/api/parser.js#L530-L534

This in turn calls [`getBlockAttributes`](https://github.com/WordPress/gutenberg/blob/0d2771b807c2654c6694f7c8036d2796c1e136c4/packages/blocks/src/api/parser.js#L285) which calls `getBlockAttribute` to map all the block attributes:

https://github.com/WordPress/gutenberg/blob/0d2771b807c2654c6694f7c8036d2796c1e136c4/packages/blocks/src/api/parser.js#L291-L301

`getBlockAttribute` is passed an `attributeSchema` argument that has the following shape/content:

```js
{
  "type": "string",
  "source": "html"
}
```

...which it uses to determine how it should parse the attributes.

* Depending on the source type (in our case `html`), [`parseWithAttributeSchema`](https://github.com/WordPress/gutenberg/blob/0d2771b807c2654c6694f7c8036d2796c1e136c4/packages/blocks/src/api/parser.js#L259) is then called with the `attrubuteSchema` above.

* This in turn hands off to `hpqParse` from [the `hpq` library](https://www.npmjs.com/package/hpq). 

https://github.com/WordPress/gutenberg/blob/0d2771b807c2654c6694f7c8036d2796c1e136c4/packages/blocks/src/api/parser.js#L219-L221

This takes a 2nd argument of the `matcher` function to use in `hpqParse`. This is determine by a call to [`matcherFromSource`](https://github.com/WordPress/gutenberg/blob/0d2771b807c2654c6694f7c8036d2796c1e136c4/packages/blocks/src/api/parser.js#L175) which uses the `source` type (in our case `html`) to retrieve the appropriate `matcher`.

https://github.com/WordPress/gutenberg/blob/0d2771b807c2654c6694f7c8036d2796c1e136c4/packages/blocks/src/api/parser.js#L184-L185

In our case this is the [`html` matcher](https://github.com/WordPress/gutenberg/blob/0d2771b807c2654c6694f7c8036d2796c1e136c4/packages/blocks/src/api/matchers.js#L12).

* We can see that the `html` matcher uses `innerHTML` to retrieve the content for use in the parsed attribute:

https://github.com/WordPress/gutenberg/blob/0d2771b807c2654c6694f7c8036d2796c1e136c4/packages/blocks/src/api/matchers.js#L40-L41

This is where the issue described above occurs. Namely:

> If a `<div>`, `<span>`, or `<noembed>` node has a child text node that includes the characters (&), (<), or (>), innerHTML returns these characters as the HTML entities "&amp;", "&lt;" and "&gt;" respectively. 

I believe this is why the `<` gets encoded to `&lt;`. But this only happens for blocks which have a source type of `html`. As far as I'm aware that is just the `core/html` block.

* Back in the `createBlockWithFallback` function, `createBlock` has now returned and we pass the result to the [`getBlockContentValidationResult`](https://github.com/WordPress/gutenberg/blob/cecabd0ce40b00d68c6ab4ab105cce7f4e46f78b/packages/blocks/src/api/validation/index.js#L668) function to determine whether the block is considered valid.

https://github.com/WordPress/gutenberg/blob/0d2771b807c2654c6694f7c8036d2796c1e136c4/packages/blocks/src/api/parser.js#L530-L548

At this point the `block` object returned from `createBlock` looks like this

```js
{
  "clientId": "8a126e6e-9055-490e-8cf3-5127b1fa9194",
  "name": "core/html",
  "isValid": true,
  "attributes": {
    "content": "3 &lt; 4"
  },
  "innerBlocks": []
}
```

and the `innerHTML` is `"3 < 4"`.

* Therefore when the [`getBlockContentValidationResult`](https://github.com/WordPress/gutenberg/blob/cecabd0ce40b00d68c6ab4ab105cce7f4e46f78b/packages/blocks/src/api/validation/index.js#L668) function is called the result is that the block is determined to be invalid due to the mismatch between the saved block content and the value of `block.attributes.content`:

https://github.com/WordPress/gutenberg/blob/cecabd0ce40b00d68c6ab4ab105cce7f4e46f78b/packages/blocks/src/api/validation/index.js#L690-L694

In the code above:

* `originalBlockContent` is `3 < 4`
* `generatedBlockContent` is `3 &lt; 4`

The reason why this fails validation is likely due to the reliance on `simple-html-tokenizer`. It appears that it will "see" the `<` from `3 < 4` as being an opening tag. See https://github.com/tildeio/simple-html-tokenizer/issues/20 for more details.

We can avoid this by correctly escaping entities.


----------

The validation of a block checks whether the following two items are "equivalent HTML"

1. `block.originalContent`.
2. `generatedBlockContent` - returned by calling `getSaveContent( blockType, block.attributes );`.

This is achieved via the `isEquivalentHTML` method and if this does not return `true` then the block is considered invalid.



## Description

* Fix HTML block validation errors due to blocks containing certain characters get incorrectly parsed. 
* Also ensure conversion of HTML block to Reusable does not cause errors.


