### PR TITLE
Fix Typo in README

### DIFF
--- a/packages/components/src/alignment-matrix-control/README.md
+++ b/packages/components/src/alignment-matrix-control/README.md
@@ -6,7 +6,7 @@ AlignmentMatrixControl components let adjust horizontal and vertical alignments 
 
 ```jsx
 import { AlignmentMatrixControl } from '@wordpress/components';
-import { useState } from '@wordpress/elememt';
+import { useState } from '@wordpress/element';
 
 const Example = () => {
 	const [ alignment, setAlignment ] = useState( 'center center' );


### PR DESCRIPTION
Import statement in code example is referencing the wrong package name.