### PR TITLE
Use WordPress Menu API

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -26,8 +26,6 @@ gutenberg_pre_init();
  * @since 0.1.0
  */
 function gutenberg_menu() {
-	global $submenu;
-
 	add_menu_page(
 		'Gutenberg',
 		'Gutenberg',
@@ -45,7 +43,7 @@ function gutenberg_menu() {
 		'gutenberg'
 	);
 
-	if ( gutenberg_use_widgets_block_editor() && isset( $submenu['themes.php'] ) ) {
+	if ( gutenberg_use_widgets_block_editor() ) {
 		add_theme_page(
 			__( 'Widgets', 'gutenberg' ),
 			__( 'Widgets', 'gutenberg' ),
@@ -53,12 +51,7 @@ function gutenberg_menu() {
 			'gutenberg-widgets',
 			'the_gutenberg_widgets'
 		);
-		$submenu['themes.php'] = array_filter(
-			$submenu['themes.php'],
-			function( $current_menu_item ) {
-				return isset( $current_menu_item[2] ) && 'widgets.php' !== $current_menu_item[2];
-			}
-		);
+		remove_submenu_page( 'themes.php', 'widgets.php' );
 	}
 
 	if ( get_option( 'gutenberg-experiments' ) ) {
@@ -85,16 +78,19 @@ function gutenberg_menu() {
 	}
 
 	if ( current_user_can( 'edit_posts' ) ) {
-		$submenu['gutenberg'][] = array(
+		add_submenu_page(
+			'gutenberg',
+			__( 'Support', 'gutenberg' ),
 			__( 'Support', 'gutenberg' ),
 			'edit_posts',
-			__( 'https://wordpress.org/support/plugin/gutenberg', 'gutenberg' ),
+			__( 'https://wordpress.org/support/plugin/gutenberg/', 'gutenberg' )
 		);
-
-		$submenu['gutenberg'][] = array(
+		add_submenu_page(
+			'gutenberg',
+			__( 'Documentation', 'gutenberg' ),
 			__( 'Documentation', 'gutenberg' ),
 			'edit_posts',
-			'https://developer.wordpress.org/block-editor/',
+			'https://developer.wordpress.org/block-editor/'
 		);
 	}
 


### PR DESCRIPTION
## Description
As a follow up to #25073 / #25054 after noticing the same warning on WordPress.org, I've converted the code away from directly modifying the `$submenu` global and using the WordPress menu API instead, which yes, supports this use-case.

## Types of changes
Swaps from direct `global $submenu` alterations to using the WordPress menu API.
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] ~~ My code follows the accessibility standards. ~~ <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] ~~ My code has proper inline documentation. ~~ <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] ~~ I've included developer documentation if appropriate. ~~ <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] ~~ I've updated all React Native files affected by any refactorings/renamings in this PR. ~~ <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
