### PR TITLE
Refactor and make consistent post and site headers.

### DIFF
--- a/packages/block-editor/src/components/preview-options/style.scss
+++ b/packages/block-editor/src/components/preview-options/style.scss
@@ -1,5 +1,4 @@
 .block-editor-post-preview__dropdown {
-	margin-right: $grid-unit-15;
 	padding: 0;
 }
 

--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -64,14 +64,11 @@
 /**
  * Buttons in the Toolbar
  */
+
 .edit-post-header__settings {
 	// Adjust button paddings to scale better to mobile.
-	.components-button.editor-post-save-draft,
 	.editor-post-saved-state,
-	.components-button.editor-post-switch-to-draft,
-	.components-button.editor-post-preview,
-	.components-button.block-editor-post-preview__dropdown {
-		padding: 0 #{ $grid-unit-15 / 2 };
+	.components-button.components-button {
 		margin-right: $grid-unit-05;
 
 		@include break-small() {
@@ -79,16 +76,14 @@
 		}
 	}
 
-	.components-button.block-editor-post-preview__dropdown,
-	.components-button.editor-post-publish-button,
-	.components-button.editor-post-publish-panel__toggle {
+	.editor-post-saved-state,
+	.components-button.is-tertiary {
 		padding: 0 #{ $grid-unit-15 / 2 };
-		margin-right: $grid-unit-05;
+	}
 
-		@include break-small() {
-			padding: 0 $grid-unit-15;
-			margin-right: $grid-unit-15;
-		}
+	.edit-post-more-menu .components-button,
+	.interface-pinned-items .components-button {
+		margin-right: 0;
 	}
 }
 

--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -13,7 +13,6 @@
 	align-items: center;
 
 	.edit-site-header-toolbar__inserter-toggle {
-		margin-left: 5px;
 		margin-right: $grid-unit-10;
 		min-width: $grid-unit-40;
 		width: $grid-unit-40;
@@ -31,9 +30,41 @@
 	margin: 0 -6px 0;
 }
 
+/**
+ * Buttons in the Toolbar
+ */
+
 .edit-site-header__actions {
-	display: flex;
-	margin-right: 8px;
+	// Adjust button paddings to scale better to mobile.
+	.editor-post-saved-state,
+	.components-button.components-button {
+		margin-right: $grid-unit-05;
+
+		@include break-small() {
+			margin-right: $grid-unit-15;
+		}
+	}
+
+	.editor-post-saved-state,
+	.components-button.is-tertiary {
+		padding: 0 #{ $grid-unit-15 / 2 };
+	}
+
+	.edit-site-more-menu .components-button,
+	.interface-pinned-items .components-button {
+		margin-right: 0;
+	}
+}
+
+.edit-site-header__actions {
+	display: inline-flex;
+	align-items: center;
+	flex-wrap: wrap;
+	padding-right: $grid-unit-05;
+
+	@include break-small () {
+		padding-right: $grid-unit-20;
+	}
 }
 
 .edit-site-header__actions-more-menu {


### PR DESCRIPTION
This PR refactors button margins in the top toolbar, and copies them to the site editor to make it consistent.

Site and post headers after this PR:

<img width="1320" alt="Screenshot 2020-09-08 at 08 46 07" src="https://user-images.githubusercontent.com/1204802/92442242-d3034880-f1af-11ea-9bbd-fbd983f119da.png">
<img width="1312" alt="Screenshot 2020-09-08 at 08 46 13" src="https://user-images.githubusercontent.com/1204802/92442246-d4347580-f1af-11ea-8ef8-bbe2948a1bde.png">

Site header before:

<img width="1316" alt="Screenshot 2020-09-08 at 08 46 30" src="https://user-images.githubusercontent.com/1204802/92442254-d696cf80-f1af-11ea-8b11-567447d3c81f.png">
