### PR TITLE
Embed Block: fix crash in isFromWordPress helper if preview.html is false

### DIFF
--- a/packages/block-library/src/embed/util.js
+++ b/packages/block-library/src/embed/util.js
@@ -63,7 +63,7 @@ export const findMoreSuitableBlock = ( url ) =>
 	);
 
 export const isFromWordPress = ( html ) =>
-	html.includes( 'class="wp-embedded-content"' );
+	html && html.includes( 'class="wp-embedded-content"' );
 
 export const getPhotoHtml = ( photo ) => {
 	// 100% width for the preview so it fits nicely into the document, some "thumbnails" are


### PR DESCRIPTION
The Facebook oEmbed provider returns `html: false` when the URL is not previewable, e.g., when it points to a Facebook page rather than a post or video.

The `isFromWordPress` helper used to use Lodash `includes( html, x)` which handles falsy values gracefully. After a refactor to `html.includes( x )` in #24090, non-string values started to trigger a `TypeError`.

Fixes #25108.
