### PR TITLE
Enable custom spacing support using theme.json

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -642,21 +642,6 @@ add_filter( 'block_editor_settings', 'gutenberg_extend_settings_custom_units' );
  *
  * @return array Filtered editor settings.
  */
-function gutenberg_extend_settings_custom_spacing( $settings ) {
-	$settings['__experimentalEnableCustomSpacing'] = get_theme_support( 'experimental-custom-spacing' );
-	return $settings;
-}
-add_filter( 'block_editor_settings', 'gutenberg_extend_settings_custom_spacing' );
-
-
-/**
- * Extends block editor settings to determine whether to use custom spacing controls.
- * Currently experimental.
- *
- * @param array $settings Default editor settings.
- *
- * @return array Filtered editor settings.
- */
 function gutenberg_extend_settings_link_color( $settings ) {
 	$settings['__experimentalEnableLinkColor'] = get_theme_support( 'experimental-link-color' );
 	return $settings;

--- a/lib/experimental-default-theme.json
+++ b/lib/experimental-default-theme.json
@@ -139,6 +139,9 @@
 			},
 			"lineHeight": {
 				"custom": false
+			},
+			"spacing": {
+				"custom": false
 			}
 		}
 	}

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -635,6 +635,12 @@ function gutenberg_experimental_global_styles_get_editor_features( $config ) {
 		}
 		$features['global']['lineHeight']['custom'] = true;
 	}
+	if ( get_theme_support( 'experimental-custom-spacing' ) ) {
+		if ( ! isset( $features['global']['spacing'] ) ) {
+			$features['global']['spacing'] = array();
+		}
+		$features['global']['spacing']['custom'] = true;
+	}
 
 	return $features;
 }
@@ -652,6 +658,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 	// These need to be added to settings always.
 	// We also need to unset the deprecated settings defined by core.
 	$settings['__experimentalFeatures'] = gutenberg_experimental_global_styles_get_editor_features( $merged );
+	
 	unset( $settings['disableCustomColors'] );
 	unset( $settings['disableCustomGradients'] );
 	unset( $settings['disableCustomFontSizes'] );

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -658,7 +658,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 	// These need to be added to settings always.
 	// We also need to unset the deprecated settings defined by core.
 	$settings['__experimentalFeatures'] = gutenberg_experimental_global_styles_get_editor_features( $merged );
-	
+
 	unset( $settings['disableCustomColors'] );
 	unset( $settings['disableCustomGradients'] );
 	unset( $settings['disableCustomFontSizes'] );

--- a/packages/block-editor/src/components/spacing-panel-control/index.js
+++ b/packages/block-editor/src/components/spacing-panel-control/index.js
@@ -1,25 +1,17 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { PanelBody } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import InspectorControls from '../inspector-controls';
+import useEditorFeature from '../use-editor-feature';
 
 export default function SpacingPanelControl( { children, ...props } ) {
-	const isSpacingEnabled = useSelect( ( select ) => {
-		const { getSettings } = select( 'core/block-editor' );
-		return get( getSettings(), '__experimentalEnableCustomSpacing' );
-	}, [] );
+	const isSpacingEnabled = useEditorFeature( 'spacing.custom' );
 
 	if ( ! isSpacingEnabled ) return null;
 

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -160,7 +160,6 @@ class EditorProvider extends Component {
 				'__experimentalBlockDirectory',
 				'__experimentalBlockPatterns',
 				'__experimentalBlockPatternCategories',
-				'__experimentalEnableCustomSpacing',
 				'__experimentalEnableLinkColor',
 				'__experimentalEnableFullSiteEditing',
 				'__experimentalEnableFullSiteEditingDemo',


### PR DESCRIPTION
Related #20588
Similar to #24761 but for custom padding.

The idea of this PR is to support disabling/enabling custom spacing support from theme.json.

**Testing instructions**

* Check that you can enable/disable custom colors support using the theme.json `spacing.custom` path.