### PR TITLE
Make items in nav view 48px tall, rather than 56px.

### DIFF
--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -37,7 +37,7 @@ $tree-item-height: 36px;
 		align-items: center;
 		width: 100%;
 		height: auto;
-		padding: $grid-unit-20 6px;
+		padding: $grid-unit-15 ($grid-unit-15 / 2);
 		margin-top: auto;
 		margin-bottom: auto;
 		text-align: left;
@@ -111,6 +111,7 @@ $tree-item-height: 36px;
 
 	.block-editor-block-navigation-block__menu-cell,
 	.block-editor-block-navigation-block__mover-cell {
+		line-height: 0;
 		width: $button-size;
 		opacity: 0;
 		vertical-align: top;
@@ -229,7 +230,7 @@ $tree-item-height: 36px;
 	}
 
 	.block-editor-block-navigation-block__contents-container {
-		min-height: 56px;
+		min-height: $grid-unit-60;
 	}
 
 	.block-editor-block-navigator-descender-line {


### PR DESCRIPTION
The items in the block navigation dialog needn't be larger than 48px. This PR addresses that. 

Before:

<img width="503" alt="Screenshot 2020-09-08 at 11 24 03" src="https://user-images.githubusercontent.com/1204802/92460299-18337480-f1c8-11ea-9017-0b510478f7d4.png">

After:

<img width="337" alt="Screenshot 2020-09-08 at 11 24 36" src="https://user-images.githubusercontent.com/1204802/92460308-19fd3800-f1c8-11ea-9735-96e5b93069f7.png">
<img width="549" alt="Screenshot 2020-09-08 at 11 39 31" src="https://user-images.githubusercontent.com/1204802/92460309-1bc6fb80-f1c8-11ea-8280-97783ede8838.png">
