### PR TITLE
Let ID-less [gallery] shortcodes fall to Shortcode block

### DIFF
--- a/packages/block-library/src/gallery/transforms.js
+++ b/packages/block-library/src/gallery/transforms.js
@@ -87,6 +87,9 @@ const transforms = {
 					},
 				},
 			},
+			isMatch( { named } ) {
+				return undefined !== named.ids;
+			},
 		},
 		{
 			// When created by drag and dropping multiple files on an insertion point


### PR DESCRIPTION
Fixes #11551

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

Until now, the Gallery block was the recipient of all `[gallery]` shortcodes. This works well for the most common use of the shortcode, when identifiers for media objects are specified (`[gallery ids="1,2,3"]`) but fails to accommodate other scenarios, as detailed in comments in #11551, especially whenever WordPress post attachments are concerned (e.g. `[gallery]`, `[gallery id="10"]`).

This pull request adds an `isMatch` predicate to the Gallery block's shortcode transform so that it only catches shortcodes which explicitly provide gallery objects via the `ids` attribute. Otherwise, assume that the shortcode is doing more work than the Gallery block can automatically accommodate and let the transform be picked up by the Shortcode block — thus leaving the original shortcode untouched.

## How has this been tested?

Using the Classic block (or Classic editor, or the CLI), create a draft with the following shortcodes:

* `[gallery ids="1,2,3"]`, where the integers represent the IDs of existing media library images
* `[gallery]`, assuming that there are images attached to the present post (but not needed for the purposes of testing)
* `[gallery id="1"]`, assuming that 1 is the ID of a WP post with attachments

Press the Classic block's _Convert to Blocks_ button. Verify that the first shortcode is converted into a Gallery block with the expected images. Verify that the remaining shortcodes are converted into Shortcode blocks and that the shortcodes therein are preserved.

The same should happen by directly pasting these shortcodes onto the block editor.

## Types of changes
Enhancement. Backwards compatibility.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
