### PR TITLE
Update: Remove duplicate style mappings from global styles

### DIFF
--- a/packages/edit-site/src/components/editor/global-styles-renderer.js
+++ b/packages/edit-site/src/components/editor/global-styles-renderer.js
@@ -1,16 +1,17 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
+import { get, kebabCase, reduce } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __EXPERIMENTAL_STYLE_MAPPINGS } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
-import {
-	STYLE_PROPS,
-	PRESET_CATEGORIES,
-	LINK_COLOR_DECLARATION,
-} from './utils';
+import { PRESET_CATEGORIES, LINK_COLOR_DECLARATION } from './utils';
 
 const mergeTrees = ( baseData, userData ) => {
 	// Deep clone from base data.
@@ -55,19 +56,24 @@ export default ( blockData, baseTree, userTree ) => {
 	 * @return {Array} An array of style declarations.
 	 */
 	const getBlockStylesDeclarations = ( blockSupports, blockStyles ) => {
-		const declarations = [];
-		Object.keys( STYLE_PROPS ).forEach( ( key ) => {
-			if (
-				blockSupports.includes( key ) &&
-				get( blockStyles, STYLE_PROPS[ key ], false )
-			) {
-				declarations.push(
-					`${ key }: ${ get( blockStyles, STYLE_PROPS[ key ] ) }`
-				);
-			}
-		} );
-
-		return declarations;
+		return reduce(
+			__EXPERIMENTAL_STYLE_MAPPINGS,
+			function ( declarations, stylePath, rawKey ) {
+				const key = rawKey.startsWith( '--' )
+					? rawKey
+					: kebabCase( rawKey );
+				if (
+					blockSupports.includes( key ) &&
+					get( blockStyles, stylePath, false )
+				) {
+					declarations.push(
+						`${ key }: ${ get( blockStyles, stylePath ) }`
+					);
+				}
+				return declarations;
+			},
+			[]
+		);
 	};
 
 	/**

--- a/packages/edit-site/src/components/editor/utils.js
+++ b/packages/edit-site/src/components/editor/utils.js
@@ -1,22 +1,9 @@
 /* CSS properties */
-export const FONT_SIZE = 'font-size';
 export const LINK_COLOR = '--wp--style--color--link';
-export const BACKGROUND_COLOR = 'background-color';
-export const GRADIENT_COLOR = 'background';
-export const TEXT_COLOR = 'color';
-export const LINE_HEIGHT = 'line-height';
 
 /* Supporting data */
 export const GLOBAL_CONTEXT = 'global';
 export const PRESET_CATEGORIES = [ 'color', 'font-size', 'gradient' ];
-export const STYLE_PROPS = {
-	[ FONT_SIZE ]: 'typography.fontSize',
-	[ LINE_HEIGHT ]: 'typography.lineHeight',
-	[ TEXT_COLOR ]: 'color.text',
-	[ BACKGROUND_COLOR ]: 'color.background',
-	[ GRADIENT_COLOR ]: 'color.gradient',
-	[ LINK_COLOR ]: 'color.link',
-};
 export const LINK_COLOR_DECLARATION = `a { color: var(${ LINK_COLOR }, #00e); }`;
 
 /* Helpers for unit processing */

--- a/packages/edit-site/src/components/sidebar/color-panel.js
+++ b/packages/edit-site/src/components/sidebar/color-panel.js
@@ -7,12 +7,11 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import {
-	BACKGROUND_COLOR,
-	LINK_COLOR,
-	TEXT_COLOR,
-	GRADIENT_COLOR,
-} from '../editor/utils';
+import { LINK_COLOR } from '../editor/utils';
+
+const BACKGROUND_COLOR = 'background-color';
+const GRADIENT_COLOR = 'background';
+const TEXT_COLOR = 'color';
 
 export default ( {
 	context: { supports, name },

--- a/packages/edit-site/src/components/sidebar/typography-panel.js
+++ b/packages/edit-site/src/components/sidebar/typography-panel.js
@@ -11,7 +11,10 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { FONT_SIZE, LINE_HEIGHT, fromPx, toPx } from '../editor/utils';
+import { fromPx, toPx } from '../editor/utils';
+
+const LINE_HEIGHT = 'line-height';
+const FONT_SIZE = 'font-size';
 
 export default ( {
 	context: { supports, name },


### PR DESCRIPTION
This updates the global styles compile mechanism to take advantage of the centralized style mappings instead of duplicating them.


## How has this been tested?
I verified the global styles sidebar still works as expected.