### PR TITLE
Add Align support to Separator block

### DIFF
--- a/packages/block-library/src/separator/block.json
+++ b/packages/block-library/src/separator/block.json
@@ -11,8 +11,7 @@
 	},
 	"supports": {
 		"anchor": true,
-		"align": true,
-		"align": ["wide","full"],
+		"align": ["center","wide","full"],
 		"html": false
 	}
 }

--- a/packages/block-library/src/separator/block.json
+++ b/packages/block-library/src/separator/block.json
@@ -11,7 +11,6 @@
 	},
 	"supports": {
 		"anchor": true,
-		"align": ["center","wide","full"],
-		"html": false
+		"align": ["center","wide","full"]
 	}
 }

--- a/packages/block-library/src/separator/block.json
+++ b/packages/block-library/src/separator/block.json
@@ -10,6 +10,7 @@
 		}
 	},
 	"supports": {
-		"anchor": true
+		"anchor": true,
+		"alignment": true
 	}
 }

--- a/packages/block-library/src/separator/block.json
+++ b/packages/block-library/src/separator/block.json
@@ -11,6 +11,8 @@
 	},
 	"supports": {
 		"anchor": true,
-		"alignment": true
+		"align": true,
+		"align": ["wide","full"],
+		"html": false
 	}
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Added support for Align controls (limited to Wide and Full) to Separator block
Addresses #25080 

## How has this been tested?
Tested in Local (by Flywheel) on Mac OSX in Chrome/Safari.

Tested with TwentyTwenty theme which renders elements as expected (with good theme support for wide end full alignment).

## Screenshots <!-- if applicable -->

<img width="1491" alt="Screen Shot 2020-09-08 at 9 20 13 pm" src="https://user-images.githubusercontent.com/1842363/92471402-41c9bb80-f21b-11ea-884e-81ecd18a1296.png">


## Types of changes
Change to existing core block - adding additional functionality/support

## Checklist:
- [x] My code is tested.
- [ x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->

