### PR TITLE
Add filtering by author support in Query block

### DIFF
--- a/packages/block-library/src/query-loop/edit.js
+++ b/packages/block-library/src/query-loop/edit.js
@@ -26,6 +26,7 @@ export default function QueryLoopEdit( {
 			tagIds = [],
 			order,
 			orderBy,
+			author,
 		} = {},
 		queryContext,
 	},
@@ -45,6 +46,9 @@ export default function QueryLoopEdit( {
 			if ( perPage ) {
 				query.per_page = perPage;
 			}
+			if ( author ) {
+				query.author = author;
+			}
 			return {
 				posts: select( 'core' ).getEntityRecords(
 					'postType',
@@ -54,7 +58,17 @@ export default function QueryLoopEdit( {
 				blocks: select( 'core/block-editor' ).getBlocks( clientId ),
 			};
 		},
-		[ perPage, page, offset, categoryIds, tagIds, order, orderBy, clientId ]
+		[
+			perPage,
+			page,
+			offset,
+			categoryIds,
+			tagIds,
+			order,
+			orderBy,
+			clientId,
+			author,
+		]
 	);
 
 	const blockContexts = useMemo(

--- a/packages/block-library/src/query-loop/index.php
+++ b/packages/block-library/src/query-loop/index.php
@@ -44,6 +44,9 @@ function render_block_core_query_loop( $attributes, $content, $block ) {
 		if ( isset( $block->context['query']['perPage'] ) ) {
 			$query['posts_per_page'] = $block->context['query']['perPage'];
 		}
+		if ( isset( $block->context['query']['author'] ) ) {
+			$query['author'] = $block->context['query']['author'];
+		}
 	}
 
 	$posts = get_posts( $query );

--- a/packages/block-library/src/query/block.json
+++ b/packages/block-library/src/query/block.json
@@ -14,7 +14,8 @@
 				"categoryIds": [],
 				"tagIds": [],
 				"order": "desc",
-				"orderBy": "date"
+				"orderBy": "date",
+				"author": null
 			}
 		}
 	},

--- a/packages/block-library/src/query/edit/query-inspector-controls.js
+++ b/packages/block-library/src/query/edit/query-inspector-controls.js
@@ -4,17 +4,29 @@
 import { PanelBody, QueryControls } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
 
 export default function QueryInspectorControls( { query, setQuery } ) {
-	const { order, orderBy } = query;
+	const { order, orderBy, author: selectedAuthorId } = query;
+	const { authorList } = useSelect( ( select ) => {
+		const { getEntityRecords } = select( 'core' );
+		return {
+			authorList: getEntityRecords( 'root', 'user', { per_page: -1 } ),
+		};
+	} );
 	return (
 		<InspectorControls>
-			<PanelBody title={ __( 'Sorting' ) }>
+			<PanelBody title={ __( 'Sorting and Filtering' ) }>
 				<QueryControls
-					{ ...{ order, orderBy } }
+					{ ...{ order, orderBy, selectedAuthorId, authorList } }
 					onOrderChange={ ( value ) => setQuery( { order: value } ) }
 					onOrderByChange={ ( value ) =>
 						setQuery( { orderBy: value } )
+					}
+					onAuthorChange={ ( value ) =>
+						setQuery( {
+							author: value !== '' ? +value : undefined,
+						} )
 					}
 				/>
 			</PanelBody>

--- a/packages/block-library/src/query/edit/query-inspector-controls.js
+++ b/packages/block-library/src/query/edit/query-inspector-controls.js
@@ -16,7 +16,7 @@ export default function QueryInspectorControls( { query, setQuery } ) {
 	}, [] );
 	return (
 		<InspectorControls>
-			<PanelBody title={ __( 'Sorting and Filtering' ) }>
+			<PanelBody title={ __( 'Sorting and filtering' ) }>
 				<QueryControls
 					{ ...{ order, orderBy, selectedAuthorId, authorList } }
 					onOrderChange={ ( value ) => setQuery( { order: value } ) }

--- a/packages/block-library/src/query/edit/query-inspector-controls.js
+++ b/packages/block-library/src/query/edit/query-inspector-controls.js
@@ -13,7 +13,7 @@ export default function QueryInspectorControls( { query, setQuery } ) {
 		return {
 			authorList: getEntityRecords( 'root', 'user', { per_page: -1 } ),
 		};
-	} );
+	}, [] );
 	return (
 		<InspectorControls>
 			<PanelBody title={ __( 'Sorting and Filtering' ) }>

--- a/packages/e2e-tests/fixtures/blocks/core__query.json
+++ b/packages/e2e-tests/fixtures/blocks/core__query.json
@@ -11,7 +11,8 @@
 				"categoryIds": [],
 				"tagIds": [],
 				"order": "desc",
-				"orderBy": "date"
+				"orderBy": "date",
+				"author": null
 			}
 		},
 		"innerBlocks": [],


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This PR ports `author` filtering support in `Query` block from `QueryControls` which is used in `Latest Posts`.

This is part of https://github.com/WordPress/gutenberg/issues/24934 (FSE milestone 5) and https://github.com/WordPress/gutenberg/issues/24521.

There still needs to be a decision about the final design of Query block, but that also depends on how many things we will include eventually and where ( toolbar, inspector controls etc..). IMO since it's easy to move the functionality between the toolbar and the inspector controls, this enhances the functionality of Query block and could be merged even without the finalized design.


<!-- Please describe what you have changed or added -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
