### PR TITLE
Make the post and site editor footers look the same.

### DIFF
--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -93,21 +93,6 @@
 	}
 }
 
-.edit-post-layout__footer {
-	display: none;
-	z-index: z-index(".edit-post-layout__footer");
-
-	// Stretch to mimic outline padding on desktop.
-	@include break-medium() {
-		display: flex;
-		background: $white;
-		height: $footer-height;
-		align-items: center;
-		font-size: $default-font-size;
-		padding: 0 ($grid-unit-15 + 6px);
-	}
-}
-
 .edit-post-layout .interface-interface-skeleton__content {
 	background-color: $light-gray-700;
 }

--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -1,7 +1,4 @@
-$footer-height: $button-size-small;
-
 @import "../../interface/src/style.scss";
-
 @import "./components/header/style.scss";
 @import "./components/header/fullscreen-mode-close/style.scss";
 @import "./components/header/header-toolbar/style.scss";

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -126,7 +126,7 @@ html.interface-interface-skeleton__html-container {
 }
 
 .interface-interface-skeleton__footer {
-	height: auto;  // Keep the height flexible.
+	height: auto; // Keep the height flexible.
 	flex-shrink: 0;
 	border-top: $border-width solid $gray-100;
 	color: $gray-900;
@@ -134,7 +134,17 @@ html.interface-interface-skeleton__html-container {
 	// On Mobile the footer is hidden
 	display: none;
 	@include break-medium() {
-		display: block;
+		display: flex;
+	}
+
+	.block-editor-block-breadcrumb {
+		z-index: z-index(".edit-post-layout__footer");
+		display: flex;
+		background: $white;
+		height: $button-size-small;
+		align-items: center;
+		font-size: $default-font-size;
+		padding: 0 ($grid-unit-15 + 6px);
 	}
 }
 


### PR DESCRIPTION
The footer in the post editor and site editor look different. That's because the CSS for styling the footer is not present in the edit-site context. This PR adresses that so they now look the same:

<img width="807" alt="Screenshot 2020-09-08 at 16 23 23" src="https://user-images.githubusercontent.com/1204802/92489260-e2a28180-f1ef-11ea-8030-753ad344e1d3.png">

<img width="495" alt="Screenshot 2020-09-08 at 16 23 33" src="https://user-images.githubusercontent.com/1204802/92489263-e3d3ae80-f1ef-11ea-9bc8-80c5ae13d231.png">
