### PR TITLE
Update: Set property to change one property accept all lodash paths.

### DIFF
--- a/packages/edit-site/src/components/editor/global-styles-provider.js
+++ b/packages/edit-site/src/components/editor/global-styles-provider.js
@@ -46,15 +46,14 @@ export default ( { children, baseStyles, contexts } ) => {
 			contexts,
 			getProperty: ( context, path ) =>
 				get( userStyles?.[ context ]?.styles, path ),
-			setProperty: ( context, newValues ) => {
+			setProperty: ( context, path, newValue ) => {
 				const newContent = { ...userStyles };
-				Object.keys( newValues ).forEach( ( key ) => {
-					set(
-						newContent,
-						`${ context }.styles.${ key }`,
-						newValues[ key ]
-					);
-				} );
+				let contextStyles = newContent?.[ context ]?.styles;
+				if ( ! contextStyles ) {
+					contextStyles = {};
+					set( newContent, [ context, 'styles' ], contextStyles );
+				}
+				set( contextStyles, path, newValue );
 				setContent( JSON.stringify( newContent ) );
 			},
 		} ),

--- a/packages/edit-site/src/components/editor/global-styles-provider.js
+++ b/packages/edit-site/src/components/editor/global-styles-provider.js
@@ -22,7 +22,7 @@ import getGlobalStyles from './global-styles-renderer';
 const GlobalStylesContext = createContext( {
 	/* eslint-disable no-unused-vars */
 	getProperty: ( context, path ) => {},
-	setProperty: ( context, newValues ) => {},
+	setProperty: ( context, path, newValue ) => {},
 	globalContext: {},
 	/* eslint-enable no-unused-vars */
 } );

--- a/packages/edit-site/src/components/sidebar/color-panel.js
+++ b/packages/edit-site/src/components/sidebar/color-panel.js
@@ -7,11 +7,12 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { LINK_COLOR } from '../editor/utils';
-
-const BACKGROUND_COLOR = 'background-color';
-const GRADIENT_COLOR = 'background';
-const TEXT_COLOR = 'color';
+import {
+	BACKGROUND_COLOR,
+	GRADIENT_COLOR,
+	LINK_COLOR,
+	TEXT_COLOR,
+} from '../editor/utils';
 
 export default ( {
 	context: { supports, name },

--- a/packages/edit-site/src/components/sidebar/color-panel.js
+++ b/packages/edit-site/src/components/sidebar/color-panel.js
@@ -7,12 +7,11 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import {
-	BACKGROUND_COLOR,
-	LINK_COLOR,
-	TEXT_COLOR,
-	GRADIENT_COLOR,
-} from '../editor/utils';
+import { LINK_COLOR } from '../editor/utils';
+
+const BACKGROUND_COLOR = 'background-color';
+const GRADIENT_COLOR = 'background';
+const TEXT_COLOR = 'color';
 
 export default ( {
 	context: { supports, name },
@@ -32,55 +31,32 @@ export default ( {
 
 	if ( supports.includes( TEXT_COLOR ) ) {
 		settings.push( {
-			colorValue: getProperty( name, 'color.text' ),
+			colorValue: getProperty( name, [ 'color', 'text' ] ),
 			onColorChange: ( value ) =>
-				setProperty( name, { 'color.text': value } ),
+				setProperty( name, [ 'color', 'text' ], value ),
 			label: __( 'Text color' ),
 		} );
 	}
 
-	/*
-	 * We want to send the entities API both colors
-	 * in a single request. This is to avod race conditions
-	 * that override the previous callback.
-	 */
-	let setBackground;
-	let backgroundSettings;
-	const backgroundPromise = new Promise(
-		( resolve ) => ( setBackground = ( value ) => resolve( value ) )
-	);
-	let setGradient;
-	let gradientSettings;
-	const gradientPromise = new Promise(
-		( resolve ) => ( setGradient = ( value ) => resolve( value ) )
-	);
-	Promise.all( [ backgroundPromise, gradientPromise ] ).then( ( values ) => {
-		setProperty( name, { ...values[ 0 ], ...values[ 1 ] } );
-	} );
+	let gradientSettings, backgroundSettings;
+
 	if ( supports.includes( BACKGROUND_COLOR ) ) {
 		backgroundSettings = {
-			colorValue: getProperty( name, 'color.background' ),
+			colorValue: getProperty( name, [ 'color', 'background' ] ),
 			onColorChange: ( value ) =>
-				setBackground( { 'color.background': value } ),
+				setProperty( name, [ 'color', 'background' ], value ),
 		};
 	} else {
 		backgroundSettings = {};
-		// Resolve the background promise, as to fire the setProperty
-		// callback when the gradient promise is resolved.
-		setBackground( undefined );
 	}
 	if ( supports.includes( GRADIENT_COLOR ) ) {
 		gradientSettings = {
-			gradientValue: getProperty( name, 'color.gradient' ),
+			gradientValue: getProperty( name, [ 'color', 'gradient' ] ),
 			onGradientChange: ( value ) =>
-				setGradient( { 'color.gradient': value } ),
-			disableCustomGradients: true,
+				setProperty( name, [ 'color', 'gradient' ], value ),
 		};
 	} else {
 		gradientSettings = {};
-		// Resolve the gradient promise, as to fire the setProperty
-		// callback when the background promise is resolved.
-		setGradient( undefined );
 	}
 
 	if (
@@ -96,9 +72,9 @@ export default ( {
 
 	if ( supports.includes( LINK_COLOR ) ) {
 		settings.push( {
-			colorValue: getProperty( name, 'color.link' ),
+			colorValue: getProperty( name, [ 'color', 'link' ] ),
 			onColorChange: ( value ) =>
-				setProperty( name, { 'color.link': value } ),
+				setProperty( name, [ 'color', 'link' ], value ),
 			label: __( 'Link color' ),
 		} );
 	}

--- a/packages/edit-site/src/components/sidebar/color-panel.js
+++ b/packages/edit-site/src/components/sidebar/color-panel.js
@@ -37,26 +37,23 @@ export default ( {
 			label: __( 'Text color' ),
 		} );
 	}
-
-	let gradientSettings, backgroundSettings;
-
+	
+	let backgroundSettings = {};
 	if ( supports.includes( BACKGROUND_COLOR ) ) {
 		backgroundSettings = {
 			colorValue: getProperty( name, [ 'color', 'background' ] ),
 			onColorChange: ( value ) =>
-				setProperty( name, [ 'color', 'background' ], value ),
+			setProperty( name, [ 'color', 'background' ], value ),
 		};
-	} else {
-		backgroundSettings = {};
 	}
+
+	let gradientSettings = {};
 	if ( supports.includes( GRADIENT_COLOR ) ) {
 		gradientSettings = {
 			gradientValue: getProperty( name, [ 'color', 'gradient' ] ),
 			onGradientChange: ( value ) =>
 				setProperty( name, [ 'color', 'gradient' ], value ),
 		};
-	} else {
-		gradientSettings = {};
 	}
 
 	if (

--- a/packages/edit-site/src/components/sidebar/color-panel.js
+++ b/packages/edit-site/src/components/sidebar/color-panel.js
@@ -37,13 +37,13 @@ export default ( {
 			label: __( 'Text color' ),
 		} );
 	}
-	
+
 	let backgroundSettings = {};
 	if ( supports.includes( BACKGROUND_COLOR ) ) {
 		backgroundSettings = {
 			colorValue: getProperty( name, [ 'color', 'background' ] ),
 			onColorChange: ( value ) =>
-			setProperty( name, [ 'color', 'background' ], value ),
+				setProperty( name, [ 'color', 'background' ], value ),
 		};
 	}
 

--- a/packages/edit-site/src/components/sidebar/typography-panel.js
+++ b/packages/edit-site/src/components/sidebar/typography-panel.js
@@ -30,20 +30,29 @@ export default ( {
 			{ supports.includes( FONT_SIZE ) && (
 				<FontSizePicker
 					value={ fromPx(
-						getProperty( name, 'typography.fontSize' )
+						getProperty( name, [ 'typography', 'fontSize' ] )
 					) }
 					onChange={ ( value ) =>
-						setProperty( name, {
-							'typography.fontSize': toPx( value ),
-						} )
+						setProperty(
+							name,
+							[ 'typography', 'fontSize' ],
+							toPx( value )
+						)
 					}
 				/>
 			) }
 			{ supports.includes( LINE_HEIGHT ) && (
 				<LineHeightControl
-					value={ getProperty( name, 'typography.lineHeight' ) }
+					value={ getProperty( name, [
+						'typography',
+						'lineHeight',
+					] ) }
 					onChange={ ( value ) =>
-						setProperty( name, { 'typography.lineHeight': value } )
+						setProperty(
+							name,
+							[ 'typography', 'lineHeight' ],
+							value
+						)
 					}
 				/>
 			) }


### PR DESCRIPTION
When trying to address https://github.com/WordPress/gutenberg/pull/25145#issuecomment-688823538, I noticed our setProperty global styles methods do not accept every lodash path but only string paths.
Previously we discovered that using string paths is slow and we have a lint rule that disallows string paths on lodash e.g: `get ( object, 'a.b' )` is not accepted by our lint rules.
I guess we should use array paths like the rest of the codebase using array paths would also allow us to use the global mappings that are in an array format.

The setProperty method allows changing multiple properties, each property is a key in the object, we can not use keys that are arrays. So this PR changes setProperty to change a single property at a time.

## How has this been tested?
I verified the global styles sidebar continues to work.
