### PR TITLE
Show Classic block contents on load

### DIFF
--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -54,7 +54,7 @@ export default class ClassicEdit extends Component {
 		if ( document.readyState === 'complete' ) {
 			this.initialize();
 		} else {
-			window.addEventListener( 'DOMContentLoaded', this.initialize );
+			window.addEventListener( 'load', this.initialize );
 		}
 	}
 

--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -51,11 +51,15 @@ export default class ClassicEdit extends Component {
 			suffix,
 		} );
 
-		document.addEventListener( 'readystatechange', () => {
-			if ( document.readyState === 'complete' ) {
-				this.initialize();
-			}
-		} );
+		if ( document.readyState === 'complete' ) {
+			this.initialize();
+		} else {
+			document.addEventListener( 'readystatechange', () => {
+				if ( document.readyState === 'complete' ) {
+					this.initialize();
+				}
+			} );
+		}
 	}
 
 	componentWillUnmount() {

--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -51,11 +51,11 @@ export default class ClassicEdit extends Component {
 			suffix,
 		} );
 
-		if ( document.readyState === 'complete' ) {
-			this.initialize();
-		} else {
-			window.addEventListener( 'load', this.initialize );
-		}
+		document.addEventListener( 'readystatechange', () => {
+			if ( document.readyState === 'complete' ) {
+				this.initialize();
+			}
+		} );
 	}
 
 	componentWillUnmount() {
@@ -70,12 +70,8 @@ export default class ClassicEdit extends Component {
 		} = this.props;
 
 		const editor = window.tinymce.get( `editor-${ clientId }` );
-		const currentContent = editor.getContent();
 
-		if (
-			prevProps.attributes.content !== content &&
-			currentContent !== content
-		) {
+		if ( prevProps.attributes.content !== content ) {
 			editor.setContent( content || '' );
 		}
 	}
@@ -148,7 +144,7 @@ export default class ClassicEdit extends Component {
 				} );
 			}
 		}, 250 );
-		editor.on( 'Paste Change input Undo Redo', debouncedOnChange );
+		// editor.on( 'Paste Change input Undo Redo', debouncedOnChange );
 
 		// We need to cancel the debounce call because when we remove
 		// the editor (onUnmount) this callback is executed in

--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -70,8 +70,12 @@ export default class ClassicEdit extends Component {
 		} = this.props;
 
 		const editor = window.tinymce.get( `editor-${ clientId }` );
+		const currentContent = editor.getContent();
 
-		if ( prevProps.attributes.content !== content ) {
+		if (
+			prevProps.attributes.content !== content &&
+			currentContent !== content
+		) {
 			editor.setContent( content || '' );
 		}
 	}
@@ -144,7 +148,7 @@ export default class ClassicEdit extends Component {
 				} );
 			}
 		}, 250 );
-		// editor.on( 'Paste Change input Undo Redo', debouncedOnChange );
+		editor.on( 'Paste Change input Undo Redo', debouncedOnChange );
 
 		// We need to cancel the debounce call because when we remove
 		// the editor (onUnmount) this callback is executed in


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes: https://github.com/WordPress/gutenberg/issues/24696

With the update of React there seems to be some `async` changes that made the initialization of `Classic` block not to be triggered. This changes the event to hook on to `load`.

