### PR TITLE
Classic block: Optional chain on possibly null editor

### DIFF
--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -76,7 +76,7 @@ export default class ClassicEdit extends Component {
 			prevProps.attributes.content !== content &&
 			currentContent !== content
 		) {
-			editor?.setContent( content || '' ); // eslint-disable-line no-unused-expressions
+			editor.setContent( content || '' );
 		}
 	}
 

--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -70,13 +70,13 @@ export default class ClassicEdit extends Component {
 		} = this.props;
 
 		const editor = window.tinymce.get( `editor-${ clientId }` );
-		const currentContent = editor.getContent();
+		const currentContent = editor?.getContent();
 
 		if (
 			prevProps.attributes.content !== content &&
 			currentContent !== content
 		) {
-			editor.setContent( content || '' );
+			editor?.setContent( content || '' ); // eslint-disable-line no-unused-expressions
 		}
 	}
 


### PR DESCRIPTION
## Description

We've observed errors where `getContent` is invoked on `null` on this
line. Use optional chaining to prevent this error from happening.

https://github.com/WordPress/gutenberg/blob/55edb95ddd588a997718b8427b4d06c1d86113c2/packages/block-library/src/classic/edit.js#L73

I don't know how to reproduce this consistently, but I have observed the error regularly on a site of mine and this change fixes the error.

On my site, the error is triggered by adding a Classic block with some content, saving the post, reloading the post in the editor then selecting the Classic block:

Introduced in https://github.com/WordPress/gutenberg/pull/23408.

## How has this been tested?

Rebuilding the plugin zip with this change and uploading it to my site.

## Screenshots

![Screen Shot on 2020-09-08 at 10-03-40](https://user-images.githubusercontent.com/841763/92513106-142b4500-f210-11ea-9649-41283ab25381.png)

## Types of changes
Bug fix: Fix an issue where the Classic block may throw an error when loaded in a post.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
