### PR TITLE
Pass block pattern name when using insertBlocks

### DIFF
--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -1095,7 +1095,7 @@ _Parameters_
 -   _index_ `?number`: Index at which block should be inserted.
 -   _rootClientId_ `?string`: Optional root client ID of block list on which to insert.
 -   _updateSelection_ `?boolean`: If true block selection will be updated.  If false, block selection will not change. Defaults to true.
--   _patternName_ `?string`: Optional If inserted as a block pattern, the namespace of the block pattern.
+-   _meta_ `?Object`: Optional Meta values to be passed to the action object.
 
 _Returns_
 

--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -1095,6 +1095,7 @@ _Parameters_
 -   _index_ `?number`: Index at which block should be inserted.
 -   _rootClientId_ `?string`: Optional root client ID of block list on which to insert.
 -   _updateSelection_ `?boolean`: If true block selection will be updated.  If false, block selection will not change. Defaults to true.
+-   _patternName_ `?string`: Optional If inserted as a block pattern, the namespace of the block pattern.
 
 _Returns_
 

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -91,7 +91,7 @@ function useInsertionPoint( {
 		return getBlockOrder( destinationRootClientId ).length;
 	}
 
-	const onInsertBlocks = ( blocks, patternName = false ) => {
+	const onInsertBlocks = ( blocks, meta ) => {
 		const selectedBlock = getSelectedBlock();
 		if (
 			! isAppender &&
@@ -105,7 +105,7 @@ function useInsertionPoint( {
 				getInsertionIndex(),
 				destinationRootClientId,
 				selectBlockOnInsert,
-				patternName
+				meta
 			);
 		}
 

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -91,7 +91,7 @@ function useInsertionPoint( {
 		return getBlockOrder( destinationRootClientId ).length;
 	}
 
-	const onInsertBlocks = ( blocks ) => {
+	const onInsertBlocks = ( blocks, patternName = false ) => {
 		const selectedBlock = getSelectedBlock();
 		if (
 			! isAppender &&
@@ -104,7 +104,8 @@ function useInsertionPoint( {
 				blocks,
 				getInsertionIndex(),
 				destinationRootClientId,
-				selectBlockOnInsert
+				selectBlockOnInsert,
+				patternName
 			);
 		}
 

--- a/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
@@ -31,7 +31,10 @@ const usePatternsState = ( onInsert ) => {
 	}, [] );
 	const { createSuccessNotice } = useDispatch( 'core/notices' );
 	const onClickPattern = useCallback( ( pattern, blocks ) => {
-		onInsert( map( blocks, ( block ) => cloneBlock( block ) ) );
+		onInsert(
+			map( blocks, ( block ) => cloneBlock( block ) ),
+			pattern.name
+		);
 		createSuccessNotice(
 			sprintf(
 				/* translators: %s: block pattern title. */

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -73,6 +73,11 @@ function InserterMenu( {
 		onSelect();
 	};
 
+	const onInsertPattern = ( blocks, patternName ) => {
+		onInsertBlocks( blocks, patternName );
+		onSelect();
+	};
+
 	const onHover = ( item ) => {
 		onToggleInsertionPoint( !! item );
 		setHoveredItem( item );
@@ -101,7 +106,10 @@ function InserterMenu( {
 	);
 
 	const patternsTab = (
-		<BlockPatternsTabs onInsert={ onInsert } filterValue={ filterValue } />
+		<BlockPatternsTabs
+			onInsert={ onInsertPattern }
+			filterValue={ filterValue }
+		/>
 	);
 
 	const reusableBlocksTab = (

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -74,7 +74,7 @@ function InserterMenu( {
 	};
 
 	const onInsertPattern = ( blocks, patternName ) => {
-		onInsertBlocks( blocks, patternName );
+		onInsertBlocks( blocks, { patternName } );
 		onSelect();
 	};
 

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -480,11 +480,11 @@ export function insertBlock(
  * Returns an action object used in signalling that an array of blocks should
  * be inserted, optionally at a specific index respective a root block list.
  *
- * @param {Object[]} blocks          Block objects to insert.
- * @param {?number}  index           Index at which block should be inserted.
- * @param {?string}  rootClientId    Optional root client ID of block list on which to insert.
- * @param {?boolean} updateSelection If true block selection will be updated.  If false, block selection will not change. Defaults to true.
- * @param {?string}  patternName     Optional If inserted as a block pattern, the namespace of the block pattern.
+ * @param {Object[]}   blocks          Block objects to insert.
+ * @param {?number}    index           Index at which block should be inserted.
+ * @param {?string}    rootClientId    Optional root client ID of block list on which to insert.
+ * @param {?boolean}   updateSelection If true block selection will be updated.  If false, block selection will not change. Defaults to true.
+ * @param {?Object}  meta             Optional Meta values to be passed to the action object.
  *
  *  @return {Object} Action object.
  */
@@ -493,7 +493,7 @@ export function* insertBlocks(
 	index,
 	rootClientId,
 	updateSelection = true,
-	patternName = false
+	meta
 ) {
 	blocks = getBlocksWithDefaultStylesApplied(
 		castArray( blocks ),
@@ -515,11 +515,11 @@ export function* insertBlocks(
 		return {
 			type: 'INSERT_BLOCKS',
 			blocks: allowedBlocks,
-			patternName,
 			index,
 			rootClientId,
 			time: Date.now(),
 			updateSelection,
+			meta,
 		};
 	}
 }

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -484,6 +484,7 @@ export function insertBlock(
  * @param {?number}  index           Index at which block should be inserted.
  * @param {?string}  rootClientId    Optional root client ID of block list on which to insert.
  * @param {?boolean} updateSelection If true block selection will be updated.  If false, block selection will not change. Defaults to true.
+ * @param {?string}  patternName     Optional If inserted as a block pattern, the namespace of the block pattern.
  *
  *  @return {Object} Action object.
  */
@@ -491,7 +492,8 @@ export function* insertBlocks(
 	blocks,
 	index,
 	rootClientId,
-	updateSelection = true
+	updateSelection = true,
+	patternName = false
 ) {
 	blocks = getBlocksWithDefaultStylesApplied(
 		castArray( blocks ),
@@ -513,6 +515,7 @@ export function* insertBlocks(
 		return {
 			type: 'INSERT_BLOCKS',
 			blocks: allowedBlocks,
+			patternName,
 			index,
 			rootClientId,
 			time: Date.now(),

--- a/packages/block-editor/src/store/test/actions.js
+++ b/packages/block-editor/src/store/test/actions.js
@@ -568,6 +568,68 @@ describe( 'actions', () => {
 				value: undefined,
 			} );
 		} );
+
+		it( 'should pass patternName through metadata to INSERT_BLOCKS action', () => {
+			const ribsBlock = {
+				clientId: 'ribs',
+				name: 'core/test-ribs',
+			};
+			const chickenBlock = {
+				clientId: 'chicken',
+				name: 'core/test-chicken',
+			};
+			const chickenRibsBlock = {
+				clientId: 'chicken-ribs',
+				name: 'core/test-chicken-ribs',
+			};
+			const blocks = [ ribsBlock, chickenBlock, chickenRibsBlock ];
+			const meta = { patternName: 'core/chicken-ribs-pattern' };
+
+			const insertBlocksGenerator = insertBlocks(
+				blocks,
+				5,
+				'testrootid',
+				false,
+				meta
+			);
+
+			// Skip getSettings select.
+			insertBlocksGenerator.next();
+
+			expect( insertBlocksGenerator.next().value ).toEqual( {
+				args: [ 'core/test-ribs', 'testrootid' ],
+				selectorName: 'canInsertBlockType',
+				storeName: 'core/block-editor',
+				type: 'SELECT',
+			} );
+
+			expect( insertBlocksGenerator.next( true ).value ).toEqual( {
+				args: [ 'core/test-chicken', 'testrootid' ],
+				selectorName: 'canInsertBlockType',
+				storeName: 'core/block-editor',
+				type: 'SELECT',
+			} );
+
+			expect( insertBlocksGenerator.next( false ).value ).toEqual( {
+				args: [ 'core/test-chicken-ribs', 'testrootid' ],
+				selectorName: 'canInsertBlockType',
+				storeName: 'core/block-editor',
+				type: 'SELECT',
+			} );
+
+			expect( insertBlocksGenerator.next( true ) ).toEqual( {
+				done: true,
+				value: {
+					type: 'INSERT_BLOCKS',
+					blocks: [ ribsBlock, chickenRibsBlock ],
+					index: 5,
+					rootClientId: 'testrootid',
+					time: expect.any( Number ),
+					updateSelection: false,
+					meta: { patternName: 'core/chicken-ribs-pattern' },
+				},
+			} );
+		} );
 	} );
 
 	describe( 'showInsertionPoint', () => {

--- a/packages/block-editor/src/store/test/actions.js
+++ b/packages/block-editor/src/store/test/actions.js
@@ -321,6 +321,7 @@ describe( 'actions', () => {
 				value: {
 					type: 'INSERT_BLOCKS',
 					blocks: [ block ],
+					patternName: false,
 					index,
 					rootClientId: 'testclientid',
 					time: expect.any( Number ),
@@ -405,6 +406,7 @@ describe( 'actions', () => {
 							attributes: { className: 'is-style-colorful' },
 						},
 					],
+					patternName: false,
 					index: 5,
 					rootClientId: 'testrootid',
 					time: expect.any( Number ),
@@ -462,6 +464,7 @@ describe( 'actions', () => {
 							attributes: { className: 'is-style-colorful' },
 						},
 					],
+					patternName: false,
 					index: 5,
 					rootClientId: 'testrootid',
 					time: expect.any( Number ),
@@ -520,6 +523,7 @@ describe( 'actions', () => {
 				value: {
 					type: 'INSERT_BLOCKS',
 					blocks: [ ribsBlock, chickenRibsBlock ],
+					patternName: false,
 					index: 5,
 					rootClientId: 'testrootid',
 					time: expect.any( Number ),

--- a/packages/block-editor/src/store/test/actions.js
+++ b/packages/block-editor/src/store/test/actions.js
@@ -321,7 +321,6 @@ describe( 'actions', () => {
 				value: {
 					type: 'INSERT_BLOCKS',
 					blocks: [ block ],
-					patternName: false,
 					index,
 					rootClientId: 'testclientid',
 					time: expect.any( Number ),
@@ -406,7 +405,6 @@ describe( 'actions', () => {
 							attributes: { className: 'is-style-colorful' },
 						},
 					],
-					patternName: false,
 					index: 5,
 					rootClientId: 'testrootid',
 					time: expect.any( Number ),
@@ -464,7 +462,6 @@ describe( 'actions', () => {
 							attributes: { className: 'is-style-colorful' },
 						},
 					],
-					patternName: false,
 					index: 5,
 					rootClientId: 'testrootid',
 					time: expect.any( Number ),
@@ -523,7 +520,6 @@ describe( 'actions', () => {
 				value: {
 					type: 'INSERT_BLOCKS',
 					blocks: [ ribsBlock, chickenRibsBlock ],
-					patternName: false,
 					index: 5,
 					rootClientId: 'testrootid',
 					time: expect.any( Number ),


### PR DESCRIPTION
## Description
With the `INSERT_BLOCKS` action, there is currently no way to tell the difference between a number of arbitrary blocks being inserted versus a defined block pattern being inserted.

Providing the pattern namespace/name within the `insertBlocks` action creator means that we can determine whether or not these blocks were inserted via a block pattern. 

The value of `patternName` is the block pattern namespace and name if inserted via a pattern, and boolean `false` if not.

This is information that could be useful for showing the pattern in the undo history, or for plugins to take advantage of. 

## How has this been tested?
Tested locally, all automated tests passing.

## Types of changes
New feature (non-breaking change which adds functionality)

## To Test

* Insert a block pattern
* Confirm that the `INSERT_BLOCK` action has passed the pattern name in the object
* Insert a block, and confirm that the pattern name is false

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
