### PR TITLE
Add regression E2E test for the classic block initialization issue

### DIFF
--- a/packages/e2e-tests/specs/editor/blocks/__snapshots__/classic.test.js.snap
+++ b/packages/e2e-tests/specs/editor/blocks/__snapshots__/classic.test.js.snap
@@ -2,6 +2,4 @@
 
 exports[`Classic Should not fail after save/reload 1`] = `"test"`;
 
-exports[`Classic Should not fail after save/reload 2`] = `"test"`;
-
 exports[`Classic should be inserted 1`] = `"test"`;

--- a/packages/e2e-tests/specs/editor/blocks/__snapshots__/classic.test.js.snap
+++ b/packages/e2e-tests/specs/editor/blocks/__snapshots__/classic.test.js.snap
@@ -1,3 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Classic Should not fail after save/reload 1`] = `"test"`;
+
+exports[`Classic Should not fail after save/reload 2`] = `"test"`;
+
 exports[`Classic should be inserted 1`] = `"test"`;

--- a/packages/e2e-tests/specs/editor/blocks/classic.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/classic.test.js
@@ -15,7 +15,6 @@ import {
 	insertBlock,
 	pressKeyWithModifier,
 	clickBlockToolbarButton,
-	switchEditorModeTo,
 	saveDraft,
 } from '@wordpress/e2e-test-utils';
 

--- a/packages/e2e-tests/specs/editor/blocks/classic.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/classic.test.js
@@ -135,11 +135,9 @@ describe( 'Classic', () => {
 		// Reload
 		// Disabling the browser disk cache is needed in order to reproduce the issue
 		// in case it regresses. To test this, revert commit 65c9f74, build and run the test.
-		await runWithoutCache( async () => {
-			await page.reload();
-			await clickClassic();
-			expect( console ).not.toHaveErrored();
-			expect( await getEditedPostContent() ).toMatchSnapshot();
-		} );
+		await runWithoutCache( () => page.reload() );
+		await clickClassic();
+		expect( console ).not.toHaveErrored();
+		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/blocks/classic.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/classic.test.js
@@ -102,13 +102,6 @@ describe( 'Classic', () => {
 	} );
 
 	it( 'Should not fail after save/reload', async () => {
-		const classicBlockSelector = 'div[aria-label^="Block: Classic"]';
-
-		const clickClassic = async () => {
-			await page.waitForSelector( classicBlockSelector );
-			await page.click( classicBlockSelector );
-		};
-
 		// Might move to utils if this becomes useful enough for other tests
 		const runWithoutCache = async ( cb ) => {
 			await page.setCacheEnabled( false );
@@ -135,7 +128,10 @@ describe( 'Classic', () => {
 		// Disabling the browser disk cache is needed in order to reproduce the issue
 		// in case it regresses. To test this, revert commit 65c9f74, build and run the test.
 		await runWithoutCache( () => page.reload() );
-		await clickClassic();
+
+		const classicBlockSelector = 'div[aria-label^="Block: Classic"]';
+		await page.waitForSelector( classicBlockSelector );
+		await page.focus( classicBlockSelector );
 		expect( console ).not.toHaveErrored();
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );

--- a/packages/e2e-tests/specs/editor/blocks/classic.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/classic.test.js
@@ -104,9 +104,12 @@ describe( 'Classic', () => {
 	it( 'Should not fail after save/reload', async () => {
 		// Might move to utils if this becomes useful enough for other tests
 		const runWithoutCache = async ( cb ) => {
-			await page.setCacheEnabled( false );
-			await cb();
-			await page.setCacheEnabled( true );
+			try {
+				await page.setCacheEnabled( false );
+				await cb();
+			} finally {
+				await page.setCacheEnabled( true );
+			}
 		};
 
 		await insertBlock( 'Classic' );

--- a/packages/e2e-tests/specs/editor/blocks/classic.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/classic.test.js
@@ -102,11 +102,11 @@ describe( 'Classic', () => {
 	} );
 
 	it( 'Should not fail after save/reload', async () => {
-		const mainBlockCSSSelector = 'div[aria-label^="Block: Classic"]';
+		const classicBlockSelector = 'div[aria-label^="Block: Classic"]';
 
 		const clickClassic = async () => {
-			await page.waitForSelector( mainBlockCSSSelector );
-			await page.click( mainBlockCSSSelector );
+			await page.waitForSelector( classicBlockSelector );
+			await page.click( classicBlockSelector );
 		};
 
 		// Might move to utils if this becomes useful enough for other tests


### PR DESCRIPTION
## Description

Adds a regression test in the client block E2E spec to avoid the regression of this issue:  https://github.com/WordPress/gutenberg/issues/24696, as suggested in https://github.com/WordPress/gutenberg/pull/25162#issuecomment-689074703.

## How has this been tested?

- Check out this branch, and apply the following diff (effectively reverting #25162 and #25163):

```diff
diff --git a/packages/block-library/src/classic/edit.js b/packages/block-library/src/classic/edit.js
index c8da3b1b6d..8195e51006 100644
--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -54,11 +54,7 @@ export default class ClassicEdit extends Component {
                if ( document.readyState === 'complete' ) {
                        this.initialize();
                } else {
-                       document.addEventListener( 'readystatechange', () => {
-                               if ( document.readyState === 'complete' ) {
-                                       this.initialize();
-                               }
-                       } );
+                       window.addEventListener( 'DOMContentLoaded', this.initialize );
                }
        }
 
@@ -74,7 +70,7 @@ export default class ClassicEdit extends Component {
                } = this.props;
 
                const editor = window.tinymce.get( `editor-${ clientId }` );
-               const currentContent = editor?.getContent();
+               const currentContent = editor.getContent();
 
                if (
                        prevProps.attributes.content !== content &&

```

- Run `npm build` and `npm run wp-env-start`.
- Make sure the Gutenberg plugin is active in your local test instance. That's `localhost:8889` -- log into wp-admin to verify (credentials: `admin`/`password`)
- Run `npm run test-e2e -- packages/e2e-tests/specs/editor/blocks/classic.test.js`. (To watch tests in interactive mode, append `--puppeteer-interactive`).
- Verify that the `Classic › Should not fail after save/reload` test fails with `TypeError: Cannot read property 'getContent' of null`.
- Now remove the patch (`git checkout -- packages/block-library/src/classic/edit.js`), and rebuild (`npm run build`).
- Re-run the e2e test. It should pass this time.

## Types of changes

New E2E test.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
