### PR TITLE
Remove Legacy Widget from Post editor

### DIFF
--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -177,7 +177,8 @@ export const registerCoreBlocks = () => {
 /**
  * Function to register experimental core blocks depending on editor settings.
  *
- * @param {Object} settings Editor settings.
+ * @param {Object}   settings Editor settings.
+ * @param {Function} filter   Optional filter function to apply for each block.
  *
  * @example
  * ```js
@@ -188,7 +189,7 @@ export const registerCoreBlocks = () => {
  */
 export const __experimentalRegisterExperimentalCoreBlocks =
 	process.env.GUTENBERG_PHASE === 2
-		? ( settings ) => {
+		? ( settings, filter = () => true ) => {
 				const { __experimentalEnableFullSiteEditing } = settings;
 
 				[
@@ -224,6 +225,8 @@ export const __experimentalRegisterExperimentalCoreBlocks =
 								postTags,
 						  ]
 						: [] ),
-				].forEach( registerBlock );
+				]
+					.filter( filter )
+					.forEach( registerBlock );
 		  }
 		: undefined;

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -96,7 +96,11 @@ export function initializeEditor(
 	);
 	registerCoreBlocks();
 	if ( process.env.GUTENBERG_PHASE === 2 ) {
-		__experimentalRegisterExperimentalCoreBlocks( settings );
+		__experimentalRegisterExperimentalCoreBlocks(
+			settings,
+			// Disable legacy widget block in Post editor.
+			( block ) => block.name !== 'core/legacy-widget'
+		);
 	}
 
 	// Show a console log warning if the browser is not in Standards rendering mode.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Close #24900.

Remove **Legacy Widget** from _Post_ editor.

The solution is to provide a second argument `filter` to `__experimentalRegisterExperimentalCoreBlocks`. The function signature is the same as the filter callback function in `Array.prototype.filter`. Not sure if there's any other way?

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Go to Post editor
2. Try to add a Legacy Widget via inserter or any other way (copy/paste, code editor)
3. It should not be possible to add Legacy Widget to Post editor
4. However, it should be possible to add Legacy Widget to other places (Site, Widgets screen, etc).

## Screenshots <!-- if applicable -->

![image](https://user-images.githubusercontent.com/7753001/92566556-ffea5500-f2ae-11ea-9e74-88b51e47a3de.png)
![image](https://user-images.githubusercontent.com/7753001/92566608-12648e80-f2af-11ea-91c4-5e16dc789378.png)
![image](https://user-images.githubusercontent.com/7753001/92566719-42139680-f2af-11ea-8e11-f6b39d425985.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
