### PR TITLE
Data: remove flowRight call from metadata reducer

### DIFF
--- a/packages/data/src/namespace-store/metadata/reducer.js
+++ b/packages/data/src/namespace-store/metadata/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { flowRight, omit, has } from 'lodash';
+import { omit, has } from 'lodash';
 import EquivalentKeyMap from 'equivalent-key-map';
 
 /**
@@ -20,7 +20,7 @@ import { onSubKey } from './utils';
  *
  * @return {Object} Next state.
  */
-const subKeysIsResolved = flowRight( [ onSubKey( 'selectorName' ) ] )(
+const subKeysIsResolved = onSubKey( 'selectorName' )(
 	( state = new EquivalentKeyMap(), action ) => {
 		switch ( action.type ) {
 			case 'START_RESOLUTION':


### PR DESCRIPTION
The `flowRight` call is useful only when it flows over two or more functions. But since the refactoring that gave each store its own metadata and the `core/data` store became just proxy to all of them, there is no `onSubKey( 'reducerKey' )` and the `flowRight` worked with just one function.
