### PR TITLE
Show download option in Audio block

### DIFF
--- a/packages/block-library/src/audio/block.json
+++ b/packages/block-library/src/audio/block.json
@@ -33,6 +33,10 @@
 			"source": "attribute",
 			"selector": "audio",
 			"attribute": "preload"
+		},
+		"showDownloadButton": {
+			"type": "boolean",
+			"default": true
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -40,7 +40,15 @@ function AudioEdit( {
 	noticeUI,
 	insertBlocksAfter,
 } ) {
-	const { id, autoplay, caption, loop, preload, src } = attributes;
+	const {
+		id,
+		autoplay,
+		caption,
+		loop,
+		preload,
+		src,
+		showDownloadButton,
+	} = attributes;
 
 	const mediaUpload = useSelect( ( select ) => {
 		const { getSettings } = select( 'core/block-editor' );
@@ -157,6 +165,13 @@ function AudioEdit( {
 						onChange={ toggleAttribute( 'loop' ) }
 						checked={ loop }
 					/>
+					<ToggleControl
+						label={ __(
+							'Show download button (only in Chrome??)'
+						) }
+						checked={ showDownloadButton }
+						onChange={ toggleAttribute( 'showDownloadButton' ) }
+					/>
 					<SelectControl
 						label={ __( 'Preload' ) }
 						value={ preload || '' }
@@ -181,7 +196,11 @@ function AudioEdit( {
 					file or change the position slider when the controls are enabled.
 				*/ }
 				<Disabled>
-					<audio controls="controls" src={ src } />
+					<audio
+						controls="controls"
+						src={ src }
+						controlsList={ ! showDownloadButton && 'nodownload' }
+					/>
 				</Disabled>
 				{ ( ! RichText.isEmpty( caption ) || isSelected ) && (
 					<RichText

--- a/packages/block-library/src/audio/save.js
+++ b/packages/block-library/src/audio/save.js
@@ -4,8 +4,14 @@
 import { RichText } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
-	const { autoplay, caption, loop, preload, src } = attributes;
-
+	const {
+		autoplay,
+		caption,
+		loop,
+		preload,
+		src,
+		showDownloadButton,
+	} = attributes;
 	return (
 		src && (
 			<figure>
@@ -15,6 +21,7 @@ export default function save( { attributes } ) {
 					autoPlay={ autoplay }
 					loop={ loop }
 					preload={ preload }
+					controlsList={ ! showDownloadButton && 'nodownload' }
 				/>
 				{ ! RichText.isEmpty( caption ) && (
 					<RichText.Content tagName="figcaption" value={ caption } />


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Resolves:https://github.com/WordPress/gutenberg/issues/25121

This PR is a to test and consider if we should implement a `show download` button in `audio` block.

By testing in Chrome (greater than version 58), Safari and Firefox, I could see that `download` is shown only in Chrome's `audio` element's implementation. I haven't looked deep enough but since Gutenberg `audio` block is implemented with `audio` HTML element, this seems to be internal implementation per browser(engine).

Since Chrome is widely used, there could be an addition of this option with a note, but would be irrelevant for other browsers..

I tested it quickly and can be achieved with `controlsList` attribute ([ref here](https://developers.google.com/web/updates/2017/03/chrome-58-media-updates#controlslist)). 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->



## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
