### PR TITLE
Android: Reset extracted RN tools only if JS bundle is not up to date

### DIFF
--- a/packages/react-native-bridge/android/build.gradle
+++ b/packages/react-native-bridge/android/build.gradle
@@ -320,6 +320,8 @@ If they are changed, the isBundleUpToDate flag is switched to false. That flag i
         doFirst {
             println "Deleting temporary folders with extracted RN tools"
         }
+        dependsOn bundleUpToDateCheck
+        onlyIf { !isBundleUpToDate() }
         delete nodeFolder, npmFolder
     }
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
In `android/react-native-bridge` project `resetExtractedRNTools` Gradle task is being run in cached builds even if the JS bundle is up to date. This in turn causes the `npmSetup` task to run again and the whole thing ends up costing 20+ seconds of build time for no gain.
<!-- Please describe what you have changed or added -->
This PR adds a `isBundleUpToDate` check to `resetExtractedRNTools` so that it's only run if the bundle will get rebuilt.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
This was tested in https://github.com/wordpress-mobile/WordPress-Android by running the initial build as well as the cached build. The initial build shouldn't be affected whereas the cached build should take 20+ seconds less. It was also tested by comparing the build scans for before and after the change.

<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
N/A

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Build file changes in `android/react-native-bridge`.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
