### PR TITLE
Search Block: Add support for setting the border radius

### DIFF
--- a/packages/block-library/src/search/block.json
+++ b/packages/block-library/src/search/block.json
@@ -29,6 +29,9 @@
 		"buttonUseIcon": {
 			"type": "bool",
 			"default": false
+		},
+		"borderRadius": {
+			"type": "number"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -24,6 +24,7 @@ import {
 	ResizableBox,
 	PanelBody,
 	BaseControl,
+	RangeControl,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { search } from '@wordpress/icons';
@@ -48,6 +49,8 @@ const MIN_WIDTH = 220;
 const MIN_WIDTH_UNIT = 'px';
 const PC_WIDTH_DEFAULT = 50;
 const PX_WIDTH_DEFAULT = 350;
+const MIN_BORDER_RADIUS_VALUE = 0;
+const MAX_BORDER_RADIUS_VALUE = 50;
 const CSS_UNITS = [
 	{ value: '%', label: '%', default: PC_WIDTH_DEFAULT },
 	{ value: 'px', label: 'px', default: PX_WIDTH_DEFAULT },
@@ -70,6 +73,7 @@ export default function SearchEdit( {
 		buttonText,
 		buttonPosition,
 		buttonUseIcon,
+		borderRadius,
 	} = attributes;
 
 	const unitControlInstanceId = useInstanceId( UnitControl );
@@ -123,10 +127,28 @@ export default function SearchEdit( {
 		};
 	};
 
+	const sharedStyles = {
+		borderRadius: borderRadius ? borderRadius + 'px' : undefined,
+	};
+
+	const sharedClasses = {
+		'no-border-radius': borderRadius === 0,
+	};
+
 	const renderTextField = () => {
+		const textFieldStyles = {
+			...sharedStyles,
+		};
+
+		const textFieldClasses = classnames(
+			'wp-block-search__input',
+			sharedClasses
+		);
+
 		return (
 			<input
-				className="wp-block-search__input"
+				className={ textFieldClasses }
+				style={ textFieldStyles }
 				aria-label={ __( 'Optional placeholder text' ) }
 				// We hide the placeholder field's placeholder when there is a value. This
 				// stops screen readers from reading the placeholder field's placeholder
@@ -143,18 +165,29 @@ export default function SearchEdit( {
 	};
 
 	const renderButton = () => {
+		const buttonStyles = {
+			...sharedStyles,
+		};
+
+		const buttonClasses = classnames(
+			'wp-block-search__button',
+			sharedClasses
+		);
+
 		return (
 			<>
 				{ buttonUseIcon && (
 					<Button
 						icon={ search }
-						className="wp-block-search__button"
+						className={ buttonClasses }
+						style={ buttonStyles }
 					/>
 				) }
 
 				{ ! buttonUseIcon && (
 					<RichText
-						className="wp-block-search__button"
+						className={ buttonClasses }
+						style={ buttonStyles }
 						aria-label={ __( 'Button text' ) }
 						placeholder={ __( 'Add button text…' ) }
 						withoutInteractiveFormatting
@@ -165,6 +198,54 @@ export default function SearchEdit( {
 					/>
 				) }
 			</>
+		);
+	};
+
+	const renderInputs = () => {
+		const wrapperStyles =
+			'button-inside' === buttonPosition ? { ...sharedStyles } : {};
+
+		const wrapperClasses = classnames(
+			'wp-block-search__inside-wrapper',
+			'button-inside' === buttonPosition ? sharedClasses : undefined
+		);
+
+		return (
+			<ResizableBox
+				size={ {
+					width: `${ width }${ widthUnit }`,
+				} }
+				className={ wrapperClasses }
+				style={ wrapperStyles }
+				isResetValueOnUnitChange
+				minWidth={ MIN_WIDTH }
+				enable={ getResizableSides() }
+				onResizeStart={ ( event, direction, elt ) => {
+					setAttributes( {
+						width: parseInt( elt.offsetWidth, 10 ),
+						widthUnit: 'px',
+					} );
+					toggleSelection( false );
+				} }
+				onResizeStop={ ( event, direction, elt, delta ) => {
+					setAttributes( {
+						width: parseInt( width + delta.width, 10 ),
+					} );
+					toggleSelection( true );
+				} }
+				showHandle={ isSelected }
+			>
+				{ ( 'button-inside' === buttonPosition ||
+					'button-outside' === buttonPosition ) && (
+					<>
+						{ renderTextField() }
+						{ renderButton() }
+					</>
+				) }
+
+				{ 'button-only' === buttonPosition && renderButton() }
+				{ 'no-button' === buttonPosition && renderTextField() }
+			</ResizableBox>
 		);
 	};
 
@@ -254,7 +335,7 @@ export default function SearchEdit( {
 			</BlockControls>
 
 			<InspectorControls>
-				<PanelBody title={ __( 'Display Settings' ) }>
+				<PanelBody title={ __( 'Design Settings' ) }>
 					<BaseControl
 						label={ __( 'Width' ) }
 						id={ unitControlInputId }
@@ -314,6 +395,18 @@ export default function SearchEdit( {
 							} ) }
 						</ButtonGroup>
 					</BaseControl>
+
+					<RangeControl
+						value={ borderRadius }
+						label={ __( 'Border Radius' ) }
+						min={ MIN_BORDER_RADIUS_VALUE }
+						max={ MAX_BORDER_RADIUS_VALUE }
+						initialPosition={ 0 }
+						allowReset
+						onChange={ ( newBorderRadius ) =>
+							setAttributes( { borderRadius: newBorderRadius } )
+						}
+					/>
 				</PanelBody>
 			</InspectorControls>
 		</>
@@ -372,6 +465,6 @@ export default function SearchEdit( {
 				{ 'button-only' === buttonPosition && renderButton() }
 				{ 'no-button' === buttonPosition && renderTextField() }
 			</ResizableBox>
-		</div>
+		</Block.div>
 	);
 }

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -114,7 +114,7 @@ function render_block_core_search( $attributes ) {
 
 	if ( ! empty( $attributes['width'] ) && ! empty( $attributes['widthUnit'] ) ) {
 		if ( ! empty( $attributes['buttonPosition'] ) && 'button-only' !== $attributes['buttonPosition'] ) {
-			$field_styles .= ' width: ' . esc_attr( $attributes['width'] ) . esc_attr( $attributes['widthUnit'] ) . ';"';
+			$field_styles .= ' width: ' . esc_attr( $attributes['width'] ) . esc_attr( $attributes['widthUnit'] ) . ';';
 		}
 	}
 


### PR DESCRIPTION
Part of: #22071

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Add support for setting the border radius on the search input field and search button in the search block. This is a single setting that will adjust the radius for both together.

![2020-09-09 15 50 41](https://user-images.githubusercontent.com/1464705/92662726-4d1cf580-f2b4-11ea-9291-9f6d0a5b19b7.gif)

## How has this been tested?
Tested locally, all unit tests passing.

## Testing Instructions

* Add a search block.
* Adjust the border radius setting and confirm the input field and button adjust accordingly.
* Confirm the border radius remains in place when changing button position settings.
* Confirm that the border radius renders correctly on the front end of the site.

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
