### PR TITLE
Add move markers to list view.

### DIFF
--- a/packages/block-editor/src/components/block-actions/index.js
+++ b/packages/block-editor/src/components/block-actions/index.js
@@ -54,6 +54,7 @@ export default function BlockActions( {
 		flashBlock,
 		setBlockMovingClientId,
 		setNavigationMode,
+		selectBlock,
 	} = useDispatch( 'core/block-editor' );
 
 	const notifyCopy = useNotifyCopy();
@@ -78,6 +79,7 @@ export default function BlockActions( {
 		},
 		onMoveTo() {
 			setNavigationMode( true );
+			selectBlock( clientIds[ 0 ] );
 			setBlockMovingClientId( clientIds[ 0 ] );
 		},
 		onGroup() {

--- a/packages/block-editor/src/components/block-navigation/block-contents.js
+++ b/packages/block-editor/src/components/block-navigation/block-contents.js
@@ -37,13 +37,28 @@ const BlockNavigationBlockContents = forwardRef(
 
 		const { clientId } = block;
 
-		const rootClientId = useSelect(
-			( select ) =>
-				select( 'core/block-editor' ).getBlockRootClientId(
-					clientId
-				) || '',
+		const {
+			rootClientId,
+			blockMovingClientId,
+			selectedBlockInBlockEditor,
+		} = useSelect(
+			( select ) => {
+				const {
+					getBlockRootClientId,
+					hasBlockMovingClientId,
+					getSelectedBlockClientId,
+				} = select( 'core/block-editor' );
+				return {
+					rootClientId: getBlockRootClientId( clientId ) || '',
+					blockMovingClientId: hasBlockMovingClientId(),
+					selectedBlockInBlockEditor: getSelectedBlockClientId(),
+				};
+			},
 			[ clientId ]
 		);
+
+		const isBlockMoveTarget =
+			blockMovingClientId && selectedBlockInBlockEditor === clientId;
 
 		const {
 			rootClientId: dropTargetRootClientId,
@@ -65,7 +80,7 @@ const BlockNavigationBlockContents = forwardRef(
 		const className = classnames(
 			'block-editor-block-navigation-block-contents',
 			{
-				'is-dropping-before': isDroppingBefore,
+				'is-dropping-before': isDroppingBefore || isBlockMoveTarget,
 				'is-dropping-after': isDroppingAfter,
 				'is-dropping-to-inner-blocks': isDroppingToInnerBlocks,
 			}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

Fixes #24807.

In the Navigation screen list view, the "Move to" option is available for blocks. This PR adds the current position marker to the list view.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Tested in browser, with keyboard. 

One thing I notice is that with keyboard navigation it is possible to get to the "Move to" option without its corresponding block being selected, and this causes the position marker to appear at the top of the Navigation block instead of in its expected position (which, when the move action begins, should be over the block being moved).

## Screenshots <!-- if applicable -->

<img width="275" alt="Screen Shot 2020-09-10 at 9 54 02 am" src="https://user-images.githubusercontent.com/8096000/92666164-df240d00-f34b-11ea-9dd4-c4ac822bc229.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
