### PR TITLE
Fix template part rename before customize bug.

### DIFF
--- a/packages/block-library/src/template-part/edit/name-panel.js
+++ b/packages/block-library/src/template-part/edit/name-panel.js
@@ -19,6 +19,13 @@ export default function TemplatePartNamePanel( { postId, setAttributes } ) {
 		'slug',
 		postId
 	);
+	const [ status, setStatus ] = useEntityProp(
+		'postType',
+		'wp_template_part',
+		'status',
+		postId
+	);
+
 	return (
 		<div className="wp-block-template-part__name-panel">
 			<TextControl
@@ -28,6 +35,9 @@ export default function TemplatePartNamePanel( { postId, setAttributes } ) {
 					setTitle( value );
 					const newSlug = cleanForSlug( value );
 					setSlug( newSlug );
+					if ( status !== 'publish' ) {
+						setStatus( 'publish' );
+					}
 					setAttributes( { slug: newSlug, postId } );
 				} }
 				onFocus={ ( event ) => event.target.select() }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Ensures renaming a template-part moves it to 'publish' status if it is not already, this fixes a bug where if we rename a theme supplied template part before customizing content, it remains stuck in the auto-draft status indefinitely and is not found in our query requests for template parts.

More on the bug/background:

When a template part auto-draft is customized, it is upgraded from 'auto-draft' to 'publish' status to signify it is customized and to allow another theme default auto-draft to be created in the background.

Currently, the rename toolbar does not handle any publish status.  Because of this, if you rename before customizing content, the template part will stay in auto-draft status under a slug which is not supplied by the theme and is not found in our search for template parts.

To reproduce the bug:
* Load a fresh theme supplied template part.
* Rename and save.
* Open the template part selection dropdown from the down chevron next to the name input in the toolbar.
* Notice the template part under the new name is not present in the list.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
* Load a fresh theme supplied template part.
* Rename and save.
* Open the template part selection dropdown from the down chevron next to the name input in the toolbar.
* Verify the template part under the new name is present in the list.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
