### PR TITLE
Update gradle-node-plugin to use actively maintained fork

### DIFF
--- a/packages/react-native-bridge/android/build.gradle
+++ b/packages/react-native-bridge/android/build.gradle
@@ -23,7 +23,7 @@ buildscript {
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
 
         if (buildGutenbergMobileJSBundle) {
-            classpath "com.moowork.gradle:gradle-node-plugin:1.3.1"
+            classpath 'com.github.node-gradle:gradle-node-plugin:3.0.0-rc2'
         }
     }
 }
@@ -44,7 +44,7 @@ def npmFolder = file("${tempFolder}/npm")
 if (buildGutenbergMobileJSBundle) {
     println 'Building the Gutenberg Mobile JS bundle'
 
-    apply plugin: 'com.moowork.node'
+    apply plugin: 'com.github.node-gradle.node'
 
     node {
         // Version of node to use.
@@ -70,7 +70,7 @@ if (buildGutenbergMobileJSBundle) {
         nodeModulesDir = file("${project.projectDir}/../../../../")
     }
 
-    npm_install {
+    npmInstall {
         args = ['--prefer-offline']
     }
 }
@@ -245,8 +245,8 @@ If they are changed, the isBundleUpToDate flag is switched to false. That flag i
         }
     }
 
-    npm_install.dependsOn bundleUpToDateCheck
-    npm_install.onlyIf { !isBundleUpToDate() }
+    npmInstall.dependsOn bundleUpToDateCheck
+    npmInstall.onlyIf { !isBundleUpToDate() }
 
     task buildJSBundle(type: NpmTask) {
         dependsOn bundleUpToDateCheck
@@ -328,8 +328,9 @@ If they are changed, the isBundleUpToDate flag is switched to false. That flag i
     backupHermesDebugAAR.dependsOn(backupHermesReleaseAAR)
     backupHermesReleaseAAR.dependsOn(copyJSBundle)
     copyJSBundle.dependsOn(buildJSBundle)
-    buildJSBundle.dependsOn(npm_install)
+    buildJSBundle.dependsOn(npmInstall)
     nodeSetup.dependsOn(resetExtractedRNTools)
+    npmSetup.dependsOn(resetExtractedRNTools)
 
     clean {
         doFirst {


### PR DESCRIPTION
## Description

This PR is updating the gradle-node-plugin used in the react-native-bridge package to use a more actively maintained fork of the plugin. This is necessary [to support building with Gradle 6.x](https://github.com/srs/gradle-node-plugin/issues/368#issuecomment-625899555), which [WPAndroid wants to start using](https://github.com/wordpress-mobile/WordPress-Android/pull/12896).

## Related PRs
https://github.com/wordpress-mobile/gutenberg-mobile/pull/2607
https://github.com/wordpress-mobile/WordPress-Android/pull/12923


## How has this been tested?
1. From WPAndroid check out https://github.com/wordpress-mobile/WordPress-Android/pull/12923 and update the submodules (which will check out this branch in `libs/gutenberg-mobile/gutenberg/`)
2. Insure that you are not building gutenberg-mobile from source (i.e. the root gradle.properties file does not set `wp.BUILD_GUTENBERG_FROM_SOURCE` to be true).
3. Perform various builds (i.e., WasabiDebug, and VanillaRelease) and ensure there are no issues (at a minimum, that the gutenberg editor can be successfully started). Note that I found that the gutenberg editor would crash when loading if I did a VanillaDebug or JalapenoDebug build, but I had those same issues without the changes in this PR, so I think the changes in this PR are fine (I haven't had time to track down the cause of this problem yet).
4. Verify that the gutenberg editor works in the Installable Build generated for the [WPAndroid PR](https://github.com/wordpress-mobile/WordPress-Android/pull/12923).

## Types of changes
Update build tooling for Android build of react-native-bridge package

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [X] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
