### PR TITLE
Block Directory: use Array.filter to implement new/unused block selectors

### DIFF
--- a/packages/block-directory/src/store/selectors.js
+++ b/packages/block-directory/src/store/selectors.js
@@ -69,14 +69,9 @@ export const getNewBlockTypes = createRegistrySelector(
 		const usedBlockTree = select( 'core/block-editor' ).getBlocks();
 		const installedBlockTypes = getInstalledBlockTypes( state );
 
-		const newBlockTypes = [];
-		installedBlockTypes.forEach( ( blockType ) => {
-			if ( hasBlockType( blockType, usedBlockTree ) ) {
-				newBlockTypes.push( blockType );
-			}
-		} );
-
-		return newBlockTypes;
+		return installedBlockTypes.filter( ( blockType ) =>
+			hasBlockType( blockType, usedBlockTree )
+		);
 	}
 );
 
@@ -93,14 +88,9 @@ export const getUnusedBlockTypes = createRegistrySelector(
 		const usedBlockTree = select( 'core/block-editor' ).getBlocks();
 		const installedBlockTypes = getInstalledBlockTypes( state );
 
-		const newBlockTypes = [];
-		installedBlockTypes.forEach( ( blockType ) => {
-			if ( ! hasBlockType( blockType, usedBlockTree ) ) {
-				newBlockTypes.push( blockType );
-			}
-		} );
-
-		return newBlockTypes;
+		return installedBlockTypes.filter(
+			( blockType ) => ! hasBlockType( blockType, usedBlockTree )
+		);
 	}
 );
 


### PR DESCRIPTION
The code that finds new or unused blocks is a perfect case for `Array.filter`.

The patch is not terribly important, just a drive-by improvement while I was learning about Gutenberg and its codebase. (in this case, looking at usages of `createRegistrySelector`)

**How to test:**
- check that unit tests pass
- check that the newly added blocks are shown in the pre-publish panel:

<img width="285" alt="Screenshot 2020-09-10 at 09 12 44" src="https://user-images.githubusercontent.com/664258/92695762-3d032580-f349-11ea-8d40-3463b8d8c312.png">

- check that no-longer used blocks are removed after removing the block from the post and saving
