### PR TITLE
Add readme for the `BlockAlignmentToolbar` component

### DIFF
--- a/packages/block-editor/src/components/block-alignment-toolbar/README.md
+++ b/packages/block-editor/src/components/block-alignment-toolbar/README.md
@@ -1,6 +1,6 @@
 # Block Alignment Toolbar
 
-The `BlockAlignmentToolbar` component is used to render image block alignment options in the editor. The different alignment options it provides are `left`, `center`, `right`, `wide` and `full`.
+The `BlockAlignmentToolbar` component is used to render block alignment options in the editor. The different alignment options it provides are `left`, `center`, `right`, `wide` and `full`.
 
 ![Image block alignment options](https://make.wordpress.org/core/files/2020/09/image-block-alignment-options.png)
 
@@ -13,7 +13,7 @@ The `BlockAlignmentToolbar` component is used to render image block alignment op
 
 ### Usage
 
-Renders an block alignment toolbar with alignments options.
+Renders a block alignment toolbar with alignments options.
 
 ```jsx
 import { BlockAlignmentToolbar } from '@wordpress/block-editor';

--- a/packages/block-editor/src/components/block-alignment-toolbar/README.md
+++ b/packages/block-editor/src/components/block-alignment-toolbar/README.md
@@ -1,0 +1,51 @@
+# Block Alignment Toolbar
+
+The `BlockAlignmentToolbar` component is used to render image block alignment options in the editor. The different alignment options it provides are `left`, `center`, `right`, `wide` and `full`.
+
+![Image block alignment options](https://make.wordpress.org/core/files/2020/09/image-block-alignment-options.png)
+
+## Table of contents
+
+1. [Development guidelines](#development-guidelines)
+2. [Related components](#related-components)
+
+## Development guidelines
+
+### Usage
+
+Renders an block alignment toolbar with alignments options.
+
+```jsx
+import { BlockAlignmentToolbar } from '@wordpress/block-editor';
+
+const MyBlockAlignmentToolbar = () => (
+	<BlockControls>
+        <BlockAlignmentToolbar 
+            value={ align }
+            onChange={ updateAlignment } 
+        />
+	</BlockControls>
+);
+```
+
+_Note:_ In this example that we render `BlockAlignmentToolbar` as a child of the `BlockControls` component.
+
+### Props
+
+### `value`
+
+-   **Type:** `String`
+-   **Default:** `undefined`
+-   **Options:**: `left`, `center`, `right`, `wide`, `full`
+
+The current value of the alignment setting. You may only choose from the `Options` listed above.
+
+### `onChange`
+
+-   **Type:** `Function`
+
+A callback function invoked when the toolbar's alignment value is changed via an interaction with any of the toolbar's buttons. Called with the new alignment value (ie: `left`, `center`, `right`, `wide`, `full`) as the only argument.
+
+## Related components
+
+Block Editor components are components that can be used to compose the UI of your block editor. Thus, they can only be used under a [`BlockEditorProvider`](https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/provider/README.md) in the components tree.


### PR DESCRIPTION
## Description
Added documentation for the block alignment toolbar component (see #22891)

## How has this been tested?
N/A, documentation only

## Types of changes
Documentation

## Checklist:
- [n/a] My code is tested.
- [n/a] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [n/a] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
