### PR TITLE
Update/retire remaining colors

### DIFF
--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -29,7 +29,6 @@ $alert-green: #4ab866;
  * Please avoid using these.
  */
 
-$light-gray-900: #a2aab2;
 $light-gray-800: #b5bcc2;
 $light-gray-700: #ccd0d4;
 $light-gray-600: #d7dade;

--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -29,5 +29,4 @@ $alert-green: #4ab866;
  * Please avoid using these.
  */
 
-$light-gray-700: #ccd0d4;
 $light-gray-600: #d7dade;

--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -29,8 +29,6 @@ $alert-green: #4ab866;
  * Please avoid using these.
  */
 
-$dark-gray-100: #8f98a1;
-
 $light-gray-900: #a2aab2;
 $light-gray-800: #b5bcc2;
 $light-gray-700: #ccd0d4;

--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -29,7 +29,6 @@ $alert-green: #4ab866;
  * Please avoid using these.
  */
 
-$dark-gray-700: #32373c;
 $dark-gray-600: #40464d;
 $dark-gray-500: #555d66;
 $dark-gray-400: #606a73;

--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -29,6 +29,5 @@ $alert-green: #4ab866;
  * Please avoid using these.
  */
 
-$light-gray-800: #b5bcc2;
 $light-gray-700: #ccd0d4;
 $light-gray-600: #d7dade;

--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -29,7 +29,6 @@ $alert-green: #4ab866;
  * Please avoid using these.
  */
 
-$dark-gray-300: #6c7781;
 $dark-gray-200: #7e8993;
 $dark-gray-150: #8d96a0;
 $dark-gray-100: #8f98a1;

--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -29,7 +29,6 @@ $alert-green: #4ab866;
  * Please avoid using these.
  */
 
-$dark-gray-600: #40464d;
 $dark-gray-500: #555d66;
 $dark-gray-400: #606a73;
 $dark-gray-300: #6c7781;

--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -29,7 +29,6 @@ $alert-green: #4ab866;
  * Please avoid using these.
  */
 
-$dark-gray-200: #7e8993;
 $dark-gray-150: #8d96a0;
 $dark-gray-100: #8f98a1;
 

--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -29,7 +29,6 @@ $alert-green: #4ab866;
  * Please avoid using these.
  */
 
-$dark-gray-400: #606a73;
 $dark-gray-300: #6c7781;
 $dark-gray-200: #7e8993;
 $dark-gray-150: #8d96a0;

--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -22,11 +22,3 @@ $light-gray-placeholder: rgba($white, 0.65);
 $alert-yellow: #f0b849;
 $alert-red: #cc1818;
 $alert-green: #4ab866;
-
-
-/**
- * Deprecated colors.
- * Please avoid using these.
- */
-
-$light-gray-600: #d7dade;

--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -29,7 +29,6 @@ $alert-green: #4ab866;
  * Please avoid using these.
  */
 
-$dark-gray-150: #8d96a0;
 $dark-gray-100: #8f98a1;
 
 $light-gray-900: #a2aab2;

--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -29,7 +29,6 @@ $alert-green: #4ab866;
  * Please avoid using these.
  */
 
-$dark-gray-500: #555d66;
 $dark-gray-400: #606a73;
 $dark-gray-300: #6c7781;
 $dark-gray-200: #7e8993;

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -205,7 +205,7 @@
 }
 
 @mixin caption-style-theme() {
-	color: $dark-gray-500;
+	color: #555;
 	font-size: $default-font-size;
 	text-align: center;
 }

--- a/packages/block-directory/src/components/block-ratings/style.scss
+++ b/packages/block-directory/src/components/block-ratings/style.scss
@@ -6,7 +6,6 @@
 	}
 
 	.block-directory-block-ratings__rating-count {
-		color: $dark-gray-400;
 		font-size: ms(-2);
 	}
 

--- a/packages/block-directory/src/components/compact-list/style.scss
+++ b/packages/block-directory/src/components/compact-list/style.scss
@@ -23,6 +23,6 @@
 }
 
 .block-directory-compact-list__item-author {
-	color: $dark-gray-500;
+	color: $gray-700;
 	font-size: 11px;
 }

--- a/packages/block-directory/src/components/downloadable-block-author-info/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-author-info/style.scss
@@ -1,5 +1,4 @@
 .block-directory-downloadable-block-author-info__content {
-	color: $dark-gray-400;
 	font-size: 12px;
 }
 

--- a/packages/block-directory/src/components/downloadable-block-info/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-info/style.scss
@@ -7,7 +7,7 @@
 	display: flex;
 	align-items: center;
 	margin-bottom: 2px;
-	color: $dark-gray-400;
+	color: $gray-700;
 	font-size: 12px;
 }
 
@@ -17,5 +17,5 @@
 
 .block-directory-downloadable-block-info__icon {
 	margin-right: 4px;
-	fill: $dark-gray-400;
+	fill: $gray-700;
 }

--- a/packages/block-directory/src/components/downloadable-block-list-item/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-list-item/style.scss
@@ -57,5 +57,5 @@
 }
 
 .block-directory-downloadable-block-list-item__content {
-	color: $dark-gray-400;
+	color: $gray-700;
 }

--- a/packages/block-directory/src/components/downloadable-block-list-item/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-list-item/style.scss
@@ -5,7 +5,7 @@
 	display: flex;
 	flex-direction: row;
 	font-size: $default-font-size;
-	color: $dark-gray-700;
+	color: $gray-900;
 	align-items: flex-start;
 	justify-content: center;
 	background: transparent;

--- a/packages/block-directory/src/components/downloadable-blocks-panel/style.scss
+++ b/packages/block-directory/src/components/downloadable-blocks-panel/style.scss
@@ -4,7 +4,7 @@
 	padding: $grid-unit-20;
 	margin: 0;
 	text-align: left;
-	color: $dark-gray-400;
+	color: $gray-700;
 }
 
 .block-directory-downloadable-blocks-panel__description.has-no-results {
@@ -13,7 +13,7 @@
 	padding: 0;
 	margin: $no-result-padding 0;
 	text-align: center;
-	color: $dark-gray-400;
+	color: $gray-700;
 	.components-spinner {
 		float: inherit;
 	}

--- a/packages/block-editor/src/components/block-card/style.scss
+++ b/packages/block-editor/src/components/block-card/style.scss
@@ -5,7 +5,7 @@
 }
 
 .block-editor-block-card__icon {
-	border: $border-width solid $light-gray-700;
+	border: $border-width solid $gray-200;
 	padding: 7px;
 	margin-right: 10px;
 	height: 36px;

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -254,7 +254,7 @@ $tree-item-height: 36px;
 			top: 1px;
 			bottom: -2px;
 			right: -1px;
-			border-right: 2px solid $light-gray-900;
+			border-right: 2px solid $gray-600;
 		}
 
 		// If a vertical line has terminated, don't draw it.
@@ -275,7 +275,7 @@ $tree-item-height: 36px;
 			top: 26px;
 			left: 100%;
 			width: 5px;
-			border-bottom: 2px solid $light-gray-900;
+			border-bottom: 2px solid $gray-600;
 		}
 	}
 }

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -41,7 +41,7 @@ $tree-item-height: 36px;
 		margin-top: auto;
 		margin-bottom: auto;
 		text-align: left;
-		color: $dark-gray-600;
+		color: $gray-900;
 		border-radius: 2px;
 		position: relative;
 

--- a/packages/block-editor/src/components/inserter-list-item/style.scss
+++ b/packages/block-editor/src/components/inserter-list-item/style.scss
@@ -10,7 +10,7 @@
 	flex-direction: column;
 	width: 100%;
 	font-size: $default-font-size;
-	color: $dark-gray-700;
+	color: $gray-900;
 	padding: $grid-unit-10;
 	align-items: stretch;
 	justify-content: center;

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -99,7 +99,7 @@ $block-inserter-tabs-height: 44px;
 		}
 
 		&::placeholder {
-			color: $dark-gray-400;
+			color: $gray-700;
 		}
 
 		&::-webkit-search-decoration,
@@ -254,7 +254,7 @@ $block-inserter-tabs-height: 44px;
 	justify-content: center;
 	align-items: center;
 	min-height: $grid-unit-60 * 3;
-	color: $dark-gray-400;
+	color: $gray-700;
 	background: $gray-100;
 }
 

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -195,7 +195,7 @@ $block-inserter-tabs-height: 44px;
 }
 
 .block-editor-inserter__no-results-icon {
-	fill: $light-gray-800;
+	fill: $gray-600;
 }
 
 .block-editor-inserter__child-blocks {

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -188,7 +188,7 @@ $block-editor-link-control-number-of-actions: 1;
 
 	.block-editor-link-control__search-item-info {
 		display: block;
-		color: $dark-gray-300;
+		color: $gray-700;
 		font-size: 0.9em;
 		line-height: 1.3;
 	}

--- a/packages/block-editor/src/components/responsive-block-control/style.scss
+++ b/packages/block-editor/src/components/responsive-block-control/style.scss
@@ -13,7 +13,7 @@
 
 .block-editor-responsive-block-control {
 	margin-bottom: $block-padding*2;
-	border-bottom: 1px solid $light-gray-600;
+	border-bottom: 1px solid $gray-400;
 	padding-bottom: $block-padding;
 
 	&:last-child {

--- a/packages/block-editor/src/components/tool-selector/style.scss
+++ b/packages/block-editor/src/components/tool-selector/style.scss
@@ -5,5 +5,5 @@
 	margin-bottom: -$grid-unit-15;
 	padding: $grid-unit-15 ($grid-unit-15 + $grid-unit-10);
 	border-top: 1px solid $gray-200;
-	color: $dark-gray-300;
+	color: $gray-700;
 }

--- a/packages/block-editor/src/components/url-input/style.scss
+++ b/packages/block-editor/src/components/url-input/style.scss
@@ -77,7 +77,7 @@ $input-size: 300px;
 
 .block-editor-url-input__suggestion {
 	padding: 4px $input-padding;
-	color: $dark-gray-300; // lightest we can use for contrast
+	color: $gray-700;
 	display: block;
 	font-size: $default-font-size;
 	cursor: pointer;

--- a/packages/block-library/src/button/editor.scss
+++ b/packages/block-library/src/button/editor.scss
@@ -34,7 +34,7 @@
 }
 
 .wp-block-button__inline-link {
-	color: $dark-gray-500;
+	color: $gray-700;
 	height: 0;
 	overflow: hidden;
 	max-width: 290px;

--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -4,7 +4,7 @@ $blocks-button__height: 3.1em;
 // to support the previous markup in addition to the new one.
 .wp-block-button__link {
 	color: $white;
-	background-color: $dark-gray-700;
+	background-color: #32373c;
 	border: none;
 	border-radius: $blocks-button__height / 2;
 	box-shadow: none;
@@ -49,7 +49,7 @@ $blocks-button__height: 3.1em;
 
 .is-style-outline .wp-block-button__link,
 .wp-block-button__link.is-style-outline {
-	color: $dark-gray-700;
+	color: #32373c;
 	background-color: transparent;
 	border: 2px solid;
 }

--- a/packages/block-library/src/calendar/style.scss
+++ b/packages/block-library/src/calendar/style.scss
@@ -27,6 +27,6 @@
 
 	table tbody,
 	table caption {
-		color: $dark-gray-600;
+		color: #40464d;
 	}
 }

--- a/packages/block-library/src/file/style.scss
+++ b/packages/block-library/src/file/style.scss
@@ -11,7 +11,7 @@
 	}
 
 	.wp-block-file__button {
-		background: $dark-gray-700;
+		background: #32373c;
 		border-radius: 2em;
 		color: $white;
 		font-size: 0.8em;

--- a/packages/block-library/src/latest-posts/style.scss
+++ b/packages/block-library/src/latest-posts/style.scss
@@ -37,7 +37,7 @@
 .wp-block-latest-posts__post-date,
 .wp-block-latest-posts__post-author {
 	display: block;
-	color: $dark-gray-300;
+	color: #555;
 	font-size: 0.8125em;
 }
 

--- a/packages/block-library/src/more/editor.scss
+++ b/packages/block-library/src/more/editor.scss
@@ -41,6 +41,6 @@
 		top: calc(50%);
 		left: 0;
 		right: 0;
-		border-top: 3px dashed $light-gray-700;
+		border-top: 3px dashed $gray-400;
 	}
 }

--- a/packages/block-library/src/more/editor.scss
+++ b/packages/block-library/src/more/editor.scss
@@ -17,7 +17,7 @@
 		text-transform: uppercase;
 		font-weight: 600;
 		font-family: $default-font;
-		color: $dark-gray-300;
+		color: $gray-700;
 		border: none;
 		box-shadow: none;
 		white-space: nowrap;

--- a/packages/block-library/src/nextpage/editor.scss
+++ b/packages/block-library/src/nextpage/editor.scss
@@ -17,7 +17,7 @@
 		text-transform: uppercase;
 		font-weight: 600;
 		font-family: $default-font;
-		color: $dark-gray-300;
+		color: $gray-700;
 		border-radius: 4px;
 		background: $white;
 		padding: 6px 8px;

--- a/packages/block-library/src/nextpage/editor.scss
+++ b/packages/block-library/src/nextpage/editor.scss
@@ -31,6 +31,6 @@
 		top: calc(50%);
 		left: 0;
 		right: 0;
-		border-top: 3px dashed $light-gray-700;
+		border-top: 3px dashed $gray-400;
 	}
 }

--- a/packages/block-library/src/pullquote/theme.scss
+++ b/packages/block-library/src/pullquote/theme.scss
@@ -2,12 +2,12 @@
 	border-top: 4px solid $dark-gray-500;
 	border-bottom: 4px solid $dark-gray-500;
 	margin-bottom: 1.75em;
-	color: $dark-gray-600;
+	color: #40464d;
 
 	cite,
 	footer,
 	&__citation {
-		color: $dark-gray-600;
+		color: #40464d;
 		text-transform: uppercase;
 		font-size: 0.8125em;
 		font-style: normal;

--- a/packages/block-library/src/pullquote/theme.scss
+++ b/packages/block-library/src/pullquote/theme.scss
@@ -1,13 +1,13 @@
 .wp-block-pullquote {
-	border-top: 4px solid $dark-gray-500;
-	border-bottom: 4px solid $dark-gray-500;
+	border-top: 4px solid #555;
+	border-bottom: 4px solid #555;
 	margin-bottom: 1.75em;
-	color: #40464d;
+	color: #555;
 
 	cite,
 	footer,
 	&__citation {
-		color: #40464d;
+		color: #555;
 		text-transform: uppercase;
 		font-size: 0.8125em;
 		font-style: normal;

--- a/packages/block-library/src/quote/theme.scss
+++ b/packages/block-library/src/quote/theme.scss
@@ -6,7 +6,7 @@
 	cite,
 	footer,
 	&__citation {
-		color: $dark-gray-300;
+		color: #555;
 		font-size: 0.8125em;
 		margin-top: 1em;
 		position: relative;

--- a/packages/block-library/src/rss/style.scss
+++ b/packages/block-library/src/rss/style.scss
@@ -31,6 +31,6 @@
 .wp-block-rss__item-publish-date,
 .wp-block-rss__item-author {
 	display: block;
-	color: $dark-gray-300;
+	color: #555;
 	font-size: 0.8125em;
 }

--- a/packages/block-library/src/search/editor.scss
+++ b/packages/block-library/src/search/editor.scss
@@ -10,7 +10,7 @@
 	.wp-block-search__input,
 	&.wp-block-search__button-inside .wp-block-search__inside-wrapper {
 		border-radius: $radius-block-ui;
-		border: 1px solid $dark-gray-200;
+		border: 1px solid $gray-600;
 		color: $dark-gray-placeholder;
 		font-family: $default-font;
 		font-size: $default-font-size;

--- a/packages/block-library/src/search/editor.scss
+++ b/packages/block-library/src/search/editor.scss
@@ -29,7 +29,7 @@
 		font-family: $default-font;
 		font-size: $default-font-size;
 		padding: 6px 10px;
-		color: $dark-gray-700;
+		color: #32373c;
 	}
 
 	&__components-button-group {

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -13,7 +13,7 @@
 	.wp-block-search__input {
 		flex-grow: 1;
 		min-width: 3em;
-		border: 1px solid $dark-gray-200;
+		border: 1px solid $gray-600;
 	}
 
 	.wp-block-search__button {
@@ -34,7 +34,7 @@
 
 	&.wp-block-search__button-inside .wp-block-search__inside-wrapper {
 		padding: $grid-unit-05;
-		border: 1px solid $dark-gray-200;
+		border: 1px solid $gray-600;
 
 		.wp-block-search__input {
 			border-radius: 0;

--- a/packages/block-library/src/subhead/editor.scss
+++ b/packages/block-library/src/subhead/editor.scss
@@ -1,5 +1,5 @@
 .edit-post-visual-editor p.wp-block-subhead {
-	color: $dark-gray-300;
+	color: #555;
 	font-size: 1.1em;
 	font-style: italic;
 }

--- a/packages/block-library/src/tag-cloud/editor.scss
+++ b/packages/block-library/src/tag-cloud/editor.scss
@@ -7,7 +7,7 @@
 	span {
 		display: inline-block;
 		margin-left: 5px;
-		color: $dark-gray-100;
+		color: $gray-700;
 		text-decoration: none;
 	}
 }

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -177,7 +177,7 @@
 		}
 
 		&:active:not(:disabled) {
-			background: $light-gray-600;
+			background: $gray-400;
 		}
 	}
 

--- a/packages/components/src/circular-option-picker/style.scss
+++ b/packages/components/src/circular-option-picker/style.scss
@@ -104,7 +104,7 @@ $color-palette-circle-spacing: 12px;
 	&:focus {
 		&::after {
 			content: "";
-			border: #{ $border-width * 2 } solid $dark-gray-400;
+			border: #{ $border-width * 2 } solid $gray-700;
 			width: 32px;
 			height: 32px;
 			position: absolute;

--- a/packages/components/src/combobox-control/style.scss
+++ b/packages/components/src/combobox-control/style.scss
@@ -1,5 +1,4 @@
 .components-combobox-control {
-	color: $dark-gray-500;
 	position: relative;
 }
 
@@ -11,7 +10,6 @@
 .components-combobox-control__button {
 	border: 1px solid $dark-gray-200;
 	border-radius: 4px;
-	color: $dark-gray-500;
 	display: inline-block;
 	min-height: 30px;
 	min-width: 130px;

--- a/packages/components/src/combobox-control/style.scss
+++ b/packages/components/src/combobox-control/style.scss
@@ -8,7 +8,7 @@
 }
 
 .components-combobox-control__button {
-	border: 1px solid $dark-gray-200;
+	border: 1px solid $gray-600;
 	border-radius: 4px;
 	display: inline-block;
 	min-height: 30px;

--- a/packages/components/src/custom-gradient-picker/style.scss
+++ b/packages/components/src/custom-gradient-picker/style.scss
@@ -92,7 +92,7 @@ $components-custom-gradient-picker__padding: 6px; // 36px container, 24px handle
 		&.is-pressed {
 			> svg {
 				background: $white;
-				border: 1px solid $dark-gray-200;
+				border: 1px solid $gray-600;
 				border-radius: 2px;
 			}
 		}

--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -135,7 +135,6 @@
 		.components-datetime__time-separator {
 			display: inline-block;
 			padding: 0 3px 0 0;
-			color: $dark-gray-500;
 		}
 
 		.components-datetime__time-field {
@@ -187,7 +186,6 @@
 }
 
 .components-datetime__timezone {
-	color: $dark-gray-500;
 	line-height: 30px;
 	margin-left: $grid-unit-05;
 	text-decoration: underline dotted;

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -11,7 +11,7 @@
 
 	&.is-disabled {
 		background: $gray-200;
-		border-color: $light-gray-700;
+		border-color: $gray-200;
 	}
 
 	&.is-active {

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -56,7 +56,7 @@
 	font-size: $default-font-size;
 	display: flex;
 	margin: 2px 4px 2px 0;
-	color: $dark-gray-700;
+	color: $gray-900;
 	max-width: 100%;
 
 	&.is-success {
@@ -152,7 +152,7 @@
 	overflow: initial;
 
 	&:hover {
-		color: $dark-gray-700;
+		color: $gray-900;
 	}
 }
 

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -76,7 +76,7 @@
 	&.is-validating {
 		.components-form-token-field__token-text,
 		.components-form-token-field__remove-token {
-			color: $dark-gray-500;
+			color: $gray-700;
 		}
 	}
 
@@ -91,7 +91,7 @@
 
 		.components-form-token-field__remove-token {
 			background: transparent;
-			color: $dark-gray-500;
+			color: $gray-700;
 			position: absolute;
 			top: 1px;
 			right: 0;
@@ -147,7 +147,7 @@
 	cursor: pointer;
 	border-radius: 0 12px 12px 0;
 	padding: 0 2px;
-	color: $dark-gray-500;
+	color: $gray-700;
 	line-height: 10px;
 	overflow: initial;
 
@@ -171,7 +171,7 @@
 }
 
 .components-form-token-field__suggestion {
-	color: $dark-gray-500;
+	color: $gray-700;
 	display: block;
 	font-size: $default-font-size;
 	padding: 4px 8px;

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -165,7 +165,7 @@
 	transition: all 0.15s ease-in-out;
 	@include reduce-motion("transition");
 	list-style: none;
-	border-top: $border-width solid $dark-gray-300;
+	border-top: $border-width solid $gray-700;
 	margin: $grid-unit-05 (-$grid-unit-05) (-$grid-unit-05);
 	padding-top: 3px;
 }

--- a/packages/components/src/notice/style.scss
+++ b/packages/components/src/notice/style.scss
@@ -45,7 +45,7 @@
 }
 
 .components-notice__dismiss {
-	color: $dark-gray-300;
+	color: $gray-700;
 
 	// Place the dismiss button at the top of the container, even when text wraps onto two lines.
 	align-self: flex-start;

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -116,7 +116,7 @@
 }
 
 .components-panel__icon {
-	color: $dark-gray-500;
+	color: $gray-700;
 	margin: -2px 0 -2px 6px;
 }
 

--- a/packages/components/src/resizable-box/style.scss
+++ b/packages/components/src/resizable-box/style.scss
@@ -49,7 +49,7 @@ $resize-handler-container-size: $resize-handler-size + ($grid-unit-05 * 2); // M
 .is-dark-theme {
 	.components-resizable-box__side-handle::before,
 	.components-resizable-box__handle::after {
-		border-color: $light-gray-600;
+		border-color: $gray-200;
 	}
 }
 

--- a/packages/components/src/spinner/style.scss
+++ b/packages/components/src/spinner/style.scss
@@ -1,6 +1,6 @@
 .components-spinner {
 	display: inline-block;
-	background-color: $dark-gray-200;
+	background-color: $gray-600;
 	width: $spinner-size;
 	height: $spinner-size;
 	opacity: 0.7;

--- a/packages/components/src/tip/style.scss
+++ b/packages/components/src/tip/style.scss
@@ -1,6 +1,6 @@
 .components-tip {
 	display: flex;
-	color: $dark-gray-500;
+	color: $gray-700;
 
 	svg {
 		align-self: center;

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -109,7 +109,7 @@
 }
 
 .edit-post-layout .interface-interface-skeleton__content {
-	background-color: $light-gray-700;
+	background-color: $gray-400;
 }
 
 // Ideally  we don't need all these nested divs.

--- a/packages/edit-post/src/components/manage-blocks-modal/style.scss
+++ b/packages/edit-post/src/components/manage-blocks-modal/style.scss
@@ -114,7 +114,7 @@
 
 	.block-editor-block-icon {
 		margin-right: 10px;
-		fill: $dark-gray-500;
+		fill: $gray-900;
 	}
 }
 

--- a/packages/edit-post/src/components/meta-boxes/meta-boxes-area/style.scss
+++ b/packages/edit-post/src/components/meta-boxes/meta-boxes-area/style.scss
@@ -87,11 +87,11 @@
 	// @todo: remove this entire rule once checkboxes are the same everywhere.
 	// See: https://github.com/WordPress/gutenberg/issues/18053
 	.metabox-location-side .postbox input[type="checkbox"] {
-		border: $border-width solid $dark-gray-300;
+		border: $border-width solid $gray-700;
 
 		&:checked {
 			background: $white;
-			border-color: $dark-gray-300;
+			border-color: $gray-700;
 		}
 
 		&::before {

--- a/packages/edit-post/src/components/sidebar/post-visibility/style.scss
+++ b/packages/edit-post/src/components/sidebar/post-visibility/style.scss
@@ -34,7 +34,7 @@
 }
 
 .edit-post-post-visibility__dialog-info {
-	color: $dark-gray-200;
+	color: $gray-700;
 	padding-left: 20px;
 	font-style: italic;
 	margin: 4px 0 0;

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -54,7 +54,7 @@ body.toplevel_page_gutenberg-edit-site {
 	}
 
 	.interface-interface-skeleton__content {
-		background-color: $light-gray-700;
+		background-color: $gray-400;
 	}
 }
 

--- a/packages/editor/src/components/autocompleters/style.scss
+++ b/packages/editor/src/components/autocompleters/style.scss
@@ -25,7 +25,7 @@
 	}
 	.editor-autocompleters__user-slug {
 		margin-left: 8px;
-		color: $dark-gray-100;
+		color: $gray-700;
 		white-space: nowrap;
 		text-overflow: ellipsis;
 		overflow: none;

--- a/packages/editor/src/components/table-of-contents/style.scss
+++ b/packages/editor/src/components/table-of-contents/style.scss
@@ -46,7 +46,7 @@
 	display: flex;
 	flex-direction: column;
 	font-size: $default-font-size;
-	color: $dark-gray-300;
+	color: $gray-900;
 	padding-right: $grid-unit-10;
 	margin-bottom: 0;
 	margin-top: $grid-unit-10;
@@ -61,7 +61,7 @@
 	font-size: 21px;
 	font-weight: 400;
 	line-height: 30px;
-	color: $dark-gray-500;
+	color: $gray-900;
 }
 
 .table-of-contents__title {


### PR DESCRIPTION
This is a big one. But it's an important one. Hopefully as you review the code diff, you'll see how the effort most literally cleans up the UI by reducing colors to a subset. In nearly every case that also means slightly higher contrast, to fit with the overall 5.5 design efforts. 

In some cases, notably block frontend styles, this PR also does it so they don't rely on variables anymore — those variables are reserved for user interface, not styles. 

I am aware that this change is breaking for any NPM users that choose to update, and rely on existing colors. However I also consider this effort to be the wrapping up of color variable retirement efforts — I don't expect this file to change a lot after this one. 

Most important change "_after_" screenshots — and really, you shouldn't note a massive difference at all:

<img width="492" alt="Screenshot 2020-09-10 at 09 22 11" src="https://user-images.githubusercontent.com/1204802/92701051-d5040d80-f34f-11ea-882d-79456cf3b291.png">

<img width="290" alt="Screenshot 2020-09-10 at 09 22 55" src="https://user-images.githubusercontent.com/1204802/92701106-e2b99300-f34f-11ea-94aa-28372a4ba30b.png">

<img width="369" alt="Screenshot 2020-09-10 at 09 23 54" src="https://user-images.githubusercontent.com/1204802/92701112-e3eac000-f34f-11ea-8d98-5a04e0956058.png">

<img width="461" alt="Screenshot 2020-09-10 at 09 29 09" src="https://user-images.githubusercontent.com/1204802/92701114-e51bed00-f34f-11ea-9299-2ee2d73a8326.png">

<img width="628" alt="Screenshot 2020-09-10 at 09 38 17" src="https://user-images.githubusercontent.com/1204802/92701121-e64d1a00-f34f-11ea-8754-97e9e5cc3009.png">

<img width="550" alt="Screenshot 2020-09-10 at 09 39 09" src="https://user-images.githubusercontent.com/1204802/92701125-e77e4700-f34f-11ea-8733-a29a4023a7ea.png">

<img width="427" alt="Screenshot 2020-09-10 at 09 40 04" src="https://user-images.githubusercontent.com/1204802/92701129-e8af7400-f34f-11ea-99ae-bc50ae9c28e8.png">

<img width="249" alt="Screenshot 2020-09-10 at 09 44 58" src="https://user-images.githubusercontent.com/1204802/92701134-e9e0a100-f34f-11ea-8b52-f5d508439623.png">

<img width="382" alt="Screenshot 2020-09-10 at 09 46 09" src="https://user-images.githubusercontent.com/1204802/92701140-ea793780-f34f-11ea-9e8e-2e18b5b5403c.png">

<img width="362" alt="Screenshot 2020-09-10 at 09 53 58" src="https://user-images.githubusercontent.com/1204802/92701143-ebaa6480-f34f-11ea-8df4-deadd91d6eaf.png">

<img width="304" alt="Screenshot 2020-09-10 at 09 55 03" src="https://user-images.githubusercontent.com/1204802/92701148-ed742800-f34f-11ea-88fc-fa97128e83cd.png">

<img width="497" alt="Screenshot 2020-09-10 at 10 01 50" src="https://user-images.githubusercontent.com/1204802/92701151-eea55500-f34f-11ea-99e9-4cbfaed4d967.png">

<img width="296" alt="Screenshot 2020-09-10 at 10 06 04" src="https://user-images.githubusercontent.com/1204802/92701173-f5cc6300-f34f-11ea-98bb-ae00decd48e9.png">

<img width="147" alt="Screenshot 2020-09-10 at 10 08 32" src="https://user-images.githubusercontent.com/1204802/92701179-f6fd9000-f34f-11ea-88df-882b33afb4a0.png">

<img width="318" alt="Screenshot 2020-09-10 at 10 13 35" src="https://user-images.githubusercontent.com/1204802/92701183-f82ebd00-f34f-11ea-8d1a-f3658b1d654c.png">

<img width="1121" alt="Screenshot 2020-09-10 at 10 14 22" src="https://user-images.githubusercontent.com/1204802/92701187-f95fea00-f34f-11ea-96c3-7983d7a6be34.png">

<img width="535" alt="Screenshot 2020-09-10 at 10 19 41" src="https://user-images.githubusercontent.com/1204802/92701191-fa911700-f34f-11ea-95bd-bbcd4a838640.png">
