### PR TITLE
Add safeguard to AuthorSelect component until authors are fetched

### DIFF
--- a/packages/components/src/query-controls/author-select.js
+++ b/packages/components/src/query-controls/author-select.js
@@ -11,6 +11,7 @@ export default function AuthorSelect( {
 	selectedAuthorId,
 	onChange,
 } ) {
+	if ( ! authorList ) return null;
 	const termsTree = buildTermsTree( authorList );
 	return (
 		<TreeSelect


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
In some cases the author list in `AuthorSelect` do not have enough time to load and that leads to fail with error.

This is just a safeguard to render only if a list of authors is provided.

## How has this been tested?
I don't know what changed, but you can test it by creating a `Query` block in master. Some times it renders and some times fails.