### PR TITLE
Fix nested features

### DIFF
--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -521,11 +521,16 @@ function gutenberg_experimental_global_styles_merge_trees( $core, $theme, $user 
 	$result = gutenberg_experimental_global_styles_normalize_schema( array() );
 
 	foreach ( array_keys( $core ) as $block_name ) {
-		foreach ( array( 'presets', 'features' ) as $subtree ) {
-			$result[ $block_name ][ $subtree ] = array_merge(
-				$core[ $block_name ][ $subtree ],
-				$theme[ $block_name ][ $subtree ],
-				$user[ $block_name ][ $subtree ]
+		$result[ $block_name ][ 'presets' ] = array_merge(
+			$core[ $block_name ][ 'presets' ],
+			$theme[ $block_name ][ 'presets' ],
+			$user[ $block_name ][ 'presets' ]
+		);
+		foreach ( array_keys( $core[ $block_name ]['features'] ) as $subtree ) {
+			$result[ $block_name ]['features'][ $subtree ] = array_merge(
+				$core[ $block_name ]['features'][ $subtree ],
+				$theme[ $block_name ]['features'][ $subtree ],
+				$user[ $block_name ]['features'][ $subtree ]
 			);
 		}
 		foreach ( array_keys( $core[ $block_name ]['styles'] ) as $subtree ) {

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -558,8 +558,19 @@ function gutenberg_experimental_global_styles_normalize_schema( $tree ) {
 			'typography' => array(),
 			'color'      => array(),
 		),
-		'features' => array(),
-		'presets'  => array(),
+		'features' => array(
+			'typography' => array(),
+			'color'      => array(),
+			'gradient'   => array(),
+			'fontSize'   => array(),
+			'lineHeight' => array(),
+			'spacing'    => array(),
+		),
+		'presets'  => array(
+			'color'     => array(),
+			'font-size' => array(),
+			'gradient'  => array()
+		),
 	);
 
 	$normalized_tree = array();

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -521,10 +521,10 @@ function gutenberg_experimental_global_styles_merge_trees( $core, $theme, $user 
 	$result = gutenberg_experimental_global_styles_normalize_schema( array() );
 
 	foreach ( array_keys( $core ) as $block_name ) {
-		$result[ $block_name ][ 'presets' ] = array_merge(
-			$core[ $block_name ][ 'presets' ],
-			$theme[ $block_name ][ 'presets' ],
-			$user[ $block_name ][ 'presets' ]
+		$result[ $block_name ]['presets'] = array_merge(
+			$core[ $block_name ]['presets'],
+			$theme[ $block_name ]['presets'],
+			$user[ $block_name ]['presets']
 		);
 		foreach ( array_keys( $core[ $block_name ]['features'] ) as $subtree ) {
 			$result[ $block_name ]['features'][ $subtree ] = array_merge(
@@ -569,7 +569,7 @@ function gutenberg_experimental_global_styles_normalize_schema( $tree ) {
 		'presets'  => array(
 			'color'     => array(),
 			'font-size' => array(),
-			'gradient'  => array()
+			'gradient'  => array(),
 		),
 	);
 


### PR DESCRIPTION
This fixes the algorithm that merges core, theme, and user preferences for `features`.

## Test

- Use a theme that declares support for link color but nothing else via theme.json. Test case at https://github.com/nosolosw/global-styles-theme/pull/17
- Make sure custom colors are still enabled.
- Make sure the link color is enabled.

Before this PR custom colors won't be enabled.