### PR TITLE
Try: Remove menu item min-width.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46959,7 +46959,7 @@
 			"dependencies": {
 				"clone-deep": {
 					"version": "0.2.4",
-					"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
+					"resolved": "http://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
 					"integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
 					"dev": true,
 					"requires": {
@@ -46993,7 +46993,7 @@
 					"dependencies": {
 						"kind-of": {
 							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+							"resolved": "http://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
 							"integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
 							"dev": true,
 							"requires": {

--- a/packages/block-editor/src/autocompleters/style.scss
+++ b/packages/block-editor/src/autocompleters/style.scss
@@ -1,5 +1,7 @@
 .block-editor-autocompleters__block {
+	white-space: nowrap;
+
 	.block-editor-block-icon {
-		margin-right: 8px;
+		margin-right: $grid-unit-10;
 	}
 }

--- a/packages/block-editor/src/components/tool-selector/style.scss
+++ b/packages/block-editor/src/components/tool-selector/style.scss
@@ -6,4 +6,5 @@
 	padding: $grid-unit-15 ($grid-unit-15 + $grid-unit-10);
 	border-top: 1px solid $gray-300;
 	color: $gray-700;
+	min-width: 280px;
 }

--- a/packages/components/src/autocomplete/style.scss
+++ b/packages/components/src/autocomplete/style.scss
@@ -1,5 +1,6 @@
 .components-autocomplete__popover .components-popover__content > div {
 	padding: $grid-unit-20;
+	min-width: 220px;
 }
 
 .components-autocomplete__result.components-button {

--- a/packages/components/src/dropdown-menu/style.scss
+++ b/packages/components/src/dropdown-menu/style.scss
@@ -57,9 +57,9 @@
 		padding-left: $grid-unit-10;
 		padding-right: $grid-unit-10;
 
-		.components-menu-item__info-wrapper {
+		/*.components-menu-item__info-wrapper {
 			max-width: calc(100% - #{ $button-size-small + $grid-unit-10 });
-		}
+		}*/
 	}
 
 	.components-menu-group {

--- a/packages/components/src/dropdown-menu/style.scss
+++ b/packages/components/src/dropdown-menu/style.scss
@@ -1,5 +1,5 @@
 .components-dropdown-menu__popover .components-popover__content {
-	width: 200px;
+	min-width: 200px;
 }
 
 .components-dropdown-menu__menu {

--- a/packages/components/src/dropdown-menu/style.scss
+++ b/packages/components/src/dropdown-menu/style.scss
@@ -56,10 +56,6 @@
 		text-align: left;
 		padding-left: $grid-unit-10;
 		padding-right: $grid-unit-10;
-
-		/*.components-menu-item__info-wrapper {
-			max-width: calc(100% - #{ $button-size-small + $grid-unit-10 });
-		}*/
 	}
 
 	.components-menu-group {

--- a/packages/components/src/menu-item/index.js
+++ b/packages/components/src/menu-item/index.js
@@ -49,7 +49,7 @@ export function MenuItem(
 	if ( info ) {
 		children = (
 			<span className="components-menu-item__info-wrapper">
-				{ children }
+				<span className="components-menu-item__item">{ children }</span>
 				<span className="components-menu-item__info">{ info }</span>
 			</span>
 		);
@@ -74,7 +74,7 @@ export function MenuItem(
 			className={ className }
 			{ ...props }
 		>
-			{ children }
+			<span className="components-menu-item__item">{ children }</span>
 			<Shortcut
 				className="components-menu-item__shortcut"
 				shortcut={ shortcut }

--- a/packages/components/src/menu-item/style.scss
+++ b/packages/components/src/menu-item/style.scss
@@ -4,7 +4,7 @@
 
 	.components-menu-items__item-icon {
 		margin-right: -2px; // This optically balances the icon.
-		margin-left: auto;
+		margin-left: $grid-unit-30;
 		display: inline-block;
 		flex: 0 0 auto;
 	}
@@ -23,19 +23,28 @@
 .components-menu-item__info-wrapper {
 	display: flex;
 	flex-direction: column;
+	margin-right: auto;
 }
 
 .components-menu-item__info {
 	margin-top: $grid-unit-05;
 	font-size: $helptext-font-size;
 	color: $gray-700;
+	white-space: normal;
+}
+
+.components-menu-item__item {
+	white-space: nowrap;
+	margin-right: auto;
+	display: inline-flex;
+	align-items: center;
 }
 
 .components-menu-item__shortcut {
 	align-self: center;
 	margin-right: 0;
 	margin-left: auto;
-	padding-left: $grid-unit-15;
+	padding-left: $grid-unit-30;
 	color: currentColor;
 
 	// Hide the keyboard shortcuts on mobile, because they aren't super-useful

--- a/packages/components/src/menu-item/test/__snapshots__/index.js.snap
+++ b/packages/components/src/menu-item/test/__snapshots__/index.js.snap
@@ -7,7 +7,11 @@ exports[`MenuItem should match snapshot when all props provided 1`] = `
   onClick={[Function]}
   role="menuitemcheckbox"
 >
-  My item
+  <span
+    className="components-menu-item__item"
+  >
+    My item
+  </span>
   <Shortcut
     className="components-menu-item__shortcut"
     shortcut="mod+shift+alt+w"
@@ -34,13 +38,21 @@ exports[`MenuItem should match snapshot when info is provided 1`] = `
   role="menuitem"
 >
   <span
-    className="components-menu-item__info-wrapper"
+    className="components-menu-item__item"
   >
-    My item
     <span
-      className="components-menu-item__info"
+      className="components-menu-item__info-wrapper"
     >
-      Extended description of My Item
+      <span
+        className="components-menu-item__item"
+      >
+        My item
+      </span>
+      <span
+        className="components-menu-item__info"
+      >
+        Extended description of My Item
+      </span>
     </span>
   </span>
   <Shortcut
@@ -55,7 +67,11 @@ exports[`MenuItem should match snapshot when isSelected and role are optionally 
   onClick={[Function]}
   role="menuitem"
 >
-  My item
+  <span
+    className="components-menu-item__item"
+  >
+    My item
+  </span>
   <Shortcut
     className="components-menu-item__shortcut"
     shortcut="mod+shift+alt+w"
@@ -81,7 +97,11 @@ exports[`MenuItem should match snapshot when only label provided 1`] = `
   className="components-menu-item__button"
   role="menuitem"
 >
-  My item
+  <span
+    className="components-menu-item__item"
+  >
+    My item
+  </span>
   <Shortcut
     className="components-menu-item__shortcut"
   />

--- a/packages/components/src/popover/style.scss
+++ b/packages/components/src/popover/style.scss
@@ -180,7 +180,6 @@ $arrow-size: 8px;
 		position: absolute;
 		height: auto;
 		overflow-y: auto;
-		min-width: 260px;
 	}
 
 	.components-popover.is-expanded & {

--- a/packages/e2e-test-utils/CHANGELOG.md
+++ b/packages/e2e-test-utils/CHANGELOG.md
@@ -2,54 +2,58 @@
 
 ## Unreleased
 
+### Nee Features
+
+-   Added `clickMenuItem` - clicks the item that matches the label in the opened menu.
+
 ## 4.5.0 (2020-04-15)
 
 ### Enhancements
 
-- `visitAdminPage` will now throw an error (emit a test failure) when there are unexpected errors on hte page.
+-   `visitAdminPage` will now throw an error (emit a test failure) when there are unexpected errors on hte page.
 
 ### New Features
 
-- Added `getPageError` function, returning a promise which resolves to an error message present in the page, if any exists.
+-   Added `getPageError` function, returning a promise which resolves to an error message present in the page, if any exists.
 
 ## 4.0.0 (2019-12-19)
 
 ### Breaking Changes
 
-- The disableNavigationMode utility was removed. By default, the editor is in edit mode now.
+-   The disableNavigationMode utility was removed. By default, the editor is in edit mode now.
 
 ### Improvements
 
-- `setBrowserViewport` accepts an object of `width`, `height` values, to assign a viewport of arbitrary size.
+-   `setBrowserViewport` accepts an object of `width`, `height` values, to assign a viewport of arbitrary size.
 
 ## 3.0.0 (2019-11-14)
 
 ### Breaking Changes
 
-- The util function `enableExperimentalFeatures` was removed. It is now available for internal usage in the `e2e-tests` package.
+-   The util function `enableExperimentalFeatures` was removed. It is now available for internal usage in the `e2e-tests` package.
 
 ## 2.0.0 (2019-05-21)
 
 ### Requirements
 
-- The minimum version of Gutenberg `5.6.0` or the minimum version of WordPress `5.2.0`.
+-   The minimum version of Gutenberg `5.6.0` or the minimum version of WordPress `5.2.0`.
 
 ### Bug Fixes
 
-- WordPress 5.2: Fix a false positive build failure caused by Dashicons font file.
-- WordPress 5.2: Fix a test failure for Classic Block media insertion caused by a change in tooltips text ([rWP45066](https://core.trac.wordpress.org/changeset/45066)).
+-   WordPress 5.2: Fix a false positive build failure caused by Dashicons font file.
+-   WordPress 5.2: Fix a test failure for Classic Block media insertion caused by a change in tooltips text ([rWP45066](https://core.trac.wordpress.org/changeset/45066)).
 
 ## 1.1.0 (2019-03-20)
 
 ### New Features
 
-- New Function: `getAllBlockInserterItemTitles` - Returns an array of strings with all inserter item titles.
-- New Function: `openAllBlockInserterCategories` - Opens all block inserter categories.
-- New Function: `getAllBlockInserterItemTitles` - Opens the global block inserter.
+-   New Function: `getAllBlockInserterItemTitles` - Returns an array of strings with all inserter item titles.
+-   New Function: `openAllBlockInserterCategories` - Opens all block inserter categories.
+-   New Function: `getAllBlockInserterItemTitles` - Opens the global block inserter.
 
 ### Requirements
 
-- The minimum version of Gutenberg `5.3.0` or the minimum version of WordPress `5.2.0`.
+-   The minimum version of Gutenberg `5.3.0` or the minimum version of WordPress `5.2.0`.
 
 ## 1.0.0 (2019-03-06)
 
@@ -59,4 +63,4 @@
 
 ### Requirements
 
-- The minimum version of Gutenberg `5.2.0` or the minimum version of WordPress `5.2.0`.
+-   The minimum version of Gutenberg `5.2.0` or the minimum version of WordPress `5.2.0`.

--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -65,6 +65,14 @@ _Parameters_
 
 -   _buttonText_ `string`: The text that appears on the button to click.
 
+<a name="clickMenuItem" href="#clickMenuItem">#</a> **clickMenuItem**
+
+Searches for an item in the menu with the text provided and clicks it.
+
+_Parameters_
+
+-   _label_ `string`: The label to search the menu item for.
+
 <a name="clickOnCloseModalButton" href="#clickOnCloseModalButton">#</a> **clickOnCloseModalButton**
 
 Click on the close button of an open modal.

--- a/packages/e2e-test-utils/src/click-menu-item.js
+++ b/packages/e2e-test-utils/src/click-menu-item.js
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import { first } from 'lodash';
+
+/**
+ * Searches for an item in the menu with the text provided and clicks it.
+ *
+ * @param {string} label The label to search the menu item for.
+ */
+export async function clickMenuItem( label ) {
+	const elementToClick = first(
+		await page.$x(
+			`//div[@role="menu"]//span[contains(concat(" ", @class, " "), " components-menu-item__item ")][contains(text(), "${ label }")]`
+		)
+	);
+	await elementToClick.click();
+}

--- a/packages/e2e-test-utils/src/click-on-more-menu-item.js
+++ b/packages/e2e-test-utils/src/click-on-more-menu-item.js
@@ -17,20 +17,10 @@ export async function clickOnMoreMenuItem( buttonLabel ) {
 	await toggleMoreMenu();
 	const moreMenuContainerSelector =
 		'//*[contains(concat(" ", @class, " "), " edit-post-more-menu__content ")]';
-	let elementToClick = first(
+	const elementToClick = first(
 		await page.$x(
-			`${ moreMenuContainerSelector }//button[contains(text(), "${ buttonLabel }")]`
+			`${ moreMenuContainerSelector }//span[contains(concat(" ", @class, " "), " components-menu-item__item ")][contains(text(), "${ buttonLabel }")]`
 		)
 	);
-	// If button is not found, the label should be on the info wrapper.
-	if ( ! elementToClick ) {
-		elementToClick = first(
-			await page.$x(
-				moreMenuContainerSelector +
-					'//button' +
-					`/*[contains(concat(" ", @class, " "), " components-menu-item__info-wrapper ")][contains(text(), "${ buttonLabel }")]`
-			)
-		);
-	}
 	await elementToClick.click();
 }

--- a/packages/e2e-test-utils/src/index.js
+++ b/packages/e2e-test-utils/src/index.js
@@ -4,6 +4,7 @@ export { clearLocalStorage } from './clear-local-storage';
 export { clickBlockAppender } from './click-block-appender';
 export { clickBlockToolbarButton } from './click-block-toolbar-button';
 export { clickButton } from './click-button';
+export { clickMenuItem } from './click-menu-item';
 export { clickOnCloseModalButton } from './click-on-close-modal-button';
 export { clickOnMoreMenuItem } from './click-on-more-menu-item';
 export { createNewPost } from './create-new-post';

--- a/packages/e2e-test-utils/src/switch-editor-mode-to.js
+++ b/packages/e2e-test-utils/src/switch-editor-mode-to.js
@@ -11,7 +11,7 @@ import { toggleMoreMenu } from './toggle-more-menu';
 export async function switchEditorModeTo( mode ) {
 	await toggleMoreMenu();
 	const [ button ] = await page.$x(
-		`//button[contains(text(), '${ mode } editor')]`
+		`//button/span[contains(text(), '${ mode } editor')]`
 	);
 	await button.click( 'button' );
 	await toggleMoreMenu();

--- a/packages/e2e-tests/specs/editor/blocks/preformatted.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/preformatted.test.js
@@ -3,10 +3,10 @@
  */
 import {
 	clickBlockToolbarButton,
+	clickMenuItem,
 	getEditedPostContent,
 	createNewPost,
 	insertBlock,
-	clickButton,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Preformatted', () => {
@@ -23,12 +23,12 @@ describe( 'Preformatted', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 
 		await clickBlockToolbarButton( 'More options' );
-		await clickButton( 'Convert to Blocks' );
+		await clickMenuItem( 'Convert to Blocks' );
 		// Once it's edited, it should be saved as BR tags.
 		await page.keyboard.type( '0' );
 		await page.keyboard.press( 'Enter' );
 		await clickBlockToolbarButton( 'More options' );
-		await clickButton( 'Edit as HTML' );
+		await clickMenuItem( 'Edit as HTML' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );

--- a/packages/e2e-tests/specs/editor/plugins/annotations.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/annotations.test.js
@@ -4,6 +4,7 @@
 import {
 	activatePlugin,
 	clickBlockToolbarButton,
+	clickMenuItem,
 	clickOnMoreMenuItem,
 	createNewPost,
 	deactivatePlugin,
@@ -11,12 +12,7 @@ import {
 
 const clickOnBlockSettingsMenuItem = async ( buttonLabel ) => {
 	await clickBlockToolbarButton( 'More options' );
-	const itemButton = (
-		await page.$x(
-			`//*[contains(@class, "block-editor-block-settings-menu__popover")]//button[contains(text(), '${ buttonLabel }')]`
-		)
-	 )[ 0 ];
-	await itemButton.click();
+	await clickMenuItem( buttonLabel );
 };
 
 const ANNOTATIONS_SELECTOR = '.annotation-text-e2e-tests';

--- a/packages/e2e-tests/specs/editor/plugins/cpt-locking.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/cpt-locking.test.js
@@ -4,6 +4,7 @@
 import {
 	activatePlugin,
 	clickBlockToolbarButton,
+	clickMenuItem,
 	createNewPost,
 	deactivatePlugin,
 	getEditedPostContent,
@@ -40,7 +41,7 @@ describe( 'cpt locking', () => {
 		);
 		await clickBlockToolbarButton( 'More options' );
 		expect(
-			await page.$x( '//button[contains(text(), "Remove block")]' )
+			await page.$x( '//button/span[contains(text(), "Remove block")]' )
 		).toHaveLength( 0 );
 	};
 
@@ -171,10 +172,7 @@ describe( 'cpt locking', () => {
 				'p1'
 			);
 			await clickBlockToolbarButton( 'More options' );
-			const [ removeBlock ] = await page.$x(
-				'//button[contains(text(), "Remove block")]'
-			);
-			await removeBlock.click();
+			await clickMenuItem( 'Remove block' );
 			expect( await getEditedPostContent() ).toMatchSnapshot();
 		} );
 
@@ -194,10 +192,8 @@ describe( 'cpt locking', () => {
 				'p1'
 			);
 			await clickBlockToolbarButton( 'More options' );
-			const [ removeBlock ] = await page.$x(
-				'//button[contains(text(), "Remove block")]'
-			);
-			await removeBlock.click();
+			await clickMenuItem( 'Remove block' );
+
 			expect( await getEditedPostContent() ).toMatchSnapshot();
 		} );
 

--- a/packages/e2e-tests/specs/editor/various/block-grouping.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-grouping.test.js
@@ -5,6 +5,7 @@ import {
 	insertBlock,
 	createNewPost,
 	clickBlockToolbarButton,
+	clickMenuItem,
 	pressKeyWithModifier,
 	getEditedPostContent,
 	transformBlockTo,
@@ -77,11 +78,7 @@ describe( 'Block Grouping', () => {
 			await pressKeyWithModifier( 'primary', 'a' );
 
 			await clickBlockToolbarButton( 'More options' );
-
-			const groupButton = await page.waitForXPath(
-				'//button[text()="Group"]'
-			);
-			await groupButton.click();
+			await clickMenuItem( 'Group' );
 
 			expect( await getEditedPostContent() ).toMatchSnapshot();
 		} );
@@ -94,19 +91,13 @@ describe( 'Block Grouping', () => {
 
 			// Group
 			await clickBlockToolbarButton( 'More options' );
-			const groupButton = await page.waitForXPath(
-				'//button[text()="Group"]'
-			);
-			await groupButton.click();
+			await clickMenuItem( 'Group' );
 
 			expect( await getEditedPostContent() ).toMatchSnapshot();
 
 			// UnGroup
 			await clickBlockToolbarButton( 'More options' );
-			const unGroupButton = await page.waitForXPath(
-				'//button[text()="Ungroup"]'
-			);
-			await unGroupButton.click();
+			await clickMenuItem( 'Ungroup' );
 
 			expect( await getEditedPostContent() ).toMatchSnapshot();
 		} );
@@ -115,7 +106,7 @@ describe( 'Block Grouping', () => {
 			await insertBlock( 'Group' );
 			await clickBlockToolbarButton( 'More options' );
 			const ungroupButtons = await page.$x(
-				'//button[text()="Ungroup"]'
+				'//button/span[text()="Ungroup"]'
 			);
 			expect( ungroupButtons ).toHaveLength( 0 );
 		} );
@@ -236,10 +227,7 @@ describe( 'Block Grouping', () => {
 			// as opposed to "transformTo()" which uses whatever is passed to it. To
 			// ensure this test is meaningful we must rely on what is registered.
 			await clickBlockToolbarButton( 'More options' );
-			const groupButton = await page.waitForXPath(
-				'//button[text()="Group"]'
-			);
-			await groupButton.click();
+			await clickMenuItem( 'Group' );
 
 			expect( await getEditedPostContent() ).toMatchSnapshot();
 		} );

--- a/packages/e2e-tests/specs/editor/various/duplicating-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/duplicating-blocks.test.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import {
+	clickMenuItem,
 	createNewPost,
 	insertBlock,
 	getEditedPostContent,
@@ -24,10 +25,7 @@ describe( 'Duplicating blocks', () => {
 		await pressKeyWithModifier( 'primary', 'a' );
 
 		await clickBlockToolbarButton( 'More options' );
-		const duplicateButton = await page.waitForXPath(
-			'//button[text()="Duplicate"]'
-		);
-		await duplicateButton.click();
+		await clickMenuItem( 'Duplicate' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );

--- a/packages/e2e-tests/specs/editor/various/editor-modes.test.js
+++ b/packages/e2e-tests/specs/editor/various/editor-modes.test.js
@@ -4,6 +4,7 @@
 import {
 	clickBlockAppender,
 	clickBlockToolbarButton,
+	clickMenuItem,
 	createNewPost,
 	getCurrentPostContent,
 	switchEditorModeTo,
@@ -27,10 +28,7 @@ describe( 'Editing modes (visual/HTML)', () => {
 
 		// Change editing mode from "Visual" to "HTML".
 		await clickBlockToolbarButton( 'More options' );
-		let changeModeButton = await page.waitForXPath(
-			'//button[text()="Edit as HTML"]'
-		);
-		await changeModeButton.click();
+		await clickMenuItem( 'Edit as HTML' );
 
 		// Wait for the block to be converted to HTML editing mode.
 		const htmlBlock = await page.$$(
@@ -40,10 +38,7 @@ describe( 'Editing modes (visual/HTML)', () => {
 
 		// Change editing mode from "HTML" back to "Visual".
 		await clickBlockToolbarButton( 'More options' );
-		changeModeButton = await page.waitForXPath(
-			'//button[text()="Edit visually"]'
-		);
-		await changeModeButton.click();
+		await clickMenuItem( 'Edit visually' );
 
 		// This block should be in "visual" mode by default.
 		visualBlock = await page.$$(
@@ -55,10 +50,7 @@ describe( 'Editing modes (visual/HTML)', () => {
 	it( 'should display sidebar in HTML mode', async () => {
 		// Change editing mode from "Visual" to "HTML".
 		await clickBlockToolbarButton( 'More options' );
-		const changeModeButton = await page.waitForXPath(
-			'//button[text()="Edit as HTML"]'
-		);
-		await changeModeButton.click();
+		await clickMenuItem( 'Edit as HTML' );
 
 		// The font size picker for the paragraph block should appear, even in
 		// HTML editing mode.
@@ -71,10 +63,7 @@ describe( 'Editing modes (visual/HTML)', () => {
 	it( 'should update HTML in HTML mode when sidebar is used', async () => {
 		// Change editing mode from "Visual" to "HTML".
 		await clickBlockToolbarButton( 'More options' );
-		const changeModeButton = await page.waitForXPath(
-			'//button[text()="Edit as HTML"]'
-		);
-		await changeModeButton.click();
+		await clickMenuItem( 'Edit as HTML' );
 
 		// Make sure the paragraph content is rendered as expected.
 		let htmlBlockContent = await page.$eval(

--- a/packages/e2e-tests/specs/editor/various/invalid-block.test.js
+++ b/packages/e2e-tests/specs/editor/various/invalid-block.test.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import {
+	clickMenuItem,
 	createNewPost,
 	clickBlockAppender,
 	clickBlockToolbarButton,
@@ -20,10 +21,7 @@ describe( 'invalid blocks', () => {
 		await clickBlockToolbarButton( 'More options' );
 
 		// Change to HTML mode and close the options
-		const changeModeButton = await page.waitForXPath(
-			'//button[text()="Edit as HTML"]'
-		);
-		await changeModeButton.click();
+		await clickMenuItem( 'Edit as HTML' );
 
 		// Focus on the textarea and enter an invalid paragraph
 		await page.click(
@@ -41,9 +39,7 @@ describe( 'invalid blocks', () => {
 			'.block-editor-warning__actions button[aria-label="More options"]'
 		);
 
-		// Click on the 'Resolve' button
-		const [ resolveButton ] = await page.$x( '//button[text()="Resolve"]' );
-		await resolveButton.click();
+		await clickMenuItem( 'Resolve' );
 
 		// Check we get the resolve modal with the appropriate contents
 		const htmlBlockContent = await page.$eval(

--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import {
+	clickMenuItem,
 	insertBlock,
 	insertReusableBlock,
 	createNewPost,
@@ -42,11 +43,7 @@ describe( 'Reusable blocks', () => {
 		await page.keyboard.type( 'Hello there!' );
 
 		await clickBlockToolbarButton( 'More options' );
-
-		const convertButton = await page.waitForXPath(
-			'//button[text()="Add to Reusable blocks"]'
-		);
-		await convertButton.click();
+		await clickMenuItem( 'Add to Reusable blocks' );
 
 		// Wait for creation to finish
 		await page.waitForXPath(
@@ -89,11 +86,7 @@ describe( 'Reusable blocks', () => {
 		await page.keyboard.type( 'Hello there!' );
 
 		await clickBlockToolbarButton( 'More options' );
-
-		const convertButton = await page.waitForXPath(
-			'//button[text()="Add to Reusable blocks"]'
-		);
-		await convertButton.click();
+		await clickMenuItem( 'Add to Reusable blocks' );
 
 		// Wait for creation to finish
 		await page.waitForXPath(
@@ -183,11 +176,7 @@ describe( 'Reusable blocks', () => {
 		await page.keyboard.type( 'Awesome Paragraph' );
 
 		await clickBlockToolbarButton( 'More options' );
-
-		const convertButton = await page.waitForXPath(
-			'//button[text()="Add to Reusable blocks"]'
-		);
-		await convertButton.click();
+		await clickMenuItem( 'Add to Reusable blocks' );
 
 		// Wait for creation to finish
 		await page.waitForXPath(
@@ -257,7 +246,7 @@ describe( 'Reusable blocks', () => {
 		// Delete the block and accept the confirmation dialog
 		await clickBlockToolbarButton( 'More options' );
 		const deleteButton = await page.waitForXPath(
-			'//button[text()="Remove from Reusable blocks"]'
+			'//button/span[text()="Remove from Reusable blocks"]'
 		);
 		await Promise.all( [ waitForAndAcceptDialog(), deleteButton.click() ] );
 
@@ -294,10 +283,7 @@ describe( 'Reusable blocks', () => {
 
 		// Convert block to a reusable block
 		await clickBlockToolbarButton( 'More options' );
-		const convertButton = await page.waitForXPath(
-			'//button[text()="Add to Reusable blocks"]'
-		);
-		await convertButton.click();
+		await clickMenuItem( 'Add to Reusable blocks' );
 
 		// Wait for creation to finish
 		await page.waitForXPath(


### PR DESCRIPTION
Popovers have a min-width. Which means you get very wide popovers in some cases:

<img width="374" alt="Screenshot 2020-09-10 at 13 02 26" src="https://user-images.githubusercontent.com/1204802/92721165-ef48e600-f365-11ea-8601-279d7b976195.png">

This PR tries removing that, so they look just right (sized according to the content inside):

<img width="356" alt="Screenshot 2020-09-10 at 13 01 40" src="https://user-images.githubusercontent.com/1204802/92721197-fa037b00-f365-11ea-8615-cdea8a96b0ab.png">

So why was it added in the first place? Well, it was added back in #9086 because an auto-expanding URL field didn't resize it. With this PR I'm revisiting that, though, because: should a textfield ever _expand_ a popover? Isn't it best those have fixed sizes? And currently, they do:

<img width="498" alt="Screenshot 2020-09-10 at 13 01 47" src="https://user-images.githubusercontent.com/1204802/92721276-20291b00-f366-11ea-99e9-26131bc464ec.png">

So, this PR would be a nice little win for toolbar dropdowns, and even a bit of cleanup. But it'd be good to test existing popovers to make sure they work as intended.