### PR TITLE
Add filter on PageAttributesParent query args

### DIFF
--- a/docs/designers-developers/developers/filters/editor-filters.md
+++ b/docs/designers-developers/developers/filters/editor-filters.md
@@ -30,6 +30,24 @@ var customPreviewMessage = function() {
 wp.hooks.addFilter( 'editor.PostPreview.interstitialMarkup', 'my-plugin/custom-preview-message', customPreviewMessage );
 ```
 
+### `editor.PageAttributesParent.queryArgs`
+
+Filters the query arguments used to populate the page attributes parent page dropdown. For instance, this can be used to add draft posts to the dropdown list. Please note that the equivalent PHP filter hook `quick_edit_dropdown_pages_args` must be used to alter the quick edit parent page dropdown.
+
+_Example:_
+
+```js
+var pageAttributesParentQuery = function( args, post ) {
+	if ( post.type === 'page' ) {
+		args.status = 'publish,draft';
+	}
+
+	return args;
+};
+
+wp.hooks.addFilter( 'editor.PageAttributesParent.queryArgs', 'my-plugin/page-attributes-parent-query', pageAttributesParentQuery );
+```
+
 ## Editor settings
 
 ### `block_editor_settings`


### PR DESCRIPTION
Modeled after the `page_attributes_dropdown_pages_args` filter hook, this allows for altering the query for the parent page dropdown in the Gutenberg editor. This is meant to address #9089 in the Gutenberg context.

## Description

Adds a filter hook to the query args used for the Page attributes parent page dropdown. This mirrors the classic editor and quick edit behavior. Note that in order for this to work with quick edit, the original PHP filter hook `quick_edit_dropdown_pages_args` must be used in tandem.

## How has this been tested?

In a separate plugin I added this JavaScript:

```
import { addFilter } from '@wordpress/hooks';

addFilter( 'editor.PageAttributesParent.queryArgs', 'crockoftime/logbookParentArgs', ( args, post ) => {
	if ( post.type === 'logbook' ) {
		args.status = 'publish,draft';
	}

	return args;
} );
```

## Screenshots <!-- if applicable -->

The highlighted selection below is a post in draft mode.

![Screen Shot 2020-09-10 at 9 24 54 AM](https://user-images.githubusercontent.com/304784/92735591-8783a280-f347-11ea-8d86-3a6421b17ad9.png)

After making the selection and saving a draft, the posts are properly nested and both are in draft mode.

![Screen Shot 2020-09-10 at 9 26 28 AM](https://user-images.githubusercontent.com/304784/92735905-cd406b00-f347-11ea-95c4-559d2e804702.png)

If the equivalent `quick_edit_dropdown_pages_args` filter hook is used via PHP, the correct post will be selected in quick edit.

![Screen Shot 2020-09-10 at 9 44 44 AM](https://user-images.githubusercontent.com/304784/92738919-607aa000-f34a-11ea-9cca-c802ab61903d.png)

## Types of changes

New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->

I don't see any guidelines about inline documentation for hooks in the JavaScript context, and the few existing editor hooks only appear to have developer documentation. ~I will add developer documentation in additional commits.~
