### PR TITLE
Add search in Query block

### DIFF
--- a/packages/block-library/src/query-loop/edit.js
+++ b/packages/block-library/src/query-loop/edit.js
@@ -27,6 +27,7 @@ export default function QueryLoopEdit( {
 			order,
 			orderBy,
 			author,
+			search,
 		} = {},
 		queryContext,
 	},
@@ -49,6 +50,9 @@ export default function QueryLoopEdit( {
 			if ( author ) {
 				query.author = author;
 			}
+			if ( search ) {
+				query.search = search;
+			}
 			return {
 				posts: select( 'core' ).getEntityRecords(
 					'postType',
@@ -68,6 +72,7 @@ export default function QueryLoopEdit( {
 			orderBy,
 			clientId,
 			author,
+			search,
 		]
 	);
 

--- a/packages/block-library/src/query-loop/index.php
+++ b/packages/block-library/src/query-loop/index.php
@@ -47,6 +47,9 @@ function render_block_core_query_loop( $attributes, $content, $block ) {
 		if ( isset( $block->context['query']['author'] ) ) {
 			$query['author'] = $block->context['query']['author'];
 		}
+		if ( isset( $block->context['query']['search'] ) ) {
+			$query['s'] = $block->context['query']['search'];
+		}
 	}
 
 	$posts = get_posts( $query );

--- a/packages/block-library/src/query/block.json
+++ b/packages/block-library/src/query/block.json
@@ -15,7 +15,7 @@
 				"tagIds": [],
 				"order": "desc",
 				"orderBy": "date",
-				"author": null,
+				"author": "",
 				"search": ""
 			}
 		}

--- a/packages/block-library/src/query/block.json
+++ b/packages/block-library/src/query/block.json
@@ -15,7 +15,8 @@
 				"tagIds": [],
 				"order": "desc",
 				"orderBy": "date",
-				"author": null
+				"author": null,
+				"search": ""
 			}
 		}
 	},

--- a/packages/block-library/src/query/edit/query-toolbar.js
+++ b/packages/block-library/src/query/edit/query-toolbar.js
@@ -7,6 +7,7 @@ import {
 	Dropdown,
 	ToolbarButton,
 	RangeControl,
+	TextControl,
 	FormTokenField,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -113,6 +114,13 @@ export default function QueryToolbar( { query, setQuery } ) {
 								onChange={ onTagsChange }
 							/>
 						) }
+						<TextControl
+							label={ __( 'Search' ) }
+							value={ query.search }
+							onChange={ ( value ) =>
+								setQuery( { search: value } )
+							}
+						/>
 					</>
 				) }
 			/>

--- a/packages/block-library/src/query/edit/query-toolbar.js
+++ b/packages/block-library/src/query/edit/query-toolbar.js
@@ -1,7 +1,13 @@
 /**
+ * External dependencies
+ */
+import { debounce } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
+import { useEffect, useState, useCallback } from '@wordpress/element';
 import {
 	Toolbar,
 	Dropdown,
@@ -34,6 +40,15 @@ export default function QueryToolbar( { query, setQuery } ) {
 			tags: getTermsInfo( _tags ),
 		};
 	}, [] );
+	const [ querySearch, setQuerySearch ] = useState( query.search );
+	const onChangeDebounced = useCallback(
+		debounce( () => setQuery( { search: querySearch } ), 250 ),
+		[ querySearch ]
+	);
+	useEffect( () => {
+		onChangeDebounced();
+		return onChangeDebounced.cancel;
+	}, [ querySearch, onChangeDebounced ] );
 
 	// Handles categories and tags changes.
 	const onTermsChange = ( terms, queryProperty ) => ( newTermValues ) => {
@@ -116,10 +131,8 @@ export default function QueryToolbar( { query, setQuery } ) {
 						) }
 						<TextControl
 							label={ __( 'Search' ) }
-							value={ query.search }
-							onChange={ ( value ) =>
-								setQuery( { search: value } )
-							}
+							value={ querySearch }
+							onChange={ ( value ) => setQuerySearch( value ) }
 						/>
 					</>
 				) }

--- a/packages/e2e-tests/fixtures/blocks/core__query.json
+++ b/packages/e2e-tests/fixtures/blocks/core__query.json
@@ -12,7 +12,7 @@
 				"tagIds": [],
 				"order": "desc",
 				"orderBy": "date",
-				"author": null,
+				"author": "",
 				"search": ""
 			}
 		},

--- a/packages/e2e-tests/fixtures/blocks/core__query.json
+++ b/packages/e2e-tests/fixtures/blocks/core__query.json
@@ -12,7 +12,8 @@
 				"tagIds": [],
 				"order": "desc",
 				"orderBy": "date",
-				"author": null
+				"author": null,
+				"search": ""
 			}
 		},
 		"innerBlocks": [],


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This PR will add search support in Query block and is part of #24934 and FSE milestone 5.

There still needs to be a decision about the final design of Query block which is in this issue: https://github.com/WordPress/gutenberg/issues/25198.

For now I've added the search control in the toolbar.

This PR also fixes a React warning about passing `null` to a select component for `authors` list.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
