### PR TITLE
Update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49817,12 +49817,12 @@
 					}
 				},
 				"tar-stream": {
-					"version": "2.1.3",
-					"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.3.tgz",
-					"integrity": "sha512-Z9yri56Dih8IaK8gncVPx4Wqt86NDmQTSh49XLZgjWpGZL9GK9HKParS2scqHCC4w6X9Gh2jwaU45V47XTKwVA==",
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
+					"integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
 					"dev": true,
 					"requires": {
-						"bl": "^4.0.1",
+						"bl": "^4.0.3",
 						"end-of-stream": "^1.4.1",
 						"fs-constants": "^1.0.0",
 						"inherits": "^2.0.3",


### PR DESCRIPTION
## Description
`package-lock.json` seems to be outdated (found via https://github.com/WordPress/gutenberg/pull/25169/checks?check_run_id=1096710041). This PR brings it back up to date.

## How has this been tested?
Check the Static Analysis job on this PR.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
