### PR TITLE
Block Supports: Ensure consistent output in different PHP versions

### DIFF
--- a/lib/block-supports/index.php
+++ b/lib/block-supports/index.php
@@ -110,9 +110,9 @@ function gutenberg_apply_block_supports( $block_content, $block ) {
 
 	// Find the <body> open/close tags. The open tag needs to be adjusted so we get inside the tag
 	// and not the tag itself.
-	$start = mb_strpos( $full_html, '<body>', 0, 'UTF-8' ) + mb_strlen( '<body>', 'UTF-8' );
-	$end   = mb_strpos( $full_html, '</body>', $start, 'UTF-8' );
-	return mb_substr( $full_html, $start, $end - $start, 'UTF-8' );
+	$start = strpos( $full_html, '<body>', 0 ) + strlen( '<body>' );
+	$end   = strpos( $full_html, '</body>', $start );
+	return substr( $full_html, $start, $end - $start );
 }
 add_filter( 'render_block', 'gutenberg_apply_block_supports', 10, 2 );
 

--- a/lib/block-supports/index.php
+++ b/lib/block-supports/index.php
@@ -112,7 +112,7 @@ function gutenberg_apply_block_supports( $block_content, $block ) {
 	// and not the tag itself.
 	$start = strpos( $full_html, '<body>', 0 ) + strlen( '<body>' );
 	$end   = strpos( $full_html, '</body>', $start );
-	return substr( $full_html, $start, $end - $start );
+	return trim( substr( $full_html, $start, $end - $start ) );
 }
 add_filter( 'render_block', 'gutenberg_apply_block_supports', 10, 2 );
 

--- a/lib/block-supports/index.php
+++ b/lib/block-supports/index.php
@@ -104,12 +104,15 @@ function gutenberg_apply_block_supports( $block_content, $block ) {
 		$block_root->setAttribute( 'style', implode( '; ', $new_styles ) . ';' );
 	}
 
-	$result = '';
-	// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-	foreach ( $body_element->childNodes as $child_node ) {
-		$result .= $dom->saveHtml( $child_node );
-	}
-	return $result;
+	// Avoid using `$dom->saveHtml( $node )` because the node results may not produce consistent
+	// whitespace for PHP < 7.3. Saving the root HTML `$dom->saveHtml()` prevents this behavior.
+	$full_html = $dom->saveHtml();
+
+	// Find the <body> open/close tags. The open tag needs to be adjusted so we get inside the tag
+	// and not the tag itself.
+	$start = mb_strpos( $full_html, '<body>', 0, 'UTF-8' ) + mb_strlen( '<body>', 'UTF-8' );
+	$end   = mb_strpos( $full_html, '</body>', $start, 'UTF-8' );
+	return mb_substr( $full_html, $start, $end - $start, 'UTF-8' );
 }
 add_filter( 'render_block', 'gutenberg_apply_block_supports', 10, 2 );
 

--- a/phpunit/class-block-supported-styles-test.php
+++ b/phpunit/class-block-supported-styles-test.php
@@ -881,6 +881,20 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensure that HTML is correctly extracted with multibyte contents.
+	 */
+	public function test_render_block_mb_html() {
+		$this->register_block_type(
+			'core/example',
+			array( 'render_callback' => true )
+		);
+
+		$result = do_blocks( '<!-- wp:core/example --><ul><li>🙂</li><li>😕</li><li>😵</li><li>😎</li></ul><!-- /wp:core/example -->' );
+
+		$this->assertEquals( '<ul class="wp-block-example"><li>🙂</li><li>😕</li><li>😵</li><li>😎</li></ul>', $result );
+	}
+
+	/**
 	 * Should not error when the rendered block is text only.
 	 */
 	public function test_render_block_rendered_text_node() {


### PR DESCRIPTION
## Description
Avoid using the `DOMDocument::saveHtml( $node )` to ensure consistent behavior across PHP versions.

In some versions of PHP (< 7.3) the `DOMDocument::saveHtml( $node )` method would format HTML introducing whitespace that could result in different rendered results in the browser.

For example, the following snippet will demonstrate different output in HTML whitespace when using `saveHtml` with the `$node` argument compared with saving the entire document:

```php
<?php

$dom = new DOMDocument();
$dom->loadHTML( "<!DOCTYPE html><html><body><ul><li>first</li><li>second</li><li>third</li></ul></html>" );
$ul = $dom->getElementsByTagName('ul')->item(0);

echo "Element node:" . PHP_EOL;
echo $dom->saveHTML( $ul ) . PHP_EOL;

echo "Root + substr:" . PHP_EOL;
$full_html = $dom->saveHtml();
$start = mb_strpos( $full_html, '<body>', 0, 'UTF-8' ) + mb_strlen( '<body>', 'UTF-8' );
$end   = mb_strpos( $full_html, '</body>', $start, 'UTF-8' );
echo mb_substr( $full_html, $start, $end - $start, 'UTF-8' );
```

Results PHP 7.3+

```
Element node:
<ul><li>first</li><li>second</li><li>third</li></ul>
Root + substr:
<ul><li>first</li><li>second</li><li>third</li></ul>
```

Results PHP 5.3.6 - 7.2: (earlier versions do not support the `$node` argument to `saveHtml`)

```
Element node:
<ul>
<li>first</li>
<li>second</li>
<li>third</li>
</ul>
Root + substr:
<ul><li>first</li><li>second</li><li>third</li></ul>
```

Addresses concerns raised here:
https://github.com/WordPress/gutenberg/pull/25028#discussion_r484484183

<!-- Please describe what you have changed or added -->

## How has this been tested?

Unit tests.

## Types of changes
Internal: Fixes a potential bug specific to certain PHP versions.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->