### PR TITLE
Docs: Add block toolbar component readme

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/README.md
+++ b/packages/block-editor/src/components/block-toolbar/README.md
@@ -1,0 +1,29 @@
+# Block Toolbar
+
+The `BlockToolbar` component is used to render a toolbar that serves as a wrapper for number of options for each block. 
+
+![Paragraph block toolbar](https://make.wordpress.org/core/files/2020/09/paragraph-block-toolbar.png)
+
+![Image block toolbar](https://make.wordpress.org/core/files/2020/09/image-block-toolbar.png)
+
+
+## Table of contents
+
+1. [Development guidelines](#development-guidelines)
+2. [Related components](#related-components)
+
+## Development guidelines
+
+### Usage
+
+Displays a block toolbar for a selected block.
+
+```jsx
+import { BlockToolbar } from '@wordpress/block-editor';
+
+const MyBlockToolbar = () => <BlockToolbar />
+```
+
+## Related components
+
+Block Editor components are components that can be used to compose the UI of your block editor. Thus, they can only be used under a [`BlockEditorProvider`](https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/provider/README.md) in the components tree.


### PR DESCRIPTION
## Description
Added documentation for the block toolbar component (see #22891)

## How has this been tested?
N/A, documentation only

## Types of changes
Documentation

## Checklist:
- [n/a] My code is tested.
- [n/a] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [n/a] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
