### PR TITLE
Global styles: Fix camelCase - kebab-case incompatibility

### DIFF
--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -492,6 +492,16 @@ function gutenberg_experimental_global_styles_resolver_styles( $block_selector, 
 	$css_rule         = '';
 	$css_declarations = '';
 
+	// Transformations for block-supports strings.
+	foreach ( $block_supports as $block_support ) {
+		// Convert camelCase to kebab-case and add to array.
+		$block_supports[] = strtolower( preg_replace( '/([a-z0-9]|(?=[A-Z]))([A-Z])/', '$1-$2', $block_support ) );
+	}
+	// When adding the kebab-case supports, we didn't check if the item exists in the array
+	// to avoid constly in_array() calls. We'll need to remove the duplicates here.
+	// This is the same as array_unique(), but faster.
+	$block_support = array_flip( array_flip( $block_supports ) );
+
 	foreach ( $block_styles as $property => $value ) {
 		// Only convert to CSS:
 		//

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -495,11 +495,11 @@ function gutenberg_experimental_global_styles_resolver_styles( $block_selector, 
 	// Transformations for block-supports strings.
 	foreach ( $block_supports as $block_support ) {
 		// Convert camelCase to kebab-case and add to array.
+		// Don't check if the item already exists with in_array(), we will remove duplicate values outside the loop.
 		$block_supports[] = strtolower( preg_replace( '/([a-z0-9]|(?=[A-Z]))([A-Z])/', '$1-$2', $block_support ) );
 	}
-	// When adding the kebab-case supports, we didn't check if the item exists in the array
-	// to avoid constly in_array() calls. We'll need to remove the duplicates here.
-	// This is the same as array_unique(), but faster.
+	// Remove duplicate items.
+	// This is the same as array_unique(), but since the array contains only strings this is more performant.
 	$block_support = array_flip( array_flip( $block_supports ) );
 
 	foreach ( $block_styles as $property => $value ) {


### PR DESCRIPTION
## Description

The `gutenberg_experimental_global_styles_resolver_styles()` function checks block-supports against the block-styles. The problem is that our `$supports` use camelCase, while block-styles use kebab-case since they are CSS.
As a result, user styles don't get printed on the front and the CSS variables don't get echoed.

## How has this been tested?

Tested with an [FSE theme](https://github.com/aristath/q) and this PR fixes printing global vars for user-selected styles (background-color for example).
Verified the same behaviour with the [`gutenberg-starter-theme-blocks`](https://github.com/WordPress/theme-experiments/tree/master/gutenberg-starter-theme-blocks) theme.

To test: Activate an FSE theme, go to the site editor and change the background color.

Note: also related to https://github.com/WordPress/gutenberg/pull/25236

## Types of changes
Account for camelCase/kebab-case transformations.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
