### PR TITLE
Navigation Component: Custom item content

### DIFF
--- a/packages/components/src/navigation/README.md
+++ b/packages/components/src/navigation/README.md
@@ -67,13 +67,6 @@ The active menu slug.
 
 Optional className for the `Navigation` component.
 
-### `onActivateItem`
-
--   Type: `function`
--   Required: No
-
-Sync the active item between the external state and the Navigation's internal state.
-
 ### `onActivateMenu`
 
 -   Type: `function`

--- a/packages/components/src/navigation/context.js
+++ b/packages/components/src/navigation/context.js
@@ -16,7 +16,6 @@ import { ROOT_MENU } from './constants';
 export const NavigationContext = createContext( {
 	activeItem: undefined,
 	activeMenu: ROOT_MENU,
-	setActiveItem: noop,
 	setActiveMenu: noop,
 } );
 export const useNavigationContext = () => useContext( NavigationContext );

--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -22,17 +22,10 @@ export default function Navigation( {
 	activeMenu = ROOT_MENU,
 	children,
 	className,
-	onActivateItem = noop,
 	onActivateMenu = noop,
 } ) {
-	const [ item, setItem ] = useState( activeItem );
 	const [ menu, setMenu ] = useState( activeMenu );
 	const [ slideOrigin, setSlideOrigin ] = useState();
-
-	const setActiveItem = ( itemId ) => {
-		setItem( itemId );
-		onActivateItem( itemId );
-	};
 
 	const setActiveMenu = ( menuId, slideInOrigin = 'left' ) => {
 		setSlideOrigin( slideInOrigin );
@@ -49,18 +42,14 @@ export default function Navigation( {
 	}, [] );
 
 	useEffect( () => {
-		if ( activeItem !== item ) {
-			setActiveItem( activeItem );
-		}
 		if ( activeMenu !== menu ) {
 			setActiveMenu( activeMenu );
 		}
 	}, [ activeItem, activeMenu ] );
 
 	const context = {
-		activeItem: item,
+		activeItem,
 		activeMenu: menu,
-		setActiveItem,
 		setActiveMenu,
 	};
 

--- a/packages/components/src/navigation/item.js
+++ b/packages/components/src/navigation/item.js
@@ -44,27 +44,27 @@ export default function NavigationItem( {
 
 	return (
 		<ItemUI className={ classes }>
-			<Button href={ href } onClick={ onItemClick } { ...props }>
-				{ title && (
-					<ItemTitleUI
-						className="components-navigation__item-title"
-						variant="body.small"
-						as="span"
-					>
-						{ title }
-					</ItemTitleUI>
-				) }
+			{ children || (
+				<Button href={ href } onClick={ onItemClick } { ...props }>
+					{ title && (
+						<ItemTitleUI
+							className="components-navigation__item-title"
+							variant="body.small"
+							as="span"
+						>
+							{ title }
+						</ItemTitleUI>
+					) }
 
-				{ children }
+					{ badge && (
+						<ItemBadgeUI className="components-navigation__item-badge">
+							{ badge }
+						</ItemBadgeUI>
+					) }
 
-				{ badge && (
-					<ItemBadgeUI className="components-navigation__item-badge">
-						{ badge }
-					</ItemBadgeUI>
-				) }
-
-				{ navigateToMenu && <Icon icon={ chevronRight } /> }
-			</Button>
+					{ navigateToMenu && <Icon icon={ chevronRight } /> }
+				</Button>
+			) }
 		</ItemUI>
 	);
 }

--- a/packages/components/src/navigation/item.js
+++ b/packages/components/src/navigation/item.js
@@ -27,7 +27,7 @@ export default function NavigationItem( {
 	title,
 	...props
 } ) {
-	const { activeItem, setActiveItem, setActiveMenu } = useNavigationContext();
+	const { activeItem, setActiveMenu } = useNavigationContext();
 
 	const classes = classnames( 'components-navigation__item', className, {
 		'is-active': item && activeItem === item,
@@ -36,9 +36,8 @@ export default function NavigationItem( {
 	const onItemClick = () => {
 		if ( navigateToMenu ) {
 			setActiveMenu( navigateToMenu );
-		} else if ( ! href ) {
-			setActiveItem( item );
 		}
+
 		onClick();
 	};
 

--- a/packages/components/src/navigation/stories/index.js
+++ b/packages/components/src/navigation/stories/index.js
@@ -26,6 +26,16 @@ const Container = styled.div`
 	max-width: 246px;
 `;
 
+const CustomComponent = ( { onClick } ) => (
+	<Button onClick={ onClick }>
+		<img
+			alt="WordPress Logo"
+			src="https://s.w.org/style/images/about/WordPress-logotype-wmark-white.png"
+			style={ { width: 50, height: 50 } }
+		/>
+	</Button>
+);
+
 function Example() {
 	const [ activeItem, setActiveItem ] = useState( 'item-1' );
 	const [ activeMenu, setActiveMenu ] = useState( 'root' );
@@ -57,10 +67,8 @@ function Example() {
 							title="External link"
 						/>
 						<NavigationItem item="item-5">
-							<img
-								alt="WordPress Logo"
-								src="https://s.w.org/style/images/about/WordPress-logotype-wmark-white.png"
-								style={ { width: 50, height: 50 } }
+							<CustomComponent
+								onClick={ () => setActiveItem( 'item-5' ) }
 							/>
 						</NavigationItem>
 					</NavigationGroup>

--- a/packages/components/src/navigation/stories/index.js
+++ b/packages/components/src/navigation/stories/index.js
@@ -26,35 +26,45 @@ const Container = styled.div`
 	max-width: 246px;
 `;
 
-// Mock navigation link
-const Link = ( { href, children, onClick } ) => (
-	<a
-		href={ href }
-		onClick={ ( event ) => {
-			event.preventDefault();
-			onClick();
-		} }
-	>
-		{ children }
-	</a>
-);
-
 function Example() {
 	const [ activeItem, setActiveItem ] = useState( 'item-1' );
 	const [ activeMenu, setActiveMenu ] = useState( 'root' );
+
+	// Mock navigation link
+	const Link = ( { href, children } ) => (
+		<a
+			className="components-button"
+			href={ href }
+			// Since we're not actually navigating pages, simulate it with on onClick
+			onClick={ ( event ) => {
+				event.preventDefault();
+				const item = href.replace( 'https://example.com/', '' );
+				setActiveItem( item );
+			} }
+		>
+			{ children }
+		</a>
+	);
 
 	return (
 		<Container>
 			<Navigation
 				activeItem={ activeItem }
 				activeMenu={ activeMenu }
-				onActivateItem={ setActiveItem }
 				onActivateMenu={ setActiveMenu }
 			>
 				<NavigationMenu title="Home">
 					<NavigationGroup title="Group 1">
-						<NavigationItem item="item-1" title="Item 1" />
-						<NavigationItem item="item-2" title="Item 2" />
+						<NavigationItem item="item-1" title="Item 1">
+							<Link href="https://example.com/item-1">
+								Item 1
+							</Link>
+						</NavigationItem>
+						<NavigationItem item="item-2">
+							<Link href="https://example.com/item-2">
+								Item 2
+							</Link>
+						</NavigationItem>
 						<NavigationItem
 							badge="2"
 							item="item-3"
@@ -70,18 +80,20 @@ function Example() {
 							title="External link"
 						/>
 						<NavigationItem item="item-5">
-							<Link
+							<a
 								href="https://wordpress.org/"
-								item="item-5"
 								// Since we're not actually navigating pages, simulate it with on onClick
-								onClick={ () => setActiveItem( 'item-5' ) }
+								onClick={ ( event ) => {
+									event.preventDefault();
+									setActiveItem( 'item-5' );
+								} }
 							>
 								<img
 									alt="WordPress Logo"
 									src="https://s.w.org/style/images/about/WordPress-logotype-wmark-white.png"
 									style={ { width: 50, height: 50 } }
 								/>
-							</Link>
+							</a>
 						</NavigationItem>
 					</NavigationGroup>
 				</NavigationMenu>
@@ -92,8 +104,17 @@ function Example() {
 					parentMenu="root"
 					title="Category"
 				>
-					<NavigationItem badge="1" item="child-1" title="Child 1" />
-					<NavigationItem item="child-2" title="Child 2" />
+					<NavigationItem
+						badge="1"
+						item="child-1"
+						title="Child 1"
+						onClick={ () => setActiveItem( 'child-1' ) }
+					/>
+					<NavigationItem
+						item="child-2"
+						title="Child 2"
+						onClick={ () => setActiveItem( 'child-2' ) }
+					/>
 					<NavigationItem
 						navigateToMenu="nested-category"
 						item="child-3"
@@ -107,8 +128,16 @@ function Example() {
 					parentMenu="category"
 					title="Nested Category"
 				>
-					<NavigationItem item="sub-child-1" title="Sub Child 1" />
-					<NavigationItem item="sub-child-2" title="Sub Child 2" />
+					<NavigationItem
+						item="sub-child-1"
+						title="Sub Child 1"
+						onClick={ () => setActiveItem( 'sub-child-1' ) }
+					/>
+					<NavigationItem
+						item="sub-child-2"
+						title="Sub Child 2"
+						onClick={ () => setActiveItem( 'sub-child-2' ) }
+					/>
 				</NavigationMenu>
 			</Navigation>
 

--- a/packages/components/src/navigation/stories/index.js
+++ b/packages/components/src/navigation/stories/index.js
@@ -26,14 +26,17 @@ const Container = styled.div`
 	max-width: 246px;
 `;
 
-const CustomComponent = ( { onClick } ) => (
-	<Button onClick={ onClick }>
-		<img
-			alt="WordPress Logo"
-			src="https://s.w.org/style/images/about/WordPress-logotype-wmark-white.png"
-			style={ { width: 50, height: 50 } }
-		/>
-	</Button>
+// Mock navigation link
+const Link = ( { href, children, onClick } ) => (
+	<a
+		href={ href }
+		onClick={ ( event ) => {
+			event.preventDefault();
+			onClick();
+		} }
+	>
+		{ children }
+	</a>
 );
 
 function Example() {
@@ -67,9 +70,18 @@ function Example() {
 							title="External link"
 						/>
 						<NavigationItem item="item-5">
-							<CustomComponent
+							<Link
+								href="https://wordpress.org/"
+								item="item-5"
+								// Since we're not actually navigating pages, simulate it with on onClick
 								onClick={ () => setActiveItem( 'item-5' ) }
-							/>
+							>
+								<img
+									alt="WordPress Logo"
+									src="https://s.w.org/style/images/about/WordPress-logotype-wmark-white.png"
+									style={ { width: 50, height: 50 } }
+								/>
+							</Link>
 						</NavigationItem>
 					</NavigationGroup>
 				</NavigationMenu>

--- a/packages/components/src/navigation/styles/navigation-styles.js
+++ b/packages/components/src/navigation/styles/navigation-styles.js
@@ -63,6 +63,10 @@ export const ItemUI = styled.li`
 
 	button,
 	a {
+		margin: 0;
+		font-weight: 400;
+		font-size: 14px;
+		line-height: 20px;
 		padding-left: 16px;
 		padding-right: 16px;
 		width: 100%;

--- a/packages/components/src/navigation/test/index.js
+++ b/packages/components/src/navigation/test/index.js
@@ -74,9 +74,7 @@ describe( 'Navigation', () => {
 	it( 'should render a custom component when menu item supplies one', async () => {
 		render( testNavigation() );
 
-		const customItem = screen.getByRole( 'button', {
-			name: 'customize me',
-		} );
+		const customItem = screen.getByText( 'customize me' );
 
 		expect( customItem ).toBeDefined();
 	} );


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/25244

# Description

Instead of rendering `NavigationItem` content inside a button, make it completely up to the consumer to handle contents if children are supplied. Normal navigation items and navigation links can be designated via props and will be rendered with a button. Otherwise, if a child element is supplied, render that and leave controlling it to the consumer.

This is a first stab at a solution. I think the level of control given to the consumer is up to debate. How much should the component handle? How much to be offloaded to the consumer?

From the WooCommerce perspective, custom item content will be used to pass in internal links for navigation without a page refresh: ie, a `Link` component tied to the page's React Router instance. There won't be a need for passing an `onClick` method to specify `activeItem` nor will that logic be required internally via `setActiveItem`. Instead a click will cause React Router to change locations and the top level `Navigation` will be passed the `activeItem` prop via the new url.

```js
import { Link } from '@woocommerce/components';
import { getNewPath } from '@woocommerce/navigation';

...

<NavigationItem>
	<Link
		href={ getNewPath( '/analytics/products', {
			filter: 'single_product',
			products: product.id,
		} ) }
		type="wc-admin"
	>
		{ product.name }
	</Link>
</NavigationItem>
```

## How has this been tested?

1. `npm run storybook:dev`
2. Ensure clicking on the WP logo correctly sets the active item.

## Screenshots <!-- if applicable -->

![Screen Shot 2020-09-14 at 2 44 34 PM](https://user-images.githubusercontent.com/1922453/93038360-e1ae9b80-f698-11ea-8087-dab5946219df.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Changes the API of Navigation component such that `NavigationItem` rendering children handle all responsibility of navigation.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
