### PR TITLE
Remove duplicate help item.

### DIFF
--- a/packages/edit-site/src/plugins/index.js
+++ b/packages/edit-site/src/plugins/index.js
@@ -9,7 +9,6 @@ import downloadjs from 'downloadjs';
 import { MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
-import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
 import { download } from '@wordpress/icons';
 
@@ -45,14 +44,6 @@ registerPlugin( 'edit-site', {
 						) }
 					>
 						{ __( 'Export' ) }
-					</MenuItem>
-					<MenuItem
-						role="menuitem"
-						href={ addQueryArgs( 'edit.php', {
-							post_type: 'wp_block',
-						} ) }
-					>
-						{ __( 'Manage all reusable blocks' ) }
 					</MenuItem>
 				</ToolsMoreMenuGroup>
 			</>

--- a/packages/edit-site/src/plugins/index.js
+++ b/packages/edit-site/src/plugins/index.js
@@ -6,12 +6,12 @@ import downloadjs from 'downloadjs';
 /**
  * WordPress dependencies
  */
-import { MenuItem, VisuallyHidden } from '@wordpress/components';
+import { MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
 import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
-import { download, external } from '@wordpress/icons';
+import { download } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -53,23 +53,6 @@ registerPlugin( 'edit-site', {
 						} ) }
 					>
 						{ __( 'Manage all reusable blocks' ) }
-					</MenuItem>
-					<MenuItem
-						role="menuitem"
-						icon={ external }
-						href={ __(
-							'https://wordpress.org/support/article/wordpress-editor/'
-						) }
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						{ __( 'Help' ) }
-						<VisuallyHidden as="span">
-							{
-								/* translators: accessibility text */
-								__( '(opens in a new tab)' )
-							}
-						</VisuallyHidden>
 					</MenuItem>
 				</ToolsMoreMenuGroup>
 			</>


### PR DESCRIPTION
The experimental site editor has two help menu items:

<img width="399" alt="Screenshot 2020-09-14 at 08 14 18" src="https://user-images.githubusercontent.com/1204802/93049971-5e725300-f662-11ea-841f-2151245c896c.png">

This PR removes one of them:

<img width="403" alt="after" src="https://user-images.githubusercontent.com/1204802/93049985-6205da00-f662-11ea-8b23-d87eff9f2c76.png">
