### PR TITLE
Docs: Add keyboard shortcuts component readme

### DIFF
--- a/packages/block-editor/src/components/keyboard-shortcuts/README.md
+++ b/packages/block-editor/src/components/keyboard-shortcuts/README.md
@@ -1,0 +1,35 @@
+# Keyboard Shortcuts
+
+The `KeyboardShortcuts` component handles the operation and behavior of keyboard shortcuts in the block editor.
+
+![Keyboard shortcuts examples](https://make.wordpress.org/core/files/2020/09/keyboard-shortcuts-examples.png)
+
+## Table of contents
+
+1. [Development guidelines](#development-guidelines)
+2. [Related components](#related-components)
+
+## Development guidelines
+
+### Usage
+
+Displays a block toolbar for a selected block.
+
+```jsx
+import { KeyboardShortcuts } from '@wordpress/block-editor';
+const MyKeyboardShortcuts = () => (
+	<KeyboardShortcuts
+		key={ currentPage }
+		shortcuts={ {
+			left: goLeft,
+			right: goRight,
+		} }
+	/>
+);
+```
+
+_Note:_ In this example, `goLeft` and `goRight` set the shortcuts keys.
+
+## Related components
+
+Block Editor components are components that can be used to compose the UI of your block editor. Thus, they can only be used under a [`BlockEditorProvider`](https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/provider/README.md) in the components tree.

--- a/packages/block-editor/src/components/keyboard-shortcuts/README.md
+++ b/packages/block-editor/src/components/keyboard-shortcuts/README.md
@@ -28,7 +28,7 @@ const MyKeyboardShortcuts = () => (
 );
 ```
 
-_Note:_ In this example, `goLeft` and `goRight` set the shortcuts keys.
+_Note:_ In this example, `goLeft` and `goRight` are used to set the shortcuts keys.
 
 ## Related components
 


### PR DESCRIPTION
## Description
Added documentation for the keyboard shortcuts component (see #22891)

## How has this been tested?
N/A, documentation only

## Types of changes
Documentation

## Checklist:
- [n/a] My code is tested.
- [n/a] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [n/a] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
