### PR TITLE
Update grid icon.

### DIFF
--- a/packages/editor/src/components/entities-saved-states/entity-type-list.js
+++ b/packages/editor/src/components/entities-saved-states/entity-type-list.js
@@ -8,7 +8,7 @@ import { some } from 'lodash';
  */
 import { useSelect } from '@wordpress/data';
 import { PanelBody } from '@wordpress/components';
-import { page, layout, grid, blockDefault } from '@wordpress/icons';
+import { page, layout } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -18,8 +18,6 @@ import EntityRecordItem from './entity-record-item';
 const ENTITY_NAME_ICONS = {
 	site: layout,
 	page,
-	post: grid,
-	wp_template: grid,
 };
 
 export default function EntityTypeList( {
@@ -37,7 +35,7 @@ export default function EntityTypeList( {
 
 	// Set icon based on type of entity.
 	const { name } = firstRecord;
-	const icon = ENTITY_NAME_ICONS[ name ] || blockDefault;
+	const icon = ENTITY_NAME_ICONS[ name ];
 
 	return (
 		<PanelBody title={ entity.label } initialOpen={ true } icon={ icon }>

--- a/packages/icons/src/library/grid.js
+++ b/packages/icons/src/library/grid.js
@@ -4,8 +4,12 @@
 import { SVG, Path } from '@wordpress/primitives';
 
 const grid = (
-	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="-2 -2 24 24">
-		<Path d="M9 9V3H3v6h6zm8 0V3h-6v6h6zm-8 8v-6H3v6h6zm8 0v-6h-6v6h6z" />
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path
+			d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7.8 16.5H5c-.3 0-.5-.2-.5-.5v-6.2h6.8v6.7zm0-8.3H4.5V5c0-.3.2-.5.5-.5h6.2v6.7zm8.3 7.8c0 .3-.2.5-.5.5h-6.2v-6.8h6.8V19zm0-7.8h-6.8V4.5H19c.3 0 .5.2.5.5v6.2z"
+			fillRule="evenodd"
+			clipRule="evenodd"
+		/>
 	</SVG>
 );
 


### PR DESCRIPTION
The site editor save dialog uses a grid icon that's a dashicon:

<img width="333" alt="Screenshot 2020-09-14 at 08 16 23" src="https://user-images.githubusercontent.com/1204802/93051836-6089e100-f665-11ea-9d4b-4c13a0866682.png">

This PR updates it:

<img width="281" alt="Screenshot 2020-09-14 at 08 35 20" src="https://user-images.githubusercontent.com/1204802/93051846-65e72b80-f665-11ea-9758-a1080c53d834.png">

However, addon question: should we be using the "layout" icon instead?

<img width="40" alt="Screenshot 2020-09-14 at 08 17 57" src="https://user-images.githubusercontent.com/1204802/93051858-6e3f6680-f665-11ea-9fea-5075c3391802.png">

Or better yet: why don't we remove the icon entirely? I'm not sure it adds anything at all:

<img width="346" alt="Screenshot 2020-09-14 at 08 37 00" src="https://user-images.githubusercontent.com/1204802/93051908-80b9a000-f665-11ea-87f4-8ea072eed2da.png">