### PR TITLE
Fix enqueue presets for Global Styles

### DIFF
--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -537,7 +537,7 @@ function gutenberg_experimental_global_styles_merge_trees( $core, $theme, $user 
 	$result = gutenberg_experimental_global_styles_normalize_schema( array() );
 
 	foreach ( array_keys( $core ) as $block_name ) {
-		foreach ( array_keys( $core[ $block_name ][ 'presets' ] ) as $subtree ) {
+		foreach ( array_keys( $core[ $block_name ]['presets'] ) as $subtree ) {
 			$result[ $block_name ]['presets'][ $subtree ] = array_merge(
 				$core[ $block_name ]['presets'][ $subtree ],
 				$theme[ $block_name ]['presets'][ $subtree ],

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -537,11 +537,13 @@ function gutenberg_experimental_global_styles_merge_trees( $core, $theme, $user 
 	$result = gutenberg_experimental_global_styles_normalize_schema( array() );
 
 	foreach ( array_keys( $core ) as $block_name ) {
-		$result[ $block_name ]['presets'] = array_merge(
-			$core[ $block_name ]['presets'],
-			$theme[ $block_name ]['presets'],
-			$user[ $block_name ]['presets']
-		);
+		foreach ( array_keys( $core[ $block_name ][ 'presets' ] ) as $subtree ) {
+			$result[ $block_name ]['presets'][ $subtree ] = array_merge(
+				$core[ $block_name ]['presets'][ $subtree ],
+				$theme[ $block_name ]['presets'][ $subtree ],
+				$user[ $block_name ]['presets'][ $subtree ]
+			);
+		}
 		foreach ( array_keys( $core[ $block_name ]['features'] ) as $subtree ) {
 			$result[ $block_name ]['features'][ $subtree ] = array_merge(
 				$core[ $block_name ]['features'][ $subtree ],


### PR DESCRIPTION
In https://github.com/WordPress/gutenberg/pull/25215 we introduced a list of presets subtrees but forgot to iterate over them. As a result, the presets wouldn't be enqueued. This PR fixes it.

## How to test

- Load Gutenberg with the FSE experiment active.
- Install & activate the GS demo theme at https://github.com/nosolosw/global-styles-theme/
- Go to the front-end and make sure the `global-styles-inline-css` inline stylesheet has the presets as CSS variables (something like this):

```css
:root {
	--wp--style--color--link: hotpink;
	--wp--preset--color--black: #000000;
	--wp--preset--color--cyan-bluish-gray: #abb8c3;
	--wp--preset--color--light-green-cyan: #7bdcb5;
	--wp--preset--color--luminous-vivid-amber: #fcb900;
	--wp--preset--color--luminous-vivid-orange: #ff6900;
	--wp--preset--color--pale-cyan-blue: #8ed1fc;
	--wp--preset--color--pale-pink: #f78da7;
	--wp--preset--color--vivid-cyan-blue: #0693e3;
	--wp--preset--color--vivid-green-cyan: #00d084;
	--wp--preset--color--vivid-purple: #9b51e0;
	--wp--preset--color--vivid-red: #cf2e2e;
	--wp--preset--color--white: #ffffff;
	--wp--preset--color--primary: rgb(131, 12, 8);
	--wp--preset--color--secondary: rgb(60, 12, 15);
	--wp--preset--color--tertiary: rgb(209, 207, 203);
	--wp--preset--color--quaternary: rgb(30, 30, 30);
	--wp--preset--font-size--small: 13;
	--wp--preset--font-size--normal: 16;
	--wp--preset--font-size--medium: 20;
	--wp--preset--font-size--large: 36;
	--wp--preset--font-size--huge: 60;
	--wp--preset--font-size--big: 32;
	--wp--preset--gradient--blush-bordeaux: linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%);
	--wp--preset--gradient--blush-light-purple: linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);
	--wp--preset--gradient--cool-to-warm-spectrum: linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);
	--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%);
	--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan: linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);
	--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);
	--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange: linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);
	--wp--preset--gradient--luminous-vivid-orange-to-vivid-red: linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);
	--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%);
	--wp--preset--gradient--pale-ocean: linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%);
	--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray: linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);
	--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%);
}
```
