### PR TITLE
`site-logo` block doesn't check its `block.json` file

### DIFF
--- a/packages/block-library/src/site-logo/index.php
+++ b/packages/block-library/src/site-logo/index.php
@@ -44,8 +44,8 @@ function render_block_core_site_logo( $attributes ) {
  */
 function register_block_core_site_logo() {
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' ) ) {
-		register_block_type(
-			'core/site-logo',
+		register_block_type_from_metadata(
+			__DIR__ . '/site-logo',
 			array(
 				'render_callback' => 'render_block_core_site_logo',
 			)


### PR DESCRIPTION
## Description

**Use `register_block_type_from_metadata` function to register `site-logo` block**

The `site-logo` block is the only remaining one using `register_block_type()` instead of `register_block_type_from_metadata()`.
As a result it doesn't use its `block.json` file and changes to that file have no effect.

This PR changes the function used to register the site-logo block and makes it consistent with all other blocks.

## How has this been tested?
Tested the site-block in the editor and the frontend. Everything works as it should (tested with an FSE theme too).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] ~~My code follows the accessibility standards.~~ <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] ~~My code has proper inline documentation.~~ <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] ~~I've included developer documentation if appropriate.~~ <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] ~~I've updated all React Native files affected by any refactorings/renamings in this PR.~~ <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
