### PR TITLE
Gallery: Add a margin declarion

### DIFF
--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -57,6 +57,7 @@
 			font-size: 0.8em;
 			background: linear-gradient(0deg, rgba($color: $black, $alpha: 0.7) 0, rgba($color: $black, $alpha: 0.3) 70%, transparent);
 			box-sizing: border-box;
+			margin: 0;
 
 			img {
 				display: inline;
@@ -137,4 +138,3 @@
 		}
 	}
 }
-


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Some themes declare margins on `figcaption`. We should explicitly declare the margin on the gallery figcaption to zero so that themes can't override it.

## How has this been tested?
Varia based themes include an override to prevent the theme leaking into the block, but we can handle this in the block directly.

## Screenshots <!-- if applicable -->
Without this line:
<img width="135" alt="Screenshot 2020-09-14 at 12 53 34" src="https://user-images.githubusercontent.com/275961/93082763-65608c00-f689-11ea-8735-243eb5ca9239.png">

With this line:
<img width="137" alt="Screenshot 2020-09-14 at 12 53 49" src="https://user-images.githubusercontent.com/275961/93082773-67c2e600-f689-11ea-9e84-9db5bfd53de5.png">

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
