### PR TITLE
Navigation component: Store navigation tree in context

### DIFF
--- a/packages/components/src/navigation/children-utils.js
+++ b/packages/components/src/navigation/children-utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { keyBy, omit } from 'lodash';
+import { cloneDeep } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -78,29 +78,29 @@ export const findNavigationItems = ( children ) => {
 		( { type } ) => type === NavigationItem
 	);
 
-	const itemsWithMenu = items.map( ( { child, parent } ) => ( {
-		...child,
-		props: { ...child.props, menu: parent?.props?.menu ?? ROOT_MENU },
-	} ) );
+	return items.reduce( ( acc, { child, parent } ) => {
+		const key = child.props.item;
 
-	const itemsWithoutChildren = itemsWithMenu.map( ( { props } ) =>
-		omit( props, 'children' )
-	);
-	const itemsByItemProp = keyBy( itemsWithoutChildren, 'item' );
+		acc[ key ] = cloneDeep( child.props );
+		acc[ key ].menu = parent?.props?.menu ?? ROOT_MENU;
+		delete acc[ key ].children;
 
-	return itemsByItemProp;
+		return acc;
+	}, {} );
 };
 
 export const findNavigationMenus = ( children ) => {
 	const menus = findChildrenWithClosestParent(
 		children,
 		( { type } ) => type === NavigationMenu
-	).map( ( { child } ) => child );
-
-	const menusWithoutChildren = menus.map( ( { props } ) =>
-		omit( props, 'children' )
 	);
-	const menusByMenuProp = keyBy( menusWithoutChildren, 'menu' );
 
-	return menusByMenuProp;
+	return menus.reduce( ( acc, { child } ) => {
+		const key = child?.props?.menu ?? ROOT_MENU;
+
+		acc[ key ] = cloneDeep( child.props );
+		delete acc[ key ].children;
+
+		return acc;
+	}, {} );
 };

--- a/packages/components/src/navigation/children-utils.js
+++ b/packages/components/src/navigation/children-utils.js
@@ -1,0 +1,109 @@
+/**
+ * External dependencies
+ */
+import { keyBy, omit } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { ROOT_MENU } from './constants';
+import NavigationItem from './item';
+import NavigationMenu from './menu';
+
+/**
+ *
+ * @typedef {Object} ChildWithClosestParent
+ * @property {WPElement} child element that matched the predicate
+ * @property {WPElement?} parent closest matching parent that matched the parentPredicate
+ */
+
+/**
+ *
+ * @param {WPElement} initialChildren children to iterate through recursively
+ * @param {Function} predicate children matching this function predicate will be returned
+ * @param {Function} parentPredicate closest parent will be determined by this function predicate
+ *
+ * @return {ChildWithClosestParent[]} children with their closest parent
+ */
+export const findChildrenWithClosestParent = (
+	initialChildren,
+	predicate,
+	parentPredicate
+) => {
+	const hasPredicate = typeof predicate === 'function';
+	const hasParentPredicate = typeof parentPredicate === 'function';
+
+	const innerRecursion = ( children, lastParent ) => {
+		let items = [];
+
+		if ( ! Array.isArray( children ) ) {
+			children = [ children ];
+		}
+
+		for ( const child of children ) {
+			if ( ! child ) {
+				continue;
+			}
+
+			const predicateOk = hasPredicate && predicate( child );
+			if ( predicateOk ) {
+				items.push( { child, parent: lastParent } );
+			}
+
+			const hasChildren = child?.props?.children;
+			if ( hasChildren ) {
+				const parentPredicateOk =
+					hasParentPredicate && parentPredicate( child );
+				if ( parentPredicateOk ) {
+					lastParent = child;
+				}
+
+				items = items.concat(
+					findChildrenWithClosestParent(
+						child.props.children,
+						predicate,
+						parentPredicate,
+						lastParent
+					)
+				);
+			}
+		}
+
+		return items;
+	};
+
+	return innerRecursion( initialChildren, null );
+};
+
+export const findNavigationItems = ( children ) => {
+	const items = findChildrenWithClosestParent(
+		children,
+		( { type } ) => type === NavigationItem
+	);
+
+	const itemsWithMenu = items.map( ( { child, parent } ) => ( {
+		...child,
+		props: { ...child.props, menu: parent?.props?.menu ?? ROOT_MENU },
+	} ) );
+
+	const itemsWithoutChildren = itemsWithMenu.map( ( { props } ) =>
+		omit( props, 'children' )
+	);
+	const itemsByItemProp = keyBy( itemsWithoutChildren, 'item' );
+
+	return itemsByItemProp;
+};
+
+export const findNavigationMenus = ( children ) => {
+	const menus = findChildrenWithClosestParent(
+		children,
+		( { type } ) => type === NavigationMenu
+	).map( ( { child } ) => child );
+
+	const menusWithoutChildren = menus.map( ( { props } ) =>
+		omit( props, 'children' )
+	);
+	const menusByMenuProp = keyBy( menusWithoutChildren, 'menu' );
+
+	return menusByMenuProp;
+};

--- a/packages/components/src/navigation/children-utils.js
+++ b/packages/components/src/navigation/children-utils.js
@@ -4,6 +4,11 @@
 import { keyBy, omit } from 'lodash';
 
 /**
+ * WordPress dependencies
+ */
+import { Children } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import { ROOT_MENU } from './constants';
@@ -36,15 +41,7 @@ export const findChildrenWithClosestParent = (
 	const innerRecursion = ( children, lastParent ) => {
 		let items = [];
 
-		if ( ! Array.isArray( children ) ) {
-			children = [ children ];
-		}
-
-		for ( const child of children ) {
-			if ( ! child ) {
-				continue;
-			}
-
+		Children.forEach( children, ( child ) => {
 			const predicateOk = hasPredicate && predicate( child );
 			if ( predicateOk ) {
 				items.push( { child, parent: lastParent } );
@@ -67,7 +64,7 @@ export const findChildrenWithClosestParent = (
 					)
 				);
 			}
-		}
+		} );
 
 		return items;
 	};

--- a/packages/components/src/navigation/context.js
+++ b/packages/components/src/navigation/context.js
@@ -18,5 +18,7 @@ export const NavigationContext = createContext( {
 	activeMenu: ROOT_MENU,
 	setActiveItem: noop,
 	setActiveMenu: noop,
+	items: {},
+	menus: {},
 } );
 export const useNavigationContext = () => useContext( NavigationContext );

--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -77,11 +77,6 @@ export default function Navigation( {
 		menus: navigationMenus,
 	};
 
-	// Make sure menus and items are available before rendering
-	if ( ! navigationMenus || ! navigationItems ) {
-		return null;
-	}
-
 	const classes = classnames( 'components-navigation', className );
 
 	return (

--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -29,8 +29,8 @@ export default function Navigation( {
 	const [ item, setItem ] = useState( activeItem );
 	const [ menu, setMenu ] = useState( activeMenu );
 	const [ slideOrigin, setSlideOrigin ] = useState();
-	const [ navigationItems, setNavigationItems ] = useState( null );
-	const [ navigationMenus, setNavigationMenus ] = useState( null );
+	const [ navigationItems, setNavigationItems ] = useState( {} );
+	const [ navigationMenus, setNavigationMenus ] = useState( {} );
 
 	const setActiveItem = ( itemId ) => {
 		setItem( itemId );

--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -16,6 +16,7 @@ import Animate from '../animate';
 import { ROOT_MENU } from './constants';
 import { NavigationContext } from './context';
 import { NavigationUI } from './styles/navigation-styles';
+import { findNavigationItems, findNavigationMenus } from './children-utils';
 
 export default function Navigation( {
 	activeItem,
@@ -28,6 +29,8 @@ export default function Navigation( {
 	const [ item, setItem ] = useState( activeItem );
 	const [ menu, setMenu ] = useState( activeMenu );
 	const [ slideOrigin, setSlideOrigin ] = useState();
+	const [ navigationItems, setNavigationItems ] = useState( null );
+	const [ navigationMenus, setNavigationMenus ] = useState( null );
 
 	const setActiveItem = ( itemId ) => {
 		setItem( itemId );
@@ -57,12 +60,27 @@ export default function Navigation( {
 		}
 	}, [ activeItem, activeMenu ] );
 
+	useEffect( () => {
+		const items = findNavigationItems( children );
+		const menus = findNavigationMenus( children );
+
+		setNavigationItems( items );
+		setNavigationMenus( menus );
+	}, [] );
+
 	const context = {
 		activeItem: item,
 		activeMenu: menu,
 		setActiveItem,
 		setActiveMenu,
+		items: navigationItems,
+		menus: navigationMenus,
 	};
+
+	// Make sure menus and items are available before rendering
+	if ( ! navigationMenus || ! navigationItems ) {
+		return null;
+	}
 
 	const classes = classnames( 'components-navigation', className );
 


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/25246

## Description
Adds `items` and `menus` to the Navigation context.
Example usage: Change back button label to the parent menu's title

`packages/components/src/navigation/menu.js`
```js
line 31:
const { activeMenu, setActiveMenu, menus } = useNavigationContext();

line 39: 
backButtonLabel =
	parentMenu === 'root' ? backButtonLabel : menus[ parentMenu ]?.title;
```

Both `items` and `menus` are objects.

Keys are based on the `item` prop for `items` and they are based on `menu` prop for `menus`. This makes them easily accessible by their slug.

Values are the props of the `NavigationItem` and `NavigationMenu` items without the `children` prop. Items also include the menu that contains the item as `menu` property.

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
