### PR TITLE
Fix stylesheet generation

### DIFF
--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -261,6 +261,19 @@ function gutenberg_experimental_global_styles_get_theme() {
 	return $theme_config;
 }
 
+function gutenberg_experimental_global_styles_get_css_property( $style_property ) {
+	switch ( $style_property ) {
+		case 'backgroundColor':
+			return 'background-color';
+		case 'fontSize':
+			return 'font-size';
+		case 'lineHeight':
+			return 'line-height';
+		default:
+			return $style_property;
+	}
+}
+
 /**
  * Return how the style property is structured.
  *
@@ -268,12 +281,12 @@ function gutenberg_experimental_global_styles_get_theme() {
  */
 function gutenberg_experimental_global_styles_get_style_property() {
 	return array(
-		'line-height'              => array( 'typography', 'lineHeight' ),
-		'font-size'                => array( 'typography', 'fontSize' ),
-		'background'               => array( 'color', 'gradient' ),
-		'background-color'         => array( 'color', 'background' ),
-		'color'                    => array( 'color', 'text' ),
 		'--wp--style--color--link' => array( 'color', 'link' ),
+		'background'               => array( 'color', 'gradient' ),
+		'backgroundColor'          => array( 'color', 'background' ),
+		'color'                    => array( 'color', 'text' ),
+		'fontSize'                 => array( 'typography', 'fontSize' ),
+		'lineHeight'               => array( 'typography', 'lineHeight' ),
 	);
 }
 
@@ -285,8 +298,8 @@ function gutenberg_experimental_global_styles_get_style_property() {
 function gutenberg_experimental_global_styles_get_support_keys() {
 	return array(
 		'--wp--style--color--link' => array( '__experimentalColor', 'linkColor' ),
-		'backgroundColor'          => array( '__experimentalColor' ),
 		'background'               => array( '__experimentalColor', 'gradients' ),
+		'backgroundColor'          => array( '__experimentalColor' ),
 		'color'                    => array( '__experimentalColor' ),
 		'fontSize'                 => array( '__experimentalFontSize' ),
 		'lineHeight'               => array( '__experimentalLineHeight' ),
@@ -489,6 +502,7 @@ function gutenberg_experimental_global_styles_get_stylesheet( $tree ) {
  * @return string The corresponding CSS rule.
  */
 function gutenberg_experimental_global_styles_resolver_styles( $block_selector, $block_supports, $block_styles ) {
+	$css_property     = '';
 	$css_rule         = '';
 	$css_declarations = '';
 
@@ -497,12 +511,18 @@ function gutenberg_experimental_global_styles_resolver_styles( $block_selector, 
 		//
 		// 1) The style attributes the block has declared support for.
 		// 2) Any CSS custom property attached to the node.
-		if ( in_array( $property, $block_supports, true ) || strstr( $property, '--' ) ) {
+		if (
+			in_array( $property, $block_supports, true ) ||
+			strstr( $property, '--' )
+		) {
+			$css_property = gutenberg_experimental_global_styles_get_css_property( $property );
 
 			// Add whitespace if SCRIPT_DEBUG is defined and set to true.
-			$css_declarations .= ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG )
-				? "\t" . $property . ': ' . $value . ";\n"
-				: $property . ':' . $value . ';';
+			if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
+				$css_declarations .= "\t" . $css_property . ': ' . $value . ";\n";
+			} else {
+				$css_declarations .= $css_property. ':' . $value . ';';
+			}
 		}
 	}
 

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -261,6 +261,12 @@ function gutenberg_experimental_global_styles_get_theme() {
 	return $theme_config;
 }
 
+/**
+ * Convert style property to its CSS name.
+ *
+ * @param string $style_property Style property name.
+ * @return string CSS property name.
+ */
 function gutenberg_experimental_global_styles_get_css_property( $style_property ) {
 	switch ( $style_property ) {
 		case 'backgroundColor':
@@ -521,7 +527,7 @@ function gutenberg_experimental_global_styles_resolver_styles( $block_selector, 
 			if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
 				$css_declarations .= "\t" . $css_property . ': ' . $value . ";\n";
 			} else {
-				$css_declarations .= $css_property. ':' . $value . ';';
+				$css_declarations .= $css_property . ':' . $value . ';';
 			}
 		}
 	}


### PR DESCRIPTION
In https://github.com/WordPress/gutenberg/pull/25185 we centralized and modified the support keys to use camelCase instead of kebab-case. By doing so, we introduced a bug by which the stylesheet generation won't be able to determine which properties to output and will only include `color` and `background`. This PR fixes it.

## How to test

- Activate the FSE experiment and the Global Styles demo theme at https://github.com/nosolosw/global-styles-theme/
- Load both edit-site and the front-end of the site and verify they look like this:

![Screenshot from 2020-09-14 17-06-15](https://user-images.githubusercontent.com/583546/93103213-a3bb7280-f6ac-11ea-8710-7789d1c1aa1b.png)

- Load the front-end of the site and find the `global-styles-inline-css` inline stylesheet. Verify the CSS props `color`, `font-size`, `line-height`, `background-color`, and `--wp--style--color--link` are present. Previously, only `color` and `background` could be present.