### PR TITLE
Remove previous aspect ratio classes on change of embed url

### DIFF
--- a/packages/block-library/src/embed/test/index.js
+++ b/packages/block-library/src/embed/test/index.js
@@ -22,6 +22,7 @@ import {
 	getClassNames,
 	createUpgradedEmbedBlock,
 	getEmbedInfoByProvider,
+	removeAspectRatioClasses,
 } from '../util';
 import { embedInstagramIcon } from '../icons';
 import variations from '../variations';
@@ -89,6 +90,33 @@ describe( 'utils', () => {
 					false
 				)
 			).toEqual( expected );
+		} );
+		it( 'should preserve existing classes and replace aspect ratio related classes with the current embed preview', () => {
+			const html = '<iframe height="3" width="4"></iframe>';
+			const expected =
+				'wp-block-embed wp-embed-aspect-4-3 wp-has-aspect-ratio';
+			expect(
+				getClassNames(
+					html,
+					'wp-block-embed wp-embed-aspect-16-9 wp-has-aspect-ratio',
+					true
+				)
+			).toEqual( expected );
+		} );
+	} );
+	describe( 'removeAspectRatioClasses', () => {
+		it( 'should preserve existing classes, if no aspect ratio classes exist', () => {
+			const existingClassNames = 'wp-block-embed is-type-video';
+			expect( removeAspectRatioClasses( existingClassNames ) ).toEqual(
+				existingClassNames
+			);
+		} );
+		it( 'should remove the aspect ratio classes', () => {
+			const existingClassNames =
+				'wp-block-embed is-type-video wp-embed-aspect-16-9 wp-has-aspect-ratio';
+			expect( removeAspectRatioClasses( existingClassNames ) ).toEqual(
+				'wp-block-embed is-type-video'
+			);
 		} );
 	} );
 	describe( 'createUpgradedEmbedBlock', () => {

--- a/packages/block-library/src/embed/util.js
+++ b/packages/block-library/src/embed/util.js
@@ -149,6 +149,24 @@ export const createUpgradedEmbedBlock = (
 };
 
 /**
+ * Removes all previously set aspect ratio related classes and return the rest
+ * existing class names.
+ *
+ * @param {string} existingClassNames Any existing class names.
+ * @return {string} The class names without any aspect ratio related class.
+ */
+export const removeAspectRatioClasses = ( existingClassNames ) => {
+	const aspectRatioClassNames = ASPECT_RATIOS.reduce(
+		( accumulator, { className } ) => {
+			accumulator[ className ] = false;
+			return accumulator;
+		},
+		{ 'wp-has-aspect-ratio': false }
+	);
+	return classnames( existingClassNames, aspectRatioClassNames );
+};
+
+/**
  * Returns class names with any relevant responsive aspect ratio names.
  *
  * @param {string}  html               The preview HTML that possibly contains an iframe with width and height set.
@@ -162,14 +180,7 @@ export function getClassNames(
 	allowResponsive = true
 ) {
 	if ( ! allowResponsive ) {
-		// Remove all of the aspect ratio related class names.
-		const aspectRatioClassNames = {
-			'wp-has-aspect-ratio': false,
-		};
-		ASPECT_RATIOS.forEach( ( { className } ) => {
-			aspectRatioClassNames[ className ] = false;
-		} );
-		return classnames( existingClassNames, aspectRatioClassNames );
+		return removeAspectRatioClasses( existingClassNames );
 	}
 
 	const previewDocument = document.implementation.createHTMLDocument( '' );
@@ -188,7 +199,7 @@ export function getClassNames(
 			const potentialRatio = ASPECT_RATIOS[ ratioIndex ];
 			if ( aspectRatio >= potentialRatio.ratio ) {
 				return classnames(
-					existingClassNames,
+					removeAspectRatioClasses( existingClassNames ),
 					potentialRatio.className,
 					'wp-has-aspect-ratio'
 				);


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes: https://github.com/WordPress/gutenberg/issues/25294

When we insert a responsive embed block, an aspect ratio related class is added to the block (like `wp-embed-aspect-16-9`). If we edit/replace this url with an embed that has different aspect ratio, it will keep both css classes, that leads to wrong styling.

Instructions to reproduce in the issue: https://github.com/WordPress/gutenberg/issues/25294

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
