### PR TITLE
BoxControl: Add ability to render custom icon to represent sides

### DIFF
--- a/packages/components/src/box-control/README.md
+++ b/packages/components/src/box-control/README.md
@@ -94,6 +94,13 @@ const Example = () => {
 
 ## Props
 
+### iconComponent
+
+A custom icon to render that visualizes the selected `BoxControl` sides.
+
+-   Type: `React.Component`
+-   Required: No
+
 ### inputProps
 
 Props for the internal [InputControl](../input-control) components.

--- a/packages/components/src/box-control/index.js
+++ b/packages/components/src/box-control/index.js
@@ -7,7 +7,7 @@ import { noop } from 'lodash';
  * WordPress dependencies
  */
 import { useInstanceId } from '@wordpress/compose';
-import { useState } from '@wordpress/element';
+import { createElement, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -45,6 +45,7 @@ function useUniqueId( idProp ) {
 }
 export default function BoxControl( {
 	id: idProp,
+	iconComponent = BoxControlIcon,
 	inputProps = defaultInputProps,
 	onChange = noop,
 	onChangeShowVisualizer = noop,
@@ -110,6 +111,8 @@ export default function BoxControl( {
 		values: inputValues,
 	};
 
+	const BoxIcon = createElement( iconComponent, { side } );
+
 	return (
 		<Root id={ id } role="region" aria-labelledby={ headingId }>
 			<Header className="component-box-control__header">
@@ -134,9 +137,7 @@ export default function BoxControl( {
 				</FlexItem>
 			</Header>
 			<HeaderControlWrapper className="component-box-control__header-control-wrapper">
-				<FlexItem>
-					<BoxControlIcon side={ side } />
-				</FlexItem>
+				<FlexItem>{ BoxIcon }</FlexItem>
 				{ isLinked && (
 					<FlexBlock>
 						<AllInputControl { ...inputControlProps } />

--- a/packages/components/src/box-control/stories/index.js
+++ b/packages/components/src/box-control/stories/index.js
@@ -79,3 +79,40 @@ const Box = styled.div`
 const Content = styled.div`
 	padding: 20px;
 `;
+
+function CustomBoxIcon( { side } ) {
+	let icon = '✊';
+	switch ( side ) {
+		case 'top':
+			icon = '☝️';
+			break;
+		case 'bottom':
+			icon = '👇';
+			break;
+		case 'left':
+			icon = '👈';
+			break;
+		case 'right':
+			icon = '👉';
+			break;
+	}
+	return (
+		<div
+			style={ {
+				fontSize: 18,
+				lineHeight: 1,
+				width: 24,
+				height: 24,
+				padding: 2,
+			} }
+		>
+			<span role="img" alt="icon">
+				{ icon }
+			</span>
+		</div>
+	);
+}
+
+export const customIcon = () => {
+	return <BoxControl iconComponent={ CustomBoxIcon } />;
+};


### PR DESCRIPTION
![box-control-custom-icon](https://user-images.githubusercontent.com/2322354/93098257-a7cb9e00-f674-11ea-98b8-c8d80b7f0c4a.gif)

(GIF above shows the BoxControl icon being rendered with a custom icon (emojis) that represent the selected side)

This update enhances the BoxControl component to allow for the ability to render a custom icon (a `React.Component`) to represent the selected side. This provides the opportunity for folks to adjust the UI for the icon if they choose to use `BoxControl` for purposes beyond `padding` (the current default implementation).

This idea was originally mentioned here:
https://github.com/WordPress/gutenberg/pull/21492

cc'ing @rmorse 

## How has this been tested?

* Locally on Storybook + Gutenberg

Easiest way to test right now...

* `npm run storybook:dev`
* Visit http://localhost:50240/?path=/story/components-boxcontrol--custom-icon

## Types of changes

* Add `iconComponent` prop to `<BoxControl />` for custom icon rendering
* Updated docs

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [n/a] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [n/a] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
