### PR TITLE
Refactor global styles theme.json shape

### DIFF
--- a/docs/designers-developers/developers/themes/theme-json.md
+++ b/docs/designers-developers/developers/themes/theme-json.md
@@ -36,13 +36,12 @@ The specification for the `experimental-theme.json` follows the three main funct
 
 ```
 {
-  "presets": {
+  "settings": {
     "color": [ ... ],
-    "font-size": [ ... ],
-    "gradient": [ ... ],
+    "typography": [ ... ],
+    "spacing": [ ... ],
   },
   "styles": { ... },
-  "features": {... }
 }
 ```
 
@@ -51,19 +50,16 @@ The file is divided into sections that represent different contexts: individual 
 ```
 {
   "global": {
-    "presets": { ... },
+    "settings": { ... },
     "styles": { ... },
-    "features": { ... }
   },
   "core/paragraph": {
-    "presets": { ... },
+    "settings": { ... },
     "styles": { ... },
-    "features": { ... }
   },
   "core/group": {
-    "presets": { ... },
+    "settings": { ... },
     "styles": { ... },
-    "features": { ... }
   }
 }
 ```
@@ -73,21 +69,21 @@ Some of the functions are context-dependant. Take, as an example, the drop cap:
 ```
 {
   "global": {
-    "features": {
+    "settings": {
       "typography": {
         "dropCap": false
       }
     }
   },
   "core/paragraph": {
-    "features": {
+    "settings": {
       "typography": {
         "dropCap": true
       }
     }
   },
   "core/image": {
-    "features": {
+    "settings": {
       "typography": {
         "dropCap": true
       }
@@ -110,17 +106,19 @@ For this input:
 
 ```
 "global": {
-  "presets": {
-    "color": [
-      {
-        "slug": "strong-magenta",
-        "value": "#a156b4"
-      },
-      {
-        "slug": "very-dark-grey",
-        "value": "#444"
-      }
-    ]
+  "settings": {
+    "color": {
+		  palette: [
+        {
+          "slug": "strong-magenta",
+          "value": "#a156b4"
+        },
+        {
+          "slug": "very-dark-grey",
+          "value": "#444"
+        }
+      ]
+    }
   }
 }
 ```
@@ -217,7 +215,7 @@ So far, this function is enabled only for the `global` section in `lib/experimen
 ```
 {
   "global": {
-    "features": {
+    "settings": {
       "typography": {
         "dropCap": false
       }
@@ -250,28 +248,32 @@ The list of features that are currently supported are:
 ```
 {
   "global": {
-    "presets": {
-      "color": [
-        {
-          "slug": <preset slug>,
-          "value": <preset value>
-        },
-        { <more colors> }
-      ],
-      "font-size": [
-        {
-          "slug": <preset slug>,
-          "value": <preset value>
-        },
-        { <more font sizes> }
-      ],
-      "gradient": [
-        {
-          "slug": <preset slug>,
-          "value": <preset value>
-        },
-        { <more gradients> }
-      ]
+    "settings": {
+      "color": {
+        palette: [
+          {
+            "slug": <preset slug>,
+            "value": <preset value>
+          },
+          { <more colors> }
+        ],
+        gradients: [
+          {
+            "slug": <preset slug>,
+            "value": <preset value>
+          },
+          { <more gradients> }
+        ]
+      },
+      "typography": {
+        fontSize: [
+          {
+            "slug": <preset slug>,
+            "value": <preset value>
+          },
+          { <more font sizes> }
+        ]
+			}
     },
     "styles: {
       "color: {

--- a/lib/experimental-default-theme.json
+++ b/lib/experimental-default-theme.json
@@ -1,148 +1,140 @@
 {
 	"global": {
-		"presets": {
-			"color": [
-				{
-					"slug": "black",
-					"value": "#000000"
-				},
-				{
-					"slug": "cyan-bluish-gray",
-					"value": "#abb8c3"
-				},
-				{
-					"slug": "light-green-cyan",
-					"value": "#7bdcb5"
-				},
-				{
-					"slug": "luminous-vivid-amber",
-					"value": "#fcb900"
-				},
-				{
-					"slug": "luminous-vivid-orange",
-					"value": "#ff6900"
-				},
-				{
-					"slug": "pale-cyan-blue",
-					"value": "#8ed1fc"
-				},
-				{
-					"slug": "pale-pink",
-					"value": "#f78da7"
-				},
-				{
-					"slug": "vivid-cyan-blue",
-					"value": "#0693e3"
-				},
-				{
-					"slug": "vivid-green-cyan",
-					"value": "#00d084"
-				},
-				{
-					"slug": "vivid-purple",
-					"value": "#9b51e0"
-				},
-				{
-					"slug": "vivid-red",
-					"value": "#cf2e2e"
-				},
-				{
-					"slug": "white",
-					"value": "#ffffff"
-				}
-			],
-			"font-size": [
-				{
-					"slug": "small",
-					"value": 13
-				},
-				{
-					"slug": "normal",
-					"value": 16
-				},
-				{
-					"slug": "medium",
-					"value": 20
-				},
-				{
-					"slug": "large",
-					"value": 36
-				},
-				{
-					"slug": "huge",
-					"value": 48
-				}
-			],
-			"gradient": [
-				{
-					"slug": "blush-bordeaux",
-					"value": "linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%)"
-				},
-				{
-					"slug": "blush-light-purple",
-					"value": "linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%)"
-				},
-				{
-					"slug": "cool-to-warm-spectrum",
-					"value": "linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%)"
-				},
-				{
-					"slug": "electric-grass",
-					"value": "linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%)"
-				},
-				{
-					"slug": "light-green-cyan-to-vivid-green-cyan",
-					"value": "linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%)"
-				},
-				{
-					"slug": "luminous-dusk",
-					"value": "linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%)"
-				},
-				{
-					"slug": "luminous-vivid-amber-to-luminous-vivid-orange",
-					"value": "linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%)"
-				},
-				{
-					"slug": "luminous-vivid-orange-to-vivid-red",
-					"value": "linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%)"
-				},
-				{
-					"slug": "midnight",
-					"value": "linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%)"
-				},
-				{
-					"slug": "pale-ocean",
-					"value": "linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%)"
-				},
-				{
-					"slug": "very-light-gray-to-cyan-bluish-gray",
-					"value": "linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%)"
-				},
-				{
-					"slug": "vivid-cyan-blue-to-vivid-purple",
-					"value": "linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)"
-				}
-			]
-		},
-		"features": {
-			"typography": {
-				"dropCap": true
-			},
+		"settings": {
 			"color": {
+				"palette": [
+					{
+						"slug": "black",
+						"value": "#000000"
+					},
+					{
+						"slug": "cyan-bluish-gray",
+						"value": "#abb8c3"
+					},
+					{
+						"slug": "light-green-cyan",
+						"value": "#7bdcb5"
+					},
+					{
+						"slug": "luminous-vivid-amber",
+						"value": "#fcb900"
+					},
+					{
+						"slug": "luminous-vivid-orange",
+						"value": "#ff6900"
+					},
+					{
+						"slug": "pale-cyan-blue",
+						"value": "#8ed1fc"
+					},
+					{
+						"slug": "pale-pink",
+						"value": "#f78da7"
+					},
+					{
+						"slug": "vivid-cyan-blue",
+						"value": "#0693e3"
+					},
+					{
+						"slug": "vivid-green-cyan",
+						"value": "#00d084"
+					},
+					{
+						"slug": "vivid-purple",
+						"value": "#9b51e0"
+					},
+					{
+						"slug": "vivid-red",
+						"value": "#cf2e2e"
+					},
+					{
+						"slug": "white",
+						"value": "#ffffff"
+					}
+				],
+				"gradients": [
+					{
+						"slug": "blush-bordeaux",
+						"value": "linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%)"
+					},
+					{
+						"slug": "blush-light-purple",
+						"value": "linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%)"
+					},
+					{
+						"slug": "cool-to-warm-spectrum",
+						"value": "linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%)"
+					},
+					{
+						"slug": "electric-grass",
+						"value": "linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%)"
+					},
+					{
+						"slug": "light-green-cyan-to-vivid-green-cyan",
+						"value": "linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%)"
+					},
+					{
+						"slug": "luminous-dusk",
+						"value": "linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%)"
+					},
+					{
+						"slug": "luminous-vivid-amber-to-luminous-vivid-orange",
+						"value": "linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%)"
+					},
+					{
+						"slug": "luminous-vivid-orange-to-vivid-red",
+						"value": "linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%)"
+					},
+					{
+						"slug": "midnight",
+						"value": "linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%)"
+					},
+					{
+						"slug": "pale-ocean",
+						"value": "linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%)"
+					},
+					{
+						"slug": "very-light-gray-to-cyan-bluish-gray",
+						"value": "linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%)"
+					},
+					{
+						"slug": "vivid-cyan-blue-to-vivid-purple",
+						"value": "linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)"
+					}
+				],
 				"custom": true,
-				"link": false
+				"link": false,
+				"customGradient": true
 			},
-			"gradient": {
-				"custom": true
-			},
-			"fontSize": {
-				"custom": true
-			},
-			"lineHeight": {
-				"custom": false
+			"typography": {
+				"dropCap": true,
+				"customFontSize": true,
+				"customLineHeight": false,
+				"fontSizes": [
+					{
+						"slug": "small",
+						"value": 13
+					},
+					{
+						"slug": "normal",
+						"value": 16
+					},
+					{
+						"slug": "medium",
+						"value": 20
+					},
+					{
+						"slug": "large",
+						"value": 36
+					},
+					{
+						"slug": "huge",
+						"value": 48
+					}
+				]
 			},
 			"spacing": {
-				"custom": false,
+				"customPadding": false,
 				"units": [ "px", "em", "rem", "vh", "vw" ]
 			}
 		}

--- a/packages/block-editor/src/components/colors-gradients/control.js
+++ b/packages/block-editor/src/components/colors-gradients/control.js
@@ -182,7 +182,7 @@ function ColorGradientControlSelect( props ) {
 		'color.custom'
 	);
 	colorGradientSettings.disableCustomGradients = ! useEditorFeature(
-		'gradient.custom'
+		'color.customGradient'
 	);
 
 	return (

--- a/packages/block-editor/src/components/colors-gradients/panel-color-gradient-settings.js
+++ b/packages/block-editor/src/components/colors-gradients/panel-color-gradient-settings.js
@@ -156,7 +156,7 @@ const PanelColorGradientSettingsSelect = ( props ) => {
 		'color.custom'
 	);
 	colorGradientSettings.disableCustomGradients = ! useEditorFeature(
-		'gradient.custom'
+		'color.customGradient'
 	);
 	return (
 		<PanelColorGradientSettingsInner

--- a/packages/block-editor/src/components/font-sizes/font-size-picker.js
+++ b/packages/block-editor/src/components/font-sizes/font-size-picker.js
@@ -14,7 +14,9 @@ function FontSizePicker( props ) {
 		( select ) => select( 'core/block-editor' ).getSettings().fontSizes,
 		[]
 	);
-	const disableCustomFontSizes = ! useEditorFeature( 'fontSize.custom' );
+	const disableCustomFontSizes = ! useEditorFeature(
+		'typography.customFontSize'
+	);
 
 	return (
 		<BaseFontSizePicker

--- a/packages/block-editor/src/components/gradient-picker/control.js
+++ b/packages/block-editor/src/components/gradient-picker/control.js
@@ -29,7 +29,7 @@ export default function GradientPickerControl( {
 			( select ) => select( 'core/block-editor' ).getSettings().gradients,
 			[]
 		) ?? [];
-	const disableCustomGradients = ! useEditorFeature( 'gradient.custom' );
+	const disableCustomGradients = ! useEditorFeature( 'color.customGradient' );
 	if ( isEmpty( gradients ) && disableCustomGradients ) {
 		return null;
 	}

--- a/packages/block-editor/src/components/gradient-picker/index.js
+++ b/packages/block-editor/src/components/gradient-picker/index.js
@@ -15,7 +15,7 @@ function GradientPickerWithGradients( props ) {
 			( select ) => select( 'core/block-editor' ).getSettings().gradients,
 			[]
 		) ?? [];
-	const disableCustomGradients = ! useEditorFeature( 'gradient.custom' );
+	const disableCustomGradients = ! useEditorFeature( 'color.customGradient' );
 
 	return (
 		<GradientPicker

--- a/packages/block-editor/src/components/spacing-panel-control/index.js
+++ b/packages/block-editor/src/components/spacing-panel-control/index.js
@@ -11,7 +11,7 @@ import InspectorControls from '../inspector-controls';
 import useEditorFeature from '../use-editor-feature';
 
 export default function SpacingPanelControl( { children, ...props } ) {
-	const isSpacingEnabled = useEditorFeature( 'spacing.custom' );
+	const isSpacingEnabled = useEditorFeature( 'spacing.customPadding' );
 
 	if ( ! isSpacingEnabled ) return null;
 

--- a/packages/block-editor/src/components/use-editor-feature/index.js
+++ b/packages/block-editor/src/components/use-editor-feature/index.js
@@ -18,15 +18,16 @@ const deprecatedFlags = {
 		settings.disableCustomColors === undefined
 			? undefined
 			: ! settings.disableCustomColors,
-	'gradient.custom': ( settings ) =>
+	'color.customGradient': ( settings ) =>
 		settings.disableCustomGradients === undefined
 			? undefined
 			: ! settings.disableCustomGradients,
-	'fontSize.custom': ( settings ) =>
+	'typography.customFontSize': ( settings ) =>
 		settings.disableCustomFontSizes === undefined
 			? undefined
 			: ! settings.disableCustomFontSizes,
-	'lineHeight.custom': ( settings ) => settings.enableCustomLineHeight,
+	'typography.customLineHeight': ( settings ) =>
+		settings.enableCustomLineHeight,
 	'spacing.units': ( settings ) => {
 		if ( settings.enableCustomUnits === undefined ) {
 			return;

--- a/packages/block-editor/src/hooks/line-height.js
+++ b/packages/block-editor/src/hooks/line-height.js
@@ -56,7 +56,7 @@ export function LineHeightEdit( props ) {
  * @return {boolean} Whether setting is disabled.
  */
 export function useIsLineHeightDisabled( { name: blockName } = {} ) {
-	const isDisabled = ! useEditorFeature( 'lineHeight.custom' );
+	const isDisabled = ! useEditorFeature( 'typography.customLineHeight' );
 
 	return (
 		! hasBlockSupport( blockName, LINE_HEIGHT_SUPPORT_KEY ) || isDisabled

--- a/packages/edit-site/src/components/editor/global-styles-renderer.js
+++ b/packages/edit-site/src/components/editor/global-styles-renderer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, kebabCase } from 'lodash';
+import { get, kebabCase, reduce } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -83,17 +83,21 @@ export default ( blockData, baseTree, userTree ) => {
 	 * @return {Array} An array of style declarations.
 	 */
 	const getBlockPresetsDeclarations = ( blockPresets ) => {
-		const declarations = [];
-		PRESET_CATEGORIES.forEach( ( category ) => {
-			if ( blockPresets?.[ category ] ) {
-				blockPresets[ category ].forEach( ( { slug, value } ) =>
+		return reduce(
+			PRESET_CATEGORIES,
+			( declarations, path, category ) => {
+				const preset = get( blockPresets, path, [] );
+				preset.forEach( ( { slug, value } ) => {
 					declarations.push(
-						`--wp--preset--${ category }--${ slug }: ${ value }`
-					)
-				);
-			}
-		} );
-		return declarations;
+						`--wp--preset--${ kebabCase(
+							category
+						) }--${ slug }: ${ value }`
+					);
+				} );
+				return declarations;
+			},
+			[]
+		);
 	};
 
 	const getBlockSelector = ( selector ) => {
@@ -113,7 +117,7 @@ export default ( blockData, baseTree, userTree ) => {
 				blockData[ context ].supports,
 				tree[ context ].styles
 			),
-			...getBlockPresetsDeclarations( tree[ context ].presets ),
+			...getBlockPresetsDeclarations( tree[ context ].settings ),
 		];
 		if ( blockDeclarations.length > 0 ) {
 			styles.push(

--- a/packages/edit-site/src/components/editor/utils.js
+++ b/packages/edit-site/src/components/editor/utils.js
@@ -1,6 +1,10 @@
 /* Supporting data */
 export const GLOBAL_CONTEXT = 'global';
-export const PRESET_CATEGORIES = [ 'color', 'font-size', 'gradient' ];
+export const PRESET_CATEGORIES = {
+	color: [ 'color', 'palette' ],
+	gradient: [ 'color', 'gradients' ],
+	fontSize: [ 'typography', 'fontSizes' ],
+};
 export const LINK_COLOR = '--wp--style--color--link';
 export const LINK_COLOR_DECLARATION = `a { color: var(${ LINK_COLOR }, #00e); }`;
 


### PR DESCRIPTION
This PR's follows a suggestion by @mtias and refactors the global styles theme.json shape. It basically ends the preset section and mixes the previous presets and features distinction into a single object.


Previous shape:
![image (5)](https://user-images.githubusercontent.com/11271197/93104915-5936f780-f6a6-11ea-89a5-560ffd234cd0.png)

New shape:
![image (4)](https://user-images.githubusercontent.com/11271197/93104946-60f69c00-f6a6-11ea-99fc-8f493c52eeac.png)

## How has this been tested?
I verified I could use the 3 types of colors (background, text, and link).
I could use a custom gradient, colors, and font sizes.
I verified I could disable dropCap using a theme theme.json configuration.

