### PR TITLE
Don't discard all promises results when one of them rejects

### DIFF
--- a/packages/edit-navigation/src/index.js
+++ b/packages/edit-navigation/src/index.js
@@ -66,7 +66,7 @@ const fetchLinkSuggestions = (
 					type: 'post',
 					subtype,
 				} ),
-			} )
+			} ).catch( () => [] ) // fail by returning no results
 		);
 	}
 
@@ -79,7 +79,7 @@ const fetchLinkSuggestions = (
 					type: 'term',
 					subtype,
 				} ),
-			} )
+			} ).catch( () => [] )
 		);
 	}
 
@@ -92,24 +92,18 @@ const fetchLinkSuggestions = (
 					type: 'post-format',
 					subtype,
 				} ),
-			} )
+			} ).catch( () => [] )
 		);
 	}
 
-	// use allSettled to preserve any successful promise(s) results when one of the promises fail
-	return Promise.allSettled( queries )
-		.then( ( results ) =>
-			results.filter( ( result ) => result.status === 'fulfilled' )
-		)
-		.then( ( results ) => results.map( ( result ) => result.value ) )
-		.then( ( results ) =>
-			map( flatten( results ).slice( 0, perPage ), ( result ) => ( {
-				id: result.id,
-				url: result.url,
-				title: decodeEntities( result.title ) || __( '(no title)' ),
-				type: result.subtype || result.type,
-			} ) )
-		);
+	return Promise.all( queries ).then( ( results ) => {
+		return map( flatten( results ).slice( 0, perPage ), ( result ) => ( {
+			id: result.id,
+			url: result.url,
+			title: decodeEntities( result.title ) || __( '(no title)' ),
+			type: result.subtype || result.type,
+		} ) );
+	} );
 };
 
 export function initialize( id, settings ) {

--- a/packages/edit-navigation/src/index.js
+++ b/packages/edit-navigation/src/index.js
@@ -96,14 +96,20 @@ const fetchLinkSuggestions = (
 		);
 	}
 
-	return Promise.all( queries ).then( ( results ) => {
-		return map( flatten( results ).slice( 0, perPage ), ( result ) => ( {
-			id: result.id,
-			url: result.url,
-			title: decodeEntities( result.title ) || __( '(no title)' ),
-			type: result.subtype || result.type,
-		} ) );
-	} );
+	// use allSettled to preserve any successful promise(s) results when one of the promises fail
+	return Promise.allSettled( queries )
+		.then( ( results ) =>
+			results.filter( ( result ) => result.status === 'fulfilled' )
+		)
+		.then( ( results ) => results.map( ( result ) => result.value ) )
+		.then( ( results ) =>
+			map( flatten( results ).slice( 0, perPage ), ( result ) => ( {
+				id: result.id,
+				url: result.url,
+				title: decodeEntities( result.title ) || __( '(no title)' ),
+				type: result.subtype || result.type,
+			} ) )
+		);
 };
 
 export function initialize( id, settings ) {

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -64,7 +64,7 @@ const fetchLinkSuggestions = (
 					type: 'post',
 					subtype,
 				} ),
-			} )
+			} ).catch( () => [] ) // fail by returning no results
 		);
 	}
 
@@ -77,7 +77,7 @@ const fetchLinkSuggestions = (
 					type: 'term',
 					subtype,
 				} ),
-			} )
+			} ).catch( () => [] )
 		);
 	}
 
@@ -90,24 +90,18 @@ const fetchLinkSuggestions = (
 					type: 'post-format',
 					subtype,
 				} ),
-			} )
+			} ).catch( () => [] )
 		);
 	}
 
-	// use allSettled to preserve any successful promise(s) results when one of the promises fail
-	return Promise.allSettled( queries )
-		.then( ( results ) =>
-			results.filter( ( result ) => result.status === 'fulfilled' )
-		)
-		.then( ( results ) => results.map( ( result ) => result.value ) )
-		.then( ( results ) =>
-			map( flatten( results ).slice( 0, perPage ), ( result ) => ( {
-				id: result.id,
-				url: result.url,
-				title: decodeEntities( result.title ) || __( '(no title)' ),
-				type: result.subtype || result.type,
-			} ) )
-		);
+	return Promise.all( queries ).then( ( results ) => {
+		return map( flatten( results ).slice( 0, perPage ), ( result ) => ( {
+			id: result.id,
+			url: result.url,
+			title: decodeEntities( result.title ) || __( '(no title)' ),
+			type: result.subtype || result.type,
+		} ) );
+	} );
 };
 
 class EditorProvider extends Component {

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -94,14 +94,20 @@ const fetchLinkSuggestions = (
 		);
 	}
 
-	return Promise.all( queries ).then( ( results ) => {
-		return map( flatten( results ).slice( 0, perPage ), ( result ) => ( {
-			id: result.id,
-			url: result.url,
-			title: decodeEntities( result.title ) || __( '(no title)' ),
-			type: result.subtype || result.type,
-		} ) );
-	} );
+	// use allSettled to preserve any successful promise(s) results when one of the promises fail
+	return Promise.allSettled( queries )
+		.then( ( results ) =>
+			results.filter( ( result ) => result.status === 'fulfilled' )
+		)
+		.then( ( results ) => results.map( ( result ) => result.value ) )
+		.then( ( results ) =>
+			map( flatten( results ).slice( 0, perPage ), ( result ) => ( {
+				id: result.id,
+				url: result.url,
+				title: decodeEntities( result.title ) || __( '(no title)' ),
+				type: result.subtype || result.type,
+			} ) )
+		);
 };
 
 class EditorProvider extends Component {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Hi there!

Some blocks, such as the Link block, have a search feature for URLs. This feature searches against 3 endpoints with different query params. These searches run concurrently using `Promise.all`. Good design but with one flaw, if any of the searches fail, all the results are discarded, due to the nature of [`Promise.all`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all#wikiArticle:~:text=It%20rejects%20immediately%20upon%20any%20of%20the%20input%20promises%20rejecting). 

~~This PR proposes using [`Promise.allSettled`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled) instead. It resolves even if one or two promises fail out of 3. I think it makes more sense since the other two promises can provide valid results just fine.~~

**Edit**: I removed `Promise.allSetted` due to the support question.

This PR proposes catching each failing request and returning an empty array in the `catch` handler, denoting an empty result. This gives the chance for the other successful promises to prevail. 

The issue has surfaced when one of the searches started failing as [shown here](https://github.com/Automattic/wp-calypso/issues/45549).

<!-- Please describe what you have changed or added -->

## How has this been tested?
I tested using a local Gutenberg instance.

## Side note
This fix is an improvement and should be probably merged anyways. But there is also an underlying issue, it's explained in this [comment](https://github.com/Automattic/wp-calypso/issues/45549#issuecomment-694837321).  

## Types of changes
bug-fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
