### PR TITLE
Add separate support keys for color and background color

### DIFF
--- a/lib/block-supports/colors.php
+++ b/lib/block-supports/colors.php
@@ -15,9 +15,9 @@ function gutenberg_register_colors_support( $block_type ) {
 	if ( property_exists( $block_type, 'supports' ) ) {
 		$color_support = gutenberg_experimental_get( $block_type->supports, array( '__experimentalColor' ), false );
 	}
-	$has_text_colors_support       = is_array( $color_support ) || $color_support;
-	$has_background_colors_support = $has_text_colors_support;
-	$has_gradients_support         = $has_text_colors_support && gutenberg_experimental_get( $color_support, array( 'gradients' ), false );
+	$has_text_colors_support       = true === $color_support || ( is_array( $color_support ) && gutenberg_experimental_get( $color_support, array( 'text' ), true ) );
+	$has_background_colors_support = true === $color_support || ( is_array( $color_support ) && gutenberg_experimental_get( $color_support, array( 'background' ), true ) );
+	$has_gradients_support         = gutenberg_experimental_get( $color_support, array( 'gradients' ), false );
 
 	if ( ! $block_type->attributes ) {
 		$block_type->attributes = array();
@@ -61,10 +61,10 @@ function gutenberg_register_colors_support( $block_type ) {
  */
 function gutenberg_apply_colors_support( $attributes, $block_attributes, $block_type ) {
 	$color_support                 = gutenberg_experimental_get( $block_type->supports, array( '__experimentalColor' ), false );
-	$has_text_colors_support       = is_array( $color_support ) || $color_support;
-	$has_background_colors_support = $has_text_colors_support;
-	$has_link_colors_support       = $has_text_colors_support && gutenberg_experimental_get( $color_support, array( 'linkColor' ), false );
-	$has_gradients_support         = $has_text_colors_support && gutenberg_experimental_get( $color_support, array( 'gradients' ), false );
+	$has_text_colors_support       = true === $color_support || ( is_array( $color_support ) && gutenberg_experimental_get( $color_support, array( 'text' ), true ) );
+	$has_background_colors_support = true === $color_support || ( is_array( $color_support ) && gutenberg_experimental_get( $color_support, array( 'background' ), true ) );
+	$has_link_colors_support       = gutenberg_experimental_get( $color_support, array( 'linkColor' ), false );
+	$has_gradients_support         = gutenberg_experimental_get( $color_support, array( 'gradients' ), false );
 
 	// Text Colors.
 	// Check support for text colors.


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/24927

This PR allows blocks in block.json to support a text color a background-color, a gradient, and a link color individually.

Previously one could not have a background without text color for example.
By default background and text are assumed to be supported provided an __experimentalColor flag exists. But blocks can disable them using background:false or text:false respectively.


## How has this been tested?
I changed the paragraph block.json to the following combinations and verified the result was always the expected one:
```
		"__experimentalColor": {
			"text": true,
			"background": false,
			"gradients": true,
			"linkColor": true
		},

		"__experimentalColor": {
			"text": true,
			"background": false,
			"linkColor": true
		},
		"__experimentalColor": {
			"text": true,
			"linkColor": true
		},
		"__experimentalColor": {
			"text": false,
			"linkColor": true
		},
		"__experimentalColor": {
			"text": false,
			"background": false,
			"gradients": false,
			"linkColor": true
		},
		"__experimentalColor": {
			"text": false,
			"background": false,
			"gradients": false,
			"linkColor": false
		},
```
