### PR TITLE
Canceling Drag and Drop with ESC immediately hides dropzone bar (#24204)

### DIFF
--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -43,6 +43,7 @@ function BlockList(
 			hasMultiSelection,
 			getGlobalBlockCount,
 			isTyping,
+			isDraggingBlocks,
 		} = select( 'core/block-editor' );
 
 		return {
@@ -54,6 +55,7 @@ function BlockList(
 			enableAnimation:
 				! isTyping() &&
 				getGlobalBlockCount() <= BLOCK_ANIMATION_THRESHOLD,
+			isDraggingBlocks: isDraggingBlocks(),
 		};
 	}
 
@@ -64,6 +66,7 @@ function BlockList(
 		orientation,
 		hasMultiSelection,
 		enableAnimation,
+		isDraggingBlocks,
 	} = useSelect( selector, [ rootClientId ] );
 
 	const Container = rootClientId ? __experimentalTagName : RootContainer;
@@ -72,7 +75,8 @@ function BlockList(
 		rootClientId,
 	} );
 
-	const isAppenderDropTarget = dropTargetIndex === blockClientIds.length;
+	const isAppenderDropTarget =
+		dropTargetIndex === blockClientIds.length && isDraggingBlocks;
 
 	return (
 		<Container
@@ -89,7 +93,8 @@ function BlockList(
 					? multiSelectedBlockClientIds.includes( clientId )
 					: selectedBlockClientId === clientId;
 
-				const isDropTarget = dropTargetIndex === index;
+				const isDropTarget =
+					dropTargetIndex === index && isDraggingBlocks;
 
 				return (
 					<AsyncModeProvider


### PR DESCRIPTION
## Description
fixes #24204

When canceling a drag and drop operation by pressing "ESC", the blue dropzone bar will now immediately disappear.  

Previously, it would only disappear after the next "Mouse Up" event.  If you pressed ESC, kept the mouse button held, moved the mouse outside the browser then released the button, the blue bar would be showing indefinitely.

## How has this been tested?
Tested manually by running `wp-env start` and `npm run dev`.

## Screenshots

Before fix:
![2020-09-14_15-09](https://user-images.githubusercontent.com/937354/93134047-c5f9c400-f69d-11ea-98d4-9de6993579a0.png)

After fix:
![2020-09-14_15-11](https://user-images.githubusercontent.com/937354/93134069-ce51ff00-f69d-11ea-812c-da3851694a99.png)

## Types of changes

* Bug fix:  The `isDraggingBlocks()` selector is now also checked when deciding to render the `is-drop-target` class.  Previously, only the `dropTargetIndex` was being checked.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
