### PR TITLE
FSE: Add basic template information to editor header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15958,6 +15958,7 @@
 				"@wordpress/plugins": "file:packages/plugins",
 				"@wordpress/primitives": "file:packages/primitives",
 				"@wordpress/url": "file:packages/url",
+				"classnames": "^2.2.5",
 				"downloadjs": "^1.4.7",
 				"file-saver": "^2.0.2",
 				"jszip": "^3.2.2",

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -50,6 +50,7 @@
 		"@wordpress/plugins": "file:../plugins",
 		"@wordpress/primitives": "file:../primitives",
 		"@wordpress/url": "file:../url",
+		"classnames": "^2.2.5",
 		"downloadjs": "^1.4.7",
 		"file-saver": "^2.0.2",
 		"jszip": "^3.2.2",

--- a/packages/edit-site/src/components/header/document-actions/index.js
+++ b/packages/edit-site/src/components/header/document-actions/index.js
@@ -7,37 +7,63 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import {
+	__experimentalGetBlockLabel as getBlockLabel,
+	getBlockType,
+} from '@wordpress/blocks';
+import { useSelect } from '@wordpress/data';
 
-export default function DocumentActions( {
-	primaryText,
-	secondaryText,
-	isSecondaryItemActive = true,
-} ) {
-	const hasSecondaryItem = !! secondaryText?.length;
+function useSecondaryText() {
+	const selectedBlock = useSelect( ( select ) => {
+		return select( 'core/block-editor' ).getSelectedBlock();
+	} );
+
+	const selectedBlockLabel =
+		selectedBlock?.name === 'core/template-part'
+			? getBlockLabel(
+					getBlockType( selectedBlock?.name ),
+					selectedBlock?.attributes
+			  )
+			: null;
+
+	if ( selectedBlockLabel ) {
+		return {
+			label: selectedBlockLabel,
+			isActive: true,
+		};
+	}
+	return {};
+}
+
+export default function DocumentActions( { documentTitle } ) {
+	const { label, isActive } = useSecondaryText();
+	// Title is active when there is no secondary item, or when the secondary
+	// item is inactive.
+	const isTitleActive = ! label?.length || ! isActive;
 	return (
 		<div className="edit-site-document-actions">
-			{ primaryText ? (
+			{ documentTitle ? (
 				<>
 					<span
 						className={ classnames(
-							'edit-site-document-actions__primary-item',
+							'edit-site-document-actions__title',
 							{
-								'is-active': ! hasSecondaryItem,
+								'is-active': isTitleActive,
 							}
 						) }
 					>
-						{ primaryText }
+						{ documentTitle }
 					</span>
-					{ secondaryText && (
+					{ label && (
 						<span
 							className={ classnames(
 								'edit-site-document-actions__secondary-item',
 								{
-									'is-active': isSecondaryItemActive,
+									'is-active': isActive,
 								}
 							) }
 						>
-							{ secondaryText }
+							{ label }
 						</span>
 					) }
 				</>

--- a/packages/edit-site/src/components/header/document-actions/index.js
+++ b/packages/edit-site/src/components/header/document-actions/index.js
@@ -6,63 +6,41 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Button, Dropdown } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { DOWN } from '@wordpress/keycodes';
 
 export default function DocumentActions( {
 	primaryText,
 	secondaryText,
-	isSecondaryItemActive = false,
+	isSecondaryItemActive = true,
 } ) {
+	const hasSecondaryItem = !! secondaryText?.length;
 	return (
 		<div className="edit-site-document-actions">
 			{ primaryText ? (
-				<Dropdown
-					position="bottom center"
-					renderToggle={ ( { onToggle, isOpen } ) => {
-						const openOnArrowDown = ( event ) => {
-							if ( ! isOpen && event.keyCode === DOWN ) {
-								event.preventDefault();
-								event.stopPropagation();
-								onToggle();
+				<>
+					<span
+						className={ classnames(
+							'edit-site-document-actions__primary-item',
+							{
+								'is-active': ! hasSecondaryItem,
 							}
-						};
-						return (
-							<Button
-								onClick={ onToggle }
-								className="edit-site-document-actions__document_root"
-								aria-haspopup="true"
-								aria-expanded={ isOpen }
-								onKeyDown={ openOnArrowDown }
-								label={ __( 'Change document settings.' ) }
-								showTooltip
-							>
-								<span> { primaryText } </span>
-								{ secondaryText && (
-									<>
-										<span className="edit-site-document-actions__separator">
-											:{ ' ' }
-										</span>
-										<span
-											className={ classnames(
-												'edit-site-document-actions__document_item',
-												{
-													'is-active':
-														isSecondaryItemActive ||
-														isOpen,
-												}
-											) }
-										>
-											{ secondaryText }
-										</span>
-									</>
-								) }
-							</Button>
-						);
-					} }
-					renderContent={ () => <div>TODO: Document Settings</div> }
-				/>
+						) }
+					>
+						{ primaryText }
+					</span>
+					{ secondaryText && (
+						<span
+							className={ classnames(
+								'edit-site-document-actions__secondary-item',
+								{
+									'is-active': isSecondaryItemActive,
+								}
+							) }
+						>
+							{ secondaryText }
+						</span>
+					) }
+				</>
 			) : (
 				__( 'Loading…' )
 			) }

--- a/packages/edit-site/src/components/header/document-actions/index.js
+++ b/packages/edit-site/src/components/header/document-actions/index.js
@@ -1,3 +1,71 @@
-export default function DocumentActions() {
-	return <div className="edit-site-document-actions">Document Actions</div>;
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { Button, Dropdown } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+
+export default function DocumentActions( {
+	templateId,
+	secondaryItem = 'Header',
+	isSecondaryItemActive = false,
+} ) {
+	// TODO: I dislike having this here...
+	const template = useSelect(
+		( select ) => {
+			const { getEntityRecord } = select( 'core' );
+
+			return getEntityRecord( 'postType', 'wp_template', templateId );
+		},
+		[ templateId ]
+	);
+
+	return (
+		<div className="edit-site-document-actions">
+			{ template ? (
+				<Dropdown
+					position="bottom center"
+					renderToggle={ ( { onToggle, isOpen } ) => {
+						return (
+							<Button
+								onClick={ onToggle }
+								className="edit-site-document-actions__document_root"
+								aria-haspopup="true"
+								aria-expanded={ isOpen }
+							>
+								<span> { template.slug } </span>
+								{ secondaryItem && (
+									<>
+										<span className="edit-site-document-actions__separator">
+											:{ ' ' }
+										</span>
+										<span
+											className={ classnames(
+												'edit-site-document-actions__document_item',
+												{
+													'is-active':
+														isSecondaryItemActive ||
+														isOpen,
+												}
+											) }
+										>
+											{ secondaryItem }
+										</span>
+									</>
+								) }
+							</Button>
+						);
+					} }
+					renderContent={ () => <div>TODO: Document Settings</div> }
+				/>
+			) : (
+				__( 'Loading…' )
+			) }
+		</div>
+	);
 }

--- a/packages/edit-site/src/components/header/document-actions/index.js
+++ b/packages/edit-site/src/components/header/document-actions/index.js
@@ -7,28 +7,17 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { Button, Dropdown } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { DOWN } from '@wordpress/keycodes';
 
 export default function DocumentActions( {
-	templateId,
-	secondaryItem = 'Header',
+	primaryText,
+	secondaryText,
 	isSecondaryItemActive = false,
 } ) {
-	// TODO: I dislike having this here...
-	const template = useSelect(
-		( select ) => {
-			const { getEntityRecord } = select( 'core' );
-
-			return getEntityRecord( 'postType', 'wp_template', templateId );
-		},
-		[ templateId ]
-	);
-
 	return (
 		<div className="edit-site-document-actions">
-			{ template ? (
+			{ primaryText ? (
 				<Dropdown
 					position="bottom center"
 					renderToggle={ ( { onToggle, isOpen } ) => {
@@ -49,8 +38,8 @@ export default function DocumentActions( {
 								label={ __( 'Change document settings.' ) }
 								showTooltip
 							>
-								<span> { template.slug } </span>
-								{ secondaryItem && (
+								<span> { primaryText } </span>
+								{ secondaryText && (
 									<>
 										<span className="edit-site-document-actions__separator">
 											:{ ' ' }
@@ -65,7 +54,7 @@ export default function DocumentActions( {
 												}
 											) }
 										>
-											{ secondaryItem }
+											{ secondaryText }
 										</span>
 									</>
 								) }

--- a/packages/edit-site/src/components/header/document-actions/index.js
+++ b/packages/edit-site/src/components/header/document-actions/index.js
@@ -9,6 +9,7 @@ import classnames from 'classnames';
 import { Button, Dropdown } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { DOWN } from '@wordpress/keycodes';
 
 export default function DocumentActions( {
 	templateId,
@@ -31,12 +32,22 @@ export default function DocumentActions( {
 				<Dropdown
 					position="bottom center"
 					renderToggle={ ( { onToggle, isOpen } ) => {
+						const openOnArrowDown = ( event ) => {
+							if ( ! isOpen && event.keyCode === DOWN ) {
+								event.preventDefault();
+								event.stopPropagation();
+								onToggle();
+							}
+						};
 						return (
 							<Button
 								onClick={ onToggle }
 								className="edit-site-document-actions__document_root"
 								aria-haspopup="true"
 								aria-expanded={ isOpen }
+								onKeyDown={ openOnArrowDown }
+								label={ __( 'Change document settings.' ) }
+								showTooltip
 							>
 								<span> { template.slug } </span>
 								{ secondaryItem && (

--- a/packages/edit-site/src/components/header/document-actions/index.js
+++ b/packages/edit-site/src/components/header/document-actions/index.js
@@ -1,0 +1,3 @@
+export default function DocumentActions() {
+	return <div className="edit-site-document-actions">Document Actions</div>;
+}

--- a/packages/edit-site/src/components/header/document-actions/index.js
+++ b/packages/edit-site/src/components/header/document-actions/index.js
@@ -18,6 +18,7 @@ function useSecondaryText() {
 		return select( 'core/block-editor' ).getSelectedBlock();
 	} );
 
+	// TODO: Handle if parent is template part too.
 	const selectedBlockLabel =
 		selectedBlock?.name === 'core/template-part'
 			? getBlockLabel(
@@ -41,11 +42,16 @@ export default function DocumentActions( { documentTitle } ) {
 	// item is inactive.
 	const isTitleActive = ! label?.length || ! isActive;
 	return (
-		<div className="edit-site-document-actions">
+		<div
+			className={ classnames( 'edit-site-document-actions', {
+				'has-secondary-label': !! label,
+			} ) }
+		>
 			{ documentTitle ? (
 				<>
-					<span
+					<div
 						className={ classnames(
+							'edit-site-document-actions__label',
 							'edit-site-document-actions__title',
 							{
 								'is-active': isTitleActive,
@@ -53,19 +59,18 @@ export default function DocumentActions( { documentTitle } ) {
 						) }
 					>
 						{ documentTitle }
-					</span>
-					{ label && (
-						<span
-							className={ classnames(
-								'edit-site-document-actions__secondary-item',
-								{
-									'is-active': isActive,
-								}
-							) }
-						>
-							{ label }
-						</span>
-					) }
+					</div>
+					<div
+						className={ classnames(
+							'edit-site-document-actions__label',
+							'edit-site-document-actions__secondary-item',
+							{
+								'is-active': isActive,
+							}
+						) }
+					>
+						{ label ?? '' }
+					</div>
 				</>
 			) : (
 				__( 'Loading…' )

--- a/packages/edit-site/src/components/header/document-actions/style.scss
+++ b/packages/edit-site/src/components/header/document-actions/style.scss
@@ -1,18 +1,14 @@
-.edit-site-document-actions__document_item {
-	color: $gray-700;
-	&.is-active {
-		color: inherit;
-	}
-}
+.edit-site-document-actions {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: space-evenly;
+	margin: 5px 0;
 
-// Apply button hover style to text even when grayed out.
-button:hover .edit-site-document-actions__document_item {
-	color: inherit;
-	&.is-active {
-		color: inherit;
+	span {
+		color: $gray-700;
+		&.is-active {
+			color: inherit;
+		}
 	}
-}
-
-.edit-site-document-actions__separator {
-	padding-right: 4px;
 }

--- a/packages/edit-site/src/components/header/document-actions/style.scss
+++ b/packages/edit-site/src/components/header/document-actions/style.scss
@@ -1,3 +1,18 @@
-.edit-site-document-actions {
-	border: 1px solid;
+.edit-site-document-actions__document_item {
+	color: $gray-700;
+	&.is-active {
+		color: inherit;
+	}
+}
+
+// Apply button hover style to text even when grayed out.
+button:hover .edit-site-document-actions__document_item {
+	color: inherit;
+	&.is-active {
+		color: inherit;
+	}
+}
+
+.edit-site-document-actions__separator {
+	padding-right: 4px;
 }

--- a/packages/edit-site/src/components/header/document-actions/style.scss
+++ b/packages/edit-site/src/components/header/document-actions/style.scss
@@ -1,0 +1,3 @@
+.edit-site-document-actions {
+	border: 1px solid;
+}

--- a/packages/edit-site/src/components/header/document-actions/style.scss
+++ b/packages/edit-site/src/components/header/document-actions/style.scss
@@ -4,10 +4,31 @@
 	align-items: center;
 	justify-content: space-evenly;
 
-	span {
+	.edit-site-document-actions__label {
 		color: $gray-700;
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		transition: height 0.25s;
+
 		&.is-active {
 			color: inherit;
+		}
+
+		&.edit-site-document-actions__title {
+			height: 100%;
+			// Otherwise, the secondary item still takes up space with height 0:
+			flex-grow: 1;
+		}
+
+		&.edit-site-document-actions__secondary-item {
+			height: 0;
+		}
+	}
+
+	&.has-secondary-label {
+		.edit-site-document-actions__label {
+			height: 50%;
 		}
 	}
 }

--- a/packages/edit-site/src/components/header/document-actions/style.scss
+++ b/packages/edit-site/src/components/header/document-actions/style.scss
@@ -3,7 +3,6 @@
 	flex-direction: column;
 	align-items: center;
 	justify-content: space-evenly;
-	margin: 5px 0;
 
 	span {
 		color: $gray-700;

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -27,6 +27,7 @@ import SaveButton from '../save-button';
 import UndoButton from './undo-redo/undo';
 import RedoButton from './undo-redo/redo';
 import FullscreenModeClose from './fullscreen-mode-close';
+import DocumentActions from './document-actions';
 
 export default function Header( {
 	openEntitiesSavedStates,
@@ -81,61 +82,72 @@ export default function Header( {
 
 	return (
 		<div className="edit-site-header">
-			<MainDashboardButton.Slot>
-				<FullscreenModeClose />
-			</MainDashboardButton.Slot>
-			<div className="edit-site-header__toolbar">
-				<Button
-					isPrimary
-					isPressed={ isInserterOpen }
-					className="edit-site-header-toolbar__inserter-toggle"
-					onClick={ onToggleInserter }
-					icon={ plus }
-					label={ _x(
-						'Add block',
-						'Generic label for block inserter button'
+			<div className="edit-site-header_start">
+				<MainDashboardButton.Slot>
+					<FullscreenModeClose />
+				</MainDashboardButton.Slot>
+				<div className="edit-site-header__toolbar">
+					<Button
+						isPrimary
+						isPressed={ isInserterOpen }
+						className="edit-site-header-toolbar__inserter-toggle"
+						onClick={ onToggleInserter }
+						icon={ plus }
+						label={ _x(
+							'Add block',
+							'Generic label for block inserter button'
+						) }
+					/>
+					<ToolSelector />
+					<UndoButton />
+					<RedoButton />
+					<BlockNavigationDropdown />
+					{ displayBlockToolbar && (
+						<div className="edit-site-header-toolbar__block-toolbar">
+							<BlockToolbar hideDragHandle />
+						</div>
 					) }
-				/>
-				<ToolSelector />
-				<UndoButton />
-				<RedoButton />
-				<BlockNavigationDropdown />
-				{ displayBlockToolbar && (
-					<div className="edit-site-header-toolbar__block-toolbar">
-						<BlockToolbar hideDragHandle />
+					<div className="edit-site-header__toolbar-switchers">
+						<PageSwitcher
+							showOnFront={ showOnFront }
+							activePage={ page }
+							onActivePageChange={ setPage }
+						/>
+						<div className="edit-site-header__toolbar-switchers-separator">
+							/
+						</div>
+						<TemplateSwitcher
+							page={ page }
+							activeId={ templateId }
+							activeTemplatePartId={ templatePartId }
+							isTemplatePart={
+								templateType === 'wp_template_part'
+							}
+							onActiveIdChange={ setTemplate }
+							onActiveTemplatePartIdChange={ setTemplatePart }
+							onAddTemplate={ addTemplate }
+							onRemoveTemplate={ removeTemplate }
+						/>
 					</div>
-				) }
-				<div className="edit-site-header__toolbar-switchers">
-					<PageSwitcher
-						showOnFront={ showOnFront }
-						activePage={ page }
-						onActivePageChange={ setPage }
-					/>
-					<div className="edit-site-header__toolbar-switchers-separator">
-						/
-					</div>
-					<TemplateSwitcher
-						page={ page }
-						activeId={ templateId }
-						activeTemplatePartId={ templatePartId }
-						isTemplatePart={ templateType === 'wp_template_part' }
-						onActiveIdChange={ setTemplate }
-						onActiveTemplatePartIdChange={ setTemplatePart }
-						onAddTemplate={ addTemplate }
-						onRemoveTemplate={ removeTemplate }
-					/>
 				</div>
 			</div>
-			<div className="edit-site-header__actions">
-				<PreviewOptions
-					deviceType={ deviceType }
-					setDeviceType={ setPreviewDeviceType }
-				/>
-				<SaveButton
-					openEntitiesSavedStates={ openEntitiesSavedStates }
-				/>
-				<PinnedItems.Slot scope="core/edit-site" />
-				<MoreMenu />
+
+			<div className="edit-site-header_center">
+				<DocumentActions />
+			</div>
+
+			<div className="edit-site-header_end">
+				<div className="edit-site-header__actions">
+					<PreviewOptions
+						deviceType={ deviceType }
+						setDeviceType={ setPreviewDeviceType }
+					/>
+					<SaveButton
+						openEntitiesSavedStates={ openEntitiesSavedStates }
+					/>
+					<PinnedItems.Slot scope="core/edit-site" />
+					<MoreMenu />
+				</div>
 			</div>
 		</div>
 	);

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -133,7 +133,7 @@ export default function Header( {
 			</div>
 
 			<div className="edit-site-header_center">
-				<DocumentActions />
+				<DocumentActions templateId={ templateId } />
 			</div>
 
 			<div className="edit-site-header_end">

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -138,10 +138,7 @@ export default function Header( {
 			</div>
 
 			<div className="edit-site-header_center">
-				<DocumentActions
-					primaryText={ template?.slug }
-					secondaryText={ 'TODO header' }
-				/>
+				<DocumentActions documentTitle={ template?.slug } />
 			</div>
 
 			<div className="edit-site-header_end">

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -37,6 +37,7 @@ export default function Header( {
 	const {
 		deviceType,
 		hasFixedToolbar,
+		template,
 		templateId,
 		templatePartId,
 		templateType,
@@ -52,14 +53,18 @@ export default function Header( {
 			getPage,
 		} = select( 'core/edit-site' );
 
-		const { show_on_front: _showOnFront } = select(
-			'core'
-		).getEditedEntityRecord( 'root', 'site' );
+		const { getEntityRecord, getEditedEntityRecord } = select( 'core' );
+		const { show_on_front: _showOnFront } = getEditedEntityRecord(
+			'root',
+			'site'
+		);
 
+		const _templateId = getTemplateId();
 		return {
 			deviceType: __experimentalGetPreviewDeviceType(),
 			hasFixedToolbar: isFeatureActive( 'fixedToolbar' ),
-			templateId: getTemplateId(),
+			templateId: _templateId,
+			template: getEntityRecord( 'postType', 'wp_template', _templateId ),
 			templatePartId: getTemplatePartId(),
 			templateType: getTemplateType(),
 			page: getPage(),
@@ -133,7 +138,10 @@ export default function Header( {
 			</div>
 
 			<div className="edit-site-header_center">
-				<DocumentActions templateId={ templateId } />
+				<DocumentActions
+					primaryText={ template?.slug }
+					secondaryText={ 'TODO header' }
+				/>
 			</div>
 
 			<div className="edit-site-header_end">

--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -10,6 +10,11 @@
 		display: flex;
 	}
 
+	.edit-site-header_center {
+		display: flex;
+		height: 100%;
+	}
+
 	.edit-site-header_end {
 		justify-content: flex-end;
 	}

--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -2,13 +2,21 @@
 	align-items: center;
 	display: flex;
 	height: $header-height;
-	justify-content: space-between;
 	box-sizing: border-box;
+
+	.edit-site-header_start,
+	.edit-site-header_end {
+		flex: 1;
+		display: flex;
+	}
+
+	.edit-site-header_end {
+		justify-content: flex-end;
+	}
 }
 
 .edit-site-header__toolbar {
 	display: flex;
-	flex-grow: 1;
 	padding-left: $grid-unit-30;
 	align-items: center;
 

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -2,6 +2,7 @@
 
 @import "./components/block-editor/style.scss";
 @import "./components/header/style.scss";
+@import "./components/header/document-actions/style.scss";
 @import "./components/header/fullscreen-mode-close/style.scss";
 @import "./components/header/more-menu/style.scss";
 @import "./components/notices/style.scss";


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Adds a basic "document actions" component which is rendered in the center of the FSE editor header. Note: the string rendered in the title is TBD. Currently it uses the template name, but we are also thinking that the page name could be more useful / easier to understand.

Also, when a template part block is directly selected, it will show its label as secondary text in the header area. We are hoping to expand this functionality to include hover, and to handle if the parent of the selected block is the template part.

This is also meant to serve as a starting point for adding a document settings dropdown to the header.

to do :
- [x] Finalize the component API (what the props should be called and how they should be passed)
- [x] Should we include the temporary dropdown now or merge without it?
- [x] Figure out how to store the "secondary" item and where to pull that data from.

Work towards #25085. cc @dubielzyk 

## How has this been tested?
locally in edit site

## Screenshots <!-- if applicable -->

_A friendly reminder that eventually, the "index" text in the left will go away._
![2020-09-17 15 27 12](https://user-images.githubusercontent.com/6265975/93535171-4b2de480-f8fb-11ea-81b9-9c0dc665629e.gif)


## Types of changes
Enhancement

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
