### PR TITLE
Open dropdown before focus on submenu item.

### DIFF
--- a/packages/block-editor/src/components/block-navigation/block.js
+++ b/packages/block-editor/src/components/block-navigation/block.js
@@ -44,7 +44,7 @@ export default function BlockNavigationBlock( {
 	const [ isHovered, setIsHovered ] = useState( false );
 	const [ isFocused, setIsFocused ] = useState( false );
 	const { clientId } = block;
-	const { isDragging, getParents } = useSelect(
+	const { isDragging, blockParents } = useSelect(
 		( select ) => {
 			const {
 				isBlockBeingDragged,
@@ -56,13 +56,11 @@ export default function BlockNavigationBlock( {
 				isDragging:
 					isBlockBeingDragged( clientId ) ||
 					isAncestorBeingDragged( clientId ),
-				getParents: getBlockParents,
+				blockParents: getBlockParents( clientId ),
 			};
 		},
 		[ clientId ]
 	);
-
-	const blockParents = getParents( clientId );
 
 	const { selectBlock: selectEditorBlock } = useDispatch(
 		'core/block-editor'


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

Fixes #24806 .

In order to focus a block inside a dropdown, we need to open that dropdown first. This PR. makes the dropdowns open by first focusing on the parents of the target block. It's not super fast if there are multiple nesting levels, but I couldn't think of a better way to do it. 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Tested in browser with keyboard.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
