### PR TITLE
Added a span tag to the text that shows in the editor when there are …

### DIFF
--- a/packages/block-library/src/tag-cloud/index.php
+++ b/packages/block-library/src/tag-cloud/index.php
@@ -22,13 +22,13 @@ function render_block_core_tag_cloud( $attributes ) {
 
 	if ( ! $tag_cloud ) {
 		$labels    = get_taxonomy_labels( get_taxonomy( $attributes['taxonomy'] ) );
-		$tag_cloud = esc_html(
+		$tag_cloud = '<span>' . esc_html(
 			sprintf(
 				/* translators: %s: taxonomy name */
 				__( 'Your site doesn&#8217;t have any %s, so there&#8217;s nothing to display here at the moment.' ),
 				strtolower( $labels->name )
 			)
-		);
+		) . '</span>';
 	}
 
 	return sprintf(


### PR DESCRIPTION
…no tags to show. This makes the text a light grey color instead of black.

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
I added <span> tags around the text that shows when there are no tags. Now, that text shows in a light grey color instead of black.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
I added the tag cloud block on my test site without any tags. After adding the span tags, the text showed up in a different color. I tested it with TwentyTwenty and TwentySeventeen

 themes.

<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/1088629/93164875-792ee100-f6cf-11ea-8bdc-0c66edfb8941.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
Span tags around the existing text.
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
