### PR TITLE
Make global dependencies relative when relevant to DOM

### DIFF
--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -109,13 +109,18 @@ const BlockComponent = forwardRef(
 		 * When a block becomes selected, transition focus to an inner tabbable.
 		 */
 		const focusTabbable = () => {
+			const { ownerDocument } = wrapper.current;
+
 			// Focus is captured by the wrapper node, so while focus transition
 			// should only consider tabbables within editable display, since it
 			// may be the wrapper itself or a side control which triggered the
 			// focus event, don't unnecessary transition to an inner tabbable.
 			if (
-				document.activeElement &&
-				isInsideRootBlock( wrapper.current, document.activeElement )
+				ownerDocument.activeElement &&
+				isInsideRootBlock(
+					wrapper.current,
+					ownerDocument.activeElement
+				)
 			) {
 				return;
 			}

--- a/packages/block-editor/src/components/block-list/use-multi-selection.js
+++ b/packages/block-editor/src/components/block-list/use-multi-selection.js
@@ -91,12 +91,15 @@ export default function useMultiSelection( ref ) {
 	 * select the entire block contents.
 	 */
 	useEffect( () => {
+		const { ownerDocument } = ref.current;
+		const { defaultView } = ownerDocument;
+
 		if ( ! hasMultiSelection || isMultiSelecting ) {
 			if ( ! selectedBlockClientId || isMultiSelecting ) {
 				return;
 			}
 
-			const selection = window.getSelection();
+			const selection = defaultView.getSelection();
 
 			if ( selection.rangeCount && ! selection.isCollapsed ) {
 				const blockNode = getBlockDOMNode( selectedBlockClientId );
@@ -129,8 +132,8 @@ export default function useMultiSelection( ref ) {
 		let startNode = getBlockDOMNode( start );
 		let endNode = getBlockDOMNode( end );
 
-		const selection = window.getSelection();
-		const range = document.createRange();
+		const selection = defaultView.getSelection();
+		const range = ownerDocument.createRange();
 
 		// The most stable way to select the whole block contents is to start
 		// and end at the deepest points.
@@ -152,7 +155,9 @@ export default function useMultiSelection( ref ) {
 
 	const onSelectionChange = useCallback(
 		( { isSelectionEnd } ) => {
-			const selection = window.getSelection();
+			const { ownerDocument } = ref.current;
+			const { defaultView } = ownerDocument;
+			const selection = defaultView.getSelection();
 
 			// If no selection is found, end multi selection and enable all rich
 			// text areas.
@@ -207,12 +212,17 @@ export default function useMultiSelection( ref ) {
 	 * Handles a mouseup event to end the current mouse multi-selection.
 	 */
 	const onSelectionEnd = useCallback( () => {
-		document.removeEventListener( 'selectionchange', onSelectionChange );
+		const { ownerDocument } = ref.current;
+		const { defaultView } = ownerDocument;
+		ownerDocument.removeEventListener(
+			'selectionchange',
+			onSelectionChange
+		);
 		// Equivalent to attaching the listener once.
-		window.removeEventListener( 'mouseup', onSelectionEnd );
+		defaultView.removeEventListener( 'mouseup', onSelectionEnd );
 		// The browser selection won't have updated yet at this point, so wait
 		// until the next animation frame to get the browser selection.
-		rafId.current = window.requestAnimationFrame( () => {
+		rafId.current = defaultView.requestAnimationFrame( () => {
 			onSelectionChange( { isSelectionEnd: true } );
 			stopMultiSelect();
 		} );
@@ -221,12 +231,14 @@ export default function useMultiSelection( ref ) {
 	// Only clean up when unmounting, these are added and cleaned up elsewhere.
 	useEffect(
 		() => () => {
-			document.removeEventListener(
+			const { ownerDocument } = ref.current;
+			const { defaultView } = ownerDocument;
+			ownerDocument.removeEventListener(
 				'selectionchange',
 				onSelectionChange
 			);
-			window.removeEventListener( 'mouseup', onSelectionEnd );
-			window.cancelAnimationFrame( rafId.current );
+			defaultView.removeEventListener( 'mouseup', onSelectionEnd );
+			defaultView.cancelAnimationFrame( rafId.current );
 		},
 		[ onSelectionChange, onSelectionEnd ]
 	);
@@ -241,15 +253,21 @@ export default function useMultiSelection( ref ) {
 				return;
 			}
 
+			const { ownerDocument } = ref.current;
+			const { defaultView } = ownerDocument;
+
 			startClientId.current = clientId;
-			anchorElement.current = document.activeElement;
+			anchorElement.current = ownerDocument.activeElement;
 			startMultiSelect();
 
 			// `onSelectionStart` is called after `mousedown` and `mouseleave`
 			// (from a block). The selection ends when `mouseup` happens anywhere
 			// in the window.
-			document.addEventListener( 'selectionchange', onSelectionChange );
-			window.addEventListener( 'mouseup', onSelectionEnd );
+			ownerDocument.addEventListener(
+				'selectionchange',
+				onSelectionChange
+			);
+			defaultView.addEventListener( 'mouseup', onSelectionEnd );
 
 			// Removing the contenteditable attributes within the block editor is
 			// essential for selection to work across editable areas. The edible

--- a/packages/block-editor/src/components/block-toolbar/expanded-block-controls-container.js
+++ b/packages/block-editor/src/components/block-toolbar/expanded-block-controls-container.js
@@ -15,6 +15,10 @@ import warning from '@wordpress/warning';
  */
 import BlockControls from '../block-controls';
 
+function getComputedStyle( node ) {
+	return node.ownerDocument.defaultView.getComputedStyle( node );
+}
+
 export default function ExpandedBlockControlsContainer( {
 	children,
 	className,
@@ -53,10 +57,7 @@ function ExpandedBlockControlsHandler( { fills, className = '', children } ) {
 			}
 			toolbarContentElement.style.position = 'absolute';
 			toolbarContentElement.style.width = 'auto';
-			const contentCSS = window.getComputedStyle(
-				toolbarContentElement,
-				null
-			);
+			const contentCSS = getComputedStyle( toolbarContentElement );
 			setDimensions( {
 				width: contentCSS.getPropertyValue( 'width' ),
 				height: contentCSS.getPropertyValue( 'height' ),

--- a/packages/block-editor/src/components/block-toolbar/utils.js
+++ b/packages/block-editor/src/components/block-toolbar/utils.js
@@ -115,7 +115,10 @@ export function useShowMoversGestures( {
 	const registerRef = useRef( false );
 
 	const isFocusedWithin = () => {
-		return ref?.current && ref.current.contains( document.activeElement );
+		return (
+			ref?.current &&
+			ref.current.contains( ref.current.ownerDocument.activeElement )
+		);
 	};
 
 	useEffect( () => {

--- a/packages/block-editor/src/components/colors/use-colors.js
+++ b/packages/block-editor/src/components/colors/use-colors.js
@@ -26,10 +26,9 @@ import InspectorControls from '../inspector-controls';
 import { useBlockEditContext } from '../block-edit';
 import ColorPanel from './color-panel';
 
-/**
- * Browser dependencies
- */
-const { getComputedStyle, Node } = window;
+function getComputedStyle( node ) {
+	return node.ownerDocument.defaultView.getComputedStyle( node );
+}
 
 const DEFAULT_COLORS = [];
 
@@ -205,7 +204,8 @@ export default function __experimentalUseColors(
 			while (
 				backgroundColor === 'rgba(0, 0, 0, 0)' &&
 				backgroundColorNode.parentNode &&
-				backgroundColorNode.parentNode.nodeType === Node.ELEMENT_NODE
+				backgroundColorNode.parentNode.nodeType ===
+					backgroundColorNode.parentNode.ELEMENT_NODE
 			) {
 				backgroundColorNode = backgroundColorNode.parentNode;
 				backgroundColor = getComputedStyle( backgroundColorNode )

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -100,12 +100,14 @@ function CopyHandler( { children } ) {
 
 		// Always handle multiple selected blocks.
 		if ( ! hasMultiSelection() ) {
+			const { target } = event;
+			const { ownerDocument } = target;
 			// If copying, only consider actual text selection as selection.
 			// Otherwise, any focus on an input field is considered.
 			const hasSelection =
 				event.type === 'copy' || event.type === 'cut'
-					? documentHasUncollapsedSelection()
-					: documentHasSelection();
+					? documentHasUncollapsedSelection( ownerDocument )
+					: documentHasSelection( ownerDocument );
 
 			// Let native copy behaviour take over in input fields.
 			if ( hasSelection ) {

--- a/packages/block-editor/src/components/keyboard-shortcuts/index.js
+++ b/packages/block-editor/src/components/keyboard-shortcuts/index.js
@@ -154,7 +154,9 @@ function KeyboardShortcuts() {
 			( event ) => {
 				event.preventDefault();
 				clearSelectedBlock();
-				window.getSelection().removeAllRanges();
+				event.target.ownerDocument.defaultView
+					.getSelection()
+					.removeAllRanges();
 			},
 			[ clientIds, clearSelectedBlock ]
 		),

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -152,7 +152,9 @@ function LinkControl( {
 		const hadFocusLoss =
 			isEndingEditWithFocus.current &&
 			wrapperNode.current &&
-			! wrapperNode.current.contains( document.activeElement );
+			! wrapperNode.current.contains(
+				wrapperNode.current.ownerDocument.activeElement
+			);
 
 		if ( hadFocusLoss ) {
 			// Prefer to focus a natural focusable descendent of the wrapper,
@@ -173,7 +175,7 @@ function LinkControl( {
 	 */
 	function stopEditing() {
 		isEndingEditWithFocus.current = !! wrapperNode.current?.contains(
-			document.activeElement
+			wrapperNode.current.ownerDocument.activeElement
 		);
 
 		setIsEditingLink( false );

--- a/packages/block-editor/src/components/observe-typing/index.js
+++ b/packages/block-editor/src/components/observe-typing/index.js
@@ -62,9 +62,13 @@ function ObserveTyping( { children, setTimeout: setSafeTimeout } ) {
 	 */
 	function toggleEventBindings( isBound ) {
 		const bindFn = isBound ? 'addEventListener' : 'removeEventListener';
-		document[ bindFn ](
+		typingContainer.current.ownerDocument[ bindFn ](
 			'selectionchange',
 			stopTypingOnSelectionUncollapse
+		);
+		typingContainer.current.ownerDocument[ bindFn ](
+			'mousemove',
+			stopTypingOnMouseMove
 		);
 		document[ bindFn ]( 'mousemove', stopTypingOnMouseMove );
 	}
@@ -97,8 +101,8 @@ function ObserveTyping( { children, setTimeout: setSafeTimeout } ) {
 	 * On selection change, unset typing flag if user has made an uncollapsed
 	 * (shift) selection.
 	 */
-	function stopTypingOnSelectionUncollapse() {
-		const selection = window.getSelection();
+	function stopTypingOnSelectionUncollapse( { target } ) {
+		const selection = target.defaultView.getSelection();
 		const isCollapsed =
 			selection.rangeCount > 0 && selection.getRangeAt( 0 ).collapsed;
 

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -45,11 +45,9 @@ import {
 } from '../../utils/dom';
 import FocusCapture from './focus-capture';
 
-/**
- * Browser constants
- */
-
-const { getSelection, getComputedStyle } = window;
+function getComputedStyle( node ) {
+	return node.ownerDocument.defaultView.getComputedStyle( node );
+}
 
 /**
  * Given an element, returns true if the element is a tabbable text field, or
@@ -561,6 +559,9 @@ export default function WritingFlow( { children } ) {
 			return;
 		}
 
+		const { ownerDocument } = container.current;
+		const { defaultView } = ownerDocument;
+
 		// When presing any key other than up or down, the initial vertical
 		// position must ALWAYS be reset. The vertical position is saved so it
 		// can be restored as well as possible on sebsequent vertical arrow key
@@ -570,7 +571,7 @@ export default function WritingFlow( { children } ) {
 		if ( ! isVertical ) {
 			verticalRect.current = null;
 		} else if ( ! verticalRect.current ) {
-			verticalRect.current = computeCaretRect();
+			verticalRect.current = computeCaretRect( defaultView );
 		}
 
 		// This logic inside this condition needs to be checked before
@@ -662,7 +663,7 @@ export default function WritingFlow( { children } ) {
 			}
 		} else if (
 			isHorizontal &&
-			getSelection().isCollapsed &&
+			defaultView.getSelection().isCollapsed &&
 			isHorizontalEdge( target, isReverseDir ) &&
 			! keepCaretInsideBlock
 		) {

--- a/packages/block-editor/src/hooks/color-panel.js
+++ b/packages/block-editor/src/hooks/color-panel.js
@@ -12,13 +12,15 @@ import ContrastChecker from '../components/contrast-checker';
 import InspectorControls from '../components/inspector-controls';
 import { getBlockDOMNode } from '../utils/dom';
 
+function getComputedStyle( node ) {
+	return node.ownerDocument.defaultView.getComputedStyle( node );
+}
+
 export default function ColorPanel( {
 	settings,
 	clientId,
 	enableContrastChecking = true,
 } ) {
-	const { getComputedStyle, Node } = window;
-
 	const [ detectedBackgroundColor, setDetectedBackgroundColor ] = useState();
 	const [ detectedColor, setDetectedColor ] = useState();
 
@@ -39,7 +41,8 @@ export default function ColorPanel( {
 		while (
 			backgroundColor === 'rgba(0, 0, 0, 0)' &&
 			backgroundColorNode.parentNode &&
-			backgroundColorNode.parentNode.nodeType === Node.ELEMENT_NODE
+			backgroundColorNode.parentNode.nodeType ===
+				backgroundColorNode.parentNode.ELEMENT_NODE
 		) {
 			backgroundColorNode = backgroundColorNode.parentNode;
 			backgroundColor = getComputedStyle( backgroundColorNode )

--- a/packages/block-editor/src/utils/dom.js
+++ b/packages/block-editor/src/utils/dom.js
@@ -95,7 +95,7 @@ export function hasInnerBlocksContext( element ) {
  *                            a block.
  */
 export function getBlockClientId( node ) {
-	while ( node && node.nodeType !== window.Node.ELEMENT_NODE ) {
+	while ( node && node.nodeType !== node.ELEMENT_NODE ) {
 		node = node.parentNode;
 	}
 

--- a/packages/block-library/src/button/color-edit.js
+++ b/packages/block-library/src/button/color-edit.js
@@ -25,6 +25,10 @@ import {
 
 const isWebPlatform = Platform.OS === 'web';
 
+function getComputedStyle( node ) {
+	return node.ownerDocument.defaultView.getComputedStyle( node );
+}
+
 // The code in this file is copied entirely from the "color" and "style" support flags
 // The flag can't be used at the moment because of the extra wrapper around
 // the button block markup.
@@ -53,8 +57,6 @@ const cleanEmptyObject = ( object ) => {
 };
 
 function ColorPanel( { settings, clientId, enableContrastChecking = true } ) {
-	const { getComputedStyle, Node } = window;
-
 	const [ detectedBackgroundColor, setDetectedBackgroundColor ] = useState();
 	const [ detectedColor, setDetectedColor ] = useState();
 
@@ -79,7 +81,8 @@ function ColorPanel( { settings, clientId, enableContrastChecking = true } ) {
 		while (
 			backgroundColor === 'rgba(0, 0, 0, 0)' &&
 			backgroundColorNode.parentNode &&
-			backgroundColorNode.parentNode.nodeType === Node.ELEMENT_NODE
+			backgroundColorNode.parentNode.nodeType ===
+				backgroundColorNode.parentNode.ELEMENT_NODE
 		) {
 			backgroundColorNode = backgroundColorNode.parentNode;
 			backgroundColor = getComputedStyle( backgroundColorNode )

--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -219,7 +219,7 @@ export default class ClassicEdit extends Component {
 			const rootNode = this.editor.getBody();
 
 			// Create the toolbar by refocussing the editor.
-			if ( document.activeElement === rootNode ) {
+			if ( rootNode.ownerDocument.activeElement === rootNode ) {
 				rootNode.blur();
 				this.editor.focus();
 			}

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -206,8 +206,10 @@ function NavigationLinkEdit( {
 	 */
 	function selectLabelText() {
 		ref.current.focus();
-		const selection = window.getSelection();
-		const range = document.createRange();
+		const { ownerDocument } = ref.current;
+		const { defaultView } = ownerDocument;
+		const selection = defaultView.getSelection();
+		const range = ownerDocument.createRange();
 		// Get the range of the current ref contents so we can add this range to the selection.
 		range.selectNodeContents( ref.current );
 		selection.removeAllRanges();

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -22,10 +22,10 @@ import { useSelect } from '@wordpress/data';
 import { useEffect, useState, useRef } from '@wordpress/element';
 import { formatLtr } from '@wordpress/icons';
 
-/**
- * Browser dependencies
- */
-const { getComputedStyle } = window;
+function getComputedStyle( node, pseudo ) {
+	return node.ownerDocument.defaultView.getComputedStyle( node, pseudo );
+}
+
 const querySelector = window.document.querySelector.bind( document );
 
 const name = 'core/paragraph';

--- a/packages/blocks/src/api/node.js
+++ b/packages/blocks/src/api/node.js
@@ -4,11 +4,6 @@
 import * as children from './children';
 
 /**
- * Browser dependencies
- */
-const { TEXT_NODE, ELEMENT_NODE } = window.Node;
-
-/**
  * A representation of a single node within a block's rich text value. If
  * representing a text node, the value is simply a string of the node value.
  * As representing an element node, it is an object of:
@@ -63,11 +58,11 @@ export function getNamedNodeMapAsObject( nodeMap ) {
  * @return {WPBlockNode} Block node equivalent to DOM node.
  */
 export function fromDOM( domNode ) {
-	if ( domNode.nodeType === TEXT_NODE ) {
+	if ( domNode.nodeType === domNode.TEXT_NODE ) {
 		return domNode.nodeValue;
 	}
 
-	if ( domNode.nodeType !== ELEMENT_NODE ) {
+	if ( domNode.nodeType !== domNode.ELEMENT_NODE ) {
 		throw new TypeError(
 			'A block node can only be created from a node of type text or ' +
 				'element.'

--- a/packages/blocks/src/api/raw-handling/comment-remover.js
+++ b/packages/blocks/src/api/raw-handling/comment-remover.js
@@ -4,18 +4,13 @@
 import { remove } from '@wordpress/dom';
 
 /**
- * Browser dependencies
- */
-const { COMMENT_NODE } = window.Node;
-
-/**
  * Looks for comments, and removes them.
  *
  * @param {Node} node The node to be processed.
  * @return {void}
  */
 export default function commentRemover( node ) {
-	if ( node.nodeType === COMMENT_NODE ) {
+	if ( node.nodeType === node.COMMENT_NODE ) {
 		remove( node );
 	}
 }

--- a/packages/blocks/src/api/raw-handling/html-formatting-remover.js
+++ b/packages/blocks/src/api/raw-handling/html-formatting-remover.js
@@ -35,7 +35,7 @@ export default function htmlFormattingRemover( node ) {
 	let parent = node;
 	while ( ( parent = parent.parentNode ) ) {
 		if (
-			parent.nodeType === window.Node.ELEMENT_NODE &&
+			parent.nodeType === parent.ELEMENT_NODE &&
 			parent.nodeName === 'PRE'
 		) {
 			return;

--- a/packages/blocks/src/api/raw-handling/normalise-blocks.js
+++ b/packages/blocks/src/api/raw-handling/normalise-blocks.js
@@ -3,11 +3,6 @@
  */
 import { isEmpty, isPhrasingContent } from '@wordpress/dom';
 
-/**
- * Browser dependencies
- */
-const { ELEMENT_NODE, TEXT_NODE } = window.Node;
-
 export default function normaliseBlocks( HTML ) {
 	const decuDoc = document.implementation.createHTMLDocument( '' );
 	const accuDoc = document.implementation.createHTMLDocument( '' );
@@ -21,7 +16,7 @@ export default function normaliseBlocks( HTML ) {
 		const node = decu.firstChild;
 
 		// Text nodes: wrap in a paragraph, or append to previous.
-		if ( node.nodeType === TEXT_NODE ) {
+		if ( node.nodeType === node.TEXT_NODE ) {
 			if ( ! node.nodeValue.trim() ) {
 				decu.removeChild( node );
 			} else {
@@ -32,7 +27,7 @@ export default function normaliseBlocks( HTML ) {
 				accu.lastChild.appendChild( node );
 			}
 			// Element nodes.
-		} else if ( node.nodeType === ELEMENT_NODE ) {
+		} else if ( node.nodeType === node.ELEMENT_NODE ) {
 			// BR nodes: create a new paragraph on double, or append to previous.
 			if ( node.nodeName === 'BR' ) {
 				if ( node.nextSibling && node.nextSibling.nodeName === 'BR' ) {

--- a/packages/blocks/src/api/raw-handling/special-comment-converter.js
+++ b/packages/blocks/src/api/raw-handling/special-comment-converter.js
@@ -4,11 +4,6 @@
 import { remove, replace } from '@wordpress/dom';
 
 /**
- * Browser dependencies
- */
-const { COMMENT_NODE } = window.Node;
-
-/**
  * Looks for `<!--nextpage-->` and `<!--more-->` comments, as well as the
  * `<!--more Some text-->` variant and its `<!--noteaser-->` companion,
  * and replaces them with a custom element representing a future block.
@@ -25,7 +20,7 @@ const { COMMENT_NODE } = window.Node;
  * @return {void}
  */
 export default function specialCommentConverter( node, doc ) {
-	if ( node.nodeType !== COMMENT_NODE ) {
+	if ( node.nodeType !== node.COMMENT_NODE ) {
 		return;
 	}
 
@@ -47,7 +42,7 @@ export default function specialCommentConverter( node, doc ) {
 		let noTeaser = false;
 		while ( ( sibling = sibling.nextSibling ) ) {
 			if (
-				sibling.nodeType === COMMENT_NODE &&
+				sibling.nodeType === sibling.COMMENT_NODE &&
 				sibling.nodeValue === 'noteaser'
 			) {
 				noTeaser = true;

--- a/packages/components/src/drop-zone/provider.js
+++ b/packages/components/src/drop-zone/provider.js
@@ -6,7 +6,7 @@ import { isEqual, find, some, filter, throttle, includes } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Component, createContext } from '@wordpress/element';
+import { Component, createContext, createRef } from '@wordpress/element';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 
 export const Context = createContext( {
@@ -80,16 +80,21 @@ class DropZoneProvider extends Component {
 			isDraggingOverDocument: false,
 			position: null,
 		};
+		this.ref = createRef();
 	}
 
 	componentDidMount() {
-		window.addEventListener( 'dragover', this.onDragOver );
-		window.addEventListener( 'mouseup', this.resetDragState );
+		const { ownerDocument } = this.ref.current;
+		const { defaultView } = ownerDocument;
+		defaultView.addEventListener( 'dragover', this.onDragOver );
+		defaultView.addEventListener( 'mouseup', this.resetDragState );
 	}
 
 	componentWillUnmount() {
-		window.removeEventListener( 'dragover', this.onDragOver );
-		window.removeEventListener( 'mouseup', this.resetDragState );
+		const { ownerDocument } = this.ref.current;
+		const { defaultView } = ownerDocument;
+		defaultView.removeEventListener( 'dragover', this.onDragOver );
+		defaultView.removeEventListener( 'mouseup', this.resetDragState );
 	}
 
 	addDropZone( dropZone ) {
@@ -257,6 +262,7 @@ class DropZoneProvider extends Component {
 	render() {
 		return (
 			<div
+				ref={ this.ref }
 				onDrop={ this.onDrop }
 				className="components-drop-zone__provider"
 			>

--- a/packages/components/src/dropdown/index.js
+++ b/packages/components/src/dropdown/index.js
@@ -63,9 +63,10 @@ export default function Dropdown( {
 	 * in case when focus is moved to the modal dialog.
 	 */
 	function closeIfFocusOutside() {
+		const { ownerDocument } = containerRef.current;
 		if (
-			! containerRef.current.contains( document.activeElement ) &&
-			! document.activeElement.closest( '[role="dialog"]' )
+			! containerRef.current.contains( ownerDocument.activeElement ) &&
+			! ownerDocument.activeElement.closest( '[role="dialog"]' )
 		) {
 			close();
 		}

--- a/packages/components/src/focusable-iframe/index.js
+++ b/packages/components/src/focusable-iframe/index.js
@@ -31,7 +31,7 @@ class FocusableIframe extends Component {
 	checkFocus() {
 		const iframe = this.node.current;
 
-		if ( document.activeElement !== iframe ) {
+		if ( iframe.ownerDocument.activeElement !== iframe ) {
 			return;
 		}
 

--- a/packages/components/src/form-token-field/test/index.js
+++ b/packages/components/src/form-token-field/test/index.js
@@ -81,7 +81,7 @@ describe( 'FormTokenField', () => {
 		return map(
 			filter(
 				div.firstChild.childNodes,
-				( childNode ) => childNode.nodeType !== window.Node.COMMENT_NODE
+				( childNode ) => childNode.nodeType !== childNode.COMMENT_NODE
 			),
 			( childNode ) => childNode.textContent
 		);

--- a/packages/components/src/form-token-field/token-input.js
+++ b/packages/components/src/form-token-field/token-input.js
@@ -15,7 +15,7 @@ class TokenInput extends Component {
 	}
 
 	hasFocus() {
-		return this.input === document.activeElement;
+		return this.input === this.input.ownerDocument.activeElement;
 	}
 
 	bindInput( ref ) {

--- a/packages/components/src/higher-order/navigate-regions/index.js
+++ b/packages/components/src/higher-order/navigate-regions/index.js
@@ -34,7 +34,9 @@ export default createHigherOrderComponent( ( WrappedComponent ) => {
 				return;
 			}
 			let nextRegion = regions[ 0 ];
-			const selectedIndex = regions.indexOf( document.activeElement );
+			const selectedIndex = regions.indexOf(
+				container.current.ownerDocument.activeElement
+			);
 			if ( selectedIndex !== -1 ) {
 				let nextIndex = selectedIndex + offset;
 				nextIndex = nextIndex === -1 ? regions.length - 1 : nextIndex;

--- a/packages/components/src/navigable-container/container.js
+++ b/packages/components/src/navigable-container/container.js
@@ -111,7 +111,9 @@ class NavigableContainer extends Component {
 			return;
 		}
 
-		const context = getFocusableContext( document.activeElement );
+		const context = getFocusableContext(
+			event.target.ownerDocument.activeElement
+		);
 		if ( ! context ) {
 			return;
 		}

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -116,13 +116,17 @@ function computeAnchorRect(
 	return withoutPadding( rect, parentNode );
 }
 
+function getComputedStyle( node ) {
+	return node.ownerDocument.defaultView.getComputedStyle( node );
+}
+
 function withoutPadding( rect, element ) {
 	const {
 		paddingTop,
 		paddingBottom,
 		paddingLeft,
 		paddingRight,
-	} = window.getComputedStyle( element );
+	} = getComputedStyle( element );
 	const top = paddingTop ? parseInt( paddingTop, 10 ) : 0;
 	const bottom = paddingBottom ? parseInt( paddingBottom, 10 ) : 0;
 	const left = paddingLeft ? parseInt( paddingLeft, 10 ) : 0;

--- a/packages/components/src/text/test/index.js
+++ b/packages/components/src/text/test/index.js
@@ -22,9 +22,13 @@ afterEach( () => {
 	container = null;
 } );
 
+function getComputedStyle( node ) {
+	return node.ownerDocument.defaultView.getComputedStyle( node );
+}
+
 function getTextStyle( node ) {
 	const text = node || container.children[ 0 ];
-	return window.getComputedStyle( text );
+	return getComputedStyle( text );
 }
 
 describe( 'Text', () => {

--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -18,6 +18,10 @@ npm install @wordpress/dom --save
 
 Get the rectangle for the selection in a container.
 
+_Parameters_
+
+-   _window_ `Window`: The window of the selection.
+
 _Returns_
 
 -   `?DOMRect`: The rectangle.
@@ -26,6 +30,10 @@ _Returns_
 
 Check whether the current document has a selection. This checks for both
 focus in an input field and general text selection.
+
+_Parameters_
+
+-   _document_ `Document`: The document to check.
 
 _Returns_
 

--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -20,7 +20,7 @@ Get the rectangle for the selection in a container.
 
 _Parameters_
 
--   _window_ `Window`: The window of the selection.
+-   _win_ `Window`: The window of the selection.
 
 _Returns_
 
@@ -33,7 +33,7 @@ focus in an input field and general text selection.
 
 _Parameters_
 
--   _document_ `Document`: The document to check.
+-   _doc_ `Document`: The document to check.
 
 _Returns_
 
@@ -47,6 +47,10 @@ elements.
 
 See: <https://developer.mozilla.org/en-US/docs/Web/API/Window/getSelection#Related_objects>.
 
+_Parameters_
+
+-   _doc_ `Document`: The document to check.
+
 _Returns_
 
 -   `boolean`: True if there is selection, false if not.
@@ -56,6 +60,10 @@ _Returns_
 Check whether the current document has any sort of selection. This includes
 ranges of text across elements and any selection inside <input> and
 <textarea> elements.
+
+_Parameters_
+
+-   _doc_ `Document`: The document to check.
 
 _Returns_
 

--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -8,17 +8,9 @@ import { includes, noop } from 'lodash';
  */
 import { isPhrasingContent } from './phrasing-content';
 
-/**
- * Browser dependencies
- */
-
-const { DOMParser, getComputedStyle } = window;
-const {
-	TEXT_NODE,
-	ELEMENT_NODE,
-	DOCUMENT_POSITION_PRECEDING,
-	DOCUMENT_POSITION_FOLLOWING,
-} = window.Node;
+function getComputedStyle( node ) {
+	return node.ownerDocument.defaultView.getComputedStyle( node );
+}
 
 /**
  * Returns true if the given selection object is in the forward direction, or
@@ -40,11 +32,11 @@ function isSelectionForward( selection ) {
 	/* eslint-disable no-bitwise */
 	// Compare whether anchor node precedes focus node. If focus node (where
 	// end of selection occurs) is after the anchor node, it is forward.
-	if ( position & DOCUMENT_POSITION_PRECEDING ) {
+	if ( position & anchorNode.DOCUMENT_POSITION_PRECEDING ) {
 		return false;
 	}
 
-	if ( position & DOCUMENT_POSITION_FOLLOWING ) {
+	if ( position & anchorNode.DOCUMENT_POSITION_FOLLOWING ) {
 		return true;
 	}
 	/* eslint-enable no-bitwise */
@@ -87,7 +79,10 @@ function isEdge( container, isReverse, onlyVertical ) {
 		return true;
 	}
 
-	const selection = window.getSelection();
+	const { ownerDocument } = container;
+	const { defaultView } = ownerDocument;
+
+	const selection = defaultView.getSelection();
 
 	if ( ! selection.rangeCount ) {
 		return false;
@@ -109,7 +104,7 @@ function isEdge( container, isReverse, onlyVertical ) {
 		return false;
 	}
 
-	const computedStyle = window.getComputedStyle( container );
+	const computedStyle = getComputedStyle( container );
 	const lineHeight = parseInt( computedStyle.lineHeight, 10 ) || 0;
 
 	// Only consider the multiline selection at the edge if the direction is
@@ -160,7 +155,12 @@ function isEdge( container, isReverse, onlyVertical ) {
 	const y = isReverse
 		? containerRect.top + buffer
 		: containerRect.bottom - buffer;
-	const testRange = hiddenCaretRangeFromPoint( document, x, y, container );
+	const testRange = hiddenCaretRangeFromPoint(
+		ownerDocument,
+		x,
+		y,
+		container
+	);
 
 	if ( ! testRange ) {
 		return false;
@@ -213,6 +213,7 @@ export function getRectangleFromRange( range ) {
 	}
 
 	const { startContainer } = range;
+	const { ownerDocument } = startContainer;
 
 	// Correct invalid "BR" ranges. The cannot contain any children.
 	if ( startContainer.nodeName === 'BR' ) {
@@ -221,7 +222,7 @@ export function getRectangleFromRange( range ) {
 			startContainer
 		);
 
-		range = document.createRange();
+		range = ownerDocument.createRange();
 		range.setStart( parentNode, index );
 		range.setEnd( parentNode, index );
 	}
@@ -234,7 +235,7 @@ export function getRectangleFromRange( range ) {
 	//
 	// See: https://stackoverflow.com/a/6847328/995445
 	if ( ! rect ) {
-		const padNode = document.createTextNode( '\u200b' );
+		const padNode = ownerDocument.createTextNode( '\u200b' );
 		// Do not modify the live range.
 		range = range.cloneRange();
 		range.insertNode( padNode );
@@ -248,9 +249,11 @@ export function getRectangleFromRange( range ) {
 /**
  * Get the rectangle for the selection in a container.
  *
+ * @param {Window} window The window of the selection.
+ *
  * @return {?DOMRect} The rectangle.
  */
-export function computeCaretRect() {
+export function computeCaretRect( window ) {
 	const selection = window.getSelection();
 	const range = selection.rangeCount ? selection.getRangeAt( 0 ) : null;
 
@@ -301,8 +304,10 @@ export function placeCaretAtHorizontalEdge( container, isReverse ) {
 		return;
 	}
 
-	const selection = window.getSelection();
-	const range = document.createRange();
+	const { ownerDocument } = container;
+	const { defaultView } = ownerDocument;
+	const selection = defaultView.getSelection();
+	const range = ownerDocument.createRange();
 
 	range.selectNodeContents( rangeTarget );
 	range.collapse( ! isReverse );
@@ -317,9 +322,9 @@ export function placeCaretAtHorizontalEdge( container, isReverse ) {
  *
  * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/caretRangeFromPoint
  *
- * @param {Document} doc The document of the range.
- * @param {number}    x   Horizontal position within the current viewport.
- * @param {number}    y   Vertical position within the current viewport.
+ * @param {Document} doc  The document of the range.
+ * @param {number}   x    Horizontal position within the current viewport.
+ * @param {number}   y    Vertical position within the current viewport.
  *
  * @return {?Range} The best range for the given point.
  */
@@ -412,7 +417,9 @@ export function placeCaretAtVerticalEdge(
 		? editableRect.bottom - buffer
 		: editableRect.top + buffer;
 
-	const range = hiddenCaretRangeFromPoint( document, x, y, container );
+	const { ownerDocument } = container;
+	const { defaultView } = ownerDocument;
+	const range = hiddenCaretRangeFromPoint( ownerDocument, x, y, container );
 
 	if ( ! range || ! container.contains( range.startContainer ) ) {
 		if (
@@ -432,7 +439,7 @@ export function placeCaretAtVerticalEdge(
 		return;
 	}
 
-	const selection = window.getSelection();
+	const selection = defaultView.getSelection();
 	selection.removeAllRanges();
 	selection.addRange( range );
 	container.focus();
@@ -496,8 +503,8 @@ export function isNumberInput( element ) {
  *
  * @return {boolean} True if there is selection, false if not.
  */
-export function documentHasTextSelection() {
-	const selection = window.getSelection();
+export function documentHasTextSelection( document ) {
+	const selection = document.defaultView.getSelection();
 	const range = selection.rangeCount ? selection.getRangeAt( 0 ) : null;
 	return range && ! range.collapsed;
 }
@@ -543,9 +550,9 @@ function inputFieldHasUncollapsedSelection( element ) {
  *
  * @return {boolean} Whether there is any sort of "selection" in the document.
  */
-export function documentHasUncollapsedSelection() {
+export function documentHasUncollapsedSelection( document ) {
 	return (
-		documentHasTextSelection() ||
+		documentHasTextSelection( document ) ||
 		inputFieldHasUncollapsedSelection( document.activeElement )
 	);
 }
@@ -554,13 +561,15 @@ export function documentHasUncollapsedSelection() {
  * Check whether the current document has a selection. This checks for both
  * focus in an input field and general text selection.
  *
+ * @param {Document} document The document to check.
+ *
  * @return {boolean} True if there is selection, false if not.
  */
-export function documentHasSelection() {
+export function documentHasSelection( document ) {
 	return (
 		isTextField( document.activeElement ) ||
 		isNumberInput( document.activeElement ) ||
-		documentHasTextSelection()
+		documentHasTextSelection( document )
 	);
 }
 
@@ -584,7 +593,9 @@ export function isEntirelySelected( element ) {
 		return true;
 	}
 
-	const selection = window.getSelection();
+	const { ownerDocument } = element;
+	const { defaultView } = ownerDocument;
+	const selection = defaultView.getSelection();
 	const range = selection.rangeCount ? selection.getRangeAt( 0 ) : null;
 
 	if ( ! range ) {
@@ -604,7 +615,7 @@ export function isEntirelySelected( element ) {
 
 	const lastChild = element.lastChild;
 	const lastChildContentLength =
-		lastChild.nodeType === TEXT_NODE
+		lastChild.nodeType === lastChild.TEXT_NODE
 			? lastChild.data.length
 			: lastChild.childNodes.length;
 
@@ -631,7 +642,7 @@ export function getScrollContainer( node ) {
 	// Scrollable if scrollable height exceeds displayed...
 	if ( node.scrollHeight > node.clientHeight ) {
 		// ...except when overflow is defined to be hidden or visible
-		const { overflowY } = window.getComputedStyle( node );
+		const { overflowY } = getComputedStyle( node );
 		if ( /(auto|scroll)/.test( overflowY ) ) {
 			return node;
 		}
@@ -657,7 +668,7 @@ export function getOffsetParent( node ) {
 	// an element node, so find the closest element node.
 	let closestElement;
 	while ( ( closestElement = node.parentNode ) ) {
-		if ( closestElement.nodeType === ELEMENT_NODE ) {
+		if ( closestElement.nodeType === closestElement.ELEMENT_NODE ) {
 			break;
 		}
 	}
@@ -765,7 +776,10 @@ export function wrap( newNode, referenceNode ) {
  * @return {string} The text content with any html removed.
  */
 export function __unstableStripHTML( html ) {
-	const document = new DOMParser().parseFromString( html, 'text/html' );
+	const document = new window.DOMParser().parseFromString(
+		html,
+		'text/html'
+	);
 	return document.body.textContent || '';
 }
 
@@ -788,7 +802,7 @@ function cleanNodeList( nodeList, doc, schema, inline ) {
 			schema.hasOwnProperty( tag ) &&
 			( ! schema[ tag ].isMatch || schema[ tag ].isMatch( node ) )
 		) {
-			if ( node.nodeType === ELEMENT_NODE ) {
+			if ( node.nodeType === node.ELEMENT_NODE ) {
 				const {
 					attributes = [],
 					classes = [],
@@ -936,11 +950,11 @@ export function isEmpty( element ) {
 	}
 
 	return Array.from( element.childNodes ).every( ( node ) => {
-		if ( node.nodeType === TEXT_NODE ) {
+		if ( node.nodeType === node.TEXT_NODE ) {
 			return ! node.nodeValue.trim();
 		}
 
-		if ( node.nodeType === ELEMENT_NODE ) {
+		if ( node.nodeType === node.ELEMENT_NODE ) {
 			if ( node.nodeName === 'BR' ) {
 				return true;
 			} else if ( node.hasAttributes() ) {

--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -249,12 +249,12 @@ export function getRectangleFromRange( range ) {
 /**
  * Get the rectangle for the selection in a container.
  *
- * @param {Window} window The window of the selection.
+ * @param {Window} win The window of the selection.
  *
  * @return {?DOMRect} The rectangle.
  */
-export function computeCaretRect( window ) {
-	const selection = window.getSelection();
+export function computeCaretRect( win ) {
+	const selection = win.getSelection();
 	const range = selection.rangeCount ? selection.getRangeAt( 0 ) : null;
 
 	if ( ! range ) {
@@ -501,10 +501,12 @@ export function isNumberInput( element ) {
  *
  * See: https://developer.mozilla.org/en-US/docs/Web/API/Window/getSelection#Related_objects.
  *
+ * @param {Document} doc The document to check.
+ *
  * @return {boolean} True if there is selection, false if not.
  */
-export function documentHasTextSelection( document ) {
-	const selection = document.defaultView.getSelection();
+export function documentHasTextSelection( doc ) {
+	const selection = doc.defaultView.getSelection();
 	const range = selection.rangeCount ? selection.getRangeAt( 0 ) : null;
 	return range && ! range.collapsed;
 }
@@ -548,12 +550,14 @@ function inputFieldHasUncollapsedSelection( element ) {
  * ranges of text across elements and any selection inside <input> and
  * <textarea> elements.
  *
+ * @param {Document} doc The document to check.
+ *
  * @return {boolean} Whether there is any sort of "selection" in the document.
  */
-export function documentHasUncollapsedSelection( document ) {
+export function documentHasUncollapsedSelection( doc ) {
 	return (
-		documentHasTextSelection( document ) ||
-		inputFieldHasUncollapsedSelection( document.activeElement )
+		documentHasTextSelection( doc ) ||
+		inputFieldHasUncollapsedSelection( doc.activeElement )
 	);
 }
 
@@ -561,15 +565,15 @@ export function documentHasUncollapsedSelection( document ) {
  * Check whether the current document has a selection. This checks for both
  * focus in an input field and general text selection.
  *
- * @param {Document} document The document to check.
+ * @param {Document} doc The document to check.
  *
  * @return {boolean} True if there is selection, false if not.
  */
-export function documentHasSelection( document ) {
+export function documentHasSelection( doc ) {
 	return (
-		isTextField( document.activeElement ) ||
-		isNumberInput( document.activeElement ) ||
-		documentHasTextSelection( document )
+		isTextField( doc.activeElement ) ||
+		isNumberInput( doc.activeElement ) ||
+		documentHasTextSelection( doc )
 	);
 }
 

--- a/packages/dom/src/focusable.js
+++ b/packages/dom/src/focusable.js
@@ -77,7 +77,9 @@ function isValidFocusableArea( element ) {
 		return false;
 	}
 
-	const img = document.querySelector( 'img[usemap="#' + map.name + '"]' );
+	const img = element.ownerDocument.querySelector(
+		'img[usemap="#' + map.name + '"]'
+	);
 	return !! img && isVisible( img );
 }
 

--- a/packages/dom/src/tabbable.js
+++ b/packages/dom/src/tabbable.js
@@ -152,7 +152,7 @@ export function find( context ) {
  *                          to the active element.
  */
 export function findPrevious( element = document.activeElement ) {
-	const focusables = findFocusable( document.body );
+	const focusables = findFocusable( element.ownerDocument.body );
 	const index = focusables.indexOf( element );
 
 	// Remove all focusables after and including `element`.
@@ -168,7 +168,7 @@ export function findPrevious( element = document.activeElement ) {
  *                          to the active element.
  */
 export function findNext( element = document.activeElement ) {
-	const focusables = findFocusable( document.body );
+	const focusables = findFocusable( element.ownerDocument.body );
 	const index = focusables.indexOf( element );
 
 	// Remove all focusables before and inside `element`.

--- a/packages/dom/src/tabbable.js
+++ b/packages/dom/src/tabbable.js
@@ -151,7 +151,7 @@ export function find( context ) {
  * @param {Element} element The focusable element before which to look. Defaults
  *                          to the active element.
  */
-export function findPrevious( element = document.activeElement ) {
+export function findPrevious( element ) {
 	const focusables = findFocusable( element.ownerDocument.body );
 	const index = focusables.indexOf( element );
 
@@ -167,7 +167,7 @@ export function findPrevious( element = document.activeElement ) {
  * @param {Element} element The focusable element after which to look. Defaults
  *                          to the active element.
  */
-export function findNext( element = document.activeElement ) {
+export function findNext( element ) {
 	const focusables = findFocusable( element.ownerDocument.body );
 	const index = focusables.indexOf( element );
 

--- a/packages/dom/src/test/utils/create-element.js
+++ b/packages/dom/src/test/utils/create-element.js
@@ -22,7 +22,7 @@ export default function createElement( type ) {
 			} while (
 				! isHidden &&
 				node &&
-				node.nodeType === window.Node.ELEMENT_NODE
+				node.nodeType === node.ELEMENT_NODE
 			);
 
 			return isHidden ? elseValue : value;

--- a/packages/e2e-tests/specs/editor/various/typewriter.test.js
+++ b/packages/e2e-tests/specs/editor/various/typewriter.test.js
@@ -9,7 +9,7 @@ describe( 'TypeWriter', () => {
 	} );
 
 	const getCaretPosition = async () =>
-		await page.evaluate( () => wp.dom.computeCaretRect().y );
+		await page.evaluate( () => wp.dom.computeCaretRect( window ).y );
 
 	// Allow the scroll position to be 1px off.
 	const BUFFER = 1;

--- a/packages/edit-post/src/components/admin-notices/index.js
+++ b/packages/edit-post/src/components/admin-notices/index.js
@@ -43,7 +43,7 @@ function getNoticeHTML( element ) {
 	const fragments = [];
 
 	for ( const child of element.childNodes ) {
-		if ( child.nodeType !== window.Node.ELEMENT_NODE ) {
+		if ( child.nodeType !== child.ELEMENT_NODE ) {
 			const value = child.nodeValue.trim();
 			if ( value ) {
 				fragments.push( child.nodeValue );

--- a/packages/edit-post/src/prevent-event-discovery.js
+++ b/packages/edit-post/src/prevent-event-discovery.js
@@ -1,10 +1,11 @@
 export default {
 	't a l e s o f g u t e n b e r g': ( event ) => {
+		const { ownerDocument } = event.target;
 		if (
-			! document.activeElement.classList.contains(
+			! ownerDocument.activeElement.classList.contains(
 				'edit-post-visual-editor'
 			) &&
-			document.activeElement !== document.body
+			ownerDocument.activeElement !== ownerDocument.body
 		) {
 			return;
 		}

--- a/packages/eslint-plugin/configs/custom.js
+++ b/packages/eslint-plugin/configs/custom.js
@@ -4,12 +4,21 @@ module.exports = {
 		'@wordpress/no-unused-vars-before-return': 'error',
 		'@wordpress/no-base-control-with-label-without-id': 'error',
 		'@wordpress/no-unguarded-get-range-at': 'error',
+		'@wordpress/no-global-active-element': 'warn',
+		'@wordpress/no-global-get-selection': 'warn',
 	},
 	overrides: [
 		{
 			files: [ '*.native.js' ],
 			rules: {
 				'@wordpress/no-base-control-with-label-without-id': 'off',
+			},
+		},
+		{
+			files: [ '*.test.js', '**/test/*.js' ],
+			rules: {
+				'@wordpress/no-global-active-element': 'off',
+				'@wordpress/no-global-get-selection': 'off',
 			},
 		},
 	],

--- a/packages/eslint-plugin/rules/__tests__/no-global-active-element.js
+++ b/packages/eslint-plugin/rules/__tests__/no-global-active-element.js
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import { RuleTester } from 'eslint';
+
+/**
+ * Internal dependencies
+ */
+import rule from '../no-global-active-element';
+
+const ruleTester = new RuleTester( {
+	parserOptions: {
+		ecmaVersion: 6,
+	},
+} );
+
+ruleTester.run( 'no-global-active-element', rule, {
+	valid: [
+		{
+			code: 'ownerDocument.activeElement;',
+		},
+	],
+	invalid: [
+		{
+			code: 'document.activeElement;',
+			errors: [ { message: 'Avoid global active element' } ],
+		},
+	],
+} );

--- a/packages/eslint-plugin/rules/__tests__/no-global-get-selection.js
+++ b/packages/eslint-plugin/rules/__tests__/no-global-get-selection.js
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import { RuleTester } from 'eslint';
+
+/**
+ * Internal dependencies
+ */
+import rule from '../no-global-get-selection';
+
+const ruleTester = new RuleTester( {
+	parserOptions: {
+		ecmaVersion: 6,
+	},
+} );
+
+ruleTester.run( 'no-global-get-selection', rule, {
+	valid: [
+		{
+			code: 'defaultView.getSelection();',
+		},
+	],
+	invalid: [
+		{
+			code: 'window.getSelection();',
+			errors: [ { message: 'Avoid global selection getting' } ],
+		},
+	],
+} );

--- a/packages/eslint-plugin/rules/__tests__/no-unguarded-get-range-at.js
+++ b/packages/eslint-plugin/rules/__tests__/no-unguarded-get-range-at.js
@@ -17,12 +17,12 @@ const ruleTester = new RuleTester( {
 ruleTester.run( 'no-unguarded-get-range-at', rule, {
 	valid: [
 		{
-			code: `const selection = window.getSelection(); const range = selection.rangeCount ? selection.getRangeAt( 0 ) : null;`,
+			code: `const selection = defaultView.getSelection(); const range = selection.rangeCount ? selection.getRangeAt( 0 ) : null;`,
 		},
 	],
 	invalid: [
 		{
-			code: `window.getSelection().getRangeAt( 0 );`,
+			code: `defaultView.getSelection().getRangeAt( 0 );`,
 			errors: [ { message: 'Avoid unguarded getRangeAt' } ],
 		},
 	],

--- a/packages/eslint-plugin/rules/no-global-active-element.js
+++ b/packages/eslint-plugin/rules/no-global-active-element.js
@@ -5,12 +5,12 @@ module.exports = {
 	},
 	create( context ) {
 		return {
-			'CallExpression[callee.object.callee.property.name="getSelection"][callee.property.name="getRangeAt"]'(
+			'MemberExpression[object.name="document"][property.name="activeElement"]'(
 				node
 			) {
 				context.report( {
 					node,
-					message: 'Avoid unguarded getRangeAt',
+					message: 'Avoid global active element',
 				} );
 			},
 		};

--- a/packages/eslint-plugin/rules/no-global-get-selection.js
+++ b/packages/eslint-plugin/rules/no-global-get-selection.js
@@ -5,12 +5,12 @@ module.exports = {
 	},
 	create( context ) {
 		return {
-			'CallExpression[callee.object.callee.property.name="getSelection"][callee.property.name="getRangeAt"]'(
+			'CallExpression[callee.object.name="window"][callee.property.name="getSelection"]'(
 				node
 			) {
 				context.report( {
 					node,
-					message: 'Avoid unguarded getRangeAt',
+					message: 'Avoid global selection getting',
 				} );
 			},
 		};

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -71,7 +71,7 @@ function InlineLinkUI( {
 		// If the caret is right before the element, select the next element.
 		element = element.nextElementSibling || element;
 
-		while ( element.nodeType !== window.Node.ELEMENT_NODE ) {
+		while ( element.nodeType !== element.ELEMENT_NODE ) {
 			element = element.parentNode;
 		}
 

--- a/packages/format-library/src/text-color/inline.js
+++ b/packages/format-library/src/text-color/inline.js
@@ -63,7 +63,7 @@ const ColorPopoverAtLink = ( { addingColor, ...props } ) => {
 		// If the caret is right before the element, select the next element.
 		element = element.nextElementSibling || element;
 
-		while ( element.nodeType !== window.Node.ELEMENT_NODE ) {
+		while ( element.nodeType !== element.ELEMENT_NODE ) {
 			element = element.parentNode;
 		}
 

--- a/packages/react-native-editor/src/jsdom-patches.js
+++ b/packages/react-native-editor/src/jsdom-patches.js
@@ -31,9 +31,6 @@ const {
 	NOT_FOUND_ERR,
 } = core;
 
-// Node types
-const { ATTRIBUTE_NODE, DOCUMENT_FRAGMENT_NODE } = Node;
-
 /**
  * Simple recursive implementation of Node.contains method
  *
@@ -93,7 +90,7 @@ Node.prototype.insertBefore = function (
 	}
 	*/
 
-	if ( newChild.nodeType && newChild.nodeType === ATTRIBUTE_NODE ) {
+	if ( newChild.nodeType && newChild.nodeType === newChild.ATTRIBUTE_NODE ) {
 		throw new core.DOMException( HIERARCHY_REQUEST_ERR );
 	}
 
@@ -106,7 +103,7 @@ Node.prototype.insertBefore = function (
 	} while ( ( current = current._parentNode ) );
 
 	// fragments are merged into the element
-	if ( newChild.nodeType === DOCUMENT_FRAGMENT_NODE ) {
+	if ( newChild.nodeType === newChild.DOCUMENT_FRAGMENT_NODE ) {
 		let tmpNode,
 			i = newChild._childNodes.length;
 		while ( i-- > 0 ) {
@@ -200,7 +197,7 @@ Object.defineProperties( Node.prototype, {
 		get() {
 			const parent = this.parentNode;
 
-			if ( parent && parent.nodeType === Node.ELEMENT_NODE ) {
+			if ( parent && parent.nodeType === parent.ELEMENT_NODE ) {
 				return parent;
 			}
 
@@ -221,7 +218,7 @@ Object.defineProperties( Node.prototype, {
 
 			let sibling = this.previousSibling;
 
-			while ( sibling && sibling.nodeType !== Node.ELEMENT_NODE ) {
+			while ( sibling && sibling.nodeType !== sibling.ELEMENT_NODE ) {
 				sibling = sibling.previousSibling;
 			}
 
@@ -242,7 +239,7 @@ Object.defineProperties( Node.prototype, {
 
 			let sibling = this.nextSibling;
 
-			while ( sibling && sibling.nodeType !== Node.ELEMENT_NODE ) {
+			while ( sibling && sibling.nodeType !== sibling.ELEMENT_NODE ) {
 				sibling = sibling.nextSibling;
 			}
 

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -826,7 +826,7 @@ function RichText( {
 			return;
 		}
 
-		if ( document.activeElement !== ref.current ) {
+		if ( ref.current.ownerDocument.activeElement !== ref.current ) {
 			return;
 		}
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

This PR is preparation for iframing the editor content, though good practice regardless.
Whenever possible, globals should never be used in the context of DOM (including events and selection), but should be relative to DOM nodes. This fits the React model.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
