### PR TITLE
Social Icons Block: let icons wrap

### DIFF
--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -10,8 +10,13 @@
 // @todo: eventually we may add a feature that lets a parent container absorb the block UI of a child block.
 // When that happens, leverage that instead of the following overrides.
 .editor-styles-wrapper .wp-block-social-link {
-	margin: 0;
-	margin-right: 8px;
+	margin: 0 8px 8px 0;
+
+	// Prevent toolbar from jumping when selecting / hovering a link
+	&.is-selected,
+	&.is-hovered {
+		transform: none;
+	}
 }
 
 .editor-styles-wrapper .wp-block-social-links {

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -12,7 +12,7 @@
 .editor-styles-wrapper .wp-block-social-link {
 	margin: 0 8px 8px 0;
 
-	// Prevent toolbar from jumping when selecting / hovering a link
+	// Prevent toolbar from jumping when selecting / hovering a link.
 	&.is-selected,
 	&.is-hovered {
 		transform: none;

--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -1,5 +1,6 @@
 .wp-block-social-links {
 	display: flex;
+	flex-wrap: wrap;
 	justify-content: flex-start;
 	padding-left: 0;
 	padding-right: 0;
@@ -20,7 +21,7 @@
 	width: 36px;
 	height: 36px;
 	border-radius: 36px; // This makes it pill-shaped instead of oval, in cases where the image fed is not perfectly sized.
-	margin-right: 8px;
+	margin: 0 8px 8px 0;
 	transition: transform 0.1s ease;
 	@include reduce-motion("transition");
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Fixes https://github.com/WordPress/gutenberg/issues/24026
- prevent overflowing by letting icons wrap
- in editor prevent toolbar from jumping

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
- Go to creating a new page
- Create a 2-columns block, where the left column is smaller than the right
- Add Social Icons block with 10 social icons in the left column
**Editor**
- Notice that all icons are clickable and icons tend to wrap to the next row
**Frontend**
- Notice that icons wrap to the next row instead of distorting

## Screenshots <!-- if applicable -->

**Icons not clickable**
Before | After
-------|------
![88240492-26d7c380-cc3c-11ea-8b74-0199316c0d1d](https://user-images.githubusercontent.com/12430020/93207246-5c43ed80-f763-11ea-8557-53f85e6f0daf.gif)|![SS 2020-09-15 at 14 55 18](https://user-images.githubusercontent.com/12430020/93207419-9ca36b80-f763-11ea-9cbf-dcfd4811471f.gif)

**Icons being distorted**
Before | After
-------|------
![](https://cln.sh/Ll4EDe+) | ![](https://cln.sh/0jkT65+)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
