### PR TITLE
Data: improve docs for registry control/selector creators

### DIFF
--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -348,7 +348,24 @@ _Returns_
 
 <a name="createRegistryControl" href="#createRegistryControl">#</a> **createRegistryControl**
 
-Mark a control as a registry control.
+Creates a control function that takes additional curried argument with the `registry` object.
+While a regular control has signature
+
+```js
+( action ) => ( iteratorOrPromise )
+```
+
+where the control works with the `action` that it's bound to, a registry control has signature:
+
+```js
+( registry ) => ( action ) => ( iteratorOrPromise )
+```
+
+A registry control is typically used to select data or dispatch an action to a registered
+store.
+
+When registering a control created with `createRegistryControl` with a store, the store
+knows which calling convention to use when executing the control.
 
 _Parameters_
 
@@ -356,19 +373,53 @@ _Parameters_
 
 _Returns_
 
--   `Function`: marked registry control.
+-   `Function`: Registry control that can be registered with a store.
 
 <a name="createRegistrySelector" href="#createRegistrySelector">#</a> **createRegistrySelector**
 
-Mark a selector as a registry selector.
+Creates a selector function that takes additional curried argument with the
+registry `select` function. While a regular selector has signature
+
+```js
+( state, ...selectorArgs ) => ( result )
+```
+
+that allows to select data from the store's `state`, a registry selector
+has signature:
+
+```js
+( select ) => ( state, ...selectorArgs ) => ( result )
+```
+
+that supports also selecting from other registered stores.
+
+_Usage_
+
+```js
+const getCurrentPostId = createRegistrySelector( ( select ) => ( state ) => {
+  return select( 'core/editor' ).getCurrentPostId();
+} );
+
+const getPostEdits = createRegistrySelector( ( select ) => ( state ) => {
+  // calling another registry selector just like any other function
+  const postType = getCurrentPostType( state );
+  const postId = getCurrentPostId( state );
+ return select( 'core' ).getEntityRecordEdits( 'postType', postType, postId );
+} );
+```
+
+Note how the `getCurrentPostId` selector can be called just like any other function,
+(it works even inside a regular non-registry selector) and we don't need to pass the
+registry as argument. The registry binding happens automatically when registering the selector
+with a store.
 
 _Parameters_
 
--   _registrySelector_ `Function`: Function receiving a registry object and returning a state selector.
+-   _registrySelector_ `Function`: Function receiving a registry `select` function and returning a state selector.
 
 _Returns_
 
--   `Function`: marked registry selector.
+-   `Function`: Registry selector that can be registered with a store.
 
 <a name="dispatch" href="#dispatch">#</a> **dispatch**
 

--- a/packages/data/src/factory.js
+++ b/packages/data/src/factory.js
@@ -6,18 +6,52 @@ import defaultRegistry from './default-registry';
 /** @typedef {import('./registry').WPDataRegistry} WPDataRegistry */
 
 /**
- * Mark a selector as a registry selector.
+ * Creates a selector function that takes additional curried argument with the
+ * registry `select` function. While a regular selector has signature
+ * ```js
+ * ( state, ...selectorArgs ) => ( result )
+ * ```
+ * that allows to select data from the store's `state`, a registry selector
+ * has signature:
+ * ```js
+ * ( select ) => ( state, ...selectorArgs ) => ( result )
+ * ```
+ * that supports also selecting from other registered stores.
  *
- * @param {Function} registrySelector Function receiving a registry object and returning a state selector.
+ * @example
+ * ```js
+ * const getCurrentPostId = createRegistrySelector( ( select ) => ( state ) => {
+ *   return select( 'core/editor' ).getCurrentPostId();
+ * } );
  *
- * @return {Function} marked registry selector.
+ * const getPostEdits = createRegistrySelector( ( select ) => ( state ) => {
+ *   // calling another registry selector just like any other function
+ *   const postType = getCurrentPostType( state );
+ *   const postId = getCurrentPostId( state );
+ *	 return select( 'core' ).getEntityRecordEdits( 'postType', postType, postId );
+ * } );
+ * ```
+ *
+ * Note how the `getCurrentPostId` selector can be called just like any other function,
+ * (it works even inside a regular non-registry selector) and we don't need to pass the
+ * registry as argument. The registry binding happens automatically when registering the selector
+ * with a store.
+ *
+ * @param {Function} registrySelector Function receiving a registry `select`
+ * function and returning a state selector.
+ *
+ * @return {Function} Registry selector that can be registered with a store.
  */
 export function createRegistrySelector( registrySelector ) {
+	// create a selector function that is bound to the registry referenced by `selector.registry`
+	// and that has the same API as a regular selector. Binding it in such a way makes it
+	// possible to call the selector directly from another selector.
 	const selector = ( ...args ) =>
 		registrySelector( selector.registry.select )( ...args );
 
 	/**
-	 * Flag indicating to selector registration mapping that the selector should
+	 * Flag indicating that the selector is a registry selector that needs the correct registry
+	 * reference to be assigned to `selecto.registry` to make it work correctly.
 	 * be mapped as a registry selector.
 	 *
 	 * @type {boolean}
@@ -25,8 +59,9 @@ export function createRegistrySelector( registrySelector ) {
 	selector.isRegistrySelector = true;
 
 	/**
-	 * Registry on which to call `select`, stubbed for non-standard usage to
-	 * use the default registry.
+	 * Registry on which to call `select`. The `defaultRegistry` value is overwritten with
+	 * the actual registry when the selector is registered with a store. Therefore, it's never
+	 * used and is assigned here only to satisfy the type constraint of the `registry` field.
 	 *
 	 * @type {WPDataRegistry}
 	 */
@@ -36,11 +71,24 @@ export function createRegistrySelector( registrySelector ) {
 }
 
 /**
- * Mark a control as a registry control.
+ * Creates a control function that takes additional curried argument with the `registry` object.
+ * While a regular control has signature
+ * ```js
+ * ( action ) => ( iteratorOrPromise )
+ * ```
+ * where the control works with the `action` that it's bound to, a registry control has signature:
+ * ```js
+ * ( registry ) => ( action ) => ( iteratorOrPromise )
+ * ```
+ * A registry control is typically used to select data or dispatch an action to a registered
+ * store.
+ *
+ * When registering a control created with `createRegistryControl` with a store, the store
+ * knows which calling convention to use when executing the control.
  *
  * @param {Function} registryControl Function receiving a registry object and returning a control.
  *
- * @return {Function} marked registry control.
+ * @return {Function} Registry control that can be registered with a store.
  */
 export function createRegistryControl( registryControl ) {
 	registryControl.isRegistryControl = true;


### PR DESCRIPTION
Updates docs for `createRegistrySelector` and `createRegistryControl` with some things I wish I could read in the docs instead of figuring them out from the code and PR discussion that introduced certain changes.
