### PR TITLE
data-controls: graduate the __unstableSyncSelect control to a stable one

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -6,7 +6,7 @@ import { castArray, get, isEqual, find } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { apiFetch, __unstableSyncSelect } from '@wordpress/data-controls';
+import { apiFetch, syncSelect } from '@wordpress/data-controls';
 import { addQueryArgs } from '@wordpress/url';
 
 /**
@@ -210,26 +210,21 @@ export function* deleteEntityRecord( kind, name, recordId, query ) {
  * @return {Object} Action object.
  */
 export function* editEntityRecord( kind, name, recordId, edits, options = {} ) {
-	const entity = yield __unstableSyncSelect(
-		'core',
-		'getEntity',
-		kind,
-		name
-	);
+	const entity = yield syncSelect( 'core', 'getEntity', kind, name );
 	if ( ! entity ) {
 		throw new Error(
 			`The entity being edited (${ kind }, ${ name }) does not have a loaded config.`
 		);
 	}
 	const { transientEdits = {}, mergedEdits = {} } = entity;
-	const record = yield __unstableSyncSelect(
+	const record = yield syncSelect(
 		'core',
 		'getRawEntityRecord',
 		kind,
 		name,
 		recordId
 	);
-	const editedRecord = yield __unstableSyncSelect(
+	const editedRecord = yield syncSelect(
 		'core',
 		'getEditedEntityRecord',
 		kind,
@@ -275,7 +270,7 @@ export function* editEntityRecord( kind, name, recordId, edits, options = {} ) {
  * an entity record, if any.
  */
 export function* undo() {
-	const undoEdit = yield __unstableSyncSelect( 'core', 'getUndoEdit' );
+	const undoEdit = yield syncSelect( 'core', 'getUndoEdit' );
 	if ( ! undoEdit ) {
 		return;
 	}
@@ -293,7 +288,7 @@ export function* undo() {
  * edit to an entity record, if any.
  */
 export function* redo() {
-	const redoEdit = yield __unstableSyncSelect( 'core', 'getRedoEdit' );
+	const redoEdit = yield syncSelect( 'core', 'getRedoEdit' );
 	if ( ! redoEdit ) {
 		return;
 	}
@@ -343,7 +338,7 @@ export function* saveEntityRecord(
 	for ( const [ key, value ] of Object.entries( record ) ) {
 		if ( typeof value === 'function' ) {
 			const evaluatedValue = value(
-				yield __unstableSyncSelect(
+				yield syncSelect(
 					'core',
 					'getEditedEntityRecord',
 					kind,
@@ -377,7 +372,7 @@ export function* saveEntityRecord(
 	let currentEdits;
 	try {
 		const path = `${ entity.baseURL }${ recordId ? '/' + recordId : '' }`;
-		const persistedRecord = yield __unstableSyncSelect(
+		const persistedRecord = yield syncSelect(
 			'core',
 			'getRawEntityRecord',
 			kind,
@@ -390,12 +385,9 @@ export function* saveEntityRecord(
 			// This is fine for now as it is the only supported autosave,
 			// but ideally this should all be handled in the back end,
 			// so the client just sends and receives objects.
-			const currentUser = yield __unstableSyncSelect(
-				'core',
-				'getCurrentUser'
-			);
+			const currentUser = yield syncSelect( 'core', 'getCurrentUser' );
 			const currentUserId = currentUser ? currentUser.id : undefined;
-			const autosavePost = yield __unstableSyncSelect(
+			const autosavePost = yield syncSelect(
 				'core',
 				'getAutosave',
 				persistedRecord.type,
@@ -487,14 +479,14 @@ export function* saveEntityRecord(
 
 			// Get the full local version of the record before the update,
 			// to merge it with the edits and then propagate it to subscribers
-			persistedEntity = yield __unstableSyncSelect(
+			persistedEntity = yield syncSelect(
 				'core',
 				'__experimentalGetEntityRecordNoResolver',
 				kind,
 				name,
 				recordId
 			);
-			currentEdits = yield __unstableSyncSelect(
+			currentEdits = yield syncSelect(
 				'core',
 				'getEntityRecordEdits',
 				kind,
@@ -541,7 +533,7 @@ export function* saveEntityRecord(
 				recordId,
 				{
 					...currentEdits,
-					...( yield __unstableSyncSelect(
+					...( yield syncSelect(
 						'core',
 						'getEntityRecordEdits',
 						kind,
@@ -575,7 +567,7 @@ export function* saveEntityRecord(
  */
 export function* saveEditedEntityRecord( kind, name, recordId, options ) {
 	if (
-		! ( yield __unstableSyncSelect(
+		! ( yield syncSelect(
 			'core',
 			'hasEditsForEntityRecord',
 			kind,
@@ -585,7 +577,7 @@ export function* saveEditedEntityRecord( kind, name, recordId, options ) {
 	) {
 		return;
 	}
-	const edits = yield __unstableSyncSelect(
+	const edits = yield syncSelect(
 		'core',
 		'getEntityRecordNonTransientEdits',
 		kind,

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -6,7 +6,7 @@ import { upperFirst, camelCase, map, find, get, startCase } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { apiFetch, __unstableSyncSelect } from '@wordpress/data-controls';
+import { apiFetch, syncSelect } from '@wordpress/data-controls';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -188,11 +188,7 @@ export const getMethodName = (
  * @return {Array} Entities
  */
 export function* getKindEntities( kind ) {
-	let entities = yield __unstableSyncSelect(
-		'core',
-		'getEntitiesByKind',
-		kind
-	);
+	let entities = yield syncSelect( 'core', 'getEntitiesByKind', kind );
 	if ( entities && entities.length !== 0 ) {
 		return entities;
 	}

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -8,11 +8,7 @@ import { find, includes, get, hasIn, compact, uniq } from 'lodash';
  */
 import { addQueryArgs } from '@wordpress/url';
 import deprecated from '@wordpress/deprecated';
-import {
-	apiFetch,
-	select,
-	__unstableSyncSelect,
-} from '@wordpress/data-controls';
+import { apiFetch, select, syncSelect } from '@wordpress/data-controls';
 
 /**
  * Internal dependencies
@@ -95,7 +91,7 @@ export function* getEntityRecord( kind, name, key = '', query ) {
 		// The resolution cache won't consider query as reusable based on the
 		// fields, so it's tested here, prior to initiating the REST request,
 		// and without causing `getEntityRecords` resolution to occur.
-		const hasRecords = yield __unstableSyncSelect(
+		const hasRecords = yield syncSelect(
 			'core',
 			'hasEntityRecords',
 			kind,

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __unstableSyncSelect } from '@wordpress/data-controls';
+import { syncSelect } from '@wordpress/data-controls';
 
 /**
  * Internal dependencies
@@ -26,12 +26,7 @@ describe( 'editEntityRecord', () => {
 			{}
 		);
 		expect( fulfillment.next().value ).toEqual(
-			__unstableSyncSelect(
-				'core',
-				'getEntity',
-				entity.kind,
-				entity.name
-			)
+			syncSelect( 'core', 'getEntity', entity.kind, entity.name )
 		);
 		// Don't pass back an entity config.
 		expect( fulfillment.next.bind( fulfillment ) ).toThrow(

--- a/packages/data-controls/CHANGELOG.md
+++ b/packages/data-controls/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Feature
+
+- Expose the `syncSelect` control for synchronous calls of registry selectors
+
 ## 1.4.0 (2019-11-14)
 
 ### Documentation

--- a/packages/data-controls/README.md
+++ b/packages/data-controls/README.md
@@ -104,11 +104,11 @@ _Returns_
 
 <a name="select" href="#select">#</a> **select**
 
-Dispatches a control action for triggering a registry select.
+Dispatches a control action for triggering and resolving a registry select.
 
 Note: when this control action is handled, it automatically considers
-selectors that may have a resolver. It will await and return the resolved
-value when the selector has not been resolved yet.
+selectors that may have a resolver. In such case, it will return a `Promise` that resolves
+after the selector finishes resolving, with the final result value.
 
 _Usage_
 
@@ -126,7 +126,36 @@ _Parameters_
 
 -   _storeKey_ `string`: The key for the store the selector belongs to
 -   _selectorName_ `string`: The name of the selector
--   _args_ `Array`: Arguments for the select.
+-   _args_ `Array`: Arguments for the selector.
+
+_Returns_
+
+-   `Object`: The control descriptor.
+
+<a name="syncSelect" href="#syncSelect">#</a> **syncSelect**
+
+Dispatches a control action for triggering a synchronous registry select.
+
+Note: This control synchronously returns the current selector value, triggering the
+resolution, but not waiting for it.
+
+_Usage_
+
+```js
+import { syncSelect } from '@wordpress/data-controls';
+
+// Action generator using `syncSelect`.
+export function* myAction() {
+	const isEditorSideBarOpened = yield syncSelect( 'core/edit-post', 'isEditorSideBarOpened' );
+	// Do stuff with the result from the `syncSelect`.
+}
+```
+
+_Parameters_
+
+-   _storeKey_ `string`: The key for the store the selector belongs to.
+-   _selectorName_ `string`: The name of the selector.
+-   _args_ `Array`: Arguments for the selector.
 
 _Returns_
 

--- a/packages/data-controls/src/index.js
+++ b/packages/data-controls/src/index.js
@@ -31,15 +31,15 @@ export const apiFetch = ( request ) => {
 };
 
 /**
- * Dispatches a control action for triggering a registry select.
+ * Dispatches a control action for triggering and resolving a registry select.
  *
  * Note: when this control action is handled, it automatically considers
- * selectors that may have a resolver. It will await and return the resolved
- * value when the selector has not been resolved yet.
+ * selectors that may have a resolver. In such case, it will return a `Promise` that resolves
+ * after the selector finishes resolving, with the final result value.
  *
  * @param {string} storeKey      The key for the store the selector belongs to
  * @param {string} selectorName  The name of the selector
- * @param {Array}  args          Arguments for the select.
+ * @param {Array}  args          Arguments for the selector.
  *
  * @example
  * ```js
@@ -64,29 +64,29 @@ export function select( storeKey, selectorName, ...args ) {
 }
 
 /**
- * Dispatches a control action for triggering a registry select.
+ * Dispatches a control action for triggering a synchronous registry select.
  *
- * Note: This functions like the `select` control, but does not wait
- * for resolvers.
+ * Note: This control synchronously returns the current selector value, triggering the
+ * resolution, but not waiting for it.
  *
  * @param {string} storeKey     The key for the store the selector belongs to.
  * @param {string} selectorName The name of the selector.
- * @param {Array}  args         Arguments for the select.
+ * @param {Array}  args         Arguments for the selector.
  *
  * @example
  * ```js
- * import { __unstableSyncSelect } from '@wordpress/data-controls';
+ * import { syncSelect } from '@wordpress/data-controls';
  *
- * // Action generator using `__unstableSyncSelect`.
+ * // Action generator using `syncSelect`.
  * export function* myAction() {
- * 	const isEditorSideBarOpened = yield __unstableSyncSelect( 'core/edit-post', 'isEditorSideBarOpened' );
- * 	// Do stuff with the result from the `__unstableSyncSelect`.
+ * 	const isEditorSideBarOpened = yield syncSelect( 'core/edit-post', 'isEditorSideBarOpened' );
+ * 	// Do stuff with the result from the `syncSelect`.
  * }
  * ```
  *
  * @return {Object} The control descriptor.
  */
-export function __unstableSyncSelect( storeKey, selectorName, ...args ) {
+export function syncSelect( storeKey, selectorName, ...args ) {
 	return {
 		type: 'SYNC_SELECT',
 		storeKey,

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -10,7 +10,7 @@ import deprecated from '@wordpress/deprecated';
 import {
 	dispatch,
 	select,
-	__unstableSyncSelect,
+	syncSelect,
 	apiFetch,
 } from '@wordpress/data-controls';
 import { parse, synchronizeBlocksWithTemplate } from '@wordpress/blocks';
@@ -679,7 +679,7 @@ export function* resetEditorBlocks( blocks, options = {} ) {
 	if ( __unstableShouldCreateUndoLevel !== false ) {
 		const { id, type } = yield select( STORE_KEY, 'getCurrentPost' );
 		const noChange =
-			( yield __unstableSyncSelect(
+			( yield syncSelect(
 				'core',
 				'getEditedEntityRecord',
 				'postType',


### PR DESCRIPTION
As discussed in #25235, there is nothing particularly unstable or controversial about the `__unstableSyncSelect` control, and it can be graduated to a stable `syncSelect` with a nice name.

This PR also replaces all the usages in other monorepo packages. Because the control had the `__unstable` prefix, I guess we don't need to worry about back compat with consumers that used it with the old name?