### PR TITLE
[Mobile] Allow newlines when pressing [Enter] in Gallery image captions [DO NOT MERGE]

### DIFF
--- a/packages/block-editor/src/components/caption/index.native.js
+++ b/packages/block-editor/src/components/caption/index.native.js
@@ -23,7 +23,7 @@ const Caption = ( {
 	shouldDisplay = true,
 	style,
 	value,
-	insertBlocksAfter = () => {},
+	insertBlocksAfter,
 } ) => (
 	<View
 		accessibilityLabel={
@@ -51,8 +51,10 @@ const Caption = ( {
 			underlineColorAndroid="transparent"
 			unstableOnFocus={ onFocus }
 			value={ value }
-			__unstableOnSplitAtEnd={ () =>
-				insertBlocksAfter( createBlock( 'core/paragraph' ) )
+			__unstableOnSplitAtEnd={
+				insertBlocksAfter
+					? () => insertBlocksAfter( createBlock( 'core/paragraph' ) )
+					: null
 			}
 			deleteEnter={ true }
 		/>


### PR DESCRIPTION
**[DO NOT MERGE][WIP]**

**Fixes** https://github.com/WordPress/gutenberg/issues/23575

## Related PRs:

## Description
On the mobile editor, gallery image captions did not allow newlines to be entered using the *enter* key at the end of the input.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots

<img width=300 src="https://user-images.githubusercontent.com/304044/93211169-84cee600-f769-11ea-805b-1047003e103a.gif" />

## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
