### PR TITLE
Navigation: menu links separator

### DIFF
--- a/packages/block-library/src/navigation-link/block.json
+++ b/packages/block-library/src/navigation-link/block.json
@@ -1,7 +1,9 @@
 {
 	"name": "core/navigation-link",
 	"category": "design",
-	"parent": [ "core/navigation" ],
+	"parent": [
+		"core/navigation"
+	],
 	"attributes": {
 		"label": {
 			"type": "string"
@@ -36,7 +38,8 @@
 		"customBackgroundColor",
 		"fontSize",
 		"customFontSize",
-		"showSubmenuIcon"
+		"showSubmenuIcon",
+		"separator"
 	],
 	"supports": {
 		"reusable": false,

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -127,6 +127,7 @@ function NavigationLinkEdit( {
 	isParentOfSelectedBlock,
 	setAttributes,
 	showSubmenuIcon,
+	separator,
 	insertLinkBlock,
 	textColor,
 	backgroundColor,
@@ -314,6 +315,7 @@ function NavigationLinkEdit( {
 					backgroundColor: rgbBackgroundColor,
 				} }
 				ref={ listItemRef }
+				data-separator={ separator }
 			>
 				<div className="wp-block-navigation-link__content">
 					<RichText
@@ -487,6 +489,7 @@ export default compose( [
 			.length;
 		const showSubmenuIcon =
 			!! navigationBlockAttributes.showSubmenuIcon && hasDescendants;
+		const separator = navigationBlockAttributes.separator;
 		const isParentOfSelectedBlock = hasSelectedInnerBlock( clientId, true );
 		const isImmediateParentOfSelectedBlock = hasSelectedInnerBlock(
 			clientId,
@@ -503,6 +506,7 @@ export default compose( [
 			hasDescendants,
 			selectedBlockHasDescendants,
 			showSubmenuIcon,
+			separator,
 			textColor: navigationBlockAttributes.textColor,
 			backgroundColor: navigationBlockAttributes.backgroundColor,
 			userCanCreatePages: select( 'core' ).canUser( 'create', 'pages' ),

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -116,7 +116,7 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 		$font_sizes['css_classes']
 	);
 	$style_attribute = ( $colors['inline_styles'] || $font_sizes['inline_styles'] );
-	$separator = $block->context['separator'] !== '' ? ' data-separator="' . $block->context['separator'] . '"' : null;
+	$separator       = ( '' !== $block->context['separator'] ) ? ' data-separator="' . $block->context['separator'] . '"' : null;
 
 	$css_classes = trim( implode( ' ', $classes ) );
 	$has_submenu = count( $block->inner_blocks ) > 0;

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -116,7 +116,7 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 		$font_sizes['css_classes']
 	);
 	$style_attribute = ( $colors['inline_styles'] || $font_sizes['inline_styles'] );
-	$separator       = ( '' !== $block->context['separator'] ) ? ' data-separator="' . $block->context['separator'] . '"' : null;
+	$separator       = ! empty( $block->context['separator'] ) ? ' data-separator="' . esc_attr( $block->context['separator'] ) . '"' : '';
 
 	$css_classes = trim( implode( ' ', $classes ) );
 	$has_submenu = count( $block->inner_blocks ) > 0;

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -116,7 +116,7 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 		$font_sizes['css_classes']
 	);
 	$style_attribute = ( $colors['inline_styles'] || $font_sizes['inline_styles'] );
-	$separator = $block->context['separator'] ? ' data-separator="' . $block->context['separator'] . '"' : null;
+	$separator = $block->context['separator'] !== '' ? ' data-separator="' . $block->context['separator'] . '"' : null;
 
 	$css_classes = trim( implode( ' ', $classes ) );
 	$has_submenu = count( $block->inner_blocks ) > 0;

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -116,6 +116,7 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 		$font_sizes['css_classes']
 	);
 	$style_attribute = ( $colors['inline_styles'] || $font_sizes['inline_styles'] );
+	$separator = $block->context['separator'] ? ' data-separator="' . $block->context['separator'] . '"' : null;
 
 	$css_classes = trim( implode( ' ', $classes ) );
 	$has_submenu = count( $block->inner_blocks ) > 0;
@@ -128,7 +129,7 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 	};
 
 	$html = '<li class="' . esc_attr( $css_classes . ( $has_submenu ? ' has-child' : '' ) ) .
-		( $is_active ? ' current-menu-item' : '' ) . '"' . $style_attribute . '>' .
+		( $is_active ? ' current-menu-item' : '' ) . '"' . $style_attribute . $separator . '>' .
 		'<a class="wp-block-navigation-link__content" ';
 
 	// Start appending HTML attributes to anchor tag.

--- a/packages/block-library/src/navigation-link/style.scss
+++ b/packages/block-library/src/navigation-link/style.scss
@@ -7,14 +7,6 @@
 	.wp-block-navigation__container:empty {
 		display: none;
 	}
-
-	&::before {
-		content: attr(data-separator);
-	}
-
-	&:first-child::before {
-		display: none;
-	}
 }
 
 .wp-block-navigation__container {

--- a/packages/block-library/src/navigation-link/style.scss
+++ b/packages/block-library/src/navigation-link/style.scss
@@ -7,6 +7,14 @@
 	.wp-block-navigation__container:empty {
 		display: none;
 	}
+
+	&::before {
+		content: attr(data-separator);
+	}
+
+	&:first-child::before {
+		display: none;
+	}
 }
 
 .wp-block-navigation__container {

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -32,7 +32,7 @@
 		},
 		"separator": {
 			"type": "string",
-			"default": null
+			"default": ""
 		}
 	},
 	"providesContext": {

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -29,6 +29,10 @@
 		"showSubmenuIcon": {
 			"type": "boolean",
 			"default": true
+		},
+		"separator": {
+			"type": "string",
+			"default": null
 		}
 	},
 	"providesContext": {
@@ -38,10 +42,14 @@
 		"customBackgroundColor": "customBackgroundColor",
 		"fontSize": "fontSize",
 		"customFontSize": "customFontSize",
-		"showSubmenuIcon": "showSubmenuIcon"
+		"showSubmenuIcon": "showSubmenuIcon",
+		"separator": "showSeparator"
 	},
 	"supports": {
-		"align": [ "wide", "full" ],
+		"align": [
+			"wide",
+			"full"
+		],
 		"anchor": true,
 		"html": false,
 		"inserter": true,

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -43,7 +43,7 @@
 		"fontSize": "fontSize",
 		"customFontSize": "customFontSize",
 		"showSubmenuIcon": "showSubmenuIcon",
-		"separator": "showSeparator"
+		"separator": "separator"
 	},
 	"supports": {
 		"align": [

--- a/packages/block-library/src/navigation/constants.js
+++ b/packages/block-library/src/navigation/constants.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 
 export const SEPARATOR_OPTIONS = [
-	{ value: null, label: __( 'None' ) },
+	{ value: '', label: __( 'None' ) },
 	{ value: '/', label: __( 'Forward Slash ( / )' ) },
 	{ value: '•', label: __( 'Bullet ( • )' ) },
 	{ value: '|', label: __( 'Pipe ( | )' ) },

--- a/packages/block-library/src/navigation/constants.js
+++ b/packages/block-library/src/navigation/constants.js
@@ -5,5 +5,7 @@ import { __ } from '@wordpress/i18n';
 
 export const SEPARATOR_OPTIONS = [
 	{ value: null, label: __( 'None' ) },
-	{ value: '/', label: __( 'Forward Slash' ) },
+	{ value: '/', label: __( 'Forward Slash ( / )' ) },
+	{ value: '•', label: __( 'Bullet ( • )' ) },
+	{ value: '|', label: __( 'Pipe ( | )' ) },
 ];

--- a/packages/block-library/src/navigation/constants.js
+++ b/packages/block-library/src/navigation/constants.js
@@ -1,0 +1,9 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export const SEPARATOR_OPTIONS = [
+	{ value: null, label: __( 'None' ) },
+	{ value: '/', label: __( 'Forward Slash' ) },
+];

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -166,16 +166,18 @@ function Navigation( {
 			</BlockControls>
 			{ navigatorModal }
 			<InspectorControls>
-				<PanelBody title={ __( 'Separators' ) }>
-					<SelectControl
-						label={ __( 'Separator' ) }
-						onChange={ ( value ) => {
-							setAttributes( { separator: value } );
-						} }
-						options={ SEPARATOR_OPTIONS }
-						value={ attributes.separator }
-					/>
-				</PanelBody>
+				{ 'horizontal' === attributes.orientation && (
+					<PanelBody title={ __( 'Separators' ) }>
+						<SelectControl
+							label={ __( 'Separator' ) }
+							onChange={ ( value ) => {
+								setAttributes( { separator: value } );
+							} }
+							options={ SEPARATOR_OPTIONS }
+							value={ attributes.separator }
+						/>
+					</PanelBody>
+				) }
 				<PanelBody title={ __( 'Display settings' ) }>
 					<ToggleControl
 						checked={ attributes.showSubmenuIcon }

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -133,7 +133,6 @@ function Navigation( {
 							: navIcons.justifyLeftIcon
 					}
 					label={ __( 'Change items justification' ) }
-					isCollapsed
 					controls={ [
 						{
 							icon: navIcons.justifyLeftIcon,

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -21,6 +21,7 @@ import {
 	ToggleControl,
 	Toolbar,
 	ToolbarGroup,
+	SelectControl,
 } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
@@ -32,6 +33,7 @@ import useBlockNavigator from './use-block-navigator';
 import BlockColorsStyleSelector from './block-colors-selector';
 import * as navIcons from './icons';
 import NavigationPlaceholder from './placeholder';
+import { SEPARATOR_OPTIONS } from './constants';
 
 function Navigation( {
 	selectedBlockHasDescendants,
@@ -164,6 +166,16 @@ function Navigation( {
 			</BlockControls>
 			{ navigatorModal }
 			<InspectorControls>
+				<PanelBody title={ __( 'Separators' ) }>
+					<SelectControl
+						label={ __( 'Separator' ) }
+						onChange={ ( value ) => {
+							setAttributes( { separator: value } );
+						} }
+						options={ SEPARATOR_OPTIONS }
+						value={ attributes.separator }
+					/>
+				</PanelBody>
 				<PanelBody title={ __( 'Display settings' ) }>
 					<ToggleControl
 						checked={ attributes.showSubmenuIcon }

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -73,6 +73,20 @@ $navigation-item-height: 46px;
 	}
 }
 
+// Move Separators to before element cause after is used for outlining the block.
+.wp-block-navigation > .wp-block-navigation__container > .wp-block-navigation-link {
+	&::before {
+		content: attr(data-separator);
+	}
+
+	&:first-child::before {
+		display: none;
+	}
+	&::after {
+		content: "";
+	}
+}
+
 /**
  * Colors Selector component
  */

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -10,11 +10,11 @@
 
 // Separators.
 .wp-block-navigation > .wp-block-navigation__container > .wp-block-navigation-link {
-	&::before {
+	&::after {
 		content: attr(data-separator);
 	}
 
-	&:first-child::before {
+	&:last-child::after {
 		display: none;
 	}
 }

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -8,6 +8,17 @@
 	}
 }
 
+// Separators.
+.wp-block-navigation > .wp-block-navigation__container > .wp-block-navigation-link {
+	&::before {
+		content: attr(data-separator);
+	}
+
+	&:first-child::before {
+		display: none;
+	}
+}
+
 // Justification.
 .items-justified-left > ul {
 	justify-content: flex-start;

--- a/packages/e2e-tests/fixtures/blocks/core__navigation.json
+++ b/packages/e2e-tests/fixtures/blocks/core__navigation.json
@@ -1,12 +1,13 @@
 [
-    {
-        "clientId": "_clientId_0",
-        "name": "core/navigation",
-        "isValid": true,
-        "attributes": {
-            "showSubmenuIcon": true
-        },
-        "innerBlocks": [],
-        "originalContent": ""
-    }
+	{
+		"clientId": "_clientId_0",
+		"name": "core/navigation",
+		"isValid": true,
+		"attributes": {
+			"separator": "",
+			"showSubmenuIcon": true
+		},
+		"innerBlocks": [],
+		"originalContent": ""
+	}
 ]


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->
Fixes https://github.com/WordPress/gutenberg/issues/23293

## Description
<!-- Please describe what you have changed or added -->
- adds a separator option ( `None, / , • , |`) for **horizontal** navigation menu blocks

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
### Manual Test 1
- add a horizontal menu (with submenus)

**Result**
- you should be able to choose a separator between ( `None, / , • , |`) from the sidebar navigation block options
- choosing a separator should display it in the editor and in the frontend. Separators should display only for the first level navigation items (not in submenus)
- choosing `None` should not display any separator in the editor and in the frontend

### Manual Test 2
- add a vertical menu (with submenus)

**Result**
- you should **NOT** be able to choose a separator from the sidebar navigation block options
- separators should not display in the editor and in the frontend

## Screenshots <!-- if applicable -->
Editor | Frontend
-------|------
![](https://cln.sh/S6OF5y+) | ![](https://cln.sh/yLOjxA+)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature (non-breaking change which adds functionality) 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
