### PR TITLE
Add link option in PostTitle block

### DIFF
--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -12,6 +12,19 @@
 		"level": {
 			"type": "number",
 			"default": 2
+		},
+		"makeLink": {
+			"type": "boolean",
+			"default": false
+		},
+		"rel": {
+			"type": "string",
+			"attribute": "rel",
+			"default": ""
+		},
+		"linkTarget": {
+			"type": "string",
+			"default": "_blank"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -10,9 +10,15 @@ import { useSelect } from '@wordpress/data';
 import {
 	AlignmentToolbar,
 	BlockControls,
+	InspectorControls,
 	__experimentalBlock as Block,
 } from '@wordpress/block-editor';
-import { ToolbarGroup } from '@wordpress/components';
+import {
+	ToolbarGroup,
+	ToggleControl,
+	TextControl,
+	PanelBody,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -21,12 +27,10 @@ import { __ } from '@wordpress/i18n';
 import HeadingLevelDropdown from '../heading/heading-level-dropdown';
 
 export default function PostTitleEdit( {
-	attributes,
+	attributes: { level, textAlign, makeLink, rel, linkTarget },
 	setAttributes,
-	context,
+	context: { postType, postId },
 } ) {
-	const { level, textAlign } = attributes;
-	const { postType, postId } = context;
 	const tagName = 0 === level ? 'p' : 'h' + level;
 
 	const post = useSelect(
@@ -44,6 +48,14 @@ export default function PostTitleEdit( {
 	}
 
 	const BlockWrapper = Block[ tagName ];
+	let title = post.title || __( 'Post Title' );
+	if ( makeLink ) {
+		title = (
+			<a href={ post.link } target={ linkTarget } rel={ rel }>
+				{ title }
+			</a>
+		);
+	}
 
 	return (
 		<>
@@ -63,12 +75,43 @@ export default function PostTitleEdit( {
 					} }
 				/>
 			</BlockControls>
+			<InspectorControls>
+				<PanelBody title={ __( 'Link settings' ) }>
+					<ToggleControl
+						label={ __( 'Make title a link' ) }
+						onChange={ () =>
+							setAttributes( { makeLink: ! makeLink } )
+						}
+						checked={ makeLink }
+					/>
+					{ makeLink && (
+						<>
+							<ToggleControl
+								label={ __( 'Open in new tab' ) }
+								onChange={ ( value ) =>
+									setAttributes( {
+										linkTarget: value ? '_blank' : '_self',
+									} )
+								}
+								checked={ linkTarget === '_blank' }
+							/>
+							<TextControl
+								label={ __( 'Link rel' ) }
+								value={ rel }
+								onChange={ ( newRel ) =>
+									setAttributes( { rel: newRel } )
+								}
+							/>
+						</>
+					) }
+				</PanelBody>
+			</InspectorControls>
 			<BlockWrapper
 				className={ classnames( {
 					[ `has-text-align-${ textAlign }` ]: textAlign,
 				} ) }
 			>
-				{ post.title || __( 'Post Title' ) }
+				{ title }
 			</BlockWrapper>
 		</>
 	);

--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -19,6 +19,7 @@ function render_block_core_post_title( $attributes, $content, $block ) {
 		return '';
 	}
 
+	$post_ID          = $block->context['postId'];
 	$tag_name         = 'h2';
 	$align_class_name = empty( $attributes['textAlign'] ) ? '' : "has-text-align-{$attributes['textAlign']}";
 
@@ -26,11 +27,16 @@ function render_block_core_post_title( $attributes, $content, $block ) {
 		$tag_name = 0 === $attributes['level'] ? 'p' : 'h' . $attributes['level'];
 	}
 
+	$title = get_the_title( $post_ID );
+	if ( isset( $attributes['makeLink'] ) && $attributes['makeLink'] ) {
+		$title = sprintf( '<a href="%1s" target="%2s" rel="%3s">%4s</a>', get_the_permalink( $post_ID ), $attributes['linkTarget'], $attributes['rel'], $title );
+	}
+
 	return sprintf(
 		'<%1$s class="%2$s">%3$s</%1$s>',
 		$tag_name,
 		esc_attr( $align_class_name ),
-		get_the_title( $block->context['postId'] )
+		$title
 	);
 }
 

--- a/packages/e2e-tests/fixtures/blocks/core__post-title.json
+++ b/packages/e2e-tests/fixtures/blocks/core__post-title.json
@@ -1,15 +1,15 @@
 [
-    {
-        "clientId": "_clientId_0",
-        "name": "core/post-title",
-        "isValid": true,
-        "attributes": {
+	{
+		"clientId": "_clientId_0",
+		"name": "core/post-title",
+		"isValid": true,
+		"attributes": {
 			"level": 2,
 			"makeLink": false,
 			"linkTarget": "_blank",
 			"rel": ""
-        },
-        "innerBlocks": [],
-        "originalContent": ""
-    }
+		},
+		"innerBlocks": [],
+		"originalContent": ""
+	}
 ]

--- a/packages/e2e-tests/fixtures/blocks/core__post-title.json
+++ b/packages/e2e-tests/fixtures/blocks/core__post-title.json
@@ -4,7 +4,10 @@
         "name": "core/post-title",
         "isValid": true,
         "attributes": {
-            "level": 2
+			"level": 2,
+			"makeLink": false,
+			"linkTarget": "_blank",
+			"rel": ""
         },
         "innerBlocks": [],
         "originalContent": ""


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Resolves: https://github.com/WordPress/gutenberg/issues/23861

Currently `PostTitle` block is rendered as plain text. This PR adds an option to make it a link and also adds attributes for selecting `target` and `rel`.

There is the need to have more `display` options in `FSE` blocks (ex. make featured image a link, manage excerpt length etc..) and this will be really useful for `Query` block.
<!-- Please describe what you have changed or added -->
## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
