### PR TITLE
Add readme for the copy handler component

### DIFF
--- a/packages/block-editor/src/components/copy-handler/README.md
+++ b/packages/block-editor/src/components/copy-handler/README.md
@@ -1,10 +1,11 @@
 # Copy Handler
 
-The `CopyHandler` component handles the copy, cut and paste events of its children blocks. It handles multiple selection of blocks as well.
+The `CopyHandler` component handles the copy/cut and paste events of its children blocks. It handles multiple selection of blocks as well.
 
-Concretely, it handles the display of success messages and takes care of copying the block to the clipboard using the [raw handling API](https://github.com/WordPress/gutenberg/tree/master/packages/blocks/src/api/raw-handling).
+Concretely, it handles the display of success messages and takes care of copying the block to the clipboard. It uses for that the [serialize function](https://github.com/WordPress/gutenberg/blob/master/packages/blocks/src/api/serializer.js), which outputs HTML augmented with the HTML-comment demarcations to denote blocks.
 
-![Copy cut behaviours](https://make.wordpress.org/core/files/2020/09/copy-cut-behaviour.gif)
+
+![Copy/cut behaviours](https://user-images.githubusercontent.com/150562/81698101-6e341d80-945d-11ea-9bfb-b20781f55033.gif)
 
 ## Table of contents
 
@@ -15,7 +16,7 @@ Concretely, it handles the display of success messages and takes care of copying
 
 ### Usage
 
-Adds the copy handler functionnalities to the editor.
+Adds block-level copy-and-paste support to the editor.
 
 ```jsx
 import { BlockList, CopyHandler } from '@wordpress/block-editor';
@@ -27,7 +28,7 @@ const MyCopyHandler = () => (
 );
 ```
 
-_Note:_ The `CopyHandler` only catches cut, copy and paste events coming from its props.children. In this example, the child is the `BlockList` component.
+_Note:_ The `CopyHandler` only catches copy/cut and paste events coming from its props.children. In this example, the child is the `BlockList` component. These events are intercepted only when there is a block-editing context and at least one block is currently selected.
 
 ### Props
 
@@ -35,7 +36,7 @@ _Note:_ The `CopyHandler` only catches cut, copy and paste events coming from it
 
 -  Type: `Element`
 
-Children are passed as children of `CopyHandler`.
+The elements to be rendered and whose `cut`, `copy` and `paste` events we'd like to intercept.
 
 ## Related components
 

--- a/packages/block-editor/src/components/copy-handler/README.md
+++ b/packages/block-editor/src/components/copy-handler/README.md
@@ -1,0 +1,42 @@
+# Copy Handler
+
+The `CopyHandler` component handles the behaviors of the editor when the user copies or cuts a block or a selection of blocks.
+
+Concretely, it handles the display of success messages and takes care of copying the block to the clipboard using the [raw handling API](https://github.com/WordPress/gutenberg/tree/master/packages/blocks/src/api/raw-handling).
+
+![Copy cut behaviours](https://make.wordpress.org/core/files/2020/09/copy-cut-behaviour.gif)
+
+## Table of contents
+
+1. [Development guidelines](#development-guidelines)
+2. [Related components](#related-components)
+
+## Development guidelines
+
+### Usage
+
+Adds the copy handler functionnalities to the editor.
+
+```jsx
+import { BlockList, CopyHandler } from '@wordpress/block-editor';
+
+const MyCopyHandler = () => (
+	<CopyHandler>
+		<BlockList />
+	</CopyHandler>
+);
+```
+
+_Note:_ The `CopyHandler` only catch cut/copy events coming from its props.children. In this example, the child is the `BlockList` component.
+
+### Props
+
+### `children`
+
+-   **Type:** `Object`
+
+An object that contains the component children.
+
+## Related components
+
+Block Editor components are components that can be used to compose the UI of your block editor. Thus, they can only be used under a [`BlockEditorProvider`](https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/provider/README.md) in the components tree.

--- a/packages/block-editor/src/components/copy-handler/README.md
+++ b/packages/block-editor/src/components/copy-handler/README.md
@@ -1,6 +1,6 @@
 # Copy Handler
 
-The `CopyHandler` component handles the behaviors of the editor when the user copies or cuts a block or a selection of blocks.
+The `CopyHandler` component handles the copy, cut and paste events of its children blocks. It handles multiple selection of blocks as well.
 
 Concretely, it handles the display of success messages and takes care of copying the block to the clipboard using the [raw handling API](https://github.com/WordPress/gutenberg/tree/master/packages/blocks/src/api/raw-handling).
 
@@ -27,15 +27,15 @@ const MyCopyHandler = () => (
 );
 ```
 
-_Note:_ The `CopyHandler` only catch cut/copy events coming from its props.children. In this example, the child is the `BlockList` component.
+_Note:_ The `CopyHandler` only catch cut, copy and paste events coming from its props.children. In this example, the child is the `BlockList` component.
 
 ### Props
 
 ### `children`
 
--   **Type:** `Object`
+-  Type: `Element`
 
-An object that contains the component children.
+Children are passed as children of `CopyHandler`.
 
 ## Related components
 

--- a/packages/block-editor/src/components/copy-handler/README.md
+++ b/packages/block-editor/src/components/copy-handler/README.md
@@ -27,7 +27,7 @@ const MyCopyHandler = () => (
 );
 ```
 
-_Note:_ The `CopyHandler` only catch cut, copy and paste events coming from its props.children. In this example, the child is the `BlockList` component.
+_Note:_ The `CopyHandler` only catches cut, copy and paste events coming from its props.children. In this example, the child is the `BlockList` component.
 
 ### Props
 


### PR DESCRIPTION
## Description
Added documentation for the copy handler component (see #22891)

## How has this been tested?
N/A, documentation only

## Types of changes
Documentation

## Checklist:
- [n/a] My code is tested.
- [n/a] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [n/a] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
