### PR TITLE
Cover: Remove default position (center/center) className from rendering

### DIFF
--- a/packages/block-library/src/cover/shared.js
+++ b/packages/block-library/src/cover/shared.js
@@ -70,16 +70,32 @@ export function attributesFromMedia( setAttributes ) {
 	};
 }
 
-export function getPositionClassName( contentPosition ) {
-	if ( contentPosition === undefined ) return '';
-
-	return POSITION_CLASSNAMES[ contentPosition ];
-}
-
+/**
+ * Checks of the contentPosition is the center (default) position.
+ *
+ * @param {string} contentPosition The current content position.
+ * @return {boolean} Whether the contentPosition is center.
+ */
 export function isContentPositionCenter( contentPosition ) {
 	return (
 		! contentPosition ||
 		contentPosition === 'center center' ||
 		contentPosition === 'center'
 	);
+}
+
+/**
+ * Retrieves the className for the current contentPosition.
+ * The default position (center) will not have a className.
+ *
+ * @param {string} contentPosition The current content position.
+ * @return {string} The className assigned to the contentPosition.
+ */
+export function getPositionClassName( contentPosition ) {
+	/*
+	 * Only render a className if the contentPosition is not center (the default).
+	 */
+	if ( isContentPositionCenter( contentPosition ) ) return '';
+
+	return POSITION_CLASSNAMES[ contentPosition ];
 }


### PR DESCRIPTION
This update fixes the contentPosition className rendering for the Cover. The default position (center/center) should not render out a className, as it is the neutral (or "unchanged") position.

<img width="580" alt="Screenshot of Chrome's inspector tools highlighting the HTML of the rendered cover blocks. The HTML code shows a Cover with a position className, one one without." src="https://user-images.githubusercontent.com/2322354/93237446-20525d80-f74e-11ea-9fff-1e9fd1ce927f.png">

(Screenshot of Chrome's inspector tools highlighting the HTML of the rendered cover blocks. The HTML code shows a Cover with a position className, one one without.)

The solution involved adding a guard within the function that retrieved the className of the contentPosition.

Resolves: https://github.com/WordPress/gutenberg/issues/24102

## How has this been tested?

Tested locally on Gutenberg

* `npm run dev`
* Add a Cover block and **save**
* Check the front-end rendered Cover block. Inspect element and ensure that it doesn't have a position className.
* Back in the Editor, Adjust the position (e.g. top/right) and **save**.
* Check the front-end rendered Cover block. Inspect element and ensure that it **does** have a position className.
* Back in the Editor, Adjust the position to center and **save**.
* Check the front-end rendered Cover block. Inspect element and ensure that it doesn't have a position className.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [n/a] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [n/a] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
