### PR TITLE
Update _colors.native.scss

### DIFF
--- a/packages/base-styles/_colors.native.scss
+++ b/packages/base-styles/_colors.native.scss
@@ -49,7 +49,6 @@ $gray-text: $gray-dark;
 $gray-text-min: darken($gray, 18%); //#537994
 
 // Shades of gray
-$studio-gray-10: #c3c4c7;
 $gray-lighten-30: lighten($gray, 30%); // #e9eff3
 $gray-darken-20: darken($gray, 20%); // #4f748e
 
@@ -76,7 +75,7 @@ $gray-100: #101517;
 // neutral (light) - black is a base color in light mode
 $light-primary: #000d; //rgba(0, 0, 0, 0.87);
 $light-secondary: #0009; //rgba(0, 0, 0, 0.6);
-$light-tertiary: #0000006d; //rgba(0, 0, 0, 0.43);
+$light-tertiary: rgba($black, 0.43);
 $light-quaternary: #0000003f; //rgba(0, 0, 0, 0.25);
 $light-dim: #0000001e; //rgba(0, 0, 0, 0.12);
 $light-ultra-dim: #0000000a; //rgba(0, 0, 0, 0.04);
@@ -84,6 +83,7 @@ $light-ultra-dim: #0000000a; //rgba(0, 0, 0, 0.04);
 // neutral (dark) - white is a base color in dark mode
 $dark-primary: #fffd; //rgba(255, 255, 255, 0.87);
 $dark-secondary: #fff9; //rgba(255, 255, 255, 0.6);
+$dark-tertiary: rgba($white, 0.43);
 $dark-quaternary: #ffffff3f; //rgba(255, 255, 255, 0.25);
 $dark-ultra-dim: #ffffff14; //rgba(255, 255, 255, 0.08);
 
@@ -94,3 +94,8 @@ $app-background-dark-alt: $background-dark-elevated;
 
 $modal-background: $white;
 $modal-background-dark: $background-dark-elevated;
+
+$block-line-color: $light-tertiary;
+$block-line-color-dark: $dark-tertiary;
+$icon-uploading-fill: $light-tertiary;
+$icon-uploading-fill-dark: $dark-tertiary;

--- a/packages/base-styles/_colors.native.scss
+++ b/packages/base-styles/_colors.native.scss
@@ -75,7 +75,7 @@ $gray-100: #101517;
 // neutral (light) - black is a base color in light mode
 $light-primary: #000d; //rgba(0, 0, 0, 0.87);
 $light-secondary: #0009; //rgba(0, 0, 0, 0.6);
-$light-tertiary: rgba($black, 0.43);
+$neutral-tertiary-light: rgba($black, 0.43);
 $light-quaternary: #0000003f; //rgba(0, 0, 0, 0.25);
 $light-dim: #0000001e; //rgba(0, 0, 0, 0.12);
 $light-ultra-dim: #0000000a; //rgba(0, 0, 0, 0.04);
@@ -83,7 +83,7 @@ $light-ultra-dim: #0000000a; //rgba(0, 0, 0, 0.04);
 // neutral (dark) - white is a base color in dark mode
 $dark-primary: #fffd; //rgba(255, 255, 255, 0.87);
 $dark-secondary: #fff9; //rgba(255, 255, 255, 0.6);
-$dark-tertiary: rgba($white, 0.43);
+$neutral-tertiary-dark: rgba($white, 0.43);
 $dark-quaternary: #ffffff3f; //rgba(255, 255, 255, 0.25);
 $dark-ultra-dim: #ffffff14; //rgba(255, 255, 255, 0.08);
 
@@ -95,7 +95,7 @@ $app-background-dark-alt: $background-dark-elevated;
 $modal-background: $white;
 $modal-background-dark: $background-dark-elevated;
 
-$block-line-color: $light-tertiary;
-$block-line-color-dark: $dark-tertiary;
-$icon-uploading-fill: $light-tertiary;
-$icon-uploading-fill-dark: $dark-tertiary;
+$block-line-color-light: $neutral-tertiary-light;
+$block-line-color-dark: $neutral-tertiary-dark;
+$icon-uploading-fill-light: $neutral-tertiary-light;
+$icon-uploading-fill-dark: $neutral-tertiary-dark;

--- a/packages/base-styles/_colors.native.scss
+++ b/packages/base-styles/_colors.native.scss
@@ -49,7 +49,7 @@ $gray-text: $gray-dark;
 $gray-text-min: darken($gray, 18%); //#537994
 
 // Shades of gray
-$gray-lighten-20: lighten($gray, 20%); // #c8d7e1
+$studio-gray-10: #c3c4c7;
 $gray-lighten-30: lighten($gray, 30%); // #e9eff3
 $gray-darken-20: darken($gray, 20%); // #4f748e
 

--- a/packages/block-library/src/more/editor.native.scss
+++ b/packages/block-library/src/more/editor.native.scss
@@ -1,7 +1,7 @@
 // @format
 
 .moreLine {
-	background-color: $gray-lighten-20;
+	background-color: $studio-gray-10;
 	height: 2;
 }
 

--- a/packages/block-library/src/more/editor.native.scss
+++ b/packages/block-library/src/more/editor.native.scss
@@ -1,7 +1,7 @@
 // @format
 
 .moreLine {
-	background-color: $block-line-color;
+	background-color: $block-line-color-light;
 	height: 2;
 }
 

--- a/packages/block-library/src/more/editor.native.scss
+++ b/packages/block-library/src/more/editor.native.scss
@@ -1,12 +1,12 @@
 // @format
 
 .moreLine {
-	background-color: $studio-gray-10;
+	background-color: $block-line-color;
 	height: 2;
 }
 
 .moreLineDark {
-	background-color: $gray-50;
+	background-color: $block-line-color-dark;
 }
 
 .moreText {

--- a/packages/block-library/src/nextpage/editor.native.scss
+++ b/packages/block-library/src/nextpage/editor.native.scss
@@ -1,7 +1,7 @@
 // @format
 
 .nextpageLine {
-	background-color: $gray-lighten-20;
+	background-color: $studio-gray-10;
 	height: 2;
 }
 

--- a/packages/block-library/src/nextpage/editor.native.scss
+++ b/packages/block-library/src/nextpage/editor.native.scss
@@ -1,12 +1,12 @@
 // @format
 
 .nextpageLine {
-	background-color: $studio-gray-10;
+	background-color: $block-line-color;
 	height: 2;
 }
 
 .nextpageLineDark {
-	background-color: $gray-50;
+	background-color: $block-line-color-dark;
 }
 
 .nextpageText {

--- a/packages/block-library/src/nextpage/editor.native.scss
+++ b/packages/block-library/src/nextpage/editor.native.scss
@@ -1,7 +1,7 @@
 // @format
 
 .nextpageLine {
-	background-color: $block-line-color;
+	background-color: $block-line-color-light;
 	height: 2;
 }
 

--- a/packages/block-library/src/pullquote/figure.native.scss
+++ b/packages/block-library/src/pullquote/figure.native.scss
@@ -5,8 +5,8 @@
 
 .light {
 	@extend %shared;
-	border-top-color: $gray-lighten-20;
-	border-bottom-color: $gray-lighten-20;
+	border-top-color: $studio-gray-10;
+	border-bottom-color: $studio-gray-10;
 }
 
 .dark {

--- a/packages/block-library/src/pullquote/figure.native.scss
+++ b/packages/block-library/src/pullquote/figure.native.scss
@@ -5,8 +5,8 @@
 
 .light {
 	@extend %shared;
-	border-top-color: $block-line-color;
-	border-bottom-color: $block-line-color;
+	border-top-color: $block-line-color-light;
+	border-bottom-color: $block-line-color-light;
 }
 
 .dark {

--- a/packages/block-library/src/pullquote/figure.native.scss
+++ b/packages/block-library/src/pullquote/figure.native.scss
@@ -5,12 +5,12 @@
 
 .light {
 	@extend %shared;
-	border-top-color: $studio-gray-10;
-	border-bottom-color: $studio-gray-10;
+	border-top-color: $block-line-color;
+	border-bottom-color: $block-line-color;
 }
 
 .dark {
 	@extend %shared;
-	border-top-color: $gray-50;
-	border-bottom-color: $gray-50;
+	border-top-color: $block-line-color-dark;
+	border-bottom-color: $block-line-color-dark;
 }

--- a/packages/block-library/src/video/style.native.scss
+++ b/packages/block-library/src/video/style.native.scss
@@ -69,7 +69,7 @@
 }
 
 .iconUploading {
-	fill: $gray-lighten-20;
+	fill: $studio-gray-10;
 	width: 100%;
 	height: 100%;
 }

--- a/packages/block-library/src/video/style.native.scss
+++ b/packages/block-library/src/video/style.native.scss
@@ -69,11 +69,11 @@
 }
 
 .iconUploading {
-	fill: $studio-gray-10;
+	fill: $icon-uploading-fill;
 	width: 100%;
 	height: 100%;
 }
 
 .iconUploadingDark {
-	fill: $gray-70;
+	fill: $icon-uploading-fill-dark;
 }

--- a/packages/block-library/src/video/style.native.scss
+++ b/packages/block-library/src/video/style.native.scss
@@ -69,7 +69,7 @@
 }
 
 .iconUploading {
-	fill: $icon-uploading-fill;
+	fill: $icon-uploading-fill-light;
 	width: 100%;
 	height: 100%;
 }

--- a/packages/components/src/mobile/image/style.native.scss
+++ b/packages/components/src/mobile/image/style.native.scss
@@ -41,7 +41,7 @@
 }
 
 .iconUpload {
-	fill: $gray-lighten-20;
+	fill: $studio-gray-10;
 	width: 100%;
 	height: 100%;
 }
@@ -115,7 +115,7 @@
 
 .retryContainer {
 	flex: 1;
-	background-color: "rgba(0, 0, 0, 0.5)";
+	background-color: rgba(0, 0, 0, 0.5);
 }
 
 .focalPointContainer {

--- a/packages/components/src/mobile/image/style.native.scss
+++ b/packages/components/src/mobile/image/style.native.scss
@@ -115,7 +115,7 @@
 
 .retryContainer {
 	flex: 1;
-	background-color: rgba(0, 0, 0, 0.5);
+	background-color: "rgba(0, 0, 0, 0.5)";
 }
 
 .focalPointContainer {

--- a/packages/components/src/mobile/image/style.native.scss
+++ b/packages/components/src/mobile/image/style.native.scss
@@ -41,13 +41,13 @@
 }
 
 .iconUpload {
-	fill: $studio-gray-10;
+	fill: $icon-uploading-fill;
 	width: 100%;
 	height: 100%;
 }
 
 .iconUploadDark {
-	fill: $gray-70;
+	fill: $icon-uploading-fill-dark;
 }
 
 .imageContainerUpload {

--- a/packages/components/src/mobile/image/style.native.scss
+++ b/packages/components/src/mobile/image/style.native.scss
@@ -41,7 +41,7 @@
 }
 
 .iconUpload {
-	fill: $icon-uploading-fill;
+	fill: $icon-uploading-fill-light;
 	width: 100%;
 	height: 100%;
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

Block lines (e.g. borders, separators, etc) and fills (e.g. icon fills)
- `gray-lighten-20` becomes `neutral-quaternary-light`
- `gray-70` (and in some cases `gray-50`) become `neutral-secondary-dark` 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

View screenshots below or build and run on device

## Screenshots <!-- if applicable -->

| | Before | After |
| - | - | - |
| Light Mode | <img width="400" alt="Screen Shot 2020-09-17 at 12 05 22" src="https://user-images.githubusercontent.com/1898325/93497172-237c5380-f8de-11ea-8a51-fba43a09b481.png"> | <img width="400" alt="Screen Shot 2020-09-17 at 11 57 55" src="https://user-images.githubusercontent.com/1898325/93496420-2e82b400-f8dd-11ea-8a02-08adbcd101a2.png"> |
| Dark Mode | <img width="400" alt="Screen Shot 2020-09-17 at 12 05 31" src="https://user-images.githubusercontent.com/1898325/93497216-33943300-f8de-11ea-850d-3d52e364a2ff.png"> | <img width="400" alt="Screen Shot 2020-09-17 at 11 58 19" src="https://user-images.githubusercontent.com/1898325/93496407-29be0000-f8dd-11ea-8446-9787465483f4.png"> |






## Types of changes
- New color palette changes

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
