### PR TITLE
Mobile: Add app background design token color

### DIFF
--- a/packages/base-styles/_colors.native.scss
+++ b/packages/base-styles/_colors.native.scss
@@ -169,3 +169,11 @@ $dark-tertiary: #ffffff6d; //rgba(255, 255, 255, 0.43);
 $dark-quaternary: #ffffff3f; //rgba(255, 255, 255, 0.25);
 $dark-dim: #ffffff26; //rgba(255, 255, 255, 0.15);
 $dark-ultra-dim: #ffffff14; //rgba(255, 255, 255, 0.08);
+
+// Design Token colors
+$app-background: $white;
+$app-background-dark: $black;
+$app-background-dark-alt: $background-dark-elevated;
+
+$modal-background: $white;
+$modal-background-dark: $background-dark-elevated;

--- a/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/styles.native.scss
+++ b/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/styles.native.scss
@@ -1,7 +1,7 @@
 .background {
-	background-color: $white;
+	background-color: $modal-background;
 }
 
 .backgroundDark {
-	background-color: $background-dark-elevated;
+	background-color: $modal-background-dark;
 }

--- a/packages/components/src/mobile/bottom-sheet/styles.native.scss
+++ b/packages/components/src/mobile/bottom-sheet/styles.native.scss
@@ -32,7 +32,7 @@
 
 
 .background {
-	background-color: $white;
+	background-color: $modal-background;
 	border-top-right-radius: 8px;
 	border-top-left-radius: 8px;
 	width: 100%;
@@ -41,7 +41,7 @@
 }
 
 .backgroundDark {
-	background-color: $background-dark-elevated;
+	background-color: $modal-background-dark;
 }
 
 .content {

--- a/packages/edit-post/src/components/header/header-toolbar/style.native.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.native.scss
@@ -2,13 +2,13 @@
 .container {
 	height: $mobile-header-toolbar-height;
 	flex-direction: row;
-	background-color: #fff;
+	background-color: $app-background;
 	border-top-color: #e9eff3;
 	border-top-width: 1px;
 }
 
 .containerDark {
-	background-color: $background-dark-elevated;
+	background-color: $app-background-dark-alt;
 	border-top-color: $background-dark-elevated;
 }
 

--- a/packages/edit-post/src/components/layout/style.native.scss
+++ b/packages/edit-post/src/components/layout/style.native.scss
@@ -2,20 +2,20 @@
 .container {
 	flex: 1;
 	justify-content: flex-start;
-	background-color: #fff;
+	background-color: $app-background;
 }
 
 .containerDark {
-	background-color: $background-dark-elevated;
+	background-color: $app-background-dark-alt;
 }
 
 .background {
 	flex: 1;
-	background-color: $white;
+	background-color: $app-background;
 }
 
 .backgroundDark {
-	background-color: $black;
+	background-color: $app-background-dark;
 }
 
 .toolbarKeyboardAvoidingView {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This PR is refactor that adds app background color as design tokens. 

This will make it possible to update the apps background color just by changing the _color.native.scss

## How has this been tested?

I tested this using the demo app. Using both dark mode as well as regular mode. 
Notice that it looks the same as before. 

## Screenshots <!-- if applicable -->
It should look the same as before.

## Types of changes
Refactor.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
