### PR TITLE
Revert removal of Facebook and Instagram embeds

### DIFF
--- a/packages/block-library/src/embed/variations.js
+++ b/packages/block-library/src/embed/variations.js
@@ -56,15 +56,12 @@ const variations = [
 		attributes: { providerNameSlug: 'youtube', responsive: true },
 	},
 	{
-		// Deprecate Facebook Embed per FB policy
-		// See: https://developers.facebook.com/docs/plugins/oembed-legacy
 		name: 'facebook',
 		title: 'Facebook',
 		icon: embedFacebookIcon,
 		keywords: [ __( 'social' ) ],
 		description: __( 'Embed a Facebook post.' ),
-		scope: [ 'block' ],
-		patterns: [],
+		patterns: [ /^https?:\/\/www\.facebook.com\/.+/i ],
 		attributes: {
 			providerNameSlug: 'facebook',
 			previewable: false,
@@ -72,15 +69,12 @@ const variations = [
 		},
 	},
 	{
-		// Deprecate Instagram per FB policy
-		// See: https://developers.facebook.com/docs/instagram/oembed-legacy
 		name: 'instagram',
 		title: 'Instagram',
 		icon: embedInstagramIcon,
 		keywords: [ __( 'image' ), __( 'social' ) ],
 		description: __( 'Embed an Instagram post.' ),
-		scope: [ 'block' ],
-		patterns: [],
+		patterns: [ /^https?:\/\/(www\.)?instagr(\.am|am\.com)\/.+/i ],
 		attributes: { providerNameSlug: 'instagram', responsive: true },
 	},
 	{


### PR DESCRIPTION
## Description

This will revert the removal of the Facebook and Instagram embed block variations. 
This reverts PR #24472 which was merged probably too soon.

The removal change does not need to go in Gutenberg 9.0, and causing a bit of dust. The Facebook embed endpoints are not expected to change until Oct 24, so we can reapply the change in 9.2 (expected release of Oct 14)

## How has this been tested?

Confirm Facebook and Instagram embed blocks show in Inspector.


## Types of changes

Reverts previous change that hid the blocks from the inspector.

