### PR TITLE
Allow Social Links within Navigation Block

### DIFF
--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -182,6 +182,7 @@ function Navigation( {
 							allowedBlocks={ [
 								'core/navigation-link',
 								'core/search',
+								'core/social-links',
 							] }
 							renderAppender={
 								( isImmediateParentOfSelectedBlock &&


### PR DESCRIPTION
## Description
Edit block config for the Navigation Block to allow Social Links Block to be inserted within it.

Addresses #25016 

## How has this been tested?
Have tested adding in Editor and viewing on front end in:
* Mac OSX Chrome
* Mac OSX Safari


## Types of changes
Update existing block.
