### PR TITLE
Pullquote opinionated styles: Try currentcolor

### DIFF
--- a/packages/block-library/src/pullquote/theme.scss
+++ b/packages/block-library/src/pullquote/theme.scss
@@ -1,13 +1,13 @@
 .wp-block-pullquote {
-	border-top: 4px solid #555;
-	border-bottom: 4px solid #555;
+	border-top: 4px solid currentColor;
+	border-bottom: 4px solid currentColor;
 	margin-bottom: 1.75em;
-	color: #555;
+	color: currentColor;
 
 	cite,
 	footer,
 	&__citation {
-		color: #555;
+		color: currentColor;
 		text-transform: uppercase;
 		font-size: 0.8125em;
 		font-style: normal;


### PR DESCRIPTION
Followup from https://github.com/WordPress/gutenberg/pull/25213#discussion_r486560966.

The pullquote has a theme.scss file containing "opinionated styles" that themes can opt into. These styles color the borders gray:

<img width="1107" alt="Screenshot 2020-09-16 at 08 38 06" src="https://user-images.githubusercontent.com/1204802/93301220-69f78280-f7f8-11ea-8222-83343524a092.png">

That's a problem in dark themes:

<img width="1021" alt="Screenshot 2020-09-16 at 08 38 25" src="https://user-images.githubusercontent.com/1204802/93301229-6e23a000-f7f8-11ea-8d76-743edebe9781.png">

Of course a theme could explicitly opt into those opinionated styles, and override them to make them just right. And they should! But we could also make the default slightly smarter. Here's the gray color replaced with `currentColor`, which makes it inherit body font colors:

<img width="1058" alt="Screenshot 2020-09-16 at 08 40 06" src="https://user-images.githubusercontent.com/1204802/93301290-898eab00-f7f8-11ea-8e8a-7f731d125fad.png">

That works out of the box in dark themes:

<img width="1060" alt="Screenshot 2020-09-16 at 08 40 20" src="https://user-images.githubusercontent.com/1204802/93301317-94494000-f7f8-11ea-8ea9-532b62b06c0b.png">
