### PR TITLE
Navigation component: Infer back button label from parent menu title

### DIFF
--- a/packages/components/src/navigation/README.md
+++ b/packages/components/src/navigation/README.md
@@ -82,9 +82,10 @@ Sync the active menu between the external state and the Navigation's internal st
 
 -   Type: `string`
 -   Required: No
--   Default: "Back"
+-   Default: parent menu's title or "Back"
 
-The back button label used in nested menus.
+The back button label used in nested menus. If not provided, the label will be inferred from the parent menu's title.
+If for some reason the parent menu's title is not available then it will default to "Back".
 
 ### className
 

--- a/packages/components/src/navigation/menu/index.js
+++ b/packages/components/src/navigation/menu/index.js
@@ -32,7 +32,11 @@ export default function NavigationMenu( props ) {
 		title,
 	} = props;
 	useNavigationTreeMenu( props );
-	const { activeMenu, setActiveMenu } = useNavigationContext();
+	const {
+		activeMenu,
+		setActiveMenu,
+		navigationTree,
+	} = useNavigationContext();
 	const isActive = activeMenu === menu;
 
 	const classes = classnames( 'components-navigation__menu', className );
@@ -51,6 +55,8 @@ export default function NavigationMenu( props ) {
 		);
 	}
 
+	const parentMenuTitle = navigationTree.getMenu( parentMenu )?.title;
+
 	return (
 		<NavigationMenuContext.Provider value={ context }>
 			<MenuUI className={ classes }>
@@ -61,7 +67,7 @@ export default function NavigationMenu( props ) {
 						onClick={ () => setActiveMenu( parentMenu, 'right' ) }
 					>
 						<Icon icon={ chevronLeft } />
-						{ backButtonLabel || __( 'Back' ) }
+						{ backButtonLabel || parentMenuTitle || __( 'Back' ) }
 					</MenuBackButtonUI>
 				) }
 				{ title && (

--- a/packages/components/src/navigation/stories/index.js
+++ b/packages/components/src/navigation/stories/index.js
@@ -120,6 +120,16 @@ function Example() {
 						item="child-3"
 						title="Nested Category"
 					/>
+					<NavigationItem
+						navigateToMenu="custom-back"
+						item="child-4"
+						title="Custom back"
+					/>
+					<NavigationItem
+						navigateToMenu="automatic-back"
+						item="child-5"
+						title="Automatic back"
+					/>
 				</NavigationMenu>
 
 				<NavigationMenu
@@ -138,6 +148,25 @@ function Example() {
 						title="Sub Child 2"
 						onClick={ () => setActiveItem( 'sub-child-2' ) }
 					/>
+				</NavigationMenu>
+
+				<NavigationMenu
+					backButtonLabel="Custom back"
+					menu="custom-back"
+					parentMenu="category"
+					title="Custom backButtonLabel"
+				>
+					<NavigationItem item="sub-2-child-1" title="Sub Child 1" />
+					<NavigationItem item="sub-2-child-2" title="Sub Child 2" />
+				</NavigationMenu>
+
+				<NavigationMenu
+					menu="automatic-back"
+					parentMenu="category"
+					title="Automatic backButtonLabel"
+				>
+					<NavigationItem item="sub-3-child-1" title="Sub Child 1" />
+					<NavigationItem item="sub-3-child-2" title="Sub Child 2" />
 				</NavigationMenu>
 			</Navigation>
 

--- a/packages/components/src/navigation/styles/navigation-styles.js
+++ b/packages/components/src/navigation/styles/navigation-styles.js
@@ -103,4 +103,5 @@ export const ItemBadgeUI = styled.span`
 
 export const ItemTitleUI = styled( Text )`
 	margin-right: auto;
+	text-align: left;
 `;

--- a/packages/components/src/navigation/styles/navigation-styles.js
+++ b/packages/components/src/navigation/styles/navigation-styles.js
@@ -103,5 +103,4 @@ export const ItemBadgeUI = styled.span`
 
 export const ItemTitleUI = styled( Text )`
 	margin-right: auto;
-	text-align: left;
 `;


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/25247
Depends on: https://github.com/WordPress/gutenberg/pull/25340

## Description
Right now we need to manually specific `backButtonLabel` or it defaults to `Back`. Rather than always doing it manually, we can infer it from the parent menu.

If `backButtonLabel` is not specified, then the parent menu's title will be the label of the back button. If for some reason parent menu's title is not available we still fallback to `Back`.

## How has this been tested?
`yarn storybook:dev`

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
