### PR TITLE
[Mobile] - Media editing - Show button for invalid images

### DIFF
--- a/packages/components/src/mobile/image/index.native.js
+++ b/packages/components/src/mobile/image/index.native.js
@@ -221,7 +221,6 @@ const ImageComponent = ( {
 
 				{ editButton &&
 					isSelected &&
-					imageData &&
 					! isUploadInProgress &&
 					! isUploadFailed && (
 						<ImageEditingButton
@@ -229,7 +228,7 @@ const ImageComponent = ( {
 								onSelectMediaUploadOption
 							}
 							openMediaOptions={ openMediaOptions }
-							url={ url }
+							url={ imageData && url }
 							pickerOptions={ mediaPickerOptions }
 						/>
 					) }

--- a/packages/components/src/mobile/media-edit/index.native.js
+++ b/packages/components/src/mobile/media-edit/index.native.js
@@ -44,10 +44,10 @@ export class MediaEdit extends React.Component {
 	}
 
 	getMediaOptionsItems() {
-		const { pickerOptions, openReplaceMediaOptions } = this.props;
+		const { pickerOptions, openReplaceMediaOptions, source } = this.props;
 
 		return compact( [
-			editOption,
+			source?.uri && editOption,
 			openReplaceMediaOptions && replaceOption,
 			...( pickerOptions ? pickerOptions : [] ),
 		] );


### PR DESCRIPTION
`Gutenberg Mobile PR` -> https://github.com/wordpress-mobile/gutenberg-mobile/pull/2623

Fixes https://github.com/WordPress/gutenberg/issues/25347

## Description
When the media editing option was [introduced](https://github.com/WordPress/gutenberg/pull/24088) to the Gallery block the `Remove` button was replaced for this one instead. By doing that the remove option was moved into the media editing options.

This PR removes a check to prevent rendering the media edit button if the image data is not loaded, this way the options `Remove` (for gallery) and `Replace` for `Image`, `Media & Text`, and `Cover` are available.

## How has this been tested?

<details><summary>Steps to test</summary>
---

- Open the app with metro running
- Create a post
- Add a Gallery block with some images
- Once the images have finished uploading, switch to HTML mode by tapping on the three dots on the top right
- Look for the first image and change the URL to an invalid one
- Go back to Visual mode by tapping on the three dots on the top right
- **Expect** to see an image placeholder instead of the previous image
- Tap on the image placeholder
- Once is selected **expect** to see the media edit button on the top right
- Tap on it and you should **expect** to see the `Remove` option

</details>

## Screenshots <!-- if applicable -->
Gallery | Media & Text | Image
-|-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/93322184-53125980-f813-11ea-9fe4-e9c38105b43c.png" width="250" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/93322228-60c7df00-f813-11ea-8997-0364051fe078.png" width="250" /></kbd> | <img src="https://user-images.githubusercontent.com/4885740/93322264-6b827400-f813-11ea-93df-726ef988a3ed.png" width="250" /></kbd>

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
