### PR TITLE
Navigation component: Ensure setActiveMenu target exist

### DIFF
--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -30,6 +30,11 @@ export default function Navigation( {
 	const navigationTree = useCreateNavigationTree();
 
 	const setActiveMenu = ( menuId, slideInOrigin = 'left' ) => {
+		const menuExists = !! navigationTree.getMenu( menuId );
+		if ( ! menuExists ) {
+			return;
+		}
+
 		setSlideOrigin( slideInOrigin );
 		setMenu( menuId );
 		onActivateMenu( menuId );

--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -30,8 +30,7 @@ export default function Navigation( {
 	const navigationTree = useCreateNavigationTree();
 
 	const setActiveMenu = ( menuId, slideInOrigin = 'left' ) => {
-		const menuExists = !! navigationTree.getMenu( menuId );
-		if ( ! menuExists ) {
+		if ( ! navigationTree.getMenu( menuId ) ) {
 			return;
 		}
 

--- a/packages/components/src/navigation/stories/index.js
+++ b/packages/components/src/navigation/stories/index.js
@@ -71,6 +71,11 @@ function Example() {
 							navigateToMenu="category"
 							title="Category"
 						/>
+						<NavigationItem
+							item="item-pointing-non-existing-menu"
+							title="Navigate to a non existing menu"
+							navigateToMenu="non-existing-menu"
+						/>
 					</NavigationGroup>
 					<NavigationGroup title="Group 2">
 						<NavigationItem

--- a/packages/components/src/navigation/styles/navigation-styles.js
+++ b/packages/components/src/navigation/styles/navigation-styles.js
@@ -103,4 +103,5 @@ export const ItemBadgeUI = styled.span`
 
 export const ItemTitleUI = styled( Text )`
 	margin-right: auto;
+	text-align: left;
 `;


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/25249
Depends on: #25340

## Description
Check if the target of `setActiveMenu` exists.

## How has this been tested?
`yarn storybook:dev`
Added a new item in the menu called `Navigate to a non-existing menu`, when clicking this nothing should happen. Without the changes though, the whole navigation menu would disappear.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
