### PR TITLE
Update theme json docs to account for latest changes

### DIFF
--- a/docs/designers-developers/developers/themes/theme-json.md
+++ b/docs/designers-developers/developers/themes/theme-json.md
@@ -190,7 +190,7 @@ The goal is that presets can be defined using this format, although, right now, 
 
 ### Styles
 
-Each block will declare which style properties it exposes. This has been coined as "implicit style attributes" of the block. These properties are then used to automatically generate the UI controls for the block in the editor, as well as being available through the `experimental-theme.json` file for themes to target.
+Each block declares which style properties it exposes. This has been coined as "implicit style attributes" of the block. These properties are then used to automatically generate the UI controls for the block in the editor, as well as being available through the `experimental-theme.json` file for themes to target.
 
 ```json
 {
@@ -211,7 +211,49 @@ Each block will declare which style properties it exposes. This has been coined 
 }
 ```
 
+For example, an input like this:
+
+```json
+{
+  "core/heading/h1": {
+    "styles": {
+      "color": {
+        "text": "var(--wp--preset--color--primary)"
+      },
+      "typography": {
+        "fontSize": "calc(1px * var(--wp--preset--font-size--huge))"
+      }
+    }
+  },
+  "core/heading/h4": {
+    "styles": {
+      "color": {
+        "text": "var(--wp--preset--color--secondary)"
+      },
+      "typography": {
+        "fontSize": "var(--wp--preset--font-size--normal)"
+      }
+    }
+  }
+}
+```
+
+will append the following style rules to the stylesheet:
+
+```css
+h1 {
+  color: var(--wp--preset--color--primary);
+  font-size: calc(1px * var(--wp--preset--font-size--huge));
+}
+h4 {
+  color: var(--wp--preset--color--secondary);
+  font-size: calc(1px * var(--wp--preset--font-size--normal));
+}
+```
+
 #### Color Properties
+
+These are the current color properties supported by blocks:
 
 | Context | Background | Gradient | Link | Text |
 | --- | --- | --- | --- | --- |
@@ -235,6 +277,8 @@ Each block will declare which style properties it exposes. This has been coined 
 [1] The heading block represents 6 distinct HTML elements: H1-H6. It comes with selectors to target each individual element (ex: core/heading/h1 for H1, etc).
 
 #### Typography Properties
+
+These are the current typography properties supported by blocks:
 
 | Context | Font Size | Line Height |
 | --- | --- | --- |

--- a/docs/designers-developers/developers/themes/theme-json.md
+++ b/docs/designers-developers/developers/themes/theme-json.md
@@ -70,6 +70,8 @@ Every context has the same structure, divided in two sections: `settings` and `s
 }
 ```
 
+This structure is the same for the three different origins that exist: core, themes, and users. Themes can override core's defaults by creating a file called `experimental-theme.json`. Users, via the site editor, will also be also to override theme's or core's preferences via an user interface that is being worked on.
+
 ### Settings
 
 The settings section has the following structure and default values:

--- a/docs/designers-developers/developers/themes/theme-json.md
+++ b/docs/designers-developers/developers/themes/theme-json.md
@@ -38,7 +38,7 @@ The Block Editor already allows the control of specific settings such as alignme
 
 The `experimental-theme.json` file is divided into sections known as "contexts", that represent a different CSS selector. For example, the `core/paragraph` context maps to `p` while `core/group` maps to `.wp-block-group`. In general, one block will map to a single context as in the cases mentioned. There are cases where one block can generate multiple contexts (different CSS selectors). For example, the heading block generates six different contexts (`core/heading/h1`, `core/heading/h2`, etc), one for each different selector (h1, h2, etc).
 
-```json
+```
 {
   "global": { ... },
   "core/paragraph": { ... },
@@ -54,7 +54,7 @@ The `experimental-theme.json` file is divided into sections known as "contexts",
 
 Every context has the same structure, divided in two sections: `settings` and `styles`. The `settings` are used to control the editor (enable/disable certain features, declare presets), taking over what was previously declared via `add_theme_support`. The `styles` will be used to create new style rules to be appended to a new stylesheet `global-styles-inline-css` enqueued in the front-end and post editor.
 
-```json
+```
 {
   "some/context": {
     "settings": {
@@ -76,7 +76,7 @@ This structure is the same for the three different origins that exist: core, the
 
 The settings section has the following structure and default values:
 
-```json
+```
 {
   "some/context": {
     "settings": {
@@ -194,7 +194,7 @@ The goal is that presets can be defined using this format, although, right now, 
 
 Each block declares which style properties it exposes. This has been coined as "implicit style attributes" of the block. These properties are then used to automatically generate the UI controls for the block in the editor, as well as being available through the `experimental-theme.json` file for themes to target.
 
-```json
+```
 {
   "some/context": {
     "styles": {

--- a/docs/designers-developers/developers/themes/theme-json.md
+++ b/docs/designers-developers/developers/themes/theme-json.md
@@ -100,9 +100,9 @@ The settings section has the following structure and default values:
 }
 ```
 
-Note, however, that not all settings are relevant for all contexts and the blocks they represent. The settings section provides an opt-in/opt-out mechanism for themes, but it's the block's responsibility to add support for the features that are relevant to it. For example, if a block doesn't implement the `dropCap` feature, a theme can't enable it for such a block through `experimental-theme.json`.
+To retain backward compatibility, `add_theme_support` declarations are considered as well. If a theme uses `add_theme_support('disable-custom-colors')`, it'll be the same as set `global.settings.color.custom` to `false`. If the `experimental-theme.json` contains any settings, these will take precedence over the values declared via `add_theme_support`.
 
-Settings can be controlled by context, providing a more fine-grained control over what exists via `add_theme_support`. As an example, let's say that a theme author wants to enable custom colors for the paragraph block exclusively. This is how it'd be done:
+Settings can also be controlled by context, providing a more fine-grained control over what exists via `add_theme_support`. As an example, let's say that a theme author wants to enable custom colors for the paragraph block exclusively. This is how it'd be done:
 
 ```json
 {
@@ -122,60 +122,71 @@ Settings can be controlled by context, providing a more fine-grained control ove
   }
 ```
 
+Note, however, that not all settings are relevant for all contexts and the blocks they represent. The settings section provides an opt-in/opt-out mechanism for themes, but it's the block's responsibility to add support for the features that are relevant to it. For example, if a block doesn't implement the `dropCap` feature, a theme can't enable it for such a block through `experimental-theme.json`.
+
 ### Presets
 
-So far, this function is only enabled for the global section.
+Presets are part of the settings section. At the moment, they only work within the `global` context. Each preset value will generate a CSS Custom Property that will be added to the new stylesheet, which follow this naming schema: `--wp--preset--{preset-category}--{preset-slug}`.
 
-The generated CSS Custom Properties follow this naming schema: `--wp--preset--{preset-category}--{preset-slug}`.
+For example, for this input:
 
-For this input:
-
-```
-"global": {
-  "settings": {
-    "color": {
-      palette: [
-        {
-          "slug": "strong-magenta",
-          "value": "#a156b4"
-        },
-        {
-          "slug": "very-dark-grey",
-          "value": "#444"
-        }
-      ]
+```json
+{
+  "global": {
+    "settings": {
+      "color": {
+        "palette": [
+          {
+            "slug": "strong-magenta",
+            "value": "#a156b4"
+          },
+          {
+            "slug": "very-dark-grey",
+            "value": "rgb(131, 12, 8)"
+          }
+        ],
+        "gradients": [
+          {
+            "slug": "blush-bordeaux",
+            "value": "linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%)"
+          },
+          {
+            "slug": "blush-light-purple",
+            "value": "linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%)"
+          },
+        ]
+      },
+      "typography": {
+        "fontSizes": [
+          {
+            "slug": "normal",
+            "value": 16
+          },
+          {
+            "slug": "big",
+            "value": 32
+          }
+        ]
+      }
     }
   }
 }
 ```
 
-The following stylesheet will be enqueued to the front-end and editor:
+The output to be enqueued will be:
 
 ```css
 :root {
   --wp--preset--color--strong-magenta: #a156b4;
   --wp--preset--color--very-dark-gray: #444;
+  --wp--preset--font-size--big: 32;
+  --wp--preset--font-size--normal: 16;
+  --wp--preset--gradient--blush-bordeaux: linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%);
+  --wp--preset--gradient--blush-light-purple: linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);
 }
 ```
 
-The goal is that presets can be defined using this format, although, right now, the name property (used to be shown in the editor) can't be translated from this file. For that reason, and to maintain backward compatibility, the presets declared via `add_theme_support` will also generate the CSS Custom Properties. The equivalent example to above is:
-
-```php
-add_theme_support( 'editor-color-palette', array(
-  array(
-    'name' => __( 'strong magenta', 'themeLangDomain' ),
-    'slug' => 'strong-magenta',
-    'color' => '#a156b4',
-  ),
-  array(
-    'name' => __( 'very dark gray', 'themeLangDomain' ),
-    'slug' => 'very-dark-gray',
-    'color' => '#444',
-  ),
-) );
-```
-
-If the `experimental-theme.json` contains any presets, these will take precedence over the ones declared via `add_theme_support`.
+The goal is that presets can be defined using this format, although, right now, the name property (used in the editor) can't be translated from this file. For that reason, and to maintain backward compatibility, the presets declared via `add_theme_support` will also generate the CSS Custom Properties. If the `experimental-theme.json` contains any presets, these will take precedence over the ones declared via `add_theme_support`.
 
 ### Styles
 
@@ -245,4 +256,3 @@ Each block will declare which style properties it exposes. This has been coined 
 | Site Title | Yes | Yes |
 
 [1] The heading block represents 6 distinct HTML elements: H1-H6. It comes with selectors to target each individual element (ex: core/heading/h1 for H1, etc).
-


### PR DESCRIPTION
This PR updates the documentation for theme.json to account for the recent changes to the shape of theme.json and new features added.

See [full document](https://github.com/WordPress/gutenberg/blob/71beca8ce490ce5d8cae0fbf783a32fabac10c81/docs/designers-developers/developers/themes/theme-json.md).