### PR TITLE
Show preview of WordPress embed in editor

### DIFF
--- a/packages/block-library/src/embed/wp-embed-preview.js
+++ b/packages/block-library/src/embed/wp-embed-preview.js
@@ -30,7 +30,13 @@ class WpEmbedPreview extends Component {
 
 	/**
 	 * Checks for WordPress embed event signaling the height
-	 * change when content loads.
+	 * change when iframe content loads or iframe's window is resized.
+	 * The event is send from WordPress core with window.postMessage function.
+	 *
+	 * References:
+	 * window.postMessage: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
+	 * WordPress core embed-template on load: https://github.com/WordPress/WordPress/blob/master/wp-includes/js/wp-embed-template.js#L143
+	 * WordPress core embed-template on resize: https://github.com/WordPress/WordPress/blob/master/wp-includes/js/wp-embed-template.js#L187
 	 *
 	 * @param {WPSyntheticEvent} event Message event.
 	 */
@@ -42,14 +48,13 @@ class WpEmbedPreview extends Component {
 			return;
 		}
 
-		const iframes = document.querySelectorAll(
-			`iframe[data-secret="${ secret }"`
-		);
-		( iframes || [] ).forEach( ( iframe ) => {
-			if ( +iframe.height !== value ) {
-				iframe.height = value;
-			}
-		} );
+		document
+			.querySelectorAll( `iframe[data-secret="${ secret }"` )
+			.forEach( ( iframe ) => {
+				if ( +iframe.height !== value ) {
+					iframe.height = value;
+				}
+			} );
 	}
 
 	/**

--- a/packages/block-library/src/embed/wp-embed-preview.js
+++ b/packages/block-library/src/embed/wp-embed-preview.js
@@ -84,9 +84,7 @@ class WpEmbedPreview extends Component {
 			<div
 				ref={ this.node }
 				className="wp-block-embed__wrapper"
-				dangerouslySetInnerHTML={ {
-					__html: html,
-				} }
+				dangerouslySetInnerHTML={ { __html: html } }
 			/>
 		);
 	}

--- a/packages/block-library/src/embed/wp-embed-preview.js
+++ b/packages/block-library/src/embed/wp-embed-preview.js
@@ -78,8 +78,10 @@ class WpEmbedPreview extends Component {
 	render() {
 		const { html } = this.props;
 		const doc = new DOMParser().parseFromString( html, 'text/html' );
-		doc.querySelector( 'iframe' ).removeAttribute( 'style' );
-		doc.querySelector( 'blockquote' ).style.display = 'none';
+		const iframe = doc.querySelector( 'iframe' );
+		if ( iframe ) iframe.removeAttribute( 'style' );
+		const blockQuote = doc.querySelector( 'blockquote' );
+		if ( blockQuote ) blockQuote.style.display = 'none';
 
 		return (
 			<div

--- a/packages/block-library/src/embed/wp-embed-preview.js
+++ b/packages/block-library/src/embed/wp-embed-preview.js
@@ -10,7 +10,7 @@ import { withGlobalEvents } from '@wordpress/compose';
  * Browser dependencies
  */
 
-const { FocusEvent } = window;
+const { FocusEvent, DOMParser } = window;
 
 class WpEmbedPreview extends Component {
 	constructor() {
@@ -77,16 +77,15 @@ class WpEmbedPreview extends Component {
 
 	render() {
 		const { html } = this.props;
-		const blockquote = this.node.current?.querySelector( 'blockquote' );
-		if ( blockquote ) blockquote.style.display = 'none';
-		const iframe = this.node.current?.querySelector( 'iframe' );
-		if ( iframe ) iframe.removeAttribute( 'style' );
+		const doc = new DOMParser().parseFromString( html, 'text/html' );
+		doc.querySelector( 'iframe' ).removeAttribute( 'style' );
+		doc.querySelector( 'blockquote' ).style.display = 'none';
 
 		return (
 			<div
 				ref={ this.node }
 				className="wp-block-embed__wrapper"
-				dangerouslySetInnerHTML={ { __html: html } }
+				dangerouslySetInnerHTML={ { __html: doc.body.innerHTML } }
 			/>
 		);
 	}

--- a/packages/block-library/src/embed/wp-embed-preview.js
+++ b/packages/block-library/src/embed/wp-embed-preview.js
@@ -29,9 +29,9 @@ class WpEmbedPreview extends Component {
 	}
 
 	/**
-	 * Checks for WordPress embed event signaling the height
-	 * change when iframe content loads or iframe's window is resized.
-	 * The event is send from WordPress core with window.postMessage function.
+	 * Checks for WordPress embed events signaling the height change when iframe
+	 * content loads or iframe's window is resized.  The event is sent from
+	 * WordPress core via the window.postMessage API.
 	 *
 	 * References:
 	 * window.postMessage: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage

--- a/packages/block-library/src/embed/wp-embed-preview.js
+++ b/packages/block-library/src/embed/wp-embed-preview.js
@@ -8,7 +8,7 @@ import { withGlobalEvents } from '@wordpress/compose';
  * Browser dependencies
  */
 
-const { FocusEvent } = window;
+const { FocusEvent, DOMParser } = window;
 
 class WpEmbedPreview extends Component {
 	constructor() {
@@ -38,11 +38,15 @@ class WpEmbedPreview extends Component {
 
 	render() {
 		const { html } = this.props;
+		const doc = new DOMParser().parseFromString( html, 'text/html' );
+		doc.querySelector( 'iframe' ).removeAttribute( 'style' );
+		doc.querySelector( 'blockquote' ).style.display = 'none';
+
 		return (
 			<div
 				ref={ this.node }
 				className="wp-block-embed__wrapper"
-				dangerouslySetInnerHTML={ { __html: html } }
+				dangerouslySetInnerHTML={ { __html: doc.body.innerHTML } }
 			/>
 		);
 	}

--- a/packages/block-library/src/embed/wp-embed-preview.js
+++ b/packages/block-library/src/embed/wp-embed-preview.js
@@ -35,19 +35,21 @@ class WpEmbedPreview extends Component {
 	 * @param {WPSyntheticEvent} event Message event.
 	 */
 	resizeWPembeds( { data: { secret, message, value } = {} } ) {
-		if ( [ secret, message, value ].some( ( attribute ) => ! attribute ) )
+		if (
+			[ secret, message, value ].some( ( attribute ) => ! attribute ) ||
+			message !== 'height'
+		) {
 			return;
-
-		if ( message === 'height' ) {
-			const iframes = document.querySelectorAll(
-				`iframe[data-secret="${ secret }"`
-			);
-			( iframes || [] ).forEach( ( iframe ) => {
-				if ( +iframe.height !== value ) {
-					iframe.height = value;
-				}
-			} );
 		}
+
+		const iframes = document.querySelectorAll(
+			`iframe[data-secret="${ secret }"`
+		);
+		( iframes || [] ).forEach( ( iframe ) => {
+			if ( +iframe.height !== value ) {
+				iframe.height = value;
+			}
+		} );
 	}
 
 	/**

--- a/packages/block-library/src/embed/wp-embed-preview.js
+++ b/packages/block-library/src/embed/wp-embed-preview.js
@@ -72,13 +72,10 @@ class WpEmbedPreview extends Component {
 
 	render() {
 		const { html } = this.props;
-		if ( this.node.current ) {
-			this.node.current.querySelector( 'blockquote' ).style.display =
-				'none';
-			this.node.current
-				.querySelector( 'iframe' )
-				.removeAttribute( 'style' );
-		}
+		const blockquote = this.node.current?.querySelector( 'blockquote' );
+		if ( blockquote ) blockquote.style.display = 'none';
+		const iframe = this.node.current?.querySelector( 'iframe' );
+		if ( iframe ) iframe.removeAttribute( 'style' );
 
 		return (
 			<div


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes: https://github.com/WordPress/gutenberg/issues/25344
Fixes: https://github.com/WordPress/gutenberg/issues/21945
Fixes: https://github.com/WordPress/gutenberg/issues/21029

Great description in this issue about the root of the problem in this issue: https://github.com/WordPress/gutenberg/issues/25344

<!-- Please describe what you have changed or added -->

## How has this been tested?
Locally

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
