### PR TITLE
Global styles fix: Global lineHeight settings from theme.json

### DIFF
--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -388,9 +388,10 @@ function gutenberg_experimental_global_styles_get_support_keys() {
  */
 function gutenberg_experimental_global_styles_get_presets_structure() {
 	return array(
-		'color'    => array( 'color', 'palette' ),
-		'gradient' => array( 'color', 'gradients' ),
-		'fontSize' => array( 'typography', 'fontSizes' ),
+		'color'      => array( 'color', 'palette' ),
+		'gradient'   => array( 'color', 'gradients' ),
+		'fontSize'   => array( 'typography', 'fontSizes' ),
+		'lineHeight' => array( 'typography', 'lineHeight' ),
 	);
 }
 


### PR DESCRIPTION
## Description
After #25301 line-height globals from theme.json stopped working.

This PR adds them back in.

## How has this been tested?
Tested with an FSE theme with updated theme.json file (https://github.com/aristath/q)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] ~~My code has proper inline documentation.~~ <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] ~~I've included developer documentation if appropriate.~~ <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] ~~I've updated all React Native files affected by any refactorings/renamings in this PR.~~ <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
