### PR TITLE
[Mobile] Buttons Block: Adds debounce in the add button action

### DIFF
--- a/packages/block-library/src/buttons/edit.native.js
+++ b/packages/block-library/src/buttons/edit.native.js
@@ -46,7 +46,7 @@ function ButtonsEdit( {
 		}
 	}, [ sizes ] );
 
-	const debounceAddNextButton = debounce( onAddNextButton, 500 );
+	const debounceAddNextButton = debounce( onAddNextButton, 200 );
 
 	const renderFooterAppender = useRef( () => (
 		<View style={ styles.appenderContainer }>

--- a/packages/block-library/src/buttons/edit.native.js
+++ b/packages/block-library/src/buttons/edit.native.js
@@ -13,6 +13,7 @@ import { withSelect, withDispatch } from '@wordpress/data';
 import { compose, useResizeObserver } from '@wordpress/compose';
 import { createBlock } from '@wordpress/blocks';
 import { useState, useEffect, useRef } from '@wordpress/element';
+import { debounce } from 'lodash';
 
 /**
  * Internal dependencies
@@ -45,11 +46,13 @@ function ButtonsEdit( {
 		}
 	}, [ sizes ] );
 
+	const debounceAddNextButton = debounce( onAddNextButton, 500 );
+
 	const renderFooterAppender = useRef( () => (
 		<View style={ styles.appenderContainer }>
 			<InnerBlocks.ButtonBlockAppender
 				isFloating={ true }
-				onAddBlock={ onAddNextButton }
+				onAddBlock={ debounceAddNextButton }
 			/>
 		</View>
 	) );
@@ -71,7 +74,7 @@ function ButtonsEdit( {
 				orientation="horizontal"
 				horizontalAlignment={ align }
 				onDeleteBlock={ shouldDelete ? onDelete : undefined }
-				onAddBlock={ onAddNextButton }
+				onAddBlock={ debounceAddNextButton }
 				parentWidth={ maxWidth }
 				marginHorizontal={ spacing }
 				marginVertical={ spacing }


### PR DESCRIPTION
**Fixes** https://github.com/wordpress-mobile/gutenberg-mobile/issues/2238

`Gutenberg Mobile PR` -> https://github.com/wordpress-mobile/gutenberg-mobile/pull/2625

## Description
### Behavior without the fix
**iOS:** When user taps fast multiple times on side "+" icon to add multiple buttons the app falls in a loop
**Android:** When user taps fast multiple times on side "+" icon to add multiple buttons the app temporary freeze and the buttons are eventually created.
### Fix
A debounce has been added in the add button action.
Extending the fix to the `ButtonBlockAppender` was considered but the reported bug was not reproduced in any other block using it. Thus adding a delay on user action was not considered necessary.

## How has this been tested?

- Create a post or page
- Add a **buttons** block
- Tap fast multiple times on side "+" icon to add multiple buttons.
- Confirm that the app does not fall in a loop (iOS) or freezes (Android)

## Screenshots

|Without the fix|With the fix|
|---|---|
<img width="320" src="https://user-images.githubusercontent.com/304044/93349726-861f1200-f840-11ea-8c38-0d5a6e5f5e2a.gif">|<img width="320" src="https://user-images.githubusercontent.com/304044/93349732-88816c00-f840-11ea-9bf6-7127343afd43.gif">|

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
