### PR TITLE
[RNMobile] Inititalize global styles with block-library style.scss

### DIFF
--- a/packages/block-editor/src/components/block-list/block.native.js
+++ b/packages/block-editor/src/components/block-list/block.native.js
@@ -67,8 +67,18 @@ class BlockListBlock extends Component {
 		return (
 			<GlobalStylesContext.Consumer>
 				{ ( globalStyle ) => {
+					const classNameList = this.props.attributes.className.split(
+						' '
+					);
+					const stylesFromClassName = classNameList.reduce(
+						( stylesOut, className ) => ( {
+							...stylesOut,
+							...globalStyle[ className ],
+						} ),
+						{}
+					);
 					const mergedStyle = {
-						...globalStyle,
+						...stylesFromClassName,
 						...this.props.wrapperProps.style,
 					};
 					return (

--- a/packages/block-editor/src/components/block-list/block.native.js
+++ b/packages/block-editor/src/components/block-list/block.native.js
@@ -67,7 +67,7 @@ class BlockListBlock extends Component {
 		return (
 			<GlobalStylesContext.Consumer>
 				{ ( globalStyle ) => {
-					const classNameList = this.props.attributes.className.split(
+					const classNameList = ( this.props.attributes.className || '' ).split(
 						' '
 					);
 					const stylesFromClassName = classNameList.reduce(

--- a/packages/block-editor/src/components/block-list/block.native.js
+++ b/packages/block-editor/src/components/block-list/block.native.js
@@ -67,9 +67,9 @@ class BlockListBlock extends Component {
 		return (
 			<GlobalStylesContext.Consumer>
 				{ ( globalStyle ) => {
-					const classNameList = ( this.props.attributes.className || '' ).split(
-						' '
-					);
+					const classNameList = (
+						this.props.attributes.className || ''
+					).split( ' ' );
 					const stylesFromClassName = classNameList.reduce(
 						( stylesOut, className ) => ( {
 							...stylesOut,

--- a/packages/block-library/src/style.native.scss
+++ b/packages/block-library/src/style.native.scss
@@ -1,0 +1,62 @@
+// This tag marks the start of the styles that apply to editing canvas contents and need to be manipulated when we resize the editor.
+#start-resizable-editor-section {
+	display: none;
+}
+
+// Background colors.
+@include background-colors();
+
+// Foreground colors.
+@include foreground-colors();
+
+.has-link-color a {
+	color: var(--wp--style--color--link, #00e);
+}
+
+// Font sizes.
+.has-small-font-size {
+	font-size: 0.8125em;
+}
+
+.has-regular-font-size, // Not used now, kept because of backward compatibility.
+.has-normal-font-size {
+	font-size: 1em;
+}
+
+.has-medium-font-size {
+	font-size: 1.25em;
+}
+
+.has-large-font-size {
+	font-size: 2.25em;
+}
+
+.has-larger-font-size, // Not used now, kept because of backward compatibility.
+.has-huge-font-size {
+	font-size: 2.625em;
+}
+
+// Text alignments.
+.has-text-align-center {
+	text-align: center;
+}
+
+.has-text-align-left {
+	/*rtl:ignore*/
+	text-align: left;
+}
+
+.has-text-align-right {
+	/*rtl:ignore*/
+	text-align: right;
+}
+
+// This tag marks the end of the styles that apply to editing canvas contents and need to be manipulated when we resize the editor.
+#end-resizable-editor-section {
+	display: none;
+}
+
+// Block alignments.
+.aligncenter {
+	clear: both;
+}

--- a/packages/block-library/src/style.native.scss
+++ b/packages/block-library/src/style.native.scss
@@ -13,29 +13,6 @@
 	color: var(--wp--style--color--link, #00e);
 }
 
-// Font sizes.
-.has-small-font-size {
-	font-size: 0.8125em;
-}
-
-.has-regular-font-size, // Not used now, kept because of backward compatibility.
-.has-normal-font-size {
-	font-size: 1em;
-}
-
-.has-medium-font-size {
-	font-size: 1.25em;
-}
-
-.has-large-font-size {
-	font-size: 2.25em;
-}
-
-.has-larger-font-size, // Not used now, kept because of backward compatibility.
-.has-huge-font-size {
-	font-size: 2.625em;
-}
-
 // Text alignments.
 .has-text-align-center {
 	text-align: center;

--- a/packages/components/src/mobile/global-styles-context/index.native.js
+++ b/packages/components/src/mobile/global-styles-context/index.native.js
@@ -3,7 +3,12 @@
  */
 import { createContext, useContext } from '@wordpress/element';
 
-const GlobalStylesContext = createContext( { style: {} } );
+/**
+ * Internal dependencies
+ */
+import styles from '../../../../block-library/src/style.native.scss';
+
+const GlobalStylesContext = createContext( styles );
 
 export const useGlobalStyles = () => {
 	const globalStyles = useContext( GlobalStylesContext );


### PR DESCRIPTION

## Description
This PR initialize global style context for mobile with styles from the block-library
This is a very early experiment and it's NOT ready to ship

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
