### PR TITLE
Remove un used styles and the dark-gray-600 color

### DIFF
--- a/packages/base-styles/_colors.native.scss
+++ b/packages/base-styles/_colors.native.scss
@@ -4,8 +4,6 @@
 $black: #000;
 $white: #fff;
 
-$dark-gray-600: #40464d;
-
 $light-gray-500: #e2e4e7; // Good for "grayed" items and borders.
 $light-gray-400: #e8eaeb; // Good for "readonly" input fields and special text selection.
 

--- a/packages/components/src/mobile/bottom-sheet/styles.native.scss
+++ b/packages/components/src/mobile/bottom-sheet/styles.native.scss
@@ -30,7 +30,6 @@
 	margin-top: $grid-unit-20 / 2;
 }
 
-
 .background {
 	background-color: $modal-background;
 	border-top-right-radius: 8px;
@@ -50,23 +49,6 @@
 
 .scrollableContent {
 	padding-bottom: 20px;
-}
-
-.head {
-	flex-direction: row;
-	width: 100%;
-	margin-bottom: 5px;
-	justify-content: space-between;
-	align-items: center;
-	align-content: center;
-	min-height: 48;
-}
-
-.title {
-	color: $dark-gray-600;
-	font-size: 18px;
-	font-weight: 600;
-	text-align: center;
 }
 
 .titleContainer {
@@ -118,10 +100,6 @@
 	flex-direction: row;
 	align-items: center;
 	flex-shrink: 0;
-}
-
-.cellIcon {
-	padding-right: 0;
 }
 
 .cellLabel {

--- a/packages/components/src/mobile/bottom-sheet/styles.native.scss
+++ b/packages/components/src/mobile/bottom-sheet/styles.native.scss
@@ -51,12 +51,6 @@
 	padding-bottom: 20px;
 }
 
-.titleContainer {
-	justify-content: center;
-	flex: 2;
-	align-content: center;
-}
-
 // Button
 
 .buttonText {


### PR DESCRIPTION
This PR removes the `dark-gray-600` color as well as the un used styles in the mobile. 

## Description
We are currently updating the colours of the mobile app and are removing colours that are not used any more. This Pr removes the used colour. 

## How has this been tested?
This has been tested by  building the app and it didn't produce any errors. 

## Screenshots <!-- if applicable -->
No changes to the app. 

## Types of changes
Removing un used code.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
