### PR TITLE
Stylelint: whitelist is now allowed-list

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -4,7 +4,7 @@
 		"at-rule-empty-line-before": null,
 		"at-rule-no-unknown": null,
 		"comment-empty-line-before": null,
-		"declaration-property-unit-whitelist": null,
+		"declaration-property-unit-allowed-list": null,
 		"font-weight-notation": null,
 		"max-line-length": null,
 		"no-descending-specificity": null,

--- a/package-lock.json
+++ b/package-lock.json
@@ -16515,7 +16515,7 @@
 				"resolve-bin": "^0.4.0",
 				"sass-loader": "^8.0.2",
 				"source-map-loader": "^0.2.4",
-				"stylelint": "^13.6.0",
+				"stylelint": "^13.7.0",
 				"stylelint-config-wordpress": "^17.0.0",
 				"terser-webpack-plugin": "^3.0.3",
 				"thread-loader": "^2.1.3",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -66,7 +66,7 @@
 		"resolve-bin": "^0.4.0",
 		"sass-loader": "^8.0.2",
 		"source-map-loader": "^0.2.4",
-		"stylelint": "^13.6.0",
+		"stylelint": "^13.7.0",
 		"stylelint-config-wordpress": "^17.0.0",
 		"terser-webpack-plugin": "^3.0.3",
 		"thread-loader": "^2.1.3",


### PR DESCRIPTION
## Description
`declaration-property-unit-whitelist` is now `declaration-property-unit-allowed-list`.
See https://github.com/stylelint/stylelint/blob/13.7.0/lib/rules/declaration-property-unit-whitelist/README.md for details.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
