### PR TITLE
Try: Show fullscreen shortcut in menu.

### DIFF
--- a/packages/edit-post/src/components/header/feature-toggle/index.js
+++ b/packages/edit-post/src/components/header/feature-toggle/index.js
@@ -20,6 +20,7 @@ function FeatureToggle( {
 	messageActivated,
 	messageDeactivated,
 	speak,
+	shortcut,
 } ) {
 	const speakMessage = () => {
 		if ( isActive ) {
@@ -36,6 +37,7 @@ function FeatureToggle( {
 			onClick={ flow( onToggle, speakMessage ) }
 			role="menuitemcheckbox"
 			info={ info }
+			shortcut={ shortcut }
 		>
 			{ label }
 		</MenuItem>

--- a/packages/edit-post/src/components/header/more-menu/style.scss
+++ b/packages/edit-post/src/components/header/more-menu/style.scss
@@ -17,7 +17,7 @@
 }
 
 .edit-post-more-menu__content .components-popover__content {
-	min-width: 260px;
+	min-width: 280px;
 
 	// Let the menu scale to fit items.
 	@include break-mobile() {

--- a/packages/edit-post/src/components/header/writing-menu/index.js
+++ b/packages/edit-post/src/components/header/writing-menu/index.js
@@ -4,6 +4,7 @@
 import { MenuGroup } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 import { useViewportMatch } from '@wordpress/compose';
+import { displayShortcut } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -40,6 +41,7 @@ function WritingMenu() {
 				info={ __( 'Work without distraction' ) }
 				messageActivated={ __( 'Fullscreen mode activated' ) }
 				messageDeactivated={ __( 'Fullscreen mode deactivated' ) }
+				shortcut={ displayShortcut.secondary( 'f' ) }
 			/>
 		</MenuGroup>
 	);


### PR DESCRIPTION
"FeatureToggles" don't show shortcut keys, but they totally can, and it just so happens that Fullscreen Mode has a shortcut. This PR surfaces that shortcut:

![keyboard](https://user-images.githubusercontent.com/1204802/93439831-4d7a4980-f8cf-11ea-8b97-66c7f647432c.gif)
