### PR TITLE
Change wording and names to not include "whitelist"

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7044,7 +7044,7 @@ Add knobs to the [ColorIndicator Story](https://github.com/WordPress/gutenberg/p
 
 = 2.8.0 =
 
-* Add a pasting schema in raw content handling. It simplifies allowing and reduces the amount of filters run. Should improve reliability, clarity, markdown conversion, and usage in blocks.
+* Add a pasting schema in raw content handling. It simplifies allowed tags and reduces the amount of filters run. Should improve reliability, clarity, markdown conversion, and usage in blocks.
 * Add “Spacer” block to create empty areas.
 * Add Server Side Render component.
 * Expand public InnerBlocks API with support for template configuration and allowedBlocks logic.

--- a/changelog.txt
+++ b/changelog.txt
@@ -9,7 +9,7 @@
   - add filtering by author support in Query block. ([25149](https://github.com/WordPress/gutenberg/pull/25149))
   - add order and order by support. ([24691](https://github.com/WordPress/gutenberg/pull/24691))
   - add tags support. ([25005](https://github.com/WordPress/gutenberg/pull/25005))
-- Navigation screen: 
+- Navigation screen:
   - add drag and drop to List View. ([23952](https://github.com/WordPress/gutenberg/pull/23952))
   - implement redesign of screen. ([25178](https://github.com/WordPress/gutenberg/pull/25178))
   - add support for advanced menu item properties. ([25062](https://github.com/WordPress/gutenberg/pull/25062))
@@ -7044,7 +7044,7 @@ Add knobs to the [ColorIndicator Story](https://github.com/WordPress/gutenberg/p
 
 = 2.8.0 =
 
-* Add a pasting schema in raw content handling. It simplifies whitelisting and reduces the amount of filters run. Should improve reliability, clarity, markdown conversion, and usage in blocks.
+* Add a pasting schema in raw content handling. It simplifies allowing and reduces the amount of filters run. Should improve reliability, clarity, markdown conversion, and usage in blocks.
 * Add “Spacer” block to create empty areas.
 * Add Server Side Render component.
 * Expand public InnerBlocks API with support for template configuration and allowedBlocks logic.

--- a/packages/blocks/src/api/raw-handling/is-inline-content.js
+++ b/packages/blocks/src/api/raw-handling/is-inline-content.js
@@ -27,12 +27,12 @@ function isInline( node, contextTag ) {
 	}
 
 	const tag = node.nodeName.toLowerCase();
-	const inlineWhitelistTagGroups = [
+	const inlineAllowedTagGroups = [
 		[ 'ul', 'li', 'ol' ],
 		[ 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ],
 	];
 
-	return inlineWhitelistTagGroups.some(
+	return inlineAllowedTagGroups.some(
 		( tagGroup ) => difference( [ tag, contextTag ], tagGroup ).length === 0
 	);
 }

--- a/packages/edit-post/README.md
+++ b/packages/edit-post/README.md
@@ -91,7 +91,7 @@ const MyPluginBlockSettingsMenuItem = () => (
 _Parameters_
 
 -   _props_ `Object`: Component props.
--   _props.allowedBlocks_ `[Array]`: An array containing a list of block names for which the item should be shown. If not present, it'll be rendered for any block. If multiple blocks are selected, it'll be shown if and only if all of them are in the whitelist.
+-   _props.allowedBlocks_ `[Array]`: An array containing a list of block names for which the item should be shown. If not present, it'll be rendered for any block. If multiple blocks are selected, it'll be shown if and only if all of them are in the allowed list.
 -   _props.icon_ `[WPBlockTypeIconRender]`: The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug string, or an SVG WP element.
 -   _props.label_ `string`: The menu item text.
 -   _props.onClick_ `Function`: Callback function to be executed when the user click the menu item.

--- a/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
+++ b/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
@@ -33,7 +33,7 @@ const shouldRenderItem = ( selectedBlocks, allowedBlocks ) =>
  * Renders a new item in the block settings menu.
  *
  * @param {Object}                props                 Component props.
- * @param {Array}                 [props.allowedBlocks] An array containing a list of block names for which the item should be shown. If not present, it'll be rendered for any block. If multiple blocks are selected, it'll be shown if and only if all of them are in the whitelist.
+ * @param {Array}                 [props.allowedBlocks] An array containing a list of block names for which the item should be shown. If not present, it'll be rendered for any block. If multiple blocks are selected, it'll be shown if and only if all of them are in the allowed list.
  * @param {WPBlockTypeIconRender} [props.icon]          The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug string, or an SVG WP element.
  * @param {string}                props.label           The menu item text.
  * @param {Function}              props.onClick         Callback function to be executed when the user click the menu item.

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -48,7 +48,7 @@
 
 ### Improvements
 
--   `'AsyncIterableIterator'` is now whitelisted as a valid TypeScript utility type.
+-   `'AsyncIterableIterator'` is now allowed as a valid TypeScript utility type.
 
 ## 5.1.0 (2020-04-30)
 

--- a/packages/eslint-plugin/configs/jsdoc.js
+++ b/packages/eslint-plugin/configs/jsdoc.js
@@ -4,7 +4,7 @@
 const globals = require( 'globals' );
 
 /**
- * The temporary list of types defined in Gutenberg which are whitelisted to avoid
+ * The temporary list of types defined in Gutenberg which are allowed to avoid
  * ESLint warnings. It should be removed once importing is going to be implemented
  * in the tool which generates public APIs from JSDoc comments. Related issue to
  * fix the root cause `@wordpress/docgen`:
@@ -27,7 +27,7 @@ const temporaryWordPressInternalTypes = [
 ];
 
 /**
- * The temporary list of external types used in Gutenberg which are whitelisted
+ * The temporary list of external types used in Gutenberg which are allowed
  * to avoid ESLint warnings. It's similar to `wordpressInternalTypes` and it
  * should be removed once the related issues is fixed:
  * https://github.com/WordPress/gutenberg/issues/18045

--- a/packages/eslint-plugin/rules/i18n-text-domain.js
+++ b/packages/eslint-plugin/rules/i18n-text-domain.js
@@ -61,7 +61,7 @@ module.exports = {
 			unnecessaryDefault: 'Unnecessary default text domain',
 			missing: 'Missing text domain',
 			useAllowedValue:
-				'Use one of the whitelisted text domains: {{ textDomains }}',
+				'Use one of the allowed text domains: {{ textDomains }}',
 		},
 		fixable: 'code',
 	},

--- a/packages/library-export-default-webpack-plugin/README.md
+++ b/packages/library-export-default-webpack-plugin/README.md
@@ -1,6 +1,6 @@
 # Library Export Default Webpack Plugin
 
-Webpack plugin for exporting `default` property for selected libraries which use ES6 Modules. Implementation is based on the Webpack's core plugin [ExportPropertyMainTemplatePlugin](https://github.com/webpack/webpack/blob/51b0df77e4f366163730ee465f01458bfad81f34/lib/ExportPropertyMainTemplatePlugin.js). The only difference is that this plugin allows to whitelist all entry point names where the default export of your entry point will be assigned to the library target.  
+Webpack plugin for exporting `default` property for selected libraries which use ES6 Modules. Implementation is based on the Webpack's core plugin [ExportPropertyMainTemplatePlugin](https://github.com/webpack/webpack/blob/51b0df77e4f366163730ee465f01458bfad81f34/lib/ExportPropertyMainTemplatePlugin.js). The only difference is that this plugin allows to include all entry point names where the default export of your entry point will be assigned to the library target.  
 
 **Note**: This plugin requires Webpack 4.0 and newer, and is not compatible with older versions.
 


### PR DESCRIPTION
## Description

Changes the wording in docs & changelogs.
Also changes the name of `inlineWhitelistTagGroups` to `inlineAllowedTagGroups`.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
