### PR TITLE
Rename makeLink to isLink in Post Title

### DIFF
--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -13,7 +13,7 @@
 			"type": "number",
 			"default": 2
 		},
-		"makeLink": {
+		"isLink": {
 			"type": "boolean",
 			"default": false
 		},

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -27,7 +27,7 @@ import { __ } from '@wordpress/i18n';
 import HeadingLevelDropdown from '../heading/heading-level-dropdown';
 
 export default function PostTitleEdit( {
-	attributes: { level, textAlign, makeLink, rel, linkTarget },
+	attributes: { level, textAlign, isLink, rel, linkTarget },
 	setAttributes,
 	context: { postType, postId },
 } ) {
@@ -49,7 +49,7 @@ export default function PostTitleEdit( {
 
 	const BlockWrapper = Block[ tagName ];
 	let title = post.title || __( 'Post Title' );
-	if ( makeLink ) {
+	if ( isLink ) {
 		title = (
 			<a href={ post.link } target={ linkTarget } rel={ rel }>
 				{ title }
@@ -79,12 +79,10 @@ export default function PostTitleEdit( {
 				<PanelBody title={ __( 'Link settings' ) }>
 					<ToggleControl
 						label={ __( 'Make title a link' ) }
-						onChange={ () =>
-							setAttributes( { makeLink: ! makeLink } )
-						}
-						checked={ makeLink }
+						onChange={ () => setAttributes( { isLink: ! isLink } ) }
+						checked={ isLink }
 					/>
-					{ makeLink && (
+					{ isLink && (
 						<>
 							<ToggleControl
 								label={ __( 'Open in new tab' ) }

--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -28,7 +28,7 @@ function render_block_core_post_title( $attributes, $content, $block ) {
 	}
 
 	$title = get_the_title( $post_ID );
-	if ( isset( $attributes['makeLink'] ) && $attributes['makeLink'] ) {
+	if ( isset( $attributes['isLink'] ) && $attributes['isLink'] ) {
 		$title = sprintf( '<a href="%1s" target="%2s" rel="%3s">%4s</a>', get_the_permalink( $post_ID ), $attributes['linkTarget'], $attributes['rel'], $title );
 	}
 

--- a/packages/e2e-tests/fixtures/blocks/core__post-title.json
+++ b/packages/e2e-tests/fixtures/blocks/core__post-title.json
@@ -5,7 +5,7 @@
 		"isValid": true,
 		"attributes": {
 			"level": 2,
-			"makeLink": false,
+			"isLink": false,
 			"linkTarget": "_blank",
 			"rel": ""
 		},


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This PR just renames the attribute of PostTitle block from `makeLink` to `isLink`.