### PR TITLE
Don't use percent units for line-height

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -4,7 +4,6 @@
 		"at-rule-empty-line-before": null,
 		"at-rule-no-unknown": null,
 		"comment-empty-line-before": null,
-		"declaration-property-unit-whitelist": null,
 		"font-weight-notation": null,
 		"max-line-length": null,
 		"no-descending-specificity": null,

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -506,7 +506,7 @@
 	overflow: hidden;
 	font-family: $editor-html-font;
 	font-size: $text-editor-font-size;
-	line-height: 150%;
+	line-height: 1.5;
 	transition: padding 0.2s linear;
 	@include reduce-motion("transition");
 


### PR DESCRIPTION
## Description
Percentage units for line-height should be avoided. See https://developer.mozilla.org/en-US/docs/Web/CSS/line-height for details

This PR changes the only instance where we use `%` values for line-height, changing `150%` to `1.5`.
Also removes the `declaration-property-unit-whitelist` rule from `stylelint` since it's no longer required.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
