### PR TITLE
Navigation component: NavigationItem expose setActiveMenu

### DIFF
--- a/packages/components/src/navigation/item.js
+++ b/packages/components/src/navigation/item.js
@@ -8,6 +8,7 @@ import { noop } from 'lodash';
  * WordPress dependencies
  */
 import { Icon, chevronRight } from '@wordpress/icons';
+import { isValidElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -41,9 +42,21 @@ export default function NavigationItem( {
 		onClick();
 	};
 
+	if ( isValidElement( children ) ) {
+		return <ItemUI className={ classes }>{ children }</ItemUI>;
+	}
+
+	if ( typeof children === 'function' ) {
+		return (
+			<ItemUI className={ classes }>
+				{ children( { setActiveMenu } ) }
+			</ItemUI>
+		);
+	}
+
 	return (
 		<ItemUI className={ classes }>
-			{ children || (
+			{
 				<Button href={ href } onClick={ onItemClick } { ...props }>
 					{ title && (
 						<ItemTitleUI
@@ -63,7 +76,7 @@ export default function NavigationItem( {
 
 					{ navigateToMenu && <Icon icon={ chevronRight } /> }
 				</Button>
-			) }
+			}
 		</ItemUI>
 	);
 }

--- a/packages/components/src/navigation/stories/index.js
+++ b/packages/components/src/navigation/stories/index.js
@@ -55,6 +55,17 @@ function Example() {
 			>
 				<NavigationMenu title="Home">
 					<NavigationGroup title="Group 1">
+						<NavigationItem item="item-2">
+							{ ( { setActiveMenu: navigateTo } ) => (
+								<button
+									onClick={ () => navigateTo( 'category' ) }
+								>
+									Expose setActiveMenu (2.)
+									<br />
+									Navigate to category
+								</button>
+							) }
+						</NavigationItem>
 						<NavigationItem item="item-1" title="Item 1">
 							<Link href="https://example.com/item-1">
 								Item 1

--- a/packages/components/src/navigation/stories/index.js
+++ b/packages/components/src/navigation/stories/index.js
@@ -55,17 +55,6 @@ function Example() {
 			>
 				<NavigationMenu title="Home">
 					<NavigationGroup title="Group 1">
-						<NavigationItem item="item-2">
-							{ ( { setActiveMenu: navigateTo } ) => (
-								<button
-									onClick={ () => navigateTo( 'category' ) }
-								>
-									Expose setActiveMenu (2.)
-									<br />
-									Navigate to category
-								</button>
-							) }
-						</NavigationItem>
 						<NavigationItem item="item-1" title="Item 1">
 							<Link href="https://example.com/item-1">
 								Item 1
@@ -107,6 +96,20 @@ function Example() {
 							</a>
 						</NavigationItem>
 					</NavigationGroup>
+					<NavigationItem item="item-custom-function">
+						{ ( { setActiveMenu: navigateTo } ) => (
+							<div
+								role="button"
+								onKeyUp={ () => {} }
+								onClick={ () => navigateTo( 'category' ) }
+								tabIndex="-1"
+							>
+								Expose setActiveMenu
+								<br />
+								Navigate to category
+							</div>
+						) }
+					</NavigationItem>
 				</NavigationMenu>
 
 				<NavigationMenu


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Expose `setActiveMenu` to `children`. Allows custom children to navigate to a menu.

## How has this been tested?
`yarn storybook:dev`

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
