### PR TITLE
Fix link color for roles without unfiltered_html capabilities

### DIFF
--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -885,7 +885,9 @@ function gutenberg_experimental_global_styles_register_cpt() {
 function gutenberg_experimental_global_styles_allow_css_var_name( $allowed_attr ) {
 	return array_merge(
 		$allowed_attr,
-		[ '--wp--style--color--link' ],
+		array(
+			'--wp--style--color--link',
+		)
 	);
 }
 
@@ -894,13 +896,13 @@ function gutenberg_experimental_global_styles_allow_css_var_name( $allowed_attr 
  * the block editor may add.
  *
  * @param boolean $allow_css Whether or not this rule should be allowed.
- * @param string $css_test_string The CSS rule to process.
+ * @param string  $css_test_string The CSS rule to process.
  * @return boolean Filtered result.
  */
 function gutenberg_experimental_global_styles_allow_css_var_value( $allow_css, $css_test_string ) {
 	$parts = explode( ':', $css_test_string, 2 );
 
-	if ( $parts[ 0 ] !== '--wp--style--color--link' ) {
+	if ( '--wp--style--color--link' !== $parts[ 0 ] ) {
 		return $allow_css;
 	}
 

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -916,7 +916,7 @@ function gutenberg_experimental_global_styles_allow_css_var_value( $allow_css, $
 	}
 
 	// We want to be specific in testing that the value for link color
-	// matches this: var(--wp--preset--color--<value-with-alphanumeric-chars-or-hyphen>)
+	// matches this: var(--wp--preset--color--<value-with-alphanumeric-chars-or-hyphen>).
 	return preg_match( '/^var\(--wp--preset--color--[A-Za-z0-9-]*\)$/', $property_value );
 }
 

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -902,7 +902,7 @@ function gutenberg_experimental_global_styles_allow_css_var_name( $allowed_attr 
 function gutenberg_experimental_global_styles_allow_css_var_value( $allow_css, $css_test_string ) {
 	$parts = explode( ':', $css_test_string, 2 );
 
-	if ( '--wp--style--color--link' !== $parts[ 0 ] ) {
+	if ( '--wp--style--color--link' !== $parts[0] ) {
 		return $allow_css;
 	}
 

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -875,6 +875,18 @@ function gutenberg_experimental_global_styles_register_cpt() {
 	register_post_type( 'wp_global_styles', $args );
 }
 
+/**
+ * Tell kses not to remove from the block markup (style attribute)
+ * the CSS variables the block editor may add.
+ */
+function gutenberg_experimental_global_styles_allow_css_variables( $allowed_attr ) {
+	return array_merge(
+		$allowed_attr,
+		[ '--wp--style--color--link' ],
+	);
+}
+
 add_action( 'init', 'gutenberg_experimental_global_styles_register_cpt' );
 add_filter( 'block_editor_settings', 'gutenberg_experimental_global_styles_settings' );
 add_action( 'wp_enqueue_scripts', 'gutenberg_experimental_global_styles_enqueue_assets' );
+add_filter( 'safe_style_css', 'gutenberg_experimental_global_styles_allow_css_variables' );

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -900,16 +900,24 @@ function gutenberg_experimental_global_styles_allow_css_var_name( $allowed_attr 
  * @return boolean Filtered result.
  */
 function gutenberg_experimental_global_styles_allow_css_var_value( $allow_css, $css_test_string ) {
-	$parts = explode( ':', $css_test_string, 2 );
+	$parts          = explode( ':', $css_test_string, 2 );
+	$property_name  = trim( $parts[0] );
+	$property_value = trim( $parts[1] );
 
-	if ( '--wp--style--color--link' !== $parts[0] ) {
+	// Pass through if we're not processing the link color property.
+	if ( '--wp--style--color--link' !== $property_name ) {
 		return $allow_css;
 	}
 
-	// The only value the block editor attaches to link color is
-	// var(--wp--preset--color--<value-with-alphanumeric-chars-or-hyphen>)
-	// so be specific in testing for that value.
-	return preg_match( '/^var\(--wp--preset--color--[A-Za-z0-9-]*\)$/', $parts[1] );
+	// Pass through if $allow_css true. This means the link color has a valid color value
+	// (the user selected a custom color).
+	if ( $allow_css ) {
+		return $allow_css;
+	}
+
+	// We want to be specific in testing that the value for link color
+	// matches this: var(--wp--preset--color--<value-with-alphanumeric-chars-or-hyphen>)
+	return preg_match( '/^var\(--wp--preset--color--[A-Za-z0-9-]*\)$/', $property_value );
 }
 
 add_action( 'init', 'gutenberg_experimental_global_styles_register_cpt' );

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -907,9 +907,9 @@ function gutenberg_experimental_global_styles_allow_css_var_value( $allow_css, $
 	}
 
 	// The only value the block editor attaches to link color is
-	// var(--wp--preset--color--<some-value-here>)
+	// var(--wp--preset--color--<value-with-alphanumeric-chars-or-hyphen>)
 	// so be specific in testing for that value.
-	return preg_match( '/var\(--wp--preset--color--.*\)/', $parts[1] );
+	return preg_match( '/^var\(--wp--preset--color--[A-Za-z0-9-]*\)$/', $parts[1] );
 }
 
 add_action( 'init', 'gutenberg_experimental_global_styles_register_cpt' );

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/link-color.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/link-color.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Link color control serializes markup properly 1`] = `
+"<!-- wp:paragraph {\\"style\\":{\\"color\\":{\\"link\\":\\"var:preset|color|black\\"}}} -->
+<p class=\\"has-link-color\\" style=\\"--wp--style--color--link:var(--wp--preset--color--black)\\">This is <a href=\\"https://wordpress.org/gutenberg\\">Gutenberg</a></p>
+<!-- /wp:paragraph -->"
+`;

--- a/packages/e2e-tests/specs/editor/various/link-color.test.js
+++ b/packages/e2e-tests/specs/editor/various/link-color.test.js
@@ -1,0 +1,69 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	clickBlockAppender,
+	createNewPost,
+	getEditedPostContent,
+	pressKeyWithModifier,
+	publishPost,
+} from '@wordpress/e2e-test-utils';
+
+describe( 'Link color', () => {
+	beforeEach( async () => {
+		await createNewPost();
+	} );
+
+	const waitForAutoFocus = async () => {
+		await page.waitForFunction(
+			() => !! document.activeElement.closest( '.block-editor-url-input' )
+		);
+	};
+
+	it( 'control serializes markup properly', async () => {
+		// Create a block with some text
+		await clickBlockAppender();
+		await page.keyboard.type( 'This is Gutenberg' );
+
+		// Select some text
+		await pressKeyWithModifier( 'shiftAlt', 'ArrowLeft' );
+
+		// Click on the Link button
+		await page.click( 'button[aria-label="Link"]' );
+
+		// Wait for the URL field to auto-focus
+		await waitForAutoFocus();
+
+		// Type a URL
+		await page.keyboard.type( 'https://wordpress.org/gutenberg' );
+
+		// Submit the link
+		await page.keyboard.press( 'Enter' );
+
+		// Simulate the theme has support for link color
+		await page.evaluate( () => {
+			wp.data.dispatch( 'core/block-editor' ).updateSettings( {
+				__experimentalFeatures: {
+					global: {
+						color: { link: true },
+					},
+				},
+			} );
+		} );
+
+		// Open color panel
+		await page.click('.block-editor-panel-color-gradient-settings .components-panel__body-toggle');
+
+		// Select first color
+		await page.click('.block-editor-panel-color-gradient-settings > .block-editor-color-gradient-control:last-child .components-circular-option-picker__option:first-child');
+
+		// Save post.
+		// We want to test that the link color control data
+		// persists after kses runs (kses filters out some markup,
+		// such as CSS variables within the style property).
+		await publishPost();
+
+		// Snapshot contains .has-link-color class and inline CSS variable
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+} );

--- a/packages/e2e-tests/specs/editor/various/link-color.test.js
+++ b/packages/e2e-tests/specs/editor/various/link-color.test.js
@@ -52,10 +52,14 @@ describe( 'Link color', () => {
 		} );
 
 		// Open color panel
-		await page.click('.block-editor-panel-color-gradient-settings .components-panel__body-toggle');
+		await page.click(
+			'.block-editor-panel-color-gradient-settings .components-panel__body-toggle'
+		);
 
 		// Select first color
-		await page.click('.block-editor-panel-color-gradient-settings > .block-editor-color-gradient-control:last-child .components-circular-option-picker__option:first-child');
+		await page.click(
+			'.block-editor-panel-color-gradient-settings > .block-editor-color-gradient-control:last-child .components-circular-option-picker__option:first-child'
+		);
 
 		// Save post.
 		// We want to test that the link color control data


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/25151