### PR TITLE
Show PostFeaturedImage in editor

### DIFF
--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -52,6 +52,7 @@
 @import "./widget-area/editor.scss";
 @import "./query-loop/editor.scss";
 @import "./query/editor.scss";
+@import "./post-featured-image/editor.scss";
 
 /**
  * Import styles from internal editor components used by the blocks.

--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -2,7 +2,8 @@
 	"name": "core/post-featured-image",
 	"category": "design",
 	"usesContext": [
-		"postId"
+		"postId",
+		"postType"
 	],
 	"supports": {
 		"html": false

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -3,8 +3,9 @@
  */
 import { useEntityProp } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
-import { ResponsiveWrapper } from '@wordpress/components';
+import { ResponsiveWrapper, Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { postFeaturedImage as icon } from '@wordpress/icons';
 
 function PostFeaturedImageDisplay( { context: { postId, postType } } ) {
 	const [ featuredImage ] = useEntityProp(
@@ -19,7 +20,12 @@ function PostFeaturedImageDisplay( { context: { postId, postType } } ) {
 		[ featuredImage ]
 	);
 	if ( ! media ) {
-		return __( 'No Featured Image is set' );
+		return (
+			<div className="post-featured-image_placeholder">
+				<Icon icon={ icon } />
+				<p> { __( 'Featured Image' ) }</p>
+			</div>
+		);
 	}
 	const alt = media.alt_text || __( 'No alternative text set' );
 	return (

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -1,35 +1,40 @@
 /**
  * WordPress dependencies
  */
-import { useEntityProp, useEntityId } from '@wordpress/core-data';
+import { useEntityProp } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { ResponsiveWrapper } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-function PostFeaturedImageDisplay() {
+function PostFeaturedImageDisplay( { context: { postId, postType } } ) {
 	const [ featuredImage ] = useEntityProp(
 		'postType',
-		'post',
-		'featured_media'
+		postType,
+		'featured_media',
+		postId
 	);
 	const media = useSelect(
 		( select ) =>
 			featuredImage && select( 'core' ).getMedia( featuredImage ),
 		[ featuredImage ]
 	);
-	return media ? (
+	if ( ! media ) {
+		return __( 'Featured Image is not set' );
+	}
+	const alt = media.alt_text || `{postType} Featured Media`;
+	return (
 		<ResponsiveWrapper
 			naturalWidth={ media.media_details.width }
 			naturalHeight={ media.media_details.height }
 		>
-			<img src={ media.source_url } alt="Post Featured Media" />
+			<img src={ media.source_url } alt={ alt } />
 		</ResponsiveWrapper>
-	) : null;
+	);
 }
 
-export default function PostFeaturedImageEdit() {
-	if ( ! useEntityId( 'postType', 'post' ) ) {
-		return __( 'Post Featured Image' );
+export default function PostFeaturedImageEdit( props ) {
+	if ( ! props.context?.postId ) {
+		return __( 'Featured Image' );
 	}
-	return <PostFeaturedImageDisplay />;
+	return <PostFeaturedImageDisplay { ...props } />;
 }

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -19,9 +19,9 @@ function PostFeaturedImageDisplay( { context: { postId, postType } } ) {
 		[ featuredImage ]
 	);
 	if ( ! media ) {
-		return __( 'Featured Image is not set' );
+		return __( 'No Featured Image is set' );
 	}
-	const alt = media.alt_text || `{postType} Featured Media`;
+	const alt = media.alt_text || __( 'No alternative text set' );
 	return (
 		<ResponsiveWrapper
 			naturalWidth={ media.media_details.width }

--- a/packages/block-library/src/post-featured-image/editor.scss
+++ b/packages/block-library/src/post-featured-image/editor.scss
@@ -1,0 +1,19 @@
+div[data-type="core/post-featured-image"] {
+	.post-featured-image_placeholder {
+		display: flex;
+		flex-direction: row;
+		align-items: flex-start;
+		border-radius: $radius-block-ui;
+		background-color: $white;
+		box-shadow: inset 0 0 0 $border-width $gray-900;
+		padding: $grid-unit-15;
+		svg {
+			margin-right: $grid-unit-15;
+		}
+		p {
+			font-family: $default-font;
+			font-size: $default-font-size;
+			margin: 0;
+		}
+	}
+}

--- a/packages/components/src/responsive-wrapper/style.scss
+++ b/packages/components/src/responsive-wrapper/style.scss
@@ -5,6 +5,10 @@
 	& > span {
 		display: block;
 	}
+	&,
+	& > img {
+		width: auto;
+	}
 }
 
 .components-responsive-wrapper__content {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes: https://github.com/WordPress/gutenberg/issues/25410

Currently when you insert a PostFeaturedImage block is displayed only a placeholder.
This PR displays the image properly.

There are going to be follow up PRs to enhance this block's functionality, like the selecting size, add link etc..
<!-- Please describe what you have changed or added -->

## How has this been tested?
Locally.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
