### PR TITLE
Remove the classic widgets panel only if the theme did not opt out of the new editor

### DIFF
--- a/lib/customizer.php
+++ b/lib/customizer.php
@@ -58,7 +58,7 @@ function gutenberg_customize_register( $wp_customize ) {
 
 	if ( gutenberg_use_widgets_block_editor() ) {
 		// Removes the core 'Widgets' panel from the Customizer if block based widgets are enabled.
-		$wp_customize->remove_panel( 'widgets' );
+		@$wp_customize->remove_panel( 'widgets' );
 		$wp_customize->add_section(
 			'gutenberg_widget_blocks',
 			array( 'title' => __( 'Widget Blocks', 'gutenberg' ) )

--- a/lib/customizer.php
+++ b/lib/customizer.php
@@ -57,6 +57,8 @@ function gutenberg_customize_register( $wp_customize ) {
 	);
 
 	if ( gutenberg_use_widgets_block_editor() ) {
+		// Removes the core 'Widgets' panel from the Customizer if block based widgets are enabled.
+		$wp_customize->remove_panel( 'widgets' );
 		$wp_customize->add_section(
 			'gutenberg_widget_blocks',
 			array( 'title' => __( 'Widget Blocks', 'gutenberg' ) )
@@ -74,25 +76,6 @@ function gutenberg_customize_register( $wp_customize ) {
 	}
 }
 add_action( 'customize_register', 'gutenberg_customize_register' );
-
-/**
- * Removes the core 'Widgets' panel from the Customizer if block based widgets are enabled.
- *
- * @param array $components Core Customizer components list.
- * @return array (Maybe) modified components list.
- */
-function gutenberg_remove_widgets_panel( $components ) {
-	if ( ! gutenberg_use_widgets_block_editor() ) {
-		return $components;
-	}
-
-	$i = array_search( 'widgets', $components, true );
-	if ( false !== $i ) {
-		unset( $components[ $i ] );
-	}
-	return $components;
-}
-add_filter( 'customize_loaded_components', 'gutenberg_remove_widgets_panel' );
 
 /**
  * Filters the Customizer widget settings arguments.


### PR DESCRIPTION
## Description
Solves #24949 in a very non-elegant way. Let's talk.

The problem is that:
* The preferred way of removing customizer panels is via the `customize_loaded_components` hook. 
* The widgets panel should only be removed if the theme does call `remove_theme_support( 'widgets-block-editor' )` in response to `after_setup_theme` action.
* `customize_loaded_components` is fired before the theme's `functions.php` is even loaded!

This PR calls `$wp_customize->remove_panel( 'widgets' );` instead, the problem is that it's discouraged and generates a warning since WP 4.5:

"Removing widgets manually will cause PHP warnings. Use the customize_loaded_components filter instead."

https://core.trac.wordpress.org/ticket/35242

It makes sense - the design seems to assume that all the panels not removed via `customize_loaded_components` are assumed to stay, there may be some core, plugin, or theme code relying on that behavior.

It seems like relying theme support is not going to work for removing the `widgets` panel. We could either not rely on theme support and figure out a different solution, or remove the panel after the fact and suppress the warning.

CC @draganescu @noisysocks @kevin940726 @talldan @youknowriad 