### PR TITLE
[Widgets editor] Update the build process to account for legacy-widget block living in edit-widgets package

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -11,8 +11,8 @@
  */
 function gutenberg_reregister_core_block_types() {
 	// Blocks directory may not exist if working from a fresh clone.
-	$blocks_dirs = [
-		dirname( __FILE__ ) . '/../build/block-library/blocks/' => [
+	$blocks_dirs = array(
+		dirname( __FILE__ ) . '/../build/block-library/blocks/' => array(
 			'block_folders' => array(
 				'audio',
 				'button',
@@ -47,22 +47,24 @@ function gutenberg_reregister_core_block_types() {
 				'video',
 				'widget-area',
 			),
-			'block_names'   => array_merge( array(
-				'archives.php'        => 'core/archives',
-				'block.php'           => 'core/block',
-				'calendar.php'        => 'core/calendar',
-				'categories.php'      => 'core/categories',
-				'cover.php'           => 'core/cover',
-				'latest-comments.php' => 'core/latest-comments',
-				'latest-posts.php'    => 'core/latest-posts',
-				'navigation.php'      => 'core/navigation',
-				'navigation-link.php' => 'core/navigation-link',
-				'rss.php'             => 'core/rss',
-				'search.php'          => 'core/search',
-				'shortcode.php'       => 'core/shortcode',
-				'social-link.php'     => 'core/social-link',
-				'tag-cloud.php'       => 'core/tag-cloud',
-			), ! gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' )
+			'block_names'   => array_merge(
+				array(
+					'archives.php'        => 'core/archives',
+					'block.php'           => 'core/block',
+					'calendar.php'        => 'core/calendar',
+					'categories.php'      => 'core/categories',
+					'cover.php'           => 'core/cover',
+					'latest-comments.php' => 'core/latest-comments',
+					'latest-posts.php'    => 'core/latest-posts',
+					'navigation.php'      => 'core/navigation',
+					'navigation-link.php' => 'core/navigation-link',
+					'rss.php'             => 'core/rss',
+					'search.php'          => 'core/search',
+					'shortcode.php'       => 'core/shortcode',
+					'social-link.php'     => 'core/social-link',
+					'tag-cloud.php'       => 'core/tag-cloud',
+				),
+				! gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' )
 				? array()
 				:
 				array(
@@ -88,8 +90,9 @@ function gutenberg_reregister_core_block_types() {
 					'site-tagline.php'            => 'core/site-tagline',
 					'site-title.php'              => 'core/site-title',
 					'template-part.php'           => 'core/template-part',
-				) ),
-		],
+				)
+			),
+		),
 		dirname( __FILE__ ) . '/../build/edit-widgets/blocks/'  => array(
 			'block_folders' => array(
 				'legacy-widget',
@@ -98,7 +101,7 @@ function gutenberg_reregister_core_block_types() {
 				'legacy-widget.php' => 'core/legacy-widget',
 			),
 		),
-	];
+	);
 	foreach ( $blocks_dirs as $blocks_dir => $details ) {
 		if ( ! file_exists( $blocks_dir ) ) {
 			return;

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -11,137 +11,146 @@
  */
 function gutenberg_reregister_core_block_types() {
 	// Blocks directory may not exist if working from a fresh clone.
-	$blocks_dir = dirname( __FILE__ ) . '/../build/block-library/blocks/';
-	if ( ! file_exists( $blocks_dir ) ) {
-		return;
-	}
-
-	$block_folders = array(
-		'audio',
-		'button',
-		'buttons',
-		'classic',
-		'code',
-		'column',
-		'columns',
-		'file',
-		'gallery',
-		'group',
-		'heading',
-		'html',
-		'image',
-		'list',
-		'media-text',
-		'missing',
-		'more',
-		'navigation-link',
-		'nextpage',
-		'paragraph',
-		'preformatted',
-		'pullquote',
-		'quote',
-		'separator',
-		'social-links',
-		'spacer',
-		'subhead',
-		'table',
-		'text-columns',
-		'verse',
-		'video',
-		'widget-area',
-	);
-
-	$block_names = array(
-		'archives.php'        => 'core/archives',
-		'block.php'           => 'core/block',
-		'calendar.php'        => 'core/calendar',
-		'categories.php'      => 'core/categories',
-		'cover.php'           => 'core/cover',
-		'latest-comments.php' => 'core/latest-comments',
-		'latest-posts.php'    => 'core/latest-posts',
-		'legacy-widget.php'   => 'core/legacy-widget',
-		'navigation.php'      => 'core/navigation',
-		'navigation-link.php' => 'core/navigation-link',
-		'rss.php'             => 'core/rss',
-		'search.php'          => 'core/search',
-		'shortcode.php'       => 'core/shortcode',
-		'social-link.php'     => 'core/social-link',
-		'tag-cloud.php'       => 'core/tag-cloud',
-	);
-
-	if ( gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' ) ) {
-		$block_names = array_merge(
-			$block_names,
-			array(
-				'post-author.php'             => 'core/post-author',
-				'post-comment.php'            => 'core/post-comment',
-				'post-comment-author.php'     => 'core/post-comment-author',
-				'post-comment-content.php'    => 'core/post-comment-content',
-				'post-comment-date.php'       => 'core/post-comment-date',
-				'post-comments.php'           => 'core/post-comments',
-				'post-comments-count.php'     => 'core/post-comments-count',
-				'post-comments-form.php'      => 'core/post-comments-form',
-				'post-content.php'            => 'core/post-content',
-				'post-date.php'               => 'core/post-date',
-				'post-excerpt.php'            => 'core/post-excerpt',
-				'post-featured-image.php'     => 'core/post-featured-image',
-				'post-hierarchical-terms.php' => 'core/post-hierarchical-terms',
-				'post-tags.php'               => 'core/post-tags',
-				'post-title.php'              => 'core/post-title',
-				'query.php'                   => 'core/query',
-				'query-loop.php'              => 'core/query-loop',
-				'query-pagination.php'        => 'core/query-pagination',
-				'site-logo.php'               => 'core/site-logo',
-				'site-tagline.php'            => 'core/site-tagline',
-				'site-title.php'              => 'core/site-title',
-				'template-part.php'           => 'core/template-part',
-			)
-		);
-	}
-
-	$registry = WP_Block_Type_Registry::get_instance();
-
-	foreach ( $block_folders as $folder_name ) {
-		$block_json_file = $blocks_dir . $folder_name . '/block.json';
-		if ( ! file_exists( $block_json_file ) ) {
+	$blocks_dirs = [
+		dirname( __FILE__ ) . '/../build/block-library/blocks/' => [
+			'block_folders' => array(
+				'audio',
+				'button',
+				'buttons',
+				'classic',
+				'code',
+				'column',
+				'columns',
+				'file',
+				'gallery',
+				'group',
+				'heading',
+				'html',
+				'image',
+				'list',
+				'media-text',
+				'missing',
+				'more',
+				'navigation-link',
+				'nextpage',
+				'paragraph',
+				'preformatted',
+				'pullquote',
+				'quote',
+				'separator',
+				'social-links',
+				'spacer',
+				'subhead',
+				'table',
+				'text-columns',
+				'verse',
+				'video',
+				'widget-area',
+			),
+			'block_names'   => array_merge( array(
+				'archives.php'        => 'core/archives',
+				'block.php'           => 'core/block',
+				'calendar.php'        => 'core/calendar',
+				'categories.php'      => 'core/categories',
+				'cover.php'           => 'core/cover',
+				'latest-comments.php' => 'core/latest-comments',
+				'latest-posts.php'    => 'core/latest-posts',
+				'navigation.php'      => 'core/navigation',
+				'navigation-link.php' => 'core/navigation-link',
+				'rss.php'             => 'core/rss',
+				'search.php'          => 'core/search',
+				'shortcode.php'       => 'core/shortcode',
+				'social-link.php'     => 'core/social-link',
+				'tag-cloud.php'       => 'core/tag-cloud',
+			), ! gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' )
+				? array()
+				:
+				array(
+					'post-author.php'             => 'core/post-author',
+					'post-comment.php'            => 'core/post-comment',
+					'post-comment-author.php'     => 'core/post-comment-author',
+					'post-comment-content.php'    => 'core/post-comment-content',
+					'post-comment-date.php'       => 'core/post-comment-date',
+					'post-comments.php'           => 'core/post-comments',
+					'post-comments-count.php'     => 'core/post-comments-count',
+					'post-comments-form.php'      => 'core/post-comments-form',
+					'post-content.php'            => 'core/post-content',
+					'post-date.php'               => 'core/post-date',
+					'post-excerpt.php'            => 'core/post-excerpt',
+					'post-featured-image.php'     => 'core/post-featured-image',
+					'post-hierarchical-terms.php' => 'core/post-hierarchical-terms',
+					'post-tags.php'               => 'core/post-tags',
+					'post-title.php'              => 'core/post-title',
+					'query.php'                   => 'core/query',
+					'query-loop.php'              => 'core/query-loop',
+					'query-pagination.php'        => 'core/query-pagination',
+					'site-logo.php'               => 'core/site-logo',
+					'site-tagline.php'            => 'core/site-tagline',
+					'site-title.php'              => 'core/site-title',
+					'template-part.php'           => 'core/template-part',
+				) ),
+		],
+		dirname( __FILE__ ) . '/../build/edit-widgets/blocks/'  => array(
+			'block_folders' => array(
+				'legacy-widget',
+			),
+			'block_names'   => array(
+				'legacy-widget.php' => 'core/legacy-widget',
+			),
+		),
+	];
+	foreach ( $blocks_dirs as $blocks_dir => $details ) {
+		if ( ! file_exists( $blocks_dir ) ) {
 			return;
 		}
+		$block_folders = $details['block_folders'];
+		$block_names   = $details['block_names'];
 
-		// Ideally, all paths to block metadata files should be listed in
-		// WordPress core. In this place we should rather use filter
-		// to replace paths with overrides defined by the plugin.
-		$metadata = json_decode( file_get_contents( $block_json_file ), true );
-		if ( ! is_array( $metadata ) || ! $metadata['name'] ) {
-			return false;
-		}
+		$registry = WP_Block_Type_Registry::get_instance();
 
-		if ( $registry->is_registered( $metadata['name'] ) ) {
-			$registry->unregister( $metadata['name'] );
-		}
-
-		register_block_type_from_metadata( $block_json_file );
-	}
-
-	foreach ( $block_names as $file => $block_names ) {
-		if ( ! file_exists( $blocks_dir . $file ) ) {
-			return;
-		}
-
-		if ( is_string( $block_names ) ) {
-			if ( $registry->is_registered( $block_names ) ) {
-				$registry->unregister( $block_names );
+		foreach ( $block_folders as $folder_name ) {
+			$block_json_file = $blocks_dir . $folder_name . '/block.json';
+			if ( ! file_exists( $block_json_file ) ) {
+				return;
 			}
-		} elseif ( is_array( $block_names ) ) {
-			foreach ( $block_names as $block_name ) {
-				if ( $registry->is_registered( $block_name ) ) {
-					$registry->unregister( $block_name );
+
+			// Ideally, all paths to block metadata files should be listed in
+			// WordPress core. In this place we should rather use filter
+			// to replace paths with overrides defined by the plugin.
+			$metadata = json_decode( file_get_contents( $block_json_file ), true );
+			if ( ! is_array( $metadata ) || ! $metadata['name'] ) {
+				return false;
+			}
+
+			if ( $registry->is_registered( $metadata['name'] ) ) {
+				$registry->unregister( $metadata['name'] );
+			}
+
+			register_block_type_from_metadata( $block_json_file );
+		}
+
+		foreach ( $block_names as $file => $block_names ) {
+			if ( ! file_exists( $blocks_dir . $file ) ) {
+				return;
+			}
+
+			if ( is_string( $block_names ) ) {
+				if ( $registry->is_registered( $block_names ) ) {
+					$registry->unregister( $block_names );
+				}
+			} elseif ( is_array( $block_names ) ) {
+				foreach ( $block_names as $block_name ) {
+					if ( $registry->is_registered( $block_name ) ) {
+						$registry->unregister( $block_name );
+					}
 				}
 			}
-		}
 
-		require $blocks_dir . $file;
+			require $blocks_dir . $file;
+		}
 	}
 }
+
 add_action( 'init', 'gutenberg_reregister_core_block_types' );
 
 /**
@@ -223,4 +232,5 @@ function gutenberg_register_legacy_social_link_blocks() {
 		);
 	}
 }
+
 add_action( 'init', 'gutenberg_register_legacy_social_link_blocks' );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,7 @@ const { DefinePlugin } = require( 'webpack' );
 const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
 const TerserPlugin = require( 'terser-webpack-plugin' );
 const postcss = require( 'postcss' );
-const { get, escapeRegExp, compact, toPairs } = require( 'lodash' );
+const { get, escapeRegExp, compact } = require( 'lodash' );
 const { basename, sep } = require( 'path' );
 
 /**
@@ -74,29 +74,6 @@ const transformBlockContent = ( content ) => {
 			)
 	);
 };
-
-const blocksDirectoryMapping = toPairs( {
-	'./packages/block-library/src/': 'build/block-library/blocks/',
-	'./packages/edit-widgets/src/blocks/': 'build/edit-widgets/blocks/',
-} );
-
-const copyBlocksWebpackMapping = blocksDirectoryMapping.flatMap(
-	( [ from, to ] ) => [
-		{
-			from: `${ from }/**/index.php`,
-			test: new RegExp( `([\\w-]+)${ escapeRegExp( sep ) }index\\.php$` ),
-			to: `${ to }/[1].php`,
-			transform: transformBlockContent,
-		},
-		{
-			from: `${ from }/*/block.json`,
-			test: new RegExp(
-				`([\\w-]+)${ escapeRegExp( sep ) }block\\.json$`
-			),
-			to: `${ to }/[1]/block.json`,
-		},
-	]
-);
 
 module.exports = {
 	optimization: {
@@ -218,7 +195,29 @@ module.exports = {
 				},
 			} ) )
 		),
-		new CopyWebpackPlugin( copyBlocksWebpackMapping ),
+		new CopyWebpackPlugin(
+			Object.entries( {
+				'./packages/block-library/src/': 'build/block-library/blocks/',
+				'./packages/edit-widgets/src/blocks/':
+					'build/edit-widgets/blocks/',
+			} ).flatMap( ( [ from, to ] ) => [
+				{
+					from: `${ from }/**/index.php`,
+					test: new RegExp(
+						`([\\w-]+)${ escapeRegExp( sep ) }index\\.php$`
+					),
+					to: `${ to }/[1].php`,
+					transform: transformBlockContent,
+				},
+				{
+					from: `${ from }/*/block.json`,
+					test: new RegExp(
+						`([\\w-]+)${ escapeRegExp( sep ) }block\\.json$`
+					),
+					to: `${ to }/[1]/block.json`,
+				},
+			] )
+		),
 		new DependencyExtractionWebpackPlugin( { injectPolyfill: true } ),
 	].filter( Boolean ),
 	watchOptions: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,6 +41,42 @@ const gutenbergPackages = Object.keys( dependencies )
 	)
 	.map( ( packageName ) => packageName.replace( WORDPRESS_NAMESPACE, '' ) );
 
+const transformBlockContent = ( content ) => {
+	content = content.toString();
+
+	// Within content, search for any function definitions. For
+	// each, replace every other reference to it in the file.
+	return (
+		content
+			.match( /^function [^\(]+/gm )
+			.reduce( ( result, functionName ) => {
+				// Trim leading "function " prefix from match.
+				functionName = functionName.slice( 9 );
+
+				// Prepend the Gutenberg prefix, substituting any
+				// other core prefix (e.g. "wp_").
+				return result.replace(
+					new RegExp( functionName, 'g' ),
+					( match ) =>
+						'gutenberg_' +
+						match.replace( /^wp_/, '' )
+				);
+			}, content )
+			// The core blocks override procedure takes place in
+			// the init action default priority to ensure that core
+			// blocks would have been registered already. Since the
+			// blocks implementations occur at the default priority
+			// and due to WordPress hooks behavior not considering
+			// mutations to the same priority during another's
+			// callback, the Gutenberg build blocks are modified
+			// to occur at a later priority.
+			.replace(
+				/(add_action\(\s*'init',\s*'gutenberg_register_block_[^']+'(?!,))/,
+				'$1, 20'
+			)
+	);
+};
+
 module.exports = {
 	optimization: {
 		// Only concatenate modules in production, when not analyzing bundles.
@@ -168,41 +204,7 @@ module.exports = {
 					`([\\w-]+)${ escapeRegExp( sep ) }index\\.php$`
 				),
 				to: 'build/block-library/blocks/[1].php',
-				transform( content ) {
-					content = content.toString();
-
-					// Within content, search for any function definitions. For
-					// each, replace every other reference to it in the file.
-					return (
-						content
-							.match( /^function [^\(]+/gm )
-							.reduce( ( result, functionName ) => {
-								// Trim leading "function " prefix from match.
-								functionName = functionName.slice( 9 );
-
-								// Prepend the Gutenberg prefix, substituting any
-								// other core prefix (e.g. "wp_").
-								return result.replace(
-									new RegExp( functionName, 'g' ),
-									( match ) =>
-										'gutenberg_' +
-										match.replace( /^wp_/, '' )
-								);
-							}, content )
-							// The core blocks override procedure takes place in
-							// the init action default priority to ensure that core
-							// blocks would have been registered already. Since the
-							// blocks implementations occur at the default priority
-							// and due to WordPress hooks behavior not considering
-							// mutations to the same priority during another's
-							// callback, the Gutenberg build blocks are modified
-							// to occur at a later priority.
-							.replace(
-								/(add_action\(\s*'init',\s*'gutenberg_register_block_[^']+'(?!,))/,
-								'$1, 20'
-							)
-					);
-				},
+				transform: transformBlockContent,
 			},
 			{
 				from: './packages/block-library/src/*/block.json',
@@ -210,6 +212,21 @@ module.exports = {
 					`([\\w-]+)${ escapeRegExp( sep ) }block\\.json$`
 				),
 				to: 'build/block-library/blocks/[1]/block.json',
+			},
+			{
+				from: './packages/edit-widgets/src/blocks/**/index.php',
+				test: new RegExp(
+					`([\\w-]+)${ escapeRegExp( sep ) }index\\.php$`
+				),
+				to: 'build/edit-widgets/blocks/[1].php',
+				transform: transformBlockContent,
+			},
+			{
+				from: './packages/edit-widgets/src/blocks/*/block.json',
+				test: new RegExp(
+					`([\\w-]+)${ escapeRegExp( sep ) }block\\.json$`
+				),
+				to: 'build/edit-widgets/blocks/[1]/block.json',
 			},
 		] ),
 		new DependencyExtractionWebpackPlugin( { injectPolyfill: true } ),


### PR DESCRIPTION
## Description

In #25371 we moved the legacy-widget block to edit-widgets package. This PR updates webpack pipelines to ensure we correctly handle the new block during the build.

One more follow-up will be required to ensure `wordpress-develop` handles this correctly.

Alternatively we could just move that block into block-library during the build, but I have some concerns about that - in particular it seems pretty counter-intuitive.

## How has this been tested?
1. Remove your existing build directory
1. Run `npm run dev`
1. Go to widgets editor
1. Confirm the legacy widget preview is broken
1. Kill `npm run dev`
1. Apply this PR
1. Run `npm run dev`
1. Go to widgets editor
1. Confirm the legacy widget preview is working

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
