### PR TITLE
WIP - try dom based hover tracking for document dropdown sublabel.

### DIFF
--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -16,7 +16,7 @@ import {
 import { _x } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
 import { Button } from '@wordpress/components';
-import { useState, useEffect, useRef, useMemo } from '@wordpress/element';
+import { useState, useEffect, useMemo } from '@wordpress/element';
 import {
 	__experimentalGetBlockLabel as getBlockLabel,
 	getBlockType,
@@ -98,8 +98,7 @@ export default function Header( {
 	}, [] );
 
 	// See if a template part is hovered when mouse moves.
-	const hoveredTemplatePartRef = useRef( '' );
-	useEffect( () => {
+	const hoveredTemplatePart = useMemo( () => {
 		const hoveredElements = document.elementsFromPoint(
 			mouseLoc.x,
 			mouseLoc.y
@@ -108,9 +107,7 @@ export default function Header( {
 		const templatePart = hoveredElements.find(
 			( element ) => element.dataset?.type === 'core/template-part'
 		);
-		hoveredTemplatePartRef.current = templatePart
-			? templatePart.dataset.block
-			: '';
+		return templatePart ? templatePart.dataset.block : '';
 	}, [ mouseLoc.x, mouseLoc.y ] );
 
 	// Get label when hovered template part changes.
@@ -118,12 +115,12 @@ export default function Header( {
 		( select ) => select( 'core/block-editor' ).getBlock
 	);
 	const hoverLabel = useMemo( () => {
-		const block = getBlock( hoveredTemplatePartRef.current );
+		const block = getBlock( hoveredTemplatePart );
 		return (
 			block &&
 			getBlockLabel( getBlockType( block.name ), block.attributes )
 		);
-	}, [ hoveredTemplatePartRef.current ] );
+	}, [ hoveredTemplatePart ] );
 
 	return (
 		<>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Exploration to go along with #25320 (alternative approaches discussed in #25469 - more details on this approach there as "Solution 3") When the mouse moves, we parse the elements it is over for a template part.  When the hovered template part changes, we get the information to change the label.

The logic is all mashed together at the moment, but gives an idea of how it could be used to determine the the document settings dropdown sublabel.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
