### PR TITLE
Fix: Edit site block inspector sidebar has wrong close label

### DIFF
--- a/packages/edit-site/src/components/sidebar/default-sidebar.js
+++ b/packages/edit-site/src/components/sidebar/default-sidebar.js
@@ -5,9 +5,8 @@ import {
 	ComplementaryArea,
 	ComplementaryAreaMoreMenuItem,
 } from '@wordpress/interface';
-import { __ } from '@wordpress/i18n';
 
-export default ( { identifier, title, icon, children } ) => {
+export default ( { identifier, title, icon, children, closeLabel } ) => {
 	return (
 		<>
 			<ComplementaryArea
@@ -15,7 +14,7 @@ export default ( { identifier, title, icon, children } ) => {
 				identifier={ identifier }
 				title={ title }
 				icon={ icon }
-				closeLabel={ __( 'Close global styles sidebar' ) }
+				closeLabel={ closeLabel }
 			>
 				{ children }
 			</ComplementaryArea>

--- a/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
@@ -19,7 +19,7 @@ import { GLOBAL_CONTEXT } from '../editor/utils';
 import TypographyPanel from './typography-panel';
 import ColorPanel from './color-panel';
 
-export default ( { identifier, title, icon } ) => {
+export default ( { identifier, title, icon, closeLabel } ) => {
 	const {
 		contexts,
 		getStyleProperty,
@@ -32,7 +32,12 @@ export default ( { identifier, title, icon } ) => {
 	}
 
 	return (
-		<DefaultSidebar identifier={ identifier } title={ title } icon={ icon }>
+		<DefaultSidebar
+			identifier={ identifier }
+			title={ title }
+			icon={ icon }
+			closeLabel={ closeLabel }
+		>
 			<TabPanel
 				tabs={ [
 					{ name: 'global', title: __( 'Global' ) },

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -23,12 +23,14 @@ export function SidebarComplementaryAreaFills() {
 				identifier="edit-site/block-inspector"
 				title={ __( 'Block Inspector' ) }
 				icon={ cog }
+				closeLabel={ __( 'Close block inspector sidebar' ) }
 			>
 				<InspectorSlot bubblesVirtually />
 			</DefaultSidebar>
 			<GlobalStylesSidebar
 				identifier="edit-site/global-styles"
 				title={ __( 'Global Styles' ) }
+				closeLabel={ __( 'Close global styles sidebar' ) }
 				icon={ typography }
 			/>
 		</>


### PR DESCRIPTION
The block inspector edit site sidebar close label says "Close global styles sidebar" instead of "Close block inspector sidebar" this PR fixes the issue.

