### PR TITLE
Post Schedule: highlight posts as calendar events

### DIFF
--- a/packages/components/src/date-time/date.js
+++ b/packages/components/src/date-time/date.js
@@ -99,8 +99,11 @@ class DatePicker extends Component {
 	}
 
 	render() {
-		const { currentDate, isInvalidDate } = this.props;
+		const { currentDate, isInvalidDate, events } = this.props;
 		const momentDate = this.getMomentDate( currentDate );
+		const key = `datepicker-controller-${
+			momentDate ? momentDate.format( 'MM-YYYY' ) : 'null'
+		}${ events?.length ? '-events-' + events.length : '' }`;
 
 		return (
 			<div className="components-datetime__date" ref={ this.nodeRef }>
@@ -111,9 +114,7 @@ class DatePicker extends Component {
 					hideKeyboardShortcutsPanel
 					// This is a hack to force the calendar to update on month or year change
 					// https://github.com/airbnb/react-dates/issues/240#issuecomment-361776665
-					key={ `datepicker-controller-${
-						momentDate ? momentDate.format( 'MM-YYYY' ) : 'null'
-					}` }
+					key={ key }
 					noBorder
 					numberOfMonths={ 1 }
 					onDateChange={ this.onChangeMoment }

--- a/packages/components/src/date-time/date.js
+++ b/packages/components/src/date-time/date.js
@@ -108,7 +108,7 @@ class DatePicker extends Component {
 		const momentDate = this.getMomentDate( currentDate );
 		const key = `datepicker-controller-${
 			momentDate ? momentDate.format( 'MM-YYYY' ) : 'null'
-		}`; //${ events?.length ? '-events-' + events.length : '' }`;
+		}${ events?.length ? '-events-' + events.length : '' }`;
 
 		return (
 			<div className="components-datetime__date" ref={ this.nodeRef }>
@@ -139,3 +139,4 @@ class DatePicker extends Component {
 }
 
 export default DatePicker;
+

--- a/packages/components/src/date-time/date.js
+++ b/packages/components/src/date-time/date.js
@@ -88,6 +88,7 @@ class DatePicker extends Component {
 		if ( ! this.props.events?.length ) {
 			return false;
 		}
+
 		if ( this.props.onMonthPreviewed ) {
 			this.props.onMonthPreviewed( date.toDate() );
 		}

--- a/packages/components/src/date-time/date.js
+++ b/packages/components/src/date-time/date.js
@@ -82,15 +82,14 @@ class DatePicker extends Component {
 		return currentDate ? moment( currentDate ) : moment();
 	}
 
-	// todo change reference to `isDayHighlighted` every time, `events` prop change
 	isDayHighlighted( date ) {
+		if ( this.props.onMonthPreviewed ) {
+			this.props.onMonthPreviewed( date.toISOString() );
+		}
+
 		// Do not highlight when no events.
 		if ( ! this.props.events?.length ) {
 			return false;
-		}
-
-		if ( this.props.onMonthPreviewed ) {
-			this.props.onMonthPreviewed( date.toDate() );
 		}
 
 		// Compare date against highlighted events.
@@ -104,7 +103,7 @@ class DatePicker extends Component {
 		const momentDate = this.getMomentDate( currentDate );
 		const key = `datepicker-controller-${
 			momentDate ? momentDate.format( 'MM-YYYY' ) : 'null'
-		}${ events?.length ? '-events-' + events.length : '' }`;
+		}`; //${ events?.length ? '-events-' + events.length : '' }`;
 
 		return (
 			<div className="components-datetime__date" ref={ this.nodeRef }>

--- a/packages/components/src/date-time/date.js
+++ b/packages/components/src/date-time/date.js
@@ -33,7 +33,12 @@ class DatePicker extends Component {
 	 * This focus loss closes the date picker popover.
 	 * Ideally we should add an upstream commit on react-dates to fix this issue.
 	 */
-	keepFocusInside() {
+	keepFocusInside( newMonthDate ) {
+		// Trigger onMonthChange callback.
+		if ( this.props.onMonthChange ) {
+			this.props.onMonthChange( newMonthDate.toISOString() );
+		}
+
 		if ( ! this.nodeRef.current ) {
 			return;
 		}

--- a/packages/components/src/date-time/index.js
+++ b/packages/components/src/date-time/index.js
@@ -43,6 +43,7 @@ export class DateTimePicker extends Component {
 			is12Hour,
 			isInvalidDate,
 			onMonthPreviewed,
+			onMonthChange,
 			onChange,
 			events,
 		} = this.props;
@@ -61,6 +62,7 @@ export class DateTimePicker extends Component {
 							onChange={ onChange }
 							isInvalidDate={ isInvalidDate }
 							onMonthPreviewed={ onMonthPreviewed }
+							onMonthChange={ onMonthChange }
 							events={ events }
 						/>
 					</>

--- a/packages/editor/src/components/post-schedule/index.js
+++ b/packages/editor/src/components/post-schedule/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { map } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { __experimentalGetSettings } from '@wordpress/date';
@@ -6,11 +11,12 @@ import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { DateTimePicker } from '@wordpress/components';
 
-export function PostSchedule( { date, onUpdateDate } ) {
+export function PostSchedule( { date, onUpdateDate, postByMonth } ) {
 	const onChange = ( newDate ) => {
 		onUpdateDate( newDate );
 		document.activeElement.blur();
 	};
+
 	const settings = __experimentalGetSettings();
 	// To know if the current timezone is a 12 hour time with look for "a" in the time format
 	// We also make sure this a is not escaped by a "/"
@@ -29,6 +35,7 @@ export function PostSchedule( { date, onUpdateDate } ) {
 			currentDate={ date }
 			onChange={ onChange }
 			is12Hour={ is12HourTime }
+			events={ postByMonth }
 		/>
 	);
 }
@@ -37,6 +44,15 @@ export default compose( [
 	withSelect( ( select ) => {
 		return {
 			date: select( 'core/editor' ).getEditedPostAttribute( 'date' ),
+			postByMonth: map(
+				select( 'core' ).getEntityRecords( 'postType', 'post', {
+					status: 'publish,future',
+				} ),
+				( { date, title } ) => ( {
+					title,
+					date: new Date( date ),
+				} )
+			),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/packages/editor/src/components/post-schedule/index.js
+++ b/packages/editor/src/components/post-schedule/index.js
@@ -46,7 +46,7 @@ export function PostSchedule() {
 					before: getDayOfTheMonth( currentMonth, false ),
 				} ),
 				( { title, type, date } ) => ( {
-					title,
+					title: title?.raw ? title.raw : title,
 					type,
 					date: new Date( date ),
 				} )
@@ -78,7 +78,7 @@ export function PostSchedule() {
 			key="date-time-picker"
 			currentDate={ postDate }
 			onChange={ updatePostDate }
-			onMonthPreviewed={ setCurrentMonthHandler }
+			onMonthChange={ setCurrentMonthHandler }
 			is12Hour={ is12HourTime }
 			events={ events }
 		/>

--- a/packages/editor/src/components/post-schedule/index.js
+++ b/packages/editor/src/components/post-schedule/index.js
@@ -6,7 +6,7 @@ import { map } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __experimentalGetSettings } from '@wordpress/date';
+import { __experimentalGetSettings, gmdate } from '@wordpress/date';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { DateTimePicker } from '@wordpress/components';
@@ -42,11 +42,26 @@ export function PostSchedule( { date, onUpdateDate, postByMonth } ) {
 
 export default compose( [
 	withSelect( ( select ) => {
+		const now = new Date();
+
+		const firstDayOfTheMonth = new Date(
+			now.getFullYear(),
+			now.getMonth(),
+			1
+		).toISOString();
+		const lastDayOfTheMonth = new Date(
+			now.getFullYear(),
+			now.getMonth() + 1,
+			1
+		).toISOString();
+
 		return {
 			date: select( 'core/editor' ).getEditedPostAttribute( 'date' ),
 			postByMonth: map(
 				select( 'core' ).getEntityRecords( 'postType', 'post', {
 					status: 'publish,future',
+					after: firstDayOfTheMonth,
+					before: lastDayOfTheMonth,
 				} ),
 				( { date, title } ) => ( {
 					title,


### PR DESCRIPTION
## Description

This PR aims to highlight events into the post schedule, picking data up the site posts filtering by status (`publish` and `future`).

**NOTE**: This main purpose of this implementation is to show certain weaknesses of the current [date component](https://github.com/airbnb/react-dates).

<img src="https://user-images.githubusercontent.com/77539/93496281-655cc800-f8e5-11ea-8684-70db043c8ec1.png" width="300px" />

fixes #13713 

### Issues

#### Lack of `onMonthViewChange` or similar

We want to know when the month view changes. It could be ideal to fetch the posts by month. I've created an `onMonthChange` callback property for the `<DatePicker >` component but, to be honest, it doesn't sound good to me because this callback is triggered by `onNextMonthClick` and `onPrevMonthClick`.

#### Lack of month view

We'd like to set a different month view, not necessarily tied to the selected date. Now, AFAIK, it isn't possible since every time that the component is mounted, it makes focus on the current date.
It means, and it's an issue that you could confirm on this PR, every time that the app gets and propagates events (site post events), it triggers a new rendering process, and the `react-dates` focuses to the current date month. If the month before to rendering was different, it will change it :-(

Also, the current implementation seems to be a little bit hacky, based on these comments:

```es6
/*
 * Todo: We should remove this function ASAP.
 * It is kept because focus is lost when we click on the previous and next month buttons.
 * This focus loss closes the date picker popover.
 * Ideally we should add an upstream commit on react-dates to fix this issue.
 */
```
[link](https://github.com/WordPress/gutenberg/blob/06200995dd3e9d6e7e6ee1b06f460883414de392/packages/components/src/date-time/date.js#L31-L35)

```es6
// This is a hack to force the calendar to update on month or year change
// https://github.com/airbnb/react-dates/issues/240#issuecomment-361776665
```
[link](https://github.com/WordPress/gutenberg/blob/06200995dd3e9d6e7e6ee1b06f460883414de392/packages/components/src/date-time/date.js#L112-L113)

## How has this been tested?

* Create a testing post, but before:
  * Add some posts to your testing site, ensuring some are published and other scheduled.
  * Be sure some posts belong to the post that you are going to use to test the post schedule.
* Set the date of the post, by clicking on the post date (`Immediately` as default)
* Change the month again and again.
* You should see the posts highlighted in the calendar.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
