### PR TITLE
Mobile: Update the border colours

### DIFF
--- a/packages/base-styles/_colors.native.scss
+++ b/packages/base-styles/_colors.native.scss
@@ -1,6 +1,4 @@
 /** @format */
-
-// Hugo's new WordPress shades of gray, from http://codepen.io/hugobaeta/pen/grJjVp.
 $black: #000;
 $white: #fff;
 
@@ -12,7 +10,6 @@ $dark-gray-600: #40464d;
 $dark-opacity-900: rgba(#000510, 0.9);
 $dark-opacity-800: rgba(#00000a, 0.85);
 $dark-opacity-600: rgba(#000913, 0.75);
-
 
 // Light opacities, for use with dark themes.
 $light-opacity-700: rgba($white, 0.85);
@@ -78,7 +75,6 @@ $light-primary: #000d; //rgba(0, 0, 0, 0.87);
 $light-secondary: #0009; //rgba(0, 0, 0, 0.6);
 $light-tertiary: #0000006d; //rgba(0, 0, 0, 0.43);
 $light-quaternary: #0000003f; //rgba(0, 0, 0, 0.25);
-$light-dim: #0000001e; //rgba(0, 0, 0, 0.12);
 $light-ultra-dim: #0000000a; //rgba(0, 0, 0, 0.04);
 
 // neutral (dark) - white is a base color in dark mode
@@ -88,6 +84,11 @@ $dark-tertiary: #ffffff6d; //rgba(255, 255, 255, 0.43);
 $dark-quaternary: #ffffff3f; //rgba(255, 255, 255, 0.25);
 $dark-ultra-dim: #ffffff14; //rgba(255, 255, 255, 0.08);
 
+// new Colours.
+$neutral-dim-light: rgba($black, 0.12);
+
+$neutral-dim-dark: rgba($white, 0.15);
+
 // Design Token colors
 $app-background: $white;
 $app-background-dark: $black;
@@ -96,17 +97,14 @@ $app-background-dark-alt: $background-dark-elevated;
 $modal-background: $white;
 $modal-background-dark: $background-dark-elevated;
 
-$border-color: $light-dim;
-$border-color-dark: $gray-70;
+$border-color: $neutral-dim-light;
+$border-color-dark: $neutral-dim-dark;
 
-$separator-color: $light-dim;
-$separator-color-dark: $gray-70;
+$modal-border-color: $neutral-dim-light;
+$modal-border-color-dark: $neutral-dim-dark;
 
-$drag-indicator: $light-dim;
-$drag-indicator-dark: $dark-ultra-dim;
+$drag-indicator: $neutral-dim-light;
+$drag-indicator-dark: $neutral-dim-dark;
 
-$slider-input-border: $light-dim;
-$slider-input-border-dark: $dark-ultra-dim;
-
-$spacer-color: $light-dim;
-$spacer-color-dark: $dark-ultra-dim;
+$spacer-color: $neutral-dim-light;
+$spacer-color-dark: $neutral-dim-dark;

--- a/packages/base-styles/_colors.native.scss
+++ b/packages/base-styles/_colors.native.scss
@@ -6,6 +6,7 @@ $white: #fff;
 
 $light-gray-500: #e2e4e7; // Good for "grayed" items and borders.
 $light-gray-400: #e8eaeb; // Good for "readonly" input fields and special text selection.
+$dark-gray-600: #40464d;
 
 // Dark opacities, for use with light themes.
 $dark-opacity-900: rgba(#000510, 0.9);
@@ -94,3 +95,18 @@ $app-background-dark-alt: $background-dark-elevated;
 
 $modal-background: $white;
 $modal-background-dark: $background-dark-elevated;
+
+$border-color: $light-dim;
+$border-color-dark: $gray-70;
+
+$separator-color: $light-dim;
+$separator-color-dark: $gray-70;
+
+$drag-indicator: $light-dim;
+$drag-indicator-dark: $dark-ultra-dim;
+
+$slider-input-border: $light-dim;
+$slider-input-border-dark: $dark-ultra-dim;
+
+$spacer-color: $light-dim;
+$spacer-color-dark: $dark-ultra-dim;

--- a/packages/base-styles/_colors.native.scss
+++ b/packages/base-styles/_colors.native.scss
@@ -100,11 +100,11 @@ $app-background-dark-alt: $background-dark-elevated;
 $modal-background: $white;
 $modal-background-dark: $background-dark-elevated;
 
-$border-color: rgba($black, 0.15);
-$border-color-dark: rgba($white, 0.25);
+$border-color: $seperator;
+$border-color-dark: $seperator-dark;
 
-$border-dashed-color: $seperator;
-$border-dashed-color-dark: $seperator-dark;
+$border-dashed-color: rgba($black, 0.25);
+$border-dashed-color-dark: rgba($white, 0.27);
 
 $modal-border-color: $seperator;
 $modal-border-color-dark: $seperator-dark;

--- a/packages/base-styles/_colors.native.scss
+++ b/packages/base-styles/_colors.native.scss
@@ -102,11 +102,11 @@ $modal-background-dark: $background-dark-elevated;
 $border-color: $seperator;
 $border-color-dark: $seperator-dark;
 
+$border-dashed-color: $seperator;
+$border-dashed-color-dark: $seperator-dark;
+
 $modal-border-color: $seperator;
 $modal-border-color-dark: $seperator-dark;
 
 $drag-indicator: $seperator;
 $drag-indicator-dark: $seperator-dark;
-
-$spacer-color: $seperator;
-$spacer-color-dark: $seperator-dark;

--- a/packages/base-styles/_colors.native.scss
+++ b/packages/base-styles/_colors.native.scss
@@ -86,8 +86,10 @@ $dark-ultra-dim: #ffffff14; //rgba(255, 255, 255, 0.08);
 
 // new Colours.
 $neutral-dim-light: rgba($black, 0.12);
-
 $neutral-dim-dark: rgba($white, 0.15);
+
+$seperator: rgba($black, 0.1);
+$seperator-dark: rgba($white, 0.18);
 
 // Design Token colors
 $app-background: $white;
@@ -97,14 +99,14 @@ $app-background-dark-alt: $background-dark-elevated;
 $modal-background: $white;
 $modal-background-dark: $background-dark-elevated;
 
-$border-color: $neutral-dim-light;
-$border-color-dark: $neutral-dim-dark;
+$border-color: $seperator;
+$border-color-dark: $seperator-dark;
 
-$modal-border-color: $neutral-dim-light;
-$modal-border-color-dark: $neutral-dim-dark;
+$modal-border-color: $seperator;
+$modal-border-color-dark: $seperator-dark;
 
-$drag-indicator: $neutral-dim-light;
-$drag-indicator-dark: $neutral-dim-dark;
+$drag-indicator: $seperator;
+$drag-indicator-dark: $seperator-dark;
 
-$spacer-color: $neutral-dim-light;
-$spacer-color-dark: $neutral-dim-dark;
+$spacer-color: $seperator;
+$spacer-color-dark: $seperator-dark;

--- a/packages/base-styles/_colors.native.scss
+++ b/packages/base-styles/_colors.native.scss
@@ -91,6 +91,7 @@ $neutral-dim-dark: rgba($white, 0.15);
 $seperator: rgba($black, 0.1);
 $seperator-dark: rgba($white, 0.18);
 
+
 // Design Token colors
 $app-background: $white;
 $app-background-dark: $black;
@@ -99,8 +100,8 @@ $app-background-dark-alt: $background-dark-elevated;
 $modal-background: $white;
 $modal-background-dark: $background-dark-elevated;
 
-$border-color: $seperator;
-$border-color-dark: $seperator-dark;
+$border-color: rgba($black, 0.15);
+$border-color-dark: rgba($white, 0.25);
 
 $border-dashed-color: $seperator;
 $border-dashed-color-dark: $seperator-dark;

--- a/packages/base-styles/_colors.native.scss
+++ b/packages/base-styles/_colors.native.scss
@@ -2,9 +2,6 @@
 $black: #000;
 $white: #fff;
 
-$light-gray-500: #e2e4e7; // Good for "grayed" items and borders.
-$light-gray-400: #e8eaeb; // Good for "readonly" input fields and special text selection.
-$dark-gray-600: #40464d;
 
 // Dark opacities, for use with light themes.
 $dark-opacity-900: rgba(#000510, 0.9);

--- a/packages/block-editor/src/components/block-list/block.native.scss
+++ b/packages/block-editor/src/components/block-list/block.native.scss
@@ -11,11 +11,11 @@
 }
 
 .dashedBorderColor {
-	border-color: $border-color;
+	border-color: $border-dashed-color;
 }
 
 .dashedBorderColorDark {
-	border-color: $border-color-dark;
+	border-color: $border-dashed-color-dark;
 }
 
 .borderFullWidth {

--- a/packages/block-editor/src/components/block-list/block.native.scss
+++ b/packages/block-editor/src/components/block-list/block.native.scss
@@ -11,11 +11,11 @@
 }
 
 .dashedBorderColor {
-	border-color: $gray;
+	border-color: $border-color;
 }
 
 .dashedBorderColorDark {
-	border-color: $gray-70;
+	border-color: $border-color-dark;
 }
 
 .borderFullWidth {

--- a/packages/block-editor/src/components/button-block-appender/styles.native.scss
+++ b/packages/block-editor/src/components/button-block-appender/styles.native.scss
@@ -16,12 +16,12 @@
 
 .appenderLight {
 	background-color: $white;
-	border: $border-width solid $light-gray-500;
+	border: $border-width solid $border-color;
 }
 
 .appenderDark {
 	background-color: $background-dark-secondary;
-	border: $border-width solid $gray-70;
+	border: $border-width solid $border-color-dark;
 }
 
 .addBlockButton {

--- a/packages/block-editor/src/components/inserter/style.native.scss
+++ b/packages/block-editor/src/components/inserter/style.native.scss
@@ -73,9 +73,9 @@
 .clipboardBlock {
 	background-color: transparent;
 	border-width: 1px;
-	border-color: $light-gray-400;
+	border-color: $border-color;
 }
 
 .clipboardBlockDark {
-	border-color: $gray-70;
+	border-color: $border-color-dark;
 }

--- a/packages/block-editor/src/components/media-placeholder/styles.native.scss
+++ b/packages/block-editor/src/components/media-placeholder/styles.native.scss
@@ -50,13 +50,13 @@
 .appender {
 	height: auto;
 	background-color: $white;
-	border: $border-width solid $light-gray-500;
+	border: $border-width solid $border-color;
 	border-radius: 4px;
 }
 
 .appenderDark {
 	background-color: $background-dark-secondary;
-	border: $border-width solid $gray-70;
+	border: $border-width solid $border-color-dark;
 }
 
 .addMediaButton {

--- a/packages/block-library/src/column/editor.native.scss
+++ b/packages/block-library/src/column/editor.native.scss
@@ -6,13 +6,13 @@
 	flex: 1;
 	padding: $block-selected-to-content;
 	background-color: $white;
-	border: $border-width dashed $border-color;
+	border: $border-width dashed $border-dashed-color;
 	border-radius: 4px;
 }
 
 .columnPlaceholderDark {
 	background-color: $black;
-	border: $border-width dashed $border-color-dark;
+	border: $border-width dashed $border-dashed-color-dark;
 }
 
 .innerBlocksBottomSpace {

--- a/packages/block-library/src/column/editor.native.scss
+++ b/packages/block-library/src/column/editor.native.scss
@@ -6,13 +6,13 @@
 	flex: 1;
 	padding: $block-selected-to-content;
 	background-color: $white;
-	border: $border-width dashed $gray;
+	border: $border-width dashed $border-color;
 	border-radius: 4px;
 }
 
 .columnPlaceholderDark {
 	background-color: $black;
-	border: $border-width dashed $gray-70;
+	border: $border-width dashed $border-color-dark;
 }
 
 .innerBlocksBottomSpace {

--- a/packages/block-library/src/group/editor.native.scss
+++ b/packages/block-library/src/group/editor.native.scss
@@ -4,13 +4,13 @@
 	margin-left: $block-selected-child-margin;
 	margin-right: $block-selected-child-margin;
 	background-color: $white;
-	border: $border-width dashed $gray;
+	border: $border-width dashed $border-color;
 	border-radius: 4px;
 }
 
 .groupPlaceholderDark {
 	background-color: $black;
-	border: $border-width dashed $gray-70;
+	border: $border-width dashed $border-color-dark;
 }
 
 .marginVerticalDense {

--- a/packages/block-library/src/group/editor.native.scss
+++ b/packages/block-library/src/group/editor.native.scss
@@ -4,13 +4,13 @@
 	margin-left: $block-selected-child-margin;
 	margin-right: $block-selected-child-margin;
 	background-color: $white;
-	border: $border-width dashed $border-color;
+	border: $border-width dashed $border-dashed-color;
 	border-radius: 4px;
 }
 
 .groupPlaceholderDark {
 	background-color: $black;
-	border: $border-width dashed $border-color-dark;
+	border: $border-width dashed $border-dashed-color-dark;
 }
 
 .marginVerticalDense {

--- a/packages/block-library/src/spacer/editor.native.scss
+++ b/packages/block-library/src/spacer/editor.native.scss
@@ -1,12 +1,12 @@
 .staticSpacer {
 	height: 20px;
 	background-color: transparent;
-	border: $border-width dashed $light-gray-500;
+	border: $border-width dashed $spacer-color;
 	border-radius: 1px;
 }
 
 .staticDarkSpacer {
-	border: $border-width dashed rgba($color: $light-gray-500, $alpha: 0.3);
+	border: $border-width dashed $spacer-color-dark;
 }
 
 .selectedSpacer {

--- a/packages/block-library/src/spacer/editor.native.scss
+++ b/packages/block-library/src/spacer/editor.native.scss
@@ -1,12 +1,12 @@
 .staticSpacer {
 	height: 20px;
 	background-color: transparent;
-	border: $border-width dashed $spacer-color;
+	border: $border-width dashed $border-dashed-color;
 	border-radius: 1px;
 }
 
 .staticDarkSpacer {
-	border: $border-width dashed $spacer-color-dark;
+	border: $border-width dashed $border-dashed-color-dark;
 }
 
 .selectedSpacer {

--- a/packages/components/src/color-indicator/style.native.scss
+++ b/packages/components/src/color-indicator/style.native.scss
@@ -27,7 +27,7 @@
 }
 
 .outline {
-	border-color: $light-dim;
+	border-color: $border-color;
 	top: 0;
 	bottom: 0;
 	left: 0;
@@ -39,7 +39,7 @@
 }
 
 .outlineDark {
-	border-color: $dark-ultra-dim;
+	border-color: $border-color-dark;
 }
 
 .selectedOutline {

--- a/packages/components/src/color-indicator/style.native.scss
+++ b/packages/components/src/color-indicator/style.native.scss
@@ -27,7 +27,7 @@
 }
 
 .outline {
-	border-color: $border-color;
+	border-color: $modal-border-color;
 	top: 0;
 	bottom: 0;
 	left: 0;
@@ -39,7 +39,7 @@
 }
 
 .outlineDark {
-	border-color: $border-color-dark;
+	border-color: $modal-border-color-dark;
 }
 
 .selectedOutline {

--- a/packages/components/src/color-palette/style.native.scss
+++ b/packages/components/src/color-palette/style.native.scss
@@ -9,14 +9,14 @@
 
 .verticalSeparator {
 	border-width: $border-width / 2;
-	border-color: $border-color;
+	border-color: $modal-border-color;
 	height: 38px;
 	margin-right: $grid-unit-20 / 2;
 	align-self: center;
 }
 
 .verticalSeparatorDark {
-	border-color: $border-color-dark;
+	border-color: $modal-border-color-dark;
 }
 
 .colorIndicator {

--- a/packages/components/src/color-palette/style.native.scss
+++ b/packages/components/src/color-palette/style.native.scss
@@ -9,14 +9,14 @@
 
 .verticalSeparator {
 	border-width: $border-width / 2;
-	border-color: $light-gray-400;
+	border-color: $border-color;
 	height: 38px;
 	margin-right: $grid-unit-20 / 2;
 	align-self: center;
 }
 
 .verticalSeparatorDark {
-	border-color: $gray-70;
+	border-color: $border-color-dark;
 }
 
 .colorIndicator {

--- a/packages/components/src/color-picker/style.native.scss
+++ b/packages/components/src/color-picker/style.native.scss
@@ -1,6 +1,6 @@
 .footer {
 	border-top-width: $border-width;
-	border-color: $border-color;
+	border-color: $modal-border-color;
 	flex-direction: row;
 	justify-content: space-between;
 	align-items: center;
@@ -10,7 +10,7 @@
 }
 
 .footerDark {
-	border-color: $border-color-dark;
+	border-color: $modal-border-color-dark;
 }
 
 .cancelButton {

--- a/packages/components/src/color-picker/style.native.scss
+++ b/packages/components/src/color-picker/style.native.scss
@@ -1,6 +1,6 @@
 .footer {
 	border-top-width: $border-width;
-	border-color: $light-gray-400;
+	border-color: $border-color;
 	flex-direction: row;
 	justify-content: space-between;
 	align-items: center;
@@ -10,7 +10,7 @@
 }
 
 .footerDark {
-	border-color: $gray-70;
+	border-color: $border-color-dark;
 }
 
 .cancelButton {

--- a/packages/components/src/mobile/bottom-sheet/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet/index.native.js
@@ -326,12 +326,18 @@ class BottomSheet extends Component {
 			styles.bottomSheetHeaderTitleDark
 		);
 
+		const dragIndicatorStyle = getStylesFromColorScheme(
+			styles.dragIndicator,
+			styles.dragIndicatorDark
+		);
+
 		let listStyle = {};
 		if ( isFullScreen ) {
-			listStyle = { flexGrow: 1 };
+			listStyle = { ...dragIndicatorStyle, flexGrow: 1 };
 		} else if ( isMaxHeightSet ) {
-			listStyle = { maxHeight };
+			listStyle = { ...dragIndicatorStyle, maxHeight };
 		}
+		
 		const listProps = {
 			disableScrollViewPanResponder: true,
 			bounces,
@@ -417,7 +423,7 @@ class BottomSheet extends Component {
 					keyboardVerticalOffset={ -safeAreaBottomInset }
 				>
 					{ ! ( Platform.OS === 'android' && isFullScreen ) && (
-						<View style={ styles.dragIndicator } />
+						<View style={ listStyle } />
 					) }
 					{ ! hideHeader && getHeader() }
 					<WrapperView

--- a/packages/components/src/mobile/bottom-sheet/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet/index.native.js
@@ -333,11 +333,11 @@ class BottomSheet extends Component {
 
 		let listStyle = {};
 		if ( isFullScreen ) {
-			listStyle = { ...dragIndicatorStyle, flexGrow: 1 };
+			listStyle = { flexGrow: 1 };
 		} else if ( isMaxHeightSet ) {
-			listStyle = { ...dragIndicatorStyle, maxHeight };
+			listStyle = { maxHeight };
 		}
-		
+
 		const listProps = {
 			disableScrollViewPanResponder: true,
 			bounces,
@@ -423,7 +423,7 @@ class BottomSheet extends Component {
 					keyboardVerticalOffset={ -safeAreaBottomInset }
 				>
 					{ ! ( Platform.OS === 'android' && isFullScreen ) && (
-						<View style={ listStyle } />
+						<View style={ dragIndicatorStyle } />
 					) }
 					{ ! hideHeader && getHeader() }
 					<WrapperView

--- a/packages/components/src/mobile/bottom-sheet/range-cell.native.scss
+++ b/packages/components/src/mobile/bottom-sheet/range-cell.native.scss
@@ -6,14 +6,14 @@
 	min-height: 25px;
 	align-self: center;
 	margin-left: 10px;
-	border-color: $slider-input-border;
+	border-color: $modal-border-color;
 	padding-top: 0;
 	padding-bottom: 0;
 	text-align: center;
 }
 
 .sliderDarkTextInput {
-	border-color: $slider-input-border-dark;
+	border-color: $modal-border-color-dark;
 }
 
 .isSelected {

--- a/packages/components/src/mobile/bottom-sheet/range-cell.native.scss
+++ b/packages/components/src/mobile/bottom-sheet/range-cell.native.scss
@@ -6,14 +6,14 @@
 	min-height: 25px;
 	align-self: center;
 	margin-left: 10px;
-	border-color: $light-gray-400;
+	border-color: $slider-input-border;
 	padding-top: 0;
 	padding-bottom: 0;
 	text-align: center;
 }
 
 .sliderDarkTextInput {
-	border-color: $gray-70;
+	border-color: $slider-input-border-dark;
 }
 
 .isSelected {

--- a/packages/components/src/mobile/bottom-sheet/styles.native.scss
+++ b/packages/components/src/mobile/bottom-sheet/styles.native.scss
@@ -7,7 +7,7 @@
 }
 
 .dragIndicator {
-	background-color: $light-gray-400;
+	background-color: $drag-indicator;
 	height: 4px;
 	width: 36px;
 	margin: auto;
@@ -15,15 +15,18 @@
 	margin-bottom: 6px;
 	border-radius: 2px;
 }
+.dragIndicatorDark {
+	background-color: $drag-indicator-dark;
+}
 
 .separator {
-	background-color: $light-gray-400;
+	background-color: $separator-color;
 	height: 1px;
 	width: 100%;
 }
 
 .separatorDark {
-	background-color: $gray-70;
+	background-color: $separator-color-dark;
 }
 
 .emptyHeader {
@@ -87,13 +90,13 @@
 }
 
 .cellSeparator {
-	background-color: $light-gray-400;
+	background-color: $separator-color;
 	height: 1px;
 	width: 100%;
 }
 
 .cellSeparatorDark {
-	background-color: $gray-70;
+	background-color: $separator-color-dark;
 }
 
 .cellRowContainer {

--- a/packages/components/src/mobile/bottom-sheet/styles.native.scss
+++ b/packages/components/src/mobile/bottom-sheet/styles.native.scss
@@ -20,13 +20,13 @@
 }
 
 .separator {
-	background-color: $separator-color;
+	background-color: $modal-border-color;
 	height: 1px;
 	width: 100%;
 }
 
 .separatorDark {
-	background-color: $separator-color-dark;
+	background-color: $modal-border-color-dark;
 }
 
 .emptyHeader {
@@ -90,13 +90,13 @@
 }
 
 .cellSeparator {
-	background-color: $separator-color;
+	background-color: $modal-border-color;
 	height: 1px;
 	width: 100%;
 }
 
 .cellSeparatorDark {
-	background-color: $separator-color-dark;
+	background-color: $modal-border-color-dark;
 }
 
 .cellRowContainer {

--- a/packages/components/src/mobile/color-settings/style.native.scss
+++ b/packages/components/src/mobile/color-settings/style.native.scss
@@ -1,11 +1,11 @@
 
 .horizontalSeparator {
 	border-bottom-width: $border-width;
-	border-color: $border-color;
+	border-color: $modal-border-color;
 }
 
 .horizontalSeparatorDark {
-	border-color: $border-color-dark;
+	border-color: $modal-border-color-dark;
 }
 
 .colorIndicator {

--- a/packages/components/src/mobile/color-settings/style.native.scss
+++ b/packages/components/src/mobile/color-settings/style.native.scss
@@ -1,11 +1,11 @@
 
 .horizontalSeparator {
 	border-bottom-width: $border-width;
-	border-color: $light-gray-400;
+	border-color: $border-color;
 }
 
 .horizontalSeparatorDark {
-	border-color: $gray-70;
+	border-color: $border-color-dark;
 }
 
 .colorIndicator {

--- a/packages/components/src/mobile/link-picker/styles.native.scss
+++ b/packages/components/src/mobile/link-picker/styles.native.scss
@@ -1,12 +1,12 @@
 .omniCell {
 	border-bottom-width: 1px;
-	border-bottom-color: $light-gray-400;
+	border-bottom-color: $border-color;
 	padding-left: 16px;
 	padding-right: 16px;
 }
 
 .omniCellDark {
-	border-bottom-color: $gray-70;
+	border-bottom-color: $border-color-dark;
 }
 
 .omniInput {

--- a/packages/components/src/mobile/modal-header-bar/styles.native.scss
+++ b/packages/components/src/mobile/modal-header-bar/styles.native.scss
@@ -50,11 +50,11 @@
 }
 
 .separator {
-	background-color: $separator-color;
+	background-color: $modal-border-color;
 	height: 1px;
 	width: 100%;
 }
 
 .separatorDark {
-	background-color: $separator-color-dark;
+	background-color: $modal-border-color-dark;
 }

--- a/packages/components/src/mobile/modal-header-bar/styles.native.scss
+++ b/packages/components/src/mobile/modal-header-bar/styles.native.scss
@@ -50,11 +50,11 @@
 }
 
 .separator {
-	background-color: $light-gray-400;
+	background-color: $separator-color;
 	height: 1px;
 	width: 100%;
 }
 
 .separatorDark {
-	background-color: #2d2d2d;
+	background-color: $separator-color-dark;
 }

--- a/packages/components/src/mobile/picker/styles.native.scss
+++ b/packages/components/src/mobile/picker/styles.native.scss
@@ -4,11 +4,11 @@
 	margin-left: -$grid-unit-20;
 	margin-right: -$grid-unit-20;
 	height: $border-width;
-	background-color: $light-gray-400;
+	background-color: $separator-color;
 }
 
 .separatorDark {
-	background-color: $gray-70;
+	background-color: $separator-color-dark;
 }
 
 .disabled {

--- a/packages/components/src/mobile/picker/styles.native.scss
+++ b/packages/components/src/mobile/picker/styles.native.scss
@@ -4,11 +4,11 @@
 	margin-left: -$grid-unit-20;
 	margin-right: -$grid-unit-20;
 	height: $border-width;
-	background-color: $separator-color;
+	background-color: $modal-border-color;
 }
 
 .separatorDark {
-	background-color: $separator-color-dark;
+	background-color: $modal-border-color-dark;
 }
 
 .disabled {

--- a/packages/components/src/mobile/segmented-control/style.native.scss
+++ b/packages/components/src/mobile/segmented-control/style.native.scss
@@ -31,7 +31,7 @@ $border-radius-ios: 7px;
 }
 
 .shadowIOS {
-	box-shadow: 0 0 8px $light-dim;
+	box-shadow: 0 0 8px $neutral-dim-light;
 	z-index: 2;
 }
 

--- a/packages/components/src/panel/actions.native.scss
+++ b/packages/components/src/panel/actions.native.scss
@@ -1,10 +1,10 @@
 .panelActionsContainer {
-	border-top-color: $light-gray-400;
+	border-top-color: $border-color;
 	border-top-width: 1px;
 }
 
 .panelActionsContainerDark {
-	border-top-color: $gray-70;
+	border-top-color: $border-color-dark;
 }
 
 .defaultLabelStyle {

--- a/packages/components/src/panel/actions.native.scss
+++ b/packages/components/src/panel/actions.native.scss
@@ -1,10 +1,10 @@
 .panelActionsContainer {
-	border-top-color: $border-color;
+	border-top-color: $modal-border-color;
 	border-top-width: 1px;
 }
 
 .panelActionsContainerDark {
-	border-top-color: $border-color-dark;
+	border-top-color: $modal-border-color-dark;
 }
 
 .defaultLabelStyle {

--- a/packages/components/src/resizable-box/style.native.scss
+++ b/packages/components/src/resizable-box/style.native.scss
@@ -1,12 +1,12 @@
 .staticSpacer {
 	height: 20px;
 	background-color: transparent;
-	border: $border-width dashed $light-gray-500;
+	border: $border-width dashed $spacer-color;
 	border-radius: 1px;
 }
 
 .staticDarkSpacer {
-	border: $border-width dashed rgba($color: $light-gray-500, $alpha: 0.3);
+	border: $border-width dashed $spacer-color-dark;
 }
 
 .selectedSpacer {

--- a/packages/components/src/resizable-box/style.native.scss
+++ b/packages/components/src/resizable-box/style.native.scss
@@ -1,12 +1,12 @@
 .staticSpacer {
 	height: 20px;
 	background-color: transparent;
-	border: $border-width dashed $spacer-color;
+	border: $border-width dashed $border-dashed-color;
 	border-radius: 1px;
 }
 
 .staticDarkSpacer {
-	border: $border-width dashed $spacer-color-dark;
+	border: $border-width dashed $border-dashed-color-dark;
 }
 
 .selectedSpacer {

--- a/packages/components/src/toolbar-group/style.native.scss
+++ b/packages/components/src/toolbar-group/style.native.scss
@@ -1,11 +1,11 @@
 .container {
 	flex-direction: row;
 	border-left-width: 1px;
-	border-color: $border-color;
+	border-color: $modal-border-color;
 	padding-left: 5px;
 	padding-right: 5px;
 }
 
 .containerDark {
-	border-color: $border-color-dark;
+	border-color: $modal-border-color-dark;
 }

--- a/packages/components/src/toolbar-group/style.native.scss
+++ b/packages/components/src/toolbar-group/style.native.scss
@@ -1,11 +1,11 @@
 .container {
 	flex-direction: row;
 	border-left-width: 1px;
-	border-color: #e9eff3;
+	border-color: $border-color;
 	padding-left: 5px;
 	padding-right: 5px;
 }
 
 .containerDark {
-	border-color: #525354;
+	border-color: $border-color-dark;
 }

--- a/packages/components/src/toolbar/style.native.scss
+++ b/packages/components/src/toolbar/style.native.scss
@@ -1,11 +1,11 @@
 .container {
 	flex-direction: row;
 	border-left-width: 1px;
-	border-color: $border-color;
+	border-color: $modal-border-color;
 	padding-left: 5px;
 	padding-right: 5px;
 }
 
 .containerDark {
-	border-color: $border-color-dark;
+	border-color: $modal-border-color-dark;
 }

--- a/packages/components/src/toolbar/style.native.scss
+++ b/packages/components/src/toolbar/style.native.scss
@@ -1,11 +1,11 @@
 .container {
 	flex-direction: row;
 	border-left-width: 1px;
-	border-color: #e9eff3;
+	border-color: $border-color;
 	padding-left: 5px;
 	padding-right: 5px;
 }
 
 .containerDark {
-	border-color: #525354;
+	border-color: $border-color-dark;
 }

--- a/packages/edit-post/src/components/header/header-toolbar/style.native.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.native.scss
@@ -3,13 +3,13 @@
 	height: $mobile-header-toolbar-height;
 	flex-direction: row;
 	background-color: $app-background;
-	border-top-color: $border-color;
+	border-top-color: $modal-border-color;
 	border-top-width: 1px;
 }
 
 .containerDark {
 	background-color: $app-background-dark-alt;
-	border-top-color: $border-color-dark;
+	border-top-color: $modal-border-color-dark;
 }
 
 .scrollableContent {

--- a/packages/edit-post/src/components/header/header-toolbar/style.native.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.native.scss
@@ -3,13 +3,13 @@
 	height: $mobile-header-toolbar-height;
 	flex-direction: row;
 	background-color: $app-background;
-	border-top-color: #e9eff3;
+	border-top-color: $border-color;
 	border-top-width: 1px;
 }
 
 .containerDark {
 	background-color: $app-background-dark-alt;
-	border-top-color: $background-dark-elevated;
+	border-top-color: $border-color-dark;
 }
 
 .scrollableContent {


### PR DESCRIPTION
## Description
This PR updates deprecates the following colour variables. 
```
$light-gray-500: #e2e4e7; // Good for "grayed" items and borders.
$light-gray-400: #e8eaeb;
$light-dim: #0000001e; //rgba(0, 0, 0, 0.12); 
```
and replaces them with 

`$neutral-dim-light: rgba($black, 0.12);`
and 
`$neutral-dim-dark: rgba($white, 0.15); `

While at the same create a few different `design tokens` which make it easier to update the colours in the future. 
## How has this been tested?
This has been tested using the demo app on both Android and iOS. In light and dark mode.  

## Screenshots <!-- if applicable -->
In order to make the different changes easier to see. I made the 
following changes to the `_colors.native.scss` file.
```
$border-color: red;
$border-color-dark: red;
$modal-border-color: orange;
$modal-border-color-dark: orange;
$drag-indicator: yellow;
$drag-indicator-dark: yellow;
$spacer-color: blue;
$spacer-color-dark: blue;
```
<details><summary>Highligheted colours</summary>
$border-color and $border-color-dark
Column Block
![Screen Shot 2020-09-17 at 2 45 49 PM](https://user-images.githubusercontent.com/115071/93531677-7bbe5000-f8f4-11ea-95b7-932577a8c7cc.png)

Media Text Block
![Screen Shot 2020-09-17 at 2 46 08 PM](https://user-images.githubusercontent.com/115071/93531699-87117b80-f8f4-11ea-8d3b-844fb590bb70.png)

Cover Block
![Screen Shot 2020-09-17 at 2 45 10 PM](https://user-images.githubusercontent.com/115071/93531631-647f6280-f8f4-11ea-86d1-2bed4c82e186.png)

Buttons Block
![Screen Shot 2020-09-17 at 2 46 27 PM](https://user-images.githubusercontent.com/115071/93531736-91cc1080-f8f4-11ea-9901-e87a0cf2fd97.png)

Contact Info Block 
![Screen Shot 2020-09-17 at 2 46 52 PM](https://user-images.githubusercontent.com/115071/93531776-a27c8680-f8f4-11ea-8fda-9f0fa06c303a.png)

$modal-border-color and $modal-border-color-dark

Toolbar 
![Screen Shot 2020-09-17 at 2 49 38 PM](https://user-images.githubusercontent.com/115071/93532015-03a45a00-f8f5-11ea-85d1-17cc642d0b8e.png)

Model colours
![Screen Shot 2020-09-17 at 3 20 46 PM](https://user-images.githubusercontent.com/115071/93534184-6ef02b00-f8f9-11ea-8abc-a2e7927c8ba2.png)
![Screen Shot 2020-09-17 at 3 20 51 PM](https://user-images.githubusercontent.com/115071/93534186-70215800-f8f9-11ea-9bd8-81fb7d35f113.png)

. 
![Screen Shot 2020-09-17 at 2 51 00 PM](https://user-images.githubusercontent.com/115071/93532112-351d2580-f8f5-11ea-9a35-211ecfe1b920.png)

![Screen Shot 2020-09-17 at 2 49 59 PM](https://user-images.githubusercontent.com/115071/93532048-10c14900-f8f5-11ea-83c4-8adcf59bbf11.png)
![Screen Shot 2020-09-17 at 2 50 14 PM](https://user-images.githubusercontent.com/115071/93532061-19198400-f8f5-11ea-9a0a-9f5ca1d6c295.png)

$drag-indicator and $drag-indicator-dark.

Notice the yellow drag handle.
![Screen Shot 2020-09-17 at 2 50 14 PM](https://user-images.githubusercontent.com/115071/93532061-19198400-f8f5-11ea-9a0a-9f5ca1d6c295.png)

$spacer-color and $spacer-color-dark.
Spacer Block
![Screen Shot 2020-09-17 at 2 44 34 PM](https://user-images.githubusercontent.com/115071/93531593-503b6580-f8f4-11ea-8890-24f73d42bb74.png)
</details>

### With the true colours. 

<details><summary>iOS</summary>

![Screen Shot 2020-09-17 at 3 27 13 PM](https://user-images.githubusercontent.com/115071/93534683-677d5180-f8fa-11ea-9c71-e9267591ab7d.png)
![Screen Shot 2020-09-17 at 3 27 20 PM](https://user-images.githubusercontent.com/115071/93534685-677d5180-f8fa-11ea-8eb2-0dc6ad7250b8.png)
![Screen Shot 2020-09-17 at 3 27 24 PM](https://user-images.githubusercontent.com/115071/93534686-6815e800-f8fa-11ea-826b-80750d288e7c.png)
![Screen Shot 2020-09-17 at 3 27 30 PM](https://user-images.githubusercontent.com/115071/93534687-68ae7e80-f8fa-11ea-8bfb-0614b4170b60.png)
![Screen Shot 2020-09-17 at 3 27 35 PM](https://user-images.githubusercontent.com/115071/93534688-68ae7e80-f8fa-11ea-94f0-c33a1442ba8e.png)
![Screen Shot 2020-09-17 at 3 27 44 PM](https://user-images.githubusercontent.com/115071/93534690-69471500-f8fa-11ea-9de3-42a2560cf8a8.png)

Toolbar
![Screen Shot 2020-09-17 at 3 28 25 PM](https://user-images.githubusercontent.com/115071/93534701-6ea45f80-f8fa-11ea-9e40-72d0c0d358f2.png)

Modal 
![Screen Shot 2020-09-17 at 3 28 49 PM](https://user-images.githubusercontent.com/115071/93534731-7cf27b80-f8fa-11ea-9607-4e1e82beba6c.png)
![Screen Shot 2020-09-17 at 3 29 52 PM](https://user-images.githubusercontent.com/115071/93534809-a27f8500-f8fa-11ea-918f-9bad68559a6a.png)
![Screen Shot 2020-09-17 at 3 29 41 PM](https://user-images.githubusercontent.com/115071/93534801-9c89a400-f8fa-11ea-8341-72478ec376a6.png)

iOS DarkMode
![Screen Shot 2020-09-17 at 3 32 51 PM](https://user-images.githubusercontent.com/115071/93535062-0e61ed80-f8fb-11ea-87bf-0a02bf502274.png)
![Screen Shot 2020-09-17 at 3 33 00 PM](https://user-images.githubusercontent.com/115071/93535067-13bf3800-f8fb-11ea-80fd-bc007e43a938.png)
![Screen Shot 2020-09-17 at 3 33 13 PM](https://user-images.githubusercontent.com/115071/93535086-1d48a000-f8fb-11ea-8bad-535fb00e0510.png)
![Screen Shot 2020-09-17 at 3 33 30 PM](https://user-images.githubusercontent.com/115071/93535100-246fae00-f8fb-11ea-998f-73260277ce62.png)

Modal
![Screen Shot 2020-09-17 at 3 31 59 PM](https://user-images.githubusercontent.com/115071/93534989-f4280f80-f8fa-11ea-8e53-2ba60b2101da.png)
![Screen Shot 2020-09-17 at 3 32 37 PM](https://user-images.githubusercontent.com/115071/93535041-06a24900-f8fb-11ea-8aa1-f0ec67bee774.png)
![Screen Shot 2020-09-17 at 3 31 26 PM](https://user-images.githubusercontent.com/115071/93534970-e3779980-f8fa-11ea-860f-302e1fba29b7.png)

![Screen Shot 2020-09-17 at 3 33 41 PM](https://user-images.githubusercontent.com/115071/93535117-2afe2580-f8fb-11ea-861c-97cf76845234.png)
![Screen Shot 2020-09-17 at 3 33 48 PM](https://user-images.githubusercontent.com/115071/93535124-2f2a4300-f8fb-11ea-8c6f-39f2b88dd8a9.png)

Toolbar
![Screen Shot 2020-09-17 at 3 34 57 PM](https://user-images.githubusercontent.com/115071/93535204-597c0080-f8fb-11ea-8c95-7da54a5d999d.png)
</details>


<details><summary>Android</summary>

Blocks

![Screen Shot 2020-09-17 at 3 43 11 PM](https://user-images.githubusercontent.com/115071/93535746-7ebd3e80-f8fc-11ea-82df-3d6dd6697750.png)
![Screen Shot 2020-09-17 at 3 43 21 PM](https://user-images.githubusercontent.com/115071/93535757-84b31f80-f8fc-11ea-9f35-e21f8dfc6cb1.png)
![Screen Shot 2020-09-17 at 3 43 32 PM](https://user-images.githubusercontent.com/115071/93535770-8b419700-f8fc-11ea-9e3a-ec047165b4fd.png)
![Screen Shot 2020-09-17 at 3 43 40 PM](https://user-images.githubusercontent.com/115071/93535780-90064b00-f8fc-11ea-9f33-5bb9fca9ccec.png)
![Screen Shot 2020-09-17 at 3 43 54 PM](https://user-images.githubusercontent.com/115071/93535797-985e8600-f8fc-11ea-9268-e14f5bbf2e48.png)
![Screen Shot 2020-09-17 at 3 45 18 PM](https://user-images.githubusercontent.com/115071/93535906-ca6fe800-f8fc-11ea-9e81-ef5454cd13c4.png)
![Screen Shot 2020-09-17 at 3 45 44 PM](https://user-images.githubusercontent.com/115071/93535947-d9ef3100-f8fc-11ea-940a-4efb477046c5.png)
![Screen Shot 2020-09-17 at 3 46 04 PM](https://user-images.githubusercontent.com/115071/93535968-e5425c80-f8fc-11ea-84b1-c6d84a2969d8.png)


Toolbar
![Screen Shot 2020-09-17 at 3 44 06 PM](https://user-images.githubusercontent.com/115071/93535813-9f859400-f8fc-11ea-8ab2-54910d4a3daa.png)

Modal 
![Screen Shot 2020-09-17 at 3 44 37 PM](https://user-images.githubusercontent.com/115071/93535847-b1ffcd80-f8fc-11ea-8597-d890718ced94.png)
![Screen Shot 2020-09-17 at 3 44 50 PM](https://user-images.githubusercontent.com/115071/93535864-b9bf7200-f8fc-11ea-81d7-2f38e42dbe52.png)

### DarkMode

Blocks

![Screen Shot 2020-09-17 at 3 47 10 PM](https://user-images.githubusercontent.com/115071/93536041-0dca5680-f8fd-11ea-8339-8fa2371bfb41.png)
![Screen Shot 2020-09-17 at 3 47 22 PM](https://user-images.githubusercontent.com/115071/93536051-1458ce00-f8fd-11ea-9c82-222389423030.png)
![Screen Shot 2020-09-17 at 3 47 33 PM](https://user-images.githubusercontent.com/115071/93536069-1ae74580-f8fd-11ea-9c38-84c1f85bfe0b.png)
![Screen Shot 2020-09-17 at 3 47 41 PM](https://user-images.githubusercontent.com/115071/93536075-1fabf980-f8fd-11ea-80b8-c7101414bccb.png)
![Screen Shot 2020-09-17 at 3 47 51 PM](https://user-images.githubusercontent.com/115071/93536089-25a1da80-f8fd-11ea-8d39-3fe23e0893f4.png)

Modal
![Screen Shot 2020-09-17 at 3 48 21 PM](https://user-images.githubusercontent.com/115071/93536128-381c1400-f8fd-11ea-99d9-5efbf87f4376.png)
![Screen Shot 2020-09-17 at 3 48 34 PM](https://user-images.githubusercontent.com/115071/93536144-3fdbb880-f8fd-11ea-8149-0e6e3f7ae103.png)
![Screen Shot 2020-09-17 at 3 48 55 PM](https://user-images.githubusercontent.com/115071/93536165-4b2ee400-f8fd-11ea-8f26-76c845619c88.png)
![Screen Shot 2020-09-17 at 3 49 08 PM](https://user-images.githubusercontent.com/115071/93536182-53871f00-f8fd-11ea-9d51-40c6349c9b3e.png)


Toolbar
![Screen Shot 2020-09-17 at 3 48 04 PM](https://user-images.githubusercontent.com/115071/93536106-2d617f00-f8fd-11ea-805a-cd9f11b9e064.png)

</details>


## Types of changes
Color Refactor.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
