### PR TITLE
Pass block pattern name when using replaceBlocks

### DIFF
--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -1237,6 +1237,7 @@ _Parameters_
 -   _blocks_ `(Object|Array<Object>)`: Replacement block(s).
 -   _indexToSelect_ `number`: Index of replacement block to select.
 -   _initialPosition_ `number`: Index of caret after in the selected block after the operation.
+-   _meta_ `?Object`: Optional Meta values to be passed to the action object.
 
 <a name="replaceInnerBlocks" href="#replaceInnerBlocks">#</a> **replaceInnerBlocks**
 

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -98,7 +98,7 @@ function useInsertionPoint( {
 			selectedBlock &&
 			isUnmodifiedDefaultBlock( selectedBlock )
 		) {
-			replaceBlocks( selectedBlock.clientId, blocks );
+			replaceBlocks( selectedBlock.clientId, blocks, null, null, meta );
 		} else {
 			insertBlocks(
 				blocks,

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -287,10 +287,11 @@ function getBlocksWithDefaultStylesApplied( blocks, blockEditorSettings ) {
  * Returns an action object signalling that a blocks should be replaced with
  * one or more replacement blocks.
  *
- * @param {(string|string[])} clientIds     Block client ID(s) to replace.
- * @param {(Object|Object[])} blocks        Replacement block(s).
- * @param {number}            indexToSelect Index of replacement block to select.
+ * @param {(string|string[])} clientIds       Block client ID(s) to replace.
+ * @param {(Object|Object[])} blocks          Replacement block(s).
+ * @param {number}            indexToSelect   Index of replacement block to select.
  * @param {number}            initialPosition Index of caret after in the selected block after the operation.
+ * @param {?Object}           meta            Optional Meta values to be passed to the action object.
  *
  * @yield {Object} Action object.
  */

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -298,7 +298,8 @@ export function* replaceBlocks(
 	clientIds,
 	blocks,
 	indexToSelect,
-	initialPosition
+	initialPosition,
+	meta
 ) {
 	clientIds = castArray( clientIds );
 	blocks = getBlocksWithDefaultStylesApplied(
@@ -330,6 +331,7 @@ export function* replaceBlocks(
 		time: Date.now(),
 		indexToSelect,
 		initialPosition,
+		meta,
 	};
 	yield* ensureDefaultBlock();
 }

--- a/packages/block-editor/src/store/test/actions.js
+++ b/packages/block-editor/src/store/test/actions.js
@@ -289,6 +289,45 @@ describe( 'actions', () => {
 				done: true,
 			} );
 		} );
+
+		it( 'should pass patternName through metadata to REPLACE_BLOCKS action', () => {
+			const blocks = [
+				{
+					clientId: 'ribs',
+					name: 'core/test-ribs',
+				},
+				{
+					clientId: 'chicken',
+					name: 'core/test-chicken',
+				},
+			];
+
+			const meta = { patternName: 'core/chicken-ribs-pattern' };
+
+			const replaceBlockGenerator = replaceBlocks(
+				[ 'chicken' ],
+				blocks,
+				null,
+				null,
+				meta
+			);
+
+			// Skip to action yield.
+			replaceBlockGenerator.next();
+			replaceBlockGenerator.next();
+			replaceBlockGenerator.next();
+			replaceBlockGenerator.next( true );
+
+			expect( replaceBlockGenerator.next( true ).value ).toEqual( {
+				type: 'REPLACE_BLOCKS',
+				clientIds: [ 'chicken' ],
+				blocks,
+				time: expect.any( Number ),
+				indexToSelect: null,
+				initialPosition: null,
+				meta: { patternName: 'core/chicken-ribs-pattern' },
+			} );
+		} );
 	} );
 
 	describe( 'insertBlock', () => {


### PR DESCRIPTION
## Description

Follow on from  #25165 as it turns out that patterns sometimes use replaceBlocks instead of insertBlocks depending on cursor location.

With the `REPLACE_BLOCKS` action, there is currently no way to tell the difference between a number of arbitrary blocks being inserted versus a defined block pattern being inserted.

Providing the pattern namespace/name within the `replaceBlocks` action creator means that we can determine whether or not these blocks were inserted via a block pattern. 

The meta value of `patternName` is the block pattern namespace and name if inserted via a pattern.

This is information that could be useful for showing the pattern in the undo history, or for plugins to take advantage of. 

## How has this been tested?
Tested locally, all automated tests passing.

## Types of changes
New feature (non-breaking change which adds functionality)

## To Test

* Insert a block pattern while cursor is sitting in a new paragraph block
* Confirm that the `REPLACE_BLOCKS` action has passed the pattern name in the object
* Replace a block, and confirm that the pattern name is false

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
