### PR TITLE
[Widgets] Try inserting intermediate sub-sections in widgets customizer

### DIFF
--- a/lib/class-wp-customize-widget-blocks-control.php
+++ b/lib/class-wp-customize-widget-blocks-control.php
@@ -18,7 +18,7 @@ class WP_Customize_Widget_Blocks_Control extends WP_Customize_Control {
 	 * @since 6.1.0
 	 */
 	public function enqueue() {
-		gutenberg_widgets_init( 'gutenberg_customizer' );
+		gutenberg_widgets_init( 'gutenberg_customizer', $this->id );
 	}
 
 	/**
@@ -29,12 +29,12 @@ class WP_Customize_Widget_Blocks_Control extends WP_Customize_Control {
 	public function render_content() {
 		?>
 			<input
-				id="_customize-input-gutenberg_widget_blocks"
+				id="_customize-input-gutenberg_widget_blocks_<?php echo esc_attr( $this->id ); ?>"
 				type="hidden"
 				value="<?php echo esc_attr( $this->value() ); ?>"
 				<?php $this->link(); ?>
 			/>
 		<?php
-		the_gutenberg_widgets( 'gutenberg_customizer' );
+		the_gutenberg_widgets( 'gutenberg_customizer', $this->id );
 	}
 }

--- a/lib/customizer.php
+++ b/lib/customizer.php
@@ -70,8 +70,8 @@ function gutenberg_customize_register( $wp_customize ) {
 			$wp_customize->add_section(
 				$section_id,
 				array(
-					'title' => $sidebar_widget[ 'name' ],
-					'panel' => 'gutenberg_widget_blocks'
+					'title' => $sidebar_widget['name'],
+					'panel' => 'gutenberg_widget_blocks',
 				)
 			);
 
@@ -91,7 +91,7 @@ function gutenberg_customize_register( $wp_customize ) {
 					$wp_customize,
 					$widget_id,
 					array(
-						'section' => $section_id,
+						'section'  => $section_id,
 						'settings' => 'gutenberg_widget_blocks_' . $widget_id,
 					)
 				)

--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -10,19 +10,20 @@
  *
  * @since 5.2.0
  *
- * @param string $page The page name the function is being called for, `'gutenberg_customizer'` for the Customizer.
+ * @param string $page      The page name the function is being called for, `'gutenberg_customizer'` for the Customizer.
+ * @param string $widget_id The widget ID the function is rendering, used in customizer.
  */
-function the_gutenberg_widgets( $page = 'appearance_page_gutenberg-widgets' ) {
+function the_gutenberg_widgets( $page = 'appearance_page_gutenberg-widgets', $widget_id = '' ) {
 	?>
 	<div
-		id="widgets-editor"
-		class="blocks-widgets-container
+		class="blocks-widgets-container widgets-editor
 		<?php
 		echo 'gutenberg_customizer' === $page
 			? ' is-in-customizer'
 			: '';
 		?>
 		"
+		<?php echo $widget_id ? 'data-widget-id="' . $widget_id . '"' : '' ?>
 	>
 	</div>
 	<?php
@@ -35,7 +36,7 @@ function the_gutenberg_widgets( $page = 'appearance_page_gutenberg-widgets' ) {
  *
  * @param string $hook Page.
  */
-function gutenberg_widgets_init( $hook ) {
+function gutenberg_widgets_init( $hook, $widget_id = '' ) {
 	if ( 'widgets.php' === $hook ) {
 		wp_enqueue_style( 'wp-block-library' );
 		wp_enqueue_style( 'wp-block-library-theme' );
@@ -98,10 +99,11 @@ function gutenberg_widgets_init( $hook ) {
 		'wp-edit-widgets',
 		sprintf(
 			'wp.domReady( function() {
-				wp.editWidgets.%s( "widgets-editor", %s );
+				wp.editWidgets.%s( "widgets-editor", %s, %s );
 			} );',
 			$initializer_name,
-			wp_json_encode( gutenberg_experiments_editor_settings( $settings ) )
+			wp_json_encode( gutenberg_experiments_editor_settings( $settings ) ),
+			wp_json_encode( $widget_id )
 		)
 	);
 

--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -23,7 +23,7 @@ function the_gutenberg_widgets( $page = 'appearance_page_gutenberg-widgets', $wi
 			: '';
 		?>
 		"
-		<?php echo $widget_id ? 'data-widget-id="' . $widget_id . '"' : '' ?>
+		<?php echo $widget_id ? 'data-widget-id="' . $widget_id . '"' : ''; ?>
 	>
 	</div>
 	<?php
@@ -34,7 +34,8 @@ function the_gutenberg_widgets( $page = 'appearance_page_gutenberg-widgets', $wi
  *
  * @since 5.2.0
  *
- * @param string $hook Page.
+ * @param string $hook      Page.
+ * @param string $widget_id The widget ID.
  */
 function gutenberg_widgets_init( $hook, $widget_id = '' ) {
 	if ( 'widgets.php' === $hook ) {

--- a/packages/edit-widgets/src/components/customizer-edit-widgets-initializer/index.js
+++ b/packages/edit-widgets/src/components/customizer-edit-widgets-initializer/index.js
@@ -19,7 +19,7 @@ import Header from '../header';
 import WidgetAreasBlockEditorProvider from '../widget-areas-block-editor-provider';
 import WidgetAreasBlockEditorContent from '../widget-areas-block-editor-content';
 
-function CustomizerEditWidgetsInitializer( { settings } ) {
+function CustomizerEditWidgetsInitializer( { widgetID, settings } ) {
 	useSimulatedMediaQuery( 'resizable-editor-section', 360 );
 	const blockEditorSettings = useMemo(
 		() => ( {
@@ -29,7 +29,7 @@ function CustomizerEditWidgetsInitializer( { settings } ) {
 		[ settings ]
 	);
 	return (
-		<WidgetAreasBlockEditorProvider>
+		<WidgetAreasBlockEditorProvider widgetID={ widgetID }>
 			<div
 				className="edit-widgets-customizer-edit-widgets-initializer__content"
 				role="region"

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
@@ -24,10 +24,16 @@ import {
  */
 import KeyboardShortcuts from '../keyboard-shortcuts';
 import { useEntityBlockEditor } from '@wordpress/core-data';
-import { buildWidgetAreasPostId, KIND, POST_TYPE } from '../../store/utils';
+import {
+	buildWidgetAreasPostId,
+	buildWidgetAreaPostId,
+	KIND,
+	POST_TYPE,
+} from '../../store/utils';
 
 export default function WidgetAreasBlockEditorProvider( {
 	blockEditorSettings,
+	widgetID,
 	...props
 } ) {
 	const { hasUploadPermissions } = useSelect( ( select ) => ( {
@@ -59,7 +65,11 @@ export default function WidgetAreasBlockEditorProvider( {
 	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
 		KIND,
 		POST_TYPE,
-		{ id: buildWidgetAreasPostId() }
+		{
+			id: widgetID
+				? buildWidgetAreaPostId( widgetID )
+				: buildWidgetAreasPostId(),
+		}
 	);
 
 	return (

--- a/packages/edit-widgets/src/index.js
+++ b/packages/edit-widgets/src/index.js
@@ -21,8 +21,6 @@ import * as legacyWidget from './blocks/legacy-widget';
 import EditWidgetsInitializer from './components/edit-widgets-initializer';
 import CustomizerEditWidgetsInitializer from './components/customizer-edit-widgets-initializer';
 
-let registered = false;
-
 /**
  * Initializes the block editor in the widgets screen.
  *
@@ -30,11 +28,8 @@ let registered = false;
  * @param {Object} settings Block editor settings.
  */
 export function initialize( id, settings ) {
-	registerCoreBlocks();
-	registerBlock( legacyWidget );
-	if ( process.env.GUTENBERG_PHASE === 2 ) {
-		__experimentalRegisterExperimentalCoreBlocks( settings );
-	}
+	registerWidgetsEditorBlocks( settings );
+
 	render(
 		<EditWidgetsInitializer settings={ settings } />,
 		document.getElementById( id )
@@ -49,16 +44,7 @@ export function initialize( id, settings ) {
  * @param {string} widgetID ID of the widget being rendered.
  */
 export function customizerInitialize( id, settings, widgetID ) {
-	// The customizer can has many widgets, it should only register blocks once.
-	if ( ! registered ) {
-		registerCoreBlocks();
-		registerBlock( legacyWidget );
-		if ( process.env.GUTENBERG_PHASE === 2 ) {
-			__experimentalRegisterExperimentalCoreBlocks( settings );
-		}
-	}
-
-	registered = true;
+	registerWidgetsEditorBlocks( settings );
 
 	render(
 		<CustomizerEditWidgetsInitializer
@@ -69,6 +55,25 @@ export function customizerInitialize( id, settings, widgetID ) {
 			`.${ id }${ widgetID ? `[data-widget-id="${ widgetID }"]` : '' }`
 		)
 	);
+}
+
+let registered = false;
+/**
+ * Register the blocks needed in the Widgets Editor. Will be a no-op if it's already been registered.
+ *
+ * @param {Object} settings Block editor settings.
+ */
+function registerWidgetsEditorBlocks( settings ) {
+	// The customizer can has many widgets, it should only register blocks once.
+	if ( ! registered ) {
+		registerCoreBlocks();
+		registerBlock( legacyWidget );
+		if ( process.env.GUTENBERG_PHASE === 2 ) {
+			__experimentalRegisterExperimentalCoreBlocks( settings );
+		}
+	}
+
+	registered = true;
 }
 
 /**

--- a/packages/edit-widgets/src/index.js
+++ b/packages/edit-widgets/src/index.js
@@ -21,6 +21,8 @@ import * as legacyWidget from './blocks/legacy-widget';
 import EditWidgetsInitializer from './components/edit-widgets-initializer';
 import CustomizerEditWidgetsInitializer from './components/customizer-edit-widgets-initializer';
 
+let registered = false;
+
 /**
  * Initializes the block editor in the widgets screen.
  *
@@ -44,16 +46,28 @@ export function initialize( id, settings ) {
  *
  * @param {string} id       ID of the root element to render the section in.
  * @param {Object} settings Block editor settings.
+ * @param {string} widgetID ID of the widget being rendered.
  */
-export function customizerInitialize( id, settings ) {
-	registerCoreBlocks();
-	registerBlock( legacyWidget );
-	if ( process.env.GUTENBERG_PHASE === 2 ) {
-		__experimentalRegisterExperimentalCoreBlocks( settings );
+export function customizerInitialize( id, settings, widgetID ) {
+	// The customizer can has many widgets, it should only register blocks once.
+	if ( ! registered ) {
+		registerCoreBlocks();
+		registerBlock( legacyWidget );
+		if ( process.env.GUTENBERG_PHASE === 2 ) {
+			__experimentalRegisterExperimentalCoreBlocks( settings );
+		}
 	}
+
+	registered = true;
+
 	render(
-		<CustomizerEditWidgetsInitializer settings={ settings } />,
-		document.getElementById( id )
+		<CustomizerEditWidgetsInitializer
+			widgetID={ widgetID }
+			settings={ settings }
+		/>,
+		document.querySelector(
+			`.${ id }${ widgetID ? `[data-widget-id="${ widgetID }"]` : '' }`
+		)
 	);
 }
 

--- a/packages/edit-widgets/src/index.js
+++ b/packages/edit-widgets/src/index.js
@@ -32,7 +32,7 @@ export function initialize( id, settings ) {
 
 	render(
 		<EditWidgetsInitializer settings={ settings } />,
-		document.getElementById( id )
+		document.querySelector( `.${ id }` )
 	);
 }
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Trying to fix #23975.

This PR is an attempt to add intermediate sub-sections to Widgets customizer. This PR still suffers from several issues including #25157, #25154, and #25201.

Still unable to get it working as expected though. The goal is to add the `widget-area` block to the editor, currently I'm adding the inner blocks of the `widget-area` block. However, I can't seem to find a way to add only one `widget-area` block to the editor? What am I missing and how should I fix this?

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Open the customizer
2. Click "Widgets"
3. View the widgets editor in the customizer in sub-sections.

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/7753001/93552951-6f91cb80-f9a4-11ea-9c20-43669ac3af13.png)

![image](https://user-images.githubusercontent.com/7753001/93552960-76204300-f9a4-11ea-8c22-466dd9275b14.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
