### PR TITLE
Add FormTokenField story

### DIFF
--- a/packages/components/src/form-token-field/stories/index.js
+++ b/packages/components/src/form-token-field/stories/index.js
@@ -1,0 +1,67 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import FormTokenField from '../';
+
+export default {
+	title: 'Components/FormTokenField',
+	component: FormTokenField,
+};
+
+const continents = [
+	'Africa',
+	'America',
+	'Antarctica',
+	'Asia',
+	'Europe',
+	'Oceania',
+];
+
+const FormTokenFieldExample = () => {
+	const [ selectedContinents, setSelectedContinents ] = useState( [] );
+
+	return (
+		<FormTokenField
+			value={ selectedContinents }
+			suggestions={ continents }
+			onChange={ ( tokens ) => setSelectedContinents( tokens ) }
+			placeholder="Type a continent"
+		/>
+	);
+};
+
+export const _default = () => {
+	return <FormTokenFieldExample />;
+};
+
+const FormTokenFieldAsyncExample = () => {
+	const [ selectedContinents, setSelectedContinents ] = useState( [] );
+	const [ availableContinents, setAvailableContinents ] = useState( [] );
+	const searchContinents = ( input ) => {
+		setTimeout( () => {
+			const available = continents.filter( ( continent ) =>
+				continent.toLowerCase().includes( input.toLowerCase() )
+			);
+			setAvailableContinents( available );
+		}, 1000 );
+	};
+
+	return (
+		<FormTokenField
+			value={ selectedContinents }
+			suggestions={ availableContinents }
+			onChange={ ( tokens ) => setSelectedContinents( tokens ) }
+			onInputChange={ searchContinents }
+			placeholder="Type a continent"
+		/>
+	);
+};
+
+export const _async = () => {
+	return <FormTokenFieldAsyncExample />;
+};

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -161,13 +161,13 @@
 	flex: 1 0 100%;
 	min-width: 100%;
 	max-height: 9em;
-	overflow-y: scroll;
+	overflow-y: auto;
 	transition: all 0.15s ease-in-out;
 	@include reduce-motion("transition");
 	list-style: none;
 	border-top: $border-width solid $gray-700;
 	margin: $grid-unit-05 (-$grid-unit-05) (-$grid-unit-05);
-	padding-top: 3px;
+	padding: 0;
 }
 
 .components-form-token-field__suggestion {
@@ -175,6 +175,7 @@
 	display: block;
 	font-size: $default-font-size;
 	padding: 4px 8px;
+	margin: 0;
 	cursor: pointer;
 
 	&.is-selected {


### PR DESCRIPTION
This PR just adds a story to the existing FormTokenField component.
It also adjusts the styling of the component to make WP agnostic.

As a follow-up, I'm planning to see if we can rewrite the ComboboxControl component to use FormTokenField under the hood instead of Downshift like suggested by @afercia