### PR TITLE
Fix 'Publish sidebar Cancel button not usable through speech recognit…

### DIFF
--- a/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
@@ -23,7 +23,8 @@ describe( 'Multi-entity save flow', () => {
 	const templatePartSelector = '*[data-type="core/template-part"]';
 	const activatedTemplatePartSelector = `${ templatePartSelector } .block-editor-block-list__layout`;
 	const savePanelSelector = '.entities-saved-states__panel';
-	const closePanelButtonSelector = 'button[aria-label="Close panel"]';
+	const closePanelButtonSelector =
+		'.editor-post-publish-panel__header-cancel-button button';
 	const createNewButtonSelector =
 		'//button[contains(text(), "New template part")]';
 

--- a/packages/editor/src/components/post-publish-panel/index.js
+++ b/packages/editor/src/components/post-publish-panel/index.js
@@ -96,8 +96,7 @@ export class PostPublishPanel extends Component {
 							</div>
 							<div className="editor-post-publish-panel__header-cancel-button">
 								<Button
-									onClick={ onClose }
-									label={ __( 'Close panel' ) }
+									onClick={ onClose }									
 									isSecondary
 								>
 									{ __( 'Cancel' ) }

--- a/packages/editor/src/components/post-publish-panel/index.js
+++ b/packages/editor/src/components/post-publish-panel/index.js
@@ -95,10 +95,7 @@ export class PostPublishPanel extends Component {
 								/>
 							</div>
 							<div className="editor-post-publish-panel__header-cancel-button">
-								<Button
-									onClick={ onClose }									
-									isSecondary
-								>
+								<Button onClick={ onClose } isSecondary>
 									{ __( 'Cancel' ) }
 								</Button>
 							</div>

--- a/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
@@ -96,7 +96,6 @@ exports[`PostPublishPanel should render the pre-publish panel if post status is 
     >
       <ForwardRef(Button)
         isSecondary={true}
-        label="Close panel"
       >
         Cancel
       </ForwardRef(Button)>
@@ -137,7 +136,6 @@ exports[`PostPublishPanel should render the pre-publish panel if the post is not
     >
       <ForwardRef(Button)
         isSecondary={true}
-        label="Close panel"
       >
         Cancel
       </ForwardRef(Button)>
@@ -178,7 +176,6 @@ exports[`PostPublishPanel should render the spinner if the post is being saved 1
     >
       <ForwardRef(Button)
         isSecondary={true}
-        label="Close panel"
       >
         Cancel
       </ForwardRef(Button)>


### PR DESCRIPTION
…ion software' issue

Related Issue: #25194

## Description
Fixes the issue of publisher sidebar cancel button not being usable through speech recognition software.

## How has this been tested?
Tested using Speech Recognition Anywhere extension on Chrome browser on Windows machine.

## Types of changes
Bug fix: Fixes the issue of publisher sidebar cancel button not being usable through speech recognition software.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
