### PR TITLE
[Widgets editor] Make the legacy widget preview functional

### DIFF
--- a/packages/edit-widgets/src/blocks/legacy-widget/edit/index.js
+++ b/packages/edit-widgets/src/blocks/legacy-widget/edit/index.js
@@ -104,7 +104,7 @@ class LegacyWidgetEdit extends Component {
 								icon={ update }
 							/>
 						) }
-						{ hasEditForm && ! WPWidget?.isReferenceWidget && (
+						{ hasEditForm && (
 							<>
 								<Button
 									className="components-tab-button"
@@ -162,7 +162,10 @@ class LegacyWidgetEdit extends Component {
 						} }
 					/>
 				) }
-				{ ( isPreview || ! hasEditForm ) && this.renderWidgetPreview() }
+				{ ( isPreview || ! hasEditForm ) &&
+					( widgetObject.isReferenceWidget
+						? this.renderWidgetPreviewUnavailable()
+						: this.renderWidgetPreview() ) }
 			</>
 		);
 	}
@@ -196,6 +199,10 @@ class LegacyWidgetEdit extends Component {
 				attributes={ omit( attributes, 'widgetId' ) }
 			/>
 		);
+	}
+
+	renderWidgetPreviewUnavailable() {
+		return <p>{ __( 'Reference widgets cannot be previewed.' ) }</p>;
 	}
 }
 

--- a/packages/edit-widgets/src/blocks/legacy-widget/edit/index.js
+++ b/packages/edit-widgets/src/blocks/legacy-widget/edit/index.js
@@ -163,7 +163,7 @@ class LegacyWidgetEdit extends Component {
 					/>
 				) }
 				{ ( isPreview || ! hasEditForm ) &&
-					( widgetObject.isReferenceWidget
+					( WPWidget?.isReferenceWidget
 						? this.renderWidgetPreviewUnavailable()
 						: this.renderWidgetPreview() ) }
 			</>

--- a/packages/edit-widgets/src/blocks/legacy-widget/edit/index.js
+++ b/packages/edit-widgets/src/blocks/legacy-widget/edit/index.js
@@ -104,7 +104,7 @@ class LegacyWidgetEdit extends Component {
 								icon={ update }
 							/>
 						) }
-						{ hasEditForm && (
+						{ hasEditForm && ! WPWidget?.isReferenceWidget && (
 							<>
 								<Button
 									className="components-tab-button"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,7 @@ const { DefinePlugin } = require( 'webpack' );
 const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
 const TerserPlugin = require( 'terser-webpack-plugin' );
 const postcss = require( 'postcss' );
-const { get, escapeRegExp, compact } = require( 'lodash' );
+const { get, escapeRegExp, compact, toPairs } = require( 'lodash' );
 const { basename, sep } = require( 'path' );
 
 /**
@@ -57,9 +57,7 @@ const transformBlockContent = ( content ) => {
 				// other core prefix (e.g. "wp_").
 				return result.replace(
 					new RegExp( functionName, 'g' ),
-					( match ) =>
-						'gutenberg_' +
-						match.replace( /^wp_/, '' )
+					( match ) => 'gutenberg_' + match.replace( /^wp_/, '' )
 				);
 			}, content )
 			// The core blocks override procedure takes place in
@@ -76,6 +74,29 @@ const transformBlockContent = ( content ) => {
 			)
 	);
 };
+
+const blocksDirectoryMapping = toPairs( {
+	'./packages/block-library/src/': 'build/block-library/blocks/',
+	'./packages/edit-widgets/src/blocks/': 'build/edit-widgets/blocks/',
+} );
+
+const copyBlocksWebpackMapping = blocksDirectoryMapping.flatMap(
+	( [ from, to ] ) => [
+		{
+			from: `${ from }/**/index.php`,
+			test: new RegExp( `([\\w-]+)${ escapeRegExp( sep ) }index\\.php$` ),
+			to: `${ to }/[1].php`,
+			transform: transformBlockContent,
+		},
+		{
+			from: `${ from }/*/block.json`,
+			test: new RegExp(
+				`([\\w-]+)${ escapeRegExp( sep ) }block\\.json$`
+			),
+			to: `${ to }/[1]/block.json`,
+		},
+	]
+);
 
 module.exports = {
 	optimization: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,40 +41,6 @@ const gutenbergPackages = Object.keys( dependencies )
 	)
 	.map( ( packageName ) => packageName.replace( WORDPRESS_NAMESPACE, '' ) );
 
-const transformBlockContent = ( content ) => {
-	content = content.toString();
-
-	// Within content, search for any function definitions. For
-	// each, replace every other reference to it in the file.
-	return (
-		content
-			.match( /^function [^\(]+/gm )
-			.reduce( ( result, functionName ) => {
-				// Trim leading "function " prefix from match.
-				functionName = functionName.slice( 9 );
-
-				// Prepend the Gutenberg prefix, substituting any
-				// other core prefix (e.g. "wp_").
-				return result.replace(
-					new RegExp( functionName, 'g' ),
-					( match ) => 'gutenberg_' + match.replace( /^wp_/, '' )
-				);
-			}, content )
-			// The core blocks override procedure takes place in
-			// the init action default priority to ensure that core
-			// blocks would have been registered already. Since the
-			// blocks implementations occur at the default priority
-			// and due to WordPress hooks behavior not considering
-			// mutations to the same priority during another's
-			// callback, the Gutenberg build blocks are modified
-			// to occur at a later priority.
-			.replace(
-				/(add_action\(\s*'init',\s*'gutenberg_register_block_[^']+'(?!,))/,
-				'$1, 20'
-			)
-	);
-};
-
 module.exports = {
 	optimization: {
 		// Only concatenate modules in production, when not analyzing bundles.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,7 @@ const { DefinePlugin } = require( 'webpack' );
 const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
 const TerserPlugin = require( 'terser-webpack-plugin' );
 const postcss = require( 'postcss' );
-const { get, escapeRegExp, compact, toPairs } = require( 'lodash' );
+const { get, escapeRegExp, compact } = require( 'lodash' );
 const { basename, sep } = require( 'path' );
 
 /**
@@ -74,29 +74,6 @@ const transformBlockContent = ( content ) => {
 			)
 	);
 };
-
-const blocksDirectoryMapping = toPairs( {
-	'./packages/block-library/src/': 'build/block-library/blocks/',
-	'./packages/edit-widgets/src/blocks/': 'build/edit-widgets/blocks/',
-} );
-
-const copyBlocksWebpackMapping = blocksDirectoryMapping.flatMap(
-	( [ from, to ] ) => [
-		{
-			from: `${ from }/**/index.php`,
-			test: new RegExp( `([\\w-]+)${ escapeRegExp( sep ) }index\\.php$` ),
-			to: `${ to }/[1].php`,
-			transform: transformBlockContent,
-		},
-		{
-			from: `${ from }/*/block.json`,
-			test: new RegExp(
-				`([\\w-]+)${ escapeRegExp( sep ) }block\\.json$`
-			),
-			to: `${ to }/[1]/block.json`,
-		},
-	]
-);
 
 module.exports = {
 	optimization: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,6 +41,42 @@ const gutenbergPackages = Object.keys( dependencies )
 	)
 	.map( ( packageName ) => packageName.replace( WORDPRESS_NAMESPACE, '' ) );
 
+const transformBlockContent = ( content ) => {
+	content = content.toString();
+
+	// Within content, search for any function definitions. For
+	// each, replace every other reference to it in the file.
+	return (
+		content
+			.match( /^function [^\(]+/gm )
+			.reduce( ( result, functionName ) => {
+				// Trim leading "function " prefix from match.
+				functionName = functionName.slice( 9 );
+
+				// Prepend the Gutenberg prefix, substituting any
+				// other core prefix (e.g. "wp_").
+				return result.replace(
+					new RegExp( functionName, 'g' ),
+					( match ) =>
+						'gutenberg_' +
+						match.replace( /^wp_/, '' )
+				);
+			}, content )
+			// The core blocks override procedure takes place in
+			// the init action default priority to ensure that core
+			// blocks would have been registered already. Since the
+			// blocks implementations occur at the default priority
+			// and due to WordPress hooks behavior not considering
+			// mutations to the same priority during another's
+			// callback, the Gutenberg build blocks are modified
+			// to occur at a later priority.
+			.replace(
+				/(add_action\(\s*'init',\s*'gutenberg_register_block_[^']+'(?!,))/,
+				'$1, 20'
+			)
+	);
+};
+
 module.exports = {
 	optimization: {
 		// Only concatenate modules in production, when not analyzing bundles.


### PR DESCRIPTION
## Description

This PR ensures that `<ServerSideRender />` uses all the attributes except `widgetId`. The presence of `widgetId` forces the server-side rendering to use "render" mode (where it uses the database data) instead of "preview" mode (where it uses the user input).

One other change here is that the preview of reference widgets is no longer supported and displays and explanatory message instead. This is because reference widgets tend to work similarly to:

```php
	wp_register_sidebar_widget(
		'marquee_greeting',
		'Marquee Greeting',
		function() {
			$greeting = get_option( 'marquee_greeting', 'Hello!' );
			printf( '<marquee>%s</marquee>', esc_html( $greeting ) );
		}
	);
```

In other words, they retrieve their own data and so it isn't possible to render them using a customized set of attributes. Even the core customizer does not support this use case and so we'll also need to address the block-based customizer editor and FSE.

Solves #25192 

## How has this been tested?
1. Go through the steps listed in https://github.com/WordPress/gutenberg/issues/25192 and confirm the preview works as expected after applying this PR.
1. Add a marquee widget to your local WP: https://gist.github.com/adamziel/526436b4cc9bc82a7221c77e00137ae1
1. Add a legacy widget block in the widgets editor and make it a marquee
1. Click "Preview", confirm the message is rendered instead of an actual preview.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
