### PR TITLE
Allow themes to enqueue custom CSS variables via theme.json

### DIFF
--- a/docs/designers-developers/developers/themes/theme-json.md
+++ b/docs/designers-developers/developers/themes/theme-json.md
@@ -96,7 +96,8 @@ The settings section has the following structure and default values:
         "customLineHeight": false, /* true to opt-in, as in add_theme_support( 'custom-line-height' ) */
         "dropCap": true, /* false to opt-out */
         "fontSizes": [ ... ], /* font size presets, as in add_theme_support('editor-font-sizes', ... ) */
-      }
+      },
+      "custom": { ... }
     }
   }
 }
@@ -189,6 +190,42 @@ The output to be enqueued will be:
 ```
 
 The goal is that presets can be defined using this format, although, right now, the name property (used in the editor) can't be translated from this file. For that reason, and to maintain backward compatibility, the presets declared via `add_theme_support` will also generate the CSS Custom Properties. If the `experimental-theme.json` contains any presets, these will take precedence over the ones declared via `add_theme_support`.
+
+### Theme-only CSS Custom Properties
+
+Besides the presets becoming CSS Custom Properties, the theme.json also allows for themes to create their own, so they don't have to be enqueued separately. Any values declared within the `settings.custom` section will be transformed to CSS Custom Properties following this naming schema: `--wp--theme--<variable-name>`.
+
+For example, for this input:
+
+```json
+{
+  "global": {
+    "settings": {
+      "custom": {
+        "base-font": 16,
+        "line-height": {
+          "small": 1.2,
+          "medium": 1.4,
+          "large": 1.8
+        }
+      }
+    }
+  }
+}
+```
+
+The output will be:
+
+```css
+:root {
+  --wp--theme--base-font: 16;
+  --wp--theme--line-height--small: 1.2;
+  --wp--theme--line-height--medium: 1.4;
+  --wp--theme--line-height--large: 1.8;
+}
+```
+
+Note that, the name of the variable is created by adding `--` in between each nesting level.
 
 ### Styles
 

--- a/docs/designers-developers/developers/themes/theme-json.md
+++ b/docs/designers-developers/developers/themes/theme-json.md
@@ -7,9 +7,9 @@
 This is documentation for the current direction and work in progress about how themes can hook into the various sub-systems that the Block Editor provides.
 
 - Rationale
-    - Presets become CSS Custom Properties
-    - Some block styles are managed
     - Settings can be controlled per block
+    - CSS Custom Properties: presets & custom
+    - Some block styles are managed
 - Specification
     - Settings
     - Styles
@@ -20,19 +20,17 @@ The Block Editor surface API has evolved at different velocities, and it's now a
 
 This describes the current efforts to consolidate the various APIs into a single point – a `experimental-theme.json` file that should be located inside the root of the theme directory.
 
-### Presets become CSS Custom Properties
+### Settings can be controlled per block
 
-Presets such as [color palettes](https://developer.wordpress.org/block-editor/developers/themes/theme-support/#block-color-palettes), [font sizes](https://developer.wordpress.org/block-editor/developers/themes/theme-support/#block-font-sizes), and [gradients](https://developer.wordpress.org/block-editor/developers/themes/theme-support/#block-gradient-presets) will be enqueued as CSS Custom Properties for themes to use.
+The Block Editor already allows the control of specific settings such as alignment, drop cap, whether it's present in the inserter, etc at the block level. The goal is to surface these for themes to control at a block level.
 
-These will be enqueued to the front-end and editor.
+### CSS Custom Properties
+
+Presets such as [color palettes](https://developer.wordpress.org/block-editor/developers/themes/theme-support/#block-color-palettes), [font sizes](https://developer.wordpress.org/block-editor/developers/themes/theme-support/#block-font-sizes), and [gradients](https://developer.wordpress.org/block-editor/developers/themes/theme-support/#block-gradient-presets) become CSS Custom Properties, and will be enqueued by the system for themes to use in both the front-end and the editors. There's also a mechanism to create your own CSS Custom Properties.
 
 ### Some block styles are managed
 
 By providing the block style properties in a structured way, the Block Editor can "manage" the CSS that comes from different origins (user, theme, and core CSS), reducing the amount of CSS loaded in the page and preventing specificity wars due to the competing needs of the components involved (themes, blocks, plugins).
-
-### Settings can be controlled per block
-
-The Block Editor already allows the control of specific settings such as alignment, drop cap, whether it's present in the inserter, etc at the block level. The goal is to surface these for themes to control.
 
 ## Specification
 
@@ -60,7 +58,8 @@ Every context has the same structure, divided in two sections: `settings` and `s
     "settings": {
       "color": [ ... ],
       "typography": [ ... ],
-      "spacing": [ ... ]
+      "spacing": [ ... ],
+      "custom": [ ... ]
     },
     "styles": {
       "color": { ... },
@@ -103,7 +102,7 @@ The settings section has the following structure and default values:
 }
 ```
 
-To retain backward compatibility, `add_theme_support` declarations are considered as well. If a theme uses `add_theme_support('disable-custom-colors')`, it'll be the same as set `global.settings.color.custom` to `false`. If the `experimental-theme.json` contains any settings, these will take precedence over the values declared via `add_theme_support`.
+To retain backward compatibility, `add_theme_support` declarations are retrofit in the proper categories. If a theme uses `add_theme_support('disable-custom-colors')`, it'll be the same as set `global.settings.color.custom` to `false`. If the `experimental-theme.json` contains any settings, these will take precedence over the values declared via `add_theme_support`.
 
 Settings can also be controlled by context, providing a more fine-grained control over what exists via `add_theme_support`. As an example, let's say that a theme author wants to enable custom colors for the paragraph block exclusively. This is how it'd be done:
 
@@ -127,7 +126,7 @@ Settings can also be controlled by context, providing a more fine-grained contro
 
 Note, however, that not all settings are relevant for all contexts and the blocks they represent. The settings section provides an opt-in/opt-out mechanism for themes, but it's the block's responsibility to add support for the features that are relevant to it. For example, if a block doesn't implement the `dropCap` feature, a theme can't enable it for such a block through `experimental-theme.json`.
 
-### Presets
+#### Presets
 
 Presets are part of the settings section. At the moment, they only work within the `global` context. Each preset value will generate a CSS Custom Property that will be added to the new stylesheet, which follow this naming schema: `--wp--preset--{preset-category}--{preset-slug}`.
 
@@ -191,9 +190,9 @@ The output to be enqueued will be:
 
 The goal is that presets can be defined using this format, although, right now, the name property (used in the editor) can't be translated from this file. For that reason, and to maintain backward compatibility, the presets declared via `add_theme_support` will also generate the CSS Custom Properties. If the `experimental-theme.json` contains any presets, these will take precedence over the ones declared via `add_theme_support`.
 
-### Theme-only CSS Custom Properties
+#### Free-form CSS Custom Properties
 
-Besides the presets becoming CSS Custom Properties, the theme.json also allows for themes to create their own, so they don't have to be enqueued separately. Any values declared within the `settings.custom` section will be transformed to CSS Custom Properties following this naming schema: `--wp--theme--<variable-name>`.
+In addition to create CSS Custom Properties for the presets, the theme.json also allows for themes to create their own, so they don't have to be enqueued separately. Any values declared within the `settings.custom` section will be transformed to CSS Custom Properties following this naming schema: `--wp--custom--<variable-name>`.
 
 For example, for this input:
 
@@ -218,10 +217,10 @@ The output will be:
 
 ```css
 :root {
-  --wp--theme--base-font: 16;
-  --wp--theme--line-height--small: 1.2;
-  --wp--theme--line-height--medium: 1.4;
-  --wp--theme--line-height--large: 1.8;
+  --wp--custom--base-font: 16;
+  --wp--custom--line-height--small: 1.2;
+  --wp--custom--line-height--medium: 1.4;
+  --wp--custom--line-height--large: 1.8;
 }
 ```
 

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -591,10 +591,9 @@ function gutenberg_experimental_global_styles_get_stylesheet( $tree ) {
 		foreach ( $presets_structure as $token => $preset_meta ) {
 			$block_preset = gutenberg_experimental_get( $tree[ $block_name ]['settings'], $preset_meta['path'] );
 			if ( ! empty( $block_preset ) ) {
-				$css_var_token                      = gutenberg_experimental_global_styles_get_css_property( $token );
-				$computed_presets[ $css_var_token ] = array();
+				$computed_presets[ $token ] = array();
 				foreach ( $block_preset as $preset_value ) {
-					$computed_presets[ $css_var_token ][ $preset_value['slug'] ] = $preset_value[ $preset_meta['key'] ];
+					$computed_presets[ $token ][ $preset_value['slug'] ] = $preset_value[ $preset_meta['key'] ];
 				}
 			}
 		}

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -19,6 +19,9 @@ function gutenberg_experimental_global_styles_has_theme_json_support() {
  * by merging the keys and binding the leaf values
  * to the new keys.
  *
+ * It also transforms camelCase names into kebab-case
+ * and substitutes '/' by '-'.
+ *
  * This is thought to be useful to generate
  * CSS Custom Properties from a tree,
  * although there's nothing in the implementation
@@ -28,8 +31,8 @@ function gutenberg_experimental_global_styles_has_theme_json_support() {
  * and the token is '--', for this input tree:
  *
  * {
- *   'property': 'value',
- *   'nested-property': {
+ *   'some/property': 'value',
+ *   'nestedProperty': {
  *     'sub-property': 'value'
  *   }
  * }
@@ -37,7 +40,7 @@ function gutenberg_experimental_global_styles_has_theme_json_support() {
  * it'll return this output:
  *
  * {
- *   '--wp--property': 'value',
+ *   '--wp--some-property': 'value',
  *   '--wp--nested-property--sub-property': 'value'
  * }
  *
@@ -50,7 +53,11 @@ function gutenberg_experimental_global_styles_has_theme_json_support() {
 function gutenberg_experimental_global_styles_get_css_vars( $tree, $prefix = '', $token = '--' ) {
 	$result = array();
 	foreach ( $tree as $property => $value ) {
-		$new_key = $prefix . str_replace( '/', '-', $property );
+		$new_key = $prefix . str_replace(
+			'/',
+			'-',
+			strtolower( preg_replace( '/(?<!^)[A-Z]/', '-$0', $property ) ) // CamelCase to kebab-case
+		);
 
 		if ( is_array( $value ) ) {
 			$new_prefix = $new_key . $token;

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -597,7 +597,7 @@ function gutenberg_experimental_global_styles_get_stylesheet( $tree ) {
 
 		// Create the CSS Custom Properties that are specific to the theme.
 		$computed_theme_props = gutenberg_experimental_get( $tree[ $block_name ]['settings'], ['custom'] );
-		$theme_props_prefix   = '--wp--theme' . $token;
+		$theme_props_prefix   = '--wp--custom' . $token;
 		$theme_variables      = gutenberg_experimental_global_styles_get_css_vars(
 			$computed_theme_props,
 			$theme_props_prefix,

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -56,7 +56,7 @@ function gutenberg_experimental_global_styles_get_css_vars( $tree, $prefix = '',
 		$new_key = $prefix . str_replace(
 			'/',
 			'-',
-			strtolower( preg_replace( '/(?<!^)[A-Z]/', '-$0', $property ) ) // CamelCase to kebab-case
+			strtolower( preg_replace( '/(?<!^)[A-Z]/', '-$0', $property ) ) // CamelCase to kebab-case.
 		);
 
 		if ( is_array( $value ) ) {

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -578,11 +578,9 @@ function gutenberg_experimental_global_styles_get_stylesheet( $tree ) {
 			continue;
 		}
 
-		$presets_structure = gutenberg_experimental_global_styles_get_presets_structure();
-
+		// Create the CSS Custom Properties for the presets.
 		$computed_presets = array();
-
-		// Extract the relevant preset info before converting them to CSS Custom Properties.
+		$presets_structure = gutenberg_experimental_global_styles_get_presets_structure();
 		foreach ( $presets_structure as $token => $preset_meta ) {
 			$block_preset = gutenberg_experimental_get( $tree[ $block_name ]['settings'], $preset_meta['path'] );
 			if ( ! empty( $block_preset ) ) {
@@ -593,17 +591,26 @@ function gutenberg_experimental_global_styles_get_stylesheet( $tree ) {
 				}
 			}
 		}
+		$token            = '--';
+		$preset_prefix    = '--wp--preset' . $token;
+		$preset_variables = gutenberg_experimental_global_styles_get_css_vars( $computed_presets, $preset_prefix, $token );
 
-		$token         = '--';
-		$prefix        = '--wp--preset' . $token;
-		$css_variables = gutenberg_experimental_global_styles_get_css_vars( $computed_presets, $prefix, $token );
+		// Create the CSS Custom Properties that are specific to the theme.
+		$computed_theme_props = gutenberg_experimental_get( $tree[ $block_name ]['settings'], ['custom'] );
+		$theme_props_prefix   = '--wp--theme' . $token;
+		$theme_variables      = gutenberg_experimental_global_styles_get_css_vars(
+			$computed_theme_props,
+			$theme_props_prefix,
+			$token
+		);
 
 		$stylesheet .= gutenberg_experimental_global_styles_resolver_styles(
 			$block_data[ $block_name ]['selector'],
 			$block_data[ $block_name ]['supports'],
 			array_merge(
 				gutenberg_experimental_global_styles_flatten_styles_tree( $tree[ $block_name ]['styles'] ),
-				$css_variables
+				$preset_variables,
+				$theme_variables
 			)
 		);
 	}
@@ -719,6 +726,7 @@ function gutenberg_experimental_global_styles_normalize_schema( $tree ) {
 		),
 		'settings' => array(
 			'color'      => array(),
+			'custom'     => array(),
 			'typography' => array(),
 			'spacing'    => array(),
 		),

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -579,7 +579,7 @@ function gutenberg_experimental_global_styles_get_stylesheet( $tree ) {
 		}
 
 		// Create the CSS Custom Properties for the presets.
-		$computed_presets = array();
+		$computed_presets  = array();
 		$presets_structure = gutenberg_experimental_global_styles_get_presets_structure();
 		foreach ( $presets_structure as $token => $preset_meta ) {
 			$block_preset = gutenberg_experimental_get( $tree[ $block_name ]['settings'], $preset_meta['path'] );
@@ -596,7 +596,7 @@ function gutenberg_experimental_global_styles_get_stylesheet( $tree ) {
 		$preset_variables = gutenberg_experimental_global_styles_get_css_vars( $computed_presets, $preset_prefix, $token );
 
 		// Create the CSS Custom Properties that are specific to the theme.
-		$computed_theme_props = gutenberg_experimental_get( $tree[ $block_name ]['settings'], ['custom'] );
+		$computed_theme_props = gutenberg_experimental_get( $tree[ $block_name ]['settings'], array( 'custom' ) );
 		$theme_props_prefix   = '--wp--custom' . $token;
 		$theme_variables      = gutenberg_experimental_global_styles_get_css_vars(
 			$computed_theme_props,

--- a/packages/edit-site/src/components/editor/global-styles-renderer.js
+++ b/packages/edit-site/src/components/editor/global-styles-renderer.js
@@ -124,7 +124,7 @@ export default ( blockData, baseTree, userTree ) => {
 			return [];
 		}
 
-		return flattenTree( blockCustom, '--wp--theme--', '--' );
+		return flattenTree( blockCustom, '--wp--custom--', '--' );
 	};
 
 	const getBlockSelector = ( selector ) => {

--- a/packages/edit-site/src/components/editor/global-styles-renderer.js
+++ b/packages/edit-site/src/components/editor/global-styles-renderer.js
@@ -100,6 +100,33 @@ export default ( blockData, baseTree, userTree ) => {
 		);
 	};
 
+	const flattenTree = ( input, prefix, token ) => {
+		let result = [];
+		Object.keys( input ).forEach( ( key ) => {
+			const newKey = prefix + key.replace( '/', '-' );
+			const newLeaf = input[ key ];
+
+			if ( newLeaf instanceof Object ) {
+				const newPrefix = newKey + token;
+				result = [
+					...result,
+					...flattenTree( newLeaf, newPrefix, token ),
+				];
+			} else {
+				result.push( `${ newKey }: ${ newLeaf }` );
+			}
+		} );
+		return result;
+	};
+
+	const getCustomDeclarations = ( blockCustom ) => {
+		if ( Object.keys( blockCustom ).length === 0 ) {
+			return [];
+		}
+
+		return flattenTree( blockCustom, '--wp--theme--', '--' );
+	};
+
 	const getBlockSelector = ( selector ) => {
 		// Can we hook into the styles generation mechanism
 		// so we can avoid having to increase the class specificity here
@@ -118,6 +145,7 @@ export default ( blockData, baseTree, userTree ) => {
 				tree[ context ].styles
 			),
 			...getBlockPresetsDeclarations( tree[ context ].settings ),
+			...getCustomDeclarations( tree[ context ].settings.custom ),
 		];
 		if ( blockDeclarations.length > 0 ) {
 			styles.push(


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/25393

This PR adds a way for themes to generate their own CSS Custom Properties via theme.json (new section `settings.custom`, see [docs](https://github.com/WordPress/gutenberg/blob/8eba9be11c7aed7c81923ad3f1bec75abc2e360b/docs/designers-developers/developers/themes/theme-json.md#theme-only-css-custom-properties)).

## How to test

- Install and activate the demo theme to be found at https://github.com/nosolosw/global-styles-theme/pull/19
- Check that front-end, post editor, and site editor reflect the line-height styles properly.