### PR TITLE
register legacy widget in the customizer

### DIFF
--- a/packages/edit-widgets/src/index.js
+++ b/packages/edit-widgets/src/index.js
@@ -47,6 +47,7 @@ export function initialize( id, settings ) {
  */
 export function customizerInitialize( id, settings ) {
 	registerCoreBlocks();
+	registerBlock( legacyWidget );
 	if ( process.env.GUTENBERG_PHASE === 2 ) {
 		__experimentalRegisterExperimentalCoreBlocks( settings );
 	}


### PR DESCRIPTION
## Description
In #25371 the legacy widget block was de-registered from the post editor. This caused a bug in the Customizer because the legacy widget block was not registered there anymore.

## How has this been tested?
Tested locally by:

- go to the customizer and notice the widget area loads (on master an error is shown in the console that `Uncaught (in promise) Error: Block type 'core/legacy-widget' is not registered.`

## Types of changes

Non breaking changes, bug fix.
