### PR TITLE
Check nonce header value before skipping adding it

### DIFF
--- a/packages/api-fetch/src/middlewares/nonce.js
+++ b/packages/api-fetch/src/middlewares/nonce.js
@@ -5,7 +5,10 @@ function createNonceMiddleware( nonce ) {
 		// If an 'X-WP-Nonce' header (or any case-insensitive variation
 		// thereof) was specified, no need to add a nonce header.
 		for ( const headerName in headers ) {
-			if ( headerName.toLowerCase() === 'x-wp-nonce' ) {
+			if (
+				headerName.toLowerCase() === 'x-wp-nonce' &&
+				headers[ headerName ] === middleware.nonce
+			) {
 				return next( options );
 			}
 		}

--- a/packages/api-fetch/src/middlewares/test/nonce.js
+++ b/packages/api-fetch/src/middlewares/test/nonce.js
@@ -20,19 +20,19 @@ describe( 'Nonce middleware', () => {
 		nonceMiddleware( requestOptions, callback );
 	} );
 
-	it( 'should not add a nonce header to requests with nonces', () => {
+	it( 'should update the nonce in requests with outdated nonces', () => {
 		expect.hasAssertions();
 
-		const nonce = 'nonce';
+		const nonce = 'new nonce';
 		const nonceMiddleware = createNonceMiddleware( nonce );
 		const requestOptions = {
 			method: 'GET',
 			path: '/wp/v2/posts',
 			headers: { 'X-WP-Nonce': 'existing nonce' },
 		};
+
 		const callback = ( options ) => {
-			expect( options ).toBe( requestOptions );
-			expect( options.headers[ 'X-WP-Nonce' ] ).toBe( 'existing nonce' );
+			expect( options.headers[ 'X-WP-Nonce' ] ).toBe( 'new nonce' );
 		};
 
 		nonceMiddleware( requestOptions, callback );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
The bug is explained [here](https://github.com/Automattic/wp-calypso/issues/40574). 

It's hard to explain the technical issue, but I'll lay the story of an authenticated HTTP request, in theory.

1. Among others, you call [`createNonceMiddleware`](https://github.com/WordPress/gutenberg/blob/master/packages/api-fetch/src/middlewares/nonce.js) to create an instance of [`middleware`](https://github.com/WordPress/gutenberg/blob/master/packages/api-fetch/src/middlewares/nonce.js#L2), and then do `middleware.nonce = nonce;` to store the value of the nonce in the middleware instance to use it during the session.

2. You issue a request, and the middleware adds the `middleware.value` value to the headers of the request. [It only does that when the header doesn't have `x-wp-nonce` header](https://github.com/WordPress/gutenberg/blob/master/packages/api-fetch/src/middlewares/nonce.js#L8-L10). 

3. After a while the nonce expires, you issue a request, it fails, but `apiFetch` [catches the failure and requests a new nonce and adds it to `middleware.nonce` for future requests](https://github.com/alshakero/gutenberg/blob/master/packages/api-fetch/src/index.js#L138-L145). The failed request is requested again and all works alright.

#### The problem

If some other place of the code creats another instance of nonceMiddleware by calling `createNonceMiddleware`. We'll have two instances of nonceMiddleware. The value of `middleware.nonce = nonce;` is no longer global-ish. In our case it's [the coblocks plugin](https://github.com/godaddy-wordpress/coblocks/blob/master/src/extensions/coblocks-settings/coblocks-settings-store.js#L11). This explains why the bug only happens on business sites. Creating another instance of the middleware isn't an issue. But now we have two competing records of the nonce, which is still not an issue.

But once the nonce expires, both instances should issue refresh calls and update it, but the problem is that when one middleware adds its version of the nonce, which may be outdated, the other instance will [step out of the way and never use its updated nonce](https://github.com/WordPress/gutenberg/blob/master/packages/api-fetch/src/middlewares/nonce.js#L8), sending a request with an outdated nonce, even though a refresh request was issued and it has the new nonce. 

This PR makes sure the nonce middleware doesn't skip adding the header value unless it's already in the header **and** has the same value.

In order for the bug to surface, there needs to be an invalid/expired nonce and two instances of `nonceMiddleware`. Explains the elusiveness of the bug.

## How has this been tested?
I tested this on a business site and it seems to fix the issue.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
