### PR TITLE
Spacer block: Allow 1px height and improve usability in the editor

### DIFF
--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -13,7 +13,7 @@ import { compose, withInstanceId } from '@wordpress/compose';
 import { withDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 
-const MIN_SPACER_HEIGHT = 20;
+const MIN_SPACER_HEIGHT = 1;
 const MAX_SPACER_HEIGHT = 500;
 
 const SpacerEdit = ( {

--- a/packages/block-library/src/spacer/editor.scss
+++ b/packages/block-library/src/spacer/editor.scss
@@ -1,3 +1,10 @@
+.block-editor-block-list__block[data-type="core/spacer"] {
+	min-height: 20px;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+}
+
 .block-library-spacer__resize-container.has-show-handle {
 	background: $gray-100;
 
@@ -8,7 +15,6 @@
 
 .block-library-spacer__resize-container {
 	clear: both;
-	margin-bottom: $default-block-margin;
 
 	// Don't show the horizontal indicator.
 	.components-resizable-box__handle::before {


### PR DESCRIPTION
In order to fix #18906, this PR changes the minimum height of the spacer block to 1px and introduces a minimum height of ~~48px~~ 20px in the editor to ensure ease of block selection.

![spacer-min-20px](https://user-images.githubusercontent.com/9000376/93840311-d46b5100-fc44-11ea-8a43-4eed322f942e.gif)

EDIT: Reduced the minimum height to 20 pixels in the editor in accordance with the current minimum height and removed some margin that was a solution for inserter overlap that is tangential to this PR. 

## How has this been tested?
Wordpress v5.5.1 with Gutenberg plugin v9.0.0

## Types of changes
Nonbreakers

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [n/a] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [n/a] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
