### PR TITLE
Add event to navigation item click handler

### DIFF
--- a/packages/components/src/navigation/item/index.js
+++ b/packages/components/src/navigation/item/index.js
@@ -45,12 +45,12 @@ export default function NavigationItem( props ) {
 		'is-active': item && activeItem === item,
 	} );
 
-	const onItemClick = () => {
+	const onItemClick = ( event ) => {
 		if ( navigateToMenu ) {
 			setActiveMenu( navigateToMenu );
 		}
 
-		onClick();
+		onClick( event );
 	};
 
 	return (


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Adds an event to the item click handler.  This allows consumers to set more conditions on the events and prevent native browser behavior on click.

This is currently needed to prevent the navigation that will occur for WooCommerce Admin items added to the new WooCommerce Navigation that uses this navigation component.  WooCommerce Admin prevents the default action and pushes history changes using React Router.

See https://github.com/woocommerce/woocommerce-admin/pull/5164 for use case.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
