### PR TITLE
Add "open in new tab" feature to Social Links Block

### DIFF
--- a/packages/block-library/src/social-link/block.json
+++ b/packages/block-library/src/social-link/block.json
@@ -15,6 +15,9 @@
 			"type": "string"
 		}
 	},
+	"usesContext": [
+		"openInNewTab"
+	],
 	"supports": {
 		"reusable": false,
 		"html": false,

--- a/packages/block-library/src/social-link/block.json
+++ b/packages/block-library/src/social-link/block.json
@@ -13,12 +13,6 @@
 		},
 		"label": {
 			"type": "string"
-		},
-		"linkTarget": {
-			"type": "string"
-		},
-		"rel": {
-			"type": "string"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/social-link/block.json
+++ b/packages/block-library/src/social-link/block.json
@@ -13,6 +13,12 @@
 		},
 		"label": {
 			"type": "string"
+		},
+		"linkTarget": {
+			"type": "string"
+		},
+		"rel": {
+			"type": "string"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -8,9 +8,8 @@ import classNames from 'classnames';
  */
 import {
 	InspectorControls,
-	URLPopover,
-	URLInput,
 	__experimentalBlock as Block,
+	__experimentalLinkControl as LinkControl,
 } from '@wordpress/block-editor';
 import { Fragment, useState } from '@wordpress/element';
 import {
@@ -18,24 +17,49 @@ import {
 	PanelBody,
 	PanelRow,
 	TextControl,
+	ToggleControl,
+	Popover,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { keyboardReturn } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import { getIconBySite, getNameBySite } from './social-list';
 
+const NEW_TAB_REL = 'noreferrer noopener';
+
 const SocialLinkEdit = ( { attributes, setAttributes, isSelected } ) => {
-	const { url, service, label } = attributes;
-	const [ showURLPopover, setPopover ] = useState( false );
+	const { url, service, label, rel, linkTarget } = attributes;
+	const [ isURLPickerOpen, setIsURLPickerOpen ] = useState( false );
 	const classes = classNames( 'wp-social-link', 'wp-social-link-' + service, {
 		'wp-social-link__is-incomplete': ! url,
 	} );
 
 	const IconComponent = getIconBySite( service );
 	const socialLinkName = getNameBySite( service );
+
+	const onToggleOpenInNewTab = ( value ) => {
+		const newLinkTarget = value ? '_blank' : undefined;
+
+		let updatedRel = rel;
+		if ( newLinkTarget && ! rel ) {
+			updatedRel = NEW_TAB_REL;
+		} else if ( ! newLinkTarget && rel === NEW_TAB_REL ) {
+			updatedRel = undefined;
+		}
+
+		setAttributes( {
+			linkTarget: newLinkTarget,
+			rel: updatedRel,
+		} );
+	};
+
+	const onSetLinkRel = ( value ) => {
+		setAttributes( { rel: value } );
+	};
+
+	const opensInNewTab = linkTarget === '_blank';
 
 	return (
 		<Fragment>
@@ -61,36 +85,44 @@ const SocialLinkEdit = ( { attributes, setAttributes, isSelected } ) => {
 						/>
 					</PanelRow>
 				</PanelBody>
+				<PanelBody title={ __( 'Link settings' ) }>
+					<ToggleControl
+						label={ __( 'Open in new tab' ) }
+						onChange={ onToggleOpenInNewTab }
+						checked={ opensInNewTab }
+					/>
+					<TextControl
+						label={ __( 'Link rel' ) }
+						value={ rel || '' }
+						onChange={ onSetLinkRel }
+					/>
+				</PanelBody>
 			</InspectorControls>
 			<Block.li className={ classes }>
-				<Button onClick={ () => setPopover( true ) }>
+				<Button onClick={ () => setIsURLPickerOpen( true ) }>
 					<IconComponent />
-					{ isSelected && showURLPopover && (
-						<URLPopover onClose={ () => setPopover( false ) }>
-							<form
-								className="block-editor-url-popover__link-editor"
-								onSubmit={ ( event ) => {
-									event.preventDefault();
-									setPopover( false );
+					{ isSelected && isURLPickerOpen && (
+						<Popover
+							position="bottom center"
+							onClose={ () => setIsURLPickerOpen( false ) }
+						>
+							<LinkControl
+								className="wp-block-navigation-link__inline-link-input"
+								value={ { url, opensInNewTab } }
+								onChange={ ( {
+									url: newURL = '',
+									opensInNewTab: newOpensInNewTab,
+								} ) => {
+									setAttributes( { url: newURL } );
+
+									if ( opensInNewTab !== newOpensInNewTab ) {
+										onToggleOpenInNewTab(
+											newOpensInNewTab
+										);
+									}
 								} }
-							>
-								<div className="block-editor-url-input">
-									<URLInput
-										value={ url }
-										onChange={ ( nextURL ) =>
-											setAttributes( { url: nextURL } )
-										}
-										placeholder={ __( 'Enter address' ) }
-										disableSuggestions={ true }
-									/>
-								</div>
-								<Button
-									icon={ keyboardReturn }
-									label={ __( 'Apply' ) }
-									type="submit"
-								/>
-							</form>
-						</URLPopover>
+							/>
+						</Popover>
 					) }
 				</Button>
 			</Block.li>

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -8,8 +8,9 @@ import classNames from 'classnames';
  */
 import {
 	InspectorControls,
+	URLPopover,
+	URLInput,
 	__experimentalBlock as Block,
-	__experimentalLinkControl as LinkControl,
 } from '@wordpress/block-editor';
 import { Fragment, useState } from '@wordpress/element';
 import {
@@ -17,49 +18,24 @@ import {
 	PanelBody,
 	PanelRow,
 	TextControl,
-	ToggleControl,
-	Popover,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
+import { keyboardReturn } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import { getIconBySite, getNameBySite } from './social-list';
 
-const NEW_TAB_REL = 'noreferrer noopener';
-
 const SocialLinkEdit = ( { attributes, setAttributes, isSelected } ) => {
-	const { url, service, label, rel, linkTarget } = attributes;
-	const [ isURLPickerOpen, setIsURLPickerOpen ] = useState( false );
+	const { url, service, label } = attributes;
+	const [ showURLPopover, setPopover ] = useState( false );
 	const classes = classNames( 'wp-social-link', 'wp-social-link-' + service, {
 		'wp-social-link__is-incomplete': ! url,
 	} );
 
 	const IconComponent = getIconBySite( service );
 	const socialLinkName = getNameBySite( service );
-
-	const onToggleOpenInNewTab = ( value ) => {
-		const newLinkTarget = value ? '_blank' : undefined;
-
-		let updatedRel = rel;
-		if ( newLinkTarget && ! rel ) {
-			updatedRel = NEW_TAB_REL;
-		} else if ( ! newLinkTarget && rel === NEW_TAB_REL ) {
-			updatedRel = undefined;
-		}
-
-		setAttributes( {
-			linkTarget: newLinkTarget,
-			rel: updatedRel,
-		} );
-	};
-
-	const onSetLinkRel = ( value ) => {
-		setAttributes( { rel: value } );
-	};
-
-	const opensInNewTab = linkTarget === '_blank';
 
 	return (
 		<Fragment>
@@ -85,44 +61,36 @@ const SocialLinkEdit = ( { attributes, setAttributes, isSelected } ) => {
 						/>
 					</PanelRow>
 				</PanelBody>
-				<PanelBody title={ __( 'Link settings' ) }>
-					<ToggleControl
-						label={ __( 'Open in new tab' ) }
-						onChange={ onToggleOpenInNewTab }
-						checked={ opensInNewTab }
-					/>
-					<TextControl
-						label={ __( 'Link rel' ) }
-						value={ rel || '' }
-						onChange={ onSetLinkRel }
-					/>
-				</PanelBody>
 			</InspectorControls>
 			<Block.li className={ classes }>
-				<Button onClick={ () => setIsURLPickerOpen( true ) }>
+				<Button onClick={ () => setPopover( true ) }>
 					<IconComponent />
-					{ isSelected && isURLPickerOpen && (
-						<Popover
-							position="bottom center"
-							onClose={ () => setIsURLPickerOpen( false ) }
-						>
-							<LinkControl
-								className="wp-block-navigation-link__inline-link-input"
-								value={ { url, opensInNewTab } }
-								onChange={ ( {
-									url: newURL = '',
-									opensInNewTab: newOpensInNewTab,
-								} ) => {
-									setAttributes( { url: newURL } );
-
-									if ( opensInNewTab !== newOpensInNewTab ) {
-										onToggleOpenInNewTab(
-											newOpensInNewTab
-										);
-									}
+					{ isSelected && showURLPopover && (
+						<URLPopover onClose={ () => setPopover( false ) }>
+							<form
+								className="block-editor-url-popover__link-editor"
+								onSubmit={ ( event ) => {
+									event.preventDefault();
+									setPopover( false );
 								} }
-							/>
-						</Popover>
+							>
+								<div className="block-editor-url-input">
+									<URLInput
+										value={ url }
+										onChange={ ( nextURL ) =>
+											setAttributes( { url: nextURL } )
+										}
+										placeholder={ __( 'Enter address' ) }
+										disableSuggestions={ true }
+									/>
+								</div>
+								<Button
+									icon={ keyboardReturn }
+									label={ __( 'Apply' ) }
+									type="submit"
+								/>
+							</form>
+						</URLPopover>
 					) }
 				</Button>
 			</Block.li>

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -8,11 +8,15 @@
 /**
  * Renders the `core/social-link` block on server.
  *
- * @param array $attributes The block attributes.
+ * @param Array   $attributes The block attributes.
+ * @param String  $content InnerBlocks content of the Block.
+ * @param WPBlock $block Block object.
  *
  * @return string Rendered HTML of the referenced block.
  */
-function render_block_core_social_link( $attributes ) {
+function render_block_core_social_link( $attributes, $content, $block ) {
+	$open_in_new_tab = $block->context['openInNewTab'];
+
 	$service    = ( isset( $attributes['service'] ) ) ? $attributes['service'] : 'Icon';
 	$url        = ( isset( $attributes['url'] ) ) ? $attributes['url'] : false;
 	$label      = ( isset( $attributes['label'] ) ) ? $attributes['label'] : block_core_social_link_get_name( $service );
@@ -23,8 +27,13 @@ function render_block_core_social_link( $attributes ) {
 		return '';
 	}
 
+	$attribute = '';
+	if ( $open_in_new_tab ) {
+		$attribute = 'rel="noopener nofollow" target="_blank"';
+	}
+
 	$icon = block_core_social_link_get_icon( $service );
-	return '<li class="wp-social-link wp-social-link-' . esc_attr( $service ) . esc_attr( $class_name ) . '"><a href="' . esc_url( $url ) . '" aria-label="' . esc_attr( $label ) . '"> ' . $icon . '</a></li>';
+	return '<li class="wp-social-link wp-social-link-' . esc_attr( $service ) . esc_attr( $class_name ) . '"><a href="' . esc_url( $url ) . '" aria-label="' . esc_attr( $label ) . '" ' . $attribute . '> ' . $icon . '</a></li>';
 }
 
 /**

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -16,8 +16,6 @@ function render_block_core_social_link( $attributes ) {
 	$service    = ( isset( $attributes['service'] ) ) ? $attributes['service'] : 'Icon';
 	$url        = ( isset( $attributes['url'] ) ) ? $attributes['url'] : false;
 	$label      = ( isset( $attributes['label'] ) ) ? $attributes['label'] : block_core_social_link_get_name( $service );
-	$target     = ( isset( $attributes['linkTarget'] ) ) ? 'target="' . esc_attr( $attributes['linkTarget'] ) . '"' : '';
-	$rel        = ( isset( $attributes['rel'] ) ) ? 'rel="' . esc_attr( $attributes['rel'] ) . '"' : '';
 	$class_name = isset( $attributes['className'] ) ? ' ' . $attributes['className'] : false;
 
 	// Don't render a link if there is no URL set.
@@ -26,7 +24,7 @@ function render_block_core_social_link( $attributes ) {
 	}
 
 	$icon = block_core_social_link_get_icon( $service );
-	return '<li class="wp-social-link wp-social-link-' . esc_attr( $service ) . esc_attr( $class_name ) . '"><a href="' . esc_url( $url ) . '" aria-label="' . esc_attr( $label ) . '"' . $rel . $target . '> ' . $icon . '</a></li>';
+	return '<li class="wp-social-link wp-social-link-' . esc_attr( $service ) . esc_attr( $class_name ) . '"><a href="' . esc_url( $url ) . '" aria-label="' . esc_attr( $label ) . '"> ' . $icon . '</a></li>';
 }
 
 /**

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -16,6 +16,8 @@ function render_block_core_social_link( $attributes ) {
 	$service    = ( isset( $attributes['service'] ) ) ? $attributes['service'] : 'Icon';
 	$url        = ( isset( $attributes['url'] ) ) ? $attributes['url'] : false;
 	$label      = ( isset( $attributes['label'] ) ) ? $attributes['label'] : block_core_social_link_get_name( $service );
+	$target     = ( isset( $attributes['linkTarget'] ) ) ? 'target="' . esc_attr( $attributes['linkTarget'] ) . '"' : '';
+	$rel        = ( isset( $attributes['rel'] ) ) ? 'rel="' . esc_attr( $attributes['rel'] ) . '"' : '';
 	$class_name = isset( $attributes['className'] ) ? ' ' . $attributes['className'] : false;
 
 	// Don't render a link if there is no URL set.
@@ -24,7 +26,7 @@ function render_block_core_social_link( $attributes ) {
 	}
 
 	$icon = block_core_social_link_get_icon( $service );
-	return '<li class="wp-social-link wp-social-link-' . esc_attr( $service ) . esc_attr( $class_name ) . '"><a href="' . esc_url( $url ) . '" aria-label="' . esc_attr( $label ) . '"> ' . $icon . '</a></li>';
+	return '<li class="wp-social-link wp-social-link-' . esc_attr( $service ) . esc_attr( $class_name ) . '"><a href="' . esc_url( $url ) . '" aria-label="' . esc_attr( $label ) . '"' . $rel . $target . '> ' . $icon . '</a></li>';
 }
 
 /**

--- a/packages/block-library/src/social-links/block.json
+++ b/packages/block-library/src/social-links/block.json
@@ -1,6 +1,15 @@
 {
 	"name": "core/social-links",
 	"category": "widgets",
+	"attributes": {
+		"openInNewTab": {
+			"type": "boolean",
+			"default": false
+		}
+	},
+	"providesContext": {
+		"openInNewTab": "openInNewTab"
+	},
 	"supports": {
 		"align": [
 			"left",

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -2,10 +2,15 @@
  * WordPress dependencies
  */
 
+import { Fragment } from '@wordpress/element';
+
 import {
 	InnerBlocks,
 	__experimentalBlock as Block,
+	InspectorControls,
 } from '@wordpress/block-editor';
+import { ToggleControl, PanelBody } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
 const ALLOWED_BLOCKS = [ 'core/social-link' ];
 
@@ -22,16 +27,33 @@ const TEMPLATE = [
 	[ 'core/social-link', { service: 'youtube' } ],
 ];
 
-export function SocialLinksEdit() {
+export function SocialLinksEdit( props ) {
+	const {
+		attributes: { openInNewTab },
+		setAttributes,
+	} = props;
 	return (
-		<InnerBlocks
-			allowedBlocks={ ALLOWED_BLOCKS }
-			templateLock={ false }
-			template={ TEMPLATE }
-			orientation="horizontal"
-			__experimentalTagName={ Block.ul }
-			__experimentalAppenderTagName="li"
-		/>
+		<Fragment>
+			<InspectorControls>
+				<PanelBody title={ __( 'Link Settings' ) }>
+					<ToggleControl
+						label={ __( 'Open Links in new Tab' ) }
+						checked={ openInNewTab }
+						onChange={ () =>
+							setAttributes( { openInNewTab: ! openInNewTab } )
+						}
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<InnerBlocks
+				allowedBlocks={ ALLOWED_BLOCKS }
+				templateLock={ false }
+				template={ TEMPLATE }
+				orientation="horizontal"
+				__experimentalTagName={ Block.ul }
+				__experimentalAppenderTagName="li"
+			/>
+		</Fragment>
 	);
 }
 

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -37,7 +37,7 @@ export function SocialLinksEdit( props ) {
 			<InspectorControls>
 				<PanelBody title={ __( 'Link Settings' ) }>
 					<ToggleControl
-						label={ __( 'Open Links in new Tab' ) }
+						label={ __( 'Open links in new tab' ) }
 						checked={ openInNewTab }
 						onChange={ () =>
 							setAttributes( { openInNewTab: ! openInNewTab } )

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -35,7 +35,7 @@ export function SocialLinksEdit( props ) {
 	return (
 		<Fragment>
 			<InspectorControls>
-				<PanelBody title={ __( 'Link Settings' ) }>
+				<PanelBody title={ __( 'Link settings' ) }>
 					<ToggleControl
 						label={ __( 'Open links in new tab' ) }
 						checked={ openInNewTab }

--- a/packages/e2e-tests/fixtures/blocks/core__social-links.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-links.json
@@ -3,7 +3,9 @@
         "clientId": "_clientId_0",
         "name": "core/social-links",
         "isValid": true,
-        "attributes": {},
+        "attributes": {
+			"openInNewTab": false
+		},
         "innerBlocks": [
             {
                 "clientId": "_clientId_0",


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
I have modified the `SocialLink` and `SocialLinks` Blocks to include the ability to open in new tab. This was implemented using the `contextProvider` API to pass the setting down to the children.

It fixes the issue outlined in #20707

Closes #20707


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
This has been tested locally with by setting up a SocialLinks block and then updating it to make sure there are no deprecation errors. 

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature & Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
