### PR TITLE
Fix image block render in Xcode 12

### DIFF
--- a/patches/react-native+0.61.5.patch
+++ b/patches/react-native+0.61.5.patch
@@ -21,6 +21,20 @@ index 65fa2bb..c5f265b 100644
      index++;
    }
  
+diff --git a/node_modules/react-native/Libraries/Image/RCTUIImageViewAnimated.m b/node_modules/react-native/Libraries/Image/RCTUIImageViewAnimated.m
+index 01aa75f..572572c 100644
+--- a/node_modules/react-native/Libraries/Image/RCTUIImageViewAnimated.m
++++ b/node_modules/react-native/Libraries/Image/RCTUIImageViewAnimated.m
+@@ -266,6 +266,9 @@ - (void)displayDidRefresh:(CADisplayLink *)displayLink
+ 
+ - (void)displayLayer:(CALayer *)layer
+ {
++  if (!_currentFrame) {
++    _currentFrame = self.image;
++  }
+   if (_currentFrame) {
+     layer.contentsScale = self.animatedImageScale;
+     layer.contents = (__bridge id)_currentFrame.CGImage;
 diff --git a/node_modules/react-native/React/Views/RCTShadowView.m b/node_modules/react-native/React/Views/RCTShadowView.m
 index 40c0cda..646f137 100644
 --- a/node_modules/react-native/React/Views/RCTShadowView.m
@@ -53,3 +67,10 @@ index 40c0cda..646f137 100644
    }
    return ancestor == shadowView;
  }
+diff --git a/node_modules/react-native/scripts/.packager.env b/node_modules/react-native/scripts/.packager.env
+new file mode 100644
+index 0000000..361f5fb
+--- /dev/null
++++ b/node_modules/react-native/scripts/.packager.env
+@@ -0,0 +1 @@
++export RCT_METRO_PORT=8081

--- a/patches/react-native+0.61.5.patch
+++ b/patches/react-native+0.61.5.patch
@@ -67,10 +67,3 @@ index 40c0cda..646f137 100644
    }
    return ancestor == shadowView;
  }
-diff --git a/node_modules/react-native/scripts/.packager.env b/node_modules/react-native/scripts/.packager.env
-new file mode 100644
-index 0000000..361f5fb
---- /dev/null
-+++ b/node_modules/react-native/scripts/.packager.env
-@@ -0,0 +1 @@
-+export RCT_METRO_PORT=8081


### PR DESCRIPTION
## Description

This PR fixes #25431 which is a bug that prevents Image blocks from rendering their images. This only affects builds made using Xcode 12.

The bug itself is in React Native itself and was fixed in RN 0.63. Since we're on RN 0.61.5, we need to apply a patch (as suggested here https://github.com/facebook/react-native/issues/29279#issuecomment-657201709).

The patch was applied using the following steps found here: https://github.com/facebook/react-native/issues/29279#issuecomment-657201709

## How has this been tested?

Ensure Xcode 12 is installed

1. Run the packager: npm run native start
2. Run the iOS demo app (open `packages/react-native-editor/ios/gutenberg.xcworkspace` and run from Xcode 12 *
3. Verify that the image block in the demo content renders its image correctly (that's to say, the image should be visible)

*There appears to be an issue running npm run native ios with Xcode 12

## Screenshots <!-- if applicable -->

<img width="300" alt="Screen Shot 2020-09-18 at 17 40 41" src="https://user-images.githubusercontent.com/1898325/93647292-13e03600-f9d6-11ea-9278-b6c2047a1662.png">

## Types of changes
- Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
