### PR TITLE
Add new $gray-200 and use for skeleton borders

### DIFF
--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -8,7 +8,7 @@ $gray-900: #1e1e1e;
 $gray-700: #757575;		// Meets 4.6:1 text contrast against white.
 $gray-600: #949494;		// Meets 3:1 UI or large text contrast against white.
 $gray-400: #ccc;
-$gray-200: #ddd;		// Used for most borders.
+$gray-300: #ddd;		// Used for most borders.
 $gray-100: #f0f0f0;
 $white: #fff;
 

--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -9,7 +9,8 @@ $gray-700: #757575;		// Meets 4.6:1 text contrast against white.
 $gray-600: #949494;		// Meets 3:1 UI or large text contrast against white.
 $gray-400: #ccc;
 $gray-300: #ddd;		// Used for most borders.
-$gray-100: #f0f0f0;
+$gray-200: #e0e0e0;		// Used sparingly for light borders.
+$gray-100: #f0f0f0;		// Used for light gray backgrounds.
 $white: #fff;
 
 // Opacities & additional colors.

--- a/packages/block-directory/src/components/downloadable-block-icon/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-icon/style.scss
@@ -6,7 +6,7 @@
 		width: $button-size;
 		height: $button-size;
 		font-size: $button-size;
-		background-color: $gray-200;
+		background-color: $gray-300;
 	}
 
 	> img {

--- a/packages/block-directory/src/components/downloadable-block-list-item/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-list-item/style.scss
@@ -10,8 +10,8 @@
 	justify-content: center;
 	background: transparent;
 	word-break: break-word;
-	border-top: $border-width solid $gray-200;
-	border-bottom: $border-width solid $gray-200;
+	border-top: $border-width solid $gray-300;
+	border-bottom: $border-width solid $gray-300;
 	transition: all 0.05s ease-in-out;
 	@include reduce-motion("transition");
 	position: relative;

--- a/packages/block-editor/src/components/block-card/style.scss
+++ b/packages/block-editor/src/components/block-card/style.scss
@@ -5,7 +5,7 @@
 }
 
 .block-editor-block-card__icon {
-	border: $border-width solid $gray-200;
+	border: $border-width solid $gray-300;
 	padding: 7px;
 	margin-right: 10px;
 	height: 36px;

--- a/packages/block-editor/src/components/block-inspector/style.scss
+++ b/packages/block-editor/src/components/block-inspector/style.scss
@@ -8,7 +8,7 @@
 	}
 	.components-panel__body {
 		border: none;
-		border-top: $border-width solid $gray-100;
+		border-top: $border-width solid $gray-200;
 	}
 
 	.block-editor-block-card {

--- a/packages/block-editor/src/components/block-mobile-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-mobile-toolbar/style.scss
@@ -1,7 +1,7 @@
 .block-editor-block-mobile-toolbar {
 	display: flex;
 	flex-direction: row;
-	border-right: $border-width solid $gray-200;
+	border-right: $border-width solid $gray-300;
 
 	.block-editor-block-mover-button {
 		width: $button-size;

--- a/packages/block-editor/src/components/block-switcher/style.scss
+++ b/packages/block-editor/src/components/block-switcher/style.scss
@@ -101,7 +101,7 @@
 	}
 
 	.components-panel__body + .components-panel__body {
-		border-top: $border-width solid $gray-100;
+		border-top: $border-width solid $gray-200;
 	}
 }
 

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -34,7 +34,7 @@
 		border: 0;
 
 		// Add a border after item groups to show as separator in the block toolbar.
-		border-right: $border-width solid $gray-200;
+		border-right: $border-width solid $gray-300;
 	}
 
 	> :last-child,

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -135,7 +135,7 @@ $block-inserter-tabs-height: 44px;
 		top: $grid-unit-10 + $grid-unit-20 + $grid-unit-60;
 		background: $white;
 		z-index: 1;
-		border-bottom: $border-width solid $gray-200;
+		border-bottom: $border-width solid $gray-300;
 
 		.components-tab-panel__tabs-item {
 			flex-grow: 1;
@@ -234,7 +234,7 @@ $block-inserter-tabs-height: 44px;
 	width: 300px;
 	background: $white;
 	border-radius: $radius-block-ui;
-	border: $border-width solid $gray-200;
+	border: $border-width solid $gray-300;
 	position: absolute;
 	top: $grid-unit-20;
 	left: calc(100% + #{$grid-unit-20});
@@ -273,7 +273,7 @@ $block-inserter-tabs-height: 44px;
 }
 
 .block-editor-inserter__tips {
-	border-top: $border-width solid $gray-200;
+	border-top: $border-width solid $gray-300;
 	padding: $grid-unit-20;
 	flex-shrink: 0;
 }
@@ -316,7 +316,7 @@ $block-inserter-tabs-height: 44px;
 }
 
 .block-editor-inserter__quick-inserter-separator {
-	border-top: $border-width solid $gray-200;
+	border-top: $border-width solid $gray-300;
 }
 
 .block-editor-inserter__popover.is-quick > .components-popover__content > div {

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -28,7 +28,7 @@ $block-editor-link-control-number-of-actions: 1;
 		padding-right: ( $button-size * $block-editor-link-control-number-of-actions ); // width of reset and submit buttons
 		margin: $grid-unit-20;
 		position: relative;
-		border: 1px solid $gray-200;
+		border: 1px solid $gray-300;
 		border-radius: $radius-block-ui;
 	}
 
@@ -122,7 +122,7 @@ $block-editor-link-control-number-of-actions: 1;
 
 	&:hover,
 	&:focus {
-		background-color: $gray-200;
+		background-color: $gray-300;
 	}
 
 	// The added specificity is needed to override.
@@ -228,7 +228,7 @@ $block-editor-link-control-number-of-actions: 1;
 		left: 0;
 		display: block;
 		width: 100%;
-		border-top: 1px solid $gray-200;
+		border-top: 1px solid $gray-300;
 	}
 }
 
@@ -238,7 +238,7 @@ $block-editor-link-control-number-of-actions: 1;
 }
 
 .block-editor-link-control__settings {
-	border-top: 1px solid $gray-200;
+	border-top: 1px solid $gray-300;
 	margin: 0;
 	padding: $grid-unit-20 $grid-unit-30;
 

--- a/packages/block-editor/src/components/tool-selector/style.scss
+++ b/packages/block-editor/src/components/tool-selector/style.scss
@@ -4,6 +4,6 @@
 	margin-right: -$grid-unit-15;
 	margin-bottom: -$grid-unit-15;
 	padding: $grid-unit-15 ($grid-unit-15 + $grid-unit-10);
-	border-top: 1px solid $gray-200;
+	border-top: 1px solid $gray-300;
 	color: $gray-700;
 }

--- a/packages/block-editor/src/components/url-input/style.scss
+++ b/packages/block-editor/src/components/url-input/style.scss
@@ -88,7 +88,7 @@ $input-size: 300px;
 	box-shadow: none;
 
 	&:hover {
-		background: $gray-200;
+		background: $gray-300;
 	}
 
 	&:focus,
@@ -116,13 +116,13 @@ $input-size: 300px;
 		width: 1px;
 		height: 24px;
 		right: -1px;
-		background: $gray-200;
+		background: $gray-300;
 	}
 }
 
 .block-editor-url-input__button-modal {
 	box-shadow: $shadow-popover;
-	border: 1px solid $gray-200;
+	border: 1px solid $gray-300;
 	background: $white;
 }
 

--- a/packages/block-editor/src/components/url-popover/style.scss
+++ b/packages/block-editor/src/components/url-popover/style.scss
@@ -1,5 +1,5 @@
 .block-editor-url-popover__additional-controls {
-	border-top: $border-width solid $gray-200;
+	border-top: $border-width solid $gray-300;
 }
 
 .block-editor-url-popover__additional-controls > div[role="menu"] .components-button:not(:disabled):not([aria-disabled="true"]):not(.is-secondary) > svg {
@@ -45,7 +45,7 @@
 
 	// Add a left divider to the toggle button.
 	border-radius: 0;
-	border-left: $border-width solid $gray-200;
+	border-left: $border-width solid $gray-300;
 	margin-left: 1px;
 
 	&[aria-expanded="true"] .dashicon {
@@ -62,7 +62,7 @@
 .block-editor-url-popover__settings {
 	display: block;
 	padding: $grid-unit-20;
-	border-top: $border-width solid $gray-200;
+	border-top: $border-width solid $gray-300;
 }
 
 .block-editor-url-popover__link-editor,

--- a/packages/block-library/src/calendar/style.scss
+++ b/packages/block-library/src/calendar/style.scss
@@ -4,7 +4,7 @@
 	th,
 	tbody td {
 		padding: 0.25em;
-		border: 1px solid $gray-200;
+		border: 1px solid $gray-300;
 	}
 
 	tfoot td {
@@ -18,7 +18,7 @@
 
 	table th {
 		font-weight: 400;
-		background: $gray-200;
+		background: $gray-300;
 	}
 
 	a {

--- a/packages/block-library/src/classic/editor.scss
+++ b/packages/block-library/src/classic/editor.scss
@@ -13,7 +13,7 @@
 
 	blockquote {
 		margin: 0;
-		box-shadow: inset 0 0 0 0 $gray-200;
+		box-shadow: inset 0 0 0 0 $gray-300;
 		border-left: 4px solid $black;
 		padding-left: 1em;
 	}
@@ -59,7 +59,7 @@
 	}
 
 	&:focus code[data-mce-selected] {
-		background: $gray-200;
+		background: $gray-300;
 	}
 
 	.alignright {
@@ -152,12 +152,12 @@
 		}
 
 		.loading-placeholder {
-			border: 1px dashed $gray-200;
+			border: 1px dashed $gray-300;
 			padding: 10px;
 		}
 
 		.wpview-error {
-			border: 1px solid $gray-200;
+			border: 1px solid $gray-300;
 			padding: 1em 0;
 			margin: 0;
 			word-wrap: break-word;
@@ -244,7 +244,7 @@ div[data-type="core/freeform"] {
 	&::before {
 		transition: border-color 0.1s linear, box-shadow 0.1s linear;
 		@include reduce-motion("transition");
-		border: $border-width solid $gray-200;
+		border: $border-width solid $gray-300;
 
 		// Windows High Contrast mode will show this outline.
 		outline: $border-width solid transparent;
@@ -299,7 +299,7 @@ div[data-type="core/freeform"] {
 	position: sticky;
 	z-index: z-index(".block-library-classic__toolbar");
 	top: 0;
-	border: $border-width solid $gray-200;
+	border: $border-width solid $gray-300;
 	border-bottom: none;
 	border-radius: $radius-block-ui;
 	margin-bottom: $grid-unit-10;

--- a/packages/block-library/src/code/theme.scss
+++ b/packages/block-library/src/code/theme.scss
@@ -3,6 +3,6 @@
 	font-size: 0.9em;
 	color: $gray-900;
 	padding: 0.8em 1em;
-	border: 1px solid $gray-200;
+	border: 1px solid $gray-300;
 	border-radius: 4px;
 }

--- a/packages/block-library/src/html/editor.scss
+++ b/packages/block-library/src/html/editor.scss
@@ -13,7 +13,7 @@
 		font-family: $editor-html-font;
 		color: $gray-900;
 		padding: 0.8em 1em;
-		border: 1px solid $gray-200;
+		border: 1px solid $gray-300;
 		border-radius: 4px;
 		max-height: 250px;
 

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -34,7 +34,7 @@
 // Separator
 .wp-block-navigation-link__separator {
 	margin: $grid-unit-10 0 $grid-unit-10;
-	border-top: $border-width solid $gray-200;
+	border-top: $border-width solid $gray-300;
 }
 
 // Popover styles

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -8,7 +8,7 @@
 }
 
 .wp-block-template-part__selection-preview-search-form {
-	border-bottom: $border-width solid $gray-200;
+	border-bottom: $border-width solid $gray-300;
 }
 
 .wp-block-template-part__selection-preview-container {
@@ -118,7 +118,7 @@
 
 	&.has-child-selected {
 		&::after {
-			box-shadow: 0 0 0 $border-width $gray-200;
+			box-shadow: 0 0 0 $border-width $gray-300;
 
 			.is-dark-theme & {
 				box-shadow: 0 0 0 $border-width-focus $gray-700;

--- a/packages/block-library/src/text-columns/editor.scss
+++ b/packages/block-library/src/text-columns/editor.scss
@@ -1,5 +1,5 @@
 .wp-block-text-columns {
 	.block-editor-rich-text__editable:focus {
-		outline: $border-width solid $gray-200;
+		outline: $border-width solid $gray-300;
 	}
 }

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -107,7 +107,7 @@
 	&.is-secondary,
 	&.is-tertiary {
 		&:active:not(:disabled) {
-			background: $gray-200;
+			background: $gray-300;
 			color: var(--wp-admin-theme-color-darker-10);
 			box-shadow: none;
 		}
@@ -121,7 +121,7 @@
 		&[aria-disabled="true"],
 		&[aria-disabled="true"]:hover {
 			color: lighten($gray-700, 5%);
-			background: lighten($gray-200, 5%);
+			background: lighten($gray-300, 5%);
 			transform: none;
 			opacity: 1;
 			box-shadow: none;

--- a/packages/components/src/combobox-control/style.scss
+++ b/packages/components/src/combobox-control/style.scss
@@ -58,7 +58,7 @@
 	padding: 10px 5px 10px 25px;
 
 	&.is-highlighted {
-		background: $gray-200;
+		background: $gray-300;
 	}
 
 	&-icon {

--- a/packages/components/src/custom-select-control/style.scss
+++ b/packages/components/src/custom-select-control/style.scss
@@ -64,7 +64,7 @@
 
 
 	&.is-highlighted {
-		background: $gray-200;
+		background: $gray-300;
 	}
 
 	&-icon {

--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -48,7 +48,7 @@
 
 .components-datetime__date {
 	min-height: 236px;
-	border-top: 1px solid $gray-200;
+	border-top: 1px solid $gray-300;
 
 	// Override external DatePicker styles.
 	.DayPickerNavigation_leftButton__horizontalDefault {

--- a/packages/components/src/dropdown-menu/style.scss
+++ b/packages/components/src/dropdown-menu/style.scss
@@ -25,7 +25,7 @@
 			display: block;
 			content: "";
 			box-sizing: content-box;
-			background-color: $gray-200;
+			background-color: $gray-300;
 			position: absolute;
 			top: -3px;
 			left: 0;

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -10,8 +10,8 @@
 
 
 	&.is-disabled {
-		background: $gray-200;
-		border-color: $gray-200;
+		background: $gray-300;
+		border-color: $gray-300;
 	}
 
 	&.is-active {
@@ -130,7 +130,7 @@
 	display: inline-block;
 	line-height: 24px;
 	height: auto;
-	background: $gray-200;
+	background: $gray-300;
 	transition: all 0.2s cubic-bezier(0.4, 1, 0.4, 1);
 	@include reduce-motion;
 }

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -23,7 +23,7 @@
 	left: 0;
 	box-sizing: border-box;
 	margin: 0;
-	border: $border-width solid $gray-200;
+	border: $border-width solid $gray-300;
 	background: $white;
 	box-shadow: $shadow-modal;
 	overflow: auto;
@@ -60,7 +60,7 @@
 // modal screen).
 .components-modal__header {
 	box-sizing: border-box;
-	border-bottom: $border-width solid $gray-200;
+	border-bottom: $border-width solid $gray-300;
 	padding: 0 $grid-unit-30;
 	display: flex;
 	flex-direction: row;

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -1,6 +1,6 @@
 .components-panel {
 	background: $white;
-	border: $border-width solid $gray-100;
+	border: $border-width solid $gray-200;
 
 	> .components-panel__header:first-child,
 	> .components-panel__body:first-child {
@@ -18,8 +18,8 @@
 }
 
 .components-panel__body {
-	border-top: $border-width solid $gray-100;
-	border-bottom: $border-width solid $gray-100;
+	border-top: $border-width solid $gray-200;
+	border-bottom: $border-width solid $gray-200;
 
 	h3 {
 		margin: 0 0 0.5em;

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -36,8 +36,8 @@
 	align-items: center;
 	padding: 0 $grid-unit-20;
 	height: $grid-unit-60;
-	border-top: $border-width solid $gray-200;
-	border-bottom: $border-width solid $gray-200;
+	border-top: $border-width solid $gray-300;
+	border-bottom: $border-width solid $gray-300;
 
 	h2 {
 		margin: 0;

--- a/packages/components/src/resizable-box/style.scss
+++ b/packages/components/src/resizable-box/style.scss
@@ -49,7 +49,7 @@ $resize-handler-container-size: $resize-handler-size + ($grid-unit-05 * 2); // M
 .is-dark-theme {
 	.components-resizable-box__side-handle::before,
 	.components-resizable-box__handle::after {
-		border-color: $gray-200;
+		border-color: $gray-300;
 	}
 }
 

--- a/packages/components/src/toolbar-group/style.scss
+++ b/packages/components/src/toolbar-group/style.scss
@@ -50,7 +50,7 @@ div.components-toolbar {
 			display: inline-block;
 			content: "";
 			box-sizing: content-box;
-			background-color: $gray-200;
+			background-color: $gray-300;
 			position: absolute;
 			top: 8px;
 			left: -3px;

--- a/packages/components/src/visually-hidden/style.scss
+++ b/packages/components/src/visually-hidden/style.scss
@@ -13,7 +13,7 @@
 }
 
 .components-visually-hidden:focus {
-	background-color: $gray-200;
+	background-color: $gray-300;
 	clip: auto !important;
 	clip-path: none;
 	color: #444;

--- a/packages/edit-navigation/src/components/editor/style.scss
+++ b/packages/edit-navigation/src/components/editor/style.scss
@@ -19,12 +19,12 @@
 }
 
 .edit-navigation-editor__list-view {
-	border-top: 1px solid $gray-200;
+	border-top: 1px solid $gray-300;
 	margin-top: $grid-unit-20;
 	padding-top: $grid-unit-20;
 
 	@include break-medium() {
-		border-left: 1px solid $gray-200;
+		border-left: 1px solid $gray-300;
 		border-top: none;
 		margin-left: $grid-unit-20;
 		margin-top: 0;

--- a/packages/edit-navigation/src/components/toolbar/style.scss
+++ b/packages/edit-navigation/src/components/toolbar/style.scss
@@ -1,7 +1,7 @@
 .edit-navigation-toolbar {
 	align-items: center;
 	background: $white;
-	border: $border-width solid $gray-200;
+	border: $border-width solid $gray-300;
 	display: flex;
 	height: $grid-unit-60 * 2;
 	padding-bottom: $grid-unit-60;
@@ -25,7 +25,7 @@
 	border-bottom: none;
 	border-left: none;
 	border-right: none;
-	border-top: 1px solid $gray-200;
+	border-top: 1px solid $gray-300;
 	position: absolute;
 	top: $grid-unit-60;
 	width: 100%;

--- a/packages/edit-post/src/components/header/header-toolbar/style.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.scss
@@ -56,7 +56,7 @@
 	left: 0;
 	right: 0;
 	background: $white;
-	border-bottom: $border-width solid $gray-200;
+	border-bottom: $border-width solid $gray-300;
 
 	&:empty {
 		display: none;
@@ -93,7 +93,7 @@
 		}
 
 		.block-editor-block-toolbar {
-			border-left: $border-width solid $gray-200;
+			border-left: $border-width solid $gray-300;
 		}
 
 		.block-editor-block-toolbar .components-toolbar-group,
@@ -122,7 +122,7 @@
 			top: $header-height + $border-width;
 			left: 0;
 			right: 0;
-			border-bottom: $border-width solid $gray-200;
+			border-bottom: $border-width solid $gray-300;
 			padding: 0;
 			background-color: $white;
 

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/style.scss
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/style.scss
@@ -17,11 +17,11 @@
 		display: flex;
 		align-items: baseline;
 		padding: 0.6rem 0;
-		border-top: 1px solid $gray-200;
+		border-top: 1px solid $gray-300;
 		margin-bottom: 0;
 
 		&:last-child {
-			border-bottom: 1px solid $gray-200;
+			border-bottom: 1px solid $gray-300;
 		}
 
 		&:empty {

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -2,7 +2,7 @@
 	flex-shrink: 0;
 }
 .edit-post-layout__metaboxes:not(:empty) {
-	border-top: $border-width solid $gray-200;
+	border-top: $border-width solid $gray-300;
 	padding: 10px 0 10px;
 	clear: both;
 
@@ -35,7 +35,7 @@
 		top: $admin-bar-height;
 		left: auto;
 		width: $sidebar-width + $border-width;
-		border-left: $border-width solid $gray-200;
+		border-left: $border-width solid $gray-300;
 		transform: translateX(+100%);
 		animation: edit-post-post-publish-panel__slide-in-animation 0.1s forwards;
 		@include reduce-motion("animation");
@@ -78,7 +78,7 @@
 	right: 0;
 	width: $sidebar-width;
 	background-color: $white;
-	border: 1px dotted $gray-200;
+	border: 1px dotted $gray-300;
 	height: auto !important; // Need to override the default sidebar positionnings
 	padding: $grid-unit-30;
 	display: flex;

--- a/packages/edit-post/src/components/manage-blocks-modal/style.scss
+++ b/packages/edit-post/src/components/manage-blocks-modal/style.scss
@@ -46,7 +46,7 @@
 }
 
 .edit-post-manage-blocks-modal__disabled-blocks-count {
-	border-top: 1px solid $gray-200;
+	border-top: 1px solid $gray-300;
 	margin-left: -$grid-unit-30;
 	margin-right: -$grid-unit-30;
 	padding-top: 0.6rem;
@@ -88,10 +88,10 @@
 .edit-post-manage-blocks-modal__checklist-item {
 	margin-bottom: 0;
 	padding-left: $grid-unit-20;
-	border-top: 1px solid $gray-200;
+	border-top: 1px solid $gray-300;
 
 	&:last-child {
-		border-bottom: 1px solid $gray-200;
+		border-bottom: 1px solid $gray-300;
 	}
 
 	.components-base-control__field {
@@ -125,5 +125,5 @@
 	margin-right: -$grid-unit-30;
 	padding-left: $grid-unit-30;
 	padding-right: $grid-unit-30;
-	border-top: $border-width solid $gray-200;
+	border-top: $border-width solid $gray-300;
 }

--- a/packages/edit-post/src/components/meta-boxes/meta-boxes-area/style.scss
+++ b/packages/edit-post/src/components/meta-boxes/meta-boxes-area/style.scss
@@ -46,7 +46,7 @@
 	}
 
 	.postbox > .inside {
-		border-bottom: $border-width solid $gray-200;
+		border-bottom: $border-width solid $gray-300;
 		color: inherit;
 		padding: 0 $block-padding $block-padding;
 		margin: 0;

--- a/packages/edit-post/src/components/options-modal/style.scss
+++ b/packages/edit-post/src/components/options-modal/style.scss
@@ -9,10 +9,10 @@
 	}
 
 	&__option {
-		border-top: 1px solid $gray-200;
+		border-top: 1px solid $gray-300;
 
 		&:last-child {
-			border-bottom: 1px solid $gray-200;
+			border-bottom: 1px solid $gray-300;
 		}
 
 		.components-base-control__field {

--- a/packages/edit-site/src/components/editor/style.scss
+++ b/packages/edit-site/src/components/editor/style.scss
@@ -7,7 +7,7 @@
 	right: 0;
 	width: $sidebar-width;
 	background-color: $white;
-	border: 1px dotted $gray-200;
+	border: 1px dotted $gray-300;
 	height: auto !important; // Need to override the default sidebar positioning
 	padding: $grid-unit-30;
 	display: flex;

--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -106,7 +106,7 @@
 	left: 0;
 	right: 0;
 	background: $white;
-	border-bottom: $border-width solid $gray-200;
+	border-bottom: $border-width solid $gray-300;
 
 	&:empty {
 		display: none;
@@ -143,7 +143,7 @@
 		}
 
 		.block-editor-block-toolbar {
-			border-left: $border-width solid $gray-200;
+			border-left: $border-width solid $gray-300;
 		}
 
 		.block-editor-block-toolbar .components-toolbar-group,

--- a/packages/edit-widgets/src/blocks/legacy-widget/editor.scss
+++ b/packages/edit-widgets/src/blocks/legacy-widget/editor.scss
@@ -26,7 +26,7 @@
 }
 
 .wp-block-legacy-widget__edit-widget-title {
-	background: $gray-200;
+	background: $gray-300;
 	color: $gray-900;
 	font-family: $default-font;
 	font-size: $default-font-size;

--- a/packages/edit-widgets/src/components/customizer-edit-widgets-initializer/style.scss
+++ b/packages/edit-widgets/src/components/customizer-edit-widgets-initializer/style.scss
@@ -2,7 +2,7 @@
 	position: relative;
 	.edit-widgets-header {
 		margin-top: -16px;
-		border-top: 1px solid $gray-200;
+		border-top: 1px solid $gray-300;
 	}
 
 	.edit-widgets-header,

--- a/packages/edit-widgets/src/components/header/style.scss
+++ b/packages/edit-widgets/src/components/header/style.scss
@@ -37,6 +37,6 @@
 }
 
 .edit-widgets-header__block-toolbar {
-	border-bottom: 1px solid $gray-200;
-	border-top: 1px solid $gray-200;
+	border-bottom: 1px solid $gray-300;
+	border-top: 1px solid $gray-300;
 }

--- a/packages/edit-widgets/src/components/sidebar/style.scss
+++ b/packages/edit-widgets/src/components/sidebar/style.scss
@@ -90,9 +90,9 @@
 
 	li {
 		margin: 0;
-		border-bottom: $border-width solid $gray-200;
+		border-bottom: $border-width solid $gray-300;
 		&:first-child {
-			border-top: $border-width solid $gray-200;
+			border-top: $border-width solid $gray-300;
 		}
 
 		button {

--- a/packages/editor/src/components/document-outline/style.scss
+++ b/packages/editor/src/components/document-outline/style.scss
@@ -16,7 +16,7 @@
 	}
 
 	.document-outline__emdash::before {
-		color: $gray-200;
+		color: $gray-300;
 		margin-right: 4px;
 	}
 
@@ -66,7 +66,7 @@
 }
 
 .document-outline__level {
-	background: $gray-200;
+	background: $gray-300;
 	color: $gray-900;
 	border-radius: 3px;
 	font-size: $default-font-size;

--- a/packages/editor/src/components/entities-saved-states/style.scss
+++ b/packages/editor/src/components/entities-saved-states/style.scss
@@ -22,7 +22,7 @@
 		top: $admin-bar-height;
 		left: auto;
 		width: $sidebar-width;
-		border-left: $border-width solid $gray-200;
+		border-left: $border-width solid $gray-300;
 
 		body.is-fullscreen-mode & {
 			top: 0;
@@ -41,7 +41,7 @@
 		padding-left: $grid-unit-10;
 		padding-right: $grid-unit-10;
 		height: $header-height + $border-width;
-		border-bottom: $border-width solid $gray-200;
+		border-bottom: $border-width solid $gray-300;
 		display: flex;
 		align-items: center;
 		align-content: space-between;
@@ -57,7 +57,7 @@
 	}
 
 	.entities-saved-states__text-prompt {
-		border-bottom: $border-width solid $gray-200;
+		border-bottom: $border-width solid $gray-300;
 		padding: $grid-unit-20;
 		padding-bottom: $grid-unit-05;
 	}

--- a/packages/editor/src/components/post-featured-image/style.scss
+++ b/packages/editor/src/components/post-featured-image/style.scss
@@ -55,7 +55,7 @@
 	text-align: center;
 
 	&:hover {
-		background: $gray-200;
+		background: $gray-300;
 		color: $gray-900;
 	}
 }

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -95,7 +95,7 @@
 }
 
 .post-publish-panel__postpublish .components-panel__body {
-	border-bottom: $border-width solid $gray-100;
+	border-bottom: $border-width solid $gray-200;
 	border-top: none;
 }
 

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -17,7 +17,7 @@
 	padding-left: $grid-unit-20;
 	padding-right: $grid-unit-20;
 	height: $header-height + $border-width;
-	border-bottom: $border-width solid $gray-200;
+	border-bottom: $border-width solid $gray-300;
 	display: flex;
 	align-items: center;
 	align-content: space-between;
@@ -129,7 +129,7 @@
 
 	input[readonly] {
 		padding: 10px;
-		background: $gray-200;
+		background: $gray-300;
 		overflow: hidden;
 		text-overflow: ellipsis;
 	}

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -97,20 +97,20 @@ html.interface-interface-skeleton__html-container {
 .interface-interface-skeleton__sidebar {
 	@include break-medium() {
 		overflow: auto;
-		border-left: $border-width solid $gray-100;
+		border-left: $border-width solid $gray-200;
 	}
 }
 
 .interface-interface-skeleton__left-sidebar {
 	@include break-medium() {
-		border-right: $border-width solid $gray-100;
+		border-right: $border-width solid $gray-200;
 	}
 }
 
 .interface-interface-skeleton__header {
 	flex-shrink: 0;
 	height: auto;  // Keep the height flexible.
-	border-bottom: $border-width solid $gray-100;
+	border-bottom: $border-width solid $gray-200;
 	z-index: z-index(".interface-interface-skeleton__header");
 	color: $gray-900;
 
@@ -128,7 +128,7 @@ html.interface-interface-skeleton__html-container {
 .interface-interface-skeleton__footer {
 	height: auto; // Keep the height flexible.
 	flex-shrink: 0;
-	border-top: $border-width solid $gray-100;
+	border-top: $border-width solid $gray-200;
 	color: $gray-900;
 
 	// On Mobile the footer is hidden

--- a/storybook/stories/playground/style.scss
+++ b/storybook/stories/playground/style.scss
@@ -34,7 +34,7 @@
 	right: 0;
 	bottom: 0;
 	width: $sidebar-width;
-	border-left: $border-width solid $gray-200;
+	border-left: $border-width solid $gray-300;
 	height: auto;
 	overflow: auto;
 	-webkit-overflow-scrolling: touch;


### PR DESCRIPTION
This PR does two things:

1. It renames all current $gray-200 borderes to $gray-300 to better fit in the scale
2. It adds a new $gray-200 border that is darker than 100 but lighter than 300.

This affords the gray-100 to be used for light background colors, the gray-200 to be used for light borders, and gray-300 for most borders.

Before:

<img width="1432" alt="borders before" src="https://user-images.githubusercontent.com/1204802/93750309-9138c000-fbfb-11ea-8d78-d1fbdd8c7f2b.png">

After:

<img width="1432" alt="Screenshot 2020-09-21 at 11 09 51" src="https://user-images.githubusercontent.com/1204802/93750319-939b1a00-fbfb-11ea-9bc2-73fd0468b6fd.png">
