### PR TITLE
Fix React error in @wordpress/block-editor docs usage example caused by applying args to setState call

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -112,7 +112,7 @@ _Related_
 
 _Parameters_
 
--   _props_ `BlockContextProviderProps`:
+-   _props_ `BlockContextProviderProps`: 
 
 <a name="BlockControls" href="#BlockControls">#</a> **BlockControls**
 
@@ -199,7 +199,7 @@ _Usage_
 
 _Parameters_
 
--   _props_ `Object`:
+-   _props_ `Object`: 
 -   _props.clientId_ `string`: Client ID of block.
 
 _Returns_
@@ -512,7 +512,7 @@ _Related_
 
 _Type_
 
--   `Object`
+-   `Object` 
 
 <a name="ToolSelector" href="#ToolSelector">#</a> **ToolSelector**
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -30,8 +30,8 @@ function MyEditorComponent () {
 	return (
 		<BlockEditorProvider
 			value={ blocks }
-			onInput={ updateBlocks }
-			onChange={ updateBlocks }
+			onInput={ ( blocks ) => updateBlocks( blocks ) }
+			onChange={ ( blocks ) => updateBlocks( blocks ) }
 		>
 			<SlotFillProvider>
 				<Popover.Slot name="block-toolbar" />
@@ -112,7 +112,7 @@ _Related_
 
 _Parameters_
 
--   _props_ `BlockContextProviderProps`: 
+-   _props_ `BlockContextProviderProps`:
 
 <a name="BlockControls" href="#BlockControls">#</a> **BlockControls**
 
@@ -199,7 +199,7 @@ _Usage_
 
 _Parameters_
 
--   _props_ `Object`: 
+-   _props_ `Object`:
 -   _props.clientId_ `string`: Client ID of block.
 
 _Returns_
@@ -512,7 +512,7 @@ _Related_
 
 _Type_
 
--   `Object` 
+-   `Object`
 
 <a name="ToolSelector" href="#ToolSelector">#</a> **ToolSelector**
 


### PR DESCRIPTION
Fix for https://github.com/WordPress/gutenberg/issues/25333

This updates the documented usage example for the `@wordpress/block-editor` docs to avoid showing the following error in the console

> Warning: State updates from the useState() and useReducer() Hooks don't support the second callback 

This is happening because `onInput` and `onChange` handlers are called with x2 args:

1. Blocks
2. Selection ranges.

Supplying the `useState` hook's update handler (ie: `updateBlocks`) as the callback causes it to be called with the **two arguments applied to it**. Unfortunately `useState` only expects **a single argument** which results in the error shown above.

This PR updates to docs to use an arrow function to ensure only a single argument is passed to the `setState` call which fixes the error. We could get fancy with partial application but for the purposes of documentation, a wrapper function is probably the easiest to understand.


## How has this been tested?
You can verify two args are provided to `onInput` and `onChange` in the associated tests for the relevant components:

https://github.com/WordPress/gutenberg/blob/f12c56320b7123ffb36cd3af713f9bf551b809fc/packages/block-editor/src/components/provider/test/use-block-sync.js#L237-L239

Other than that you'd have to test up a test environment which I haven't had the chance to do.


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
