### PR TITLE
Navigation component: Add color to menu and group title

### DIFF
--- a/packages/components/src/navigation/styles/navigation-styles.js
+++ b/packages/components/src/navigation/styles/navigation-styles.js
@@ -50,14 +50,14 @@ export const MenuBackButtonUI = styled( Button )`
 export const MenuTitleUI = styled( Text )`
 	padding: 4px 0 4px 16px;
 	margin-bottom: 8px;
-	color: #f0f0f0;
+	color: ${ G2.gray[ 100 ] };
 `;
 
 export const GroupTitleUI = styled( Text )`
 	margin-top: 8px;
 	padding: 4px 0 4px 16px;
 	text-transform: uppercase;
-	color: #f0f0f0;
+	color: ${ G2.gray[ 100 ] };
 `;
 
 export const ItemUI = styled.li`

--- a/packages/components/src/navigation/styles/navigation-styles.js
+++ b/packages/components/src/navigation/styles/navigation-styles.js
@@ -50,12 +50,14 @@ export const MenuBackButtonUI = styled( Button )`
 export const MenuTitleUI = styled( Text )`
 	padding: 4px 0 4px 16px;
 	margin-bottom: 8px;
+	color: #f0f0f0;
 `;
 
 export const GroupTitleUI = styled( Text )`
 	margin-top: 8px;
 	padding: 4px 0 4px 16px;
 	text-transform: uppercase;
+	color: #f0f0f0;
 `;
 
 export const ItemUI = styled.li`


### PR DESCRIPTION
## Description
Add `color` property to `MenuTitleUi` and `GroupTitleUi` to make them more specific.

See https://github.com/WordPress/gutenberg/pull/25506

## Types of changes
Bug Fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
