### PR TITLE
Simplify the generation of CSS variables in theme.json

### DIFF
--- a/docs/designers-developers/developers/themes/theme-json.md
+++ b/docs/designers-developers/developers/themes/theme-json.md
@@ -96,7 +96,8 @@ The settings section has the following structure and default values:
         "customLineHeight": false, /* true to opt-in, as in add_theme_support( 'custom-line-height' ) */
         "dropCap": true, /* false to opt-out */
         "fontSizes": [ ... ], /* font size presets, as in add_theme_support('editor-font-sizes', ... ) */
-      }
+      },
+      "custom": { ... }
     }
   }
 }
@@ -189,6 +190,42 @@ The output to be enqueued will be:
 ```
 
 The goal is that presets can be defined using this format, although, right now, the name property (used in the editor) can't be translated from this file. For that reason, and to maintain backward compatibility, the presets declared via `add_theme_support` will also generate the CSS Custom Properties. If the `experimental-theme.json` contains any presets, these will take precedence over the ones declared via `add_theme_support`.
+
+### Theme-only CSS Custom Properties
+
+Besides the presets becoming CSS Custom Properties, the theme.json also allows for themes to create their own, so they don't have to be enqueued separately. Any values declared within the `settings.custom` section will be transformed to CSS Custom Properties following this naming schema: `--wp--theme--<variable-name>`.
+
+For example, for this input:
+
+```json
+{
+  "global": {
+    "settings": {
+      "custom": {
+        "base-font": 16,
+        "line-height": {
+          "small": 1.2,
+          "medium": 1.4,
+          "large": 1.8
+        }
+      }
+    }
+  }
+}
+```
+
+The output will be:
+
+```css
+:root {
+  --wp--theme--base-font: 16;
+  --wp--theme--line-height--small: 1.2;
+  --wp--theme--line-height--medium: 1.4;
+  --wp--theme--line-height--large: 1.8;
+}
+```
+
+Note that, the name of the variable is created by adding `--` in between each nesting level.
 
 ### Styles
 

--- a/lib/experimental-default-theme.json
+++ b/lib/experimental-default-theme.json
@@ -3,128 +3,32 @@
 		"settings": {
 			"color": {
 				"palette": [
-					{
-						"name": "Black",
-						"slug": "black",
-						"color": "#000000"
-					},
-					{
-						"name": "Cyan bluish gray",
-						"slug": "cyan-bluish-gray",
-						"color": "#abb8c3"
-					},
-					{
-						"name": "White",
-						"slug": "white",
-						"color": "#ffffff"
-					},
-					{
-						"name": "Pale pink",
-						"slug": "pale-pink",
-						"color": "#f78da7"
-					},
-					{
-						"name": "Vivid red",
-						"slug": "vivid-red",
-						"color": "#cf2e2e"
-					},
-					{
-						"name": "Luminous vivid orange",
-						"slug": "luminous-vivid-orange",
-						"color": "#ff6900"
-					},
-					{
-						"name": "Luminous vivid amber",
-						"slug": "luminous-vivid-amber",
-						"color": "#fcb900"
-					},
-					{
-						"name": "Light green cyan",
-						"slug": "light-green-cyan",
-						"color": "#7bdcb5"
-					},
-					{
-						"name": "Vivid green cyan",
-						"slug": "vivid-green-cyan",
-						"color": "#00d084"
-					},
-					{
-						"name": "Pale cyan blue",
-						"slug": "pale-cyan-blue",
-						"color": "#8ed1fc"
-					},
-					{
-						"name": "Vivid cyan blue",
-						"slug": "vivid-cyan-blue",
-						"color": "#0693e3"
-					},
-					{
-						"name": "Vivid purple",
-						"slug": "vivid-purple",
-						"color": "#9b51e0"
-					}
+					"black",
+					"cyan-bluish-gray",
+					"white",
+					"pale-pink",
+					"vivid-red",
+					"luminous-vivid-orange",
+					"luminous-vivid-amber",
+					"light-green-cyan",
+					"vivid-green-cyan",
+					"pale-cyan-blue",
+					"vivid-cyan-blue",
+					"vivid-purple"
 				],
 				"gradients": [
-					{
-						"name": "Vivid cyan blue to vivid purple",
-						"gradient": "linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)",
-						"slug": "vivid-cyan-blue-to-vivid-purple"
-					},
-					{
-						"name": "Light green cyan to vivid green cyan",
-						"gradient": "linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%)",
-						"slug": "light-green-cyan-to-vivid-green-cyan"
-					},
-					{
-						"name": "Luminous vivid amber to luminous vivid orange",
-						"gradient": "linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%)",
-						"slug": "luminous-vivid-amber-to-luminous-vivid-orange"
-					},
-					{
-						"name": "Luminous vivid orange to vivid red",
-						"gradient": "linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%)",
-						"slug": "luminous-vivid-orange-to-vivid-red"
-					},
-					{
-						"name": "Very light gray to cyan bluish gray",
-						"gradient": "linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%)",
-						"slug": "very-light-gray-to-cyan-bluish-gray"
-					},
-					{
-						"name": "Cool to warm spectrum",
-						"gradient": "linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%)",
-						"slug": "cool-to-warm-spectrum"
-					},
-					{
-						"name": "Blush light purple",
-						"gradient": "linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%)",
-						"slug": "blush-light-purple"
-					},
-					{
-						"name": "Blush bordeaux",
-						"gradient": "linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%)",
-						"slug": "blush-bordeaux"
-					},
-					{
-						"name": "Luminous dusk",
-						"gradient": "linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%)",
-						"slug": "luminous-dusk"
-					},
-					{
-						"name": "Pale ocean",
-						"gradient": "linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%)",
-						"slug": "pale-ocean"
-					},
-					{
-						"name": "Electric grass",
-						"gradient": "linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%)",
-						"slug": "electric-grass"
-					},
-					{
-						"name": "Midnight",
-						"gradient": "linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%)",
-						"slug": "midnight"
-					}
+					"vivid-cyan-blue-to-vivid-purple",
+					"light-green-cyan-to-vivid-green-cyan",
+					"luminous-vivid-amber-to-luminous-vivid-orange",
+					"luminous-vivid-orange-to-vivid-red",
+					"very-light-gray-to-cyan-bluish-gray",
+					"cool-to-warm-spectrum",
+					"blush-light-purple",
+					"blush-bordeaux",
+					"luminous-dusk",
+					"pale-ocean",
+					"electric-grass",
+					"midnight"
 				],
 				"custom": true,
 				"link": false,
@@ -134,32 +38,48 @@
 				"dropCap": true,
 				"customFontSize": true,
 				"customLineHeight": false,
-				"fontSizes": [
-					{
-						"slug": "small",
-						"size": 13
-					},
-					{
-						"slug": "normal",
-						"size": 16
-					},
-					{
-						"slug": "medium",
-						"size": 20
-					},
-					{
-						"slug": "large",
-						"size": 36
-					},
-					{
-						"slug": "huge",
-						"size": 48
-					}
-				]
+				"fontSizes": [ "small", "normal", "medium", "large", "huge" ]
 			},
 			"spacing": {
 				"customPadding": false,
 				"units": [ "px", "em", "rem", "vh", "vw" ]
+			}
+		},
+		"vars": {
+			"color": {
+				"black": "#000000",
+				"white": "#ffffff",
+				"cyan-bluish-gray": "#abb8c3",
+				"pale-pink": "#f78da7",
+				"vivid-red": "#cf2e2e",
+				"luminous-vivid-orange": "#ff6900",
+				"luminous-vivid-amber": "#fcb900",
+				"light-green-cyan": "#7bdcb5",
+				"vivid-green-cyan": "#00d084",
+				"pale-cyan-blue": "#8ed1fc",
+				"vivid-cyan-blue": "#0693e3",
+				"vivid-purple": "#9b51e0"
+			},
+			"gradient": {
+				"vivid-cyan-blue-to-vivid-purple": "linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)",
+				"light-green-cyan-to-vivid-green-cyan": "linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%)",
+				"luminous-vivid-amber-to-luminous-vivid-orange": "linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%)",
+				"luminous-vivid-orange-to-vivid-red": "linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%)",
+				"very-light-gray-to-cyan-bluish-gray": "linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%)",
+				"cool-to-warm-spectrum": "linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%)",
+				"blush-light-purple": "linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%)",
+				"blush-bordeaux": "linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%)",
+				"luminous-dusk": "linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%)",
+				"pale-ocean": "linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%)",
+				"electric-grass": "linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%)",
+				"midnight": "linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%)"
+			},
+			"font-size": {
+				"small": 13,
+				"normal": 16,
+				"medium": 20,
+				"large": 36,
+				"huge": 48
 			}
 		}
 	}

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -597,7 +597,7 @@ function gutenberg_experimental_global_styles_get_stylesheet( $tree ) {
 
 		// Create the CSS Custom Properties that are specific to the theme.
 		$computed_theme_props = gutenberg_experimental_get( $tree[ $block_name ]['settings'], ['custom'] );
-		$theme_props_prefix   = '--wp--theme' . $token;
+		$theme_props_prefix   = '--wp--custom' . $token;
 		$theme_variables      = gutenberg_experimental_global_styles_get_css_vars(
 			$computed_theme_props,
 			$theme_props_prefix,

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -692,7 +692,6 @@ function gutenberg_experimental_global_styles_normalize_schema( $tree ) {
 		),
 		'settings' => array(
 			'color'      => array(),
-			'custom'     => array(),
 			'typography' => array(),
 			'spacing'    => array(),
 		),

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -578,11 +578,9 @@ function gutenberg_experimental_global_styles_get_stylesheet( $tree ) {
 			continue;
 		}
 
-		$presets_structure = gutenberg_experimental_global_styles_get_presets_structure();
-
+		// Create the CSS Custom Properties for the presets.
 		$computed_presets = array();
-
-		// Extract the relevant preset info before converting them to CSS Custom Properties.
+		$presets_structure = gutenberg_experimental_global_styles_get_presets_structure();
 		foreach ( $presets_structure as $token => $preset_meta ) {
 			$block_preset = gutenberg_experimental_get( $tree[ $block_name ]['settings'], $preset_meta['path'] );
 			if ( ! empty( $block_preset ) ) {
@@ -593,17 +591,26 @@ function gutenberg_experimental_global_styles_get_stylesheet( $tree ) {
 				}
 			}
 		}
+		$token            = '--';
+		$preset_prefix    = '--wp--preset' . $token;
+		$preset_variables = gutenberg_experimental_global_styles_get_css_vars( $computed_presets, $preset_prefix, $token );
 
-		$token         = '--';
-		$prefix        = '--wp--preset' . $token;
-		$css_variables = gutenberg_experimental_global_styles_get_css_vars( $computed_presets, $prefix, $token );
+		// Create the CSS Custom Properties that are specific to the theme.
+		$computed_theme_props = gutenberg_experimental_get( $tree[ $block_name ]['settings'], ['custom'] );
+		$theme_props_prefix   = '--wp--theme' . $token;
+		$theme_variables      = gutenberg_experimental_global_styles_get_css_vars(
+			$computed_theme_props,
+			$theme_props_prefix,
+			$token
+		);
 
 		$stylesheet .= gutenberg_experimental_global_styles_resolver_styles(
 			$block_data[ $block_name ]['selector'],
 			$block_data[ $block_name ]['supports'],
 			array_merge(
 				gutenberg_experimental_global_styles_flatten_styles_tree( $tree[ $block_name ]['styles'] ),
-				$css_variables
+				$preset_variables,
+				$theme_variables
 			)
 		);
 	}
@@ -719,6 +726,7 @@ function gutenberg_experimental_global_styles_normalize_schema( $tree ) {
 		),
 		'settings' => array(
 			'color'      => array(),
+			'custom'     => array(),
 			'typography' => array(),
 			'spacing'    => array(),
 		),

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -203,11 +203,11 @@ function gutenberg_experimental_global_styles_get_core() {
 		'vivid-purple'          => __( 'Vivid purple', 'gutenberg' ),
 	);
 
-	if ( ! empty( $config['global']['settings']['color']['palette'] ) ) {
-		foreach ( $config['global']['settings']['color']['palette'] as &$color ) {
-			$color['name'] = $default_colors_i18n[ $color['slug'] ];
-		}
-	}
+	// if ( ! empty( $config['global']['settings']['color']['palette'] ) ) {
+	// 	foreach ( $config['global']['settings']['color']['palette'] as &$color ) {
+	// 		$color['name'] = $default_colors_i18n[ $color['slug'] ];
+	// 	}
+	// }
 
 	$default_gradients_i18n = array(
 		'vivid-cyan-blue-to-vivid-purple'               => __( 'Vivid cyan blue to vivid purple', 'gutenberg' ),
@@ -224,11 +224,11 @@ function gutenberg_experimental_global_styles_get_core() {
 		'midnight'                                      => __( 'Midnight', 'gutenberg' ),
 	);
 
-	if ( ! empty( $config['global']['settings']['color']['gradients'] ) ) {
-		foreach ( $config['global']['settings']['color']['gradients'] as &$gradient ) {
-			$gradient['name'] = $default_gradients_i18n[ $gradient['slug'] ];
-		}
-	}
+	// if ( ! empty( $config['global']['settings']['color']['gradients'] ) ) {
+	// 	foreach ( $config['global']['settings']['color']['gradients'] as &$gradient ) {
+	// 		$gradient['name'] = $default_gradients_i18n[ $gradient['slug'] ];
+	// 	}
+	// }
 	// End i18n logic to remove when JSON i18 strings are extracted.
 	return $config;
 }
@@ -406,28 +406,6 @@ function gutenberg_experimental_global_styles_get_support_keys() {
 }
 
 /**
- * Returns how the presets css variables are structured on the global styles data.
- *
- * @return array Presets structure
- */
-function gutenberg_experimental_global_styles_get_presets_structure() {
-	return array(
-		'color'    => array(
-			'path' => array( 'color', 'palette' ),
-			'key'  => 'color',
-		),
-		'gradient' => array(
-			'path' => array( 'color', 'gradients' ),
-			'key'  => 'gradient',
-		),
-		'fontSize' => array(
-			'path' => array( 'typography', 'fontSizes' ),
-			'key'  => 'size',
-		),
-	);
-}
-
-/**
  * Returns the style features a particular block supports.
  *
  * @param array $supports The block supports array.
@@ -578,29 +556,11 @@ function gutenberg_experimental_global_styles_get_stylesheet( $tree ) {
 			continue;
 		}
 
-		// Create the CSS Custom Properties for the presets.
-		$computed_presets  = array();
-		$presets_structure = gutenberg_experimental_global_styles_get_presets_structure();
-		foreach ( $presets_structure as $token => $preset_meta ) {
-			$block_preset = gutenberg_experimental_get( $tree[ $block_name ]['settings'], $preset_meta['path'] );
-			if ( ! empty( $block_preset ) ) {
-				$css_var_token                      = gutenberg_experimental_global_styles_get_css_property( $token );
-				$computed_presets[ $css_var_token ] = array();
-				foreach ( $block_preset as $preset_value ) {
-					$computed_presets[ $css_var_token ][ $preset_value['slug'] ] = $preset_value[ $preset_meta['key'] ];
-				}
-			}
-		}
 		$token            = '--';
-		$preset_prefix    = '--wp--preset' . $token;
-		$preset_variables = gutenberg_experimental_global_styles_get_css_vars( $computed_presets, $preset_prefix, $token );
-
-		// Create the CSS Custom Properties that are specific to the theme.
-		$computed_theme_props = gutenberg_experimental_get( $tree[ $block_name ]['settings'], array( 'custom' ) );
-		$theme_props_prefix   = '--wp--custom' . $token;
-		$theme_variables      = gutenberg_experimental_global_styles_get_css_vars(
-			$computed_theme_props,
-			$theme_props_prefix,
+		$preset_prefix    = '--wp' . $token;
+		$preset_variables = gutenberg_experimental_global_styles_get_css_vars(
+			$tree[ $block_name ]['vars'],
+			$preset_prefix,
 			$token
 		);
 
@@ -609,8 +569,7 @@ function gutenberg_experimental_global_styles_get_stylesheet( $tree ) {
 			$block_data[ $block_name ]['supports'],
 			array_merge(
 				gutenberg_experimental_global_styles_flatten_styles_tree( $tree[ $block_name ]['styles'] ),
-				$preset_variables,
-				$theme_variables
+				$preset_variables
 			)
 		);
 	}
@@ -706,6 +665,13 @@ function gutenberg_experimental_global_styles_merge_trees( $core, $theme, $user 
 				$user[ $block_name ]['styles'][ $subtree ]
 			);
 		}
+		foreach ( array_keys( $core[ $block_name ]['vars'] ) as $subtree ) {
+			$result[ $block_name ]['vars'][ $subtree ] = array_merge(
+				$core[ $block_name ]['vars'][ $subtree ],
+				$theme[ $block_name ]['vars'][ $subtree ],
+				$user[ $block_name ]['vars'][ $subtree ]
+			);
+		}
 	}
 
 	return $result;
@@ -729,6 +695,12 @@ function gutenberg_experimental_global_styles_normalize_schema( $tree ) {
 			'custom'     => array(),
 			'typography' => array(),
 			'spacing'    => array(),
+		),
+		'vars' => array(
+			'color'       => array(),
+			'font-size'   => array(),
+			'line-height' => array(),
+			'gradient'    => array()
 		),
 	);
 

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -579,7 +579,7 @@ function gutenberg_experimental_global_styles_get_stylesheet( $tree ) {
 		}
 
 		// Create the CSS Custom Properties for the presets.
-		$computed_presets = array();
+		$computed_presets  = array();
 		$presets_structure = gutenberg_experimental_global_styles_get_presets_structure();
 		foreach ( $presets_structure as $token => $preset_meta ) {
 			$block_preset = gutenberg_experimental_get( $tree[ $block_name ]['settings'], $preset_meta['path'] );
@@ -596,7 +596,7 @@ function gutenberg_experimental_global_styles_get_stylesheet( $tree ) {
 		$preset_variables = gutenberg_experimental_global_styles_get_css_vars( $computed_presets, $preset_prefix, $token );
 
 		// Create the CSS Custom Properties that are specific to the theme.
-		$computed_theme_props = gutenberg_experimental_get( $tree[ $block_name ]['settings'], ['custom'] );
+		$computed_theme_props = gutenberg_experimental_get( $tree[ $block_name ]['settings'], array( 'custom' ) );
 		$theme_props_prefix   = '--wp--custom' . $token;
 		$theme_variables      = gutenberg_experimental_global_styles_get_css_vars(
 			$computed_theme_props,

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -765,7 +765,41 @@ function gutenberg_experimental_global_styles_get_editor_settings( $config ) {
 		} else {
 			$settings[ $context ] = $config[ $context ]['settings'];
 		}
+
+		// Adapt color presets to proper format
+		$settings[ $context ]['color']['palette'] = array();
+		$preset_colors = gutenberg_experimental_get( $config[ $context ], ['settings', 'color', 'palette'], [] );
+		foreach( $preset_colors as $preset_slug ) {
+			$settings[ $context ]['color']['palette'][] = array(
+				'name'  => $preset_slug, // TODO: fix i18n
+				'slug'  => $preset_slug,
+				'color' => $config[ $context ]['vars']['color'][ $preset_slug ],
+			);
+		}
+
+		// Adapt gradient presets to proper format
+		$settings[ $context ]['color']['gradients'] = array();
+		$preset_gradients = gutenberg_experimental_get( $config[ $context ], ['settings', 'color', 'gradients'], [] );
+		foreach( $preset_gradients as $preset_slug ) {
+			$settings[ $context ]['color']['gradients'][] = array(
+				'name'     => $preset_slug, // TODO: fix i18n
+				'slug'     => $preset_slug,
+				'gradient' => $config[ $context ]['vars']['gradient'][ $preset_slug ],
+			);
+		}
+
+		// Adapt font-size presets to proper format
+		$settings[ $context ]['typography']['fontSizes'] = array();
+		$preset_font_sizes = gutenberg_experimental_get( $config[ $context ], ['settings', 'color', 'palette'], [] );
+		foreach( $preset_font_sizes as $preset_slug ) {
+			$settings[ $context ]['typography']['fontSizes'][] = array(
+				'name' => $preset_slug, // TODO: fix i18n
+				'slug' => $preset_slug,
+				'size' => $config[ $context ]['vars']['font-size'][ $preset_slug ],
+			);
+		}
 	}
+
 	return $settings;
 }
 

--- a/packages/edit-site/src/components/editor/global-styles-renderer.js
+++ b/packages/edit-site/src/components/editor/global-styles-renderer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, kebabCase, reduce } from 'lodash';
+import { get, kebabCase } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -11,7 +11,7 @@ import { __EXPERIMENTAL_STYLE_PROPERTY as STYLE_PROPERTY } from '@wordpress/bloc
 /**
  * Internal dependencies
  */
-import { PRESET_CATEGORIES, LINK_COLOR_DECLARATION } from './utils';
+import { LINK_COLOR_DECLARATION } from './utils';
 
 const mergeTrees = ( baseData, userData ) => {
 	// Deep clone from base data.
@@ -75,31 +75,6 @@ export default ( blockData, baseTree, userTree ) => {
 		return declarations;
 	};
 
-	/**
-	 * Transform given preset tree into a set of style declarations.
-	 *
-	 * @param {Object} blockPresets
-	 *
-	 * @return {Array} An array of style declarations.
-	 */
-	const getBlockPresetsDeclarations = ( blockPresets ) => {
-		return reduce(
-			PRESET_CATEGORIES,
-			( declarations, { path, key }, category ) => {
-				const preset = get( blockPresets, path, [] );
-				preset.forEach( ( value ) => {
-					declarations.push(
-						`--wp--preset--${ kebabCase( category ) }--${
-							value.slug
-						}: ${ value[ key ] }`
-					);
-				} );
-				return declarations;
-			},
-			[]
-		);
-	};
-
 	const flattenTree = ( input, prefix, token ) => {
 		let result = [];
 		Object.keys( input ).forEach( ( key ) => {
@@ -119,14 +94,6 @@ export default ( blockData, baseTree, userTree ) => {
 		return result;
 	};
 
-	const getCustomDeclarations = ( blockCustom ) => {
-		if ( Object.keys( blockCustom ).length === 0 ) {
-			return [];
-		}
-
-		return flattenTree( blockCustom, '--wp--custom--', '--' );
-	};
-
 	const getBlockSelector = ( selector ) => {
 		// Can we hook into the styles generation mechanism
 		// so we can avoid having to increase the class specificity here
@@ -144,8 +111,7 @@ export default ( blockData, baseTree, userTree ) => {
 				blockData[ context ].supports,
 				tree[ context ].styles
 			),
-			...getBlockPresetsDeclarations( tree[ context ].settings ),
-			...getCustomDeclarations( tree[ context ].settings.custom ),
+			...flattenTree( baseTree[ context ].vars, '--wp--', '--' ),
 		];
 		if ( blockDeclarations.length > 0 ) {
 			styles.push(

--- a/packages/edit-site/src/components/editor/global-styles-renderer.js
+++ b/packages/edit-site/src/components/editor/global-styles-renderer.js
@@ -124,7 +124,7 @@ export default ( blockData, baseTree, userTree ) => {
 			return [];
 		}
 
-		return flattenTree( blockCustom, '--wp--theme--', '--' );
+		return flattenTree( blockCustom, '--wp--custom--', '--' );
 	};
 
 	const getBlockSelector = ( selector ) => {

--- a/packages/edit-site/src/components/editor/global-styles-renderer.js
+++ b/packages/edit-site/src/components/editor/global-styles-renderer.js
@@ -100,6 +100,33 @@ export default ( blockData, baseTree, userTree ) => {
 		);
 	};
 
+	const flattenTree = ( input, prefix, token ) => {
+		let result = [];
+		Object.keys( input ).forEach( ( key ) => {
+			const newKey = prefix + key.replace( '/', '-' );
+			const newLeaf = input[ key ];
+
+			if ( newLeaf instanceof Object ) {
+				const newPrefix = newKey + token;
+				result = [
+					...result,
+					...flattenTree( newLeaf, newPrefix, token ),
+				];
+			} else {
+				result.push( `${ newKey }: ${ newLeaf }` );
+			}
+		} );
+		return result;
+	};
+
+	const getCustomDeclarations = ( blockCustom ) => {
+		if ( Object.keys( blockCustom ).length === 0 ) {
+			return [];
+		}
+
+		return flattenTree( blockCustom, '--wp--theme--', '--' );
+	};
+
 	const getBlockSelector = ( selector ) => {
 		// Can we hook into the styles generation mechanism
 		// so we can avoid having to increase the class specificity here
@@ -118,6 +145,7 @@ export default ( blockData, baseTree, userTree ) => {
 				tree[ context ].styles
 			),
 			...getBlockPresetsDeclarations( tree[ context ].settings ),
+			...getCustomDeclarations( tree[ context ].settings.custom ),
 		];
 		if ( blockDeclarations.length > 0 ) {
 			styles.push(

--- a/packages/edit-site/src/components/editor/utils.js
+++ b/packages/edit-site/src/components/editor/utils.js
@@ -1,10 +1,5 @@
 /* Supporting data */
 export const GLOBAL_CONTEXT = 'global';
-export const PRESET_CATEGORIES = {
-	color: { path: [ 'color', 'palette' ], key: 'color' },
-	gradient: { path: [ 'color', 'gradients' ], key: 'gradient' },
-	fontSize: { path: [ 'typography', 'fontSizes' ], key: 'size' },
-};
 export const LINK_COLOR = '--wp--style--color--link';
 export const LINK_COLOR_DECLARATION = `a { color: var(${ LINK_COLOR }, #00e); }`;
 


### PR DESCRIPTION
This is a prototype to discuss an alternative to https://github.com/WordPress/gutenberg/pull/25446 It's not fully working, the goal is to provide a space for conversation. For reference, it may be useful to take a look at the full theme.json a theme would have to write https://github.com/nosolosw/global-styles-theme/pull/21

### Rationale

In looking at how some themes use CSS variables today, I've found a few things we should consider:

- They tend to have more CSS variables than preset categories. Ex: line-height, spacing, typescale, etc.
- For each preset category, some values are not available as a preset value, although it should be added as a CSS variable. Ex: a theme may have 5 colors as color palette, but then uses 12 CSS variables (including the presets).

Another thing we should consider is how presets can scale when we are able to define them within different contexts (at the moment, they can only be defined via the `global` context).

### Proposal

This PR experiments how we can do this differently by:

1. Removing the distinction between "presets" and "custom/free-form" CSS variables. It adds them all within a new `vars` section for each context (everything within this object will be converted to a CSS variable).

Input:

```
{
  "global": {
    "vars": {
      "color": {
        "primary": "#000000",
        "primary-hover": "#3C8067",
        "secondary": "#3C8067",
        "secondary-hover": "#336D58",
        "tertiary": "rgb(209, 207, 203)",
        "alert": {
          "success": "yellowgreen",
          "info": "skyblue",
          "warning": "gold",
          "error": "salmon"
        }
      },
      "type-scale": {
        "base": 16,
        "ratio": 1.2
      }
    }
  }
}
```

Output:

```css
--wp--color--primary: #000000;
--wp--color--primary-hover: #3C8067;
--wp--color--secondary: #3C8067;
--wp--color--secondary-hover: #336D58;
--wp--color--tertiary: rgb(209, 207, 203);
--wp--color--alert--success: yellowgreen;
--wp--color--alert--info: skyblue;
--wp--color--alert--warning: gold;
--wp--color--alert--error: salmon;
--wp--type-scale--base: 16;
--wp--type-scale--ratio: 1.2;
```

2. The theme declares the editor presets by passing only the slug. This simplifies all the book-keeping we have to do for processing presets and that is exposed in theme.json (slug, value, name). Creating presets for different contexts is also greatly simplified. Ex: 

```
{
  "global":{
    "settings": {
      "color": {
        "palette": [ "primary", "secondary", "tertiary", "background", "foreground" ]
      }
    }
  },
  "core/paragraph":{
    "settings": {
      "color": {
        "palette": [ "primary", "secondary", "tertiary" ]
      }
    }
  }
}
```

### Challenge: internationalization

When we offer presets per context, if we use today's structure we'd have something like this (note how the values and strings are repeated):

```json
{
  "global":{
    "settings": {
      "color": {
        "palette": [
            {
                "slug": "primary",
                "name": "Primary",
                "value": "#000000"
            },
            {
                "slug": "secondary",
                "name": "Secondary",
                "value": "#3C8067"
            },
            {
                "slug": "tertiary",
                "name": "Tertiary",
                "value": "rgb(209, 207, 203)"
            },
            {
                "slug": "background",
                "name": "Background",
                "value": "#FFFFFF"
            },
            {
                "slug": "foreground",
                "name": "Foreground",
                "value": "#333333"
            }
        ]
      }
    }
  },
  "core/paragraph":{
    "settings": {
      "color": {
        "palette": [
            {
                "slug": "primary",
                "name": "Primary",
                "value": "#000000"
            },
            {
                "slug": "secondary",
                "name": "Secondary",
                "value": "#3C8067"
            },
            {
                "slug": "tertiary",
                "name": "Tertiary",
                "value": "rgb(209, 207, 203)"
            }
        ]
      }
    }
  }
}
```

By absorbing the values of presets in the `vars` section we gain some simplicity. How would we deal with internationalization in this case?

**Option 1**. Use a key/value mapping, where the key is the slug and the value the string to internationalize. I like that this keeps things together where they are needed (i18n is only used in the presets).

```json
{
  "global":{
    "settings": {
      "color": {
        "palette": {
            "primary": "Primary",
            "secondary": "Secondary",
            "tertiary": "Tertiary",
            "background": "Background",
            "foreground": "Foreground"
        }
      }
    }
  },
  "core/paragraph":{
    "settings": {
      "color": {
        "palette": {
            "primary": "Primary",
            "secondary": "Secondary",
            "tertiary": "Tertiary"
        }
      }
    }
  }
}
```

**Option 2**. In the first option, there's still some repetition (string to internationalize). An alternative would be to centralize them as well. This breaks the collocation between the preset slug and the preset name but gives wp-cli a single stable key to look for strings (helping us to evolve the theme.json shape without the need for changes in wp-cli as well).

```json
{
  "global":{
    "settings": {
      "color": {
        "palette": [ "primary", "secondary", "tertiary", "background", "foreground" ],
        "i18n": {
          "primary": "Primary",
          "secondary": "Secondary",
          "tertiary": "Tertiary",
          "background": "Background",
          "foreground": "Foreground"
        }
      }
    }
  },
  "core/paragraph":{
    "settings": {
      "color": {
        "palette": [ "primary", "secondary", "tertiary" ]
      }
    }
  }
}
```