### PR TITLE
Fix typo: add_filter/apply_filters

### DIFF
--- a/lib/template-parts.php
+++ b/lib/template-parts.php
@@ -159,7 +159,7 @@ function filter_rest_wp_template_part_collection_params( $query_params ) {
 	);
 	return $query_params;
 }
-apply_filters( 'rest_wp_template_part_collection_params', 'filter_rest_wp_template_part_collection_params', 99, 1 );
+add_filter( 'rest_wp_template_part_collection_params', 'filter_rest_wp_template_part_collection_params', 99, 1 );
 
 /**
  * Filter for supporting the `resolved`, `template`, and `theme` parameters in `wp_template_part` queries.


### PR DESCRIPTION
## Description
In https://github.com/WordPress/gutenberg/pull/21851 there was a typo and instead of `add_filter` we used `apply_filters` on the `rest_wp_template_part_collection_params` hook.
This PR fixes that.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
