### PR TITLE
Block API: deprecate experimental Block.* component

### DIFF
--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -18,6 +18,7 @@ import { focus, isTextField, placeCaretAtHorizontalEdge } from '@wordpress/dom';
 import { ENTER, BACKSPACE, DELETE } from '@wordpress/keycodes';
 import { __, sprintf } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -286,14 +287,11 @@ export function useBlockWrapperProps( props = {}, { __unstableIsHtml } = {} ) {
 }
 
 const BlockComponent = forwardRef(
-	(
-		{ children, tagName: TagName = 'div', __unstableIsHtml, ...props },
-		ref
-	) => {
-		const blockWrapperProps = useBlockWrapperProps(
-			{ ...props, ref },
-			{ __unstableIsHtml }
-		);
+	( { children, tagName: TagName = 'div', ...props }, ref ) => {
+		deprecated( 'wp.blockEditor.__experimentalBlock', {
+			alternative: 'wp.blockEditor.__experimentalUseBlockWrapperProps',
+		} );
+		const blockWrapperProps = useBlockWrapperProps( { ...props, ref } );
 		return <TagName { ...blockWrapperProps }>{ children }</TagName>;
 	}
 );

--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -18,6 +18,7 @@ import { focus, isTextField, placeCaretAtHorizontalEdge } from '@wordpress/dom';
 import { ENTER, BACKSPACE, DELETE } from '@wordpress/keycodes';
 import { __, sprintf } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -287,6 +288,9 @@ export function useBlockWrapperProps( props = {}, { __unstableIsHtml } = {} ) {
 
 const BlockComponent = forwardRef(
 	( { children, tagName: TagName = 'div', ...props }, ref ) => {
+		deprecated( 'wp.blockEditor.__experimentalBlock', {
+			alternative: 'wp.blockEditor.__experimentalUseBlockWrapperProps',
+		} );
 		const blockWrapperProps = useBlockWrapperProps( { ...props, ref } );
 		return <TagName { ...blockWrapperProps }>{ children }</TagName>;
 	}

--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -18,7 +18,6 @@ import { focus, isTextField, placeCaretAtHorizontalEdge } from '@wordpress/dom';
 import { ENTER, BACKSPACE, DELETE } from '@wordpress/keycodes';
 import { __, sprintf } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
-import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -288,9 +287,6 @@ export function useBlockWrapperProps( props = {}, { __unstableIsHtml } = {} ) {
 
 const BlockComponent = forwardRef(
 	( { children, tagName: TagName = 'div', ...props }, ref ) => {
-		deprecated( 'wp.blockEditor.__experimentalBlock', {
-			alternative: 'wp.blockEditor.__experimentalUseBlockWrapperProps',
-		} );
 		const blockWrapperProps = useBlockWrapperProps( { ...props, ref } );
 		return <TagName { ...blockWrapperProps }>{ children }</TagName>;
 	}

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -40,7 +40,7 @@ import BlockInvalidWarning from './block-invalid-warning';
 import BlockCrashWarning from './block-crash-warning';
 import BlockCrashBoundary from './block-crash-boundary';
 import BlockHtml from './block-html';
-import { Block } from './block-wrapper';
+import { useBlockWrapperProps } from './block-wrapper';
 
 export const BlockListBlockContext = createContext();
 
@@ -66,6 +66,14 @@ function mergeWrapperProps( propsA, propsB ) {
 	}
 
 	return newProps;
+}
+
+function Block( { children, isHtml, ...props } ) {
+	return (
+		<div { ...useBlockWrapperProps( props, { __unstableIsHtml: isHtml } ) }>
+			{ children }
+		</div>
+	);
 }
 
 function BlockListBlock( {
@@ -219,10 +227,10 @@ function BlockListBlock( {
 
 	if ( ! isValid ) {
 		block = (
-			<Block.div>
+			<Block>
 				<BlockInvalidWarning clientId={ clientId } />
 				<div>{ getSaveElement( blockType, attributes ) }</div>
-			</Block.div>
+			</Block>
 		);
 	} else if ( mode === 'html' ) {
 		// Render blockEdit so the inspector controls don't disappear.
@@ -230,15 +238,15 @@ function BlockListBlock( {
 		block = (
 			<>
 				<div style={ { display: 'none' } }>{ blockEdit }</div>
-				<Block.div __unstableIsHtml>
+				<Block isHtml>
 					<BlockHtml clientId={ clientId } />
-				</Block.div>
+				</Block>
 			</>
 		);
 	} else if ( lightBlockWrapper ) {
 		block = blockEdit;
 	} else {
-		block = <Block.div { ...wrapperProps }>{ blockEdit }</Block.div>;
+		block = <Block { ...wrapperProps }>{ blockEdit }</Block>;
 	}
 
 	return (
@@ -247,9 +255,9 @@ function BlockListBlock( {
 				{ block }
 			</BlockCrashBoundary>
 			{ !! hasError && (
-				<Block.div>
+				<Block>
 					<BlockCrashWarning />
-				</Block.div>
+				</Block>
 			) }
 		</BlockListBlockContext.Provider>
 	);

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -80,8 +80,8 @@ function BlockList(
 
 	return (
 		<Container
-			{ ...__experimentalPassedProps }
 			ref={ ref }
+			{ ...__experimentalPassedProps }
 			className={ classnames(
 				'block-editor-block-list__layout',
 				className,

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -80,8 +80,8 @@ function BlockList(
 
 	return (
 		<Container
-			ref={ ref }
 			{ ...__experimentalPassedProps }
+			ref={ ref }
 			className={ classnames(
 				'block-editor-block-list__layout',
 				className,

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -11,7 +11,7 @@ import {
 	BlockControls,
 	BlockVerticalAlignmentToolbar,
 	InspectorControls,
-	__experimentalBlock as Block,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import { PanelBody, RangeControl } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -52,6 +52,10 @@ function ColumnEdit( {
 	};
 
 	const hasWidth = Number.isFinite( width );
+	const blockWrapperProps = useBlockWrapperProps( {
+		className: classes,
+		style: hasWidth ? { flexBasis: width + '%' } : undefined,
+	} );
 
 	return (
 		<>
@@ -83,15 +87,10 @@ function ColumnEdit( {
 			<InnerBlocks
 				templateLock={ false }
 				renderAppender={
-					hasChildBlocks
-						? undefined
-						: () => <InnerBlocks.ButtonBlockAppender />
+					hasChildBlocks ? undefined : InnerBlocks.ButtonBlockAppender
 				}
-				__experimentalTagName={ Block.div }
-				__experimentalPassedProps={ {
-					className: classes,
-					style: hasWidth ? { flexBasis: width + '%' } : undefined,
-				} }
+				__experimentalTagName="div"
+				__experimentalPassedProps={ blockWrapperProps }
 			/>
 		</>
 	);

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -11,7 +11,7 @@ import {
 	BlockControls,
 	BlockVerticalAlignmentToolbar,
 	InspectorControls,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+	__experimentalBlock as Block,
 } from '@wordpress/block-editor';
 import { PanelBody, RangeControl } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -52,10 +52,6 @@ function ColumnEdit( {
 	};
 
 	const hasWidth = Number.isFinite( width );
-	const blockWrapperProps = useBlockWrapperProps( {
-		className: classes,
-		style: hasWidth ? { flexBasis: width + '%' } : undefined,
-	} );
 
 	return (
 		<>
@@ -91,8 +87,11 @@ function ColumnEdit( {
 						? undefined
 						: () => <InnerBlocks.ButtonBlockAppender />
 				}
-				__experimentalTagName="div"
-				__experimentalPassedProps={ blockWrapperProps }
+				__experimentalTagName={ Block.div }
+				__experimentalPassedProps={ {
+					className: classes,
+					style: hasWidth ? { flexBasis: width + '%' } : undefined,
+				} }
 			/>
 		</>
 	);

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -11,7 +11,7 @@ import {
 	BlockControls,
 	BlockVerticalAlignmentToolbar,
 	InspectorControls,
-	__experimentalBlock as Block,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import { PanelBody, RangeControl } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -52,6 +52,10 @@ function ColumnEdit( {
 	};
 
 	const hasWidth = Number.isFinite( width );
+	const blockWrapperProps = useBlockWrapperProps( {
+		className: classes,
+		style: hasWidth ? { flexBasis: width + '%' } : undefined,
+	} );
 
 	return (
 		<>
@@ -87,11 +91,8 @@ function ColumnEdit( {
 						? undefined
 						: () => <InnerBlocks.ButtonBlockAppender />
 				}
-				__experimentalTagName={ Block.div }
-				__experimentalPassedProps={ {
-					className: classes,
-					style: hasWidth ? { flexBasis: width + '%' } : undefined,
-				} }
+				__experimentalTagName="div"
+				__experimentalPassedProps={ blockWrapperProps }
 			/>
 		</>
 	);

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -4,12 +4,12 @@
 import { useSelect } from '@wordpress/data';
 import {
 	InnerBlocks,
-	__experimentalBlock as Block,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import { __experimentalBoxControl as BoxControl } from '@wordpress/components';
 const { __Visualizer: BoxControlVisualizer } = BoxControl;
 
-function GroupEdit( { attributes, className, clientId } ) {
+function GroupEdit( { attributes, clientId } ) {
 	const hasInnerBlocks = useSelect(
 		( select ) => {
 			const { getBlock } = select( 'core/block-editor' );
@@ -18,26 +18,25 @@ function GroupEdit( { attributes, className, clientId } ) {
 		},
 		[ clientId ]
 	);
-	const BlockWrapper = Block[ attributes.tagName ];
+	const blockWrapperProps = useBlockWrapperProps();
+	const { tagName: TagName = 'div' } = attributes;
 
 	return (
-		<BlockWrapper className={ className }>
+		<TagName { ...blockWrapperProps }>
 			<BoxControlVisualizer
 				values={ attributes.style?.spacing?.padding }
 				showValues={ attributes.style?.visualizers?.padding }
 			/>
 			<InnerBlocks
 				renderAppender={
-					hasInnerBlocks
-						? undefined
-						: () => <InnerBlocks.ButtonBlockAppender />
+					hasInnerBlocks ? undefined : InnerBlocks.ButtonBlockAppender
 				}
 				__experimentalTagName="div"
 				__experimentalPassedProps={ {
 					className: 'wp-block-group__inner-container',
 				} }
 			/>
-		</BlockWrapper>
+		</TagName>
 	);
 }
 

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -4,7 +4,7 @@
 import { useSelect } from '@wordpress/data';
 import {
 	InnerBlocks,
-	__experimentalBlock as Block,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import { __experimentalBoxControl as BoxControl } from '@wordpress/components';
 const { __Visualizer: BoxControlVisualizer } = BoxControl;
@@ -18,10 +18,11 @@ function GroupEdit( { attributes, className, clientId } ) {
 		},
 		[ clientId ]
 	);
-	const BlockWrapper = Block[ attributes.tagName ];
+	const TagName = attributes.tagName;
+	const blockWrapperProps = useBlockWrapperProps( { className } );
 
 	return (
-		<BlockWrapper className={ className }>
+		<TagName { ...blockWrapperProps }>
 			<BoxControlVisualizer
 				values={ attributes.style?.spacing?.padding }
 				showValues={ attributes.style?.visualizers?.padding }
@@ -37,7 +38,7 @@ function GroupEdit( { attributes, className, clientId } ) {
 					className: 'wp-block-group__inner-container',
 				} }
 			/>
-		</BlockWrapper>
+		</TagName>
 	);
 }
 

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -4,7 +4,7 @@
 import { useSelect } from '@wordpress/data';
 import {
 	InnerBlocks,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+	__experimentalBlock as Block,
 } from '@wordpress/block-editor';
 import { __experimentalBoxControl as BoxControl } from '@wordpress/components';
 const { __Visualizer: BoxControlVisualizer } = BoxControl;
@@ -18,11 +18,10 @@ function GroupEdit( { attributes, className, clientId } ) {
 		},
 		[ clientId ]
 	);
-	const TagName = attributes.tagName;
-	const blockWrapperProps = useBlockWrapperProps( { className } );
+	const BlockWrapper = Block[ attributes.tagName ];
 
 	return (
-		<TagName { ...blockWrapperProps }>
+		<BlockWrapper className={ className }>
 			<BoxControlVisualizer
 				values={ attributes.style?.spacing?.padding }
 				showValues={ attributes.style?.visualizers?.padding }
@@ -38,7 +37,7 @@ function GroupEdit( { attributes, className, clientId } ) {
 					className: 'wp-block-group__inner-container',
 				} }
 			/>
-		</TagName>
+		</BlockWrapper>
 	);
 }
 

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -12,7 +12,7 @@ import {
 	AlignmentToolbar,
 	BlockControls,
 	RichText,
-	__experimentalBlock as Block,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import { ToolbarGroup } from '@wordpress/components';
 
@@ -30,6 +30,12 @@ function HeadingEdit( {
 } ) {
 	const { align, content, level, placeholder } = attributes;
 	const tagName = 'h' + level;
+	const blockWrapperProps = useBlockWrapperProps( {
+		className: classnames( {
+			[ `has-text-align-${ align }` ]: align,
+		} ),
+		style: mergedStyle,
+	} );
 
 	return (
 		<>
@@ -51,7 +57,7 @@ function HeadingEdit( {
 			</BlockControls>
 			<RichText
 				identifier="content"
-				tagName={ Block[ tagName ] }
+				tagName={ tagName }
 				value={ content }
 				onChange={ ( value ) => setAttributes( { content: value } ) }
 				onMerge={ mergeBlocks }
@@ -67,12 +73,9 @@ function HeadingEdit( {
 				} }
 				onReplace={ onReplace }
 				onRemove={ () => onReplace( [] ) }
-				className={ classnames( {
-					[ `has-text-align-${ align }` ]: align,
-				} ) }
 				placeholder={ placeholder || __( 'Write heading…' ) }
 				textAlign={ align }
-				style={ mergedStyle }
+				{ ...blockWrapperProps }
 			/>
 		</>
 	);

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -11,7 +11,7 @@ import {
 	AlignmentToolbar,
 	BlockControls,
 	InspectorControls,
-	__experimentalBlock as Block,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import {
 	ToolbarGroup,
@@ -31,7 +31,7 @@ export default function PostTitleEdit( {
 	setAttributes,
 	context: { postType, postId },
 } ) {
-	const tagName = 0 === level ? 'p' : 'h' + level;
+	const TagName = 0 === level ? 'p' : 'h' + level;
 
 	const post = useSelect(
 		( select ) =>
@@ -43,11 +43,16 @@ export default function PostTitleEdit( {
 		[ postType, postId ]
 	);
 
+	const blockWrapperProps = useBlockWrapperProps( {
+		className: classnames( {
+			[ `has-text-align-${ textAlign }` ]: textAlign,
+		} ),
+	} );
+
 	if ( ! post ) {
 		return null;
 	}
 
-	const BlockWrapper = Block[ tagName ];
 	let title = post.title || __( 'Post Title' );
 	if ( isLink ) {
 		title = (
@@ -104,13 +109,7 @@ export default function PostTitleEdit( {
 					) }
 				</PanelBody>
 			</InspectorControls>
-			<BlockWrapper
-				className={ classnames( {
-					[ `has-text-align-${ textAlign }` ]: textAlign,
-				} ) }
-			>
-				{ title }
-			</BlockWrapper>
+			<TagName { ...blockWrapperProps }>{ title }</TagName>
 		</>
 	);
 }

--- a/packages/block-library/src/preformatted/edit.js
+++ b/packages/block-library/src/preformatted/edit.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import {
 	RichText,
-	__experimentalBlock as Block,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 } from '@wordpress/block-editor';
 
 export default function PreformattedEdit( {
@@ -15,10 +15,11 @@ export default function PreformattedEdit( {
 	style,
 } ) {
 	const { content } = attributes;
+	const blockWrapperProps = useBlockWrapperProps( { className, style } );
 
 	return (
 		<RichText
-			tagName={ Block.pre }
+			tagName="pre"
 			identifier="content"
 			preserveWhiteSpace
 			value={ content }
@@ -28,9 +29,8 @@ export default function PreformattedEdit( {
 				} );
 			} }
 			placeholder={ __( 'Write preformatted text…' ) }
-			className={ className }
-			style={ style }
 			onMerge={ mergeBlocks }
+			{ ...blockWrapperProps }
 		/>
 	);
 }

--- a/packages/block-library/src/preformatted/edit.js
+++ b/packages/block-library/src/preformatted/edit.js
@@ -11,11 +11,9 @@ export default function PreformattedEdit( {
 	attributes,
 	mergeBlocks,
 	setAttributes,
-	className,
-	style,
 } ) {
 	const { content } = attributes;
-	const blockWrapperProps = useBlockWrapperProps( { className, style } );
+	const blockWrapperProps = useBlockWrapperProps();
 
 	return (
 		<RichText

--- a/packages/block-library/src/site-tagline/edit.js
+++ b/packages/block-library/src/site-tagline/edit.js
@@ -9,7 +9,7 @@ import classnames from 'classnames';
 import { useEntityProp } from '@wordpress/core-data';
 import {
 	AlignmentToolbar,
-	__experimentalBlock as Block,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 	BlockControls,
 	RichText,
 } from '@wordpress/block-editor';
@@ -22,6 +22,7 @@ export default function SiteTaglineEdit( { attributes, setAttributes } ) {
 		'site',
 		'description'
 	);
+	const blockWrapperProps = useBlockWrapperProps();
 
 	return (
 		<>
@@ -41,8 +42,9 @@ export default function SiteTaglineEdit( { attributes, setAttributes } ) {
 				} ) }
 				onChange={ setSiteTagline }
 				placeholder={ __( 'Site Tagline' ) }
-				tagName={ Block.p }
+				tagName="p"
 				value={ siteTagline }
+				{ ...blockWrapperProps }
 			/>
 		</>
 	);

--- a/packages/block-library/src/site-title/edit/index.js
+++ b/packages/block-library/src/site-title/edit/index.js
@@ -12,7 +12,7 @@ import {
 	RichText,
 	AlignmentToolbar,
 	BlockControls,
-	__experimentalBlock as Block,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 } from '@wordpress/block-editor';
 
 /**
@@ -24,6 +24,11 @@ export default function SiteTitleEdit( { attributes, setAttributes } ) {
 	const { level, textAlign } = attributes;
 	const [ title, setTitle ] = useEntityProp( 'root', 'site', 'title' );
 	const tagName = level === 0 ? 'p' : `h${ level }`;
+	const blockWrapperProps = useBlockWrapperProps( {
+		className: classnames( {
+			[ `has-text-align-${ textAlign }` ]: textAlign,
+		} ),
+	} );
 
 	return (
 		<>
@@ -44,15 +49,13 @@ export default function SiteTitleEdit( { attributes, setAttributes } ) {
 			</BlockControls>
 
 			<RichText
-				tagName={ Block[ tagName ] }
+				tagName={ tagName }
 				placeholder={ __( 'Site Title' ) }
 				value={ title }
 				onChange={ setTitle }
-				className={ classnames( {
-					[ `has-text-align-${ textAlign }` ]: textAlign,
-				} ) }
 				allowedFormats={ [] }
 				disableLineBreaks
+				{ ...blockWrapperProps }
 			/>
 		</>
 	);

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -6,7 +6,7 @@ import { Fragment } from '@wordpress/element';
 
 import {
 	InnerBlocks,
-	__experimentalBlock as Block,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 	InspectorControls,
 } from '@wordpress/block-editor';
 import { ToggleControl, PanelBody } from '@wordpress/components';
@@ -32,6 +32,7 @@ export function SocialLinksEdit( props ) {
 		attributes: { openInNewTab },
 		setAttributes,
 	} = props;
+	const blockWrapperProps = useBlockWrapperProps();
 	return (
 		<Fragment>
 			<InspectorControls>
@@ -50,7 +51,8 @@ export function SocialLinksEdit( props ) {
 				templateLock={ false }
 				template={ TEMPLATE }
 				orientation="horizontal"
-				__experimentalTagName={ Block.ul }
+				__experimentalTagName="ul"
+				__experimentalPassedProps={ blockWrapperProps }
 				__experimentalAppenderTagName="li"
 			/>
 		</Fragment>

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -6,7 +6,7 @@ import { Fragment } from '@wordpress/element';
 
 import {
 	InnerBlocks,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+	__experimentalBlock as Block,
 	InspectorControls,
 } from '@wordpress/block-editor';
 import { ToggleControl, PanelBody } from '@wordpress/components';
@@ -32,7 +32,6 @@ export function SocialLinksEdit( props ) {
 		attributes: { openInNewTab },
 		setAttributes,
 	} = props;
-	const blockWrapperProps = useBlockWrapperProps();
 	return (
 		<Fragment>
 			<InspectorControls>
@@ -51,8 +50,7 @@ export function SocialLinksEdit( props ) {
 				templateLock={ false }
 				template={ TEMPLATE }
 				orientation="horizontal"
-				__experimentalTagName="ul"
-				__experimentalPassedProps={ blockWrapperProps }
+				__experimentalTagName={ Block.ul }
 				__experimentalAppenderTagName="li"
 			/>
 		</Fragment>

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -5,7 +5,7 @@ import { useRef, useEffect } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	BlockControls,
-	__experimentalBlock as Block,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import { Dropdown, ToolbarGroup, ToolbarButton } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -21,7 +21,7 @@ import TemplatePartPlaceholder from './placeholder';
 import TemplatePartSelection from './selection';
 
 export default function TemplatePartEdit( {
-	attributes: { postId: _postId, slug, theme, tagName },
+	attributes: { postId: _postId, slug, theme, tagName: TagName },
 	setAttributes,
 	clientId,
 } ) {
@@ -64,12 +64,12 @@ export default function TemplatePartEdit( {
 		}
 	}, [ innerBlocks ] );
 
-	const BlockWrapper = Block[ tagName ];
+	const blockWrapperProps = useBlockWrapperProps();
 
 	if ( postId ) {
 		// Part of a template file, post ID already resolved.
 		return (
-			<BlockWrapper>
+			<TagName { ...blockWrapperProps }>
 				<BlockControls>
 					<ToolbarGroup className="wp-block-template-part__block-control-group">
 						<TemplatePartNamePanel
@@ -104,15 +104,15 @@ export default function TemplatePartEdit( {
 					postId={ postId }
 					hasInnerBlocks={ innerBlocks.length > 0 }
 				/>
-			</BlockWrapper>
+			</TagName>
 		);
 	}
 	if ( ! initialSlug.current && ! initialTheme.current ) {
 		// Fresh new block.
 		return (
-			<BlockWrapper>
+			<TagName { ...blockWrapperProps }>
 				<TemplatePartPlaceholder setAttributes={ setAttributes } />
-			</BlockWrapper>
+			</TagName>
 		);
 	}
 	// Part of a template file, post ID not resolved yet.

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -5,7 +5,7 @@ import { useRef, useEffect } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	BlockControls,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+	__experimentalBlock as Block,
 } from '@wordpress/block-editor';
 import { Dropdown, ToolbarGroup, ToolbarButton } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -21,7 +21,7 @@ import TemplatePartPlaceholder from './placeholder';
 import TemplatePartSelection from './selection';
 
 export default function TemplatePartEdit( {
-	attributes: { postId: _postId, slug, theme, tagName: TagName },
+	attributes: { postId: _postId, slug, theme, tagName },
 	setAttributes,
 	clientId,
 } ) {
@@ -64,12 +64,12 @@ export default function TemplatePartEdit( {
 		}
 	}, [ innerBlocks ] );
 
-	const blockWrapperProps = useBlockWrapperProps();
+	const BlockWrapper = Block[ tagName ];
 
 	if ( postId ) {
 		// Part of a template file, post ID already resolved.
 		return (
-			<TagName { ...blockWrapperProps }>
+			<BlockWrapper>
 				<BlockControls>
 					<ToolbarGroup className="wp-block-template-part__block-control-group">
 						<TemplatePartNamePanel
@@ -104,15 +104,15 @@ export default function TemplatePartEdit( {
 					postId={ postId }
 					hasInnerBlocks={ innerBlocks.length > 0 }
 				/>
-			</TagName>
+			</BlockWrapper>
 		);
 	}
 	if ( ! initialSlug.current && ! initialTheme.current ) {
 		// Fresh new block.
 		return (
-			<TagName { ...blockWrapperProps }>
+			<BlockWrapper>
 				<TemplatePartPlaceholder setAttributes={ setAttributes } />
-			</TagName>
+			</BlockWrapper>
 		);
 	}
 	// Part of a template file, post ID not resolved yet.

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -7,7 +7,12 @@ import {
 	BlockControls,
 	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 } from '@wordpress/block-editor';
-import { Dropdown, ToolbarGroup, ToolbarButton } from '@wordpress/components';
+import {
+	Dropdown,
+	ToolbarGroup,
+	ToolbarButton,
+	Spinner,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { chevronUp, chevronDown } from '@wordpress/icons';
 
@@ -117,7 +122,7 @@ export default function TemplatePartEdit( {
 					hasInnerBlocks={ innerBlocks.length > 0 }
 				/>
 			) }
-			{ isUnresolvedTemplateFile && __( 'Loading…' ) }
+			{ isUnresolvedTemplateFile && <Spinner /> }
 		</TagName>
 	);
 }

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -5,7 +5,7 @@ import { useRef, useEffect } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	BlockControls,
-	__experimentalBlock as Block,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import { Dropdown, ToolbarGroup, ToolbarButton } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -21,7 +21,7 @@ import TemplatePartPlaceholder from './placeholder';
 import TemplatePartSelection from './selection';
 
 export default function TemplatePartEdit( {
-	attributes: { postId: _postId, slug, theme, tagName },
+	attributes: { postId: _postId, slug, theme, tagName: TagName = 'div' },
 	setAttributes,
 	clientId,
 } ) {
@@ -64,12 +64,12 @@ export default function TemplatePartEdit( {
 		}
 	}, [ innerBlocks ] );
 
-	const BlockWrapper = Block[ tagName ];
+	const blockWrapperProps = useBlockWrapperProps();
 
 	if ( postId ) {
 		// Part of a template file, post ID already resolved.
 		return (
-			<BlockWrapper>
+			<TagName { ...blockWrapperProps }>
 				<BlockControls>
 					<ToolbarGroup className="wp-block-template-part__block-control-group">
 						<TemplatePartNamePanel
@@ -104,15 +104,15 @@ export default function TemplatePartEdit( {
 					postId={ postId }
 					hasInnerBlocks={ innerBlocks.length > 0 }
 				/>
-			</BlockWrapper>
+			</TagName>
 		);
 	}
 	if ( ! initialSlug.current && ! initialTheme.current ) {
 		// Fresh new block.
 		return (
-			<BlockWrapper>
+			<TagName { ...blockWrapperProps }>
 				<TemplatePartPlaceholder setAttributes={ setAttributes } />
-			</BlockWrapper>
+			</TagName>
 		);
 	}
 	// Part of a template file, post ID not resolved yet.

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -66,10 +66,20 @@ export default function TemplatePartEdit( {
 
 	const blockWrapperProps = useBlockWrapperProps();
 
-	if ( postId ) {
-		// Part of a template file, post ID already resolved.
-		return (
-			<TagName { ...blockWrapperProps }>
+	// Part of a template file, post ID already resolved.
+	const isTemplateFile = !! postId;
+	// Fresh new block.
+	const isPlaceholder =
+		! postId && ! initialSlug.current && ! initialTheme.current;
+	// Part of a template file, post ID not resolved yet.
+	const isUnresolvedTemplateFile = ! isPlaceholder && ! postId;
+
+	return (
+		<TagName { ...blockWrapperProps }>
+			{ isPlaceholder && (
+				<TemplatePartPlaceholder setAttributes={ setAttributes } />
+			) }
+			{ isTemplateFile && (
 				<BlockControls>
 					<ToolbarGroup className="wp-block-template-part__block-control-group">
 						<TemplatePartNamePanel
@@ -100,21 +110,14 @@ export default function TemplatePartEdit( {
 						/>
 					</ToolbarGroup>
 				</BlockControls>
+			) }
+			{ isTemplateFile && (
 				<TemplatePartInnerBlocks
 					postId={ postId }
 					hasInnerBlocks={ innerBlocks.length > 0 }
 				/>
-			</TagName>
-		);
-	}
-	if ( ! initialSlug.current && ! initialTheme.current ) {
-		// Fresh new block.
-		return (
-			<TagName { ...blockWrapperProps }>
-				<TemplatePartPlaceholder setAttributes={ setAttributes } />
-			</TagName>
-		);
-	}
-	// Part of a template file, post ID not resolved yet.
-	return null;
+			) }
+			{ isUnresolvedTemplateFile && __( 'Loading…' ) }
+		</TagName>
+	);
 }

--- a/packages/block-library/src/template-part/edit/inner-blocks.js
+++ b/packages/block-library/src/template-part/edit/inner-blocks.js
@@ -4,7 +4,6 @@
 import { useEntityBlockEditor } from '@wordpress/core-data';
 import { InnerBlocks } from '@wordpress/block-editor';
 
-const renderAppender = () => <InnerBlocks.ButtonBlockAppender />;
 export default function TemplatePartInnerBlocks( {
 	postId: id,
 	hasInnerBlocks,
@@ -20,7 +19,9 @@ export default function TemplatePartInnerBlocks( {
 			onInput={ onInput }
 			onChange={ onChange }
 			__experimentalTagName="div"
-			renderAppender={ hasInnerBlocks ? undefined : renderAppender }
+			renderAppender={
+				hasInnerBlocks ? undefined : InnerBlocks.ButtonBlockAppender
+			}
 		/>
 	);
 }

--- a/packages/block-library/src/verse/edit.js
+++ b/packages/block-library/src/verse/edit.js
@@ -11,7 +11,7 @@ import {
 	RichText,
 	BlockControls,
 	AlignmentToolbar,
-	__experimentalBlock as Block,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 } from '@wordpress/block-editor';
 
 export default function VerseEdit( {
@@ -21,6 +21,11 @@ export default function VerseEdit( {
 	mergeBlocks,
 } ) {
 	const { textAlign, content } = attributes;
+	const blockWrapperProps = useBlockWrapperProps( {
+		className: classnames( className, {
+			[ `has-text-align-${ textAlign }` ]: textAlign,
+		} ),
+	} );
 
 	return (
 		<>
@@ -33,7 +38,7 @@ export default function VerseEdit( {
 				/>
 			</BlockControls>
 			<RichText
-				tagName={ Block.pre }
+				tagName="pre"
 				identifier="content"
 				preserveWhiteSpace
 				value={ content }
@@ -43,11 +48,9 @@ export default function VerseEdit( {
 					} );
 				} }
 				placeholder={ __( 'Write…' ) }
-				className={ classnames( className, {
-					[ `has-text-align-${ textAlign }` ]: textAlign,
-				} ) }
 				onMerge={ mergeBlocks }
 				textAlign={ textAlign }
+				{ ...blockWrapperProps }
 			/>
 		</>
 	);

--- a/packages/block-library/src/verse/edit.js
+++ b/packages/block-library/src/verse/edit.js
@@ -17,12 +17,11 @@ import {
 export default function VerseEdit( {
 	attributes,
 	setAttributes,
-	className,
 	mergeBlocks,
 } ) {
 	const { textAlign, content } = attributes;
 	const blockWrapperProps = useBlockWrapperProps( {
-		className: classnames( className, {
+		className: classnames( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
 		} ),
 	} );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

With the newly introduced `useBlockWrapperProps` in #23034, the experimental `Block.*` component can be deprecated. Since plugins are likely to use this component (even though it's experimental), we should not remove it for at least a few releases.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
