### PR TITLE
Control editor font sizes from theme.json

### DIFF
--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -133,11 +133,6 @@ function gutenberg_edit_site_init( $hook ) {
 		'siteUrl'           => site_url(),
 	);
 
-	list( $font_sizes, ) = (array) get_theme_support( 'editor-font-sizes' );
-
-	if ( false !== $font_sizes ) {
-		$settings['fontSizes'] = $font_sizes;
-	}
 	$settings['styles'] = gutenberg_get_editor_styles();
 	$settings           = gutenberg_experimental_global_styles_settings( $settings );
 

--- a/lib/experimental-default-theme.json
+++ b/lib/experimental-default-theme.json
@@ -136,24 +136,29 @@
 				"customLineHeight": false,
 				"fontSizes": [
 					{
+						"name": "Small",
 						"slug": "small",
 						"size": 13
 					},
 					{
+						"name": "Normal",
 						"slug": "normal",
 						"size": 16
 					},
 					{
+						"name": "Medium",
 						"slug": "medium",
 						"size": 20
 					},
 					{
+						"name": "Large",
 						"slug": "large",
 						"size": 36
 					},
 					{
+						"name": "Huge",
 						"slug": "huge",
-						"size": 48
+						"size": 42
 					}
 				]
 			},

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -229,6 +229,20 @@ function gutenberg_experimental_global_styles_get_core() {
 			$gradient['name'] = $default_gradients_i18n[ $gradient['slug'] ];
 		}
 	}
+
+	$default_font_sizes_i18n = array(
+		'small'  => __( 'Small', 'gutenberg' ),
+		'normal' => __( 'Normal', 'gutenberg' ),
+		'medium' => __( 'Medium', 'gutenberg' ),
+		'large'  => __( 'Large', 'gutenberg' ),
+		'huge'   => __( 'Huge', 'gutenberg' ),
+	);
+
+	if ( ! empty( $config['global']['settings']['typography']['fontSizes'] ) ) {
+		foreach ( $config['global']['settings']['typography']['fontSizes'] as &$font_size ) {
+			$font_size['name'] = $default_font_sizes_i18n[ $font_size['slug'] ];
+		}
+	}
 	// End i18n logic to remove when JSON i18 strings are extracted.
 	return $config;
 }
@@ -806,6 +820,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 
 	unset( $settings['colors'] );
 	unset( $settings['gradients'] );
+	unset( $settings['fontSizes'] );
 	unset( $settings['disableCustomColors'] );
 	unset( $settings['disableCustomGradients'] );
 	unset( $settings['disableCustomFontSizes'] );

--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -87,11 +87,6 @@ function gutenberg_widgets_init( $hook ) {
 		gutenberg_get_legacy_widget_settings()
 	);
 
-	list( $font_sizes, ) = (array) get_theme_support( 'editor-font-sizes' );
-
-	if ( false !== $font_sizes ) {
-		$settings['fontSizes'] = $font_sizes;
-	}
 	$settings = gutenberg_experimental_global_styles_settings( $settings );
 
 	wp_add_inline_script(

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
-- The block editor does not contain default colors and gradients anymore. If one wants to take advantage of these features, please explicitly pass colors and gradients settings or use the new __experimentalFeatures setting that is available.
+- The block editor does not contain default colors, gradients, and font sizes anymore. If one wants to take advantage of these features, please explicitly pass colors, gradients, and/or settings or use the new __experimentalFeatures setting that is available.
 
 
 ## 4.0.0 (2020-05-28)

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -477,7 +477,6 @@ _Properties_
 
 -   _alignWide_ `boolean`: Enable/Disable Wide/Full Alignments
 -   _availableLegacyWidgets_ `Array`: Array of objects representing the legacy widgets available.
--   _fontSizes_ `Array`: Available font sizes
 -   _imageEditing_ `boolean`: Image Editing settings set to false to disable.
 -   _imageSizes_ `Array`: Available image sizes
 -   _maxWidth_ `number`: Max width to constraint resizing

--- a/packages/block-editor/src/components/font-sizes/font-size-picker.js
+++ b/packages/block-editor/src/components/font-sizes/font-size-picker.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { FontSizePicker as BaseFontSizePicker } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -10,10 +9,7 @@ import { useSelect } from '@wordpress/data';
 import useEditorFeature from '../use-editor-feature';
 
 function FontSizePicker( props ) {
-	const fontSizes = useSelect(
-		( select ) => select( 'core/block-editor' ).getSettings().fontSizes,
-		[]
-	);
+	const fontSizes = useEditorFeature( 'typography.fontSizes' );
 	const disableCustomFontSizes = ! useEditorFeature(
 		'typography.customFontSize'
 	);

--- a/packages/block-editor/src/components/font-sizes/with-font-sizes.js
+++ b/packages/block-editor/src/components/font-sizes/with-font-sizes.js
@@ -8,12 +8,14 @@ import { find, pickBy, reduce, some, upperFirst } from 'lodash';
  */
 import { createHigherOrderComponent, compose } from '@wordpress/compose';
 import { Component } from '@wordpress/element';
-import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { getFontSize, getFontSizeClass } from './utils';
+import useEditorFeature from '../use-editor-feature';
+
+const DEFAULT_FONT_SIZES = [];
 
 /**
  * Higher-order component, which handles font size logic for class generation,
@@ -44,14 +46,20 @@ export default ( ...fontSizeNames ) => {
 
 	return createHigherOrderComponent(
 		compose( [
-			withSelect( ( select ) => {
-				const { fontSizes } = select(
-					'core/block-editor'
-				).getSettings();
-				return {
-					fontSizes,
-				};
-			} ),
+			createHigherOrderComponent(
+				( WrappedComponent ) => ( props ) => {
+					const fontSizes =
+						useEditorFeature( 'typography.fontSizes' ) ||
+						DEFAULT_FONT_SIZES;
+					return (
+						<WrappedComponent
+							{ ...props }
+							fontSizes={ fontSizes }
+						/>
+					);
+				},
+				'withFontSizes'
+			),
 			( WrappedComponent ) => {
 				return class extends Component {
 					constructor( props ) {

--- a/packages/block-editor/src/components/use-editor-feature/index.js
+++ b/packages/block-editor/src/components/use-editor-feature/index.js
@@ -26,6 +26,8 @@ const deprecatedFlags = {
 		settings.disableCustomGradients === undefined
 			? undefined
 			: ! settings.disableCustomGradients,
+	'typography.fontSizes': ( settings ) =>
+		settings.fontSizes === undefined ? undefined : settings.fontSizes,
 	'typography.customFontSize': ( settings ) =>
 		settings.disableCustomFontSizes === undefined
 			? undefined

--- a/packages/block-editor/src/hooks/font-size.js
+++ b/packages/block-editor/src/hooks/font-size.js
@@ -3,8 +3,8 @@
  */
 import { addFilter } from '@wordpress/hooks';
 import { hasBlockSupport } from '@wordpress/blocks';
-import { useSelect } from '@wordpress/data';
 import TokenList from '@wordpress/token-list';
+import { createHigherOrderComponent } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -16,7 +16,7 @@ import {
 	FontSizePicker,
 } from '../components/font-sizes';
 import { cleanEmptyObject } from './utils';
-import { createHigherOrderComponent } from '@wordpress/compose';
+import useEditorFeature from '../components/use-editor-feature';
 
 export const FONT_SIZE_SUPPORT_KEY = '__experimentalFontSize';
 
@@ -90,12 +90,6 @@ function addEditProps( settings ) {
 	return settings;
 }
 
-function useFontSizes() {
-	return useSelect(
-		( select ) => select( 'core/block-editor' ).getSettings().fontSizes
-	);
-}
-
 /**
  * Inspector control panel containing the font size related configuration
  *
@@ -109,7 +103,7 @@ export function FontSizeEdit( props ) {
 		setAttributes,
 	} = props;
 	const isDisabled = useIsFontSizeDisabled( props );
-	const fontSizes = useFontSizes();
+	const fontSizes = useEditorFeature( 'typography.fontSizes' );
 
 	if ( isDisabled ) {
 		return null;
@@ -147,7 +141,7 @@ export function FontSizeEdit( props ) {
  * @return {boolean} Whether setting is disabled.
  */
 export function useIsFontSizeDisabled( { name: blockName } = {} ) {
-	const fontSizes = useFontSizes();
+	const fontSizes = useEditorFeature( 'typography.fontSizes' );
 	const hasFontSizes = fontSizes.length;
 
 	return (
@@ -165,7 +159,7 @@ export function useIsFontSizeDisabled( { name: blockName } = {} ) {
  */
 const withFontSizeInlineStyles = createHigherOrderComponent(
 	( BlockListBlock ) => ( props ) => {
-		const fontSizes = useFontSizes();
+		const fontSizes = useEditorFeature( 'typography.fontSizes' );
 		const {
 			name: blockName,
 			attributes: { fontSize, style },

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 export const PREFERENCES_DEFAULTS = {
 	insertUsage: {},
@@ -13,7 +13,6 @@ export const PREFERENCES_DEFAULTS = {
  * @typedef {Object} SETTINGS_DEFAULT
  * @property {boolean} alignWide Enable/Disable Wide/Full Alignments
  * @property {Array} availableLegacyWidgets Array of objects representing the legacy widgets available.
- * @property {Array} fontSizes Available font sizes
  * @property {boolean} imageEditing Image Editing settings set to false to disable.
  * @property {Array} imageSizes Available image sizes
  * @property {number} maxWidth Max width to constraint resizing
@@ -36,34 +35,6 @@ export const PREFERENCES_DEFAULTS = {
  */
 export const SETTINGS_DEFAULTS = {
 	alignWide: false,
-
-	fontSizes: [
-		{
-			name: _x( 'Small', 'font size name' ),
-			size: 13,
-			slug: 'small',
-		},
-		{
-			name: _x( 'Normal', 'font size name' ),
-			size: 16,
-			slug: 'normal',
-		},
-		{
-			name: _x( 'Medium', 'font size name' ),
-			size: 20,
-			slug: 'medium',
-		},
-		{
-			name: _x( 'Large', 'font size name' ),
-			size: 36,
-			slug: 'large',
-		},
-		{
-			name: _x( 'Huge', 'font size name' ),
-			size: 42,
-			slug: 'huge',
-		},
-	],
 
 	imageSizes: [
 		{ slug: 'thumbnail', name: __( 'Thumbnail' ) },


### PR DESCRIPTION
This PR allows theme.json to control the font sizes from theme.json.
It updates the objects in experimental-default-theme.json because meanwhile the defaults were changed.

Similar to https://github.com/WordPress/gutenberg/pull/25419 (that one was for colors and gradients).

## How has this been tested?
I verified I could change font sizes by changing the values on experimental-default-theme.json (provided theme, the color palette was disabled).
I verified I could set a different set of font sizes just for the paragraph block by using theme.json.