### PR TITLE
Remove appender from unselected Buttons and Social Icons block.

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/index.js
+++ b/packages/block-editor/src/components/block-list-appender/index.js
@@ -38,9 +38,7 @@ function BlockListAppender( {
 	if ( CustomAppender ) {
 		// Prefer custom render prop if provided.
 		appender = <CustomAppender />;
-	} else if ( canInsertDefaultBlock ) {
-		// Render the default block appender when renderAppender has not been
-		// provided and the context supports use of the default appender.
+	} else {
 		const isDocumentAppender = ! rootClientId;
 		const isParentSelected = selectedBlockClientId === rootClientId;
 		const isAnotherDefaultAppenderAlreadyDisplayed =
@@ -50,26 +48,31 @@ function BlockListAppender( {
 		if (
 			! isDocumentAppender &&
 			! isParentSelected &&
-			isAnotherDefaultAppenderAlreadyDisplayed
+			( ! selectedBlockClientId ||
+				isAnotherDefaultAppenderAlreadyDisplayed )
 		) {
 			return null;
 		}
 
-		appender = (
-			<DefaultBlockAppender
-				rootClientId={ rootClientId }
-				lastBlockClientId={ last( blockClientIds ) }
-			/>
-		);
-	} else {
-		// Fallback in the case no renderAppender has been provided and the
-		// default block can't be inserted.
-		appender = (
-			<ButtonBlockAppender
-				rootClientId={ rootClientId }
-				className="block-list-appender__toggle"
-			/>
-		);
+		if ( canInsertDefaultBlock ) {
+			// Render the default block appender when renderAppender has not been
+			// provided and the context supports use of the default appender.
+			appender = (
+				<DefaultBlockAppender
+					rootClientId={ rootClientId }
+					lastBlockClientId={ last( blockClientIds ) }
+				/>
+			);
+		} else {
+			// Fallback in the case no renderAppender has been provided and the
+			// default block can't be inserted.
+			appender = (
+				<ButtonBlockAppender
+					rootClientId={ rootClientId }
+					className="block-list-appender__toggle"
+				/>
+			);
+		}
 	}
 
 	return (


### PR DESCRIPTION
## Description
Fixes #21805. Turns out this was a generic issue, and fixing it fixes similar issues with other blocks, e.g. the Social Icons block. It also helps to unblock #23222, which in turn will help unblock #23168. In other words, please review this PR. :stuck_out_tongue:

## How has this been tested?
I've made sure that the Buttons block appender now only appears when the Buttons block or one of its children is selected. The appender is not visible when any other blocks (or no blocks) are selected, as expected.

## Screenshots
Note that no blocks are selected in any of these pictures. Note that in the old (broken) behavior, the appender is invisible (but still taking up space) for the Buttons block; I'm still not sure why it was invisible for the Buttons block.
### Before
![image](https://user-images.githubusercontent.com/19592990/93818284-c951fa00-fc1f-11ea-8b9c-a9f4b8044b1f.png)

### After
![image](https://user-images.githubusercontent.com/19592990/93818315-d53dbc00-fc1f-11ea-9ee3-b52875aa02d0.png)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
