### PR TITLE
Add navigation back button as separate component

### DIFF
--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -68,6 +68,7 @@ export { default as Modal } from './modal';
 export { default as ScrollLock } from './scroll-lock';
 export { NavigableMenu, TabbableContainer } from './navigable-container';
 export { default as __experimentalNavigation } from './navigation';
+export { default as __experimentalNavigationBackButton } from './navigation/back-button';
 export { default as __experimentalNavigationGroup } from './navigation/group';
 export { default as __experimentalNavigationItem } from './navigation/item';
 export { default as __experimentalNavigationMenu } from './navigation/menu';

--- a/packages/components/src/navigation/back-button/index.js
+++ b/packages/components/src/navigation/back-button/index.js
@@ -15,8 +15,13 @@ import { Icon, chevronLeft } from '@wordpress/icons';
 import { useNavigationContext } from '../context';
 import { MenuBackButtonUI } from '../styles/navigation-styles';
 
-export default function NavigationMenu( props ) {
-	const { backButtonLabel, className, href, onClick, parentMenu } = props;
+export default function NavigationMenu( {
+	backButtonLabel,
+	className,
+	href,
+	onClick,
+	parentMenu,
+} ) {
 	const { setActiveMenu, navigationTree } = useNavigationContext();
 
 	const classes = classnames(

--- a/packages/components/src/navigation/back-button/index.js
+++ b/packages/components/src/navigation/back-button/index.js
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Icon, chevronLeft } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { useNavigationContext } from '../context';
+import { MenuBackButtonUI } from '../styles/navigation-styles';
+
+export default function NavigationMenu( props ) {
+	const { backButtonLabel, className, href, onClick, parentMenu } = props;
+	const { setActiveMenu, navigationTree } = useNavigationContext();
+
+	const classes = classnames(
+		'components-navigation__back-button',
+		className
+	);
+
+	const parentMenuTitle = navigationTree.getMenu( parentMenu )?.title;
+
+	return (
+		<MenuBackButtonUI
+			className={ classes }
+			isTertiary
+			href={ href }
+			onClick={ () =>
+				parentMenu ? setActiveMenu( parentMenu, 'right' ) : onClick
+			}
+		>
+			<Icon icon={ chevronLeft } />
+			{ backButtonLabel || parentMenuTitle || __( 'Back' ) }
+		</MenuBackButtonUI>
+	);
+}

--- a/packages/components/src/navigation/menu/index.js
+++ b/packages/components/src/navigation/menu/index.js
@@ -4,21 +4,12 @@
 import classnames from 'classnames';
 
 /**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
-import { Icon, chevronLeft } from '@wordpress/icons';
-
-/**
  * Internal dependencies
  */
 import { ROOT_MENU } from '../constants';
 import { useNavigationContext } from '../context';
-import {
-	MenuBackButtonUI,
-	MenuTitleUI,
-	MenuUI,
-} from '../styles/navigation-styles';
+import { MenuTitleUI, MenuUI } from '../styles/navigation-styles';
+import NavigationBackButton from '../back-button';
 import { NavigationMenuContext } from './context';
 import { useNavigationTreeMenu } from './use-navigation-tree-menu';
 
@@ -32,11 +23,7 @@ export default function NavigationMenu( props ) {
 		title,
 	} = props;
 	useNavigationTreeMenu( props );
-	const {
-		activeMenu,
-		setActiveMenu,
-		navigationTree,
-	} = useNavigationContext();
+	const { activeMenu } = useNavigationContext();
 	const isActive = activeMenu === menu;
 
 	const classes = classnames( 'components-navigation__menu', className );
@@ -55,20 +42,14 @@ export default function NavigationMenu( props ) {
 		);
 	}
 
-	const parentMenuTitle = navigationTree.getMenu( parentMenu )?.title;
-
 	return (
 		<NavigationMenuContext.Provider value={ context }>
 			<MenuUI className={ classes }>
 				{ parentMenu && (
-					<MenuBackButtonUI
-						className="components-navigation__back-button"
-						isTertiary
-						onClick={ () => setActiveMenu( parentMenu, 'right' ) }
-					>
-						<Icon icon={ chevronLeft } />
-						{ backButtonLabel || parentMenuTitle || __( 'Back' ) }
-					</MenuBackButtonUI>
+					<NavigationBackButton
+						backButtonLabel={ backButtonLabel }
+						parentMenu={ parentMenu }
+					/>
 				) }
 				{ title && (
 					<MenuTitleUI

--- a/packages/components/src/navigation/styles/navigation-styles.js
+++ b/packages/components/src/navigation/styles/navigation-styles.js
@@ -15,7 +15,7 @@ export const NavigationUI = styled.div`
 	width: 100%;
 	background-color: ${ G2.darkGray.primary };
 	color: #f0f0f0;
-	padding: 8px;
+	padding: 0 8px;
 	overflow: hidden;
 `;
 
@@ -51,6 +51,10 @@ export const MenuTitleUI = styled( Text )`
 	padding: 4px 0 4px 16px;
 	margin-bottom: 8px;
 	color: ${ G2.gray[ 100 ] };
+
+	&:not( :first-child ) {
+		margin-top: 24px;
+	}
 `;
 
 export const GroupTitleUI = styled( Text )`

--- a/packages/components/src/navigation/styles/navigation-styles.js
+++ b/packages/components/src/navigation/styles/navigation-styles.js
@@ -29,6 +29,9 @@ export const MenuUI = styled.div`
 		margin: 0;
 		list-style: none;
 	}
+	.components-navigation__back-button {
+		margin-bottom: 24px;
+	}
 `;
 
 export const MenuBackButtonUI = styled( Button )`
@@ -51,10 +54,6 @@ export const MenuTitleUI = styled( Text )`
 	padding: 4px 0 4px 16px;
 	margin-bottom: 8px;
 	color: ${ G2.gray[ 100 ] };
-
-	&:not( :first-child ) {
-		margin-top: 24px;
-	}
 `;
 
 export const GroupTitleUI = styled( Text )`


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Separates the back button to a separate component so we can reuse styling for back buttons outside the parent/child relationship of menus.  Also sneaks in a small styling change to fix margin between menu and buttons.

Used for the "WordPress Dashboard" button in the WooCommerce menu.

## How has this been tested?
Tested using storybook examples and in the wc nav repo.

## Screenshots <!-- if applicable -->
<img width="308" alt="Screen Shot 2020-09-21 at 3 10 45 PM" src="https://user-images.githubusercontent.com/10561050/93810425-51072b00-fc57-11ea-8473-8c014b03488f.png">


## Testing

1. Run `npm run storybook:dev`.
1. Make sure no regressions have occurred with back buttons.