### PR TITLE
Spacer block: allow 1px height yet keep editor preview accuracy and improve selectability

### DIFF
--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -13,8 +13,9 @@ import { compose, withInstanceId } from '@wordpress/compose';
 import { withDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 
-const MIN_SPACER_HEIGHT = 20;
+const MIN_SPACER_HEIGHT = 1;
 const MAX_SPACER_HEIGHT = 500;
+const MIN_SPACER_HEIGHT_EDITOR = 48;
 
 const SpacerEdit = ( {
 	attributes,
@@ -29,6 +30,20 @@ const SpacerEdit = ( {
 		setAttributes( {
 			height: value,
 		} );
+	};
+
+	const style = {};
+
+	const updateStyle = ( newHeight ) => {
+		const cheat = Math.max( 0, MIN_SPACER_HEIGHT_EDITOR - newHeight ) / 2;
+		style.top = `${ cheat }px`;
+		style.margin = `-${ cheat }px 0`;
+	};
+
+	updateStyle( height );
+
+	const handleOnResize = ( event, direction, elt, delta ) => {
+		updateStyle( parseInt( height + delta.height, 10 ) );
 	};
 
 	const handleOnResizeStart = ( ...args ) => {
@@ -58,6 +73,7 @@ const SpacerEdit = ( {
 				size={ {
 					height,
 				} }
+				style={ style }
 				minHeight={ MIN_SPACER_HEIGHT }
 				enable={ {
 					top: false,
@@ -69,6 +85,7 @@ const SpacerEdit = ( {
 					bottomLeft: false,
 					topLeft: false,
 				} }
+				onResize={ handleOnResize }
 				onResizeStart={ handleOnResizeStart }
 				onResizeStop={ handleOnResizeStop }
 				showHandle={ isSelected }

--- a/packages/block-library/src/spacer/editor.scss
+++ b/packages/block-library/src/spacer/editor.scss
@@ -1,3 +1,7 @@
+.block-editor-block-list__block[data-type="core/spacer"] {
+	min-height: 48px;
+}
+
 .block-library-spacer__resize-container.has-show-handle {
 	background: $gray-100;
 


### PR DESCRIPTION
Welcome back to another iteration of how we might fix: #18906. Here the spacer block gets a minimum height of 1px in the frontend and 48px in the editor. In order to keep the preview inside the editor accurate, the spacer block will apply negative margins as appropriate:

![spacer-min-height-margin-cheat](https://user-images.githubusercontent.com/9000376/93841391-498c5580-fc48-11ea-85a8-8ef9f5f3b5ba.gif)

## How has this been tested?
in Worpress 5.5.1 with Gutenberg plugin 9.0.0

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
