### PR TITLE
Try: Fix nesting container margin smarts.

### DIFF
--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -108,14 +108,6 @@
 	margin-bottom: $default-block-margin;
 }
 
-.block-editor-block-list__layout > .wp-block:first-child {
-	margin-top: 0;
-}
-
-.block-editor-block-list__layout > .wp-block:last-child {
-	margin-bottom: 0;
-}
-
 // This tag marks the end of the styles that apply to editing canvas contents and need to be manipulated when we resize the editor.
 #end-resizable-editor-section {
 	display: none;


### PR DESCRIPTION
In https://github.com/WordPress/gutenberg/pull/24966#discussion_r492530558 padding support was added to the group block. As part of that, the first and last child of child blocks had their top and bottom margins zeroed out. The intention was noble: to make the padding act more predictably in a world where margin collapsing is a nightmare hellride to understand.

However it had a side effect — the group has an appender block at the end, which grabs that bottom margin rule, unless an adjacent block is selected:

![appender](https://user-images.githubusercontent.com/1204802/93855484-e0442b00-fcb7-11ea-9664-24e935962de3.gif)

<img width="1094" alt="Screenshot 2020-09-22 at 09 36 51" src="https://user-images.githubusercontent.com/1204802/93855602-08cc2500-fcb8-11ea-838f-f5637a2c7e82.png">

This PR removes that rule, which although the intent was noble, it has consequences. The rules of margin collapsing really are weird and unpredictable, but I worry that trying to outsmart them we'll eventually create so many edgecases that it just ends up adding complexity. Here's after:

<img width="1060" alt="Screenshot 2020-09-22 at 09 44 32" src="https://user-images.githubusercontent.com/1204802/93855711-3c0eb400-fcb8-11ea-98f7-4dab2f0209c9.png">

Yes I know, my in development theme has crazy tall margins:

<img width="1100" alt="Screenshot 2020-09-22 at 09 40 06" src="https://user-images.githubusercontent.com/1204802/93855725-42049500-fcb8-11ea-9949-3955977da345.png">

