### PR TITLE
Reduce minimum spacer height to 1px, while still retaining clickable area

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -364,7 +364,7 @@
 .block-editor-block-list__insertion-point {
 	position: relative;
 	z-index: z-index(".block-editor-block-list__insertion-point");
-	margin-top: -$block-padding;
+	margin-top: -$block-padding * 2;
 }
 
 .block-editor-block-list__insertion-point-indicator {
@@ -385,9 +385,6 @@
 	}
 
 	justify-content: center;
-
-	// Clicks on the inserter are redirected to the nearest tabbable element.
-	cursor: text;
 
 	// Hide the inserter above the selected block.
 	&.is-inserter-hidden .block-editor-inserter__toggle {
@@ -419,8 +416,8 @@
 		padding: 0;
 
 		// Special dimensions for this button.
-		min-width: 24px;
-		height: 24px;
+		min-width: $button-size-small;
+		height: $button-size-small;
 
 		&:hover {
 			color: $white;

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -9,7 +9,7 @@ $block-inserter-tabs-height: 44px;
 	padding: 0;
 	font-family: $default-font;
 	font-size: $default-font-size;
-	line-height: $default-line-height;
+	line-height: 0;
 
 	@include break-medium {
 		position: relative;

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -13,7 +13,7 @@ import { compose, withInstanceId } from '@wordpress/compose';
 import { withDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 
-const MIN_SPACER_HEIGHT = 20;
+const MIN_SPACER_HEIGHT = 1;
 const MAX_SPACER_HEIGHT = 500;
 
 const SpacerEdit = ( {

--- a/packages/block-library/src/spacer/editor.scss
+++ b/packages/block-library/src/spacer/editor.scss
@@ -1,3 +1,15 @@
+.block-editor-block-list__block[data-type="core/spacer"] {
+	// This generates an invisible field above the spacer, which makes its minimum clickable-to-select height larger.
+	&::before {
+		content: "";
+		display: block;
+		position: absolute;
+		width: 100%;
+		height: $button-size-small;
+		transform: translateY(-#{$button-size-small / 2});
+	}
+}
+
 .block-library-spacer__resize-container.has-show-handle {
 	background: $gray-100;
 


### PR DESCRIPTION
This PR takes a different approach to allowing a 1px tall spacer block. Alternative to #25525. Fixes #18906. Mitigates #24460.

The primary problem is that the sibling inserter above and below a 1px spacer block makes it appear hard to select the spacer.

It does a few things. First off, through a line height it fixes an issue with the sibling inserter being too tall. That red area is the clickable area shown for debug purposes:

<img width="1165" alt="Screenshot 2020-09-22 at 09 29 41" src="https://user-images.githubusercontent.com/1204802/93858526-9447b500-fcbc-11ea-8ed6-9e357e74f7b4.png">
<img width="1043" alt="Screenshot 2020-09-22 at 09 29 58" src="https://user-images.githubusercontent.com/1204802/93858540-97db3c00-fcbc-11ea-9ee0-86837cf9b15d.png">

Fixed:
<img width="1075" alt="Screenshot 2020-09-22 at 09 31 52" src="https://user-images.githubusercontent.com/1204802/93858542-990c6900-fcbc-11ea-88ca-f1fb9bccb9b9.png">

It alos changes the sibling inserter cursor from being hardcoded to `text`, to not being changed at all. In practice that means when you try to click a 1px spacer, you're technically clicking the sibling inserter hover area, but that area redirects to the nearest block which in most cases means the spacer block. So this is more of a visual change — when the cursor was text it didn't seem like a click would select the spacer block when in fact it would:

![click](https://user-images.githubusercontent.com/1204802/93858695-dd980480-fcbc-11ea-96de-f226998b32c7.gif)

And finally, it adds a hidden "sizer" above the spacer block which provides a minimum clickable area:

![click resizer](https://user-images.githubusercontent.com/1204802/93858729-ebe62080-fcbc-11ea-8bf4-975188b3d827.gif)

Here, it's shown in red, that's only for debug purposes. I believe we tried this in the past and it didn't work, but it seems to work fine here:

![click resizer](https://user-images.githubusercontent.com/1204802/93858811-09b38580-fcbd-11ea-9389-cc2415c0a18d.gif)

CC and props: @stokesman for the initial work. 