### PR TITLE
[Mobile] - Image block - Update image url

### DIFF
--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -38,7 +38,7 @@ import {
 	BlockStyles,
 } from '@wordpress/block-editor';
 import { __, sprintf } from '@wordpress/i18n';
-import { getProtocol } from '@wordpress/url';
+import { getProtocol, hasQueryArg } from '@wordpress/url';
 import { doAction, hasAction } from '@wordpress/hooks';
 import { compose, withPreferredColorScheme } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
@@ -540,9 +540,16 @@ export default compose( [
 			isSelected,
 		} = props;
 		const { imageSizes } = getSettings();
+		const isNotFileUrl = id && getProtocol( url ) !== 'file:';
 
 		const shouldGetMedia =
-			id && isSelected && getProtocol( url ) !== 'file:';
+			( isSelected && isNotFileUrl ) ||
+			// Edge case to update the image after uploading if the block gets unselected
+			// Check if it's the original image and not the resized one with queryparams
+			( ! isSelected &&
+				isNotFileUrl &&
+				url &&
+				! hasQueryArg( url, 'w' ) );
 		return {
 			image: shouldGetMedia ? getMedia( id ) : null,
 			imageSizes,


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/25418

`Gutenberg Mobile PR` -> https://github.com/wordpress-mobile/gutenberg-mobile/pull/2652

## Description
An issue [was reported](https://github.com/WordPress/gutenberg/issues/25418
) of the Image block not keeping its image size after duplicating, after some investigation it turns out that if the block is not selected while an upload is in process it won't request the image data, sizes, and resized URL when it finishes.

On the web editor, it works differently because when the post request is made to upload the image it returns the resized URL and data, where in mobile it just returns the full size URL of the image.

This PR handles the case of updating the final resized URL of the image when the block is not selected and there's an ongoing upload.

## How has this been tested?

<details><summary>Steps to test</summary>
---

Using this [image](https://images.pexels.com/photos/1851164/pexels-photo-1851164.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260) or another one with a similar aspect ratio (so the change is more visible).

- Open the WordPress app with metro running.
- Add an Image block.
- Select an image to upload and once its beginning to upload _quickly_ tap on the title or another block.
- **Expect** to see the resized image once the image finishes uploading.
- **Without** selecting the block, toggle the editor to HTML mode.
- **Expect** to see the URL of the Image block with the `?w` query param.
- Duplicate the block.
- **Expect** to see the image with the same size as the original block.

</details>

## Screenshots

Before | After
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/93868257-81d47800-fcca-11ea-9e25-d9668161b165.gif" width="250" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/93868262-8436d200-fcca-11ea-85f5-b2ddbb56d437.gif" width="250" /></kbd> 

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
