### PR TITLE
Add border to block "Edit as HTML" style.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -498,6 +498,7 @@
 .block-editor-block-list__block .block-editor-block-list__block-html-textarea {
 	display: block;
 	margin: 0;
+	padding: $grid-unit-15;
 	width: 100%;
 	border: none;
 	outline: none;

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -501,7 +501,8 @@
 	width: 100%;
 	border: none;
 	outline: none;
-	box-shadow: none;
+	border-radius: 2px;
+	box-shadow: inset 0 0 0 $border-width $gray-900;
 	resize: none;
 	overflow: hidden;
 	font-family: $editor-html-font;
@@ -511,7 +512,7 @@
 	@include reduce-motion("transition");
 
 	&:focus {
-		box-shadow: none;
+		box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color);
 	}
 }
 


### PR DESCRIPTION
## Description
Adds visible borders to blocks in "Edit as HTML" mode.

[According to WCAG 2.1](https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html), text input fields ought to have a sufficient level of contrast with their surrounding background. And while Twenty Twenty uses a tan background that does contrast with the white textarea, this is far from the norm. Most themes use white backgrounds, so in those cases the field would blend in with the background. That's not good, especially in this particular case where the field isn't even trying to be WYSIWYG. It doesn't even indicate focus properly.

Additionally, most non-WYSIWYG text inputs in our UI have a certain look to them, which this field lacks in `master`.

This PR solves both issues by giving this text field the same look as other standard text inputs across the editor UI.

## Screenshots

### Before

#### Unselected
![image](https://user-images.githubusercontent.com/19592990/93916547-556f2a80-fccf-11ea-97f5-2c3a46321bf9.png)

#### Selected
![image](https://user-images.githubusercontent.com/19592990/93916022-813de080-fcce-11ea-99b5-6779cade5857.png)

### After
#### Unselected
![image](https://user-images.githubusercontent.com/19592990/93916360-0a551780-fccf-11ea-84d9-bcf97a23ac10.png)

**Update:** I've added some padding.
![image](https://user-images.githubusercontent.com/19592990/94042522-54063680-fd91-11ea-918f-7d4af6fb2ca6.png)

#### Selected
![image](https://user-images.githubusercontent.com/19592990/93916295-ea255880-fcce-11ea-9d7d-bcef87e8220f.png)

**Update:** I've added some padding.
![image](https://user-images.githubusercontent.com/19592990/94042573-62545280-fd91-11ea-800b-314e75488e61.png)


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
