### PR TITLE
Navigation Component: Fix NavigationBackButton component name

### DIFF
--- a/packages/components/src/navigation/back-button/index.js
+++ b/packages/components/src/navigation/back-button/index.js
@@ -15,7 +15,7 @@ import { Icon, chevronLeft } from '@wordpress/icons';
 import { useNavigationContext } from '../context';
 import { MenuBackButtonUI } from '../styles/navigation-styles';
 
-export default function NavigationMenu( {
+export default function NavigationBackButton( {
 	backButtonLabel,
 	className,
 	href,


### PR DESCRIPTION
Fix the `NavigationBackButton` component name introduced in #25520 with the incorrect name.

Apologize because I missed it while reviewing the code, and even suggested a change _that included the error_. 😆 