### PR TITLE
Document Actions: Add post content block to header template areas

### DIFF
--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -243,15 +243,17 @@ _Returns_
 
 <a name="getBlockParentsByBlockName" href="#getBlockParentsByBlockName">#</a> **getBlockParentsByBlockName**
 
-Given a block client ID and a block name,
-returns the list of all its parents from top to bottom,
-filtered by the given name.
+Given a block client ID and a block name, returns the list of all its parents
+from top to bottom, filtered by the given name(s). For example, if passed
+'core/group' as the blockName, it will only return parents which are group
+blocks. If passed `[ 'core/group', 'core/cover']`, as the blockName, it will
+return parents which are group blocks and parents which are cover blocks.
 
 _Parameters_
 
 -   _state_ `Object`: Editor state.
 -   _clientId_ `string`: Block from which to find root client ID.
--   _blockName_ `string`: Block name to filter.
+-   _blockName_ `(string|Array<string>)`: Block name(s) to filter.
 -   _ascending_ `boolean`: Order results from bottom to top (true) or top to bottom (false).
 
 _Returns_

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -513,14 +513,16 @@ export const getBlockParents = createSelector(
 );
 
 /**
- * Given a block client ID and a block name,
- * returns the list of all its parents from top to bottom,
- * filtered by the given name.
+ * Given a block client ID and a block name, returns the list of all its parents
+ * from top to bottom, filtered by the given name(s). For example, if passed
+ * 'core/group' as the blockName, it will only return parents which are group
+ * blocks. If passed `[ 'core/group', 'core/cover']`, as the blockName, it will
+ * return parents which are group blocks and parents which are cover blocks.
  *
- * @param {Object} state     Editor state.
- * @param {string} clientId  Block from which to find root client ID.
- * @param {string} blockName Block name to filter.
- * @param {boolean} ascending Order results from bottom to top (true) or top to bottom (false).
+ * @param {Object}          state     Editor state.
+ * @param {string}          clientId  Block from which to find root client ID.
+ * @param {string|string[]} blockName Block name(s) to filter.
+ * @param {boolean}         ascending Order results from bottom to top (true) or top to bottom (false).
  *
  * @return {Array} ClientIDs of the parent blocks.
  */
@@ -533,7 +535,12 @@ export const getBlockParentsByBlockName = createSelector(
 					id,
 					name: getBlockName( state, id ),
 				} ) ),
-				{ name: blockName }
+				( { name } ) => {
+					if ( Array.isArray( blockName ) ) {
+						return blockName.includes( name );
+					}
+					return name === blockName;
+				}
 			),
 			( { id } ) => id
 		);

--- a/packages/edit-site/src/components/header/document-actions/index.js
+++ b/packages/edit-site/src/components/header/document-actions/index.js
@@ -20,6 +20,9 @@ function getBlockDisplayText( block ) {
 		: null;
 }
 
+// We want to show information in the header if we are editing a "template area."
+const TEMPLATE_AREAS = [ 'core/template-part', 'core/post-content' ];
+
 function useSecondaryText() {
 	const {
 		selectedBlock,
@@ -35,11 +38,10 @@ function useSecondaryText() {
 		};
 	} );
 
-	// Check if current block is a template part:
-	const selectedBlockLabel =
-		selectedBlock?.name === 'core/template-part'
-			? getBlockDisplayText( selectedBlock )
-			: null;
+	// Check if current block is a template area:
+	const selectedBlockLabel = TEMPLATE_AREAS.includes( selectedBlock?.name )
+		? getBlockDisplayText( selectedBlock )
+		: null;
 
 	if ( selectedBlockLabel ) {
 		return {
@@ -48,12 +50,9 @@ function useSecondaryText() {
 		};
 	}
 
-	// Check if an ancestor of the current block is a template part:
+	// Check if an ancestor of the current block is a template area:
 	const templatePartParents = !! selectedBlock
-		? getBlockParentsByBlockName(
-				selectedBlock?.clientId,
-				'core/template-part'
-		  )
+		? getBlockParentsByBlockName( selectedBlock?.clientId, TEMPLATE_AREAS )
 		: [];
 
 	if ( templatePartParents.length ) {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Adds "post content" bock to the header "subtext" area (just like template part blocks). Resolves #25543. It just says "Post Content" for now because that's the label for the block. If we want that to be different, we should update the block label rather than hardcoding something.

Todo:
- [ ] Add a new test case to the unit tests for the selector I updated.

## How has this been tested?
Locally, in edit site.

## Screenshots <!-- if applicable -->
![2020-09-22 15 31 55](https://user-images.githubusercontent.com/6265975/93944772-709b6380-fcea-11ea-9e38-0005bb48bdd0.gif)

## Types of changes
enhancement

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
