### PR TITLE
Hide the quick side inserter when the user is typing

### DIFF
--- a/packages/block-editor/src/components/block-list/block-popover.js
+++ b/packages/block-editor/src/components/block-list/block-popover.js
@@ -64,8 +64,10 @@ function BlockPopover( {
 	const [ isInserterShown, setIsInserterShown ] = useState( false );
 	const blockNodes = useContext( BlockNodes );
 
+	// Controls when the side inserter on empty lines should
+	// be shown, including writing and selection modes.
 	const showEmptyBlockSideInserter =
-		! isNavigationMode && isEmptyDefaultBlock && isValid;
+		! isTyping && ! isNavigationMode && isEmptyDefaultBlock && isValid;
 	const shouldShowBreadcrumb = isNavigationMode;
 	const shouldShowContextualToolbar =
 		! isNavigationMode &&

--- a/packages/e2e-tests/specs/editor/various/adding-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/adding-blocks.test.js
@@ -9,6 +9,7 @@ import {
 	setBrowserViewport,
 	closeGlobalBlockInserter,
 	searchForBlock,
+	showBlockToolbar,
 } from '@wordpress/e2e-test-utils';
 
 /** @typedef {import('puppeteer').ElementHandle} ElementHandle */
@@ -137,6 +138,7 @@ describe( 'adding blocks', () => {
 	it( 'should not allow transfer of focus outside of the block-insertion menu once open', async () => {
 		// Enter the default block and click the inserter toggle button to the left of it.
 		await page.keyboard.press( 'ArrowDown' );
+		await showBlockToolbar();
 		await page.click(
 			'.block-editor-block-list__empty-block-inserter .block-editor-inserter__toggle'
 		);


### PR DESCRIPTION
This tweak covers cases where on entering a new line (pressing Enter) the [+] would become briefly visible before disappearing again with the first characters typed.