### PR TITLE
[apiFetch] Fix preloading middleware referencing stale data

### DIFF
--- a/packages/api-fetch/src/middlewares/preloading.js
+++ b/packages/api-fetch/src/middlewares/preloading.js
@@ -35,10 +35,7 @@ export function getStablePath( path ) {
 
 function createPreloadingMiddleware( preloadedData ) {
 	const cache = Object.keys( preloadedData ).reduce( ( result, path ) => {
-		result[ getStablePath( path ) ] = {
-			...preloadedData[ path ],
-			hasBeenPreloaded: false,
-		};
+		result[ getStablePath( path ) ] = preloadedData[ path ];
 		return result;
 	}, {} );
 
@@ -48,21 +45,21 @@ function createPreloadingMiddleware( preloadedData ) {
 			const method = options.method || 'GET';
 			const path = getStablePath( options.path );
 
-			if (
-				'GET' === method &&
-				cache[ path ] &&
-				! cache[ path ].hasBeenPreloaded
-			) {
-				cache[ path ].hasBeenPreloaded = true;
+			if ( 'GET' === method && cache[ path ] ) {
+				const cacheData = cache[ path ];
+
+				// Unsetting the cache key ensures that the data is only preloaded a single time
+				delete cache[ path ];
+
 				return Promise.resolve(
 					parse
-						? cache[ path ].body
+						? cacheData.body
 						: new window.Response(
-								JSON.stringify( cache[ path ].body ),
+								JSON.stringify( cacheData.body ),
 								{
 									status: 200,
 									statusText: 'OK',
-									headers: cache[ path ].headers,
+									headers: cacheData.headers,
 								}
 						  )
 				);

--- a/packages/api-fetch/src/middlewares/preloading.js
+++ b/packages/api-fetch/src/middlewares/preloading.js
@@ -35,7 +35,10 @@ export function getStablePath( path ) {
 
 function createPreloadingMiddleware( preloadedData ) {
 	const cache = Object.keys( preloadedData ).reduce( ( result, path ) => {
-		result[ getStablePath( path ) ] = preloadedData[ path ];
+		result[ getStablePath( path ) ] = {
+			...preloadedData[ path ],
+			hasBeenPreloaded: false,
+		};
 		return result;
 	}, {} );
 
@@ -45,7 +48,12 @@ function createPreloadingMiddleware( preloadedData ) {
 			const method = options.method || 'GET';
 			const path = getStablePath( options.path );
 
-			if ( 'GET' === method && cache[ path ] ) {
+			if (
+				'GET' === method &&
+				cache[ path ] &&
+				! cache[ path ].hasBeenPreloaded
+			) {
+				cache[ path ].hasBeenPreloaded = true;
 				return Promise.resolve(
 					parse
 						? cache[ path ].body

--- a/packages/api-fetch/src/middlewares/test/preloading.js
+++ b/packages/api-fetch/src/middlewares/test/preloading.js
@@ -27,26 +27,82 @@ describe( 'Preloading Middleware', () => {
 		} );
 	} );
 
-	it( 'should return the preloaded data if provided', () => {
-		const body = {
-			status: 'this is the preloaded response',
-		};
-		const preloadedData = {
-			'wp/v2/posts': {
-				body,
-			},
-		};
-		const preloadingMiddleware = createPreloadingMiddleware(
-			preloadedData
-		);
-		const requestOptions = {
-			method: 'GET',
-			path: 'wp/v2/posts',
-		};
+	describe( 'given preloaded data', () => {
+		describe( 'when data is requested from a preloaded endpoint', () => {
+			describe( 'and it is requested for the first time', () => {
+				it( 'should return the preloaded data', () => {
+					const body = {
+						status: 'this is the preloaded response',
+					};
+					const preloadedData = {
+						'wp/v2/posts': {
+							body,
+						},
+					};
+					const preloadingMiddleware = createPreloadingMiddleware(
+						preloadedData
+					);
+					const requestOptions = {
+						method: 'GET',
+						path: 'wp/v2/posts',
+					};
 
-		const response = preloadingMiddleware( requestOptions );
-		return response.then( ( value ) => {
-			expect( value ).toEqual( body );
+					const response = preloadingMiddleware( requestOptions );
+					return response.then( ( value ) => {
+						expect( value ).toEqual( body );
+					} );
+				} );
+			} );
+
+			describe( 'and it has already been requested', () => {
+				it( 'should not return the preloaded data', () => {
+					const body = {
+						status: 'this is the preloaded response',
+					};
+					const preloadedData = {
+						'wp/v2/posts': {
+							body,
+						},
+					};
+					const preloadingMiddleware = createPreloadingMiddleware(
+						preloadedData
+					);
+					const requestOptions = {
+						method: 'GET',
+						path: 'wp/v2/posts',
+					};
+					const nextSpy = jest.fn();
+
+					preloadingMiddleware( requestOptions, nextSpy );
+					expect( nextSpy ).not.toHaveBeenCalled();
+					preloadingMiddleware( requestOptions, nextSpy );
+					expect( nextSpy ).toHaveBeenCalled();
+				} );
+			} );
+		} );
+
+		describe( 'when the requested data is not from a preloaded endpoint', () => {
+			it( 'should not return preloaded data', () => {
+				const body = {
+					status: 'this is the preloaded response',
+				};
+				const preloadedData = {
+					'wp/v2/posts': {
+						body,
+					},
+				};
+				const preloadingMiddleware = createPreloadingMiddleware(
+					preloadedData
+				);
+				const requestOptions = {
+					method: 'GET',
+					path: 'wp/v2/fake_resource',
+				};
+				const nextSpy = jest.fn();
+
+				preloadingMiddleware( requestOptions, nextSpy );
+				expect( nextSpy ).toHaveBeenCalled();
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Unblocks https://github.com/WordPress/gutenberg/pull/25386

The logic for preloading middleware in the apiFetch library caches preloaded data. As it stands today, if an apiFetch request is made that matches a preloaded endpoint, it will reference the cache.

The problem is that the cache is never invalidated during a session. When updates are persisted to the WordPress database, the cache doesn't change, and requests to preloaded endpoints will continue to reference stale, preloaded data. This continues until a session has ended (browser is refreshed or closed).

Example of Unexpected Behavior:
- We're trying to implement [a feature where the user can update page title and page slug](https://github.com/WordPress/gutenberg/pull/25386) in the site editor
- Upon saving changes to the page entity, local state is updated with the new title. This, however, is short lived.
- In the [Page Switcher component](https://github.com/WordPress/gutenberg/blob/master/packages/edit-site/src/components/page-switcher/index.js#L25), there is a `getEntityRecords( 'postType', 'page' )` selector. The selector resolution is invalidated because we've just persisted changes to the page title.
- `getEntityRecords( 'postType', 'page' )` will resolve an apiFetch request to `/wp/v2/pages?context=edit`, [which is a preloaded path](https://github.com/WordPress/gutenberg/blob/master/lib/edit-site-page.php#L146-L153) . This returns cached and stale preloaded data.
- The UI reverts any page title updates to a previous state. It incorrectly presents data that was initially preloaded instead of a new page title.

Our solution is to only reference cached data a single time for each preloaded endpoint, after which subsequent requests skip preloading middleware.

### Note:
I'm definitely going to lean on the expertise of others that have written code for the preloading middleware. This is my first time working extensively in the `apiFetch` library, and I'd appreciate any and all feedback 🙏 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
I tested these fixes on https://github.com/WordPress/gutenberg/pull/25386. I'm not certain if there is a better way to do this. If anyone has better suggestions, feel free to let me know.

1. Checkout the branch in https://github.com/WordPress/gutenberg/pull/25386 called `try/add_page_name_to_document_settings`
2. Spin up a local WordPress instance. From the project root:
  a. Execute `npx wp-env start` in the terminal
  b. Execute `npm run dev` in the terminal
3. Open the WordPress UI at http://localhost:8888/wp-admin and sign in with the username `admin` and the password `password`.
4. Enable site editing in the local dev environment
  a. Click on Appearance < Themes in the sidebar and activate the seedlet blocks theme
  b. Click on Gutenberg < Experiments in the sidebar and check the Full Site Editing Feature
5. Set the home page as a static page
  a. Navigate to Settings > Reading > Your homepage displays
  b. Select "A static page" and assign "sample page"
6. Navigate to the site editor from the wp-admin sidebar
7. Verify problematic behavior
  a. Click on the topbar label called "singular"
  b. Type in a new page name
  c. Note how the title of the page also changes in content of the block editor
  d. Click on update design and then save
  e. Note how the title of the page reverts to "sample page", but updates correctly upon page refresh
8. Verify bug fix
  a. Open another terminal window and execute `git cherry-pick a570088` (pulls in the bug fix from this branch)
  b. Revisit the site editor (referesh the page if you haven't already)
  c. Click on the topbar label called "singular"
  d. Type in a new page name
  e. Note how the title of the page also changes in content of the block editor
  f. Click on update design and then save
  g. Note how the title of the page correctly reflects the newly updated value
  h. Execute `git reset --hard HEAD~1` to revert to original branch state

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix that is blocking https://github.com/WordPress/gutenberg/pull/25386

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
