### PR TITLE
Search Block: Add support for setting the border radius

### DIFF
--- a/packages/block-library/src/search/block.json
+++ b/packages/block-library/src/search/block.json
@@ -29,6 +29,9 @@
 		"buttonUseIcon": {
 			"type": "bool",
 			"default": false
+		},
+		"borderRadius": {
+			"type": "number"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -24,6 +24,7 @@ import {
 	ResizableBox,
 	PanelBody,
 	BaseControl,
+	RangeControl,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { search } from '@wordpress/icons';
@@ -48,6 +49,8 @@ const MIN_WIDTH = 220;
 const MIN_WIDTH_UNIT = 'px';
 const PC_WIDTH_DEFAULT = 50;
 const PX_WIDTH_DEFAULT = 350;
+const MIN_BORDER_RADIUS_VALUE = 0;
+const MAX_BORDER_RADIUS_VALUE = 50;
 const CSS_UNITS = [
 	{ value: '%', label: '%', default: PC_WIDTH_DEFAULT },
 	{ value: 'px', label: 'px', default: PX_WIDTH_DEFAULT },
@@ -70,6 +73,7 @@ export default function SearchEdit( {
 		buttonText,
 		buttonPosition,
 		buttonUseIcon,
+		borderRadius,
 	} = attributes;
 
 	const unitControlInstanceId = useInstanceId( UnitControl );
@@ -123,10 +127,28 @@ export default function SearchEdit( {
 		};
 	};
 
+	const sharedStyles = {
+		borderRadius: borderRadius ? borderRadius + 'px' : undefined,
+	};
+
+	const sharedClasses = {
+		'no-border-radius': borderRadius === 0,
+	};
+
 	const renderTextField = () => {
+		const textFieldStyles = {
+			...sharedStyles,
+		};
+
+		const textFieldClasses = classnames(
+			'wp-block-search__input',
+			sharedClasses
+		);
+
 		return (
 			<input
-				className="wp-block-search__input"
+				className={ textFieldClasses }
+				style={ textFieldStyles }
 				aria-label={ __( 'Optional placeholder text' ) }
 				// We hide the placeholder field's placeholder when there is a value. This
 				// stops screen readers from reading the placeholder field's placeholder
@@ -143,18 +165,29 @@ export default function SearchEdit( {
 	};
 
 	const renderButton = () => {
+		const buttonStyles = {
+			...sharedStyles,
+		};
+
+		const buttonClasses = classnames(
+			'wp-block-search__button',
+			sharedClasses
+		);
+
 		return (
 			<>
 				{ buttonUseIcon && (
 					<Button
 						icon={ search }
-						className="wp-block-search__button"
+						className={ buttonClasses }
+						style={ buttonStyles }
 					/>
 				) }
 
 				{ ! buttonUseIcon && (
 					<RichText
-						className="wp-block-search__button"
+						className={ buttonClasses }
+						style={ buttonStyles }
 						aria-label={ __( 'Button text' ) }
 						placeholder={ __( 'Add button text…' ) }
 						withoutInteractiveFormatting
@@ -165,6 +198,54 @@ export default function SearchEdit( {
 					/>
 				) }
 			</>
+		);
+	};
+
+	const renderInputs = () => {
+		const wrapperStyles =
+			'button-inside' === buttonPosition ? { ...sharedStyles } : {};
+
+		const wrapperClasses = classnames(
+			'wp-block-search__inside-wrapper',
+			'button-inside' === buttonPosition ? sharedClasses : undefined
+		);
+
+		return (
+			<ResizableBox
+				size={ {
+					width: `${ width }${ widthUnit }`,
+				} }
+				className={ wrapperClasses }
+				style={ wrapperStyles }
+				isResetValueOnUnitChange
+				minWidth={ MIN_WIDTH }
+				enable={ getResizableSides() }
+				onResizeStart={ ( event, direction, elt ) => {
+					setAttributes( {
+						width: parseInt( elt.offsetWidth, 10 ),
+						widthUnit: 'px',
+					} );
+					toggleSelection( false );
+				} }
+				onResizeStop={ ( event, direction, elt, delta ) => {
+					setAttributes( {
+						width: parseInt( width + delta.width, 10 ),
+					} );
+					toggleSelection( true );
+				} }
+				showHandle={ isSelected }
+			>
+				{ ( 'button-inside' === buttonPosition ||
+					'button-outside' === buttonPosition ) && (
+					<>
+						{ renderTextField() }
+						{ renderButton() }
+					</>
+				) }
+
+				{ 'button-only' === buttonPosition && renderButton() }
+				{ 'no-button' === buttonPosition && renderTextField() }
+			</ResizableBox>
 		);
 	};
 
@@ -254,7 +335,7 @@ export default function SearchEdit( {
 			</BlockControls>
 
 			<InspectorControls>
-				<PanelBody title={ __( 'Display Settings' ) }>
+				<PanelBody title={ __( 'Design Settings' ) }>
 					<BaseControl
 						label={ __( 'Width' ) }
 						id={ unitControlInputId }
@@ -314,6 +395,18 @@ export default function SearchEdit( {
 							} ) }
 						</ButtonGroup>
 					</BaseControl>
+
+					<RangeControl
+						value={ borderRadius }
+						label={ __( 'Border Radius' ) }
+						min={ MIN_BORDER_RADIUS_VALUE }
+						max={ MAX_BORDER_RADIUS_VALUE }
+						initialPosition={ 0 }
+						allowReset
+						onChange={ ( newBorderRadius ) =>
+							setAttributes( { borderRadius: newBorderRadius } )
+						}
+					/>
 				</PanelBody>
 			</InspectorControls>
 		</>
@@ -338,40 +431,7 @@ export default function SearchEdit( {
 				/>
 			) }
 
-			<ResizableBox
-				size={ {
-					width: `${ width }${ widthUnit }`,
-				} }
-				className="wp-block-search__inside-wrapper"
-				isResetValueOnUnitChange
-				minWidth={ MIN_WIDTH }
-				enable={ getResizableSides() }
-				onResizeStart={ ( event, direction, elt ) => {
-					setAttributes( {
-						width: parseInt( elt.offsetWidth, 10 ),
-						widthUnit: 'px',
-					} );
-					toggleSelection( false );
-				} }
-				onResizeStop={ ( event, direction, elt, delta ) => {
-					setAttributes( {
-						width: parseInt( width + delta.width, 10 ),
-					} );
-					toggleSelection( true );
-				} }
-				showHandle={ isSelected }
-			>
-				{ ( 'button-inside' === buttonPosition ||
-					'button-outside' === buttonPosition ) && (
-					<>
-						{ renderTextField() }
-						{ renderButton() }
-					</>
-				) }
-
-				{ 'button-only' === buttonPosition && renderButton() }
-				{ 'no-button' === buttonPosition && renderTextField() }
-			</ResizableBox>
+			{ renderInputs() }
 		</div>
 	);
 }

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -138,10 +138,10 @@ export default function SearchEdit( {
 		if ( 'button-inside' === buttonPosition ) {
 			// Uses min value of 1 as having no radius when the outer does is jarring.
 			const radius = Math.max( borderRadius - DEFAULT_INPUT_PADDING, 1 );
-			return radius ? radius + 'px' : undefined;
+			return radius ? `${ radius }px` : undefined;
 		}
 
-		return borderRadius + 'px';
+		return `${ borderRadius }px`;
 	};
 
 	const sharedStyles = {
@@ -223,7 +223,7 @@ export default function SearchEdit( {
 			'button-inside' === buttonPosition
 				? {
 						borderRadius: borderRadius
-							? borderRadius + 'px'
+							? `${ borderRadius }px`
 							: undefined,
 				  }
 				: {};

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -56,6 +56,9 @@ const CSS_UNITS = [
 	{ value: 'px', label: 'px', default: PX_WIDTH_DEFAULT },
 ];
 
+// Used to calculate adjustment to inner button border radius.
+const DEFAULT_INPUT_PADDING = 4;
+
 export default function SearchEdit( {
 	className,
 	attributes,
@@ -127,8 +130,22 @@ export default function SearchEdit( {
 		};
 	};
 
+	const getInnerBorderRadiusStyle = () => {
+		if ( ! borderRadius ) {
+			return undefined;
+		}
+
+		if ( 'button-inside' === buttonPosition ) {
+			// Uses min value of 1 as having no radius when the outer does is jarring.
+			const radius = Math.max( borderRadius - DEFAULT_INPUT_PADDING, 1 );
+			return radius ? radius + 'px' : undefined;
+		}
+
+		return borderRadius + 'px';
+	};
+
 	const sharedStyles = {
-		borderRadius: borderRadius ? borderRadius + 'px' : undefined,
+		borderRadius: getInnerBorderRadiusStyle(),
 	};
 
 	const sharedClasses = {
@@ -203,7 +220,13 @@ export default function SearchEdit( {
 
 	const renderInputs = () => {
 		const wrapperStyles =
-			'button-inside' === buttonPosition ? { ...sharedStyles } : {};
+			'button-inside' === buttonPosition
+				? {
+						borderRadius: borderRadius
+							? borderRadius + 'px'
+							: undefined,
+				  }
+				: {};
 
 		const wrapperClasses = classnames(
 			'wp-block-search__inside-wrapper',

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -240,7 +240,6 @@ export default function SearchEdit( {
 				} }
 				className={ wrapperClasses }
 				style={ wrapperStyles }
-				isResetValueOnUnitChange
 				minWidth={ MIN_WIDTH }
 				enable={ getResizableSides() }
 				onResizeStart={ ( event, direction, elt ) => {

--- a/packages/block-library/src/search/icons.js
+++ b/packages/block-library/src/search/icons.js
@@ -18,7 +18,7 @@ export const buttonOutside = (
 			height="9.5"
 			transform="rotate(-90 4.75 15.25)"
 			stroke="currentColor"
-			stroke-width="1.5"
+			strokeWidth="1.5"
 			fill="none"
 		/>
 		<Rect x="16" y="10" width="4" height="4" rx="1" fill="currentColor" />
@@ -34,7 +34,7 @@ export const buttonInside = (
 			height="14.5"
 			transform="rotate(-90 4.75 15.25)"
 			stroke="currentColor"
-			stroke-width="1.5"
+			strokeWidth="1.5"
 			fill="none"
 		/>
 		<Rect x="14" y="10" width="4" height="4" rx="1" fill="currentColor" />
@@ -51,7 +51,7 @@ export const noButton = (
 			transform="rotate(-90 4.75 15.25)"
 			stroke="currentColor"
 			fill="none"
-			stroke-width="1.5"
+			strokeWidth="1.5"
 		/>
 	</SVG>
 );
@@ -66,7 +66,7 @@ export const buttonWithIcon = (
 			rx="1.25"
 			stroke="currentColor"
 			fill="none"
-			stroke-width="1.5"
+			strokeWidth="1.5"
 		/>
 		<Rect x="8" y="11" width="8" height="2" fill="currentColor" />
 	</SVG>
@@ -82,7 +82,7 @@ export const toggleLabel = (
 			transform="rotate(-90 4.75 17.25)"
 			stroke="currentColor"
 			fill="none"
-			stroke-width="1.5"
+			strokeWidth="1.5"
 		/>
 		<Rect x="4" y="7" width="10" height="2" fill="currentColor" />
 	</SVG>

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -41,6 +41,7 @@ function render_block_core_search( $attributes ) {
 
 	$shared_classes = block_core_search_build_css_border_radius( $attributes )['css_classes'];
 	$shared_styles  = block_core_search_build_css_border_radius( $attributes )['inline_styles'];
+	$wrapper_styles = block_core_search_build_css_border_radius( $attributes )['wrapper_styles'];
 
 	if ( $show_label ) {
 		if ( ! empty( $attributes['label'] ) ) {
@@ -111,12 +112,12 @@ function render_block_core_search( $attributes ) {
 	);
 
 	$field_styles = ( array_key_exists( 'buttonPosition', $attributes ) && 'button-inside' === $attributes['buttonPosition'] )
-		? $shared_styles
+		? $wrapper_styles
 		: '';
 
 	if ( $has_width && $has_width_unit ) {
 		if ( ! empty( $attributes['buttonPosition'] ) && 'button-only' !== $attributes['buttonPosition'] ) {
-			$field_styles .= ' width: ' . esc_attr( $attributes['width'] ) . esc_attr( $attributes['widthUnit'] ) . ';"';
+			$field_styles .= ' width: ' . esc_attr( $attributes['width'] ) . esc_attr( $attributes['widthUnit'] ) . ';';
 		}
 	}
 
@@ -156,23 +157,40 @@ add_action( 'init', 'register_block_core_search' );
  * @return array Border radius CSS classes and inline styles.
  */
 function block_core_search_build_css_border_radius( $attributes ) {
+	$padding       = 4;
 	$border_radius = array(
-		'css_classes'   => array(),
-		'inline_styles' => '',
+		'css_classes'    => array(),
+		'inline_styles'  => '',
+		'wrapper_styles' => '',
 	);
 
 	$has_border_radius = array_key_exists( 'borderRadius', $attributes );
 
-	if ( $has_border_radius ) {
-		$border_radius['css_classes'][] = ( 0 === $attributes['borderRadius'] )
-			? 'no-border-radius'
-			: '';
-
-		$border_radius['inline_styles'] = sprintf(
-			'border-radius: %spx;',
-			esc_attr( $attributes['borderRadius'] )
-		);
+	if ( ! $has_border_radius ) {
+		return $border_radius;
 	}
+
+	$border_radius['css_classes'][] = ( 0 === $attributes['borderRadius'] )
+		? 'no-border-radius'
+		: '';
+
+	$button_inside = array_key_exists( 'buttonPosition', $attributes )
+		&& 'button-inside' === $attributes['buttonPosition'];
+
+	// Uses min value of 1 as having no radius when the outer does is jarring.
+	$radius = $button_inside
+		? max( $attributes['borderRadius'] - $padding, 1 )
+		: $attributes['borderRadius'];
+
+	$border_radius['inline_styles'] = sprintf(
+		'border-radius: %spx;',
+		esc_attr( $radius )
+	);
+
+	$border_radius['wrapper_styles'] = sprintf(
+		'border-radius: %spx;',
+		esc_attr( $attributes['borderRadius'] )
+	);
 
 	return $border_radius;
 }

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -22,25 +22,25 @@ function render_block_core_search( $attributes ) {
 	$attributes = wp_parse_args(
 		$attributes,
 		array(
-			'label'		 => __( 'Search' ),
+			'label'      => __( 'Search' ),
 			'buttonText' => __( 'Search' ),
 		)
 	);
 
-	$input_id			= 'wp-block-search__input-' . ++$instance_id;
-	$base_classnames	= block_core_build_base_classnames( $attributes );
-	$show_label			= array_key_exists( 'showLabel', $attributes );
-	$use_icon_button	= array_key_exists( 'buttonUseIcon', $attributes ) && $attributes['buttonUseIcon'];
-	$has_width			= array_key_exists( 'width', $attributes );
-	$has_width_unit		= array_key_exists( 'widthUnit', $attributes );
-	$show_input			= array_key_exists( 'buttonPosition', $attributes ) && 'button-only' === $attributes['buttonPosition'] ? false : true;
-	$show_button		= array_key_exists( 'buttonPosition', $attributes ) && 'no-button' === $attributes['buttonPosition'] ? false : true;
-	$label_markup		= '';
-	$input_markup		= '';
-	$button_markup		= '';
+	$input_id        = 'wp-block-search__input-' . ++$instance_id;
+	$base_classnames = block_core_build_base_classnames( $attributes );
+	$show_label      = array_key_exists( 'showLabel', $attributes );
+	$use_icon_button = array_key_exists( 'buttonUseIcon', $attributes ) && $attributes['buttonUseIcon'];
+	$has_width       = array_key_exists( 'width', $attributes );
+	$has_width_unit  = array_key_exists( 'widthUnit', $attributes );
+	$show_input      = array_key_exists( 'buttonPosition', $attributes ) && 'button-only' === $attributes['buttonPosition'] ? false : true;
+	$show_button     = array_key_exists( 'buttonPosition', $attributes ) && 'no-button' === $attributes['buttonPosition'] ? false : true;
+	$label_markup    = '';
+	$input_markup    = '';
+	$button_markup   = '';
 
-	$shared_classes		= block_core_search_build_css_border_radius( $attributes )['css_classes'];
-	$shared_styles		= block_core_search_build_css_border_radius( $attributes )['inline_styles'];
+	$shared_classes = block_core_search_build_css_border_radius( $attributes )['css_classes'];
+	$shared_styles  = block_core_search_build_css_border_radius( $attributes )['inline_styles'];
 
 	if ( $show_label ) {
 		if ( ! empty( $attributes['label'] ) ) {
@@ -63,7 +63,7 @@ function render_block_core_search( $attributes ) {
 			array( 'wp-block-search__input' ),
 			array_filter( $shared_classes )
 		);
-		$input_styles = $shared_styles;
+		$input_styles  = $shared_styles;
 
 		$input_markup = sprintf(
 			'<input type="search" id="%1$s" %2$s%3$sname="s" value="%4$s" placeholder="%5$s" required />',
@@ -80,7 +80,8 @@ function render_block_core_search( $attributes ) {
 			array( 'wp-block-search__button' ),
 			array_filter( $shared_classes )
 		);
-		$button_styles = $shared_styles;
+
+		$button_styles          = $shared_styles;
 		$button_internal_markup = '';
 
 		if ( ! $use_icon_button ) {
@@ -108,11 +109,12 @@ function render_block_core_search( $attributes ) {
 			? array_filter( $shared_classes )
 			: array()
 	);
+
 	$field_styles = ( array_key_exists( 'buttonPosition', $attributes ) && 'button-inside' === $attributes['buttonPosition'] )
 		? $shared_styles
 		: '';
 
-	if ( ! empty( $attributes['width'] ) && ! empty( $attributes['widthUnit'] ) ) {
+	if ( $has_width && $has_width_unit ) {
 		if ( ! empty( $attributes['buttonPosition'] ) && 'button-only' !== $attributes['buttonPosition'] ) {
 			$field_styles .= ' width: ' . esc_attr( $attributes['width'] ) . esc_attr( $attributes['widthUnit'] ) . ';"';
 		}
@@ -159,10 +161,10 @@ function block_core_search_build_css_border_radius( $attributes ) {
 		'inline_styles' => '',
 	);
 
-	$has_border_radius  = array_key_exists( 'borderRadius', $attributes );
+	$has_border_radius = array_key_exists( 'borderRadius', $attributes );
 
 	if ( $has_border_radius ) {
-		$border_radius['css_classes'][] = ( $attributes['borderRadius'] === 0 )
+		$border_radius['css_classes'][] = ( 0 === $attributes['borderRadius'] )
 			? 'no-border-radius'
 			: '';
 


### PR DESCRIPTION
## Description

This PR initially extended the work done in https://github.com/WordPress/gutenberg/pull/25203 which has since been abandoned in favour of this.

#### Changes Included
* Add support for setting border radius on search input field and button in the Search block.
* Single border radius setting that will adjust the radius for both together.
* Adjusts inner border radii values so they remain visually consistent with outer wrapper when button is positioned inside.
* Also resolves linter issues and an extraneous `"` character in the markup.

#### Notes
* Only uses simple formula: `innerBorderRadius = wrapperBorderRadius - wrapperPadding`
* This isn't an exact fix as it doesn't take into account border width and padding variations that could be introduced via themes or maybe Global Styles.

## Screencast
![](https://user-images.githubusercontent.com/1464705/92662726-4d1cf580-f2b4-11ea-9291-9f6d0a5b19b7.gif)


## How has this been tested?
Manual Testing.

#### Testing Instructions
1. Apply this PR
2. Add multiple search blocks to a post
3. Configure each search block's border radius and button positions differently. Including:
    * Button outside: no border radius
    * Button outside: border radius
    * Button inside: no border radius
    * Button inside: border radius < 4px (less than the wrapper's padding, should result in 1px inner radius)
    * Button inside: border radius > 4px (greater than wrapper's padding, results in (outer radius - padding))
4. Inspect editor markup and confirm calculations
5. Save post and view on frontend
6. Inspect markup again confirming calculations on frontend

## Screenshots <!-- if applicable -->

| Editor | Frontend |
|-------|----------|
| <img width="699" alt="Screen Shot 2020-09-23 at 4 23 29 pm" src="https://user-images.githubusercontent.com/60436221/93974505-3cdb3f00-fdb9-11ea-8b05-319911696d0f.png"> | <img width="648" alt="Screen Shot 2020-09-23 at 4 23 35 pm" src="https://user-images.githubusercontent.com/60436221/93974513-41075c80-fdb9-11ea-9f7c-feed40954e1d.png"> |

## Types of changes
Enhancement.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
