### PR TITLE
Firefox: fix disappearing toolbar

### DIFF
--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -203,13 +203,11 @@ export function useBlockWrapperProps( props = {}, { __unstableIsHtml } = {} ) {
 			}
 		}
 
-		function onMouseLeave( { which, buttons } ) {
-			// The primary button must be pressed to initiate selection. Fall back
-			// to `which` if the standard `buttons` property is falsy. There are
-			// cases where Firefox might always set `buttons` to `0`.
+		function onMouseLeave( { buttons } ) {
+			// The primary button must be pressed to initiate selection.
 			// See https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons
 			// See https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/which
-			if ( ( buttons || which ) === 1 ) {
+			if ( buttons === 1 ) {
 				onSelectionStart( clientId );
 			}
 		}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

Fixes #25526.

The cause of this bug is the switch from a React synthetic event to a native event. It seems that the `buttons` property didn't work correctly in the past for Firefox, but it works correctly for the native event.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
