### PR TITLE
Navigation component: Add back button click handler

### DIFF
--- a/packages/components/src/navigation/README.md
+++ b/packages/components/src/navigation/README.md
@@ -87,6 +87,13 @@ Sync the active menu between the external state and the Navigation's internal st
 The back button label used in nested menus. If not provided, the label will be inferred from the parent menu's title.
 If for some reason the parent menu's title is not available then it will default to "Back".
 
+### `onBackButtonClick`
+
+-   Type: `function`
+-   Required: No
+
+A callback to handle clicking on the back button. If this prop is provided then the back button will be shown.
+
 ### className
 
 -   Type: `string`

--- a/packages/components/src/navigation/back-button/index.js
+++ b/packages/components/src/navigation/back-button/index.js
@@ -34,8 +34,10 @@ function NavigationBackButton(
 			className={ classes }
 			href={ href }
 			isTertiary
-			onClick={ () =>
-				parentMenu ? setActiveMenu( parentMenu, 'right' ) : onClick
+			onClick={ ( ...args ) =>
+				parentMenu
+					? setActiveMenu( parentMenu, 'right' )
+					: onClick( ...args )
 			}
 			ref={ ref }
 		>

--- a/packages/components/src/navigation/back-button/index.js
+++ b/packages/components/src/navigation/back-button/index.js
@@ -34,10 +34,10 @@ function NavigationBackButton(
 			className={ classes }
 			href={ href }
 			isTertiary
-			onClick={ ( ...args ) =>
+			onClick={
 				parentMenu
-					? setActiveMenu( parentMenu, 'right' )
-					: onClick( ...args )
+					? () => setActiveMenu( parentMenu, 'right' )
+					: onClick
 			}
 			ref={ ref }
 		>

--- a/packages/components/src/navigation/back-button/index.js
+++ b/packages/components/src/navigation/back-button/index.js
@@ -29,17 +29,23 @@ function NavigationBackButton(
 
 	const parentMenuTitle = navigationTree.getMenu( parentMenu )?.title;
 
+	const handleOnClick = ( event ) => {
+		if ( typeof onClick === 'function' ) {
+			onClick( event );
+		}
+
+		if ( parentMenu && ! event.defaultPrevented ) {
+			setActiveMenu( parentMenu, 'right' );
+		}
+	};
+
 	return (
 		<MenuBackButtonUI
 			className={ classes }
 			href={ href }
 			isTertiary
-			onClick={
-				parentMenu
-					? () => setActiveMenu( parentMenu, 'right' )
-					: onClick
-			}
 			ref={ ref }
+			onClick={ handleOnClick }
 		>
 			<Icon icon={ chevronLeft } />
 			{ backButtonLabel || parentMenuTitle || __( 'Back' ) }

--- a/packages/components/src/navigation/menu/index.js
+++ b/packages/components/src/navigation/menu/index.js
@@ -21,6 +21,7 @@ export default function NavigationMenu( props ) {
 		menu = ROOT_MENU,
 		parentMenu,
 		title,
+		onBackButtonClick,
 	} = props;
 	useNavigationTreeMenu( props );
 	const { activeMenu } = useNavigationContext();
@@ -45,10 +46,11 @@ export default function NavigationMenu( props ) {
 	return (
 		<NavigationMenuContext.Provider value={ context }>
 			<MenuUI className={ classes }>
-				{ parentMenu && (
+				{ ( parentMenu || onBackButtonClick ) && (
 					<NavigationBackButton
 						backButtonLabel={ backButtonLabel }
 						parentMenu={ parentMenu }
+						onClick={ onBackButtonClick }
 					/>
 				) }
 				{ title && (

--- a/packages/components/src/navigation/stories/more-examples.js
+++ b/packages/components/src/navigation/stories/more-examples.js
@@ -19,6 +19,10 @@ export function MoreExamplesStory() {
 		const timeout = setTimeout( () => setDelayedBadge( 2 ), 1500 );
 		return () => clearTimeout( timeout );
 	} );
+	const [ backButtonBadge, setBackButtonBadge ] = useState( 1 );
+	const [ backButtonPreventedBadge, setBackButtonPreventedBadge ] = useState(
+		1
+	);
 
 	return (
 		<Navigation activeItem={ activeItem } className="navigation-story">
@@ -32,6 +36,17 @@ export function MoreExamplesStory() {
 						item="item-sub-menu"
 						navigateToMenu="sub-menu"
 						title="Sub-Menu with Custom Back Label"
+					/>
+					<NavigationItem
+						item="item-custom-back-click-handler"
+						navigateToMenu="custom-back-click-handler-menu"
+						title="Custom Back Click Handler"
+						badge={ backButtonBadge }
+					/>
+					<NavigationItem
+						item="item-custom-back-click-handler-prevented"
+						navigateToMenu="custom-back-click-handler-prevented-menu"
+						title="Prevent back navigation"
 					/>
 					<NavigationItem
 						item="item-nonexistent-menu"
@@ -81,6 +96,33 @@ export function MoreExamplesStory() {
 					item="child-2"
 					onClick={ () => setActiveItem( 'child-2' ) }
 					title="Child 2"
+				/>
+			</NavigationMenu>
+
+			<NavigationMenu
+				menu="custom-back-click-handler-menu"
+				title="Custom back button click handler"
+				parentMenu="root"
+				onBackButtonClick={ () =>
+					setBackButtonBadge( backButtonBadge + 1 )
+				}
+				backButtonLabel="Increment badge and go back"
+			/>
+
+			<NavigationMenu
+				menu="custom-back-click-handler-prevented-menu"
+				title="Custom back button click handler prevented"
+				parentMenu="root"
+				onBackButtonClick={ ( event ) => {
+					event.preventDefault();
+					setBackButtonPreventedBadge( backButtonPreventedBadge + 1 );
+				} }
+				backButtonLabel="Increment badge"
+			>
+				<NavigationItem
+					item="custom-back-click-prevented-child-1"
+					title="You can't go back from here"
+					badge={ backButtonPreventedBadge }
 				/>
 			</NavigationMenu>
 		</Navigation>


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/issues/25247

## Description
Allow specifying custom back button click handler.

## How has this been tested?
- Run in terminal: `yarn storybook:dev`
- Click **Category**
- Click **Custom back click handler**
- Click **Go back to root**

## Screenshots
![image](https://user-images.githubusercontent.com/2256104/94013825-ed8e1200-fdaa-11ea-9f88-f54520e819be.png)

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
