### PR TITLE
Add documentation for useResizeCanvas

### DIFF
--- a/packages/block-editor/src/components/use-resize-canvas/README.md
+++ b/packages/block-editor/src/components/use-resize-canvas/README.md
@@ -1,0 +1,45 @@
+# useResizeCanvas
+
+This function generates inline CSS suitable for resizing a container to fit a device's dimensions. It adjusts the CSS according to the current device dimensions. It has no effect on desktop.
+
+On-page CSS media queries are also updated to match the width of the device.
+
+Note that this is currently experimental, and is available as `__experimentalUseResizeCanvas`.
+
+## Table of contents
+
+1. [Development guidelines](#development-guidelines)
+
+## Development guidelines
+
+### Usage
+
+The function returns a style object which can be applied to a container. It is passed the current device type, which can be obtained from `__experimentalGetPreviewDeviceType`.
+
+```jsx
+import { __experimentalUseResizeCanvas as useResizeCanvas } from '@wordpress/block-editor';
+
+function ResizedContainer() {
+	const deviceType = useSelect( ( select ) => {
+		return select( 'core/edit-post' ).__experimentalGetPreviewDeviceType();
+	}, [] );
+	const inlineStyles = useResizeCanvas( deviceType );
+
+	return (
+		<div style={ resizeStyles }>
+			Your content
+		</div>
+	)
+}
+```
+
+## Props
+
+The hook accepts the following props.
+
+### deviceType
+
+The type of device the container is rendered into. Accepted values are: `Mobile`, `Tablet`, and `Desktop`.
+
+-   Type: `String`
+-   Required: Yes

--- a/packages/block-editor/src/components/use-resize-canvas/README.md
+++ b/packages/block-editor/src/components/use-resize-canvas/README.md
@@ -1,6 +1,6 @@
 # useResizeCanvas
 
-This function generates inline CSS suitable for resizing a container to fit a device's dimensions. It adjusts the CSS according to the current device dimensions. It has no effect on desktop.
+This React hook generates inline CSS suitable for resizing a container to fit a device's dimensions. It adjusts the CSS according to the current device dimensions. It has no effect on desktop.
 
 On-page CSS media queries are also updated to match the width of the device.
 
@@ -14,7 +14,7 @@ Note that this is currently experimental, and is available as `__experimentalUse
 
 ### Usage
 
-The function returns a style object which can be applied to a container. It is passed the current device type, which can be obtained from `__experimentalGetPreviewDeviceType`.
+The hook returns a style object which can be applied to a container. It is passed the current device type, which can be obtained from `__experimentalGetPreviewDeviceType`.
 
 ```jsx
 import { __experimentalUseResizeCanvas as useResizeCanvas } from '@wordpress/block-editor';


### PR DESCRIPTION
## Description
Add documentation for the `useResizeCanvas` function. See https://github.com/WordPress/gutenberg/issues/22891

## How has this been tested?
N/A, documentation only

## Types of changes
Documentation

## Checklist:
- [n/a] My code is tested.
- [n/a] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [n/a] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [n/a] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
