### PR TITLE
Show proper message on trash of an entity

### DIFF
--- a/packages/editor/src/store/utils/notice-builder.js
+++ b/packages/editor/src/store/utils/notice-builder.js
@@ -31,11 +31,18 @@ export function getNotificationArgumentsForSaveSuccess( data ) {
 	const publishStatus = [ 'publish', 'private', 'future' ];
 	const isPublished = includes( publishStatus, previousPost.status );
 	const willPublish = includes( publishStatus, post.status );
+	const isTrashed = post.status === 'trash';
 
 	let noticeMessage;
 	let shouldShowLink = get( postType, [ 'viewable' ], false );
 
-	if ( ! isPublished && ! willPublish ) {
+	// Since there is not a label for a post_type `trash` action,
+	// we add the message manually.
+	// Reference: https://developer.wordpress.org/reference/functions/get_post_type_labels/
+	if ( isTrashed ) {
+		noticeMessage = `${ postType.labels.singular_name } trashed.`;
+		shouldShowLink = false;
+	} else if ( ! isPublished && ! willPublish ) {
 		// If saving a non-published post, don't show notice.
 		noticeMessage = null;
 	} else if ( isPublished && ! willPublish ) {

--- a/packages/editor/src/store/utils/test/notice-builder.js
+++ b/packages/editor/src/store/utils/test/notice-builder.js
@@ -17,6 +17,7 @@ describe( 'getNotificationArgumentsForSaveSuccess()', () => {
 			item_scheduled: 'scheduled',
 			item_updated: 'updated',
 			view_item: 'view',
+			singular_name: 'post',
 		},
 		viewable: false,
 	};
@@ -73,6 +74,11 @@ describe( 'getNotificationArgumentsForSaveSuccess()', () => {
 					actions: [ { label: 'view', url: 'some_link' } ],
 				},
 			],
+		],
+		[
+			'when post is trashed',
+			[ 'publish', 'trash' ],
+			[ 'post trashed.', defaultExpectedAction ],
 		],
 	].forEach(
 		( [


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes: https://github.com/WordPress/gutenberg/issues/19144

When moving a post to `trash` from the Document settings pane in Gutenberg, shows a wrong message (`reverted to draft`).
This is because we don't handle the `trash` case. 

Since there is not a label for a post_type `trash` action, I have added that manually with a message: `{Singular name of entity's labels} trashed`.
The singular name is dynamic per post type.

Reference: https://developer.wordpress.org/reference/functions/get_post_type_labels/
<!-- Please describe what you have changed or added -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
