### PR TITLE
Add aria-haspopup to CircularOptionPicker component

### DIFF
--- a/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
+++ b/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
@@ -79,6 +79,7 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
           >
             <button
               aria-expanded={false}
+              aria-haspopup="true"
               aria-label="Custom color picker"
               className="components-button is-link"
               onClick={[Function]}

--- a/packages/components/src/circular-option-picker/index.js
+++ b/packages/components/src/circular-option-picker/index.js
@@ -64,6 +64,7 @@ function DropdownLinkAction( {
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<Button
 					aria-expanded={ isOpen }
+					aria-haspopup="true"
 					onClick={ onToggle }
 					isLink
 					{ ...buttonProps }

--- a/packages/components/src/color-palette/test/__snapshots__/index.js.snap
+++ b/packages/components/src/color-palette/test/__snapshots__/index.js.snap
@@ -89,6 +89,7 @@ exports[`ColorPalette Dropdown .renderContent should render dropdown content 1`]
 exports[`ColorPalette Dropdown .renderToggle should render dropdown content 1`] = `
 <button
   aria-expanded={true}
+  aria-haspopup="true"
   aria-label="Custom color picker"
   className="components-button is-link"
   onClick={[MockFunction]}
@@ -110,12 +111,14 @@ exports[`ColorPalette Dropdown should render it correctly 1`] = `
   >
     <ForwardRef(Button)
       aria-expanded={false}
+      aria-haspopup="true"
       aria-label="Custom color picker"
       isLink={true}
       onClick={[Function]}
     >
       <button
         aria-expanded={false}
+        aria-haspopup="true"
         aria-label="Custom color picker"
         className="components-button is-link"
         onClick={[Function]}
@@ -538,12 +541,14 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
             >
               <ForwardRef(Button)
                 aria-expanded={false}
+                aria-haspopup="true"
                 aria-label="Custom color picker"
                 isLink={true}
                 onClick={[Function]}
               >
                 <button
                   aria-expanded={false}
+                  aria-haspopup="true"
                   aria-label="Custom color picker"
                   className="components-button is-link"
                   onClick={[Function]}


### PR DESCRIPTION
This PR adds the `aria-haspopup` property to the CircularOptionPicker component used in the ColorPalette and GradientPicker components.

See https://github.com/WordPress/gutenberg/issues/24796 for a detailed explanation.
