### PR TITLE
Add documentation for colors component

### DIFF
--- a/packages/block-editor/src/components/colors/README.md
+++ b/packages/block-editor/src/components/colors/README.md
@@ -2,7 +2,7 @@
 
 Set of functions to enable color functionality in Blocks.
 
-## withColors HOC
+## `withColors` HOC
 
 A higher-order component, which handles color logic for class generation color value, retrieval and color attribute setting.
 
@@ -15,7 +15,7 @@ export default compose(
 );
 ```
 
-## createCustomColors HOC
+## `createCustomColors` HOC
 
 A higher-order component factory for creating a 'withCustomColors' HOC, which handles color logic for class generation color value, retrieval and color attribute setting. Use this higher-order component to work with a custom set of colors.
 
@@ -36,7 +36,7 @@ export default compose(
 );
 ```
 
-## useColors hook
+## `useColors` hook
 
 Experimental hook that combines the functionality of the `withColors` HOC and `PanelColorSettings`, with `InspectorControls` into an easy to use `useColors` hook.
 It takes an array of color configuration objects for its first parameter. The second parameter is an optional hooks dependency array for cases where you have closures in your configuration objects, and the third is an optional string to overwrite the default panel title, `__( 'Color Settings' )`.

--- a/packages/block-editor/src/components/colors/README.md
+++ b/packages/block-editor/src/components/colors/README.md
@@ -69,3 +69,8 @@ function MyColorfulComponent() {
 ### Note on sunsetting.
 
 The functionality provided by the `useColors` hook is also available in the form of a—[also currently experimental](https://github.com/WordPress/gutenberg/pull/21021)—support key, `__experimentalColor`. It's expected that the support key version of this feature sunsets the hook.
+
+## Related components.
+
+-   [`PanelColorSettings`](https://github.com/WordPress/gutenberg/blob/bb00ad891db9937862b16867dcebd2a4d830ea86/packages/block-editor/src/components/panel-color-settings/index.js).
+-   [`InspectorControls`](https://github.com/WordPress/gutenberg/blob/bb00ad891db9937862b16867dcebd2a4d830ea86/packages/block-editor/src/components/inspector-controls/README.md).

--- a/packages/block-editor/src/components/colors/README.md
+++ b/packages/block-editor/src/components/colors/README.md
@@ -1,0 +1,71 @@
+# Color HOC and Hook
+
+Set of functions to enable color functionality in Blocks.
+
+## withColors HOC
+
+A higher-order component, which handles color logic for class generation color value, retrieval and color attribute setting.
+
+### Usage
+
+```jsx
+export default compose(
+	withColors( 'backgroundColor', { textColor: 'color' } ),
+	MyColorfulComponent
+);
+```
+
+## createCustomColors HOC
+
+A higher-order component factory for creating a 'withCustomColors' HOC, which handles color logic for class generation color value, retrieval and color attribute setting. Use this higher-order component to work with a custom set of colors.
+
+### Usage
+
+```jsx
+import { createCustomColorsHOC } from '@wordpress/block-editor';
+
+const CUSTOM_COLORS = [
+	{ name: 'Red', slug: 'red', color: '#ff0000' },
+	{ name: 'Blue', slug: 'blue', color: '#0000ff' },
+];
+const withCustomColors = createCustomColorsHOC( CUSTOM_COLORS );
+
+export default compose(
+	withCustomColors( 'backgroundColor', 'borderColor' ),
+	MyColorfulComponent
+);
+```
+
+## useColors hook
+
+Experimental hook that combines the functionality of the `withColors` HOC and `PanelColorSettings`, with `InspectorControls` into an easy to use `useColors` hook.
+It takes an array of color configuration objects for its first parameter. The second parameter is an optional hooks dependency array for cases where you have closures in your configuration objects, and the third is an optional string to overwrite the default panel title, `__( 'Color Settings' )`.
+
+### Usage
+
+```jsx
+import { __experimentalUseColors } from '@wordpress/block-editor';
+
+function MyColorfulComponent() {
+	const { TextColor } = __experimentalUseColors(
+		[ { name: 'textColor', property: 'color' } ],
+		{
+			contrastCheckers: [
+				{
+					textColor: true,
+				},
+			],
+		}
+	);
+
+	return (
+		<>
+			<TextColor>{ /* Colorful content */ }</TextColor>
+		</>
+	);
+}
+```
+
+### Note on sunsetting.
+
+The functionality provided by the `useColors` hook is also available in the form of a—[also currently experimental](https://github.com/WordPress/gutenberg/pull/21021)—support key, `__experimentalColor`. It's expected that the support key version of this feature sunsets the hook.

--- a/packages/block-editor/src/components/colors/README.md
+++ b/packages/block-editor/src/components/colors/README.md
@@ -38,7 +38,8 @@ export default compose(
 
 ## `useColors` hook
 
-Experimental hook that combines the functionality of the `withColors` HOC and `PanelColorSettings`, with `InspectorControls` into an easy to use `useColors` hook.
+Provides the functionality of `withColors` as a React hook.
+
 It takes an array of color configuration objects for its first parameter. The second parameter is an optional hooks dependency array for cases where you have closures in your configuration objects, and the third is an optional string to overwrite the default panel title, `__( 'Color Settings' )`.
 
 ### Usage


### PR DESCRIPTION
## Description
Adding documentation for the colors component. This component provides a collection of color tools for Blocks, most of which were already documented on the code itself.

See https://github.com/WordPress/gutenberg/issues/22891

## How has this been tested?
Documentation only.

## Types of changes
Documentation.

## Checklist:
- n/a My code is tested.
- n/a My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- n/a My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- n/a My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- n/a I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
