### PR TITLE
Post: add backdate warning

### DIFF
--- a/packages/edit-post/src/components/sidebar/post-schedule/index.js
+++ b/packages/edit-post/src/components/sidebar/post-schedule/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { PanelRow, Dropdown, Button, Notice } from '@wordpress/components';
+import { PanelRow, Dropdown, Button } from '@wordpress/components';
 import {
 	PostSchedule as PostScheduleForm,
 	PostScheduleLabel,
@@ -32,13 +32,7 @@ export function PostSchedule() {
 					renderContent={ () => <PostScheduleForm /> }
 				/>
 			</PanelRow>
-			<Notice
-				status="warning"
-				isDismissible={ false }
-				className="edit-post-post-schedule-warning"
-			>
-				{ __( 'Your post will be backdated.' ) }
-			</Notice>
+			<PostScheduleForm.Warning />
 		</PostScheduleCheck>
 	);
 }

--- a/packages/edit-post/src/components/sidebar/post-schedule/index.js
+++ b/packages/edit-post/src/components/sidebar/post-schedule/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { PanelRow, Dropdown, Button } from '@wordpress/components';
+import { PanelRow, Dropdown, Button, Notice } from '@wordpress/components';
 import {
 	PostSchedule as PostScheduleForm,
 	PostScheduleLabel,
@@ -32,6 +32,13 @@ export function PostSchedule() {
 					renderContent={ () => <PostScheduleForm /> }
 				/>
 			</PanelRow>
+			<Notice
+				status="warning"
+				isDismissible={ false }
+				className="edit-post-post-schedule-warning"
+			>
+				{ __( 'Your post will be backdated.' ) }
+			</Notice>
 		</PostScheduleCheck>
 	);
 }

--- a/packages/edit-post/src/components/sidebar/post-schedule/style.scss
+++ b/packages/edit-post/src/components/sidebar/post-schedule/style.scss
@@ -15,4 +15,8 @@
 
 .edit-post-post-schedule-warning {
 	margin: 0;
+
+	.edit-post-post-status & {
+		margin-top: $grid-unit;
+	}
 }

--- a/packages/edit-post/src/components/sidebar/post-schedule/style.scss
+++ b/packages/edit-post/src/components/sidebar/post-schedule/style.scss
@@ -12,3 +12,7 @@
 .components-button.edit-post-post-schedule__toggle {
 	text-align: right;
 }
+
+.edit-post-post-schedule-warning {
+	margin: 0;
+}

--- a/packages/editor/src/components/post-publish-panel/prepublish.js
+++ b/packages/editor/src/components/post-publish-panel/prepublish.js
@@ -7,7 +7,7 @@ import { get } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { PanelBody } from '@wordpress/components';
+import { PanelBody, Notice } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 
 /**
@@ -80,6 +80,13 @@ function PostPublishPanelPrepublish( {
 					>
 						<PostSchedule />
 					</PanelBody>
+					<Notice
+						status="warning"
+						isDismissible={ false }
+						className="editor-post-publish-panel__warning"
+					>
+						{ __( 'Your post will be backdated.' ) }
+					</Notice>
 				</>
 			) }
 			<MaybePostFormatPanel />

--- a/packages/editor/src/components/post-publish-panel/prepublish.js
+++ b/packages/editor/src/components/post-publish-panel/prepublish.js
@@ -80,7 +80,7 @@ function PostPublishPanelPrepublish( {
 					>
 						<PostSchedule />
 					</PanelBody>
-					<PanelBody>
+					<PanelBody className="editor-post-publish-panel_warning">
 						<PostSchedule.Warning />
 					</PanelBody>
 				</>

--- a/packages/editor/src/components/post-publish-panel/prepublish.js
+++ b/packages/editor/src/components/post-publish-panel/prepublish.js
@@ -7,7 +7,7 @@ import { get } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { PanelBody, Notice } from '@wordpress/components';
+import { PanelBody } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 
 /**
@@ -80,13 +80,9 @@ function PostPublishPanelPrepublish( {
 					>
 						<PostSchedule />
 					</PanelBody>
-					<Notice
-						status="warning"
-						isDismissible={ false }
-						className="editor-post-publish-panel__warning"
-					>
-						{ __( 'Your post will be backdated.' ) }
-					</Notice>
+					<PanelBody>
+						<PostSchedule.Warning />
+					</PanelBody>
 				</>
 			) }
 			<MaybePostFormatPanel />

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -151,6 +151,7 @@
 	margin: 0;
 }
 
-.editor-post-publish-panel_warning {
+.editor-post-publish-panel_warning.is-opened {
 	border-top: 0;
+	padding-top: $grid-unit-05;
 }

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -150,3 +150,7 @@
 .editor-post-publish-panel__warning {
 	margin: 0;
 }
+
+.editor-post-publish-panel_warning {
+	border-top: 0;
+}

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -146,3 +146,7 @@
 .post-publish-panel__tip {
 	color: $alert-yellow;
 }
+
+.editor-post-publish-panel__warning {
+	margin: 0;
+}

--- a/packages/editor/src/components/post-schedule/index.js
+++ b/packages/editor/src/components/post-schedule/index.js
@@ -7,11 +7,17 @@ import { DateTimePicker, Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 export function Warning() {
-	const date = useSelect( ( select ) =>
-		select( 'core/editor' ).getEditedPostAttribute( 'date' )
-	);
+	const { date, isFloating } = useSelect( ( select ) => {
+		const { getEditedPostAttribute, isEditedPostDateFloating } = select(
+			'core/editor'
+		);
+		return {
+			date: getEditedPostAttribute( 'date' ),
+			isFloating: isEditedPostDateFloating(),
+		};
+	} );
 
-	if ( Date.parse( date ) >= Date.now() ) {
+	if ( isFloating || Date.parse( date ) >= Date.now() ) {
 		return null;
 	}
 

--- a/packages/editor/src/components/post-schedule/index.js
+++ b/packages/editor/src/components/post-schedule/index.js
@@ -2,13 +2,37 @@
  * WordPress dependencies
  */
 import { __experimentalGetSettings } from '@wordpress/date';
-import { withSelect, withDispatch } from '@wordpress/data';
-import { compose } from '@wordpress/compose';
-import { DateTimePicker } from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { DateTimePicker, Notice } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
-export function PostSchedule( { date, onUpdateDate } ) {
+export function Warning() {
+	const date = useSelect( ( select ) =>
+		select( 'core/editor' ).getEditedPostAttribute( 'date' )
+	);
+
+	if ( Date.parse( date ) >= Date.now() ) {
+		return null;
+	}
+
+	return (
+		<Notice
+			status="warning"
+			isDismissible={ false }
+			className="edit-post-post-schedule-warning"
+		>
+			{ __( 'Your post will be backdated.' ) }
+		</Notice>
+	);
+}
+
+export function PostSchedule() {
+	const date = useSelect( ( select ) =>
+		select( 'core/editor' ).getEditedPostAttribute( 'date' )
+	);
+	const { editPost } = useDispatch( 'core/editor' );
 	const onChange = ( newDate ) => {
-		onUpdateDate( newDate );
+		editPost( { date: newDate } );
 		document.activeElement.blur();
 	};
 	const settings = __experimentalGetSettings();
@@ -33,17 +57,6 @@ export function PostSchedule( { date, onUpdateDate } ) {
 	);
 }
 
-export default compose( [
-	withSelect( ( select ) => {
-		return {
-			date: select( 'core/editor' ).getEditedPostAttribute( 'date' ),
-		};
-	} ),
-	withDispatch( ( dispatch ) => {
-		return {
-			onUpdateDate( date ) {
-				dispatch( 'core/editor' ).editPost( { date } );
-			},
-		};
-	} ),
-] )( PostSchedule );
+PostSchedule.Warning = Warning;
+
+export default PostSchedule;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

Adds a notice to posts when the "scheduled" publish date is in the past. 

Addresses https://github.com/WordPress/gutenberg/issues/13230. 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
