### PR TITLE
Add ContrastChecker component readme (block-editor)

### DIFF
--- a/packages/block-editor/src/components/contrast-checker/README.md
+++ b/packages/block-editor/src/components/contrast-checker/README.md
@@ -15,7 +15,7 @@ A notice will be rendered if the color combination of text and background colors
 Checks the contrast of a `13px` dark gray font against a light gray background.
 
 ```jsx
-import { ContrastChecker } from '@wordpress/block-editor/';
+import { ContrastChecker } from '@wordpress/block-editor';
 
 const Example = () => {
 	return (

--- a/packages/block-editor/src/components/contrast-checker/README.md
+++ b/packages/block-editor/src/components/contrast-checker/README.md
@@ -1,0 +1,73 @@
+# ContrastChecker
+
+ContrastChecker component determines if contrast for text styles is sufficient (WCAG 2.0 AA) when used with a given background color. ContrastCheker also accounts for background color transparency (alpha) as well as font sizes.
+
+A notice will be rendered if the color combination of text and background colors are low.
+
+## Table of contents
+
+1. [Development guidelines](#development-guidelines)
+
+## Developer guidelines
+
+### Usage
+
+Checks the contrast of a `13px` dark gray font against a light gray background.
+
+```jsx
+import { ContrastChecker } from '@wordpress/block-editor/';
+
+const Example = () => {
+	return (
+		<ContrastChecker
+			fontSize={ 13 }
+			textColor="#111"
+			backgroundColor="#eee"
+		/>
+	);
+};
+```
+
+### Props
+
+#### backgroundColor
+
+The background color to check the contrast of text against.
+
+-   Type: `String`
+-   Required: No
+
+#### fallbackBackgroundColor
+
+A fallback background color value, in case `backgroundColor` is not available.
+
+-   Type: `String`
+-   Required: No
+
+#### fallbackTextColor
+
+A fallback text color value, in case `textColor` is not available.
+
+-   Type: `String`
+-   Required: No
+
+#### fontSize
+
+The font-size (as a `px` value) of the text to check the contrast against.
+
+-   Type: `Number`
+-   Required: No
+
+#### isLargeText
+
+Whether the text is large (approximately `24px` or higher).
+
+-   Type: `Boolean`
+-   Required: No
+
+#### textColor
+
+The text color to check the contrast of the background against.
+
+-   Type: `String`
+-   Required: No


### PR DESCRIPTION
This update adds `README.md` documentation for the `ContrastChecker` component in `@wordpress/block-library`.
See https://github.com/WordPress/gutenberg/issues/22891

### How has this been tested?
Documentation only.

### Types of changes
Documentation.

## Checklist:
- [n/a] My code is tested.
- [n/a] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [n/a] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [n/a] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
