### PR TITLE
Add aria-haspopup attribute to CustomGradientBar component

### DIFF
--- a/packages/components/src/custom-gradient-picker/control-points.js
+++ b/packages/components/src/custom-gradient-picker/control-points.js
@@ -105,6 +105,7 @@ function ControlPointButton( {
 					color
 				) }
 				aria-describedby={ descriptionId }
+				aria-haspopup="true"
 				aria-expanded={ isOpen }
 				className={ classnames(
 					'components-custom-gradient-picker__control-point-button',

--- a/packages/components/src/custom-gradient-picker/custom-gradient-bar.js
+++ b/packages/components/src/custom-gradient-picker/custom-gradient-bar.js
@@ -50,6 +50,7 @@ function InsertPoint( {
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<Button
 					aria-expanded={ isOpen }
+					aria-haspopup="true"
 					onClick={ () => {
 						if ( isOpen ) {
 							onCloseInserter();


### PR DESCRIPTION
This PR adds the `aria-haspopup` property to the CustomGradientBar component. See https://github.com/WordPress/gutenberg/issues/24796 for a detailed explanation.
