### PR TITLE
Navigation Component: Split Stories to Improve Their Consumption

### DIFF
--- a/packages/components/src/navigation/stories/controlled-state.js
+++ b/packages/components/src/navigation/stories/controlled-state.js
@@ -1,0 +1,123 @@
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import Navigation from '..';
+import NavigationItem from '../item';
+import NavigationMenu from '../menu';
+
+export function ControlledStateStory() {
+	const [ activeItem, setActiveItem ] = useState( 'item-1' );
+	const [ activeMenu, setActiveMenu ] = useState( 'root' );
+
+	// Mock navigation link
+	const Link = ( { href, children } ) => (
+		<Button
+			href={ href }
+			// Since we're not actually navigating pages, simulate it with on onClick
+			onClick={ ( event ) => {
+				event.preventDefault();
+				const item = href.replace( 'https://example.com/', '' );
+				setActiveItem( item );
+			} }
+		>
+			{ children }
+		</Button>
+	);
+
+	return (
+		<>
+			<Navigation
+				activeItem={ activeItem }
+				activeMenu={ activeMenu }
+				className="navigation-story"
+				onActivateMenu={ setActiveMenu }
+			>
+				<NavigationMenu title="Home">
+					<NavigationItem item="item-1" title="Item 1">
+						<Link href="https://example.com/item-1">Item 1</Link>
+					</NavigationItem>
+					<NavigationItem item="item-2">
+						<Link href="https://example.com/item-2">Item 2</Link>
+					</NavigationItem>
+					<NavigationItem
+						item="item-sub-menu"
+						navigateToMenu="sub-menu"
+						title="Sub-Menu"
+					/>
+				</NavigationMenu>
+				<NavigationMenu
+					menu="sub-menu"
+					parentMenu="root"
+					title="Sub-Menu"
+				>
+					<NavigationItem
+						item="child-1"
+						onClick={ () => setActiveItem( 'child-1' ) }
+						title="Child 1"
+					/>
+					<NavigationItem
+						item="child-2"
+						onClick={ () => setActiveItem( 'child-2' ) }
+						title="Child 2"
+					/>
+					<NavigationItem
+						item="child-nested-sub-menu"
+						navigateToMenu="nested-sub-menu"
+						title="Nested Sub-Menu"
+					/>
+				</NavigationMenu>
+				<NavigationMenu
+					menu="nested-sub-menu"
+					parentMenu="sub-menu"
+					title="Nested Sub-Menu"
+				>
+					<NavigationItem
+						item="sub-child-1"
+						onClick={ () => setActiveItem( 'sub-child-1' ) }
+						title="Sub-Child 1"
+					/>
+					<NavigationItem
+						item="sub-child-2"
+						onClick={ () => setActiveItem( 'sub-child-2' ) }
+						title="Sub-Child 2"
+					/>
+				</NavigationMenu>
+			</Navigation>
+
+			<div className="navigation-story__aside">
+				<p>
+					Menu <code>{ activeMenu }</code> is active.
+					<br />
+					Item <code>{ activeItem }</code> is active.
+				</p>
+				<p>
+					<Button
+						isSecondary
+						onClick={ () => {
+							setActiveMenu( 'nested-sub-menu' );
+						} }
+					>
+						Open the Nested Sub-Menu menu
+					</Button>
+				</p>
+				<p>
+					<Button
+						isSecondary
+						onClick={ () => {
+							setActiveItem( 'child-2' );
+							setActiveMenu( 'sub-menu' );
+						} }
+					>
+						Navigate to Child 2 item
+					</Button>
+				</p>
+			</div>
+		</>
+	);
+}

--- a/packages/components/src/navigation/stories/controlled-state.js
+++ b/packages/components/src/navigation/stories/controlled-state.js
@@ -16,7 +16,7 @@ export function ControlledStateStory() {
 	const [ activeMenu, setActiveMenu ] = useState( 'root' );
 
 	// Mock navigation link
-	const Link = ( { href, children } ) => (
+	const MockLink = ( { href, children } ) => (
 		<Button
 			href={ href }
 			// Since we're not actually navigating pages, simulate it with on onClick
@@ -40,10 +40,14 @@ export function ControlledStateStory() {
 			>
 				<NavigationMenu title="Home">
 					<NavigationItem item="item-1" title="Item 1">
-						<Link href="https://example.com/item-1">Item 1</Link>
+						<MockLink href="https://example.com/item-1">
+							Item 1
+						</MockLink>
 					</NavigationItem>
 					<NavigationItem item="item-2">
-						<Link href="https://example.com/item-2">Item 2</Link>
+						<MockLink href="https://example.com/item-2">
+							Item 2
+						</MockLink>
 					</NavigationItem>
 					<NavigationItem
 						item="item-sub-menu"

--- a/packages/components/src/navigation/stories/default.js
+++ b/packages/components/src/navigation/stories/default.js
@@ -1,0 +1,71 @@
+/**
+ * WordPress dependencies
+ */
+import { Icon, wordpress } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import Navigation from '..';
+import NavigationGroup from '../group';
+import NavigationItem from '../item';
+import NavigationMenu from '../menu';
+
+export function DefaultStory() {
+	return (
+		<Navigation activeItem="item-1" className="navigation-story">
+			<NavigationMenu title="Home">
+				<NavigationGroup title="Menu Group">
+					<NavigationItem item="item-1" title="Item 1" />
+					<NavigationItem item="item-2" title="Item 2" />
+					<NavigationItem
+						badge="5"
+						item="item-sub-menu"
+						navigateToMenu="sub-menu"
+						title="Sub-Menu"
+					/>
+					<NavigationItem item="item-3" title="Item 3" />
+				</NavigationGroup>
+				<NavigationGroup title="External Links">
+					<NavigationItem
+						href="https://wordpress.org/"
+						item="item-4"
+						target="_blank"
+						title="WordPress.org"
+					/>
+					<NavigationItem item="item-5">
+						<a
+							className="navigation-story__wordpress-icon"
+							href="https://wordpress.org/"
+							target="_blank"
+							rel="noreferrer"
+						>
+							<Icon icon={ wordpress } />
+						</a>
+					</NavigationItem>
+				</NavigationGroup>
+			</NavigationMenu>
+
+			<NavigationMenu menu="sub-menu" parentMenu="root" title="Sub-Menu">
+				<NavigationItem item="child-1" title="Child 1" />
+				<NavigationItem item="child-2" title="Child 2" />
+				<NavigationItem
+					badge="2"
+					item="child-nested-sub-menu"
+					navigateToMenu="nested-sub-menu"
+					title="Nested Sub-Menu"
+				/>
+			</NavigationMenu>
+
+			<NavigationMenu
+				backButtonLabel="Custom Back Button Label"
+				menu="nested-sub-menu"
+				parentMenu="sub-menu"
+				title="Nested Sub-Menu"
+			>
+				<NavigationItem item="sub-child-1" title="Sub-Child 1" />
+				<NavigationItem item="sub-child-2" title="Sub-Child 2" />
+			</NavigationMenu>
+		</Navigation>
+	);
+}

--- a/packages/components/src/navigation/stories/default.js
+++ b/packages/components/src/navigation/stories/default.js
@@ -1,69 +1,69 @@
 /**
  * WordPress dependencies
  */
-import { Icon, wordpress } from '@wordpress/icons';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import Navigation from '..';
-import NavigationGroup from '../group';
 import NavigationItem from '../item';
 import NavigationMenu from '../menu';
 
 export function DefaultStory() {
-	return (
-		<Navigation activeItem="item-1" className="navigation-story">
-			<NavigationMenu title="Home">
-				<NavigationGroup title="Menu Group">
-					<NavigationItem item="item-1" title="Item 1" />
-					<NavigationItem item="item-2" title="Item 2" />
-					<NavigationItem
-						badge="5"
-						item="item-sub-menu"
-						navigateToMenu="sub-menu"
-						title="Sub-Menu"
-					/>
-					<NavigationItem item="item-3" title="Item 3" />
-				</NavigationGroup>
-				<NavigationGroup title="External Links">
-					<NavigationItem
-						href="https://wordpress.org/"
-						item="item-4"
-						target="_blank"
-						title="WordPress.org"
-					/>
-					<NavigationItem item="item-5">
-						<a
-							className="navigation-story__wordpress-icon"
-							href="https://wordpress.org/"
-							target="_blank"
-							rel="noreferrer"
-						>
-							<Icon icon={ wordpress } />
-						</a>
-					</NavigationItem>
-				</NavigationGroup>
-			</NavigationMenu>
+	const [ activeItem, setActiveItem ] = useState( 'item-1' );
 
-			<NavigationMenu menu="sub-menu" parentMenu="root" title="Sub-Menu">
-				<NavigationItem item="child-1" title="Child 1" />
-				<NavigationItem item="child-2" title="Child 2" />
+	return (
+		<Navigation activeItem={ activeItem } className="navigation-story">
+			<NavigationMenu title="Home">
 				<NavigationItem
-					badge="2"
+					item="item-1"
+					onClick={ () => setActiveItem( 'item-1' ) }
+					title="Item 1"
+				/>
+				<NavigationItem
+					item="item-2"
+					onClick={ () => setActiveItem( 'item-2' ) }
+					title="Item 2"
+				/>
+				<NavigationItem
+					item="item-sub-menu"
+					navigateToMenu="sub-menu"
+					title="Sub-Menu"
+				/>
+			</NavigationMenu>
+			<NavigationMenu menu="sub-menu" parentMenu="root" title="Sub-Menu">
+				<NavigationItem
+					item="child-1"
+					onClick={ () => setActiveItem( 'child-1' ) }
+					title="Child 1"
+				/>
+				<NavigationItem
+					item="child-2"
+					onClick={ () => setActiveItem( 'child-2' ) }
+					title="Child 2"
+				/>
+				<NavigationItem
 					item="child-nested-sub-menu"
 					navigateToMenu="nested-sub-menu"
 					title="Nested Sub-Menu"
 				/>
 			</NavigationMenu>
-
 			<NavigationMenu
 				menu="nested-sub-menu"
 				parentMenu="sub-menu"
 				title="Nested Sub-Menu"
 			>
-				<NavigationItem item="sub-child-1" title="Sub-Child 1" />
-				<NavigationItem item="sub-child-2" title="Sub-Child 2" />
+				<NavigationItem
+					item="sub-child-1"
+					onClick={ () => setActiveItem( 'sub-child-1' ) }
+					title="Sub-Child 1"
+				/>
+				<NavigationItem
+					item="sub-child-2"
+					onClick={ () => setActiveItem( 'sub-child-2' ) }
+					title="Sub-Child 2"
+				/>
 			</NavigationMenu>
 		</Navigation>
 	);

--- a/packages/components/src/navigation/stories/default.js
+++ b/packages/components/src/navigation/stories/default.js
@@ -58,7 +58,6 @@ export function DefaultStory() {
 			</NavigationMenu>
 
 			<NavigationMenu
-				backButtonLabel="Custom Back Button Label"
 				menu="nested-sub-menu"
 				parentMenu="sub-menu"
 				title="Nested Sub-Menu"

--- a/packages/components/src/navigation/stories/index.js
+++ b/packages/components/src/navigation/stories/index.js
@@ -1,210 +1,27 @@
 /**
- * External dependencies
- */
-import styled from '@emotion/styled';
-
-/**
- * WordPress dependencies
- */
-import { Button } from '@wordpress/components';
-import { useEffect, useState } from '@wordpress/element';
-
-/**
  * Internal dependencies
  */
 import Navigation from '..';
+import NavigationBackButton from '../back-button';
 import NavigationGroup from '../group';
 import NavigationItem from '../item';
 import NavigationMenu from '../menu';
+import { DefaultStory } from './default';
+import { ControlledStateStory } from './controlled-state';
+import { MoreExamplesStory } from './more-examples';
+import './style.css';
 
 export default {
 	title: 'Components/Navigation',
 	component: Navigation,
+	subcomponents: {
+		NavigationBackButton,
+		NavigationGroup,
+		NavigationItem,
+		NavigationMenu,
+	},
 };
 
-const Container = styled.div`
-	max-width: 246px;
-`;
-
-function Example() {
-	const [ activeItem, setActiveItem ] = useState( 'item-1' );
-	const [ activeMenu, setActiveMenu ] = useState( 'root' );
-
-	const [ delayedBadge, setDelayedBadge ] = useState();
-	useEffect( () => {
-		const timeout = setTimeout( () => setDelayedBadge( 2 ), 1500 );
-		return () => clearTimeout( timeout );
-	} );
-
-	// Mock navigation link
-	const Link = ( { href, children } ) => (
-		<a
-			className="components-button"
-			href={ href }
-			// Since we're not actually navigating pages, simulate it with on onClick
-			onClick={ ( event ) => {
-				event.preventDefault();
-				const item = href.replace( 'https://example.com/', '' );
-				setActiveItem( item );
-			} }
-		>
-			{ children }
-		</a>
-	);
-
-	return (
-		<Container>
-			<Navigation
-				activeItem={ activeItem }
-				activeMenu={ activeMenu }
-				onActivateMenu={ setActiveMenu }
-			>
-				<NavigationMenu title="Home">
-					<NavigationGroup title="Group 1">
-						<NavigationItem item="item-1" title="Item 1">
-							<Link href="https://example.com/item-1">
-								Item 1
-							</Link>
-						</NavigationItem>
-						<NavigationItem item="item-2">
-							<Link href="https://example.com/item-2">
-								Item 2
-							</Link>
-						</NavigationItem>
-						<NavigationItem
-							badge="2"
-							item="item-3"
-							navigateToMenu="category"
-							title="Category"
-						/>
-						<NavigationItem
-							badge={ delayedBadge }
-							item="item-3-fetching-badge"
-							navigateToMenu="category"
-							title="Delayed badge"
-						/>
-						<NavigationItem
-							item="item-pointing-non-existing-menu"
-							title="Navigate to a non existing menu"
-							navigateToMenu="non-existing-menu"
-						/>
-					</NavigationGroup>
-					<NavigationGroup title="Group 2">
-						<NavigationItem
-							href="https://wordpress.org/"
-							item="item-4"
-							target="_blank"
-							title="External link"
-						/>
-						<NavigationItem item="item-5">
-							<a
-								href="https://wordpress.org/"
-								// Since we're not actually navigating pages, simulate it with on onClick
-								onClick={ ( event ) => {
-									event.preventDefault();
-									setActiveItem( 'item-5' );
-								} }
-							>
-								<img
-									alt="WordPress Logo"
-									src="https://s.w.org/style/images/about/WordPress-logotype-wmark-white.png"
-									style={ { width: 50, height: 50 } }
-								/>
-							</a>
-						</NavigationItem>
-					</NavigationGroup>
-				</NavigationMenu>
-
-				<NavigationMenu
-					backButtonLabel="Home"
-					menu="category"
-					parentMenu="root"
-					title="Category"
-				>
-					<NavigationItem
-						badge="1"
-						item="child-1"
-						title="Child 1"
-						onClick={ () => setActiveItem( 'child-1' ) }
-					/>
-					<NavigationItem
-						item="child-2"
-						title="Child 2"
-						onClick={ () => setActiveItem( 'child-2' ) }
-					/>
-					<NavigationItem
-						navigateToMenu="nested-category"
-						item="child-3"
-						title="Nested Category"
-					/>
-					<NavigationItem
-						navigateToMenu="custom-back"
-						item="child-4"
-						title="Custom back"
-					/>
-					<NavigationItem
-						navigateToMenu="automatic-back"
-						item="child-5"
-						title="Automatic back"
-					/>
-				</NavigationMenu>
-
-				<NavigationMenu
-					backButtonLabel="Category"
-					menu="nested-category"
-					parentMenu="category"
-					title="Nested Category"
-				>
-					<NavigationItem
-						item="sub-child-1"
-						title="Sub Child 1"
-						onClick={ () => setActiveItem( 'sub-child-1' ) }
-					/>
-					<NavigationItem
-						item="sub-child-2"
-						title="Sub Child 2"
-						onClick={ () => setActiveItem( 'sub-child-2' ) }
-					/>
-				</NavigationMenu>
-
-				<NavigationMenu
-					backButtonLabel="Custom back"
-					menu="custom-back"
-					parentMenu="category"
-					title="Custom backButtonLabel"
-				>
-					<NavigationItem item="sub-2-child-1" title="Sub Child 1" />
-					<NavigationItem item="sub-2-child-2" title="Sub Child 2" />
-				</NavigationMenu>
-
-				<NavigationMenu
-					menu="automatic-back"
-					parentMenu="category"
-					title="Automatic backButtonLabel"
-				>
-					<NavigationItem item="sub-3-child-1" title="Sub Child 1" />
-					<NavigationItem item="sub-3-child-2" title="Sub Child 2" />
-				</NavigationMenu>
-			</Navigation>
-
-			<div style={ { margin: '48px 0 0 24px' } }>
-				<p>
-					Item <code>{ activeItem }</code> is active.
-				</p>
-
-				<Button
-					isSecondary
-					onClick={ () => {
-						setActiveItem( 'child-2' );
-						setActiveMenu( 'category' );
-					} }
-					style={ { marginTop: '12px' } }
-				>
-					Link to Child 2
-				</Button>
-			</div>
-		</Container>
-	);
-}
-
-export const _default = () => <Example />;
+export const _default = () => <DefaultStory />;
+export const controlledState = () => <ControlledStateStory />;
+export const moreExamples = () => <MoreExamplesStory />;

--- a/packages/components/src/navigation/stories/more-examples.js
+++ b/packages/components/src/navigation/stories/more-examples.js
@@ -1,0 +1,38 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import Navigation from '..';
+import NavigationItem from '../item';
+import NavigationMenu from '../menu';
+
+export function MoreExamplesStory() {
+	const [ delayedBadge, setDelayedBadge ] = useState();
+	useEffect( () => {
+		const timeout = setTimeout( () => setDelayedBadge( 2 ), 1500 );
+		return () => clearTimeout( timeout );
+	} );
+
+	return (
+		<Navigation className="navigation-story">
+			<NavigationMenu title="Home">
+				<NavigationItem item="item-1" title="Item 1" />
+				<NavigationItem item="item-2" title="Item 2" />
+				<NavigationItem
+					item="item-nonexistent-menu"
+					navigateToMenu="nonexistent-menu"
+					title="Navigate to Nonexistent Menu"
+				/>
+				<NavigationItem
+					badge={ delayedBadge }
+					item="item-delayed-badge"
+					title="Item with a Delayed Badge"
+				/>
+			</NavigationMenu>
+		</Navigation>
+	);
+}

--- a/packages/components/src/navigation/stories/more-examples.js
+++ b/packages/components/src/navigation/stories/more-examples.js
@@ -2,15 +2,18 @@
  * WordPress dependencies
  */
 import { useEffect, useState } from '@wordpress/element';
+import { Icon, wordpress } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import Navigation from '..';
+import NavigationGroup from '../group';
 import NavigationItem from '../item';
 import NavigationMenu from '../menu';
 
 export function MoreExamplesStory() {
+	const [ activeItem, setActiveItem ] = useState( 'child-1' );
 	const [ delayedBadge, setDelayedBadge ] = useState();
 	useEffect( () => {
 		const timeout = setTimeout( () => setDelayedBadge( 2 ), 1500 );
@@ -18,35 +21,67 @@ export function MoreExamplesStory() {
 	} );
 
 	return (
-		<Navigation className="navigation-story">
+		<Navigation activeItem={ activeItem } className="navigation-story">
 			<NavigationMenu title="Home">
-				<NavigationItem item="item-1" title="Item 1" />
-				<NavigationItem item="item-2" title="Item 2" />
-				<NavigationItem
-					item="item-sub-menu"
-					navigateToMenu="sub-menu"
-					title="Sub-Menu"
-				/>
-				<NavigationItem
-					item="item-nonexistent-menu"
-					navigateToMenu="nonexistent-menu"
-					title="Navigate to Nonexistent Menu"
-				/>
-				<NavigationItem
-					badge={ delayedBadge }
-					item="item-delayed-badge"
-					title="Item with a Delayed Badge"
-				/>
+				<NavigationGroup title="Items without Active State">
+					<NavigationItem item="item-1" title="Item 1" />
+					<NavigationItem item="item-2" title="Item 2" />
+				</NavigationGroup>
+				<NavigationGroup title="Items with Unusual Features">
+					<NavigationItem
+						item="item-sub-menu"
+						navigateToMenu="sub-menu"
+						title="Sub-Menu with Custom Back Label"
+					/>
+					<NavigationItem
+						item="item-nonexistent-menu"
+						navigateToMenu="nonexistent-menu"
+						title="Navigate to Nonexistent Menu"
+					/>
+					<NavigationItem
+						badge={ delayedBadge }
+						item="item-delayed-badge"
+						onClick={ () => setActiveItem( 'item-delayed-badge' ) }
+						title="Item with a Delayed Badge"
+					/>
+				</NavigationGroup>
+				<NavigationGroup title="External Links">
+					<NavigationItem
+						href="https://wordpress.org/"
+						item="item-4"
+						target="_blank"
+						title="WordPress.org"
+					/>
+					<NavigationItem item="item-5">
+						<a
+							className="navigation-story__wordpress-icon"
+							href="https://wordpress.org/"
+							target="_blank"
+							rel="noreferrer"
+						>
+							<Icon icon={ wordpress } />
+							<em>Custom Content</em>
+						</a>
+					</NavigationItem>
+				</NavigationGroup>
 			</NavigationMenu>
 
 			<NavigationMenu
 				backButtonLabel="Custom Back Button Label"
 				menu="sub-menu"
 				parentMenu="root"
-				title="Sub-Menu"
+				title="Sub-Menu with Custom Back Label"
 			>
-				<NavigationItem item="child-1" title="Child 1" />
-				<NavigationItem item="child-2" title="Child 2" />
+				<NavigationItem
+					item="child-1"
+					onClick={ () => setActiveItem( 'child-1' ) }
+					title="Child 1"
+				/>
+				<NavigationItem
+					item="child-2"
+					onClick={ () => setActiveItem( 'child-2' ) }
+					title="Child 2"
+				/>
 			</NavigationMenu>
 		</Navigation>
 	);

--- a/packages/components/src/navigation/stories/more-examples.js
+++ b/packages/components/src/navigation/stories/more-examples.js
@@ -23,6 +23,11 @@ export function MoreExamplesStory() {
 				<NavigationItem item="item-1" title="Item 1" />
 				<NavigationItem item="item-2" title="Item 2" />
 				<NavigationItem
+					item="item-sub-menu"
+					navigateToMenu="sub-menu"
+					title="Sub-Menu"
+				/>
+				<NavigationItem
 					item="item-nonexistent-menu"
 					navigateToMenu="nonexistent-menu"
 					title="Navigate to Nonexistent Menu"
@@ -32,6 +37,16 @@ export function MoreExamplesStory() {
 					item="item-delayed-badge"
 					title="Item with a Delayed Badge"
 				/>
+			</NavigationMenu>
+
+			<NavigationMenu
+				backButtonLabel="Custom Back Button Label"
+				menu="sub-menu"
+				parentMenu="root"
+				title="Sub-Menu"
+			>
+				<NavigationItem item="child-1" title="Child 1" />
+				<NavigationItem item="child-2" title="Child 2" />
 			</NavigationMenu>
 		</Navigation>
 	);

--- a/packages/components/src/navigation/stories/style.css
+++ b/packages/components/src/navigation/stories/style.css
@@ -1,0 +1,14 @@
+.navigation-story {
+	max-width: 300px;
+}
+
+.navigation-story__aside {
+	margin: 48px 0 0 24px;
+}
+
+.navigation-story__wordpress-icon svg {
+	fill: #949494;
+}
+.navigation-story__wordpress-icon:hover svg {
+	fill: #ddd;
+}

--- a/packages/components/src/navigation/stories/style.css
+++ b/packages/components/src/navigation/stories/style.css
@@ -6,8 +6,13 @@
 	margin: 48px 0 0 24px;
 }
 
+.navigation-story__wordpress-icon {
+	align-items: center;
+	display: inline-flex;
+}
 .navigation-story__wordpress-icon svg {
 	fill: #949494;
+	margin-right: 8px;
 }
 .navigation-story__wordpress-icon:hover svg {
 	fill: #ddd;


### PR DESCRIPTION
## Description

While working on the Navigation component, I've realized that every time we add a new feature, we just update the one story with, for example, a new navigation item using the new feature.
IMHO this has quickly become unreadable, the story a mix of all kinds of stuff (its navigation is sometimes controlled and sometimes uncontrolled, there are examples hidden in sub-menus, etc.)

In this PR I've split it into 3 separate stories:
- Default: the `Navigation` component at its minimum. Folks can start here to understand how it can be composed.
- Controlled State: this is what we expect to be the most likely usage. The state is controlled externally, items control their own active state, etc.
- More Examples: this is where we should add minor features that we think are worthy of being showcased, but are not big enough to deserve their own full-fledged story.

When we introduce a new feature (e.g. the [Search](https://github.com/WordPress/gutenberg/pull/25315/files/4776170b3745e963ffac695756eae38ede515bf9..a926291f68c527a90bf742c230138982bb592197#diff-d0a3484bdc3e3290d7d4cf2205a11b40)), we should consider if it's concise enough that can belong to an existing story, or if we should create a new one instead.

## How has this been tested?
`npm run storybook:dev`

## Types of changes
Component Storybook update.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
