### PR TITLE
[Mobile] - MediaUpload - Remove dashicons and use icons instead

### DIFF
--- a/packages/block-editor/src/components/media-upload/index.native.js
+++ b/packages/block-editor/src/components/media-upload/index.native.js
@@ -13,7 +13,13 @@ import {
 	requestMediaPicker,
 	mediaSources,
 } from '@wordpress/react-native-bridge';
-import { capturePhoto, captureVideo, image, wordpress } from '@wordpress/icons';
+import {
+	capturePhoto,
+	captureVideo,
+	image,
+	video,
+	wordpress,
+} from '@wordpress/icons';
 
 export const MEDIA_TYPE_IMAGE = 'image';
 export const MEDIA_TYPE_VIDEO = 'video';
@@ -125,9 +131,9 @@ export class MediaUpload extends React.Component {
 		const isVideo = isOneType && allowedTypes.includes( MEDIA_TYPE_VIDEO );
 
 		if ( isImage || ! isOneType ) {
-			return 'format-image';
+			return image;
 		} else if ( isVideo ) {
-			return 'format-video';
+			return video;
 		}
 	}
 

--- a/packages/components/src/dropdown-menu/index.native.js
+++ b/packages/components/src/dropdown-menu/index.native.js
@@ -11,6 +11,7 @@ import { DOWN } from '@wordpress/keycodes';
 import deprecated from '@wordpress/deprecated';
 import { BottomSheet, PanelBody } from '@wordpress/components';
 import { withPreferredColorScheme } from '@wordpress/compose';
+import { menu } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -38,7 +39,7 @@ function DropdownMenu( {
 	children,
 	className,
 	controls,
-	icon = 'menu',
+	icon = menu,
 	label,
 	popoverProps,
 	toggleProps,


### PR DESCRIPTION
`Gutenberg Mobile PR` -> https://github.com/wordpress-mobile/gutenberg-mobile/pull/2660

## Description
After [this PR](https://github.com/WordPress/gutenberg/pull/20003/) some dashicons were left to update causing the `MediaUpload` component to break on Android. This PR changes those icons to use some from the Icons library.

## How has this been tested?
- Open the app on Android with metro running
- Add any block that allows to upload any media e.g Image block
- Tap on the placeholder
- **Expect** to see the picker without any crashes

## Screenshots <!-- if applicable -->
Before | After
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/94038401-ab72c980-fdc6-11ea-9a2e-d63cc458c4d7.png" width="250" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/94038629-fc82bd80-fdc6-11ea-916a-d2df824e4926.png" width="250" /></kbd> 

**Note**: The icons are slightly different. cc @iamthomasbishop 

We were using for:

**Image**: https://developer.wordpress.org/resource/dashicons/#format-image
**Video**: https://developer.wordpress.org/resource/dashicons/#format-video

**Update**: there was also [another icon](https://github.com/WordPress/gutenberg/pull/25576#pullrequestreview-494893785) that was set as default for the `DropdownMenu` component. This component is used in the `Heading` block but since this block passes its own icon, it wasn't causing issues. I updated it to prevent a future crash.

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
