### PR TITLE
Set default link for images using image_default_link_type option 

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -327,7 +327,7 @@ function gutenberg_add_media_default_link_type( $scripts ) {
 	$scripts->add_inline_script(
 		'wp-mediaelement',
 		sprintf(
-			'var wp.media.defaultLink = %s;',
+			'var wp.media.defaultLinkType = %s;',
 			wp_json_encode( $default_link_type )
 		),
 		'after'

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -305,6 +305,37 @@ function gutenberg_add_date_settings_timezone( $scripts ) {
 add_action( 'wp_default_scripts', 'gutenberg_add_date_settings_timezone', 20 );
 
 /**
+ * Adds Media Setting for default link type
+ *
+ * This can be removed when plugin support requires WordPress 5.6.0+.
+ *
+ * The script registration occurs in core wp-includes/script-loader.php
+ * wp_default_packages_inline_scripts()
+ *
+ * @since 9.?
+ *
+ * @param WP_Scripts $scripts WP_Scripts object.
+ */
+function gutenberg_add_media_default_link_type( $scripts ) {
+	if ( ! did_action( 'init' ) ) {
+		return;
+	}
+
+	// Read option from WordPress
+	$default_link_type = get_option( 'image_default_link_type', '' );
+
+	$scripts->add_inline_script(
+		'wp-mediaelement',
+		sprintf(
+			'var wp.media.defaultLink = %s;',
+			wp_json_encode( $default_link_type )
+		),
+		'after'
+	);
+}
+add_action( 'wp_default_scripts', 'gutenberg_add_media_default_link_type', 20 );
+
+/**
  * Filters default block categories to substitute legacy category names with new
  * block categories.
  *

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -305,37 +305,6 @@ function gutenberg_add_date_settings_timezone( $scripts ) {
 add_action( 'wp_default_scripts', 'gutenberg_add_date_settings_timezone', 20 );
 
 /**
- * Adds Media Setting for default link type
- *
- * This can be removed when plugin support requires WordPress 5.6.0+.
- *
- * The script registration occurs in core wp-includes/script-loader.php
- * wp_default_packages_inline_scripts()
- *
- * @since 9.?
- *
- * @param WP_Scripts $scripts WP_Scripts object.
- */
-function gutenberg_add_media_default_link_type( $scripts ) {
-	if ( ! did_action( 'init' ) ) {
-		return;
-	}
-
-	// Read option from WordPress
-	$default_link_type = get_option( 'image_default_link_type', '' );
-
-	$scripts->add_inline_script(
-		'wp-mediaelement',
-		sprintf(
-			'var wp.media.defaultLinkType = %s;',
-			wp_json_encode( $default_link_type )
-		),
-		'after'
-	);
-}
-add_action( 'wp_default_scripts', 'gutenberg_add_media_default_link_type', 20 );
-
-/**
  * Filters default block categories to substitute legacy category names with new
  * block categories.
  *

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -60,8 +60,7 @@
 			"type": "string"
 		},
 		"linkDestination": {
-			"type": "string",
-			"default": "none"
+			"type": "string"
 		},
 		"linkTarget": {
 			"type": "string",

--- a/packages/block-library/src/image/deprecated.js
+++ b/packages/block-library/src/image/deprecated.js
@@ -59,7 +59,6 @@ const blockAttributes = {
 	},
 	linkDestination: {
 		type: 'string',
-		default: 'none',
 	},
 	linkTarget: {
 		type: 'string',

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -21,6 +21,8 @@ import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { image as icon } from '@wordpress/icons';
 
+/* global wp */
+
 /**
  * Internal dependencies
  */
@@ -83,7 +85,6 @@ export function ImageEdit( {
 		caption,
 		align,
 		id,
-		linkDestination,
 		width,
 		height,
 		sizeSlug,
@@ -152,6 +153,21 @@ export function ImageEdit( {
 			additionalAttributes = { url };
 		}
 
+		// Check if default link setting should be used.
+		let linkDestination = attributes.linkDestination;
+
+		if ( ! linkDestination && wp.media.view.settings.defaultProps.link ) {
+			// The constants used in Gutenberg do not match WP options.
+			// TODO: fix this
+			if ( wp.media.view.settings.defaultProps.link === 'file' ) {
+				linkDestination = LINK_DESTINATION_MEDIA;
+			} else if ( wp.media.view.settings.defaultProps.link === 'post' ) {
+				linkDestination = LINK_DESTINATION_ATTACHMENT;
+			} else {
+				linkDestination = wp.media.view.settings.defaultProps.link;
+			}
+		}
+
 		// Check if the image is linked to it's media.
 		if ( linkDestination === LINK_DESTINATION_MEDIA ) {
 			// Update the media link.
@@ -167,6 +183,7 @@ export function ImageEdit( {
 		setAttributes( {
 			...mediaAttributes,
 			...additionalAttributes,
+			linkDestination,
 		} );
 	}
 

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -168,6 +168,9 @@ export function ImageEdit( {
 			}
 		}
 
+		// If still not set, set to "none" for back compat.
+		linkDestination = linkDestination ? linkDestination : 'none';
+
 		// Check if the image is linked to it's media.
 		if ( linkDestination === LINK_DESTINATION_MEDIA ) {
 			// Update the media link.

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -177,7 +177,6 @@ export function ImageEdit( {
 					linkDestination = LINK_DESTINATION_CUSTOM;
 					break;
 				case LINK_DESTINATION_NONE:
-				default:
 					linkDestination = LINK_DESTINATION_NONE;
 					break;
 			}

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -161,7 +161,10 @@ export function ImageEdit( {
 			// Use the WordPress option to determine the proper default.
 			// The constants used in Gutenberg do not match WP options so a little more complicated than ideal.
 			// TODO: fix this in a follow up PR, requires updating media-text and ui component.
-			switch ( wp.media.view.settings.defaultProps.link ) {
+			switch (
+				wp?.media?.view?.settings?.defaultProps?.link ||
+				LINK_DESTINATION_NONE
+			) {
 				case 'file':
 				case LINK_DESTINATION_MEDIA:
 					linkDestination = LINK_DESTINATION_MEDIA;

--- a/packages/e2e-tests/fixtures/blocks/core__image.json
+++ b/packages/e2e-tests/fixtures/blocks/core__image.json
@@ -6,8 +6,7 @@
         "attributes": {
             "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==",
             "alt": "",
-            "caption": "",
-            "linkDestination": "none"
+            "caption": ""
         },
         "innerBlocks": [],
         "originalContent": "<figure class=\"wp-block-image\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" /></figure>"

--- a/packages/e2e-tests/fixtures/blocks/core__image__center-caption.json
+++ b/packages/e2e-tests/fixtures/blocks/core__image__center-caption.json
@@ -7,8 +7,7 @@
             "align": "center",
             "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==",
             "alt": "",
-            "caption": "Give it a try. Press the \"really wide\" button on the image toolbar.",
-            "linkDestination": "none"
+            "caption": "Give it a try. Press the \"really wide\" button on the image toolbar."
         },
         "innerBlocks": [],
         "originalContent": "<div class=\"wp-block-image\"><figure class=\"aligncenter\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" /><figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure></div>"

--- a/packages/e2e-tests/fixtures/blocks/core__image__deprecated-1.json
+++ b/packages/e2e-tests/fixtures/blocks/core__image__deprecated-1.json
@@ -7,8 +7,7 @@
             "align": "left",
             "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==",
             "alt": "",
-            "caption": "",
-            "linkDestination": "none"
+            "caption": ""
         },
         "innerBlocks": [],
         "originalContent": "<figure class=\"wp-block-image alignleft\" style=\"max-width:50%\">\n\t<img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" />\n</figure>"

--- a/packages/e2e-tests/fixtures/blocks/core__image__deprecated-2.json
+++ b/packages/e2e-tests/fixtures/blocks/core__image__deprecated-2.json
@@ -9,8 +9,7 @@
             "alt": "",
             "caption": "",
             "width": 100,
-            "height": 100,
-            "linkDestination": "none"
+            "height": 100
         },
         "innerBlocks": [],
         "originalContent": "<figure class=\"wp-block-image alignleft\">\n\t<img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" width=\"100\" height=\"100\" />\n</figure>"

--- a/packages/e2e-tests/fixtures/blocks/core__image__deprecated-3.json
+++ b/packages/e2e-tests/fixtures/blocks/core__image__deprecated-3.json
@@ -9,8 +9,7 @@
             "alt": "",
             "caption": "",
             "width": 100,
-            "height": 100,
-            "linkDestination": "none"
+            "height": 100
         },
         "innerBlocks": [],
         "originalContent": "<figure class=\"wp-block-image alignleft is-resized\">\n\t<img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" width=\"100\" height=\"100\" />\n</figure>"

--- a/packages/e2e-tests/specs/editor/blocks/image.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/image.test.js
@@ -77,7 +77,7 @@ describe( 'Image', () => {
 		);
 
 		const regex3 = new RegExp(
-			`<!-- wp:image {"id":\\d+,"sizeSlug":"large"} -->\\s*<figure class="wp-block-image size-large"><img src="[^"]+\\/${ filename2 }\\.png" alt="" class="wp-image-\\d+"/></figure>\\s*<!-- \\/wp:image -->`
+			`<!-- wp:image {"id":\\d+,"sizeSlug":"large","linkDestination":"none"} -->\\s*<figure class="wp-block-image size-large"><img src="[^"]+\\/${ filename2 }\\.png" alt="" class="wp-image-\\d+"/></figure>\\s*<!-- \\/wp:image -->`
 		);
 		expect( await getEditedPostContent() ).toMatch( regex3 );
 

--- a/packages/e2e-tests/specs/editor/blocks/image.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/image.test.js
@@ -48,7 +48,7 @@ describe( 'Image', () => {
 		const filename = await upload( '.wp-block-image input[type="file"]' );
 
 		const regex = new RegExp(
-			`<!-- wp:image {"id":\\d+,"sizeSlug":"large"} -->\\s*<figure class="wp-block-image size-large"><img src="[^"]+\\/${ filename }\\.png" alt="" class="wp-image-\\d+"/></figure>\\s*<!-- \\/wp:image -->`
+			`<!-- wp:image {"id":\\d+,"sizeSlug":"large","linkDestination":"none"} -->\\s*<figure class="wp-block-image size-large"><img src="[^"]+\\/${ filename }\\.png" alt="" class="wp-image-\\d+"/></figure>\\s*<!-- \\/wp:image -->`
 		);
 		expect( await getEditedPostContent() ).toMatch( regex );
 	} );
@@ -58,7 +58,7 @@ describe( 'Image', () => {
 		const filename1 = await upload( '.wp-block-image input[type="file"]' );
 
 		const regex1 = new RegExp(
-			`<!-- wp:image {"id":\\d+,"sizeSlug":"large"} -->\\s*<figure class="wp-block-image size-large"><img src="[^"]+\\/${ filename1 }\\.png" alt="" class="wp-image-\\d+"/></figure>\\s*<!-- \\/wp:image -->`
+			`<!-- wp:image {"id":\\d+,"sizeSlug":"large","linkDestination":"none"} -->\\s*<figure class="wp-block-image size-large"><img src="[^"]+\\/${ filename1 }\\.png" alt="" class="wp-image-\\d+"/></figure>\\s*<!-- \\/wp:image -->`
 		);
 		expect( await getEditedPostContent() ).toMatch( regex1 );
 
@@ -66,7 +66,7 @@ describe( 'Image', () => {
 		await page.click( '[aria-label="Image size presets"] button' );
 
 		const regex2 = new RegExp(
-			`<!-- wp:image {"id":\\d+,"width":3,"height":3,"sizeSlug":"large"} -->\\s*<figure class="wp-block-image size-large is-resized"><img src="[^"]+\\/${ filename1 }\\.png" alt="" class="wp-image-\\d+" width="3" height="3"\\/><\\/figure>\\s*<!-- /wp:image -->`
+			`<!-- wp:image {"id":\\d+,"width":3,"height":3,"sizeSlug":"large","linkDestination":"none"} -->\\s*<figure class="wp-block-image size-large is-resized"><img src="[^"]+\\/${ filename1 }\\.png" alt="" class="wp-image-\\d+" width="3" height="3"\\/><\\/figure>\\s*<!-- /wp:image -->`
 		);
 
 		expect( await getEditedPostContent() ).toMatch( regex2 );


### PR DESCRIPTION
## Description

Use the option for image_default_link_type to set default link for images.
The related PR for galleries is #25582 

Fixes #10173

## How has this been tested?

1. Set the WordPress option `image_default_link_type` to "file" or "post"
You can set by going to your site's `wp-admin/options.php` page or via a plugin using a function like:

```
add_action( 'after_setup_theme', function() {
    update_option( 'image_default_link_type', 'file' );
});
```

2. Add an image in the editor and confirm the default link type is automatically selected.

![confirm-media-link](https://user-images.githubusercontent.com/45363/94055479-d989e680-fd91-11ea-9fdf-d028438f01c4.gif)


## Types of changes

This unsets the default link type in Gutenberg none in favor of the WordPress option default. It checks to see if the option is set and sets the linkDestination based on the option.

There is an unfortunate mismtach between what Gutenberg thinks the option should be and what the historic option values are. The classic editor and previous use `file` to represent Media File, and `post` to represent "Attachment Page". The Gutenberg constants used are `media` and `attachment`.

 

