### PR TITLE
Move custom-fields note in 'Register Meta Field' documentation

### DIFF
--- a/docs/designers-developers/developers/tutorials/metabox/meta-block-2-register-meta.md
+++ b/docs/designers-developers/developers/tutorials/metabox/meta-block-2-register-meta.md
@@ -4,6 +4,8 @@ A post meta field is a WordPress object used to store extra data about a post. Y
 
 When registering the field, note the `show_in_rest` parameter. This ensures the data will be included in the REST API, which the block editor uses to load and save meta data. See the [`register_post_meta`](https://developer.wordpress.org/reference/functions/register_post_meta/) function definition for extra information.
 
+Additionally, your post type needs to support `custom-fields` for `register_post_meta` function to work
+
 To register the field, create a PHP plugin file called `myguten-meta-block.php` including:
 
 ```php
@@ -35,4 +37,3 @@ register_post_meta( 'post', '_myguten_protected_key', array(
 	}
 ) );
 ```
-**Note:** Your post type needs to support `custom-fields` for `register_post_meta` function to work.


### PR DESCRIPTION
Closes #25583

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

Moves the note about `custom-fields` being required for the post type closer to the beginning of the document.

## Types of changes
Documentation update.