### PR TITLE
Remove outdated link in comment.

### DIFF
--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -206,7 +206,6 @@ export function useBlockWrapperProps( props = {}, { __unstableIsHtml } = {} ) {
 		function onMouseLeave( { buttons } ) {
 			// The primary button must be pressed to initiate selection.
 			// See https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons
-			// See https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/which
 			if ( buttons === 1 ) {
 				onSelectionStart( clientId );
 			}


### PR DESCRIPTION
Just a tiny comment tweak. The removed link was no longer relevant after the changes in #25554.