### PR TITLE
Stop auto-focusing Navigation block in Navigation screen.

### DIFF
--- a/packages/edit-navigation/src/components/editor/block-view.js
+++ b/packages/edit-navigation/src/components/editor/block-view.js
@@ -1,26 +1,16 @@
 /**
  * WordPress dependencies
  */
-import { useSelect, useDispatch } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
-import { WritingFlow, ObserveTyping, BlockList } from '@wordpress/block-editor';
+import { BlockList, ObserveTyping, WritingFlow } from '@wordpress/block-editor';
 import { Spinner } from '@wordpress/components';
 
+/**
+ * The current navigation rendered in the form of a core Navigation block.
+ *
+ * @param {Object}  props           Component props.
+ * @param {boolean} props.isPending Whether the navigation post has loaded.
+ */
 export default function BlockView( { isPending } ) {
-	const rootClientId = useSelect(
-		( select ) => select( 'core/block-editor' ).getBlocks()[ 0 ]?.clientId,
-		[]
-	);
-
-	const { selectBlock } = useDispatch( 'core/block-editor' );
-
-	// Select the root Navigation block when it becomes available.
-	useEffect( () => {
-		if ( rootClientId ) {
-			selectBlock( rootClientId );
-		}
-	}, [ rootClientId, selectBlock ] );
-
 	return (
 		<div className="edit-navigation-editor__block-view">
 			{ isPending ? (


### PR DESCRIPTION
## Description
Fixes #25298. I also added a JSDoc comment while I was at it.

## How has this been tested?
I opened the experimental Navigation screen and made sure my focus didn't get auto-moved to the Navigation block.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
