### PR TITLE
Fix color contrast in code editor.

### DIFF
--- a/packages/edit-post/src/components/text-editor/style.scss
+++ b/packages/edit-post/src/components/text-editor/style.scss
@@ -18,7 +18,7 @@
 
 		// Always show outlines in code editor
 		.editor-post-title__input {
-			border: $border-width solid $gray-400;
+			border: $border-width solid $gray-700;
 			margin-bottom: -$border-width;
 
 			// Same padding as body.
@@ -28,7 +28,8 @@
 			}
 
 			&:focus {
-				border: $border-width solid $gray-900;
+				border-color: var(--wp-admin-theme-color);
+				box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color);
 			}
 		}
 

--- a/packages/edit-post/src/components/text-editor/style.scss
+++ b/packages/edit-post/src/components/text-editor/style.scss
@@ -18,7 +18,7 @@
 
 		// Always show outlines in code editor
 		.editor-post-title__input {
-			border: $border-width solid $gray-700;
+			border: $border-width solid $gray-600;
 			margin-bottom: -$border-width;
 
 			// Same padding as body.

--- a/packages/editor/src/components/post-text-editor/style.scss
+++ b/packages/editor/src/components/post-text-editor/style.scss
@@ -1,5 +1,5 @@
 .edit-post-text-editor__body textarea.editor-post-text-editor {
-	border: $border-width solid $gray-700;
+	border: $border-width solid $gray-600;
 	border-radius: 0;
 	display: block;
 	margin: 0;

--- a/packages/editor/src/components/post-text-editor/style.scss
+++ b/packages/editor/src/components/post-text-editor/style.scss
@@ -1,5 +1,6 @@
 .edit-post-text-editor__body textarea.editor-post-text-editor {
-	border: $border-width solid $gray-400;
+	border: $border-width solid $gray-700;
+	border-radius: 0;
 	display: block;
 	margin: 0;
 	width: 100%;
@@ -8,8 +9,9 @@
 	overflow: hidden;
 	font-family: $editor-html-font;
 	line-height: 2.4;
-	border-radius: 0;
 	min-height: 200px;
+	transition: border 0.1s ease-out, box-shadow 0.1s linear;
+	@include reduce-motion("transition");
 
 	// Same padding as title.
 	padding: $grid-unit-20;
@@ -24,10 +26,24 @@
 	}
 
 	&:focus {
-		border: $border-width solid $gray-900;
-		box-shadow: none;
+		border-color: var(--wp-admin-theme-color);
+		box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color);
 
 		// Elevate the z-index on focus so the focus style is uncropped.
 		position: relative;
+	}
+
+	&::-webkit-input-placeholder {
+		color: $dark-gray-placeholder;
+	}
+
+	&::-moz-placeholder {
+		color: $dark-gray-placeholder;
+		// Override Firefox default.
+		opacity: 1;
+	}
+
+	&:-ms-input-placeholder {
+		color: $dark-gray-placeholder;
 	}
 }

--- a/packages/editor/src/components/post-title/style.scss
+++ b/packages/editor/src/components/post-title/style.scss
@@ -34,17 +34,18 @@
 		font-weight: bold;
 		line-height: 1.4;
 
-		// Large text needs a 3:1 contrast ratio.
 		&::-webkit-input-placeholder {
-			color: $medium-gray-placeholder;
+			color: $dark-gray-placeholder;
 		}
 
 		&::-moz-placeholder {
-			color: $medium-gray-placeholder;
+			color: $dark-gray-placeholder;
+			// Override Firefox default.
+			opacity: 1;
 		}
 
 		&:-ms-input-placeholder {
-			color: $medium-gray-placeholder;
+			color: $dark-gray-placeholder;
 		}
 
 		&:focus {


### PR DESCRIPTION
## Description
Fixes #25562.

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/19592990/94086260-0a890c00-fdd0-11ea-8b60-68ffa66b3045.png)
![image](https://user-images.githubusercontent.com/19592990/94086266-12e14700-fdd0-11ea-8edb-82766052ea58.png)
![image](https://user-images.githubusercontent.com/19592990/94086275-1a085500-fdd0-11ea-8135-b4e6f81a1108.png)

### After
![image](https://user-images.githubusercontent.com/19592990/94086087-8b93d380-fdcf-11ea-89d9-2892fc8deffb.png)
![image](https://user-images.githubusercontent.com/19592990/94086107-964e6880-fdcf-11ea-9ac0-15ffba2481f6.png)
![image](https://user-images.githubusercontent.com/19592990/94086119-9ea6a380-fdcf-11ea-8810-521f7621cb2a.png)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
