### PR TITLE
Document Actions: Use page name for header info section

### DIFF
--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -37,7 +37,6 @@ export default function Header( {
 	const {
 		deviceType,
 		hasFixedToolbar,
-		template,
 		templateId,
 		templatePartId,
 		templateType,
@@ -53,7 +52,7 @@ export default function Header( {
 			getPage,
 		} = select( 'core/edit-site' );
 
-		const { getEntityRecord, getEditedEntityRecord } = select( 'core' );
+		const { getEditedEntityRecord } = select( 'core' );
 		const { show_on_front: _showOnFront } = getEditedEntityRecord(
 			'root',
 			'site'
@@ -64,7 +63,6 @@ export default function Header( {
 			deviceType: __experimentalGetPreviewDeviceType(),
 			hasFixedToolbar: isFeatureActive( 'fixedToolbar' ),
 			templateId: _templateId,
-			template: getEntityRecord( 'postType', 'wp_template', _templateId ),
 			templatePartId: getTemplatePartId(),
 			templateType: getTemplateType(),
 			page: getPage(),
@@ -138,7 +136,7 @@ export default function Header( {
 			</div>
 
 			<div className="edit-site-header_center">
-				<DocumentActions documentTitle={ template?.slug } />
+				<DocumentActions documentTitle={ page?.label } />
 			</div>
 
 			<div className="edit-site-header_end">

--- a/packages/edit-site/src/components/page-switcher/index.js
+++ b/packages/edit-site/src/components/page-switcher/index.js
@@ -104,6 +104,7 @@ export default function PageSwitcher( {
 			slug: post.slug,
 			path: getPathAndQueryString( post.url ),
 			context: { postType: post.type, postId: post.id },
+			label: post.title,
 		} );
 
 	const activePath = activePage?.path;

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { select, dispatch, apiFetch } from '@wordpress/data-controls';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -147,6 +148,7 @@ export function* showHomepage() {
 
 	const page = {
 		path: '/',
+		label: showOnFront === 'page' ? __( 'Homepage' ) : __( 'All Posts' ),
 		context:
 			showOnFront === 'page'
 				? {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Use the page name for the header info section. The "page name" here means the label for the "active site page" in the site editor. So for a page/post, it will be the page/post title. For the category, it would be the category name.

resolves #25546

## How has this been tested?
Locally in edit site.

## Screenshots <!-- if applicable -->
![2020-09-23 17 08 18](https://user-images.githubusercontent.com/6265975/94086393-a52d1f00-fdbf-11ea-99c6-c05d4f0e7b63.gif)

## Types of changes
Enhancement.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
