### PR TITLE
Add aria-haspopup to the media flow Replace button

### DIFF
--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -121,6 +121,7 @@ const MediaReplaceFlow = ( {
 					<ToolbarButton
 						ref={ editMediaButtonRef }
 						aria-expanded={ isOpen }
+						aria-haspopup="true"
 						onClick={ onToggle }
 						onKeyDown={ openOnArrowDown }
 					>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This adds the `aria-haspopup` property to the Replace toolbar button in the MediaReplaceFlow component. See #24796 for details.

## How has this been tested?
Manual testing only: insert an image and inspect the Replace toolbar button. Ensure that it has `aria-haspopup=true`.
