### PR TITLE
Add aria-haspopup to the ToolSelector

### DIFF
--- a/packages/block-editor/src/components/tool-selector/index.js
+++ b/packages/block-editor/src/components/tool-selector/index.js
@@ -44,6 +44,7 @@ function ToolSelector( props, ref ) {
 					ref={ ref }
 					icon={ isNavigationTool ? selectIcon : editIcon }
 					aria-expanded={ isOpen }
+					aria-haspopup="true"
 					onClick={ onToggle }
 					/* translators: button label text should, if possible, be under 16 characters. */
 					label={ __( 'Modes' ) }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This adds the aria-haspopup property to the ToolSelector component. See #24796 for details.

## How has this been tested?
Manual only. Inspect the Modes button, and confirm that it has the `aria-haspopup=true` property.