### PR TITLE
Add aria-haspopup property to the TableOfContents component

### DIFF
--- a/packages/editor/src/components/table-of-contents/index.js
+++ b/packages/editor/src/components/table-of-contents/index.js
@@ -32,6 +32,7 @@ function TableOfContents(
 					onClick={ hasBlocks ? onToggle : undefined }
 					icon={ info }
 					aria-expanded={ isOpen }
+					aria-haspopup="true"
 					/* translators: button label text should, if possible, be under 16 characters. */
 					label={ __( 'Details' ) }
 					tooltipPosition="bottom"


### PR DESCRIPTION
Adds the `aria-haspopup` property to the TableOfContents component. See #24796 for details.