### PR TITLE
Revert "Show proper message on trash of an entity"

### DIFF
--- a/packages/editor/src/store/utils/notice-builder.js
+++ b/packages/editor/src/store/utils/notice-builder.js
@@ -31,18 +31,11 @@ export function getNotificationArgumentsForSaveSuccess( data ) {
 	const publishStatus = [ 'publish', 'private', 'future' ];
 	const isPublished = includes( publishStatus, previousPost.status );
 	const willPublish = includes( publishStatus, post.status );
-	const isTrashed = post.status === 'trash';
 
 	let noticeMessage;
 	let shouldShowLink = get( postType, [ 'viewable' ], false );
 
-	// Since there is not a label for a post_type `trash` action,
-	// we add the message manually.
-	// Reference: https://developer.wordpress.org/reference/functions/get_post_type_labels/
-	if ( isTrashed ) {
-		noticeMessage = `${ postType.labels.singular_name } trashed.`;
-		shouldShowLink = false;
-	} else if ( ! isPublished && ! willPublish ) {
+	if ( ! isPublished && ! willPublish ) {
 		// If saving a non-published post, don't show notice.
 		noticeMessage = null;
 	} else if ( isPublished && ! willPublish ) {

--- a/packages/editor/src/store/utils/test/notice-builder.js
+++ b/packages/editor/src/store/utils/test/notice-builder.js
@@ -17,7 +17,6 @@ describe( 'getNotificationArgumentsForSaveSuccess()', () => {
 			item_scheduled: 'scheduled',
 			item_updated: 'updated',
 			view_item: 'view',
-			singular_name: 'post',
 		},
 		viewable: false,
 	};
@@ -74,11 +73,6 @@ describe( 'getNotificationArgumentsForSaveSuccess()', () => {
 					actions: [ { label: 'view', url: 'some_link' } ],
 				},
 			],
-		],
-		[
-			'when post is trashed',
-			[ 'publish', 'trash' ],
-			[ 'post trashed.', defaultExpectedAction ],
 		],
 	].forEach(
 		( [


### PR DESCRIPTION
Reverts WordPress/gutenberg#25563

This is because the string is not translatable and opened a ticket in core here: https://core.trac.wordpress.org/ticket/51387.

When this is resolved the previous PR will take the string from labels. 