### PR TITLE
Add aria-haspopup property to the BlockNavigation component

### DIFF
--- a/packages/block-editor/src/components/block-navigation/dropdown.js
+++ b/packages/block-editor/src/components/block-navigation/dropdown.js
@@ -52,6 +52,7 @@ function BlockNavigationDropdownToggle( {
 			ref={ innerRef }
 			icon={ MenuIcon }
 			aria-expanded={ isOpen }
+			aria-haspopup="true"
 			onClick={ isEnabled ? onToggle : undefined }
 			/* translators: button label text should, if possible, be under 16 characters. */
 			label={ __( 'Outline' ) }


### PR DESCRIPTION
Adds the `aria-haspopup` property to the TableOfContents component. See #24796 for details.