### PR TITLE
Change toolbar drag remove labels

### DIFF
--- a/packages/block-editor/src/components/block-mover/index.js
+++ b/packages/block-editor/src/components/block-mover/index.js
@@ -13,7 +13,7 @@ import { ToolbarGroup, ToolbarItem, Button } from '@wordpress/components';
 import { getBlockType } from '@wordpress/blocks';
 import { useState } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
+import { _n } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -40,9 +40,6 @@ function BlockMover( {
 		return null;
 	}
 
-	const label =
-		clientIds.length === 1 ? __( 'Drag Block' ) : __( 'Drag Blocks' );
-
 	// We emulate a disabled state because forcefully applying the `disabled`
 	// attribute on the buttons while it has focus causes the screen to change
 	// to an unfocused state (body as active element) without firing blur on,
@@ -64,7 +61,11 @@ function BlockMover( {
 							icon={ dragHandle }
 							className="block-editor-block-mover__drag-handle"
 							aria-hidden="true"
-							label={ label }
+							label={ _n(
+								'Drag block',
+								'Drag blocks',
+								clientIds.length
+							) }
 							// Should not be able to tab to drag handle as this
 							// button can only be used with a pointer device.
 							tabIndex="-1"

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -186,8 +186,8 @@ export function BlockSettingsDropdown( {
 										shortcut={ shortcuts.remove }
 									>
 										{ _n(
-											'Remove Block',
-											'Remove Blocks',
+											'Remove block',
+											'Remove blocks',
 											count
 										) }
 									</MenuItem>

--- a/packages/e2e-tests/specs/editor/plugins/cpt-locking.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/cpt-locking.test.js
@@ -40,7 +40,7 @@ describe( 'cpt locking', () => {
 		);
 		await clickBlockToolbarButton( 'More options' );
 		expect(
-			await page.$x( '//button[contains(text(), "Remove Block")]' )
+			await page.$x( '//button[contains(text(), "Remove block")]' )
 		).toHaveLength( 0 );
 	};
 
@@ -172,7 +172,7 @@ describe( 'cpt locking', () => {
 			);
 			await clickBlockToolbarButton( 'More options' );
 			const [ removeBlock ] = await page.$x(
-				'//button[contains(text(), "Remove Block")]'
+				'//button[contains(text(), "Remove block")]'
 			);
 			await removeBlock.click();
 			expect( await getEditedPostContent() ).toMatchSnapshot();

--- a/packages/e2e-tests/specs/editor/various/block-deletion.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-deletion.test.js
@@ -45,7 +45,7 @@ const clickOnBlockSettingsMenuRemoveBlockButton = async () => {
 		await page.keyboard.press( 'Tab' );
 
 		isRemoveButton = await page.evaluate( () => {
-			return document.activeElement.innerText.includes( 'Remove Block' );
+			return document.activeElement.innerText.includes( 'Remove block' );
 		} );
 
 		// Stop looping once we find the button


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This is a follow up PR based on this comment: https://github.com/WordPress/gutenberg/pull/25606#pullrequestreview-495448111
This PR changes the labels from `drag` and ` remove` options in a toolbar (`sentence-case`). `Blocks`  changed to `blocks`.
