### PR TITLE
Fix custom CSS variables in the editor

### DIFF
--- a/packages/edit-site/src/components/editor/global-styles-renderer.js
+++ b/packages/edit-site/src/components/editor/global-styles-renderer.js
@@ -103,7 +103,7 @@ export default ( blockData, baseTree, userTree ) => {
 	const flattenTree = ( input, prefix, token ) => {
 		let result = [];
 		Object.keys( input ).forEach( ( key ) => {
-			const newKey = prefix + key.replace( '/', '-' );
+			const newKey = prefix + kebabCase( key.replace( '/', '-' ) );
 			const newLeaf = input[ key ];
 
 			if ( newLeaf instanceof Object ) {


### PR DESCRIPTION
Follow up to https://github.com/WordPress/gutenberg/pull/25446

Fixes CamelCase to kebab-case conversion within edit-site.