### PR TITLE
Site Editor: Update Navigation Panel Toggle UI

### DIFF
--- a/packages/components/src/navigation/back-button/index.js
+++ b/packages/components/src/navigation/back-button/index.js
@@ -6,6 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
+import { forwardRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Icon, chevronLeft } from '@wordpress/icons';
 
@@ -15,13 +16,10 @@ import { Icon, chevronLeft } from '@wordpress/icons';
 import { useNavigationContext } from '../context';
 import { MenuBackButtonUI } from '../styles/navigation-styles';
 
-export default function NavigationBackButton( {
-	backButtonLabel,
-	className,
-	href,
-	onClick,
-	parentMenu,
-} ) {
+function NavigationBackButton(
+	{ backButtonLabel, className, href, onClick, parentMenu },
+	ref
+) {
 	const { setActiveMenu, navigationTree } = useNavigationContext();
 
 	const classes = classnames(
@@ -34,14 +32,17 @@ export default function NavigationBackButton( {
 	return (
 		<MenuBackButtonUI
 			className={ classes }
-			isTertiary
 			href={ href }
+			isTertiary
 			onClick={ () =>
 				parentMenu ? setActiveMenu( parentMenu, 'right' ) : onClick
 			}
+			ref={ ref }
 		>
 			<Icon icon={ chevronLeft } />
 			{ backButtonLabel || parentMenuTitle || __( 'Back' ) }
 		</MenuBackButtonUI>
 	);
 }
+
+export default forwardRef( NavigationBackButton );

--- a/packages/edit-site/src/components/header/navigation-toggle/index.js
+++ b/packages/edit-site/src/components/header/navigation-toggle/index.js
@@ -35,7 +35,7 @@ function NavigationToggle( { icon, isOpen, onClick } ) {
 		return null;
 	}
 
-	let buttonIcon = <Icon size="32px" icon={ wordpress } />;
+	let buttonIcon = <Icon size="36px" icon={ wordpress } />;
 
 	if ( siteIconUrl ) {
 		buttonIcon = (
@@ -48,7 +48,7 @@ function NavigationToggle( { icon, isOpen, onClick } ) {
 	} else if ( isRequestingSiteIcon ) {
 		buttonIcon = null;
 	} else if ( icon ) {
-		buttonIcon = <Icon size="32px" icon={ icon } />;
+		buttonIcon = <Icon size="36px" icon={ icon } />;
 	}
 
 	return (

--- a/packages/edit-site/src/components/header/navigation-toggle/style.scss
+++ b/packages/edit-site/src/components/header/navigation-toggle/style.scss
@@ -17,8 +17,9 @@
 	width: 300px;
 
 	// Delay to sync with `NavigationPanel` animation
-	transition: 93ms cubic-bezier(0, 0, 0.2, 1);
-	transition-delay: 7ms;
+	transition: width 80ms linear;
+	transition-delay: 20ms;
+	@include reduce-motion("transition");
 
 	.edit-site-navigation-toggle__button {
 		background: $gray-900;

--- a/packages/edit-site/src/components/header/navigation-toggle/style.scss
+++ b/packages/edit-site/src/components/header/navigation-toggle/style.scss
@@ -6,7 +6,8 @@
 		background: $gray-900;
 		border-radius: 0;
 		display: flex;
-		height: $header-height;
+		height: $header-height + $border-width; // Cover header border
+		width: $header-height;
 	}
 }
 
@@ -14,6 +15,10 @@
 	flex-shrink: 0;
 	height: $header-height + $border-width; // Cover header border
 	width: 300px;
+
+	// Delay to sync with `NavigationPanel` animation
+	transition: 93ms cubic-bezier(0, 0, 0.2, 1);
+	transition-delay: 7ms;
 
 	.edit-site-navigation-toggle__button {
 		background: $gray-900;

--- a/packages/edit-site/src/components/header/navigation-toggle/style.scss
+++ b/packages/edit-site/src/components/header/navigation-toggle/style.scss
@@ -2,43 +2,54 @@
 	display: none;
 
 	@include break-medium() {
-		display: flex;
 		align-items: center;
-		background-color: #1e1e1e;
-		height: 61px;
+		background: $gray-900;
 		border-radius: 0;
+		display: flex;
+		height: $header-height;
 	}
 }
 
 .edit-site-navigation-toggle.is-open {
+	flex-shrink: 0;
+	height: $header-height + $border-width; // Cover header border
 	width: 300px;
-}
 
-.edit-site-navigation-toggle__button {
-	color: #fff;
-	margin-left: 14px;
-	margin-right: 14px;
-
-	&:hover {
-		color: #ddd;
+	.edit-site-navigation-toggle__button {
+		background: $gray-900;
 	}
 }
 
-.edit-site-navigation-toggle.components-button.has-icon {
-	justify-content: flex-start;
-	padding: 0;
-	height: 32px;
-	width: 32px;
-	min-width: 32px;
+.edit-site-navigation-toggle__button {
+	align-items: center;
+	background: #23282e; // WP-admin gray.
+	color: $white;
+	height: $header-height + $border-width; // Cover header border
+	width: $header-height;
+
+	&.has-icon {
+		min-width: $header-height;
+
+		&:hover {
+			background: #32373d; // WP-admin light-gray.
+			color: $white;
+		}
+		&:active {
+			color: $white;
+		}
+		&:focus {
+			box-shadow: inset 0 0 0 $border-width-focus var(--wp-admin-theme-color), inset 0 0 0 3px $white;
+		}
+	}
 }
 
 .edit-site-navigation-toggle__site-title {
 	font-style: normal;
 	font-weight: 600;
-	font-size: 13px;
-	line-height: 16px;
-	color: #ddd;
-	margin-right: 14px;
+	font-size: $default-font-size;
+	line-height: $default-line-height;
+	color: $gray-300;
+	margin: 0 $grid-unit-20 0 $grid-unit-10;
 
 	display: -webkit-box;
 	-webkit-line-clamp: 2;

--- a/packages/edit-site/src/components/header/navigation-toggle/style.scss
+++ b/packages/edit-site/src/components/header/navigation-toggle/style.scss
@@ -43,6 +43,10 @@
 	}
 }
 
+.edit-site-navigation-toggle__site-icon {
+	width: 36px;
+}
+
 .edit-site-navigation-toggle__site-title {
 	font-style: normal;
 	font-weight: 600;

--- a/packages/edit-site/src/components/left-sidebar/navigation-panel/index.js
+++ b/packages/edit-site/src/components/left-sidebar/navigation-panel/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import {
 	__experimentalNavigation as Navigation,
 	__experimentalNavigationBackButton as NavigationBackButton,
@@ -15,6 +15,11 @@ import { __ } from '@wordpress/i18n';
 
 const NavigationPanel = () => {
 	const [ showPreview, setShowPreview ] = useState( false );
+	const ref = useRef();
+
+	useEffect( () => {
+		ref.current.focus();
+	}, [ ref ] );
 
 	return (
 		<div className="edit-site-navigation-panel">
@@ -23,8 +28,8 @@ const NavigationPanel = () => {
 					backButtonLabel={ __( 'Dashboard' ) }
 					className="edit-site-navigation-panel__back-to-dashboard"
 					href="index.php"
+					ref={ ref }
 				/>
-
 				<NavigationMenu title="Home">
 					<NavigationGroup title="Example group">
 						<NavigationItem

--- a/packages/edit-site/src/components/left-sidebar/navigation-panel/index.js
+++ b/packages/edit-site/src/components/left-sidebar/navigation-panel/index.js
@@ -1,14 +1,8 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
 import { useEffect, useRef, useState } from '@wordpress/element';
 import {
-	Animate,
 	__experimentalNavigation as Navigation,
 	__experimentalNavigationBackButton as NavigationBackButton,
 	__experimentalNavigationGroup as NavigationGroup,
@@ -28,53 +22,40 @@ const NavigationPanel = () => {
 	}, [ ref ] );
 
 	return (
-		<Animate type="slide-in" options={ { origin: 'right' } }>
-			{ ( { className: animateClassName } ) => (
-				<div
-					className={ classnames(
-						'edit-site-navigation-panel',
-						animateClassName
-					) }
-				>
-					<Navigation>
-						<NavigationBackButton
-							backButtonLabel={ __( 'Dashboard' ) }
-							className="edit-site-navigation-panel__back-to-dashboard"
-							href="index.php"
-							ref={ ref }
+		<div className="edit-site-navigation-panel">
+			<Navigation>
+				<NavigationBackButton
+					backButtonLabel={ __( 'Dashboard' ) }
+					className="edit-site-navigation-panel__back-to-dashboard"
+					href="index.php"
+					ref={ ref }
+				/>
+				<NavigationMenu title="Home">
+					<NavigationGroup title="Example group">
+						<NavigationItem
+							item="item-preview"
+							title="Hover to show preview"
+							onMouseEnter={ () => setShowPreview( true ) }
+							onMouseLeave={ () => setShowPreview( false ) }
 						/>
-						<NavigationMenu title="Home">
-							<NavigationGroup title="Example group">
-								<NavigationItem
-									item="item-preview"
-									title="Hover to show preview"
-									onMouseEnter={ () =>
-										setShowPreview( true )
-									}
-									onMouseLeave={ () =>
-										setShowPreview( false )
-									}
-								/>
-							</NavigationGroup>
-						</NavigationMenu>
-					</Navigation>
+					</NavigationGroup>
+				</NavigationMenu>
+			</Navigation>
 
-					{ showPreview && (
-						<div className="edit-site-navigation-panel__preview">
-							<BlockPreview
-								blocks={ [
-									getBlockFromExample(
-										'core/paragraph',
-										getBlockType( 'core/paragraph' ).example
-									),
-								] }
-								viewportWidth={ 1200 }
-							/>
-						</div>
-					) }
+			{ showPreview && (
+				<div className="edit-site-navigation-panel__preview">
+					<BlockPreview
+						blocks={ [
+							getBlockFromExample(
+								'core/paragraph',
+								getBlockType( 'core/paragraph' ).example
+							),
+						] }
+						viewportWidth={ 1200 }
+					/>
 				</div>
 			) }
-		</Animate>
+		</div>
 	);
 };
 

--- a/packages/edit-site/src/components/left-sidebar/navigation-panel/index.js
+++ b/packages/edit-site/src/components/left-sidebar/navigation-panel/index.js
@@ -1,8 +1,14 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { useEffect, useRef, useState } from '@wordpress/element';
 import {
+	Animate,
 	__experimentalNavigation as Navigation,
 	__experimentalNavigationBackButton as NavigationBackButton,
 	__experimentalNavigationGroup as NavigationGroup,
@@ -22,40 +28,53 @@ const NavigationPanel = () => {
 	}, [ ref ] );
 
 	return (
-		<div className="edit-site-navigation-panel">
-			<Navigation>
-				<NavigationBackButton
-					backButtonLabel={ __( 'Dashboard' ) }
-					className="edit-site-navigation-panel__back-to-dashboard"
-					href="index.php"
-					ref={ ref }
-				/>
-				<NavigationMenu title="Home">
-					<NavigationGroup title="Example group">
-						<NavigationItem
-							item="item-preview"
-							title="Hover to show preview"
-							onMouseEnter={ () => setShowPreview( true ) }
-							onMouseLeave={ () => setShowPreview( false ) }
+		<Animate type="slide-in" options={ { origin: 'right' } }>
+			{ ( { className: animateClassName } ) => (
+				<div
+					className={ classnames(
+						'edit-site-navigation-panel',
+						animateClassName
+					) }
+				>
+					<Navigation>
+						<NavigationBackButton
+							backButtonLabel={ __( 'Dashboard' ) }
+							className="edit-site-navigation-panel__back-to-dashboard"
+							href="index.php"
+							ref={ ref }
 						/>
-					</NavigationGroup>
-				</NavigationMenu>
-			</Navigation>
+						<NavigationMenu title="Home">
+							<NavigationGroup title="Example group">
+								<NavigationItem
+									item="item-preview"
+									title="Hover to show preview"
+									onMouseEnter={ () =>
+										setShowPreview( true )
+									}
+									onMouseLeave={ () =>
+										setShowPreview( false )
+									}
+								/>
+							</NavigationGroup>
+						</NavigationMenu>
+					</Navigation>
 
-			{ showPreview && (
-				<div className="edit-site-navigation-panel__preview">
-					<BlockPreview
-						blocks={ [
-							getBlockFromExample(
-								'core/paragraph',
-								getBlockType( 'core/paragraph' ).example
-							),
-						] }
-						viewportWidth={ 1200 }
-					/>
+					{ showPreview && (
+						<div className="edit-site-navigation-panel__preview">
+							<BlockPreview
+								blocks={ [
+									getBlockFromExample(
+										'core/paragraph',
+										getBlockType( 'core/paragraph' ).example
+									),
+								] }
+								viewportWidth={ 1200 }
+							/>
+						</div>
+					) }
 				</div>
 			) }
-		</div>
+		</Animate>
 	);
 };
 

--- a/packages/edit-site/src/components/left-sidebar/navigation-panel/index.js
+++ b/packages/edit-site/src/components/left-sidebar/navigation-panel/index.js
@@ -4,12 +4,14 @@
 import { useState } from '@wordpress/element';
 import {
 	__experimentalNavigation as Navigation,
+	__experimentalNavigationBackButton as NavigationBackButton,
 	__experimentalNavigationGroup as NavigationGroup,
 	__experimentalNavigationItem as NavigationItem,
 	__experimentalNavigationMenu as NavigationMenu,
 } from '@wordpress/components';
 import { getBlockType, getBlockFromExample } from '@wordpress/blocks';
 import { BlockPreview } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
 
 const NavigationPanel = () => {
 	const [ showPreview, setShowPreview ] = useState( false );
@@ -17,13 +19,13 @@ const NavigationPanel = () => {
 	return (
 		<div className="edit-site-navigation-panel">
 			<Navigation>
-				<NavigationMenu title="Home">
-					<NavigationItem
-						item="item-back"
-						title="Back to dashboard"
-						href="index.php"
-					/>
+				<NavigationBackButton
+					backButtonLabel={ __( 'Dashboard' ) }
+					className="edit-site-navigation-panel__back-to-dashboard"
+					href="index.php"
+				/>
 
+				<NavigationMenu title="Home">
 					<NavigationGroup title="Example group">
 						<NavigationItem
 							item="item-preview"

--- a/packages/edit-site/src/components/left-sidebar/navigation-panel/style.scss
+++ b/packages/edit-site/src/components/left-sidebar/navigation-panel/style.scss
@@ -12,9 +12,14 @@
 	border-radius: 0;
 	border-bottom: $border-width solid $gray-700;
 	height: auto;
-	margin-left: -#{$grid-unit};
+	margin-left: -6px; // +2px to display the focus box-shadow
+	margin-top: 2px; // +2px to display the focus box-shadow
 	padding: $grid-unit $grid-unit-20;
-	width: calc(100% + #{$grid-unit-20});
+	width: calc(100% + #{$grid-unit-15});
+
+	&:focus:not(:disabled) {
+		border-bottom-color: transparent;
+	}
 }
 
 .edit-site-navigation-panel__preview {

--- a/packages/edit-site/src/components/left-sidebar/navigation-panel/style.scss
+++ b/packages/edit-site/src/components/left-sidebar/navigation-panel/style.scss
@@ -1,7 +1,18 @@
 .edit-site-navigation-panel {
-	position: relative;
+	animation: edit-site-navigation-panel__slide-in 0.1s linear;
 	height: 100%;
+	position: relative;
 	width: 300px;
+	@include reduce-motion("animation");
+
+	@keyframes edit-site-navigation-panel__slide-in {
+		from {
+			transform: translateX(-100%);
+		}
+		to {
+			transform: translateX(0%);
+		}
+	}
 
 	.components-navigation {
 		height: 100%;

--- a/packages/edit-site/src/components/left-sidebar/navigation-panel/style.scss
+++ b/packages/edit-site/src/components/left-sidebar/navigation-panel/style.scss
@@ -8,6 +8,15 @@
 	}
 }
 
+.edit-site-navigation-panel__back-to-dashboard.components-button.is-tertiary {
+	border-radius: 0;
+	border-bottom: 1px solid $gray-700;
+	height: auto;
+	margin-left: -#{$grid-unit};
+	padding: $grid-unit $grid-unit-20;
+	width: calc(100% + #{$grid-unit-20});
+}
+
 .edit-site-navigation-panel__preview {
 	display: none;
 	border: $border-width solid $gray-400;

--- a/packages/edit-site/src/components/left-sidebar/navigation-panel/style.scss
+++ b/packages/edit-site/src/components/left-sidebar/navigation-panel/style.scss
@@ -10,7 +10,7 @@
 
 .edit-site-navigation-panel__back-to-dashboard.components-button.is-tertiary {
 	border-radius: 0;
-	border-bottom: 1px solid $gray-700;
+	border-bottom: $border-width solid $gray-700;
 	height: auto;
 	margin-left: -#{$grid-unit};
 	padding: $grid-unit $grid-unit-20;


### PR DESCRIPTION
## Description

Update the toggle UI and the back navigation of the Site Editor navigation panel.

See: https://github.com/WordPress/gutenberg/issues/23939

## How has this been tested?

Tested in the local Gutenberg wp-env with the FSE experiment enabled, in the Site Editor.

## Screenshots

| Post Editor (for reference) | Site Editor (collapsed) | Site Editor (expanded) |
| - | - | - |
| <img width="262" alt="Screenshot 2020-09-24 at 16 13 49" src="https://user-images.githubusercontent.com/2070010/94157530-a292fe00-fe81-11ea-8eef-ba91bb3a23b7.png"> | <img width="271" alt="Screenshot 2020-09-24 at 16 14 24" src="https://user-images.githubusercontent.com/2070010/94157547-a7f04880-fe81-11ea-838e-cc291b9c6af9.png"> | <img width="507" alt="Screenshot 2020-09-24 at 16 14 37" src="https://user-images.githubusercontent.com/2070010/94157559-aaeb3900-fe81-11ea-85f8-8dcd8d1411ad.png"> |

## Types of changes
New feature (non-breaking change which adds functionality

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
