### PR TITLE
Avoid hard coding group block name in transform

### DIFF
--- a/packages/block-library/src/group/index.js
+++ b/packages/block-library/src/group/index.js
@@ -94,10 +94,10 @@ export const settings = {
 				isMultiBlock: true,
 				blocks: [ '*' ],
 				__experimentalConvert( blocks ) {
-					// Avoid transforming a single `core/group` Block
+					// Avoid transforming a single instance of this block
 					if (
 						blocks.length === 1 &&
-						blocks[ 0 ].name === 'core/group'
+						blocks[ 0 ].name === this.blockName
 					) {
 						return;
 					}
@@ -130,7 +130,7 @@ export const settings = {
 					} );
 
 					return createBlock(
-						'core/group',
+						this.blockName,
 						{
 							align: widestAlignment,
 						},


### PR DESCRIPTION

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This allows the block to be extended in a block with a different name. I have overridden `core/group` with a custom version of the group block, but it will not allow transforming since this is hard-coded.

## How has this been tested?
This should be covered by existing tests.

## Types of changes
This should function the same in all existing usage, but allow transforms using the name of the block it is embedded in.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] ~~I've included developer documentation if appropriate.~~
- [ ] ~~I've updated all React Native files affected by any refactorings/renamings in this PR.~~
