### PR TITLE
Document Actions: Fix document title misalignment with an open nav sidebar

### DIFF
--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -43,6 +43,7 @@ $button-size: 36px;
 $button-size-small: 24px;
 $header-height: 60px;
 $panel-header-height: $grid-unit-60;
+$nav-sidebar-width: 300px;
 $admin-bar-height: 32px;
 $admin-bar-height-big: 46px;
 $admin-sidebar-width: 160px;

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useState, useMemo, useCallback } from '@wordpress/element';
+import { useEffect, useState, useMemo, useCallback } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	SlotFillProvider,
@@ -153,6 +153,16 @@ function Editor() {
 		[ page?.context ]
 	);
 
+	const isNavigationOpen = leftSidebarContent === 'navigation';
+
+	useEffect( () => {
+		if ( isNavigationOpen ) {
+			document.body.classList.add( 'is-navigation-sidebar-open' );
+		} else {
+			document.body.classList.remove( 'is-navigation-sidebar-open' );
+		}
+	}, [ isNavigationOpen ] );
+
 	const toggleLeftSidebarContent = ( value ) =>
 		setLeftSidebarContent( leftSidebarContent === value ? null : value );
 
@@ -220,8 +230,7 @@ function Editor() {
 															)
 														}
 														isNavigationOpen={
-															leftSidebarContent ===
-															'navigation'
+															isNavigationOpen
 														}
 														onToggleNavigation={ () =>
 															toggleLeftSidebarContent(

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -90,13 +90,13 @@ export default function Header( {
 				'navigation-open': isNavigationOpen,
 			} ) }
 		>
-			<MainDashboardButton.Slot>
-				<NavigationToggle
-					isOpen={ isNavigationOpen }
-					onClick={ onToggleNavigation }
-				/>
-			</MainDashboardButton.Slot>
-			<div className="edit-site-header_toolbar-container">
+			<div className="edit-site-header_start">
+				<MainDashboardButton.Slot>
+					<NavigationToggle
+						isOpen={ isNavigationOpen }
+						onClick={ onToggleNavigation }
+					/>
+				</MainDashboardButton.Slot>
 				<div className="edit-site-header__toolbar">
 					<Button
 						isPrimary
@@ -128,11 +128,11 @@ export default function Header( {
 				</div>
 			</div>
 
-			<div className="edit-site-header_document-actions-container">
+			<div className="edit-site-header_center">
 				<DocumentActions documentTitle={ template?.slug } />
 			</div>
 
-			<div className="edit-site-header_actions-container">
+			<div className="edit-site-header_end">
 				<div className="edit-site-header__actions">
 					<PreviewOptions
 						deviceType={ deviceType }

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { useViewportMatch } from '@wordpress/compose';
@@ -80,14 +85,18 @@ export default function Header( {
 		! isLargeViewport || deviceType !== 'Desktop' || hasFixedToolbar;
 
 	return (
-		<div className="edit-site-header">
+		<div
+			className={ classnames( 'edit-site-header', {
+				'navigation-open': isNavigationOpen,
+			} ) }
+		>
+			<MainDashboardButton.Slot>
+				<NavigationToggle
+					isOpen={ isNavigationOpen }
+					onClick={ onToggleNavigation }
+				/>
+			</MainDashboardButton.Slot>
 			<div className="edit-site-header_start">
-				<MainDashboardButton.Slot>
-					<NavigationToggle
-						isOpen={ isNavigationOpen }
-						onClick={ onToggleNavigation }
-					/>
-				</MainDashboardButton.Slot>
 				<div className="edit-site-header__toolbar">
 					<Button
 						isPrimary

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -1,11 +1,7 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
+import { useEffect } from '@wordpress/element';
 import { useViewportMatch } from '@wordpress/compose';
 import {
 	BlockNavigationDropdown,
@@ -80,16 +76,20 @@ export default function Header( {
 		setPage,
 	} = useDispatch( 'core/edit-site' );
 
+	useEffect( () => {
+		if ( isNavigationOpen ) {
+			document.body.classList.add( 'is-navigation-sidebar-open' );
+		} else {
+			document.body.classList.remove( 'is-navigation-sidebar-open' );
+		}
+	}, [ isNavigationOpen ] );
+
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const displayBlockToolbar =
 		! isLargeViewport || deviceType !== 'Desktop' || hasFixedToolbar;
 
 	return (
-		<div
-			className={ classnames( 'edit-site-header', {
-				'navigation-open': isNavigationOpen,
-			} ) }
-		>
+		<div className="edit-site-header">
 			<div className="edit-site-header_start">
 				<MainDashboardButton.Slot>
 					<NavigationToggle

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { useEffect } from '@wordpress/element';
 import { useViewportMatch } from '@wordpress/compose';
 import {
 	BlockNavigationDropdown,
@@ -75,14 +74,6 @@ export default function Header( {
 		__experimentalSetPreviewDeviceType: setPreviewDeviceType,
 		setPage,
 	} = useDispatch( 'core/edit-site' );
-
-	useEffect( () => {
-		if ( isNavigationOpen ) {
-			document.body.classList.add( 'is-navigation-sidebar-open' );
-		} else {
-			document.body.classList.remove( 'is-navigation-sidebar-open' );
-		}
-	}, [ isNavigationOpen ] );
 
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const displayBlockToolbar =

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -96,7 +96,7 @@ export default function Header( {
 					onClick={ onToggleNavigation }
 				/>
 			</MainDashboardButton.Slot>
-			<div className="edit-site-header_start">
+			<div className="edit-site-header_toolbar-container">
 				<div className="edit-site-header__toolbar">
 					<Button
 						isPrimary
@@ -128,11 +128,11 @@ export default function Header( {
 				</div>
 			</div>
 
-			<div className="edit-site-header_center">
+			<div className="edit-site-header_document-actions-container">
 				<DocumentActions documentTitle={ template?.slug } />
 			</div>
 
-			<div className="edit-site-header_end">
+			<div className="edit-site-header_actions-container">
 				<div className="edit-site-header__actions">
 					<PreviewOptions
 						deviceType={ deviceType }

--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -21,7 +21,7 @@
 }
 
 // Keeps the document title centered when the sidebar is open
-.navigation-open {
+body.is-navigation-sidebar-open {
 	.edit-site-header_start {
 		flex-basis: $nav-sidebar-width;
 	}

--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -20,10 +20,10 @@
 	}
 }
 
-// TODO: Figure out where to place variable for 300px sidebar width
+// Keeps the document title centered when the sidebar is open
 .navigation-open {
 	.edit-site-header_center {
-		margin-left: 300px;
+		margin-left: $nav-sidebar-width;
 	}
 }
 

--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -22,8 +22,8 @@
 
 // Keeps the document title centered when the sidebar is open
 .navigation-open {
-	.edit-site-header_center {
-		margin-left: $nav-sidebar-width;
+	.edit-site-header_start {
+		flex-basis: $nav-sidebar-width;
 	}
 }
 

--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -5,13 +5,13 @@
 	box-sizing: border-box;
 	position: relative;
 
-	.edit-site-header_start,
-	.edit-site-header_end {
+	.edit-site-header_toolbar-container,
+	.edit-site-header_actions-container {
 		flex: 1;
 		display: flex;
 	}
 
-	.edit-site-header_center {
+	.edit-site-header_document-actions-container {
 		display: flex;
 		height: 100%;
 		left: 50%;
@@ -20,7 +20,7 @@
 		position: absolute;
 	}
 
-	.edit-site-header_end {
+	.edit-site-header_actions-container {
 		justify-content: flex-end;
 	}
 }
@@ -28,7 +28,7 @@
 .navigation-open {
 	position: initial;
 
-	.edit-site-header_center {
+	.edit-site-header_document-actions-container {
 		left: auto;
 		top: auto;
 		transform: none;

--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -3,6 +3,7 @@
 	display: flex;
 	height: $header-height;
 	box-sizing: border-box;
+	position: relative;
 
 	.edit-site-header_start,
 	.edit-site-header_end {
@@ -13,10 +14,25 @@
 	.edit-site-header_center {
 		display: flex;
 		height: 100%;
+		left: 50%;
+		top: 50%;
+		transform: translate(-50%, -50%);
+		position: absolute;
 	}
 
 	.edit-site-header_end {
 		justify-content: flex-end;
+	}
+}
+
+.navigation-open {
+	position: initial;
+
+	.edit-site-header_center {
+		left: auto;
+		top: auto;
+		transform: none;
+		position: initial;
 	}
 }
 

--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -3,36 +3,27 @@
 	display: flex;
 	height: $header-height;
 	box-sizing: border-box;
-	position: relative;
 
-	.edit-site-header_toolbar-container,
-	.edit-site-header_actions-container {
+	.edit-site-header_start,
+	.edit-site-header_end {
 		flex: 1;
 		display: flex;
 	}
 
-	.edit-site-header_document-actions-container {
+	.edit-site-header_center {
 		display: flex;
 		height: 100%;
-		left: 50%;
-		top: 50%;
-		transform: translate(-50%, -50%);
-		position: absolute;
 	}
 
-	.edit-site-header_actions-container {
+	.edit-site-header_end {
 		justify-content: flex-end;
 	}
 }
 
+// TODO: Figure out where to place variable for 300px sidebar width
 .navigation-open {
-	position: initial;
-
-	.edit-site-header_document-actions-container {
-		left: auto;
-		top: auto;
-		transform: none;
-		position: initial;
+	.edit-site-header_center {
+		margin-left: 300px;
 	}
 }
 

--- a/packages/edit-site/src/components/left-sidebar/navigation-panel/style.scss
+++ b/packages/edit-site/src/components/left-sidebar/navigation-panel/style.scss
@@ -2,7 +2,7 @@
 	animation: edit-site-navigation-panel__slide-in 0.1s linear;
 	height: 100%;
 	position: relative;
-	width: 300px;
+	width: $nav-sidebar-width;
 	@include reduce-motion("animation");
 
 	@keyframes edit-site-navigation-panel__slide-in {
@@ -59,7 +59,7 @@
 .edit-site-navigation-panel__preview {
 	display: none;
 	border: $border-width solid $gray-400;
-	width: 300px;
+	width: $nav-sidebar-width;
 	padding: $grid-unit-20;
 	background: $white;
 	box-shadow: $shadow-popover;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
The document title in the site editor isn't center aligned with content when the new navigation sidebar is open.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Set up the site editor in a local dev environment
2. Navigate to the site editor from the wp-admin sidebar
3. Note the centered positioning of the topbar document title
4. Open the new navigation sidebar by clicking on the wordpress icon in the top left corner of the screen
5. Note that the positioning of the topbar document title is still centered with editor content

## Screenshots <!-- if applicable -->
### Before
![Before](https://user-images.githubusercontent.com/5414230/94202703-fc3ffc00-fe72-11ea-90b8-10e7f6e24cbb.gif)

### After
![After](https://user-images.githubusercontent.com/5414230/94202592-cc90f400-fe72-11ea-984f-c9ef1783e79f.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix which addresses https://github.com/WordPress/gutenberg/issues/25629.

Elaborating more on the approach, there are two scenarios we have to support.

1. When the nav sidebar is closed, we want to center the document title with editor content, which happens to match the browser viewport.
2. When the nav sidebar is open, the center of editor content no longer matches the center of the browser viewport. The center becomes a segment of the viewport. 

Moving the nav sidebar component outside of the `edit-site-header_start` wrapper with the existing flex layout solves # 2. To handle situation # 1, I absolutely position the document title in the middle of the page. Opening the sidebar just removes all references to absolute positioning. Closing the sidebar reintroduces absolute positioning.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
