### PR TITLE
Simplify Button styles and remove isTertiary.

### DIFF
--- a/packages/block-editor/src/components/block-breadcrumb/index.js
+++ b/packages/block-editor/src/components/block-breadcrumb/index.js
@@ -55,7 +55,7 @@ function BlockBreadcrumb() {
 				{ hasSelection && (
 					<Button
 						className="block-editor-block-breadcrumb__button"
-						isTertiary
+						isSecondary
 						onClick={ clearSelectedBlock }
 					>
 						{ __( 'Document' ) }
@@ -67,7 +67,7 @@ function BlockBreadcrumb() {
 				<li key={ parentClientId }>
 					<Button
 						className="block-editor-block-breadcrumb__button"
-						isTertiary
+						isSecondary
 						onClick={ () => selectBlock( parentClientId ) }
 					>
 						<BlockTitle clientId={ parentClientId } />

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -282,7 +282,7 @@ export function MediaPlaceholder( {
 						className="block-editor-media-placeholder__button"
 						onClick={ openURLInput }
 						isPressed={ isURLInputVisible }
-						isTertiary
+						isSecondary
 					>
 						{ __( 'Insert from URL' ) }
 					</Button>
@@ -315,7 +315,7 @@ export function MediaPlaceholder( {
 				render={ ( { open } ) => {
 					return (
 						<Button
-							isTertiary
+							isSecondary
 							onClick={ ( event ) => {
 								event.stopPropagation();
 								open();

--- a/packages/block-editor/src/components/preview-options/index.js
+++ b/packages/block-editor/src/components/preview-options/index.js
@@ -29,7 +29,7 @@ export default function PreviewOptions( {
 		position: 'bottom left',
 	};
 	const toggleProps = {
-		isTertiary: true,
+		isSecondary: true,
 		className: 'block-editor-post-preview__button-toggle',
 		disabled: ! isEnabled,
 		/* translators: button label text should, if possible, be under 16 characters. */

--- a/packages/block-library/src/template-part/edit/placeholder/index.js
+++ b/packages/block-library/src/template-part/edit/placeholder/index.js
@@ -55,7 +55,7 @@ export default function TemplatePartPlaceholder( { setAttributes } ) {
 						>
 							{ __( 'Choose existing' ) }
 						</Button>
-						<Button isTertiary onClick={ onCreate }>
+						<Button isSecondary onClick={ onCreate }>
 							{ __( 'New template part' ) }
 						</Button>
 					</>

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -201,7 +201,7 @@ function VideoEdit( {
 									  ) }
 							</p>
 							{ !! poster && (
-								<Button onClick={ onRemovePoster } isTertiary>
+								<Button onClick={ onRemovePoster } isSecondary>
 									{ __( 'Remove' ) }
 								</Button>
 							) }

--- a/packages/components/src/button/README.md
+++ b/packages/components/src/button/README.md
@@ -153,14 +153,6 @@ Renders a primary button style.
 -   Required: No
 -   Default: `false`
 
-#### isTertiary
-
-Renders a text-based button style.
-
--   Type: `Boolean`
--   Required: No
--   Default: `false`
-
 #### isDestructive
 
 Renders a red text-based button style to indicate destructive behavior.

--- a/packages/components/src/button/index.js
+++ b/packages/components/src/button/index.js
@@ -50,11 +50,16 @@ export function Button( props, ref ) {
 		} );
 	}
 
+	if ( isTertiary ) {
+		deprecated( 'Button isTertiary prop', {
+			alternative: 'isSecondary',
+		} );
+	}
+
 	const classes = classnames( 'components-button', className, {
-		'is-secondary': isDefault || isSecondary,
+		'is-secondary': isSecondary || isDefault || isTertiary,
 		'is-primary': isPrimary,
 		'is-small': isSmall,
-		'is-tertiary': isTertiary,
 		'is-pressed': isPressed,
 		'is-busy': isBusy,
 		'is-link': isLink,

--- a/packages/components/src/button/stories/index.js
+++ b/packages/components/src/button/stories/index.js
@@ -39,12 +39,6 @@ export const secondary = () => {
 	return <Button isSecondary>{ label }</Button>;
 };
 
-export const tertiary = () => {
-	const label = text( 'Label', 'Tertiary Button' );
-
-	return <Button isTertiary>{ label }</Button>;
-};
-
 export const isDestructive = () => {
 	const label = text( 'Label', 'Destructive Button' );
 	const isSmall = boolean( 'isSmall', false );
@@ -165,13 +159,9 @@ export const buttons = () => {
 				<Button isSecondary isSmall>
 					Secondary Button
 				</Button>
-				<Button isTertiary isSmall>
-					Tertiary Button
-				</Button>
 				<Button isSmall icon={ more } />
 				<Button isSmall isPrimary icon={ more } />
 				<Button isSmall isSecondary icon={ more } />
-				<Button isSmall isTertiary icon={ more } />
 				<Button isSmall isPrimary icon={ more }>
 					Icon & Text
 				</Button>
@@ -182,11 +172,9 @@ export const buttons = () => {
 				<Button>Button</Button>
 				<Button isPrimary>Primary Button</Button>
 				<Button isSecondary>Secondary Button</Button>
-				<Button isTertiary>Tertiary Button</Button>
 				<Button icon={ more } />
 				<Button isPrimary icon={ more } />
 				<Button isSecondary icon={ more } />
-				<Button isTertiary icon={ more } />
 				<Button isPrimary icon={ more }>
 					Icon & Text
 				</Button>

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -12,7 +12,7 @@
 	height: $button-size;
 	align-items: center;
 	box-sizing: border-box;
-	padding: 6px 12px;
+	padding: #{ $grid-unit-15 / 2 } $grid-unit-15;
 	border-radius: $radius-block-ui;
 	color: $gray-900;
 
@@ -101,11 +101,16 @@
 	}
 
 	/**
-	 * Secondary and tertiary buttons.
+	 * Secondary button style.
 	 */
 
-	&.is-secondary,
-	&.is-tertiary {
+	&.is-secondary {
+		box-shadow: inset 0 0 0 $border-width currentColor;
+		outline: 1px solid transparent; // Shown in high contrast mode.
+		white-space: nowrap;
+		color: $gray-900;
+		background: transparent;
+
 		&:active:not(:disabled) {
 			background: $gray-300;
 			color: var(--wp-admin-theme-color-darker-10);
@@ -126,37 +131,11 @@
 			opacity: 1;
 			box-shadow: none;
 		}
-	}
-
-	/**
-	 * Secondary button style.
-	 */
-
-	&.is-secondary {
-		box-shadow: inset 0 0 0 $border-width var(--wp-admin-theme-color);
-		outline: 1px solid transparent; // Shown in high contrast mode.
-		white-space: nowrap;
-		color: var(--wp-admin-theme-color);
-		background: transparent;
-	}
-
-	/**
-	 * Tertiary buttons.
-	 */
-
-	&.is-tertiary {
-		white-space: nowrap;
-		color: var(--wp-admin-theme-color);
-		background: transparent;
-		padding: 6px; // This reduces the horizontal padding on tertiary/text buttons, so as to space them optically.
 
 		.dashicon {
 			display: inline-block;
 			flex: 0 0 auto;
 		}
-
-		// Windows High Contrast mode.
-		outline: 1px dotted transparent;
 	}
 
 	/**

--- a/packages/components/src/flex/stories/index.js
+++ b/packages/components/src/flex/stories/index.js
@@ -222,7 +222,7 @@ export const exampleActions = () => {
 	return (
 		<EnhancedFlex { ...props }>
 			<FlexItem>
-				<Button icon={ arrowLeft } isTertiary />
+				<Button icon={ arrowLeft } isSecondary />
 			</FlexItem>
 			<FlexItem>
 				<Flex justify="left" gap="small">

--- a/packages/components/src/navigation/back-button/index.js
+++ b/packages/components/src/navigation/back-button/index.js
@@ -34,7 +34,7 @@ export default function NavigationBackButton( {
 	return (
 		<MenuBackButtonUI
 			className={ classes }
-			isTertiary
+			isSecondary
 			href={ href }
 			onClick={ () =>
 				parentMenu ? setActiveMenu( parentMenu, 'right' ) : onClick

--- a/packages/components/src/navigation/styles/navigation-styles.js
+++ b/packages/components/src/navigation/styles/navigation-styles.js
@@ -35,7 +35,7 @@ export const MenuUI = styled.div`
 `;
 
 export const MenuBackButtonUI = styled( Button )`
-	&.is-tertiary {
+	&.is-secondary {
 		color: ${ G2.lightGray.ui };
 
 		&:hover:not( :disabled ) {

--- a/packages/components/src/snackbar/index.js
+++ b/packages/components/src/snackbar/index.js
@@ -86,7 +86,7 @@ function Snackbar(
 						<Button
 							key={ index }
 							href={ url }
-							isTertiary
+							isSecondary
 							onClick={ ( event ) => {
 								event.stopPropagation();
 								if ( onClick ) {

--- a/packages/edit-navigation/src/components/header/index.js
+++ b/packages/edit-navigation/src/components/header/index.js
@@ -48,7 +48,7 @@ export default function Header( { menus, selectedMenuId, onSelectMenu } ) {
 					position="bottom center"
 					renderToggle={ ( { isOpen, onToggle } ) => (
 						<Button
-							isTertiary
+							isSecondary
 							aria-expanded={ isOpen }
 							onClick={ onToggle }
 						>
@@ -68,7 +68,7 @@ export default function Header( { menus, selectedMenuId, onSelectMenu } ) {
 					position="bottom center"
 					renderToggle={ ( { isOpen, onToggle } ) => (
 						<Button
-							isTertiary
+							isSecondary
 							aria-expanded={ isOpen }
 							onClick={ onToggle }
 						>

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -92,13 +92,13 @@ function HeaderToolbar() {
 				hasOutlineItemsDisabled={ isTextModeEnabled }
 				repositionDropdown={ showIconLabels && ! isWideViewport }
 				showTooltip={ ! showIconLabels }
-				isTertiary={ showIconLabels }
+				isSecondary={ showIconLabels }
 			/>
 			<ToolbarItem
 				as={ BlockNavigationDropdown }
 				isDisabled={ isTextModeEnabled }
 				showTooltip={ ! showIconLabels }
-				isTertiary={ showIconLabels }
+				isSecondary={ showIconLabels }
 			/>
 		</>
 	);
@@ -143,19 +143,19 @@ function HeaderToolbar() {
 						<ToolbarItem
 							as={ ToolSelector }
 							showTooltip={ ! showIconLabels }
-							isTertiary={ showIconLabels }
+							isSecondary={ showIconLabels }
 							disabled={ isTextModeEnabled }
 						/>
 					) }
 					<ToolbarItem
 						as={ EditorHistoryUndo }
 						showTooltip={ ! showIconLabels }
-						isTertiary={ showIconLabels }
+						isSecondary={ showIconLabels }
 					/>
 					<ToolbarItem
 						as={ EditorHistoryRedo }
 						showTooltip={ ! showIconLabels }
-						isTertiary={ showIconLabels }
+						isSecondary={ showIconLabels }
 					/>
 					{ overflowItems }
 				</>
@@ -192,11 +192,11 @@ function HeaderToolbar() {
 							<MenuGroup label={ __( 'Edit' ) }>
 								<EditorHistoryUndo
 									showTooltip={ ! showIconLabels }
-									isTertiary={ showIconLabels }
+									isSecondary={ showIconLabels }
 								/>
 								<EditorHistoryRedo
 									showTooltip={ ! showIconLabels }
-									isTertiary={ showIconLabels }
+									isSecondary={ showIconLabels }
 								/>
 							</MenuGroup>
 							<MenuGroup>{ overflowItems }</MenuGroup>

--- a/packages/edit-post/src/components/header/more-menu/index.js
+++ b/packages/edit-post/src/components/header/more-menu/index.js
@@ -35,7 +35,7 @@ const MoreMenu = ( { showIconLabels } ) => {
 			popoverProps={ POPOVER_PROPS }
 			toggleProps={ {
 				showTooltip: ! showIconLabels,
-				isTertiary: showIconLabels,
+				isSecondary: showIconLabels,
 				...TOGGLE_PROPS,
 			} }
 		>

--- a/packages/edit-post/src/components/header/more-menu/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/header/more-menu/test/__snapshots__/index.js.snap
@@ -23,7 +23,7 @@ exports[`MoreMenu should match snapshot 1`] = `
     }
     toggleProps={
       Object {
-        "isTertiary": undefined,
+        "isSecondary": undefined,
         "showTooltip": true,
         "tooltipPosition": "bottom",
       }

--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -66,23 +66,19 @@
  */
 
 .edit-post-header__settings {
-	// Adjust button paddings to scale better to mobile.
-	.editor-post-saved-state,
-	.components-button.components-button {
-		margin-right: $grid-unit-05;
-
-		@include break-small() {
-			margin-right: $grid-unit-15;
-		}
+	> * {
+		margin-right: $grid-unit-15;
 	}
 
-	.editor-post-saved-state,
-	.components-button.is-tertiary {
-		padding: 0 #{ $grid-unit-15 / 2 };
+	> :last-child {
+		margin-right: 0;
 	}
 
-	.edit-post-more-menu .components-button,
-	.interface-pinned-items .components-button {
+	.interface-pinned-items {
+		margin-right: 0;
+	}
+
+	.edit-post-more-menu .components-button {
 		margin-right: 0;
 	}
 }
@@ -130,12 +126,7 @@
 			background-color: transparent;
 		}
 	}
-	.is-tertiary {
-		&:active {
-			box-shadow: 0 0 0 1.5px var(--wp-admin-theme-color);
-			background-color: transparent;
-		}
-	}
+
 	// Exception for drodpdown toggle buttons.
 	// Exception for the fullscreen mode button.
 	// Temporary exception for block toolbar (pending design).
@@ -168,12 +159,10 @@
 		}
 	}
 	.components-dropdown-menu__toggle {
-		margin-left: $grid-unit;
 		padding-left: $grid-unit;
 		padding-right: $grid-unit;
 
 		@include break-small {
-			margin-left: $grid-unit-15;
 			padding-left: $grid-unit-15;
 			padding-right: $grid-unit-15;
 		}
@@ -197,6 +186,33 @@
 	}
 }
 
+.show-icon-labels .edit-post-header-toolbar {
+	> * {
+		margin-right: $grid-unit-05;
+	}
+
+	> :last-child {
+		margin-right: 0;
+	}
+}
+
+.show-icon-labels .interface-pinned-items {
+	margin-right: $grid-unit-15;
+
+	// Apply standard secondary button styles, but only when the button isn't pressed.
+	> .components-button:not(.is-pressed) {
+		&:not(:focus) {
+			box-shadow: inset 0 0 0 $border-width currentColor;
+		}
+
+		&:active:not(:disabled) {
+			background: $gray-300;
+			color: var(--wp-admin-theme-color-darker-10);
+			box-shadow: none;
+		}
+	}
+}
+
 .edit-post-header__dropdown {
 	.components-menu-item__button.components-menu-item__button,
 	.components-button.editor-history__undo,
@@ -208,6 +224,12 @@
 		width: 14.625rem;
 		text-align: left;
 		justify-content: flex-start;
+	}
+
+	// Remove default secondary button border.
+	.components-button.is-secondary:not(:focus),
+	.components-button.is-secondary:hover:not(:focus) {
+		box-shadow: none;
 	}
 }
 
@@ -223,7 +245,7 @@
 	> .components-button.has-icon {
 		margin: 0;
 		padding: 6px 6px 6px $grid-unit;
-		width: 14.625rem;
+		width: 100%;
 		justify-content: flex-start;
 
 		&[aria-expanded="true"] svg {

--- a/packages/edit-post/src/components/sidebar/post-schedule/index.js
+++ b/packages/edit-post/src/components/sidebar/post-schedule/index.js
@@ -23,7 +23,7 @@ export function PostSchedule() {
 								className="edit-post-post-schedule__toggle"
 								onClick={ onToggle }
 								aria-expanded={ isOpen }
-								isTertiary
+								isSecondary
 							>
 								<PostScheduleLabel />
 							</Button>

--- a/packages/edit-post/src/components/sidebar/post-visibility/index.js
+++ b/packages/edit-post/src/components/sidebar/post-visibility/index.js
@@ -29,7 +29,7 @@ export function PostVisibility() {
 									aria-expanded={ isOpen }
 									className="edit-post-post-visibility__toggle"
 									onClick={ onToggle }
-									isTertiary
+									isSecondary
 								>
 									<PostVisibilityLabel />
 								</Button>

--- a/packages/edit-post/src/components/text-editor/index.js
+++ b/packages/edit-post/src/components/text-editor/index.js
@@ -19,7 +19,7 @@ function TextEditor( { onExit, isRichEditingEnabled } ) {
 				<div className="edit-post-text-editor__toolbar">
 					<h2>{ __( 'Editing code' ) }</h2>
 					<Button
-						isTertiary
+						isSecondary
 						onClick={ onExit }
 						shortcut={ displayShortcut.secondary( 'm' ) }
 					>

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -10,11 +10,10 @@
 	& .components-button {
 		font-family: $default-font;
 		font-size: $default-font-size;
-		padding: 6px 12px;
+		padding: #{ $grid-unit-15 / 2 } $grid-unit-15;
 
-		&.is-tertiary,
 		&.has-icon {
-			padding: 6px;
+			padding: #{ $grid-unit-15 / 2 };
 		}
 	}
 

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -4,10 +4,9 @@
 .edit-site-block-editor__editor-styles-wrapper  .components-button {
 	font-family: $default-font;
 	font-size: $default-font-size;
-	padding: 6px 12px;
+	padding: #{ $grid-unit-15 / 2 } $grid-unit-15;
 
-	&.is-tertiary,
 	&.has-icon {
-		padding: 6px;
+		padding: #{ $grid-unit-15 / 2 };
 	}
 }

--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -48,21 +48,6 @@
  */
 
 .edit-site-header__actions {
-	// Adjust button paddings to scale better to mobile.
-	.editor-post-saved-state,
-	.components-button.components-button {
-		margin-right: $grid-unit-05;
-
-		@include break-small() {
-			margin-right: $grid-unit-15;
-		}
-	}
-
-	.editor-post-saved-state,
-	.components-button.is-tertiary {
-		padding: 0 #{ $grid-unit-15 / 2 };
-	}
-
 	.edit-site-more-menu .components-button,
 	.interface-pinned-items .components-button {
 		margin-right: 0;

--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -196,7 +196,7 @@ export class PostPreviewButton extends Component {
 
 		return (
 			<Button
-				isTertiary={ ! this.props.className }
+				isSecondary={ ! this.props.className }
 				className={ classNames }
 				href={ href }
 				target={ this.getWindowTarget() }

--- a/packages/editor/src/components/post-preview-button/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-preview-button/test/__snapshots__/index.js.snap
@@ -5,7 +5,7 @@ exports[`PostPreviewButton render() should render currentPostLink otherwise 1`] 
   className="editor-post-preview"
   disabled={false}
   href="https://wordpress.org/?p=1"
-  isTertiary={true}
+  isSecondary={true}
   onClick={[Function]}
   target="wp-preview-1"
 >
@@ -23,7 +23,7 @@ exports[`PostPreviewButton render() should render previewLink if provided 1`] = 
   className="editor-post-preview"
   disabled={false}
   href="https://wordpress.org/?p=1&preview=true"
-  isTertiary={true}
+  isSecondary={true}
   onClick={[Function]}
   target="wp-preview-1"
 >

--- a/packages/editor/src/components/post-saved-state/index.js
+++ b/packages/editor/src/components/post-saved-state/index.js
@@ -166,7 +166,7 @@ export default function PostSavedState( {
 			className="editor-post-save-draft"
 			onClick={ () => savePost() }
 			shortcut={ displayShortcut.primary( 's' ) }
-			isTertiary
+			isSecondary
 		>
 			{ label }
 		</Button>

--- a/packages/editor/src/components/post-saved-state/style.scss
+++ b/packages/editor/src/components/post-saved-state/style.scss
@@ -1,8 +1,9 @@
 .editor-post-saved-state {
 	display: flex;
 	align-items: center;
+	min-width: $button-size;
 	width: $button-size - $grid-unit-10;
-	padding: #{ $grid-unit-05 * 3 } $grid-unit-05;
+	padding: #{ $grid-unit-15 / 2 } $grid-unit-15;
 	color: $gray-700;
 	overflow: hidden;
 	white-space: nowrap;
@@ -16,7 +17,6 @@
 
 	@include break-small() {
 		width: auto;
-		padding: $grid-unit-10 #{ $grid-unit-05 * 3 };
 		text-indent: inherit;
 
 		svg {

--- a/packages/editor/src/components/post-saved-state/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-saved-state/test/__snapshots__/index.js.snap
@@ -5,7 +5,7 @@ exports[`PostSavedState returns a switch to draft link if the post is published 
 exports[`PostSavedState should return Save button if edits to be saved 1`] = `
 <ForwardRef(Button)
   className="editor-post-save-draft"
-  isTertiary={true}
+  isSecondary={true}
   onClick={[Function]}
   shortcut="Ctrl+S"
 >

--- a/packages/editor/src/components/post-switch-to-draft-button/index.js
+++ b/packages/editor/src/components/post-switch-to-draft-button/index.js
@@ -40,7 +40,7 @@ function PostSwitchToDraftButton( {
 			className="editor-post-switch-to-draft"
 			onClick={ onSwitch }
 			disabled={ isSaving }
-			isTertiary
+			isSecondary
 		>
 			{ isMobileViewport ? __( 'Draft' ) : __( 'Switch to draft' ) }
 		</Button>

--- a/packages/editor/src/components/post-trash/index.js
+++ b/packages/editor/src/components/post-trash/index.js
@@ -17,7 +17,7 @@ function PostTrash( { isNew, postId, postType, ...props } ) {
 		<Button
 			className="editor-post-trash"
 			isDestructive
-			isTertiary
+			isSecondary
 			onClick={ onClick }
 		>
 			{ __( 'Move to trash' ) }

--- a/packages/interface/src/components/pinned-items/style.scss
+++ b/packages/interface/src/components/pinned-items/style.scss
@@ -2,8 +2,6 @@
 	display: flex;
 
 	.components-button {
-		margin-left: $grid-unit-05;
-
 		svg {
 			max-width: $icon-size;
 			max-height: $icon-size;


### PR DESCRIPTION
## Description
Fixes #23890.

This PR attempts to improve the accessibility of the `Button` component's styles. In general, I tried to clean up some of the messy CSS and make everything more consistent.

The accent color is now used more consistently on buttons: it is now only used for hover, focus, and primary styles. (With the exception of `isLink` buttons, which I haven't touched in this PR.) I always thought it was confusing how the accent color was used as the default outline color of some buttons, but the hover outline color of others.

I've deprecated `isTertiary` and turned it into an alias of `isSecondary` (similar to what happened to `isDefault`). I couldn't find any rhyme or reason as to when one would be chosen over the other, so I figured it would make sense to just merge them.

## How has this been tested?
I've checked just about every button I could find in the UI, both with "Show icon labels" on and with it off, to make sure there are no broken/missing styles.

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/19592990/94205175-58614b00-fe88-11ea-9542-530744b3ee0e.png)
![image](https://user-images.githubusercontent.com/19592990/94205355-c86fd100-fe88-11ea-8b0d-7317f5c65954.png)
![image](https://user-images.githubusercontent.com/19592990/94205631-4a5ffa00-fe89-11ea-845f-69b1fd2fb3fe.png)
![image](https://user-images.githubusercontent.com/19592990/94205106-27811600-fe88-11ea-9202-18a0c994705c.png)
![image](https://user-images.githubusercontent.com/19592990/94205767-957a0d00-fe89-11ea-8a29-b550f28e3bbd.png)
![image](https://user-images.githubusercontent.com/19592990/94205944-edb10f00-fe89-11ea-93b5-9b3276b8a294.png)
![image](https://user-images.githubusercontent.com/19592990/94206050-2bae3300-fe8a-11ea-8788-2fb3ff7a2e99.png)
![image](https://user-images.githubusercontent.com/19592990/94206748-ca875f00-fe8b-11ea-9c08-ce02a0561f91.png)
![image](https://user-images.githubusercontent.com/19592990/94206853-03bfcf00-fe8c-11ea-8055-af226e8db15b.png)
![image](https://user-images.githubusercontent.com/19592990/94207105-83e63480-fe8c-11ea-80d0-1e21faa3f499.png)

### After
![image](https://user-images.githubusercontent.com/19592990/94205221-7af36400-fe88-11ea-9480-920fcef45e65.png)
![image](https://user-images.githubusercontent.com/19592990/94205312-ac6c2f80-fe88-11ea-8301-91ed51bcd792.png)
![image](https://user-images.githubusercontent.com/19592990/94205552-27cde100-fe89-11ea-9cbc-e55731a26280.png)
![image](https://user-images.githubusercontent.com/19592990/94205013-f86aa480-fe87-11ea-985e-928214fb06a6.png)
![image](https://user-images.githubusercontent.com/19592990/94205841-ba6e8000-fe89-11ea-874e-850bf1b43321.png)
![image](https://user-images.githubusercontent.com/19592990/94205880-ca865f80-fe89-11ea-8fec-c0f77d551e1e.png)
![image](https://user-images.githubusercontent.com/19592990/94206117-4e404c00-fe8a-11ea-99ae-ffa6e16324f1.png)
![image](https://user-images.githubusercontent.com/19592990/94206603-7f6d4c00-fe8b-11ea-8bf5-02da5fab8002.png)
![image](https://user-images.githubusercontent.com/19592990/94206909-27831500-fe8c-11ea-988d-f05d2a8f671c.png)
![image](https://user-images.githubusercontent.com/19592990/94207033-61ecb200-fe8c-11ea-8cad-df2fd24f0544.png)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
