### PR TITLE
Inner blocks: try hook approach

### DIFF
--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -32,7 +32,10 @@ export { default as __experimentalGradientPickerPanel } from './gradient-picker/
 export { default as __experimentalColorGradientControl } from './colors-gradients/control';
 export { default as __experimentalPanelColorGradientSettings } from './colors-gradients/panel-color-gradient-settings';
 export { default as __experimentalImageSizeControl } from './image-size-control';
-export { default as InnerBlocks } from './inner-blocks';
+export {
+	default as InnerBlocks,
+	useInnerBlocksProps as __experimentalUseInnerBlocksProps,
+} from './inner-blocks';
 export { default as InspectorAdvancedControls } from './inspector-advanced-controls';
 export { default as InspectorControls } from './inspector-controls';
 export { default as __experimentalLinkControl } from './link-control';

--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -3,7 +3,7 @@
  */
 import {
 	__experimentalAlignmentHookSettingsProvider as AlignmentHookSettingsProvider,
-	InnerBlocks,
+	__experimentalUseInnerBlocksProps as useInnerBlocksProps,
 	useBlockProps,
 } from '@wordpress/block-editor';
 
@@ -22,15 +22,14 @@ const alignmentHooksSetting = {
 
 function ButtonsEdit() {
 	const blockProps = useBlockProps();
+	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		allowedBlocks: ALLOWED_BLOCKS,
+		template: BUTTONS_TEMPLATE,
+		orientation: 'horizontal',
+	} );
 	return (
 		<AlignmentHookSettingsProvider value={ alignmentHooksSetting }>
-			<InnerBlocks
-				allowedBlocks={ ALLOWED_BLOCKS }
-				__experimentalPassedProps={ blockProps }
-				__experimentalTagName="div"
-				template={ BUTTONS_TEMPLATE }
-				orientation="horizontal"
-			/>
+			<div { ...innerBlocksProps } />
 		</AlignmentHookSettingsProvider>
 	);
 }

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -12,6 +12,7 @@ import {
 	BlockVerticalAlignmentToolbar,
 	InspectorControls,
 	useBlockProps,
+	__experimentalUseInnerBlocksProps as useInnerBlocksProps,
 } from '@wordpress/block-editor';
 import {
 	PanelBody,
@@ -58,6 +59,12 @@ function ColumnEdit( {
 		className: classes,
 		style: width ? { flexBasis: width } : undefined,
 	} );
+	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		templateLock: false,
+		renderAppender: hasChildBlocks
+			? undefined
+			: InnerBlocks.ButtonBlockAppender,
+	} );
 
 	return (
 		<>
@@ -89,14 +96,7 @@ function ColumnEdit( {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<InnerBlocks
-				templateLock={ false }
-				renderAppender={
-					hasChildBlocks ? undefined : InnerBlocks.ButtonBlockAppender
-				}
-				__experimentalTagName="div"
-				__experimentalPassedProps={ blockProps }
-			/>
+			<div { ...innerBlocksProps } />
 		</>
 	);
 }

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -12,7 +12,7 @@ import { PanelBody, RangeControl, Notice } from '@wordpress/components';
 
 import {
 	InspectorControls,
-	InnerBlocks,
+	__experimentalUseInnerBlocksProps as useInnerBlocksProps,
 	BlockControls,
 	BlockVerticalAlignmentToolbar,
 	__experimentalBlockVariationPicker,
@@ -66,6 +66,11 @@ function ColumnsEditContainer( {
 	const blockProps = useBlockProps( {
 		className: classes,
 	} );
+	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		allowedBlocks: ALLOWED_BLOCKS,
+		orientation: 'horizontal',
+		renderAppender: false,
+	} );
 
 	return (
 		<>
@@ -93,13 +98,7 @@ function ColumnsEditContainer( {
 					) }
 				</PanelBody>
 			</InspectorControls>
-			<InnerBlocks
-				allowedBlocks={ ALLOWED_BLOCKS }
-				orientation="horizontal"
-				__experimentalTagName="div"
-				__experimentalPassedProps={ blockProps }
-				renderAppender={ false }
-			/>
+			<div { ...innerBlocksProps } />
 		</>
 	);
 }

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -26,13 +26,13 @@ import { compose, withInstanceId, useInstanceId } from '@wordpress/compose';
 import {
 	BlockControls,
 	BlockIcon,
-	InnerBlocks,
 	InspectorControls,
 	MediaPlaceholder,
 	MediaReplaceFlow,
 	withColors,
 	ColorPalette,
 	useBlockProps,
+	__experimentalUseInnerBlocksProps as useInnerBlocksProps,
 	__experimentalUseGradient,
 	__experimentalPanelColorGradientSettings as PanelColorGradientSettings,
 	__experimentalUnitControl as UnitControl,
@@ -430,6 +430,12 @@ function CoverEdit( {
 	);
 
 	const blockProps = useBlockProps();
+	const innerBlocksProps = useInnerBlocksProps(
+		{
+			className: 'wp-block-cover__inner-container',
+		},
+		{ template: INNER_BLOCKS_TEMPLATE }
+	);
 
 	if ( ! hasBackground ) {
 		const placeholderIcon = <BlockIcon icon={ icon } />;
@@ -554,13 +560,7 @@ function CoverEdit( {
 					/>
 				) }
 				{ isBlogUrl && <Spinner /> }
-				<InnerBlocks
-					__experimentalTagName="div"
-					__experimentalPassedProps={ {
-						className: 'wp-block-cover__inner-container',
-					} }
-					template={ INNER_BLOCKS_TEMPLATE }
-				/>
+				<div { ...innerBlocksProps } />
 			</div>
 		</>
 	);

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -2,7 +2,11 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+import {
+	InnerBlocks,
+	useBlockProps,
+	__experimentalUseInnerBlocksProps as useInnerBlocksProps,
+} from '@wordpress/block-editor';
 import { __experimentalBoxControl as BoxControl } from '@wordpress/components';
 const { __Visualizer: BoxControlVisualizer } = BoxControl;
 
@@ -17,6 +21,16 @@ function GroupEdit( { attributes, clientId } ) {
 	);
 	const blockProps = useBlockProps();
 	const { tagName: TagName = 'div' } = attributes;
+	const innerBlocksProps = useInnerBlocksProps(
+		{
+			className: 'wp-block-group__inner-container',
+		},
+		{
+			renderAppender: hasInnerBlocks
+				? undefined
+				: InnerBlocks.ButtonBlockAppender,
+		}
+	);
 
 	return (
 		<TagName { ...blockProps }>
@@ -24,15 +38,7 @@ function GroupEdit( { attributes, clientId } ) {
 				values={ attributes.style?.spacing?.padding }
 				showValues={ attributes.style?.visualizers?.padding }
 			/>
-			<InnerBlocks
-				renderAppender={
-					hasInnerBlocks ? undefined : InnerBlocks.ButtonBlockAppender
-				}
-				__experimentalTagName="div"
-				__experimentalPassedProps={ {
-					className: 'wp-block-group__inner-container',
-				} }
-			/>
+			<div { ...innerBlocksProps } />
 		</TagName>
 	);
 }

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -13,7 +13,7 @@ import { useState } from '@wordpress/element';
 import {
 	BlockControls,
 	BlockVerticalAlignmentToolbar,
-	InnerBlocks,
+	__experimentalUseInnerBlocksProps as useInnerBlocksProps,
 	InspectorControls,
 	useBlockProps,
 	__experimentalImageURLInputUI as ImageURLInputUI,
@@ -285,6 +285,16 @@ function MediaTextEdit( { attributes, isSelected, setAttributes } ) {
 		style,
 	} );
 
+	const innerBlocksProps = useInnerBlocksProps(
+		{
+			className: 'wp-block-media-text__content',
+		},
+		{
+			template: TEMPLATE,
+			templateInsertUpdatesSelection: false,
+		}
+	);
+
 	return (
 		<>
 			<InspectorControls>{ mediaTextGeneralSettings }</InspectorControls>
@@ -329,14 +339,7 @@ function MediaTextEdit( { attributes, isSelected, setAttributes } ) {
 						mediaWidth,
 					} }
 				/>
-				<InnerBlocks
-					__experimentalTagName="div"
-					__experimentalPassedProps={ {
-						className: 'wp-block-media-text__content',
-					} }
-					template={ TEMPLATE }
-					templateInsertUpdatesSelection={ false }
-				/>
+				<div { ...innerBlocksProps } />
 			</div>
 		</>
 	);

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -29,6 +29,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import {
 	BlockControls,
 	InnerBlocks,
+	__experimentalUseInnerBlocksProps as useInnerBlocksProps,
 	InspectorControls,
 	RichText,
 	__experimentalLinkControl as LinkControl,
@@ -262,6 +263,29 @@ function NavigationLinkEdit( {
 		},
 	} );
 
+	const innerBlocksProps = useInnerBlocksProps(
+		{
+			className: classnames( 'wp-block-navigation__container', {
+				'is-parent-of-selected-block':
+					isParentOfSelectedBlock &&
+					// Don't select as parent of selected block while dragging.
+					! isDraggingBlocks,
+			} ),
+		},
+		{
+			allowedBlocks: [ 'core/navigation-link' ],
+			renderAppender:
+				( isSelected && hasDescendants ) ||
+				( isImmediateParentOfSelectedBlock &&
+					! selectedBlockHasDescendants ) ||
+				// Show the appender while dragging to allow inserting element between item and the appender.
+				( isDraggingBlocks && hasDescendants )
+					? InnerBlocks.DefaultAppender
+					: false,
+			__experimentalAppenderTagName: 'li',
+		}
+	);
+
 	return (
 		<Fragment>
 			<BlockControls>
@@ -420,31 +444,7 @@ function NavigationLinkEdit( {
 						<ItemSubmenuIcon />
 					</span>
 				) }
-				<InnerBlocks
-					allowedBlocks={ [ 'core/navigation-link' ] }
-					renderAppender={
-						( isSelected && hasDescendants ) ||
-						( isImmediateParentOfSelectedBlock &&
-							! selectedBlockHasDescendants ) ||
-						// Show the appender while dragging to allow inserting element between item and the appender.
-						( isDraggingBlocks && hasDescendants )
-							? InnerBlocks.DefaultAppender
-							: false
-					}
-					__experimentalTagName="ul"
-					__experimentalAppenderTagName="li"
-					__experimentalPassedProps={ {
-						className: classnames(
-							'wp-block-navigation__container',
-							{
-								'is-parent-of-selected-block':
-									isParentOfSelectedBlock &&
-									// Don't select as parent of selected block while dragging.
-									! isDraggingBlocks,
-							}
-						),
-					} }
-				/>
+				<ul { ...innerBlocksProps } />
 			</li>
 		</Fragment>
 	);

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -10,6 +10,7 @@ import classnames from 'classnames';
 import { useState } from '@wordpress/element';
 import {
 	InnerBlocks,
+	__experimentalUseInnerBlocksProps as useInnerBlocksProps,
 	InspectorControls,
 	BlockControls,
 	useBlockProps,
@@ -49,6 +50,33 @@ function Navigation( {
 	const blockProps = useBlockProps();
 	const { navigatorToolbarButton, navigatorModal } = useBlockNavigator(
 		clientId
+	);
+
+	const innerBlocksProps = useInnerBlocksProps(
+		{
+			className: 'wp-block-navigation__container',
+		},
+		{
+			allowedBlocks: [
+				'core/navigation-link',
+				'core/search',
+				'core/social-links',
+			],
+			orientation: attributes.orientation || 'horizontal',
+			renderAppender:
+				( isImmediateParentOfSelectedBlock &&
+					! selectedBlockHasDescendants ) ||
+				isSelected
+					? InnerBlocks.DefaultAppender
+					: false,
+			templateInsertUpdatesSelection: false,
+			__experimentalAppenderTagName: 'li',
+			__experimentalCaptureToolbars: true,
+			// Template lock set to false here so that the Nav
+			// Block on the experimental menus screen does not
+			// inherit templateLock={ 'all' }.
+			templateLock: false,
+		}
 	);
 
 	if ( isPlaceholderShown ) {
@@ -150,32 +178,7 @@ function Navigation( {
 					blockClassNames
 				) }
 			>
-				<InnerBlocks
-					allowedBlocks={ [
-						'core/navigation-link',
-						'core/search',
-						'core/social-links',
-					] }
-					renderAppender={
-						( isImmediateParentOfSelectedBlock &&
-							! selectedBlockHasDescendants ) ||
-						isSelected
-							? InnerBlocks.DefaultAppender
-							: false
-					}
-					templateInsertUpdatesSelection={ false }
-					orientation={ attributes.orientation || 'horizontal' }
-					__experimentalTagName="ul"
-					__experimentalAppenderTagName="li"
-					__experimentalPassedProps={ {
-						className: 'wp-block-navigation__container',
-					} }
-					__experimentalCaptureToolbars={ true }
-					// Template lock set to false here so that the Nav
-					// Block on the experimental menus screen does not
-					// inherit templateLock={ 'all' }.
-					templateLock={ false }
-				/>
+				<ul { ...innerBlocksProps } />
 			</nav>
 		</>
 	);

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -5,7 +5,7 @@
 import { Fragment } from '@wordpress/element';
 
 import {
-	InnerBlocks,
+	__experimentalUseInnerBlocksProps as useInnerBlocksProps,
 	useBlockProps,
 	InspectorControls,
 } from '@wordpress/block-editor';
@@ -33,6 +33,13 @@ export function SocialLinksEdit( props ) {
 		setAttributes,
 	} = props;
 	const blockProps = useBlockProps();
+	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		allowedBlocks: ALLOWED_BLOCKS,
+		templateLock: false,
+		template: TEMPLATE,
+		orientation: 'horizontal',
+		__experimentalAppenderTagName: 'li',
+	} );
 	return (
 		<Fragment>
 			<InspectorControls>
@@ -46,15 +53,7 @@ export function SocialLinksEdit( props ) {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<InnerBlocks
-				allowedBlocks={ ALLOWED_BLOCKS }
-				templateLock={ false }
-				template={ TEMPLATE }
-				orientation="horizontal"
-				__experimentalTagName="ul"
-				__experimentalPassedProps={ blockProps }
-				__experimentalAppenderTagName="li"
-			/>
+			<ul { ...innerBlocksProps } />
 		</Fragment>
 	);
 }

--- a/packages/block-library/src/template-part/edit/inner-blocks.js
+++ b/packages/block-library/src/template-part/edit/inner-blocks.js
@@ -2,7 +2,10 @@
  * WordPress dependencies
  */
 import { useEntityBlockEditor } from '@wordpress/core-data';
-import { InnerBlocks } from '@wordpress/block-editor';
+import {
+	InnerBlocks,
+	__experimentalUseInnerBlocksProps as useInnerBlocksProps,
+} from '@wordpress/block-editor';
 
 export default function TemplatePartInnerBlocks( {
 	postId: id,
@@ -13,15 +16,16 @@ export default function TemplatePartInnerBlocks( {
 		'wp_template_part',
 		{ id }
 	);
-	return (
-		<InnerBlocks
-			value={ blocks }
-			onInput={ onInput }
-			onChange={ onChange }
-			__experimentalTagName="div"
-			renderAppender={
-				hasInnerBlocks ? undefined : InnerBlocks.ButtonBlockAppender
-			}
-		/>
+	const innerBlocksProps = useInnerBlocksProps(
+		{},
+		{
+			value: blocks,
+			onInput,
+			onChange,
+			renderAppender: hasInnerBlocks
+				? undefined
+				: InnerBlocks.ButtonBlockAppender,
+		}
 	);
+	return <div { ...innerBlocksProps } />;
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

New experimental API.

Currently, `<InnerBlocks />` renders a wrapper, but `<InnerBlocks.Content>` doesn't. Instead, we have to allow customising the wrapper tag name props through the `__experimentalTagName` and `__experimentalPassedProps` props.

Currently:

```js
const blockProps = useBlockProps( { className: 'pull' } );

<InnerBlocks
	orientation="vertical"
	__experimentalTagName="blockquote"
	__experimentalPassedProps={ blockWrapperProps }
/>
```

With a hook:

```js
const props = __experimentalUseInnerBlocksProps(
	useBlockProps( { className: 'pull' } ),
	{ orientation: 'vertical' } // Inner blocks options.
);

<blockquote { ...props } />
```

Allowing the block author to render the block wrapper gives some more freedom.
You can now render something before or after the content:

```js
const props = __experimentalUseInnerBlocksProps(
	useBlockProps( { className: 'pull' } ),
	{ orientation: 'vertical' } // Inner blocks options.
);

<blockquote { ...props }>
	{ props.children  }
	<cite>{ attributes.cite }</cite>
</blockquote>
```

In the future, we could allow more control over the children:

```js
const props = __experimentalUseInnerBlocksProps(
	{ className: 'menu' },
	{ orientation: 'vertical' } // Inner blocks options.
);

<ul { ...props }>
	{ props.children.map( ( child ) => <li>{ child }</li> )  }
</ul>
```

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
