### PR TITLE
[RNMobile] Gallery Block - Shows "Choose images" instead of "Choose image"

### DIFF
--- a/packages/block-editor/src/components/media-upload/index.native.js
+++ b/packages/block-editor/src/components/media-upload/index.native.js
@@ -160,7 +160,7 @@ export class MediaUpload extends React.Component {
 	}
 
 	render() {
-		const { allowedTypes = [], isReplacingMedia } = this.props;
+		const { allowedTypes = [], isReplacingMedia, multiple } = this.props;
 		const isOneType = allowedTypes.length === 1;
 		const isImage = isOneType && allowedTypes.includes( MEDIA_TYPE_IMAGE );
 		const isVideo = isOneType && allowedTypes.includes( MEDIA_TYPE_VIDEO );
@@ -174,7 +174,9 @@ export class MediaUpload extends React.Component {
 			if ( isReplacingMedia ) {
 				pickerTitle = __( 'Replace image' );
 			} else {
-				pickerTitle = __( 'Choose image' );
+				pickerTitle = multiple
+					? __( 'Choose images' )
+					: __( 'Choose image' );
 			}
 		} else if ( isVideo ) {
 			if ( isReplacingMedia ) {


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/2632

## Description
The logic within the  MediaUpload component that renders a picker on mobile was modified. When the `pickerTitle` is that of an image being added I checked to see if multiple images were being requested. Once this is the case, "Choose Images" is shown otherwise "Choose image" is shown. 

## How has this been tested?

This was tested on both iOS and Android. 
To test and verify this behavior, follow the instructions below. 

### Image Block
1. Add an Image Block.
2. Click "ADD IMAGE". 
3. Once the picker is shown verify that the Picker's Title is "Choose image". 

### Gallery Block
1. Add a Gallery Block.
2. Click "ADD MEDIA". 
3. Once the picker is shown verify that the Picker's Title is "Choose images". 

## Screenshots <!-- if applicable -->

### Android

Image Block | Gallery Block 
--------|-------
<kbd><img src="https://user-images.githubusercontent.com/1509205/94209426-f4dc1b00-fe91-11ea-9f9f-28cf3da25f53.png" width="320"></kbd>  |  <kbd><img src="https://user-images.githubusercontent.com/1509205/94209430-f9083880-fe91-11ea-9b6f-201e303f0149.png" width="320"></kbd> 

### iOS

Image Block | Gallery Block 
--------|-------
<kbd><img src="https://user-images.githubusercontent.com/1509205/94209660-7764da80-fe92-11ea-8941-12a39d6ba588.png" width="320"></kbd>  |  <kbd><img src="https://user-images.githubusercontent.com/1509205/94209663-79c73480-fe92-11ea-8a4d-bcc02b638f29.png" width="320"></kbd>

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
