### PR TITLE
Refactor Buttons block native edit component to use hooks.

### DIFF
--- a/packages/block-library/src/buttons/edit.native.js
+++ b/packages/block-library/src/buttons/edit.native.js
@@ -1,19 +1,20 @@
 /**
  * External dependencies
  */
+import { debounce } from 'lodash';
 import { View } from 'react-native';
+
 /**
  * WordPress dependencies
  */
 import {
-	InnerBlocks,
 	__experimentalAlignmentHookSettingsProvider as AlignmentHookSettingsProvider,
+	InnerBlocks,
 } from '@wordpress/block-editor';
-import { withSelect, withDispatch } from '@wordpress/data';
-import { compose, useResizeObserver } from '@wordpress/compose';
 import { createBlock } from '@wordpress/blocks';
+import { useResizeObserver } from '@wordpress/compose';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useState, useEffect, useRef } from '@wordpress/element';
-import { debounce } from 'lodash';
 
 /**
  * Internal dependencies
@@ -24,19 +25,42 @@ import styles from './editor.scss';
 const ALLOWED_BLOCKS = [ buttonBlockName ];
 const BUTTONS_TEMPLATE = [ [ 'core/button' ] ];
 
-function ButtonsEdit( {
-	isSelected,
-	attributes,
-	onDelete,
-	onAddNextButton,
-	shouldDelete,
-	isInnerButtonSelected,
-} ) {
-	const { align } = attributes;
+function ButtonsEdit( { attributes: { align }, clientId, isSelected } ) {
 	const [ resizeObserver, sizes ] = useResizeObserver();
 	const [ maxWidth, setMaxWidth ] = useState( 0 );
 	const shouldRenderFooterAppender = isSelected || isInnerButtonSelected;
 	const { marginLeft: spacing } = styles.spacing;
+
+	const { getBlockOrder, isInnerButtonSelected, shouldDelete } = useSelect(
+		( select ) => {
+			const {
+				getBlockCount,
+				getBlockOrder: _getBlockOrder,
+				getBlockParents,
+				getSelectedBlockClientId,
+			} = select( 'core/block-editor' );
+			const selectedBlockClientId = getSelectedBlockClientId();
+			const selectedBlockParents = getBlockParents(
+				selectedBlockClientId,
+				true
+			);
+
+			return {
+				getBlockOrder: _getBlockOrder,
+				isInnerButtonSelected: selectedBlockParents[ 0 ] === clientId,
+				// The purpose of `shouldDelete` check is giving the ability to
+				// pass to mobile toolbar function called `onDelete` which removes
+				// the whole `Buttons` container along with the last inner button
+				// when there is exactly one button.
+				shouldDelete: getBlockCount( clientId ) === 1,
+			};
+		},
+		[ clientId ]
+	);
+
+	const { insertBlock, removeBlock, selectBlock } = useDispatch(
+		'core/block-editor'
+	);
 
 	useEffect( () => {
 		const margins = 2 * styles.parent.marginRight;
@@ -46,7 +70,26 @@ function ButtonsEdit( {
 		}
 	}, [ sizes ] );
 
+	function onAddNextButton( selectedId ) {
+		const order = getBlockOrder( clientId );
+		const selectedButtonIndex = order.findIndex(
+			( i ) => i === selectedId
+		);
+
+		const index =
+			selectedButtonIndex === -1 ? order.length + 1 : selectedButtonIndex;
+
+		const insertedBlock = createBlock( 'core/button' );
+
+		insertBlock( insertedBlock, index, clientId );
+		selectBlock( insertedBlock.clientId );
+	}
+
 	const debounceAddNextButton = debounce( onAddNextButton, 200 );
+
+	function onDelete() {
+		removeBlock( clientId );
+	}
 
 	const renderFooterAppender = useRef( () => (
 		<View style={ styles.appenderContainer }>
@@ -83,56 +126,4 @@ function ButtonsEdit( {
 	);
 }
 
-export default compose(
-	withSelect( ( select, { clientId } ) => {
-		const {
-			getBlockCount,
-			getBlockParents,
-			getSelectedBlockClientId,
-		} = select( 'core/block-editor' );
-		const selectedBlockClientId = getSelectedBlockClientId();
-		const selectedBlockParents = getBlockParents(
-			selectedBlockClientId,
-			true
-		);
-
-		return {
-			// The purpose of `shouldDelete` check is giving the ability to pass to
-			// mobile toolbar function called `onDelete` which removes the whole
-			// `Buttons` container along with the last inner button when
-			// there is exactly one button.
-			shouldDelete: getBlockCount( clientId ) === 1,
-			isInnerButtonSelected: selectedBlockParents[ 0 ] === clientId,
-		};
-	} ),
-	withDispatch( ( dispatch, { clientId }, registry ) => {
-		const { selectBlock, removeBlock, insertBlock } = dispatch(
-			'core/block-editor'
-		);
-		const { getBlockOrder } = registry.select( 'core/block-editor' );
-
-		return {
-			// The purpose of `onAddNextButton` is giving the ability to automatically
-			// adding `Button` inside `Buttons` block on the appender press event.
-			onAddNextButton: ( selectedId ) => {
-				const order = getBlockOrder( clientId );
-				const selectedButtonIndex = order.findIndex(
-					( i ) => i === selectedId
-				);
-
-				const index =
-					selectedButtonIndex === -1
-						? order.length + 1
-						: selectedButtonIndex;
-
-				const insertedBlock = createBlock( 'core/button' );
-
-				insertBlock( insertedBlock, index, clientId );
-				selectBlock( insertedBlock.clientId );
-			},
-			onDelete: () => {
-				removeBlock( clientId );
-			},
-		};
-	} )
-)( ButtonsEdit );
+export default ButtonsEdit;

--- a/packages/block-library/src/buttons/edit.native.js
+++ b/packages/block-library/src/buttons/edit.native.js
@@ -25,7 +25,11 @@ import styles from './editor.scss';
 const ALLOWED_BLOCKS = [ buttonBlockName ];
 const BUTTONS_TEMPLATE = [ [ 'core/button' ] ];
 
-function ButtonsEdit( { attributes: { align }, clientId, isSelected } ) {
+export default function ButtonsEdit( {
+	attributes: { align },
+	clientId,
+	isSelected,
+} ) {
 	const [ resizeObserver, sizes ] = useResizeObserver();
 	const [ maxWidth, setMaxWidth ] = useState( 0 );
 	const shouldRenderFooterAppender = isSelected || isInnerButtonSelected;
@@ -70,7 +74,7 @@ function ButtonsEdit( { attributes: { align }, clientId, isSelected } ) {
 		}
 	}, [ sizes ] );
 
-	function onAddNextButton( selectedId ) {
+	const onAddNextButton = debounce( ( selectedId ) => {
 		const order = getBlockOrder( clientId );
 		const selectedButtonIndex = order.findIndex(
 			( i ) => i === selectedId
@@ -83,19 +87,13 @@ function ButtonsEdit( { attributes: { align }, clientId, isSelected } ) {
 
 		insertBlock( insertedBlock, index, clientId );
 		selectBlock( insertedBlock.clientId );
-	}
-
-	const debounceAddNextButton = debounce( onAddNextButton, 200 );
-
-	function onDelete() {
-		removeBlock( clientId );
-	}
+	}, 200 );
 
 	const renderFooterAppender = useRef( () => (
 		<View style={ styles.appenderContainer }>
 			<InnerBlocks.ButtonBlockAppender
 				isFloating={ true }
-				onAddBlock={ debounceAddNextButton }
+				onAddBlock={ onAddNextButton }
 			/>
 		</View>
 	) );
@@ -116,8 +114,10 @@ function ButtonsEdit( { attributes: { align }, clientId, isSelected } ) {
 				}
 				orientation="horizontal"
 				horizontalAlignment={ align }
-				onDeleteBlock={ shouldDelete ? onDelete : undefined }
-				onAddBlock={ debounceAddNextButton }
+				onDeleteBlock={
+					shouldDelete ? () => removeBlock( clientId ) : undefined
+				}
+				onAddBlock={ onAddNextButton }
 				parentWidth={ maxWidth }
 				marginHorizontal={ spacing }
 				marginVertical={ spacing }
@@ -125,5 +125,3 @@ function ButtonsEdit( { attributes: { align }, clientId, isSelected } ) {
 		</AlignmentHookSettingsProvider>
 	);
 }
-
-export default ButtonsEdit;


### PR DESCRIPTION
## Description
This PR refactors the Buttons block native edit implementation to use `useSelect` and `useDispatch` instead of their HOC counterparts.

## How has this been tested?
It hasn't. I need someone from the native mobile team to test out this PR and make sure everything works.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
