### PR TITLE
[Widgets] Add titles to Legacy Widgets

### DIFF
--- a/packages/edit-widgets/src/blocks/legacy-widget/edit/handler.js
+++ b/packages/edit-widgets/src/blocks/legacy-widget/edit/handler.js
@@ -7,6 +7,7 @@ import { get } from 'lodash';
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
+import { VisuallyHidden } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { withInstanceId } from '@wordpress/compose';
 
@@ -14,7 +15,6 @@ import { withInstanceId } from '@wordpress/compose';
  * Internal dependencies
  */
 import LegacyWidgetEditDomManager from './dom-manager';
-import classNames from 'classnames';
 
 const { XMLHttpRequest, FormData } = window;
 
@@ -84,12 +84,11 @@ class LegacyWidgetEditHandler extends Component {
 			title = widgetTitle;
 		}
 
+		const RootComponent = isVisible ? 'div' : VisuallyHidden;
 		return (
-			<div
-				className={ classNames(
-					'wp-block-legacy-widget__edit-handler',
-					{ 'is-hidden': ! isVisible }
-				) }
+			<RootComponent
+				key="edit-handler"
+				className="wp-block-legacy-widget__edit-handler"
 			>
 				{ title && (
 					<div className="wp-block-legacy-widget__edit-widget-title">
@@ -119,7 +118,7 @@ class LegacyWidgetEditHandler extends Component {
 						form={ form }
 					/>
 				</div>
-			</div>
+			</RootComponent>
 		);
 	}
 

--- a/packages/edit-widgets/src/blocks/legacy-widget/edit/handler.js
+++ b/packages/edit-widgets/src/blocks/legacy-widget/edit/handler.js
@@ -7,7 +7,6 @@ import { get } from 'lodash';
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { VisuallyHidden } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { withInstanceId } from '@wordpress/compose';
 
@@ -84,11 +83,17 @@ class LegacyWidgetEditHandler extends Component {
 			title = widgetTitle;
 		}
 
-		const RootComponent = isVisible ? 'div' : VisuallyHidden;
+		const componentProps = isVisible
+			? {}
+			: {
+					style: { display: 'none' },
+					hidden: true,
+					'aria-hidden': 'true',
+			  };
 		return (
-			<RootComponent
-				key="edit-handler"
+			<div
 				className="wp-block-legacy-widget__edit-handler"
+				{ ...componentProps }
 			>
 				{ title && (
 					<div className="wp-block-legacy-widget__edit-widget-title">
@@ -118,7 +123,7 @@ class LegacyWidgetEditHandler extends Component {
 						form={ form }
 					/>
 				</div>
-			</RootComponent>
+			</div>
 		);
 	}
 

--- a/packages/edit-widgets/src/blocks/legacy-widget/edit/handler.js
+++ b/packages/edit-widgets/src/blocks/legacy-widget/edit/handler.js
@@ -14,6 +14,7 @@ import { withInstanceId } from '@wordpress/compose';
  * Internal dependencies
  */
 import LegacyWidgetEditDomManager from './dom-manager';
+import classNames from 'classnames';
 
 const { XMLHttpRequest, FormData } = window;
 
@@ -64,7 +65,7 @@ class LegacyWidgetEditHandler extends Component {
 			number,
 			idBase,
 			instance,
-			isSelected,
+			isVisible,
 			widgetName,
 		} = this.props;
 		const { form } = this.state;
@@ -75,17 +76,21 @@ class LegacyWidgetEditHandler extends Component {
 
 		const widgetTitle = get( instance, [ 'title' ] );
 		let title = null;
-		if ( isSelected ) {
-			if ( widgetTitle && widgetName ) {
-				title = `${ widgetName }: ${ widgetTitle }`;
-			} else if ( ! widgetTitle && widgetName ) {
-				title = widgetName;
-			} else if ( widgetTitle && ! widgetName ) {
-				title = widgetTitle;
-			}
+		if ( widgetTitle && widgetName ) {
+			title = `${ widgetName }: ${ widgetTitle }`;
+		} else if ( ! widgetTitle && widgetName ) {
+			title = widgetName;
+		} else if ( widgetTitle && ! widgetName ) {
+			title = widgetTitle;
 		}
+
 		return (
-			<>
+			<div
+				className={ classNames(
+					'wp-block-legacy-widget__edit-handler',
+					{ 'is-hidden': ! isVisible }
+				) }
+			>
 				{ title && (
 					<div className="wp-block-legacy-widget__edit-widget-title">
 						{ title }
@@ -114,7 +119,7 @@ class LegacyWidgetEditHandler extends Component {
 						form={ form }
 					/>
 				</div>
-			</>
+			</div>
 		);
 	}
 

--- a/packages/edit-widgets/src/blocks/legacy-widget/edit/index.js
+++ b/packages/edit-widgets/src/blocks/legacy-widget/edit/index.js
@@ -31,7 +31,6 @@ function LegacyWidgetEdit( {
 	widgetAreaId,
 } ) {
 	const [ hasEditForm, setHasEditForm ] = useState( true );
-	// If the block is not selected, defaults to show the preview, otherwise show the edit form.
 	const [ isPreview, setIsPreview ] = useState( false );
 	const shouldHidePreview = ! isPreview && hasEditForm;
 

--- a/packages/edit-widgets/src/blocks/legacy-widget/edit/index.js
+++ b/packages/edit-widgets/src/blocks/legacy-widget/edit/index.js
@@ -21,15 +21,25 @@ import LegacyWidgetPlaceholder from './placeholder';
 import WidgetPreview from './widget-preview';
 
 class LegacyWidgetEdit extends Component {
-	constructor() {
-		super( ...arguments );
+	constructor( props ) {
+		super( props );
 		this.state = {
 			hasEditForm: true,
-			isPreview: false,
+			// If the block is not selected, defaults to show the preview, otherwise show the edit form.
+			isPreview: ! props.isSelected,
 		};
 		this.switchToEdit = this.switchToEdit.bind( this );
 		this.switchToPreview = this.switchToPreview.bind( this );
 		this.changeWidget = this.changeWidget.bind( this );
+	}
+
+	componentDidUpdate( prevProps ) {
+		// If isSelected changed, reset isPreview based on isSelected.
+		if ( this.props.isSelected !== prevProps.isSelected ) {
+			this.setState( {
+				isPreview: ! this.props.isSelected,
+			} );
+		}
 	}
 
 	render() {
@@ -42,8 +52,10 @@ class LegacyWidgetEdit extends Component {
 			setAttributes,
 			widgetId,
 			WPWidget,
+			widgetAreaId,
 		} = this.props;
 		const { isPreview, hasEditForm } = this.state;
+		const shouldShowPreview = isPreview || ! hasEditForm;
 		if ( ! WPWidget ) {
 			return (
 				<LegacyWidgetPlaceholder
@@ -162,10 +174,24 @@ class LegacyWidgetEdit extends Component {
 						} }
 					/>
 				) }
-				{ ( isPreview || ! hasEditForm ) &&
-					( WPWidget?.isReferenceWidget
-						? this.renderWidgetPreviewUnavailable()
-						: this.renderWidgetPreview() ) }
+				{ WPWidget?.isReferenceWidget ? (
+					<p
+						style={
+							shouldShowPreview ? undefined : { display: 'none' }
+						}
+					>
+						{ __( 'Reference widgets cannot be previewed.' ) }
+					</p>
+				) : (
+					<WidgetPreview
+						style={
+							shouldShowPreview ? undefined : { display: 'none' }
+						}
+						className="wp-block-legacy-widget__preview"
+						widgetAreaId={ widgetAreaId }
+						attributes={ omit( attributes, 'widgetId' ) }
+					/>
+				) }
 			</>
 		);
 	}
@@ -188,21 +214,6 @@ class LegacyWidgetEdit extends Component {
 
 	switchToPreview() {
 		this.setState( { isPreview: true } );
-	}
-
-	renderWidgetPreview() {
-		const { attributes, widgetAreaId } = this.props;
-		return (
-			<WidgetPreview
-				className="wp-block-legacy-widget__preview"
-				widgetAreaId={ widgetAreaId }
-				attributes={ omit( attributes, 'widgetId' ) }
-			/>
-		);
-	}
-
-	renderWidgetPreviewUnavailable() {
-		return <p>{ __( 'Reference widgets cannot be previewed.' ) }</p>;
 	}
 }
 

--- a/packages/edit-widgets/src/blocks/legacy-widget/edit/index.js
+++ b/packages/edit-widgets/src/blocks/legacy-widget/edit/index.js
@@ -6,7 +6,7 @@ import { get, omit } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { useState, useEffect } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { Button, PanelBody, ToolbarGroup } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { withSelect } from '@wordpress/data';
@@ -24,7 +24,6 @@ function LegacyWidgetEdit( {
 	attributes,
 	availableLegacyWidgets,
 	hasPermissionsToManageWidgets,
-	isSelected,
 	prerenderedEditForm,
 	setAttributes,
 	widgetId,
@@ -33,13 +32,8 @@ function LegacyWidgetEdit( {
 } ) {
 	const [ hasEditForm, setHasEditForm ] = useState( true );
 	// If the block is not selected, defaults to show the preview, otherwise show the edit form.
-	const [ isPreview, setIsPreview ] = useState( ! isSelected );
+	const [ isPreview, setIsPreview ] = useState( false );
 	const shouldHidePreview = ! isPreview && hasEditForm;
-
-	// If isSelected changed, reset isPreview based on isSelected.
-	useEffect( () => {
-		setIsPreview( ! isSelected );
-	}, [ isSelected ] );
 
 	function changeWidget() {
 		switchToEdit();
@@ -145,7 +139,6 @@ function LegacyWidgetEdit( {
 			{ inspectorControls }
 			{ hasEditForm && (
 				<LegacyWidgetEditHandler
-					isSelected={ isSelected }
 					isVisible={ ! isPreview }
 					id={ widgetId }
 					idBase={ attributes.idBase || widgetId }

--- a/packages/edit-widgets/src/blocks/legacy-widget/edit/index.js
+++ b/packages/edit-widgets/src/blocks/legacy-widget/edit/index.js
@@ -34,7 +34,7 @@ function LegacyWidgetEdit( {
 	const [ hasEditForm, setHasEditForm ] = useState( true );
 	// If the block is not selected, defaults to show the preview, otherwise show the edit form.
 	const [ isPreview, setIsPreview ] = useState( ! isSelected );
-	const shouldShowPreview = isPreview || ! hasEditForm;
+	const shouldHidePreview = ! isPreview && hasEditForm;
 
 	// If isSelected changed, reset isPreview based on isSelected.
 	useEffect( () => {
@@ -177,18 +177,12 @@ function LegacyWidgetEdit( {
 				/>
 			) }
 			{ WPWidget?.isReferenceWidget ? (
-				<p
-					style={
-						shouldShowPreview ? undefined : { display: 'none' }
-					}
-				>
+				<p hidden={ shouldHidePreview }>
 					{ __( 'Reference widgets cannot be previewed.' ) }
 				</p>
 			) : (
 				<WidgetPreview
-					style={
-						shouldShowPreview ? undefined : { display: 'none' }
-					}
+					hidden={ shouldHidePreview }
 					className="wp-block-legacy-widget__preview"
 					widgetAreaId={ widgetAreaId }
 					attributes={ omit( attributes, 'widgetId' ) }

--- a/packages/edit-widgets/src/blocks/legacy-widget/edit/widget-preview.js
+++ b/packages/edit-widgets/src/blocks/legacy-widget/edit/widget-preview.js
@@ -32,9 +32,7 @@ function WidgetPreview( { widgetAreaId, attributes, ...props } ) {
 						'body',
 						'scrollHeight',
 					] );
-					if ( iframeContentHeight !== height ) {
-						setHeight( iframeContentHeight );
-					}
+					setHeight( iframeContentHeight );
 				} }
 				src={ iframeUrl }
 				height={ height + HEIGHT_MARGIN }

--- a/packages/edit-widgets/src/blocks/legacy-widget/edit/widget-preview.js
+++ b/packages/edit-widgets/src/blocks/legacy-widget/edit/widget-preview.js
@@ -8,12 +8,13 @@ import { get } from 'lodash';
  */
 import { addQueryArgs } from '@wordpress/url';
 import { Disabled, FocusableIframe } from '@wordpress/components';
-import { useState } from '@wordpress/element';
+import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
 
-function WidgetPreview( { widgetAreaId, attributes, ...props } ) {
+function WidgetPreview( { widgetAreaId, attributes, hidden, ...props } ) {
 	const DEFAULT_HEIGHT = 300;
 	const HEIGHT_MARGIN = 20;
 	const [ height, setHeight ] = useState( DEFAULT_HEIGHT );
+	const iframeRef = useRef();
 	const currentUrl = document.location.href;
 	const siteUrl = currentUrl.substr( 0, currentUrl.indexOf( 'wp-admin/' ) );
 	const iframeUrl = addQueryArgs( siteUrl, {
@@ -22,20 +23,34 @@ function WidgetPreview( { widgetAreaId, attributes, ...props } ) {
 			sidebarId: widgetAreaId,
 		},
 	} );
+
+	const resetIframeHeight = useCallback( () => {
+		setHeight(
+			get( iframeRef.current, [
+				'contentDocument',
+				'body',
+				'scrollHeight',
+			] )
+		);
+	}, [] );
+
+	// Reset the iframe height after the component is not hidden anymore.
+	// If the component is still in the hidden state, scrollHeight will always be 0.
+	useEffect( () => {
+		if ( ! hidden ) {
+			resetIframeHeight();
+		}
+	}, [ hidden, resetIframeHeight ] );
+
 	return (
-		<Disabled>
+		<Disabled hidden={ hidden }>
 			<FocusableIframe
-				onLoad={ ( event ) => {
-					const iframeContentHeight = get( event, [
-						'currentTarget',
-						'contentDocument',
-						'body',
-						'scrollHeight',
-					] );
-					setHeight( iframeContentHeight );
+				onLoad={ () => {
+					resetIframeHeight();
 				} }
 				src={ iframeUrl }
 				height={ height + HEIGHT_MARGIN }
+				iframeRef={ iframeRef }
 				{ ...props }
 			/>
 		</Disabled>

--- a/packages/edit-widgets/src/blocks/legacy-widget/editor.scss
+++ b/packages/edit-widgets/src/blocks/legacy-widget/editor.scss
@@ -26,10 +26,15 @@
 }
 
 .wp-block-legacy-widget__edit-widget-title {
-	background: $gray-300;
-	color: $gray-900;
+	color: $black;
 	font-family: $default-font;
 	font-size: $default-font-size;
-	padding: $grid-unit-10 $block-padding;
+	padding: $block-padding 18px;
 	font-weight: 600;
+	border-bottom: $border-width solid $gray-900;
+}
+
+.block-editor-block-list__block.is-selected {
+	border: $border-width solid $gray-900;
+	border-radius: $radius-block-ui;
 }

--- a/packages/edit-widgets/src/blocks/legacy-widget/editor.scss
+++ b/packages/edit-widgets/src/blocks/legacy-widget/editor.scss
@@ -38,3 +38,12 @@
 	border: $border-width solid $gray-900;
 	border-radius: $radius-block-ui;
 }
+
+.wp-block:not(.is-selected) > .wp-block-legacy-widget__edit-handler {
+	border: 1px solid #1e1e1e;
+	border-radius: 2px;
+}
+
+.wp-block-legacy-widget__edit-handler.is-hidden {
+	display: none;
+}

--- a/packages/edit-widgets/src/blocks/legacy-widget/editor.scss
+++ b/packages/edit-widgets/src/blocks/legacy-widget/editor.scss
@@ -40,8 +40,8 @@
 }
 
 .wp-block:not(.is-selected) > .wp-block-legacy-widget__edit-handler {
-	border: 1px solid #1e1e1e;
-	border-radius: 2px;
+	border: $border-width solid $gray-900;
+	border-radius: $radius-block-ui;
 }
 
 .wp-block-legacy-widget__edit-handler.is-hidden {

--- a/packages/edit-widgets/src/blocks/legacy-widget/editor.scss
+++ b/packages/edit-widgets/src/blocks/legacy-widget/editor.scss
@@ -43,7 +43,3 @@
 	border: 1px solid #1e1e1e;
 	border-radius: 2px;
 }
-
-.wp-block-legacy-widget__edit-handler.is-hidden {
-	display: none;
-}

--- a/packages/edit-widgets/src/blocks/legacy-widget/editor.scss
+++ b/packages/edit-widgets/src/blocks/legacy-widget/editor.scss
@@ -34,12 +34,7 @@
 	border-bottom: $border-width solid $gray-900;
 }
 
-.block-editor-block-list__block.is-selected {
-	border: $border-width solid $gray-900;
-	border-radius: $radius-block-ui;
-}
-
-.wp-block:not(.is-selected) > .wp-block-legacy-widget__edit-handler {
+.wp-block > .wp-block-legacy-widget__edit-handler {
 	border: $border-width solid $gray-900;
 	border-radius: $radius-block-ui;
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
First step towards #24566 - it displays widget titles by default. The next step here would be to default to the preview depending on whether or not data entry is required.

Also refactored `<LegacyWidgetEdit>` to function component.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Go to the new widgets screen.
2. Create a new widget or just use the existing ones.
3. Switch between edit and preview mode and also try to move focus out of it.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
