### PR TITLE
Update docs to use allowedFormats instead of the deprecated formattingControls

### DIFF
--- a/docs/designers-developers/developers/richtext.md
+++ b/docs/designers-developers/developers/richtext.md
@@ -48,7 +48,7 @@ registerBlockType( /* ... */, {
 				tagName="h2" // The tag here is the element output and editable in the admin
 				className={ className }
 				value={ attributes.content } // Any existing content, either from the database or an attribute default
-				formattingControls={ [ 'bold', 'italic' ] } // Allow the content to be made bold or italic, but do not allow other formatting options
+				allowedFormats={ [ 'core/bold', 'core/italic' ] } // Allow the content to be made bold or italic, but do not allow other formatting options
 				onChange={ ( content ) => setAttributes( { content } ) } // Store updated content as a block attribute
 				placeholder={ __( 'Heading...' ) } // Display this text before any content has been added by the user
 			/>
@@ -78,7 +78,7 @@ wp.blocks.registerBlockType( /* ... */, {
 			tagName: 'h2',  // The tag here is the element output and editable in the admin
 			className: props.className,
 			value: props.attributes.content, // Any existing content, either from the database or an attribute default
-			formattingControls: [ 'bold', 'italic' ], // Allow the content to be made bold or italic, but do not allow other formatting options
+			allowedFormats: [ 'core/bold', 'core/italic' ], // Allow the content to be made bold or italic, but do not allow other formatting options
 			onChange: function( content ) {
 				props.setAttributes( { content: content } ); // Store updated content as a block attribute
 			},
@@ -114,4 +114,4 @@ If the HTML tags from text formatting such as `<strong>` or `<em>` are being esc
 
 Before moving forward, consider if using the RichText component makes sense at all. Would it be better to use a basic `input` or `textarea` element? If you don't think any formatting should be possible, these HTML tags may make more sense.
 
-If you'd still like to use RichText, you can eliminate all of the formatting options by specifying the `formattingControls` property as `formattingControls={ [] }` (ESNext). It's possible you'll continue to see formatting options for adding code, an inline image or other formatting. Don't worry, you've found an existing bug that should be fixed soon.
+If you'd still like to use RichText, you can eliminate all of the formatting options by specifying the `withoutInteractiveFormatting` property.


### PR DESCRIPTION


<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Updated docs to use allowedFormats instead of the deprecated formattingControls: https://github.com/WordPress/gutenberg/pull/14542
Removed comment about existing bug as that has been fixed: https://github.com/WordPress/gutenberg/issues/14528

## How has this been tested?
Only documentation changes. Have written similar code in my own projects.

## Types of changes
Doc update

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
