### PR TITLE
[Widgets] Fix toolbar not fixed to top and not horizontally scrollable.

### DIFF
--- a/packages/edit-widgets/src/components/customizer-edit-widgets-initializer/style.scss
+++ b/packages/edit-widgets/src/components/customizer-edit-widgets-initializer/style.scss
@@ -1,5 +1,21 @@
+// Disable the lint rule since the id has "_" in it, and this is the only way to select it.
+// stylelint-disable selector-id-pattern
+#customize-theme-controls #sub-accordion-section-gutenberg_widget_blocks.open {
+	// To make position: sticky work, we have to provide a fixed height to the overflow parent.
+	height: 100%;
+}
+
 .edit-widgets-customizer-edit-widgets-initializer__content {
 	position: relative;
+
+	.edit-widgets-header-container {
+		position: sticky;
+		// customize-pane-child has a 12px padding.
+		top: -12px;
+		// The blue outline for active blocks has z-index of 1, we want to be greater than that.
+		z-index: 2;
+	}
+
 	.edit-widgets-header {
 		margin-top: -16px;
 		border-top: 1px solid $gray-300;
@@ -10,6 +26,12 @@
 		background: #fff;
 		margin-left: -12px;
 		margin-right: -12px;
+
+		.block-editor-block-toolbar {
+			// Use auto instead of scroll so that it won't show the scroll bar if it doesn't have to.
+			overflow-x: auto;
+			overflow-y: hidden;
+		}
 	}
 	.edit-widgets-sidebar {
 		margin-left: -12px;

--- a/packages/edit-widgets/src/components/header/index.js
+++ b/packages/edit-widgets/src/components/header/index.js
@@ -27,7 +27,7 @@ function Header( { isCustomizer } ) {
 	const rootClientId = useLastSelectedRootId();
 
 	return (
-		<>
+		<div className="edit-widgets-header-container">
 			<div className="edit-widgets-header">
 				<NavigableToolbar
 					className="edit-widgets-header-toolbar"
@@ -71,7 +71,7 @@ function Header( { isCustomizer } ) {
 					<BlockToolbar hideDragHandle />
 				</div>
 			) }
-		</>
+		</div>
 	);
 }
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Close https://github.com/WordPress/gutenberg/issues/25201#issuecomment-698319603.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Go to the customizer
2. Click Widget blocks.
3. Scroll it vertically, the toolbar should be fixed to top.
4. Click on any widget, scroll the toolbar horizontally, it should be scrollable.

## Screenshots <!-- if applicable -->
![Kapture 2020-09-25 at 17 10 43](https://user-images.githubusercontent.com/7753001/94249162-14d31380-ff52-11ea-9e29-0f7935a7956a.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
