### PR TITLE
Hooks: Add font style hook and use for navigation block

### DIFF
--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -41,12 +41,6 @@ function gutenberg_register_typography_support( $block_type ) {
 			'type' => 'string',
 		);
 	}
-
-	if ( $has_font_style_support && ! array_key_exists( 'fontStyle', $block_type->attributes ) ) {
-		$block_type->attributes['fontStyle'] = array(
-			'type' => 'string',
-		);
-	}
 }
 
 /**
@@ -88,14 +82,29 @@ function gutenberg_apply_typography_support( $attributes, $block_attributes, $bl
 		}
 	}
 
-	// Font Style.
+	// Font Styles e.g. bold, italic, underline & strikethrough.
 	if ( $has_font_style_support ) {
-		$has_font_style = array_key_exists( 'fontStyle', $block_attributes );
+		$has_font_styles = isset( $block_attributes['style']['typography']['fontStyles'] );
 
-		// Apply required class or style.
-		if ( $has_font_style ) {
+		// Apply required CSS classes.
+		if ( $has_font_styles ) {
 			$attributes['css_classes'][] = 'has-font-style';
-			$attributes['css_classes'][] = sprintf( 'has-%s-font-style', $block_attributes['fontStyle'] );
+
+			// CSS class names chosen to be more explicit than generic `has-<something>-font-style`.
+			$font_style_classes = array(
+				'bold'          => 'has-bold-font-weight',
+				'italic'        => 'has-italic-font-style',
+				'underline'     => 'has-underline-text-decoration',
+				'strikethrough' => 'has-strikethrough-text-decoration',
+			);
+
+			$style_selections = $block_attributes['style']['typography']['fontStyles'];
+
+			foreach ( $style_selections as $style => $turned_on ) {
+				if ( $turned_on ) {
+					$attributes['css_classes'][] = $font_style_classes[ $style ];
+				}
+			}
 		}
 	}
 

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -94,6 +94,7 @@ function gutenberg_apply_typography_support( $attributes, $block_attributes, $bl
 
 		// Apply required class or style.
 		if ( $has_font_style ) {
+			$attributes['css_classes'][] = 'has-font-style';
 			$attributes['css_classes'][] = sprintf( 'has-%s-font-style', $block_attributes['fontStyle'] );
 		}
 	}

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -16,6 +16,11 @@ function gutenberg_register_typography_support( $block_type ) {
 		$has_font_size_support = gutenberg_experimental_get( $block_type->supports, array( '__experimentalFontSize' ), false );
 	}
 
+	$has_font_style_support = false;
+	if ( property_exists( $block_type, 'supports' ) ) {
+		$has_font_style_support = gutenberg_experimental_get( $block_type->supports, array( '__experimentalFontStyle' ), false );
+	}
+
 	$has_line_height_support = false;
 	if ( property_exists( $block_type, 'supports' ) ) {
 		$has_line_height_support = gutenberg_experimental_get( $block_type->supports, array( '__experimentalLineHeight' ), false );
@@ -25,7 +30,7 @@ function gutenberg_register_typography_support( $block_type ) {
 		$block_type->attributes = array();
 	}
 
-	if ( ( $has_font_size_support || $has_line_height_support ) && ! array_key_exists( 'style', $block_type->attributes ) ) {
+	if ( ( $has_font_size_support || $has_font_style_support || $has_line_height_support ) && ! array_key_exists( 'style', $block_type->attributes ) ) {
 		$block_type->attributes['style'] = array(
 			'type' => 'object',
 		);
@@ -33,6 +38,12 @@ function gutenberg_register_typography_support( $block_type ) {
 
 	if ( $has_font_size_support && ! array_key_exists( 'fontSize', $block_type->attributes ) ) {
 		$block_type->attributes['fontSize'] = array(
+			'type' => 'string',
+		);
+	}
+
+	if ( $has_font_style_support && ! array_key_exists( 'fontStyle', $block_type->attributes ) ) {
+		$block_type->attributes['fontStyle'] = array(
 			'type' => 'string',
 		);
 	}
@@ -54,6 +65,11 @@ function gutenberg_apply_typography_support( $attributes, $block_attributes, $bl
 		$has_font_size_support = gutenberg_experimental_get( $block_type->supports, array( '__experimentalFontSize' ), false );
 	}
 
+	$has_font_style_support = false;
+	if ( property_exists( $block_type, 'supports' ) ) {
+		$has_font_style_support = gutenberg_experimental_get( $block_type->supports, array( '__experimentalFontStyle' ), false );
+	}
+
 	$has_line_height_support = false;
 	if ( property_exists( $block_type, 'supports' ) ) {
 		$has_line_height_support = gutenberg_experimental_get( $block_type->supports, array( '__experimentalLineHeight' ), false );
@@ -69,6 +85,16 @@ function gutenberg_apply_typography_support( $attributes, $block_attributes, $bl
 			$attributes['css_classes'][] = sprintf( 'has-%s-font-size', $block_attributes['fontSize'] );
 		} elseif ( $has_custom_font_size ) {
 			$attributes['inline_styles'][] = sprintf( 'font-size: %spx;', $block_attributes['style']['typography']['fontSize'] );
+		}
+	}
+
+	// Font Style.
+	if ( $has_font_style_support ) {
+		$has_font_style = array_key_exists( 'fontStyle', $block_attributes );
+
+		// Apply required class or style.
+		if ( $has_font_style ) {
+			$attributes['css_classes'][] = sprintf( 'has-%s-font-style', $block_attributes['fontStyle'] );
 		}
 	}
 

--- a/lib/experimental-default-theme.json
+++ b/lib/experimental-default-theme.json
@@ -161,18 +161,12 @@
 						"size": 42
 					}
 				],
-				"fontStyles": [
-					{
-						"name": "Normal",
-						"slug": "normal",
-						"style": "normal"
-					},
-					{
-						"name": "Italics",
-						"slug": "italics",
-						"style": "italic"
-					}
-				]
+				"fontStyles": {
+					"bold": true,
+					"italic": true,
+					"underline": true,
+					"strikethrough": true
+				}
 			},
 			"spacing": {
 				"customPadding": false,

--- a/lib/experimental-default-theme.json
+++ b/lib/experimental-default-theme.json
@@ -160,6 +160,18 @@
 						"slug": "huge",
 						"size": 42
 					}
+				],
+				"fontStyles": [
+					{
+						"name": "Normal",
+						"slug": "normal",
+						"style": "normal"
+					},
+					{
+						"name": "Italics",
+						"slug": "italics",
+						"style": "italic"
+					}
 				]
 			},
 			"spacing": {

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -387,8 +387,6 @@ function gutenberg_experimental_global_styles_get_css_property( $style_property 
 			return 'background-color';
 		case 'fontSize':
 			return 'font-size';
-		case 'fontStyle':
-			return 'font-style';
 		case 'lineHeight':
 			return 'line-height';
 		default:
@@ -408,7 +406,6 @@ function gutenberg_experimental_global_styles_get_style_property() {
 		'backgroundColor'          => array( 'color', 'background' ),
 		'color'                    => array( 'color', 'text' ),
 		'fontSize'                 => array( 'typography', 'fontSize' ),
-		'fontStyle'                => array( 'typography', 'fontStyle' ),
 		'lineHeight'               => array( 'typography', 'lineHeight' ),
 	);
 }
@@ -425,7 +422,6 @@ function gutenberg_experimental_global_styles_get_support_keys() {
 		'backgroundColor'          => array( '__experimentalColor' ),
 		'color'                    => array( '__experimentalColor' ),
 		'fontSize'                 => array( '__experimentalFontSize' ),
-		'fontStyle'                => array( '__experimentalFontStyle' ),
 		'lineHeight'               => array( '__experimentalLineHeight' ),
 	);
 }
@@ -448,10 +444,6 @@ function gutenberg_experimental_global_styles_get_presets_structure() {
 		'fontSize'  => array(
 			'path' => array( 'typography', 'fontSizes' ),
 			'key'  => 'size',
-		),
-		'fontStyle' => array(
-			'path' => array( 'typography', 'fontStyles' ),
-			'key'  => 'style',
 		),
 	);
 }

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -387,6 +387,8 @@ function gutenberg_experimental_global_styles_get_css_property( $style_property 
 			return 'background-color';
 		case 'fontSize':
 			return 'font-size';
+		case 'fontStyle':
+			return 'font-style';
 		case 'lineHeight':
 			return 'line-height';
 		default:
@@ -406,6 +408,7 @@ function gutenberg_experimental_global_styles_get_style_property() {
 		'backgroundColor'          => array( 'color', 'background' ),
 		'color'                    => array( 'color', 'text' ),
 		'fontSize'                 => array( 'typography', 'fontSize' ),
+		'fontStyle'                => array( 'typography', 'fontStyle' ),
 		'lineHeight'               => array( 'typography', 'lineHeight' ),
 	);
 }
@@ -422,6 +425,7 @@ function gutenberg_experimental_global_styles_get_support_keys() {
 		'backgroundColor'          => array( '__experimentalColor' ),
 		'color'                    => array( '__experimentalColor' ),
 		'fontSize'                 => array( '__experimentalFontSize' ),
+		'fontStyle'                => array( '__experimentalFontStyle' ),
 		'lineHeight'               => array( '__experimentalLineHeight' ),
 	);
 }
@@ -433,17 +437,21 @@ function gutenberg_experimental_global_styles_get_support_keys() {
  */
 function gutenberg_experimental_global_styles_get_presets_structure() {
 	return array(
-		'color'    => array(
+		'color'     => array(
 			'path' => array( 'color', 'palette' ),
 			'key'  => 'color',
 		),
-		'gradient' => array(
+		'gradient'  => array(
 			'path' => array( 'color', 'gradients' ),
 			'key'  => 'gradient',
 		),
-		'fontSize' => array(
+		'fontSize'  => array(
 			'path' => array( 'typography', 'fontSizes' ),
 			'key'  => 'size',
+		),
+		'fontStyle' => array(
+			'path' => array( 'typography', 'fontStyles' ),
+			'key'  => 'style',
 		),
 	);
 }

--- a/packages/block-editor/src/hooks/font-style.js
+++ b/packages/block-editor/src/hooks/font-style.js
@@ -1,0 +1,166 @@
+/**
+ * WordPress dependencies
+ */
+import TokenList from '@wordpress/token-list';
+import { addFilter } from '@wordpress/hooks';
+import { hasBlockSupport } from '@wordpress/blocks';
+import { SelectControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import useEditorFeature from '../components/use-editor-feature';
+import { cleanEmptyObject } from './utils';
+
+export const FONT_STYLE_SUPPORT_KEY = '__experimentalFontStyle';
+
+/**
+ * Filters registered block settings, extending attributes to include
+ * `fontStyle`.
+ *
+ * @param  {Object} settings Original block settings
+ * @return {Object}          Filtered block settings
+ */
+function addAttributes( settings ) {
+	if ( ! hasBlockSupport( settings, FONT_STYLE_SUPPORT_KEY ) ) {
+		return settings;
+	}
+
+	// Allow blocks to specify a default value if needed.
+	if ( ! settings.attributes.fontStyle ) {
+		Object.assign( settings.attributes, { fontStyle: { type: 'string' } } );
+	}
+
+	return settings;
+}
+
+/**
+ * Override props assigned to save component to inject font style.
+ *
+ * @param  {Object} props      Additional props applied to save element
+ * @param  {Object} blockType  Block type
+ * @param  {Object} attributes Block attributes
+ * @return {Object}            Filtered props applied to save element
+ */
+function addSaveProps( props, blockType, attributes ) {
+	if ( ! hasBlockSupport( blockType, FONT_STYLE_SUPPORT_KEY ) ) {
+		return props;
+	}
+
+	// Use TokenList to de-dupe classes.
+	const classes = new TokenList( props.className );
+	classes.add( `has-${ attributes.fontStyle }-font-style` );
+	const newClassName = classes.value;
+	props.className = newClassName ? newClassName : undefined;
+
+	return props;
+}
+
+/**
+ * Filters registered block settings to expand the block edit wrapper
+ * by applying the desired classname.
+ *
+ * @param  {Object} settings Original block settings
+ * @return {Object}          Filtered block settings
+ */
+function addEditProps( settings ) {
+	if ( ! hasBlockSupport( settings, FONT_STYLE_SUPPORT_KEY ) ) {
+		return settings;
+	}
+
+	const existingGetEditWrapperProps = settings.getEditWrapperProps;
+	settings.getEditWrapperProps = ( attributes ) => {
+		let props = {};
+		if ( existingGetEditWrapperProps ) {
+			props = existingGetEditWrapperProps( attributes );
+		}
+		return addSaveProps( props, settings, attributes );
+	};
+
+	return settings;
+}
+
+/**
+ * Inspector control panel containing the font style option for italics.
+ *
+ * @param {Object} props
+ * @return {WPElement} Font style edit element.
+ */
+export function FontStyleEdit( props ) {
+	const {
+		attributes: { style },
+		setAttributes,
+	} = props;
+
+	const isDisabled = useIsFontStyleDisabled( props );
+
+	if ( isDisabled ) {
+		return null;
+	}
+
+	const onChange = ( fontStyle ) => {
+		const newStyle = {
+			...style,
+			typography: {
+				...style?.typography,
+				fontStyle: fontStyle ? fontStyle : undefined,
+			},
+		};
+
+		setAttributes( {
+			style: cleanEmptyObject( newStyle ),
+			fontStyle,
+		} );
+	};
+
+	const styleOptions = [
+		{
+			label: __( 'Normal' ),
+			value: '',
+		},
+		{
+			label: __( 'Italics' ),
+			value: 'italic',
+		},
+	];
+
+	return (
+		<SelectControl
+			options={ styleOptions }
+			value={ style?.typography?.fontStyle }
+			label={ __( 'Font Style' ) }
+			onChange={ onChange }
+		/>
+	);
+}
+
+/**
+ * Hook to check if font-style settings have been disabled.
+ *
+ * @param {string} name Name of the block.
+ * @return {boolean} Whether or not the setting is disabled.
+ */
+export function useIsFontStyleDisabled( { name: blockName } = {} ) {
+	const fontStyles = useEditorFeature( 'typography.fontStyles' );
+	const hasFontStyles = fontStyles.length;
+
+	return (
+		! hasBlockSupport( blockName, FONT_STYLE_SUPPORT_KEY ) ||
+		! hasFontStyles
+	);
+}
+
+addFilter(
+	'blocks.registerBlockType',
+	'core/font/addAttribute',
+	addAttributes
+);
+
+addFilter(
+	'blocks.getSaveContent.extraProps',
+	'core/font/addSaveProps',
+	addSaveProps
+);
+
+addFilter( 'blocks.registerBlockType', 'core/font/addEditProps', addEditProps );

--- a/packages/block-editor/src/hooks/font-style.js
+++ b/packages/block-editor/src/hooks/font-style.js
@@ -22,14 +22,18 @@ export const FONT_STYLE_SUPPORT_KEY = '__experimentalFontStyle';
  * @param  {Object} settings Original block settings
  * @return {Object}          Filtered block settings
  */
-function addAttributes( settings ) {
+function addAttribute( settings ) {
 	if ( ! hasBlockSupport( settings, FONT_STYLE_SUPPORT_KEY ) ) {
 		return settings;
 	}
 
 	// Allow blocks to specify a default value if needed.
-	if ( ! settings.attributes.fontStyle ) {
-		Object.assign( settings.attributes, { fontStyle: { type: 'string' } } );
+	if ( ! settings.attributes?.fontStyle ) {
+		// Handle edge case where attributes is undefined as well.
+		settings.attributes = {
+			...settings.attributes,
+			fontStyle: { type: 'string' },
+		};
 	}
 
 	return settings;
@@ -48,11 +52,14 @@ function addSaveProps( props, blockType, attributes ) {
 		return props;
 	}
 
-	// Use TokenList to de-dupe classes.
-	const classes = new TokenList( props.className );
-	classes.add( `has-${ attributes.fontStyle }-font-style` );
-	const newClassName = classes.value;
-	props.className = newClassName ? newClassName : undefined;
+	if ( attributes.fontStyle ) {
+		// Use TokenList to de-dupe classes.
+		const classes = new TokenList( props.className );
+		classes.add( `has-font-style` );
+		classes.add( `has-${ attributes.fontStyle }-font-style` );
+		const newClassName = classes.value;
+		props.className = newClassName ? newClassName : undefined;
+	}
 
 	return props;
 }
@@ -153,14 +160,18 @@ export function useIsFontStyleDisabled( { name: blockName } = {} ) {
 
 addFilter(
 	'blocks.registerBlockType',
-	'core/font/addAttribute',
-	addAttributes
+	'core/font-style/addAttribute',
+	addAttribute
 );
 
 addFilter(
 	'blocks.getSaveContent.extraProps',
-	'core/font/addSaveProps',
+	'core/font-style/addSaveProps',
 	addSaveProps
 );
 
-addFilter( 'blocks.registerBlockType', 'core/font/addEditProps', addEditProps );
+addFilter(
+	'blocks.registerBlockType',
+	'core/font-style/addEditProps',
+	addEditProps
+);

--- a/packages/block-editor/src/hooks/test/font-style.js
+++ b/packages/block-editor/src/hooks/test/font-style.js
@@ -11,7 +11,7 @@ import { applyFilters } from '@wordpress/hooks';
 /**
  * Internal dependencies
  */
-import '../font-style';
+import { fontStyleClasses } from '../font-style';
 
 describe( 'custom font styles', () => {
 	const blockSettings = {
@@ -35,27 +35,18 @@ describe( 'custom font styles', () => {
 		},
 	};
 
-	describe( 'addAttribute()', () => {
-		const addAttribute = applyFilters.bind(
-			null,
-			'blocks.registerBlockType'
-		);
-
-		it( 'should do nothing if the settings do not define font style support', () => {
-			const settings = addAttribute( blockSettings );
-			expect( settings.attributes ).toBeUndefined();
-		} );
-
-		it( 'should do nothing if the settings disable font style support', () => {
-			const settings = addAttribute( settingsWithoutSupport );
-			expect( settings.attributes ).toBeUndefined();
-		} );
-
-		it( 'should assign a new font style attribute', () => {
-			const settings = addAttribute( settingsWithSupport );
-			expect( settings.attributes ).toHaveProperty( 'fontStyle' );
-		} );
-	} );
+	const styles = {
+		style: {
+			typography: {
+				fontStyles: {
+					bold: true,
+					italic: true,
+					underline: true,
+					strikethrough: true,
+				},
+			},
+		}
+	};
 
 	describe( 'addSaveProps', () => {
 		const addSaveProps = applyFilters.bind(
@@ -64,23 +55,22 @@ describe( 'custom font styles', () => {
 		);
 
 		it( 'should do nothing if font style support disabled', () => {
-			const extraProps = addSaveProps( {}, settingsWithoutSupport, {
-				fontStyle: 'italic',
-			} );
-			expect( extraProps ).not.toHaveProperty( 'className' );
+			const props = addSaveProps( {}, settingsWithoutSupport, styles );
+			expect( props ).not.toHaveProperty( 'className' );
 		} );
 
 		it( 'should not add CSS class if font style is not set', () => {
-			const extraProps = addSaveProps( {}, settingsWithSupport, {} );
-			expect( extraProps ).not.toHaveProperty( 'className' );
+			const props = addSaveProps( {}, settingsWithSupport, {} );
+			expect( props ).not.toHaveProperty( 'className' );
 		} );
 
 		it( 'should add CSS classes if font style is present', () => {
-			const extraProps = addSaveProps( {}, settingsWithSupport, {
-				fontStyle: 'italic',
-			} );
-			expect( extraProps.className ).toMatch( 'has-font-style' );
-			expect( extraProps.className ).toMatch( 'has-italic-font-style' );
+			const props = addSaveProps( {}, settingsWithSupport, styles );
+			expect( props.className ).toMatch( 'has-font-style' );
+			expect( props.className ).toMatch( fontStyleClasses.bold );
+			expect( props.className ).toMatch( fontStyleClasses.italic );
+			expect( props.className ).toMatch( fontStyleClasses.underline );
+			expect( props.className ).toMatch( fontStyleClasses.strikethrough );
 		} );
 	} );
 
@@ -103,11 +93,12 @@ describe( 'custom font styles', () => {
 
 		it( 'should add css classes to edit props when font style is supported', () => {
 			const settings = addEditProps( settingsWithSupport );
-			const props = settings.getEditWrapperProps( {
-				fontStyle: 'italic',
-			} );
+			const props = settings.getEditWrapperProps( styles );
 			expect( props.className ).toMatch( 'has-font-style' );
-			expect( props.className ).toMatch( 'has-italic-font-style' );
+			expect( props.className ).toMatch( fontStyleClasses.bold );
+			expect( props.className ).toMatch( fontStyleClasses.italic );
+			expect( props.className ).toMatch( fontStyleClasses.underline );
+			expect( props.className ).toMatch( fontStyleClasses.strikethrough );
 		} );
 	} );
 } );

--- a/packages/block-editor/src/hooks/test/font-style.js
+++ b/packages/block-editor/src/hooks/test/font-style.js
@@ -1,0 +1,113 @@
+/**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { applyFilters } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import '../font-style';
+
+describe( 'custom font styles', () => {
+	const blockSettings = {
+		name: 'lorem/ipsum',
+		save: noop,
+		category: 'text',
+		title: 'block title',
+	};
+
+	const settingsWithSupport = {
+		...blockSettings,
+		supports: {
+			__experimentalFontStyle: true,
+		},
+	};
+
+	const settingsWithoutSupport = {
+		...blockSettings,
+		supports: {
+			__experimentalFontStyle: false,
+		},
+	};
+
+	describe( 'addAttribute()', () => {
+		const addAttribute = applyFilters.bind(
+			null,
+			'blocks.registerBlockType'
+		);
+
+		it( 'should do nothing if the settings do not define font style support', () => {
+			const settings = addAttribute( blockSettings );
+			expect( settings.attributes ).toBeUndefined();
+		} );
+
+		it( 'should do nothing if the settings disable font style support', () => {
+			const settings = addAttribute( settingsWithoutSupport );
+			expect( settings.attributes ).toBeUndefined();
+		} );
+
+		it( 'should assign a new font style attribute', () => {
+			const settings = addAttribute( settingsWithSupport );
+			expect( settings.attributes ).toHaveProperty( 'fontStyle' );
+		} );
+	} );
+
+	describe( 'addSaveProps', () => {
+		const addSaveProps = applyFilters.bind(
+			null,
+			'blocks.getSaveContent.extraProps'
+		);
+
+		it( 'should do nothing if font style support disabled', () => {
+			const extraProps = addSaveProps( {}, settingsWithoutSupport, {
+				fontStyle: 'italic',
+			} );
+			expect( extraProps ).not.toHaveProperty( 'className' );
+		} );
+
+		it( 'should not add CSS class if font style is not set', () => {
+			const extraProps = addSaveProps( {}, settingsWithSupport, {} );
+			expect( extraProps ).not.toHaveProperty( 'className' );
+		} );
+
+		it( 'should add CSS classes if font style is present', () => {
+			const extraProps = addSaveProps( {}, settingsWithSupport, {
+				fontStyle: 'italic',
+			} );
+			expect( extraProps.className ).toMatch( 'has-font-style' );
+			expect( extraProps.className ).toMatch( 'has-italic-font-style' );
+		} );
+	} );
+
+	describe( 'addEditProps', () => {
+		const addEditProps = applyFilters.bind(
+			null,
+			'blocks.registerBlockType'
+		);
+
+		it( 'should not modify edit wrapper props when no font style support', () => {
+			const settings = addEditProps( blockSettings );
+			// Test settings don't have getEditWrapperProps so should stay undefined.
+			expect( settings.getEditWrapperProps ).toBeUndefined();
+		} );
+
+		it( 'should add getEditWrapperProps when font style is supported', () => {
+			const settings = addEditProps( settingsWithSupport );
+			expect( settings.getEditWrapperProps ).toBeDefined();
+		} );
+
+		it( 'should add css classes to edit props when font style is supported', () => {
+			const settings = addEditProps( settingsWithSupport );
+			const props = settings.getEditWrapperProps( {
+				fontStyle: 'italic',
+			} );
+			expect( props.className ).toMatch( 'has-font-style' );
+			expect( props.className ).toMatch( 'has-italic-font-style' );
+		} );
+	} );
+} );

--- a/packages/block-editor/src/hooks/test/font-style.js
+++ b/packages/block-editor/src/hooks/test/font-style.js
@@ -45,7 +45,7 @@ describe( 'custom font styles', () => {
 					strikethrough: true,
 				},
 			},
-		}
+		},
 	};
 
 	describe( 'addSaveProps', () => {

--- a/packages/block-editor/src/hooks/typography.js
+++ b/packages/block-editor/src/hooks/typography.js
@@ -21,10 +21,16 @@ import {
 	FontSizeEdit,
 	useIsFontSizeDisabled,
 } from './font-size';
+import {
+	FONT_STYLE_SUPPORT_KEY,
+	FontStyleEdit,
+	useIsFontStyleDisabled,
+} from './font-style';
 
 export const TYPOGRAPHY_SUPPORT_KEYS = [
 	LINE_HEIGHT_SUPPORT_KEY,
 	FONT_SIZE_SUPPORT_KEY,
+	FONT_STYLE_SUPPORT_KEY,
 ];
 
 export function TypographyPanel( props ) {
@@ -38,6 +44,7 @@ export function TypographyPanel( props ) {
 			<PanelBody title={ __( 'Typography' ) }>
 				<FontSizeEdit { ...props } />
 				<LineHeightEdit { ...props } />
+				<FontStyleEdit { ...props } />
 			</PanelBody>
 		</InspectorControls>
 	);
@@ -56,6 +63,7 @@ function useIsTypographyDisabled( props = {} ) {
 	const configs = [
 		useIsFontSizeDisabled( props ),
 		useIsLineHeightDisabled( props ),
+		useIsFontStyleDisabled( props ),
 	];
 
 	return configs.filter( Boolean ).length === configs.length;

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -95,13 +95,22 @@
 }
 
 // Font Styles.
-.editor-styles-wrapper .has-normal-font-style {
-	font-style: normal;
+.editor-styles-wrapper .has-bold-font-weight {
+	font-weight: bold;
 }
 
 .editor-styles-wrapper .has-italic-font-style {
 	font-style: italic;
 }
+
+.editor-styles-wrapper .has-underline-text-decoration {
+	text-decoration: underline;
+}
+
+.editor-styles-wrapper .has-strikethrough-text-decoration {
+	text-decoration: line-through;
+}
+
 
 /**
  * Editor Normalization Styles

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -94,6 +94,15 @@
 	font-size: 42px;
 }
 
+// Font Styles.
+.editor-styles-wrapper .has-normal-font-style {
+	font-style: normal;
+}
+
+.editor-styles-wrapper .has-italic-font-style {
+	font-style: italic;
+}
+
 /**
  * Editor Normalization Styles
  *

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -52,3 +52,16 @@
 		display: none;
 	}
 }
+
+// Font Styles: Text Decorations
+.wp-block-navigation.has-underline-text-decoration {
+	.wp-block-navigation-link__content {
+		text-decoration: underline;
+	}
+}
+
+.wp-block-navigation.has-strikethrough-text-decoration {
+	.wp-block-navigation-link__content {
+		text-decoration: line-through;
+	}
+}

--- a/packages/block-library/src/navigation-link/style.scss
+++ b/packages/block-library/src/navigation-link/style.scss
@@ -103,10 +103,15 @@
 	}
 }
 
+.wp-block-navigation:not(.has-underline-text-decoration):not(.has-strikethrough-text-decoration) {
+	.wp-block-navigation-link__content {
+		text-decoration: none;
+	}
+}
+
 // All links
 .wp-block-navigation-link__content {
 	color: inherit;
-	text-decoration: none;
 	padding: 0.5em 1em;
 
 	+ .wp-block-navigation-link__content {

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -53,7 +53,7 @@
 		"__experimentalColor": {
 			"textColor": true,
 			"backgroundColor": true
-		}
+		},
 		"__experimentalFontStyle": true
 	}
 }

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -54,5 +54,6 @@
 			"textColor": true,
 			"backgroundColor": true
 		}
+		"__experimentalFontStyle": true
 	}
 }

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -80,12 +80,20 @@
 }
 
 // Font Styles.
-.has-normal-font-style {
-	font-style: normal;
+.has-bold-font-weight {
+	font-weight: bold;
 }
 
 .has-italic-font-style {
 	font-style: italic;
+}
+
+.has-underline-text-decoration {
+	text-decoration: underline;
+}
+
+.has-strikethrough-text-decoration {
+	text-decoration: line-through;
 }
 
 // Text alignments.

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -79,6 +79,15 @@
 	font-size: 2.625em;
 }
 
+// Font Styles.
+.has-normal-font-style {
+	font-style: normal;
+}
+
+.has-italic-font-style {
+	font-style: italic;
+}
+
 // Text alignments.
 .has-text-align-center {
 	text-align: center;

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -17,6 +17,7 @@ export const __EXPERIMENTAL_STYLE_PROPERTY = {
 	backgroundColor: [ 'color', 'background' ],
 	color: [ 'color', 'text' ],
 	fontSize: [ 'typography', 'fontSize' ],
+	fontStyle: [ 'typography', 'fontStyle' ],
 	lineHeight: [ 'typography', 'lineHeight' ],
 	paddingBottom: [ 'spacing', 'padding', 'bottom' ],
 	paddingLeft: [ 'spacing', 'padding', 'left' ],


### PR DESCRIPTION
https://github.com/WordPress/gutenberg/issues/25234
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Add block support flag and hook to set various font styles e.g. bold, italic, underline, strikethrough. 

The font style controls are included within the existing typography controls along with those from the font size and line height hooks. They are simply a collection of buttons to toggle each style on and off.

## How has this been tested?
Tests: `packages/block-editor/src/hooks/test/font-style.js`

Manually tested using navigation block.

#### Test Instructions
1. Add a navigation block to a post and select it.
2. You should see new font style buttons under the Inspector Controls > Typography section.
3. Toggle the various style buttons and confirm the block updates visually as you'd expect.
4. With a font style toggled on, inspect the navigation block in dev tools and confirm that the block includes a `has-font-style` in its css classes along with the style's specific css class as per below:
    * bold => has-bold-font-weight
    * italic => has-italic-font-style
    * underline => has-underline-text-decoration
    * strikethrough => has-strikethrough-text-decoration
5. Save the post and view on the frontend.
6. The same font style choices and class names should be reflected on the frontend.

## Screenshots <!-- if applicable -->

![FontStyleSelections](https://user-images.githubusercontent.com/60436221/95430091-9b461700-098e-11eb-8f42-cf88e4e8af2e.gif)

## Types of changes
Enhancement

## Next Steps
- [ ] Write tests `class-block-supported-styles-test.php`

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
