### PR TITLE
Block API: stabilize light block hook

### DIFF
--- a/docs/designers-developers/developers/block-api/block-metadata.md
+++ b/docs/designers-developers/developers/block-api/block-metadata.md
@@ -11,6 +11,7 @@ To register a new block type using metadata that can be shared between codebase 
 
 ```json
 {
+	"apiVersion": 2,
 	"name": "my-plugin/notice",
 	"title": "Notice",
 	"category": "text",
@@ -32,7 +33,6 @@ To register a new block type using metadata that can be shared between codebase 
 	"usesContext": [ "groupId" ],
 	"supports": {
 		"align": true,
-		"lightBlockWrapper": true
 	},
 	"styles": [
 		{ "name": "default", "label": "Default", "isDefault": true },

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -558,6 +558,25 @@ _Related_
 
 Undocumented declaration.
 
+<a name="useBlockWrapperProps" href="#useBlockWrapperProps">#</a> **useBlockWrapperProps**
+
+This hook is used to lighly mark an element as a block element. Call this
+hook and pass the returned props to the element to mark as a block. If you
+define a ref for the element, it is important to pass the ref to this hook,
+which the hooks in turn will pass to the component through the props it
+returns. Optionally, you can also pass any other props through this hook, and
+they will be merged and returned.
+
+_Parameters_
+
+-   _props_ `Object`: Optional. Props to pass to the element. Must contain the ref if one is defined.
+-   _options_ `Object`: Options for internal use only.
+-   _options.\_\_unstableIsHtml_ `boolean`: 
+
+_Returns_
+
+-   `Object`: Props to pass to the element to mark as a block.
+
 <a name="validateThemeColors" href="#validateThemeColors">#</a> **validateThemeColors**
 
 Given an array of theme colors checks colors for validity

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -561,11 +561,12 @@ Undocumented declaration.
 <a name="useBlockProps" href="#useBlockProps">#</a> **useBlockProps**
 
 This hook is used to lightly mark an element as a block element. The element
-should be the outer element of a block. Call this hook and pass the returned
-props to the element to mark as a block. If you define a ref for the element,
-it is important to pass the ref to this hook, which the hooks in turn will
-pass to the component through the props it returns. Optionally, you can also
-pass any other props through this hook, and they will be merged and returned.
+should be the outermost element of a block. Call this hook and pass the
+returned props to the element to mark as a block. If you define a ref for the
+element, it is important to pass the ref to this hook, which the hook in turn
+will pass to the component through the props it returns. Optionally, you can
+also pass any other props through this hook, and they will be merged and
+returned.
 
 _Parameters_
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -560,7 +560,7 @@ Undocumented declaration.
 
 <a name="useBlockProps" href="#useBlockProps">#</a> **useBlockProps**
 
-This hook is used to lighly mark an element as a block element. Call this
+This hook is used to lightly mark an element as a block element. Call this
 hook and pass the returned props to the element to mark as a block. If you
 define a ref for the element, it is important to pass the ref to this hook,
 which the hooks in turn will pass to the component through the props it

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -558,7 +558,7 @@ _Related_
 
 Undocumented declaration.
 
-<a name="useBlockWrapperProps" href="#useBlockWrapperProps">#</a> **useBlockWrapperProps**
+<a name="useBlockProps" href="#useBlockProps">#</a> **useBlockProps**
 
 This hook is used to lighly mark an element as a block element. Call this
 hook and pass the returned props to the element to mark as a block. If you

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -560,12 +560,12 @@ Undocumented declaration.
 
 <a name="useBlockProps" href="#useBlockProps">#</a> **useBlockProps**
 
-This hook is used to lightly mark an element as a block element. Call this
-hook and pass the returned props to the element to mark as a block. If you
-define a ref for the element, it is important to pass the ref to this hook,
-which the hooks in turn will pass to the component through the props it
-returns. Optionally, you can also pass any other props through this hook, and
-they will be merged and returned.
+This hook is used to lightly mark an element as a block element. The element
+should be the outer element of a block. Call this hook and pass the returned
+props to the element to mark as a block. If you define a ref for the element,
+it is important to pass the ref to this hook, which the hooks in turn will
+pass to the component through the props it returns. Optionally, you can also
+pass any other props through this hook, and they will be merged and returned.
 
 _Parameters_
 

--- a/packages/block-editor/src/components/block-edit/edit.js
+++ b/packages/block-editor/src/components/block-edit/edit.js
@@ -53,7 +53,7 @@ export const Edit = ( props ) => {
 
 	if (
 		blockType.apiVersion > 1 ||
-		hasBlockSupport( blockType, 'lightBlockWrapper', true )
+		hasBlockSupport( blockType, 'lightBlockWrapper', false )
 	) {
 		return <Component { ...props } context={ context } />;
 	}

--- a/packages/block-editor/src/components/block-edit/edit.js
+++ b/packages/block-editor/src/components/block-edit/edit.js
@@ -51,7 +51,7 @@ export const Edit = ( props ) => {
 	// them preferentially as the render value for the block.
 	const Component = blockType.edit || blockType.save;
 
-	if ( blockType.apiVersion >= 1 ) {
+	if ( blockType.apiVersion > 1 ) {
 		return <Component { ...props } context={ context } />;
 	}
 

--- a/packages/block-editor/src/components/block-edit/edit.js
+++ b/packages/block-editor/src/components/block-edit/edit.js
@@ -51,7 +51,10 @@ export const Edit = ( props ) => {
 	// them preferentially as the render value for the block.
 	const Component = blockType.edit || blockType.save;
 
-	if ( blockType.apiVersion > 1 ) {
+	if (
+		blockType.apiVersion > 1 ||
+		hasBlockSupport( blockType, 'lightBlockWrapper', true )
+	) {
 		return <Component { ...props } context={ context } />;
 	}
 

--- a/packages/block-editor/src/components/block-edit/edit.js
+++ b/packages/block-editor/src/components/block-edit/edit.js
@@ -50,13 +50,8 @@ export const Edit = ( props ) => {
 	// with which a block is displayed. If `blockType` is valid, assign
 	// them preferentially as the render value for the block.
 	const Component = blockType.edit || blockType.save;
-	const lightBlockWrapper = hasBlockSupport(
-		blockType,
-		'lightBlockWrapper',
-		false
-	);
 
-	if ( lightBlockWrapper ) {
+	if ( blockType.apiVersion >= 1 ) {
 		return <Component { ...props } context={ context } />;
 	}
 

--- a/packages/block-editor/src/components/block-edit/test/edit.js
+++ b/packages/block-editor/src/components/block-edit/test/edit.js
@@ -104,12 +104,10 @@ describe( 'Edit', () => {
 		it( 'should assign context', () => {
 			const edit = ( { context } ) => context.value;
 			registerBlockType( 'core/test-block', {
+				apiVersion: 1,
 				category: 'text',
 				title: 'block title',
 				usesContext: [ 'value' ],
-				supports: {
-					lightBlockWrapper: true,
-				},
 				edit,
 				save: noop,
 			} );

--- a/packages/block-editor/src/components/block-edit/test/edit.js
+++ b/packages/block-editor/src/components/block-edit/test/edit.js
@@ -104,7 +104,7 @@ describe( 'Edit', () => {
 		it( 'should assign context', () => {
 			const edit = ( { context } ) => context.value;
 			registerBlockType( 'core/test-block', {
-				apiVersion: 1,
+				apiVersion: 2,
 				category: 'text',
 				title: 'block title',
 				usesContext: [ 'value' ],

--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -311,7 +311,7 @@ useBlockWrapperProps.save = getBlockProps;
 const BlockComponent = forwardRef(
 	( { children, tagName: TagName = 'div', ...props }, ref ) => {
 		deprecated( 'wp.blockEditor.__experimentalBlock', {
-			alternative: 'wp.blockEditor.__experimentalUseBlockWrapperProps',
+			alternative: 'wp.blockEditor.useBlockWrapperProps',
 		} );
 		const blockWrapperProps = useBlockWrapperProps( { ...props, ref } );
 		return <TagName { ...blockWrapperProps }>{ children }</TagName>;

--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -45,7 +45,7 @@ import ELEMENTS from './block-wrapper-elements';
  *
  * @return {Object} Props to pass to the element to mark as a block.
  */
-export function useBlockWrapperProps( props = {}, { __unstableIsHtml } = {} ) {
+export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 	const fallbackRef = useRef();
 	const ref = props.ref || fallbackRef;
 	const onSelectionStart = useContext( Context );
@@ -311,10 +311,10 @@ useBlockWrapperProps.save = getBlockProps;
 const BlockComponent = forwardRef(
 	( { children, tagName: TagName = 'div', ...props }, ref ) => {
 		deprecated( 'wp.blockEditor.__experimentalBlock', {
-			alternative: 'wp.blockEditor.useBlockWrapperProps',
+			alternative: 'wp.blockEditor.useBlockProps',
 		} );
-		const blockWrapperProps = useBlockWrapperProps( { ...props, ref } );
-		return <TagName { ...blockWrapperProps }>{ children }</TagName>;
+		const blockProps = useBlockProps( { ...props, ref } );
+		return <TagName { ...blockProps }>{ children }</TagName>;
 	}
 );
 

--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -32,11 +32,12 @@ import ELEMENTS from './block-wrapper-elements';
 
 /**
  * This hook is used to lightly mark an element as a block element. The element
- * should be the outer element of a block. Call this hook and pass the returned
- * props to the element to mark as a block. If you define a ref for the element,
- * it is important to pass the ref to this hook, which the hooks in turn will
- * pass to the component through the props it returns. Optionally, you can also
- * pass any other props through this hook, and they will be merged and returned.
+ * should be the outermost element of a block. Call this hook and pass the
+ * returned props to the element to mark as a block. If you define a ref for the
+ * element, it is important to pass the ref to this hook, which the hook in turn
+ * will pass to the component through the props it returns. Optionally, you can
+ * also pass any other props through this hook, and they will be merged and
+ * returned.
  *
  * @param {Object}  props   Optional. Props to pass to the element. Must contain
  *                          the ref if one is defined.
@@ -306,7 +307,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
  *
  * @param {Object} props Optional. Props to pass to the element.
  */
-useBlockWrapperProps.save = getBlockProps;
+useBlockProps.save = getBlockProps;
 
 const BlockComponent = forwardRef(
 	( { children, tagName: TagName = 'div', ...props }, ref ) => {

--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -31,12 +31,12 @@ import { BlockListBlockContext } from './block';
 import ELEMENTS from './block-wrapper-elements';
 
 /**
- * This hook is used to lightly mark an element as a block element. Call this
- * hook and pass the returned props to the element to mark as a block. If you
- * define a ref for the element, it is important to pass the ref to this hook,
- * which the hooks in turn will pass to the component through the props it
- * returns. Optionally, you can also pass any other props through this hook, and
- * they will be merged and returned.
+ * This hook is used to lightly mark an element as a block element. The element
+ * should be the outer element of a block. Call this hook and pass the returned
+ * props to the element to mark as a block. If you define a ref for the element,
+ * it is important to pass the ref to this hook, which the hooks in turn will
+ * pass to the component through the props it returns. Optionally, you can also
+ * pass any other props through this hook, and they will be merged and returned.
  *
  * @param {Object}  props   Optional. Props to pass to the element. Must contain
  *                          the ref if one is defined.

--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -31,7 +31,7 @@ import { BlockListBlockContext } from './block';
 import ELEMENTS from './block-wrapper-elements';
 
 /**
- * This hook is used to lighly mark an element as a block element. Call this
+ * This hook is used to lightly mark an element as a block element. Call this
  * hook and pass the returned props to the element to mark as a block. If you
  * define a ref for the element, it is important to pass the ref to this hook,
  * which the hooks in turn will pass to the component through the props it

--- a/packages/block-editor/src/components/block-list/block-wrapper.native.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.native.js
@@ -8,7 +8,7 @@ import { __unstableGetBlockProps as getBlockProps } from '@wordpress/blocks';
  */
 import ELEMENTS from './block-wrapper-elements';
 
-export function useBlockWrapperProps( props = {} ) {
+export function useBlockProps( props = {} ) {
 	return props;
 }
 

--- a/packages/block-editor/src/components/block-list/block-wrapper.native.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.native.js
@@ -12,7 +12,7 @@ export function useBlockProps( props = {} ) {
 	return props;
 }
 
-useBlockWrapperProps.save = getBlockProps;
+useBlockProps.save = getBlockProps;
 
 const ExtendedBlockComponent = ELEMENTS.reduce( ( acc, element ) => {
 	acc[ element ] = element;

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -40,7 +40,7 @@ import BlockInvalidWarning from './block-invalid-warning';
 import BlockCrashWarning from './block-crash-warning';
 import BlockCrashBoundary from './block-crash-boundary';
 import BlockHtml from './block-html';
-import { useBlockWrapperProps } from './block-wrapper';
+import { useBlockProps } from './block-wrapper';
 
 export const BlockListBlockContext = createContext();
 
@@ -70,7 +70,7 @@ function mergeWrapperProps( propsA, propsB ) {
 
 function Block( { children, isHtml, ...props } ) {
 	return (
-		<div { ...useBlockWrapperProps( props, { __unstableIsHtml: isHtml } ) }>
+		<div { ...useBlockProps( props, { __unstableIsHtml: isHtml } ) }>
 			{ children }
 		</div>
 	);

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -126,11 +126,7 @@ function BlockListBlock( {
 	const onBlockError = () => setErrorState( true );
 
 	const blockType = getBlockType( name );
-	const lightBlockWrapper = hasBlockSupport(
-		blockType,
-		'lightBlockWrapper',
-		false
-	);
+	const lightBlockWrapper = blockType.apiVersion >= 1;
 	const isUnregisteredBlock = name === getUnregisteredTypeHandlerName();
 
 	// Determine whether the block has props to apply to the wrapper.

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -128,7 +128,7 @@ function BlockListBlock( {
 	const blockType = getBlockType( name );
 	const lightBlockWrapper =
 		blockType.apiVersion > 1 ||
-		hasBlockSupport( blockType, 'lightBlockWrapper', true );
+		hasBlockSupport( blockType, 'lightBlockWrapper', false );
 	const isUnregisteredBlock = name === getUnregisteredTypeHandlerName();
 
 	// Determine whether the block has props to apply to the wrapper.

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -126,7 +126,9 @@ function BlockListBlock( {
 	const onBlockError = () => setErrorState( true );
 
 	const blockType = getBlockType( name );
-	const lightBlockWrapper = blockType.apiVersion > 1;
+	const lightBlockWrapper =
+		blockType.apiVersion > 1 ||
+		hasBlockSupport( blockType, 'lightBlockWrapper', true );
 	const isUnregisteredBlock = name === getUnregisteredTypeHandlerName();
 
 	// Determine whether the block has props to apply to the wrapper.

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -126,7 +126,7 @@ function BlockListBlock( {
 	const onBlockError = () => setErrorState( true );
 
 	const blockType = getBlockType( name );
-	const lightBlockWrapper = blockType.apiVersion >= 1;
+	const lightBlockWrapper = blockType.apiVersion > 1;
 	const isUnregisteredBlock = name === getUnregisteredTypeHandlerName();
 
 	// Determine whether the block has props to apply to the wrapper.

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -70,7 +70,7 @@ export { default as BlockInspector } from './block-inspector';
 export { default as BlockList } from './block-list';
 export {
 	Block as __experimentalBlock,
-	useBlockWrapperProps as __experimentalUseBlockWrapperProps,
+	useBlockWrapperProps,
 } from './block-list/block-wrapper';
 export { default as BlockMover } from './block-mover';
 export { default as BlockPreview } from './block-preview';

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -70,7 +70,7 @@ export { default as BlockInspector } from './block-inspector';
 export { default as BlockList } from './block-list';
 export {
 	Block as __experimentalBlock,
-	useBlockWrapperProps,
+	useBlockProps,
 } from './block-list/block-wrapper';
 export { default as BlockMover } from './block-mover';
 export { default as BlockPreview } from './block-preview';

--- a/packages/block-editor/src/components/index.native.js
+++ b/packages/block-editor/src/components/index.native.js
@@ -59,7 +59,7 @@ export { default as __unstableEditorStyles } from './editor-styles';
 export { default as Inserter } from './inserter';
 export {
 	Block as __experimentalBlock,
-	useBlockWrapperProps,
+	useBlockProps,
 } from './block-list/block-wrapper';
 export { default as FloatingToolbar } from './floating-toolbar';
 

--- a/packages/block-editor/src/components/index.native.js
+++ b/packages/block-editor/src/components/index.native.js
@@ -59,7 +59,7 @@ export { default as __unstableEditorStyles } from './editor-styles';
 export { default as Inserter } from './inserter';
 export {
 	Block as __experimentalBlock,
-	useBlockWrapperProps as __experimentalUseBlockWrapperProps,
+	useBlockWrapperProps,
 } from './block-list/block-wrapper';
 export { default as FloatingToolbar } from './floating-toolbar';
 

--- a/packages/block-library/src/audio/block.json
+++ b/packages/block-library/src/audio/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 1,
+	"apiVersion": 2,
 	"name": "core/audio",
 	"category": "media",
 	"attributes": {

--- a/packages/block-library/src/audio/block.json
+++ b/packages/block-library/src/audio/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 1,
 	"name": "core/audio",
 	"category": "media",
 	"attributes": {
@@ -37,7 +38,6 @@
 	},
 	"supports": {
 		"anchor": true,
-		"align": true,
-		"lightBlockWrapper": true
+		"align": true
 	}
 }

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -16,7 +16,7 @@ import {
 	MediaPlaceholder,
 	MediaReplaceFlow,
 	RichText,
-	useBlockWrapperProps,
+	useBlockProps,
 } from '@wordpress/block-editor';
 import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -41,7 +41,7 @@ function AudioEdit( {
 	insertBlocksAfter,
 } ) {
 	const { id, autoplay, caption, loop, preload, src } = attributes;
-	const blockWrapperProps = useBlockWrapperProps();
+	const blockProps = useBlockProps();
 	const mediaUpload = useSelect( ( select ) => {
 		const { getSettings } = select( 'core/block-editor' );
 		return getSettings().mediaUpload;
@@ -116,7 +116,7 @@ function AudioEdit( {
 	}
 	if ( ! src ) {
 		return (
-			<div { ...blockWrapperProps }>
+			<div { ...blockProps }>
 				<MediaPlaceholder
 					icon={ <BlockIcon icon={ icon } /> }
 					onSelect={ onSelectAudio }
@@ -175,7 +175,7 @@ function AudioEdit( {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<figure { ...blockWrapperProps }>
+			<figure { ...blockProps }>
 				{ /*
 					Disable the audio tag so the user clicking on it won't play the
 					file or change the position slider when the controls are enabled.

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -16,7 +16,7 @@ import {
 	MediaPlaceholder,
 	MediaReplaceFlow,
 	RichText,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+	useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';

--- a/packages/block-library/src/audio/save.js
+++ b/packages/block-library/src/audio/save.js
@@ -1,17 +1,14 @@
 /**
  * WordPress dependencies
  */
-import {
-	RichText,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
-} from '@wordpress/block-editor';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
 	const { autoplay, caption, loop, preload, src } = attributes;
 
 	return (
 		src && (
-			<figure { ...useBlockWrapperProps.save() }>
+			<figure { ...useBlockProps.save() }>
 				<audio
 					controls="controls"
 					src={ src }

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 1,
 	"name": "core/button",
 	"category": "design",
 	"parent": [
@@ -57,7 +58,6 @@
 		"anchor": true,
 		"align": true,
 		"alignWide": false,
-		"reusable": false,
-		"lightBlockWrapper": true
+		"reusable": false
 	}
 }

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 1,
+	"apiVersion": 2,
 	"name": "core/button",
 	"category": "design",
 	"parent": [

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -22,7 +22,7 @@ import {
 	BlockControls,
 	InspectorControls,
 	RichText,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+	useBlockWrapperProps,
 	__experimentalLinkControl as LinkControl,
 	__experimentalUseEditorFeature as useEditorFeature,
 } from '@wordpress/block-editor';

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -22,7 +22,7 @@ import {
 	BlockControls,
 	InspectorControls,
 	RichText,
-	useBlockWrapperProps,
+	useBlockProps,
 	__experimentalLinkControl as LinkControl,
 	__experimentalUseEditorFeature as useEditorFeature,
 } from '@wordpress/block-editor';
@@ -197,12 +197,12 @@ function ButtonEdit( props ) {
 	);
 
 	const colorProps = getColorAndStyleProps( attributes, colors, true );
-	const blockWrapperProps = useBlockWrapperProps();
+	const blockProps = useBlockProps();
 
 	return (
 		<>
 			<ColorEdit { ...props } />
-			<div { ...blockWrapperProps }>
+			<div { ...blockProps }>
 				<RichText
 					placeholder={ placeholder || __( 'Add text…' ) }
 					value={ text }

--- a/packages/block-library/src/button/save.js
+++ b/packages/block-library/src/button/save.js
@@ -6,10 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import {
-	RichText,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
-} from '@wordpress/block-editor';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -36,7 +33,7 @@ export default function save( { attributes } ) {
 	// A title will no longer be assigned for new or updated button block links.
 
 	return (
-		<div { ...useBlockWrapperProps.save() }>
+		<div { ...useBlockProps.save() }>
 			<RichText.Content
 				tagName="a"
 				className={ buttonClasses }

--- a/packages/block-library/src/buttons/block.json
+++ b/packages/block-library/src/buttons/block.json
@@ -1,10 +1,10 @@
 {
+	"apiVersion": 1,
 	"name": "core/buttons",
 	"category": "design",
 	"supports": {
 		"anchor": true,
 		"align": true,
-		"alignWide": false,
-		"lightBlockWrapper": true
+		"alignWide": false
 	}
 }

--- a/packages/block-library/src/buttons/block.json
+++ b/packages/block-library/src/buttons/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 1,
+	"apiVersion": 2,
 	"name": "core/buttons",
 	"category": "design",
 	"supports": {

--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -4,7 +4,7 @@
 import {
 	__experimentalAlignmentHookSettingsProvider as AlignmentHookSettingsProvider,
 	InnerBlocks,
-	useBlockWrapperProps,
+	useBlockProps,
 } from '@wordpress/block-editor';
 
 /**
@@ -21,12 +21,12 @@ const alignmentHooksSetting = {
 };
 
 function ButtonsEdit() {
-	const blockWrapperProps = useBlockWrapperProps();
+	const blockProps = useBlockProps();
 	return (
 		<AlignmentHookSettingsProvider value={ alignmentHooksSetting }>
 			<InnerBlocks
 				allowedBlocks={ ALLOWED_BLOCKS }
-				__experimentalPassedProps={ blockWrapperProps }
+				__experimentalPassedProps={ blockProps }
 				__experimentalTagName="div"
 				template={ BUTTONS_TEMPLATE }
 				orientation="horizontal"

--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -4,7 +4,7 @@
 import {
 	__experimentalAlignmentHookSettingsProvider as AlignmentHookSettingsProvider,
 	InnerBlocks,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+	useBlockWrapperProps,
 } from '@wordpress/block-editor';
 
 /**

--- a/packages/block-library/src/buttons/save.js
+++ b/packages/block-library/src/buttons/save.js
@@ -1,14 +1,11 @@
 /**
  * WordPress dependencies
  */
-import {
-	InnerBlocks,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
-} from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
 export default function save() {
 	return (
-		<div { ...useBlockWrapperProps.save() }>
+		<div { ...useBlockProps.save() }>
 			<InnerBlocks.Content />
 		</div>
 	);

--- a/packages/block-library/src/code/block.json
+++ b/packages/block-library/src/code/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 1,
+	"apiVersion": 2,
 	"name": "core/code",
 	"category": "text",
 	"attributes": {

--- a/packages/block-library/src/code/block.json
+++ b/packages/block-library/src/code/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 1,
 	"name": "core/code",
 	"category": "text",
 	"attributes": {
@@ -9,7 +10,6 @@
 		}
 	},
 	"supports": {
-		"anchor": true,
-		"lightBlockWrapper": true
+		"anchor": true
 	}
 }

--- a/packages/block-library/src/code/edit.js
+++ b/packages/block-library/src/code/edit.js
@@ -2,12 +2,12 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { RichText, useBlockWrapperProps } from '@wordpress/block-editor';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
 
 export default function CodeEdit( { attributes, setAttributes } ) {
-	const blockWrapperProps = useBlockWrapperProps();
+	const blockProps = useBlockProps();
 	return (
-		<pre { ...blockWrapperProps }>
+		<pre { ...blockProps }>
 			<RichText
 				tagName="code"
 				value={ attributes.content }

--- a/packages/block-library/src/code/edit.js
+++ b/packages/block-library/src/code/edit.js
@@ -2,10 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	RichText,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
-} from '@wordpress/block-editor';
+import { RichText, useBlockWrapperProps } from '@wordpress/block-editor';
 
 export default function CodeEdit( { attributes, setAttributes } ) {
 	const blockWrapperProps = useBlockWrapperProps();

--- a/packages/block-library/src/code/save.js
+++ b/packages/block-library/src/code/save.js
@@ -1,10 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	RichText,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
-} from '@wordpress/block-editor';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -13,7 +10,7 @@ import { escape } from './utils';
 
 export default function save( { attributes } ) {
 	return (
-		<pre { ...useBlockWrapperProps.save() }>
+		<pre { ...useBlockProps.save() }>
 			<RichText.Content
 				tagName="code"
 				value={ escape( attributes.content ) }

--- a/packages/block-library/src/column/block.json
+++ b/packages/block-library/src/column/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 1,
+	"apiVersion": 2,
 	"name": "core/column",
 	"category": "text",
 	"parent": [

--- a/packages/block-library/src/column/block.json
+++ b/packages/block-library/src/column/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 1,
 	"name": "core/column",
 	"category": "text",
 	"parent": [
@@ -15,7 +16,6 @@
 	"supports": {
 		"anchor": true,
 		"reusable": false,
-		"html": false,
-		"lightBlockWrapper": true
+		"html": false
 	}
 }

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -11,7 +11,7 @@ import {
 	BlockControls,
 	BlockVerticalAlignmentToolbar,
 	InspectorControls,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+	useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import {
 	PanelBody,

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -11,7 +11,7 @@ import {
 	BlockControls,
 	BlockVerticalAlignmentToolbar,
 	InspectorControls,
-	useBlockWrapperProps,
+	useBlockProps,
 } from '@wordpress/block-editor';
 import {
 	PanelBody,
@@ -54,7 +54,7 @@ function ColumnEdit( {
 		} );
 	};
 
-	const blockWrapperProps = useBlockWrapperProps( {
+	const blockProps = useBlockProps( {
 		className: classes,
 		style: width ? { flexBasis: width } : undefined,
 	} );
@@ -95,7 +95,7 @@ function ColumnEdit( {
 					hasChildBlocks ? undefined : InnerBlocks.ButtonBlockAppender
 				}
 				__experimentalTagName="div"
-				__experimentalPassedProps={ blockWrapperProps }
+				__experimentalPassedProps={ blockProps }
 			/>
 		</>
 	);

--- a/packages/block-library/src/column/save.js
+++ b/packages/block-library/src/column/save.js
@@ -6,10 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import {
-	InnerBlocks,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
-} from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
 	const { verticalAlignment, width } = attributes;
@@ -25,7 +22,7 @@ export default function save( { attributes } ) {
 
 	return (
 		<div
-			{ ...useBlockWrapperProps.save( {
+			{ ...useBlockProps.save( {
 				className: wrapperClasses,
 				style,
 			} ) }

--- a/packages/block-library/src/columns/block.json
+++ b/packages/block-library/src/columns/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 1,
 	"name": "core/columns",
 	"category": "design",
 	"attributes": {
@@ -13,7 +14,6 @@
 			"full"
 		],
 		"html": false,
-		"lightBlockWrapper": true,
 		"color": {
 			"gradients": true,
 			"link": true

--- a/packages/block-library/src/columns/block.json
+++ b/packages/block-library/src/columns/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 1,
+	"apiVersion": 2,
 	"name": "core/columns",
 	"category": "design",
 	"attributes": {

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -16,7 +16,7 @@ import {
 	BlockControls,
 	BlockVerticalAlignmentToolbar,
 	__experimentalBlockVariationPicker,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+	useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import { withDispatch, useDispatch, useSelect } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -16,7 +16,7 @@ import {
 	BlockControls,
 	BlockVerticalAlignmentToolbar,
 	__experimentalBlockVariationPicker,
-	useBlockWrapperProps,
+	useBlockProps,
 } from '@wordpress/block-editor';
 import { withDispatch, useDispatch, useSelect } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
@@ -63,7 +63,7 @@ function ColumnsEditContainer( {
 		[ `are-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,
 	} );
 
-	const blockWrapperProps = useBlockWrapperProps( {
+	const blockProps = useBlockProps( {
 		className: classes,
 	} );
 
@@ -97,7 +97,7 @@ function ColumnsEditContainer( {
 				allowedBlocks={ ALLOWED_BLOCKS }
 				orientation="horizontal"
 				__experimentalTagName="div"
-				__experimentalPassedProps={ blockWrapperProps }
+				__experimentalPassedProps={ blockProps }
 				renderAppender={ false }
 			/>
 		</>
@@ -228,10 +228,10 @@ function Placeholder( { clientId, name, setAttributes } ) {
 		[ name ]
 	);
 	const { replaceInnerBlocks } = useDispatch( 'core/block-editor' );
-	const blockWrapperProps = useBlockWrapperProps();
+	const blockProps = useBlockProps();
 
 	return (
-		<div { ...blockWrapperProps }>
+		<div { ...blockProps }>
 			<__experimentalBlockVariationPicker
 				icon={ get( blockType, [ 'icon', 'src' ] ) }
 				label={ get( blockType, [ 'title' ] ) }

--- a/packages/block-library/src/columns/save.js
+++ b/packages/block-library/src/columns/save.js
@@ -6,10 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import {
-	InnerBlocks,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
-} from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
 	const { verticalAlignment } = attributes;
@@ -19,7 +16,7 @@ export default function save( { attributes } ) {
 	} );
 
 	return (
-		<div { ...useBlockWrapperProps.save( { className } ) }>
+		<div { ...useBlockProps.save( { className } ) }>
 			<InnerBlocks.Content />
 		</div>
 	);

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 1,
+	"apiVersion": 2,
 	"name": "core/cover",
 	"category": "media",
 	"attributes": {

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 1,
 	"name": "core/cover",
 	"category": "media",
 	"attributes": {
@@ -49,7 +50,6 @@
 		"anchor": true,
 		"align": true,
 		"html": false,
-		"lightBlockWrapper": true,
 		"__experimentalPadding": true
 	}
 }

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -31,7 +31,7 @@ import {
 	MediaReplaceFlow,
 	withColors,
 	ColorPalette,
-	useBlockWrapperProps,
+	useBlockProps,
 	__experimentalUseGradient,
 	__experimentalPanelColorGradientSettings as PanelColorGradientSettings,
 	__experimentalUnitControl as UnitControl,
@@ -426,7 +426,7 @@ function CoverEdit( {
 		</>
 	);
 
-	const blockWrapperProps = useBlockWrapperProps();
+	const blockProps = useBlockProps();
 
 	if ( ! hasBackground ) {
 		const placeholderIcon = <BlockIcon icon={ icon } />;
@@ -436,10 +436,10 @@ function CoverEdit( {
 			<>
 				{ controls }
 				<div
-					{ ...blockWrapperProps }
+					{ ...blockProps }
 					className={ classnames(
 						'is-placeholder',
-						blockWrapperProps.className
+						blockProps.className
 					) }
 				>
 					<MediaPlaceholder
@@ -493,9 +493,9 @@ function CoverEdit( {
 		<>
 			{ controls }
 			<div
-				{ ...blockWrapperProps }
-				className={ classnames( classes, blockWrapperProps.className ) }
-				style={ { ...style, ...blockWrapperProps.style } }
+				{ ...blockProps }
+				className={ classnames( classes, blockProps.className ) }
+				style={ { ...style, ...blockProps.style } }
 				data-url={ url }
 			>
 				<BoxControlVisualizer

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -31,7 +31,7 @@ import {
 	MediaReplaceFlow,
 	withColors,
 	ColorPalette,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+	useBlockWrapperProps,
 	__experimentalUseGradient,
 	__experimentalPanelColorGradientSettings as PanelColorGradientSettings,
 	__experimentalUnitControl as UnitControl,

--- a/packages/block-library/src/cover/save.js
+++ b/packages/block-library/src/cover/save.js
@@ -10,7 +10,7 @@ import {
 	InnerBlocks,
 	getColorClassName,
 	__experimentalGetGradientClass,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+	useBlockProps,
 } from '@wordpress/block-editor';
 
 /**
@@ -96,7 +96,7 @@ export default function save( { attributes } ) {
 	);
 
 	return (
-		<div { ...useBlockWrapperProps.save( { className: classes, style } ) }>
+		<div { ...useBlockProps.save( { className: classes, style } ) }>
 			{ url && ( gradient || customGradient ) && dimRatio !== 0 && (
 				<span
 					aria-hidden="true"

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 1,
 	"name": "core/group",
 	"category": "design",
 	"attributes": {
@@ -14,7 +15,6 @@
 		],
 		"anchor": true,
 		"html": false,
-		"lightBlockWrapper": true,
 		"color": {
 			"gradients": true,
 			"link": true

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 1,
+	"apiVersion": 2,
 	"name": "core/group",
 	"category": "design",
 	"attributes": {

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -2,10 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import {
-	InnerBlocks,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
-} from '@wordpress/block-editor';
+import { InnerBlocks, useBlockWrapperProps } from '@wordpress/block-editor';
 import { __experimentalBoxControl as BoxControl } from '@wordpress/components';
 const { __Visualizer: BoxControlVisualizer } = BoxControl;
 

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { InnerBlocks, useBlockWrapperProps } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 import { __experimentalBoxControl as BoxControl } from '@wordpress/components';
 const { __Visualizer: BoxControlVisualizer } = BoxControl;
 
@@ -15,11 +15,11 @@ function GroupEdit( { attributes, clientId } ) {
 		},
 		[ clientId ]
 	);
-	const blockWrapperProps = useBlockWrapperProps();
+	const blockProps = useBlockProps();
 	const { tagName: TagName = 'div' } = attributes;
 
 	return (
-		<TagName { ...blockWrapperProps }>
+		<TagName { ...blockProps }>
 			<BoxControlVisualizer
 				values={ attributes.style?.spacing?.padding }
 				showValues={ attributes.style?.visualizers?.padding }

--- a/packages/block-library/src/group/save.js
+++ b/packages/block-library/src/group/save.js
@@ -1,16 +1,13 @@
 /**
  * WordPress dependencies
  */
-import {
-	InnerBlocks,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
-} from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
 	const { tagName: Tag } = attributes;
 
 	return (
-		<Tag { ...useBlockWrapperProps.save() }>
+		<Tag { ...useBlockProps.save() }>
 			<div className="wp-block-group__inner-container">
 				<InnerBlocks.Content />
 			</div>

--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 1,
 	"name": "core/heading",
 	"category": "text",
 	"attributes": {
@@ -22,7 +23,6 @@
 	"supports": {
 		"anchor": true,
 		"className": false,
-		"lightBlockWrapper": true,
 		"color": {
 			"link": true
 		},

--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 1,
+	"apiVersion": 2,
 	"name": "core/heading",
 	"category": "text",
 	"attributes": {

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -12,7 +12,7 @@ import {
 	AlignmentToolbar,
 	BlockControls,
 	RichText,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+	useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import { ToolbarGroup } from '@wordpress/components';
 

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -12,7 +12,7 @@ import {
 	AlignmentToolbar,
 	BlockControls,
 	RichText,
-	useBlockWrapperProps,
+	useBlockProps,
 } from '@wordpress/block-editor';
 import { ToolbarGroup } from '@wordpress/components';
 
@@ -30,7 +30,7 @@ function HeadingEdit( {
 } ) {
 	const { align, content, level, placeholder } = attributes;
 	const tagName = 'h' + level;
-	const blockWrapperProps = useBlockWrapperProps( {
+	const blockProps = useBlockProps( {
 		className: classnames( {
 			[ `has-text-align-${ align }` ]: align,
 		} ),
@@ -75,7 +75,7 @@ function HeadingEdit( {
 				onRemove={ () => onReplace( [] ) }
 				placeholder={ placeholder || __( 'Write heading…' ) }
 				textAlign={ align }
-				{ ...blockWrapperProps }
+				{ ...blockProps }
 			/>
 		</>
 	);

--- a/packages/block-library/src/heading/save.js
+++ b/packages/block-library/src/heading/save.js
@@ -6,10 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import {
-	RichText,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
-} from '@wordpress/block-editor';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
 	const { align, content, level } = attributes;
@@ -20,7 +17,7 @@ export default function save( { attributes } ) {
 	} );
 
 	return (
-		<TagName { ...useBlockWrapperProps.save( { className } ) }>
+		<TagName { ...useBlockProps.save( { className } ) }>
 			<RichText.Content value={ content } />
 		</TagName>
 	);

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 1,
 	"name": "core/image",
 	"category": "media",
 	"attributes": {
@@ -70,7 +71,6 @@
 		}
 	},
 	"supports": {
-		"anchor": true,
-		"lightBlockWrapper": true
+		"anchor": true
 	}
 }

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 1,
+	"apiVersion": 2,
 	"name": "core/image",
 	"category": "media",
 	"attributes": {

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -15,7 +15,7 @@ import {
 	BlockControls,
 	BlockIcon,
 	MediaPlaceholder,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+	useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -15,7 +15,7 @@ import {
 	BlockControls,
 	BlockIcon,
 	MediaPlaceholder,
-	useBlockWrapperProps,
+	useBlockProps,
 } from '@wordpress/block-editor';
 import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -303,7 +303,7 @@ export function ImageEdit( {
 		[ `size-${ sizeSlug }` ]: sizeSlug,
 	} );
 
-	const blockWrapperProps = useBlockWrapperProps( {
+	const blockProps = useBlockProps( {
 		ref,
 		className: classes,
 	} );
@@ -311,7 +311,7 @@ export function ImageEdit( {
 	return (
 		<>
 			{ controls }
-			<figure { ...blockWrapperProps }>
+			<figure { ...blockProps }>
 				{ url && (
 					<Image
 						attributes={ attributes }

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -7,10 +7,7 @@ import { isEmpty } from 'lodash';
 /**
  * WordPress dependencies
  */
-import {
-	RichText,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
-} from '@wordpress/block-editor';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
 	const {
@@ -70,14 +67,14 @@ export default function save( { attributes } ) {
 
 	if ( 'left' === align || 'right' === align || 'center' === align ) {
 		return (
-			<div { ...useBlockWrapperProps.save() }>
+			<div { ...useBlockProps.save() }>
 				<figure className={ classes }>{ figure }</figure>
 			</div>
 		);
 	}
 
 	return (
-		<figure { ...useBlockWrapperProps.save( { className: classes } ) }>
+		<figure { ...useBlockProps.save( { className: classes } ) }>
 			{ figure }
 		</figure>
 	);

--- a/packages/block-library/src/list/block.json
+++ b/packages/block-library/src/list/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 1,
+	"apiVersion": 2,
 	"name": "core/list",
 	"category": "text",
 	"attributes": {

--- a/packages/block-library/src/list/block.json
+++ b/packages/block-library/src/list/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 1,
 	"name": "core/list",
 	"category": "text",
 	"attributes": {
@@ -30,7 +31,6 @@
 		"color": {
 			"gradients": true
 		},
-		"__unstablePasteTextInline": true,
-		"lightBlockWrapper": true
+		"__unstablePasteTextInline": true
 	}
 }

--- a/packages/block-library/src/list/edit.js
+++ b/packages/block-library/src/list/edit.js
@@ -7,7 +7,7 @@ import {
 	RichText,
 	BlockControls,
 	RichTextShortcut,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+	useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import { ToolbarGroup } from '@wordpress/components';
 import {

--- a/packages/block-library/src/list/edit.js
+++ b/packages/block-library/src/list/edit.js
@@ -7,7 +7,7 @@ import {
 	RichText,
 	BlockControls,
 	RichTextShortcut,
-	useBlockWrapperProps,
+	useBlockProps,
 } from '@wordpress/block-editor';
 import { ToolbarGroup } from '@wordpress/components';
 import {
@@ -154,7 +154,7 @@ export default function ListEdit( {
 		</>
 	);
 
-	const blockWrapperProps = useBlockWrapperProps();
+	const blockProps = useBlockProps();
 
 	return (
 		<>
@@ -180,7 +180,7 @@ export default function ListEdit( {
 				start={ start }
 				reversed={ reversed }
 				type={ type }
-				{ ...blockWrapperProps }
+				{ ...blockProps }
 			>
 				{ controls }
 			</RichText>

--- a/packages/block-library/src/list/save.js
+++ b/packages/block-library/src/list/save.js
@@ -1,17 +1,14 @@
 /**
  * WordPress dependencies
  */
-import {
-	RichText,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
-} from '@wordpress/block-editor';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
 	const { ordered, values, type, reversed, start } = attributes;
 	const TagName = ordered ? 'ol' : 'ul';
 
 	return (
-		<TagName { ...useBlockWrapperProps.save( { type, reversed, start } ) }>
+		<TagName { ...useBlockProps.save( { type, reversed, start } ) }>
 			<RichText.Content value={ values } multiline="li" />
 		</TagName>
 	);

--- a/packages/block-library/src/media-text/block.json
+++ b/packages/block-library/src/media-text/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 1,
 	"name": "core/media-text",
 	"category": "media",
 	"attributes": {
@@ -84,7 +85,6 @@
 		"anchor": true,
 		"align": [ "wide", "full" ],
 		"html": false,
-		"lightBlockWrapper": true,
 		"color": {
 			"gradients": true,
 			"link": true

--- a/packages/block-library/src/media-text/block.json
+++ b/packages/block-library/src/media-text/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 1,
+	"apiVersion": 2,
 	"name": "core/media-text",
 	"category": "media",
 	"attributes": {

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -15,7 +15,7 @@ import {
 	BlockVerticalAlignmentToolbar,
 	InnerBlocks,
 	InspectorControls,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+	useBlockWrapperProps,
 	__experimentalImageURLInputUI as ImageURLInputUI,
 	__experimentalImageSizeControl as ImageSizeControl,
 } from '@wordpress/block-editor';

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -15,7 +15,7 @@ import {
 	BlockVerticalAlignmentToolbar,
 	InnerBlocks,
 	InspectorControls,
-	useBlockWrapperProps,
+	useBlockProps,
 	__experimentalImageURLInputUI as ImageURLInputUI,
 	__experimentalImageSizeControl as ImageSizeControl,
 } from '@wordpress/block-editor';
@@ -280,7 +280,7 @@ function MediaTextEdit( { attributes, isSelected, setAttributes } ) {
 		</PanelBody>
 	);
 
-	const blockWrapperProps = useBlockWrapperProps( {
+	const blockProps = useBlockProps( {
 		className: classNames,
 		style,
 	} );
@@ -310,7 +310,7 @@ function MediaTextEdit( { attributes, isSelected, setAttributes } ) {
 					</ToolbarGroup>
 				) }
 			</BlockControls>
-			<div { ...blockWrapperProps }>
+			<div { ...blockProps }>
 				<MediaContainer
 					className="wp-block-media-text__media"
 					onSelectMedia={ onSelectMedia }

--- a/packages/block-library/src/media-text/save.js
+++ b/packages/block-library/src/media-text/save.js
@@ -7,10 +7,7 @@ import { noop, isEmpty } from 'lodash';
 /**
  * WordPress dependencies
  */
-import {
-	InnerBlocks,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
-} from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -91,7 +88,7 @@ export default function save( { attributes } ) {
 		gridTemplateColumns,
 	};
 	return (
-		<div { ...useBlockWrapperProps.save( { className, style } ) }>
+		<div { ...useBlockProps.save( { className, style } ) }>
 			<figure
 				className="wp-block-media-text__media"
 				style={ backgroundStyles }

--- a/packages/block-library/src/navigation-link/block.json
+++ b/packages/block-library/src/navigation-link/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 1,
 	"name": "core/navigation-link",
 	"category": "design",
 	"parent": [ "core/navigation" ],
@@ -40,7 +41,6 @@
 	],
 	"supports": {
 		"reusable": false,
-		"html": false,
-		"lightBlockWrapper": true
+		"html": false
 	}
 }

--- a/packages/block-library/src/navigation-link/block.json
+++ b/packages/block-library/src/navigation-link/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 1,
+	"apiVersion": 2,
 	"name": "core/navigation-link",
 	"category": "design",
 	"parent": [ "core/navigation" ],

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -32,7 +32,7 @@ import {
 	InspectorControls,
 	RichText,
 	__experimentalLinkControl as LinkControl,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+	useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import { isURL, prependHTTP } from '@wordpress/url';
 import {

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -32,7 +32,7 @@ import {
 	InspectorControls,
 	RichText,
 	__experimentalLinkControl as LinkControl,
-	useBlockWrapperProps,
+	useBlockProps,
 } from '@wordpress/block-editor';
 import { isURL, prependHTTP } from '@wordpress/url';
 import {
@@ -239,7 +239,7 @@ function NavigationLinkEdit( {
 		};
 	}
 
-	const blockWrapperProps = useBlockWrapperProps( {
+	const blockProps = useBlockProps( {
 		ref: listItemRef,
 		className: classnames( {
 			'is-editing':
@@ -318,7 +318,7 @@ function NavigationLinkEdit( {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<li { ...blockWrapperProps }>
+			<li { ...blockProps }>
 				<div className="wp-block-navigation-link__content">
 					<RichText
 						ref={ ref }

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 1,
+	"apiVersion": 2,
 	"name": "core/navigation",
 	"category": "design",
 	"attributes": {

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 1,
 	"name": "core/navigation",
 	"category": "design",
 	"attributes": {
@@ -48,7 +49,6 @@
 		"anchor": true,
 		"html": false,
 		"inserter": true,
-		"lightBlockWrapper": true,
 		"fontSize": true,
 		"color": {
 			"textColor": true,

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -12,7 +12,7 @@ import {
 	InnerBlocks,
 	InspectorControls,
 	BlockControls,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+	useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import { useDispatch, withSelect, withDispatch } from '@wordpress/data';
 import { PanelBody, ToggleControl, ToolbarGroup } from '@wordpress/components';

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -12,7 +12,7 @@ import {
 	InnerBlocks,
 	InspectorControls,
 	BlockControls,
-	useBlockWrapperProps,
+	useBlockProps,
 } from '@wordpress/block-editor';
 import { useDispatch, withSelect, withDispatch } from '@wordpress/data';
 import { PanelBody, ToggleControl, ToolbarGroup } from '@wordpress/components';
@@ -46,7 +46,7 @@ function Navigation( {
 
 	const { selectBlock } = useDispatch( 'core/block-editor' );
 
-	const blockProps = useBlockWrapperProps();
+	const blockProps = useBlockProps();
 	const { navigatorToolbarButton, navigatorModal } = useBlockNavigator(
 		clientId
 	);

--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 1,
+	"apiVersion": 2,
 	"name": "core/paragraph",
 	"category": "text",
 	"attributes": {

--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 1,
 	"name": "core/paragraph",
 	"category": "text",
 	"attributes": {
@@ -29,7 +30,6 @@
 	"supports": {
 		"anchor": true,
 		"className": false,
-		"lightBlockWrapper": true,
 		"color": {
 			"link": true
 		},

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -13,7 +13,7 @@ import {
 	BlockControls,
 	InspectorControls,
 	RichText,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+	useBlockWrapperProps,
 	getFontSize,
 	__experimentalUseEditorFeature as useEditorFeature,
 } from '@wordpress/block-editor';

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -13,7 +13,7 @@ import {
 	BlockControls,
 	InspectorControls,
 	RichText,
-	useBlockWrapperProps,
+	useBlockProps,
 	getFontSize,
 	__experimentalUseEditorFeature as useEditorFeature,
 } from '@wordpress/block-editor';
@@ -117,7 +117,7 @@ function ParagraphBlock( {
 		minHeight: dropCapMinimumHeight,
 	};
 
-	const blockWrapperProps = useBlockWrapperProps( {
+	const blockProps = useBlockProps( {
 		className: classnames( {
 			'has-drop-cap': dropCap,
 			[ `has-text-align-${ align }` ]: align,
@@ -164,7 +164,7 @@ function ParagraphBlock( {
 			<RichText
 				identifier="content"
 				tagName="p"
-				{ ...blockWrapperProps }
+				{ ...blockProps }
 				value={ content }
 				onChange={ ( newContent ) =>
 					setAttributes( { content: newContent } )

--- a/packages/block-library/src/paragraph/save.js
+++ b/packages/block-library/src/paragraph/save.js
@@ -6,10 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import {
-	RichText,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
-} from '@wordpress/block-editor';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
 	const { align, content, dropCap, direction } = attributes;
@@ -19,7 +16,7 @@ export default function save( { attributes } ) {
 	} );
 
 	return (
-		<p { ...useBlockWrapperProps.save( { className, dir: direction } ) }>
+		<p { ...useBlockProps.save( { className, dir: direction } ) }>
 			<RichText.Content value={ content } />
 		</p>
 	);

--- a/packages/block-library/src/post-author/block.json
+++ b/packages/block-library/src/post-author/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 1,
+	"apiVersion": 2,
 	"name": "core/post-author",
 	"category": "design",
 	"attributes": {

--- a/packages/block-library/src/post-author/block.json
+++ b/packages/block-library/src/post-author/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 1,
 	"name": "core/post-author",
 	"category": "design",
 	"attributes": {
@@ -26,7 +27,6 @@
 	],
 	"supports": {
 		"html": false,
-		"lightBlockWrapper": true,
 		"fontSize": true,
 		"color": {
 			"gradients": true,

--- a/packages/block-library/src/post-author/edit.js
+++ b/packages/block-library/src/post-author/edit.js
@@ -12,7 +12,7 @@ import {
 	BlockControls,
 	InspectorControls,
 	RichText,
-	useBlockWrapperProps,
+	useBlockProps,
 } from '@wordpress/block-editor';
 import { PanelBody, SelectControl, ToggleControl } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -55,7 +55,7 @@ function PostAuthorEdit( { isSelected, context, attributes, setAttributes } ) {
 		} );
 	}
 
-	const blockWrapperProps = useBlockWrapperProps( {
+	const blockProps = useBlockProps( {
 		className: classnames( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
 		} ),
@@ -118,7 +118,7 @@ function PostAuthorEdit( { isSelected, context, attributes, setAttributes } ) {
 				/>
 			</BlockControls>
 
-			<div { ...blockWrapperProps }>
+			<div { ...blockProps }>
 				{ showAvatar && authorDetails && (
 					<div className="wp-block-post-author__avatar">
 						<img

--- a/packages/block-library/src/post-author/edit.js
+++ b/packages/block-library/src/post-author/edit.js
@@ -12,7 +12,7 @@ import {
 	BlockControls,
 	InspectorControls,
 	RichText,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+	useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import { PanelBody, SelectControl, ToggleControl } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';

--- a/packages/block-library/src/post-comment-date/edit.js
+++ b/packages/block-library/src/post-comment-date/edit.js
@@ -5,7 +5,7 @@ import { useEntityProp } from '@wordpress/core-data';
 import { __experimentalGetSettings, dateI18n } from '@wordpress/date';
 import {
 	InspectorControls,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+	useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import { PanelBody, CustomSelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';

--- a/packages/block-library/src/post-comment-date/edit.js
+++ b/packages/block-library/src/post-comment-date/edit.js
@@ -3,10 +3,7 @@
  */
 import { useEntityProp } from '@wordpress/core-data';
 import { __experimentalGetSettings, dateI18n } from '@wordpress/date';
-import {
-	InspectorControls,
-	useBlockWrapperProps,
-} from '@wordpress/block-editor';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { PanelBody, CustomSelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
@@ -25,7 +22,7 @@ export default function Edit( { attributes, context, setAttributes } ) {
 		} )
 	);
 	const resolvedFormat = format || siteDateFormat || settings.formats.date;
-	const blockWrapperProps = useBlockWrapperProps( { className } );
+	const blockProps = useBlockProps( { className } );
 
 	return (
 		<>
@@ -47,7 +44,7 @@ export default function Edit( { attributes, context, setAttributes } ) {
 				</PanelBody>
 			</InspectorControls>
 
-			<div { ...blockWrapperProps }>
+			<div { ...blockProps }>
 				<time dateTime={ dateI18n( 'c', date ) }>
 					{ dateI18n( resolvedFormat, date ) }
 				</time>

--- a/packages/block-library/src/post-comments-count/block.json
+++ b/packages/block-library/src/post-comments-count/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 1,
 	"name": "core/post-comments-count",
 	"category": "design",
 	"attributes": {
@@ -11,7 +12,6 @@
 	],
 	"supports": {
 		"html": false,
-		"lightBlockWrapper": true,
 		"color": {
 			"gradients": true
 		},

--- a/packages/block-library/src/post-comments-count/block.json
+++ b/packages/block-library/src/post-comments-count/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 1,
+	"apiVersion": 2,
 	"name": "core/post-comments-count",
 	"category": "design",
 	"attributes": {

--- a/packages/block-library/src/post-comments-count/edit.js
+++ b/packages/block-library/src/post-comments-count/edit.js
@@ -10,7 +10,7 @@ import {
 	AlignmentToolbar,
 	BlockControls,
 	Warning,
-	useBlockWrapperProps,
+	useBlockProps,
 } from '@wordpress/block-editor';
 import { useState, useEffect } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
@@ -25,7 +25,7 @@ export default function PostCommentsCountEdit( {
 	const { textAlign } = attributes;
 	const { postId } = context;
 	const [ commentsCount, setCommentsCount ] = useState();
-	const blockWrapperProps = useBlockWrapperProps( {
+	const blockProps = useBlockProps( {
 		className: classnames( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
 		} ),
@@ -59,7 +59,7 @@ export default function PostCommentsCountEdit( {
 					} }
 				/>
 			</BlockControls>
-			<div { ...blockWrapperProps }>
+			<div { ...blockProps }>
 				{ postId && commentsCount !== undefined ? (
 					commentsCount
 				) : (

--- a/packages/block-library/src/post-comments-count/edit.js
+++ b/packages/block-library/src/post-comments-count/edit.js
@@ -10,7 +10,7 @@ import {
 	AlignmentToolbar,
 	BlockControls,
 	Warning,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+	useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import { useState, useEffect } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';

--- a/packages/block-library/src/post-comments-form/block.json
+++ b/packages/block-library/src/post-comments-form/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 1,
 	"name": "core/post-comments-form",
 	"category": "design",
 	"attributes": {
@@ -12,7 +13,6 @@
 	],
 	"supports": {
 		"html": false,
-		"lightBlockWrapper": true,
 		"color": {
 			"gradients": true,
 			"link": true

--- a/packages/block-library/src/post-comments-form/block.json
+++ b/packages/block-library/src/post-comments-form/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 1,
+	"apiVersion": 2,
 	"name": "core/post-comments-form",
 	"category": "design",
 	"attributes": {

--- a/packages/block-library/src/post-comments-form/edit.js
+++ b/packages/block-library/src/post-comments-form/edit.js
@@ -10,7 +10,7 @@ import {
 	AlignmentToolbar,
 	BlockControls,
 	Warning,
-	useBlockWrapperProps,
+	useBlockProps,
 } from '@wordpress/block-editor';
 import { useEntityProp } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
@@ -28,7 +28,7 @@ export default function PostCommentsFormEdit( {
 		'comment_status',
 		postId
 	);
-	const blockWrapperProps = useBlockWrapperProps( {
+	const blockProps = useBlockProps( {
 		className: classnames( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
 		} ),
@@ -44,7 +44,7 @@ export default function PostCommentsFormEdit( {
 					} }
 				/>
 			</BlockControls>
-			<div { ...blockWrapperProps }>
+			<div { ...blockProps }>
 				{ ! commentStatus && (
 					<Warning>
 						{ __(

--- a/packages/block-library/src/post-comments-form/edit.js
+++ b/packages/block-library/src/post-comments-form/edit.js
@@ -10,7 +10,7 @@ import {
 	AlignmentToolbar,
 	BlockControls,
 	Warning,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+	useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import { useEntityProp } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';

--- a/packages/block-library/src/post-comments/block.json
+++ b/packages/block-library/src/post-comments/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 1,
 	"name": "core/post-comments",
 	"category": "design",
 	"attributes": {
@@ -12,7 +13,6 @@
 	],
 	"supports": {
 		"html": false,
-		"lightBlockWrapper": true,
 		"align": [
 			"wide",
 			"full"

--- a/packages/block-library/src/post-comments/block.json
+++ b/packages/block-library/src/post-comments/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 1,
+	"apiVersion": 2,
 	"name": "core/post-comments",
 	"category": "design",
 	"attributes": {

--- a/packages/block-library/src/post-comments/edit.js
+++ b/packages/block-library/src/post-comments/edit.js
@@ -11,7 +11,7 @@ import {
 	AlignmentToolbar,
 	BlockControls,
 	Warning,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+	useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { RawHTML } from '@wordpress/element';

--- a/packages/block-library/src/post-comments/edit.js
+++ b/packages/block-library/src/post-comments/edit.js
@@ -11,7 +11,7 @@ import {
 	AlignmentToolbar,
 	BlockControls,
 	Warning,
-	useBlockWrapperProps,
+	useBlockProps,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { RawHTML } from '@wordpress/element';
@@ -49,7 +49,7 @@ export default function PostCommentsEdit( {
 } ) {
 	const { postType, postId } = context;
 	const { textAlign } = attributes;
-	const blockWrapperProps = useBlockWrapperProps( {
+	const blockProps = useBlockProps( {
 		className: classnames( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
 		} ),
@@ -72,7 +72,7 @@ export default function PostCommentsEdit( {
 				/>
 			</BlockControls>
 
-			<div { ...blockWrapperProps }>
+			<div { ...blockProps }>
 				<PostCommentsDisplay postId={ postId } />
 			</div>
 		</>

--- a/packages/block-library/src/post-date/block.json
+++ b/packages/block-library/src/post-date/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 1,
+	"apiVersion": 2,
 	"name": "core/post-date",
 	"category": "design",
 	"attributes": {

--- a/packages/block-library/src/post-date/block.json
+++ b/packages/block-library/src/post-date/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 1,
 	"name": "core/post-date",
 	"category": "design",
 	"attributes": {
@@ -15,7 +16,6 @@
 	],
 	"supports": {
 		"html": false,
-		"lightBlockWrapper": true,
 		"color": {
 			"gradients": true
 		},

--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -13,7 +13,7 @@ import {
 	AlignmentToolbar,
 	BlockControls,
 	InspectorControls,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+	useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import {
 	ToolbarGroup,

--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -13,7 +13,7 @@ import {
 	AlignmentToolbar,
 	BlockControls,
 	InspectorControls,
-	useBlockWrapperProps,
+	useBlockProps,
 } from '@wordpress/block-editor';
 import {
 	ToolbarGroup,
@@ -56,7 +56,7 @@ export default function PostDateEdit( { attributes, context, setAttributes } ) {
 		} )
 	);
 	const resolvedFormat = format || siteFormat || settings.formats.date;
-	const blockWrapperProps = useBlockWrapperProps( {
+	const blockProps = useBlockProps( {
 		className: classnames( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
 		} ),
@@ -105,7 +105,7 @@ export default function PostDateEdit( { attributes, context, setAttributes } ) {
 				</PanelBody>
 			</InspectorControls>
 
-			<div { ...blockWrapperProps }>
+			<div { ...blockProps }>
 				{ date && (
 					<time dateTime={ dateI18n( 'c', date ) }>
 						{ dateI18n( resolvedFormat, date ) }

--- a/packages/block-library/src/post-excerpt/block.json
+++ b/packages/block-library/src/post-excerpt/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 1,
+	"apiVersion": 2,
 	"name": "core/post-excerpt",
 	"category": "design",
 	"attributes": {

--- a/packages/block-library/src/post-excerpt/block.json
+++ b/packages/block-library/src/post-excerpt/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 1,
 	"name": "core/post-excerpt",
 	"category": "design",
 	"attributes": {
@@ -23,7 +24,6 @@
 	],
 	"supports": {
 		"html": false,
-		"lightBlockWrapper": true,
 		"fontSize": true,
 		"color": {
 			"gradients": true,

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -14,7 +14,7 @@ import {
 	InspectorControls,
 	RichText,
 	Warning,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+	useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import { PanelBody, RangeControl, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -14,7 +14,7 @@ import {
 	InspectorControls,
 	RichText,
 	Warning,
-	useBlockWrapperProps,
+	useBlockProps,
 } from '@wordpress/block-editor';
 import { PanelBody, RangeControl, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -57,7 +57,7 @@ function PostExcerptEditor( {
 		postId,
 		postType
 	);
-	const blockWrapperProps = useBlockWrapperProps( {
+	const blockProps = useBlockProps( {
 		className: classnames( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
 		} ),
@@ -97,7 +97,7 @@ function PostExcerptEditor( {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<div { ...blockWrapperProps }>
+			<div { ...blockProps }>
 				<RichText
 					className={
 						! showMoreOnNewLine &&

--- a/packages/block-library/src/post-hierarchical-terms/block.json
+++ b/packages/block-library/src/post-hierarchical-terms/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 1,
+	"apiVersion": 2,
 	"name": "core/post-hierarchical-terms",
 	"category": "design",
 	"attributes": {

--- a/packages/block-library/src/post-hierarchical-terms/block.json
+++ b/packages/block-library/src/post-hierarchical-terms/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 1,
 	"name": "core/post-hierarchical-terms",
 	"category": "design",
 	"attributes": {
@@ -15,7 +16,6 @@
 	],
 	"supports": {
 		"html": false,
-		"lightBlockWrapper": true,
 		"fontSize": true,
 		"color": {
 			"gradients": true,

--- a/packages/block-library/src/post-hierarchical-terms/edit.js
+++ b/packages/block-library/src/post-hierarchical-terms/edit.js
@@ -11,7 +11,7 @@ import {
 	AlignmentToolbar,
 	BlockControls,
 	Warning,
-	useBlockWrapperProps,
+	useBlockProps,
 	__experimentalBlockVariationPicker as BlockVariationPicker,
 } from '@wordpress/block-editor';
 import { Spinner } from '@wordpress/components';
@@ -81,7 +81,7 @@ export default function PostHierarchicalTermsEdit( {
 	const hasPost = postId && postType;
 	const hasHierarchicalTermLinks =
 		hierarchicalTermLinks && hierarchicalTermLinks.length > 0;
-	const blockWrapperProps = useBlockWrapperProps( {
+	const blockProps = useBlockProps( {
 		className: classnames( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
 		} ),
@@ -89,7 +89,7 @@ export default function PostHierarchicalTermsEdit( {
 
 	if ( ! hasPost ) {
 		return (
-			<div { ...blockWrapperProps }>
+			<div { ...blockProps }>
 				<Warning>
 					{ __( 'Post Hierarchical Terms block: post not found.' ) }
 				</Warning>
@@ -99,7 +99,7 @@ export default function PostHierarchicalTermsEdit( {
 
 	if ( ! term ) {
 		return (
-			<div { ...blockWrapperProps }>
+			<div { ...blockProps }>
 				<BlockVariationPicker
 					icon={ blockType?.icon?.src }
 					label={ blockType?.title }
@@ -122,7 +122,7 @@ export default function PostHierarchicalTermsEdit( {
 					} }
 				/>
 			</BlockControls>
-			<div { ...blockWrapperProps }>
+			<div { ...blockProps }>
 				{ isLoadingHierarchicalTermLinks && <Spinner /> }
 
 				{ hasHierarchicalTermLinks &&

--- a/packages/block-library/src/post-hierarchical-terms/edit.js
+++ b/packages/block-library/src/post-hierarchical-terms/edit.js
@@ -11,7 +11,7 @@ import {
 	AlignmentToolbar,
 	BlockControls,
 	Warning,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+	useBlockWrapperProps,
 	__experimentalBlockVariationPicker as BlockVariationPicker,
 } from '@wordpress/block-editor';
 import { Spinner } from '@wordpress/components';

--- a/packages/block-library/src/post-tags/block.json
+++ b/packages/block-library/src/post-tags/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 1,
+	"apiVersion": 2,
 	"name": "core/post-tags",
 	"category": "design",
 	"attributes": {

--- a/packages/block-library/src/post-tags/block.json
+++ b/packages/block-library/src/post-tags/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 1,
 	"name": "core/post-tags",
 	"category": "design",
 	"attributes": {
@@ -9,7 +10,6 @@
 	"usesContext": [ "postId", "postType" ],
 	"supports": {
 		"html": false,
-		"lightBlockWrapper": true,
 		"fontSize": true,
 		"color": {
 			"gradients": true,

--- a/packages/block-library/src/post-tags/edit.js
+++ b/packages/block-library/src/post-tags/edit.js
@@ -10,7 +10,7 @@ import { useEntityProp } from '@wordpress/core-data';
 import {
 	BlockControls,
 	Warning,
-	useBlockWrapperProps,
+	useBlockProps,
 	AlignmentToolbar,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
@@ -77,7 +77,7 @@ export default function PostTagsEdit( { context, attributes, setAttributes } ) {
 		);
 	}
 
-	const blockWrapperProps = useBlockWrapperProps( {
+	const blockProps = useBlockProps( {
 		className: classnames( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
 		} ),
@@ -93,7 +93,7 @@ export default function PostTagsEdit( { context, attributes, setAttributes } ) {
 					} }
 				/>
 			</BlockControls>
-			<div { ...blockWrapperProps }>{ display }</div>
+			<div { ...blockProps }>{ display }</div>
 		</>
 	);
 }

--- a/packages/block-library/src/post-tags/edit.js
+++ b/packages/block-library/src/post-tags/edit.js
@@ -10,7 +10,7 @@ import { useEntityProp } from '@wordpress/core-data';
 import {
 	BlockControls,
 	Warning,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+	useBlockWrapperProps,
 	AlignmentToolbar,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';

--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 1,
+	"apiVersion": 2,
 	"name": "core/post-title",
 	"category": "design",
 	"usesContext": [

--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 1,
 	"name": "core/post-title",
 	"category": "design",
 	"usesContext": [
@@ -29,7 +30,6 @@
 	},
 	"supports": {
 		"html": false,
-		"lightBlockWrapper": true,
 		"color": {
 			"gradients": true
 		},

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -11,7 +11,7 @@ import {
 	AlignmentToolbar,
 	BlockControls,
 	InspectorControls,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+	useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import {
 	ToolbarGroup,

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -11,7 +11,7 @@ import {
 	AlignmentToolbar,
 	BlockControls,
 	InspectorControls,
-	useBlockWrapperProps,
+	useBlockProps,
 } from '@wordpress/block-editor';
 import {
 	ToolbarGroup,
@@ -43,7 +43,7 @@ export default function PostTitleEdit( {
 		[ postType, postId ]
 	);
 
-	const blockWrapperProps = useBlockWrapperProps( {
+	const blockProps = useBlockProps( {
 		className: classnames( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
 		} ),
@@ -109,7 +109,7 @@ export default function PostTitleEdit( {
 					) }
 				</PanelBody>
 			</InspectorControls>
-			<TagName { ...blockWrapperProps }>{ title }</TagName>
+			<TagName { ...blockProps }>{ title }</TagName>
 		</>
 	);
 }

--- a/packages/block-library/src/preformatted/block.json
+++ b/packages/block-library/src/preformatted/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 1,
 	"name": "core/preformatted",
 	"category": "text",
 	"attributes": {
@@ -11,7 +12,6 @@
 		}
 	},
 	"supports": {
-		"anchor": true,
-		"lightBlockWrapper": true
+		"anchor": true
 	}
 }

--- a/packages/block-library/src/preformatted/block.json
+++ b/packages/block-library/src/preformatted/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 1,
+	"apiVersion": 2,
 	"name": "core/preformatted",
 	"category": "text",
 	"attributes": {

--- a/packages/block-library/src/preformatted/edit.js
+++ b/packages/block-library/src/preformatted/edit.js
@@ -2,10 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	RichText,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
-} from '@wordpress/block-editor';
+import { RichText, useBlockWrapperProps } from '@wordpress/block-editor';
 
 export default function PreformattedEdit( {
 	attributes,

--- a/packages/block-library/src/preformatted/edit.js
+++ b/packages/block-library/src/preformatted/edit.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { RichText, useBlockWrapperProps } from '@wordpress/block-editor';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
 
 export default function PreformattedEdit( {
 	attributes,
@@ -10,7 +10,7 @@ export default function PreformattedEdit( {
 	setAttributes,
 } ) {
 	const { content } = attributes;
-	const blockWrapperProps = useBlockWrapperProps();
+	const blockProps = useBlockProps();
 
 	return (
 		<RichText
@@ -25,7 +25,7 @@ export default function PreformattedEdit( {
 			} }
 			placeholder={ __( 'Write preformatted text…' ) }
 			onMerge={ mergeBlocks }
-			{ ...blockWrapperProps }
+			{ ...blockProps }
 		/>
 	);
 }

--- a/packages/block-library/src/preformatted/save.js
+++ b/packages/block-library/src/preformatted/save.js
@@ -1,16 +1,13 @@
 /**
  * WordPress dependencies
  */
-import {
-	RichText,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
-} from '@wordpress/block-editor';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
 	const { content } = attributes;
 
 	return (
-		<pre { ...useBlockWrapperProps.save() }>
+		<pre { ...useBlockProps.save() }>
 			<RichText.Content value={ content } />
 		</pre>
 	);

--- a/packages/block-library/src/query-loop/block.json
+++ b/packages/block-library/src/query-loop/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 1,
 	"name": "core/query-loop",
 	"category": "design",
 	"usesContext": [
@@ -8,7 +9,6 @@
 	],
 	"supports": {
 		"reusable": false,
-		"lightBlockWrapper": true,
 		"html": false
 	}
 }

--- a/packages/block-library/src/query-loop/block.json
+++ b/packages/block-library/src/query-loop/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 1,
+	"apiVersion": 2,
 	"name": "core/query-loop",
 	"category": "design",
 	"usesContext": [

--- a/packages/block-library/src/query-loop/edit.js
+++ b/packages/block-library/src/query-loop/edit.js
@@ -7,7 +7,7 @@ import {
 	BlockContextProvider,
 	InnerBlocks,
 	BlockPreview,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+	useBlockWrapperProps,
 } from '@wordpress/block-editor';
 
 /**

--- a/packages/block-library/src/query-loop/edit.js
+++ b/packages/block-library/src/query-loop/edit.js
@@ -7,7 +7,7 @@ import {
 	BlockContextProvider,
 	InnerBlocks,
 	BlockPreview,
-	useBlockWrapperProps,
+	useBlockProps,
 } from '@wordpress/block-editor';
 
 /**
@@ -88,10 +88,10 @@ export default function QueryLoopEdit( {
 			} ) ),
 		[ posts ]
 	);
-	const blockWrapperProps = useBlockWrapperProps();
+	const blockProps = useBlockProps();
 
 	return (
-		<div { ...blockWrapperProps }>
+		<div { ...blockProps }>
 			{ blockContexts &&
 				blockContexts.map( ( blockContext ) => (
 					<BlockContextProvider

--- a/packages/block-library/src/query/block.json
+++ b/packages/block-library/src/query/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 1,
 	"name": "core/query",
 	"category": "design",
 	"attributes": {
@@ -25,7 +26,6 @@
 		"query": "query"
 	},
 	"supports": {
-		"html": false,
-		"lightBlockWrapper": true
+		"html": false
 	}
 }

--- a/packages/block-library/src/query/block.json
+++ b/packages/block-library/src/query/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 1,
+	"apiVersion": 2,
 	"name": "core/query",
 	"category": "design",
 	"attributes": {

--- a/packages/block-library/src/query/edit/index.js
+++ b/packages/block-library/src/query/edit/index.js
@@ -7,7 +7,7 @@ import { useEffect } from '@wordpress/element';
 import {
 	BlockControls,
 	InnerBlocks,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+	useBlockWrapperProps,
 } from '@wordpress/block-editor';
 
 /**

--- a/packages/block-library/src/query/edit/index.js
+++ b/packages/block-library/src/query/edit/index.js
@@ -7,7 +7,7 @@ import { useEffect } from '@wordpress/element';
 import {
 	BlockControls,
 	InnerBlocks,
-	useBlockWrapperProps,
+	useBlockProps,
 } from '@wordpress/block-editor';
 
 /**
@@ -24,7 +24,7 @@ export default function QueryEdit( {
 	setAttributes,
 } ) {
 	const instanceId = useInstanceId( QueryEdit );
-	const blockWrapperProps = useBlockWrapperProps();
+	const blockProps = useBlockProps();
 	const { postsPerPage } = useSelect( ( select ) => {
 		const { getSettings } = select( 'core/block-editor' );
 		return {
@@ -52,7 +52,7 @@ export default function QueryEdit( {
 			<BlockControls>
 				<QueryToolbar query={ query } setQuery={ updateQuery } />
 			</BlockControls>
-			<div { ...blockWrapperProps }>
+			<div { ...blockProps }>
 				<QueryProvider>
 					<InnerBlocks template={ TEMPLATE } />
 				</QueryProvider>

--- a/packages/block-library/src/quote/block.json
+++ b/packages/block-library/src/quote/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 1,
 	"name": "core/quote",
 	"category": "text",
 	"attributes": {
@@ -20,7 +21,6 @@
 		}
 	},
 	"supports": {
-		"anchor": true,
-		"lightBlockWrapper": true
+		"anchor": true
 	}
 }

--- a/packages/block-library/src/quote/block.json
+++ b/packages/block-library/src/quote/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 1,
+	"apiVersion": 2,
 	"name": "core/quote",
 	"category": "text",
 	"attributes": {

--- a/packages/block-library/src/quote/edit.js
+++ b/packages/block-library/src/quote/edit.js
@@ -11,7 +11,7 @@ import {
 	AlignmentToolbar,
 	BlockControls,
 	RichText,
-	useBlockWrapperProps,
+	useBlockProps,
 } from '@wordpress/block-editor';
 import { BlockQuotation } from '@wordpress/components';
 import { createBlock } from '@wordpress/blocks';
@@ -26,7 +26,7 @@ export default function QuoteEdit( {
 	insertBlocksAfter,
 } ) {
 	const { align, value, citation } = attributes;
-	const blockWrapperProps = useBlockWrapperProps( {
+	const blockProps = useBlockProps( {
 		className: classnames( className, {
 			[ `has-text-align-${ align }` ]: align,
 		} ),
@@ -42,7 +42,7 @@ export default function QuoteEdit( {
 					} }
 				/>
 			</BlockControls>
-			<BlockQuotation { ...blockWrapperProps }>
+			<BlockQuotation { ...blockProps }>
 				<RichText
 					identifier="value"
 					multiline

--- a/packages/block-library/src/quote/edit.js
+++ b/packages/block-library/src/quote/edit.js
@@ -11,7 +11,7 @@ import {
 	AlignmentToolbar,
 	BlockControls,
 	RichText,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+	useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import { BlockQuotation } from '@wordpress/components';
 import { createBlock } from '@wordpress/blocks';

--- a/packages/block-library/src/quote/save.js
+++ b/packages/block-library/src/quote/save.js
@@ -6,10 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import {
-	RichText,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
-} from '@wordpress/block-editor';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
 	const { align, value, citation } = attributes;
@@ -19,7 +16,7 @@ export default function save( { attributes } ) {
 	} );
 
 	return (
-		<blockquote { ...useBlockWrapperProps.save( { className } ) }>
+		<blockquote { ...useBlockProps.save( { className } ) }>
 			<RichText.Content multiline value={ value } />
 			{ ! RichText.isEmpty( citation ) && (
 				<RichText.Content tagName="cite" value={ citation } />

--- a/packages/block-library/src/search/block.json
+++ b/packages/block-library/src/search/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 1,
+	"apiVersion": 2,
 	"name": "core/search",
 	"category": "widgets",
 	"attributes": {

--- a/packages/block-library/src/search/block.json
+++ b/packages/block-library/src/search/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 1,
 	"name": "core/search",
 	"category": "widgets",
 	"attributes": {
@@ -33,7 +34,6 @@
 	},
 	"supports": {
 		"align": [ "left", "center", "right" ],
-		"html": false,
-		"lightBlockWrapper": true
+		"html": false
 	}
 }

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import {
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+	useBlockWrapperProps,
 	BlockControls,
 	InspectorControls,
 	RichText,

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import {
-	useBlockWrapperProps,
+	useBlockProps,
 	BlockControls,
 	InspectorControls,
 	RichText,
@@ -319,12 +319,12 @@ export default function SearchEdit( {
 		</>
 	);
 
-	const blockWrapperProps = useBlockWrapperProps( {
+	const blockProps = useBlockProps( {
 		className: getBlockClassNames(),
 	} );
 
 	return (
-		<div { ...blockWrapperProps }>
+		<div { ...blockProps }>
 			{ controls }
 
 			{ showLabel && (

--- a/packages/block-library/src/site-logo/block.json
+++ b/packages/block-library/src/site-logo/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 1,
 	"name": "core/site-logo",
 	"category": "layout",
 	"attributes": {
@@ -10,7 +11,6 @@
 		}
 	},
 	"supports": {
-		"html": false,
-		"lightBlockWrapper": true
+		"html": false
 	}
 }

--- a/packages/block-library/src/site-logo/block.json
+++ b/packages/block-library/src/site-logo/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 1,
+	"apiVersion": 2,
 	"name": "core/site-logo",
 	"category": "layout",
 	"attributes": {

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -26,7 +26,7 @@ import {
 	InspectorControls,
 	MediaPlaceholder,
 	MediaReplaceFlow,
-	useBlockWrapperProps,
+	useBlockProps,
 } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { trash } from '@wordpress/icons';
@@ -364,14 +364,14 @@ export default function LogoEdit( {
 
 	const key = !! logoUrl;
 
-	const blockWrapperProps = useBlockWrapperProps( {
+	const blockProps = useBlockProps( {
 		ref,
 		className: classes,
 		key,
 	} );
 
 	return (
-		<div { ...blockWrapperProps }>
+		<div { ...blockProps }>
 			{ controls }
 			{ logoUrl && logoImage }
 			{ ! logoUrl && mediaPlaceholder }

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -26,7 +26,7 @@ import {
 	InspectorControls,
 	MediaPlaceholder,
 	MediaReplaceFlow,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+	useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { trash } from '@wordpress/icons';

--- a/packages/block-library/src/site-tagline/block.json
+++ b/packages/block-library/src/site-tagline/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 1,
 	"name": "core/site-tagline",
 	"category": "design",
 	"attributes": {
@@ -8,7 +9,6 @@
 	},
 	"supports": {
 		"html": false,
-		"lightBlockWrapper": true,
 		"color": {
 			"gradients": true
 		},

--- a/packages/block-library/src/site-tagline/block.json
+++ b/packages/block-library/src/site-tagline/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 1,
+	"apiVersion": 2,
 	"name": "core/site-tagline",
 	"category": "design",
 	"attributes": {

--- a/packages/block-library/src/site-tagline/edit.js
+++ b/packages/block-library/src/site-tagline/edit.js
@@ -9,7 +9,7 @@ import classnames from 'classnames';
 import { useEntityProp } from '@wordpress/core-data';
 import {
 	AlignmentToolbar,
-	useBlockWrapperProps,
+	useBlockProps,
 	BlockControls,
 	RichText,
 } from '@wordpress/block-editor';
@@ -22,7 +22,7 @@ export default function SiteTaglineEdit( { attributes, setAttributes } ) {
 		'site',
 		'description'
 	);
-	const blockWrapperProps = useBlockWrapperProps();
+	const blockProps = useBlockProps();
 
 	return (
 		<>
@@ -44,7 +44,7 @@ export default function SiteTaglineEdit( { attributes, setAttributes } ) {
 				placeholder={ __( 'Site Tagline' ) }
 				tagName="p"
 				value={ siteTagline }
-				{ ...blockWrapperProps }
+				{ ...blockProps }
 			/>
 		</>
 	);

--- a/packages/block-library/src/site-tagline/edit.js
+++ b/packages/block-library/src/site-tagline/edit.js
@@ -9,7 +9,7 @@ import classnames from 'classnames';
 import { useEntityProp } from '@wordpress/core-data';
 import {
 	AlignmentToolbar,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+	useBlockWrapperProps,
 	BlockControls,
 	RichText,
 } from '@wordpress/block-editor';

--- a/packages/block-library/src/site-title/block.json
+++ b/packages/block-library/src/site-title/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 1,
+	"apiVersion": 2,
 	"name": "core/site-title",
 	"category": "design",
 	"attributes": {

--- a/packages/block-library/src/site-title/block.json
+++ b/packages/block-library/src/site-title/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 1,
 	"name": "core/site-title",
 	"category": "design",
 	"attributes": {
@@ -12,7 +13,6 @@
 	},
 	"supports": {
 		"html": false,
-		"lightBlockWrapper": true,
 		"color": {
 			"gradients": true
 		},

--- a/packages/block-library/src/site-title/edit/index.js
+++ b/packages/block-library/src/site-title/edit/index.js
@@ -12,7 +12,7 @@ import {
 	RichText,
 	AlignmentToolbar,
 	BlockControls,
-	useBlockWrapperProps,
+	useBlockProps,
 } from '@wordpress/block-editor';
 
 /**
@@ -24,7 +24,7 @@ export default function SiteTitleEdit( { attributes, setAttributes } ) {
 	const { level, textAlign } = attributes;
 	const [ title, setTitle ] = useEntityProp( 'root', 'site', 'title' );
 	const tagName = level === 0 ? 'p' : `h${ level }`;
-	const blockWrapperProps = useBlockWrapperProps( {
+	const blockProps = useBlockProps( {
 		className: classnames( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
 		} ),
@@ -55,7 +55,7 @@ export default function SiteTitleEdit( { attributes, setAttributes } ) {
 				onChange={ setTitle }
 				allowedFormats={ [] }
 				disableLineBreaks
-				{ ...blockWrapperProps }
+				{ ...blockProps }
 			/>
 		</>
 	);

--- a/packages/block-library/src/site-title/edit/index.js
+++ b/packages/block-library/src/site-title/edit/index.js
@@ -12,7 +12,7 @@ import {
 	RichText,
 	AlignmentToolbar,
 	BlockControls,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+	useBlockWrapperProps,
 } from '@wordpress/block-editor';
 
 /**

--- a/packages/block-library/src/social-link/block.json
+++ b/packages/block-library/src/social-link/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 1,
 	"name": "core/social-link",
 	"category": "widgets",
 	"parent": [
@@ -20,7 +21,6 @@
 	],
 	"supports": {
 		"reusable": false,
-		"html": false,
-		"lightBlockWrapper": true
+		"html": false
 	}
 }

--- a/packages/block-library/src/social-link/block.json
+++ b/packages/block-library/src/social-link/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 1,
+	"apiVersion": 2,
 	"name": "core/social-link",
 	"category": "widgets",
 	"parent": [

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -10,7 +10,7 @@ import {
 	InspectorControls,
 	URLPopover,
 	URLInput,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+	useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import { Fragment, useState } from '@wordpress/element';
 import {

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -10,7 +10,7 @@ import {
 	InspectorControls,
 	URLPopover,
 	URLInput,
-	useBlockWrapperProps,
+	useBlockProps,
 } from '@wordpress/block-editor';
 import { Fragment, useState } from '@wordpress/element';
 import {
@@ -36,7 +36,7 @@ const SocialLinkEdit = ( { attributes, setAttributes, isSelected } ) => {
 
 	const IconComponent = getIconBySite( service );
 	const socialLinkName = getNameBySite( service );
-	const blockWrapperProps = useBlockWrapperProps( { className: classes } );
+	const blockProps = useBlockProps( { className: classes } );
 
 	return (
 		<Fragment>
@@ -63,7 +63,7 @@ const SocialLinkEdit = ( { attributes, setAttributes, isSelected } ) => {
 					</PanelRow>
 				</PanelBody>
 			</InspectorControls>
-			<li { ...blockWrapperProps }>
+			<li { ...blockProps }>
 				<Button onClick={ () => setPopover( true ) }>
 					<IconComponent />
 					{ isSelected && showURLPopover && (

--- a/packages/block-library/src/social-links/block.json
+++ b/packages/block-library/src/social-links/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 1,
+	"apiVersion": 2,
 	"name": "core/social-links",
 	"category": "widgets",
 	"attributes": {

--- a/packages/block-library/src/social-links/block.json
+++ b/packages/block-library/src/social-links/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 1,
 	"name": "core/social-links",
 	"category": "widgets",
 	"attributes": {
@@ -16,7 +17,6 @@
 			"center",
 			"right"
 		],
-		"lightBlockWrapper": true,
 		"anchor": true
 	}
 }

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -6,7 +6,7 @@ import { Fragment } from '@wordpress/element';
 
 import {
 	InnerBlocks,
-	useBlockWrapperProps,
+	useBlockProps,
 	InspectorControls,
 } from '@wordpress/block-editor';
 import { ToggleControl, PanelBody } from '@wordpress/components';
@@ -32,7 +32,7 @@ export function SocialLinksEdit( props ) {
 		attributes: { openInNewTab },
 		setAttributes,
 	} = props;
-	const blockWrapperProps = useBlockWrapperProps();
+	const blockProps = useBlockProps();
 	return (
 		<Fragment>
 			<InspectorControls>
@@ -52,7 +52,7 @@ export function SocialLinksEdit( props ) {
 				template={ TEMPLATE }
 				orientation="horizontal"
 				__experimentalTagName="ul"
-				__experimentalPassedProps={ blockWrapperProps }
+				__experimentalPassedProps={ blockProps }
 				__experimentalAppenderTagName="li"
 			/>
 		</Fragment>

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -6,7 +6,7 @@ import { Fragment } from '@wordpress/element';
 
 import {
 	InnerBlocks,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+	useBlockWrapperProps,
 	InspectorControls,
 } from '@wordpress/block-editor';
 import { ToggleControl, PanelBody } from '@wordpress/components';

--- a/packages/block-library/src/social-links/save.js
+++ b/packages/block-library/src/social-links/save.js
@@ -1,14 +1,11 @@
 /**
  * WordPress dependencies
  */
-import {
-	InnerBlocks,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
-} from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
 export default function save() {
 	return (
-		<ul { ...useBlockWrapperProps.save() }>
+		<ul { ...useBlockProps.save() }>
 			<InnerBlocks.Content />
 		</ul>
 	);

--- a/packages/block-library/src/template-part/block.json
+++ b/packages/block-library/src/template-part/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 1,
 	"name": "core/template-part",
 	"category": "design",
 	"attributes": {
@@ -19,7 +20,6 @@
 	"supports": {
 		"align": true,
 		"html": false,
-		"lightBlockWrapper": true,
 		"color": {
 			"gradients": true,
 			"link": true

--- a/packages/block-library/src/template-part/block.json
+++ b/packages/block-library/src/template-part/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 1,
+	"apiVersion": 2,
 	"name": "core/template-part",
 	"category": "design",
 	"attributes": {

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -3,10 +3,7 @@
  */
 import { useRef, useEffect } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
-import {
-	BlockControls,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
-} from '@wordpress/block-editor';
+import { BlockControls, useBlockWrapperProps } from '@wordpress/block-editor';
 import {
 	Dropdown,
 	ToolbarGroup,

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -3,7 +3,7 @@
  */
 import { useRef, useEffect } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { BlockControls, useBlockWrapperProps } from '@wordpress/block-editor';
+import { BlockControls, useBlockProps } from '@wordpress/block-editor';
 import {
 	Dropdown,
 	ToolbarGroup,
@@ -66,7 +66,7 @@ export default function TemplatePartEdit( {
 		}
 	}, [ innerBlocks ] );
 
-	const blockWrapperProps = useBlockWrapperProps();
+	const blockProps = useBlockProps();
 
 	// Part of a template file, post ID already resolved.
 	const isTemplateFile = !! postId;
@@ -77,7 +77,7 @@ export default function TemplatePartEdit( {
 	const isUnresolvedTemplateFile = ! isPlaceholder && ! postId;
 
 	return (
-		<TagName { ...blockWrapperProps }>
+		<TagName { ...blockProps }>
 			{ isPlaceholder && (
 				<TemplatePartPlaceholder setAttributes={ setAttributes } />
 			) }

--- a/packages/block-library/src/verse/block.json
+++ b/packages/block-library/src/verse/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 1,
 	"name": "core/verse",
 	"category": "text",
 	"attributes": {
@@ -14,7 +15,6 @@
 		}
 	},
 	"supports": {
-		"anchor": true,
-		"lightBlockWrapper": true
+		"anchor": true
 	}
 }

--- a/packages/block-library/src/verse/block.json
+++ b/packages/block-library/src/verse/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 1,
+	"apiVersion": 2,
 	"name": "core/verse",
 	"category": "text",
 	"attributes": {

--- a/packages/block-library/src/verse/edit.js
+++ b/packages/block-library/src/verse/edit.js
@@ -11,7 +11,7 @@ import {
 	RichText,
 	BlockControls,
 	AlignmentToolbar,
-	useBlockWrapperProps,
+	useBlockProps,
 } from '@wordpress/block-editor';
 
 export default function VerseEdit( {
@@ -20,7 +20,7 @@ export default function VerseEdit( {
 	mergeBlocks,
 } ) {
 	const { textAlign, content } = attributes;
-	const blockWrapperProps = useBlockWrapperProps( {
+	const blockProps = useBlockProps( {
 		className: classnames( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
 		} ),
@@ -49,7 +49,7 @@ export default function VerseEdit( {
 				placeholder={ __( 'Write…' ) }
 				onMerge={ mergeBlocks }
 				textAlign={ textAlign }
-				{ ...blockWrapperProps }
+				{ ...blockProps }
 			/>
 		</>
 	);

--- a/packages/block-library/src/verse/edit.js
+++ b/packages/block-library/src/verse/edit.js
@@ -11,7 +11,7 @@ import {
 	RichText,
 	BlockControls,
 	AlignmentToolbar,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+	useBlockWrapperProps,
 } from '@wordpress/block-editor';
 
 export default function VerseEdit( {

--- a/packages/block-library/src/verse/save.js
+++ b/packages/block-library/src/verse/save.js
@@ -6,10 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import {
-	RichText,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
-} from '@wordpress/block-editor';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
 	const { textAlign, content } = attributes;
@@ -19,7 +16,7 @@ export default function save( { attributes } ) {
 	} );
 
 	return (
-		<pre { ...useBlockWrapperProps.save( { className } ) }>
+		<pre { ...useBlockProps.save( { className } ) }>
 			<RichText.Content value={ content } />
 		</pre>
 	);

--- a/packages/block-library/src/video/block.json
+++ b/packages/block-library/src/video/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 1,
 	"name": "core/video",
 	"category": "media",
 	"attributes": {
@@ -63,7 +64,6 @@
 	},
 	"supports": {
 		"anchor": true,
-		"align": true,
-		"lightBlockWrapper": true
+		"align": true
 	}
 }

--- a/packages/block-library/src/video/block.json
+++ b/packages/block-library/src/video/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 1,
+	"apiVersion": 2,
 	"name": "core/video",
 	"category": "media",
 	"attributes": {

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -18,7 +18,7 @@ import {
 	MediaUploadCheck,
 	MediaReplaceFlow,
 	RichText,
-	useBlockWrapperProps,
+	useBlockProps,
 } from '@wordpress/block-editor';
 import { useRef, useEffect } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
@@ -110,11 +110,11 @@ function VideoEdit( {
 		noticeOperations.createErrorNotice( message );
 	}
 
-	const blockWrapperProps = useBlockWrapperProps();
+	const blockProps = useBlockProps();
 
 	if ( ! src ) {
 		return (
-			<div { ...blockWrapperProps }>
+			<div { ...blockProps }>
 				<MediaPlaceholder
 					icon={ <BlockIcon icon={ icon } /> }
 					onSelect={ onSelectVideo }
@@ -209,7 +209,7 @@ function VideoEdit( {
 					</MediaUploadCheck>
 				</PanelBody>
 			</InspectorControls>
-			<figure { ...blockWrapperProps }>
+			<figure { ...blockProps }>
 				{ /*
 					Disable the video tag so the user clicking on it won't play the
 					video when the controls are enabled.

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -18,7 +18,7 @@ import {
 	MediaUploadCheck,
 	MediaReplaceFlow,
 	RichText,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+	useBlockWrapperProps,
 } from '@wordpress/block-editor';
 import { useRef, useEffect } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';

--- a/packages/block-library/src/video/save.js
+++ b/packages/block-library/src/video/save.js
@@ -1,10 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	RichText,
-	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
-} from '@wordpress/block-editor';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
 	const {
@@ -19,7 +16,7 @@ export default function save( { attributes } ) {
 		playsInline,
 	} = attributes;
 	return (
-		<figure { ...useBlockWrapperProps.save() }>
+		<figure { ...useBlockProps.save() }>
 			{ src && (
 				<video
 					autoPlay={ autoplay }

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -9,6 +9,7 @@ export const DEPRECATED_ENTRY_KEYS = [
 	'save',
 	'migrate',
 	'isEligible',
+	'apiVersion',
 ];
 
 export const __EXPERIMENTAL_STYLE_PROPERTY = {

--- a/packages/blocks/src/api/serializer.js
+++ b/packages/blocks/src/api/serializer.js
@@ -17,7 +17,6 @@ import {
 	getBlockType,
 	getFreeformContentHandlerName,
 	getUnregisteredTypeHandlerName,
-	hasBlockSupport,
 } from './registration';
 import { normalizeBlockType } from './utils';
 import BlockContentProvider from '../block-content-provider';
@@ -120,7 +119,7 @@ export function getSaveElement(
 	if (
 		isObject( element ) &&
 		hasFilter( 'blocks.getSaveContent.extraProps' ) &&
-		! hasBlockSupport( blockType, 'lightBlockWrapper', false )
+		! blockType.apiVersion
 	) {
 		/**
 		 * Filters the props applied to the block save result element.

--- a/phpunit/class-register-block-type-from-metadata-test.php
+++ b/phpunit/class-register-block-type-from-metadata-test.php
@@ -182,8 +182,7 @@ class Register_Block_Type_From_Metadata_Test extends WP_UnitTestCase {
 		$this->assertEqualSets( array( 'groupId' ), $result->uses_context );
 		$this->assertEquals(
 			array(
-				'align'             => true,
-				'lightBlockWrapper' => true,
+				'align' => true,
 			),
 			$result->supports
 		);

--- a/phpunit/fixtures/block.json
+++ b/phpunit/fixtures/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 1,
+	"apiVersion": 2,
 	"name": "my-plugin/notice",
 	"title": "Notice",
 	"category": "common",

--- a/phpunit/fixtures/block.json
+++ b/phpunit/fixtures/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 1,
 	"name": "my-plugin/notice",
 	"title": "Notice",
 	"category": "common",
@@ -26,8 +27,7 @@
 		}
 	},
 	"supports": {
-		"align": true,
-		"lightBlockWrapper": true
+		"align": true
 	},
 	"styles": [
 		{


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

Blocked by #25644.
This is solid and ready to be used by plugins.

Remaining questions:

* ~Rename to `useBlockProps`? https://github.com/WordPress/gutenberg/pull/25633#issuecomment-698847418~ Yes
* ~Keep the `lightBlockWrapper` supports key or introduce versioning?~ Version

After this we should update documentation with the new recommended API, e.g. https://developer.wordpress.org/block-editor/developers/block-api/block-edit-save/.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
