### PR TITLE
Block API: light block edit/save symmetry

### DIFF
--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -19,6 +19,7 @@ import { ENTER, BACKSPACE, DELETE } from '@wordpress/keycodes';
 import { __, sprintf } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import deprecated from '@wordpress/deprecated';
+import { getBlockProps } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -285,6 +286,13 @@ export function useBlockWrapperProps( props = {}, { __unstableIsHtml } = {} ) {
 		style: { ...wrapperProps.style, ...props.style },
 	};
 }
+
+/**
+ * Call within a save function to get the props for the block wrapper.
+ *
+ * @param {Object} props Optional. Props to pass to the element.
+ */
+useBlockWrapperProps.save = getBlockProps;
 
 const BlockComponent = forwardRef(
 	( { children, tagName: TagName = 'div', ...props }, ref ) => {

--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -19,7 +19,7 @@ import { ENTER, BACKSPACE, DELETE } from '@wordpress/keycodes';
 import { __, sprintf } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import deprecated from '@wordpress/deprecated';
-import { getBlockProps } from '@wordpress/blocks';
+import { __unstableGetBlockProps as getBlockProps } from '@wordpress/blocks';
 
 /**
  * Internal dependencies

--- a/packages/block-editor/src/components/block-list/block-wrapper.native.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.native.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { getBlockProps } from '@wordpress/blocks';
+
+/**
  * Internal dependencies
  */
 import ELEMENTS from './block-wrapper-elements';
@@ -6,6 +11,8 @@ import ELEMENTS from './block-wrapper-elements';
 export function useBlockWrapperProps( props = {} ) {
 	return props;
 }
+
+useBlockWrapperProps.save = getBlockProps;
 
 const ExtendedBlockComponent = ELEMENTS.reduce( ( acc, element ) => {
 	acc[ element ] = element;

--- a/packages/block-editor/src/components/block-list/block-wrapper.native.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.native.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { getBlockProps } from '@wordpress/blocks';
+import { __unstableGetBlockProps as getBlockProps } from '@wordpress/blocks';
 
 /**
  * Internal dependencies

--- a/packages/block-library/src/audio/save.js
+++ b/packages/block-library/src/audio/save.js
@@ -3,12 +3,12 @@
  */
 import { RichText } from '@wordpress/block-editor';
 
-export default function save( { attributes } ) {
+export default function save( { attributes, getBlockProps } ) {
 	const { autoplay, caption, loop, preload, src } = attributes;
 
 	return (
 		src && (
-			<figure>
+			<figure { ...getBlockProps() }>
 				<audio
 					controls="controls"
 					src={ src }

--- a/packages/block-library/src/audio/save.js
+++ b/packages/block-library/src/audio/save.js
@@ -1,15 +1,17 @@
 /**
  * WordPress dependencies
  */
-import { RichText } from '@wordpress/block-editor';
-import { getBlockProps } from '@wordpress/blocks';
+import {
+	RichText,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+} from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
 	const { autoplay, caption, loop, preload, src } = attributes;
 
 	return (
 		src && (
-			<figure { ...getBlockProps() }>
+			<figure { ...useBlockWrapperProps.save() }>
 				<audio
 					controls="controls"
 					src={ src }

--- a/packages/block-library/src/audio/save.js
+++ b/packages/block-library/src/audio/save.js
@@ -2,8 +2,9 @@
  * WordPress dependencies
  */
 import { RichText } from '@wordpress/block-editor';
+import { getBlockProps } from '@wordpress/blocks';
 
-export default function save( { attributes, getBlockProps } ) {
+export default function save( { attributes } ) {
 	const { autoplay, caption, loop, preload, src } = attributes;
 
 	return (

--- a/packages/block-library/src/button/save.js
+++ b/packages/block-library/src/button/save.js
@@ -13,7 +13,7 @@ import { RichText } from '@wordpress/block-editor';
  */
 import getColorAndStyleProps from './color-props';
 
-export default function save( { attributes } ) {
+export default function save( { attributes, getBlockProps } ) {
 	const { borderRadius, linkTarget, rel, text, title, url } = attributes;
 	const colorProps = getColorAndStyleProps( attributes );
 	const buttonClasses = classnames(
@@ -33,7 +33,7 @@ export default function save( { attributes } ) {
 	// A title will no longer be assigned for new or updated button block links.
 
 	return (
-		<div>
+		<div { ...getBlockProps() }>
 			<RichText.Content
 				tagName="a"
 				className={ buttonClasses }

--- a/packages/block-library/src/button/save.js
+++ b/packages/block-library/src/button/save.js
@@ -7,13 +7,14 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { RichText } from '@wordpress/block-editor';
+import { getBlockProps } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
 import getColorAndStyleProps from './color-props';
 
-export default function save( { attributes, getBlockProps } ) {
+export default function save( { attributes } ) {
 	const { borderRadius, linkTarget, rel, text, title, url } = attributes;
 	const colorProps = getColorAndStyleProps( attributes );
 	const buttonClasses = classnames(

--- a/packages/block-library/src/button/save.js
+++ b/packages/block-library/src/button/save.js
@@ -6,8 +6,10 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { RichText } from '@wordpress/block-editor';
-import { getBlockProps } from '@wordpress/blocks';
+import {
+	RichText,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+} from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -34,7 +36,7 @@ export default function save( { attributes } ) {
 	// A title will no longer be assigned for new or updated button block links.
 
 	return (
-		<div { ...getBlockProps() }>
+		<div { ...useBlockWrapperProps.save() }>
 			<RichText.Content
 				tagName="a"
 				className={ buttonClasses }

--- a/packages/block-library/src/buttons/save.js
+++ b/packages/block-library/src/buttons/save.js
@@ -1,12 +1,14 @@
 /**
  * WordPress dependencies
  */
-import { InnerBlocks } from '@wordpress/block-editor';
-import { getBlockProps } from '@wordpress/blocks';
+import {
+	InnerBlocks,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+} from '@wordpress/block-editor';
 
 export default function save() {
 	return (
-		<div { ...getBlockProps() }>
+		<div { ...useBlockWrapperProps.save() }>
 			<InnerBlocks.Content />
 		</div>
 	);

--- a/packages/block-library/src/buttons/save.js
+++ b/packages/block-library/src/buttons/save.js
@@ -3,9 +3,9 @@
  */
 import { InnerBlocks } from '@wordpress/block-editor';
 
-export default function save() {
+export default function save( { getBlockProps } ) {
 	return (
-		<div>
+		<div { ...getBlockProps() }>
 			<InnerBlocks.Content />
 		</div>
 	);

--- a/packages/block-library/src/buttons/save.js
+++ b/packages/block-library/src/buttons/save.js
@@ -2,8 +2,9 @@
  * WordPress dependencies
  */
 import { InnerBlocks } from '@wordpress/block-editor';
+import { getBlockProps } from '@wordpress/blocks';
 
-export default function save( { getBlockProps } ) {
+export default function save() {
 	return (
 		<div { ...getBlockProps() }>
 			<InnerBlocks.Content />

--- a/packages/block-library/src/code/save.js
+++ b/packages/block-library/src/code/save.js
@@ -2,13 +2,14 @@
  * WordPress dependencies
  */
 import { RichText } from '@wordpress/block-editor';
+import { getBlockProps } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
 import { escape } from './utils';
 
-export default function save( { attributes, getBlockProps } ) {
+export default function save( { attributes } ) {
 	return (
 		<pre { ...getBlockProps() }>
 			<RichText.Content

--- a/packages/block-library/src/code/save.js
+++ b/packages/block-library/src/code/save.js
@@ -8,9 +8,9 @@ import { RichText } from '@wordpress/block-editor';
  */
 import { escape } from './utils';
 
-export default function save( { attributes } ) {
+export default function save( { attributes, getBlockProps } ) {
 	return (
-		<pre>
+		<pre { ...getBlockProps() }>
 			<RichText.Content
 				tagName="code"
 				value={ escape( attributes.content ) }

--- a/packages/block-library/src/code/save.js
+++ b/packages/block-library/src/code/save.js
@@ -1,8 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { RichText } from '@wordpress/block-editor';
-import { getBlockProps } from '@wordpress/blocks';
+import {
+	RichText,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+} from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -11,7 +13,7 @@ import { escape } from './utils';
 
 export default function save( { attributes } ) {
 	return (
-		<pre { ...getBlockProps() }>
+		<pre { ...useBlockWrapperProps.save() }>
 			<RichText.Content
 				tagName="code"
 				value={ escape( attributes.content ) }

--- a/packages/block-library/src/column/save.js
+++ b/packages/block-library/src/column/save.js
@@ -7,8 +7,9 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { InnerBlocks } from '@wordpress/block-editor';
+import { getBlockProps } from '@wordpress/blocks';
 
-export default function save( { attributes, getBlockProps } ) {
+export default function save( { attributes } ) {
 	const { verticalAlignment, width } = attributes;
 
 	const wrapperClasses = classnames( {

--- a/packages/block-library/src/column/save.js
+++ b/packages/block-library/src/column/save.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  */
 import { InnerBlocks } from '@wordpress/block-editor';
 
-export default function save( { attributes } ) {
+export default function save( { attributes, getBlockProps } ) {
 	const { verticalAlignment, width } = attributes;
 
 	const wrapperClasses = classnames( {
@@ -21,7 +21,7 @@ export default function save( { attributes } ) {
 	}
 
 	return (
-		<div className={ wrapperClasses } style={ style }>
+		<div { ...getBlockProps( { className: wrapperClasses, style } ) }>
 			<InnerBlocks.Content />
 		</div>
 	);

--- a/packages/block-library/src/column/save.js
+++ b/packages/block-library/src/column/save.js
@@ -6,8 +6,10 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { InnerBlocks } from '@wordpress/block-editor';
-import { getBlockProps } from '@wordpress/blocks';
+import {
+	InnerBlocks,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+} from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
 	const { verticalAlignment, width } = attributes;
@@ -22,7 +24,12 @@ export default function save( { attributes } ) {
 	}
 
 	return (
-		<div { ...getBlockProps( { className: wrapperClasses, style } ) }>
+		<div
+			{ ...useBlockWrapperProps.save( {
+				className: wrapperClasses,
+				style,
+			} ) }
+		>
 			<InnerBlocks.Content />
 		</div>
 	);

--- a/packages/block-library/src/columns/save.js
+++ b/packages/block-library/src/columns/save.js
@@ -7,8 +7,9 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { InnerBlocks } from '@wordpress/block-editor';
+import { getBlockProps } from '@wordpress/blocks';
 
-export default function save( { attributes, getBlockProps } ) {
+export default function save( { attributes } ) {
 	const { verticalAlignment } = attributes;
 
 	const className = classnames( {

--- a/packages/block-library/src/columns/save.js
+++ b/packages/block-library/src/columns/save.js
@@ -6,8 +6,10 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { InnerBlocks } from '@wordpress/block-editor';
-import { getBlockProps } from '@wordpress/blocks';
+import {
+	InnerBlocks,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+} from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
 	const { verticalAlignment } = attributes;
@@ -17,7 +19,7 @@ export default function save( { attributes } ) {
 	} );
 
 	return (
-		<div { ...getBlockProps( { className } ) }>
+		<div { ...useBlockWrapperProps.save( { className } ) }>
 			<InnerBlocks.Content />
 		</div>
 	);

--- a/packages/block-library/src/columns/save.js
+++ b/packages/block-library/src/columns/save.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  */
 import { InnerBlocks } from '@wordpress/block-editor';
 
-export default function save( { attributes } ) {
+export default function save( { attributes, getBlockProps } ) {
 	const { verticalAlignment } = attributes;
 
 	const className = classnames( {
@@ -16,7 +16,7 @@ export default function save( { attributes } ) {
 	} );
 
 	return (
-		<div className={ className ? className : undefined }>
+		<div { ...getBlockProps( { className } ) }>
 			<InnerBlocks.Content />
 		</div>
 	);

--- a/packages/block-library/src/cover/save.js
+++ b/packages/block-library/src/cover/save.js
@@ -10,8 +10,8 @@ import {
 	InnerBlocks,
 	getColorClassName,
 	__experimentalGetGradientClass,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
 } from '@wordpress/block-editor';
-import { getBlockProps } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -96,7 +96,7 @@ export default function save( { attributes } ) {
 	);
 
 	return (
-		<div { ...getBlockProps( { className: classes, style } ) }>
+		<div { ...useBlockWrapperProps.save( { className: classes, style } ) }>
 			{ url && ( gradient || customGradient ) && dimRatio !== 0 && (
 				<span
 					aria-hidden="true"

--- a/packages/block-library/src/cover/save.js
+++ b/packages/block-library/src/cover/save.js
@@ -11,6 +11,7 @@ import {
 	getColorClassName,
 	__experimentalGetGradientClass,
 } from '@wordpress/block-editor';
+import { getBlockProps } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -24,7 +25,7 @@ import {
 	getPositionClassName,
 } from './shared';
 
-export default function save( { attributes, getBlockProps } ) {
+export default function save( { attributes } ) {
 	const {
 		backgroundType,
 		gradient,

--- a/packages/block-library/src/cover/save.js
+++ b/packages/block-library/src/cover/save.js
@@ -24,7 +24,7 @@ import {
 	getPositionClassName,
 } from './shared';
 
-export default function save( { attributes } ) {
+export default function save( { attributes, getBlockProps } ) {
 	const {
 		backgroundType,
 		gradient,
@@ -95,7 +95,7 @@ export default function save( { attributes } ) {
 	);
 
 	return (
-		<div className={ classes } style={ style }>
+		<div { ...getBlockProps( { className: classes, style } ) }>
 			{ url && ( gradient || customGradient ) && dimRatio !== 0 && (
 				<span
 					aria-hidden="true"

--- a/packages/block-library/src/group/save.js
+++ b/packages/block-library/src/group/save.js
@@ -1,14 +1,16 @@
 /**
  * WordPress dependencies
  */
-import { InnerBlocks } from '@wordpress/block-editor';
-import { getBlockProps } from '@wordpress/blocks';
+import {
+	InnerBlocks,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+} from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
 	const { tagName: Tag } = attributes;
 
 	return (
-		<Tag { ...getBlockProps() }>
+		<Tag { ...useBlockWrapperProps.save() }>
 			<div className="wp-block-group__inner-container">
 				<InnerBlocks.Content />
 			</div>

--- a/packages/block-library/src/group/save.js
+++ b/packages/block-library/src/group/save.js
@@ -3,11 +3,11 @@
  */
 import { InnerBlocks } from '@wordpress/block-editor';
 
-export default function save( { attributes } ) {
+export default function save( { attributes, getBlockProps } ) {
 	const { tagName: Tag } = attributes;
 
 	return (
-		<Tag>
+		<Tag { ...getBlockProps() }>
 			<div className="wp-block-group__inner-container">
 				<InnerBlocks.Content />
 			</div>

--- a/packages/block-library/src/group/save.js
+++ b/packages/block-library/src/group/save.js
@@ -2,8 +2,9 @@
  * WordPress dependencies
  */
 import { InnerBlocks } from '@wordpress/block-editor';
+import { getBlockProps } from '@wordpress/blocks';
 
-export default function save( { attributes, getBlockProps } ) {
+export default function save( { attributes } ) {
 	const { tagName: Tag } = attributes;
 
 	return (

--- a/packages/block-library/src/heading/save.js
+++ b/packages/block-library/src/heading/save.js
@@ -7,8 +7,9 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { RichText } from '@wordpress/block-editor';
+import { getBlockProps } from '@wordpress/blocks';
 
-export default function save( { attributes, getBlockProps } ) {
+export default function save( { attributes } ) {
 	const { align, content, level } = attributes;
 	const TagName = 'h' + level;
 

--- a/packages/block-library/src/heading/save.js
+++ b/packages/block-library/src/heading/save.js
@@ -8,19 +8,17 @@ import classnames from 'classnames';
  */
 import { RichText } from '@wordpress/block-editor';
 
-export default function save( { attributes } ) {
+export default function save( { attributes, getBlockProps } ) {
 	const { align, content, level } = attributes;
-	const tagName = 'h' + level;
+	const TagName = 'h' + level;
 
 	const className = classnames( {
 		[ `has-text-align-${ align }` ]: align,
 	} );
 
 	return (
-		<RichText.Content
-			className={ className ? className : undefined }
-			tagName={ tagName }
-			value={ content }
-		/>
+		<TagName { ...getBlockProps( { className } ) }>
+			<RichText.Content value={ content } />
+		</TagName>
 	);
 }

--- a/packages/block-library/src/heading/save.js
+++ b/packages/block-library/src/heading/save.js
@@ -6,8 +6,10 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { RichText } from '@wordpress/block-editor';
-import { getBlockProps } from '@wordpress/blocks';
+import {
+	RichText,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+} from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
 	const { align, content, level } = attributes;
@@ -18,7 +20,7 @@ export default function save( { attributes } ) {
 	} );
 
 	return (
-		<TagName { ...getBlockProps( { className } ) }>
+		<TagName { ...useBlockWrapperProps.save( { className } ) }>
 			<RichText.Content value={ content } />
 		</TagName>
 	);

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -9,7 +9,7 @@ import { isEmpty } from 'lodash';
  */
 import { RichText } from '@wordpress/block-editor';
 
-export default function save( { attributes } ) {
+export default function save( { attributes, getBlockProps } ) {
 	const {
 		url,
 		alt,
@@ -67,11 +67,15 @@ export default function save( { attributes } ) {
 
 	if ( 'left' === align || 'right' === align || 'center' === align ) {
 		return (
-			<div>
+			<div { ...getBlockProps() }>
 				<figure className={ classes }>{ figure }</figure>
 			</div>
 		);
 	}
 
-	return <figure className={ classes }>{ figure }</figure>;
+	return (
+		<figure { ...getBlockProps( { className: classes } ) }>
+			{ figure }
+		</figure>
+	);
 }

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -7,8 +7,10 @@ import { isEmpty } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { RichText } from '@wordpress/block-editor';
-import { getBlockProps } from '@wordpress/blocks';
+import {
+	RichText,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+} from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
 	const {
@@ -68,14 +70,14 @@ export default function save( { attributes } ) {
 
 	if ( 'left' === align || 'right' === align || 'center' === align ) {
 		return (
-			<div { ...getBlockProps() }>
+			<div { ...useBlockWrapperProps.save() }>
 				<figure className={ classes }>{ figure }</figure>
 			</div>
 		);
 	}
 
 	return (
-		<figure { ...getBlockProps( { className: classes } ) }>
+		<figure { ...useBlockWrapperProps.save( { className: classes } ) }>
 			{ figure }
 		</figure>
 	);

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -8,8 +8,9 @@ import { isEmpty } from 'lodash';
  * WordPress dependencies
  */
 import { RichText } from '@wordpress/block-editor';
+import { getBlockProps } from '@wordpress/blocks';
 
-export default function save( { attributes, getBlockProps } ) {
+export default function save( { attributes } ) {
 	const {
 		url,
 		alt,

--- a/packages/block-library/src/list/save.js
+++ b/packages/block-library/src/list/save.js
@@ -2,8 +2,9 @@
  * WordPress dependencies
  */
 import { RichText } from '@wordpress/block-editor';
+import { getBlockProps } from '@wordpress/blocks';
 
-export default function save( { attributes, getBlockProps } ) {
+export default function save( { attributes } ) {
 	const { ordered, values, type, reversed, start } = attributes;
 	const TagName = ordered ? 'ol' : 'ul';
 

--- a/packages/block-library/src/list/save.js
+++ b/packages/block-library/src/list/save.js
@@ -3,18 +3,13 @@
  */
 import { RichText } from '@wordpress/block-editor';
 
-export default function save( { attributes } ) {
+export default function save( { attributes, getBlockProps } ) {
 	const { ordered, values, type, reversed, start } = attributes;
-	const tagName = ordered ? 'ol' : 'ul';
+	const TagName = ordered ? 'ol' : 'ul';
 
 	return (
-		<RichText.Content
-			tagName={ tagName }
-			value={ values }
-			type={ type }
-			reversed={ reversed }
-			start={ start }
-			multiline="li"
-		/>
+		<TagName { ...getBlockProps( { type, reversed, start } ) }>
+			<RichText.Content value={ values } multiline="li" />
+		</TagName>
 	);
 }

--- a/packages/block-library/src/list/save.js
+++ b/packages/block-library/src/list/save.js
@@ -1,15 +1,17 @@
 /**
  * WordPress dependencies
  */
-import { RichText } from '@wordpress/block-editor';
-import { getBlockProps } from '@wordpress/blocks';
+import {
+	RichText,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+} from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
 	const { ordered, values, type, reversed, start } = attributes;
 	const TagName = ordered ? 'ol' : 'ul';
 
 	return (
-		<TagName { ...getBlockProps( { type, reversed, start } ) }>
+		<TagName { ...useBlockWrapperProps.save( { type, reversed, start } ) }>
 			<RichText.Content value={ values } multiline="li" />
 		</TagName>
 	);

--- a/packages/block-library/src/media-text/save.js
+++ b/packages/block-library/src/media-text/save.js
@@ -17,7 +17,7 @@ import { DEFAULT_MEDIA_SIZE_SLUG } from './constants';
 
 const DEFAULT_MEDIA_WIDTH = 50;
 
-export default function save( { attributes } ) {
+export default function save( { attributes, getBlockProps } ) {
 	const {
 		isStackedOnMobile,
 		mediaAlt,
@@ -88,7 +88,7 @@ export default function save( { attributes } ) {
 		gridTemplateColumns,
 	};
 	return (
-		<div className={ className } style={ style }>
+		<div { ...getBlockProps( { className, style } ) }>
 			<figure
 				className="wp-block-media-text__media"
 				style={ backgroundStyles }

--- a/packages/block-library/src/media-text/save.js
+++ b/packages/block-library/src/media-text/save.js
@@ -8,6 +8,7 @@ import { noop, isEmpty } from 'lodash';
  * WordPress dependencies
  */
 import { InnerBlocks } from '@wordpress/block-editor';
+import { getBlockProps } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -17,7 +18,7 @@ import { DEFAULT_MEDIA_SIZE_SLUG } from './constants';
 
 const DEFAULT_MEDIA_WIDTH = 50;
 
-export default function save( { attributes, getBlockProps } ) {
+export default function save( { attributes } ) {
 	const {
 		isStackedOnMobile,
 		mediaAlt,

--- a/packages/block-library/src/media-text/save.js
+++ b/packages/block-library/src/media-text/save.js
@@ -7,8 +7,10 @@ import { noop, isEmpty } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { InnerBlocks } from '@wordpress/block-editor';
-import { getBlockProps } from '@wordpress/blocks';
+import {
+	InnerBlocks,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+} from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -89,7 +91,7 @@ export default function save( { attributes } ) {
 		gridTemplateColumns,
 	};
 	return (
-		<div { ...getBlockProps( { className, style } ) }>
+		<div { ...useBlockWrapperProps.save( { className, style } ) }>
 			<figure
 				className="wp-block-media-text__media"
 				style={ backgroundStyles }

--- a/packages/block-library/src/paragraph/save.js
+++ b/packages/block-library/src/paragraph/save.js
@@ -6,8 +6,10 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { RichText } from '@wordpress/block-editor';
-import { getBlockProps } from '@wordpress/blocks';
+import {
+	RichText,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+} from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
 	const { align, content, dropCap, direction } = attributes;
@@ -17,7 +19,7 @@ export default function save( { attributes } ) {
 	} );
 
 	return (
-		<p { ...getBlockProps( { className, dir: direction } ) }>
+		<p { ...useBlockWrapperProps.save( { className, dir: direction } ) }>
 			<RichText.Content value={ content } />
 		</p>
 	);

--- a/packages/block-library/src/paragraph/save.js
+++ b/packages/block-library/src/paragraph/save.js
@@ -7,8 +7,9 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { RichText } from '@wordpress/block-editor';
+import { getBlockProps } from '@wordpress/blocks';
 
-export default function save( { attributes, getBlockProps } ) {
+export default function save( { attributes } ) {
 	const { align, content, dropCap, direction } = attributes;
 	const className = classnames( {
 		'has-drop-cap': dropCap,

--- a/packages/block-library/src/paragraph/save.js
+++ b/packages/block-library/src/paragraph/save.js
@@ -8,20 +8,16 @@ import classnames from 'classnames';
  */
 import { RichText } from '@wordpress/block-editor';
 
-export default function save( { attributes } ) {
+export default function save( { attributes, getBlockProps } ) {
 	const { align, content, dropCap, direction } = attributes;
-
 	const className = classnames( {
 		'has-drop-cap': dropCap,
 		[ `has-text-align-${ align }` ]: align,
 	} );
 
 	return (
-		<RichText.Content
-			tagName="p"
-			className={ className ? className : undefined }
-			value={ content }
-			dir={ direction }
-		/>
+		<p { ...getBlockProps( { className, dir: direction } ) }>
+			<RichText.Content value={ content } />
+		</p>
 	);
 }

--- a/packages/block-library/src/preformatted/save.js
+++ b/packages/block-library/src/preformatted/save.js
@@ -3,8 +3,12 @@
  */
 import { RichText } from '@wordpress/block-editor';
 
-export default function save( { attributes } ) {
+export default function save( { attributes, getBlockProps } ) {
 	const { content } = attributes;
 
-	return <RichText.Content tagName="pre" value={ content } />;
+	return (
+		<pre { ...getBlockProps() }>
+			<RichText.Content value={ content } />
+		</pre>
+	);
 }

--- a/packages/block-library/src/preformatted/save.js
+++ b/packages/block-library/src/preformatted/save.js
@@ -1,14 +1,16 @@
 /**
  * WordPress dependencies
  */
-import { RichText } from '@wordpress/block-editor';
-import { getBlockProps } from '@wordpress/blocks';
+import {
+	RichText,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+} from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
 	const { content } = attributes;
 
 	return (
-		<pre { ...getBlockProps() }>
+		<pre { ...useBlockWrapperProps.save() }>
 			<RichText.Content value={ content } />
 		</pre>
 	);

--- a/packages/block-library/src/preformatted/save.js
+++ b/packages/block-library/src/preformatted/save.js
@@ -2,8 +2,9 @@
  * WordPress dependencies
  */
 import { RichText } from '@wordpress/block-editor';
+import { getBlockProps } from '@wordpress/blocks';
 
-export default function save( { attributes, getBlockProps } ) {
+export default function save( { attributes } ) {
 	const { content } = attributes;
 
 	return (

--- a/packages/block-library/src/quote/save.js
+++ b/packages/block-library/src/quote/save.js
@@ -6,8 +6,10 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { RichText } from '@wordpress/block-editor';
-import { getBlockProps } from '@wordpress/blocks';
+import {
+	RichText,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+} from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
 	const { align, value, citation } = attributes;
@@ -17,7 +19,7 @@ export default function save( { attributes } ) {
 	} );
 
 	return (
-		<blockquote { ...getBlockProps( { className } ) }>
+		<blockquote { ...useBlockWrapperProps.save( { className } ) }>
 			<RichText.Content multiline value={ value } />
 			{ ! RichText.isEmpty( citation ) && (
 				<RichText.Content tagName="cite" value={ citation } />

--- a/packages/block-library/src/quote/save.js
+++ b/packages/block-library/src/quote/save.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  */
 import { RichText } from '@wordpress/block-editor';
 
-export default function save( { attributes } ) {
+export default function save( { attributes, getBlockProps } ) {
 	const { align, value, citation } = attributes;
 
 	const className = classnames( {
@@ -16,7 +16,7 @@ export default function save( { attributes } ) {
 	} );
 
 	return (
-		<blockquote className={ className }>
+		<blockquote { ...getBlockProps( { className } ) }>
 			<RichText.Content multiline value={ value } />
 			{ ! RichText.isEmpty( citation ) && (
 				<RichText.Content tagName="cite" value={ citation } />

--- a/packages/block-library/src/quote/save.js
+++ b/packages/block-library/src/quote/save.js
@@ -7,8 +7,9 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { RichText } from '@wordpress/block-editor';
+import { getBlockProps } from '@wordpress/blocks';
 
-export default function save( { attributes, getBlockProps } ) {
+export default function save( { attributes } ) {
 	const { align, value, citation } = attributes;
 
 	const className = classnames( {

--- a/packages/block-library/src/social-links/save.js
+++ b/packages/block-library/src/social-links/save.js
@@ -3,9 +3,9 @@
  */
 import { InnerBlocks } from '@wordpress/block-editor';
 
-export default function save( { className } ) {
+export default function save( { getBlockProps } ) {
 	return (
-		<ul className={ className }>
+		<ul { ...getBlockProps() }>
 			<InnerBlocks.Content />
 		</ul>
 	);

--- a/packages/block-library/src/social-links/save.js
+++ b/packages/block-library/src/social-links/save.js
@@ -2,8 +2,9 @@
  * WordPress dependencies
  */
 import { InnerBlocks } from '@wordpress/block-editor';
+import { getBlockProps } from '@wordpress/blocks';
 
-export default function save( { getBlockProps } ) {
+export default function save() {
 	return (
 		<ul { ...getBlockProps() }>
 			<InnerBlocks.Content />

--- a/packages/block-library/src/social-links/save.js
+++ b/packages/block-library/src/social-links/save.js
@@ -1,12 +1,14 @@
 /**
  * WordPress dependencies
  */
-import { InnerBlocks } from '@wordpress/block-editor';
-import { getBlockProps } from '@wordpress/blocks';
+import {
+	InnerBlocks,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+} from '@wordpress/block-editor';
 
 export default function save() {
 	return (
-		<ul { ...getBlockProps() }>
+		<ul { ...useBlockWrapperProps.save() }>
 			<InnerBlocks.Content />
 		</ul>
 	);

--- a/packages/block-library/src/verse/save.js
+++ b/packages/block-library/src/verse/save.js
@@ -6,8 +6,10 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { RichText } from '@wordpress/block-editor';
-import { getBlockProps } from '@wordpress/blocks';
+import {
+	RichText,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+} from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
 	const { textAlign, content } = attributes;
@@ -17,7 +19,7 @@ export default function save( { attributes } ) {
 	} );
 
 	return (
-		<pre { ...getBlockProps( { className } ) }>
+		<pre { ...useBlockWrapperProps.save( { className } ) }>
 			<RichText.Content value={ content } />
 		</pre>
 	);

--- a/packages/block-library/src/verse/save.js
+++ b/packages/block-library/src/verse/save.js
@@ -7,8 +7,9 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { RichText } from '@wordpress/block-editor';
+import { getBlockProps } from '@wordpress/blocks';
 
-export default function save( { attributes, getBlockProps } ) {
+export default function save( { attributes } ) {
 	const { textAlign, content } = attributes;
 
 	const className = classnames( {

--- a/packages/block-library/src/verse/save.js
+++ b/packages/block-library/src/verse/save.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  */
 import { RichText } from '@wordpress/block-editor';
 
-export default function save( { attributes } ) {
+export default function save( { attributes, getBlockProps } ) {
 	const { textAlign, content } = attributes;
 
 	const className = classnames( {
@@ -16,10 +16,8 @@ export default function save( { attributes } ) {
 	} );
 
 	return (
-		<RichText.Content
-			tagName="pre"
-			className={ className }
-			value={ content }
-		/>
+		<pre { ...getBlockProps( { className } ) }>
+			<RichText.Content value={ content } />
+		</pre>
 	);
 }

--- a/packages/block-library/src/video/save.js
+++ b/packages/block-library/src/video/save.js
@@ -1,8 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { RichText } from '@wordpress/block-editor';
-import { getBlockProps } from '@wordpress/blocks';
+import {
+	RichText,
+	__experimentalUseBlockWrapperProps as useBlockWrapperProps,
+} from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
 	const {
@@ -17,7 +19,7 @@ export default function save( { attributes } ) {
 		playsInline,
 	} = attributes;
 	return (
-		<figure { ...getBlockProps() }>
+		<figure { ...useBlockWrapperProps.save() }>
 			{ src && (
 				<video
 					autoPlay={ autoplay }

--- a/packages/block-library/src/video/save.js
+++ b/packages/block-library/src/video/save.js
@@ -3,7 +3,7 @@
  */
 import { RichText } from '@wordpress/block-editor';
 
-export default function save( { attributes } ) {
+export default function save( { attributes, getBlockProps } ) {
 	const {
 		autoplay,
 		caption,
@@ -16,7 +16,7 @@ export default function save( { attributes } ) {
 		playsInline,
 	} = attributes;
 	return (
-		<figure>
+		<figure { ...getBlockProps() }>
 			{ src && (
 				<video
 					autoPlay={ autoplay }

--- a/packages/block-library/src/video/save.js
+++ b/packages/block-library/src/video/save.js
@@ -2,8 +2,9 @@
  * WordPress dependencies
  */
 import { RichText } from '@wordpress/block-editor';
+import { getBlockProps } from '@wordpress/blocks';
 
-export default function save( { attributes, getBlockProps } ) {
+export default function save( { attributes } ) {
 	const {
 		autoplay,
 		caption,

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -300,7 +300,11 @@ _Returns_
 
 <a name="getBlockProps" href="#getBlockProps">#</a> **getBlockProps**
 
-Undocumented declaration.
+Call within a save function to get the props for the block wrapper.
+
+_Parameters_
+
+-   _props_ `Object`: Optional. Props to pass to the element.
 
 <a name="getBlockSupport" href="#getBlockSupport">#</a> **getBlockSupport**
 

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -298,6 +298,10 @@ _Returns_
 
 -   `string`: The block's default menu item class.
 
+<a name="getBlockProps" href="#getBlockProps">#</a> **getBlockProps**
+
+Undocumented declaration.
+
 <a name="getBlockSupport" href="#getBlockSupport">#</a> **getBlockSupport**
 
 Returns the block support value for a feature, if defined.

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -298,14 +298,6 @@ _Returns_
 
 -   `string`: The block's default menu item class.
 
-<a name="getBlockProps" href="#getBlockProps">#</a> **getBlockProps**
-
-Call within a save function to get the props for the block wrapper.
-
-_Parameters_
-
--   _props_ `Object`: Optional. Props to pass to the element.
-
 <a name="getBlockSupport" href="#getBlockSupport">#</a> **getBlockSupport**
 
 Returns the block support value for a feature, if defined.

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -24,6 +24,7 @@ export {
 	getBlockMenuDefaultClassName,
 	getSaveElement,
 	getSaveContent,
+	getBlockProps,
 } from './serializer';
 export { isValidBlockContent } from './validation';
 export { getCategories, setCategories, updateCategory } from './categories';

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -24,7 +24,7 @@ export {
 	getBlockMenuDefaultClassName,
 	getSaveElement,
 	getSaveContent,
-	getBlockProps,
+	getBlockProps as __unstableGetBlockProps,
 } from './serializer';
 export { isValidBlockContent } from './validation';
 export { getCategories, setCategories, updateCategory } from './categories';

--- a/packages/blocks/src/api/serializer.js
+++ b/packages/blocks/src/api/serializer.js
@@ -69,6 +69,18 @@ export function getBlockMenuDefaultClassName( blockName ) {
 	);
 }
 
+const blockPropsProvider = {};
+
+export function getBlockProps( props ) {
+	const { blockType, attributes } = blockPropsProvider;
+	return applyFilters(
+		'blocks.getSaveContent.extraProps',
+		{ ...props },
+		blockType,
+		attributes
+	);
+}
+
 /**
  * Given a block type containing a save render implementation and attributes, returns the
  * enhanced element to be saved or string when raw HTML expected.
@@ -95,16 +107,10 @@ export function getSaveElement(
 		save = instance.render.bind( instance );
 	}
 
-	function getBlockProps( props ) {
-		return applyFilters(
-			'blocks.getSaveContent.extraProps',
-			{ ...props },
-			blockType,
-			attributes
-		);
-	}
+	blockPropsProvider.blockType = blockType;
+	blockPropsProvider.attributes = attributes;
 
-	let element = save( { attributes, innerBlocks, getBlockProps } );
+	let element = save( { attributes, innerBlocks } );
 
 	if (
 		isObject( element ) &&

--- a/packages/blocks/src/api/serializer.js
+++ b/packages/blocks/src/api/serializer.js
@@ -71,7 +71,12 @@ export function getBlockMenuDefaultClassName( blockName ) {
 
 const blockPropsProvider = {};
 
-export function getBlockProps( props ) {
+/**
+ * Call within a save function to get the props for the block wrapper.
+ *
+ * @param {Object} props Optional. Props to pass to the element.
+ */
+export function getBlockProps( props = {} ) {
 	const { blockType, attributes } = blockPropsProvider;
 	return applyFilters(
 		'blocks.getSaveContent.extraProps',

--- a/packages/blocks/src/api/serializer.js
+++ b/packages/blocks/src/api/serializer.js
@@ -17,6 +17,7 @@ import {
 	getBlockType,
 	getFreeformContentHandlerName,
 	getUnregisteredTypeHandlerName,
+	hasBlockSupport,
 } from './registration';
 import { normalizeBlockType } from './utils';
 import BlockContentProvider from '../block-content-provider';
@@ -94,11 +95,21 @@ export function getSaveElement(
 		save = instance.render.bind( instance );
 	}
 
-	let element = save( { attributes, innerBlocks } );
+	function getBlockProps( props ) {
+		return applyFilters(
+			'blocks.getSaveContent.extraProps',
+			{ ...props },
+			blockType,
+			attributes
+		);
+	}
+
+	let element = save( { attributes, innerBlocks, getBlockProps } );
 
 	if (
 		isObject( element ) &&
-		hasFilter( 'blocks.getSaveContent.extraProps' )
+		hasFilter( 'blocks.getSaveContent.extraProps' ) &&
+		! hasBlockSupport( blockType, 'lightBlockWrapper', false )
 	) {
 		/**
 		 * Filters the props applied to the block save result element.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

Replaces the earlier attempt #20721.
Things have changed now with the replacement of the block component by a hook in #23034.

> This PR mirrors `useBlockProps` for light blocks in the save component, much like we do now for InnerBlocks and RichText. The benefit of this is that we could automatically add blocks classes with this component (if not opting out), making it seem less like a magical things that gets added during serialisation.
>
> Another benefit is that a block could potentially render something around the actual block (such as an alignment wrapper), which is possible right now in the edit function, but not in the save function.

This must be done before stabilising the new (light) block API, because we're using the supports flag to adjust serialisation.
It creates a bit of consistency in the API, the only difference being that for `edit` it's a hook adding behaviours and for `save` it's a simple function `useBlockProps.save` to insert (filtered) attributes on the block wrapper.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
