### PR TITLE
Add new block supports page to the handbook

### DIFF
--- a/docs/designers-developers/developers/block-api/README.md
+++ b/docs/designers-developers/developers/block-api/README.md
@@ -8,6 +8,7 @@ The following sections will walk you through the existing block APIs:
 - [Edit and Save](/docs/designers-developers/developers/block-api/block-edit-save.md)
 - [Attributes](/docs/designers-developers/developers/block-api/block-attributes.md)
 - [Deprecated blocks](/docs/designers-developers/developers/block-api/block-deprecation.md)
+- [Supports](/docs/designers-developers/developers/block-api/block-supports.md)
 - [Transformations](/docs/designers-developers/developers/block-api/block-transforms.md)
 - [Templates](/docs/designers-developers/developers/block-api/block-templates.md)
 - [Annotations](/docs/designers-developers/developers/block-api/block-annotations.md)

--- a/docs/designers-developers/developers/block-api/block-metadata.md
+++ b/docs/designers-developers/developers/block-api/block-metadata.md
@@ -255,9 +255,7 @@ See [the block context documentation](/docs/designers-developers/developers/bloc
 -   Property: `supports`
 -   Default: `{}`
 
-It contains as set of options to control features used in the editor.
-
-See the [the supports documentation](/docs/designers-developers/developers/block-api/block-registration.md#supports-optional) for more details.
+It contains as set of options to control features used in the editor. See the [the supports documentation](/docs/designers-developers/developers/block-api/block-supports.md) for more details.
 
 ### Style Variations
 

--- a/docs/designers-developers/developers/block-api/block-registration.md
+++ b/docs/designers-developers/developers/block-api/block-registration.md
@@ -270,6 +270,12 @@ variations: [
 ],
 ```
 
+#### supports (optional)
+
+-   ***Type:*** `Object`
+
+Supports contains as set of options to control features used in the editor. See the [the supports documentation](/docs/designers-developers/developers/block-api/block-supports.md) for more details.
+
 #### transforms (optional)
 
 -   **Type:** `Object`
@@ -287,103 +293,6 @@ Setting `parent` lets a block require that it is only available when nested with
 ```js
 // Only allow this block when it is nested in a Columns block
 parent: [ 'core/columns' ],
-```
-
-#### supports (optional)
-
-_Some [block supports](#supports-optional) — for example, `anchor` or `className` — apply their attributes by adding additional props on the element returned by `save`. This will work automatically for default HTML tag elements (`div`, etc). However, if the return value of your `save` is a custom component element, you will need to ensure that your custom component handles these props in order for the attributes to be persisted._
-
--   **Type:** `Object`
-
-Optional block extended support features. The following options are supported:
-
--   `align` (default `false`): This property adds block controls which allow to change block's alignment. _Important: It doesn't work with dynamic blocks yet._
-
-```js
-// Add the support for block's alignment (left, center, right, wide, full).
-align: true,
-// Pick which alignment options to display.
-align: [ 'left', 'right', 'full' ],
-```
-
-When supports align is used the block attributes definition is extended to include an align attribute with a string type.
-By default, no alignment is assigned to the block.
-The block can apply a default alignment by specifying its own align attribute with a default e.g.:
-
-```
-attributes: {
-	...
-	align: {
-		type: 'string',
-		default: 'right'
-	},
-	...
-}
-```
-
--   `alignWide` (default `true`): This property allows to enable [wide alignment](/docs/designers-developers/developers/themes/theme-support.md#wide-alignment) for your theme. To disable this behavior for a single block, set this flag to `false`.
-
-```js
-// Remove the support for wide alignment.
-alignWide: false,
-```
-
--   `defaultStylePicker` (default `true`): When the style picker is shown, a dropdown is displayed so the user can select a default style for this block type. If you prefer not to show the dropdown, set this property to `false`.
-
-```js
-// Remove the Default Style picker.
-defaultStylePicker: false,
-```
-
-
--   `anchor` (default `false`): Anchors let you link directly to a specific block on a page. This property adds a field to define an id for the block and a button to copy the direct link.
-
-```js
-// Add the support for an anchor link.
-anchor: true,
-```
-
--   `customClassName` (default `true`): This property adds a field to define a custom className for the block's wrapper.
-
-```js
-// Remove the support for the custom className.
-customClassName: false,
-```
-
--   `className` (default `true`): By default, the class `.wp-block-your-block-name` is added to the root element of your saved markup. This helps having a consistent mechanism for styling blocks that themes and plugins can rely on. If for whatever reason a class is not desired on the markup, this functionality can be disabled.
-
-```js
-// Remove the support for the generated className.
-className: false,
-```
-
--   `html` (default `true`): By default, a block's markup can be edited individually. To disable this behavior, set `html` to `false`.
-
-```js
-// Remove support for an HTML mode.
-html: false,
-```
-
--   `inserter` (default `true`): By default, all blocks will appear in the inserter. To hide a block so that it can only be inserted programmatically, set `inserter` to `false`.
-
-```js
-// Hide this block from the inserter.
-inserter: false,
-```
-
--   `multiple` (default `true`): A non-multiple block can be inserted into each post, one time only. For example, the built-in 'More' block cannot be inserted again if it already exists in the post being edited. A non-multiple block's icon is automatically dimmed (unclickable) to prevent multiple instances.
-
-```js
-// Use the block just once per post
-multiple: false,
-```
-
--   `reusable` (default `true`): A block may want to disable the ability of being converted into a reusable block.
-    By default all blocks can be converted to a reusable block. If supports reusable is set to false, the option to convert the block into a reusable block will not appear.
-
-```js
-// Don't allow the block to be converted into a reusable block.
-reusable: false,
 ```
 
 ## Block Collections

--- a/docs/designers-developers/developers/block-api/block-supports.md
+++ b/docs/designers-developers/developers/block-api/block-supports.md
@@ -2,112 +2,174 @@
 
 Block Supports is the API that allows a block to declare features used in the editor.
 
-_Some [block supports](#supports-optional) — for example, `anchor` or `className` — apply their attributes by adding additional props on the element returned by `save`. This will work automatically for default HTML tag elements (`div`, etc). However, if the return value of your `save` is a custom component element, you will need to ensure that your custom component handles these props in order for the attributes to be persisted._
+Some block supports — for example, `anchor` or `className` — apply their attributes by adding additional props on the element returned by `save`. This will work automatically for default HTML tag elements (`div`, etc). However, if the return value of your `save` is a custom component element, you will need to ensure that your custom component handles these props in order for the attributes to be persisted.
 
 ## anchor
 
--   `anchor` (default `false`): Anchors let you link directly to a specific block on a page. This property adds a field to define an id for the block and a button to copy the direct link.
+- Type: `boolean`
+- Default value: `false`
+- Related attribute: none
+
+Anchors let you link directly to a specific block on a page. This property adds a field to define an id for the block and a button to copy the direct link.
 
 ```js
-// Add the support for an anchor link.
-anchor: true,
+// Declare support for anchor links.
+supports: {
+    anchor: true
+}
 ```
 
 ## align
 
--   `align` (default `false`): This property adds block controls which allow to change block's alignment. _Important: It doesn't work with dynamic blocks yet._
+- Type: `boolean` or `array`
+- Default value: `false`
+- Related attribute: `align`
+
+This property adds block controls which allow to change block's alignment. _Important: It doesn't work with dynamic blocks yet._
 
 ```js
-// Add the support for block's alignment (left, center, right, wide, full).
-align: true,
-// Pick which alignment options to display.
-align: [ 'left', 'right', 'full' ],
+supports: {
+    // Declare support for block's alignment.
+    // This adds support for all the options:
+    // left, center, right, wide, and full.
+    align: true
+}
 ```
 
-When supports align is used the block attributes definition is extended to include an align attribute with a string type.
-By default, no alignment is assigned to the block.
-The block can apply a default alignment by specifying its own align attribute with a default e.g.:
-
+```js
+supports: {
+    // Declare support for specific alignment options.
+    align: [ 'left', 'right', 'full' ]
+}
 ```
+
+When the block declares support for `align`, the attributes definition is extended to include an align attribute with a `string` type. By default, no alignment is assigned. The block can apply a default alignment by specifying its own `align` attribute with a default e.g.:
+
+```js
 attributes: {
-	...
-	align: {
-		type: 'string',
-		default: 'right'
-	},
-	...
+    align: {
+        type: 'string',
+        default: 'right'
+    }
 }
 ```
 
 ## alignWide
 
--   `alignWide` (default `true`): This property allows to enable [wide alignment](/docs/designers-developers/developers/themes/theme-support.md#wide-alignment) for your theme. To disable this behavior for a single block, set this flag to `false`.
+- Type: `boolean`
+- Default value: `true`
+- Related attribute: none
+
+This property allows to enable [wide alignment](/docs/designers-developers/developers/themes/theme-support.md#wide-alignment) for your theme. To disable this behavior for a single block, set this flag to `false`.
 
 ```js
-// Remove the support for wide alignment.
-alignWide: false,
+supports: {
+    // Remove the support for wide alignment.
+    alignWide: false
+}
 ```
 
 ## className
 
--   `className` (default `true`): By default, the class `.wp-block-your-block-name` is added to the root element of your saved markup. This helps having a consistent mechanism for styling blocks that themes and plugins can rely on. If for whatever reason a class is not desired on the markup, this functionality can be disabled.
+- Type: `boolean`
+- Default value: `true`
+- Related attribute: none
+
+By default, the class `.wp-block-your-block-name` is added to the root element of your saved markup. This helps having a consistent mechanism for styling blocks that themes and plugins can rely on. If, for whatever reason, a class is not desired on the markup, this functionality can be disabled.
 
 ```js
-// Remove the support for the generated className.
-className: false,
+supports: {
+    // Remove the support for the generated className.
+    className: false
+}
 ```
 
 ## customClassName
 
--   `customClassName` (default `true`): This property adds a field to define a custom className for the block's wrapper.
+- Type: `boolean`
+- Default value: `true`
+- Related attribute: none
+
+This property adds a field to define a custom className for the block's wrapper.
 
 ```js
-// Remove the support for the custom className.
-customClassName: false,
+supports: {
+    // Remove the support for the custom className.
+    customClassName: false
+}
 ```
 
 ## defaultStylePicker
 
--   `defaultStylePicker` (default `true`): When the style picker is shown, a dropdown is displayed so the user can select a default style for this block type. If you prefer not to show the dropdown, set this property to `false`.
+- Type: `boolean`
+- Default value: `true`
+- Related attribute: none
+
+When the style picker is shown, a dropdown is displayed so the user can select a default style for this block type. If you prefer not to show the dropdown, set this property to `false`.
 
 ```js
-// Remove the Default Style picker.
-defaultStylePicker: false,
+supports: {
+    // Remove the Default Style picker.
+    defaultStylePicker: false
+}
 ```
 
 ## html
 
--   `html` (default `true`): By default, a block's markup can be edited individually. To disable this behavior, set `html` to `false`.
+- Type: `boolean`
+- Default value: `true`
+- Related attribute: none
+
+By default, a block's markup can be edited individually. To disable this behavior, set `html` to `false`.
 
 ```js
-// Remove support for an HTML mode.
-html: false,
+supports: {
+    // Remove support for an HTML mode.
+    html: false
+}
 ```
 
 ## inserter
 
--   `inserter` (default `true`): By default, all blocks will appear in the inserter. To hide a block so that it can only be inserted programmatically, set `inserter` to `false`.
+- Type: `boolean`
+- Default value: `true`
+- Related attribute: none
+
+By default, all blocks will appear in the inserter. To hide a block so that it can only be inserted programmatically, set `inserter` to `false`.
 
 ```js
-// Hide this block from the inserter.
-inserter: false,
+supports: {
+    // Hide this block from the inserter.
+    inserter: false
+}
 ```
 
 ## multiple
 
--   `multiple` (default `true`): A non-multiple block can be inserted into each post, one time only. For example, the built-in 'More' block cannot be inserted again if it already exists in the post being edited. A non-multiple block's icon is automatically dimmed (unclickable) to prevent multiple instances.
+- Type: `boolean`
+- Default value: `true`
+- Related attribute: none
+
+A non-multiple block can be inserted into each post, one time only. For example, the built-in 'More' block cannot be inserted again if it already exists in the post being edited. A non-multiple block's icon is automatically dimmed (unclickable) to prevent multiple instances.
 
 ```js
-// Use the block just once per post
-multiple: false,
+supports: {
+    // Use the block just once per post
+    multiple: false
+}
 ```
 
 ## reusable
 
--   `reusable` (default `true`): A block may want to disable the ability of being converted into a reusable block.
-    By default all blocks can be converted to a reusable block. If supports reusable is set to false, the option to convert the block into a reusable block will not appear.
+- Type: `boolean`
+- Default value: `true`
+- Related attribute: none
+
+A block may want to disable the ability of being converted into a reusable block. By default all blocks can be converted to a reusable block. If supports reusable is set to false, the option to convert the block into a reusable block will not appear.
 
 ```js
-// Don't allow the block to be converted into a reusable block.
-reusable: false,
+supports: {
+    // Don't allow the block to be converted into a reusable block.
+    reusable: false
+}
 ```

--- a/docs/designers-developers/developers/block-api/block-supports.md
+++ b/docs/designers-developers/developers/block-api/block-supports.md
@@ -8,7 +8,6 @@ Some block supports — for example, `anchor` or `className` — apply their att
 
 - Type: `boolean`
 - Default value: `false`
-- Related attribute: none
 
 Anchors let you link directly to a specific block on a page. This property adds a field to define an id for the block and a button to copy the direct link.
 
@@ -23,7 +22,6 @@ supports: {
 
 - Type: `boolean` or `array`
 - Default value: `false`
-- Related attribute: `align`
 
 This property adds block controls which allow to change block's alignment. _Important: It doesn't work with dynamic blocks yet._
 
@@ -58,7 +56,6 @@ attributes: {
 
 - Type: `boolean`
 - Default value: `true`
-- Related attribute: none
 
 This property allows to enable [wide alignment](/docs/designers-developers/developers/themes/theme-support.md#wide-alignment) for your theme. To disable this behavior for a single block, set this flag to `false`.
 
@@ -73,7 +70,6 @@ supports: {
 
 - Type: `boolean`
 - Default value: `true`
-- Related attribute: none
 
 By default, the class `.wp-block-your-block-name` is added to the root element of your saved markup. This helps having a consistent mechanism for styling blocks that themes and plugins can rely on. If, for whatever reason, a class is not desired on the markup, this functionality can be disabled.
 
@@ -88,7 +84,6 @@ supports: {
 
 - Type: `boolean`
 - Default value: `true`
-- Related attribute: none
 
 This property adds a field to define a custom className for the block's wrapper.
 
@@ -103,7 +98,6 @@ supports: {
 
 - Type: `boolean`
 - Default value: `true`
-- Related attribute: none
 
 When the style picker is shown, a dropdown is displayed so the user can select a default style for this block type. If you prefer not to show the dropdown, set this property to `false`.
 
@@ -118,7 +112,6 @@ supports: {
 
 - Type: `boolean`
 - Default value: `true`
-- Related attribute: none
 
 By default, a block's markup can be edited individually. To disable this behavior, set `html` to `false`.
 
@@ -133,7 +126,6 @@ supports: {
 
 - Type: `boolean`
 - Default value: `true`
-- Related attribute: none
 
 By default, all blocks will appear in the inserter. To hide a block so that it can only be inserted programmatically, set `inserter` to `false`.
 
@@ -148,7 +140,6 @@ supports: {
 
 - Type: `boolean`
 - Default value: `true`
-- Related attribute: none
 
 A non-multiple block can be inserted into each post, one time only. For example, the built-in 'More' block cannot be inserted again if it already exists in the post being edited. A non-multiple block's icon is automatically dimmed (unclickable) to prevent multiple instances.
 
@@ -163,7 +154,6 @@ supports: {
 
 - Type: `boolean`
 - Default value: `true`
-- Related attribute: none
 
 A block may want to disable the ability of being converted into a reusable block. By default all blocks can be converted to a reusable block. If supports reusable is set to false, the option to convert the block into a reusable block will not appear.
 

--- a/docs/designers-developers/developers/block-api/block-supports.md
+++ b/docs/designers-developers/developers/block-api/block-supports.md
@@ -1,0 +1,113 @@
+# Block Supports
+
+Block Supports is the API that allows a block to declare features used in the editor.
+
+_Some [block supports](#supports-optional) — for example, `anchor` or `className` — apply their attributes by adding additional props on the element returned by `save`. This will work automatically for default HTML tag elements (`div`, etc). However, if the return value of your `save` is a custom component element, you will need to ensure that your custom component handles these props in order for the attributes to be persisted._
+
+## anchor
+
+-   `anchor` (default `false`): Anchors let you link directly to a specific block on a page. This property adds a field to define an id for the block and a button to copy the direct link.
+
+```js
+// Add the support for an anchor link.
+anchor: true,
+```
+
+## align
+
+-   `align` (default `false`): This property adds block controls which allow to change block's alignment. _Important: It doesn't work with dynamic blocks yet._
+
+```js
+// Add the support for block's alignment (left, center, right, wide, full).
+align: true,
+// Pick which alignment options to display.
+align: [ 'left', 'right', 'full' ],
+```
+
+When supports align is used the block attributes definition is extended to include an align attribute with a string type.
+By default, no alignment is assigned to the block.
+The block can apply a default alignment by specifying its own align attribute with a default e.g.:
+
+```
+attributes: {
+	...
+	align: {
+		type: 'string',
+		default: 'right'
+	},
+	...
+}
+```
+
+## alignWide
+
+-   `alignWide` (default `true`): This property allows to enable [wide alignment](/docs/designers-developers/developers/themes/theme-support.md#wide-alignment) for your theme. To disable this behavior for a single block, set this flag to `false`.
+
+```js
+// Remove the support for wide alignment.
+alignWide: false,
+```
+
+## className
+
+-   `className` (default `true`): By default, the class `.wp-block-your-block-name` is added to the root element of your saved markup. This helps having a consistent mechanism for styling blocks that themes and plugins can rely on. If for whatever reason a class is not desired on the markup, this functionality can be disabled.
+
+```js
+// Remove the support for the generated className.
+className: false,
+```
+
+## customClassName
+
+-   `customClassName` (default `true`): This property adds a field to define a custom className for the block's wrapper.
+
+```js
+// Remove the support for the custom className.
+customClassName: false,
+```
+
+## defaultStylePicker
+
+-   `defaultStylePicker` (default `true`): When the style picker is shown, a dropdown is displayed so the user can select a default style for this block type. If you prefer not to show the dropdown, set this property to `false`.
+
+```js
+// Remove the Default Style picker.
+defaultStylePicker: false,
+```
+
+## html
+
+-   `html` (default `true`): By default, a block's markup can be edited individually. To disable this behavior, set `html` to `false`.
+
+```js
+// Remove support for an HTML mode.
+html: false,
+```
+
+## inserter
+
+-   `inserter` (default `true`): By default, all blocks will appear in the inserter. To hide a block so that it can only be inserted programmatically, set `inserter` to `false`.
+
+```js
+// Hide this block from the inserter.
+inserter: false,
+```
+
+## multiple
+
+-   `multiple` (default `true`): A non-multiple block can be inserted into each post, one time only. For example, the built-in 'More' block cannot be inserted again if it already exists in the post being edited. A non-multiple block's icon is automatically dimmed (unclickable) to prevent multiple instances.
+
+```js
+// Use the block just once per post
+multiple: false,
+```
+
+## reusable
+
+-   `reusable` (default `true`): A block may want to disable the ability of being converted into a reusable block.
+    By default all blocks can be converted to a reusable block. If supports reusable is set to false, the option to convert the block into a reusable block will not appear.
+
+```js
+// Don't allow the block to be converted into a reusable block.
+reusable: false,
+```

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -120,6 +120,12 @@
 		"parent": "block-api"
 	},
 	{
+		"title": "Block Supports",
+		"slug": "block-supports",
+		"markdown_source": "../docs/designers-developers/developers/block-api/block-supports.md",
+		"parent": "block-api"
+	},
+	{
 		"title": "Block Transforms",
 		"slug": "block-transforms",
 		"markdown_source": "../docs/designers-developers/developers/block-api/block-transforms.md",

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -21,6 +21,7 @@
 			{ "docs/designers-developers/developers/block-api/block-attributes.md": [] },
 			{ "docs/designers-developers/developers/block-api/block-context.md": [] },
 			{ "docs/designers-developers/developers/block-api/block-deprecation.md": [] },
+			{ "docs/designers-developers/developers/block-api/block-supports.md": [] },
 			{ "docs/designers-developers/developers/block-api/block-transforms.md": [] },
 			{ "docs/designers-developers/developers/block-api/block-templates.md": [] },
 			{ "docs/designers-developers/developers/block-api/block-patterns.md": [] },


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/20161

This PR extracts and extends the existing Block Support API docs into a sub-section of "Block API Reference".

- Adds and/or normalizes contents for every type of block support currently available.
- Refactors the existing sections within block registration & block metadata to point to the new page.
- Adds a new page to the handbook.
