### PR TITLE
Correct HTTP prefix for the local environment

### DIFF
--- a/docs/designers-developers/developers/tutorials/create-block/wp-plugin.md
+++ b/docs/designers-developers/developers/tutorials/create-block/wp-plugin.md
@@ -55,7 +55,7 @@ Let's confirm the plugin is loaded and working.
 wp-env start
 ```
 
-This will start your local WordPress site and use the current directory as your plugin directory. In your browser, go to https://localhost:8888/wp-admin/ and login, the default username is "admin" and password is "password", no quotes.
+This will start your local WordPress site and use the current directory as your plugin directory. In your browser, go to http://localhost:8888/wp-admin/ and login, the default username is "admin" and password is "password", no quotes.
 
 ### Confirm Plugin Installed
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Correct HTTP prefix for the local environment which doesn't support the HTTPS at the moment.
If the developer goes to the HTTPS version, as described in the docs, the next error occurs in the browser: 
```
localhost sent an invalid response.
ERR_SSL_PROTOCOL_ERROR
```
This may confuse beginner developers.

## How has this been tested?

Verified that Markdown is correctly formatted.

## Screenshots <!-- if applicable -->

## Types of changes
N/A

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
