### PR TITLE
[RNMobile] Show button settings when the Button block is initially added

### DIFF
--- a/packages/block-library/src/button/edit.native.js
+++ b/packages/block-library/src/button/edit.native.js
@@ -37,6 +37,7 @@ import getColorAndStyleProps from './color-props';
 const MIN_BORDER_RADIUS_VALUE = 0;
 const MAX_BORDER_RADIUS_VALUE = 50;
 const INITIAL_MAX_WIDTH = 108;
+const MIN_BUTTON_WIDTH = 40;
 
 class ButtonEdit extends Component {
 	constructor( props ) {
@@ -313,7 +314,7 @@ class ButtonEdit extends Component {
 		// different than empty string.
 		const minWidth =
 			isButtonFocused || ( ! isButtonFocused && text && text !== '' )
-				? 40
+				? MIN_BUTTON_WIDTH
 				: placeholderTextWidth;
 		// To achieve proper expanding and shrinking `RichText` on Android, there is a need to set
 		// a `placeholder` as an empty string when `RichText` is focused,

--- a/packages/block-library/src/button/edit.native.js
+++ b/packages/block-library/src/button/edit.native.js
@@ -37,7 +37,7 @@ import getColorAndStyleProps from './color-props';
 const MIN_BORDER_RADIUS_VALUE = 0;
 const MAX_BORDER_RADIUS_VALUE = 50;
 const INITIAL_MAX_WIDTH = 108;
-const MIN_BUTTON_WIDTH = 40;
+const MIN_WIDTH = 40;
 
 class ButtonEdit extends Component {
 	constructor( props ) {
@@ -314,7 +314,7 @@ class ButtonEdit extends Component {
 		// different than empty string.
 		const minWidth =
 			isButtonFocused || ( ! isButtonFocused && text && text !== '' )
-				? MIN_BUTTON_WIDTH
+				? MIN_WIDTH
 				: placeholderTextWidth;
 		// To achieve proper expanding and shrinking `RichText` on Android, there is a need to set
 		// a `placeholder` as an empty string when `RichText` is focused,

--- a/packages/block-library/src/button/edit.native.js
+++ b/packages/block-library/src/button/edit.native.js
@@ -313,7 +313,7 @@ class ButtonEdit extends Component {
 		// different than empty string.
 		const minWidth =
 			isButtonFocused || ( ! isButtonFocused && text && text !== '' )
-				? 1
+				? 40
 				: placeholderTextWidth;
 		// To achieve proper expanding and shrinking `RichText` on Android, there is a need to set
 		// a `placeholder` as an empty string when `RichText` is focused,


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/2657

Gutenberg Mobile PR https://github.com/wordpress-mobile/gutenberg-mobile/pull/2671

## Description
Currently, when the Button block is added the block isn't wide enough to display the settings button. You would have to type some text for it to become visible. This change increases the `minWidth` of the Button block so that the control has enough space to be shown. 

## How has this been tested?
This has been tested by adding the Button block to the canvas on both Android & iOS and the settings button is visible. 

To test: 

1. Open the inserter. 
2. Add the Button block. 
3. Observe that the settings button is visible without typing anything. 

## Screenshots <!-- if applicable -->

iOS | Android 
--------|-------
 <kbd><img src="https://user-images.githubusercontent.com/1509205/94324220-7a2d0180-ff5e-11ea-97de-404e20c61726.gif" width="320"></kbd>      |     <kbd><img src="https://user-images.githubusercontent.com/1509205/94324214-739e8a00-ff5e-11ea-8ce3-c7d187d46f03.gif" width="320"></kbd>
  
## Types of changes

- This PR currently branches from a button fix, thus it will remain a draft until that PR is merged and the base branch is then set back to `master`. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
