### PR TITLE
jest-puppeteer-axe: migrate to @axe-core/puppeteer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,23 @@
 				"@octokit/rest": "^16.15.0"
 			}
 		},
+		"@axe-core/puppeteer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@axe-core/puppeteer/-/puppeteer-4.0.0.tgz",
+			"integrity": "sha512-APFc2iRmrmUfqdBUevjsMxJliDudWPwvCU5Pzw2uKZ0sMVtW3rQuElTcfJCHFq8KOZSSO0BPD+lK+pXOx1ta5Q==",
+			"dev": true,
+			"requires": {
+				"axe-core": "^4.0.1"
+			},
+			"dependencies": {
+				"axe-core": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.0.2.tgz",
+					"integrity": "sha512-arU1h31OGFu+LPrOLGZ7nB45v940NMDMEJeNmbutu57P+UFDVnkZg3e+J1I2HJRZ9hT7gO8J91dn/PMrAiKakA==",
+					"dev": true
+				}
+			}
+		},
 		"@babel/code-frame": {
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
@@ -17898,8 +17915,8 @@
 			"version": "file:packages/jest-puppeteer-axe",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "^7.11.2",
-				"axe-puppeteer": "^1.1.0"
+				"@axe-core/puppeteer": "^4.0.0",
+				"@babel/runtime": "^7.11.2"
 			},
 			"dependencies": {
 				"@babel/runtime": {
@@ -26464,15 +26481,6 @@
 			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.3.tgz",
 			"integrity": "sha512-HZpLE7xu05+8AbpqXITGdxp1Xwk8ysAXrg7MiKRY27py3DAyEJpoJQo1727pWF3F+O79V3r+cTWhOzfB49P89w==",
 			"dev": true
-		},
-		"axe-puppeteer": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/axe-puppeteer/-/axe-puppeteer-1.1.0.tgz",
-			"integrity": "sha512-VS17Y1rDQe6A0PdeTPxwOSBfmOdj6efgxyre9cN1du1snnVilczSDtQsgifBKBlzoL/3DKfGpgIi+N+zrzODOg==",
-			"dev": true,
-			"requires": {
-				"axe-core": "^3.5.3"
-			}
 		},
 		"axobject-query": {
 			"version": "2.0.2",

--- a/packages/e2e-tests/config/setup-test-framework.js
+++ b/packages/e2e-tests/config/setup-test-framework.js
@@ -201,6 +201,8 @@ async function runAxeTestsForBlockEditor() {
 			'link-name',
 			'listitem',
 			'region',
+			'aria-required-children',
+			'aria-required-parent',
 		],
 		exclude: [
 			// Ignores elements created by metaboxes.

--- a/packages/e2e-tests/config/setup-test-framework.js
+++ b/packages/e2e-tests/config/setup-test-framework.js
@@ -203,6 +203,7 @@ async function runAxeTestsForBlockEditor() {
 			'region',
 			'aria-required-children',
 			'aria-required-parent',
+			'frame-title',
 		],
 		exclude: [
 			// Ignores elements created by metaboxes.

--- a/packages/jest-puppeteer-axe/CHANGELOG.md
+++ b/packages/jest-puppeteer-axe/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## New Features
 
-- The `axe-puppeteer` dependency has been updated from requiring `^1.0.0` to requiring `^1.1.0`.
+- Migrated to [@axe-core/puppeteer](https://github.com/dequelabs/axe-core-npm/tree/develop/packages/puppeteer).
 
 ## 1.1.0 (2019-05-21)
 

--- a/packages/jest-puppeteer-axe/CHANGELOG.md
+++ b/packages/jest-puppeteer-axe/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Unreleased
 
-## New Features
+### New Features
 
-- Migrated to [@axe-core/puppeteer](https://github.com/dequelabs/axe-core-npm/tree/develop/packages/puppeteer).
+- Migrated `axe-puppeteer` to its new package name  [@axe-core/puppeteer](https://github.com/dequelabs/axe-core-npm/tree/develop/packages/puppeteer).
 
 ## 1.1.0 (2019-05-21)
 

--- a/packages/jest-puppeteer-axe/package.json
+++ b/packages/jest-puppeteer-axe/package.json
@@ -25,14 +25,15 @@
 		"node": ">=8"
 	},
 	"files": [
+
 		"build",
 		"build-module"
 	],
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.11.2",
-		"axe-puppeteer": "^1.1.0"
+	  	"@axe-core/puppeteer": "^4.0.0",
+		"@babel/runtime": "^7.11.2"
 	},
 	"peerDependencies": {
 		"jest": ">=24",

--- a/packages/jest-puppeteer-axe/package.json
+++ b/packages/jest-puppeteer-axe/package.json
@@ -25,14 +25,13 @@
 		"node": ">=8"
 	},
 	"files": [
-
 		"build",
 		"build-module"
 	],
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-	  	"@axe-core/puppeteer": "^4.0.0",
+		"@axe-core/puppeteer": "^4.0.0",
 		"@babel/runtime": "^7.11.2"
 	},
 	"peerDependencies": {

--- a/packages/jest-puppeteer-axe/src/index.js
+++ b/packages/jest-puppeteer-axe/src/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import AxePuppeteer from 'axe-puppeteer';
+import AxePuppeteer from '@axe-core/puppeteer';
 
 /** @typedef {import('puppeteer').Page} Page */
 
@@ -60,7 +60,7 @@ function formatViolations( violations ) {
  * @see https://www.deque.com/axe/
  * It is possible to pass optional Axe API options to perform customized check.
  *
- * @see https://github.com/dequelabs/axe-puppeteer
+ * @see https://github.com/dequelabs/axe-core-npm/tree/develop/packages/puppeteer
  *
  * @param {Page}          page                 Puppeteer's page instance.
  * @param {?Object}       params               Optional params that allow better control over Axe API.


### PR DESCRIPTION
`axe-puppeteer` is deprecated and renamed to `@axe-core/puppeteer`, see https://github.com/dequelabs/axe-puppeteer#deprecated-axe-puppeteer