### PR TITLE
[Mobile] Adds editorMode initial property

### DIFF
--- a/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/GutenbergProps.kt
+++ b/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/GutenbergProps.kt
@@ -11,6 +11,7 @@ data class GutenbergProps @JvmOverloads constructor(
     val translations: Bundle,
     val isDarkMode: Boolean,
     val htmlModeEnabled: Boolean,
+    val isPreview: Boolean = false,
     val isModalLayoutPickerEnabled: Boolean = false
 ) {
 
@@ -21,6 +22,9 @@ data class GutenbergProps @JvmOverloads constructor(
         putString(PROP_POST_TYPE, postType)
         putBundle(PROP_TRANSLATIONS, translations)
         putBoolean(PROP_INITIAL_HTML_MODE_ENABLED, htmlModeEnabled)
+
+        val editorMode = if (isPreview) PROP_EDITOR_MODE_PREVIEW else PROP_EDITOR_MODE_EDITOR
+        putString(PROP_EDITOR_MODE, editorMode)
 
         putBundle(PROP_CAPABILITIES, getUpdatedCapabilitiesProps())
 
@@ -52,6 +56,10 @@ data class GutenbergProps @JvmOverloads constructor(
         private const val PROP_TRANSLATIONS = "translations"
         private const val PROP_COLORS = "colors"
         private const val PROP_GRADIENTS = "gradients"
+
+        private const val PROP_EDITOR_MODE = "editorMode"
+        private const val PROP_EDITOR_MODE_PREVIEW = "preview"
+        private const val PROP_EDITOR_MODE_EDITOR = "editor"
 
         const val PROP_CAPABILITIES = "capabilities"
         const val PROP_CAPABILITIES_MENTIONS = "mentions"


### PR DESCRIPTION
**Fixes:** https://github.com/wordpress-mobile/gutenberg-mobile/issues/2452

**Related PRs:**
- `WordPress-Android`: https://github.com/wordpress-mobile/WordPress-Android/pull/13022
- `gutenberg-mobile`: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2674

## Description
Adds `editorMode` initial property with values `editor`(default) and `preview`

## How has this been tested?
This feature can be tested by using the build from https://github.com/wordpress-mobile/WordPress-Android/pull/13022

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
