### PR TITLE
fix undefined index notice in Social Link Block

### DIFF
--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -15,7 +15,7 @@
  * @return string Rendered HTML of the referenced block.
  */
 function render_block_core_social_link( $attributes, $content, $block ) {
-	$open_in_new_tab = $block->context['openInNewTab'];
+	$open_in_new_tab = array_key_exists( 'openInNewTab', $block->context ) ? $block->context['openInNewTab'] : false;
 
 	$service    = ( isset( $attributes['service'] ) ) ? $attributes['service'] : 'Icon';
 	$url        = ( isset( $attributes['url'] ) ) ? $attributes['url'] : false;

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -15,7 +15,7 @@
  * @return string Rendered HTML of the referenced block.
  */
 function render_block_core_social_link( $attributes, $content, $block ) {
-	$open_in_new_tab = array_key_exists( 'openInNewTab', $block->context ) ? $block->context['openInNewTab'] : false;
+	$open_in_new_tab = ( isset( $block->context['openInNewTab'] ) ) ? $block->context['openInNewTab'] : false;
 
 	$service    = ( isset( $attributes['service'] ) ) ? $attributes['service'] : 'Icon';
 	$url        = ( isset( $attributes['url'] ) ) ? $attributes['url'] : false;

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -15,7 +15,7 @@
  * @return string Rendered HTML of the referenced block.
  */
 function render_block_core_social_link( $attributes, $content, $block ) {
-	$open_in_new_tab = ( isset( $block->context['openInNewTab'] ) ) ? $block->context['openInNewTab'] : false;
+	$open_in_new_tab = isset( $block->context['openInNewTab'] ) ? $block->context['openInNewTab'] : false;
 
 	$service    = ( isset( $attributes['service'] ) ) ? $attributes['service'] : 'Icon';
 	$url        = ( isset( $attributes['url'] ) ) ? $attributes['url'] : false;


### PR DESCRIPTION
This is a follow up PR to #25468. @afercia found that there is an error that throws undefined notices: https://github.com/WordPress/gutenberg/pull/25468#issuecomment-698320131

This PR addresses that. 