### PR TITLE
Remove duplicate key from tsconfig.base.json

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,7 +5,6 @@
 		"allowSyntheticDefaultImports": true,
 		"jsx": "preserve",
 		"target": "esnext",
-		"types": ["react", "node", "requestidlecallback"],
 		"module": "esnext",
 		"lib": [ "dom", "esnext" ],
 		"declaration": true,
@@ -30,7 +29,8 @@
 		"esModuleInterop": false,
 		"resolveJsonModule": true,
 
-		"typeRoots": [ "./typings", "./node_modules/@types" ]
+		"typeRoots": [ "./typings", "./node_modules/@types" ],
+		"types": []
 	},
 	"exclude": [
 		"**/benchmark",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -30,8 +30,7 @@
 		"esModuleInterop": false,
 		"resolveJsonModule": true,
 
-		"typeRoots": [ "./typings", "./node_modules/@types" ],
-		"types": []
+		"typeRoots": [ "./typings", "./node_modules/@types" ]
 	},
 	"exclude": [
 		"**/benchmark",


### PR DESCRIPTION
## Description
This a very simple PR that removes the duplicate `types` key in root tsconfig.base.json file. 

Current config contains `["react", "node", "requestidlecallback"],` and `[]` as `types` property value.
```json
{
	"compilerOptions": {
                 ...
		"target": "esnext",
		"types": ["react", "node", "requestidlecallback"],
                ...

		"typeRoots": [ "./typings", "./node_modules/@types" ],
		"types": []
	},
        ...
}

```
