### PR TITLE
[Widgets] Auto expand the last selected widget area when opening the inserter

### DIFF
--- a/packages/block-library/src/widget-area/edit/index.js
+++ b/packages/block-library/src/widget-area/edit/index.js
@@ -15,19 +15,9 @@ export default function WidgetAreaEdit( {
 	className,
 	attributes: { id, name },
 } ) {
-	const { index, isOpen } = useSelect(
-		( select ) => {
-			const blockIndex = select( 'core/block-editor' ).getBlockIndex(
-				clientId
-			);
-
-			return {
-				index: blockIndex,
-				isOpen: select( 'core/edit-widgets' ).getIsWidgetAreaOpen(
-					blockIndex
-				),
-			};
-		},
+	const isOpen = useSelect(
+		( select ) =>
+			select( 'core/edit-widgets' ).getIsWidgetAreaOpen( clientId ),
 		[ clientId ]
 	);
 	const { setIsWidgetAreaOpen } = useDispatch( 'core/edit-widgets' );
@@ -38,7 +28,7 @@ export default function WidgetAreaEdit( {
 				title={ name }
 				opened={ isOpen }
 				onToggle={ ( opened ) => {
-					setIsWidgetAreaOpen( index, opened );
+					setIsWidgetAreaOpen( clientId, opened );
 				} }
 			>
 				<EntityProvider

--- a/packages/block-library/src/widget-area/edit/index.js
+++ b/packages/block-library/src/widget-area/edit/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { EntityProvider } from '@wordpress/core-data';
 import { Panel, PanelBody } from '@wordpress/components';
 
@@ -15,14 +15,32 @@ export default function WidgetAreaEdit( {
 	className,
 	attributes: { id, name },
 } ) {
-	const index = useSelect(
-		( select ) => select( 'core/block-editor' ).getBlockIndex( clientId ),
+	const { index, isOpen } = useSelect(
+		( select ) => {
+			const blockIndex = select( 'core/block-editor' ).getBlockIndex(
+				clientId
+			);
+
+			return {
+				index: blockIndex,
+				isOpen: select( 'core/edit-widgets' ).getIsWidgetAreaOpen(
+					blockIndex
+				),
+			};
+		},
 		[ clientId ]
 	);
+	const { setIsWidgetAreaOpen } = useDispatch( 'core/edit-widgets' );
 
 	return (
 		<Panel className={ className }>
-			<PanelBody title={ name } initialOpen={ index === 0 }>
+			<PanelBody
+				title={ name }
+				opened={ isOpen }
+				onToggle={ ( opened ) => {
+					setIsWidgetAreaOpen( index, opened );
+				} }
+			>
 				<EntityProvider
 					kind="root"
 					type="postType"

--- a/packages/edit-widgets/src/components/header/index.js
+++ b/packages/edit-widgets/src/components/header/index.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { ToolbarItem } from '@wordpress/components';
 import {
@@ -25,6 +26,16 @@ const inserterToggleProps = { isPrimary: true };
 function Header( { isCustomizer } ) {
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const rootClientId = useLastSelectedRootId();
+	const isAllWidgetAreasClosed = useSelect( ( select ) =>
+		select( 'core/edit-widgets' ).getIsAllWidgetAreasClosed()
+	);
+	const { setIsWidgetAreaOpen } = useDispatch( 'core/edit-widgets' );
+
+	function handleInserterOpen( isOpen ) {
+		if ( isOpen && isAllWidgetAreasClosed ) {
+			setIsWidgetAreaOpen( 0, isOpen );
+		}
+	}
 
 	return (
 		<>
@@ -43,6 +54,7 @@ function Header( { isCustomizer } ) {
 									...toolbarItemProps,
 								} }
 								rootClientId={ rootClientId }
+								onToggle={ handleInserterOpen }
 							/>
 						) }
 					</ToolbarItem>

--- a/packages/edit-widgets/src/components/header/index.js
+++ b/packages/edit-widgets/src/components/header/index.js
@@ -32,10 +32,13 @@ function Header( { isCustomizer } ) {
 		[ rootClientId ]
 	);
 	const { setIsWidgetAreaOpen } = useDispatch( 'core/edit-widgets' );
+	const { selectBlock } = useDispatch( 'core/block-editor' );
 
 	function handleInserterOpen( isOpen ) {
-		// Open the last selected widget area when opening the inserter.
 		if ( isOpen && ! isLastSelectedWidgetAreaOpen ) {
+			// Select the last selected block if hasn't already.
+			selectBlock( rootClientId );
+			// Open the last selected widget area when opening the inserter.
 			setIsWidgetAreaOpen( rootClientId, isOpen );
 		}
 	}

--- a/packages/edit-widgets/src/components/header/index.js
+++ b/packages/edit-widgets/src/components/header/index.js
@@ -26,14 +26,17 @@ const inserterToggleProps = { isPrimary: true };
 function Header( { isCustomizer } ) {
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const rootClientId = useLastSelectedRootId();
-	const isAllWidgetAreasClosed = useSelect( ( select ) =>
-		select( 'core/edit-widgets' ).getIsAllWidgetAreasClosed()
+	const isLastSelectedWidgetAreaOpen = useSelect(
+		( select ) =>
+			select( 'core/edit-widgets' ).getIsWidgetAreaOpen( rootClientId ),
+		[ rootClientId ]
 	);
 	const { setIsWidgetAreaOpen } = useDispatch( 'core/edit-widgets' );
 
 	function handleInserterOpen( isOpen ) {
-		if ( isOpen && isAllWidgetAreasClosed ) {
-			setIsWidgetAreaOpen( 0, isOpen );
+		// Open the last selected widget area when opening the inserter.
+		if ( isOpen && ! isLastSelectedWidgetAreaOpen ) {
+			setIsWidgetAreaOpen( rootClientId, isOpen );
 		}
 	}
 

--- a/packages/edit-widgets/src/hooks/use-last-selected-root-id.js
+++ b/packages/edit-widgets/src/hooks/use-last-selected-root-id.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -18,28 +17,21 @@ const useLastSelectedRootId = () => {
 			POST_TYPE,
 			buildWidgetAreasPostId()
 		);
-		if ( widgetAreasPost ) {
-			return widgetAreasPost?.blocks[ 0 ]?.clientId;
-		}
+		return widgetAreasPost?.blocks[ 0 ]?.clientId;
 	}, [] );
-
-	const lastSelectedRootIdRef = useRef();
-	if ( ! lastSelectedRootIdRef.current && firstRootId ) {
-		lastSelectedRootIdRef.current = firstRootId;
-	}
 
 	const selectedRootId = useSelect( ( select ) => {
 		const { getBlockRootClientId, getBlockSelectionEnd } = select(
 			'core/block-editor'
 		);
-		return getBlockRootClientId( getBlockSelectionEnd() );
+		const blockSelectionEnd = getBlockSelectionEnd();
+		const blockRootClientId = getBlockRootClientId( blockSelectionEnd );
+		// getBlockRootClientId returns an empty string for top-level blocks, in which case just return the block id.
+		return blockRootClientId === '' ? blockSelectionEnd : blockRootClientId;
 	}, [] );
 
-	if ( selectedRootId ) {
-		lastSelectedRootIdRef.current = selectedRootId;
-	}
-
-	return lastSelectedRootIdRef.current;
+	// Fallbacks to the first widget area.
+	return selectedRootId || firstRootId;
 };
 
 export default useLastSelectedRootId;

--- a/packages/edit-widgets/src/store/actions.js
+++ b/packages/edit-widgets/src/store/actions.js
@@ -164,7 +164,7 @@ export function setWidgetAreasOpenState( widgetAreasOpenState ) {
 /**
  * Sets the open state of the widget area.
  *
- * @param  {number}  clientId   The clientId of the widget area.
+ * @param  {string}  clientId   The clientId of the widget area.
  * @param  {boolean} isOpen     Whether the widget area should be opened.
  * @return {Object}             Action.
  */

--- a/packages/edit-widgets/src/store/actions.js
+++ b/packages/edit-widgets/src/store/actions.js
@@ -151,8 +151,8 @@ export function setWidgetIdForClientId( clientId, widgetId ) {
 /**
  * Sets the open state of all the widget areas.
  *
- * @param  {Array<boolean>} widgetAreasOpenState An array of the open states of all the widget areas.
- * @return {Object}                              Action.
+ * @param  {Object} widgetAreasOpenState The open states of all the widget areas.
+ * @return {Object}                      Action.
  */
 export function setWidgetAreasOpenState( widgetAreasOpenState ) {
 	return {
@@ -164,14 +164,14 @@ export function setWidgetAreasOpenState( widgetAreasOpenState ) {
 /**
  * Sets the open state of the widget area.
  *
- * @param  {number} index   The index of the widget area.
- * @param  {boolean} isOpen Whether the widget area should be opened.
- * @return {Object}         Action.
+ * @param  {number}  clientId   The clientId of the widget area.
+ * @param  {boolean} isOpen     Whether the widget area should be opened.
+ * @return {Object}             Action.
  */
-export function setIsWidgetAreaOpen( index, isOpen ) {
+export function setIsWidgetAreaOpen( clientId, isOpen ) {
 	return {
 		type: 'SET_IS_WIDGET_AREA_OPEN',
-		index,
+		clientId,
 		isOpen,
 	};
 }

--- a/packages/edit-widgets/src/store/actions.js
+++ b/packages/edit-widgets/src/store/actions.js
@@ -147,3 +147,31 @@ export function setWidgetIdForClientId( clientId, widgetId ) {
 		widgetId,
 	};
 }
+
+/**
+ * Sets the open state of all the widget areas.
+ *
+ * @param  {Array<boolean>} widgetAreasOpenState An array of the open states of all the widget areas.
+ * @return {Object}                              Action.
+ */
+export function setWidgetAreasOpenState( widgetAreasOpenState ) {
+	return {
+		type: 'SET_WIDGET_AREAS_OPEN_STATE',
+		widgetAreasOpenState,
+	};
+}
+
+/**
+ * Sets the open state of the widget area.
+ *
+ * @param  {number} index   The index of the widget area.
+ * @param  {boolean} isOpen Whether the widget area should be opened.
+ * @return {Object}         Action.
+ */
+export function setIsWidgetAreaOpen( index, isOpen ) {
+	return {
+		type: 'SET_IS_WIDGET_AREA_OPEN',
+		index,
+		isOpen,
+	};
+}

--- a/packages/edit-widgets/src/store/reducer.js
+++ b/packages/edit-widgets/src/store/reducer.js
@@ -31,7 +31,7 @@ export function mapping( state, action ) {
 /**
  * Controls the open state of the widget areas.
  *
- * @param {Object}  state  Redux state
+ * @param {Object} state   Redux state
  * @param {Object} action  Redux action
  * @return {Array}         Updated state
  */

--- a/packages/edit-widgets/src/store/reducer.js
+++ b/packages/edit-widgets/src/store/reducer.js
@@ -31,21 +31,22 @@ export function mapping( state, action ) {
 /**
  * Controls the open state of the widget areas.
  *
- * @param {Array}  state  Redux state
- * @param {Object} action Redux action
- * @return {Array}        Updated state
+ * @param {Object}  state  Redux state
+ * @param {Object} action  Redux action
+ * @return {Array}         Updated state
  */
-export function widgetAreasOpenState( state = [], action ) {
+export function widgetAreasOpenState( state = {}, action ) {
 	const { type } = action;
 	switch ( type ) {
 		case 'SET_WIDGET_AREAS_OPEN_STATE': {
 			return action.widgetAreasOpenState;
 		}
 		case 'SET_IS_WIDGET_AREA_OPEN': {
-			const { index, isOpen } = action;
-			const list = state.slice();
-			list[ index ] = isOpen;
-			return list;
+			const { clientId, isOpen } = action;
+			return {
+				...state,
+				[ clientId ]: isOpen,
+			};
 		}
 		default: {
 			return state;

--- a/packages/edit-widgets/src/store/reducer.js
+++ b/packages/edit-widgets/src/store/reducer.js
@@ -28,6 +28,32 @@ export function mapping( state, action ) {
 	return state || {};
 }
 
+/**
+ * Controls the open state of the widget areas.
+ *
+ * @param {Array}  state  Redux state
+ * @param {Object} action Redux action
+ * @return {Array}        Updated state
+ */
+export function widgetAreasOpenState( state = [], action ) {
+	const { type } = action;
+	switch ( type ) {
+		case 'SET_WIDGET_AREAS_OPEN_STATE': {
+			return action.widgetAreasOpenState;
+		}
+		case 'SET_IS_WIDGET_AREA_OPEN': {
+			const { index, isOpen } = action;
+			const list = state.slice();
+			list[ index ] = isOpen;
+			return list;
+		}
+		default: {
+			return state;
+		}
+	}
+}
+
 export default combineReducers( {
 	mapping,
+	widgetAreasOpenState,
 } );

--- a/packages/edit-widgets/src/store/resolvers.js
+++ b/packages/edit-widgets/src/store/resolvers.js
@@ -7,6 +7,7 @@ import { createBlock } from '@wordpress/blocks';
  * Internal dependencies
  */
 import { resolveWidgetAreas, select, dispatch } from './controls';
+import { setWidgetAreasOpenState } from './actions';
 import {
 	KIND,
 	POST_TYPE,
@@ -60,6 +61,10 @@ export function* getWidgetAreas() {
 			} )
 		);
 	}
+
+	yield setWidgetAreasOpenState(
+		widgetAreaBlocks.map( ( _, index ) => index === 0 )
+	);
 
 	yield persistStubPost( buildWidgetAreasPostId(), widgetAreaBlocks );
 

--- a/packages/edit-widgets/src/store/resolvers.js
+++ b/packages/edit-widgets/src/store/resolvers.js
@@ -62,9 +62,12 @@ export function* getWidgetAreas() {
 		);
 	}
 
-	yield setWidgetAreasOpenState(
-		widgetAreaBlocks.map( ( _, index ) => index === 0 )
-	);
+	const widgetAreasOpenState = {};
+	widgetAreaBlocks.forEach( ( widgetAreaBlock, index ) => {
+		// Defaults to open the first widget area.
+		widgetAreasOpenState[ widgetAreaBlock.clientId ] = index === 0;
+	} );
+	yield setWidgetAreasOpenState( widgetAreasOpenState );
 
 	yield persistStubPost( buildWidgetAreasPostId(), widgetAreaBlocks );
 

--- a/packages/edit-widgets/src/store/selectors.js
+++ b/packages/edit-widgets/src/store/selectors.js
@@ -160,3 +160,28 @@ export const hasResolvedWidgetAreas = createRegistrySelector(
 		return true;
 	}
 );
+
+/**
+ * Gets whether the widget area is opened.
+ *
+ * @param {Array}  state The open state of the widget areas.
+ * @param {number} index The index of the widget area.
+ * @return {boolean}     True if the widget area is open.
+ */
+export const getIsWidgetAreaOpen = ( state, index ) => {
+	const { widgetAreasOpenState } = state;
+	return !! widgetAreasOpenState[ index ];
+};
+
+/**
+ * Returns true if all the widget areas is closed.
+ *
+ * @param {Array} state The open state of the widget areas.
+ * @return {boolean}    True if all the widget area is closed.
+ */
+export const getIsAllWidgetAreasClosed = ( state ) => {
+	const { widgetAreasOpenState } = state;
+	return Object.values( widgetAreasOpenState ).every(
+		( isOpen ) => ! isOpen
+	);
+};

--- a/packages/edit-widgets/src/store/selectors.js
+++ b/packages/edit-widgets/src/store/selectors.js
@@ -164,24 +164,11 @@ export const hasResolvedWidgetAreas = createRegistrySelector(
 /**
  * Gets whether the widget area is opened.
  *
- * @param {Array}  state The open state of the widget areas.
- * @param {number} index The index of the widget area.
- * @return {boolean}     True if the widget area is open.
+ * @param {Array}  state    The open state of the widget areas.
+ * @param {number} clientId The clientId of the widget area.
+ * @return {boolean}        True if the widget area is open.
  */
-export const getIsWidgetAreaOpen = ( state, index ) => {
+export const getIsWidgetAreaOpen = ( state, clientId ) => {
 	const { widgetAreasOpenState } = state;
-	return !! widgetAreasOpenState[ index ];
-};
-
-/**
- * Returns true if all the widget areas is closed.
- *
- * @param {Array} state The open state of the widget areas.
- * @return {boolean}    True if all the widget area is closed.
- */
-export const getIsAllWidgetAreasClosed = ( state ) => {
-	const { widgetAreasOpenState } = state;
-	return Object.values( widgetAreasOpenState ).every(
-		( isOpen ) => ! isOpen
-	);
+	return !! widgetAreasOpenState[ clientId ];
 };

--- a/packages/edit-widgets/src/store/selectors.js
+++ b/packages/edit-widgets/src/store/selectors.js
@@ -165,7 +165,7 @@ export const hasResolvedWidgetAreas = createRegistrySelector(
  * Gets whether the widget area is opened.
  *
  * @param {Array}  state    The open state of the widget areas.
- * @param {number} clientId The clientId of the widget area.
+ * @param {string} clientId The clientId of the widget area.
  * @return {boolean}        True if the widget area is open.
  */
 export const getIsWidgetAreaOpen = ( state, clientId ) => {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Fix #25648 and fix #25650.

Auto expand the last selected widget area when opening the inserter.

Done it by registering a `@wordpress/data` state `widgetAreasOpenState` in `edit-widgets` store. Potentially makes it easier to manage the open state in the future.

This PR fixes two issues together since they are very similar and might be easier to understand when reviewing as a whole.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Open the widgets screen.
2. The first widget area should default to open.
3. The inserter should insert a block at the top of the first widget area.
4. Close the first widget area, open the second widget area.
5. The inserter should insert a block at the top of the second widget area.
6. Close the second widget area, but **without losing its focus**.
7. The inserter should expand the second widget area and insert a block at the top of the second widget area.
8. Close all widget areas, click elsewhere to lose their focuses.
9. The inserter should expand the first widget area and insert a block at the top of the first widget area.

## Screenshots <!-- if applicable -->
![Kapture 2020-09-28 at 16 30 44](https://user-images.githubusercontent.com/7753001/94408898-03834480-01a8-11eb-9e5a-0c14d85822a9.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
