### PR TITLE
InnerBlocks: simplify into single component

### DIFF
--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -28,28 +28,27 @@ import { BlockContextProvider } from '../block-context';
 import { useBlockEditContext } from '../block-edit/context';
 import useBlockSync from '../provider/use-block-sync';
 
-/**
- * InnerBlocks is a component which allows a single block to have multiple blocks
- * as children. The UncontrolledInnerBlocks component is used whenever the inner
- * blocks are not controlled by another entity. In other words, it is normally
- * used for inner blocks in the post editor
- *
- * @param {Object} props The component props.
- */
-function UncontrolledInnerBlocks( props ) {
+const ForwardedInnerBlocks = forwardRef( ( props, ref ) => {
+	const { clientId } = useBlockEditContext();
+	const fallbackRef = useRef();
+	const forwardedRef = ref || fallbackRef;
+
+	// This hook keeps the innerBlocks of the block in the block-editor store in
+	// sync with the blocks of the controlling entity. An example of an inner
+	// block controller is a template part block, which provides its own blocks
+	// from the template part entity data source.
+	useBlockSync( props );
+
 	const {
-		clientId,
 		allowedBlocks,
 		template,
 		templateLock,
-		forwardedRef,
 		templateInsertUpdatesSelection,
 		__experimentalCaptureToolbars: captureToolbars,
 		orientation,
 	} = props;
 
 	const isSmallScreen = useViewportMatch( 'medium', '<' );
-
 	const { hasOverlay, block, enableClickThrough } = useSelect( ( select ) => {
 		const {
 			getBlock,
@@ -114,42 +113,6 @@ function UncontrolledInnerBlocks( props ) {
 	}
 
 	return <div className="block-editor-inner-blocks">{ blockList }</div>;
-}
-
-/**
- * The controlled inner blocks component wraps the uncontrolled inner blocks
- * component with the blockSync hook. This keeps the innerBlocks of the block in
- * the block-editor store in sync with the blocks of the controlling entity. An
- * example of an inner block controller is a template part block, which provides
- * its own blocks from the template part entity data source.
- *
- * @param {Object} props The component props.
- */
-function ControlledInnerBlocks( props ) {
-	useBlockSync( props );
-	return <UncontrolledInnerBlocks { ...props } />;
-}
-
-/**
- * Wrapped InnerBlocks component which detects whether to use the controlled or
- * uncontrolled variations of the InnerBlocks component. This is the component
- * which should be used throughout the application.
- */
-const ForwardedInnerBlocks = forwardRef( ( props, ref ) => {
-	const { clientId } = useBlockEditContext();
-	const fallbackRef = useRef();
-
-	const allProps = {
-		clientId,
-		forwardedRef: ref || fallbackRef,
-		...props,
-	};
-
-	// Detects if the InnerBlocks should be controlled by an incoming value.
-	if ( props.value && props.onChange ) {
-		return <ControlledInnerBlocks { ...allProps } />;
-	}
-	return <UncontrolledInnerBlocks { ...allProps } />;
 } );
 
 // Expose default appender placeholders as components.

--- a/packages/block-editor/src/components/provider/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/use-block-sync.js
@@ -71,6 +71,7 @@ export default function useBlockSync( {
 	onChange = noop,
 	onInput = noop,
 } ) {
+	const isControlled = !! controlledBlocks;
 	const registry = useRegistry();
 
 	const {
@@ -114,6 +115,10 @@ export default function useBlockSync( {
 	}, [ onInput, onChange ] );
 
 	useEffect( () => {
+		if ( ! isControlled ) {
+			return;
+		}
+
 		const {
 			getSelectionStart,
 			getSelectionEnd,
@@ -183,10 +188,14 @@ export default function useBlockSync( {
 		} );
 
 		return () => unsubscribe();
-	}, [ registry, clientId ] );
+	}, [ registry, clientId, isControlled ] );
 
 	// Determine if blocks need to be reset when they change.
 	useEffect( () => {
+		if ( ! isControlled ) {
+			return;
+		}
+
 		if ( pendingChanges.current.outgoing.includes( controlledBlocks ) ) {
 			// Skip block reset if the value matches expected outbound sync
 			// triggered by this component by a preceding change detection.
@@ -215,5 +224,5 @@ export default function useBlockSync( {
 				);
 			}
 		}
-	}, [ controlledBlocks, clientId ] );
+	}, [ controlledBlocks, clientId, isControlled ] );
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

`InnerBlocks` is currently a wrapper around several components to work around a conditional `useBlockSync` call. By adjusting the `useBlockSync` hook to skip controlled (valueless) block lists, we can consolidate `InnerBlocks` into a single component.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
