### PR TITLE
[Widget Editor] Fixed sidebar inserter

### DIFF
--- a/packages/edit-widgets/src/components/header/index.js
+++ b/packages/edit-widgets/src/components/header/index.js
@@ -38,6 +38,25 @@ function Header() {
 	);
 	const { selectBlock } = useDispatch( 'core/block-editor' );
 	const rootClientId = useLastSelectedRootId();
+	const handleClick = () => {
+		if ( isInserterOpened ) {
+			// Focusing the inserter button closes the inserter popover
+			inserterButton.current.focus();
+		} else {
+			if ( ! isLastSelectedWidgetAreaOpen ) {
+				// Select the last selected block if hasn't already.
+				selectBlock( rootClientId );
+				// Open the last selected widget area when opening the inserter.
+				setIsWidgetAreaOpen( rootClientId, true );
+			}
+			// The DOM updates resulting from selectBlock() and setIsInserterOpened() calls are applied the
+			// same tick and pretty much in a random order. The inserter is closed if any other part of the
+			// app receives focus. If selectBlock() happens to take effect after setIsInserterOpened() then
+			// the inserter is visible for a brief moment and then gets auto-closed due to focus moving to
+			// the selected block.
+			window.requestAnimationFrame( () => setIsInserterOpened( true ) );
+		}
+	};
 
 	return (
 		<>
@@ -59,26 +78,7 @@ function Header() {
 							onMouseDown={ ( event ) => {
 								event.preventDefault();
 							} }
-							onClick={ () => {
-								if ( isInserterOpened ) {
-									// Focusing the inserter button closes the inserter popover
-									inserterButton.current.focus();
-								} else {
-									if ( ! isLastSelectedWidgetAreaOpen ) {
-										// Select the last selected block if hasn't already.
-										selectBlock( rootClientId );
-										// Open the last selected widget area when opening the inserter.
-										setIsWidgetAreaOpen(
-											rootClientId,
-											true
-										);
-									}
-									// eslint-disable-next-line @wordpress/react-no-unsafe-timeout
-									setTimeout( () =>
-										setIsInserterOpened( true )
-									);
-								}
-							} }
+							onClick={ handleClick }
 							icon={ plus }
 							/* translators: button label text should, if possible, be under 16
 					characters. */

--- a/packages/edit-widgets/src/components/header/index.js
+++ b/packages/edit-widgets/src/components/header/index.js
@@ -42,7 +42,7 @@ function Header() {
 	return (
 		<>
 			<div className="edit-widgets-header">
-				<div>
+				<div className="edit-widgets-header__navigable-toolbar-wrapper">
 					<h1 className="edit-widgets-header__title">
 						{ __( 'Widgets' ) }
 					</h1>

--- a/packages/edit-widgets/src/components/header/index.js
+++ b/packages/edit-widgets/src/components/header/index.js
@@ -2,75 +2,96 @@
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
-import { ToolbarItem } from '@wordpress/components';
+import { __, _x } from '@wordpress/i18n';
+import { Button, ToolbarItem } from '@wordpress/components';
 import {
 	BlockNavigationDropdown,
 	BlockToolbar,
-	Inserter,
 	NavigableToolbar,
 } from '@wordpress/block-editor';
 import { PinnedItems } from '@wordpress/interface';
 import { useViewportMatch } from '@wordpress/compose';
+import { plus } from '@wordpress/icons';
+import { useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import SaveButton from '../save-button';
-import useLastSelectedRootId from '../../hooks/use-last-selected-root-id';
 import UndoButton from './undo-redo/undo';
 import RedoButton from './undo-redo/redo';
-
-const inserterToggleProps = { isPrimary: true };
+import useLastSelectedRootId from '../../hooks/use-last-selected-root-id';
 
 function Header() {
+	const inserterButton = useRef();
 	const isLargeViewport = useViewportMatch( 'medium' );
-	const rootClientId = useLastSelectedRootId();
 	const isLastSelectedWidgetAreaOpen = useSelect(
 		( select ) =>
 			select( 'core/edit-widgets' ).getIsWidgetAreaOpen( rootClientId ),
 		[ rootClientId ]
 	);
-	const { setIsWidgetAreaOpen } = useDispatch( 'core/edit-widgets' );
+	const isInserterOpened = useSelect( ( select ) =>
+		select( 'core/edit-widgets' ).isInserterOpened()
+	);
+	const { setIsWidgetAreaOpen, setIsInserterOpened } = useDispatch(
+		'core/edit-widgets'
+	);
 	const { selectBlock } = useDispatch( 'core/block-editor' );
-
-	function handleInserterOpen( isOpen ) {
-		if ( isOpen && ! isLastSelectedWidgetAreaOpen ) {
-			// Select the last selected block if hasn't already.
-			selectBlock( rootClientId );
-			// Open the last selected widget area when opening the inserter.
-			setIsWidgetAreaOpen( rootClientId, isOpen );
-		}
-	}
+	const rootClientId = useLastSelectedRootId();
 
 	return (
 		<>
 			<div className="edit-widgets-header">
-				<NavigableToolbar
-					className="edit-widgets-header-toolbar"
-					aria-label={ __( 'Document tools' ) }
-				>
-					<ToolbarItem>
-						{ ( toolbarItemProps ) => (
-							<Inserter
-								position="bottom right"
-								showInserterHelpPanel
-								toggleProps={ {
-									...inserterToggleProps,
-									...toolbarItemProps,
-								} }
-								rootClientId={ rootClientId }
-								onToggle={ handleInserterOpen }
-							/>
-						) }
-					</ToolbarItem>
-					<ToolbarItem as={ UndoButton } />
-					<ToolbarItem as={ RedoButton } />
-					<ToolbarItem as={ BlockNavigationDropdown } />
-				</NavigableToolbar>
-				<h1 className="edit-widgets-header__title">
-					{ __( 'Block Areas' ) }
-				</h1>
+				<div>
+					<h1 className="edit-widgets-header__title">
+						{ __( 'Widgets' ) }
+					</h1>
+					<NavigableToolbar
+						className="edit-widgets-header-toolbar"
+						aria-label={ __( 'Document tools' ) }
+					>
+						<ToolbarItem
+							ref={ inserterButton }
+							as={ Button }
+							className="edit-widgets-header-toolbar__inserter-toggle"
+							isPrimary
+							isPressed={ isInserterOpened }
+							onMouseDown={ ( event ) => {
+								event.preventDefault();
+							} }
+							onClick={ () => {
+								if ( isInserterOpened ) {
+									// Focusing the inserter button closes the inserter popover
+									inserterButton.current.focus();
+								} else {
+									if ( ! isLastSelectedWidgetAreaOpen ) {
+										// Select the last selected block if hasn't already.
+										selectBlock( rootClientId );
+										// Open the last selected widget area when opening the inserter.
+										setIsWidgetAreaOpen(
+											rootClientId,
+											true
+										);
+									}
+									// eslint-disable-next-line @wordpress/react-no-unsafe-timeout
+									setTimeout( () =>
+										setIsInserterOpened( true )
+									);
+								}
+							} }
+							icon={ plus }
+							/* translators: button label text should, if possible, be under 16
+					characters. */
+							label={ _x(
+								'Add block',
+								'Generic label for block inserter button'
+							) }
+						/>
+						<ToolbarItem as={ UndoButton } />
+						<ToolbarItem as={ RedoButton } />
+						<ToolbarItem as={ BlockNavigationDropdown } />
+					</NavigableToolbar>
+				</div>
 				<div className="edit-widgets-header__actions">
 					<SaveButton />
 					<PinnedItems.Slot scope="core/edit-widgets" />

--- a/packages/edit-widgets/src/components/header/style.scss
+++ b/packages/edit-widgets/src/components/header/style.scss
@@ -4,6 +4,11 @@
 	justify-content: space-between;
 	height: $header-height;
 	padding: 0 $grid-unit-20;
+	overflow: auto;
+
+	@include break-small {
+		overflow: visible;
+	}
 }
 
 .edit-widgets-header__navigable-toolbar-wrapper {

--- a/packages/edit-widgets/src/components/header/style.scss
+++ b/packages/edit-widgets/src/components/header/style.scss
@@ -40,3 +40,41 @@
 	border-bottom: 1px solid $gray-300;
 	border-top: 1px solid $gray-300;
 }
+
+.edit-widgets-header-toolbar {
+	// The Toolbar component adds different styles to buttons, so we reset them
+	// here to the original button styles
+	> .components-button.has-icon,
+	> .components-dropdown > .components-button.has-icon {
+		height: $button-size;
+		min-width: $button-size;
+		padding: 6px;
+
+		&.is-pressed {
+			background: $gray-900;
+		}
+
+		&:focus:not(:disabled) {
+			box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color), inset 0 0 0 $border-width $white;
+			outline: 1px solid transparent;
+		}
+
+		&::before {
+			display: none;
+		}
+	}
+}
+
+.edit-widgets-header-toolbar__inserter-toggle.edit-widgets-header-toolbar__inserter-toggle {
+	padding-left: $grid-unit;
+	padding-right: $grid-unit;
+
+	@include break-small {
+		padding-left: $grid-unit-15;
+		padding-right: $grid-unit-15;
+	}
+
+	&::after {
+		content: none;
+	}
+}

--- a/packages/edit-widgets/src/components/header/style.scss
+++ b/packages/edit-widgets/src/components/header/style.scss
@@ -6,6 +6,12 @@
 	padding: 0 $grid-unit-20;
 }
 
+.edit-widgets-header__navigable-toolbar-wrapper {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
 .edit-widgets-header-toolbar {
 	border: none;
 
@@ -27,9 +33,9 @@
 }
 
 .edit-widgets-header__title {
-	font-size: 16px;
-	padding: 0 20px;
-	margin: 0;
+	font-size: 20px;
+	padding: 0;
+	margin: 0 20px 0 0;
 }
 
 .edit-widgets-header__actions {

--- a/packages/edit-widgets/src/components/layout/index.js
+++ b/packages/edit-widgets/src/components/layout/index.js
@@ -1,8 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { Popover } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
+import { Popover, Button } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
+import { close } from '@wordpress/icons';
+import { __experimentalLibrary as Library } from '@wordpress/block-editor';
+import { useEffect } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { InterfaceSkeleton, ComplementaryArea } from '@wordpress/interface';
 import { PluginArea } from '@wordpress/plugins';
 
@@ -13,20 +17,73 @@ import WidgetAreasBlockEditorProvider from '../widget-areas-block-editor-provide
 import Header from '../header';
 import Sidebar from '../sidebar';
 import WidgetAreasBlockEditorContent from '../widget-areas-block-editor-content';
+import PopoverWrapper from './popover-wrapper';
+import useLastSelectedRootId from '../../hooks/use-last-selected-root-id';
 
 function Layout( { blockEditorSettings } ) {
-	const hasSidebarEnabled = useSelect(
-		( select ) =>
-			!! select( 'core/interface' ).getActiveComplementaryArea(
-				'core/edit-widgets'
-			)
+	const isMobileViewport = useViewportMatch( 'medium', '<' );
+	const isHugeViewport = useViewportMatch( 'huge', '>=' );
+	const { setIsInserterOpened, closeGeneralSidebar } = useDispatch(
+		'core/edit-widgets'
 	);
+	const rootClientId = useLastSelectedRootId();
+
+	const { hasSidebarEnabled, isInserterOpened } = useSelect( ( select ) => ( {
+		hasSidebarEnabled: !! select(
+			'core/interface'
+		).getActiveComplementaryArea( 'core/edit-widgets' ),
+		isInserterOpened: !! select( 'core/edit-widgets' ).isInserterOpened(),
+	} ) );
+
+	// Inserter and Sidebars are mutually exclusive
+	useEffect( () => {
+		if ( hasSidebarEnabled && ! isHugeViewport ) {
+			setIsInserterOpened( false );
+		}
+	}, [ hasSidebarEnabled, isHugeViewport ] );
+
+	useEffect( () => {
+		if ( isInserterOpened && ! isHugeViewport ) {
+			closeGeneralSidebar();
+		}
+	}, [ isInserterOpened, isHugeViewport ] );
+
 	return (
 		<WidgetAreasBlockEditorProvider
 			blockEditorSettings={ blockEditorSettings }
 		>
 			<InterfaceSkeleton
 				header={ <Header /> }
+				leftSidebar={
+					isInserterOpened && (
+						<PopoverWrapper
+							className="edit-widgets-layout__inserter-panel-popover-wrapper"
+							onClose={ () => setIsInserterOpened( false ) }
+						>
+							<div className="edit-widgets-layout__inserter-panel">
+								<div className="edit-widgets-layout__inserter-panel-header">
+									<Button
+										icon={ close }
+										onClick={ () =>
+											setIsInserterOpened( false )
+										}
+									/>
+								</div>
+								<div className="edit-widgets-layout__inserter-panel-content">
+									<Library
+										showInserterHelpPanel
+										onSelect={ () => {
+											if ( isMobileViewport ) {
+												setIsInserterOpened( false );
+											}
+										} }
+										rootClientId={ rootClientId }
+									/>
+								</div>
+							</div>
+						</PopoverWrapper>
+					)
+				}
 				sidebar={
 					hasSidebarEnabled && (
 						<ComplementaryArea.Slot scope="core/edit-widgets" />

--- a/packages/edit-widgets/src/components/layout/popover-wrapper.js
+++ b/packages/edit-widgets/src/components/layout/popover-wrapper.js
@@ -1,0 +1,57 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	withConstrainedTabbing,
+	withFocusReturn,
+	withFocusOutside,
+} from '@wordpress/components';
+import { Component } from '@wordpress/element';
+import { ESCAPE } from '@wordpress/keycodes';
+
+function stopPropagation( event ) {
+	event.stopPropagation();
+}
+
+const DetectOutside = withFocusOutside(
+	class extends Component {
+		handleFocusOutside( event ) {
+			this.props.onFocusOutside( event );
+		}
+
+		render() {
+			return this.props.children;
+		}
+	}
+);
+
+const FocusManaged = withConstrainedTabbing(
+	withFocusReturn( ( { children } ) => children )
+);
+
+export default function PopoverWrapper( { onClose, children, className } ) {
+	// Event handlers
+	const maybeClose = ( event ) => {
+		// Close on escape
+		if ( event.keyCode === ESCAPE && onClose ) {
+			event.stopPropagation();
+			onClose();
+		}
+	};
+
+	// Disable reason: this stops certain events from propagating outside of the component.
+	//   - onMouseDown is disabled as this can cause interactions with other DOM elements
+	/* eslint-disable jsx-a11y/no-static-element-interactions */
+	return (
+		<div
+			className={ className }
+			onKeyDown={ maybeClose }
+			onMouseDown={ stopPropagation }
+		>
+			<DetectOutside onFocusOutside={ onClose }>
+				<FocusManaged>{ children }</FocusManaged>
+			</DetectOutside>
+		</div>
+	);
+	/* eslint-enable jsx-a11y/no-static-element-interactions */
+}

--- a/packages/edit-widgets/src/components/layout/style.scss
+++ b/packages/edit-widgets/src/components/layout/style.scss
@@ -1,0 +1,37 @@
+
+// Ideally  we don't need all these nested divs.
+// Removing these requires a refactoring of the different a11y HoCs.
+.edit-widgets-layout__inserter-panel-popover-wrapper {
+	&,
+	& > div,
+	& > div > div,
+	& > div > div > div {
+		height: 100%;
+	}
+}
+
+.edit-widgets-layout__inserter-panel {
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+}
+
+.edit-widgets-layout__inserter-panel-header {
+	padding-top: $grid-unit-10;
+	padding-right: $grid-unit-10;
+	display: flex;
+	justify-content: flex-end;
+
+	@include break-medium() {
+		display: none;
+	}
+}
+
+.edit-widgets-layout__inserter-panel-content {
+	// Leave space for the close button
+	height: calc(100% - #{$button-size} - #{$grid-unit-10});
+
+	@include break-medium() {
+		height: 100%;
+	}
+}

--- a/packages/edit-widgets/src/components/layout/style.scss
+++ b/packages/edit-widgets/src/components/layout/style.scss
@@ -14,6 +14,9 @@
 	height: 100%;
 	display: flex;
 	flex-direction: column;
+	.block-editor-inserter__menu {
+		overflow: hidden;
+	}
 }
 
 .edit-widgets-layout__inserter-panel-header {

--- a/packages/edit-widgets/src/store/actions.js
+++ b/packages/edit-widgets/src/store/actions.js
@@ -175,3 +175,29 @@ export function setIsWidgetAreaOpen( clientId, isOpen ) {
 		isOpen,
 	};
 }
+
+/**
+ * Returns an action object used to open/close the inserter.
+ *
+ * @param {boolean} value A boolean representing whether the inserter should be opened or closed.
+ * @return {Object} Action object.
+ */
+export function setIsInserterOpened( value ) {
+	return {
+		type: 'SET_IS_INSERTER_OPENED',
+		value,
+	};
+}
+
+/**
+ * Returns an action object signalling that the user closed the sidebar.
+ *
+ * @yield {Object} Action object.
+ */
+export function* closeGeneralSidebar() {
+	yield dispatch(
+		'core/interface',
+		'disableComplementaryArea',
+		'core/edit-widgets'
+	);
+}

--- a/packages/edit-widgets/src/store/reducer.js
+++ b/packages/edit-widgets/src/store/reducer.js
@@ -54,7 +54,22 @@ export function widgetAreasOpenState( state = {}, action ) {
 	}
 }
 
+/**
+ * Reducer tracking whether the inserter is open.
+ *
+ * @param {boolean} state
+ * @param {Object}  action
+ */
+function isInserterOpened( state = false, action ) {
+	switch ( action.type ) {
+		case 'SET_IS_INSERTER_OPENED':
+			return action.value;
+	}
+	return state;
+}
+
 export default combineReducers( {
 	mapping,
+	isInserterOpened,
 	widgetAreasOpenState,
 } );

--- a/packages/edit-widgets/src/store/selectors.js
+++ b/packages/edit-widgets/src/store/selectors.js
@@ -172,3 +172,14 @@ export const getIsWidgetAreaOpen = ( state, clientId ) => {
 	const { widgetAreasOpenState } = state;
 	return !! widgetAreasOpenState[ clientId ];
 };
+
+/**
+ * Returns true if the inserter is opened.
+ *
+ * @param  {Object}  state Global application state.
+ *
+ * @return {boolean} Whether the inserter is opened.
+ */
+export function isInserterOpened( state ) {
+	return state.isInserterOpened;
+}

--- a/packages/edit-widgets/src/style.scss
+++ b/packages/edit-widgets/src/style.scss
@@ -4,6 +4,7 @@
 @import "./components/header/style.scss";
 @import "./components/sidebar/style.scss";
 @import "./components/notices/style.scss";
+@import "./components/layout/style.scss";
 
 // In order to use mix-blend-mode, this element needs to have an explicitly set background-color
 // We scope it to .wp-toolbar to be wp-admin only, to prevent bleed into other implementations


### PR DESCRIPTION
## Description

Solves #25649

**Side-note:** As the fixed sidebar inserter may also be useful in the navigation editor, and other editors yet to come, it could be a good idea to extract reusable parts to the interface package.

## How has this been tested?

1. Go to widgets editor
1. Click "Add widget"
1. Confirm the inserter was displayed in form of a fixed sidebar
1. Confirm the interactions make sense (clicking outside hides the inserter, it's not displayed together with the right sidebar on small screens)
1. Confirm the inserter actually works

## Screenshots

<img width="1279" alt="Zrzut ekranu 2020-09-29 o 10 27 58" src="https://user-images.githubusercontent.com/205419/94532671-76d79580-023e-11eb-9f61-6e7dfac61fe9.png">

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
