### PR TITLE
Date: Ensure timezone offset is a number

### DIFF
--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -506,7 +506,7 @@ function buildMoment( dateValue, timezone = '' ) {
 		return dateMoment.tz( settings.timezone.string );
 	}
 
-	return dateMoment.utcOffset( settings.timezone.offset );
+	return dateMoment.utcOffset( Number( settings.timezone.offset ) );
 }
 
 /**


### PR DESCRIPTION
When using a UTC offset timezone (instead of a named timezone), the offset is saved as a numeric string. This is not understood by moment, which expects either a number or a formatted string (ex "+08:00"). This means dates are not formatted correctly for sites with `UTC` timezones. You can see this by changing the settings on a site between 2 options that represent the same time, ex "UTC-7" and "Vancouver".

```
wp.date.dateI18n('F j, Y g:i a', 1601532000000 )
  -> Vancouver: "September 30, 2020 11:00 pm"
  -> UTC-7: "October 1, 2020 2:00 am" (this is my local time, EDT)
```

Alternately you can see the problem more clearly by trying to pass in a string timezone offset to `date`:

```
wp.date.date('F j, Y g:i a', 1601532000000, '-7' )
  ⚠️ Moment Timezone has no data for -7.
```

Fixes #21977

## How has this been tested?
Tested in browser as described above (with UTC-7 and UTC+1:30), and ran unit tests.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

