### PR TITLE
Remove the right margin for the right-most list items in the lastest posts block

### DIFF
--- a/packages/block-library/src/latest-posts/style.scss
+++ b/packages/block-library/src/latest-posts/style.scss
@@ -28,7 +28,11 @@
 	@include break-small {
 		@for $i from 2 through 6 {
 			&.columns-#{ $i } li {
-				width: calc((100% / #{ $i }) - 1.25em);
+				width: calc((100% / #{ $i }) - 1.25em + (1.25em / #{ $i }));
+
+				&:nth-child( #{ $i }n ) {
+					margin-right: 0;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
I came across this while building the Latest Posts block's theme styles for Twenty Twenty: https://github.com/WordPress/twentytwentyone/pull/153.

Currently, the Latest Posts block's grid mode includes a right-margin declaration for the right-most items in the grid. This causes all items to be slightly off to the left: 

![Screen Shot 2020-09-28 at 3 24 03 PM](https://user-images.githubusercontent.com/1202812/94476557-a636c580-019e-11eb-9fc7-b67d7488b266.png)

This PR adds an additional style to remove the right-margin from that item. It also re-adjusts the width of each item to account for the change: 

![Screen Shot 2020-09-28 at 3 18 49 PM](https://user-images.githubusercontent.com/1202812/94476492-8f906e80-019e-11eb-810d-5fcc26a4a24f.png)

---

I tested in Twenty Twenty and Twenty Nineteen, and didn't see any issues. The width changes didn't seem to be picked up in the editor for Twenty because of the theme's more specific styles. But it didn't cause any issues there, and it looked great on the front end.
