### PR TITLE
Navigation block: Use unbounded query when requesting top level pages

### DIFF
--- a/packages/block-library/src/navigation/placeholder.js
+++ b/packages/block-library/src/navigation/placeholder.js
@@ -194,6 +194,7 @@ function NavigationPlaceholder( { onCreate }, ref ) {
 					parent: 0,
 					order: 'asc',
 					orderby: 'id',
+					per_page: -1,
 				},
 			];
 			const menusParameters = [ { per_page: -1 } ];


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/19266.

Use an unbounded query (`per_page=-1`) when fetching top level pages for the Navigation block's _Create from all top-level pages_ function.

#### To test

1. Create 11 or more top level pages.
2. Add a Navigation block.
3. Select `Create from all top pages`.
4. All top level pages should appear as menu items.