### PR TITLE
Use h3 in the legacy widget title

### DIFF
--- a/packages/edit-widgets/src/blocks/legacy-widget/edit/handler.js
+++ b/packages/edit-widgets/src/blocks/legacy-widget/edit/handler.js
@@ -96,9 +96,9 @@ class LegacyWidgetEditHandler extends Component {
 				{ ...componentProps }
 			>
 				{ title && (
-					<div className="wp-block-legacy-widget__edit-widget-title">
+					<h3 className="wp-block-legacy-widget__edit-widget-title">
 						{ title }
-					</div>
+					</h3>
 				) }
 				<div
 					className="wp-block-legacy-widget__edit-container"

--- a/packages/edit-widgets/src/blocks/legacy-widget/editor.scss
+++ b/packages/edit-widgets/src/blocks/legacy-widget/editor.scss
@@ -25,11 +25,12 @@
 	padding: $grid-unit-10 $block-padding;
 }
 
-.wp-block-legacy-widget__edit-widget-title {
+.components-panel__body .wp-block-legacy-widget__edit-widget-title {
 	color: $black;
 	font-family: $default-font;
 	font-size: $default-font-size;
 	padding: $block-padding 18px;
+	margin: 0;
 	font-weight: 600;
 	border-bottom: $border-width solid $gray-900;
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Resolve https://github.com/WordPress/gutenberg/issues/24566#issuecomment-700184647.

Use `<h3>` in the legacy widget title.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Go to widgets screen.
2. Add some legacy widgets.
3. Confirm that the titles of the legacy widgets are `<h3>` by either inspecting or using assistant technology.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
