### PR TITLE
Navigation Block: Fix link colors and remove unnecessary classes

### DIFF
--- a/packages/block-library/src/navigation-link/block.json
+++ b/packages/block-library/src/navigation-link/block.json
@@ -31,12 +31,6 @@
 		}
 	},
 	"usesContext": [
-		"textColor",
-		"customTextColor",
-		"backgroundColor",
-		"customBackgroundColor",
-		"fontSize",
-		"customFontSize",
 		"showSubmenuIcon"
 	],
 	"supports": {

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { escape, get, head, find } from 'lodash';
+import { escape, head } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -129,10 +129,6 @@ function NavigationLinkEdit( {
 	setAttributes,
 	showSubmenuIcon,
 	insertLinkBlock,
-	textColor,
-	backgroundColor,
-	rgbTextColor,
-	rgbBackgroundColor,
 	selectedBlockHasDescendants,
 	userCanCreatePages = false,
 	userCanCreatePosts = false,
@@ -167,7 +163,7 @@ function NavigationLinkEdit( {
 
 	// Show the LinkControl on mount if the URL is empty
 	// ( When adding a new menu item)
-	// This can't be done in the useState call because it cconflicts
+	// This can't be done in the useState call because it conflicts
 	// with the autofocus behavior of the BlockListBlock component.
 	useEffect( () => {
 		if ( ! url ) {
@@ -252,15 +248,7 @@ function NavigationLinkEdit( {
 			'is-dragging-within': isDraggingWithin,
 			'has-link': !! url,
 			'has-child': hasDescendants,
-			'has-text-color': rgbTextColor,
-			[ `has-${ textColor }-color` ]: !! textColor,
-			'has-background': rgbBackgroundColor,
-			[ `has-${ backgroundColor }-background-color` ]: !! backgroundColor,
 		} ),
-		style: {
-			color: rgbTextColor,
-			backgroundColor: rgbBackgroundColor,
-		},
 	} );
 
 	const innerBlocksProps = useInnerBlocksProps(
@@ -450,27 +438,6 @@ function NavigationLinkEdit( {
 	);
 }
 
-/**
- * Returns the color object matching the slug, or undefined.
- *
- * @param {Array}  colors      The editor settings colors array.
- * @param {string} colorSlug   A string containing the color slug.
- * @param {string} customColor A string containing the custom color value.
- *
- * @return {Object} Color object included in the editor settings colors, or Undefined.
- */
-const getColorObjectByColorSlug = ( colors, colorSlug, customColor ) => {
-	if ( customColor ) {
-		return customColor;
-	}
-
-	if ( ! colors || ! colors.length ) {
-		return;
-	}
-
-	return get( find( colors, { slug: colorSlug } ), 'color' );
-};
-
 export default compose( [
 	withSelect( ( select, ownProps ) => {
 		const {
@@ -479,14 +446,12 @@ export default compose( [
 			hasSelectedInnerBlock,
 			getBlockParentsByBlockName,
 			getSelectedBlockClientId,
-			getSettings,
 		} = select( 'core/block-editor' );
 		const { clientId } = ownProps;
 		const rootBlock = head(
 			getBlockParentsByBlockName( clientId, 'core/navigation' )
 		);
 		const navigationBlockAttributes = getBlockAttributes( rootBlock );
-		const colors = get( getSettings(), 'colors', [] );
 		const hasDescendants = !! getClientIdsOfDescendants( [ clientId ] )
 			.length;
 		const showSubmenuIcon =
@@ -507,20 +472,8 @@ export default compose( [
 			hasDescendants,
 			selectedBlockHasDescendants,
 			showSubmenuIcon,
-			textColor: navigationBlockAttributes.textColor,
-			backgroundColor: navigationBlockAttributes.backgroundColor,
 			userCanCreatePages: select( 'core' ).canUser( 'create', 'pages' ),
 			userCanCreatePosts: select( 'core' ).canUser( 'create', 'posts' ),
-			rgbTextColor: getColorObjectByColorSlug(
-				colors,
-				navigationBlockAttributes.textColor,
-				navigationBlockAttributes.customTextColor
-			),
-			rgbBackgroundColor: getColorObjectByColorSlug(
-				colors,
-				navigationBlockAttributes.backgroundColor,
-				navigationBlockAttributes.customBackgroundColor
-			),
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps, registry ) => {

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -6,86 +6,6 @@
  */
 
 /**
- * Build an array with CSS classes and inline styles defining the colors
- * which will be applied to the navigation markup in the front-end.
- *
- * @param  array $context Navigation block context.
- * @return array Colors CSS classes and inline styles.
- */
-function block_core_navigation_link_build_css_colors( $context ) {
-	$colors = array(
-		'css_classes'   => array(),
-		'inline_styles' => '',
-	);
-
-	// Text color.
-	$has_named_text_color  = array_key_exists( 'textColor', $context );
-	$has_custom_text_color = array_key_exists( 'customTextColor', $context );
-
-	// If has text color.
-	if ( $has_custom_text_color || $has_named_text_color ) {
-		// Add has-text-color class.
-		$colors['css_classes'][] = 'has-text-color';
-	}
-
-	if ( $has_named_text_color ) {
-		// Add the color class.
-		$colors['css_classes'][] = sprintf( 'has-%s-color', $context['textColor'] );
-	} elseif ( $has_custom_text_color ) {
-		// Add the custom color inline style.
-		$colors['inline_styles'] .= sprintf( 'color: %s;', $context['customTextColor'] );
-	}
-
-	// Background color.
-	$has_named_background_color  = array_key_exists( 'backgroundColor', $context );
-	$has_custom_background_color = array_key_exists( 'customBackgroundColor', $context );
-
-	// If has background color.
-	if ( $has_custom_background_color || $has_named_background_color ) {
-		// Add has-background class.
-		$colors['css_classes'][] = 'has-background';
-	}
-
-	if ( $has_named_background_color ) {
-		// Add the background-color class.
-		$colors['css_classes'][] = sprintf( 'has-%s-background-color', $context['backgroundColor'] );
-	} elseif ( $has_custom_background_color ) {
-		// Add the custom background-color inline style.
-		$colors['inline_styles'] .= sprintf( 'background-color: %s;', $context['customBackgroundColor'] );
-	}
-
-	return $colors;
-}
-
-/**
- * Build an array with CSS classes and inline styles defining the font sizes
- * which will be applied to the navigation markup in the front-end.
- *
- * @param  array $context Navigation block context.
- * @return array Font size CSS classes and inline styles.
- */
-function block_core_navigation_link_build_css_font_sizes( $context ) {
-	// CSS classes.
-	$font_sizes = array(
-		'css_classes'   => array(),
-		'inline_styles' => '',
-	);
-
-	$has_named_font_size  = array_key_exists( 'fontSize', $context );
-	$has_custom_font_size = array_key_exists( 'customFontSize', $context );
-
-	if ( $has_named_font_size ) {
-		// Add the font size class.
-		$font_sizes['css_classes'][] = sprintf( 'has-%s-font-size', $context['fontSize'] );
-	} elseif ( $has_custom_font_size ) {
-		// Add the custom font size inline style.
-		$font_sizes['inline_styles'] = sprintf( 'font-size: %spx;', $context['customFontSize'] );
-	}
-
-	return $font_sizes;
-}
-
-/**
  * Returns the top-level submenu SVG chevron icon.
  *
  * @return string
@@ -109,31 +29,14 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$colors          = block_core_navigation_link_build_css_colors( $block->context );
-	$font_sizes      = block_core_navigation_link_build_css_font_sizes( $block->context );
-	$classes         = array_merge(
-		$colors['css_classes'],
-		$font_sizes['css_classes']
-	);
-	$style_attribute = ( $colors['inline_styles'] || $font_sizes['inline_styles'] );
-
-	$css_classes = trim( implode( ' ', $classes ) );
+	$css_classes = ! empty( $attributes['className'] ) ? implode( ' ', (array) $attributes['className'] ) : '';
 	$has_submenu = count( $block->inner_blocks ) > 0;
 	$is_active   = ! empty( $attributes['id'] ) && ( get_the_ID() === $attributes['id'] );
 
-	$class_name = ! empty( $attributes['className'] ) ? implode( ' ', (array) $attributes['className'] ) : false;
+	$css_classes .= $has_submenu ? ' has-child' : '';
+	$css_classes .= $is_active ? ' current-menu-item' : '';
 
-	if ( false !== $class_name ) {
-		$css_classes .= ' ' . $class_name;
-	};
-
-	$wrapper_attributes = get_block_wrapper_attributes(
-		array(
-			'class' => $css_classes . ( $has_submenu ? ' has-child' : '' ) .
-				( $is_active ? ' current-menu-item' : '' ),
-			'style' => $style_attribute,
-		)
-	);
+	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $css_classes ) );
 	$html               = '<li ' . $wrapper_attributes . '>' .
 		'<a class="wp-block-navigation-link__content" ';
 

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -33,12 +33,6 @@
 		}
 	},
 	"providesContext": {
-		"textColor": "textColor",
-		"customTextColor": "customTextColor",
-		"backgroundColor": "backgroundColor",
-		"customBackgroundColor": "customBackgroundColor",
-		"fontSize": "fontSize",
-		"customFontSize": "customFontSize",
 		"showSubmenuIcon": "showSubmenuIcon"
 	},
 	"supports": {

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useEffect, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import {
 	InnerBlocks,
 	__experimentalUseInnerBlocksProps as useInnerBlocksProps,
@@ -77,17 +77,6 @@ function Navigation( {
 			templateLock: false,
 		}
 	);
-
-	const {
-		style: { color, backgroundColor },
-	} = blockProps;
-
-	useEffect( () => {
-		setAttributes( {
-			customTextColor: color,
-			customBackgroundColor: backgroundColor,
-		} );
-	}, [ color, backgroundColor, setAttributes ] );
 
 	if ( isPlaceholderShown ) {
 		return (

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import {
 	InnerBlocks,
 	__experimentalUseInnerBlocksProps as useInnerBlocksProps,
@@ -77,6 +77,17 @@ function Navigation( {
 			templateLock: false,
 		}
 	);
+
+	const {
+		style: { color, backgroundColor },
+	} = blockProps;
+
+	useEffect( () => {
+		setAttributes( {
+			customTextColor: color,
+			customBackgroundColor: backgroundColor,
+		} );
+	}, [ color, backgroundColor, setAttributes ] );
 
 	if ( isPlaceholderShown ) {
 		return (

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -28,6 +28,11 @@ $navigation-item-height: 46px;
 	padding: $grid-unit-20;
 }
 
+// Ensure that navigation links get selected color
+.editor-styles-wrapper .wp-block-navigation.has-text-color .wp-block-navigation-link {
+	color: currentColor;
+}
+
 // Ensure that an empty block has space around the appender.
 .wp-block-navigation__container {
 	min-height: $navigation-item-height;

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -31,7 +31,9 @@ function block_core_navigation_build_css_colors( $attributes ) {
 	if ( $has_named_text_color ) {
 		// Add the color class.
 		$colors['css_classes'][] = sprintf( 'has-%s-color', $attributes['textColor'] );
-	} elseif ( $has_custom_text_color ) {
+	}
+
+	if ( $has_custom_text_color ) {
 		// Add the custom color inline style.
 		$colors['inline_styles'] .= sprintf( 'color: %s;', $attributes['customTextColor'] );
 	}
@@ -49,7 +51,9 @@ function block_core_navigation_build_css_colors( $attributes ) {
 	if ( $has_named_background_color ) {
 		// Add the background-color class.
 		$colors['css_classes'][] = sprintf( 'has-%s-background-color', $attributes['backgroundColor'] );
-	} elseif ( $has_custom_background_color ) {
+	}
+
+	if ( $has_custom_background_color ) {
 		// Add the custom background-color inline style.
 		$colors['inline_styles'] .= sprintf( 'background-color: %s;', $attributes['customBackgroundColor'] );
 	}

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -6,86 +6,6 @@
  */
 
 /**
- * Build an array with CSS classes and inline styles defining the colors
- * which will be applied to the navigation markup in the front-end.
- *
- * @param  array $attributes Navigation block attributes.
- * @return array Colors CSS classes and inline styles.
- */
-function block_core_navigation_build_css_colors( $attributes ) {
-	$colors = array(
-		'css_classes'   => array(),
-		'inline_styles' => '',
-	);
-
-	// Text color.
-	$has_named_text_color  = array_key_exists( 'textColor', $attributes );
-	$has_custom_text_color = array_key_exists( 'customTextColor', $attributes );
-
-	// If has text color.
-	if ( $has_custom_text_color || $has_named_text_color ) {
-		// Add has-text-color class.
-		$colors['css_classes'][] = 'has-text-color';
-	}
-
-	if ( $has_named_text_color ) {
-		// Add the color class.
-		$colors['css_classes'][] = sprintf( 'has-%s-color', $attributes['textColor'] );
-	} elseif ( $has_custom_text_color ) {
-		// Add the custom color inline style.
-		$colors['inline_styles'] .= sprintf( 'color: %s;', $attributes['customTextColor'] );
-	}
-
-	// Background color.
-	$has_named_background_color  = array_key_exists( 'backgroundColor', $attributes );
-	$has_custom_background_color = array_key_exists( 'customBackgroundColor', $attributes );
-
-	// If has background color.
-	if ( $has_custom_background_color || $has_named_background_color ) {
-		// Add has-background class.
-		$colors['css_classes'][] = 'has-background';
-	}
-
-	if ( $has_named_background_color ) {
-		// Add the background-color class.
-		$colors['css_classes'][] = sprintf( 'has-%s-background-color', $attributes['backgroundColor'] );
-	} elseif ( $has_custom_background_color ) {
-		// Add the custom background-color inline style.
-		$colors['inline_styles'] .= sprintf( 'background-color: %s;', $attributes['customBackgroundColor'] );
-	}
-
-	return $colors;
-}
-
-/**
- * Build an array with CSS classes and inline styles defining the font sizes
- * which will be applied to the navigation markup in the front-end.
- *
- * @param  array $attributes Navigation block attributes.
- * @return array Font size CSS classes and inline styles.
- */
-function block_core_navigation_build_css_font_sizes( $attributes ) {
-	// CSS classes.
-	$font_sizes = array(
-		'css_classes'   => array(),
-		'inline_styles' => '',
-	);
-
-	$has_named_font_size  = array_key_exists( 'fontSize', $attributes );
-	$has_custom_font_size = array_key_exists( 'customFontSize', $attributes );
-
-	if ( $has_named_font_size ) {
-		// Add the font size class.
-		$font_sizes['css_classes'][] = sprintf( 'has-%s-font-size', $attributes['fontSize'] );
-	} elseif ( $has_custom_font_size ) {
-		// Add the custom font size inline style.
-		$font_sizes['inline_styles'] = sprintf( 'font-size: %spx;', $attributes['customFontSize'] );
-	}
-
-	return $font_sizes;
-}
-
-/**
  * Returns the top-level submenu SVG chevron icon.
  *
  * @return string
@@ -125,11 +45,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$colors     = block_core_navigation_build_css_colors( $attributes );
-	$font_sizes = block_core_navigation_build_css_font_sizes( $attributes );
-	$classes    = array_merge(
-		$colors['css_classes'],
-		$font_sizes['css_classes'],
+	$classes = array_merge(
 		( isset( $attributes['orientation'] ) && 'vertical' === $attributes['orientation'] ) ? array( 'is-vertical' ) : array(),
 		isset( $attributes['itemsJustification'] ) ? array( 'items-justified-' . $attributes['itemsJustification'] ) : array()
 	);
@@ -144,7 +60,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array(
 			'class' => implode( ' ', $classes ),
-			'style' => $block_styles . $colors['inline_styles'] . $font_sizes['inline_styles'],
+			'style' => $block_styles,
 		)
 	);
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -31,9 +31,7 @@ function block_core_navigation_build_css_colors( $attributes ) {
 	if ( $has_named_text_color ) {
 		// Add the color class.
 		$colors['css_classes'][] = sprintf( 'has-%s-color', $attributes['textColor'] );
-	}
-
-	if ( $has_custom_text_color ) {
+	} elseif ( $has_custom_text_color ) {
 		// Add the custom color inline style.
 		$colors['inline_styles'] .= sprintf( 'color: %s;', $attributes['customTextColor'] );
 	}
@@ -51,9 +49,7 @@ function block_core_navigation_build_css_colors( $attributes ) {
 	if ( $has_named_background_color ) {
 		// Add the background-color class.
 		$colors['css_classes'][] = sprintf( 'has-%s-background-color', $attributes['backgroundColor'] );
-	}
-
-	if ( $has_custom_background_color ) {
+	} elseif ( $has_custom_background_color ) {
 		// Add the custom background-color inline style.
 		$colors['inline_styles'] .= sprintf( 'background-color: %s;', $attributes['customBackgroundColor'] );
 	}

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -1,10 +1,19 @@
 // Default background and font color
-.wp-block-navigation:not(.has-background) .wp-block-navigation__container {
-	.wp-block-navigation-link:not(.has-text-color) {
+.wp-block-navigation:not(.has-background):not(.has-text-color) .wp-block-navigation__container {
+	.wp-block-navigation-link {
 		color: $gray-900;
 	}
 	.wp-block-navigation__container {
 		background-color: $white;
+	}
+}
+
+// Ensure submenus inherit background colors from main navigation block
+.wp-block-navigation__container {
+	background-color: inherit;
+
+	.wp-block-navigation-link {
+		background-color: inherit;
 	}
 }
 

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -1,9 +1,11 @@
 // Default background and font color
-.wp-block-navigation:not(.has-background):not(.has-text-color) .wp-block-navigation__container {
-	.wp-block-navigation-link {
+.wp-block-navigation:not(.has-background) {
+	&:not(.has-text-color) .wp-block-navigation__container .wp-block-navigation-link {
 		color: $gray-900;
 	}
-	.wp-block-navigation__container {
+
+	// Only default submenu backgrounds
+	.wp-block-navigation__container .wp-block-navigation__container {
 		background-color: $white;
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/25889

## Description
This improves the display of color selections for the navigation block between the editor and frontend. It also removes unneeded css classes and styles from the inner links allowing them to inherit the colors from the main navigation block itself.

### Changes Included
* Removes unnecessary block context passing of colors
  * `packages/block-library/src/navigation/block.json`
  * `packages/block-library/src/navigation-link/block.json`
* CSS now allows colors to be inherited by navigation links from the main navigation block and fixes color consistency between editor and frontend for most themes.
  * `packages/block-library/src/navigation/editor.scss`
  * `packages/block-library/src/navigation/style.scss`
* Removes manual application of block support classes and styles for colors in navigation link within the editor. 
  * `packages/block-library/src/navigation-link/edit.js`
* Removes manual generation and application of colors and font size classes and styles from server side rendering. These are block supports and provided automatically via `get_block_wrapper_attributes()`
  * `packages/block-library/src/navigation/index.php`
  * `packages/block-library/src/navigation-link/index.php`

## How has this been tested?
Manually tested. 

Tried multiple themes and multiple color combinations between named and custom colors. Used a mix of full featured and basic themes. In particular the themes tested with were:

- TwentyTwenty
- Maywood
- Varia

#### Testing Instructions
1. Before applying this PR branch
2. Create a post and add a navigation block to it
3. Change around color settings noticing odd behaviours
4. Save different color combinations and compare with frontend for unexpected results
5. Checkout this PR branch
6. Change around color settings and confirm it behaves visually as you would expect
6. Save different combinations and confirm these choices are reflected on the frontend

## Screenshots <!-- if applicable -->

#### Before
| TwentyTwenty | Maywood | Varia |
|---------------|-----------|------|
| ![NavigationBlockColors-TwentyTwenty-Bug](https://user-images.githubusercontent.com/60436221/94518366-24619d80-026d-11eb-8ca7-09570506e94a.gif) | ![NavigationBlockColors-Maywood-Bug](https://user-images.githubusercontent.com/60436221/94518351-1d3a8f80-026d-11eb-8683-c9c3bd87f189.gif) | ![NavigationBlockColors-Varia-Bug](https://user-images.githubusercontent.com/60436221/94518379-27f52480-026d-11eb-93f0-bdca36e8c178.gif) |

#### After
| TwentyTwenty | Maywood | Varia |
|---------------|-----------|------|
| ![NavigationBlockColors-TwentyTwenty-fix](https://user-images.githubusercontent.com/60436221/94518371-262b6100-026d-11eb-8e7d-a51450d48561.gif) | ![NavigationBlockColors-Maywood-fix](https://user-images.githubusercontent.com/60436221/94518361-2297da00-026d-11eb-8c4f-787ec261b4d2.gif) | ![NavigationBlockColors-Varia-fix](https://user-images.githubusercontent.com/60436221/94518383-29bee800-026d-11eb-8def-598b1ddf60c6.gif) |

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
