### PR TITLE
Display before_widget/after_widget when rendering WP_Widget_Block

### DIFF
--- a/lib/class-wp-widget-block.php
+++ b/lib/class-wp-widget-block.php
@@ -53,7 +53,9 @@ class WP_Widget_Block extends WP_Widget {
 	 * @global WP_Post $post Global post object.
 	 */
 	public function widget( $args, $instance ) {
+		echo $args['before_widget'];
 		echo do_blocks( $instance['content'] );
+		echo $args['after_widget'];
 	}
 
 	/**


### PR DESCRIPTION
## Description
Solves #25670

**Before:**

<img width="522" alt="94534135-53ade580-0240-11eb-9bc0-2a6278a0888e" src="https://user-images.githubusercontent.com/205419/94534637-e77fb180-0240-11eb-88e2-0755c5d85b2d.png">

**After:**

<img width="581" alt="Zrzut ekranu 2020-09-29 o 10 45 43" src="https://user-images.githubusercontent.com/205419/94534664-f0708300-0240-11eb-86de-4f218aba7ec7.png">

## How has this been tested?
1. Go to the widgets editor
1. Add a few blocks
1. Save
1. Go to frontend
1. Confirm all widgets including blocks are rendered using the same HTML wrappers (`.widget`)

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
