### PR TITLE
Mark the color support flag as stable

### DIFF
--- a/lib/block-supports/colors.php
+++ b/lib/block-supports/colors.php
@@ -13,7 +13,7 @@
 function gutenberg_register_colors_support( $block_type ) {
 	$color_support = false;
 	if ( property_exists( $block_type, 'supports' ) ) {
-		$color_support = gutenberg_experimental_get( $block_type->supports, array( '__experimentalColor' ), false );
+		$color_support = gutenberg_experimental_get( $block_type->supports, array( 'color' ), false );
 	}
 	$has_text_colors_support       = true === $color_support || ( is_array( $color_support ) && gutenberg_experimental_get( $color_support, array( 'text' ), true ) );
 	$has_background_colors_support = true === $color_support || ( is_array( $color_support ) && gutenberg_experimental_get( $color_support, array( 'background' ), true ) );
@@ -60,10 +60,10 @@ function gutenberg_register_colors_support( $block_type ) {
  * @return array Colors CSS classes and inline styles.
  */
 function gutenberg_apply_colors_support( $attributes, $block_attributes, $block_type ) {
-	$color_support                 = gutenberg_experimental_get( $block_type->supports, array( '__experimentalColor' ), false );
+	$color_support                 = gutenberg_experimental_get( $block_type->supports, array( 'color' ), false );
 	$has_text_colors_support       = true === $color_support || ( is_array( $color_support ) && gutenberg_experimental_get( $color_support, array( 'text' ), true ) );
 	$has_background_colors_support = true === $color_support || ( is_array( $color_support ) && gutenberg_experimental_get( $color_support, array( 'background' ), true ) );
-	$has_link_colors_support       = gutenberg_experimental_get( $color_support, array( 'linkColor' ), false );
+	$has_link_colors_support       = gutenberg_experimental_get( $color_support, array( 'link' ), false );
 	$has_gradients_support         = gutenberg_experimental_get( $color_support, array( 'gradients' ), false );
 
 	// Text Colors.

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -417,10 +417,10 @@ function gutenberg_experimental_global_styles_get_style_property() {
  */
 function gutenberg_experimental_global_styles_get_support_keys() {
 	return array(
-		'--wp--style--color--link' => array( '__experimentalColor', 'linkColor' ),
-		'background'               => array( '__experimentalColor', 'gradients' ),
-		'backgroundColor'          => array( '__experimentalColor' ),
-		'color'                    => array( '__experimentalColor' ),
+		'--wp--style--color--link' => array( 'color', 'link' ),
+		'background'               => array( 'color', 'gradients' ),
+		'backgroundColor'          => array( 'color' ),
+		'color'                    => array( 'color' ),
 		'fontSize'                 => array( '__experimentalFontSize' ),
 		'lineHeight'               => array( '__experimentalLineHeight' ),
 	);
@@ -485,8 +485,8 @@ function gutenberg_experimental_global_styles_get_block_data() {
 					'supports' => array(
 						'__experimentalSelector' => ':root',
 						'__experimentalFontSize' => true,
-						'__experimentalColor'    => array(
-							'linkColor' => true,
+						'color'                  => array(
+							'link'      => true,
 							'gradients' => true,
 						),
 					),

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -30,7 +30,7 @@ import { cleanEmptyObject } from './utils';
 import ColorPanel from './color-panel';
 import useEditorFeature from '../components/use-editor-feature';
 
-export const COLOR_SUPPORT_KEY = '__experimentalColor';
+export const COLOR_SUPPORT_KEY = 'color';
 const EMPTY_ARRAY = [];
 
 const hasColorSupport = ( blockType ) => {
@@ -40,7 +40,7 @@ const hasColorSupport = ( blockType ) => {
 	const colorSupport = getBlockSupport( blockType, COLOR_SUPPORT_KEY );
 	return (
 		colorSupport &&
-		( colorSupport.linkColor === true ||
+		( colorSupport.link === true ||
 			colorSupport.gradient === true ||
 			colorSupport.background !== false ||
 			colorSupport.text !== false )
@@ -54,7 +54,7 @@ const hasLinkColorSupport = ( blockType ) => {
 
 	const colorSupport = getBlockSupport( blockType, COLOR_SUPPORT_KEY );
 
-	return isObject( colorSupport ) && !! colorSupport.linkColor;
+	return isObject( colorSupport ) && !! colorSupport.link;
 };
 
 const hasGradientSupport = ( blockType ) => {

--- a/packages/block-library/src/button/deprecated.js
+++ b/packages/block-library/src/button/deprecated.js
@@ -85,7 +85,7 @@ const deprecated = [
 		supports: {
 			align: true,
 			alignWide: false,
-			__experimentalColor: { gradients: true },
+			color: { gradients: true },
 		},
 		attributes: {
 			...blockAttributes,

--- a/packages/block-library/src/columns/block.json
+++ b/packages/block-library/src/columns/block.json
@@ -14,9 +14,9 @@
 		],
 		"html": false,
 		"lightBlockWrapper": true,
-		"__experimentalColor": {
+		"color": {
 			"gradients": true,
-			"linkColor": true
+			"link": true
 		}
 	}
 }

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -15,9 +15,9 @@
 		"anchor": true,
 		"html": false,
 		"lightBlockWrapper": true,
-		"__experimentalColor": {
+		"color": {
 			"gradients": true,
-			"linkColor": true
+			"link": true
 		},
 		"__experimentalPadding": true
 	}

--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -23,8 +23,8 @@
 		"anchor": true,
 		"className": false,
 		"lightBlockWrapper": true,
-		"__experimentalColor": {
-			"linkColor": true
+		"color": {
+			"link": true
 		},
 		"__experimentalFontSize": true,
 		"__experimentalLineHeight": true,

--- a/packages/block-library/src/list/block.json
+++ b/packages/block-library/src/list/block.json
@@ -27,7 +27,7 @@
 	"supports": {
 		"anchor": true,
 		"className": false,
-		"__experimentalColor": {
+		"color": {
 			"gradients": true
 		},
 		"__unstablePasteTextInline": true,

--- a/packages/block-library/src/media-text/block.json
+++ b/packages/block-library/src/media-text/block.json
@@ -85,9 +85,9 @@
 		"align": [ "wide", "full" ],
 		"html": false,
 		"lightBlockWrapper": true,
-		"__experimentalColor": {
+		"color": {
 			"gradients": true,
-			"linkColor": true
+			"link": true
 		}
 	}
 }

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -50,7 +50,7 @@
 		"inserter": true,
 		"lightBlockWrapper": true,
 		"__experimentalFontSize": true,
-		"__experimentalColor": {
+		"color": {
 			"textColor": true,
 			"backgroundColor": true
 		}

--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -30,8 +30,8 @@
 		"anchor": true,
 		"className": false,
 		"lightBlockWrapper": true,
-		"__experimentalColor": {
-			"linkColor": true
+		"color": {
+			"link": true
 		},
 		"__experimentalFontSize": true,
 		"__experimentalLineHeight": true,

--- a/packages/block-library/src/post-author/block.json
+++ b/packages/block-library/src/post-author/block.json
@@ -28,9 +28,9 @@
 		"html": false,
 		"lightBlockWrapper": true,
 		"__experimentalFontSize": true,
-		"__experimentalColor": {
+		"color": {
 			"gradients": true,
-			"linkColor": true
+			"link": true
 		},
 		"__experimentalLineHeight": true
 	}

--- a/packages/block-library/src/post-comments-count/block.json
+++ b/packages/block-library/src/post-comments-count/block.json
@@ -12,7 +12,7 @@
 	"supports": {
 		"html": false,
 		"lightBlockWrapper": true,
-		"__experimentalColor": {
+		"color": {
 			"gradients": true
 		},
 		"__experimentalFontSize": true,

--- a/packages/block-library/src/post-comments-form/block.json
+++ b/packages/block-library/src/post-comments-form/block.json
@@ -13,9 +13,9 @@
 	"supports": {
 		"html": false,
 		"lightBlockWrapper": true,
-		"__experimentalColor": {
+		"color": {
 			"gradients": true,
-			"linkColor": true
+			"link": true
 		},
 		"__experimentalFontSize": true,
 		"__experimentalLineHeight": true

--- a/packages/block-library/src/post-comments/block.json
+++ b/packages/block-library/src/post-comments/block.json
@@ -18,9 +18,9 @@
 			"full"
 		],
 		"__experimentalFontSize": true,
-		"__experimentalColor": {
+		"color": {
 			"gradients": true,
-			"linkColor": true
+			"link": true
 		},
 		"__experimentalLineHeight": true
 	}

--- a/packages/block-library/src/post-date/block.json
+++ b/packages/block-library/src/post-date/block.json
@@ -16,7 +16,7 @@
 	"supports": {
 		"html": false,
 		"lightBlockWrapper": true,
-		"__experimentalColor": {
+		"color": {
 			"gradients": true
 		},
 		"__experimentalFontSize": true,

--- a/packages/block-library/src/post-excerpt/block.json
+++ b/packages/block-library/src/post-excerpt/block.json
@@ -25,9 +25,9 @@
 		"html": false,
 		"lightBlockWrapper": true,
 		"__experimentalFontSize": true,
-		"__experimentalColor": {
+		"color": {
 			"gradients": true,
-			"linkColor": true
+			"link": true
 		},
 		"__experimentalLineHeight": true
 	}

--- a/packages/block-library/src/post-hierarchical-terms/block.json
+++ b/packages/block-library/src/post-hierarchical-terms/block.json
@@ -17,9 +17,9 @@
 		"html": false,
 		"lightBlockWrapper": true,
 		"__experimentalFontSize": true,
-		"__experimentalColor": {
+		"color": {
 			"gradients": true,
-			"linkColor": true
+			"link": true
 		},
 		"__experimentalLineHeight": true
 	}

--- a/packages/block-library/src/post-tags/block.json
+++ b/packages/block-library/src/post-tags/block.json
@@ -11,9 +11,9 @@
 		"html": false,
 		"lightBlockWrapper": true,
 		"__experimentalFontSize": true,
-		"__experimentalColor": {
+		"color": {
 			"gradients": true,
-			"linkColor": true
+			"link": true
 		},
 		"__experimentalLineHeight": true
 	}

--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -30,7 +30,7 @@
 	"supports": {
 		"html": false,
 		"lightBlockWrapper": true,
-		"__experimentalColor": {
+		"color": {
 			"gradients": true
 		},
 		"__experimentalFontSize": true,

--- a/packages/block-library/src/site-tagline/block.json
+++ b/packages/block-library/src/site-tagline/block.json
@@ -9,7 +9,7 @@
 	"supports": {
 		"html": false,
 		"lightBlockWrapper": true,
-		"__experimentalColor": {
+		"color": {
 			"gradients": true
 		},
 		"__experimentalFontSize": true,

--- a/packages/block-library/src/site-title/block.json
+++ b/packages/block-library/src/site-title/block.json
@@ -13,7 +13,7 @@
 	"supports": {
 		"html": false,
 		"lightBlockWrapper": true,
-		"__experimentalColor": {
+		"color": {
 			"gradients": true
 		},
 		"__experimentalFontSize": true,

--- a/packages/block-library/src/template-part/block.json
+++ b/packages/block-library/src/template-part/block.json
@@ -20,9 +20,9 @@
 		"align": true,
 		"html": false,
 		"lightBlockWrapper": true,
-		"__experimentalColor": {
+		"color": {
 			"gradients": true,
-			"linkColor": true
+			"link": true
 		}
 	}
 }

--- a/packages/edit-navigation/src/index.js
+++ b/packages/edit-navigation/src/index.js
@@ -43,7 +43,7 @@ function removeNavigationBlockSettingsUnsupportedFeatures( settings, name ) {
 			...omit( settings.supports, [
 				'anchor',
 				'customClassName',
-				'__experimentalColor',
+				'color',
 				'__experimentalFontSize',
 			] ),
 			customClassName: false,

--- a/phpunit/class-block-supported-styles-test.php
+++ b/phpunit/class-block-supported-styles-test.php
@@ -143,7 +143,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$block_type_settings = array(
 			'attributes'      => array(),
 			'supports'        => array(
-				'__experimentalColor' => true,
+				'color' => true,
 			),
 			'render_callback' => true,
 		);
@@ -175,7 +175,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$block_type_settings = array(
 			'attributes'      => array(),
 			'supports'        => array(
-				'__experimentalColor' => true,
+				'color' => true,
 			),
 			'render_callback' => true,
 		);
@@ -212,8 +212,8 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$block_type_settings = array(
 			'attributes'      => array(),
 			'supports'        => array(
-				'__experimentalColor' => array(
-					'linkColor' => true,
+				'color' => array(
+					'link' => true,
 				),
 			),
 			'render_callback' => true,
@@ -243,8 +243,8 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$block_type_settings = array(
 			'attributes'      => array(),
 			'supports'        => array(
-				'__experimentalColor' => array(
-					'linkColor' => true,
+				'color' => array(
+					'link' => true,
 				),
 			),
 			'render_callback' => true,
@@ -274,7 +274,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$block_type_settings = array(
 			'attributes'      => array(),
 			'supports'        => array(
-				'__experimentalColor' => array(
+				'color' => array(
 					'gradients' => true,
 				),
 			),
@@ -305,7 +305,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$block_type_settings = array(
 			'attributes'      => array(),
 			'supports'        => array(
-				'__experimentalColor' => array(
+				'color' => array(
 					'gradients' => true,
 				),
 			),
@@ -570,9 +570,9 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$block_type_settings = array(
 			'attributes'      => array(),
 			'supports'        => array(
-				'__experimentalColor'      => array(
+				'color'                    => array(
 					'gradients' => true,
-					'linkColor' => true,
+					'link'      => true,
 				),
 				'__experimentalFontSize'   => true,
 				'__experimentalLineHeight' => true,
@@ -660,9 +660,9 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 			'attributes' => array(),
 			'supports'   => array(
 				'align'                    => true,
-				'__experimentalColor'      => array(
+				'color'                    => array(
 					'gradients' => true,
-					'linkColor' => true,
+					'link'      => true,
 				),
 				'__experimentalFontSize'   => true,
 				'__experimentalLineHeight' => true,


### PR DESCRIPTION
With this PR, third-party block authors using the "light block wrapper" will be able to add colors support with a single line of code to their custom blocks. In follow-up PRs, we'll be stabilizing other support flags too.
I've also renamed "linkColor" key to just "link" to avoid the redunduncy.

link color remains experimental though because it relies on Global styles and still uses an experimental theme flag.