### PR TITLE
Mark the font size support flag as stable

### DIFF
--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -13,7 +13,7 @@
 function gutenberg_register_typography_support( $block_type ) {
 	$has_font_size_support = false;
 	if ( property_exists( $block_type, 'supports' ) ) {
-		$has_font_size_support = gutenberg_experimental_get( $block_type->supports, array( '__experimentalFontSize' ), false );
+		$has_font_size_support = gutenberg_experimental_get( $block_type->supports, array( 'fontSize' ), false );
 	}
 
 	$has_line_height_support = false;
@@ -51,7 +51,7 @@ function gutenberg_register_typography_support( $block_type ) {
 function gutenberg_apply_typography_support( $attributes, $block_attributes, $block_type ) {
 	$has_font_size_support = false;
 	if ( property_exists( $block_type, 'supports' ) ) {
-		$has_font_size_support = gutenberg_experimental_get( $block_type->supports, array( '__experimentalFontSize' ), false );
+		$has_font_size_support = gutenberg_experimental_get( $block_type->supports, array( 'fontSize' ), false );
 	}
 
 	$has_line_height_support = false;

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -485,7 +485,7 @@ function gutenberg_experimental_global_styles_get_block_data() {
 					'supports' => array(
 						'__experimentalSelector' => ':root',
 						'fontSize'               => true,
-						'color'    => array(
+						'color'                  => array(
 							'linkColor' => true,
 							'gradients' => true,
 						),

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -417,11 +417,11 @@ function gutenberg_experimental_global_styles_get_style_property() {
  */
 function gutenberg_experimental_global_styles_get_support_keys() {
 	return array(
-		'--wp--style--color--link' => array( 'color', 'link' ),
+		'--wp--style--color--link' => array( 'color', 'linkColor' ),
 		'background'               => array( 'color', 'gradients' ),
 		'backgroundColor'          => array( 'color' ),
 		'color'                    => array( 'color' ),
-		'fontSize'                 => array( '__experimentalFontSize' ),
+		'fontSize'                 => array( 'fontSize' ),
 		'lineHeight'               => array( '__experimentalLineHeight' ),
 	);
 }
@@ -484,9 +484,9 @@ function gutenberg_experimental_global_styles_get_block_data() {
 				array(
 					'supports' => array(
 						'__experimentalSelector' => ':root',
-						'__experimentalFontSize' => true,
-						'color'                  => array(
-							'link'      => true,
+						'fontSize'               => true,
+						'color'    => array(
+							'linkColor' => true,
 							'gradients' => true,
 						),
 					),

--- a/packages/block-editor/src/hooks/font-size.js
+++ b/packages/block-editor/src/hooks/font-size.js
@@ -18,7 +18,7 @@ import {
 import { cleanEmptyObject } from './utils';
 import useEditorFeature from '../components/use-editor-feature';
 
-export const FONT_SIZE_SUPPORT_KEY = '__experimentalFontSize';
+export const FONT_SIZE_SUPPORT_KEY = 'fontSize';
 
 /**
  * Filters registered block settings, extending attributes to include

--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -26,7 +26,7 @@
 		"color": {
 			"link": true
 		},
-		"__experimentalFontSize": true,
+		"fontSize": true,
 		"__experimentalLineHeight": true,
 		"__experimentalSelector": {
 			"core/heading/h1": "h1",

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -49,7 +49,7 @@
 		"html": false,
 		"inserter": true,
 		"lightBlockWrapper": true,
-		"__experimentalFontSize": true,
+		"fontSize": true,
 		"color": {
 			"textColor": true,
 			"backgroundColor": true

--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -33,7 +33,7 @@
 		"color": {
 			"link": true
 		},
-		"__experimentalFontSize": true,
+		"fontSize": true,
 		"__experimentalLineHeight": true,
 		"__experimentalSelector": "p",
 		"__unstablePasteTextInline": true

--- a/packages/block-library/src/post-author/block.json
+++ b/packages/block-library/src/post-author/block.json
@@ -27,7 +27,7 @@
 	"supports": {
 		"html": false,
 		"lightBlockWrapper": true,
-		"__experimentalFontSize": true,
+		"fontSize": true,
 		"color": {
 			"gradients": true,
 			"link": true

--- a/packages/block-library/src/post-comments-count/block.json
+++ b/packages/block-library/src/post-comments-count/block.json
@@ -15,7 +15,7 @@
 		"color": {
 			"gradients": true
 		},
-		"__experimentalFontSize": true,
+		"fontSize": true,
 		"__experimentalLineHeight": true
 	}
 }

--- a/packages/block-library/src/post-comments-form/block.json
+++ b/packages/block-library/src/post-comments-form/block.json
@@ -17,7 +17,7 @@
 			"gradients": true,
 			"link": true
 		},
-		"__experimentalFontSize": true,
+		"fontSize": true,
 		"__experimentalLineHeight": true
 	}
 }

--- a/packages/block-library/src/post-comments/block.json
+++ b/packages/block-library/src/post-comments/block.json
@@ -17,7 +17,7 @@
 			"wide",
 			"full"
 		],
-		"__experimentalFontSize": true,
+		"fontSize": true,
 		"color": {
 			"gradients": true,
 			"link": true

--- a/packages/block-library/src/post-date/block.json
+++ b/packages/block-library/src/post-date/block.json
@@ -19,7 +19,7 @@
 		"color": {
 			"gradients": true
 		},
-		"__experimentalFontSize": true,
+		"fontSize": true,
 		"__experimentalLineHeight": true
 	}
 }

--- a/packages/block-library/src/post-excerpt/block.json
+++ b/packages/block-library/src/post-excerpt/block.json
@@ -24,7 +24,7 @@
 	"supports": {
 		"html": false,
 		"lightBlockWrapper": true,
-		"__experimentalFontSize": true,
+		"fontSize": true,
 		"color": {
 			"gradients": true,
 			"link": true

--- a/packages/block-library/src/post-hierarchical-terms/block.json
+++ b/packages/block-library/src/post-hierarchical-terms/block.json
@@ -16,7 +16,7 @@
 	"supports": {
 		"html": false,
 		"lightBlockWrapper": true,
-		"__experimentalFontSize": true,
+		"fontSize": true,
 		"color": {
 			"gradients": true,
 			"link": true

--- a/packages/block-library/src/post-tags/block.json
+++ b/packages/block-library/src/post-tags/block.json
@@ -10,7 +10,7 @@
 	"supports": {
 		"html": false,
 		"lightBlockWrapper": true,
-		"__experimentalFontSize": true,
+		"fontSize": true,
 		"color": {
 			"gradients": true,
 			"link": true

--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -33,7 +33,7 @@
 		"color": {
 			"gradients": true
 		},
-		"__experimentalFontSize": true,
+		"fontSize": true,
 		"__experimentalLineHeight": true,
 		"__experimentalSelector": {
 			"core/post-title/h1": "h1",

--- a/packages/block-library/src/site-tagline/block.json
+++ b/packages/block-library/src/site-tagline/block.json
@@ -12,7 +12,7 @@
 		"color": {
 			"gradients": true
 		},
-		"__experimentalFontSize": true,
+		"fontSize": true,
 		"__experimentalLineHeight": true
 	}
 }

--- a/packages/block-library/src/site-title/block.json
+++ b/packages/block-library/src/site-title/block.json
@@ -16,7 +16,7 @@
 		"color": {
 			"gradients": true
 		},
-		"__experimentalFontSize": true,
+		"fontSize": true,
 		"__experimentalLineHeight": true
 	}
 }

--- a/packages/edit-navigation/src/index.js
+++ b/packages/edit-navigation/src/index.js
@@ -44,7 +44,7 @@ function removeNavigationBlockSettingsUnsupportedFeatures( settings, name ) {
 				'anchor',
 				'customClassName',
 				'color',
-				'__experimentalFontSize',
+				'fontSize',
 			] ),
 			customClassName: false,
 		},

--- a/phpunit/class-block-supported-styles-test.php
+++ b/phpunit/class-block-supported-styles-test.php
@@ -372,7 +372,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$block_type_settings = array(
 			'attributes'      => array(),
 			'supports'        => array(
-				'__experimentalFontSize' => true,
+				'fontSize' => true,
 			),
 			'render_callback' => true,
 		);
@@ -401,7 +401,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$block_type_settings = array(
 			'attributes'      => array(),
 			'supports'        => array(
-				'__experimentalFontSize' => true,
+				'fontSize' => true,
 			),
 			'render_callback' => true,
 		);
@@ -574,7 +574,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 					'gradients' => true,
 					'link'      => true,
 				),
-				'__experimentalFontSize'   => true,
+				'fontSize'                 => true,
 				'__experimentalLineHeight' => true,
 				'align'                    => true,
 			),
@@ -618,7 +618,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$block_type_settings = array(
 			'attributes'      => array(),
 			'supports'        => array(
-				'__experimentalFontSize' => true,
+				'fontSize' => true,
 			),
 			'render_callback' => true,
 		);
@@ -664,7 +664,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 					'gradients' => true,
 					'link'      => true,
 				),
-				'__experimentalFontSize'   => true,
+				'fontSize'                 => true,
 				'__experimentalLineHeight' => true,
 			),
 		);


### PR DESCRIPTION
Similar to #25694 

With this PR, third-party block authors using the "light block wrapper" will be able to add font-size support with a single line of code to their custom blocks.
