### PR TITLE
Add EditorStyles CSS to the widgets editor

### DIFF
--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -77,7 +77,11 @@ function gutenberg_widgets_init( $hook ) {
 		gutenberg_get_legacy_widget_settings()
 	);
 
-	$settings = apply_filters( 'block_editor_settings', $settings, null );
+	// This purposefully does not rely on apply_filters( 'block_editor_settings', $settings, null );
+	// Applying that filter would bring over multitude of features from the post editor, some of which
+	// may be undesirable. Instead of using that filter, we simply pick just the settings that are needed.
+	$settings = gutenberg_experimental_global_styles_settings( $settings );
+	$settings = gutenberg_extend_block_editor_styles( $settings );
 
 	wp_add_inline_script(
 		'wp-edit-widgets',

--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -77,7 +77,7 @@ function gutenberg_widgets_init( $hook ) {
 		gutenberg_get_legacy_widget_settings()
 	);
 
-	$settings = gutenberg_experimental_global_styles_settings( $settings );
+	$settings = apply_filters( 'block_editor_settings', $settings, null );
 
 	wp_add_inline_script(
 		'wp-edit-widgets',

--- a/packages/edit-widgets/src/blocks/legacy-widget/editor.scss
+++ b/packages/edit-widgets/src/blocks/legacy-widget/editor.scss
@@ -3,6 +3,7 @@
 		border: none;
 		display: block;
 		box-shadow: none;
+		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	}
 	// Reset z-index set on https://github.com/WordPress/wordpress-develop/commit/f26d4d37351a55fd1fc5dad0f5fef8f0f964908c.
 	.widget.open {

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
@@ -17,6 +17,7 @@ import { useMemo } from '@wordpress/element';
 import {
 	BlockEditorProvider,
 	BlockEditorKeyboardShortcuts,
+	__unstableEditorStyles as EditorStyles,
 } from '@wordpress/block-editor';
 
 /**
@@ -64,6 +65,7 @@ export default function WidgetAreasBlockEditorProvider( {
 
 	return (
 		<>
+			<EditorStyles styles={ settings.styles } />
 			<BlockEditorKeyboardShortcuts.Register />
 			<KeyboardShortcuts.Register />
 			<SlotFillProvider>


### PR DESCRIPTION
## Description

Solves #17391 by using the same `<EditorStyles />` as in the post editor.

## How has this been tested?

1. Go to widgets editor.
1. Add a list.
1. Confirm it's rendered in the same way as in the post editor (think margins, list marker).

## Screenshots <!-- if applicable -->

<img width="693" alt="Zrzut ekranu 2020-09-29 o 13 52 09" src="https://user-images.githubusercontent.com/205419/94554863-fbd0a800-025a-11eb-8e6d-ca21590ac0f2.png">

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
