### PR TITLE
RichText: remove native props for web

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -106,7 +106,6 @@ function RichTextWrapper(
 		multiline,
 		inlineToolbar,
 		wrapperClassName,
-		className,
 		autocompleters,
 		onReplace,
 		placeholder,
@@ -120,10 +119,6 @@ function RichTextWrapper(
 		__unstableOnSplitAtEnd: onSplitAtEnd,
 		__unstableOnSplitMiddle: onSplitMiddle,
 		identifier,
-		// To do: find a better way to implicitly inherit props.
-		start: startAttr,
-		reversed,
-		style,
 		preserveWhiteSpace,
 		__unstableEmbedURLOnPaste,
 		__unstableDisableFormats: disableFormats,
@@ -557,9 +552,6 @@ function RichTextWrapper(
 			selectionEnd={ selectionEnd }
 			onSelectionChange={ onSelectionChange }
 			tagName={ tagName }
-			className={ classnames( classes, className, {
-				'keep-placeholder-on-focus': keepPlaceholderOnFocus,
-			} ) }
 			placeholder={ placeholder }
 			allowedFormats={ adjustedAllowedFormats }
 			withoutInteractiveFormatting={ withoutInteractiveFormatting }
@@ -577,11 +569,8 @@ function RichTextWrapper(
 			__unstableDidAutomaticChange={ didAutomaticChange }
 			__unstableUndo={ undo }
 			__unstableDisableFormats={ disableFormats }
-			style={ style }
 			preserveWhiteSpace={ preserveWhiteSpace }
 			disabled={ disabled }
-			start={ startAttr }
-			reversed={ reversed }
 			unstableOnFocus={ unstableOnFocus }
 			__unstableAllowPrefixTransformations={
 				__unstableAllowPrefixTransformations
@@ -614,6 +603,7 @@ function RichTextWrapper(
 			// Destructuring the id prop before { ...props } doesn't work
 			// correctly on web https://github.com/WordPress/gutenberg/pull/25624
 			id={ props.id }
+			style={ props.style }
 		>
 			{ ( {
 				isSelected: nestedIsSelected,
@@ -643,13 +633,27 @@ function RichTextWrapper(
 							<TagName
 								{ ...editableProps }
 								{ ...props }
+								style={
+									props.style
+										? {
+												...props.style,
+												...editableProps.style,
+										  }
+										: editableProps.style
+								}
+								className={ classnames(
+									classes,
+									props.className,
+									editableProps.className,
+									{
+										'keep-placeholder-on-focus': keepPlaceholderOnFocus,
+									}
+								) }
 								aria-autocomplete={
 									listBoxId ? 'list' : undefined
 								}
 								aria-owns={ listBoxId }
 								aria-activedescendant={ activeId }
-								start={ startAttr }
-								reversed={ reversed }
 								onKeyDown={ ( event ) => {
 									onKeyDown( event );
 									editableProps.onKeyDown( event );

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -600,8 +600,9 @@ function RichTextWrapper(
 			maxWidth={ maxWidth }
 			onBlur={ onBlur }
 			setRef={ setRef }
-			// Destructuring the id prop before { ...props } doesn't work
-			// correctly on web https://github.com/WordPress/gutenberg/pull/25624
+			// Props to be set on the editable container are destructured on the
+			// element itself for web (see below), but passed through rich text
+			// for native.
 			id={ props.id }
 			style={ props.style }
 		>

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import classnames from 'classnames';
 import { find, isNil } from 'lodash';
 
 /**
@@ -139,8 +138,6 @@ function RichText(
 		children,
 		allowedFormats,
 		withoutInteractiveFormatting,
-		style,
-		className,
 		placeholder,
 		disabled,
 		preserveWhiteSpace,
@@ -168,7 +165,6 @@ function RichText(
 		__unstableOnExitFormattedText: onExitFormattedText,
 		__unstableOnCreateUndoLevel: onCreateUndoLevel,
 		__unstableIsSelected: isSelected,
-		...remainingProps
 	},
 	ref
 ) {
@@ -1103,10 +1099,9 @@ function RichText(
 		role: 'textbox',
 		'aria-multiline': true,
 		'aria-label': placeholder,
-		...remainingProps,
 		ref,
-		style: style ? { ...style, whiteSpace } : defaultStyle,
-		className: classnames( 'rich-text', className ),
+		style: defaultStyle,
+		className: 'rich-text',
 		onPaste: handlePaste,
 		onInput: handleInput,
 		onCompositionStart: handleCompositionStart,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

These props are eventually passed down to the container element, which causes a bunch or error to be logged. They should only be passed down in native context.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
