### PR TITLE
UnitControl: Enable keyboard access (via tab) to unit select by default

### DIFF
--- a/packages/components/src/unit-control/index.js
+++ b/packages/components/src/unit-control/index.js
@@ -30,7 +30,7 @@ function UnitControl(
 		disableUnits = false,
 		isPressEnterToChange = false,
 		isResetValueOnUnitChange = false,
-		isUnitSelectTabbable = false,
+		isUnitSelectTabbable = true,
 		label,
 		onChange = noop,
 		onUnitChange = noop,


### PR DESCRIPTION
This update ensures the unit `select` element within `UnitControl` is keyboard accessible by default.
The solution was to adjust the default setting for the component via the `isUnitSelectTabbable` prop.

![Screen Capture on 2020-09-29 at 10-19-52](https://user-images.githubusercontent.com/2322354/94571210-b9e53900-023d-11eb-8274-dbb9fbf90fef.gif)

(GIF above demonstrates keyboard tabbing through elements, including the unit `select`)

Resolves: https://github.com/WordPress/gutenberg/issues/25703



## How has this been tested?

Local Gutenberg

* `npm run dev`
* Add a Cover block
* Click on the Height control
* Press <kbd>Tab</kbd>. Ensure that you the unit `select` can be accessed.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [n/a] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [n/a] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [n/a] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
