### PR TITLE
Update Block Based Themes Documentation

### DIFF
--- a/docs/designers-developers/developers/themes/block-based-themes.md
+++ b/docs/designers-developers/developers/themes/block-based-themes.md
@@ -17,6 +17,7 @@ A very simple block-based theme is structured like so:
 ```
 theme
 |__ style.css
+|__ experimental-theme.json
 |__ functions.php
 |__ block-templates
     |__ index.html
@@ -30,7 +31,7 @@ theme
     |__ ...
 ```
 
-The difference with existing WordPress themes is that the different templates in the template hierarchy, and template parts, are block templates instead of php files.
+The difference with existing WordPress themes is that the different templates in the template hierarchy, and template parts, are block templates instead of php files. In addition, this example includes an [`experimental-theme.json`](/docs/designers-developers/developers/themes/theme-json.md) file for some styles.  
 
 ## What is a block template?
 
@@ -111,17 +112,21 @@ As we're still early in the process, the number of blocks specifically dedicated
 - Post Title
 - Post Content
 - Post Author
+- Post Comment
+- Post Comment Author
+- Post Comment Date
 - Post Comments
-- Post CommentsCount
-- Post CommentsForm
+- Post Comments Count
+- Post Comments Form
 - Post Date
 - Post Excerpt
 - Post Featured Image
+- Post Hierarchical Terms
 - Post Tags
 
 ## Styling
 
-One of the most important aspects of themes (if not the most important) is the styling. While initially you'll be able to provide styles and enqueue them using the same hooks themes have always used, this is an area that is still [being explored](https://github.com/WordPress/gutenberg/issues/9534).
+One of the most important aspects of themes (if not the most important) is the styling. While initially you'll be able to provide styles and enqueue them using the same hooks themes have always used, the [Global Styles](/docs/designers-developers/developers/themes/theme-json.md) effort will provide a scaffolding for adding many theme styles in the future. 
 
 ## Resources
 


### PR DESCRIPTION
This PR includes a few small updates to the block based themes documentation: 

 - It updates the list of site building blocks, as per [the list in `block-library/src/index.js`](https://github.com/WordPress/gutenberg/blob/e8bf6264452010b040e66ab30dc3f9eebf79789a/packages/block-library/src/index.js#L199-L220).
- It adds a `experimental-theme.json` file to the file list for the example block-based theme. 
- It updates the "Styling" section so that it links to the recently(ish)-added [theme-json](https://github.com/WordPress/gutenberg/blob/d5c7950990a2cc28b2d3fe4ddbe4e7e5655e957e/docs/designers-developers/developers/themes/theme-json.md) documentation.

(I should also note that I noticed this page is missing from the handbook for some reason. I thought maybe it needed an updated `manifest.json`, but running `npm run docs:build` came back with no changes. 🤔 I filed an issue here: #25707). 