### PR TITLE
Add color palette edit functionality to global styles

### DIFF
--- a/packages/components/src/color-edit/index.js
+++ b/packages/components/src/color-edit/index.js
@@ -37,7 +37,7 @@ function ColorOption( {
 	onChange,
 	onRemove,
 	onConfirm,
-	confirmLabel = __( 'Ok' ),
+	confirmLabel = __( 'OK' ),
 	isEditingNameOnMount = false,
 	isEditingColorOnMount = false,
 	onCancel,

--- a/packages/components/src/color-edit/index.js
+++ b/packages/components/src/color-edit/index.js
@@ -222,7 +222,7 @@ function ColorInserter( { onInsert, onCancel } ) {
 	);
 }
 
-export default function ColorEdit( { colors = [], onChange } ) {
+export default function ColorEdit( { colors, onChange, emptyUI } ) {
 	const [ isInsertingColor, setIsInsertingColor ] = useState( false );
 	return (
 		<BaseControl>
@@ -246,54 +246,61 @@ export default function ColorEdit( { colors = [], onChange } ) {
 					) }
 				</div>
 				<div>
-					{ colors.map( ( color, index ) => {
-						return (
-							<ColorOption
-								key={ index }
-								color={ color.color }
-								name={ color.name }
-								slug={ color.slug }
-								onChange={ ( newColor ) => {
-									onChange(
-										colors.map(
-											( currentColor, currentIndex ) => {
-												if ( currentIndex === index ) {
-													return newColor;
+					{ ! isEmpty( colors ) &&
+						colors.map( ( color, index ) => {
+							return (
+								<ColorOption
+									key={ index }
+									color={ color.color }
+									name={ color.name }
+									slug={ color.slug }
+									onChange={ ( newColor ) => {
+										onChange(
+											colors.map(
+												(
+													currentColor,
+													currentIndex
+												) => {
+													if (
+														currentIndex === index
+													) {
+														return newColor;
+													}
+													return currentColor;
 												}
-												return currentColor;
-											}
-										)
-									);
-								} }
-								onRemove={ () => {
-									onChange(
-										colors.filter(
-											( _currentColor, currentIndex ) => {
-												if ( currentIndex === index ) {
-													return false;
+											)
+										);
+									} }
+									onRemove={ () => {
+										onChange(
+											colors.filter(
+												(
+													_currentColor,
+													currentIndex
+												) => {
+													if (
+														currentIndex === index
+													) {
+														return false;
+													}
+													return true;
 												}
-												return true;
-											}
-										)
-									);
-								} }
-							/>
-						);
-					} ) }
-					{ ! isInsertingColor &&
-						isEmpty( colors ) &&
-						__(
-							'There are no user-defined colors. Add some colors and create your palette!'
-						) }
+											)
+										);
+									} }
+								/>
+							);
+						} ) }
 					{ isInsertingColor && (
 						<ColorInserter
 							onInsert={ ( newColor ) => {
 								setIsInsertingColor( false );
-								onChange( [ ...colors, newColor ] );
+								onChange( [ ...( colors || [] ), newColor ] );
 							} }
 							onCancel={ () => setIsInsertingColor( false ) }
 						/>
 					) }
+					{ ! isInsertingColor && isEmpty( colors ) && emptyUI }
 				</div>
 			</fieldset>
 		</BaseControl>

--- a/packages/components/src/color-edit/index.js
+++ b/packages/components/src/color-edit/index.js
@@ -1,0 +1,301 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { isEmpty, kebabCase } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { useEffect, useState } from '@wordpress/element';
+import { edit, close, chevronDown, chevronUp, plus } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import Dropdown from '../dropdown';
+import CircularOptionPicker from '../circular-option-picker';
+import ColorPicker from '../color-picker';
+import Button from '../button';
+import TextControl from '../text-control';
+import BaseControl from '../base-control';
+
+function DropdownOpenOnMount( { shouldOpen, isOpen, onToggle } ) {
+	useEffect( () => {
+		if ( shouldOpen && ! isOpen ) {
+			onToggle();
+		}
+	}, [] );
+	return null;
+}
+
+function ColorOption( {
+	color,
+	name,
+	slug,
+	onChange,
+	onRemove,
+	onConfirm,
+	confirmLabel = __( 'Ok' ),
+	isEditingNameOnMount = false,
+	isEditingColorOnMount = false,
+	onCancel,
+} ) {
+	const [ isHover, setIsHover ] = useState( false );
+	const [ isFocused, setIsFocused ] = useState( false );
+	const [ isEditingName, setIsEditingName ] = useState(
+		isEditingNameOnMount
+	);
+	const [ isShowingAdvancedPanel, setIsShowingAdvancedPanel ] = useState(
+		false
+	);
+
+	const isShowingControls =
+		isHover || isFocused || isEditingName || isShowingAdvancedPanel;
+
+	return (
+		<div
+			tabIndex={ 0 }
+			className={ classnames( 'components-color-edit__color-option', {
+				'is-hover':
+					isHover && ! isEditingName && ! isShowingAdvancedPanel,
+			} ) }
+			onMouseEnter={ () => setIsHover( true ) }
+			onMouseLeave={ () => setIsHover( false ) }
+			onFocus={ () => setIsFocused( true ) }
+			onBlur={ () => setIsFocused( false ) }
+			aria-label={
+				name
+					? // translators: %s: The name of the color e.g: "vivid red".
+					  sprintf( __( 'Color: %s' ), name )
+					: // translators: %s: color hex code e.g: "#f00".
+					  sprintf( __( 'Color code: %s' ), color )
+			}
+		>
+			<div className="components-color-edit__color-option-main-area">
+				<Dropdown
+					renderToggle={ ( { isOpen, onToggle } ) => (
+						<>
+							<DropdownOpenOnMount
+								shouldOpen={ isEditingColorOnMount }
+								isOpen={ isOpen }
+								onToggle={ onToggle }
+							/>
+							<CircularOptionPicker.Option
+								style={ { backgroundColor: color, color } }
+								aria-expanded={ isOpen }
+								aria-haspopup="true"
+								onClick={ onToggle }
+								aria-label={ __( 'Edit color value' ) }
+							/>
+						</>
+					) }
+					renderContent={ () => (
+						<ColorPicker
+							color={ color }
+							onChangeComplete={ ( newColor ) =>
+								onChange( {
+									color: newColor.hex,
+									slug,
+									name,
+								} )
+							}
+							disableAlpha
+						/>
+					) }
+				/>
+				{ ! isEditingName && (
+					<div className="components-color-edit__color-option-color-name">
+						{ name }
+					</div>
+				) }
+				{ isEditingName && (
+					<>
+						<TextControl
+							className="components-color-edit__color-option-color-name-input"
+							hideLabelFromVision
+							onChange={ ( newColorName ) =>
+								onChange( {
+									color,
+									slug: kebabCase( newColorName ),
+									name: newColorName,
+								} )
+							}
+							label={ __( 'Color name' ) }
+							placeholder={ __( 'Name' ) }
+							value={ name }
+						/>
+						<Button
+							onClick={ () => {
+								setIsEditingName( false );
+								setIsFocused( false );
+								if ( onConfirm ) {
+									onConfirm();
+								}
+							} }
+							isPrimary
+						>
+							{ confirmLabel }
+						</Button>
+					</>
+				) }
+				{ ! isEditingName && (
+					<>
+						<Button
+							className={ classnames( {
+								'components-color-edit__hidden-control': ! isShowingControls,
+							} ) }
+							icon={ edit }
+							label={ __( 'Edit color name' ) }
+							onClick={ () => setIsEditingName( true ) }
+						/>
+						<Button
+							className={ classnames( {
+								'components-color-edit__hidden-control': ! isShowingControls,
+							} ) }
+							icon={ close }
+							label={ __( 'Remove color' ) }
+							onClick={ onRemove }
+						/>
+					</>
+				) }
+				<Button
+					className={ classnames( {
+						'components-color-edit__hidden-control': ! isShowingControls,
+					} ) }
+					icon={ isShowingAdvancedPanel ? chevronUp : chevronDown }
+					label={ __( 'Additional color settings' ) }
+					onClick={ () => {
+						if ( isShowingAdvancedPanel ) {
+							setIsFocused( false );
+						}
+						setIsShowingAdvancedPanel( ! isShowingAdvancedPanel );
+					} }
+					aria-expanded={ isShowingAdvancedPanel }
+				/>
+			</div>
+			{ onCancel && (
+				<Button
+					className="components-color-edit__cancel-button"
+					onClick={ onCancel }
+				>
+					{ __( 'Cancel' ) }
+				</Button>
+			) }
+			{ isShowingAdvancedPanel && (
+				<TextControl
+					className="components-color-edit__slug-input"
+					onChange={ ( newSlug ) =>
+						onChange( {
+							color,
+							slug: newSlug,
+							name,
+						} )
+					}
+					label={ __( 'Slug' ) }
+					value={ slug }
+				/>
+			) }
+		</div>
+	);
+}
+
+function ColorInserter( { onInsert, onCancel } ) {
+	const [ color, setColor ] = useState( {
+		color: '#fff',
+		name: '',
+		slug: '',
+	} );
+	return (
+		<ColorOption
+			color={ color.color }
+			name={ color.name }
+			slug={ color.slug }
+			onChange={ setColor }
+			confirmLabel={ __( 'Save' ) }
+			onConfirm={ () => onInsert( color ) }
+			isEditingNameOnMount
+			isEditingColorOnMount
+			onCancel={ onCancel }
+		/>
+	);
+}
+
+export default function ColorEdit( { colors = [], onChange } ) {
+	const [ isInsertingColor, setIsInsertingColor ] = useState( false );
+	return (
+		<BaseControl>
+			<fieldset>
+				<div className="components-color-edit__label-and-insert-container">
+					<legend>
+						<div>
+							<BaseControl.VisualLabel>
+								{ __( 'Color palette' ) }
+							</BaseControl.VisualLabel>
+						</div>
+					</legend>
+					{ ! isInsertingColor && (
+						<Button
+							onClick={ () => {
+								setIsInsertingColor( true );
+							} }
+							className="components-color-edit__insert-button"
+							icon={ plus }
+						/>
+					) }
+				</div>
+				<div>
+					{ colors.map( ( color, index ) => {
+						return (
+							<ColorOption
+								key={ index }
+								color={ color.color }
+								name={ color.name }
+								slug={ color.slug }
+								onChange={ ( newColor ) => {
+									onChange(
+										colors.map(
+											( currentColor, currentIndex ) => {
+												if ( currentIndex === index ) {
+													return newColor;
+												}
+												return currentColor;
+											}
+										)
+									);
+								} }
+								onRemove={ () => {
+									onChange(
+										colors.filter(
+											( _currentColor, currentIndex ) => {
+												if ( currentIndex === index ) {
+													return false;
+												}
+												return true;
+											}
+										)
+									);
+								} }
+							/>
+						);
+					} ) }
+					{ ! isInsertingColor &&
+						isEmpty( colors ) &&
+						__(
+							'There are no user-defined colors. Add some colors and create your palette!'
+						) }
+					{ isInsertingColor && (
+						<ColorInserter
+							onInsert={ ( newColor ) => {
+								setIsInsertingColor( false );
+								onChange( [ ...colors, newColor ] );
+							} }
+							onCancel={ () => setIsInsertingColor( false ) }
+						/>
+					) }
+				</div>
+			</fieldset>
+		</BaseControl>
+	);
+}

--- a/packages/components/src/color-edit/style.scss
+++ b/packages/components/src/color-edit/style.scss
@@ -1,0 +1,42 @@
+.components-color-edit__color-option-main-area {
+	display: flex;
+	align-items: center;
+	.components-circular-option-picker__option-wrapper {
+		margin: $grid-unit-10;
+	}
+}
+
+.components-color-edit__color-option.is-hover {
+	background: $gray-200;
+}
+
+.components-color-edit__cancel-button {
+	float: right;
+}
+
+.components-color-edit__color-option-color-name {
+	width: 100%;
+}
+.components-color-edit__label-and-insert-container {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+}
+
+.components-color-edit__insert-button {
+	margin-top: -$grid-unit-10;
+}
+
+.components-color-edit__hidden-control {
+	position: relative;
+	left: -9999px;
+}
+
+.components-color-edit__color-option-color-name-input .components-base-control__field {
+	margin-bottom: 0;
+	margin-right: $grid-unit-10;
+}
+
+.components-color-edit__slug-input {
+	margin-left: $grid-unit-10;
+}

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -27,6 +27,7 @@ export { default as CardHeader } from './card/header';
 export { default as CardMedia } from './card/media';
 export { default as CheckboxControl } from './checkbox-control';
 export { default as ClipboardButton } from './clipboard-button';
+export { default as __experimentalColorEdit } from './color-edit';
 export { default as ColorIndicator } from './color-indicator';
 export { default as ColorPalette } from './color-palette';
 export { default as ColorPicker } from './color-picker';

--- a/packages/components/src/style.scss
+++ b/packages/components/src/style.scss
@@ -5,6 +5,7 @@
 @import "./button/style.scss";
 @import "./checkbox-control/style.scss";
 @import "./circular-option-picker/style.scss";
+@import "./color-edit/style.scss";
 @import "./color-indicator/style.scss";
 @import "./color-picker/style.scss";
 @import "./combobox-control/style.scss";

--- a/packages/edit-site/src/components/editor/global-styles-provider.js
+++ b/packages/edit-site/src/components/editor/global-styles-provider.js
@@ -25,6 +25,8 @@ const EMPTY_CONTENT = '{}';
 
 const GlobalStylesContext = createContext( {
 	/* eslint-disable no-unused-vars */
+	getSetting: ( context, path ) => {},
+	setSetting: ( context, path, newValue ) => {},
 	getStyleProperty: ( context, propertyName ) => {},
 	setStyleProperty: ( context, propertyName, newValue ) => {},
 	globalContext: {},
@@ -57,6 +59,18 @@ export default ( { children, baseStyles, contexts } ) => {
 	const nextValue = useMemo(
 		() => ( {
 			contexts,
+			getSetting: ( context, path ) =>
+				get( userStyles?.[ context ]?.settings, path ),
+			setSetting: ( context, path, newValue ) => {
+				const newContent = { ...userStyles };
+				let contextSettings = newContent?.[ context ]?.settings;
+				if ( ! contextSettings ) {
+					contextSettings = {};
+					set( newContent, [ context, 'settings' ], contextSettings );
+				}
+				set( contextSettings, path, newValue );
+				setContent( JSON.stringify( newContent ) );
+			},
 			getStyleProperty: ( context, propertyName ) =>
 				get(
 					userStyles?.[ context ]?.styles,

--- a/packages/edit-site/src/components/sidebar/color-palette-panel.js
+++ b/packages/edit-site/src/components/sidebar/color-palette-panel.js
@@ -1,0 +1,18 @@
+/**
+ * WordPress dependencies
+ */
+import { __experimentalColorEdit as ColorEdit } from '@wordpress/components';
+
+const EMPTY_ARRAY = [];
+
+export default ( { contextName, getSetting, setSetting } ) => {
+	const colors = getSetting( contextName, 'color.palette' ) || EMPTY_ARRAY;
+	return (
+		<ColorEdit
+			colors={ colors }
+			onChange={ ( newColors ) => {
+				setSetting( contextName, 'color.palette', newColors );
+			} }
+		/>
+	);
+};

--- a/packages/edit-site/src/components/sidebar/color-palette-panel.js
+++ b/packages/edit-site/src/components/sidebar/color-palette-panel.js
@@ -1,18 +1,40 @@
 /**
  * WordPress dependencies
  */
-import { __experimentalColorEdit as ColorEdit } from '@wordpress/components';
-
-const EMPTY_ARRAY = [];
+import {
+	Button,
+	__experimentalColorEdit as ColorEdit,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
 export default ( { contextName, getSetting, setSetting } ) => {
-	const colors = getSetting( contextName, 'color.palette' ) || EMPTY_ARRAY;
+	const colors = getSetting( contextName, 'color.palette' );
+	let emptyUI;
+	if ( colors === undefined ) {
+		emptyUI = __(
+			'Using theme or core default colors. Add some colors to create your own color palette instead.'
+		);
+	} else if ( colors && colors.length === 0 ) {
+		emptyUI = (
+			<>
+				<p>{ __( 'Using an empty color palette.' ) }</p>
+				<Button
+					isSmall
+					isSecondary
+					onClick={ () => setSetting( contextName, 'color.palette' ) }
+				>
+					{ __( 'Reset to theme/core defaults' ) }
+				</Button>
+			</>
+		);
+	}
 	return (
 		<ColorEdit
 			colors={ colors }
 			onChange={ ( newColors ) => {
 				setSetting( contextName, 'color.palette', newColors );
 			} }
+			emptyUI={ emptyUI }
 		/>
 	);
 };

--- a/packages/edit-site/src/components/sidebar/color-panel.js
+++ b/packages/edit-site/src/components/sidebar/color-panel.js
@@ -8,11 +8,14 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { LINK_COLOR } from '../editor/utils';
+import ColorPalettePanel from './color-palette-panel';
 
 export default ( {
 	context: { supports, name },
 	getStyleProperty,
 	setStyleProperty,
+	getSetting,
+	setSetting,
 } ) => {
 	if (
 		! supports.includes( 'color' ) &&
@@ -76,6 +79,13 @@ export default ( {
 		<PanelColorGradientSettings
 			title={ __( 'Color' ) }
 			settings={ settings }
-		/>
+		>
+			<ColorPalettePanel
+				key={ 'color-palette-panel-' + name }
+				contextName={ name }
+				getSetting={ getSetting }
+				setSetting={ setSetting }
+			/>
+		</PanelColorGradientSettings>
 	);
 };

--- a/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
@@ -27,6 +27,8 @@ export default ( { identifier, title, icon, closeLabel } ) => {
 		contexts,
 		getStyleProperty,
 		setStyleProperty,
+		getSetting,
+		setSetting,
 	} = useGlobalStylesContext();
 	const [ canRestart, onReset ] = useGlobalStylesReset();
 
@@ -131,6 +133,8 @@ export default ( { identifier, title, icon, closeLabel } ) => {
 												setStyleProperty={
 													setStyleProperty
 												}
+												getSetting={ getSetting }
+												setSetting={ setSetting }
 											/>,
 										].filter( Boolean ) }
 									</PanelBody>
@@ -159,6 +163,8 @@ export default ( { identifier, title, icon, closeLabel } ) => {
 							} }
 							getStyleProperty={ getStyleProperty }
 							setStyleProperty={ setStyleProperty }
+							getSetting={ getSetting }
+							setSetting={ setSetting }
 						/>,
 					].filter( Boolean );
 				} }


### PR DESCRIPTION
This PR allows the user to configure a global color palette or even a color palette for a specific block.


## Limitations
- The colors created by the user don't work well when applied, that happens because we are not automatically generating CSS classes for theme.json yet and rely on themes providing them. There will be a parallel PR that fixes that.
- We don't show the default colors applied by the theme. That happens because we don't yet retrieve the theme and core defaults on global styles, e.g: if the theme sets a default font size the global styles sidebar does not show it. That is an existing issue with global styles that is going to be solved in parallel.
- When we change the color palette, and then go the block editor on the edit site, the new colors don't appear, they only appear after the saving and reload of the editor. That happens because the settings passed to the block editor are a static object retrieved from the server, it should be dynamic as the user can now change these settings. Another PR will solve this issue.
- The UI may take advantage of some enhancements. @noahshrader  I tried to follow your mockups adapting them to the current state of the sidebar, but it still required lots of custom code because we did not have any component that fits. I am open to feedback for changes that should happen on the first version.


## Screenshots <!-- if applicable -->

![image](https://user-images.githubusercontent.com/11271197/94588670-1d8e5700-027c-11eb-959a-7d263054fb5a.png)

![image](https://user-images.githubusercontent.com/11271197/94588691-2bdc7300-027c-11eb-8adc-71c0b6a8199c.png)

![image](https://user-images.githubusercontent.com/11271197/94588984-9a213580-027c-11eb-8bca-f16faab35386.png)


## Tests
I added a custom color palette I saved the design and verified the colors were persisted.
I verified I could change the color code, name, and slug of existing colors.
I verified I could remove colors.
