### PR TITLE
Define text color for warning message component

### DIFF
--- a/packages/block-editor/src/components/warning/style.scss
+++ b/packages/block-editor/src/components/warning/style.scss
@@ -14,6 +14,7 @@
 		line-height: $default-line-height;
 		font-family: $default-font;
 		font-size: $default-font-size;
+		color: $gray-900;
 		margin: 0 0 1em;
 
 	}


### PR DESCRIPTION
The warning component does not declare a text color for its text. Depending on the way a theme's CSS rolls in, this can result in the warning message inheriting the theme's text color. Here's an example where it's inheriting the `#ffffff` text color from the theme, found while working through Twenty Twenty One (https://github.com/WordPress/twentytwentyone/issues/159): 

![Screen Shot 2020-09-29 at 1 44 23 PM](https://user-images.githubusercontent.com/1202812/94597296-64b82000-025b-11eb-812b-38f8b7c1dbb0.png)

To prevent this, This PR defines the text color for the component. This is similar to what Gutenberg already does [for the placeholder component](block-editor-warning). 

![Screen Shot 2020-09-29 at 1 52 48 PM](https://user-images.githubusercontent.com/1202812/94597410-86b1a280-025b-11eb-9eb9-decaf2d490c2.png)


