### PR TITLE
Add option to make Post Featured Image a link

### DIFF
--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -1,6 +1,21 @@
 {
 	"name": "core/post-featured-image",
 	"category": "design",
+	"attributes": {
+		"isLink": {
+			"type": "boolean",
+			"default": false
+		},
+		"rel": {
+			"type": "string",
+			"attribute": "rel",
+			"default": ""
+		},
+		"linkTarget": {
+			"type": "string",
+			"default": "_blank"
+		}
+	},
 	"usesContext": [
 		"postId",
 		"postType"

--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -13,7 +13,7 @@
 		},
 		"linkTarget": {
 			"type": "string",
-			"default": "_blank"
+			"default": "_self"
 		}
 	},
 	"usesContext": [

--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -5,15 +5,6 @@
 		"isLink": {
 			"type": "boolean",
 			"default": false
-		},
-		"rel": {
-			"type": "string",
-			"attribute": "rel",
-			"default": ""
-		},
-		"linkTarget": {
-			"type": "string",
-			"default": "_self"
 		}
 	},
 	"usesContext": [

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -13,6 +13,13 @@ import { __ } from '@wordpress/i18n';
 import { postFeaturedImage as icon } from '@wordpress/icons';
 import { InspectorControls } from '@wordpress/block-editor';
 
+const placeholderChip = (
+	<div className="post-featured-image_placeholder">
+		<Icon icon={ icon } />
+		<p> { __( 'Featured Image' ) }</p>
+	</div>
+);
+
 function PostFeaturedImageDisplay( {
 	attributes: { isLink, rel, linkTarget },
 	setAttributes,
@@ -35,12 +42,7 @@ function PostFeaturedImageDisplay( {
 		[ postType, postId, featuredImage ]
 	);
 	if ( ! media ) {
-		return (
-			<div className="post-featured-image_placeholder">
-				<Icon icon={ icon } />
-				<p> { __( 'Featured Image' ) }</p>
-			</div>
-		);
+		return placeholderChip;
 	}
 	const alt = media.alt_text || __( 'No alternative text set' );
 	let image = <img src={ media.source_url } alt={ alt } />;
@@ -91,7 +93,7 @@ function PostFeaturedImageDisplay( {
 
 export default function PostFeaturedImageEdit( props ) {
 	if ( ! props.context?.postId ) {
-		return __( 'Featured Image' );
+		return placeholderChip;
 	}
 	return <PostFeaturedImageDisplay { ...props } />;
 }

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -3,13 +3,8 @@
  */
 import { useEntityProp } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
-import {
-	Icon,
-	ToggleControl,
-	TextControl,
-	PanelBody,
-} from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { Icon, ToggleControl, PanelBody } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
 import { postFeaturedImage as icon } from '@wordpress/icons';
 import { InspectorControls } from '@wordpress/block-editor';
 
@@ -21,7 +16,7 @@ const placeholderChip = (
 );
 
 function PostFeaturedImageDisplay( {
-	attributes: { isLink, rel, linkTarget },
+	attributes: { isLink },
 	setAttributes,
 	context: { postId, postType },
 } ) {
@@ -31,62 +26,36 @@ function PostFeaturedImageDisplay( {
 		'featured_media',
 		postId
 	);
-	const { media, post } = useSelect(
-		( select ) => {
-			const { getMedia, getEditedEntityRecord } = select( 'core' );
-			return {
-				media: featuredImage && getMedia( featuredImage ),
-				post: getEditedEntityRecord( 'postType', postType, postId ),
-			};
-		},
-		[ postType, postId, featuredImage ]
+	const media = useSelect(
+		( select ) =>
+			featuredImage && select( 'core' ).getMedia( featuredImage ),
+		[ featuredImage ]
 	);
-	if ( ! media ) {
-		return placeholderChip;
-	}
-	const alt = media.alt_text || __( 'No alternative text set' );
-	let image = <img src={ media.source_url } alt={ alt } />;
-	if ( isLink ) {
-		image = (
-			<a href={ post.link } target={ linkTarget } rel={ rel }>
-				{ image }
-			</a>
-		);
-	}
+	const image = ! media ? (
+		placeholderChip
+	) : (
+		<img
+			src={ media.source_url }
+			alt={ media.alt_text || __( 'No alternative text set' ) }
+		/>
+	);
+
 	return (
 		<>
 			<InspectorControls>
 				<PanelBody title={ __( 'Link settings' ) }>
 					<ToggleControl
-						label={ __( 'Make featured image a link' ) }
+						label={ sprintf(
+							// translators: %s: Name of the post type e.g: "post".
+							__( 'Link to %s' ),
+							postType
+						) }
 						onChange={ () => setAttributes( { isLink: ! isLink } ) }
 						checked={ isLink }
 					/>
-					{ isLink && (
-						<>
-							<ToggleControl
-								label={ __( 'Open in new tab' ) }
-								onChange={ ( value ) =>
-									setAttributes( {
-										linkTarget: value ? '_blank' : '_self',
-									} )
-								}
-								checked={ linkTarget === '_blank' }
-							/>
-							<TextControl
-								label={ __( 'Link rel' ) }
-								value={ rel }
-								onChange={ ( newRel ) =>
-									setAttributes( { rel: newRel } )
-								}
-							/>
-						</>
-					) }
 				</PanelBody>
 			</InspectorControls>
-			<div className={ isLink ? 'post-featured-image__link' : '' }>
-				{ image }
-			</div>
+			{ image }
 		</>
 	);
 }

--- a/packages/block-library/src/post-featured-image/editor.scss
+++ b/packages/block-library/src/post-featured-image/editor.scss
@@ -16,4 +16,15 @@ div[data-type="core/post-featured-image"] {
 			margin: 0;
 		}
 	}
+	.post-featured-image__link {
+		line-height: 0;
+		a {
+			display: inline-block;
+		}
+	}
+	img {
+		max-width: 100%;
+		height: auto;
+		display: block;
+	}
 }

--- a/packages/block-library/src/post-featured-image/editor.scss
+++ b/packages/block-library/src/post-featured-image/editor.scss
@@ -16,12 +16,6 @@ div[data-type="core/post-featured-image"] {
 			margin: 0;
 		}
 	}
-	.post-featured-image__link {
-		line-height: 0;
-		a {
-			display: inline-block;
-		}
-	}
 	img {
 		max-width: 100%;
 		height: auto;

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -22,7 +22,7 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 	$featured_image = get_the_post_thumbnail( $post_ID );
 
 	if ( isset( $attributes['isLink'] ) && $attributes['isLink'] ) {
-		$featured_image = sprintf( '<a href="%1s" target="%2s" rel="%3s">%4s</a>', get_the_permalink( $post_ID ), $attributes['linkTarget'], $attributes['rel'], $featured_image );
+		$featured_image = sprintf( '<a href="%1s">%2s</a>', get_the_permalink( $post_ID ), $featured_image );
 	}
 
 	return '<p>' . $featured_image . '</p>';

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -17,8 +17,15 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 	if ( ! isset( $block->context['postId'] ) ) {
 		return '';
 	}
+	$post_ID = $block->context['postId'];
 
-	return '<p>' . get_the_post_thumbnail( $block->context['postId'] ) . '</p>';
+	$featured_image = get_the_post_thumbnail( $post_ID );
+
+	if ( isset( $attributes['isLink'] ) && $attributes['isLink'] ) {
+		$featured_image = sprintf( '<a href="%1s" target="%2s" rel="%3s">%4s</a>', get_the_permalink( $post_ID ), $attributes['linkTarget'], $attributes['rel'], $featured_image );
+	}
+
+	return '<p>' . $featured_image . '</p>';
 }
 
 /**

--- a/packages/block-library/src/post-featured-image/style.scss
+++ b/packages/block-library/src/post-featured-image/style.scss
@@ -1,0 +1,5 @@
+.wp-block-post-featured-image {
+	a {
+		display: inline-block;
+	}
+}

--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -24,7 +24,7 @@
 		},
 		"linkTarget": {
 			"type": "string",
-			"default": "_blank"
+			"default": "_self"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -36,6 +36,7 @@
 @import "./table/style.scss";
 @import "./text-columns/style.scss";
 @import "./video/style.scss";
+@import "./post-featured-image/style.scss";
 
 // The following selectors have increased specificity (using the :root prefix)
 // to assure colors take effect over another base class color, mainly to let

--- a/packages/components/src/responsive-wrapper/style.scss
+++ b/packages/components/src/responsive-wrapper/style.scss
@@ -5,10 +5,6 @@
 	& > span {
 		display: block;
 	}
-	&,
-	& > img {
-		width: auto;
-	}
 }
 
 .components-responsive-wrapper__content {

--- a/packages/e2e-tests/fixtures/blocks/core__post-featured-image.json
+++ b/packages/e2e-tests/fixtures/blocks/core__post-featured-image.json
@@ -1,12 +1,12 @@
 [
-    {
-        "clientId": "_clientId_0",
-        "name": "core/post-featured-image",
-        "isValid": true,
+	{
+		"clientId": "_clientId_0",
+		"name": "core/post-featured-image",
+		"isValid": true,
 		"attributes": {
 			"isLink": false
 		},
-        "innerBlocks": [],
-        "originalContent": ""
-    }
+		"innerBlocks": [],
+		"originalContent": ""
+	}
 ]

--- a/packages/e2e-tests/fixtures/blocks/core__post-featured-image.json
+++ b/packages/e2e-tests/fixtures/blocks/core__post-featured-image.json
@@ -3,7 +3,11 @@
         "clientId": "_clientId_0",
         "name": "core/post-featured-image",
         "isValid": true,
-        "attributes": {},
+		"attributes": {
+			"isLink": false,
+			"linkTarget": "_blank",
+			"rel": ""
+		},
         "innerBlocks": [],
         "originalContent": ""
     }

--- a/packages/e2e-tests/fixtures/blocks/core__post-featured-image.json
+++ b/packages/e2e-tests/fixtures/blocks/core__post-featured-image.json
@@ -5,7 +5,7 @@
         "isValid": true,
 		"attributes": {
 			"isLink": false,
-			"linkTarget": "_blank",
+			"linkTarget": "_self",
 			"rel": ""
 		},
         "innerBlocks": [],

--- a/packages/e2e-tests/fixtures/blocks/core__post-featured-image.json
+++ b/packages/e2e-tests/fixtures/blocks/core__post-featured-image.json
@@ -4,9 +4,7 @@
         "name": "core/post-featured-image",
         "isValid": true,
 		"attributes": {
-			"isLink": false,
-			"linkTarget": "_self",
-			"rel": ""
+			"isLink": false
 		},
         "innerBlocks": [],
         "originalContent": ""

--- a/packages/e2e-tests/fixtures/blocks/core__post-title.json
+++ b/packages/e2e-tests/fixtures/blocks/core__post-title.json
@@ -6,7 +6,7 @@
 		"attributes": {
 			"level": 2,
 			"isLink": false,
-			"linkTarget": "_blank",
+			"linkTarget": "_self",
 			"rel": ""
 		},
 		"innerBlocks": [],


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This PR adds an option to make Post Featured Image block a link. ~It handles `target` and `rel` attributes as well.~
<!-- Please describe what you have changed or added -->

## How has this been tested?
Locally

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
