### PR TITLE
Document Settings: Fix document title hover and select animations

### DIFF
--- a/packages/edit-site/src/components/header/document-actions/index.js
+++ b/packages/edit-site/src/components/header/document-actions/index.js
@@ -79,9 +79,7 @@ export default function DocumentActions( { documentTitle } ) {
 	return (
 		<div
 			className={ classnames( 'edit-site-document-actions', {
-				// Handles slide up and slide down animations
 				'has-secondary-label': !! label,
-				'has-no-secondary-label': ! label,
 			} ) }
 		>
 			{ documentTitle ? (

--- a/packages/edit-site/src/components/header/document-actions/index.js
+++ b/packages/edit-site/src/components/header/document-actions/index.js
@@ -79,7 +79,9 @@ export default function DocumentActions( { documentTitle } ) {
 	return (
 		<div
 			className={ classnames( 'edit-site-document-actions', {
+				// Handles slide up and slide down animations
 				'has-secondary-label': !! label,
+				'has-no-secondary-label': ! label,
 			} ) }
 		>
 			{ documentTitle ? (
@@ -101,7 +103,6 @@ export default function DocumentActions( { documentTitle } ) {
 							'edit-site-document-actions__label',
 							'edit-site-document-actions__secondary-item',
 							{
-								// 'is-active': isActive,
 								'is-secondary-title-active': isActive,
 							}
 						) }

--- a/packages/edit-site/src/components/header/document-actions/index.js
+++ b/packages/edit-site/src/components/header/document-actions/index.js
@@ -88,7 +88,6 @@ export default function DocumentActions( { documentTitle } ) {
 				<>
 					<div
 						className={ classnames(
-							'edit-site-document-actions__label',
 							'edit-site-document-actions__title',
 							{
 								'is-active': isTitleActive,
@@ -100,7 +99,6 @@ export default function DocumentActions( { documentTitle } ) {
 					</div>
 					<div
 						className={ classnames(
-							'edit-site-document-actions__label',
 							'edit-site-document-actions__secondary-item',
 							{
 								'is-secondary-title-active': isActive,

--- a/packages/edit-site/src/components/header/document-actions/index.js
+++ b/packages/edit-site/src/components/header/document-actions/index.js
@@ -90,6 +90,7 @@ export default function DocumentActions( { documentTitle } ) {
 							'edit-site-document-actions__title',
 							{
 								'is-active': isTitleActive,
+								'is-secondary-title-active': isActive,
 							}
 						) }
 					>
@@ -100,7 +101,8 @@ export default function DocumentActions( { documentTitle } ) {
 							'edit-site-document-actions__label',
 							'edit-site-document-actions__secondary-item',
 							{
-								'is-active': isActive,
+								// 'is-active': isActive,
+								'is-secondary-title-active': isActive,
 							}
 						) }
 					>

--- a/packages/edit-site/src/components/header/document-actions/style.scss
+++ b/packages/edit-site/src/components/header/document-actions/style.scss
@@ -11,9 +11,14 @@
 		align-items: center;
 	}
 
+	&.has-no-secondary-label {
+		animation: titleSlideDown 0.2s;
+		transform: translateY(0);
+	}
+
 	&.has-secondary-label {
 		.edit-site-document-actions__title {
-			animation: titleAnimation 0.2s;
+			animation: titleSlideUp 0.2s;
 			color: $gray-900;
 			font-weight: bold;
 			transform: translateY(-12px);
@@ -25,7 +30,7 @@
 		}
 
 		.edit-site-document-actions__secondary-item {
-			animation: secondaryTitleAnimation 0.2s;
+			animation: secondaryTitleSlideUpAndFadeIn 0.2s;
 			color: $gray-700;
 			font-weight: normal;
 			position: absolute;
@@ -39,7 +44,7 @@
 	}
 }
 
-@keyframes titleAnimation {
+@keyframes titleSlideUp {
 	from {
 		transform: translateY(0);
 	}
@@ -48,7 +53,16 @@
 	}
 }
 
-@keyframes secondaryTitleAnimation {
+@keyframes titleSlideDown {
+	from {
+		transform: translateY(-12px);
+	}
+	to {
+		transform: translateY(-0);
+	}
+}
+
+@keyframes secondaryTitleSlideUpAndFadeIn {
 	from {
 		opacity: 0;
 		transform: translateY(20px);

--- a/packages/edit-site/src/components/header/document-actions/style.scss
+++ b/packages/edit-site/src/components/header/document-actions/style.scss
@@ -5,14 +5,18 @@
 	justify-content: space-evenly;
 	position: relative;
 
-	&.has-no-secondary-label {
-		animation: titleSlideDown 0.2s;
-		transform: translateY(0);
+	.edit-site-document-actions__title {
+		transition: transform 0.2s;
+	}
+
+	.edit-site-document-actions__secondary-item {
+		opacity: 0;
+		transform: translateY(20px);
+		transition: transform 0.2s;
 	}
 
 	&.has-secondary-label {
 		.edit-site-document-actions__title {
-			animation: titleSlideUp 0.2s;
 			color: $gray-900;
 			font-weight: bold;
 			transform: translateY(-12px);
@@ -24,9 +28,9 @@
 		}
 
 		.edit-site-document-actions__secondary-item {
-			animation: secondaryTitleSlideUpAndFadeIn 0.2s;
 			color: $gray-700;
 			font-weight: normal;
+			opacity: 1;
 			position: absolute;
 			transform: translateY(12px);
 
@@ -35,35 +39,5 @@
 				font-weight: bold;
 			}
 		}
-	}
-}
-
-@keyframes titleSlideUp {
-	from {
-		transform: translateY(0);
-	}
-	to {
-		transform: translateY(-12px);
-	}
-}
-
-@keyframes titleSlideDown {
-	from {
-		transform: translateY(-12px);
-	}
-	to {
-		transform: translateY(-0);
-	}
-}
-
-@keyframes secondaryTitleSlideUpAndFadeIn {
-	from {
-		opacity: 0;
-		transform: translateY(20px);
-	}
-
-	to {
-		opacity: 1;
-		transform: translateY(12px);
 	}
 }

--- a/packages/edit-site/src/components/header/document-actions/style.scss
+++ b/packages/edit-site/src/components/header/document-actions/style.scss
@@ -14,31 +14,26 @@
 	&.has-secondary-label {
 		.edit-site-document-actions__title {
 			animation: titleAnimation 0.2s;
-			transform: translateY(-12px);
 			color: $gray-900;
 			font-weight: bold;
+			transform: translateY(-12px);
 
 			&.is-secondary-title-active {
-				animation: titleAnimation 0.2s;
-				transform: translateY(-12px);
 				color: $gray-700;
 				font-weight: normal;
 			}
 		}
 
 		.edit-site-document-actions__secondary-item {
+			animation: secondaryTitleAnimation 0.2s;
 			color: $gray-700;
 			font-weight: normal;
 			position: absolute;
-			animation: secondaryTitleAnimation 0.2s;
 			transform: translateY(12px);
 
 			&.is-secondary-title-active {
-				position: absolute;
-				animation: secondaryTitleAnimation 0.2s;
-				transform: translateY(12px);
-				font-weight: bold;
 				color: $gray-900;
+				font-weight: bold;
 			}
 		}
 	}

--- a/packages/edit-site/src/components/header/document-actions/style.scss
+++ b/packages/edit-site/src/components/header/document-actions/style.scss
@@ -3,32 +3,64 @@
 	flex-direction: column;
 	align-items: center;
 	justify-content: space-evenly;
+	position: relative;
 
 	.edit-site-document-actions__label {
-		color: $gray-700;
 		display: flex;
 		justify-content: center;
 		align-items: center;
-		transition: height 0.25s;
-
-		&.is-active {
-			color: inherit;
-		}
-
-		&.edit-site-document-actions__title {
-			height: 100%;
-			// Otherwise, the secondary item still takes up space with height 0:
-			flex-grow: 1;
-		}
-
-		&.edit-site-document-actions__secondary-item {
-			height: 0;
-		}
 	}
 
 	&.has-secondary-label {
-		.edit-site-document-actions__label {
-			height: 50%;
+		.edit-site-document-actions__title {
+			animation: titleAnimation 0.2s;
+			transform: translateY(-12px);
+			color: $gray-900;
+			font-weight: bold;
+
+			&.is-secondary-title-active {
+				animation: titleAnimation 0.2s;
+				transform: translateY(-12px);
+				color: $gray-700;
+				font-weight: normal;
+			}
 		}
+
+		.edit-site-document-actions__secondary-item {
+			color: $gray-700;
+			font-weight: normal;
+			position: absolute;
+			animation: secondaryTitleAnimation 0.2s;
+			transform: translateY(12px);
+
+			&.is-secondary-title-active {
+				position: absolute;
+				animation: secondaryTitleAnimation 0.2s;
+				transform: translateY(12px);
+				font-weight: bold;
+				color: $gray-900;
+			}
+		}
+	}
+}
+
+@keyframes titleAnimation {
+	from {
+		transform: translateY(0);
+	}
+	to {
+		transform: translateY(-12px);
+	}
+}
+
+@keyframes secondaryTitleAnimation {
+	from {
+		opacity: 0;
+		transform: translateY(20px);
+	}
+
+	to {
+		opacity: 1;
+		transform: translateY(12px);
 	}
 }

--- a/packages/edit-site/src/components/header/document-actions/style.scss
+++ b/packages/edit-site/src/components/header/document-actions/style.scss
@@ -5,12 +5,6 @@
 	justify-content: space-evenly;
 	position: relative;
 
-	.edit-site-document-actions__label {
-		display: flex;
-		justify-content: center;
-		align-items: center;
-	}
-
 	&.has-no-secondary-label {
 		animation: titleSlideDown 0.2s;
 		transform: translateY(0);

--- a/packages/edit-site/src/components/header/document-actions/style.scss
+++ b/packages/edit-site/src/components/header/document-actions/style.scss
@@ -7,6 +7,7 @@
 	position: relative;
 
 	.edit-site-document-actions__title {
+		font-weight: bold;
 		transition: transform 0.2s;
 		@include reduce-motion(transition);
 	}

--- a/packages/edit-site/src/components/header/document-actions/style.scss
+++ b/packages/edit-site/src/components/header/document-actions/style.scss
@@ -8,12 +8,18 @@
 
 	.edit-site-document-actions__title {
 		transition: transform 0.2s;
+		@media ( prefers-reduced-motion: reduce ) {
+			transition-duration: 0ms;
+		}
 	}
 
 	.edit-site-document-actions__secondary-item {
 		opacity: 0;
 		transform: translateY(20px);
 		transition: transform 0.2s;
+		@media ( prefers-reduced-motion: reduce ) {
+			transition-duration: 0ms;
+		}
 	}
 
 	&.has-secondary-label {

--- a/packages/edit-site/src/components/header/document-actions/style.scss
+++ b/packages/edit-site/src/components/header/document-actions/style.scss
@@ -8,18 +8,14 @@
 
 	.edit-site-document-actions__title {
 		transition: transform 0.2s;
-		@media ( prefers-reduced-motion: reduce ) {
-			transition-duration: 0ms;
-		}
+		@include reduce-motion(transition);
 	}
 
 	.edit-site-document-actions__secondary-item {
 		opacity: 0;
 		transform: translateY(20px);
 		transition: transform 0.2s;
-		@media ( prefers-reduced-motion: reduce ) {
-			transition-duration: 0ms;
-		}
+		@include reduce-motion(transition);
 	}
 
 	&.has-secondary-label {

--- a/packages/edit-site/src/components/header/document-actions/style.scss
+++ b/packages/edit-site/src/components/header/document-actions/style.scss
@@ -2,7 +2,8 @@
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-	justify-content: space-evenly;
+	justify-content: center;
+	height: 100%;
 	position: relative;
 
 	.edit-site-document-actions__title {
@@ -17,6 +18,7 @@
 
 	&.has-secondary-label {
 		.edit-site-document-actions__title {
+			position: absolute;
 			color: $gray-900;
 			font-weight: bold;
 			transform: translateY(-12px);
@@ -31,7 +33,7 @@
 			color: $gray-700;
 			font-weight: normal;
 			opacity: 1;
-			position: absolute;
+			white-space: nowrap;
 			transform: translateY(12px);
 
 			&.is-secondary-title-active {

--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -12,6 +12,7 @@
 
 	.edit-site-header_center {
 		display: flex;
+		align-items: center;
 		height: 100%;
 	}
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
The hover and select animation for document title can be improved in a few ways as identified by the design team:
- The template part name appears to overflow the topbar, and doesn't fade-in
- The label colors and boldness don't match what has been specified in mocks
- The appearance of the secondary label clips the bottom border of the topbar

We are using these updates as an opportunity to refactor the technical implementation to improve animation performance.

Ideally, the animations would look like this.

![document-info-animation](https://user-images.githubusercontent.com/191598/94184845-85a2fe80-fe72-11ea-96ae-84c6e81571c1.gif)

Here's the same animation slowed down to help see the transitions:

![document-info-animation-slow](https://user-images.githubusercontent.com/191598/94185257-124dbc80-fe73-11ea-9e69-b5cbcdb6dccb.gif)


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Spin up a local WordPress instance. From the project root:
  a. Execute `npx wp-env start` in the terminal
  b. Execute `npm run dev` in the terminal
2. Open the WordPress UI at http://localhost:8888/wp-admin and sign in with the username `admin` and the password `password`.
3. Enable site editing in the local dev environment
  a. Click on Appearance < Themes in the sidebar and activate the seedlet blocks theme
  b. Click on Gutenberg < Experiments in the sidebar and check the Full Site Editing Feature
4. Navigate to the site editor
5. Hover over any template part and note the document title hover animation
6. Select any template part and note the document title select animation
7. Verify that these match the ideal animations provided by the design team
8. Ensure that the solution respects responsive behavior (when the browser viewport is shrunk or enlarged)

## Screenshots <!-- if applicable -->
### Before
![document-info-animate-bug](https://user-images.githubusercontent.com/191598/94184334-c0586700-fe71-11ea-8606-6912827272a6.gif)

### After
![2020-10-01 16 44 54](https://user-images.githubusercontent.com/5414230/94874020-b4d2e600-0405-11eb-87f9-f9b53cfb63b8.gif)



## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Fixes https://github.com/WordPress/gutenberg/issues/25545

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
