### PR TITLE
Button Block: use computed style to set default border-radius

### DIFF
--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -39,22 +39,29 @@ import getColorAndStyleProps from './color-props';
 const NEW_TAB_REL = 'noreferrer noopener';
 const MIN_BORDER_RADIUS_VALUE = 0;
 const MAX_BORDER_RADIUS_VALUE = 50;
-const INITIAL_BORDER_RADIUS_POSITION = 5;
 
 const EMPTY_ARRAY = [];
 
-function BorderPanel( { borderRadius = '', setAttributes } ) {
-	const initialBorderRadius = borderRadius;
-	const setBorderRadius = useCallback(
-		( newBorderRadius ) => {
-			if ( newBorderRadius === undefined )
-				setAttributes( {
-					borderRadius: initialBorderRadius,
-				} );
-			else setAttributes( { borderRadius: newBorderRadius } );
-		},
-		[ setAttributes ]
+let computedBorderRadius;
+document.addEventListener( 'readystatechange', () => {
+	// returns early until styles are loaded
+	if ( document.readyState !== 'complete' ) return;
+	const sample = document.createElement( 'a' );
+	sample.className = 'wp-block-button__link';
+	const wrapper = document.createElement( 'div' );
+	wrapper.className = 'editor-styles-wrapper';
+	wrapper.hidden = true;
+	wrapper.appendChild( sample );
+	document.body.appendChild( wrapper );
+	computedBorderRadius = parseFloat(
+		window.getComputedStyle( sample ).getPropertyValue( 'border-radius' )
 	);
+	document.body.removeChild( wrapper );
+} );
+
+function BorderPanel( { borderRadius = '', setAttributes } ) {
+	const setBorderRadius = ( value ) =>
+		setAttributes( { borderRadius: value } );
 	return (
 		<PanelBody title={ __( 'Border settings' ) }>
 			<RangeControl
@@ -62,7 +69,7 @@ function BorderPanel( { borderRadius = '', setAttributes } ) {
 				label={ __( 'Border radius' ) }
 				min={ MIN_BORDER_RADIUS_VALUE }
 				max={ MAX_BORDER_RADIUS_VALUE }
-				initialPosition={ INITIAL_BORDER_RADIUS_POSITION }
+				initialPosition={ computedBorderRadius }
 				allowReset
 				onChange={ setBorderRadius }
 			/>


### PR DESCRIPTION
Taking a stab at #17596, this employs `getComputedStyle` to define the default border-radius for buttons. 

In a theme with square buttons:
![button-intial-radius-0](https://user-images.githubusercontent.com/9000376/94626723-7eb02d80-0270-11eb-99b6-b898dd708903.gif)

Sorry about the weird artifacts on the bottom of these screen captures. Hopefully, they're not too distracting.

In a theme defining a border-radius larger than the current built-in maximum (and in units other than pixels thus the floating number):
![button-intial-radius](https://user-images.githubusercontent.com/9000376/94626994-2e859b00-0271-11eb-9cb7-0fd15b2ebbb6.gif)

It could be set up so that the maximum border-radius is raised by the computed style but not sure that's desired.

This works well with any theme I've tested. I think an issue could arise if a theme/plugin defines style variations that are supposed to have a different border-radius. I've not tested it but if I've done my thinking correctly they would show in-canvas with the intended border-radius but the range control would read as if they have the computed radius. I think that could be worked around too but at the moment this is mainly aimed at sparking conversation. 

## How has this been tested?
Tested in
Wordpress 5.5.1

## Types of changes
Non-breaking enhancement

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [n/a] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [?] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
