### PR TITLE
Return early on the onSelectionEnd and useEffect if defaultView is no…

### DIFF
--- a/packages/block-editor/src/components/block-list/use-multi-selection.js
+++ b/packages/block-editor/src/components/block-list/use-multi-selection.js
@@ -218,6 +218,9 @@ export default function useMultiSelection( ref ) {
 			'selectionchange',
 			onSelectionChange
 		);
+
+		if ( ! defaultView ) return;
+
 		// Equivalent to attaching the listener once.
 		defaultView.removeEventListener( 'mouseup', onSelectionEnd );
 		// The browser selection won't have updated yet at this point, so wait
@@ -237,6 +240,9 @@ export default function useMultiSelection( ref ) {
 				'selectionchange',
 				onSelectionChange
 			);
+
+			if ( ! defaultView ) return;
+
 			defaultView.removeEventListener( 'mouseup', onSelectionEnd );
 			defaultView.cancelAnimationFrame( rafId.current );
 		},


### PR DESCRIPTION
Hacky (temporary?) fix for https://github.com/Automattic/wp-calypso/issues/46025. 

I don't know if this is a Gutenberg or Calypso issue or both. 