### PR TITLE
Widgets editor: Preload request to /sidebars

### DIFF
--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -79,6 +79,24 @@ function gutenberg_widgets_init( $hook ) {
 
 	$settings = gutenberg_experimental_global_styles_settings( $settings );
 
+	$preload_paths = array(
+		array( '/wp/v2/media', 'OPTIONS' ),
+		'/__experimental/sidebars?context=edit',
+	);
+	$preload_data  = array_reduce(
+		$preload_paths,
+		'rest_preload_api_request',
+		array()
+	);
+	wp_add_inline_script(
+		'wp-api-fetch',
+		sprintf(
+			'wp.apiFetch.use( wp.apiFetch.createPreloadingMiddleware( %s ) );',
+			wp_json_encode( $preload_data )
+		),
+		'after'
+	);
+
 	wp_add_inline_script(
 		'wp-edit-widgets',
 		sprintf(

--- a/packages/edit-widgets/src/store/resolvers.js
+++ b/packages/edit-widgets/src/store/resolvers.js
@@ -69,12 +69,12 @@ export function* getWidgetAreas() {
 	} );
 	yield setWidgetAreasOpenState( widgetAreasOpenState );
 
-	yield persistStubPost( buildWidgetAreasPostId(), widgetAreaBlocks );
-
 	yield {
 		type: 'SET_WIDGET_TO_CLIENT_ID_MAPPING',
 		mapping: widgetIdToClientId,
 	};
+
+	yield persistStubPost( buildWidgetAreasPostId(), widgetAreaBlocks );
 }
 
 const persistStubPost = function* ( id, blocks ) {


### PR DESCRIPTION
Closes https://github.com/WordPress/gutenberg/issues/24869.

- Improves performance of initial page load by prefetching the REST API request to `/sidebars`.

- Makes it so that the `widgetIdToClientId` mapping is available by the time `core/legacy-widget` blocks do their initial render. This means that `prerenderedEditForm` is available to the block which it can use instead of performing an additional XHR request. See https://github.com/WordPress/gutenberg/pull/24855.

### To test

1. Navigate to Appearance → Widgets.
2. The widget areas and Legacy Widget blocks should appear immediately. 