### PR TITLE
[Widgets Editor] Fix widget-area accessibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17469,6 +17469,7 @@
 				"@wordpress/url": "file:packages/url",
 				"classnames": "^2.2.5",
 				"lodash": "^4.17.19",
+				"reakit": "^1.1.0",
 				"rememo": "^3.0.0"
 			},
 			"dependencies": {

--- a/packages/components/src/panel/README.md
+++ b/packages/components/src/panel/README.md
@@ -142,6 +142,13 @@ Whether or not the panel will start open.
 -   Required: No
 -   Default: true
 
+###### children
+
+The rendered children. If the children is a `Function`, it will be called with an object with the `opened` property and return its value.
+
+-   Type: `React.ReactNode | Function`
+-   Required: No
+
 ---
 
 #### PanelRow

--- a/packages/components/src/panel/body.js
+++ b/packages/components/src/panel/body.js
@@ -69,7 +69,9 @@ export function PanelBody(
 				onClick={ handleOnToggle }
 				title={ title }
 			/>
-			{ isOpened && children }
+			{ typeof children === 'function'
+				? children( { isOpened } )
+				: isOpened && children }
 		</div>
 	);
 }

--- a/packages/components/src/panel/body.js
+++ b/packages/components/src/panel/body.js
@@ -70,7 +70,7 @@ export function PanelBody(
 				title={ title }
 			/>
 			{ typeof children === 'function'
-				? children( { isOpened } )
+				? children( { opened: isOpened } )
 				: isOpened && children }
 		</div>
 	);

--- a/packages/components/src/panel/test/body.js
+++ b/packages/components/src/panel/test/body.js
@@ -57,6 +57,28 @@ describe( 'PanelBody', () => {
 
 			expect( panelContent ).toBeTruthy();
 		} );
+
+		it( 'should call the children function, if specified', () => {
+			const { container, rerender } = render(
+				<PanelBody opened={ true }>
+					{ ( { opened } ) => <div hidden={ opened }>Content</div> }
+				</PanelBody>
+			);
+			let panelContent = getPanelBodyContent( container );
+
+			expect( panelContent ).toBeTruthy();
+			expect( panelContent.getAttribute( 'hidden' ) ).toBe( '' );
+
+			rerender(
+				<PanelBody opened={ false }>
+					{ ( { opened } ) => <div hidden={ opened }>Content</div> }
+				</PanelBody>
+			);
+			panelContent = getPanelBodyContent( container );
+
+			expect( panelContent ).toBeTruthy();
+			expect( panelContent.getAttribute( 'hidden' ) ).toBeNull();
+		} );
 	} );
 
 	describe( 'toggling', () => {

--- a/packages/edit-widgets/package.json
+++ b/packages/edit-widgets/package.json
@@ -52,6 +52,7 @@
 		"@wordpress/url": "file:../url",
 		"classnames": "^2.2.5",
 		"lodash": "^4.17.19",
+		"reakit": "^1.1.0",
 		"rememo": "^3.0.0"
 	},
 	"publishConfig": {

--- a/packages/edit-widgets/src/blocks/widget-area/edit/index.js
+++ b/packages/edit-widgets/src/blocks/widget-area/edit/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { DisclosureContent } from 'reakit/Disclosure';
+
+/**
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -26,37 +31,26 @@ export default function WidgetAreaEdit( {
 		<Panel className={ className }>
 			<PanelBody
 				title={ name }
-				// This workaround is required to ensure LegacyWidget blocks are not unmounted when the panel is collapsed.
-				// Unmounting legacy widgets may have unintended consequences (e.g. TinyMCE not being properly reinitialized)
-				opened={ true }
+				opened={ isOpen }
 				onToggle={ () => {
 					setIsWidgetAreaOpen( clientId, ! isOpen );
 				} }
-				className={ isOpen ? 'widget-area-is-opened' : '' }
+				isVisuallyHidden
 			>
-				<EntityProvider
-					kind="root"
-					type="postType"
-					id={ `widget-area-${ id }` }
-				>
-					<InnerBlocksContainer isOpen={ isOpen } />
-				</EntityProvider>
+				{ ( { isOpened } ) => (
+					// This is required to ensure LegacyWidget blocks are not unmounted when the panel is collapsed.
+					// Unmounting legacy widgets may have unintended consequences (e.g. TinyMCE not being properly reinitialized)
+					<DisclosureContent visible={ isOpened }>
+						<EntityProvider
+							kind="root"
+							type="postType"
+							id={ `widget-area-${ id }` }
+						>
+							<WidgetAreaInnerBlocks />
+						</EntityProvider>
+					</DisclosureContent>
+				) }
 			</PanelBody>
 		</Panel>
-	);
-}
-
-function InnerBlocksContainer( { isOpen } ) {
-	const props = isOpen
-		? {}
-		: {
-				hidden: true,
-				'aria-hidden': true,
-				style: { display: 'none' },
-		  };
-	return (
-		<div { ...props }>
-			<WidgetAreaInnerBlocks />
-		</div>
 	);
 }

--- a/packages/edit-widgets/src/blocks/widget-area/edit/index.js
+++ b/packages/edit-widgets/src/blocks/widget-area/edit/index.js
@@ -35,12 +35,11 @@ export default function WidgetAreaEdit( {
 				onToggle={ () => {
 					setIsWidgetAreaOpen( clientId, ! isOpen );
 				} }
-				isVisuallyHidden
 			>
-				{ ( { isOpened } ) => (
+				{ ( { opened } ) => (
 					// This is required to ensure LegacyWidget blocks are not unmounted when the panel is collapsed.
 					// Unmounting legacy widgets may have unintended consequences (e.g. TinyMCE not being properly reinitialized)
-					<DisclosureContent visible={ isOpened }>
+					<DisclosureContent visible={ opened }>
 						<EntityProvider
 							kind="root"
 							type="postType"

--- a/packages/edit-widgets/src/blocks/widget-area/editor.scss
+++ b/packages/edit-widgets/src/blocks/widget-area/editor.scss
@@ -2,15 +2,6 @@
 	max-width: $widget-area-width;
 }
 
-.wp-block-widget-area > .components-panel__body {
-	&.is-opened:not(.widget-area-is-opened) {
-		padding: 0;
-		> .components-panel__body-title {
-			padding: 0;
-			margin: 0;
-		}
-	}
-	> .block-editor-inner-blocks {
-		padding-top: $grid-unit-30;
-	}
+.wp-block-widget-area > .components-panel__body > .block-editor-inner-blocks {
+	padding-top: $grid-unit-30;
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Fix #25675.

Remove the workaround introduced in #25645, by changing the `<PanelBody>` component to accept `children` as function and making use of the `<DiscloureContent>` component is `reakit`. 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Go to widgets screen
2. Try toggling the widget areas
3. Inspect the elements, and confirm that the panel body is not unmounted when collapsing.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
