### PR TITLE
BlockList: fix for unavailable ref on unmount

### DIFF
--- a/packages/block-editor/src/components/block-list/use-multi-selection.js
+++ b/packages/block-editor/src/components/block-list/use-multi-selection.js
@@ -229,19 +229,19 @@ export default function useMultiSelection( ref ) {
 	}, [ onSelectionChange, stopMultiSelect ] );
 
 	// Only clean up when unmounting, these are added and cleaned up elsewhere.
-	useEffect(
-		() => () => {
-			const { ownerDocument } = ref.current;
-			const { defaultView } = ownerDocument;
+	useEffect( () => {
+		const { ownerDocument } = ref.current;
+		const { defaultView } = ownerDocument;
+
+		return () => {
 			ownerDocument.removeEventListener(
 				'selectionchange',
 				onSelectionChange
 			);
 			defaultView.removeEventListener( 'mouseup', onSelectionEnd );
 			defaultView.cancelAnimationFrame( rafId.current );
-		},
-		[ onSelectionChange, onSelectionEnd ]
-	);
+		};
+	}, [ onSelectionChange, onSelectionEnd ] );
 
 	/**
 	 * Binds event handlers to the document for tracking a pending multi-select


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

Fix for https://github.com/Automattic/wp-calypso/issues/46025

What is still strange to me is that the ref _should_ be available, based on the test here: https://codepen.io/iseulde/pen/rNegKdy.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
