### PR TITLE
Initialize the state before rendering widgets editor

### DIFF
--- a/packages/edit-widgets/src/components/edit-widgets-initializer/index.js
+++ b/packages/edit-widgets/src/components/edit-widgets-initializer/index.js
@@ -3,7 +3,26 @@
  */
 import Layout from '../layout';
 
+/**
+ * WordPress dependencies
+ */
+import { useDispatch } from '@wordpress/data';
+import { useEffect, useState } from '@wordpress/element';
+
 function EditWidgetsInitializer( { settings } ) {
+	// Since this module relies on the idea of using a "stub post", a state must be initialized
+	// first, or the data layer would attempt to retrieve the stub post from the API.
+	const { initializeState } = useDispatch( 'core/edit-widgets' );
+	const [ stateInitialized, setStateInitialized ] = useState( false );
+	useEffect( () => {
+		initializeState();
+		setStateInitialized( true );
+	}, [] );
+
+	if ( ! stateInitialized ) {
+		return <div></div>;
+	}
+
 	return <Layout blockEditorSettings={ settings } />;
 }
 

--- a/packages/edit-widgets/src/components/edit-widgets-initializer/index.js
+++ b/packages/edit-widgets/src/components/edit-widgets-initializer/index.js
@@ -20,7 +20,7 @@ function EditWidgetsInitializer( { settings } ) {
 	}, [] );
 
 	if ( ! stateInitialized ) {
-		return <div></div>;
+		return null;
 	}
 
 	return <Layout blockEditorSettings={ settings } />;

--- a/packages/edit-widgets/src/store/actions.js
+++ b/packages/edit-widgets/src/store/actions.js
@@ -33,6 +33,14 @@ export function* initializeState() {
 	yield persistStubPost( buildWidgetAreasPostId(), [] );
 }
 
+/**
+ * Persists a stub post with given ID to core data store. The post is meant to be in-memory only and
+ * shouldn't be saved via the API.
+ *
+ * @param  {string} id Post ID.
+ * @param  {Array}  blocks Blocks the post should consist of.
+ * @return {Object} The post object.
+ */
 export const persistStubPost = function* ( id, blocks ) {
 	const stubPost = createStubPost( id, blocks );
 	const args = [ KIND, POST_TYPE, id ];

--- a/packages/edit-widgets/src/store/actions.js
+++ b/packages/edit-widgets/src/store/actions.js
@@ -15,11 +15,40 @@ import { dispatch, select, getWidgetToClientIdMapping } from './controls';
 import { transformBlockToWidget } from './transformers';
 import {
 	buildWidgetAreaPostId,
+	buildWidgetAreasPostId,
 	buildWidgetAreasQuery,
+	createStubPost,
 	KIND,
 	POST_TYPE,
 	WIDGET_AREA_ENTITY_TYPE,
 } from './utils';
+
+/**
+ * Initializes the stub post before rendering the widgets editor.
+ * Required in order to ensure the data layer won't try to resolve the stub post.
+ *
+ * @access private
+ */
+export function* initializeState() {
+	yield persistStubPost( buildWidgetAreasPostId(), [] );
+}
+
+export const persistStubPost = function* ( id, blocks ) {
+	const stubPost = createStubPost( id, blocks );
+	const args = [ KIND, POST_TYPE, id ];
+	yield dispatch( 'core', 'startResolution', 'getEntityRecord', args );
+	yield dispatch(
+		'core',
+		'receiveEntityRecords',
+		KIND,
+		POST_TYPE,
+		stubPost,
+		{ id: stubPost.id },
+		false
+	);
+	yield dispatch( 'core', 'finishResolution', 'getEntityRecord', args );
+	return stubPost;
+};
 
 export function* saveEditedWidgetAreas() {
 	const editedWidgetAreas = yield select(

--- a/packages/edit-widgets/src/store/actions.js
+++ b/packages/edit-widgets/src/store/actions.js
@@ -44,6 +44,7 @@ export function* initializeState() {
 export const persistStubPost = function* ( id, blocks ) {
 	const stubPost = createStubPost( id, blocks );
 	const args = [ KIND, POST_TYPE, id ];
+	// This is the magic that prevents core-data from trying to resolve the entity
 	yield dispatch( 'core', 'startResolution', 'getEntityRecord', args );
 	yield dispatch(
 		'core',

--- a/packages/edit-widgets/src/store/resolvers.js
+++ b/packages/edit-widgets/src/store/resolvers.js
@@ -6,11 +6,10 @@ import { createBlock } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import { resolveWidgetAreas, select, dispatch } from './controls';
-import { setWidgetAreasOpenState } from './actions';
+import { resolveWidgetAreas, select } from './controls';
+import { persistStubPost, setWidgetAreasOpenState } from './actions';
 import {
 	KIND,
-	POST_TYPE,
 	WIDGET_AREA_ENTITY_TYPE,
 	buildWidgetAreasQuery,
 	buildWidgetAreaPostId,
@@ -76,31 +75,3 @@ export function* getWidgetAreas() {
 		mapping: widgetIdToClientId,
 	};
 }
-
-const persistStubPost = function* ( id, blocks ) {
-	const stubPost = createStubPost( id, blocks );
-	const args = [ KIND, POST_TYPE, id ];
-	yield dispatch( 'core', 'startResolution', 'getEntityRecord', args );
-	yield dispatch(
-		'core',
-		'receiveEntityRecords',
-		KIND,
-		POST_TYPE,
-		stubPost,
-		{ id: stubPost.id },
-		false
-	);
-	yield dispatch( 'core', 'finishResolution', 'getEntityRecord', args );
-	return stubPost;
-};
-
-const createStubPost = ( id, blocks ) => ( {
-	id,
-	slug: id,
-	status: 'draft',
-	type: 'page',
-	blocks,
-	meta: {
-		widgetAreaId: id,
-	},
-} );

--- a/packages/edit-widgets/src/store/utils.js
+++ b/packages/edit-widgets/src/store/utils.js
@@ -43,3 +43,22 @@ export const buildWidgetAreasPostId = () => `widget-areas`;
 export function buildWidgetAreasQuery() {
 	return {};
 }
+
+/**
+ * Creates a stub post with given id and set of blocks. Used as a governing entity records
+ * for all widget areas.
+ *
+ * @param {string} id Post ID.
+ * @param {Array} blocks The list of blocks.
+ * @return {Object} A stub post object formatted in compliance with the data layer.
+ */
+export const createStubPost = ( id, blocks ) => ( {
+	id,
+	slug: id,
+	status: 'draft',
+	type: 'page',
+	blocks,
+	meta: {
+		widgetAreaId: id,
+	},
+} );


### PR DESCRIPTION
## Description

The widgets editor uses a "stub post" as a container for all widget areas. It must be initialized upfront or the data layer would attempt an API resolution. This PR adds that initialization.

## How has this been tested?
1. Go to the widgets editor.
1. Confirm there are no 404 XHR requests in your network tab.
1. Confirm the editor still works and saves the data correctly.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
