### PR TITLE
[RNMobile] Rotation Fix - correct BottomSheet in ModalLinkUI

### DIFF
--- a/packages/format-library/src/link/modal.native.js
+++ b/packages/format-library/src/link/modal.native.js
@@ -22,6 +22,7 @@ const ModalLinkUI = ( { isVisible, ...restProps } ) => {
 				isChildrenScrollable
 				isVisible={ isVisible }
 				hideHeader
+				onClose={ restProps.onClose }
 			>
 				<BottomSheet.NavigationContainer animate main>
 					<BottomSheet.NavigationScreen name={ screens.settings }>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

Fixes: https://github.com/wordpress-mobile/gutenberg-mobile/issues/2681

## Description
<!-- Please describe what you have changed or added -->

Fix the crash observed when rotating the device with focused paragraph. 

## How has this been tested?

1.Create a new Post or Page
2. Make an edit like typing into a paragraph block
3. Rotate the device
4. Expect there is no crash

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

![rotation_fix](https://user-images.githubusercontent.com/22746080/94692328-b54e7c80-0332-11eb-9884-23d01e48ba3c.gif)

## Types of changes

Pass missing `onClose` in `BottomSheet` within `ModalLinkUI`.

<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [X] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
