### PR TITLE
Register each reference widget as a separate block

### DIFF
--- a/lib/widgets.php
+++ b/lib/widgets.php
@@ -174,6 +174,7 @@ function gutenberg_get_legacy_widget_settings() {
 					null,
 				'isReferenceWidget' => false,
 				'isHidden'          => in_array( $class, $widgets_to_exclude_from_legacy_widget_block, true ),
+				'blockName'         => 'core/legacy-widget',
 			);
 		}
 	}
@@ -195,6 +196,7 @@ function gutenberg_get_legacy_widget_settings() {
 				'name'              => html_entity_decode( $widget_obj['name'] ),
 				'description'       => html_entity_decode( wp_widget_description( $widget_id ) ),
 				'isReferenceWidget' => true,
+				'blockName'         => 'core/legacy-widget-' . preg_replace( '#[^a-zA-Z0-9-]#', '-', $widget_id ),
 			);
 		}
 	}
@@ -288,4 +290,3 @@ function change_post_template_to_widget_preview( $template ) {
 	return $template;
 }
 add_filter( 'template_include', 'change_post_template_to_widget_preview' );
-

--- a/packages/edit-widgets/src/blocks/legacy-widget/edit/index.js
+++ b/packages/edit-widgets/src/blocks/legacy-widget/edit/index.js
@@ -6,10 +6,11 @@ import { get, omit } from 'lodash';
 /**
  * WordPress dependencies
  */
+import { createBlock } from '@wordpress/blocks';
 import { useState } from '@wordpress/element';
 import { Button, PanelBody, ToolbarGroup } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { withSelect } from '@wordpress/data';
+import { useDispatch, withSelect } from '@wordpress/data';
 import { BlockControls, InspectorControls } from '@wordpress/block-editor';
 import { update } from '@wordpress/icons';
 
@@ -23,6 +24,7 @@ import WidgetPreview from './widget-preview';
 function LegacyWidgetEdit( {
 	attributes,
 	availableLegacyWidgets,
+	clientId,
 	hasPermissionsToManageWidgets,
 	prerenderedEditForm,
 	setAttributes,
@@ -33,6 +35,7 @@ function LegacyWidgetEdit( {
 	const [ hasEditForm, setHasEditForm ] = useState( true );
 	const [ isPreview, setIsPreview ] = useState( false );
 	const shouldHidePreview = ! isPreview && hasEditForm;
+	const { replaceBlocks } = useDispatch( 'core/block-editor' );
 
 	function changeWidget() {
 		switchToEdit();
@@ -59,26 +62,8 @@ function LegacyWidgetEdit( {
 				availableLegacyWidgets={ availableLegacyWidgets }
 				hasPermissionsToManageWidgets={ hasPermissionsToManageWidgets }
 				onChangeWidget={ ( newWidget ) => {
-					const {
-						isReferenceWidget,
-						id_base: idBase,
-					} = availableLegacyWidgets[ newWidget ];
-
-					if ( isReferenceWidget ) {
-						setAttributes( {
-							instance: {},
-							idBase,
-							referenceWidgetName: newWidget,
-							widgetClass: undefined,
-						} );
-					} else {
-						setAttributes( {
-							instance: {},
-							idBase,
-							referenceWidgetName: undefined,
-							widgetClass: newWidget,
-						} );
-					}
+					const { blockName } = availableLegacyWidgets[ newWidget ];
+					replaceBlocks( clientId, createBlock( blockName, {} ) );
 				} }
 			/>
 		);

--- a/packages/edit-widgets/src/blocks/legacy-widget/index.php
+++ b/packages/edit-widgets/src/blocks/legacy-widget/index.php
@@ -9,12 +9,22 @@
  * Register legacy widget block.
  */
 function register_block_core_legacy_widget() {
-	register_block_type_from_metadata(
+	$block_type     = register_block_type_from_metadata(
 		__DIR__ . '/legacy-widget',
 		array(
 			'render_callback' => 'render_block_core_legacy_widget',
 		)
 	);
+	$settings       = gutenberg_get_legacy_widget_settings();
+	$legacy_widgets = $settings['availableLegacyWidgets'];
+	foreach ( $legacy_widgets as $widget_id => $legacy_widget ) {
+		if ( ! $legacy_widget['isReferenceWidget'] ) {
+			continue;
+		}
+		$legacy_block       = clone $block_type;
+		$legacy_block->name = $legacy_widget['blockName'];
+		WP_Block_Type_Registry::get_instance()->register( $legacy_block );
+	}
 }
 
 /**

--- a/packages/edit-widgets/src/index.js
+++ b/packages/edit-widgets/src/index.js
@@ -17,7 +17,7 @@ import {
  */
 import './store';
 import './hooks';
-import { create as createLegacyWidget } from './blocks/legacy-widget';
+import { create as createLegacyWidgetBlocks } from './blocks/legacy-widget';
 import * as widgetArea from './blocks/widget-area';
 import EditWidgetsInitializer from './components/edit-widgets-initializer';
 
@@ -31,7 +31,8 @@ export function initialize( id, settings ) {
 	registerCoreBlocks();
 	if ( process.env.GUTENBERG_PHASE === 2 ) {
 		__experimentalRegisterExperimentalCoreBlocks( settings );
-		registerBlock( createLegacyWidget( settings ) );
+		const blocks = createLegacyWidgetBlocks( settings );
+		blocks.forEach( registerBlock );
 		registerBlock( widgetArea );
 	}
 	render(


### PR DESCRIPTION
## Description

Solves https://github.com/WordPress/gutenberg/issues/25494

Before this PR, reference widgets were registered as variations of the `legacy-widget` block. Unfortunately, the requirements for handling reference widgets are very different from regular widgets. One such example is that there should never be more than one reference widget present. This feature is already supported at the block level via `supports.multiple = false`. Unfortunately, it's not possible to use that setting for specific variations.

This PR attempts to solve the problem by registering each reference widget as a separate block. It is a highly unusual pattern as each block usually comes with it's own block.json and a set of components. That being said, widgets are dynamic in nature, so relying on anything generated during the transpilation wouldn't work.

Let's discuss this approach. Are there any downsides? Are there any better ways of achieving the same result?

**Side note:** If this PR were to be merged, we should add a lot of inline comments to explain what's happening. As I wasn't sure if it's a viable approach, I didn't include any documentation in this initial attempt.

## How has this been tested?
1. Add a reference widget to your WordPress, for example marquee: https://gist.github.com/adamziel/526436b4cc9bc82a7221c77e00137ae1
1. Go to the widgets editor, confirm Marquee is available in the block inserter.
1. Insert the **Legacy Widget** block, confirm Marquee is on the list of available blocks.
1. Choose Marquee, confirm it worked.
1. Confirm Marquee is greyed out in the block inserter.
1. Add another Legacy Widget, confirm you are not able to add another Marquee.
1. Remove the Marquee, insert another one using block inserter, confirm you're unable to insert yet another one.

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
