### PR TITLE
Navigation Component: Hide navigation item if target menu is empty

### DIFF
--- a/packages/components/src/navigation/README.md
+++ b/packages/components/src/navigation/README.md
@@ -137,12 +137,19 @@ The parent menu slug; used by nested menus to indicate their parent menu.
 
 When `hasSearch` is active and `onSearch` is provided, this controls the value of the search input. Required when the `onSearch` prop is provided.
 
+### `isEmpty`
+
+-   Type: `boolean`
+-   Required: No
+
+Indicates whether the menu is empty or not. Used together with the `hideIfTargetMenuEmpty` prop of Navigation Item.
+
 ### `title`
 
 -   Type: `string`
 -   Required: No
 
-The menu title. It's also the field used by the menu search function. 
+The menu title. It's also the field used by the menu search function.
 
 ## Navigation Group Props
 
@@ -200,6 +207,13 @@ The unique identifier of the item.
 -   Required: No
 
 The child menu slug. If provided, clicking on the item will navigate to the target menu.
+
+### `hideIfTargetMenuEmpty`
+
+-   Type: `boolean`
+-   Required: No
+
+Indicates whether this item should be hidden if the menu specified in `navigateToMenu` is marked as empty in the `isEmpty` prop. Used together with the `isEmpty` prop of Navigation Menu.
 
 ### `onClick`
 

--- a/packages/components/src/navigation/context.js
+++ b/packages/components/src/navigation/context.js
@@ -17,6 +17,7 @@ export const NavigationContext = createContext( {
 	activeItem: undefined,
 	activeMenu: ROOT_MENU,
 	setActiveMenu: noop,
+	isEmpty: noop,
 
 	navigationTree: {
 		items: {},

--- a/packages/components/src/navigation/context.js
+++ b/packages/components/src/navigation/context.js
@@ -17,7 +17,7 @@ export const NavigationContext = createContext( {
 	activeItem: undefined,
 	activeMenu: ROOT_MENU,
 	setActiveMenu: noop,
-	isEmpty: noop,
+	isMenuEmpty: noop,
 
 	navigationTree: {
 		items: {},

--- a/packages/components/src/navigation/context.js
+++ b/packages/components/src/navigation/context.js
@@ -29,6 +29,9 @@ export const NavigationContext = createContext( {
 		getMenu: noop,
 		addMenu: noop,
 		removeMenu: noop,
+		menusDirectChildren: {},
+		traverseMenu: noop,
+		isMenuEmpty: noop,
 	},
 } );
 export const useNavigationContext = () => useContext( NavigationContext );

--- a/packages/components/src/navigation/context.js
+++ b/packages/components/src/navigation/context.js
@@ -29,7 +29,7 @@ export const NavigationContext = createContext( {
 		getMenu: noop,
 		addMenu: noop,
 		removeMenu: noop,
-		menusDirectChildren: {},
+		directSubMenus: {},
 		traverseMenu: noop,
 		isMenuEmpty: noop,
 	},

--- a/packages/components/src/navigation/context.js
+++ b/packages/components/src/navigation/context.js
@@ -29,7 +29,7 @@ export const NavigationContext = createContext( {
 		getMenu: noop,
 		addMenu: noop,
 		removeMenu: noop,
-		directSubMenus: {},
+		childMenu: {},
 		traverseMenu: noop,
 		isMenuEmpty: noop,
 	},

--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -58,7 +58,7 @@ export default function Navigation( {
 	const findByParentMenu = ( parentMenu ) =>
 		navigationTree.parentMenuToMenu[ parentMenu ] || [];
 
-	const isEmpty = ( menuToCheck ) => {
+	const isMenuEmpty = ( menuToCheck ) => {
 		let count = 0;
 
 		if ( ! navigationTree.menus[ menuToCheck ]?.isEmpty ) {
@@ -88,8 +88,8 @@ export default function Navigation( {
 		activeItem,
 		activeMenu: menu,
 		setActiveMenu,
+		isMenuEmpty,
 		navigationTree,
-		isEmpty,
 	};
 
 	const classes = classnames( 'components-navigation', className );

--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -55,11 +55,41 @@ export default function Navigation( {
 		}
 	}, [ activeMenu ] );
 
+	const findByParentMenu = ( parentMenu ) =>
+		navigationTree.parentMenuToMenu[ parentMenu ] || [];
+
+	const isEmpty = ( menuToCheck ) => {
+		let count = 0;
+
+		if ( ! navigationTree.menus[ menuToCheck ]?.isEmpty ) {
+			count++;
+		}
+
+		const visited = [];
+		let queue = findByParentMenu( menuToCheck );
+		let current;
+		while ( queue.length ) {
+			current = queue.shift();
+
+			if ( current && ! visited.includes( current.menu ) ) {
+				if ( ! current.isEmpty ) {
+					count++;
+				}
+
+				visited.push( current.menu );
+				queue = [ ...queue, ...findByParentMenu( current.menu ) ];
+			}
+		}
+
+		return count === 0;
+	};
+
 	const context = {
 		activeItem,
 		activeMenu: menu,
 		setActiveMenu,
 		navigationTree,
+		isEmpty,
 	};
 
 	const classes = classnames( 'components-navigation', className );

--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -55,45 +55,10 @@ export default function Navigation( {
 		}
 	}, [ activeMenu ] );
 
-	const traverseMenu = ( startMenu, callback ) => {
-		const visited = [];
-		let queue = [ startMenu ];
-		let current;
-
-		while ( queue.length ) {
-			current = navigationTree.getMenu( queue.shift() );
-
-			if ( ! current || visited.includes( current.menu ) ) {
-				continue;
-			}
-
-			visited.push( current.menu );
-			queue = [
-				...queue,
-				...( navigationTree.parentMenuToMenu[ current.menu ] || [] ),
-			];
-
-			callback( current );
-		}
-	};
-
-	const isMenuEmpty = ( menuToCheck ) => {
-		let count = 0;
-
-		traverseMenu( menuToCheck, ( current ) => {
-			if ( ! current.isEmpty ) {
-				count++;
-			}
-		} );
-
-		return count === 0;
-	};
-
 	const context = {
 		activeItem,
 		activeMenu: menu,
 		setActiveMenu,
-		isMenuEmpty,
 		navigationTree,
 	};
 

--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -55,31 +55,36 @@ export default function Navigation( {
 		}
 	}, [ activeMenu ] );
 
-	const findByParentMenu = ( parentMenu ) =>
-		navigationTree.parentMenuToMenu[ parentMenu ] || [];
+	const traverseMenu = ( startMenu, callback ) => {
+		const visited = [];
+		let queue = [ startMenu ];
+		let current;
+
+		while ( queue.length ) {
+			current = navigationTree.getMenu( queue.shift() );
+
+			if ( ! current || visited.includes( current.menu ) ) {
+				continue;
+			}
+
+			visited.push( current.menu );
+			queue = [
+				...queue,
+				...( navigationTree.parentMenuToMenu[ current.menu ] || [] ),
+			];
+
+			callback( current );
+		}
+	};
 
 	const isMenuEmpty = ( menuToCheck ) => {
 		let count = 0;
 
-		if ( ! navigationTree.menus[ menuToCheck ]?.isEmpty ) {
-			count++;
-		}
-
-		const visited = [];
-		let queue = findByParentMenu( menuToCheck );
-		let current;
-		while ( queue.length ) {
-			current = queue.shift();
-
-			if ( current && ! visited.includes( current.menu ) ) {
-				if ( ! current.isEmpty ) {
-					count++;
-				}
-
-				visited.push( current.menu );
-				queue = [ ...queue, ...findByParentMenu( current.menu ) ];
+		traverseMenu( menuToCheck, ( current ) => {
+			if ( ! current.isEmpty ) {
+				count++;
 			}
-		}
+		} );
 
 		return count === 0;
 	};

--- a/packages/components/src/navigation/item/index.js
+++ b/packages/components/src/navigation/item/index.js
@@ -54,6 +54,9 @@ export default function NavigationItem( props ) {
 		return null;
 	}
 
+	// If hideIfTargetMenuEmpty prop is true
+	// And the menu we are supposed to navigate to
+	// Is marked as empty, then we skip rendering the item
 	if (
 		hideIfTargetMenuEmpty &&
 		navigateToMenu &&

--- a/packages/components/src/navigation/item/index.js
+++ b/packages/components/src/navigation/item/index.js
@@ -32,13 +32,6 @@ export default function NavigationItem( props ) {
 		hideIfTargetMenuEmpty,
 		...restProps
 	} = props;
-	useNavigationTreeItem( props );
-	const {
-		activeItem,
-		setActiveMenu,
-		navigationTree: { isMenuEmpty },
-	} = useNavigationContext();
-	const { isActive } = useNavigationMenuContext();
 
 	const [ itemId ] = useState( uniqueId( 'item-' ) );
 
@@ -60,7 +53,7 @@ export default function NavigationItem( props ) {
 	if (
 		hideIfTargetMenuEmpty &&
 		navigateToMenu &&
-		isMenuEmpty( navigateToMenu )
+		navigationTree.isMenuEmpty( navigateToMenu )
 	) {
 		return null;
 	}

--- a/packages/components/src/navigation/item/index.js
+++ b/packages/components/src/navigation/item/index.js
@@ -33,7 +33,7 @@ export default function NavigationItem( props ) {
 		...restProps
 	} = props;
 	useNavigationTreeItem( props );
-	const { activeItem, setActiveMenu, isEmpty } = useNavigationContext();
+	const { activeItem, setActiveMenu, isMenuEmpty } = useNavigationContext();
 	const { isActive } = useNavigationMenuContext();
 
 	const [ itemId ] = useState( uniqueId( 'item-' ) );
@@ -53,7 +53,7 @@ export default function NavigationItem( props ) {
 	if (
 		hideIfTargetMenuEmpty &&
 		navigateToMenu &&
-		isEmpty( navigateToMenu )
+		isMenuEmpty( navigateToMenu )
 	) {
 		return null;
 	}

--- a/packages/components/src/navigation/item/index.js
+++ b/packages/components/src/navigation/item/index.js
@@ -29,8 +29,12 @@ export default function NavigationItem( props ) {
 		navigateToMenu,
 		onClick = noop,
 		title,
+		hideIfTargetMenuEmpty,
 		...restProps
 	} = props;
+	useNavigationTreeItem( props );
+	const { activeItem, setActiveMenu, isEmpty } = useNavigationContext();
+	const { isActive } = useNavigationMenuContext();
 
 	const [ itemId ] = useState( uniqueId( 'item-' ) );
 
@@ -43,6 +47,14 @@ export default function NavigationItem( props ) {
 	const isRTL = useRTL();
 
 	if ( ! navigationTree.getItem( itemId )?._isVisible ) {
+		return null;
+	}
+
+	if (
+		hideIfTargetMenuEmpty &&
+		navigateToMenu &&
+		isEmpty( navigateToMenu )
+	) {
 		return null;
 	}
 

--- a/packages/components/src/navigation/item/index.js
+++ b/packages/components/src/navigation/item/index.js
@@ -33,7 +33,11 @@ export default function NavigationItem( props ) {
 		...restProps
 	} = props;
 	useNavigationTreeItem( props );
-	const { activeItem, setActiveMenu, isMenuEmpty } = useNavigationContext();
+	const {
+		activeItem,
+		setActiveMenu,
+		navigationTree: { isMenuEmpty },
+	} = useNavigationContext();
 	const { isActive } = useNavigationMenuContext();
 
 	const [ itemId ] = useState( uniqueId( 'item-' ) );

--- a/packages/components/src/navigation/stories/hide-if-empty.js
+++ b/packages/components/src/navigation/stories/hide-if-empty.js
@@ -1,0 +1,55 @@
+/**
+ * Internal dependencies
+ */
+import Navigation from '..';
+import NavigationItem from '../item';
+import NavigationMenu from '../menu';
+
+export function HideIFEmptyStory() {
+	return (
+		<>
+			<Navigation>
+				<NavigationMenu title="Home" menu="root" isEmpty={ false }>
+					<NavigationItem
+						navigateToMenu="root-sub-1"
+						title="To sub 1 (hidden)"
+						hideIfTargetMenuEmpty
+					/>
+
+					<NavigationItem
+						navigateToMenu="root-sub-2"
+						title="To sub 2 (visible)"
+						hideIfTargetMenuEmpty
+					/>
+
+					<NavigationItem
+						navigateToMenu="root-sub-1-sub-1"
+						title="To sub 1-1 (hidden)"
+						hideIfTargetMenuEmpty
+					/>
+				</NavigationMenu>
+
+				<NavigationMenu
+					menu="root-sub-1"
+					parentMenu="root"
+					isEmpty={ true }
+				/>
+				<NavigationMenu
+					menu="root-sub-2"
+					parentMenu="root"
+					isEmpty={ false }
+				/>
+				<NavigationMenu
+					menu="root-sub-1-sub-1"
+					parentMenu="root-sub-1"
+					isEmpty={ true }
+				/>
+			</Navigation>
+
+			<p>
+				This story contains 3 navigation items and 4 menus. You should
+				only see one item: <strong>To sub 2 (visible)</strong>
+			</p>
+		</>
+	);
+}

--- a/packages/components/src/navigation/stories/hide-if-empty.js
+++ b/packages/components/src/navigation/stories/hide-if-empty.js
@@ -8,7 +8,7 @@ import NavigationMenu from '../menu';
 export function HideIFEmptyStory() {
 	return (
 		<>
-			<Navigation>
+			<Navigation className="navigation-story">
 				<NavigationMenu title="Home" menu="root" isEmpty={ false }>
 					<NavigationItem
 						navigateToMenu="root-sub-1"
@@ -38,7 +38,9 @@ export function HideIFEmptyStory() {
 					menu="root-sub-2"
 					parentMenu="root"
 					isEmpty={ false }
-				/>
+				>
+					<NavigationItem title="This menu is visible" />
+				</NavigationMenu>
 				<NavigationMenu
 					menu="root-sub-1-sub-1"
 					parentMenu="root-sub-1"

--- a/packages/components/src/navigation/stories/hide-if-empty.js
+++ b/packages/components/src/navigation/stories/hide-if-empty.js
@@ -5,7 +5,7 @@ import Navigation from '..';
 import NavigationItem from '../item';
 import NavigationMenu from '../menu';
 
-export function HideIFEmptyStory() {
+export function HideIfEmptyStory() {
 	return (
 		<>
 			<Navigation className="navigation-story">

--- a/packages/components/src/navigation/stories/index.js
+++ b/packages/components/src/navigation/stories/index.js
@@ -29,3 +29,44 @@ export const controlledState = () => <ControlledStateStory />;
 export const groups = () => <GroupStory />;
 export const search = () => <SearchStory />;
 export const moreExamples = () => <MoreExamplesStory />;
+
+export const Test = () => {
+	return (
+		<Navigation>
+			<NavigationMenu title="Home" menu="root" isEmpty={ false }>
+				<NavigationItem
+					navigateToMenu="root-sub-1"
+					title="To sub 1 (hidden)"
+					hideIfTargetMenuEmpty
+				/>
+
+				<NavigationItem
+					navigateToMenu="root-sub-2"
+					title="To sub 2"
+					hideIfTargetMenuEmpty
+				/>
+
+				<NavigationItem
+					navigateToMenu="root-sub-1-sub-1"
+					title="To sub 1-1 (hidden)"
+					hideIfTargetMenuEmpty
+				/>
+			</NavigationMenu>
+			<NavigationMenu
+				menu="root-sub-1"
+				parentMenu="root"
+				isEmpty={ true }
+			/>
+			<NavigationMenu
+				menu="root-sub-2"
+				parentMenu="root"
+				isEmpty={ false }
+			/>
+			<NavigationMenu
+				menu="root-sub-1-sub-1"
+				parentMenu="root-sub-1"
+				isEmpty={ true }
+			/>
+		</Navigation>
+	);
+};

--- a/packages/components/src/navigation/stories/index.js
+++ b/packages/components/src/navigation/stories/index.js
@@ -11,6 +11,7 @@ import { GroupStory } from './group';
 import { ControlledStateStory } from './controlled-state';
 import { SearchStory } from './search';
 import { MoreExamplesStory } from './more-examples';
+import { HideIFEmptyStory } from './hide-if-empty';
 import './style.css';
 
 export default {
@@ -29,44 +30,4 @@ export const controlledState = () => <ControlledStateStory />;
 export const groups = () => <GroupStory />;
 export const search = () => <SearchStory />;
 export const moreExamples = () => <MoreExamplesStory />;
-
-export const Test = () => {
-	return (
-		<Navigation>
-			<NavigationMenu title="Home" menu="root" isEmpty={ false }>
-				<NavigationItem
-					navigateToMenu="root-sub-1"
-					title="To sub 1 (hidden)"
-					hideIfTargetMenuEmpty
-				/>
-
-				<NavigationItem
-					navigateToMenu="root-sub-2"
-					title="To sub 2"
-					hideIfTargetMenuEmpty
-				/>
-
-				<NavigationItem
-					navigateToMenu="root-sub-1-sub-1"
-					title="To sub 1-1 (hidden)"
-					hideIfTargetMenuEmpty
-				/>
-			</NavigationMenu>
-			<NavigationMenu
-				menu="root-sub-1"
-				parentMenu="root"
-				isEmpty={ true }
-			/>
-			<NavigationMenu
-				menu="root-sub-2"
-				parentMenu="root"
-				isEmpty={ false }
-			/>
-			<NavigationMenu
-				menu="root-sub-1-sub-1"
-				parentMenu="root-sub-1"
-				isEmpty={ true }
-			/>
-		</Navigation>
-	);
-};
+export const hideIfEmpty = () => <HideIFEmptyStory />;

--- a/packages/components/src/navigation/stories/index.js
+++ b/packages/components/src/navigation/stories/index.js
@@ -11,7 +11,7 @@ import { GroupStory } from './group';
 import { ControlledStateStory } from './controlled-state';
 import { SearchStory } from './search';
 import { MoreExamplesStory } from './more-examples';
-import { HideIFEmptyStory } from './hide-if-empty';
+import { HideIfEmptyStory } from './hide-if-empty';
 import './style.css';
 
 export default {
@@ -30,4 +30,4 @@ export const controlledState = () => <ControlledStateStory />;
 export const groups = () => <GroupStory />;
 export const search = () => <SearchStory />;
 export const moreExamples = () => <MoreExamplesStory />;
-export const hideIfEmpty = () => <HideIFEmptyStory />;
+export const hideIfEmpty = () => <HideIfEmptyStory />;

--- a/packages/components/src/navigation/use-create-navigation-tree.js
+++ b/packages/components/src/navigation/use-create-navigation-tree.js
@@ -23,10 +23,8 @@ export const useCreateNavigationTree = () => {
 		removeNode: removeMenu,
 	} = useNavigationTreeNodes();
 
-	const [ menusDirectChildren, setMenusDirectChildren ] = useState( {} );
-
-	const getDirectChildrenOfMenu = ( menu ) =>
-		menusDirectChildren[ menu ] || [];
+	const [ directSubMenus, setDirectSubMenus ] = useState( {} );
+	const getDirectSubMenus = ( menu ) => directSubMenus[ menu ] || [];
 
 	const traverseMenu = ( startMenu, callback ) => {
 		const visited = [];
@@ -41,7 +39,7 @@ export const useCreateNavigationTree = () => {
 			}
 
 			visited.push( current.menu );
-			queue = [ ...queue, ...getDirectChildrenOfMenu( current.menu ) ];
+			queue = [ ...queue, ...getDirectSubMenus( current.menu ) ];
 
 			callback( current );
 		}
@@ -68,7 +66,7 @@ export const useCreateNavigationTree = () => {
 		menus,
 		getMenu,
 		addMenu: ( key, value ) => {
-			setMenusDirectChildren( ( state ) => {
+			setDirectSubMenus( ( state ) => {
 				const newState = { ...state };
 
 				if ( ! newState[ value.parentMenu ] ) {
@@ -83,7 +81,7 @@ export const useCreateNavigationTree = () => {
 			addMenu( key, value );
 		},
 		removeMenu,
-		menusDirectChildren,
+		directSubMenus,
 		traverseMenu,
 		isMenuEmpty,
 	};

--- a/packages/components/src/navigation/use-create-navigation-tree.js
+++ b/packages/components/src/navigation/use-create-navigation-tree.js
@@ -23,6 +23,13 @@ export const useCreateNavigationTree = () => {
 		removeNode: removeMenu,
 	} = useNavigationTreeNodes();
 
+	/**
+	 * Stores direct nested menus of menus
+	 * This makes it easy to traverse menu tree
+	 *
+	 * Key is the menu prop of the menu
+	 * Value is an array of menu keys
+	 */
 	const [ directSubMenus, setDirectSubMenus ] = useState( {} );
 	const getDirectSubMenus = ( menu ) => directSubMenus[ menu ] || [];
 

--- a/packages/components/src/navigation/use-create-navigation-tree.js
+++ b/packages/components/src/navigation/use-create-navigation-tree.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import { useNavigationTreeNodes } from './use-navigation-tree-nodes';
@@ -11,6 +16,7 @@ export const useCreateNavigationTree = () => {
 		removeNode: removeItem,
 	} = useNavigationTreeNodes();
 
+	const [ parentMenuToMenu, setParentMenuToMenu ] = useState( {} );
 	const {
 		nodes: menus,
 		getNode: getMenu,
@@ -26,7 +32,16 @@ export const useCreateNavigationTree = () => {
 
 		menus,
 		getMenu,
-		addMenu,
+		addMenu: ( key, value ) => {
+			setParentMenuToMenu( ( state ) => ( {
+				...state,
+				[ value.parentMenu ]: state[ value.parentMenu ]
+					? [ ...state[ value.parentMenu ], key ]
+					: [ key ],
+			} ) );
+			addMenu( key, value );
+		},
 		removeMenu,
+		parentMenuToMenu,
 	};
 };

--- a/packages/components/src/navigation/use-create-navigation-tree.js
+++ b/packages/components/src/navigation/use-create-navigation-tree.js
@@ -48,20 +48,23 @@ export const useCreateNavigationTree = () => {
 			visited.push( current.menu );
 			queue = [ ...queue, ...getChildMenu( current.menu ) ];
 
-			callback( current );
+			if ( callback( current ) === false ) {
+				break;
+			}
 		}
 	};
 
 	const isMenuEmpty = ( menuToCheck ) => {
-		let count = 0;
+		let isEmpty = true;
 
 		traverseMenu( menuToCheck, ( current ) => {
 			if ( ! current.isEmpty ) {
-				count++;
+				isEmpty = false;
+				return false;
 			}
 		} );
 
-		return count === 0;
+		return isEmpty;
 	};
 
 	return {

--- a/packages/components/src/navigation/use-create-navigation-tree.js
+++ b/packages/components/src/navigation/use-create-navigation-tree.js
@@ -30,8 +30,8 @@ export const useCreateNavigationTree = () => {
 	 * Key is the menu prop of the menu
 	 * Value is an array of menu keys
 	 */
-	const [ directSubMenus, setDirectSubMenus ] = useState( {} );
-	const getDirectSubMenus = ( menu ) => directSubMenus[ menu ] || [];
+	const [ childMenu, setChildMenu ] = useState( {} );
+	const getChildMenu = ( menu ) => childMenu[ menu ] || [];
 
 	const traverseMenu = ( startMenu, callback ) => {
 		const visited = [];
@@ -46,7 +46,7 @@ export const useCreateNavigationTree = () => {
 			}
 
 			visited.push( current.menu );
-			queue = [ ...queue, ...getDirectSubMenus( current.menu ) ];
+			queue = [ ...queue, ...getChildMenu( current.menu ) ];
 
 			callback( current );
 		}
@@ -73,7 +73,7 @@ export const useCreateNavigationTree = () => {
 		menus,
 		getMenu,
 		addMenu: ( key, value ) => {
-			setDirectSubMenus( ( state ) => {
+			setChildMenu( ( state ) => {
 				const newState = { ...state };
 
 				if ( ! newState[ value.parentMenu ] ) {
@@ -88,7 +88,7 @@ export const useCreateNavigationTree = () => {
 			addMenu( key, value );
 		},
 		removeMenu,
-		directSubMenus,
+		directSubMenus: childMenu,
 		traverseMenu,
 		isMenuEmpty,
 	};

--- a/packages/components/src/navigation/use-create-navigation-tree.js
+++ b/packages/components/src/navigation/use-create-navigation-tree.js
@@ -88,7 +88,7 @@ export const useCreateNavigationTree = () => {
 			addMenu( key, value );
 		},
 		removeMenu,
-		directSubMenus: childMenu,
+		childMenu,
 		traverseMenu,
 		isMenuEmpty,
 	};


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
The need for a solution like this came up in this PR: https://github.com/WordPress/gutenberg/pull/25739

We need a solution to mark `NavigationMenu` as empty and avoid rendering all the `NavigationItem` which are supposed to navigate to the empty menu. This is pretty straightforward for 1 level `Navigation`, but we can nest `NavigationMenu`s which makes the a lot more interesting.

This implementation traverses our `navigationTree` and goes through all the nested menus to check if they are empty. Empty is based on the `isEmpty` prop which should be specified by the consumer on `NavigationMenu` component. A menu is not considered empty if any nested menus are `isEmpty={ false }`.

-----

This implementation exposes two new functions in the `navigationTree` context:

**traverseMenu**

This function takes two parameters, first is the menu we should start traversing from. Second parameter is a callback which will be called for the menu specified in the first parameter and all the menus that are nested.

**isMenuEmpty**

This function takes one parameter, the menu we would like to check if it is empty or not. This function uses `traverseMenu` to go traverse the menu specified in the first parameter. If the specified menu is empty and all nested nested menus are empty as well, then this function returns `true`. Otherwise it returns `false`

-----

`NavigationItem` has a new boolean prop: **hideIfTargetMenuEmpty**. If `hideIfTargetMenuEmpty` is `true`, then it checks the `navigateToMenu` menu for emptiness. If the menu is empty, then this `NavigationItem` won't be rendered.

## How has this been tested?
- `yarn storybook:dev`
- `Navigation` -> `Hide If Empty`

## Screenshots <!-- if applicable -->

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->

Fixes #26265 