### PR TITLE
External Link: Use CSS-in-JS

### DIFF
--- a/packages/block-library/src/embed/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/embed/test/__snapshots__/index.js.snap
@@ -1,6 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`core/embed block edit matches snapshot 1`] = `
+.emotion-0 {
+  width: 1.4em;
+  height: 1.4em;
+  margin: -0.2em 0.1em 0;
+  vertical-align: middle;
+  fill: currentColor;
+}
+
 <div
   class="components-placeholder wp-block-embed is-large"
 >
@@ -66,7 +74,7 @@ exports[`core/embed block edit matches snapshot 1`] = `
         </span>
         <svg
           aria-hidden="true"
-          class="components-external-link__icon"
+          class="components-external-link__icon emotion-0 emotion-1"
           focusable="false"
           height="24"
           role="img"

--- a/packages/components/src/external-link/index.js
+++ b/packages/components/src/external-link/index.js
@@ -9,12 +9,13 @@ import { compact, uniq } from 'lodash';
  */
 import { __ } from '@wordpress/i18n';
 import { forwardRef } from '@wordpress/element';
-import { external, Icon } from '@wordpress/icons';
+import { external } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import VisuallyHidden from '../visually-hidden';
+import { StyledIcon } from './styles/external-link-styles';
 
 export function ExternalLink(
 	{ href, children, className, rel = '', ...additionalProps },
@@ -41,7 +42,7 @@ export function ExternalLink(
 					__( '(opens in a new tab)' )
 				}
 			</VisuallyHidden>
-			<Icon
+			<StyledIcon
 				icon={ external }
 				className="components-external-link__icon"
 			/>

--- a/packages/components/src/external-link/style.scss
+++ b/packages/components/src/external-link/style.scss
@@ -1,7 +1,0 @@
-.components-external-link__icon {
-	width: 1.4em;
-	height: 1.4em;
-	margin: -0.2em 0.1em 0;
-	vertical-align: middle;
-	fill: currentColor;
-}

--- a/packages/components/src/external-link/styles/external-link-styles.js
+++ b/packages/components/src/external-link/styles/external-link-styles.js
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import styled from '@emotion/styled';
+
+/**
+ * WordPress dependencies
+ */
+import { Icon } from '@wordpress/icons';
+
+export const StyledIcon = styled( Icon )`
+	width: 1.4em;
+	height: 1.4em;
+	margin: -0.2em 0.1em 0;
+	vertical-align: middle;
+	fill: currentColor;
+`;

--- a/packages/components/src/style.scss
+++ b/packages/components/src/style.scss
@@ -17,7 +17,6 @@
 @import "./drop-zone/style.scss";
 @import "./dropdown/style.scss";
 @import "./dropdown-menu/style.scss";
-@import "./external-link/style.scss";
 @import "./font-size-picker/style.scss";
 @import "./form-toggle/style.scss";
 @import "./form-token-field/style.scss";


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This PR updates the `ExternalLink` component to use CSS-in-JS similar to how newer components do like the `AnglePickerControl` and `Text`. This also maintains the existing classname on the `Icon` even though it isn't being used by the component itself, it allows the `Icon` to still be targeted by consumers, making this a non-breaking change.

## How has this been tested?
I've run storybook and observed that there are new visual differences in before and after.

## Screenshots <!-- if applicable -->
Before:
<img width="122" alt="Captura de Tela 2020-09-30 às 10 45 33" src="https://user-images.githubusercontent.com/24264157/94721014-16158f00-030a-11eb-83ba-e12c5fc27bfc.png">

After:
<img width="165" alt="Captura de Tela 2020-09-30 às 10 43 53" src="https://user-images.githubusercontent.com/24264157/94721017-1877e900-030a-11eb-91c9-9ab905f7865d.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
