### PR TITLE
Ensure focus of input when InputControl spinner arrows are pressed

### DIFF
--- a/packages/components/src/input-control/input-field.js
+++ b/packages/components/src/input-control/input-field.js
@@ -39,6 +39,7 @@ function InputField(
 		setIsFocused,
 		stateReducer = ( state ) => state,
 		value: valueProp,
+		type,
 		...props
 	},
 	ref
@@ -100,6 +101,19 @@ function InputField(
 			}
 		}
 	};
+
+	/*
+	 * Works around the odd UA (e.g. Firefox) that does not focus inputs of
+	 * type=number when their spinner arrows are pressed.
+	 */
+	let handleOnMouseDown;
+	if ( type === 'number' ) {
+		handleOnMouseDown = ( event ) => {
+			if ( event.target !== event.target.ownerDocument.activeElement ) {
+				event.target.focus();
+			}
+		};
+	}
 
 	const handleOnFocus = ( event ) => {
 		onFocus( event );
@@ -191,9 +205,11 @@ function InputField(
 			onChange={ handleOnChange }
 			onFocus={ handleOnFocus }
 			onKeyDown={ handleOnKeyDown }
+			onMouseDown={ handleOnMouseDown }
 			ref={ ref }
 			size={ size }
 			value={ value }
+			type={ type }
 		/>
 	);
 }


### PR DESCRIPTION
There's currently no separate issue for this. It was reported here: https://github.com/WordPress/gutenberg/pull/25528#issuecomment-701450017

In Firefox (and maybe some other UA out there) number inputs are not focused when their spinners are pressed:
![focus-spinner](https://user-images.githubusercontent.com/9000376/94735047-f76dc300-031e-11eb-96fc-62641cc311b0.gif)

As demonstrated in the screen capture it prevents the value from updating. Without focus the spinners cannot cause the component to update due to value sync logic introduced in 2d5106a.

This PR adds a little workaround to fix the issue by adding a handler for `onmousedown` when InputControl is of number type. The handler focuses the input in case it's not.

## How has this been tested?
With WordPress 5.5.1

## Types of changes
bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [n/a] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [n/a] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
