### PR TITLE
Widgets editor: Add basic options for extensibility

### DIFF
--- a/packages/edit-widgets/src/components/sidebar/block-areas.js
+++ b/packages/edit-widgets/src/components/sidebar/block-areas.js
@@ -4,37 +4,28 @@
 import { useDispatch, useSelect } from '@wordpress/data';
 import { blockDefault } from '@wordpress/icons';
 import { BlockIcon } from '@wordpress/block-editor';
-import { Button } from '@wordpress/components';
+import { Button, Slot } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-function BlockArea( { clientId } ) {
-	const { name, selectedBlock } = useSelect(
-		( select ) => {
-			const { getBlockAttributes, getBlockSelectionStart } = select(
-				'core/block-editor'
-			);
-			return {
-				name: getBlockAttributes( clientId ).name,
-				selectedBlock: getBlockSelectionStart(),
-			};
-		},
-		[ clientId ]
+function BlockArea( { block } ) {
+	const selectedBlock = useSelect(
+		( select ) => select( 'core/block-editor' ).getBlockSelectionStart(),
+		[]
 	);
+
 	const { selectBlock } = useDispatch( 'core/block-editor' );
-	const isSelected = selectedBlock === clientId;
+
+	if ( block.name !== 'core/widget-area' ) {
+		return null;
+	}
+
 	return (
 		<li>
 			<Button
-				aria-expanded={ isSelected }
-				onClick={
-					isSelected
-						? undefined
-						: () => {
-								selectBlock( clientId );
-						  }
-				}
+				aria-expanded={ selectedBlock === block.clientId }
+				onClick={ () => selectBlock( block.clientId ) }
 			>
-				{ name }
+				{ block.attributes.name }
 				<span className="edit-widgets-block-areas__edit">
 					{ __( 'Edit' ) }
 				</span>
@@ -44,10 +35,13 @@ function BlockArea( { clientId } ) {
 }
 
 export default function BlockAreas() {
-	const blockOrder = useSelect( ( select ) => {
-		return select( 'core/block-editor' ).getBlockOrder();
-	} );
-	const hasBlockAreas = blockOrder.length > 0;
+	const blocks = useSelect(
+		( select ) => select( 'core/block-editor' ).getBlocks(),
+		[]
+	);
+
+	const hasBlockAreas = blocks.length > 0;
+
 	return (
 		<>
 			<div className="edit-widgets-block-areas">
@@ -68,10 +62,13 @@ export default function BlockAreas() {
 						) }
 					</div>
 				</div>
+
+				<Slot name="WidgetAreas.Sidebar" />
+
 				{ hasBlockAreas && (
 					<ul>
-						{ blockOrder.map( ( clientId ) => (
-							<BlockArea key={ clientId } clientId={ clientId } />
+						{ blocks.map( ( block ) => (
+							<BlockArea key={ block.clientId } block={ block } />
 						) ) }
 					</ul>
 				) }

--- a/packages/edit-widgets/src/components/sidebar/block-areas.js
+++ b/packages/edit-widgets/src/components/sidebar/block-areas.js
@@ -4,7 +4,7 @@
 import { useDispatch, useSelect } from '@wordpress/data';
 import { blockDefault } from '@wordpress/icons';
 import { BlockIcon } from '@wordpress/block-editor';
-import { Button, Slot } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 function BlockArea( { block } ) {
@@ -62,8 +62,6 @@ export default function BlockAreas() {
 						) }
 					</div>
 				</div>
-
-				<Slot name="WidgetAreas.Sidebar" />
 
 				{ hasBlockAreas && (
 					<ul>

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
@@ -76,6 +76,7 @@ export default function WidgetAreasBlockEditorProvider( {
 							onInput={ onInput }
 							onChange={ onChange }
 							settings={ settings }
+							useSubRegistry={ false }
 							{ ...props }
 						/>
 					</FocusReturnProvider>


### PR DESCRIPTION
Closes https://github.com/WordPress/gutenberg/issues/18068.

Adds some really basic options for extending the widgets editor.

<img width="1304" alt="Screen Shot 2020-10-01 at 15 40 13" src="https://user-images.githubusercontent.com/612155/94772206-78e75300-03fc-11eb-8d02-915c96cca3cc.png">

- ~Adds a `WidgetAreas.Sidebar` `Fill` component so that third party plugins can add custom UI to the widget editor's sidebar.~

- Sets the widget editor's `BlockEditorProvider` to not use a sub-registry, so that third party plugins can add custom blocks (including custom UI) to the block editor used in this screen.

### How to test

Paste this into your DevTools console:

<details><summary>Expand</summary>
<p>

```js
var el = wp.element.createElement;

wp.plugins.registerPlugin( 'test-plugin', {
	render() {
		return el(
			wp.components.Fill,
			{ name: 'WidgetAreas.Sidebar' },
			el(
				'p',
				{},
				'Hello there!'
			)
		);
	},
} );

wp.blocks.registerBlockType( 'test-plugin/hello', {
	title: 'Hello',
	edit() {
		return el(
			'p',
			{},
			'Hello there!'
		);
	},
} );

var existingBlocks = wp.data.select( 'core/block-editor' ).getBlocks();
wp.data.dispatch( 'core/block-editor' ).resetBlocks( [
	wp.blocks.createBlock( 'test-plugin/hello' ),
	...existingBlocks,
	wp.blocks.createBlock( 'test-plugin/hello' ),
] );
```

</p>
</details>