### PR TITLE
Fix widget insertion from sidebar block library by using a declared insertionPoint prop

### DIFF
--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -32,6 +32,7 @@ function useInsertionPoint( {
 	clientId,
 	isAppender,
 	selectBlockOnInsert,
+	insertionIndex,
 } ) {
 	const {
 		destinationRootClientId,
@@ -76,6 +77,10 @@ function useInsertionPoint( {
 	} = useDispatch( 'core/block-editor' );
 
 	function getInsertionIndex() {
+		if ( insertionIndex !== undefined ) {
+			return insertionIndex;
+		}
+
 		// If the clientId is defined, we insert at the position of the block.
 		if ( clientId ) {
 			return getBlockIndex( clientId, destinationRootClientId );
@@ -83,7 +88,7 @@ function useInsertionPoint( {
 
 		// If there's a selected block, and the selected block is not the destination root block, we insert after the selected block.
 		const end = getBlockSelectionEnd();
-		if ( ! isAppender && end && end !== destinationRootClientId ) {
+		if ( ! isAppender && end ) {
 			return getBlockIndex( end, destinationRootClientId ) + 1;
 		}
 

--- a/packages/block-editor/src/components/inserter/library.js
+++ b/packages/block-editor/src/components/inserter/library.js
@@ -19,7 +19,8 @@ function InserterLibrary( {
 	isAppender,
 	showInserterHelpPanel,
 	showMostUsedBlocks = false,
-	__experimentalSelectBlockOnInsert: selectBlockOnInsert,
+	__experimentalSelectBlockOnInsert,
+	__experimentalInsertionIndex,
 	onSelect = noop,
 } ) {
 	const destinationRootClientId = useSelect(
@@ -41,7 +42,10 @@ function InserterLibrary( {
 			isAppender={ isAppender }
 			showInserterHelpPanel={ showInserterHelpPanel }
 			showMostUsedBlocks={ showMostUsedBlocks }
-			__experimentalSelectBlockOnInsert={ selectBlockOnInsert }
+			__experimentalSelectBlockOnInsert={
+				__experimentalSelectBlockOnInsert
+			}
+			__experimentalInsertionIndex={ __experimentalInsertionIndex }
 		/>
 	);
 }

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -26,6 +26,7 @@ function InserterMenu( {
 	clientId,
 	isAppender,
 	__experimentalSelectBlockOnInsert,
+	__experimentalInsertionIndex,
 	onSelect,
 	showInserterHelpPanel,
 	showMostUsedBlocks,
@@ -46,6 +47,7 @@ function InserterMenu( {
 		clientId,
 		isAppender,
 		selectBlockOnInsert: __experimentalSelectBlockOnInsert,
+		insertionIndex: __experimentalInsertionIndex,
 	} );
 	const { hasPatterns, hasReusableBlocks } = useSelect( ( select ) => {
 		const {

--- a/packages/edit-widgets/src/components/header/index.js
+++ b/packages/edit-widgets/src/components/header/index.js
@@ -20,16 +20,18 @@ import { useRef } from '@wordpress/element';
 import SaveButton from '../save-button';
 import UndoButton from './undo-redo/undo';
 import RedoButton from './undo-redo/redo';
-import useLastSelectedRootId from '../../hooks/use-last-selected-root-id';
+import useLastSelectedWidgetArea from '../../hooks/use-last-selected-widget-area';
 
 function Header() {
 	const inserterButton = useRef();
 	const isLargeViewport = useViewportMatch( 'medium' );
-	const rootClientId = useLastSelectedRootId();
+	const widgetAreaClientId = useLastSelectedWidgetArea();
 	const isLastSelectedWidgetAreaOpen = useSelect(
 		( select ) =>
-			select( 'core/edit-widgets' ).getIsWidgetAreaOpen( rootClientId ),
-		[ rootClientId ]
+			select( 'core/edit-widgets' ).getIsWidgetAreaOpen(
+				widgetAreaClientId
+			),
+		[ widgetAreaClientId ]
 	);
 	const isInserterOpened = useSelect( ( select ) =>
 		select( 'core/edit-widgets' ).isInserterOpened()
@@ -45,9 +47,9 @@ function Header() {
 		} else {
 			if ( ! isLastSelectedWidgetAreaOpen ) {
 				// Select the last selected block if hasn't already.
-				selectBlock( rootClientId );
+				selectBlock( widgetAreaClientId );
 				// Open the last selected widget area when opening the inserter.
-				setIsWidgetAreaOpen( rootClientId, true );
+				setIsWidgetAreaOpen( widgetAreaClientId, true );
 			}
 			// The DOM updates resulting from selectBlock() and setIsInserterOpened() calls are applied the
 			// same tick and pretty much in a random order. The inserter is closed if any other part of the

--- a/packages/edit-widgets/src/components/layout/interface.js
+++ b/packages/edit-widgets/src/components/layout/interface.js
@@ -15,7 +15,7 @@ import { InterfaceSkeleton, ComplementaryArea } from '@wordpress/interface';
 import Header from '../header';
 import WidgetAreasBlockEditorContent from '../widget-areas-block-editor-content';
 import PopoverWrapper from './popover-wrapper';
-import useLastSelectedRootId from '../../hooks/use-last-selected-root-id';
+import useWidgetLibraryInsertionPoint from '../../hooks/use-widget-library-insertion-point';
 
 function Interface( { blockEditorSettings } ) {
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
@@ -23,7 +23,7 @@ function Interface( { blockEditorSettings } ) {
 	const { setIsInserterOpened, closeGeneralSidebar } = useDispatch(
 		'core/edit-widgets'
 	);
-	const rootClientId = useLastSelectedRootId( 'layout' );
+	const { rootClientId, insertionIndex } = useWidgetLibraryInsertionPoint();
 
 	const { hasSidebarEnabled, isInserterOpened } = useSelect( ( select ) => ( {
 		hasSidebarEnabled: !! select(
@@ -72,6 +72,9 @@ function Interface( { blockEditorSettings } ) {
 										}
 									} }
 									rootClientId={ rootClientId }
+									__experimentalInsertionIndex={
+										insertionIndex
+									}
 								/>
 							</div>
 						</div>

--- a/packages/edit-widgets/src/hooks/use-last-selected-widget-area.js
+++ b/packages/edit-widgets/src/hooks/use-last-selected-widget-area.js
@@ -14,19 +14,8 @@ import { buildWidgetAreasPostId, KIND, POST_TYPE } from '../store/utils';
  *
  * @return {string} clientId of the widget area last selected.
  */
-const useLastSelectedWidgetArea = () => {
-	const firstRootId = useSelect( ( select ) => {
-		// Default to the first widget area
-		const { getEntityRecord } = select( 'core' );
-		const widgetAreasPost = getEntityRecord(
-			KIND,
-			POST_TYPE,
-			buildWidgetAreasPostId()
-		);
-		return widgetAreasPost?.blocks[ 0 ]?.clientId;
-	}, [] );
-
-	const selectedRootId = useSelect( ( select ) => {
+const useLastSelectedWidgetArea = () =>
+	useSelect( ( select ) => {
 		const { getBlockSelectionEnd, getBlockParents, getBlockName } = select(
 			'core/block-editor'
 		);
@@ -49,11 +38,16 @@ const useLastSelectedWidgetArea = () => {
 		if ( rootWidgetAreaClientId ) {
 			return rootWidgetAreaClientId;
 		}
-	}, [] );
 
-	// If no widget area has been selected, return the clientId of the first
-	// area.
-	return selectedRootId || firstRootId;
-};
+		// If no widget area has been selected, return the clientId of the first
+		// area.
+		const { getEntityRecord } = select( 'core' );
+		const widgetAreasPost = getEntityRecord(
+			KIND,
+			POST_TYPE,
+			buildWidgetAreasPostId()
+		);
+		return widgetAreasPost?.blocks[ 0 ]?.clientId;
+	}, [] );
 
 export default useLastSelectedWidgetArea;

--- a/packages/edit-widgets/src/hooks/use-last-selected-widget-area.js
+++ b/packages/edit-widgets/src/hooks/use-last-selected-widget-area.js
@@ -8,6 +8,12 @@ import { useSelect } from '@wordpress/data';
  */
 import { buildWidgetAreasPostId, KIND, POST_TYPE } from '../store/utils';
 
+/**
+ * A react hook that returns the client id of the last widget area to have
+ * been selected, or to have a selected block within it.
+ *
+ * @return {string} clientId of the widget area last selected.
+ */
 const useLastSelectedWidgetArea = () => {
 	const firstRootId = useSelect( ( select ) => {
 		// Default to the first widget area
@@ -26,12 +32,15 @@ const useLastSelectedWidgetArea = () => {
 		);
 		const blockSelectionEndClientId = getBlockSelectionEnd();
 
+		// If the selected block is a widget area, return its clientId.
 		if (
 			getBlockName( blockSelectionEndClientId ) === 'core/widget-area'
 		) {
 			return blockSelectionEndClientId;
 		}
 
+		// Otherwise, find the clientId of the top-level widget area by looking
+		// through the selected block's parents.
 		const blockParents = getBlockParents( blockSelectionEndClientId );
 		const rootWidgetAreaClientId = blockParents.find(
 			( clientId ) => getBlockName( clientId ) === 'core/widget-area'
@@ -42,7 +51,8 @@ const useLastSelectedWidgetArea = () => {
 		}
 	}, [] );
 
-	// Fallbacks to the first widget area.
+	// If no widget area has been selected, return the clientId of the first
+	// area.
 	return selectedRootId || firstRootId;
 };
 

--- a/packages/edit-widgets/src/hooks/use-last-selected-widget-area.js
+++ b/packages/edit-widgets/src/hooks/use-last-selected-widget-area.js
@@ -8,7 +8,7 @@ import { useSelect } from '@wordpress/data';
  */
 import { buildWidgetAreasPostId, KIND, POST_TYPE } from '../store/utils';
 
-const useLastSelectedRootId = () => {
+const useLastSelectedWidgetArea = () => {
 	const firstRootId = useSelect( ( select ) => {
 		// Default to the first widget area
 		const { getEntityRecord } = select( 'core' );
@@ -21,17 +21,29 @@ const useLastSelectedRootId = () => {
 	}, [] );
 
 	const selectedRootId = useSelect( ( select ) => {
-		const { getBlockRootClientId, getBlockSelectionEnd } = select(
+		const { getBlockSelectionEnd, getBlockParents, getBlockName } = select(
 			'core/block-editor'
 		);
-		const blockSelectionEnd = getBlockSelectionEnd();
-		const blockRootClientId = getBlockRootClientId( blockSelectionEnd );
-		// getBlockRootClientId returns an empty string for top-level blocks, in which case just return the block id.
-		return blockRootClientId === '' ? blockSelectionEnd : blockRootClientId;
+		const blockSelectionEndClientId = getBlockSelectionEnd();
+
+		if (
+			getBlockName( blockSelectionEndClientId ) === 'core/widget-area'
+		) {
+			return blockSelectionEndClientId;
+		}
+
+		const blockParents = getBlockParents( blockSelectionEndClientId );
+		const rootWidgetAreaClientId = blockParents.find(
+			( clientId ) => getBlockName( clientId ) === 'core/widget-area'
+		);
+
+		if ( rootWidgetAreaClientId ) {
+			return rootWidgetAreaClientId;
+		}
 	}, [] );
 
 	// Fallbacks to the first widget area.
 	return selectedRootId || firstRootId;
 };
 
-export default useLastSelectedRootId;
+export default useLastSelectedWidgetArea;

--- a/packages/edit-widgets/src/hooks/use-widget-library-insertion-point.js
+++ b/packages/edit-widgets/src/hooks/use-widget-library-insertion-point.js
@@ -1,0 +1,54 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { buildWidgetAreasPostId, KIND, POST_TYPE } from '../store/utils';
+
+const useWidgetLibraryInsertionPoint = () => {
+	const firstRootId = useSelect( ( select ) => {
+		// Default to the first widget area
+		const { getEntityRecord } = select( 'core' );
+		const widgetAreasPost = getEntityRecord(
+			KIND,
+			POST_TYPE,
+			buildWidgetAreasPostId()
+		);
+		return widgetAreasPost?.blocks[ 0 ]?.clientId;
+	}, [] );
+
+	return useSelect(
+		( select ) => {
+			const {
+				getBlockRootClientId,
+				getBlockSelectionEnd,
+				getBlockOrder,
+				getBlockIndex,
+			} = select( 'core/block-editor' );
+
+			const clientId = getBlockSelectionEnd() || firstRootId;
+			const rootClientId = getBlockRootClientId( clientId );
+
+			// If the selected block is at the root level, it's a widget area and
+			// blocks can't be inserted here. Return this block as the root and the
+			// last child clientId indicating insertion at the end.
+			if ( clientId && rootClientId === '' ) {
+				return {
+					rootClientId: clientId,
+					insertionIndex: getBlockOrder( clientId ).length,
+				};
+			}
+
+			return {
+				rootClientId,
+				insertionIndex: getBlockIndex( clientId, rootClientId ) + 1,
+			};
+		},
+		[ firstRootId ]
+	);
+};
+
+export default useWidgetLibraryInsertionPoint;


### PR DESCRIPTION


<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
An alternative way to handle #25727 (this PR merges into that one).

# Primer
Insertion on the widgets page is somewhat unique in comparison to the post editor. There are multiple `widget-area` blocks that act as roots for block insertion.

The trouble is that when inserting from the library, the default behavior is to insert after the selected block, but for these widget areas, we always want to insert inside of them.

This PR allows for the definition of an `insertionIndex` for the block `Library` component. When defined it overrides the behavior the library has where it defaults to inserting after the selection.

## How has this been tested?
**With a widget area selected**
1. Select a widget area.
2. Click the + button for the inserter in the header
3. Insert a block
4. The block should be inserted at the end of the widget area

**With a block inside a widget area selected**
1. Select a block within a widget area
2. Click the + button for the inserter in the header
3. Insert a block
4. The block should be inserted after the block selected in step 1.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
