### PR TITLE
Add/line height support flag stable

### DIFF
--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -18,7 +18,7 @@ function gutenberg_register_typography_support( $block_type ) {
 
 	$has_line_height_support = false;
 	if ( property_exists( $block_type, 'supports' ) ) {
-		$has_line_height_support = gutenberg_experimental_get( $block_type->supports, array( '__experimentalLineHeight' ), false );
+		$has_line_height_support = gutenberg_experimental_get( $block_type->supports, array( 'lineHeight' ), false );
 	}
 
 	if ( ! $block_type->attributes ) {
@@ -56,7 +56,7 @@ function gutenberg_apply_typography_support( $attributes, $block_attributes, $bl
 
 	$has_line_height_support = false;
 	if ( property_exists( $block_type, 'supports' ) ) {
-		$has_line_height_support = gutenberg_experimental_get( $block_type->supports, array( '__experimentalLineHeight' ), false );
+		$has_line_height_support = gutenberg_experimental_get( $block_type->supports, array( 'lineHeight' ), false );
 	}
 
 	// Font Size.

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -422,7 +422,7 @@ function gutenberg_experimental_global_styles_get_support_keys() {
 		'backgroundColor'          => array( 'color' ),
 		'color'                    => array( 'color' ),
 		'fontSize'                 => array( 'fontSize' ),
-		'lineHeight'               => array( '__experimentalLineHeight' ),
+		'lineHeight'               => array( 'lineHeight' ),
 	);
 }
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -400,6 +400,10 @@ _Related_
 
 -   <https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/inspector-controls/README.md>
 
+<a name="LineHeightControl" href="#LineHeightControl">#</a> **LineHeightControl**
+
+Undocumented declaration.
+
 <a name="MediaPlaceholder" href="#MediaPlaceholder">#</a> **MediaPlaceholder**
 
 _Related_

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -36,7 +36,7 @@ export { default as InnerBlocks } from './inner-blocks';
 export { default as InspectorAdvancedControls } from './inspector-advanced-controls';
 export { default as InspectorControls } from './inspector-controls';
 export { default as __experimentalLinkControl } from './link-control';
-export { default as __experimentalLineHeightControl } from './line-height-control';
+export { default as LineHeightControl } from './line-height-control';
 export { default as MediaReplaceFlow } from './media-replace-flow';
 export { default as MediaPlaceholder } from './media-placeholder';
 export { default as MediaUpload } from './media-upload';

--- a/packages/block-editor/src/components/index.native.js
+++ b/packages/block-editor/src/components/index.native.js
@@ -13,7 +13,7 @@ export { default as AlignmentToolbar } from './alignment-toolbar';
 export { default as InnerBlocks } from './inner-blocks';
 export { default as InspectorAdvancedControls } from './inspector-advanced-controls';
 export { default as InspectorControls } from './inspector-controls';
-export { default as __experimentalLineHeightControl } from './line-height-control';
+export { default as LineHeightControl } from './line-height-control';
 export { default as PlainText } from './plain-text';
 export {
 	default as RichText,

--- a/packages/block-editor/src/hooks/line-height.js
+++ b/packages/block-editor/src/hooks/line-height.js
@@ -10,7 +10,7 @@ import LineHeightControl from '../components/line-height-control';
 import { cleanEmptyObject } from './utils';
 import useEditorFeature from '../components/use-editor-feature';
 
-export const LINE_HEIGHT_SUPPORT_KEY = '__experimentalLineHeight';
+export const LINE_HEIGHT_SUPPORT_KEY = 'lineHeight';
 
 /**
  * Inspector control panel containing the line height related configuration

--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -27,7 +27,7 @@
 			"link": true
 		},
 		"fontSize": true,
-		"__experimentalLineHeight": true,
+		"lineHeight": true,
 		"__experimentalSelector": {
 			"core/heading/h1": "h1",
 			"core/heading/h2": "h2",

--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -34,7 +34,7 @@
 			"link": true
 		},
 		"fontSize": true,
-		"__experimentalLineHeight": true,
+		"lineHeight": true,
 		"__experimentalSelector": "p",
 		"__unstablePasteTextInline": true
 	}

--- a/packages/block-library/src/post-author/block.json
+++ b/packages/block-library/src/post-author/block.json
@@ -32,6 +32,6 @@
 			"gradients": true,
 			"link": true
 		},
-		"__experimentalLineHeight": true
+		"lineHeight": true
 	}
 }

--- a/packages/block-library/src/post-comments-count/block.json
+++ b/packages/block-library/src/post-comments-count/block.json
@@ -16,6 +16,6 @@
 			"gradients": true
 		},
 		"fontSize": true,
-		"__experimentalLineHeight": true
+		"lineHeight": true
 	}
 }

--- a/packages/block-library/src/post-comments-form/block.json
+++ b/packages/block-library/src/post-comments-form/block.json
@@ -18,6 +18,6 @@
 			"link": true
 		},
 		"fontSize": true,
-		"__experimentalLineHeight": true
+		"lineHeight": true
 	}
 }

--- a/packages/block-library/src/post-comments/block.json
+++ b/packages/block-library/src/post-comments/block.json
@@ -22,6 +22,6 @@
 			"gradients": true,
 			"link": true
 		},
-		"__experimentalLineHeight": true
+		"lineHeight": true
 	}
 }

--- a/packages/block-library/src/post-date/block.json
+++ b/packages/block-library/src/post-date/block.json
@@ -20,6 +20,6 @@
 			"gradients": true
 		},
 		"fontSize": true,
-		"__experimentalLineHeight": true
+		"lineHeight": true
 	}
 }

--- a/packages/block-library/src/post-excerpt/block.json
+++ b/packages/block-library/src/post-excerpt/block.json
@@ -29,6 +29,6 @@
 			"gradients": true,
 			"link": true
 		},
-		"__experimentalLineHeight": true
+		"lineHeight": true
 	}
 }

--- a/packages/block-library/src/post-hierarchical-terms/block.json
+++ b/packages/block-library/src/post-hierarchical-terms/block.json
@@ -21,6 +21,6 @@
 			"gradients": true,
 			"link": true
 		},
-		"__experimentalLineHeight": true
+		"lineHeight": true
 	}
 }

--- a/packages/block-library/src/post-tags/block.json
+++ b/packages/block-library/src/post-tags/block.json
@@ -15,6 +15,6 @@
 			"gradients": true,
 			"link": true
 		},
-		"__experimentalLineHeight": true
+		"lineHeight": true
 	}
 }

--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -34,7 +34,7 @@
 			"gradients": true
 		},
 		"fontSize": true,
-		"__experimentalLineHeight": true,
+		"lineHeight": true,
 		"__experimentalSelector": {
 			"core/post-title/h1": "h1",
 			"core/post-title/h2": "h2",

--- a/packages/block-library/src/site-tagline/block.json
+++ b/packages/block-library/src/site-tagline/block.json
@@ -13,6 +13,6 @@
 			"gradients": true
 		},
 		"fontSize": true,
-		"__experimentalLineHeight": true
+		"lineHeight": true
 	}
 }

--- a/packages/block-library/src/site-title/block.json
+++ b/packages/block-library/src/site-title/block.json
@@ -17,6 +17,6 @@
 			"gradients": true
 		},
 		"fontSize": true,
-		"__experimentalLineHeight": true
+		"lineHeight": true
 	}
 }

--- a/packages/edit-site/src/components/sidebar/typography-panel.js
+++ b/packages/edit-site/src/components/sidebar/typography-panel.js
@@ -1,10 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	FontSizePicker,
-	__experimentalLineHeightControl as LineHeightControl,
-} from '@wordpress/block-editor';
+import { FontSizePicker, LineHeightControl } from '@wordpress/block-editor';
 import { PanelBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 

--- a/phpunit/class-block-supported-styles-test.php
+++ b/phpunit/class-block-supported-styles-test.php
@@ -458,7 +458,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$block_type_settings = array(
 			'attributes'      => array(),
 			'supports'        => array(
-				'__experimentalLineHeight' => true,
+				'lineHeight' => true,
 			),
 			'render_callback' => true,
 		);
@@ -570,13 +570,13 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$block_type_settings = array(
 			'attributes'      => array(),
 			'supports'        => array(
-				'color'                    => array(
+				'color'      => array(
 					'gradients' => true,
 					'link'      => true,
 				),
-				'fontSize'                 => true,
-				'__experimentalLineHeight' => true,
-				'align'                    => true,
+				'fontSize'   => true,
+				'lineHeight' => true,
+				'align'      => true,
 			),
 			'render_callback' => true,
 		);
@@ -659,13 +659,13 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$block_type_settings = array(
 			'attributes' => array(),
 			'supports'   => array(
-				'align'                    => true,
-				'color'                    => array(
+				'align'      => true,
+				'color'      => array(
 					'gradients' => true,
 					'link'      => true,
 				),
-				'fontSize'                 => true,
-				'__experimentalLineHeight' => true,
+				'fontSize'   => true,
+				'lineHeight' => true,
 			),
 		);
 		$this->register_block_type( 'core/example', $block_type_settings );


### PR DESCRIPTION
Similar to #25694 

With this PR, third-party block authors using the "light block wrapper" will be able to add line-height support with a single line of code to their custom blocks.

It also marks the LineHeightControl component used by this flag as stable as well;