### PR TITLE
Tools: Add bin/diff-php-changes.sh to track PHP changes

### DIFF
--- a/bin/diff-php-changes.sh
+++ b/bin/diff-php-changes.sh
@@ -6,6 +6,7 @@ usage: $0 [--filter=<filter>] <range>
     List PHP files that have been added, deleted and/or modified files
     within Git range <range>. For example:
 
+	$(basename $0) origin/wp/5.5..origin/wp/trunk
 	$(basename $0) --filter=Ar origin/wp/5.5..origin/wp/trunk
 
 Optionally filter according to \`git diff --diff-filter\`, e.g.

--- a/bin/diff-php-changes.sh
+++ b/bin/diff-php-changes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 _usage() {
 	cat <<EOD
@@ -6,8 +6,8 @@ usage: $0 [--filter=<filter>] <range>
     List PHP files that have been added, deleted and/or modified files
     within Git range <range>. For example:
 
-	$(basename $0) origin/wp/5.5..origin/wp/trunk
-	$(basename $0) --filter=Ar origin/wp/5.5..origin/wp/trunk
+	$(basename "$0") origin/wp/5.5..origin/wp/trunk
+	$(basename "$0") --filter=Ar origin/wp/5.5..origin/wp/trunk
 
 Optionally filter according to \`git diff --diff-filter\`, e.g.
  --filter=A	Show added paths

--- a/bin/diff-php-changes.sh
+++ b/bin/diff-php-changes.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+_usage() {
+	cat <<EOD
+usage: $0 [-adm] <range>
+    List PHP files that have been added, deleted and/or modified files
+    within Git range <range>. For example:
+
+    $(basename $0) origin/wp/5.5..origin/wp/trunk
+
+Enable filtering by passing one or more of the following options:
+ -a	Show added files [default]
+ -d	Show deleted files [default]
+ -m	Show modified files [default]
+ -h	Show this help screen
+EOD
+	exit 1
+}
+
+_diff_php() {
+	git diff "$range" -- '*.php'
+}
+
+_diff_php_plus() {
+	_diff_php | grep ^+++ | cut -c 6-
+}
+
+_diff_php_minus() {
+	_diff_php | grep ^--- | cut -c 6-
+}
+
+_compare() {
+	comm "$1" <(_diff_php_minus | sort) <(_diff_php_plus | sort) \
+		| grep -v ^dev/null
+}
+
+_print_added() {
+	_compare -13 | sed "s/^/added:		/"
+}
+
+_print_deleted() {
+	_compare -23 | sed "s/^/deleted:	/"
+}
+
+_print_modified() {
+	_compare -12 | sed "s/^/modified:	/"
+}
+
+_main() {
+	local args
+	if ! args=$(getopt hadm "$@"); then
+		_usage
+		exit 2
+	fi
+
+	# shellcheck disable=2086
+	set -- $args
+	for arg; do
+		case "$arg" in
+			-h|--help) _usage; shift;;
+			-a|--added) has_filter=true; show_added=true; shift;;
+			-d|--deleted) has_filter=true; show_deleted=true; shift;;
+			-m|--modified) has_filter=true; show_modified=true; shift;;
+			--) shift; break;;
+		esac
+	done
+
+	[ $# != 1 ] && _usage
+
+	range="$1"
+	echo "### $range"
+	[ -z "$has_filter" ] || [ -n "$show_added" ] && _print_added
+	[ -z "$has_filter" ] || [ -n "$show_deleted" ] && _print_deleted
+	[ -z "$has_filter" ] || [ -n "$show_modified" ] && _print_modified
+}
+
+_main "$@"

--- a/bin/diff-php-changes.sh
+++ b/bin/diff-php-changes.sh
@@ -12,6 +12,8 @@ Enable filtering by passing one or more of the following options:
  -a	Show added files [default]
  -d	Show deleted files [default]
  -m	Show modified files [default]
+
+Other options:
  -h	Show this help screen
 EOD
 	exit 1


### PR DESCRIPTION
## Description

This PR introduces a shell script seeking to make backporting PHP changes from Gutenberg to WordPress core slightly easier by listing PHP files that have been added, removed, or modified between two Git revisions:

## Examples

```
usage: ./bin/diff-php-changes.sh [--filter=<filter>] <range>
    List PHP files that have been added, deleted and/or modified files
    within Git range <range>. For example:

	diff-php-changes.sh origin/wp/5.5..origin/wp/trunk
	diff-php-changes.sh --filter=Ar origin/wp/5.5..origin/wp/trunk

Optionally filter according to `git diff --diff-filter`, e.g.
 --filter=A	Show added paths
 --filter=AD	Show added and deleted paths
 --filter=MR	Show modified and renamed paths
 --filter=d	Exclude deleted paths

Other options:
 -h	Show this help screen
```

```
$ ./bin/diff-php-changes.sh --filter=D origin/wp/5.5..origin/wp/trunk
### origin/wp/5.5..origin/wp/trunk
D       lib/class-experimental-wp-widget-blocks-manager.php
D       lib/class-wp-rest-widget-areas-controller.php
D       lib/editor-features.php
D       lib/patterns/large-header-paragraph.php
```