### PR TITLE
core-data: use builtin data controls instead of deprecated data-controls ones

### DIFF
--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -6,7 +6,8 @@ import { upperFirst, camelCase, map, find, get, startCase } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { apiFetch, syncSelect } from '@wordpress/data-controls';
+import { controls } from '@wordpress/data';
+import { apiFetch } from '@wordpress/data-controls';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -188,7 +189,7 @@ export const getMethodName = (
  * @return {Array} Entities
  */
 export function* getKindEntities( kind ) {
-	let entities = yield syncSelect( 'core', 'getEntitiesByKind', kind );
+	let entities = yield controls.select( 'core', 'getEntitiesByKind', kind );
 	if ( entities && entities.length !== 0 ) {
 		return entities;
 	}

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -8,7 +8,8 @@ import { find, includes, get, hasIn, compact, uniq } from 'lodash';
  */
 import { addQueryArgs } from '@wordpress/url';
 import deprecated from '@wordpress/deprecated';
-import { apiFetch, select, syncSelect } from '@wordpress/data-controls';
+import { controls } from '@wordpress/data';
+import { apiFetch } from '@wordpress/data-controls';
 
 /**
  * Internal dependencies
@@ -91,7 +92,7 @@ export function* getEntityRecord( kind, name, key = '', query ) {
 		// The resolution cache won't consider query as reusable based on the
 		// fields, so it's tested here, prior to initiating the REST request,
 		// and without causing `getEntityRecords` resolution to occur.
-		const hasRecords = yield syncSelect(
+		const hasRecords = yield controls.select(
 			'core',
 			'hasEntityRecords',
 			kind,
@@ -297,7 +298,7 @@ export function* canUser( action, resource, id ) {
  * @param {number} postId   The id of the parent post.
  */
 export function* getAutosaves( postType, postId ) {
-	const { rest_base: restBase } = yield select(
+	const { rest_base: restBase } = yield controls.resolveSelect(
 		'core',
 		'getPostType',
 		postType
@@ -321,5 +322,5 @@ export function* getAutosaves( postType, postId ) {
  * @param {number} postId   The id of the parent post.
  */
 export function* getAutosave( postType, postId ) {
-	yield select( 'core', 'getAutosaves', postType, postId );
+	yield controls.resolveSelect( 'core', 'getAutosaves', postType, postId );
 }

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { syncSelect } from '@wordpress/data-controls';
+import { controls } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -26,7 +26,7 @@ describe( 'editEntityRecord', () => {
 			{}
 		);
 		expect( fulfillment.next().value ).toEqual(
-			syncSelect( 'core', 'getEntity', entity.kind, entity.name )
+			controls.select( 'core', 'getEntity', entity.kind, entity.name )
 		);
 		// Don't pass back an entity config.
 		expect( fulfillment.next.bind( fulfillment ) ).toThrow(

--- a/packages/core-data/src/utils/if-not-resolved.js
+++ b/packages/core-data/src/utils/if-not-resolved.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { select } from '@wordpress/data-controls';
+import { controls } from '@wordpress/data';
 
 /**
  * Higher-order function which invokes the given resolver only if it has not
@@ -20,7 +20,7 @@ const ifNotResolved = ( resolver, selectorName ) =>
 	 * @param {...any} args Original resolver arguments.
 	 */
 	function* resolveIfNotResolved( ...args ) {
-		const hasStartedResolution = yield select(
+		const hasStartedResolution = yield controls.select(
 			'core',
 			'hasStartedResolution',
 			selectorName,

--- a/packages/core-data/src/utils/test/if-not-resolved.js
+++ b/packages/core-data/src/utils/test/if-not-resolved.js
@@ -1,20 +1,22 @@
 /**
  * WordPress dependencies
  */
-import { select } from '@wordpress/data-controls';
+import { controls } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import ifNotResolved from '../if-not-resolved';
 
-jest.mock( '@wordpress/data-controls', () => ( {
-	select: jest.fn(),
+jest.mock( '@wordpress/data', () => ( {
+	controls: {
+		select: jest.fn(),
+	},
 } ) );
 
 describe( 'ifNotResolved', () => {
 	beforeEach( () => {
-		select.mockReset();
+		controls.select.mockReset();
 	} );
 
 	it( 'returns a new function', () => {
@@ -26,7 +28,7 @@ describe( 'ifNotResolved', () => {
 	} );
 
 	it( 'triggers original resolver if not already resolved', () => {
-		select.mockImplementation( ( _storeKey, selectorName ) => ( {
+		controls.select.mockImplementation( ( _storeKey, selectorName ) => ( {
 			_nextValue:
 				selectorName === 'hasStartedResolution' ? false : undefined,
 		} ) );
@@ -49,7 +51,7 @@ describe( 'ifNotResolved', () => {
 	} );
 
 	it( 'does not trigger original resolver if already resolved', () => {
-		select.mockImplementation( ( _storeKey, selectorName ) => ( {
+		controls.select.mockImplementation( ( _storeKey, selectorName ) => ( {
 			_nextValue:
 				selectorName === 'hasStartedResolution' ? true : undefined,
 		} ) );


### PR DESCRIPTION
Followup to #25362 that removes the deprecated `data-controls` controls from the `core-data` package. Except `apiFetch`, we use only the builtin `select` and `resolveSelect` controls.

The patch to `ifNotResolved` helper deserves special attention: it used to call `select( 'core', 'hasFinishedResolution' )`, which in the `data-controls` version does internally `__experimentalResolveSelect`, i.e., waits for the resolver resolution. But the `hasFinishedResolution` selector never has any resolver: we want to read the value synchronously. Therefore, as the straightforward replacement would be `resolveSelect`, I'm fixing a little bug (not observable anyway) by using the synchronous `select` control.