### PR TITLE
Make the custom spacing theme support flag and block support API stable

### DIFF
--- a/docs/designers-developers/developers/themes/theme-json.md
+++ b/docs/designers-developers/developers/themes/theme-json.md
@@ -87,7 +87,7 @@ The settings section has the following structure and default values:
         "palette": [ ... ], /* color presets, as in add_theme_support('editor-color-palette', ... ) */
       },
       "spacing": {
-        "customPadding": false, /* true to opt-in, as in add_theme_support('experimental-custom-spacing') */
+        "customPadding": false, /* true to opt-in, as in add_theme_support('custom-spacing') */
         "units": [ "px", "em", "rem", "vh", "vw" ], /* filter values, as in add_theme_support('custom-units', ... ) */
       },
       "typography": {

--- a/docs/designers-developers/developers/themes/theme-support.md
+++ b/docs/designers-developers/developers/themes/theme-support.md
@@ -388,12 +388,12 @@ To make the content resize and keep its aspect ratio, the `<body>` element needs
 add_theme_support( 'responsive-embeds' );
 ```
 
-## Experimental — Cover block padding
+## Cover block padding
 
-Using the Gutenberg plugin (version 8.3 or later), Cover blocks can provide padding controls in the editor for users. This is off by default, and requires the theme to opt in by declaring support:
+Some blocks can provide padding controls in the editor for users. This is off by default, and requires the theme to opt in by declaring support:
 
 ```php
-add_theme_support('experimental-custom-spacing');
+add_theme_support('custom-spacing');
 ```
 
 ## Experimental — Link color control

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -289,7 +289,7 @@ function gutenberg_experimental_global_styles_get_theme_support_settings() {
 		}
 		$theme_settings['global']['settings']['typography']['customLineHeight'] = true;
 	}
-	if ( get_theme_support( 'experimental-custom-spacing' ) ) {
+	if ( get_theme_support( 'custom-spacing' ) ) {
 		if ( ! isset( $theme_settings['global']['settings']['spacing'] ) ) {
 			$theme_settings['global']['settings']['spacing'] = array();
 		}

--- a/packages/block-editor/src/hooks/padding.js
+++ b/packages/block-editor/src/hooks/padding.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Platform } from '@wordpress/element';
-import { hasBlockSupport } from '@wordpress/blocks';
+import { getBlockSupport } from '@wordpress/blocks';
 import { __experimentalBoxControl as BoxControl } from '@wordpress/components';
 
 /**
@@ -12,7 +12,12 @@ import { __experimentalBoxControl as BoxControl } from '@wordpress/components';
 import { cleanEmptyObject } from './utils';
 import { useCustomUnits } from '../components/unit-control';
 
-export const PADDING_SUPPORT_KEY = '__experimentalPadding';
+export const SPACING_SUPPORT_KEY = 'spacing';
+
+const hasPaddingSupport = ( blockName ) => {
+	const spacingSupport = getBlockSupport( blockName, SPACING_SUPPORT_KEY );
+	return spacingSupport && spacingSupport.padding !== false;
+};
 
 /**
  * Inspector control panel containing the line height related configuration
@@ -30,7 +35,7 @@ export function PaddingEdit( props ) {
 
 	const units = useCustomUnits();
 
-	if ( ! hasBlockSupport( blockName, PADDING_SUPPORT_KEY ) ) {
+	if ( ! hasPaddingSupport( blockName ) ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -18,13 +18,13 @@ import { createHigherOrderComponent } from '@wordpress/compose';
  */
 import { COLOR_SUPPORT_KEY, ColorEdit } from './color';
 import { TypographyPanel, TYPOGRAPHY_SUPPORT_KEYS } from './typography';
-import { PADDING_SUPPORT_KEY, PaddingEdit } from './padding';
+import { SPACING_SUPPORT_KEY, PaddingEdit } from './padding';
 import SpacingPanelControl from '../components/spacing-panel-control';
 
 const styleSupportKeys = [
 	...TYPOGRAPHY_SUPPORT_KEYS,
 	COLOR_SUPPORT_KEY,
-	PADDING_SUPPORT_KEY,
+	SPACING_SUPPORT_KEY,
 ];
 
 const hasStyleSupport = ( blockType ) =>
@@ -148,16 +148,16 @@ export const withBlockControls = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
 		const { name: blockName } = props;
 
-		const hasPaddingSupport = hasBlockSupport(
+		const hasSpacingSupport = hasBlockSupport(
 			blockName,
-			PADDING_SUPPORT_KEY
+			SPACING_SUPPORT_KEY
 		);
 
 		return [
 			<TypographyPanel key="typography" { ...props } />,
 			<ColorEdit key="colors" { ...props } />,
 			<BlockEdit key="edit" { ...props } />,
-			hasPaddingSupport && (
+			hasSpacingSupport && (
 				<SpacingPanelControl key="spacing">
 					<PaddingEdit { ...props } />
 				</SpacingPanelControl>

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -50,6 +50,8 @@
 		"anchor": true,
 		"align": true,
 		"html": false,
-		"__experimentalPadding": true
+		"spacing": {
+			"padding": true
+		}
 	}
 }

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -19,6 +19,8 @@
 			"gradients": true,
 			"link": true
 		},
-		"__experimentalPadding": true
+		"spacing": {
+			"padding": true
+		}
 	}
 }


### PR DESCRIPTION
Similar to #25694 

With this PR, third-party block authors using the "light block wrapper" will be able to add padding support with a single line of code to their custom blocks.

It also marks the custom-spacing theme support flag as stable as well.