### PR TITLE
Block Support: Add border radius support

### DIFF
--- a/lib/block-supports/border.php
+++ b/lib/block-supports/border.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Border block support flag.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Registers the style attribute used by the border feature if needed for block types that
+ * support borders.
+ *
+ * @param WP_Block_Type $block_type Block Type.
+ */
+function gutenberg_register_border_support( $block_type ) {
+	// Determine border related features supported.
+	// Border width, style etc can be added in the future.
+	$has_border_radius_support = gutenberg_has_border_support( $block_type, 'radius' );
+
+	// Setup attributes and styles within that if needed.
+	if ( ! $block_type->attributes ) {
+		$block_type->attributes = array();
+	}
+
+	if ( $has_border_radius_support && ! array_key_exists( 'style', $block_type->attributes ) ) {
+		$block_type->attributes['style'] = array(
+			'type' => 'object',
+		);
+	}
+}
+
+/**
+ * Adds CSS classes and inline styles for border styles to the incoming
+ * attributes array. This will be applied to the block markup in the front-end.
+ *
+ * @param WP_Block_type $block_type       Block type.
+ * @param array         $block_attributes Block attributes.
+ *
+ * @return array Border CSS classes and inline styles.
+ */
+function gutenberg_apply_border_support( $block_type, $block_attributes ) {
+	// Arrays used to ease addition of further border related features in future.
+	$styles = array();
+
+	// Border Radius.
+	if ( gutenberg_has_border_support( $block_type, 'radius' ) ) {
+		if ( isset( $block_attributes['style']['border']['radius'] ) ) {
+			$border_radius = intval( $block_attributes['style']['border']['radius'] );
+			$styles[]      = sprintf( 'border-radius: %dpx;', $border_radius );
+		}
+	}
+
+	// Border width, style etc can be added here.
+
+	// Collect classes and styles.
+	$attributes = array();
+
+	if ( ! empty( $styles ) ) {
+		$attributes['style'] = implode( ' ', $styles );
+	}
+
+	return $attributes;
+}
+
+/**
+ * Checks whether the current block type supports the feature requested.
+ *
+ * @param WP_Block_Type $block_type Block type to check for support.
+ * @param string        $feature    Name of the feature to check support for.
+ * @param mixed         $default    Fallback value for feature support, defaults to false.
+ *
+ * @return boolean                  Whether or not the feature is supported.
+ */
+function gutenberg_has_border_support( $block_type, $feature, $default = false ) {
+	$block_support = false;
+	if ( property_exists( $block_type, 'supports' ) ) {
+		$block_support = gutenberg_experimental_get( $block_type->supports, array( '__experimentalBorder' ), $default );
+	}
+
+	return true === $block_support || ( is_array( $block_support ) && gutenberg_experimental_get( $block_support, array( $feature ), false ) );
+}
+
+// Register the block support.
+WP_Block_Supports::get_instance()->register(
+	'border',
+	array(
+		'register_attribute' => 'gutenberg_register_border_support',
+		'apply'              => 'gutenberg_apply_border_support',
+	)
+);

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -50,6 +50,7 @@ class WP_Theme_JSON {
 		'--wp--style--color--link',
 		'background',
 		'backgroundColor',
+		'border',
 		'color',
 		'fontFamily',
 		'fontSize',
@@ -114,6 +115,9 @@ class WP_Theme_JSON {
 			),
 		),
 		'settings' => array(
+			'border'     => array(
+				'customRadius' => null,
+			),
 			'color'      => array(
 				'custom'         => null,
 				'customGradient' => null,
@@ -283,6 +287,10 @@ class WP_Theme_JSON {
 		'backgroundColor'          => array(
 			'value'   => array( 'color', 'background' ),
 			'support' => array( 'color' ),
+		),
+		'borderRadius'             => array(
+			'value'   => array( 'border', 'radius' ),
+			'support' => array( '__experimentalBorder' ),
 		),
 		'color'                    => array(
 			'value'   => array( 'color', 'text' ),

--- a/lib/experimental-default-theme.json
+++ b/lib/experimental-default-theme.json
@@ -250,6 +250,9 @@
 			"spacing": {
 				"customPadding": false,
 				"units": [ "px", "em", "rem", "vh", "vw" ]
+			},
+			"border": {
+				"customRadius": true
 			}
 		}
 	}

--- a/lib/load.php
+++ b/lib/load.php
@@ -135,3 +135,4 @@ require __DIR__ . '/block-supports/colors.php';
 require __DIR__ . '/block-supports/align.php';
 require __DIR__ . '/block-supports/typography.php';
 require __DIR__ . '/block-supports/custom-classname.php';
+require __DIR__ . '/block-supports/border.php';

--- a/packages/block-editor/src/hooks/border-radius.js
+++ b/packages/block-editor/src/hooks/border-radius.js
@@ -1,0 +1,79 @@
+/**
+ * WordPress dependencies
+ */
+import { getBlockSupport } from '@wordpress/blocks';
+import { RangeControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import useEditorFeature from '../components/use-editor-feature';
+import { BORDER_SUPPORT_KEY } from './border';
+import { cleanEmptyObject } from './utils';
+
+const MIN_BORDER_RADIUS_VALUE = 0;
+const MAX_BORDER_RADIUS_VALUE = 50;
+
+/**
+ * Inspector control panel containing the border radius related configuration.
+ *
+ * @param  {Object} props Block properties.
+ * @return {WPElement}    Border radius edit element.
+ */
+export function BorderRadiusEdit( props ) {
+	const {
+		attributes: { style },
+		setAttributes,
+	} = props;
+
+	if ( useIsBorderRadiusDisabled( props ) ) {
+		return null;
+	}
+
+	const onChange = ( newRadius ) => {
+		const newStyle = {
+			...style,
+			border: {
+				...style?.border,
+				radius: newRadius,
+			},
+		};
+
+		setAttributes( { style: cleanEmptyObject( newStyle ) } );
+	};
+
+	return (
+		<RangeControl
+			value={ style?.border?.radius }
+			label={ __( 'Border radius' ) }
+			min={ MIN_BORDER_RADIUS_VALUE }
+			max={ MAX_BORDER_RADIUS_VALUE }
+			initialPosition={ 0 }
+			allowReset
+			onChange={ onChange }
+		/>
+	);
+}
+
+/**
+ * Determines if there is border radius support.
+ *
+ * @param  {string|Object} blockType Block name or Block Type object.
+ * @return {boolean}                 Whether there is support.
+ */
+export function hasBorderRadiusSupport( blockType ) {
+	const support = getBlockSupport( blockType, BORDER_SUPPORT_KEY );
+	return true === support || ( support && !! support.radius );
+}
+
+/**
+ * Custom hook that checks if border radius settings have been disabled.
+ *
+ * @param  {string} name The name of the block.
+ * @return {boolean}                 Whether border radius setting is disabled.
+ */
+export function useIsBorderRadiusDisabled( { name: blockName } = {} ) {
+	const isDisabled = ! useEditorFeature( 'border.customRadius' );
+	return ! hasBorderRadiusSupport( blockName ) || isDisabled;
+}

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -1,0 +1,67 @@
+/**
+ * WordPress dependencies
+ */
+import { getBlockSupport } from '@wordpress/blocks';
+import { PanelBody } from '@wordpress/components';
+import { Platform } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import InspectorControls from '../components/inspector-controls';
+import { BorderRadiusEdit, useIsBorderRadiusDisabled } from './border-radius';
+
+export const BORDER_SUPPORT_KEY = '__experimentalBorder';
+
+export function BorderPanel( props ) {
+	const isDisabled = useIsBorderDisabled( props );
+	const isSupported = hasBorderSupport( props.name );
+
+	if ( isDisabled || ! isSupported ) {
+		return null;
+	}
+
+	return (
+		<InspectorControls>
+			<PanelBody title={ __( 'Border settings' ) }>
+				<BorderRadiusEdit { ...props } />
+			</PanelBody>
+		</InspectorControls>
+	);
+}
+
+/**
+ * Determine whether there is block support for borders.
+ *
+ * @param {string} blockName Block name.
+ * @return {boolean}         Whether there is support.
+ */
+export function hasBorderSupport( blockName ) {
+	if ( Platform.OS !== 'web' ) {
+		return false;
+	}
+
+	const support = getBlockSupport( blockName, BORDER_SUPPORT_KEY );
+
+	// Further border properties to be added in future iterations.
+	// e.g. support && ( support.radius || support.width || support.style )
+	return true === support || ( support && support.radius );
+}
+
+/**
+ * Determines whether there is any block support for borders e.g. border radius,
+ * style, width etc.
+ *
+ * @param  {Object} props Block properties.
+ * @return {boolean}      If border support is completely disabled.
+ */
+const useIsBorderDisabled = ( props = {} ) => {
+	// Further border properties to be added in future iterations.
+	// e.g. const configs = [
+	// 		useIsBorderRadiusDisabled( props ),
+	//		useIsBorderWidthDisabled( props ),
+	// ];
+	const configs = [ useIsBorderRadiusDisabled( props ) ];
+	return configs.filter( Boolean ).length === configs.length;
+};

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -16,6 +16,7 @@ import { createHigherOrderComponent } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
+import { BORDER_SUPPORT_KEY, BorderPanel } from './border';
 import { COLOR_SUPPORT_KEY, ColorEdit } from './color';
 import { TypographyPanel, TYPOGRAPHY_SUPPORT_KEYS } from './typography';
 import { SPACING_SUPPORT_KEY, PaddingEdit } from './padding';
@@ -23,6 +24,7 @@ import SpacingPanelControl from '../components/spacing-panel-control';
 
 const styleSupportKeys = [
 	...TYPOGRAPHY_SUPPORT_KEYS,
+	BORDER_SUPPORT_KEY,
 	COLOR_SUPPORT_KEY,
 	SPACING_SUPPORT_KEY,
 ];
@@ -156,6 +158,7 @@ export const withBlockControls = createHigherOrderComponent(
 
 		return [
 			<TypographyPanel key="typography" { ...props } />,
+			<BorderPanel key="border" { ...props } />,
 			<ColorEdit key="colors" { ...props } />,
 			<BlockEdit key="edit" { ...props } />,
 			hasSpacingSupport && (

--- a/packages/block-editor/src/hooks/test/style.js
+++ b/packages/block-editor/src/hooks/test/style.js
@@ -17,9 +17,11 @@ describe( 'getInlineStyles', () => {
 			getInlineStyles( {
 				color: { text: 'red', background: 'black' },
 				typography: { lineHeight: 1.5, fontSize: 10 },
+				border: { radius: 10 },
 			} )
 		).toEqual( {
 			backgroundColor: 'black',
+			borderRadius: 10,
 			color: 'red',
 			lineHeight: 1.5,
 			fontSize: 10,

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -25,6 +25,10 @@ export const __EXPERIMENTAL_STYLE_PROPERTY = {
 		value: [ 'color', 'background' ],
 		support: [ 'color' ],
 	},
+	borderRadius: {
+		value: [ 'border', 'radius' ],
+		support: [ '__experimentalBorder', 'radius' ],
+	},
 	color: {
 		value: [ 'color', 'text' ],
 		support: [ 'color' ],


### PR DESCRIPTION
## Description

#### Background

To allow designers to produce different kinds of patterns using different blocks there is a need to provide control over a block's border radius. Some example use cases are:

* https://github.com/WordPress/gutenberg/issues/22071
* https://github.com/WordPress/gutenberg/issues/26559
* https://github.com/WordPress/gutenberg/issues/26556

Initially, this was attempted via an adhoc approach adding the feature directly to the search block https://github.com/WordPress/gutenberg/pull/25553. This PR adds border radius to the block support tools so that it may be leveraged by other blocks. 

The intention is to also expand this to include border width and style options. There is also the possibility to allow selection of which borders show i.e. all, top, right, bottom, left, none.

#### Changes

* Adds new block support for borders similar to the typography and color tools
* Adds border radius hook to the borders support providing; inspector controls, attributes and styles

## How has this been tested?
Tests: 
* `packages/block-editor/src/hooks/tests/style.js`

Manually, by opting in to border radius support for test blocks such as the group and image blocks. 

#### Testing Setup

To be able to manually test this you will need a block that has opted into the border radius support. The group block is probably easiest to do this with and will be used in the testing instructions that follow.

To opt into border radius support for the group block simply add into the `supports` setting in
`packages/block-library/src/group/block.json` the following code:

```
        "__experimentalBorder": {
            "radius": true
        }
```

#### Testing Instructions
1. Create a new post and add a group block, setting a prominent background color on the group
2. Selecting the group block, in the inspector panel, drag the border radius slider and confirm the block reflects this
3. Type a border radius value into the text input and confirm that is reflected
4. Click the reset button and there should no longer be a border radius applied to the block
5. Set a border radius value again and then save the post
6. Confirm border radius values are present on the frontend

## Screenshots <!-- if applicable -->
![BorderRadiusSupport](https://user-images.githubusercontent.com/60436221/101314690-bf49aa00-38a4-11eb-9626-541cfce41859.gif)

## Types of changes
New feature.

## Next Step
* Update `docs/designers-developers/developers/block-api/block-supports.md` once stable.

## Future Iterations:
* Add support for border width
* Add support for border style
* Add support for top, right, bottom, left borders

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
