### PR TITLE
Include edit-widgets php files in build

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -109,7 +109,12 @@ npm run build
 php bin/generate-gutenberg-php.php > gutenberg.tmp.php
 mv gutenberg.tmp.php gutenberg.php
 
-build_files=$(ls build/*/*.{js,css,asset.php} build/block-library/blocks/*.php build/block-library/blocks/*/block.json)
+build_files=$(
+	ls build/*/*.{js,css,asset.php} \
+	build/block-library/blocks/*.php build/block-library/blocks/*/block.json \
+	build/edit-widgets/blocks/*.php build/edit-widgets/blocks/*/block.json \
+)
+
 
 # Generate the plugin zip file.
 status "Creating archive... 🎁"


### PR DESCRIPTION
## Description

The plugin build is currently broken after https://github.com/WordPress/gutenberg/pull/25371 which moved the `core/legacy-widget` block to the `edit-widgets` package. This directory now includes `block.json` and `index.php` files which should be included in the plugin build just like `block-library`.

This causes PHP fatal errors in the widget block editor like:

```
 Uncaught Error: Call to a member function render() on null in …/wp-content/plugins/gutenberg/lib/widget-preview-template.php:37
```

Props to @david-binda for spotting missing files and fatals.

## How has this been tested?

Install the 9.1.0 plugin from the plugin repository and the PHP fatals can be observed when visiting the new Widgets block editor.

Confirm that the necessary files were missing from v9.1.0:

```
npm run build:plugin-zip; unzip -l gutenberg.zip | grep edit-widgets
      394  10-02-2020 16:41   build/edit-widgets/index.asset.php
    71426  10-02-2020 16:41   build/edit-widgets/index.js
    14599  10-02-2020 16:41   build/edit-widgets/style-rtl.css
    14579  10-02-2020 16:41   build/edit-widgets/style.css
```

In this branch

```
npm run build:plugin-zip; unzip -l gutenberg.zip | grep edit-widgets
     2724  10-02-2020 16:53   build/edit-widgets/blocks/legacy-widget.php
      356  10-02-2020 16:53   build/edit-widgets/blocks/legacy-widget/block.json
      266  10-02-2020 16:53   build/edit-widgets/blocks/widget-area/block.json
      403  10-02-2020 16:53   build/edit-widgets/index.asset.php
    83575  10-02-2020 16:53   build/edit-widgets/index.js
    14894  10-02-2020 16:53   build/edit-widgets/style-rtl.css
    14874  10-02-2020 16:53   build/edit-widgets/style.css
```


## Types of changes
Bug fix (non-breaking change which fixes an issue) 

Fix missing files from the plugin build.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
