### PR TITLE
Change is_valid_widget() method visibility from private to public

### DIFF
--- a/lib/class-wp-rest-widget-utils-controller.php
+++ b/lib/class-wp-rest-widget-utils-controller.php
@@ -89,7 +89,7 @@ class WP_REST_Widget_Utils_Controller extends WP_REST_Controller {
 	 * @return boolean| True if the widget being referenced exists and false otherwise.
 	 * @since 5.2.0
 	 */
-	private function is_valid_widget( $widget_class ) {
+	public function is_valid_widget( $widget_class ) {
 		$widget_class = urldecode( $widget_class );
 		global $wp_widget_factory;
 		if ( ! $widget_class ) {


### PR DESCRIPTION
## Description
Change the WP_REST_Widget_Utils_Controller::is_valid_widget() method visibility from private to public to avoid the warning described in the issue https://github.com/WordPress/gutenberg/issues/25789

Closes https://github.com/WordPress/gutenberg/issues/25789