### PR TITLE
Edit: Pass editor features dynamically

### DIFF
--- a/packages/edit-site/src/components/editor/global-styles-provider.js
+++ b/packages/edit-site/src/components/editor/global-styles-provider.js
@@ -70,7 +70,6 @@ export default function GlobalStylesProvider( {
 	const nextValue = useMemo(
 		() => ( {
 			contexts,
-			mergedStyles,
 			getSetting: ( context, path ) =>
 				get( userStyles?.[ context ]?.settings, path ),
 			setSetting: ( context, path, newValue ) => {

--- a/packages/edit-site/src/components/editor/global-styles-provider.js
+++ b/packages/edit-site/src/components/editor/global-styles-provider.js
@@ -29,7 +29,6 @@ const EMPTY_CONTENT = '{}';
 
 const GlobalStylesContext = createContext( {
 	/* eslint-disable no-unused-vars */
-	mergedStyles: {},
 	getSetting: ( context, path ) => {},
 	setSetting: ( context, path, newValue ) => {},
 	getStyleProperty: ( context, propertyName ) => {},

--- a/packages/edit-site/src/components/editor/global-styles-renderer.js
+++ b/packages/edit-site/src/components/editor/global-styles-renderer.js
@@ -13,7 +13,7 @@ import { __EXPERIMENTAL_STYLE_PROPERTY as STYLE_PROPERTY } from '@wordpress/bloc
  */
 import { PRESET_CATEGORIES, LINK_COLOR_DECLARATION } from './utils';
 
-const mergeTrees = ( baseData, userData ) => {
+export const mergeTrees = ( baseData, userData ) => {
 	// Deep clone from base data.
 	//
 	// We don't use cloneDeep from lodash here
@@ -21,12 +21,16 @@ const mergeTrees = ( baseData, userData ) => {
 	// see https://github.com/lodash/lodash/issues/1984
 	const mergedTree = JSON.parse( JSON.stringify( baseData ) );
 
-	const styleKeys = [ 'typography', 'color' ];
+	const styleKeys = [ 'typography', 'color', 'custom', 'spacing' ];
 	Object.keys( userData ).forEach( ( context ) => {
 		styleKeys.forEach( ( key ) => {
-			// Normalize object shape: make sure the key exists under styles.
+			// Normalize object shape: make sure the key exists under styles and settings.
 			if ( ! mergedTree[ context ].styles?.[ key ] ) {
 				mergedTree[ context ].styles[ key ] = {};
+			}
+
+			if ( ! mergedTree[ context ].settings?.[ key ] ) {
+				mergedTree[ context ].settings[ key ] = {};
 			}
 
 			// Merge data: base + user.
@@ -34,18 +38,21 @@ const mergeTrees = ( baseData, userData ) => {
 				...mergedTree[ context ].styles[ key ],
 				...userData[ context ]?.styles?.[ key ],
 			};
+
+			mergedTree[ context ].settings[ key ] = {
+				...mergedTree[ context ].settings[ key ],
+				...userData[ context ]?.settings?.[ key ],
+			};
 		} );
 	} );
 
 	return mergedTree;
 };
-
-export default ( blockData, baseTree, userTree ) => {
+export default ( blockData, tree ) => {
 	const styles = [];
 	// Can this be converted to a context, as the global context?
 	// See comment in the server.
 	styles.push( LINK_COLOR_DECLARATION );
-	const tree = mergeTrees( baseTree, userTree );
 
 	/**
 	 * Transform given style tree into a set of style declarations.

--- a/packages/edit-site/src/components/editor/global-styles-renderer.js
+++ b/packages/edit-site/src/components/editor/global-styles-renderer.js
@@ -19,7 +19,7 @@ export const mergeTrees = ( baseData, userData ) => {
 	// We don't use cloneDeep from lodash here
 	// because we know the data is JSON compatible,
 	// see https://github.com/lodash/lodash/issues/1984
-	const mergedTree = JSON.parse( JSON.stringify( baseData ) );
+	const mergedTree = baseData ? JSON.parse( JSON.stringify( baseData ) ) : {};
 
 	const styleKeys = [ 'typography', 'color' ];
 	const settingKeys = [ 'typography', 'color', 'custom', 'spacing' ];

--- a/packages/edit-site/src/components/editor/global-styles-renderer.js
+++ b/packages/edit-site/src/components/editor/global-styles-renderer.js
@@ -21,9 +21,9 @@ export const mergeTrees = ( baseData, userData ) => {
 	// see https://github.com/lodash/lodash/issues/1984
 	const mergedTree = JSON.parse( JSON.stringify( baseData ) );
 
-	const styleKeys = [ 'typography', 'color', 'custom', 'spacing' ];
+	const validMergeKeys = [ 'typography', 'color', 'custom', 'spacing' ];
 	Object.keys( userData ).forEach( ( context ) => {
-		styleKeys.forEach( ( key ) => {
+		validMergeKeys.forEach( ( key ) => {
 			// Normalize object shape: make sure the key exists under styles and settings.
 			if ( ! mergedTree[ context ].styles?.[ key ] ) {
 				mergedTree[ context ].styles[ key ] = {};

--- a/packages/edit-site/src/components/editor/global-styles-renderer.js
+++ b/packages/edit-site/src/components/editor/global-styles-renderer.js
@@ -21,24 +21,26 @@ export const mergeTrees = ( baseData, userData ) => {
 	// see https://github.com/lodash/lodash/issues/1984
 	const mergedTree = JSON.parse( JSON.stringify( baseData ) );
 
-	const validMergeKeys = [ 'typography', 'color', 'custom', 'spacing' ];
+	const styleKeys = [ 'typography', 'color' ];
+	const settingKeys = [ 'typography', 'color', 'custom', 'spacing' ];
 	Object.keys( userData ).forEach( ( context ) => {
-		validMergeKeys.forEach( ( key ) => {
-			// Normalize object shape: make sure the key exists under styles and settings.
+		styleKeys.forEach( ( key ) => {
+			// Normalize object shape.
 			if ( ! mergedTree[ context ].styles?.[ key ] ) {
 				mergedTree[ context ].styles[ key ] = {};
 			}
-
-			if ( ! mergedTree[ context ].settings?.[ key ] ) {
-				mergedTree[ context ].settings[ key ] = {};
-			}
-
-			// Merge data: base + user.
+			// Merge base + user data.
 			mergedTree[ context ].styles[ key ] = {
 				...mergedTree[ context ].styles[ key ],
 				...userData[ context ]?.styles?.[ key ],
 			};
-
+		} );
+		settingKeys.forEach( ( key ) => {
+			// Normalize object shape.
+			if ( ! mergedTree[ context ].settings?.[ key ] ) {
+				mergedTree[ context ].settings[ key ] = {};
+			}
+			// Merge base + user data.
 			mergedTree[ context ].settings[ key ] = {
 				...mergedTree[ context ].settings[ key ],
 				...userData[ context ]?.settings?.[ key ],
@@ -48,6 +50,7 @@ export const mergeTrees = ( baseData, userData ) => {
 
 	return mergedTree;
 };
+
 export default ( blockData, tree ) => {
 	const styles = [];
 	// Can this be converted to a context, as the global context?

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -211,3 +211,17 @@ export function setIsInserterOpened( isOpen ) {
 		isOpen,
 	};
 }
+
+/**
+ * Returns an action object used to update the settings.
+ *
+ * @param {Object} settings New settings.
+ *
+ * @return {Object} Action object.
+ */
+export function updateSettings( settings ) {
+	return {
+		type: 'UPDATE_SETTINGS',
+		settings,
+	};
+}


### PR DESCRIPTION
This PR applies a change that dynamically passes the block editor features to the edit-site.
The user can change these features now, so we need to compute them dynamically.
This PR is a follow-up to https://github.com/WordPress/gutenberg/pull/25711, and with it, after the user changes the color palette, the change is immediately reflected on the block editor, and we can see the colors available changed.