### PR TITLE
Add a dark mode to the post title

### DIFF
--- a/packages/editor/src/components/post-title/style.scss
+++ b/packages/editor/src/components/post-title/style.scss
@@ -48,6 +48,21 @@
 			color: $dark-gray-placeholder;
 		}
 
+		.is-dark-theme & {
+			&::-webkit-input-placeholder {
+				color: $light-gray-placeholder;
+			}
+
+			&::-moz-placeholder {
+				opacity: 1; // Necessary because Firefox reduces this from 1.
+				color: $light-gray-placeholder;
+			}
+
+			&:-ms-input-placeholder {
+				color: $light-gray-placeholder;
+			}
+		}
+
 		&:focus {
 			border: $border-width solid transparent;
 			outline: $border-width solid transparent;


### PR DESCRIPTION
## Description
Dark mode switches the placeholders to be a light color. This adds code so that post title placeholders also are light in dark mode.

This duplicates a chunk of code, so we might want to create a mixin.

## How has this been tested?
- Add theme support for dark mode (`add_theme_support( 'dark-editor-style' );`)
- Switch to a theme that has dark mode
- Check that the post title placeholder is light

## Screenshots <!-- if applicable -->

Before
<img width="996" alt="Screenshot 2020-10-02 at 16 35 25" src="https://user-images.githubusercontent.com/275961/94941821-5d984880-04cd-11eb-951b-5f83d1a09046.png">

After
<img width="994" alt="Screenshot 2020-10-02 at 16 35 33" src="https://user-images.githubusercontent.com/275961/94941816-5a9d5800-04cd-11eb-991d-98caf5047c6e.png">

## Types of changes
<!-- New feature (non-breaking change which adds functionality) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
