### PR TITLE
Fix PHP warning in widget utils REST controller

### DIFF
--- a/lib/class-wp-rest-widget-utils-controller.php
+++ b/lib/class-wp-rest-widget-utils-controller.php
@@ -88,6 +88,7 @@ class WP_REST_Widget_Utils_Controller extends WP_REST_Controller {
 	 *
 	 * @return boolean| True if the widget being referenced exists and false otherwise.
 	 * @since 5.2.0
+	 * @access public
 	 */
 	public function is_valid_widget( $widget_class ) {
 		$widget_class = urldecode( $widget_class );

--- a/lib/class-wp-rest-widget-utils-controller.php
+++ b/lib/class-wp-rest-widget-utils-controller.php
@@ -89,7 +89,7 @@ class WP_REST_Widget_Utils_Controller extends WP_REST_Controller {
 	 * @return boolean| True if the widget being referenced exists and false otherwise.
 	 * @since 5.2.0
 	 */
-	private function is_valid_widget( $widget_class ) {
+	public function is_valid_widget( $widget_class ) {
 		$widget_class = urldecode( $widget_class );
 		global $wp_widget_factory;
 		if ( ! $widget_class ) {


### PR DESCRIPTION
The `WP_REST_Widget_Utils_Controller::is_valid_widget` method needs to be public in order to be accessible as a callback (since it's being called from outside the class, via `call_user_func`).

This commit fixes the warning by changing the method's visibility from `private` to `public`.

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This commit changes the `WP_REST_Widget_Utils_Controller::is_valid_widget` method's visibility from `private` to `public`

## How has this been tested?
This has been manually tested on the new widgets screen, while checking the PHP error logs.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
