### PR TITLE
Classic block: edit in modal

### DIFF
--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -1,16 +1,16 @@
 /**
- * External dependencies
- */
-import { debounce } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { BlockControls } from '@wordpress/block-editor';
-import { ToolbarGroup } from '@wordpress/components';
-import { useEffect, useRef } from '@wordpress/element';
+import {
+	ToolbarGroup,
+	ToolbarButton,
+	Modal,
+	Button,
+} from '@wordpress/components';
+import { useEffect, useState, RawHTML } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { BACKSPACE, DELETE, F10, isKeyboardEvent } from '@wordpress/keycodes';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -19,221 +19,97 @@ import ConvertToBlocksButton from './convert-to-blocks-button';
 
 const { wp } = window;
 
-function isTmceEmpty( editor ) {
-	// When tinyMce is empty the content seems to be:
-	// <p><br data-mce-bogus="1"></p>
-	// avoid expensive checks for large documents
-	const body = editor.getBody();
-	if ( body.childNodes.length > 1 ) {
-		return false;
-	} else if ( body.childNodes.length === 0 ) {
-		return true;
-	}
-	if ( body.childNodes[ 0 ].childNodes.length > 1 ) {
-		return false;
-	}
-	return /^\n?$/.test( body.innerText || body.textContent );
-}
-
-export default function ClassicEdit( {
-	clientId,
-	attributes: { content },
-	setAttributes,
-	onReplace,
-} ) {
-	const didMount = useRef( false );
-
+function ClassicEdit( props ) {
+	const styles = useSelect(
+		( select ) => select( 'core/block-editor' ).getSettings().styles
+	);
 	useEffect( () => {
-		if ( ! didMount.current ) {
-			return;
-		}
-
-		const editor = window.tinymce.get( `editor-${ clientId }` );
-		const currentContent = editor?.getContent();
-
-		if ( currentContent !== content ) {
-			editor.setContent( content || '' );
-		}
-	}, [ content ] );
-
-	useEffect( () => {
-		const { baseURL, suffix } = window.wpEditorL10n.tinymce;
-
-		didMount.current = true;
+		const { baseURL, suffix, settings } = window.wpEditorL10n.tinymce;
 
 		window.tinymce.EditorManager.overrideDefaults( {
 			base_url: baseURL,
 			suffix,
 		} );
 
-		function onSetup( editor ) {
-			let bookmark;
-
-			if ( content ) {
-				editor.on( 'loadContent', () => editor.setContent( content ) );
-			}
-
-			editor.on( 'blur', () => {
-				bookmark = editor.selection.getBookmark( 2, true );
-				// There is an issue with Chrome and the editor.focus call in core at https://core.trac.wordpress.org/browser/trunk/src/js/_enqueues/lib/link.js#L451.
-				// This causes a scroll to the top of editor content on return from some content updating dialogs so tracking
-				// scroll position until this is fixed in core.
-				const scrollContainer = document.querySelector(
-					'.interface-interface-skeleton__content'
-				);
-				const scrollPosition = scrollContainer.scrollTop;
-
-				setAttributes( {
-					content: editor.getContent(),
-				} );
-
-				editor.once( 'focus', () => {
-					if ( bookmark ) {
-						editor.selection.moveToBookmark( bookmark );
-						if ( scrollContainer.scrollTop !== scrollPosition ) {
-							scrollContainer.scrollTop = scrollPosition;
-						}
-					}
-				} );
-
-				return false;
-			} );
-
-			editor.on( 'mousedown touchstart', () => {
-				bookmark = null;
-			} );
-
-			const debouncedOnChange = debounce( () => {
-				const value = editor.getContent();
-
-				if ( value !== editor._lastChange ) {
-					editor._lastChange = value;
-					setAttributes( {
-						content: value,
+		wp.oldEditor.initialize( props.id, {
+			tinymce: {
+				...settings,
+				height: 500,
+				setup( editor ) {
+					editor.on( 'init', () => {
+						const doc = editor.getDoc();
+						styles.forEach( ( { css } ) => {
+							const styleEl = doc.createElement( 'style' );
+							styleEl.innerHTML = css;
+							doc.head.appendChild( styleEl );
+						} );
 					} );
-				}
-			}, 250 );
-			editor.on( 'Paste Change input Undo Redo', debouncedOnChange );
-
-			// We need to cancel the debounce call because when we remove
-			// the editor (onUnmount) this callback is executed in
-			// another tick. This results in setting the content to empty.
-			editor.on( 'remove', debouncedOnChange.cancel );
-
-			editor.on( 'keydown', ( event ) => {
-				if ( isKeyboardEvent.primary( event, 'z' ) ) {
-					// Prevent the gutenberg undo kicking in so TinyMCE undo stack works as expected
-					event.stopPropagation();
-				}
-
-				if (
-					( event.keyCode === BACKSPACE ||
-						event.keyCode === DELETE ) &&
-					isTmceEmpty( editor )
-				) {
-					// delete the block
-					onReplace( [] );
-					event.preventDefault();
-					event.stopImmediatePropagation();
-				}
-
-				const { altKey } = event;
-				/*
-				 * Prevent Mousetrap from kicking in: TinyMCE already uses its own
-				 * `alt+f10` shortcut to focus its toolbar.
-				 */
-				if ( altKey && event.keyCode === F10 ) {
-					event.stopPropagation();
-				}
-			} );
-
-			editor.on( 'init', () => {
-				const rootNode = editor.getBody();
-
-				// Create the toolbar by refocussing the editor.
-				if ( rootNode.ownerDocument.activeElement === rootNode ) {
-					rootNode.blur();
-					editor.focus();
-				}
-			} );
-		}
-
-		function initialize() {
-			const { settings } = window.wpEditorL10n.tinymce;
-			wp.oldEditor.initialize( `editor-${ clientId }`, {
-				tinymce: {
-					...settings,
-					inline: true,
-					content_css: false,
-					fixed_toolbar_container: `#toolbar-${ clientId }`,
-					setup: onSetup,
 				},
-			} );
-		}
-
-		function onReadyStateChange() {
-			if ( document.readyState === 'complete' ) {
-				initialize();
-			}
-		}
-
-		if ( document.readyState === 'complete' ) {
-			initialize();
-		} else {
-			document.addEventListener( 'readystatechange', onReadyStateChange );
-		}
+			},
+		} );
 
 		return () => {
-			document.removeEventListener(
-				'readystatechange',
-				onReadyStateChange
-			);
-			wp.oldEditor.remove( `editor-${ clientId }` );
+			wp.oldEditor.remove( props.id );
 		};
 	}, [] );
 
-	function focus() {
-		const editor = window.tinymce.get( `editor-${ clientId }` );
-		if ( editor ) {
-			editor.focus();
-		}
-	}
+	return <textarea { ...props } />;
+}
 
-	function onToolbarKeyDown( event ) {
-		// Prevent WritingFlow from kicking in and allow arrows navigation on the toolbar.
-		event.stopPropagation();
-		// Prevent Mousetrap from moving focus to the top toolbar when pressing `alt+f10` on this block toolbar.
-		event.nativeEvent.stopImmediatePropagation();
-	}
+export default function Edit( props ) {
+	const {
+		clientId,
+		attributes: { content },
+		setAttributes,
+		onReplace,
+	} = props;
+	const [ isOpen, setOpen ] = useState( false );
+	const id = `editor-${ clientId }`;
+	const label = __( 'Classic Edit' );
+	const title = (
+		<>
+			{ label }
+			<div style={ { position: 'absolute', right: '30px', top: '12px' } }>
+				<Button
+					onClick={ () =>
+						content ? setOpen( false ) : onReplace( [] )
+					}
+				>
+					{ __( 'Cancel' ) }
+				</Button>
+				<Button
+					isPrimary
+					onClick={ () => {
+						setAttributes( {
+							content: wp.oldEditor.getContent( id ),
+						} );
+						setOpen( false );
+					} }
+				>
+					{ __( 'Save' ) }
+				</Button>
+			</div>
+		</>
+	);
 
-	// Disable reasons:
-	//
-	// jsx-a11y/no-static-element-interactions
-	//  - the toolbar itself is non-interactive, but must capture events
-	//    from the KeyboardShortcuts component to stop their propagation.
-
-	/* eslint-disable jsx-a11y/no-static-element-interactions */
 	return (
 		<>
 			<BlockControls>
 				<ToolbarGroup>
+					<ToolbarButton onClick={ () => setOpen( true ) }>
+						{ label }
+					</ToolbarButton>
+				</ToolbarGroup>
+				<ToolbarGroup>
 					<ConvertToBlocksButton clientId={ clientId } />
 				</ToolbarGroup>
 			</BlockControls>
-			<div
-				key="toolbar"
-				id={ `toolbar-${ clientId }` }
-				className="block-library-classic__toolbar"
-				onClick={ focus }
-				data-placeholder={ __( 'Classic' ) }
-				onKeyDown={ onToolbarKeyDown }
-			/>
-			<div
-				key="editor"
-				id={ `editor-${ clientId }` }
-				className="wp-block-freeform block-library-rich-text__tinymce"
-			/>
+			{ content && <RawHTML>{ content }</RawHTML> }
+			{ ( isOpen || ! content ) && (
+				<Modal title={ title } isDismissible={ false }>
+					<ClassicEdit id={ id } defaultValue={ content } />
+				</Modal>
+			) }
 		</>
 	);
-	/* eslint-enable jsx-a11y/no-static-element-interactions */
 }


### PR DESCRIPTION
Fixes #14134, #9672.

Proof of Concept

This PR changes the Classic Block so that it's edited within a modal instead the rest of the post content.

* Results in less complexity in the Classic Block and makes it easier to maintain.
* Fixes a bunch of issues such as (confusing) double undo/redo buttons.
* Avoids the content being pushed around on focus/blur caused by the classic toolbar. No toolbar should ever be inserted in the content in the first place.
* Isolates the Classic editor from the rest of the block editor.
* Just like the real classic editor, the content will now be loaded in an iframe, so it's closer to the experience pre-Gutenberg.

## Preview

<img width="748" alt="Screenshot 2020-10-02 at 21 18 29" src="https://user-images.githubusercontent.com/4710635/94956976-b11e8c80-04f5-11eb-87e7-70dd27b8552a.png">

## Modal

<img width="789" alt="Screenshot 2020-10-02 at 21 18 36" src="https://user-images.githubusercontent.com/4710635/94956989-b5e34080-04f5-11eb-970f-0b50c9161c27.png">

