### PR TITLE
Document Actions: Fix Block Editor Inserter Overlap with Document Titles

### DIFF
--- a/packages/edit-site/src/components/header/document-actions/style.scss
+++ b/packages/edit-site/src/components/header/document-actions/style.scss
@@ -1,5 +1,4 @@
 .edit-site-document-actions {
-	background-color: $white;
 	display: flex;
 	flex-direction: column;
 	align-items: center;

--- a/packages/edit-site/src/components/header/document-actions/style.scss
+++ b/packages/edit-site/src/components/header/document-actions/style.scss
@@ -1,4 +1,5 @@
 .edit-site-document-actions {
+	background-color: $white;
 	display: flex;
 	flex-direction: column;
 	align-items: center;

--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -1,5 +1,6 @@
 .edit-site-header {
 	align-items: center;
+	background-color: $white;
 	display: flex;
 	height: $header-height;
 	box-sizing: border-box;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
When scrolling through the block editor, if a sibling inserter is being displayed, it will overlap the document actions labels.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Set up the site editor locally
2. Navigate to the site editor 
3. Hover over a sibling inserter
4. Scroll down through the editor until the inserter would overlap the document actions labels
5. Verify that there is no visual overlap

## Screenshots <!-- if applicable -->
### Before
<img width="999" alt="Screen Shot 2020-10-02 at 5 06 04 PM" src="https://user-images.githubusercontent.com/5414230/94978297-9f2af280-04d1-11eb-888a-b5e43c1bd095.png">

### After
![2020-10-02 17 08 00](https://user-images.githubusercontent.com/5414230/94978437-34c68200-04d2-11eb-81b4-6f031379abf0.gif)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
