### PR TITLE
Fix incorrect attribute type specified in Search block

### DIFF
--- a/packages/block-library/src/search/block.json
+++ b/packages/block-library/src/search/block.json
@@ -7,7 +7,7 @@
 			"type": "string"
 		},
 		"showLabel": {
-			"type": "bool",
+			"type": "boolean",
 			"default": true
 		},
 		"placeholder": {
@@ -28,7 +28,7 @@
 			"default": "button-outside"
 		},
 		"buttonUseIcon": {
-			"type": "bool",
+			"type": "boolean",
 			"default": false
 		}
 	},


### PR DESCRIPTION
Avoid Notice: rest_validate_value_from_schema
Change the type for `showLabel` and `buttonUseIcon` from `"bool"` to `"boolean"` to avoid notices when `WP_DEBUG` is true.

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
I've corrected the values to avoid Notices from `rest_validate_value_from_schema`
<!-- Please describe what you have changed or added -->

## How has this been tested?
In a local development environment. After applying the change I edited and viewed the Search block I'd created earlier. The Notices were no longer displayed.
<!-- Please describe in detail how you tested your changes. --> 
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/2474435/95011995-f0032e00-062c-11eb-9db8-d6ca89f9f93a.png)

## Types of changes
Typo fix.
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
