### PR TITLE
Add/relative units for font size

### DIFF
--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -61,7 +66,9 @@ export default function FontSizePicker( {
 		[ fontSizes, disableCustomFontSizes ]
 	);
 
-	const [ advancedFontSizing, setAdvancedFontSizing ] = useState( false );
+	const [ advancedFontSizing, setAdvancedFontSizing ] = useState(
+		! Number.isFinite( value ) && value !== undefined
+	);
 
 	if ( ! options ) {
 		return null;
@@ -74,7 +81,11 @@ export default function FontSizePicker( {
 	const customInputProps = advancedFontSizing
 		? {
 				id: fontSizePickerNumberId,
-				className: 'components-font-size-picker__number-full-size',
+				className: classnames(
+					'components-font-size-picker__number',
+					advancedFontSizing &&
+						'components-font-size-picker__number--full-size'
+				),
 				onChange: ( event ) => onChange( event.target.value ),
 				ariaLabel: __( 'Custom' ),
 				value: value || '',
@@ -93,7 +104,13 @@ export default function FontSizePicker( {
 	return (
 		<fieldset className="components-font-size-picker">
 			<VisuallyHidden as="legend">{ __( 'Font size' ) }</VisuallyHidden>
-			<div className="components-font-size-picker__controls">
+			<div
+				className={ classnames(
+					'components-font-size-picker__controls',
+					advancedFontSizing &&
+						'components-font-size-picker__controls--full-size'
+				) }
+			>
 				{ fontSizes.length > 0 && ! advancedFontSizing && (
 					<CustomSelectControl
 						className={ 'components-font-size-picker__select' }
@@ -133,7 +150,10 @@ export default function FontSizePicker( {
 			<div>
 				<ToggleControl
 					label="Advanced font sizing"
-					onChange={ () => setAdvancedFontSizing( !advancedFontSizing ) }
+					onChange={ () =>
+						setAdvancedFontSizing( ! advancedFontSizing )
+					}
+					help="Toggle to activate custom font-sizing settings"
 					checked={ advancedFontSizing }
 				/>
 			</div>

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { useInstanceId } from '@wordpress/compose';
 import { textColor } from '@wordpress/icons';
-import { useMemo } from '@wordpress/element';
+import { useMemo, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -13,6 +13,7 @@ import Button from '../button';
 import RangeControl from '../range-control';
 import CustomSelectControl from '../custom-select-control';
 import VisuallyHidden from '../visually-hidden';
+import ToggleControl from '../toggle-control';
 
 const DEFAULT_FONT_SIZE = 'default';
 const CUSTOM_FONT_SIZE = 'custom';
@@ -60,6 +61,8 @@ export default function FontSizePicker( {
 		[ fontSizes, disableCustomFontSizes ]
 	);
 
+	const [ advancedFontSizing, setAdvancedFontSizing ] = useState( false );
+
 	if ( ! options ) {
 		return null;
 	}
@@ -68,11 +71,30 @@ export default function FontSizePicker( {
 
 	const fontSizePickerNumberId = `components-font-size-picker__number#${ instanceId }`;
 
+	const customInputProps = advancedFontSizing
+		? {
+				id: fontSizePickerNumberId,
+				className: 'components-font-size-picker__number-full-size',
+				onChange: ( event ) => onChange( event.target.value ),
+				ariaLabel: __( 'Custom' ),
+				value: value || '',
+				placeholder: 'e.g. calc(2rem - 13.5px)',
+		  }
+		: {
+				id: fontSizePickerNumberId,
+				className: 'components-font-size-picker__number',
+				type: 'number',
+				min: 1,
+				onChange: ( event ) => onChange( Number( event.target.value ) ),
+				ariaLabel: __( 'Custom' ),
+				value: value || '',
+		  };
+
 	return (
 		<fieldset className="components-font-size-picker">
 			<VisuallyHidden as="legend">{ __( 'Font size' ) }</VisuallyHidden>
 			<div className="components-font-size-picker__controls">
-				{ fontSizes.length > 0 && (
+				{ fontSizes.length > 0 && ! advancedFontSizing && (
 					<CustomSelectControl
 						className={ 'components-font-size-picker__select' }
 						label={ __( 'Font size' ) }
@@ -93,17 +115,7 @@ export default function FontSizePicker( {
 						<label htmlFor={ fontSizePickerNumberId }>
 							{ __( 'Custom' ) }
 						</label>
-						<input
-							id={ fontSizePickerNumberId }
-							className="components-font-size-picker__number"
-							type="number"
-							min={ 1 }
-							onChange={ ( event ) => {
-								onChange( Number( event.target.value ) );
-							} }
-							aria-label={ __( 'Custom' ) }
-							value={ value || '' }
-						/>
+						<input { ...customInputProps } />
 					</div>
 				) }
 				<Button
@@ -117,6 +129,13 @@ export default function FontSizePicker( {
 				>
 					{ __( 'Reset' ) }
 				</Button>
+			</div>
+			<div>
+				<ToggleControl
+					label="Advanced font sizing"
+					onChange={ () => setAdvancedFontSizing( !advancedFontSizing ) }
+					checked={ advancedFontSizing }
+				/>
 			</div>
 			{ withSlider && (
 				<RangeControl

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -90,7 +90,7 @@ export default function FontSizePicker( {
 				onChange: ( event ) => onChange( event.target.value ),
 				ariaLabel: __( 'Custom' ),
 				value: value || '',
-				placeholder: 'e.g. calc(2rem - 13.5px)',
+				placeholder: __( 'e.g. calc(2rem - 13.5px)' ),
 		  }
 		: {
 				id: fontSizePickerNumberId,
@@ -150,11 +150,13 @@ export default function FontSizePicker( {
 			</div>
 			<div>
 				<ToggleControl
-					label="Advanced font sizing"
+					label={ __( 'Advanced font sizing' ) }
 					onChange={ () =>
 						setAdvancedFontSizing( ! advancedFontSizing )
 					}
-					help="Toggle to activate custom font-sizing settings"
+					help={ __(
+						'Toggle to activate custom font-sizing settings'
+					) }
 					checked={ advancedFontSizing }
 				/>
 			</div>

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { isNil, isNumber } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -67,7 +68,7 @@ export default function FontSizePicker( {
 	);
 
 	const [ advancedFontSizing, setAdvancedFontSizing ] = useState(
-		! Number.isFinite( value ) && value !== undefined
+		! isNumber( value ) && ! isNil( value )
 	);
 
 	if ( ! options ) {

--- a/packages/components/src/font-size-picker/style.scss
+++ b/packages/components/src/font-size-picker/style.scss
@@ -27,7 +27,13 @@
 		&-container {
 			display: flex;
 			flex-direction: column;
+			flex-grow: 1;
 		}
+	}
+
+	.components-font-size-picker__number-full-size {
+		@extend .components-font-size-picker__number;
+		width: calc(100% - #{$grid-unit-10 + 2 * $border-width});
 	}
 
 	// Allow the font-size picker dropdown to grow in width.

--- a/packages/components/src/font-size-picker/style.scss
+++ b/packages/components/src/font-size-picker/style.scss
@@ -15,7 +15,7 @@
 		margin-left: 0;
 		margin-right: $grid-unit-10;
 		margin-top: $grid-unit-10;
-		width: 54px;
+		width: 56px;
 
 		// Show the reset button as disabled until a value is entered.
 		&[value=""] + .components-button {
@@ -29,11 +29,10 @@
 			flex-direction: column;
 			flex-grow: 1;
 		}
-	}
 
-	.components-font-size-picker__number-full-size {
-		@extend .components-font-size-picker__number;
-		width: calc(100% - #{$grid-unit-10 + 2 * $border-width});
+		&--full-size {
+			width: auto;
+		}
 	}
 
 	// Allow the font-size picker dropdown to grow in width.
@@ -44,6 +43,10 @@
 	.components-color-palette__clear {
 		height: 30px;
 		margin-top: 26px;
+	}
+
+	&--full-size {
+		flex: 0 0 100%;
 	}
 }
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes: #23323 
This PR adds the option to set custom CSS font sizes to font-size-picker component by adding a switch toggle underneath `Font sizes` dropdown. 

Currently, when the user sees a dropdown with the predefined font-sizes, an adjacent `custom` field which accepts only numbers and shows the font size using pixels for units of measure, and the reset button which clears the custom field and sets font size to `default`. 

To allow for writing more complex sizing formulas in this PR adds a toggle which when activated removes the font-size dropdown and renders a large custom field which in addition accepts string values.

<!-- Please describe what you have changed or added -->

## How has this been tested?
This is a draft still so will add tests when changes are accepted.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
Toggle OFF.
This is the default state of the toggle. 

![image](https://user-images.githubusercontent.com/17088041/95075552-0981a400-0719-11eb-9d35-08c1b90859d2.png)  

Toggle ON.

![image](https://user-images.githubusercontent.com/17088041/95075513-f66ed400-0718-11eb-965b-a2c878d94dc9.png)


## Types of changes
New feature (non-breaking change which adds functionality).
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
