### PR TITLE
[Widgets editor] Load custom block assets

### DIFF
--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -125,3 +125,21 @@ function gutenberg_widgets_init( $hook ) {
 	wp_enqueue_style( 'wp-format-library' );
 }
 add_action( 'admin_enqueue_scripts', 'gutenberg_widgets_init' );
+
+/**
+ * Tells the script loader to load the scripts and styles of custom block on widgets editor screen.
+ *
+ * @param bool $is_block_editor_screen Current decision about loading block assets.
+ * @return bool Filtered decision about loading block assets.
+ */
+function widgets_editor_load_block_editor_scripts_and_styles( $is_block_editor_screen ) {
+	global $current_screen;
+	if ( $current_screen->base === 'appearance_page_gutenberg-widgets' ) {
+		return true;
+	}
+
+	return $is_block_editor_screen;
+}
+
+add_filter( 'should_load_block_editor_scripts_and_styles', 'widgets_editor_load_block_editor_scripts_and_styles' );
+

--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -132,7 +132,7 @@ add_action( 'admin_enqueue_scripts', 'gutenberg_widgets_init' );
  * @param bool $is_block_editor_screen Current decision about loading block assets.
  * @return bool Filtered decision about loading block assets.
  */
-function widgets_editor_load_block_editor_scripts_and_styles( $is_block_editor_screen ) {
+function gutenberg_widgets_editor_load_block_editor_scripts_and_styles( $is_block_editor_screen ) {
 	if ( 'appearance_page_gutenberg-widgets' === get_current_screen()->base ) {
 		return true;
 	}
@@ -140,4 +140,5 @@ function widgets_editor_load_block_editor_scripts_and_styles( $is_block_editor_s
 	return $is_block_editor_screen;
 }
 
-add_filter( 'should_load_block_editor_scripts_and_styles', 'widgets_editor_load_block_editor_scripts_and_styles' );
+add_filter( 'should_load_block_editor_scripts_and_styles', 'gutenberg_widgets_editor_load_block_editor_scripts_and_styles' );
+

--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -134,7 +134,7 @@ add_action( 'admin_enqueue_scripts', 'gutenberg_widgets_init' );
  */
 function widgets_editor_load_block_editor_scripts_and_styles( $is_block_editor_screen ) {
 	global $current_screen;
-	if ( $current_screen->base === 'appearance_page_gutenberg-widgets' ) {
+	if ( 'appearance_page_gutenberg-widgets' === $current_screen->base ) {
 		return true;
 	}
 

--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -133,8 +133,7 @@ add_action( 'admin_enqueue_scripts', 'gutenberg_widgets_init' );
  * @return bool Filtered decision about loading block assets.
  */
 function widgets_editor_load_block_editor_scripts_and_styles( $is_block_editor_screen ) {
-	global $current_screen;
-	if ( 'appearance_page_gutenberg-widgets' === $current_screen->base ) {
+	if ( 'appearance_page_gutenberg-widgets' === get_current_screen()->base ) {
 		return true;
 	}
 
@@ -142,4 +141,3 @@ function widgets_editor_load_block_editor_scripts_and_styles( $is_block_editor_s
 }
 
 add_filter( 'should_load_block_editor_scripts_and_styles', 'widgets_editor_load_block_editor_scripts_and_styles' );
-


### PR DESCRIPTION
## Description
Fixes https://github.com/WordPress/gutenberg/issues/15644 by plugging into `should_load_block_editor_scripts_and_styles` filter and returning `true` on widgets editor screen.

Note that this PR will only fix the problem on latest WP trunk, but it won't break anything on older WP versions.

## How has this been tested?
1. Use latest WP trun
1. Apply this PR
1. Install and activate, let's say, the CoBlocks plugin
1. Go to the widgets editor, add a "map" block to any widget area
1. Confirm it worked

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
