### PR TITLE
Transform multiple selected blocks to Columns block

### DIFF
--- a/packages/block-editor/src/autocompleters/block.js
+++ b/packages/block-editor/src/autocompleters/block.js
@@ -1,13 +1,16 @@
 /**
  * External dependencies
  */
-import { noop, map, orderBy } from 'lodash';
+import { noop, orderBy } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { createBlock } from '@wordpress/blocks';
+import {
+	createBlock,
+	createBlocksFromInnerBlocksTemplate,
+} from '@wordpress/blocks';
 import { useMemo } from '@wordpress/element';
 
 /**
@@ -18,18 +21,6 @@ import useBlockTypesState from '../components/inserter/hooks/use-block-types-sta
 import BlockIcon from '../components/block-icon';
 
 const SHOWN_BLOCK_TYPES = 9;
-
-const createBlocksFromInnerBlocksTemplate = ( innerBlocksTemplate ) => {
-	return map(
-		innerBlocksTemplate,
-		( [ name, attributes, innerBlocks = [] ] ) =>
-			createBlock(
-				name,
-				attributes,
-				createBlocksFromInnerBlocksTemplate( innerBlocks )
-			)
-	);
-};
 
 /** @typedef {import('@wordpress/block-editor').WPEditorInserterItem} WPEditorInserterItem */
 

--- a/packages/block-editor/src/components/block-variation-picker/index.native.js
+++ b/packages/block-editor/src/components/block-variation-picker/index.native.js
@@ -8,14 +8,13 @@ import {
 	TouchableWithoutFeedback,
 	Platform,
 } from 'react-native';
-import { map } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { withSelect, useDispatch } from '@wordpress/data';
 import { compose, usePreferredColorSchemeStyle } from '@wordpress/compose';
-import { createBlock } from '@wordpress/blocks';
+import { createBlocksFromInnerBlocksTemplate } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import {
 	PanelBody,
@@ -32,18 +31,6 @@ import { useMemo } from '@wordpress/element';
 import styles from './style.scss';
 
 const hitSlop = { top: 22, bottom: 22, left: 22, right: 22 };
-
-function createBlocksFromInnerBlocksTemplate( innerBlocksTemplate ) {
-	return map(
-		innerBlocksTemplate,
-		( [ name, attributes, innerBlocks = [] ] ) =>
-			createBlock(
-				name,
-				attributes,
-				createBlocksFromInnerBlocksTemplate( innerBlocks )
-			)
-	);
-}
 
 function BlockVariationPicker( { isVisible, onClose, clientId, variations } ) {
 	const { replaceInnerBlocks } = useDispatch( 'core/block-editor' );

--- a/packages/block-editor/src/components/inserter/hooks/use-block-types-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-block-types-state.js
@@ -1,27 +1,12 @@
 /**
- * External dependencies
- */
-import { map } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useEffect } from '@wordpress/element';
-import { createBlock } from '@wordpress/blocks';
+import {
+	createBlock,
+	createBlocksFromInnerBlocksTemplate,
+} from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
-
-// Copied over from the Columns block. It seems like it should become part of public API.
-const createBlocksFromInnerBlocksTemplate = ( innerBlocksTemplate ) => {
-	return map(
-		innerBlocksTemplate,
-		( [ name, attributes, innerBlocks = [] ] ) =>
-			createBlock(
-				name,
-				attributes,
-				createBlocksFromInnerBlocksTemplate( innerBlocks )
-			)
-	);
-};
 
 /**
  * Retrieves the block types inserter state.

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { dropRight, get, map, times } from 'lodash';
+import { dropRight, get, times } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -19,7 +19,10 @@ import {
 	useBlockProps,
 } from '@wordpress/block-editor';
 import { withDispatch, useDispatch, useSelect } from '@wordpress/data';
-import { createBlock } from '@wordpress/blocks';
+import {
+	createBlock,
+	createBlocksFromInnerBlocksTemplate,
+} from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -197,18 +200,6 @@ const ColumnsEditContainerWrapper = withDispatch(
 		},
 	} )
 )( ColumnsEditContainer );
-
-const createBlocksFromInnerBlocksTemplate = ( innerBlocksTemplate ) => {
-	return map(
-		innerBlocksTemplate,
-		( [ name, attributes, innerBlocks = [] ] ) =>
-			createBlock(
-				name,
-				attributes,
-				createBlocksFromInnerBlocksTemplate( innerBlocks )
-			)
-	);
-};
 
 function Placeholder( { clientId, name, setAttributes } ) {
 	const { blockType, defaultVariation, variations } = useSelect(

--- a/packages/block-library/src/columns/index.js
+++ b/packages/block-library/src/columns/index.js
@@ -12,6 +12,7 @@ import edit from './edit';
 import metadata from './block.json';
 import save from './save';
 import variations from './variations';
+import transforms from './transforms';
 
 const { name } = metadata;
 
@@ -84,4 +85,5 @@ export const settings = {
 	deprecated,
 	edit,
 	save,
+	transforms,
 };

--- a/packages/block-library/src/columns/transforms.js
+++ b/packages/block-library/src/columns/transforms.js
@@ -1,0 +1,39 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	createBlock,
+	createBlocksFromInnerBlocksTemplate,
+} from '@wordpress/blocks';
+
+const MAXIMUM_SELECTED_BLOCKS = 6;
+
+const transforms = {
+	from: [
+		{
+			type: 'block',
+			isMultiBlock: true,
+			blocks: [ '*' ],
+			__experimentalConvert: ( blocks ) => {
+				const columnWidth = +( 100 / blocks.length ).toFixed( 2 );
+				const innerBlocksTemplate = blocks.map(
+					( { name, attributes, innerBlocks } ) => [
+						'core/column',
+						{ width: `${ columnWidth }%` },
+						[ [ name, { ...attributes }, innerBlocks ] ],
+					]
+				);
+				return createBlock(
+					'core/columns',
+					{},
+					createBlocksFromInnerBlocksTemplate( innerBlocksTemplate )
+				);
+			},
+			isMatch: ( { length: selectedBlocksLength } ) =>
+				selectedBlocksLength > 1 &&
+				selectedBlocksLength <= MAXIMUM_SELECTED_BLOCKS,
+		},
+	],
+};
+
+export default transforms;

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -205,6 +205,21 @@ _Returns_
 
 -   `Object`: Block object.
 
+<a name="createBlocksFromInnerBlocksTemplate" href="#createBlocksFromInnerBlocksTemplate">#</a> **createBlocksFromInnerBlocksTemplate**
+
+Given an array of InnerBlocks templates or Block Objects,
+returns an array of created Blocks from them.
+It handles the case of having InnerBlocks as Blocks by
+converting them to the proper format to continue recursively.
+
+_Parameters_
+
+-   _innerBlocksOrTemplate_ `Array`: Nested blocks or InnerBlocks templates.
+
+_Returns_
+
+-   `Array<Object>`: Array of Block objects.
+
 <a name="doBlocksMatchTemplate" href="#doBlocksMatchTemplate">#</a> **doBlocksMatchTemplate**
 
 Checks whether a list of blocks matches a template by comparing the block names.

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -92,6 +92,34 @@ export function createBlock( name, attributes = {}, innerBlocks = [] ) {
 }
 
 /**
+ * Given an array of InnerBlocks templates or Block Objects,
+ * returns an array of created Blocks from them.
+ * It handles the case of having InnerBlocks as Blocks by
+ * converting them to the proper format to continue recursively.
+ *
+ * @param {Array} innerBlocksOrTemplate Nested blocks or InnerBlocks templates.
+ *
+ * @return {Object[]} Array of Block objects.
+ */
+export function createBlocksFromInnerBlocksTemplate( innerBlocksOrTemplate ) {
+	return innerBlocksOrTemplate.map( ( innerBlock ) => {
+		const innerBlockTemplate = Array.isArray( innerBlock )
+			? innerBlock
+			: [
+					innerBlock.name,
+					innerBlock.attributes,
+					innerBlock.innerBlocks,
+			  ];
+		const [ name, attributes, innerBlocks = [] ] = innerBlockTemplate;
+		return createBlock(
+			name,
+			attributes,
+			createBlocksFromInnerBlocksTemplate( innerBlocks )
+		);
+	} );
+}
+
+/**
  * Given a block object, returns a copy of the block object, optionally merging
  * new attributes and/or replacing its inner blocks.
  *

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -101,7 +101,9 @@ export function createBlock( name, attributes = {}, innerBlocks = [] ) {
  *
  * @return {Object[]} Array of Block objects.
  */
-export function createBlocksFromInnerBlocksTemplate( innerBlocksOrTemplate ) {
+export function createBlocksFromInnerBlocksTemplate(
+	innerBlocksOrTemplate = []
+) {
 	return innerBlocksOrTemplate.map( ( innerBlock ) => {
 		const innerBlockTemplate = Array.isArray( innerBlock )
 			? innerBlock

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -1,5 +1,6 @@
 export {
 	createBlock,
+	createBlocksFromInnerBlocksTemplate,
 	cloneBlock,
 	getPossibleBlockTransformations,
 	switchToBlockType,

--- a/packages/e2e-tests/specs/editor/various/block-switcher.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-switcher.test.js
@@ -82,4 +82,48 @@ describe( 'Block Switcher', () => {
 		// Verify the correct block transforms appear.
 		expect( await getAvailableBlockTransforms() ).toHaveLength( 0 );
 	} );
+
+	describe( 'Conditional tranformation options', () => {
+		describe( 'Columns tranforms', () => {
+			it( 'Should show Columns block only if selected blocks are between limits (2-6)', async () => {
+				await insertBlock( 'List' );
+				await page.keyboard.type( 'List content' );
+				await insertBlock( 'Heading' );
+				await page.keyboard.type( 'I am a header' );
+				await page.keyboard.down( 'Shift' );
+				await page.keyboard.press( 'ArrowUp' );
+				await page.keyboard.up( 'Shift' );
+				expect( await getAvailableBlockTransforms() ).toEqual(
+					expect.arrayContaining( [ 'Columns' ] )
+				);
+			} );
+			it( 'Should NOT show Columns transform only if selected blocks are more than max limit(6)', async () => {
+				await insertBlock( 'List' );
+				await page.keyboard.type( 'List content' );
+				await insertBlock( 'Heading' );
+				await page.keyboard.type( 'I am a header' );
+				await page.keyboard.press( 'Enter' );
+				await page.keyboard.type( 'First paragraph' );
+				await page.keyboard.press( 'Enter' );
+				await page.keyboard.type( 'Second paragraph' );
+				await page.keyboard.press( 'Enter' );
+				await page.keyboard.type( 'Third paragraph' );
+				await page.keyboard.press( 'Enter' );
+				await page.keyboard.type( 'Fourth paragraph' );
+				await page.keyboard.press( 'Enter' );
+				await page.keyboard.type( 'Fifth paragraph' );
+				await page.keyboard.down( 'Shift' );
+				await page.keyboard.press( 'ArrowUp' );
+				await page.keyboard.press( 'ArrowUp' );
+				await page.keyboard.press( 'ArrowUp' );
+				await page.keyboard.press( 'ArrowUp' );
+				await page.keyboard.press( 'ArrowUp' );
+				await page.keyboard.press( 'ArrowUp' );
+				await page.keyboard.up( 'Shift' );
+				expect( await getAvailableBlockTransforms() ).not.toEqual(
+					expect.arrayContaining( [ 'Columns' ] )
+				);
+			} );
+		} );
+	} );
 } );

--- a/packages/e2e-tests/specs/editor/various/block-switcher.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-switcher.test.js
@@ -112,14 +112,8 @@ describe( 'Block Switcher', () => {
 				await page.keyboard.type( 'Fourth paragraph' );
 				await page.keyboard.press( 'Enter' );
 				await page.keyboard.type( 'Fifth paragraph' );
-				await page.keyboard.down( 'Shift' );
-				await page.keyboard.press( 'ArrowUp' );
-				await page.keyboard.press( 'ArrowUp' );
-				await page.keyboard.press( 'ArrowUp' );
-				await page.keyboard.press( 'ArrowUp' );
-				await page.keyboard.press( 'ArrowUp' );
-				await page.keyboard.press( 'ArrowUp' );
-				await page.keyboard.up( 'Shift' );
+				await pressKeyWithModifier( 'primary', 'a' );
+				await pressKeyWithModifier( 'primary', 'a' );
 				expect( await getAvailableBlockTransforms() ).not.toEqual(
 					expect.arrayContaining( [ 'Columns' ] )
 				);


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Resolves: https://github.com/WordPress/gutenberg/issues/16504

This PR adds the ability to transform multiple selected blocks in a `Columns` block. For now the `Columns` transformation is available from the menu only if selected blocks are `between two and six`. The number `six` is selected as for now this is the current `max` columns allowed by a `Columns` block.

You can create a `Columns` block from any other block, including InnerBlocks themselves. 

<!-- Please describe what you have changed or added -->

## How has this been tested?
Locally for now.
You can test this PR by doing the following:
1. Go to a post/page
2. Create some blocks, even a block with InnerBlocks like a `Group` block.
3. Multi select blocks (between 2-6)
4. Click on transform menu and select `Columns`


## Types of changes
A new function (`createBlocksFromInnerBlocksTemplate`) for creating blocks from `InnerBlocks template` have been exposed to the public API. A version of this function has been used(duplicated) in more than one places to implement the relative functionality.

## Todos left

- [x] Unit tests for `createBlocksFromInnerBlocksTemplate`.
- [x] e2e tests for the transformation to `Columns`.
- [x] Use the new function to appropriate places.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
