### PR TITLE
Support for ephemeral entities

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -157,7 +157,7 @@ export function* deleteEntityRecord( kind, name, recordId, query ) {
 	const entity = find( entities, { kind, name } );
 	let error;
 	let deletedRecord = false;
-	if ( ! entity ) {
+	if ( ! entity || entity.ephemeral ) {
 		return;
 	}
 
@@ -327,7 +327,7 @@ export function* saveEntityRecord(
 ) {
 	const entities = yield getKindEntities( kind );
 	const entity = find( entities, { kind, name } );
-	if ( ! entity ) {
+	if ( ! entity || entity.ephemeral ) {
 		return;
 	}
 	const entityIdKey = entity.key || DEFAULT_ENTITY_KEY;

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -56,7 +56,7 @@ export function* getCurrentUser() {
 export function* getEntityRecord( kind, name, key = '', query ) {
 	const entities = yield getKindEntities( kind );
 	const entity = find( entities, { kind, name } );
-	if ( ! entity ) {
+	if ( ! entity || entity.ephemeral ) {
 		return;
 	}
 
@@ -133,7 +133,7 @@ export const getEditedEntityRecord = ifNotResolved(
 export function* getEntityRecords( kind, name, query = {} ) {
 	const entities = yield getKindEntities( kind );
 	const entity = find( entities, { kind, name } );
-	if ( ! entity ) {
+	if ( ! entity || entity.ephemeral ) {
 		return;
 	}
 


### PR DESCRIPTION
Both navigation editor and widgets editor need a top-level entity record to store all the blocks. While post editor may just use the post entity that comes from the API, there is no corresponding concept in the navigation editor or the widgets editors. At the moment both editors use a "fake" post entity record that's never resolved from the API or persisted to the API. This requires carefully dispatching actions to avoid triggering any resolvers. In other words, it's a hack.

This PR proposes first-class support for ephemeral entities right in the data layer. An ephemeral entity is one that exists only in the memory, it isn't stored in the API and therefore interacting with related entity records should not trigger any network activity.

This is how widgets editor would make use of ephemeral entities: https://github.com/WordPress/gutenberg/pull/25832

This PR would require unit tests and documentation in order to be mergeable. If the idea gets traction, I'll be happy to add both.