### PR TITLE
Iterations on options modal

### DIFF
--- a/packages/e2e-test-utils/src/disable-pre-publish-checks.js
+++ b/packages/e2e-test-utils/src/disable-pre-publish-checks.js
@@ -8,6 +8,6 @@ import { toggleMoreMenu } from './toggle-more-menu';
  * Disables Pre-publish checks.
  */
 export async function disablePrePublishChecks() {
-	await toggleScreenOption( 'Pre-publish checklist', false );
+	await toggleScreenOption( 'Include pre-publish checklist', false );
 	await toggleMoreMenu();
 }

--- a/packages/e2e-test-utils/src/disable-pre-publish-checks.js
+++ b/packages/e2e-test-utils/src/disable-pre-publish-checks.js
@@ -8,6 +8,6 @@ import { toggleMoreMenu } from './toggle-more-menu';
  * Disables Pre-publish checks.
  */
 export async function disablePrePublishChecks() {
-	await toggleScreenOption( 'Pre-publish checks', false );
+	await toggleScreenOption( 'Pre-publish checklist', false );
 	await toggleMoreMenu();
 }

--- a/packages/e2e-test-utils/src/enable-pre-publish-checks.js
+++ b/packages/e2e-test-utils/src/enable-pre-publish-checks.js
@@ -8,6 +8,6 @@ import { toggleMoreMenu } from './toggle-more-menu';
  * Enables Pre-publish checks.
  */
 export async function enablePrePublishChecks() {
-	await toggleScreenOption( 'Pre-publish checks', true );
+	await toggleScreenOption( 'Pre-publish checklist', true );
 	await toggleMoreMenu();
 }

--- a/packages/e2e-test-utils/src/enable-pre-publish-checks.js
+++ b/packages/e2e-test-utils/src/enable-pre-publish-checks.js
@@ -8,6 +8,6 @@ import { toggleMoreMenu } from './toggle-more-menu';
  * Enables Pre-publish checks.
  */
 export async function enablePrePublishChecks() {
-	await toggleScreenOption( 'Pre-publish checklist', true );
+	await toggleScreenOption( 'Include pre-publish checklist', true );
 	await toggleMoreMenu();
 }

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -141,9 +141,7 @@ export function PreferencesModal( { isModalActive, isViewable, closeModal } ) {
 			</Section>
 			<MetaBoxesSection
 				title={ __( 'Additional panels' ) }
-				description={ __(
-					'Add extra areas to the editor.'
-				) }
+				description={ __( 'Add extra areas to the editor.' ) }
 			/>
 		</Modal>
 	);

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -62,9 +62,7 @@ export function PreferencesModal( { isModalActive, isViewable, closeModal } ) {
 			<Section title={ __( 'Keyboard' ) }>
 				<EnableFeature
 					featureName="keepCaretInsideBlock"
-					help={ __(
-						'Keeps keyboard cursor inside active block.'
-					) }
+					help={ __( 'Keeps keyboard cursor inside active block.' ) }
 					label={ __( 'Contain the text cursor' ) }
 				/>
 			</Section>

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -46,7 +46,7 @@ export function PreferencesModal( { isModalActive, isViewable, closeModal } ) {
 			<Section title={ __( 'General' ) }>
 				<EnablePublishSidebarOption
 					help={ __(
-						'Allow setting of tags, check dates for instance.'
+						'Allows review of document settings before publishing.'
 					) }
 					label={ __( 'Pre-publish checklist' ) }
 				/>
@@ -63,7 +63,7 @@ export function PreferencesModal( { isModalActive, isViewable, closeModal } ) {
 				<EnableFeature
 					featureName="keepCaretInsideBlock"
 					help={ __(
-						'When using the keyboard contains to active block.'
+						'Keeps keyboard cursor inside active block.'
 					) }
 					label={ __( 'Contain the text cursor' ) }
 				/>
@@ -75,7 +75,7 @@ export function PreferencesModal( { isModalActive, isViewable, closeModal } ) {
 				/>
 				<EnableFeature
 					featureName="reducedUI"
-					help={ __( 'Reduces toolbar and outlines.' ) }
+					help={ __( 'Reduces options in toolbar and outlines.' ) }
 					label={ __( 'Compact interface' ) }
 				/>
 				<EnableFeature

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -36,7 +36,6 @@ export function PreferencesModal( { isModalActive, isViewable, closeModal } ) {
 	if ( ! isModalActive ) {
 		return null;
 	}
-
 	return (
 		<Modal
 			className="edit-post-preferences-modal"
@@ -46,37 +45,43 @@ export function PreferencesModal( { isModalActive, isViewable, closeModal } ) {
 		>
 			<Section title={ __( 'General' ) }>
 				<EnablePublishSidebarOption
-					label={ __( 'Pre-publish checks' ) }
+					help={ __(
+						'Allow setting of tags, check dates for instance.'
+					) }
+					label={ __( 'Pre-publish checklist' ) }
 				/>
 				<EnableFeature
 					featureName="mostUsedBlocks"
-					label={ __(
-						'Enable the Most Used Blocks category in the block library'
-					) }
+					label={ __( 'Most used blocks in library' ) }
 				/>
 				<EnableFeature
 					featureName="showIconLabels"
-					label={ __( 'Show button text labels' ) }
+					label={ __( 'Button text labels' ) }
 				/>
 			</Section>
 			<Section title={ __( 'Keyboard' ) }>
 				<EnableFeature
 					featureName="keepCaretInsideBlock"
-					label={ __( 'Contain text cursor inside active block' ) }
+					help={ __(
+						'When using the keyboard contains to active block.'
+					) }
+					label={ __( 'Contain the text cursor' ) }
 				/>
 			</Section>
-			<Section title={ __( 'Writing Mode' ) }>
+			<Section title={ __( 'Appearance' ) }>
 				<EnableFeature
 					featureName="themeStyles"
-					label={ __( 'Theme Styles' ) }
+					label={ __( 'Use theme styles' ) }
 				/>
 				<EnableFeature
 					featureName="reducedUI"
-					label={ __( 'Compact UI' ) }
+					help={ __( 'Reduces toolbar and outlines.' ) }
+					label={ __( 'Compact interface' ) }
 				/>
 				<EnableFeature
 					featureName="focusMode"
-					label={ __( 'Spotlight' ) }
+					help={ __( 'Highlights the current block.' ) }
+					label={ __( 'Activate spotlight mode' ) }
 				/>
 			</Section>
 			<Section title={ __( 'Document panels' ) }>

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -67,7 +67,7 @@ export function PreferencesModal( { isModalActive, isViewable, closeModal } ) {
 				<EnableFeature
 					featureName="keepCaretInsideBlock"
 					help={ __(
-						'Aids screen readers by preventing text caret leaving blocks.'
+						'Prevents text caret from leaving blocks to aid screen readers.'
 					) }
 					label={ __( 'Contain text cursor inside block.' ) }
 				/>
@@ -95,7 +95,7 @@ export function PreferencesModal( { isModalActive, isViewable, closeModal } ) {
 			</Section>
 			<Section
 				title={ __( 'Document settings' ) }
-				description={ __( 'Choose what displays in the post panel.' ) }
+				description={ __( 'Choose what displays in the panel.' ) }
 			>
 				<EnablePluginDocumentSettingPanelOption.Slot />
 				{ isViewable && (

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -46,43 +46,57 @@ export function PreferencesModal( { isModalActive, isViewable, closeModal } ) {
 			<Section title={ __( 'General' ) }>
 				<EnablePublishSidebarOption
 					help={ __(
-						'Allows review of document settings before publishing.'
+						'Review settings such as categories and tags.'
 					) }
-					label={ __( 'Pre-publish checklist' ) }
+					label={ __( 'Include pre-publish checklist' ) }
 				/>
 				<EnableFeature
 					featureName="mostUsedBlocks"
-					label={ __( 'Most used blocks in library' ) }
+					help={ __(
+						'Places the most frequent blocks in the block library.'
+					) }
+					label={ __( 'Show most used blocks' ) }
 				/>
 				<EnableFeature
 					featureName="showIconLabels"
-					label={ __( 'Button text labels' ) }
+					help={ __( 'Shows text instead of icons in toolbar.' ) }
+					label={ __( 'Display button labels' ) }
 				/>
 			</Section>
 			<Section title={ __( 'Keyboard' ) }>
 				<EnableFeature
 					featureName="keepCaretInsideBlock"
-					help={ __( 'Keeps keyboard cursor inside active block.' ) }
-					label={ __( 'Contain the text cursor' ) }
+					help={ __(
+						'Aids screen readers by preventing text caret leaving blocks.'
+					) }
+					label={ __( 'Contain text cursor inside block.' ) }
 				/>
 			</Section>
 			<Section title={ __( 'Appearance' ) }>
 				<EnableFeature
 					featureName="themeStyles"
+					help={ __( 'Make the editor look like your theme.' ) }
 					label={ __( 'Use theme styles' ) }
 				/>
 				<EnableFeature
 					featureName="reducedUI"
-					help={ __( 'Reduces options in toolbar and outlines.' ) }
-					label={ __( 'Compact interface' ) }
+					help={ __(
+						'Compacts options and outlines in the toolbar.'
+					) }
+					label={ __( 'Reduce the interface' ) }
 				/>
 				<EnableFeature
 					featureName="focusMode"
-					help={ __( 'Highlights the current block.' ) }
+					help={ __(
+						'Highlights the current block and fades other content.'
+					) }
 					label={ __( 'Spotlight mode' ) }
 				/>
 			</Section>
-			<Section title={ __( 'Document panels' ) }>
+			<Section
+				title={ __( 'Document settings' ) }
+				description={ __( 'Choose what displays in the post panel.' ) }
+			>
 				<EnablePluginDocumentSettingPanelOption.Slot />
 				{ isViewable && (
 					<EnablePanelOption
@@ -125,7 +139,12 @@ export function PreferencesModal( { isModalActive, isViewable, closeModal } ) {
 					/>
 				</PageAttributesCheck>
 			</Section>
-			<MetaBoxesSection title={ __( 'Advanced panels' ) } />
+			<MetaBoxesSection
+				title={ __( 'Additional panels' ) }
+				description={ __(
+					'Add extra areas to the editor, such as one for custom fields.'
+				) }
+			/>
 		</Modal>
 	);
 }

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -81,7 +81,7 @@ export function PreferencesModal( { isModalActive, isViewable, closeModal } ) {
 				<EnableFeature
 					featureName="focusMode"
 					help={ __( 'Highlights the current block.' ) }
-					label={ __( 'Activate spotlight mode' ) }
+					label={ __( 'Spotlight mode' ) }
 				/>
 			</Section>
 			<Section title={ __( 'Document panels' ) }>

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -67,7 +67,7 @@ export function PreferencesModal( { isModalActive, isViewable, closeModal } ) {
 				<EnableFeature
 					featureName="keepCaretInsideBlock"
 					help={ __(
-						'Prevents text caret from leaving blocks to aid screen readers.'
+						'Aids screen readers by stopping text caret from leaving blocks.'
 					) }
 					label={ __( 'Contain text cursor inside block.' ) }
 				/>

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -142,7 +142,7 @@ export function PreferencesModal( { isModalActive, isViewable, closeModal } ) {
 			<MetaBoxesSection
 				title={ __( 'Additional panels' ) }
 				description={ __(
-					'Add extra areas to the editor, such as one for custom fields.'
+					'Add extra areas to the editor.'
 				) }
 			/>
 		</Modal>

--- a/packages/edit-post/src/components/preferences-modal/options/base.js
+++ b/packages/edit-post/src/components/preferences-modal/options/base.js
@@ -3,10 +3,11 @@
  */
 import { CheckboxControl } from '@wordpress/components';
 
-function BaseOption( { label, isChecked, onChange, children } ) {
+function BaseOption( { help, label, isChecked, onChange, children } ) {
 	return (
 		<div className="edit-post-preferences-modal__option">
 			<CheckboxControl
+				help={ help }
 				label={ label }
 				checked={ isChecked }
 				onChange={ onChange }

--- a/packages/edit-post/src/components/preferences-modal/section.js
+++ b/packages/edit-post/src/components/preferences-modal/section.js
@@ -1,8 +1,13 @@
-const Section = ( { title, children } ) => (
+const Section = ( { description, title, children } ) => (
 	<section className="edit-post-preferences-modal__section">
 		<h2 className="edit-post-preferences-modal__section-title">
 			{ title }
 		</h2>
+		{ description && (
+			<p className="edit-post-preferences-modal__section-description">
+				{ description }
+			</p>
+		) }
 		{ children }
 	</section>
 );

--- a/packages/edit-post/src/components/preferences-modal/style.scss
+++ b/packages/edit-post/src/components/preferences-modal/style.scss
@@ -40,7 +40,7 @@
 	}
 
 	.components-base-control__help {
-		margin: 0 0 $grid-unit-05 ( $grid-unit-50 + 2px );
+		margin: -$grid-unit-05 0 $grid-unit-05 ( $grid-unit-50 + 2px );
 		font-size: $default-font-size - 1px;
 		color: $gray-700;
 	}

--- a/packages/edit-post/src/components/preferences-modal/style.scss
+++ b/packages/edit-post/src/components/preferences-modal/style.scss
@@ -40,8 +40,9 @@
 	}
 
 	.components-base-control__help {
-		margin: -8px 0 $grid-unit-05 ( $grid-unit-50 + 2px );
+		margin: -$grid-unit-10 0 $grid-unit-10 ( $grid-unit-50 + 2px );
 		font-size: $default-font-size - 1px;
+		font-style: normal;
 		color: $gray-700;
 	}
 }

--- a/packages/edit-post/src/components/preferences-modal/style.scss
+++ b/packages/edit-post/src/components/preferences-modal/style.scss
@@ -38,4 +38,10 @@
 			max-width: 300px;
 		}
 	}
+
+	.components-base-control__help {
+		margin: 0 0 $grid-unit-05 ( $grid-unit-50 + 2px );
+		font-size: $default-font-size - 1px;
+		color: $gray-700;
+	}
 }

--- a/packages/edit-post/src/components/preferences-modal/style.scss
+++ b/packages/edit-post/src/components/preferences-modal/style.scss
@@ -40,7 +40,7 @@
 	}
 
 	.components-base-control__help {
-		margin: -$grid-unit-05 0 $grid-unit-05 ( $grid-unit-50 + 2px );
+		margin: -8px 0 $grid-unit-05 ( $grid-unit-50 + 2px );
 		font-size: $default-font-size - 1px;
 		color: $gray-700;
 	}

--- a/packages/edit-post/src/components/preferences-modal/style.scss
+++ b/packages/edit-post/src/components/preferences-modal/style.scss
@@ -36,7 +36,7 @@
 
 	.components-base-control__help {
 		margin: -$grid-unit-10 0 $grid-unit-10 ( $grid-unit-50 + 2px );
-		font-size: $default-font-size - 1px;
+		font-size: $helptext-font-size;
 		font-style: normal;
 		color: $gray-700;
 	}

--- a/packages/edit-post/src/components/preferences-modal/style.scss
+++ b/packages/edit-post/src/components/preferences-modal/style.scss
@@ -1,6 +1,6 @@
 .edit-post-preferences-modal {
 	&__section {
-		margin: 0 0 2rem 0;
+		margin: 0 0 2.5rem 0;
 	}
 
 	&__section-title {

--- a/packages/edit-post/src/components/preferences-modal/style.scss
+++ b/packages/edit-post/src/components/preferences-modal/style.scss
@@ -9,11 +9,6 @@
 	}
 
 	&__option {
-		border-top: 1px solid $gray-300;
-
-		&:last-child {
-			border-bottom: 1px solid $gray-300;
-		}
 
 		.components-base-control__field {
 			align-items: center;

--- a/packages/edit-post/src/components/preferences-modal/style.scss
+++ b/packages/edit-post/src/components/preferences-modal/style.scss
@@ -40,4 +40,10 @@
 		font-style: normal;
 		color: $gray-700;
 	}
+	.edit-post-preferences-modal__section-description {
+		margin: -$grid-unit-10 0 $grid-unit-10 0;
+		font-size: $helptext-font-size;
+		font-style: normal;
+		color: $gray-700;
+	}
 }

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
@@ -29,7 +29,7 @@ exports[`PreferencesModal should match snapshot when the modal is active 1`] = `
   >
     <WithSelect(WithDispatch(BaseOption))
       featureName="keepCaretInsideBlock"
-      help="Prevents text caret from leaving blocks to aid screen readers."
+      help="Aids screen readers by stopping text caret from leaving blocks."
       label="Contain text cursor inside block."
     />
   </Section>

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
@@ -46,7 +46,7 @@ exports[`PreferencesModal should match snapshot when the modal is active 1`] = `
     <WithSelect(WithDispatch(BaseOption))
       featureName="focusMode"
       help="Highlights the current block."
-      label="Activate spotlight mode"
+      label="Spotlight mode"
     />
   </Section>
   <Section

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
@@ -10,16 +10,18 @@ exports[`PreferencesModal should match snapshot when the modal is active 1`] = `
     title="General"
   >
     <WithSelect(WithDispatch(IfViewportMatches(BaseOption)))
-      help="Allows review of document settings before publishing."
-      label="Pre-publish checklist"
+      help="Review settings such as categories and tags."
+      label="Include pre-publish checklist"
     />
     <WithSelect(WithDispatch(BaseOption))
       featureName="mostUsedBlocks"
-      label="Most used blocks in library"
+      help="Places the most frequent blocks in the block library."
+      label="Show most used blocks"
     />
     <WithSelect(WithDispatch(BaseOption))
       featureName="showIconLabels"
-      label="Button text labels"
+      help="Shows text instead of icons in toolbar."
+      label="Display button labels"
     />
   </Section>
   <Section
@@ -27,8 +29,8 @@ exports[`PreferencesModal should match snapshot when the modal is active 1`] = `
   >
     <WithSelect(WithDispatch(BaseOption))
       featureName="keepCaretInsideBlock"
-      help="Keeps keyboard cursor inside active block."
-      label="Contain the text cursor"
+      help="Aids screen readers by preventing text caret leaving blocks."
+      label="Contain text cursor inside block."
     />
   </Section>
   <Section
@@ -36,21 +38,23 @@ exports[`PreferencesModal should match snapshot when the modal is active 1`] = `
   >
     <WithSelect(WithDispatch(BaseOption))
       featureName="themeStyles"
+      help="Make the editor look like your theme."
       label="Use theme styles"
     />
     <WithSelect(WithDispatch(BaseOption))
       featureName="reducedUI"
-      help="Reduces options in toolbar and outlines."
-      label="Compact interface"
+      help="Compacts options and outlines in the toolbar."
+      label="Reduce the interface"
     />
     <WithSelect(WithDispatch(BaseOption))
       featureName="focusMode"
-      help="Highlights the current block."
+      help="Highlights the current block and fades other content."
       label="Spotlight mode"
     />
   </Section>
   <Section
-    title="Document panels"
+    description="Choose what displays in the post panel."
+    title="Document settings"
   >
     <EnablePluginDocumentSettingPanelOptionSlot />
     <WithSelect(PostTaxonomies)
@@ -89,7 +93,8 @@ exports[`PreferencesModal should match snapshot when the modal is active 1`] = `
     </WithSelect(PageAttributesCheck)>
   </Section>
   <WithSelect(MetaBoxesSection)
-    title="Advanced panels"
+    description="Add extra areas to the editor, such as one for custom fields."
+    title="Additional panels"
   />
 </WithInstanceId(Modal)>
 `;

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
@@ -29,7 +29,7 @@ exports[`PreferencesModal should match snapshot when the modal is active 1`] = `
   >
     <WithSelect(WithDispatch(BaseOption))
       featureName="keepCaretInsideBlock"
-      help="Aids screen readers by preventing text caret leaving blocks."
+      help="Prevents text caret from leaving blocks to aid screen readers."
       label="Contain text cursor inside block."
     />
   </Section>
@@ -53,7 +53,7 @@ exports[`PreferencesModal should match snapshot when the modal is active 1`] = `
     />
   </Section>
   <Section
-    description="Choose what displays in the post panel."
+    description="Choose what displays in the panel."
     title="Document settings"
   >
     <EnablePluginDocumentSettingPanelOptionSlot />

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
@@ -10,7 +10,7 @@ exports[`PreferencesModal should match snapshot when the modal is active 1`] = `
     title="General"
   >
     <WithSelect(WithDispatch(IfViewportMatches(BaseOption)))
-      help="Allow setting of tags, check dates for instance."
+      help="Allows review of document settings before publishing."
       label="Pre-publish checklist"
     />
     <WithSelect(WithDispatch(BaseOption))
@@ -27,7 +27,7 @@ exports[`PreferencesModal should match snapshot when the modal is active 1`] = `
   >
     <WithSelect(WithDispatch(BaseOption))
       featureName="keepCaretInsideBlock"
-      help="When using the keyboard contains to active block."
+      help="Keeps keyboard cursor inside active block."
       label="Contain the text cursor"
     />
   </Section>
@@ -40,7 +40,7 @@ exports[`PreferencesModal should match snapshot when the modal is active 1`] = `
     />
     <WithSelect(WithDispatch(BaseOption))
       featureName="reducedUI"
-      help="Reduces toolbar and outlines."
+      help="Reduces options in toolbar and outlines."
       label="Compact interface"
     />
     <WithSelect(WithDispatch(BaseOption))

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
@@ -93,7 +93,7 @@ exports[`PreferencesModal should match snapshot when the modal is active 1`] = `
     </WithSelect(PageAttributesCheck)>
   </Section>
   <WithSelect(MetaBoxesSection)
-    description="Add extra areas to the editor, such as one for custom fields."
+    description="Add extra areas to the editor."
     title="Additional panels"
   />
 </WithInstanceId(Modal)>

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
@@ -10,15 +10,16 @@ exports[`PreferencesModal should match snapshot when the modal is active 1`] = `
     title="General"
   >
     <WithSelect(WithDispatch(IfViewportMatches(BaseOption)))
-      label="Pre-publish checks"
+      help="Allow setting of tags, check dates for instance."
+      label="Pre-publish checklist"
     />
     <WithSelect(WithDispatch(BaseOption))
       featureName="mostUsedBlocks"
-      label="Enable the Most Used Blocks category in the block library"
+      label="Most used blocks in library"
     />
     <WithSelect(WithDispatch(BaseOption))
       featureName="showIconLabels"
-      label="Show button text labels"
+      label="Button text labels"
     />
   </Section>
   <Section
@@ -26,23 +27,26 @@ exports[`PreferencesModal should match snapshot when the modal is active 1`] = `
   >
     <WithSelect(WithDispatch(BaseOption))
       featureName="keepCaretInsideBlock"
-      label="Contain text cursor inside active block"
+      help="When using the keyboard contains to active block."
+      label="Contain the text cursor"
     />
   </Section>
   <Section
-    title="Writing Mode"
+    title="Appearance"
   >
     <WithSelect(WithDispatch(BaseOption))
       featureName="themeStyles"
-      label="Theme Styles"
+      label="Use theme styles"
     />
     <WithSelect(WithDispatch(BaseOption))
       featureName="reducedUI"
-      label="Compact UI"
+      help="Reduces toolbar and outlines."
+      label="Compact interface"
     />
     <WithSelect(WithDispatch(BaseOption))
       featureName="focusMode"
-      label="Spotlight"
+      help="Highlights the current block."
+      label="Activate spotlight mode"
     />
   </Section>
   <Section


### PR DESCRIPTION
A few iterations to the options modal in line with #24965 as a step for this release, whilst the new design is being worked on.

This PR is starting to focus on the points highlighted in the comment by @mtias:

> Improve the copy of each setting, make them more concrete and cohesive (some are many words long, some just a few)
Utilize longer descriptions when necessary (similar to "Top Toolbar") to provide more context.
Reorganize the main sections.

## Changes
I have done some copy changes and worked on bringing in the same style for help text, however, for now, kept the checkboxes. One point to note that could be done if copy is agreed in time is moving also to toggles for this release.

Here you can see a visual of what this PR results in:

![image](https://user-images.githubusercontent.com/253067/95097359-4c497900-0725-11eb-9762-7c59abaff9ae.png)

## Feedback
I don't consider this to be a final PR, I would love feedback and here are a few areas to focus that, although general feedback is as always welcome.

- Clarity: do the changes bring clearer definitions? What changes are missing and should be brought in?
- Uniformity of text: does this help with the variations?

I would also love a code review as there is some style adding and I need to be sure doing that correctly in this case. Work will continue with the design over on the issue, but let's get something in for this release as an iterative step. Thanks in advance.

## Next steps
Once I have feedback, I want to work to within a few days getting something merged for this as we can always iterate from this point. 

## Thanks
Props to @jasmussen and @ItsJonQ for helping me working through some code hunting and setup fun to get this PR brewed.