### PR TITLE
[Mobile] - Gallery - Allow removing image when it's in failed state

### DIFF
--- a/packages/block-library/src/gallery/gallery-image-style.native.scss
+++ b/packages/block-library/src/gallery/gallery-image-style.native.scss
@@ -58,34 +58,6 @@ $caption-background-color: rgba(0, 0, 0, 0.4);
 	justify-content: space-between;
 }
 
-.uploadFailedContainer {
-	position: absolute;
-	background-color: rgba(0, 0, 0, 0.5);
-	width: 100%;
-	height: 100%;
-	justify-content: center;
-	align-items: center;
-}
-
-.uploadFailed {
-	width: 24px;
-	height: 24px;
-	justify-content: center;
-	align-items: center;
-}
-
-.uploadFailedIcon {
-	fill: #fff;
-	width: 100%;
-	height: 100%;
-}
-
-.uploadFailedText {
-	color: #fff;
-	font-size: 14px;
-	margin-top: 5px;
-}
-
 .captionContainer {
 	flex: 1;
 	flex-direction: row;

--- a/packages/block-library/src/gallery/gallery-image.native.js
+++ b/packages/block-library/src/gallery/gallery-image.native.js
@@ -5,7 +5,6 @@ import {
 	StyleSheet,
 	View,
 	ScrollView,
-	Text,
 	TouchableWithoutFeedback,
 } from 'react-native';
 import { isEmpty } from 'lodash';
@@ -19,7 +18,7 @@ import {
 	requestImageFullscreenPreview,
 } from '@wordpress/react-native-bridge';
 import { Component } from '@wordpress/element';
-import { Icon, Image } from '@wordpress/components';
+import { Image } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { Caption, MediaUploadProgress } from '@wordpress/block-editor';
 import { getProtocol } from '@wordpress/url';
@@ -233,21 +232,9 @@ class GalleryImage extends Component {
 					onSelectMediaUploadOption={ this.onSelectMedia }
 					resizeMode={ resizeMode }
 					url={ url }
+					retryMessage={ retryMessage }
+					retryIcon={ warning }
 				/>
-
-				{ isUploadFailed && (
-					<View style={ style.uploadFailedContainer }>
-						<View style={ style.uploadFailed }>
-							<Icon
-								icon={ warning }
-								{ ...style.uploadFailedIcon }
-							/>
-						</View>
-						<Text style={ style.uploadFailedText }>
-							{ retryMessage }
-						</Text>
-					</View>
-				) }
 
 				{ ! isUploadInProgress && isSelected && (
 					<View style={ style.toolbarContainer }>

--- a/packages/components/src/mobile/image/index.native.js
+++ b/packages/components/src/mobile/image/index.native.js
@@ -42,6 +42,7 @@ const ImageComponent = ( {
 	openMediaOptions,
 	resizeMode,
 	retryMessage,
+	retryIcon,
 	url,
 	shapeStyle,
 	width: imageWidth,
@@ -78,7 +79,12 @@ const ImageComponent = ( {
 		let iconStyle;
 		switch ( iconType ) {
 			case ICON_TYPE.RETRY:
-				return <Icon icon={ SvgIconRetry } { ...styles.iconRetry } />;
+				return (
+					<Icon
+						icon={ retryIcon || SvgIconRetry }
+						{ ...styles.iconRetry }
+					/>
+				);
 			case ICON_TYPE.PLACEHOLDER:
 				iconStyle = iconPlaceholderStyles;
 				break;
@@ -210,7 +216,12 @@ const ImageComponent = ( {
 							styles.retryContainer,
 						] }
 					>
-						<View style={ styles.modalIcon }>
+						<View
+							style={ [
+								styles.retryIcon,
+								retryIcon && styles.customRetryIcon,
+							] }
+						>
 							{ getIcon( ICON_TYPE.RETRY ) }
 						</View>
 						<Text style={ styles.uploadFailedText }>
@@ -219,19 +230,14 @@ const ImageComponent = ( {
 					</View>
 				) }
 
-				{ editButton &&
-					isSelected &&
-					! isUploadInProgress &&
-					! isUploadFailed && (
-						<ImageEditingButton
-							onSelectMediaUploadOption={
-								onSelectMediaUploadOption
-							}
-							openMediaOptions={ openMediaOptions }
-							url={ imageData && url }
-							pickerOptions={ mediaPickerOptions }
-						/>
-					) }
+				{ editButton && isSelected && ! isUploadInProgress && (
+					<ImageEditingButton
+						onSelectMediaUploadOption={ onSelectMediaUploadOption }
+						openMediaOptions={ openMediaOptions }
+						url={ ! isUploadFailed && imageData && url }
+						pickerOptions={ mediaPickerOptions }
+					/>
+				) }
 			</View>
 		</View>
 	);

--- a/packages/components/src/mobile/image/style.native.scss
+++ b/packages/components/src/mobile/image/style.native.scss
@@ -16,13 +16,17 @@
 	height: 100%;
 }
 
-.modalIcon {
+.retryIcon {
 	width: 80px;
 	height: 80px;
 	justify-content: center;
 	align-items: center;
 }
 
+.customRetryIcon {
+	width: 24px;
+	height: 24px;
+}
 
 .iconRetry {
 	fill: #fff;


### PR DESCRIPTION
`Gutenberg Mobile PR` -> https://github.com/wordpress-mobile/gutenberg-mobile/pull/2691

## Description
This PR fixes https://github.com/WordPress/gutenberg/issues/25712 by allowing removing an image within a Gallery block when its upload failed. By showing the edit button with the `Remove` option.

## How has this been tested?

<details><summary>Steps to test</summary>

- Open the app with metro running
- Add a Gallery block
- Turn off the internet connection
- Add some images to the gallery
- **Expect** to see the images failing
- Tap on any of the failed images and **expect** to see the retry menu
- Tap on Dismiss
- Tap on the media edit button
- **Expect** to see the `Delete` option
- Tap on it and **expect** to see the image removed
</details>

## Screenshots <!-- if applicable -->
iOS | Android
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/95099531-44430680-0730-11eb-8e8f-0ddc613f8df5.gif" width="250" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/95099535-45743380-0730-11eb-905d-6a6c5a386457.gif" width="250" /></kbd> 

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
