### PR TITLE
Disabled: Use CSS-in-JS

### DIFF
--- a/packages/components/src/disabled/index.js
+++ b/packages/components/src/disabled/index.js
@@ -15,6 +15,11 @@ import {
 } from '@wordpress/element';
 import { focus } from '@wordpress/dom';
 
+/**
+ * Internal dependencies
+ */
+import { StyledWrapper } from './styles/disabled-styles';
+
 const { Consumer, Provider } = createContext( false );
 
 /**
@@ -87,13 +92,13 @@ function Disabled( { className, children, ...props } ) {
 
 	return (
 		<Provider value={ true }>
-			<div
+			<StyledWrapper
 				ref={ node }
 				className={ classnames( className, 'components-disabled' ) }
 				{ ...props }
 			>
 				{ children }
-			</div>
+			</StyledWrapper>
 		</Provider>
 	);
 }

--- a/packages/components/src/disabled/styles/disabled-styles.js
+++ b/packages/components/src/disabled/styles/disabled-styles.js
@@ -1,9 +1,14 @@
-.components-disabled {
+/**
+ * External dependencies
+ */
+import styled from '@emotion/styled';
+
+export const StyledWrapper = styled.div`
 	position: relative;
 	pointer-events: none;
 
 	&::after {
-		content: "";
+		content: '';
 		position: absolute;
 		top: 0;
 		right: 0;
@@ -15,4 +20,4 @@
 	* {
 		pointer-events: none;
 	}
-}
+`;

--- a/packages/components/src/style.scss
+++ b/packages/components/src/style.scss
@@ -12,7 +12,6 @@
 @import "./custom-select-control/style.scss";
 @import "./date-time/style.scss";
 @import "./dimension-control/style.scss";
-@import "./disabled/style.scss";
 @import "./draggable/style.scss";
 @import "./drop-zone/style.scss";
 @import "./dropdown/style.scss";


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This PR updates the `Disabled` component to use CSS-in-JS similar to how newer components do like the `AnglePickerControl` and `Text`.

## How has this been tested?
I've compared the before and after in storybook and there are neither visual nor behavior differences between the this and what currently exists.

## Screenshots
Before:
<img width="761" alt="Captura de Tela 2020-10-05 às 13 22 43" src="https://user-images.githubusercontent.com/24264157/95128176-e4d3ff00-070d-11eb-86ce-4204b164faf3.png">

After:
<img width="750" alt="Captura de Tela 2020-10-05 às 13 22 52" src="https://user-images.githubusercontent.com/24264157/95128184-e7365900-070d-11eb-8570-44a26f39bfd8.png">


## Types of changes
Non-breaking changes. The classnames are preserved so consumers are still able to target and pass classnames to the styled element.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
