### PR TITLE
Remove non-core blocks from default editor content

### DIFF
--- a/packages/react-native-editor/src/initial-html.js
+++ b/packages/react-native-editor/src/initial-html.js
@@ -223,20 +223,6 @@ else:
 <h2>Jetpack</h2>
 <!-- /wp:heading -->
 
-<!-- wp:jetpack/contact-info -->
-<div class="wp-block-jetpack-contact-info"><!-- wp:jetpack/email {"email":"me@wordpress.org"} -->
-<div class="wp-block-jetpack-email"><a href="mailto:me@wordpress.org">me@wordpress.org</a></div>
-<!-- /wp:jetpack/email -->
-
-<!-- wp:jetpack/phone {"phone":"+1"} -->
-<div class="wp-block-jetpack-phone"><a href="tel:+1">+1</a></div>
-<!-- /wp:jetpack/phone -->
-
-<!-- wp:jetpack/address {"address":"Random Street"} -->
-<div class="wp-block-jetpack-address"><div class="jetpack-address__address jetpack-address__address1">Random Street</div></div>
-<!-- /wp:jetpack/address --></div>
-<!-- /wp:jetpack/contact-info -->
-
 <!-- wp:heading -->
 <h2>Unsupported</h2>
 <!-- /wp:heading -->

--- a/packages/react-native-editor/src/initial-html.js
+++ b/packages/react-native-editor/src/initial-html.js
@@ -220,10 +220,6 @@ else:
 <!-- /wp:shortcode -->
 
 <!-- wp:heading -->
-<h2>Jetpack</h2>
-<!-- /wp:heading -->
-
-<!-- wp:heading -->
 <h2>Unsupported</h2>
 <!-- /wp:heading -->
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This PR removes non-core blocks from the `react-native-editor` package, which removes them from the demo app.
These blocks have been added here: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2690

## How has this been tested?
1. Run `npm run native start:reset` to run the packager
2. Run `npm run native ios` or `npm run native android` to load the Gutenberg demo app
3. Ensure there are no blocks in the demo content that belong in the gutenberg-mobile repo (e.g. Jetpack blocks)

## Types of changes
- Bug fix (tweak)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
