### PR TITLE
Fix blue line indicator not showing at the end

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/index.js
+++ b/packages/block-editor/src/components/block-list-appender/index.js
@@ -18,7 +18,7 @@ import DefaultBlockAppender from '../default-block-appender';
 import ButtonBlockAppender from '../button-block-appender';
 
 // A Context to store the map of the appender map.
-export const AppenderContext = createContext();
+export const AppenderNodesContext = createContext();
 
 function stopPropagation( event ) {
 	event.stopPropagation();
@@ -34,7 +34,7 @@ function BlockListAppender( {
 	selectedBlockClientId,
 	tagName: TagName = 'div',
 } ) {
-	const appenderMap = useContext( AppenderContext );
+	const appenderNodesMap = useContext( AppenderNodesContext );
 
 	if ( isLocked || CustomAppender === false ) {
 		return null;
@@ -103,10 +103,10 @@ function BlockListAppender( {
 			ref={ ( ref ) => {
 				if ( ref ) {
 					// Set the reference of the "Appender" with `rootClientId` as key.
-					appenderMap.set( rootClientId || '', ref );
+					appenderNodesMap.set( rootClientId || '', ref );
 				} else {
 					// If it un-mounts, cleanup the map.
-					appenderMap.delete( rootClientId || '' );
+					appenderNodesMap.delete( rootClientId || '' );
 				}
 			} }
 		>

--- a/packages/block-editor/src/components/block-list-appender/index.js
+++ b/packages/block-editor/src/components/block-list-appender/index.js
@@ -89,7 +89,11 @@ function BlockListAppender( {
 			// Prevent the block from being selected when the appender is
 			// clicked.
 			onFocus={ stopPropagation }
-			className={ classnames( 'block-list-appender', className ) }
+			className={ classnames(
+				'block-list-appender',
+				'wp-block',
+				className
+			) }
 		>
 			{ appender }
 		</TagName>

--- a/packages/block-editor/src/components/block-list-appender/index.js
+++ b/packages/block-editor/src/components/block-list-appender/index.js
@@ -7,6 +7,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
+import { createContext, useContext } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
 import { getDefaultBlockName } from '@wordpress/blocks';
 
@@ -15,6 +16,9 @@ import { getDefaultBlockName } from '@wordpress/blocks';
  */
 import DefaultBlockAppender from '../default-block-appender';
 import ButtonBlockAppender from '../button-block-appender';
+
+// A Context to store the map of the appender map.
+export const AppenderContext = createContext();
 
 function stopPropagation( event ) {
 	event.stopPropagation();
@@ -30,6 +34,8 @@ function BlockListAppender( {
 	selectedBlockClientId,
 	tagName: TagName = 'div',
 } ) {
+	const appenderMap = useContext( AppenderContext );
+
 	if ( isLocked || CustomAppender === false ) {
 		return null;
 	}
@@ -94,6 +100,15 @@ function BlockListAppender( {
 				'wp-block',
 				className
 			) }
+			ref={ ( ref ) => {
+				if ( ref ) {
+					// Set the reference of the "Appender" with `rootClientId` as key.
+					appenderMap.set( rootClientId || '', ref );
+				} else {
+					// If it un-mounts, cleanup the map.
+					appenderMap.delete( rootClientId || '' );
+				}
+			} }
 		>
 			{ appender }
 		</TagName>

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -13,14 +13,16 @@ import { useRef, forwardRef } from '@wordpress/element';
  * Internal dependencies
  */
 import BlockListBlock from './block';
-import BlockListAppender, { AppenderContext } from '../block-list-appender';
+import BlockListAppender, {
+	AppenderNodesContext,
+} from '../block-list-appender';
 import RootContainer from './root-container';
 import useBlockDropZone from '../use-block-drop-zone';
 
 /**
  * A map to store the reference of each "Appenders" rendered with `rootClientId` as key.
  */
-const appenderMap = new Map();
+const appenderNodesMap = new Map();
 
 /**
  * If the block count exceeds the threshold, we disable the reordering animation
@@ -87,7 +89,7 @@ function BlockList(
 		dropTargetIndex === blockClientIds.length && isDraggingBlocks;
 
 	return (
-		<AppenderContext.Provider value={ appenderMap }>
+		<AppenderNodesContext.Provider value={ appenderNodesMap }>
 			<Container
 				{ ...__experimentalPassedProps }
 				ref={ element }
@@ -140,7 +142,7 @@ function BlockList(
 					} ) }
 				/>
 			</Container>
-		</AppenderContext.Provider>
+		</AppenderNodesContext.Provider>
 	);
 }
 

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -13,9 +13,14 @@ import { useRef, forwardRef } from '@wordpress/element';
  * Internal dependencies
  */
 import BlockListBlock from './block';
-import BlockListAppender from '../block-list-appender';
+import BlockListAppender, { AppenderContext } from '../block-list-appender';
 import RootContainer from './root-container';
 import useBlockDropZone from '../use-block-drop-zone';
+
+/**
+ * A map to store the reference of each "Appenders" rendered with `rootClientId` as key.
+ */
+const appenderMap = new Map();
 
 /**
  * If the block count exceeds the threshold, we disable the reordering animation
@@ -82,57 +87,60 @@ function BlockList(
 		dropTargetIndex === blockClientIds.length && isDraggingBlocks;
 
 	return (
-		<Container
-			{ ...__experimentalPassedProps }
-			ref={ element }
-			className={ classnames(
-				'block-editor-block-list__layout',
-				className,
-				__experimentalPassedProps.className
-			) }
-		>
-			{ blockClientIds.map( ( clientId, index ) => {
-				const isBlockInSelection = hasMultiSelection
-					? multiSelectedBlockClientIds.includes( clientId )
-					: selectedBlockClientId === clientId;
+		<AppenderContext.Provider value={ appenderMap }>
+			<Container
+				{ ...__experimentalPassedProps }
+				ref={ element }
+				className={ classnames(
+					'block-editor-block-list__layout',
+					className,
+					__experimentalPassedProps.className
+				) }
+			>
+				{ blockClientIds.map( ( clientId, index ) => {
+					const isBlockInSelection = hasMultiSelection
+						? multiSelectedBlockClientIds.includes( clientId )
+						: selectedBlockClientId === clientId;
 
-				const isDropTarget =
-					dropTargetIndex === index && isDraggingBlocks;
+					const isDropTarget =
+						dropTargetIndex === index && isDraggingBlocks;
 
-				return (
-					<AsyncModeProvider
-						key={ clientId }
-						value={ ! isBlockInSelection }
-					>
-						<BlockListBlock
-							rootClientId={ rootClientId }
-							clientId={ clientId }
-							// This prop is explicitely computed and passed down
-							// to avoid being impacted by the async mode
-							// otherwise there might be a small delay to trigger the animation.
-							index={ index }
-							enableAnimation={ enableAnimation }
-							className={ classnames( {
-								'is-drop-target': isDropTarget,
-								'is-dropping-horizontally':
-									isDropTarget &&
-									orientation === 'horizontal',
-							} ) }
-						/>
-					</AsyncModeProvider>
-				);
-			} ) }
-			<BlockListAppender
-				tagName={ __experimentalAppenderTagName }
-				rootClientId={ rootClientId }
-				renderAppender={ renderAppender }
-				className={ classnames( {
-					'is-drop-target': isAppenderDropTarget,
-					'is-dropping-horizontally':
-						isAppenderDropTarget && orientation === 'horizontal',
+					return (
+						<AsyncModeProvider
+							key={ clientId }
+							value={ ! isBlockInSelection }
+						>
+							<BlockListBlock
+								rootClientId={ rootClientId }
+								clientId={ clientId }
+								// This prop is explicitely computed and passed down
+								// to avoid being impacted by the async mode
+								// otherwise there might be a small delay to trigger the animation.
+								index={ index }
+								enableAnimation={ enableAnimation }
+								className={ classnames( {
+									'is-drop-target': isDropTarget,
+									'is-dropping-horizontally':
+										isDropTarget &&
+										orientation === 'horizontal',
+								} ) }
+							/>
+						</AsyncModeProvider>
+					);
 				} ) }
-			/>
-		</Container>
+				<BlockListAppender
+					tagName={ __experimentalAppenderTagName }
+					rootClientId={ rootClientId }
+					renderAppender={ renderAppender }
+					className={ classnames( {
+						'is-drop-target': isAppenderDropTarget,
+						'is-dropping-horizontally':
+							isAppenderDropTarget &&
+							orientation === 'horizontal',
+					} ) }
+				/>
+			</Container>
+		</AppenderContext.Provider>
 	);
 }
 

--- a/packages/block-editor/src/components/block-list/insertion-point.js
+++ b/packages/block-editor/src/components/block-list/insertion-point.js
@@ -17,7 +17,7 @@ import { placeCaretAtVerticalEdge } from '@wordpress/dom';
 import Inserter from '../inserter';
 import { getClosestTabbable } from '../writing-flow';
 import { getBlockDOMNode } from '../../utils/dom';
-import { AppenderContext } from '../block-list-appender';
+import { AppenderNodesContext } from '../block-list-appender';
 
 function InsertionPointInserter( {
 	clientId,
@@ -106,7 +106,7 @@ function InsertionPointPopover( {
 	containerRef,
 	showInsertionPoint,
 } ) {
-	const appenderMap = useContext( AppenderContext );
+	const appenderNodesMap = useContext( AppenderNodesContext );
 	const element = useMemo( () => {
 		if ( clientId ) {
 			return getBlockDOMNode( clientId );
@@ -115,8 +115,8 @@ function InsertionPointPopover( {
 		// Can't find the element, might be at the end of the block list, or inside an empty block list.
 		// We instead try to find the "Appender" and place the indicator above it.
 		// `rootClientId` could be null or undefined when there's no parent block, we normalize it to an empty string.
-		return appenderMap.get( rootClientId || '' );
-	}, [ clientId, rootClientId, appenderMap ] );
+		return appenderNodesMap.get( rootClientId || '' );
+	}, [ clientId, rootClientId, appenderNodesMap ] );
 
 	return (
 		<Popover

--- a/packages/block-editor/src/components/block-list/insertion-point.js
+++ b/packages/block-editor/src/components/block-list/insertion-point.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { useState, useRef, useMemo } from '@wordpress/element';
+import { useState, useRef, useMemo, useContext } from '@wordpress/element';
 import { Popover } from '@wordpress/components';
 import { placeCaretAtVerticalEdge } from '@wordpress/dom';
 
@@ -17,6 +17,7 @@ import { placeCaretAtVerticalEdge } from '@wordpress/dom';
 import Inserter from '../inserter';
 import { getClosestTabbable } from '../writing-flow';
 import { getBlockDOMNode } from '../../utils/dom';
+import { AppenderContext } from '../block-list-appender';
 
 function InsertionPointInserter( {
 	clientId,
@@ -105,20 +106,17 @@ function InsertionPointPopover( {
 	containerRef,
 	showInsertionPoint,
 } ) {
+	const appenderMap = useContext( AppenderContext );
 	const element = useMemo( () => {
 		if ( clientId ) {
 			return getBlockDOMNode( clientId );
 		}
 
 		// Can't find the element, might be at the end of the block list, or inside an empty block list.
-		// We instead try to place the indicator at the end of the list, where the "Appender" usually lives.
-		const rootElement = getBlockDOMNode( rootClientId );
-		const blocks = rootElement?.querySelectorAll( '.wp-block' );
-
-		if ( blocks ) {
-			return blocks[ blocks.length - 1 ];
-		}
-	}, [ clientId, rootClientId ] );
+		// We instead try to find the "Appender" and place the indicator above it.
+		// `rootClientId` could be null or undefined when there's no parent block, we normalize it to an empty string.
+		return appenderMap.get( rootClientId || '' );
+	}, [ clientId, rootClientId, appenderMap ] );
 
 	return (
 		<Popover

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -367,7 +367,7 @@
 	margin-top: -$block-padding * 2;
 
 	&.is-insert-after {
-		margin-top: 0;
+		margin-top: $block-padding;
 	}
 }
 

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -365,6 +365,10 @@
 	position: relative;
 	z-index: z-index(".block-editor-block-list__insertion-point");
 	margin-top: -$block-padding * 2;
+
+	&.is-insert-after {
+		margin-top: 0;
+	}
 }
 
 .block-editor-block-list__insertion-point-indicator {

--- a/packages/e2e-tests/specs/editor/various/adding-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/adding-blocks.test.js
@@ -8,6 +8,7 @@ import {
 	pressKeyTimes,
 	setBrowserViewport,
 	closeGlobalBlockInserter,
+	searchForBlock,
 } from '@wordpress/e2e-test-utils';
 
 /** @typedef {import('puppeteer').ElementHandle} ElementHandle */
@@ -261,5 +262,37 @@ describe( 'adding blocks', () => {
 		);
 		await coverBlock.click();
 		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	// Check for regression of https://github.com/WordPress/gutenberg/issues/25785
+	it( 'inserts a block should show a blue line indicator', async () => {
+		// First insert a random Paragraph.
+		await insertBlock( 'Paragraph' );
+		await page.keyboard.type( 'First paragraph' );
+
+		// Open the global inserter and search for the Heading block.
+		await searchForBlock( 'Heading' );
+
+		const headingButton = (
+			await page.$x( `//button//span[contains(text(), 'Heading')]` )
+		 )[ 0 ];
+
+		// Hover over the block should show the blue line indicator.
+		await headingButton.hover();
+
+		// Should show the blue line indicator somewhere.
+		const indicator = await page.$(
+			'.block-editor-block-list__insertion-point-indicator'
+		);
+		const indicatorRect = await indicator.boundingBox();
+
+		const paragraphBlock = await page.$(
+			'p[aria-label="Paragraph block"]'
+		);
+		const paragraphRect = await paragraphBlock.boundingBox();
+
+		// The blue line indicator should be below the last block.
+		expect( indicatorRect.x ).toBe( paragraphRect.x );
+		expect( indicatorRect.y > paragraphRect.y ).toBe( true );
 	} );
 } );

--- a/packages/edit-widgets/src/blocks/widget-area/edit/inner-blocks.js
+++ b/packages/edit-widgets/src/blocks/widget-area/edit/inner-blocks.js
@@ -15,6 +15,7 @@ export default function WidgetAreaInnerBlocks() {
 			onInput={ onInput }
 			onChange={ onChange }
 			templateLock={ false }
+			renderAppender={ InnerBlocks.DefaultBlockAppender }
 		/>
 	);
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->
**This PR is based on #25727 to make sure e2e passes. It should be rebased to master once #25727 merged.**

## Description
<!-- Please describe what you have changed or added -->
Fix #25785, related to #25727. Also fixes https://github.com/WordPress/gutenberg/issues/25785#issuecomment-702659374.

Fix the blue line indicator is not showing at the end when using the global inserter to try to insert a block in a post or in a widget area.

This is more complicated than I thought, I couldn't think of any better way to do this, please feel free to give me some suggestions and guidance.

Internally, I use a `AppenderContext` to store a `Map` to keep the Appender's references. Then we can inject the blue line indicator alongside the appender, which usually lives at the end of the block list.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Run the e2e test, or...

1. Go to Post editor, create a new post
2. Click the global inserter, hover over the Heading block
3. Observe the blue line indicator is showing at the end
4. Create some blocks, observe that (2) and (3) still works
5. Select any block in between
6. Click the global inserter, hover over the Heading block
7. Observe that the blue line indicator is showing in between blocks

The same steps can also be tested in the widget editor.

## Screenshots <!-- if applicable -->

**Post editor**
![Kapture 2020-10-06 at 11 17 15](https://user-images.githubusercontent.com/7753001/95156289-c1ba5580-07c8-11eb-8a35-baa6f471d67d.gif)

**Widget editor**
![Kapture 2020-10-06 at 11 18 32](https://user-images.githubusercontent.com/7753001/95156293-c7b03680-07c8-11eb-9db7-a204e3216f1a.gif)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
