### PR TITLE
Unify help description text styling

### DIFF
--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -18,6 +18,7 @@ $mobile-text-min-font-size: 16px; // Any font size below 16px will cause Mobile 
 $border-width: 1px;
 $border-width-focus: 1.5px;
 $border-width-tab: 4px;
+$helptext-font-size: 12px;
 
 /**
  * Grid System.

--- a/packages/components/src/base-control/style.scss
+++ b/packages/components/src/base-control/style.scss
@@ -17,7 +17,7 @@
 
 	.components-base-control__help {
 		margin-top: -$grid-unit-10;
-		font-size: $default-font-size - 1px;
+		font-size: $helptext-font-size;
 		font-style: normal;
 		color: $gray-700;
 	}

--- a/packages/components/src/base-control/style.scss
+++ b/packages/components/src/base-control/style.scss
@@ -17,6 +17,8 @@
 
 	.components-base-control__help {
 		margin-top: -$grid-unit-10;
-		font-style: italic;
+		font-size: $default-font-size - 1px;
+		font-style: normal;
+		color: $gray-700;
 	}
 }

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -48,7 +48,7 @@
 }
 
 .components-form-token-field__help {
-	font-size: $default-font-size - 1px;
+	font-size: $helptext-font-size;
 	font-style: normal;
 	color: $gray-700;
 }

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -48,7 +48,9 @@
 }
 
 .components-form-token-field__help {
-	font-style: italic;
+	font-size: $default-font-size - 1px;
+	font-style: normal;
+	color: $gray-700;
 }
 
 // Tokens

--- a/packages/components/src/menu-item/style.scss
+++ b/packages/components/src/menu-item/style.scss
@@ -27,7 +27,7 @@
 
 .components-menu-item__info {
 	margin-top: $grid-unit-05;
-	font-size: $default-font-size - 1px;
+	font-size: $helptext-font-size;
 	color: $gray-700;
 }
 


### PR DESCRIPTION
This brings in the toolbar styling across help classes and also to the base help class. In my work on options I am currently having to work around the italic styling, so this will avoid me having to do that by fixing the base style. It also brings in the style to the sidebar. Linked to issue #25851.

## Visuals of PR in action
![image](https://user-images.githubusercontent.com/253067/95176152-5f575a00-07b4-11eb-9c94-c24a955d2125.png)

## Feedback
I am generally looking for code review on this PR and also looking for design feedback, specifically around where this could also be iterated if anything was missed class wise or other aspects.