### PR TITLE
[RNMobile] Making missing block help button tappable when block is not yet selected

### DIFF
--- a/packages/block-library/src/missing/edit.native.js
+++ b/packages/block-library/src/missing/edit.native.js
@@ -1,7 +1,12 @@
 /**
  * External dependencies
  */
-import { View, Text, TouchableWithoutFeedback } from 'react-native';
+import {
+	View,
+	Text,
+	TouchableWithoutFeedback,
+	TouchableHighlight,
+} from 'react-native';
 
 /**
  * WordPress dependencies
@@ -18,7 +23,7 @@ import { normalizeIconObject } from '@wordpress/blocks';
 import { Component } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { help, plugins } from '@wordpress/icons';
-import { withSelect } from '@wordpress/data';
+import { withSelect, withDispatch } from '@wordpress/data';
 import { applyFilters } from '@wordpress/hooks';
 
 /**
@@ -32,6 +37,7 @@ export class UnsupportedBlockEdit extends Component {
 		this.state = { showHelp: false };
 		this.toggleSheet = this.toggleSheet.bind( this );
 		this.requestFallback = this.requestFallback.bind( this );
+		this.onHelpButtonPressed = this.onHelpButtonPressed.bind( this );
 	}
 
 	toggleSheet() {
@@ -53,15 +59,25 @@ export class UnsupportedBlockEdit extends Component {
 		);
 
 		return (
-			<View style={ styles.helpIconContainer }>
+			<TouchableHighlight
+				onPress={ this.onHelpButtonPressed }
+				style={ styles.helpIconContainer }
+			>
 				<Icon
 					className="unsupported-icon-help"
 					label={ __( 'Help icon' ) }
 					icon={ help }
 					color={ infoIconStyle.color }
 				/>
-			</View>
+			</TouchableHighlight>
 		);
+	}
+
+	onHelpButtonPressed() {
+		if ( ! this.props.isSelected ) {
+			this.props.selectBlock();
+		}
+		this.toggleSheet();
 	}
 
 	requestFallback() {
@@ -251,6 +267,14 @@ export default compose( [
 			canEnableUnsupportedBlockEditor:
 				getSettings( 'capabilities' )
 					.canEnableUnsupportedBlockEditor === true,
+		};
+	} ),
+	withDispatch( ( dispatch, ownProps ) => {
+		const { selectBlock } = dispatch( 'core/block-editor' );
+		return {
+			selectBlock() {
+				selectBlock( ownProps.clientId );
+			},
 		};
 	} ),
 	withPreferredColorScheme,

--- a/packages/block-library/src/missing/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/missing/test/__snapshots__/edit.native.js.snap
@@ -15,7 +15,19 @@ exports[`Missing block renders without crashing 1`] = `
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
 >
-  <View>
+  <View
+    accessible={true}
+    focusable={true}
+    isTVSelectable={true}
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={null}
+  >
     Svg
   </View>
   Svg


### PR DESCRIPTION
fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/2680

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This PR makes the missing block help button enabled and tappable when the block itself is not yet selected.
Tapping on this button will both select the block and trigger the Bottom Sheet as shown in the gif.

After the whole block is selected, all the block becomes the tap target (as before).

![click-over-missing-block](https://user-images.githubusercontent.com/9772967/95188583-e9abb800-07cc-11eb-846f-f6b7b30b10c2.gif)


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
- With a non-selected missing block on the content:
- Press on a missing block (outside the help (?) button).
  - The block should become selected.
- Tap again on the block.
  - The bottom sheet should appear.
- Deselect the missing block.
- Tap on the help button (?).
  - The bottom sheet should appear right away.
  - The block should have become selected.

cc @iamthomasbishop 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
