### PR TITLE
Flatten BlockList: root container

### DIFF
--- a/packages/block-editor/src/components/block-list/insertion-point.js
+++ b/packages/block-editor/src/components/block-list/insertion-point.js
@@ -135,7 +135,7 @@ function InsertionPointPopover( {
 	);
 }
 
-export default function InsertionPoint( { children, containerRef } ) {
+export default function useInsertionPoint( containerRef ) {
 	const [ isInserterShown, setIsInserterShown ] = useState( false );
 	const [ isInserterForced, setIsInserterForced ] = useState( false );
 	const [ inserterClientId, setInserterClientId ] = useState( null );
@@ -208,29 +208,20 @@ export default function InsertionPoint( { children, containerRef } ) {
 
 	const isVisible = isInserterShown || isInserterForced || isInserterVisible;
 
-	return (
-		<>
-			{ ! isMultiSelecting && isVisible && (
-				<InsertionPointPopover
-					clientId={
-						isInserterVisible ? selectedClientId : inserterClientId
-					}
-					isInserterShown={ isInserterShown }
-					isInserterForced={ isInserterForced }
-					setIsInserterForced={ setIsInserterForced }
-					containerRef={ containerRef }
-					showInsertionPoint={ isInserterVisible }
-				/>
-			) }
-			<div
-				onMouseMove={
-					! isInserterForced && ! isMultiSelecting
-						? onMouseMove
-						: undefined
+	return {
+		onMouseMove:
+			! isInserterForced && ! isMultiSelecting ? onMouseMove : undefined,
+		popover: ! isMultiSelecting && isVisible && (
+			<InsertionPointPopover
+				clientId={
+					isInserterVisible ? selectedClientId : inserterClientId
 				}
-			>
-				{ children }
-			</div>
-		</>
-	);
+				isInserterShown={ isInserterShown }
+				isInserterForced={ isInserterForced }
+				setIsInserterForced={ setIsInserterForced }
+				containerRef={ containerRef }
+				showInsertionPoint={ isInserterVisible }
+			/>
+		),
+	};
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

This avoids an extra div and fragment rendered around the root block list.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
