### PR TITLE
Export react-native-editor's initial-html

### DIFF
--- a/packages/react-native-editor/index.js
+++ b/packages/react-native-editor/index.js
@@ -5,6 +5,6 @@ import 'react-native-gesture-handler';
 /**
  * Internal dependencies
  */
-import { setupGutenberg } from './src';
+import { doGutenbergNativeSetup } from './src';
 
-setupGutenberg();
+doGutenbergNativeSetup();

--- a/packages/react-native-editor/index.js
+++ b/packages/react-native-editor/index.js
@@ -5,4 +5,6 @@ import 'react-native-gesture-handler';
 /**
  * Internal dependencies
  */
-import './src';
+import { setupGutenberg } from './src';
+
+setupGutenberg();

--- a/packages/react-native-editor/src/index.js
+++ b/packages/react-native-editor/src/index.js
@@ -136,8 +136,8 @@ const setupLocale = ( locale, extraTranslations ) => {
 	blocksRegistered = true;
 };
 
-export const initialHtmlGutenberg = initialHtml;
-export const setupGutenberg = () => {
+export { initialHtml as initialHtmlGutenberg };
+export function setupGutenberg() {
 	reactNativeSetup();
 	gutenbergSetup();
-};
+}

--- a/packages/react-native-editor/src/index.js
+++ b/packages/react-native-editor/src/index.js
@@ -136,7 +136,7 @@ const setupLocale = ( locale, extraTranslations ) => {
 	blocksRegistered = true;
 };
 
-export initialHtml from './initial-html';
+export const initialHtmlGutenberg = initialHtml;
 export const setupGutenberg = () => {
 	reactNativeSetup();
 	gutenbergSetup();

--- a/packages/react-native-editor/src/index.js
+++ b/packages/react-native-editor/src/index.js
@@ -136,5 +136,8 @@ const setupLocale = ( locale, extraTranslations ) => {
 	blocksRegistered = true;
 };
 
-reactNativeSetup();
-gutenbergSetup();
+export initialHtml from './initial-html';
+export const setupGutenberg = () => {
+	reactNativeSetup();
+	gutenbergSetup();
+};

--- a/packages/react-native-editor/src/index.js
+++ b/packages/react-native-editor/src/index.js
@@ -137,7 +137,7 @@ const setupLocale = ( locale, extraTranslations ) => {
 };
 
 export { initialHtml as initialHtmlGutenberg };
-export function setupGutenberg() {
+export function doGutenbergNativeSetup() {
 	reactNativeSetup();
 	gutenbergSetup();
 }


### PR DESCRIPTION
## Description

Exporting `initial-html` for use in gutenberg-mobile (see https://github.com/wordpress-mobile/gutenberg-mobile/pull/2690)

## How has this been tested?
- [x] Make sure all tests pass

## Types of changes
- New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
