### PR TITLE
Add meaningful labels for the Widgets screen ARIA landmarks.

### DIFF
--- a/packages/edit-widgets/src/components/layout/interface.js
+++ b/packages/edit-widgets/src/components/layout/interface.js
@@ -8,6 +8,7 @@ import { __experimentalLibrary as Library } from '@wordpress/block-editor';
 import { useEffect } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { InterfaceSkeleton, ComplementaryArea } from '@wordpress/interface';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -16,6 +17,15 @@ import Header from '../header';
 import WidgetAreasBlockEditorContent from '../widget-areas-block-editor-content';
 import PopoverWrapper from './popover-wrapper';
 import useWidgetLibraryInsertionPoint from '../../hooks/use-widget-library-insertion-point';
+
+const interfaceLabels = {
+	/* translators: accessibility text for the widgets screen top bar landmark region. */
+	header: __( 'Widgets top bar' ),
+	/* translators: accessibility text for the widgets screen content landmark region. */
+	body: __( 'Widgets and blocks' ),
+	/* translators: accessibility text for the widgets screen settings landmark region. */
+	sidebar: __( 'Widgets settings' ),
+};
 
 function Interface( { blockEditorSettings } ) {
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
@@ -47,6 +57,7 @@ function Interface( { blockEditorSettings } ) {
 
 	return (
 		<InterfaceSkeleton
+			labels={ interfaceLabels }
 			header={ <Header /> }
 			leftSidebar={
 				isInserterOpened && (


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This tiny PR provides more meaningful names for the ARIA landmarks in the new Widgets screen by passing specific labels instead of relying on the defaults.



## How has this been tested?
See test instructions on the issue #25864 

## Screenshots <!-- if applicable -->

Before:

<img width="1296" alt="Screenshot 2020-10-05 at 18 12 58" src="https://user-images.githubusercontent.com/1682452/95223070-74a2a780-07f9-11eb-8d7c-bee966302374.png">


After:

<img width="1289" alt="Screenshot 2020-10-06 at 17 24 16" src="https://user-images.githubusercontent.com/1682452/95223085-79675b80-07f9-11eb-81e9-ee2086c934d9.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->

Fixes #25864 