### PR TITLE
Site editor: Mount both wp_template and wp_template_part EntityProviders to avoid remounting

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -176,130 +176,148 @@ function Editor() {
 					<EntityProvider kind="root" type="site">
 						<EntityProvider
 							kind="postType"
-							type={ templateType }
-							id={ entityId }
+							type={ 'wp_template' }
+							id={
+								templateType === 'wp_template' ? entityId : null
+							}
 						>
 							<EntityProvider
 								kind="postType"
-								type="wp_global_styles"
+								type="wp_template_part"
 								id={
-									settings.__experimentalGlobalStylesUserEntityId
+									templateType === 'wp_template_part'
+										? entityId
+										: null
 								}
 							>
-								<BlockContextProvider value={ blockContext }>
-									<FocusReturnProvider>
-										<GlobalStylesProvider
-											baseStyles={
-												settings.__experimentalGlobalStylesBaseStyles
-											}
-											contexts={
-												settings.__experimentalGlobalStylesContexts
-											}
-										>
-											<KeyboardShortcuts.Register />
-											<SidebarComplementaryAreaFills />
-											<InterfaceSkeleton
-												labels={ interfaceLabels }
-												leftSidebar={
-													<LeftSidebar
-														content={
-															leftSidebarContent
-														}
-														setContent={
-															setLeftSidebarContent
-														}
-													/>
+								<EntityProvider
+									kind="postType"
+									type="wp_global_styles"
+									id={
+										settings.__experimentalGlobalStylesUserEntityId
+									}
+								>
+									<BlockContextProvider
+										value={ blockContext }
+									>
+										<FocusReturnProvider>
+											<GlobalStylesProvider
+												baseStyles={
+													settings.__experimentalGlobalStylesBaseStyles
 												}
-												sidebar={
-													sidebarIsOpened && (
-														<ComplementaryArea.Slot scope="core/edit-site" />
-													)
+												contexts={
+													settings.__experimentalGlobalStylesContexts
 												}
-												header={
-													<Header
-														openEntitiesSavedStates={
-															openEntitiesSavedStates
-														}
-														isInserterOpen={
-															leftSidebarContent ===
-															'inserter'
-														}
-														onToggleInserter={ () =>
-															toggleLeftSidebarContent(
-																'inserter'
-															)
-														}
-														isNavigationOpen={
-															isNavigationOpen
-														}
-														onToggleNavigation={ () =>
-															toggleLeftSidebarContent(
-																'navigation'
-															)
-														}
-													/>
-												}
-												content={
-													<BlockSelectionClearer
-														className="edit-site-visual-editor"
-														style={ inlineStyles }
-													>
-														<Notices />
-														<Popover.Slot name="block-toolbar" />
-														{ template && (
-															<BlockEditor
-																setIsInserterOpen={ (
-																	isInserterOpen
-																) =>
-																	setLeftSidebarContent(
-																		isInserterOpen
-																			? 'inserter'
-																			: null
-																	)
-																}
-															/>
-														) }
-														<KeyboardShortcuts />
-													</BlockSelectionClearer>
-												}
-												actions={
-													<>
-														<EntitiesSavedStates
-															isOpen={
-																isEntitiesSavedStatesOpen
+											>
+												<KeyboardShortcuts.Register />
+												<SidebarComplementaryAreaFills />
+												<InterfaceSkeleton
+													labels={ interfaceLabels }
+													leftSidebar={
+														<LeftSidebar
+															content={
+																leftSidebarContent
 															}
-															close={
-																closeEntitiesSavedStates
+															setContent={
+																setLeftSidebarContent
 															}
 														/>
-														{ ! isEntitiesSavedStatesOpen && (
-															<div className="edit-site-editor__toggle-save-panel">
-																<Button
-																	isSecondary
-																	className="edit-site-editor__toggle-save-panel-button"
-																	onClick={
-																		openEntitiesSavedStates
+													}
+													sidebar={
+														sidebarIsOpened && (
+															<ComplementaryArea.Slot scope="core/edit-site" />
+														)
+													}
+													header={
+														<Header
+															openEntitiesSavedStates={
+																openEntitiesSavedStates
+															}
+															isInserterOpen={
+																leftSidebarContent ===
+																'inserter'
+															}
+															onToggleInserter={ () =>
+																toggleLeftSidebarContent(
+																	'inserter'
+																)
+															}
+															isNavigationOpen={
+																isNavigationOpen
+															}
+															onToggleNavigation={ () =>
+																toggleLeftSidebarContent(
+																	'navigation'
+																)
+															}
+														/>
+													}
+													content={
+														<BlockSelectionClearer
+															className="edit-site-visual-editor"
+															style={
+																inlineStyles
+															}
+														>
+															<Notices />
+															<Popover.Slot name="block-toolbar" />
+															{ template && (
+																<BlockEditor
+																	setIsInserterOpen={ (
+																		isInserterOpen
+																	) =>
+																		setLeftSidebarContent(
+																			isInserterOpen
+																				? 'inserter'
+																				: null
+																		)
 																	}
-																	aria-expanded={
-																		false
-																	}
-																>
-																	{ __(
-																		'Open save panel'
-																	) }
-																</Button>
-															</div>
-														) }
-													</>
-												}
-												footer={ <BlockBreadcrumb /> }
-											/>
-											<Popover.Slot />
-											<PluginArea />
-										</GlobalStylesProvider>
-									</FocusReturnProvider>
-								</BlockContextProvider>
-							</EntityProvider>
+																/>
+															) }
+															<KeyboardShortcuts />
+														</BlockSelectionClearer>
+													}
+													actions={
+														<>
+															<EntitiesSavedStates
+																isOpen={
+																	isEntitiesSavedStatesOpen
+																}
+																close={
+																	closeEntitiesSavedStates
+																}
+															/>
+															{ ! isEntitiesSavedStatesOpen && (
+																<div className="edit-site-editor__toggle-save-panel">
+																	<Button
+																		isSecondary
+																		className="edit-site-editor__toggle-save-panel-button"
+																		onClick={
+																			openEntitiesSavedStates
+																		}
+																		aria-expanded={
+																			false
+																		}
+																	>
+																		{ __(
+																			'Open save panel'
+																		) }
+																	</Button>
+																</div>
+															) }
+														</>
+													}
+													footer={
+														<BlockBreadcrumb />
+													}
+												/>
+												<Popover.Slot />
+												<PluginArea />
+											</GlobalStylesProvider>
+										</FocusReturnProvider>
+									</BlockContextProvider>
+								</EntityProvider>
+							</EntityProvider>{ ' ' }
 						</EntityProvider>
 					</EntityProvider>
 				</DropZoneProvider>

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -317,7 +317,7 @@ function Editor() {
 										</FocusReturnProvider>
 									</BlockContextProvider>
 								</EntityProvider>
-							</EntityProvider>{ ' ' }
+							</EntityProvider>
 						</EntityProvider>
 					</EntityProvider>
 				</DropZoneProvider>


### PR DESCRIPTION
Fixes: #25743

## Description
`EntityProvider` uses a different context provider component for each entity type. Which results in a remount since we are changing the component.

Unfortunately, `EntityProvider` is at the top of our tree, which results in a full Editor remount. Causing all the states to be lost. To avoid the remount, we introduce both `EntityProvider` in the tree, rather than one dynamic component.

## How has this been tested?
* `yarn wp-env start`
* Enable FSE
* Open Site Editor
* Click site logo to toggle the navigation sidebar

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
