### PR TITLE
Fix insertion indicator margin

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -369,7 +369,6 @@
 	&.is-insert-after {
 		margin-top: $block-padding;
 	}
-	
 }
 
 .block-editor-block-list__insertion-point-indicator {

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -364,11 +364,12 @@
 .block-editor-block-list__insertion-point {
 	position: relative;
 	z-index: z-index(".block-editor-block-list__insertion-point");
-	margin-top: -$block-padding * 2;
+	margin-top: -$block-padding;
 
 	&.is-insert-after {
 		margin-top: $block-padding;
 	}
+	
 }
 
 .block-editor-block-list__insertion-point-indicator {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Fix #25848.

Fix insertion blue line indicator position.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Go to the Widgets screen
2. Add a legacy widget block
3. Add any block next to it
4. Select the legacy block
5. Use the global inserter and search for a random block
6. Hover over the block in the inserter
7. Observe the blue line indicator is in between of those 2 blocks.

It also affects the post editor too.

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/7753001/95312967-27d6d380-08c2-11eb-88f4-034cd5f18429.png)
![image](https://user-images.githubusercontent.com/7753001/95313049-40df8480-08c2-11eb-9c5c-9aa0e7ff3819.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
