### PR TITLE
Site Editor: Add missing localization to the templates sidebar

### DIFF
--- a/packages/edit-site/src/components/left-sidebar/navigation-panel/constants.js
+++ b/packages/edit-site/src/components/left-sidebar/navigation-panel/constants.js
@@ -8,7 +8,7 @@ export const TEMPLATES_DEFAULT_DETAILS = {
 	'front-page': {
 		title: _x( 'Front Page', 'template name' ),
 		description: __(
-			'Front page template, for both a static page or blog posts index'
+			'Front page template, whether it displays the blog posts index or a static page'
 		),
 	},
 	archive: {
@@ -34,8 +34,8 @@ export const TEMPLATES_DEFAULT_DETAILS = {
 
 	// Pages
 	page: {
-		title: __( 'Page' ),
-		description: __( 'Single page template' ),
+		title: __( 'Single Page' ),
+		description: __( 'Template for single pages' ),
 	},
 
 	// Posts
@@ -44,8 +44,8 @@ export const TEMPLATES_DEFAULT_DETAILS = {
 		description: __( 'Template for the latest blog posts' ),
 	},
 	single: {
-		title: _x( 'Single', 'template name' ),
-		description: __( 'Single post template' ),
+		title: __( 'Single Post' ),
+		description: __( 'Template for single posts' ),
 	},
 };
 

--- a/packages/edit-site/src/components/left-sidebar/navigation-panel/constants.js
+++ b/packages/edit-site/src/components/left-sidebar/navigation-panel/constants.js
@@ -1,53 +1,51 @@
+/**
+ * WordPress dependencies
+ */
+import { __, _x } from '@wordpress/i18n';
+
 export const TEMPLATES_DEFAULT_DETAILS = {
 	// General
 	'front-page': {
-		title: 'Front page',
-		description: '',
+		title: _x( 'Front Page', 'template name' ),
+		description: __(
+			'Front page template, for both a static page or blog posts index'
+		),
 	},
 	archive: {
-		title: 'Archive',
-		description:
-			'Displays the content lists when no other template is found',
-	},
-	single: {
-		title: 'Single',
-		description: 'Displays the content of a single post',
+		title: _x( 'Archive', 'template name' ),
+		description: __( 'Generic archive template' ),
 	},
 	singular: {
-		title: 'Singular',
-		description: 'Displays the content of a single page',
+		title: _x( 'Singular', 'template name' ),
+		description: __( 'Default template for both single posts and pages' ),
 	},
 	index: {
-		title: 'Default (index)',
-		description: 'Displays the content of a single page',
+		title: _x( 'Index', 'template name' ),
+		description: __( 'Default template' ),
 	},
 	search: {
-		title: 'Search results',
-		description: '',
+		title: _x( 'Search Results', 'template name' ),
+		description: __( 'Search results template' ),
 	},
 	'404': {
-		title: '404',
-		description: 'Displayed when a non-existing page requested',
+		title: _x( '404 (Not Found)', 'template name' ),
+		description: __( 'Template for "not found" errors' ),
 	},
 
 	// Pages
 	page: {
-		title: 'Default (Page)',
-		description: 'Displays the content of a single page',
+		title: __( 'Page' ),
+		description: __( 'Single page template' ),
 	},
 
 	// Posts
 	home: {
-		title: 'Posts (home)',
-		description: 'Displayed on your homepage',
+		title: __( 'Home Page' ),
+		description: __( 'Template for the latest blog posts' ),
 	},
-	'archive-post': {
-		title: 'Default (Post archive)',
-		description: 'Displays a list of posts',
-	},
-	'single-post': {
-		title: 'Default (Single post)',
-		description: 'Displays the content of a single post',
+	single: {
+		title: _x( 'Single', 'template name' ),
+		description: __( 'Single post template' ),
 	},
 };
 

--- a/packages/edit-site/src/components/left-sidebar/navigation-panel/constants.js
+++ b/packages/edit-site/src/components/left-sidebar/navigation-panel/constants.js
@@ -52,11 +52,10 @@ export const TEMPLATES_DEFAULT_DETAILS = {
 export const TEMPLATES_GENERAL = [
 	'front-page',
 	'archive',
-	'single',
 	'singular',
 	'index',
 	'search',
 	'404',
 ];
 
-export const TEMPLATES_POSTS = [ 'single-post', 'archive-post', 'home' ];
+export const TEMPLATES_POSTS = [ 'home', 'single' ];

--- a/packages/edit-site/src/components/left-sidebar/navigation-panel/index.js
+++ b/packages/edit-site/src/components/left-sidebar/navigation-panel/index.js
@@ -69,14 +69,14 @@ const NavigationPanel = () => {
 					/>
 				) }
 
-				<NavigationMenu title="Theme">
+				<NavigationMenu title={ __( 'Theme' ) }>
 					<NavigationItem
-						title="Templates"
+						title={ __( 'Templates' ) }
 						navigateToMenu="templates"
 					/>
 
 					<NavigationItem
-						title="Template parts"
+						title={ __( 'Template Parts' ) }
 						navigateToMenu="template-parts"
 					/>
 

--- a/packages/edit-site/src/components/left-sidebar/navigation-panel/menus/template-parts.js
+++ b/packages/edit-site/src/components/left-sidebar/navigation-panel/menus/template-parts.js
@@ -31,7 +31,7 @@ export default function TemplatePartsMenu( { onActivateItem } ) {
 	return (
 		<NavigationMenu
 			menu="template-parts"
-			title="Template Parts"
+			title={ __( 'Template Parts' ) }
 			parentMenu="root"
 		>
 			<TemplateNavigationItems

--- a/packages/edit-site/src/components/left-sidebar/navigation-panel/menus/templates-all.js
+++ b/packages/edit-site/src/components/left-sidebar/navigation-panel/menus/templates-all.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { __experimentalNavigationMenu as NavigationMenu } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -12,7 +13,7 @@ export default function TemplatesAllMenu( { templates, onActivateItem } ) {
 	return (
 		<NavigationMenu
 			menu="templates-all"
-			title="All templates"
+			title={ __( 'All Templates' ) }
 			parentMenu="templates"
 		>
 			<TemplateNavigationItems

--- a/packages/edit-site/src/components/left-sidebar/navigation-panel/menus/templates-pages.js
+++ b/packages/edit-site/src/components/left-sidebar/navigation-panel/menus/templates-pages.js
@@ -5,6 +5,7 @@ import {
 	__experimentalNavigationGroup as NavigationGroup,
 	__experimentalNavigationMenu as NavigationMenu,
 } from '@wordpress/components';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -20,10 +21,10 @@ export default function TemplatesPagesMenu( { templates, onActivateItem } ) {
 	return (
 		<NavigationMenu
 			menu="templates-pages"
-			title="Pages"
+			title={ __( 'Pages' ) }
 			parentMenu="templates"
 		>
-			<NavigationGroup title="Specific">
+			<NavigationGroup title={ _x( 'Specific', 'specific templates' ) }>
 				<TemplateNavigationItems
 					templates={ specificPageTemplates }
 					onActivateItem={ onActivateItem }
@@ -31,7 +32,7 @@ export default function TemplatesPagesMenu( { templates, onActivateItem } ) {
 			</NavigationGroup>
 
 			{ defaultTemplate && (
-				<NavigationGroup title="General">
+				<NavigationGroup title={ _x( 'General', 'general templates' ) }>
 					<TemplateNavigationItems
 						templates={ defaultTemplate }
 						onActivateItem={ onActivateItem }

--- a/packages/edit-site/src/components/left-sidebar/navigation-panel/menus/templates-posts.js
+++ b/packages/edit-site/src/components/left-sidebar/navigation-panel/menus/templates-posts.js
@@ -5,6 +5,7 @@ import {
 	__experimentalNavigationGroup as NavigationGroup,
 	__experimentalNavigationMenu as NavigationMenu,
 } from '@wordpress/components';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -23,17 +24,17 @@ export default function TemplatePostsMenu( { templates, onActivateItem } ) {
 	return (
 		<NavigationMenu
 			menu="templates-posts"
-			title="Posts"
+			title={ __( 'Posts' ) }
 			parentMenu="templates"
 		>
-			<NavigationGroup title="Specific">
+			<NavigationGroup title={ _x( 'Specific', 'specific templates' ) }>
 				<TemplateNavigationItems
 					templates={ specificTemplates }
 					onActivateItem={ onActivateItem }
 				/>
 			</NavigationGroup>
 
-			<NavigationGroup title="General">
+			<NavigationGroup title={ _x( 'General', 'general templates' ) }>
 				<TemplateNavigationItems
 					templates={ generalTemplates }
 					onActivateItem={ onActivateItem }

--- a/packages/edit-site/src/components/left-sidebar/navigation-panel/menus/templates.js
+++ b/packages/edit-site/src/components/left-sidebar/navigation-panel/menus/templates.js
@@ -5,6 +5,7 @@ import {
 	__experimentalNavigationItem as NavigationItem,
 	__experimentalNavigationMenu as NavigationMenu,
 } from '@wordpress/components';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -31,10 +32,23 @@ export default function TemplatesMenu( { onActivateItem } ) {
 	);
 
 	return (
-		<NavigationMenu menu="templates" title="Templates" parentMenu="root">
-			<NavigationItem navigateToMenu="templates-all" title="All" />
-			<NavigationItem navigateToMenu="templates-pages" title="Pages" />
-			<NavigationItem navigateToMenu="templates-posts" title="Posts" />
+		<NavigationMenu
+			menu="templates"
+			title={ __( 'Templates' ) }
+			parentMenu="root"
+		>
+			<NavigationItem
+				navigateToMenu="templates-all"
+				title={ _x( 'All', 'all templates' ) }
+			/>
+			<NavigationItem
+				navigateToMenu="templates-pages"
+				title={ __( 'Pages' ) }
+			/>
+			<NavigationItem
+				navigateToMenu="templates-posts"
+				title={ __( 'Posts' ) }
+			/>
 
 			<TemplateNavigationItems
 				templates={ generalTemplates }


### PR DESCRIPTION
## Description

When approving #25739 I've completely failed to check for i18n.
Here I've localized all strings contained in the Site Editor's template sidebar, adding contexts where I felt it was needed.

I've also reworded the default templates (and reordered them, and removed a couple that aren't really default) names and description to match the [Template Hierarchy](https://developer.wordpress.org/themes/basics/template-hierarchy/) docs as closely as possible.

Hopefully I haven't missed anything!

## How has this been tested?
In the Site Editor.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
