### PR TITLE
InnerBlocks: handle own wrapper

### DIFF
--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -23,17 +23,34 @@ import useBlockDropZone from '../use-block-drop-zone';
  */
 const BLOCK_ANIMATION_THRESHOLD = 200;
 
-function BlockList(
-	{
-		className,
-		rootClientId,
-		renderAppender,
-		__experimentalTagName = 'div',
-		__experimentalAppenderTagName,
-		__experimentalPassedProps = {},
-	},
-	ref
-) {
+function BlockList( { className, rootClientId, renderAppender }, ref ) {
+	const Container = rootClientId ? 'div' : RootContainer;
+	const fallbackRef = useRef();
+	const wrapperRef = ref || fallbackRef;
+
+	return (
+		<Container
+			ref={ wrapperRef }
+			className={ classnames(
+				'block-editor-block-list__layout',
+				className
+			) }
+		>
+			<BlockListItems
+				rootClientId={ rootClientId }
+				renderAppender={ renderAppender }
+				wrapperRef={ wrapperRef }
+			/>
+		</Container>
+	);
+}
+
+export function BlockListItems( {
+	rootClientId,
+	renderAppender,
+	__experimentalAppenderTagName,
+	wrapperRef,
+} ) {
 	function selector( select ) {
 		const {
 			getBlockOrder,
@@ -69,12 +86,8 @@ function BlockList(
 		isDraggingBlocks,
 	} = useSelect( selector, [ rootClientId ] );
 
-	const fallbackRef = useRef();
-	const element = __experimentalPassedProps.ref || ref || fallbackRef;
-
-	const Container = rootClientId ? __experimentalTagName : RootContainer;
 	const dropTargetIndex = useBlockDropZone( {
-		element,
+		element: wrapperRef,
 		rootClientId,
 	} );
 
@@ -82,15 +95,7 @@ function BlockList(
 		dropTargetIndex === blockClientIds.length && isDraggingBlocks;
 
 	return (
-		<Container
-			{ ...__experimentalPassedProps }
-			ref={ element }
-			className={ classnames(
-				'block-editor-block-list__layout',
-				className,
-				__experimentalPassedProps.className
-			) }
-		>
+		<>
 			{ blockClientIds.map( ( clientId, index ) => {
 				const isBlockInSelection = hasMultiSelection
 					? multiSelectedBlockClientIds.includes( clientId )
@@ -132,7 +137,7 @@ function BlockList(
 						isAppenderDropTarget && orientation === 'horizontal',
 				} ) }
 			/>
-		</Container>
+		</>
 	);
 }
 

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -23,7 +23,7 @@ import getBlockContext from './get-block-context';
 /**
  * Internal dependencies
  */
-import BlockList from '../block-list';
+import { BlockListItems } from '../block-list';
 import { BlockContextProvider } from '../block-context';
 import { useBlockEditContext } from '../block-edit/context';
 import useBlockSync from '../provider/use-block-sync';
@@ -46,6 +46,11 @@ function UncontrolledInnerBlocks( props ) {
 		templateInsertUpdatesSelection,
 		__experimentalCaptureToolbars: captureToolbars,
 		orientation,
+		renderAppender,
+		__experimentalTagName: TagName = 'div',
+		__experimentalPassedProps: passedProps = {},
+		__experimentalAppenderTagName,
+		className,
 	} = props;
 
 	const isSmallScreen = useViewportMatch( 'medium', '<' );
@@ -98,19 +103,29 @@ function UncontrolledInnerBlocks( props ) {
 		templateInsertUpdatesSelection
 	);
 
-	const classes = classnames( {
-		'has-overlay': hasOverlay,
-		'is-capturing-toolbar': captureToolbars,
-	} );
-
 	const blockList = (
 		<BlockContextProvider value={ context }>
-			<BlockList
-				{ ...props }
-				ref={ forwardedRef }
-				rootClientId={ clientId }
-				className={ classes }
-			/>
+			<TagName
+				{ ...passedProps }
+				className={ classnames(
+					'block-editor-block-list__layout',
+					className,
+					passedProps.className,
+					{
+						'has-overlay': hasOverlay,
+						'is-capturing-toolbar': captureToolbars,
+					}
+				) }
+			>
+				<BlockListItems
+					wrapperRef={ forwardedRef }
+					rootClientId={ clientId }
+					renderAppender={ renderAppender }
+					__experimentalAppenderTagName={
+						__experimentalAppenderTagName
+					}
+				/>
+			</TagName>
 		</BlockContextProvider>
 	);
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
 Now we arrive at the core of the e2e test problem in #25633, which seems to be moving the handling of the wrapper tag to inner blocks. 
## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
