### PR TITLE
Add Custom Post Types support in Query block

### DIFF
--- a/packages/block-library/src/query-loop/block.json
+++ b/packages/block-library/src/query-loop/block.json
@@ -5,8 +5,7 @@
 	"usesContext": [
 		"queryId",
 		"query",
-		"queryContext",
-		"postId"
+		"queryContext"
 	],
 	"supports": {
 		"reusable": false,

--- a/packages/block-library/src/query-loop/block.json
+++ b/packages/block-library/src/query-loop/block.json
@@ -5,7 +5,8 @@
 	"usesContext": [
 		"queryId",
 		"query",
-		"queryContext"
+		"queryContext",
+		"postId"
 	],
 	"supports": {
 		"reusable": false,

--- a/packages/block-library/src/query-loop/edit.js
+++ b/packages/block-library/src/query-loop/edit.js
@@ -33,9 +33,9 @@ export default function QueryLoopEdit( {
 			orderBy,
 			author,
 			search,
+			exclude,
 		} = {},
 		queryContext,
-		postId,
 	},
 } ) {
 	const [ { page } ] = useQueryContext() || queryContext || [ {} ];
@@ -59,8 +59,8 @@ export default function QueryLoopEdit( {
 			if ( search ) {
 				query.search = search;
 			}
-			if ( postId ) {
-				query.exclude = [ postId ];
+			if ( exclude?.length ) {
+				query.exclude = exclude;
 			}
 			return {
 				posts: select( 'core' ).getEntityRecords(
@@ -83,7 +83,7 @@ export default function QueryLoopEdit( {
 			author,
 			search,
 			postType,
-			postId,
+			exclude,
 		]
 	);
 

--- a/packages/block-library/src/query-loop/edit.js
+++ b/packages/block-library/src/query-loop/edit.js
@@ -27,6 +27,7 @@ export default function QueryLoopEdit( {
 			perPage,
 			offset,
 			categoryIds,
+			postType,
 			tagIds = [],
 			order,
 			orderBy,
@@ -34,6 +35,7 @@ export default function QueryLoopEdit( {
 			search,
 		} = {},
 		queryContext,
+		postId,
 	},
 } ) {
 	const [ { page } ] = useQueryContext() || queryContext || [ {} ];
@@ -57,10 +59,13 @@ export default function QueryLoopEdit( {
 			if ( search ) {
 				query.search = search;
 			}
+			if ( postId ) {
+				query.exclude = [ postId ];
+			}
 			return {
 				posts: select( 'core' ).getEntityRecords(
 					'postType',
-					'post',
+					postType,
 					query
 				),
 				blocks: select( 'core/block-editor' ).getBlocks( clientId ),
@@ -77,6 +82,8 @@ export default function QueryLoopEdit( {
 			clientId,
 			author,
 			search,
+			postType,
+			postId,
 		]
 	);
 

--- a/packages/block-library/src/query-loop/index.php
+++ b/packages/block-library/src/query-loop/index.php
@@ -26,6 +26,9 @@ function render_block_core_query_loop( $attributes, $content, $block ) {
 	);
 
 	if ( isset( $block->context['query'] ) ) {
+		if ( isset( $block->context['query']['postType'] ) ) {
+			$query['post_type'] = $block->context['query']['postType'];
+		}
 		if ( isset( $block->context['query']['perPage'] ) ) {
 			$query['offset'] = ( $block->context['query']['perPage'] * ( $page - 1 ) ) + $block->context['query']['offset'];
 		}

--- a/packages/block-library/src/query-loop/index.php
+++ b/packages/block-library/src/query-loop/index.php
@@ -29,6 +29,9 @@ function render_block_core_query_loop( $attributes, $content, $block ) {
 		if ( isset( $block->context['query']['postType'] ) ) {
 			$query['post_type'] = $block->context['query']['postType'];
 		}
+		if ( isset( $block->context['query']['exclude'] ) ) {
+			$query['post__not_in'] = $block->context['query']['exclude'];
+		}
 		if ( isset( $block->context['query']['perPage'] ) ) {
 			$query['offset'] = ( $block->context['query']['perPage'] * ( $page - 1 ) ) + $block->context['query']['offset'];
 		}

--- a/packages/block-library/src/query/block.json
+++ b/packages/block-library/src/query/block.json
@@ -27,6 +27,9 @@
 		"queryId": "queryId",
 		"query": "query"
 	},
+	"usesContext": [
+		"postId"
+	],
 	"supports": {
 		"html": false
 	}

--- a/packages/block-library/src/query/block.json
+++ b/packages/block-library/src/query/block.json
@@ -12,12 +12,14 @@
 				"perPage": null,
 				"pages": 1,
 				"offset": 0,
+				"postType": "post",
 				"categoryIds": [],
 				"tagIds": [],
 				"order": "desc",
 				"orderBy": "date",
 				"author": "",
-				"search": ""
+				"search": "",
+				"exclude": []
 			}
 		}
 	},

--- a/packages/block-library/src/query/edit/index.js
+++ b/packages/block-library/src/query/edit/index.js
@@ -33,6 +33,9 @@ export default function QueryEdit( {
 				+getSettings().postsPerPage || DEFAULTS_POSTS_PER_PAGE,
 		};
 	}, [] );
+	// Changes in query property (which is an object) need to be in the same callback,
+	// because updates are batched after the render and changes in different query properties
+	// would cause to overide previous wanted changes.
 	useEffect( () => {
 		const newQuery = {};
 		if ( postId && ! query.exclude.length ) {

--- a/packages/block-library/src/query/edit/index.js
+++ b/packages/block-library/src/query/edit/index.js
@@ -18,7 +18,7 @@ import QueryProvider from './query-provider';
 import QueryInspectorControls from './query-inspector-controls';
 import { DEFAULTS_POSTS_PER_PAGE } from '../constants';
 
-const TEMPLATE = [ [ 'core/query-loop' ], [ 'core/query-pagination' ] ];
+const TEMPLATE = [ [ 'core/query-loop' ] ];
 export default function QueryEdit( {
 	attributes: { queryId, query },
 	context: { postId },

--- a/packages/block-library/src/query/edit/index.js
+++ b/packages/block-library/src/query/edit/index.js
@@ -38,7 +38,7 @@ export default function QueryEdit( {
 	// would cause to overide previous wanted changes.
 	useEffect( () => {
 		const newQuery = {};
-		if ( postId && ! query.exclude.length ) {
+		if ( postId && ! query.exclude?.length ) {
 			newQuery.exclude = [ postId ];
 		}
 		if ( ! query.perPage && postsPerPage ) {
@@ -55,9 +55,8 @@ export default function QueryEdit( {
 			setAttributes( { queryId: instanceId } );
 		}
 	}, [ queryId, instanceId ] );
-	const updateQuery = ( newQuery ) => {
+	const updateQuery = ( newQuery ) =>
 		setAttributes( { query: { ...query, ...newQuery } } );
-	};
 	return (
 		<>
 			<QueryInspectorControls query={ query } setQuery={ updateQuery } />

--- a/packages/block-library/src/query/edit/index.js
+++ b/packages/block-library/src/query/edit/index.js
@@ -21,6 +21,7 @@ import { DEFAULTS_POSTS_PER_PAGE } from '../constants';
 const TEMPLATE = [ [ 'core/query-loop' ], [ 'core/query-pagination' ] ];
 export default function QueryEdit( {
 	attributes: { queryId, query },
+	context: { postId },
 	setAttributes,
 } ) {
 	const instanceId = useInstanceId( QueryEdit );
@@ -33,10 +34,17 @@ export default function QueryEdit( {
 		};
 	}, [] );
 	useEffect( () => {
-		if ( ! query.perPage && postsPerPage ) {
-			updateQuery( { perPage: postsPerPage } );
+		const newQuery = {};
+		if ( postId && ! query.exclude.length ) {
+			newQuery.exclude = [ postId ];
 		}
-	}, [ query.perPage ] );
+		if ( ! query.perPage && postsPerPage ) {
+			newQuery.perPage = postsPerPage;
+		}
+		if ( Object.keys( newQuery ).length ) {
+			updateQuery( newQuery );
+		}
+	}, [ query.perPage, query.exclude, postId ] );
 	// We need this for multi-query block pagination.
 	// Query parameters for each block are scoped to their ID.
 	useEffect( () => {
@@ -44,8 +52,9 @@ export default function QueryEdit( {
 			setAttributes( { queryId: instanceId } );
 		}
 	}, [ queryId, instanceId ] );
-	const updateQuery = ( newQuery ) =>
+	const updateQuery = ( newQuery ) => {
 		setAttributes( { query: { ...query, ...newQuery } } );
+	};
 	return (
 		<>
 			<QueryInspectorControls query={ query } setQuery={ updateQuery } />

--- a/packages/block-library/src/query/edit/query-inspector-controls.js
+++ b/packages/block-library/src/query/edit/query-inspector-controls.js
@@ -12,11 +12,12 @@ import {
 	QueryControls,
 	TextControl,
 	FormTokenField,
+	SelectControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
-import { useEffect, useState, useCallback } from '@wordpress/element';
+import { useEffect, useState, useCallback, useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -25,23 +26,70 @@ import { getTermsInfo } from '../utils';
 import { MAX_FETCHED_TERMS } from '../constants';
 
 export default function QueryInspectorControls( { query, setQuery } ) {
-	const { order, orderBy, author: selectedAuthorId } = query;
-	const { authorList, categories, tags } = useSelect( ( select ) => {
-		const { getEntityRecords } = select( 'core' );
-		const termsQuery = { per_page: MAX_FETCHED_TERMS };
-		const _categories = getEntityRecords(
-			'taxonomy',
-			'category',
-			termsQuery
-		);
-		const _tags = getEntityRecords( 'taxonomy', 'post_tag', termsQuery );
-		return {
-			categories: getTermsInfo( _categories ),
-			tags: getTermsInfo( _tags ),
-			authorList: getEntityRecords( 'root', 'user', { per_page: -1 } ),
-		};
-	}, [] );
-
+	const { order, orderBy, author: selectedAuthorId, postType } = query;
+	const [ showCategories, setShowCategories ] = useState( true );
+	const [ showTags, setShowTags ] = useState( true );
+	const { authorList, categories, tags, postTypes } = useSelect(
+		( select ) => {
+			const { getEntityRecords, getPostTypes } = select( 'core' );
+			const termsQuery = { per_page: MAX_FETCHED_TERMS };
+			const _categories = getEntityRecords(
+				'taxonomy',
+				'category',
+				termsQuery
+			);
+			const _tags = getEntityRecords(
+				'taxonomy',
+				'post_tag',
+				termsQuery
+			);
+			const excludedPostTypes = [ 'attachment' ];
+			const filteredPostTypes = getPostTypes()?.filter(
+				( { viewable, slug } ) =>
+					viewable && ! excludedPostTypes.includes( slug )
+			);
+			return {
+				categories: getTermsInfo( _categories ),
+				tags: getTermsInfo( _tags ),
+				authorList: getEntityRecords( 'root', 'user', {
+					per_page: -1,
+				} ),
+				postTypes: filteredPostTypes,
+			};
+		},
+		[]
+	);
+	const postTypesTaxonomiesMap = useMemo( () => {
+		if ( ! postTypes?.length ) return;
+		return postTypes.reduce( ( accumulator, type ) => {
+			accumulator[ type.slug ] = type.taxonomies;
+			return accumulator;
+		}, {} );
+	}, [ postTypes ] );
+	useEffect( () => {
+		if ( ! postTypesTaxonomiesMap ) return;
+		const postTypeTaxonomies = postTypesTaxonomiesMap[ postType ];
+		setShowCategories( postTypeTaxonomies.includes( 'category' ) );
+		setShowTags( postTypeTaxonomies.includes( 'post_tag' ) );
+	}, [ postType, postTypesTaxonomiesMap ] );
+	const postTypesSelectOptions = useMemo(
+		() =>
+			( postTypes || [] ).map( ( { labels, slug } ) => ( {
+				label: labels.singular_name,
+				value: slug,
+			} ) ),
+		[ postTypes ]
+	);
+	const onPostTypeChange = ( newValue ) => {
+		const updateQuery = { postType: newValue };
+		if ( ! postTypesTaxonomiesMap[ newValue ].includes( 'category' ) ) {
+			updateQuery.categoryIds = [];
+		}
+		if ( ! postTypesTaxonomiesMap[ newValue ].includes( 'post_tag' ) ) {
+			updateQuery.tagIds = [];
+		}
+		setQuery( updateQuery );
+	};
 	// Handles categories and tags changes.
 	const onTermsChange = ( terms, queryProperty ) => ( newTermValues ) => {
 		const termIds = newTermValues.reduce( ( accumulator, termValue ) => {
@@ -65,20 +113,14 @@ export default function QueryInspectorControls( { query, setQuery } ) {
 	}, [ querySearch, onChangeDebounced ] );
 	return (
 		<InspectorControls>
-			<PanelBody title={ __( 'Sorting and filtering' ) }>
-				<QueryControls
-					{ ...{ order, orderBy, selectedAuthorId, authorList } }
-					onOrderChange={ ( value ) => setQuery( { order: value } ) }
-					onOrderByChange={ ( value ) =>
-						setQuery( { orderBy: value } )
-					}
-					onAuthorChange={ ( value ) =>
-						setQuery( {
-							author: value !== '' ? +value : undefined,
-						} )
-					}
+			<PanelBody title={ __( 'Filtering and Sorting' ) }>
+				<SelectControl
+					options={ postTypesSelectOptions }
+					value={ postType }
+					label={ __( 'Post Type' ) }
+					onChange={ onPostTypeChange }
 				/>
-				{ categories?.terms?.length > 0 && (
+				{ showCategories && categories?.terms?.length > 0 && (
 					<FormTokenField
 						label={ __( 'Categories' ) }
 						value={ ( query.categoryIds || [] ).map(
@@ -91,7 +133,7 @@ export default function QueryInspectorControls( { query, setQuery } ) {
 						onChange={ onCategoriesChange }
 					/>
 				) }
-				{ tags?.terms?.length > 0 && (
+				{ showTags && tags?.terms?.length > 0 && (
 					<FormTokenField
 						label={ __( 'Tags' ) }
 						value={ ( query.tagIds || [] ).map( ( tagId ) => ( {
@@ -102,6 +144,18 @@ export default function QueryInspectorControls( { query, setQuery } ) {
 						onChange={ onTagsChange }
 					/>
 				) }
+				<QueryControls
+					{ ...{ order, orderBy, selectedAuthorId, authorList } }
+					onOrderChange={ ( value ) => setQuery( { order: value } ) }
+					onOrderByChange={ ( value ) =>
+						setQuery( { orderBy: value } )
+					}
+					onAuthorChange={ ( value ) =>
+						setQuery( {
+							author: value !== '' ? +value : undefined,
+						} )
+					}
+				/>
 				<TextControl
 					label={ __( 'Search' ) }
 					value={ querySearch }

--- a/packages/e2e-tests/fixtures/blocks/core__query.json
+++ b/packages/e2e-tests/fixtures/blocks/core__query.json
@@ -8,12 +8,14 @@
 				"perPage": null,
 				"pages": 1,
 				"offset": 0,
+				"postType": "post",
 				"categoryIds": [],
 				"tagIds": [],
 				"order": "desc",
 				"orderBy": "date",
 				"author": "",
-				"search": ""
+				"search": "",
+				"exclude": []
 			}
 		},
 		"innerBlocks": [],


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Part of: https://github.com/WordPress/gutenberg/issues/24934, which is part of https://github.com/WordPress/gutenberg/issues/24762.

This PR add Custom Post Types support in `Query` Block. This is the first step for full support of CPTs and handles some use cases but more work is needed to be fully flexible.

### Some notes for this PR:

1. When we retrieve the `post types` we check the supported `taxonomies` for each post type. Since we have support for `categories` and `post tags` as a separate filter, we hide/show them taking into account the supported ones. When he have filters for example in `tags` and change post type to `pages`, we clear the previous filter.

This needs more investigation for how custom taxonomies are registered and associated with each post type. Testing with WooCommerce for extra post types and taxonomies and taxonomies doesn't give the expected results. In addition there will be changes in the future to support `taxonomies` in general and not specifically categories and tags, as are now (In follow up PR).

2. I have placed the post type filter in `inspector controls` to be close to the hide/show of other coupled filters (categories etc..). This might probably change with the custom taxonomies support and other rest API limitations that exist now.

3. I have introduced an extra check to exclude the current entity from the results. This needs more testing to also avoid infinite recursive loops. 

4. I have removed `Pagination` block from default, because most use cases of `Query` would be to show list of entities in various pages, especially in `home page`.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
