### PR TITLE
Version bump to 9.1.1

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -5,7 +5,7 @@
  * Description: Printing since 1440. This is the development plugin for the new block editor in core.
  * Requires at least: 5.3
  * Requires PHP: 5.6
- * Version: 9.1.0
+ * Version: 9.1.1
  * Author: Gutenberg Team
  * Text Domain: gutenberg
  *

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "9.1.0",
+	"version": "9.1.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "9.1.0",
+	"version": "9.1.1",
 	"private": true,
 	"description": "A new WordPress editor experience.",
 	"author": "The WordPress Contributors",


### PR DESCRIPTION
= 9.1.1 =

### Bug Fixes

- Widgets Screen:
  - Include edit-widgets php files in build https://github.com/WordPress/gutenberg/pull/25792
  - Fix PHP warining in widget utils controller https://github.com/WordPress/gutenberg/pull/25797
  - Initialize the state before rendering widgets editor https://github.com/WordPress/gutenberg/pull/25736
  - Fix insertion point in widget areas https://github.com/WordPress/gutenberg/pull/25727
