### PR TITLE
Site editor: Store navigation panel's active menu state in the store

### DIFF
--- a/packages/edit-site/src/components/left-sidebar/navigation-panel/index.js
+++ b/packages/edit-site/src/components/left-sidebar/navigation-panel/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useEffect, useRef, useState } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 import {
 	__experimentalNavigation as Navigation,
 	__experimentalNavigationMenu as NavigationMenu,
@@ -24,31 +24,38 @@ export const {
 } = createSlotFill( 'EditSiteNavigationPanelPreview' );
 
 const NavigationPanel = () => {
-	const [ activeMenu, setActiveMenu ] = useState( 'root' );
 	const ref = useRef();
 
 	useEffect( () => {
-		ref.current.focus();
+		if ( ref.current ) {
+			ref.current.focus();
+		}
 	}, [ ref ] );
 
-	const { templateId, templatePartId, templateType } = useSelect(
+	const { templateId, templatePartId, templateType, activeMenu } = useSelect(
 		( select ) => {
 			const {
 				getTemplateId,
 				getTemplatePartId,
 				getTemplateType,
+				getNavigationPanelActiveMenu,
 			} = select( 'core/edit-site' );
 
 			return {
 				templateId: getTemplateId(),
 				templatePartId: getTemplatePartId(),
 				templateType: getTemplateType(),
+				activeMenu: getNavigationPanelActiveMenu(),
 			};
 		},
 		[]
 	);
 
-	const { setTemplate, setTemplatePart } = useDispatch( 'core/edit-site' );
+	const {
+		setTemplate,
+		setTemplatePart,
+		setNavigationPanelActiveMenu,
+	} = useDispatch( 'core/edit-site' );
 
 	return (
 		<div className="edit-site-navigation-panel">
@@ -58,7 +65,8 @@ const NavigationPanel = () => {
 						? `${ templateType }-${ templateId }`
 						: `${ templateType }-${ templatePartId }`
 				}
-				onActivateMenu={ setActiveMenu }
+				activeMenu={ activeMenu }
+				onActivateMenu={ setNavigationPanelActiveMenu }
 			>
 				{ activeMenu === 'root' && (
 					<NavigationBackButton

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -159,3 +159,17 @@ export function* showHomepage() {
 	const homeTemplate = yield* setPage( page );
 	yield setHomeTemplateId( homeTemplate );
 }
+
+/**
+ * Returns an action object used to set the active navigation panel menu.
+ *
+ * @param {string} menu Menu prop of active menu.
+ *
+ * @return {Object} Action object.
+ */
+export function setNavigationPanelActiveMenu( menu ) {
+	return {
+		type: 'SET_NAVIGATION_PANEL_ACTIVE_MENU',
+		value: menu,
+	};
+}

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -170,6 +170,6 @@ export function* showHomepage() {
 export function setNavigationPanelActiveMenu( menu ) {
 	return {
 		type: 'SET_NAVIGATION_PANEL_ACTIVE_MENU',
-		value: menu,
+		menu,
 	};
 }

--- a/packages/edit-site/src/store/reducer.js
+++ b/packages/edit-site/src/store/reducer.js
@@ -185,7 +185,7 @@ export function homeTemplateId( state, action ) {
 function navigationPanelActiveMenu( state = 'root', action ) {
 	switch ( action.type ) {
 		case 'SET_NAVIGATION_PANEL_ACTIVE_MENU':
-			return action.value;
+			return action.menu;
 	}
 	return state;
 }

--- a/packages/edit-site/src/store/reducer.js
+++ b/packages/edit-site/src/store/reducer.js
@@ -174,6 +174,22 @@ export function homeTemplateId( state, action ) {
 	return state;
 }
 
+/**
+ * Reducer for navigation panel's active menu.
+ *
+ * @param {Object} state Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+function navigationPanelActiveMenu( state = 'root', action ) {
+	switch ( action.type ) {
+		case 'SET_NAVIGATION_PANEL_ACTIVE_MENU':
+			return action.value;
+	}
+	return state;
+}
+
 export default combineReducers( {
 	preferences,
 	deviceType,
@@ -183,4 +199,5 @@ export default combineReducers( {
 	templateType,
 	page,
 	homeTemplateId,
+	navigationPanelActiveMenu,
 } );

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -137,3 +137,14 @@ export function getTemplateType( state ) {
 export function getPage( state ) {
 	return state.page;
 }
+
+/**
+ * Returns the active menu in the navigation panel.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {string} Active menu.
+ */
+export function getNavigationPanelActiveMenu( state ) {
+	return state.navigationPanelActiveMenu;
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Store navigation panel's active menu state in the global state. Whenever we open the navigation panel it will show the menu where we last closed it.

## How has this been tested?
* `yarn wp-env start`
* Enable FSE
* Open Site Editor
* Click site logo to toggle the navigation sidebar

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
