### PR TITLE
InputControl: Reverting recent changes, which affected updates

### DIFF
--- a/packages/components/src/angle-picker-control/angle-circle.js
+++ b/packages/components/src/angle-picker-control/angle-circle.js
@@ -31,8 +31,7 @@ function AngleCircle( { value, onChange, ...props } ) {
 		// Prevent (drag) mouse events from selecting and accidentally
 		// triggering actions from other elements.
 		event.preventDefault();
-		// Ensure the input isn't focused as preventDefault would leave it
-		document.activeElement.blur();
+
 		onChange( getAngle( centerX, centerY, event.clientX, event.clientY ) );
 	};
 

--- a/packages/components/src/box-control/test/index.js
+++ b/packages/components/src/box-control/test/index.js
@@ -28,7 +28,6 @@ describe( 'BoxControl', () => {
 			const input = container.querySelector( 'input' );
 			const unitSelect = container.querySelector( 'select' );
 
-			input.focus();
 			fireEvent.change( input, { target: { value: '100%' } } );
 			fireEvent.keyDown( input, { keyCode: ENTER } );
 
@@ -42,17 +41,14 @@ describe( 'BoxControl', () => {
 			const { container, getByText } = render( <BoxControl /> );
 			const input = container.querySelector( 'input' );
 			const unitSelect = container.querySelector( 'select' );
-			const reset = getByText( /Reset/ );
 
-			input.focus();
 			fireEvent.change( input, { target: { value: '100px' } } );
 			fireEvent.keyDown( input, { keyCode: ENTER } );
 
 			expect( input.value ).toBe( '100' );
 			expect( unitSelect.value ).toBe( 'px' );
 
-			reset.focus();
-			fireEvent.click( reset );
+			fireEvent.click( getByText( /Reset/ ) );
 
 			expect( input.value ).toBe( '' );
 			expect( unitSelect.value ).toBe( 'px' );
@@ -72,17 +68,14 @@ describe( 'BoxControl', () => {
 			const { container, getByText } = render( <Example /> );
 			const input = container.querySelector( 'input' );
 			const unitSelect = container.querySelector( 'select' );
-			const reset = getByText( /Reset/ );
 
-			input.focus();
 			fireEvent.change( input, { target: { value: '100px' } } );
 			fireEvent.keyDown( input, { keyCode: ENTER } );
 
 			expect( input.value ).toBe( '100' );
 			expect( unitSelect.value ).toBe( 'px' );
 
-			reset.focus();
-			fireEvent.click( reset );
+			fireEvent.click( getByText( /Reset/ ) );
 
 			expect( input.value ).toBe( '' );
 			expect( unitSelect.value ).toBe( 'px' );
@@ -109,17 +102,14 @@ describe( 'BoxControl', () => {
 			const { container, getByText } = render( <Example /> );
 			const input = container.querySelector( 'input' );
 			const unitSelect = container.querySelector( 'select' );
-			const reset = getByText( /Reset/ );
 
-			input.focus();
 			fireEvent.change( input, { target: { value: '100px' } } );
 			fireEvent.keyDown( input, { keyCode: ENTER } );
 
 			expect( input.value ).toBe( '100' );
 			expect( unitSelect.value ).toBe( 'px' );
 
-			reset.focus();
-			fireEvent.click( reset );
+			fireEvent.click( getByText( /Reset/ ) );
 
 			expect( input.value ).toBe( '' );
 			expect( unitSelect.value ).toBe( 'px' );

--- a/packages/components/src/input-control/index.js
+++ b/packages/components/src/input-control/index.js
@@ -34,7 +34,9 @@ export function InputControl(
 		isPressEnterToChange = false,
 		label,
 		labelPosition = 'top',
+		onBlur = noop,
 		onChange = noop,
+		onFocus = noop,
 		onValidate = noop,
 		onKeyDown = noop,
 		prefix,
@@ -49,6 +51,16 @@ export function InputControl(
 
 	const id = useUniqueId( idProp );
 	const classes = classNames( 'components-input-control', className );
+
+	const handleOnBlur = ( event ) => {
+		onBlur( event );
+		setIsFocused( false );
+	};
+
+	const handleOnFocus = ( event ) => {
+		onFocus( event );
+		setIsFocused( true );
+	};
 
 	return (
 		<InputBase
@@ -71,9 +83,10 @@ export function InputControl(
 				className="components-input-control__input"
 				disabled={ disabled }
 				id={ id }
-				isFocused={ isFocused }
 				isPressEnterToChange={ isPressEnterToChange }
+				onBlur={ handleOnBlur }
 				onChange={ onChange }
+				onFocus={ handleOnFocus }
 				onKeyDown={ onKeyDown }
 				onValidate={ onValidate }
 				ref={ ref }

--- a/packages/components/src/input-control/input-field.js
+++ b/packages/components/src/input-control/input-field.js
@@ -21,7 +21,7 @@ function InputField(
 	{
 		disabled = false,
 		dragDirection = 'n',
-		dragThreshold = 10,
+		dragThreshold = 15,
 		id,
 		isDragEnabled = false,
 		isPressEnterToChange = false,

--- a/packages/components/src/input-control/input-field.js
+++ b/packages/components/src/input-control/input-field.js
@@ -7,7 +7,7 @@ import { useDrag } from 'react-use-gesture';
 /**
  * WordPress dependencies
  */
-import { forwardRef } from '@wordpress/element';
+import { useEffect, useRef, forwardRef } from '@wordpress/element';
 import { UP, DOWN, ENTER } from '@wordpress/keycodes';
 /**
  * Internal dependencies
@@ -16,7 +16,6 @@ import { useDragCursor } from './utils';
 import { Input } from './styles/input-control-styles';
 import { useInputControlStateReducer } from './state';
 import { isValueEmpty } from '../utils/values';
-import { useUpdateEffect } from '../utils';
 
 function InputField(
 	{
@@ -25,7 +24,6 @@ function InputField(
 		dragThreshold = 10,
 		id,
 		isDragEnabled = false,
-		isFocused,
 		isPressEnterToChange = false,
 		onBlur = noop,
 		onChange = noop,
@@ -36,7 +34,6 @@ function InputField(
 		onKeyDown = noop,
 		onValidate = noop,
 		size = 'default',
-		setIsFocused,
 		stateReducer = ( state ) => state,
 		value: valueProp,
 		...props
@@ -66,27 +63,35 @@ function InputField(
 
 	const { _event, value, isDragging, isDirty } = state;
 
+	const valueRef = useRef( value );
 	const dragCursor = useDragCursor( isDragging, dragDirection );
 
-	/*
-	 * Syncs value state using the focus state to determine the direction.
-	 * Without focus it updates the value from the props. With focus it
-	 * propagates the value and event through onChange.
-	 */
-	useUpdateEffect( () => {
-		if ( valueProp === value ) {
+	useEffect( () => {
+		/**
+		 * Handles syncing incoming value changes with internal state.
+		 * This effectively enables a "controlled" state.
+		 * https://reactjs.org/docs/forms.html#controlled-components
+		 */
+		if ( valueProp !== valueRef.current ) {
+			update( valueProp );
+			valueRef.current = valueProp;
+
+			// Quick return to avoid firing the onChange callback
 			return;
 		}
-		if ( ! isFocused ) {
-			update( valueProp );
-		} else if ( ! isDirty ) {
+
+		/**
+		 * Fires the onChange callback when internal state value changes.
+		 */
+		if ( value !== valueRef.current && ! isDirty ) {
 			onChange( value, { event: _event } );
+
+			valueRef.current = value;
 		}
-	}, [ value, isDirty, isFocused, valueProp ] );
+	}, [ value, isDirty, valueProp ] );
 
 	const handleOnBlur = ( event ) => {
 		onBlur( event );
-		setIsFocused( false );
 
 		/**
 		 * If isPressEnterToChange is set, this commits the value to
@@ -103,7 +108,6 @@ function InputField(
 
 	const handleOnFocus = ( event ) => {
 		onFocus( event );
-		setIsFocused( true );
 	};
 
 	const handleOnChange = ( event ) => {

--- a/packages/components/src/input-control/input-field.js
+++ b/packages/components/src/input-control/input-field.js
@@ -39,7 +39,6 @@ function InputField(
 		setIsFocused,
 		stateReducer = ( state ) => state,
 		value: valueProp,
-		type,
 		...props
 	},
 	ref
@@ -101,19 +100,6 @@ function InputField(
 			}
 		}
 	};
-
-	/*
-	 * Works around the odd UA (e.g. Firefox) that does not focus inputs of
-	 * type=number when their spinner arrows are pressed.
-	 */
-	let handleOnMouseDown;
-	if ( type === 'number' ) {
-		handleOnMouseDown = ( event ) => {
-			if ( event.target !== event.target.ownerDocument.activeElement ) {
-				event.target.focus();
-			}
-		};
-	}
 
 	const handleOnFocus = ( event ) => {
 		onFocus( event );
@@ -205,11 +191,9 @@ function InputField(
 			onChange={ handleOnChange }
 			onFocus={ handleOnFocus }
 			onKeyDown={ handleOnKeyDown }
-			onMouseDown={ handleOnMouseDown }
 			ref={ ref }
 			size={ size }
 			value={ value }
-			type={ type }
 		/>
 	);
 }

--- a/packages/components/src/input-control/test/index.js
+++ b/packages/components/src/input-control/test/index.js
@@ -49,7 +49,7 @@ describe( 'InputControl', () => {
 			render( <InputControl value="Hello" onChange={ spy } /> );
 
 			const input = getInput();
-			input.focus();
+
 			fireEvent.change( input, { target: { value: 'There' } } );
 
 			expect( input.value ).toBe( 'There' );
@@ -59,23 +59,21 @@ describe( 'InputControl', () => {
 		it( 'should work as a controlled component', () => {
 			const spy = jest.fn();
 			const { rerender } = render(
-				<InputControl value="one" onChange={ spy } />
+				<InputControl value="Original" onChange={ spy } />
 			);
 
 			const input = getInput();
 
-			input.focus();
-			fireEvent.change( input, { target: { value: 'two' } } );
+			fireEvent.change( input, { target: { value: 'State' } } );
 
-			// Ensuring <InputControl /> is controlled
-			fireEvent.blur( input );
+			// Assuming <InputControl /> is controlled...
 
 			// Updating the value
-			rerender( <InputControl value="three" onChange={ spy } /> );
+			rerender( <InputControl value="New" onChange={ spy } /> );
 
-			expect( input.value ).toBe( 'three' );
+			expect( input.value ).toBe( 'New' );
 
-			/*
+			/**
 			 * onChange called only once. onChange is not called when a
 			 * parent component explicitly passed a (new value) change down to
 			 * the <InputControl />.
@@ -91,7 +89,7 @@ describe( 'InputControl', () => {
 
 			const input = getInput();
 
-			// Assuming <InputControl /> is controlled (not focused)
+			// Assuming <InputControl /> is controlled...
 
 			// Updating the value
 			rerender( <InputControl value="New" onChange={ spy } /> );

--- a/packages/components/src/range-control/README.md
+++ b/packages/components/src/range-control/README.md
@@ -230,6 +230,12 @@ The minimum value accepted. If smaller values are inserted onChange will not be 
 
 #### max
 
+The maximum value accepted. If higher values are inserted onChange will not be called and the value gets reverted when blur event fires.
+
+-   Type: `Number`
+-   Required: No
+-   Platform: Web | Mobile
+
 #### railColor
 
 Customizes the (background) color of the rail element.
@@ -237,12 +243,6 @@ Customizes the (background) color of the rail element.
 -   Type: `String`
 -   Required: No
 -   Platform: Web
-
-The maximum value accepted. If higher values are inserted onChange will not be called and the value gets reverted when blur event fires.
-
--   Type: `Number`
--   Required: No
--   Platform: Web | Mobile
 
 #### renderTooltipContent
 

--- a/packages/components/src/range-control/README.md
+++ b/packages/components/src/range-control/README.md
@@ -213,7 +213,8 @@ const MyRangeControl() {
 
 #### onChange
 
-A function that receives the new value. The value will be less than `max` and more than `min` unless a reset (enabled by `allowReset`) has occured. In which case the value will be either that of `resetFallbackValue` if it has been specified or otherwise `undefined`.
+A function that receives the new value.
+If allowReset is true, when onChange is called without any parameter passed it should reset the value.
 
 -   Type: `function`
 -   Required: Yes
@@ -221,21 +222,13 @@ A function that receives the new value. The value will be less than `max` and mo
 
 #### min
 
-The minimum `value` allowed.
+The minimum value accepted. If smaller values are inserted onChange will not be called and the value gets reverted when blur event fires.
 
 -   Type: `Number`
 -   Required: No
--   Default: 0
 -   Platform: Web | Mobile
 
 #### max
-
-The maximum `value` allowed.
-
--   Type: `Number`
--   Required: No
--   Default: 100
--   Platform: Web | Mobile
 
 #### railColor
 
@@ -244,6 +237,12 @@ Customizes the (background) color of the rail element.
 -   Type: `String`
 -   Required: No
 -   Platform: Web
+
+The maximum value accepted. If higher values are inserted onChange will not be called and the value gets reverted when blur event fires.
+
+-   Type: `Number`
+-   Required: No
+-   Platform: Web | Mobile
 
 #### renderTooltipContent
 

--- a/packages/components/src/range-control/index.js
+++ b/packages/components/src/range-control/index.js
@@ -26,13 +26,13 @@ import {
 	ActionRightWrapper,
 	AfterIconWrapper,
 	BeforeIconWrapper,
-	InputNumber,
 	Root,
 	Track,
 	ThumbWrapper,
 	Thumb,
 	Wrapper,
 } from './styles/range-control-styles';
+import InputField from './input-field';
 import { useRTL } from '../utils/rtl';
 
 function RangeControl(
@@ -77,7 +77,6 @@ function RangeControl(
 		value: valueProp,
 		initial: initialPosition,
 	} );
-	const isResetPendent = useRef( false );
 	const [ showTooltip, setShowTooltip ] = useState( showTooltipProp );
 	const [ isFocused, setIsFocused ] = useState( false );
 
@@ -120,33 +119,17 @@ function RangeControl(
 
 	const handleOnRangeChange = ( event ) => {
 		const nextValue = parseFloat( event.target.value );
-		setValue( nextValue );
-		onChange( nextValue );
+		handleOnChange( nextValue );
 	};
 
 	const handleOnChange = ( nextValue ) => {
-		nextValue = parseFloat( nextValue );
-		setValue( nextValue );
-		/*
-		 * Calls onChange only when nextValue is numeric
-		 * otherwise may queue a reset for the blur event.
-		 */
-		if ( ! isNaN( nextValue ) ) {
-			if ( nextValue < min || nextValue > max ) {
-				nextValue = floatClamp( nextValue, min, max );
-			}
-			onChange( nextValue );
-			isResetPendent.current = false;
-		} else if ( allowReset ) {
-			isResetPendent.current = true;
-		}
-	};
-
-	const handleOnInputNumberBlur = () => {
-		if ( isResetPendent.current ) {
+		if ( isNaN( nextValue ) ) {
 			handleOnReset();
-			isResetPendent.current = false;
+			return;
 		}
+
+		setValue( nextValue );
+		onChange( nextValue );
 	};
 
 	const handleOnReset = () => {
@@ -273,16 +256,14 @@ function RangeControl(
 					</AfterIconWrapper>
 				) }
 				{ withInputField && (
-					<InputNumber
-						aria-label={ label }
-						className="components-range-control__number"
+					<InputField
 						disabled={ disabled }
-						inputMode="decimal"
 						isShiftStepEnabled={ isShiftStepEnabled }
+						label={ label }
 						max={ max }
 						min={ min }
-						onBlur={ handleOnInputNumberBlur }
 						onChange={ handleOnChange }
+						onReset={ handleOnReset }
 						shiftStep={ shiftStep }
 						step={ step }
 						value={ inputSliderValue }

--- a/packages/components/src/range-control/index.js
+++ b/packages/components/src/range-control/index.js
@@ -129,7 +129,7 @@ function RangeControl(
 		}
 
 		setValue( nextValue );
-		onChange( nextValue );
+		onChange( clamp( nextValue, min, max ) );
 	};
 
 	const handleOnReset = () => {

--- a/packages/components/src/range-control/input-field.js
+++ b/packages/components/src/range-control/input-field.js
@@ -1,0 +1,86 @@
+/**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { ENTER } from '@wordpress/keycodes';
+
+/**
+ * Internal dependencies
+ */
+import { useControlledState } from '../utils/hooks';
+import { InputNumber } from './styles/range-control-styles';
+
+export default function InputField( {
+	label,
+	onBlur = noop,
+	onChange = noop,
+	onReset = noop,
+	onKeyDown = noop,
+	value: valueProp,
+	...props
+} ) {
+	/**
+	 * This component stores an internal (input) value state, derived from
+	 * the incoming value prop.
+	 *
+	 * This allows for the <input /> to be updated independently before the
+	 * value is applied and propagated. This independent updating action is
+	 * necessary to accommodate individual keystroke values that may not
+	 * be considered "valid" (e.g. within the min - max range).
+	 */
+	const [ value, setValue ] = useControlledState( valueProp );
+
+	const handleOnReset = ( event ) => {
+		onReset( event );
+		setValue( '' );
+	};
+
+	const handleOnCommit = ( event ) => {
+		const nextValue = parseFloat( event.target.value );
+
+		if ( isNaN( nextValue ) ) {
+			handleOnReset();
+			return;
+		}
+
+		setValue( nextValue );
+		onChange( nextValue );
+	};
+
+	const handleOnBlur = ( event ) => {
+		onBlur( event );
+		handleOnCommit( event );
+	};
+
+	const handleOnChange = ( next ) => {
+		handleOnCommit( { target: { value: next } } );
+	};
+
+	const handleOnKeyDown = ( event ) => {
+		const { keyCode } = event;
+		onKeyDown( event );
+
+		if ( keyCode === ENTER ) {
+			event.preventDefault();
+			handleOnCommit( event );
+		}
+	};
+
+	return (
+		<InputNumber
+			aria-label={ label }
+			className="components-range-control__number"
+			inputMode="decimal"
+			onBlur={ handleOnBlur }
+			onChange={ handleOnChange }
+			onKeyDown={ handleOnKeyDown }
+			type="number"
+			value={ value }
+			{ ...props }
+		/>
+	);
+}

--- a/packages/components/src/range-control/input-field.js
+++ b/packages/components/src/range-control/input-field.js
@@ -7,11 +7,11 @@ import { noop } from 'lodash';
  * WordPress dependencies
  */
 import { ENTER } from '@wordpress/keycodes';
+import { useEffect, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import { useControlledState } from '../utils/hooks';
 import { InputNumber } from './styles/range-control-styles';
 
 export default function InputField( {
@@ -32,7 +32,14 @@ export default function InputField( {
 	 * necessary to accommodate individual keystroke values that may not
 	 * be considered "valid" (e.g. within the min - max range).
 	 */
-	const [ value, setValue ] = useControlledState( valueProp );
+	const [ value, setValue ] = useState( valueProp );
+
+	/**
+	 * Syncs incoming value (prop) within internal state.
+	 */
+	useEffect( () => {
+		setValue( valueProp );
+	}, [ valueProp ] );
 
 	const handleOnReset = ( event ) => {
 		onReset( event );
@@ -56,8 +63,23 @@ export default function InputField( {
 		handleOnCommit( event );
 	};
 
-	const handleOnChange = ( next ) => {
-		handleOnCommit( { target: { value: next } } );
+	const handleOnChange = ( next, { event } ) => {
+		const nextValue = parseFloat( next );
+		setValue( nextValue );
+
+		/**
+		 * Prevent submitting if changes are invalid.
+		 * This only applies to values being entered via KEY_DOWN.
+		 *
+		 * Pressing the up/down arrows of the HTML input also triggers a
+		 * change event. However, those values will be (pre)validated by the
+		 * HTML input.
+		 */
+		if ( event.target.checkValidity && ! event.target.checkValidity() ) {
+			return;
+		}
+
+		handleOnCommit( event );
 	};
 
 	const handleOnKeyDown = ( event ) => {

--- a/packages/components/src/range-control/test/index.js
+++ b/packages/components/src/range-control/test/index.js
@@ -57,7 +57,7 @@ describe( 'RangeControl', () => {
 	} );
 
 	describe( 'validation', () => {
-		it( 'should not apply new value is lower than minimum', () => {
+		it( 'should not apply if new value is lower than minimum', () => {
 			const { container } = render( <RangeControl min={ 11 } /> );
 
 			const rangeInput = getRangeInput( container );

--- a/packages/components/src/range-control/test/index.js
+++ b/packages/components/src/range-control/test/index.js
@@ -27,11 +27,10 @@ describe( 'RangeControl', () => {
 			const rangeInput = getRangeInput( container );
 			const numberInput = getNumberInput( container );
 
-			rangeInput.focus();
 			fireEvent.change( rangeInput, { target: { value: '5' } } );
 
-			numberInput.focus();
 			fireEvent.change( numberInput, { target: { value: '10' } } );
+			fireEvent.blur( numberInput );
 
 			expect( onChange ).toHaveBeenCalledWith( 5 );
 			expect( onChange ).toHaveBeenCalledWith( 10 );
@@ -58,7 +57,7 @@ describe( 'RangeControl', () => {
 	} );
 
 	describe( 'validation', () => {
-		it( 'should not apply if new value is lower than minimum', () => {
+		it( 'should not apply new value is lower than minimum', () => {
 			const { container } = render( <RangeControl min={ 11 } /> );
 
 			const rangeInput = getRangeInput( container );
@@ -70,7 +69,7 @@ describe( 'RangeControl', () => {
 			expect( rangeInput.value ).not.toBe( '10' );
 		} );
 
-		it( 'should not apply if new value is greater than maximum', () => {
+		it( 'should not apply new value is greater than maximum', () => {
 			const { container } = render( <RangeControl max={ 20 } /> );
 
 			const rangeInput = getRangeInput( container );
@@ -82,38 +81,20 @@ describe( 'RangeControl', () => {
 			expect( rangeInput.value ).not.toBe( '21' );
 		} );
 
-		it( 'should not call onChange if new value is invalid', () => {
+		it( 'should call onChange if new value is valid', () => {
 			const onChange = jest.fn();
 			const { container } = render(
 				<RangeControl onChange={ onChange } min={ 10 } max={ 20 } />
 			);
 
-			const numberInput = getNumberInput( container );
-
-			numberInput.focus();
-			fireEvent.change( numberInput, { target: { value: '25e' } } );
-
-			expect( onChange ).not.toHaveBeenCalled();
-		} );
-
-		it( 'should keep invalid values in number input until loss of focus', () => {
-			const onChange = jest.fn();
-			const { container } = render(
-				<RangeControl onChange={ onChange } min={ -1 } max={ 1 } />
-			);
-
 			const rangeInput = getRangeInput( container );
 			const numberInput = getNumberInput( container );
 
-			numberInput.focus();
-			fireEvent.change( numberInput, { target: { value: '-1.1' } } );
-
-			expect( numberInput.value ).toBe( '-1.1' );
-			expect( rangeInput.value ).toBe( '-1' );
-
+			fireEvent.change( numberInput, { target: { value: '15' } } );
 			fireEvent.blur( numberInput );
-			expect( onChange ).toHaveBeenCalledWith( -1 );
-			expect( numberInput.value ).toBe( '-1' );
+
+			expect( onChange ).toHaveBeenCalledWith( 15 );
+			expect( rangeInput.value ).toBe( '15' );
 		} );
 
 		it( 'should validate when provided a max or min of zero', () => {
@@ -124,7 +105,6 @@ describe( 'RangeControl', () => {
 			const rangeInput = getRangeInput( container );
 			const numberInput = getNumberInput( container );
 
-			numberInput.focus();
 			fireEvent.change( numberInput, { target: { value: '1' } } );
 			fireEvent.blur( numberInput );
 
@@ -139,15 +119,19 @@ describe( 'RangeControl', () => {
 			const rangeInput = getRangeInput( container );
 			const numberInput = getNumberInput( container );
 
-			numberInput.focus();
-
 			fireEvent.change( numberInput, { target: { value: '-101' } } );
+			fireEvent.blur( numberInput );
+
 			expect( rangeInput.value ).toBe( '-100' );
 
 			fireEvent.change( numberInput, { target: { value: '-49' } } );
+			fireEvent.blur( numberInput );
+
 			expect( rangeInput.value ).toBe( '-50' );
 
 			fireEvent.change( numberInput, { target: { value: '-50' } } );
+			fireEvent.blur( numberInput );
+
 			expect( rangeInput.value ).toBe( '-50' );
 		} );
 
@@ -164,13 +148,14 @@ describe( 'RangeControl', () => {
 			const rangeInput = getRangeInput( container );
 			const numberInput = getNumberInput( container );
 
-			numberInput.focus();
 			fireEvent.change( numberInput, { target: { value: '0.125' } } );
+			fireEvent.blur( numberInput );
 
 			expect( onChange ).toHaveBeenCalledWith( 0.125 );
 			expect( rangeInput.value ).toBe( '0.125' );
 
 			fireEvent.change( numberInput, { target: { value: '0.225' } } );
+			fireEvent.blur( numberInput );
 
 			expect( onChange ).toHaveBeenCalledWith( 0.225 );
 			expect( rangeInput.value ).toBe( '0.225' );
@@ -244,14 +229,13 @@ describe( 'RangeControl', () => {
 			const rangeInput = getRangeInput( container );
 			const numberInput = getNumberInput( container );
 
-			rangeInput.focus();
 			fireEvent.change( rangeInput, { target: { value: 13 } } );
 
 			expect( rangeInput.value ).toBe( '13' );
 			expect( numberInput.value ).toBe( '13' );
 
-			numberInput.focus();
 			fireEvent.change( numberInput, { target: { value: 7 } } );
+			fireEvent.blur( numberInput );
 
 			expect( rangeInput.value ).toBe( '7' );
 			expect( numberInput.value ).toBe( '7' );

--- a/packages/components/src/range-control/test/index.js
+++ b/packages/components/src/range-control/test/index.js
@@ -66,7 +66,7 @@ describe( 'RangeControl', () => {
 			fireEvent.change( numberInput, { target: { value: '10' } } );
 			fireEvent.blur( numberInput );
 
-			expect( rangeInput.value ).not.toBe( '10' );
+			expect( rangeInput.value ).toBe( '11' );
 		} );
 
 		it( 'should not apply new value is greater than maximum', () => {

--- a/packages/components/src/unit-control/test/index.js
+++ b/packages/components/src/unit-control/test/index.js
@@ -1,32 +1,46 @@
 /**
  * External dependencies
  */
-import { render, fireEvent } from '@testing-library/react';
+import { render, unmountComponentAtNode } from 'react-dom';
+import { act, Simulate } from 'react-dom/test-utils';
+import { render as testRender } from '@testing-library/react';
 
 /**
  * WordPress dependencies
  */
-import { UP, DOWN, ENTER } from '@wordpress/keycodes';
+import { UP, DOWN } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
  */
 import UnitControl from '../';
 
-const getComponent = () =>
-	document.body.querySelector( '.components-unit-control' );
-const getInput = () =>
-	document.body.querySelector( '.components-unit-control input' );
-const getSelect = () =>
-	document.body.querySelector( '.components-unit-control select' );
+let container = null;
 
-const fireKeyDown = ( data ) =>
-	fireEvent.keyDown( document.activeElement || document.body, data );
+beforeEach( () => {
+	container = document.createElement( 'div' );
+	document.body.appendChild( container );
+} );
+
+afterEach( () => {
+	unmountComponentAtNode( container );
+	container.remove();
+	container = null;
+} );
+
+const getComponent = () =>
+	container.querySelector( '.components-unit-control' );
+const getInput = () =>
+	container.querySelector( '.components-unit-control input' );
+const getSelect = () =>
+	container.querySelector( '.components-unit-control select' );
 
 describe( 'UnitControl', () => {
 	describe( 'Basic rendering', () => {
 		it( 'should render', () => {
-			render( <UnitControl /> );
+			act( () => {
+				render( <UnitControl />, container );
+			} );
 			const input = getInput();
 			const select = getSelect();
 
@@ -35,7 +49,9 @@ describe( 'UnitControl', () => {
 		} );
 
 		it( 'should render custom className', () => {
-			render( <UnitControl className="hello" /> );
+			act( () => {
+				render( <UnitControl className="hello" />, container );
+			} );
 
 			const el = getComponent();
 
@@ -43,7 +59,9 @@ describe( 'UnitControl', () => {
 		} );
 
 		it( 'should not render select, if units are disabled', () => {
-			render( <UnitControl unit="em" units={ false } /> );
+			act( () => {
+				render( <UnitControl unit="em" units={ false } />, container );
+			} );
 			const input = getInput();
 			const select = getSelect();
 
@@ -54,39 +72,61 @@ describe( 'UnitControl', () => {
 
 	describe( 'Value', () => {
 		it( 'should update value on change', () => {
-			let state = '50px';
-			const setState = jest.fn( ( value ) => ( state = value ) );
+			let state = 50;
+			const setState = ( nextState ) => ( state = nextState );
 
-			render( <UnitControl value={ state } onChange={ setState } /> );
+			act( () => {
+				render(
+					<UnitControl value={ state } onChange={ setState } />,
+					container
+				);
+			} );
 
 			const input = getInput();
-			input.focus();
-			fireEvent.change( input, { target: { value: 62 } } );
 
-			expect( setState ).toHaveBeenCalledTimes( 1 );
+			act( () => {
+				Simulate.change( input, { target: { value: 62 } } );
+			} );
+
 			expect( state ).toBe( '62px' );
 		} );
 
 		it( 'should increment value on UP press', () => {
-			let state = '50px';
+			let state = 50;
 			const setState = ( nextState ) => ( state = nextState );
 
-			render( <UnitControl value={ state } onChange={ setState } /> );
+			act( () => {
+				render(
+					<UnitControl value={ state } onChange={ setState } />,
+					container
+				);
+			} );
 
-			getInput().focus();
-			fireKeyDown( { keyCode: UP } );
+			const input = getInput();
+
+			act( () => {
+				Simulate.keyDown( input, { keyCode: UP } );
+			} );
 
 			expect( state ).toBe( '51px' );
 		} );
 
 		it( 'should increment value on UP + SHIFT press, with step', () => {
-			let state = '50px';
+			let state = 50;
 			const setState = ( nextState ) => ( state = nextState );
 
-			render( <UnitControl value={ state } onChange={ setState } /> );
+			act( () => {
+				render(
+					<UnitControl value={ state } onChange={ setState } />,
+					container
+				);
+			} );
 
-			getInput().focus();
-			fireKeyDown( { keyCode: UP, shiftKey: true } );
+			const input = getInput();
+
+			act( () => {
+				Simulate.keyDown( input, { keyCode: UP, shiftKey: true } );
+			} );
 
 			expect( state ).toBe( '60px' );
 		} );
@@ -95,10 +135,18 @@ describe( 'UnitControl', () => {
 			let state = 50;
 			const setState = ( nextState ) => ( state = nextState );
 
-			render( <UnitControl value={ state } onChange={ setState } /> );
+			act( () => {
+				render(
+					<UnitControl value={ state } onChange={ setState } />,
+					container
+				);
+			} );
 
-			getInput().focus();
-			fireKeyDown( { keyCode: DOWN } );
+			const input = getInput();
+
+			act( () => {
+				Simulate.keyDown( input, { keyCode: DOWN } );
+			} );
 
 			expect( state ).toBe( '49px' );
 		} );
@@ -107,10 +155,18 @@ describe( 'UnitControl', () => {
 			let state = 50;
 			const setState = ( nextState ) => ( state = nextState );
 
-			render( <UnitControl value={ state } onChange={ setState } /> );
+			act( () => {
+				render(
+					<UnitControl value={ state } onChange={ setState } />,
+					container
+				);
+			} );
 
-			getInput().focus();
-			fireKeyDown( { keyCode: DOWN, shiftKey: true } );
+			const input = getInput();
+
+			act( () => {
+				Simulate.keyDown( input, { keyCode: DOWN, shiftKey: true } );
+			} );
 
 			expect( state ).toBe( '40px' );
 		} );
@@ -121,11 +177,18 @@ describe( 'UnitControl', () => {
 			let state = 'px';
 			const setState = ( nextState ) => ( state = nextState );
 
-			render( <UnitControl unit={ state } onUnitChange={ setState } /> );
+			act( () => {
+				render(
+					<UnitControl unit={ state } onUnitChange={ setState } />,
+					container
+				);
+			} );
 
 			const select = getSelect();
-			select.focus();
-			fireEvent.change( select, { target: { value: 'em' } } );
+
+			act( () => {
+				Simulate.change( select, { target: { value: 'em' } } );
+			} );
 
 			expect( state ).toBe( 'em' );
 		} );
@@ -135,8 +198,9 @@ describe( 'UnitControl', () => {
 				{ value: 'pt', label: 'pt', default: 0 },
 				{ value: 'vmax', label: 'vmax', default: 10 },
 			];
-
-			render( <UnitControl units={ units } /> );
+			act( () => {
+				render( <UnitControl units={ units } />, container );
+			} );
 
 			const select = getSelect();
 			const options = select.querySelectorAll( 'option' );
@@ -157,24 +221,29 @@ describe( 'UnitControl', () => {
 				{ value: 'pt', label: 'pt', default: 25 },
 				{ value: 'vmax', label: 'vmax', default: 75 },
 			];
-
-			render(
-				<UnitControl
-					isResetValueOnUnitChange
-					units={ units }
-					onChange={ setState }
-					value={ state }
-				/>
-			);
+			act( () => {
+				render(
+					<UnitControl
+						isResetValueOnUnitChange
+						units={ units }
+						onChange={ setState }
+						value={ state }
+					/>,
+					container
+				);
+			} );
 
 			const select = getSelect();
-			select.focus();
 
-			fireEvent.change( select, { target: { value: 'vmax' } } );
+			act( () => {
+				Simulate.change( select, { target: { value: 'vmax' } } );
+			} );
 
 			expect( state ).toBe( '75vmax' );
 
-			fireEvent.change( select, { target: { value: 'pt' } } );
+			act( () => {
+				Simulate.change( select, { target: { value: 'pt' } } );
+			} );
 
 			expect( state ).toBe( '25pt' );
 		} );
@@ -187,136 +256,146 @@ describe( 'UnitControl', () => {
 				{ value: 'pt', label: 'pt', default: 25 },
 				{ value: 'vmax', label: 'vmax', default: 75 },
 			];
-
-			render(
-				<UnitControl
-					isResetValueOnUnitChange={ false }
-					value={ state }
-					units={ units }
-					onChange={ setState }
-				/>
-			);
+			act( () => {
+				render(
+					<UnitControl
+						isResetValueOnUnitChange={ false }
+						value={ state }
+						units={ units }
+						onChange={ setState }
+					/>,
+					container
+				);
+			} );
 
 			const select = getSelect();
-			select.focus();
 
-			fireEvent.change( select, { target: { value: 'vmax' } } );
+			act( () => {
+				Simulate.change( select, { target: { value: 'vmax' } } );
+			} );
 
 			expect( state ).toBe( '50vmax' );
 
-			fireEvent.change( select, { target: { value: 'pt' } } );
+			act( () => {
+				Simulate.change( select, { target: { value: 'pt' } } );
+			} );
 
 			expect( state ).toBe( '50pt' );
 		} );
 	} );
-
 	describe( 'Unit Parser', () => {
 		let state = '10px';
-		const setState = jest.fn( ( nextState ) => ( state = nextState ) );
+		const setState = ( nextState ) => ( state = nextState );
 
 		it( 'should parse unit from input', () => {
-			render(
-				<UnitControl
-					value={ state }
-					onChange={ setState }
-					isPressEnterToChange
-				/>
-			);
+			act( () => {
+				render(
+					<UnitControl value={ state } onChange={ setState } />,
+					container
+				);
+			} );
 
 			const input = getInput();
-			input.focus();
-			fireEvent.change( input, { target: { value: '55 em' } } );
-			fireKeyDown( { keyCode: ENTER } );
+
+			act( () => {
+				Simulate.change( input, { target: { value: '55 em' } } );
+			} );
 
 			expect( state ).toBe( '55em' );
 		} );
 
 		it( 'should parse PX unit from input', () => {
-			render(
-				<UnitControl
-					value={ state }
-					onChange={ setState }
-					isPressEnterToChange
-				/>
-			);
+			act( () => {
+				render(
+					<UnitControl value={ state } onChange={ setState } />,
+					container
+				);
+			} );
 
 			const input = getInput();
-			input.focus();
-			fireEvent.change( input, { target: { value: '61   PX' } } );
-			fireKeyDown( { keyCode: ENTER } );
+
+			act( () => {
+				Simulate.change( input, { target: { value: '61   PX' } } );
+			} );
 
 			expect( state ).toBe( '61px' );
 		} );
 
 		it( 'should parse EM unit from input', () => {
-			render(
-				<UnitControl
-					value={ state }
-					onChange={ setState }
-					isPressEnterToChange
-				/>
-			);
+			act( () => {
+				render(
+					<UnitControl value={ state } onChange={ setState } />,
+					container
+				);
+			} );
 
 			const input = getInput();
-			input.focus();
-			fireEvent.change( input, { target: { value: '55 em' } } );
-			fireKeyDown( { keyCode: ENTER } );
+
+			act( () => {
+				Simulate.change( input, { target: { value: '55 em' } } );
+			} );
 
 			expect( state ).toBe( '55em' );
 		} );
 
 		it( 'should parse % unit from input', () => {
-			render(
-				<UnitControl
-					value={ state }
-					onChange={ setState }
-					isPressEnterToChange
-				/>
-			);
+			act( () => {
+				render(
+					<UnitControl value={ state } onChange={ setState } />,
+					container
+				);
+			} );
 
 			const input = getInput();
-			input.focus();
-			fireEvent.change( input, { target: { value: '-10  %' } } );
-			fireKeyDown( { keyCode: ENTER } );
+
+			act( () => {
+				Simulate.change( input, { target: { value: '-10  %' } } );
+			} );
 
 			expect( state ).toBe( '-10%' );
 		} );
 
 		it( 'should parse REM unit from input', () => {
-			render(
-				<UnitControl
-					value={ state }
-					onChange={ setState }
-					isPressEnterToChange
-				/>
-			);
+			act( () => {
+				render(
+					<UnitControl value={ state } onChange={ setState } />,
+					container
+				);
+			} );
 
 			const input = getInput();
-			input.focus();
-			fireEvent.change( input, {
-				target: { value: '123       rEm  ' },
+
+			act( () => {
+				Simulate.change( input, {
+					target: { value: '123       rEm  ' },
+				} );
 			} );
-			fireKeyDown( { keyCode: ENTER } );
 
 			expect( state ).toBe( '123rem' );
 		} );
 
 		it( 'should update unit after initial render and with new unit prop', () => {
-			const { rerender } = render( <UnitControl value={ '10%' } /> );
+			const { container: testContainer, rerender } = testRender(
+				<UnitControl value={ '10%' } />
+			);
 
-			const select = getSelect();
+			const select = testContainer.querySelector( 'select' );
 
 			expect( select.value ).toBe( '%' );
 
-			rerender( <UnitControl value={ '20' } unit="em" /> );
+			rerender( <UnitControl value={ state } unit="em" /> );
 
 			expect( select.value ).toBe( 'em' );
 		} );
 
 		it( 'should fallback to default unit if parsed unit is invalid', () => {
-			render( <UnitControl value={ '10null' } /> );
+			const { container: testContainer } = testRender(
+				<UnitControl value={ '10null' } />
+			);
 
-			expect( getSelect().value ).toBe( 'px' );
+			const select = testContainer.querySelector( 'select' );
+
+			expect( select.value ).toBe( 'px' );
 		} );
 	} );
 } );


### PR DESCRIPTION
This update reverts 2 recent updates on the `InputControl` component:

https://github.com/WordPress/gutenberg/pull/25609
https://github.com/WordPress/gutenberg/pull/25753

I've noticed some issues in the BoxControl component in Gutenberg with the updates. In particular...

* adding new values and pressing `Tab` to commit
* drag to update no longer works :(

<img width="306" alt="Screen Shot 2020-10-07 at 12 08 36 PM" src="https://user-images.githubusercontent.com/2322354/95357435-d9abdb00-0895-11eb-8fd5-0e76950fd771.png">

cc'ing @stokesman 

Looking back at the initial issue (https://github.com/WordPress/gutenberg/issues/24460), these updates are attempting to fix some number input entering.

~I haven't been able to replicate the issues. Maybe I'm not entering things correctly (to break it) in my keyboard?~
~I'd love to know more info about this.~
~On top of reverts, I'd like to add solutions for the issues mentioned in https://github.com/WordPress/gutenberg/issues/24460~

## Updates

Beyond the revert, the changes can be seen here:

https://github.com/WordPress/gutenberg/pull/25913/files#diff-559f6ca9af4f175b7f7d4b1741a7f4d6R66-R83

https://github.com/WordPress/gutenberg/pull/25913/files#diff-559f6ca9af4f175b7f7d4b1741a7f4d6R30-R42

### 📹 Demo + Walkthrough

I recorded a video demo + walkthrough that showcases the issue and describes the fixes:
https://www.loom.com/share/22b6d3b1b61140e4a667ed61a6858f52

### ⚛️ Fixing State Handling

The issue was that the inner number input wasn't correctly handling and coordinating values/changes between the UI element (`input[type="number"]`) and the state that exists within the wrapping `RangeControl` component.

The solution involved swapping `useControlledState` for a simple `useState` + `useEffect` hook combination for state management and syncing within the inner number `InputField`.

The solution also involved (re)adding the HTML validation step before "commiting" (firing the `onChange`) callback. This allows for "invalid" state to be held within the number input before pushing it upwards.

What this means, is that users will be able to **type** in values like `123`, when the `min` attribute is set to `20`.

Previously, it would **jump** to `20` because typing in the initial character (`1`) would trigger onChange immediately... which clamps the value and propagates it updates.

This is no longer the case! (Thank goodness)

### 🗜 Clamping onChange

Secondly, the final value that is sent from the `RangeControl` onChange callback is clamped. Previously, this was not the case. We also didn't spot this problem due to the above mentioned issue.

## How has this been tested?

* Confirm reverting the commits fixes BoxControl issues and overall drag to update interaction
* Confirm `RangeControl` state flow is working

(Note: For drag to update, I think order matters for the `onMouseDown` callback. This isn't as tricky as the update that adjusts the update mechanism to rely on the `blur` event)


## How to test

* Run `npm run dev`
* Add a Cover block
* Adjust the height using the input control. This should work.
* Add a Columns block
* Interfacing with the RangeControl + accompanying number input should work.

## Checklist:
- [x] My code is tested.
- [n/a] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [n/a] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [n/a] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [n/a] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
