### PR TITLE
Heading block: add wide and full width options

### DIFF
--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -21,6 +21,7 @@
 		}
 	},
 	"supports": {
+		"align": [ "full", "wide" ],
 		"anchor": true,
 		"className": false,
 		"color": {


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/25655