### PR TITLE
Social Links: Add ability to change social icon sizes

### DIFF
--- a/packages/block-library/src/social-link/editor.scss
+++ b/packages/block-library/src/social-link/editor.scss
@@ -6,14 +6,15 @@
 	button {
 		font-size: inherit;
 		color: currentColor;
-		padding: 0;
 		height: auto;
 		line-height: 0;
+
+		// This rule is duplicated from the style.scss and needs to be the same as there.
+		padding: 0.25em;
 	}
 }
-/*
+
 .wp-block-social-links.is-style-pill-shape .wp-social-link button {
-	padding-left: 16px;
-	padding-right: 16px;
+	padding-left: 0.6666em;
+	padding-right: 0.6666em;
 }
-*/

--- a/packages/block-library/src/social-link/editor.scss
+++ b/packages/block-library/src/social-link/editor.scss
@@ -1,6 +1,7 @@
 .wp-block-social-links .wp-social-link button {
 	color: currentColor;
 	padding: 6px;
+	height: var(--wp-social-link-size);
 }
 
 .wp-block-social-links.is-style-pill-shape .wp-social-link button {

--- a/packages/block-library/src/social-link/editor.scss
+++ b/packages/block-library/src/social-link/editor.scss
@@ -15,6 +15,6 @@
 }
 
 .wp-block-social-links.is-style-pill-shape .wp-social-link button {
-	padding-left: 0.6666em;
-	padding-right: 0.6666em;
+	padding-left: calc((2/3) * 1em);
+	padding-right: calc((2/3) * 1em);
 }

--- a/packages/block-library/src/social-link/editor.scss
+++ b/packages/block-library/src/social-link/editor.scss
@@ -1,10 +1,18 @@
-.wp-block-social-links .wp-social-link button {
-	color: currentColor;
-	padding: 6px;
-	height: var(--wp-social-link-size);
-}
+// The editor uses the button component, the frontend uses a link.
+// Therefore we unstyle the button component to make it more like the frontend.
+.wp-block-social-links .wp-social-link {
+	line-height: 0;
 
+	button {
+		color: currentColor;
+		padding: 0;
+		height: auto;
+		line-height: 0;
+	}
+}
+/*
 .wp-block-social-links.is-style-pill-shape .wp-social-link button {
 	padding-left: 16px;
 	padding-right: 16px;
 }
+*/

--- a/packages/block-library/src/social-link/editor.scss
+++ b/packages/block-library/src/social-link/editor.scss
@@ -4,6 +4,7 @@
 	line-height: 0;
 
 	button {
+		font-size: inherit;
 		color: currentColor;
 		padding: 0;
 		height: auto;

--- a/packages/block-library/src/social-links/block.json
+++ b/packages/block-library/src/social-links/block.json
@@ -7,7 +7,7 @@
 			"type": "boolean",
 			"default": false
 		},
-		"iconSize": {
+		"size": {
 			"type": "string"
 		}
 	},

--- a/packages/block-library/src/social-links/block.json
+++ b/packages/block-library/src/social-links/block.json
@@ -6,6 +6,9 @@
 		"openInNewTab": {
 			"type": "boolean",
 			"default": false
+		},
+		"iconSize": {
+			"type": "string"
 		}
 	},
 	"providesContext": {

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -66,7 +66,11 @@ export function SocialLinksEdit( props ) {
 				<ToolbarGroup>
 					<ToolbarItem>
 						{ () => (
-							<DropdownMenu label={ __( 'Size' ) }>
+							<DropdownMenu
+								label={ __( 'Size' ) }
+								text={ __( 'Size' ) }
+								icon={ null }
+							>
 								{ ( onClose ) => (
 									<MenuGroup>
 										{ sizeOptions.map( ( entry ) => {

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -74,7 +74,10 @@ export function SocialLinksEdit( props ) {
 				<Dropdown
 					className={ 'icon-size-picker__dropdown' }
 					contentClassName={ 'icon-size-picker__dropdowncontent' }
-					popoverProps={ { position: 'bottom right' } }
+					popoverProps={ {
+						isAlternate: true,
+						position: 'bottom right',
+					} }
 					renderToggle={ ( { isOpen, onToggle } ) => (
 						<ToolbarGroup>
 							<ToolbarButton

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -25,6 +25,7 @@ import {
 	ToolbarGroup,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { check } from '@wordpress/icons';
 import { DOWN } from '@wordpress/keycodes';
 
 const ALLOWED_BLOCKS = [ 'core/social-link' ];
@@ -91,14 +92,17 @@ export function SocialLinksEdit( props ) {
 							{ sizeOptions.map( ( entry ) => {
 								return (
 									<MenuItem
-										key={ entry.value }
-										role="menuitemradio"
+										icon={
+											iconSize === entry.value && check
+										}
 										isSelected={ iconSize === entry.value }
+										key={ entry.value }
 										onClick={ () =>
 											setAttributes( {
 												iconSize: entry.value,
 											} )
 										}
+										role="menuitemradio"
 									>
 										{ entry.name }
 									</MenuItem>

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -96,7 +96,11 @@ export function SocialLinksEdit( props ) {
 								return (
 									<MenuItem
 										icon={
-											iconSize === entry.value && check
+											( iconSize === entry.value ||
+												( ! iconSize &&
+													entry.value ===
+														'has-normal-icon-size' ) ) &&
+											check
 										}
 										isSelected={ iconSize === entry.value }
 										key={ entry.value }

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -16,17 +16,16 @@ import {
 	InspectorControls,
 } from '@wordpress/block-editor';
 import {
-	Dropdown,
+	DropdownMenu,
 	MenuGroup,
 	MenuItem,
 	PanelBody,
 	ToggleControl,
-	ToolbarButton,
+	ToolbarItem,
 	ToolbarGroup,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { check } from '@wordpress/icons';
-import { DOWN } from '@wordpress/keycodes';
 
 const ALLOWED_BLOCKS = [ 'core/social-link' ];
 
@@ -61,63 +60,48 @@ export function SocialLinksEdit( props ) {
 		__experimentalAppenderTagName: 'li',
 	} );
 
-	const openOnArrowDown = ( event ) => {
-		if ( event.keyCode === DOWN ) {
-			event.preventDefault();
-			event.stopPropagation();
-			event.target.click();
-		}
-	};
 	return (
 		<Fragment>
 			<BlockControls>
-				<Dropdown
-					className={ 'icon-size-picker__dropdown' }
-					contentClassName={ 'icon-size-picker__dropdowncontent' }
-					popoverProps={ {
-						isAlternate: true,
-						position: 'bottom right',
-					} }
-					renderToggle={ ( { isOpen, onToggle } ) => (
-						<ToolbarGroup>
-							<ToolbarButton
-								onClick={ onToggle }
-								onKeyDown={ openOnArrowDown }
-								aria-expanded={ isOpen }
-								aria-haspopup="true"
-							>
-								{ __( 'Size' ) }
-							</ToolbarButton>
-						</ToolbarGroup>
-					) }
-					renderContent={ () => (
-						<MenuGroup label={ __( 'Icon size' ) }>
-							{ sizeOptions.map( ( entry ) => {
-								return (
-									<MenuItem
-										icon={
-											( size === entry.value ||
-												( ! size &&
-													entry.value ===
-														'has-normal-icon-size' ) ) &&
-											check
-										}
-										isSelected={ size === entry.value }
-										key={ entry.value }
-										onClick={ () =>
-											setAttributes( {
-												size: entry.value,
-											} )
-										}
-										role="menuitemradio"
-									>
-										{ entry.name }
-									</MenuItem>
-								);
-							} ) }
-						</MenuGroup>
-					) }
-				/>
+				<ToolbarGroup>
+					<ToolbarItem>
+						{ () => (
+							<DropdownMenu label={ __( 'Size' ) }>
+								{ ( onClose ) => (
+									<MenuGroup>
+										{ sizeOptions.map( ( entry ) => {
+											return (
+												<MenuItem
+													icon={
+														( size ===
+															entry.value ||
+															( ! size &&
+																entry.value ===
+																	'has-normal-icon-size' ) ) &&
+														check
+													}
+													isSelected={
+														size === entry.value
+													}
+													key={ entry.value }
+													onClick={ () => {
+														setAttributes( {
+															size: entry.value,
+														} );
+													} }
+													onClose={ onClose }
+													role="menuitemradio"
+												>
+													{ entry.name }
+												</MenuItem>
+											);
+										} ) }
+									</MenuGroup>
+								) }
+							</DropdownMenu>
+						) }
+					</ToolbarItem>
+				</ToolbarGroup>
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Link settings' ) }>

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classNames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 
@@ -9,14 +14,45 @@ import {
 	useBlockProps,
 	InspectorControls,
 } from '@wordpress/block-editor';
-import { ToggleControl, PanelBody } from '@wordpress/components';
+import {
+	CustomSelectControl,
+	PanelBody,
+	ToggleControl,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 const ALLOWED_BLOCKS = [ 'core/social-link' ];
 
+// The default_option is used for the CustomSelectControl if no value is found.
+// This prevents deprecation issues for social links without a default size set.
+const defaultOption = {
+	name: __( 'Normal' ),
+	key: 'has-normal-icon-size',
+	style: { fontSize: '100%' },
+};
+
+const iconOptions = [
+	{
+		key: 'has-small-icon-size',
+		name: __( 'Small' ),
+		style: { fontSize: '75%' },
+	},
+	defaultOption,
+	{
+		name: __( 'Large' ),
+		key: 'has-large-icon-size',
+		style: { fontSize: '150%' },
+	},
+	{
+		name: __( 'Huge' ),
+		key: 'has-huge-icon-size',
+		style: { fontSize: '200%' },
+	},
+];
+
 export function SocialLinksEdit( props ) {
 	const {
-		attributes: { openInNewTab },
+		attributes: { iconSize, openInNewTab },
 		setAttributes,
 	} = props;
 
@@ -28,7 +64,8 @@ export function SocialLinksEdit( props ) {
 		</div>
 	);
 
-	const blockProps = useBlockProps();
+	const className = classNames( iconSize );
+	const blockProps = useBlockProps( { className } );
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: ALLOWED_BLOCKS,
 		orientation: 'horizontal',
@@ -36,9 +73,25 @@ export function SocialLinksEdit( props ) {
 		templateLock: false,
 		__experimentalAppenderTagName: 'li',
 	} );
+
 	return (
 		<Fragment>
 			<InspectorControls>
+				<PanelBody title={ __( 'Icon size' ) }>
+					<CustomSelectControl
+						className={ 'components-icon-size-picker__select' }
+						label={ __( 'Icon size' ) }
+						options={ iconOptions }
+						value={
+							iconOptions.find(
+								( option ) => option.key === iconSize
+							) || defaultOption
+						}
+						onChange={ ( { selectedItem } ) => {
+							setAttributes( { iconSize: selectedItem.key } );
+						} }
+					/>
+				</PanelBody>
 				<PanelBody title={ __( 'Link settings' ) }>
 					<ToggleControl
 						label={ __( 'Open links in new tab' ) }

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -45,9 +45,9 @@ export function SocialLinksEdit( props ) {
 
 	const SocialPlaceholder = (
 		<div className="wp-block-social-links__social-placeholder">
-			<div className="wp-block-social-link wp-social-link-facebook"></div>
-			<div className="wp-block-social-link wp-social-link-twitter"></div>
-			<div className="wp-block-social-link wp-social-link-instagram"></div>
+			<div className="wp-social-link wp-social-link-facebook"></div>
+			<div className="wp-social-link wp-social-link-twitter"></div>
+			<div className="wp-social-link wp-social-link-instagram"></div>
 		</div>
 	);
 

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -39,7 +39,7 @@ const sizeOptions = [
 
 export function SocialLinksEdit( props ) {
 	const {
-		attributes: { iconSize, openInNewTab },
+		attributes: { size, openInNewTab },
 		setAttributes,
 	} = props;
 
@@ -51,7 +51,7 @@ export function SocialLinksEdit( props ) {
 		</div>
 	);
 
-	const className = classNames( iconSize );
+	const className = classNames( size );
 	const blockProps = useBlockProps( { className } );
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: ALLOWED_BLOCKS,
@@ -96,17 +96,17 @@ export function SocialLinksEdit( props ) {
 								return (
 									<MenuItem
 										icon={
-											( iconSize === entry.value ||
-												( ! iconSize &&
+											( size === entry.value ||
+												( ! size &&
 													entry.value ===
 														'has-normal-icon-size' ) ) &&
 											check
 										}
-										isSelected={ iconSize === entry.value }
+										isSelected={ size === entry.value }
 										key={ entry.value }
 										onClick={ () =>
 											setAttributes( {
-												iconSize: entry.value,
+												size: entry.value,
 											} )
 										}
 										role="menuitemradio"

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -10,44 +10,30 @@ import classNames from 'classnames';
 import { Fragment } from '@wordpress/element';
 
 import {
+	BlockControls,
 	__experimentalUseInnerBlocksProps as useInnerBlocksProps,
 	useBlockProps,
 	InspectorControls,
 } from '@wordpress/block-editor';
 import {
-	CustomSelectControl,
+	Dropdown,
+	MenuGroup,
+	MenuItem,
 	PanelBody,
 	ToggleControl,
+	ToolbarButton,
+	ToolbarGroup,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { DOWN } from '@wordpress/keycodes';
 
 const ALLOWED_BLOCKS = [ 'core/social-link' ];
 
-// The default_option is used for the CustomSelectControl if no value is found.
-// This prevents deprecation issues for social links without a default size set.
-const defaultOption = {
-	name: __( 'Normal' ),
-	key: 'has-normal-icon-size',
-	style: { fontSize: '100%' },
-};
-
-const iconOptions = [
-	{
-		key: 'has-small-icon-size',
-		name: __( 'Small' ),
-		style: { fontSize: '75%' },
-	},
-	defaultOption,
-	{
-		name: __( 'Large' ),
-		key: 'has-large-icon-size',
-		style: { fontSize: '150%' },
-	},
-	{
-		name: __( 'Huge' ),
-		key: 'has-huge-icon-size',
-		style: { fontSize: '200%' },
-	},
+const sizeOptions = [
+	{ name: __( 'Small' ), value: 'has-small-icon-size' },
+	{ name: __( 'Normal' ), value: 'has-normal-icon-size' },
+	{ name: __( 'Large' ), value: 'has-large-icon-size' },
+	{ name: __( 'Huge' ), value: 'has-huge-icon-size' },
 ];
 
 export function SocialLinksEdit( props ) {
@@ -74,24 +60,55 @@ export function SocialLinksEdit( props ) {
 		__experimentalAppenderTagName: 'li',
 	} );
 
+	const openOnArrowDown = ( event ) => {
+		if ( event.keyCode === DOWN ) {
+			event.preventDefault();
+			event.stopPropagation();
+			event.target.click();
+		}
+	};
 	return (
 		<Fragment>
+			<BlockControls>
+				<Dropdown
+					className={ 'icon-size-picker__dropdown' }
+					contentClassName={ 'icon-size-picker__dropdowncontent' }
+					popoverProps={ { position: 'bottom right' } }
+					renderToggle={ ( { isOpen, onToggle } ) => (
+						<ToolbarGroup>
+							<ToolbarButton
+								onClick={ onToggle }
+								onKeyDown={ openOnArrowDown }
+								aria-expanded={ isOpen }
+								aria-haspopup="true"
+							>
+								{ __( 'Size' ) }
+							</ToolbarButton>
+						</ToolbarGroup>
+					) }
+					renderContent={ () => (
+						<MenuGroup label={ __( 'Icon size' ) }>
+							{ sizeOptions.map( ( entry ) => {
+								return (
+									<MenuItem
+										key={ entry.value }
+										role="menuitemradio"
+										isSelected={ iconSize === entry.value }
+										onClick={ () =>
+											setAttributes( {
+												iconSize: entry.value,
+											} )
+										}
+									>
+										{ entry.name }
+									</MenuItem>
+								);
+							} ) }
+						</MenuGroup>
+					) }
+				/>
+			</BlockControls>
 			<InspectorControls>
-				<PanelBody title={ __( 'Icon size' ) }>
-					<CustomSelectControl
-						className={ 'components-icon-size-picker__select' }
-						label={ __( 'Icon size' ) }
-						options={ iconOptions }
-						value={
-							iconOptions.find(
-								( option ) => option.key === iconSize
-							) || defaultOption
-						}
-						onChange={ ( { selectedItem } ) => {
-							setAttributes( { iconSize: selectedItem.key } );
-						} }
-					/>
-				</PanelBody>
 				<PanelBody title={ __( 'Link settings' ) }>
 					<ToggleControl
 						label={ __( 'Open links in new tab' ) }

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -60,6 +60,11 @@ export function SocialLinksEdit( props ) {
 		__experimentalAppenderTagName: 'li',
 	} );
 
+	const POPOVER_PROPS = {
+		position: 'bottom right',
+		isAlternate: true,
+	};
+
 	return (
 		<Fragment>
 			<BlockControls>
@@ -70,6 +75,7 @@ export function SocialLinksEdit( props ) {
 								label={ __( 'Size' ) }
 								text={ __( 'Size' ) }
 								icon={ null }
+								popoverProps={ POPOVER_PROPS }
 							>
 								{ ( onClose ) => (
 									<MenuGroup>

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -70,14 +70,20 @@ export function SocialLinksEdit( props ) {
 			<BlockControls>
 				<ToolbarGroup>
 					<ToolbarItem>
-						{ () => (
+						{ ( toggleProps ) => (
 							<DropdownMenu
 								label={ __( 'Size' ) }
-								text={ __( 'Size' ) }
+								text={
+									// Display size value Small, Large, etc..
+									sizeOptions.find(
+										( opt ) => opt.value === size
+									).name || __( 'Size' )
+								}
 								icon={ null }
 								popoverProps={ POPOVER_PROPS }
+								toggleProps={ toggleProps }
 							>
-								{ ( onClose ) => (
+								{ ( { onClose } ) => (
 									<MenuGroup>
 										{ sizeOptions.map( ( entry ) => {
 											return (

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -73,12 +73,7 @@ export function SocialLinksEdit( props ) {
 						{ ( toggleProps ) => (
 							<DropdownMenu
 								label={ __( 'Size' ) }
-								text={
-									// Display size value Small, Large, etc..
-									sizeOptions.find(
-										( opt ) => opt.value === size
-									).name || __( 'Size' )
-								}
+								text={ __( 'Size' ) }
 								icon={ null }
 								popoverProps={ POPOVER_PROPS }
 								toggleProps={ toggleProps }

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -34,7 +34,7 @@
 		opacity: 0.8;
 	}
 }
-
+// @todo fix these so they work for placeholders
 .is-style-logos-only .wp-block-social-links__social-placeholder .wp-block-social-link::before {
 	content: "";
 	display: block;

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -21,34 +21,28 @@
 // Placeholder/setup state.
 .wp-block-social-links__social-placeholder {
 	display: flex;
-	min-height: 24px;
+	opacity: 0.8;
 
 	.wp-social-link {
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		margin: $grid-unit-05 $grid-unit-10 $grid-unit-05 0;
-		width: 36px;
-		height: 36px;
-		border-radius: $radius-round;
-		opacity: 0.8;
-	}
-}
-// @todo fix these so they work for placeholders
-.is-style-logos-only .wp-block-social-links__social-placeholder .wp-block-social-link::before {
-	content: "";
-	display: block;
-	width: 18px;
-	height: 18px;
-	border-radius: $radius-round;
-	opacity: 0.8;
-	background: currentColor;
-}
+		padding: 0.25em;
 
-.is-style-pill-shape .wp-block-social-links__social-placeholder .wp-block-social-link {
-	border-radius: 9999px;
-	padding-left: 16px + 12px;
-	padding-right: 16px + 12px;
+		.is-style-pill-shape & {
+			padding-left: 0.6666em;
+			padding-right: 0.6666em;
+		}
+	}
+
+	.wp-social-link::before {
+		content: "";
+		display: block;
+		width: 1em;
+		height: 1em;
+		border-radius: $radius-round;
+
+		.is-style-logos-only & {
+			background: currentColor;
+		}
+	}
 }
 
 // Polish the Appender.

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -32,6 +32,10 @@
 		}
 	}
 
+	.wp-social-link:hover {
+		transform: none;
+	}
+
 	.wp-social-link::before {
 		content: "";
 		display: block;

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -7,11 +7,8 @@
 }
 
 // Prevent toolbar from jumping when selecting / hovering a link.
-.editor-styles-wrapper .wp-block-social-link {
-	&.is-selected,
-	&.is-hovered {
-		transform: none;
-	}
+.wp-social-link:hover {
+	transform: none;
 }
 
 .editor-styles-wrapper .wp-block-social-links {
@@ -30,10 +27,6 @@
 			padding-left: calc((2/3) * 1em);
 			padding-right: calc((2/3) * 1em);
 		}
-	}
-
-	.wp-social-link:hover {
-		transform: none;
 	}
 
 	.wp-social-link::before {

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -6,13 +6,8 @@
 	}
 }
 
-// Reduce the paddings, margins, and UI of inner-blocks.
-// @todo: eventually we may add a feature that lets a parent container absorb the block UI of a child block.
-// When that happens, leverage that instead of the following overrides.
+// Prevent toolbar from jumping when selecting / hovering a link.
 .editor-styles-wrapper .wp-block-social-link {
-	margin: 0 8px 8px 0;
-
-	// Prevent toolbar from jumping when selecting / hovering a link.
 	&.is-selected,
 	&.is-hovered {
 		transform: none;
@@ -26,12 +21,13 @@
 // Placeholder/setup state.
 .wp-block-social-links__social-placeholder {
 	display: flex;
+	min-height: 24px;
 
-	.wp-block-social-link {
+	.wp-social-link {
 		display: inline-flex;
 		align-items: center;
 		justify-content: center;
-		margin: 0 $grid-unit-10 $grid-unit-10 0;
+		margin: $grid-unit-05 $grid-unit-10 $grid-unit-05 0;
 		width: 36px;
 		height: 36px;
 		border-radius: $radius-round;
@@ -57,9 +53,14 @@
 
 // Polish the Appender.
 .wp-block-social-links .block-list-appender {
-	margin: 0 0 $grid-unit-10 0;
+	margin: -$grid-unit-10 0;
 	display: flex;
 	align-items: center;
+
+	svg {
+		width: $icon-size;
+		height: $icon-size;
+	}
 }
 
 // Center flex items. This has an equivalent in style.scss.
@@ -71,12 +72,6 @@
 // @todo: Look at improving the preview component to make this unnecessary.
 .block-editor-block-preview__content .wp-social-link:disabled {
 	opacity: 1;
-}
-
-// Selected/unselected states.
-// Unselected block is preview, selected has additional options.
-[data-type="core/social-links"]:not(.is-selected):not(.has-child-selected) .wp-block-social-links {
-	min-height: 36px; // This height matches the height of the buttons and ensures an empty block doesn't collapse.
 }
 
 // Unconfigured placeholder links are semitransparent.

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -27,8 +27,8 @@
 		padding: 0.25em;
 
 		.is-style-pill-shape & {
-			padding-left: 0.6666em;
-			padding-right: 0.6666em;
+			padding-left: calc((2/3) * 1em);
+			padding-right: calc((2/3) * 1em);
 		}
 	}
 

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -70,7 +70,7 @@
 
 // Improve the preview, ensure buttons are fully opaque despite being disabled.
 // @todo: Look at improving the preview component to make this unnecessary.
-.block-editor-block-preview__content .wp-social-link:disabled {
+.block-editor-block-preview__content .components-button:disabled {
 	opacity: 1;
 }
 
@@ -95,11 +95,4 @@
 
 	// Windows High Contrast mode will show this outline, but not the box-shadow.
 	outline: 2px solid transparent;
-}
-
-// To ensure a better selection footprint when editing, attach the margin to the block container.
-// @todo: This can very probably be removed entirely when this block receives a lighter DOM.
-.is-navigate-mode .block-editor-block-list__layout .block-editor-block-list__block[data-type="core/social-link"].is-selected::after,
-.block-editor-block-list__layout .block-editor-block-list__block[data-type="core/social-link"]:not([contenteditable]):focus::after {
-	right: 8px;
 }

--- a/packages/block-library/src/social-links/save.js
+++ b/packages/block-library/src/social-links/save.js
@@ -10,10 +10,10 @@ import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
 export default function save( props ) {
 	const {
-		attributes: { iconSize },
+		attributes: { size },
 	} = props;
 
-	const className = classNames( iconSize );
+	const className = classNames( size );
 
 	return (
 		<ul { ...useBlockProps.save( { className } ) }>

--- a/packages/block-library/src/social-links/save.js
+++ b/packages/block-library/src/social-links/save.js
@@ -1,11 +1,22 @@
 /**
+ * External dependencies
+ */
+import classNames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
-export default function save() {
+export default function save( props ) {
+	const {
+		attributes: { iconSize },
+	} = props;
+
+	const className = classNames( iconSize );
+
 	return (
-		<ul { ...useBlockProps.save() }>
+		<ul { ...useBlockProps.save( { className } ) }>
 			<InnerBlocks.Content />
 		</ul>
 	);

--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -23,7 +23,9 @@
 
 		// By setting the font size, we can scale icons and paddings consistently based on that.
 		// This also allows themes to override this, if need be.
-		padding: 0.25em;
+		a {
+			padding: 0.25em;
+		}
 
 		svg {
 			width: 1em;
@@ -116,7 +118,7 @@
 	}
 
 	.wp-social-link a {
-		padding-left: 16px;
-		padding-right: 16px;
+		padding-left: 0.6666em;
+		padding-right: 0.6666em;
 	}
 }

--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -118,7 +118,7 @@
 	}
 
 	.wp-social-link a {
-		padding-left: 0.6666em;
-		padding-right: 0.6666em;
+		padding-left: calc((2/3) * 1em);
+		padding-right: calc((2/3) * 1em);
 	}
 }

--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -1,6 +1,23 @@
-.wp-social-link {
-	--social-link-size: 36px;
-	--social-link-logo-size: 24px;
+
+// Normal / default size
+:root {
+	--wp-social-link-size: 36px;
+	--wp-social-link-logo-size: 24px;
+}
+
+.has-huge-icon-size > .wp-social-link {
+	--wp-social-link-size: 60px;
+	--wp-social-link-logo-size: 48px;
+}
+
+.has-large-icon-size > .wp-social-link {
+	--wp-social-link-size: 48px;
+	--wp-social-link-logo-size: 36px;
+}
+
+.has-small-icon-size > .wp-social-link {
+	--wp-social-link-size: 30px;
+	--wp-social-link-logo-size: 18px;
 }
 
 .wp-block-social-links {
@@ -46,8 +63,8 @@
 	svg {
 		color: currentColor;
 		fill: currentColor;
-		width: var(--social-link-logo-size);
-		height: var(--social-link-logo-size);
+		width: var(--wp-social-link-logo-size);
+		height: var(--wp-social-link-logo-size);
 	}
 
 	&:hover {

--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -1,25 +1,3 @@
-
-// Normal / default size
-:root {
-	--wp-social-link-size: 36px;
-	--wp-social-link-logo-size: 24px;
-}
-
-.has-huge-icon-size > .wp-social-link {
-	--wp-social-link-size: 60px;
-	--wp-social-link-logo-size: 48px;
-}
-
-.has-large-icon-size > .wp-social-link {
-	--wp-social-link-size: 48px;
-	--wp-social-link-logo-size: 36px;
-}
-
-.has-small-icon-size > .wp-social-link {
-	--wp-social-link-size: 30px;
-	--wp-social-link-logo-size: 18px;
-}
-
 .wp-block-social-links {
 	display: flex;
 	flex-wrap: wrap;
@@ -38,19 +16,58 @@
 		border-bottom: 0;
 		box-shadow: none;
 	}
+
+	// Vertically balance the margin of each icon.
+	.wp-social-link {
+		margin: 4px 8px 4px 0;
+	}
+
+	// Icon sizes.
+	// Small.
+	&.has-small-icon-size {
+		svg {
+			width: 18px;
+			height: 18px;
+		}
+	}
+
+	// Normal/default.
+	&,
+	&.has-normal-icon-size {
+		// 24 & 36 button
+		svg {
+			width: 24px;
+			height: 24px;
+		}
+	}
+
+	// Large.
+	&.has-large-icon-size {
+		svg {
+			width: 36px;
+			height: 36px;
+		}
+	}
+
+	// Huge.
+	&.has-huge-icon-size {
+		svg {
+			width: 48px;
+			height: 48px;
+		}
+	}
 }
 
 .wp-social-link {
 	display: block;
-	width: var(--social-link-size);
-	height: var(--social-link-size);
 	border-radius: 9999px; // This makes it pill-shaped instead of oval, in cases where the image fed is not perfectly sized.
-	margin: 0 8px 8px 0;
 	transition: transform 0.1s ease;
 	@include reduce-motion("transition");
 
+	// Dimensions.
+	height: auto;
+
 	a {
-		padding: 6px;
 		display: block;
 		line-height: 0;
 		transition: transform 0.1s ease;
@@ -63,8 +80,6 @@
 	svg {
 		color: currentColor;
 		fill: currentColor;
-		width: var(--wp-social-link-logo-size);
-		height: var(--wp-social-link-logo-size);
 	}
 
 	&:hover {

--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -1,3 +1,8 @@
+.wp-social-link {
+	--social-link-size: 36px;
+	--social-link-logo-size: 24px;
+}
+
 .wp-block-social-links {
 	display: flex;
 	flex-wrap: wrap;
@@ -20,8 +25,8 @@
 
 .wp-social-link {
 	display: block;
-	width: 36px;
-	height: 36px;
+	width: var(--social-link-size);
+	height: var(--social-link-size);
 	border-radius: 9999px; // This makes it pill-shaped instead of oval, in cases where the image fed is not perfectly sized.
 	margin: 0 8px 8px 0;
 	transition: transform 0.1s ease;
@@ -41,6 +46,8 @@
 	svg {
 		color: currentColor;
 		fill: currentColor;
+		width: var(--social-link-logo-size);
+		height: var(--social-link-logo-size);
 	}
 
 	&:hover {
@@ -69,10 +76,6 @@
 
 		// Make these bigger.
 		padding: 4px;
-		svg {
-			width: 28px;
-			height: 28px;
-		}
 	}
 
 	@import "../social-link/socials-without-bg.scss";

--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -20,41 +20,37 @@
 	// Vertically balance the margin of each icon.
 	.wp-social-link {
 		margin: 4px 8px 4px 0;
+
+		// By setting the font size, we can scale icons and paddings consistently based on that.
+		// This also allows themes to override this, if need be.
+		padding: 0.25em;
+
+		svg {
+			width: 1em;
+			height: 1em;
+		}
 	}
 
 	// Icon sizes.
 	// Small.
 	&.has-small-icon-size {
-		svg {
-			width: 18px;
-			height: 18px;
-		}
+		font-size: 16px; // 16 makes for a quarter-padding that keeps the icon centered.
 	}
 
 	// Normal/default.
 	&,
 	&.has-normal-icon-size {
-		// 24 & 36 button
-		svg {
-			width: 24px;
-			height: 24px;
-		}
+		font-size: 24px;
 	}
 
 	// Large.
 	&.has-large-icon-size {
-		svg {
-			width: 36px;
-			height: 36px;
-		}
+		font-size: 36px;
 	}
 
 	// Huge.
 	&.has-huge-icon-size {
-		svg {
-			width: 48px;
-			height: 48px;
-		}
+		font-size: 48px;
 	}
 }
 

--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -19,7 +19,10 @@
 
 	// Vertically balance the margin of each icon.
 	.wp-social-link {
-		margin: 4px 8px 4px 0;
+		// This needs specificity to override some themes.
+		&.wp-social-link.wp-social-link {
+			margin: 4px 8px 4px 0;
+		}
 
 		// By setting the font size, we can scale icons and paddings consistently based on that.
 		// This also allows themes to override this, if need be.


### PR DESCRIPTION
## Description

This adds a size button control to the block toolbar, that lets you pick between 4 different sizes of icons (Small, Normal, Large, Huge). Those sizes affect the default style, the pill shape style, the logos only style, and even those variations of the new setup state as well.

Fixes #17276

## How has this been tested?

- (Backwards Compatibility) Create a post with social icons and confirm after applying the PR that they still can be edited and changed.
- Add social icons, adjust their sizes using the sidebar
- Confirm the new sizes look right in the editor and published.

## Screenshots

![social-link-size](https://user-images.githubusercontent.com/45363/95382604-bafe1200-089e-11eb-81c3-8a95621b1e75.gif)


## Types of changes

- Adds new attribute for size for Social Links
- Adds CustomSelect control to adjust sizes
- Adds custom CSS property for different sizes