### PR TITLE
Fix e2e tests related to template parts

### DIFF
--- a/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
@@ -168,7 +168,7 @@ describe( 'Multi-entity editor states', () => {
 	} );
 
 	it( 'should not dirty an entity by switching to it in the template dropdown', async () => {
-		await clickTemplateItem( 'Template parts', 'header' );
+		await clickTemplateItem( 'Template Parts', 'header' );
 
 		// Wait for blocks to load.
 		await page.waitForSelector( '.wp-block' );

--- a/packages/e2e-tests/specs/experiments/template-part.test.js
+++ b/packages/e2e-tests/specs/experiments/template-part.test.js
@@ -44,12 +44,11 @@ describe( 'Template Part', () => {
 			await page.waitForSelector( '.edit-site-visual-editor' );
 		} );
 
-		// eslint-disable-next-line jest/no-disabled-tests
-		it.skip( 'Should load customizations when in a template even if only the slug and theme attributes are set.', async () => {
+		it( 'Should load customizations when in a template even if only the slug and theme attributes are set.', async () => {
 			// Switch to editing the header template part.
 			await navigationPanel.open();
 			await navigationPanel.backToRoot();
-			await navigationPanel.navigate( 'Template parts' );
+			await navigationPanel.navigate( 'Template Parts' );
 			await navigationPanel.clickItemByText( 'header' );
 
 			// Edit it.

--- a/packages/edit-site/src/components/left-sidebar/navigation-panel/menus/template-parts.js
+++ b/packages/edit-site/src/components/left-sidebar/navigation-panel/menus/template-parts.js
@@ -15,13 +15,10 @@ import TemplateNavigationItems from '../template-navigation-items';
 
 export default function TemplatePartsMenu( { onActivateItem } ) {
 	const templateParts = useSelect( ( select ) => {
-		const currentTheme = select( 'core' ).getCurrentTheme()?.textdomain;
-
 		return select( 'core' ).getEntityRecords(
 			'postType',
 			'wp_template_part',
 			{
-				theme: currentTheme,
 				status: [ 'publish', 'auto-draft' ],
 				per_page: -1,
 			}


### PR DESCRIPTION
**Note: There are still other e2e tests failing. This just fixes the most immediate issues. I haven't been able to track down solid fixes for the others quite yet.**

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
A few e2e tests are failing in master. The issue (I think) is that the text of a button is "Template Part", but the test queries for an xpath with text "Template part".

Additionally, there was an issue where the new nav sidebar did not display demo template parts, because it was querying for template parts associated only with the current theme.

This also reverts the previous attempt to skip failing tests in #25918.

Closes #25919



## How has this been tested?
e2e tests should not report issues with template parts in this PR.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
