### PR TITLE
Social Link: Rename mail to email

### DIFF
--- a/packages/block-library/src/social-link/variations.js
+++ b/packages/block-library/src/social-link/variations.js
@@ -175,7 +175,7 @@ const variations = [
 	{
 		name: 'mail',
 		attributes: { service: 'mail' },
-		title: 'Mail',
+		title: 'Email',
 		icon: MailIcon,
 	},
 	{

--- a/packages/block-library/src/social-link/variations.js
+++ b/packages/block-library/src/social-link/variations.js
@@ -175,7 +175,8 @@ const variations = [
 	{
 		name: 'mail',
 		attributes: { service: 'mail' },
-		title: 'Email',
+		title: 'Mail',
+		keywords: [ 'email', 'e-mail' ],
 		icon: MailIcon,
 	},
 	{


### PR DESCRIPTION
## Description

This makes the mail icon show if the user searches for mail or email.
The property value does not change, it stays as 'mail' so is still
compatibility with any existing social links.

The title change only allows it show up in search for both.

Fixes #21733


## How has this been tested?

Feature check:

1. Add a social link block and search for "mail" and "email" when adding an icon.

Compatibility check:

1. Create an existing social link block using the "mail" icon
2. Apply the PR and confirm the existing link works.


## Types of changes

1. Adds the keywords: email and e-mail to the Mail entry

