### PR TITLE
Block Directory: Filter out disallowed blocks before showing available blocks

### DIFF
--- a/packages/block-directory/src/components/downloadable-blocks-panel/index.js
+++ b/packages/block-directory/src/components/downloadable-blocks-panel/index.js
@@ -90,13 +90,15 @@ export default compose( [
 			'block-directory/search'
 		);
 
-		const searchResultBlocks = getDownloadableBlocks( filterValue ).filter(
-			( block ) => {
-				return canInsertBlockType( block, rootClientId, true );
-			}
-		);
+		function getInstallableBlocks( term ) {
+			return getDownloadableBlocks( term ).filter( ( block ) =>
+				canInsertBlockType( block, rootClientId, true )
+			);
+		}
 
-		const downloadableItems = hasPermission ? searchResultBlocks : [];
+		const downloadableItems = hasPermission
+			? getInstallableBlocks( filterValue )
+			: [];
 		const isLoading = isRequestingDownloadableBlocks( filterValue );
 
 		return {

--- a/packages/block-directory/src/components/downloadable-blocks-panel/index.js
+++ b/packages/block-directory/src/components/downloadable-blocks-panel/index.js
@@ -7,6 +7,7 @@ import { withSelect } from '@wordpress/data';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { Spinner } from '@wordpress/components';
 import { speak } from '@wordpress/a11y';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -77,19 +78,25 @@ function DownloadableBlocksPanel( {
 }
 
 export default compose( [
-	withSelect( ( select, { filterValue } ) => {
+	withSelect( ( select, { filterValue, rootClientId = null } ) => {
 		const {
 			getDownloadableBlocks,
 			isRequestingDownloadableBlocks,
 		} = select( blockDirectoryStore );
+		const { canInsertBlockType } = select( blockEditorStore );
 
 		const hasPermission = select( 'core' ).canUser(
 			'read',
 			'block-directory/search'
 		);
-		const downloadableItems = hasPermission
-			? getDownloadableBlocks( filterValue )
-			: [];
+
+		const searchResultBlocks = getDownloadableBlocks( filterValue ).filter(
+			( block ) => {
+				return canInsertBlockType( block, rootClientId, true );
+			}
+		);
+
+		const downloadableItems = hasPermission ? searchResultBlocks : [];
 		const isLoading = isRequestingDownloadableBlocks( filterValue );
 
 		return {

--- a/packages/block-directory/src/plugins/inserter-menu-downloadable-blocks-panel/index.js
+++ b/packages/block-directory/src/plugins/inserter-menu-downloadable-blocks-panel/index.js
@@ -21,7 +21,13 @@ function InserterMenuDownloadableBlocksPanel() {
 
 	return (
 		<__experimentalInserterMenuExtension>
-			{ ( { onSelect, onHover, filterValue, hasItems } ) => {
+			{ ( {
+				onSelect,
+				onHover,
+				filterValue,
+				hasItems,
+				rootClientId,
+			} ) => {
 				if ( hasItems || ! filterValue ) {
 					return null;
 				}
@@ -34,6 +40,7 @@ function InserterMenuDownloadableBlocksPanel() {
 					<DownloadableBlocksPanel
 						onSelect={ onSelect }
 						onHover={ onHover }
+						rootClientId={ rootClientId }
 						filterValue={ debouncedFilterValue }
 						isWaiting={ filterValue !== debouncedFilterValue }
 					/>

--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -153,7 +153,7 @@ function InserterSearchResults( {
 						onHover,
 						filterValue,
 						hasItems,
-						rootClientId,
+						rootClientId: destinationRootClientId,
 					} }
 				>
 					{ ( fills ) => {

--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -153,6 +153,7 @@ function InserterSearchResults( {
 						onHover,
 						filterValue,
 						hasItems,
+						rootClientId,
 					} }
 				>
 					{ ( fills ) => {

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1260,7 +1260,11 @@ const canInsertBlockTypeUnmemoized = (
 		return defaultResult;
 	};
 
-	const blockType = getBlockType( blockName );
+	let blockType = getBlockType( blockName );
+	if ( 'object' === typeof blockName ) {
+		blockType = blockName;
+		blockName = blockType.name;
+	}
 	if ( ! blockType ) {
 		return false;
 	}

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1234,7 +1234,8 @@ export function getTemplateLock( state, rootClientId ) {
  * inside another memoized selector is just a waste of time.
  *
  * @param {Object}         state        Editor state.
- * @param {string|Object}  blockName    The block type object, or a string name of
+ * @param {string|Object}  blockName    The block type object, e.g., the response
+ *                                      from the block directory; or a string name of
  *                                      an installed block type, e.g.' core/paragraph'.
  * @param {?string}        rootClientId Optional root client ID of block list.
  *

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1263,7 +1263,7 @@ const canInsertBlockTypeUnmemoized = (
 	};
 
 	let blockType;
-	if ( 'object' === typeof blockName ) {
+	if ( blockName && 'object' === typeof blockName ) {
 		blockType = blockName;
 		blockName = blockType.name;
 	} else {

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1261,10 +1261,12 @@ const canInsertBlockTypeUnmemoized = (
 		return defaultResult;
 	};
 
-	let blockType = getBlockType( blockName );
+	let blockType;
 	if ( 'object' === typeof blockName ) {
 		blockType = blockName;
 		blockName = blockType.name;
+	} else {
+		blockType = getBlockType( blockName );
 	}
 	if ( ! blockType ) {
 		return false;

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1233,9 +1233,10 @@ export function getTemplateLock( state, rootClientId ) {
  * This function is not exported and not memoized because using a memoized selector
  * inside another memoized selector is just a waste of time.
  *
- * @param {Object}  state        Editor state.
- * @param {string}  blockName    The name of the block type, e.g.' core/paragraph'.
- * @param {?string} rootClientId Optional root client ID of block list.
+ * @param {Object}         state        Editor state.
+ * @param {string|Object}  blockName    The block type object, or a string name of
+ *                                      an installed block type, e.g.' core/paragraph'.
+ * @param {?string}        rootClientId Optional root client ID of block list.
  *
  * @return {boolean} Whether the given block type is allowed to be inserted.
  */


### PR DESCRIPTION
## Description

Some blocks (or post types) have a restricted list of what can be added (`allowedBlocks`, aka child blocks), and we might not be able to add a new block to those containers. Currently, we list all found blocks regardless of this issue, which causes unexpected results when the user tries to add them.

This PR follows from #22240 & #24148, but should fix the root issue at both.

I've updated the `canInsertBlockType` selector to accept an object for the blockType. If an object is passed in, it will not use `getBlockType`, which would only work for an already-installed block type. This should be fine for existing uses of the selector, since they'll pass in a string & behavior will stay the same. For the block directory, we can pass in our block object, so that potential downloadable blocks can be checked against the current container.

## How has this been tested?
You can download & install this [example container block](https://gist.github.com/ryelle/cacdba5c888153d97eae38db775dec7f) that only allows `"core/image", "core/heading", "core/paragraph", "book-review-block/book-review"` in the container, and has a filter in the PHP file to restrict blocks in all post types to just 

```
'core/paragraph',
// This plugin block.
'ryelle-i18n/i18n-demo',
// Some blocks from wordpress.org.
'book-review-block/book-review',
'a8c/starscape'
```

Now search for "Stars", and you'll see two results in the main editor content, and 1 available result in the demo block. Search for something totally different (ex, recipe), and you'll get the "No blocks found in your library." result.

## Screenshots

In the post, I've set allowedBlocks to allow these 2 blocks that return for the query `stars` (in reality, 4 blocks are returned)

![Screen Shot 2020-10-07 at 5 11 46 PM](https://user-images.githubusercontent.com/541093/95388417-463bcf80-08c0-11eb-931d-f035ca796084.png)

In this container block, only one block matches allowedBlocks, so only one is shown:

![Screen Shot 2020-10-07 at 5 11 19 PM](https://user-images.githubusercontent.com/541093/95388414-463bcf80-08c0-11eb-96e0-92a07ea6703d.png)

