### PR TITLE
[RNMobile] Update Preview handling for better Android support

### DIFF
--- a/packages/edit-post/src/editor.native.js
+++ b/packages/edit-post/src/editor.native.js
@@ -10,13 +10,12 @@ import { I18nManager } from 'react-native';
  */
 import { Component } from '@wordpress/element';
 import { EditorProvider } from '@wordpress/editor';
-import { parse, serialize } from '@wordpress/blocks';
+import { parse, serialize, rawHandler } from '@wordpress/blocks';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { subscribeSetFocusOnTitle } from '@wordpress/react-native-bridge';
 import { SlotFillProvider } from '@wordpress/components';
 import { Preview } from '@wordpress/block-editor';
-import { rawHandler } from '@wordpress/blocks';
 
 /**
  * Internal dependencies

--- a/packages/edit-post/src/editor.native.js
+++ b/packages/edit-post/src/editor.native.js
@@ -105,7 +105,7 @@ class Editor extends Component {
 		if ( editorMode === 'preview' ) {
 			return <Preview blocks={ rawHandler( { HTML: initialHtml } ) } />;
 		}
-		return <Layout setTitleRef={ this.setTitleRef } />
+		return <Layout setTitleRef={ this.setTitleRef } />;
 	}
 
 	render() {

--- a/packages/edit-post/src/editor.native.js
+++ b/packages/edit-post/src/editor.native.js
@@ -15,6 +15,8 @@ import { withDispatch, withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { subscribeSetFocusOnTitle } from '@wordpress/react-native-bridge';
 import { SlotFillProvider } from '@wordpress/components';
+import { Preview } from '@wordpress/block-editor';
+import { rawHandler } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -100,6 +102,13 @@ class Editor extends Component {
 		this.postTitleRef = titleRef;
 	}
 
+	editorMode( initialHtml, editorMode ) {
+		if ( editorMode === 'preview' ) {
+			return <Preview blocks={ rawHandler( { HTML: initialHtml } ) } />;
+		}
+		return <Layout setTitleRef={ this.setTitleRef } />
+	}
+
 	render() {
 		const {
 			settings,
@@ -113,6 +122,8 @@ class Editor extends Component {
 			postType,
 			colors,
 			gradients,
+			initialHtml,
+			editorMode,
 			...props
 		} = this.props;
 
@@ -135,7 +146,7 @@ class Editor extends Component {
 				// make sure the post content is in sync with gutenberg store
 				// to avoid marking the post as modified when simply loaded
 				// For now, let's assume: serialize( parse( html ) ) !== html
-				raw: serialize( parse( props.initialHtml || '' ) ),
+				raw: serialize( parse( initialHtml || '' ) ),
 			},
 			type: postType,
 			status: 'draft',
@@ -151,7 +162,7 @@ class Editor extends Component {
 					useSubRegistry={ false }
 					{ ...props }
 				>
-					<Layout setTitleRef={ this.setTitleRef } />
+					{ this.editorMode( initialHtml, editorMode ) }
 				</EditorProvider>
 			</SlotFillProvider>
 		);

--- a/packages/edit-post/src/index.native.js
+++ b/packages/edit-post/src/index.native.js
@@ -2,12 +2,10 @@
  * WordPress dependencies
  */
 import '@wordpress/core-data';
-import { Preview } from '@wordpress/block-editor';
 import '@wordpress/viewport';
 import '@wordpress/notices';
 import '@wordpress/format-library';
 import { render } from '@wordpress/element';
-import { rawHandler } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -32,15 +30,5 @@ export function initializeEditor( id, postType, postId ) {
 
 	editorInitialized = true;
 
-	render( <EditorMode postId={ postId } postType={ postType } />, id );
-}
-
-function EditorMode( props ) {
-	const { initialHtml, editorMode } = props;
-
-	if ( editorMode === 'preview' ) {
-		return <Preview blocks={ rawHandler( { HTML: initialHtml } ) } />;
-	}
-
-	return <Editor { ...props } />;
+	render( <Editor postId={ postId } postType={ postType } />, id );
 }

--- a/packages/editor/src/components/provider/index.native.js
+++ b/packages/editor/src/components/provider/index.native.js
@@ -15,7 +15,6 @@ import RNReactNativeGutenbergBridge, {
 	subscribeUpdateCapabilities,
 	subscribeShowNotice,
 } from '@wordpress/react-native-bridge';
-import { rawHandler } from '@wordpress/blocks';
 
 /**
  * WordPress dependencies

--- a/packages/editor/src/components/provider/index.native.js
+++ b/packages/editor/src/components/provider/index.native.js
@@ -15,6 +15,7 @@ import RNReactNativeGutenbergBridge, {
 	subscribeUpdateCapabilities,
 	subscribeShowNotice,
 } from '@wordpress/react-native-bridge';
+import { rawHandler } from '@wordpress/blocks';
 
 /**
  * WordPress dependencies


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->
**Fixes** https://github.com/wordpress-mobile/gutenberg-mobile/issues/2452
**Related PR**
`gutenberg-mobile` https://github.com/wordpress-mobile/gutenberg-mobile/pull/2696

## Description
<!-- Please describe what you have changed or added -->
On Android the loading of the editor is dependent on [editorDidMount](https://github.com/WordPress/gutenberg/blob/7e5a113cf4b705259cc7f510d836e9184f5ab5f8/packages/editor/src/components/provider/index.native.js#L195-L197) as the callback to signal that the editor has finished loading. With that, the Preview should be rendered within the `EditorProvider` component to share that event. This PR moves the `EditorMode` logic to the `Editor` and loads differently based on that.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

<details>
<summary><strong>To disable or enable the development version of Modal Layout Picker</strong></summary>

- Open the app from the build that allows FeatureFlags such as a PR build or a local development build
    - By default, the modal layout picker will be disabled.
    - From the site page:
        - Click on your Gravatar.
        - Click on App Settings.
        - Click on Debug.
        - Toggle "Gutenberg Modal Layout Picker" to enable or disable the picker
            <img width=300 src="https://user-images.githubusercontent.com/3384451/90816133-c8b10580-e2f9-11ea-8584-6bbfd7e523e2.gif" />
</details>

### On WPAndroid:
Download the Android app with the Preview functionality from https://github.com/wordpress-mobile/WordPress-Android/pull/13022

With the metro server running 
1. Open the MLP either via the FAB icon > Site Page or by navigating to Pages and selecting the ➕ 
1. Select a layout
1. Select Preview
1. Expect to see the loading indicator
1. Expect to see the layout preview loaded successfully
1. Validate that the loading indicator is dismissed

### On WPiOS:
With the metro server running

1. Enable MLP 
2. Open the MLP either via the FAB icon > Site Page or by navigating to Pages and selecting the ➕ 
3. Select a layout
4. Select Preview

**Expect** The Preview to load

Also, open existing posts/pages and create new posts/pages and expect those to load as well.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
