### PR TITLE
Fix: input control drag and box control change

### DIFF
--- a/packages/components/src/input-control/input-field.js
+++ b/packages/components/src/input-control/input-field.js
@@ -102,19 +102,6 @@ function InputField(
 		}
 	};
 
-	/*
-	 * Works around the odd UA (e.g. Firefox) that does not focus inputs of
-	 * type=number when their spinner arrows are pressed.
-	 */
-	let handleOnMouseDown;
-	if ( type === 'number' ) {
-		handleOnMouseDown = ( event ) => {
-			if ( event.target !== event.target.ownerDocument.activeElement ) {
-				event.target.focus();
-			}
-		};
-	}
-
 	const handleOnFocus = ( event ) => {
 		onFocus( event );
 		setIsFocused( true );
@@ -164,7 +151,6 @@ function InputField(
 		( dragProps ) => {
 			const { distance, dragging, event } = dragProps;
 
-			if ( ! isDragEnabled ) return;
 			if ( ! distance ) return;
 			event.stopPropagation();
 
@@ -192,10 +178,29 @@ function InputField(
 		}
 	);
 
+	const { onMouseDown, onTouchStart } = isDragEnabled
+		? dragGestureProps()
+		: {};
+	let handleOnMouseDown = onMouseDown;
+
+	/*
+	 * Works around the odd UA (e.g. Firefox) that does not focus inputs of
+	 * type=number when their spinner arrows are pressed.
+	 */
+	if ( type === 'number' ) {
+		handleOnMouseDown = ( event ) => {
+			if ( event.target !== event.target.ownerDocument.activeElement ) {
+				event.target.focus();
+			}
+			if ( isDragEnabled ) {
+				onMouseDown( event );
+			}
+		};
+	}
+
 	return (
 		<Input
 			{ ...props }
-			{ ...dragGestureProps() }
 			className="components-input-control__input"
 			disabled={ disabled }
 			dragCursor={ dragCursor }
@@ -206,6 +211,7 @@ function InputField(
 			onFocus={ handleOnFocus }
 			onKeyDown={ handleOnKeyDown }
 			onMouseDown={ handleOnMouseDown }
+			onTouchStart={ onTouchStart }
 			ref={ ref }
 			size={ size }
 			value={ value }

--- a/packages/components/src/input-control/state.js
+++ b/packages/components/src/input-control/state.js
@@ -131,10 +131,8 @@ function inputControlStateReducer( composedStateReducers ) {
 				break;
 
 			case actionTypes.UPDATE:
-				if ( payload.value !== state.value ) {
-					nextState.value = payload.value;
-					nextState.isDirty = false;
-				}
+				nextState.value = payload.value;
+				nextState.isDirty = false;
 				break;
 
 			/**
@@ -218,7 +216,7 @@ export function useInputControlStateReducer(
 	 * Actions for the reducer
 	 */
 	const change = createChangeEvent( actionTypes.CHANGE );
-	const inValidate = createChangeEvent( actionTypes.INVALIDATE );
+	const invalidate = createChangeEvent( actionTypes.INVALIDATE );
 	const reset = createChangeEvent( actionTypes.RESET );
 	const commit = createChangeEvent( actionTypes.COMMIT );
 	const update = createChangeEvent( actionTypes.UPDATE );
@@ -238,7 +236,7 @@ export function useInputControlStateReducer(
 		drag,
 		dragEnd,
 		dragStart,
-		inValidate,
+		invalidate,
 		pressDown,
 		pressEnter,
 		pressUp,

--- a/packages/components/src/number-control/index.js
+++ b/packages/components/src/number-control/index.js
@@ -150,11 +150,11 @@ export function NumberControl(
 		}
 
 		/**
-		 * Handles ENTER key press and submit
+		 * Handles commit (ENTER key press or on blur if isPressEnterToChange)
 		 */
 		if (
 			type === inputControlActionTypes.PRESS_ENTER ||
-			type === inputControlActionTypes.SUBMIT
+			type === inputControlActionTypes.COMMIT
 		) {
 			state.value = roundClamp( currentValue, min, max );
 		}


### PR DESCRIPTION
As an alternative to #25913, adds some changes that fix the issues:
- avoid overwriting the react-use-gesture drag handlers 54e0484
- fix `InputControl`'s handling of blur commits  78a0e90

Additionally, some minor enhancements:
- let UnitControl trigger parsed unit changes even if the parsed value is the same 79949f9
- corrects a small oversight in NumberControl to get value resolution working for blur commits d6aec80

Here's visual of what the UnitControl change enables:
Before | After
------- | -------
![unit-change-plz](https://user-images.githubusercontent.com/9000376/95638078-58487a00-0a48-11eb-89c3-2395c0dfb89a.gif) | ![unit-change-haz](https://user-images.githubusercontent.com/9000376/95638121-6eeed100-0a48-11eb-8559-410eba28e3fb.gif)

## How has this been tested?
Storybook and Wordpress 5.5.1

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
