### PR TITLE
Fix search suggestions in WordPress Core

### DIFF
--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -53,6 +53,15 @@ const fetchLinkSuggestions = async (
 	{ isInitialSuggestions, type, subtype, page, perPage: perPageArg } = {},
 	{ disablePostFormats = false } = {}
 ) => {
+	// Only allow specifying a type argument in the Gutenberg plugin. This is
+	// because WordPress Core does not yet support type=term or type=post-format
+	// when hitting /wp/v2/search. This if() can be removed once the PHP code
+	// added in https://github.com/WordPress/gutenberg/pull/22600 has been
+	// committed to WordPress Core.
+	if ( process.env.GUTENBERG_PHASE === 1 ) {
+		type = 'post';
+	}
+
 	const perPage = perPageArg || isInitialSuggestions ? 3 : 20;
 
 	const queries = [];


### PR DESCRIPTION
Force `fetchLinkSuggestions()` to always set `type=post` when the JavaScript has been bundled for use in WordPress Core. This is because WordPress Core does not yet have the necesasry PHP to support specifying `type=term` or `type=post-format` in `/wp/v2/search`.

This check can be removed when the PHP added in https://github.com/WordPress/gutenberg/pull/22600 has been committed to WordPress Core.

cc. @tellthemachines 