### PR TITLE
Check that get_current_screen is callable

### DIFF
--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -133,7 +133,7 @@ add_action( 'admin_enqueue_scripts', 'gutenberg_widgets_init' );
  * @return bool Filtered decision about loading block assets.
  */
 function gutenberg_widgets_editor_load_block_editor_scripts_and_styles( $is_block_editor_screen ) {
-	if ( 'appearance_page_gutenberg-widgets' === get_current_screen()->base ) {
+	if ( is_callable( 'get_current_screen' ) && 'appearance_page_gutenberg-widgets' === get_current_screen()->base ) {
 		return true;
 	}
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Checks that `get_current_screen` is callable before calling it.

This was causing PHP notice to show up on the site front end, and prevented any content from displaying:
1. `wp-env clean all`
2. `wp-env start --update`
3. (obviously logged out because of the above.

This also appears to resolve the e2e issue described here: https://github.com/WordPress/gutenberg/pull/25826#issuecomment-705252901

## How has this been tested?
With this change, I do not see an error in the above scenario.

## Screenshots <!-- if applicable -->
the error is:

```
Fatal error: Uncaught Error: Call to undefined function get_current_screen() in /var/www/html/wp-content/plugins/gutenberg/lib/widgets-page.php:136 Stack trace: #0 /var/www/html/wp-includes/class-wp-hook.php(287): gutenberg_widgets_editor_load_block_editor_scripts_and_styles(false) #1 /var/www/html/wp-includes/plugin.php(206): WP_Hook->apply_filters(false, Array) #2 /var/www/html/wp-includes/script-loader.php(2232): apply_filters(‘should_load_blo...‘, false) #3 /var/www/html/wp-includes/script-loader.php(2246): wp_should_load_block_editor_scripts_and_styles() #4 /var/www/html/wp-includes/class-wp-hook.php(287): wp_enqueue_registered_block_scripts_and_styles(‘’) #5 /var/www/html/wp-includes/class-wp-hook.php(311): WP_Hook->apply_filters(‘’, Array) #6 /var/www/html/wp-includes/plugin.php(478): WP_Hook->do_action(Array) #7 /var/www/html/wp-includes/script-loader.php(2208): do_action(‘enqueue_block_a...‘) #8 /var/www/html/wp-includes/class-wp-hook.php(287): wp_common_block_scripts_and_styles(‘’) #9 /var/www/html/wp-includes/c in /var/www/html/wp-content/plugins/gutenberg/lib/widgets-page.php on line 136
```

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
