### PR TITLE
Social Links: Update Placeholder experience when first inserting Social Links

### DIFF
--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -30,7 +30,7 @@ const appenderNodesMap = new Map();
  */
 const BLOCK_ANIMATION_THRESHOLD = 200;
 
-function BlockList( { className, rootClientId, renderAppender }, ref ) {
+function BlockList( { className, placeholder rootClientId, renderAppender }, ref ) {
 	const Container = rootClientId ? 'div' : RootContainer;
 	const fallbackRef = useRef();
 	const wrapperRef = ref || fallbackRef;
@@ -45,6 +45,7 @@ function BlockList( { className, rootClientId, renderAppender }, ref ) {
 				) }
 			>
 				<BlockListItems
+					placeholder={ placeholder }
 					rootClientId={ rootClientId }
 					renderAppender={ renderAppender }
 					wrapperRef={ wrapperRef }
@@ -136,6 +137,7 @@ function Items( {
 					</AsyncModeProvider>
 				);
 			} ) }
+			{ blockClientIds.length < 1 && placeholder }
 			<BlockListAppender
 				tagName={ __experimentalAppenderTagName }
 				rootClientId={ rootClientId }

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -30,7 +30,7 @@ const appenderNodesMap = new Map();
  */
 const BLOCK_ANIMATION_THRESHOLD = 200;
 
-function BlockList( { className, placeholder rootClientId, renderAppender }, ref ) {
+function BlockList( { className, placeholder, rootClientId, renderAppender }, ref ) {
 	const Container = rootClientId ? 'div' : RootContainer;
 	const fallbackRef = useRef();
 	const wrapperRef = ref || fallbackRef;
@@ -56,6 +56,7 @@ function BlockList( { className, placeholder rootClientId, renderAppender }, ref
 }
 
 function Items( {
+	placeholder,
 	rootClientId,
 	renderAppender,
 	__experimentalAppenderTagName,

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -30,7 +30,10 @@ const appenderNodesMap = new Map();
  */
 const BLOCK_ANIMATION_THRESHOLD = 200;
 
-function BlockList( { className, placeholder, rootClientId, renderAppender }, ref ) {
+function BlockList(
+	{ className, placeholder, rootClientId, renderAppender },
+	ref
+) {
 	const Container = rootClientId ? 'div' : RootContainer;
 	const fallbackRef = useRef();
 	const wrapperRef = ref || fallbackRef;

--- a/packages/block-editor/src/components/inner-blocks/README.md
+++ b/packages/block-editor/src/components/inner-blocks/README.md
@@ -162,5 +162,7 @@ Determines whether the toolbars of _all_ child Blocks (applied deeply, recursive
 
 For example, a button block, deeply nested in several levels of block `X` that utilises this property will see the button block's toolbar displayed on block `X`'s toolbar area.
 
+### `placeholder`
 
-
+* **Type:** `Function`
+* **Default:** - `undefined`. The placeholder is an optional function that can be passed in to be a rendered component placed in front of the appender. This can be used to represent an example state prior to any blocks being placed. See the Social Links for an implementation example.

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -48,6 +48,7 @@ function UncontrolledInnerBlocks( props ) {
 		__experimentalAppenderTagName,
 		renderAppender,
 		orientation,
+		placeholder,
 	} = props;
 
 	useNestedSettingsUpdate(
@@ -88,6 +89,8 @@ function UncontrolledInnerBlocks( props ) {
 				renderAppender={ renderAppender }
 				__experimentalAppenderTagName={ __experimentalAppenderTagName }
 				wrapperRef={ wrapperRef }
+				className={ classes }
+				placeholder={ placeholder }
 			/>
 		</BlockContextProvider>
 	);

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -89,7 +89,6 @@ function UncontrolledInnerBlocks( props ) {
 				renderAppender={ renderAppender }
 				__experimentalAppenderTagName={ __experimentalAppenderTagName }
 				wrapperRef={ wrapperRef }
-				className={ classes }
 				placeholder={ placeholder }
 			/>
 		</BlockContextProvider>

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -22,9 +22,9 @@ export function SocialLinksEdit( props ) {
 
 	const SocialPlaceholder = (
 		<div className="wp-block-social-links__social-placeholder">
-			<div className="wp-block-social-links__social-placeholder__blue"></div>
-			<div className="wp-block-social-links__social-placeholder__pink"></div>
-			<div className="wp-block-social-links__social-placeholder__orange"></div>
+			<div className="wp-block-social-link wp-social-link-facebook"></div>
+			<div className="wp-block-social-link wp-social-link-twitter"></div>
+			<div className="wp-block-social-link wp-social-link-instagram"></div>
 		</div>
 	);
 

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -30,9 +30,8 @@ export function SocialLinksEdit( props ) {
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: ALLOWED_BLOCKS,
 		orientation: 'horizontal',
-		placeholder={ SocialPlaceholder }
+		placeholder: SocialPlaceholder,
 		templateLock: false,
-		template: TEMPLATE,
 		__experimentalAppenderTagName: 'li',
 	} );
 	return (

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -14,30 +14,25 @@ import { __ } from '@wordpress/i18n';
 
 const ALLOWED_BLOCKS = [ 'core/social-link' ];
 
-// Template contains the links that show when start.
-const TEMPLATE = [
-	[
-		'core/social-link',
-		{ service: 'wordpress', url: 'https://wordpress.org' },
-	],
-	[ 'core/social-link', { service: 'facebook' } ],
-	[ 'core/social-link', { service: 'twitter' } ],
-	[ 'core/social-link', { service: 'instagram' } ],
-	[ 'core/social-link', { service: 'linkedin' } ],
-	[ 'core/social-link', { service: 'youtube' } ],
-];
-
 export function SocialLinksEdit( props ) {
 	const {
 		attributes: { openInNewTab },
 		setAttributes,
 	} = props;
+
+	const SocialPlaceholder = (
+		<div className="wp-block-social-links__social-placeholder">
+			Use [+] to add icons.
+		</div>
+	);
+
 	const blockProps = useBlockProps();
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: ALLOWED_BLOCKS,
+		orientation: 'horizontal',
+		placeholder={ SocialPlaceholder }
 		templateLock: false,
 		template: TEMPLATE,
-		orientation: 'horizontal',
 		__experimentalAppenderTagName: 'li',
 	} );
 	return (

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -22,7 +22,9 @@ export function SocialLinksEdit( props ) {
 
 	const SocialPlaceholder = (
 		<div className="wp-block-social-links__social-placeholder">
-			Use [+] to add icons.
+			<div className="wp-block-social-links__social-placeholder__blue"></div>
+			<div className="wp-block-social-links__social-placeholder__pink"></div>
+			<div className="wp-block-social-links__social-placeholder__orange"></div>
 		</div>
 	);
 

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -22,34 +22,19 @@
 .editor-styles-wrapper .wp-block-social-links {
 	padding: 0;
 }
-.wp-block-social-links__social-placeholder div {
+.wp-block-social-links__social-placeholder .wp-block-social-link {
 	display: inline-block;
-	margin: 0 8px;
-	padding: 4px;
-	width: 24px;
-	height: 24px;
-	border-radius: 12px;
-}
-
-.wp-block-social-links__social-placeholder__blue {
-	background-color: rgba(52, 153, 205, 0.5);
-	box-shadow: 0 0 8px 8px rgba(52, 153, 205, 0.5);
-}
-
-
-.wp-block-social-links__social-placeholder__pink {
-	background-color: rgba(240, 0, 117, 0.5);
-	box-shadow: 0 0 8px 8px rgba(240, 0, 117, 0.5);
-}
-
-.wp-block-social-links__social-placeholder__orange {
-	background-color: rgba(255, 153, 0, 0.5);
-	box-shadow: 0 0 8px 8px rgba(255, 153, 0, 0.5);
+	margin: 0 $grid-unit-10 0 0;
+	padding: $grid-unit-05;
+	width: 36px;
+	height: 36px;
+	border-radius: $radius-round;
+	opacity: 0.8;
 }
 
 // Polish the Appender.
 .wp-block-social-links .block-list-appender {
-	margin: 0;
+	margin: 0 0 $grid-unit-10 0;
 	display: flex;
 	align-items: center;
 }

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -22,12 +22,29 @@
 .editor-styles-wrapper .wp-block-social-links {
 	padding: 0;
 }
-.wp-block-social-links__social-placeholder {
-	background-color: #aaa;
-	border-radius: 8px;
-	margin: 8px;
+.wp-block-social-links__social-placeholder div {
+	display: inline-block;
+	margin: 0 8px;
 	padding: 4px;
-	font-size: 13px;
+	width: 24px;
+	height: 24px;
+	border-radius: 12px;
+}
+
+.wp-block-social-links__social-placeholder__blue {
+	background-color: #3499cd;
+	box-shadow: 0 0 8px 8px #3499cd;
+}
+
+
+.wp-block-social-links__social-placeholder__pink {
+	background-color: #f00075;
+	box-shadow: 0 0 8px 8px #f00075;
+}
+
+.wp-block-social-links__social-placeholder__orange {
+	background-color: #f90;
+	box-shadow: 0 0 8px 8px #f90;
 }
 
 // Polish the Appender.

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -32,19 +32,19 @@
 }
 
 .wp-block-social-links__social-placeholder__blue {
-	background-color: #3499cd;
-	box-shadow: 0 0 8px 8px #3499cd;
+	background-color: rgba(52, 153, 205, 0.5);
+	box-shadow: 0 0 8px 8px rgba(52, 153, 205, 0.5);
 }
 
 
 .wp-block-social-links__social-placeholder__pink {
-	background-color: #f00075;
-	box-shadow: 0 0 8px 8px #f00075;
+	background-color: rgba(240, 0, 117, 0.5);
+	box-shadow: 0 0 8px 8px rgba(240, 0, 117, 0.5);
 }
 
 .wp-block-social-links__social-placeholder__orange {
-	background-color: #f90;
-	box-shadow: 0 0 8px 8px #f90;
+	background-color: rgba(255, 153, 0, 0.5);
+	box-shadow: 0 0 8px 8px rgba(255, 153, 0, 0.5);
 }
 
 // Polish the Appender.

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -22,14 +22,33 @@
 .editor-styles-wrapper .wp-block-social-links {
 	padding: 0;
 }
+
+// Placeholder/setup state.
 .wp-block-social-links__social-placeholder .wp-block-social-link {
-	display: inline-block;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
 	margin: 0 $grid-unit-10 0 0;
-	padding: $grid-unit-05;
 	width: 36px;
 	height: 36px;
 	border-radius: $radius-round;
 	opacity: 0.8;
+}
+
+.is-style-logos-only .wp-block-social-links__social-placeholder .wp-block-social-link::before {
+	content: "";
+	display: block;
+	width: 18px;
+	height: 18px;
+	border-radius: $radius-round;
+	opacity: 0.8;
+	background: #ccc;
+}
+
+.is-style-pill-shape .wp-block-social-links__social-placeholder .wp-block-social-link {
+	border-radius: 9999px;
+	padding-left: 16px + 12px;
+	padding-right: 16px + 12px;
 }
 
 // Polish the Appender.

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -22,6 +22,13 @@
 .editor-styles-wrapper .wp-block-social-links {
 	padding: 0;
 }
+.wp-block-social-links__social-placeholder {
+	background-color: #aaa;
+	border-radius: 8px;
+	margin: 8px;
+	padding: 4px;
+	font-size: 13px;
+}
 
 // Polish the Appender.
 .wp-block-social-links .block-list-appender {

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -24,15 +24,19 @@
 }
 
 // Placeholder/setup state.
-.wp-block-social-links__social-placeholder .wp-block-social-link {
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	margin: 0 $grid-unit-10 0 0;
-	width: 36px;
-	height: 36px;
-	border-radius: $radius-round;
-	opacity: 0.8;
+.wp-block-social-links__social-placeholder {
+	display: flex;
+
+	.wp-block-social-link {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		margin: 0 $grid-unit-10 $grid-unit-10 0;
+		width: 36px;
+		height: 36px;
+		border-radius: $radius-round;
+		opacity: 0.8;
+	}
 }
 
 .is-style-logos-only .wp-block-social-links__social-placeholder .wp-block-social-link::before {
@@ -42,7 +46,7 @@
 	height: 18px;
 	border-radius: $radius-round;
 	opacity: 0.8;
-	background: #ccc;
+	background: currentColor;
 }
 
 .is-style-pill-shape .wp-block-social-links__social-placeholder .wp-block-social-link {

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -47,22 +47,6 @@
 	min-height: 36px; // This height matches the height of the buttons and ensures an empty block doesn't collapse.
 }
 
-// Disappear but show on hover or nav mode focus.
-[data-type="core/social-links"] .wp-social-link__is-incomplete {
-	transition: transform 0.1s ease;
-	transform-origin: center center;
-}
-
-[data-type="core/social-links"]:not(.is-selected):not(.has-child-selected) {
-	.wp-social-link__is-incomplete {
-		opacity: 0;
-		transform: scale(0);
-		width: 0;
-		padding: 0;
-		margin-right: 0;
-	}
-}
-
 // Unconfigured placeholder links are semitransparent.
 .wp-social-link.wp-social-link__is-incomplete {
 	opacity: 0.5;

--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -20,7 +20,7 @@
 	display: block;
 	width: 36px;
 	height: 36px;
-	border-radius: 36px; // This makes it pill-shaped instead of oval, in cases where the image fed is not perfectly sized.
+	border-radius: 9999px; // This makes it pill-shaped instead of oval, in cases where the image fed is not perfectly sized.
 	margin: 0 8px 8px 0;
 	transition: transform 0.1s ease;
 	@include reduce-motion("transition");


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

Adds a new placeholder prop to InnerBlocks and BlockList to render in front of the appender if specified and no blocks.

An example component is passed in with the Social Links to display when no links have been added. The template of default links is also removed. Combined this is intended to provide a better experience than the appearing/disappearing links that require to be removed, while still be clearing what is happening.

@jasmussen Can you try this out, I have a temp placeholder there that can use some better style and improvement.

Fixes: #19020 
Fixes: #21700

## How has this been tested?

1. Create a block with social links
2. Apply the change and confirm nothing breaks with existing block.

1. When adding new social confirm the placeholder shows and not the old default list.
2. Confirm the placeholder is removed when a new link is added
3. Confirm the placeholder does not break or effect other InnerBlocks (columns is a good test)

## Screenshots

![social-link-placeholder](https://user-images.githubusercontent.com/45363/95410058-d9ccca80-08d7-11eb-8d6d-a9cd4f962750.gif)


## Types of changes

- Adds placeholder prop to BlockList component, and renders if no blocks
- Adds placeholder prop to InnerBlock passing forward to BlockList
- Add example placeholder to Social Links block
- Remove template constant passed to InnerBlocks so no default icons inserted
- Do not hide the icons when the block is not selected, this matches the image placeholder experience

## Checklist:

- [ ] API documentation update still required.

