### PR TITLE
Widgets editor: Display Widget Area's name and description in the sidebar

### DIFF
--- a/packages/edit-widgets/src/components/sidebar/index.js
+++ b/packages/edit-widgets/src/components/sidebar/index.js
@@ -23,10 +23,10 @@ const SIDEBAR_ACTIVE_BY_DEFAULT = Platform.select( {
 /**
  * Internal dependencies
  */
-import BlockAreas from './block-areas';
+import WidgetAreas from './widget-areas';
 
 const CORE_WIDGET_COMPLEMENTARY_AREAS = {
-	'edit-widgets/block-areas': __( 'Block areas' ),
+	'edit-widgets/widget-areas': __( 'Widget Areas' ),
 	'edit-widgets/block-inspector': __( 'Block' ),
 };
 
@@ -53,7 +53,7 @@ function ComplementaryAreaHeader( { activeComplementaryArea } ) {
 							) }
 							aria-label={
 								isActive
-									? // translators: %s: sidebar label e.g: "Block areas".
+									? // translators: %s: sidebar label e.g: "Widget Areas".
 									  sprintf( __( '%s (selected)' ), label )
 									: label
 							}
@@ -85,7 +85,7 @@ export default function Sidebar() {
 		const selectionStart = getBlockSelectionStart();
 		if ( ! CORE_WIDGET_COMPLEMENTARY_AREAS[ activeArea ] ) {
 			if ( ! selectionStart ) {
-				activeArea = 'edit-widgets/block-areas';
+				activeArea = 'edit-widgets/widget-areas';
 			} else {
 				activeArea = 'edit-widgets/block-inspector';
 			}
@@ -104,7 +104,7 @@ export default function Sidebar() {
 	useEffect( () => {
 		if (
 			hasSelectedNonAreaBlock &&
-			currentArea === 'edit-widgets/block-areas' &&
+			currentArea === 'edit-widgets/widget-areas' &&
 			isGeneralSidebarOpen
 		) {
 			enableComplementaryArea(
@@ -119,7 +119,7 @@ export default function Sidebar() {
 		) {
 			enableComplementaryArea(
 				'core/edit-widgets',
-				'edit-widgets/block-areas'
+				'edit-widgets/widget-areas'
 			);
 		}
 	}, [ hasSelectedNonAreaBlock, enableComplementaryArea ] );
@@ -141,7 +141,7 @@ export default function Sidebar() {
 			icon={ cog }
 			isActiveByDefault={ SIDEBAR_ACTIVE_BY_DEFAULT }
 		>
-			{ currentArea === 'edit-widgets/block-areas' && <BlockAreas /> }
+			{ currentArea === 'edit-widgets/widget-areas' && <WidgetAreas /> }
 			{ currentArea === 'edit-widgets/block-inspector' && (
 				<BlockInspector />
 			) }

--- a/packages/edit-widgets/src/components/sidebar/index.js
+++ b/packages/edit-widgets/src/components/sidebar/index.js
@@ -142,9 +142,16 @@ export default function Sidebar() {
 			isActiveByDefault={ SIDEBAR_ACTIVE_BY_DEFAULT }
 		>
 			{ currentArea === 'edit-widgets/widget-areas' && <WidgetAreas /> }
-			{ currentArea === 'edit-widgets/block-inspector' && (
-				<BlockInspector />
-			) }
+			{ currentArea === 'edit-widgets/block-inspector' &&
+				( hasSelectedNonAreaBlock ? (
+					<BlockInspector />
+				) : (
+					// Pretend that Widget Areas are part of the UI by not
+					// showing the Block Inspector when one is selected.
+					<span className="block-editor-block-inspector__no-blocks">
+						{ __( 'No block selected.' ) }
+					</span>
+				) ) }
 		</ComplementaryArea>
 	);
 }

--- a/packages/edit-widgets/src/components/sidebar/index.js
+++ b/packages/edit-widgets/src/components/sidebar/index.js
@@ -19,6 +19,12 @@ const SIDEBAR_ACTIVE_BY_DEFAULT = Platform.select( {
 	native: false,
 } );
 
+const BLOCK_INSPECTOR_IDENTIFIER = 'edit-widgets/block-inspector';
+
+// Widget areas were one called block areas, so use 'edit-widgets/block-areas'
+// for backwards compatibility.
+const WIDGET_AREAS_IDENTIFIER = 'edit-widgets/block-areas';
+
 /**
  * Internal dependencies
  */
@@ -67,9 +73,9 @@ export default function Sidebar() {
 		let activeArea = getActiveComplementaryArea( 'core/edit-widgets' );
 		if ( ! activeArea ) {
 			if ( selectedBlock ) {
-				activeArea = 'edit-widgets/block-inspector';
+				activeArea = BLOCK_INSPECTOR_IDENTIFIER;
 			} else {
-				activeArea = 'edit-widgets/widget-areas';
+				activeArea = WIDGET_AREAS_IDENTIFIER;
 			}
 		}
 
@@ -104,22 +110,22 @@ export default function Sidebar() {
 	useEffect( () => {
 		if (
 			hasSelectedNonAreaBlock &&
-			currentArea === 'edit-widgets/widget-areas' &&
+			currentArea === WIDGET_AREAS_IDENTIFIER &&
 			isGeneralSidebarOpen
 		) {
 			enableComplementaryArea(
 				'core/edit-widgets',
-				'edit-widgets/block-inspector'
+				BLOCK_INSPECTOR_IDENTIFIER
 			);
 		}
 		if (
 			! hasSelectedNonAreaBlock &&
-			currentArea === 'edit-widgets/block-inspector' &&
+			currentArea === BLOCK_INSPECTOR_IDENTIFIER &&
 			isGeneralSidebarOpen
 		) {
 			enableComplementaryArea(
 				'core/edit-widgets',
-				'edit-widgets/widget-areas'
+				WIDGET_AREAS_IDENTIFIER
 			);
 		}
 	}, [ hasSelectedNonAreaBlock, enableComplementaryArea ] );
@@ -131,23 +137,21 @@ export default function Sidebar() {
 				<ul>
 					<li>
 						<ComplementaryAreaTab
-							identifier="edit-widgets/widget-areas"
+							identifier={ WIDGET_AREAS_IDENTIFIER }
 							label={
 								selectedWidgetAreaBlock
 									? selectedWidgetAreaBlock.attributes.name
 									: __( 'Widget Areas' )
 							}
-							isActive={
-								currentArea === 'edit-widgets/widget-areas'
-							}
+							isActive={ currentArea === WIDGET_AREAS_IDENTIFIER }
 						/>
 					</li>
 					<li>
 						<ComplementaryAreaTab
-							identifier="edit-widgets/block-inspector"
+							identifier={ BLOCK_INSPECTOR_IDENTIFIER }
 							label={ __( 'Block' ) }
 							isActive={
-								currentArea === 'edit-widgets/block-inspector'
+								currentArea === BLOCK_INSPECTOR_IDENTIFIER
 							}
 						/>
 					</li>
@@ -162,14 +166,14 @@ export default function Sidebar() {
 			icon={ cog }
 			isActiveByDefault={ SIDEBAR_ACTIVE_BY_DEFAULT }
 		>
-			{ currentArea === 'edit-widgets/widget-areas' && (
+			{ currentArea === WIDGET_AREAS_IDENTIFIER && (
 				<WidgetAreas
 					selectedWidgetAreaId={
 						selectedWidgetAreaBlock?.attributes.id
 					}
 				/>
 			) }
-			{ currentArea === 'edit-widgets/block-inspector' &&
+			{ currentArea === BLOCK_INSPECTOR_IDENTIFIER &&
 				( hasSelectedNonAreaBlock ? (
 					<BlockInspector />
 				) : (

--- a/packages/edit-widgets/src/components/sidebar/style.scss
+++ b/packages/edit-widgets/src/components/sidebar/style.scss
@@ -74,7 +74,7 @@
 	}
 }
 
-.edit-widgets-block-areas__top-container {
+.edit-widgets-widget-areas__top-container {
 	display: flex;
 	padding: $grid-unit-20;
 	.block-editor-block-icon {
@@ -82,7 +82,7 @@
 	}
 }
 
-.edit-widgets-block-areas {
+.edit-widgets-widget-areas {
 	ul {
 		list-style: none;
 		margin-bottom: -$border-width;
@@ -106,7 +106,7 @@
 	}
 }
 
-.edit-widgets-block-areas__edit {
+.edit-widgets-widget-areas__edit {
 	float: right;
 	/* Mimics the default link style in common.css */
 	color: #0073aa;

--- a/packages/edit-widgets/src/components/sidebar/style.scss
+++ b/packages/edit-widgets/src/components/sidebar/style.scss
@@ -81,34 +81,3 @@
 		margin-right: $grid-unit-20;
 	}
 }
-
-.edit-widgets-widget-areas {
-	ul {
-		list-style: none;
-		margin-bottom: -$border-width;
-	}
-
-	li {
-		margin: 0;
-		border-bottom: $border-width solid $gray-300;
-		&:first-child {
-			border-top: $border-width solid $gray-300;
-		}
-
-		button {
-			display: block;
-			width: 100%;
-			font-weight: 600;
-			padding: $grid-unit-20;
-			height: auto;
-			text-align: left;
-		}
-	}
-}
-
-.edit-widgets-widget-areas__edit {
-	float: right;
-	/* Mimics the default link style in common.css */
-	color: #0073aa;
-	font-weight: 400;
-}

--- a/packages/edit-widgets/src/components/sidebar/widget-areas.js
+++ b/packages/edit-widgets/src/components/sidebar/widget-areas.js
@@ -6,25 +6,38 @@ import { blockDefault } from '@wordpress/icons';
 import { BlockIcon } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
-export default function WidgetAreas() {
-	const blocks = useSelect(
-		( select ) => select( 'core/block-editor' ).getBlocks(),
+export default function WidgetAreas( { selectedWidgetAreaId } ) {
+	const widgetAreas = useSelect(
+		( select ) => select( 'core/edit-widgets' ).getWidgetAreas(),
 		[]
 	);
 
-	const hasWidgetAreas = blocks.length > 0;
+	const selectedWidgetArea =
+		selectedWidgetAreaId &&
+		widgetAreas?.find(
+			( widgetArea ) => widgetArea.id === selectedWidgetAreaId
+		);
+
+	let description;
+	if ( ! selectedWidgetArea ) {
+		description = __(
+			'Widget Areas are global parts in your site’s layout that can accept blocks. These vary by theme, but are typically parts like your Sidebar or Footer.'
+		);
+	} else if ( selectedWidgetAreaId === 'wp_inactive_widgets' ) {
+		description = __(
+			'Blocks in this Widget Area will not be displayed in your site.'
+		);
+	} else {
+		description = selectedWidgetArea.description;
+	}
 
 	return (
 		<div className="edit-widgets-widget-areas">
 			<div className="edit-widgets-widget-areas__top-container">
 				<BlockIcon icon={ blockDefault } />
 				<div>
-					<p>
-						{ __(
-							"Widget Areas are global parts in your site's layout that can accept blocks. These vary by theme, but are typically parts like your Sidebar or Footer."
-						) }
-					</p>
-					{ ! hasWidgetAreas && (
+					<p>{ description }</p>
+					{ widgetAreas?.length === 0 && (
 						<p>
 							{ __(
 								'Your theme does not contain any Widget Areas.'

--- a/packages/edit-widgets/src/components/sidebar/widget-areas.js
+++ b/packages/edit-widgets/src/components/sidebar/widget-areas.js
@@ -7,7 +7,7 @@ import { BlockIcon } from '@wordpress/block-editor';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-function BlockArea( { block } ) {
+function WidgetArea( { block } ) {
 	const selectedBlock = useSelect(
 		( select ) => select( 'core/block-editor' ).getBlockSelectionStart(),
 		[]
@@ -26,7 +26,7 @@ function BlockArea( { block } ) {
 				onClick={ () => selectBlock( block.clientId ) }
 			>
 				{ block.attributes.name }
-				<span className="edit-widgets-block-areas__edit">
+				<span className="edit-widgets-widget-areas__edit">
 					{ __( 'Edit' ) }
 				</span>
 			</Button>
@@ -34,39 +34,42 @@ function BlockArea( { block } ) {
 	);
 }
 
-export default function BlockAreas() {
+export default function WidgetAreas() {
 	const blocks = useSelect(
 		( select ) => select( 'core/block-editor' ).getBlocks(),
 		[]
 	);
 
-	const hasBlockAreas = blocks.length > 0;
+	const hasWidgetAreas = blocks.length > 0;
 
 	return (
 		<>
-			<div className="edit-widgets-block-areas">
-				<div className="edit-widgets-block-areas__top-container">
+			<div className="edit-widgets-widget-areas">
+				<div className="edit-widgets-widget-areas__top-container">
 					<BlockIcon icon={ blockDefault } />
 					<div>
 						<p>
 							{ __(
-								'Block Areas (also known as "Widget Areas") are global parts in your site\'s layout that can accept blocks. These vary by theme, but are typically parts like your Sidebar or Footer.'
+								"Widget Areas are global parts in your site's layout that can accept blocks. These vary by theme, but are typically parts like your Sidebar or Footer."
 							) }
 						</p>
-						{ ! hasBlockAreas && (
+						{ ! hasWidgetAreas && (
 							<p>
 								{ __(
-									'Your theme does not contain block areas.'
+									'Your theme does not contain any Widget Areas.'
 								) }
 							</p>
 						) }
 					</div>
 				</div>
 
-				{ hasBlockAreas && (
+				{ hasWidgetAreas && (
 					<ul>
 						{ blocks.map( ( block ) => (
-							<BlockArea key={ block.clientId } block={ block } />
+							<WidgetArea
+								key={ block.clientId }
+								block={ block }
+							/>
 						) ) }
 					</ul>
 				) }

--- a/packages/edit-widgets/src/components/sidebar/widget-areas.js
+++ b/packages/edit-widgets/src/components/sidebar/widget-areas.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
 import { blockDefault } from '@wordpress/icons';
 import { BlockIcon } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
@@ -12,11 +13,14 @@ export default function WidgetAreas( { selectedWidgetAreaId } ) {
 		[]
 	);
 
-	const selectedWidgetArea =
-		selectedWidgetAreaId &&
-		widgetAreas?.find(
-			( widgetArea ) => widgetArea.id === selectedWidgetAreaId
-		);
+	const selectedWidgetArea = useMemo(
+		() =>
+			selectedWidgetAreaId &&
+			widgetAreas?.find(
+				( widgetArea ) => widgetArea.id === selectedWidgetAreaId
+			),
+		[ selectedWidgetAreaId, widgetAreas ]
+	);
 
 	let description;
 	if ( ! selectedWidgetArea ) {

--- a/packages/edit-widgets/src/components/sidebar/widget-areas.js
+++ b/packages/edit-widgets/src/components/sidebar/widget-areas.js
@@ -1,38 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { blockDefault } from '@wordpress/icons';
 import { BlockIcon } from '@wordpress/block-editor';
-import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-
-function WidgetArea( { block } ) {
-	const selectedBlock = useSelect(
-		( select ) => select( 'core/block-editor' ).getBlockSelectionStart(),
-		[]
-	);
-
-	const { selectBlock } = useDispatch( 'core/block-editor' );
-
-	if ( block.name !== 'core/widget-area' ) {
-		return null;
-	}
-
-	return (
-		<li>
-			<Button
-				aria-expanded={ selectedBlock === block.clientId }
-				onClick={ () => selectBlock( block.clientId ) }
-			>
-				{ block.attributes.name }
-				<span className="edit-widgets-widget-areas__edit">
-					{ __( 'Edit' ) }
-				</span>
-			</Button>
-		</li>
-	);
-}
 
 export default function WidgetAreas() {
 	const blocks = useSelect(
@@ -43,37 +15,24 @@ export default function WidgetAreas() {
 	const hasWidgetAreas = blocks.length > 0;
 
 	return (
-		<>
-			<div className="edit-widgets-widget-areas">
-				<div className="edit-widgets-widget-areas__top-container">
-					<BlockIcon icon={ blockDefault } />
-					<div>
+		<div className="edit-widgets-widget-areas">
+			<div className="edit-widgets-widget-areas__top-container">
+				<BlockIcon icon={ blockDefault } />
+				<div>
+					<p>
+						{ __(
+							"Widget Areas are global parts in your site's layout that can accept blocks. These vary by theme, but are typically parts like your Sidebar or Footer."
+						) }
+					</p>
+					{ ! hasWidgetAreas && (
 						<p>
 							{ __(
-								"Widget Areas are global parts in your site's layout that can accept blocks. These vary by theme, but are typically parts like your Sidebar or Footer."
+								'Your theme does not contain any Widget Areas.'
 							) }
 						</p>
-						{ ! hasWidgetAreas && (
-							<p>
-								{ __(
-									'Your theme does not contain any Widget Areas.'
-								) }
-							</p>
-						) }
-					</div>
+					) }
 				</div>
-
-				{ hasWidgetAreas && (
-					<ul>
-						{ blocks.map( ( block ) => (
-							<WidgetArea
-								key={ block.clientId }
-								block={ block }
-							/>
-						) ) }
-					</ul>
-				) }
 			</div>
-		</>
+		</div>
 	);
 }


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/25745.
Closes https://github.com/WordPress/gutenberg/issues/24838.
Closes https://github.com/WordPress/gutenberg/issues/25190.

![sidebar](https://user-images.githubusercontent.com/612155/95425357-e14faa80-098f-11eb-9d03-0cfb99244893.gif)

This PR implements the mockup in https://github.com/WordPress/gutenberg/issues/25745#issuecomment-705016495.

- Renames _Block Areas_ to _Widget Areas_.
- Removes the list of Widget Areas from the sidebar.
- Displays the currently selected Widget Area's name and description in the sidebar.

### How to test

1. Navigate to Appearance → Widgets.
2. Look at the sidebar. Experiment with opening the sidebar, closing the sidebar, selecting blocks, selecting widget areas, and selecting nothing.