### PR TITLE
[Widgets Editor] Add save keyboard shortcut

### DIFF
--- a/packages/edit-widgets/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-widgets/src/components/keyboard-shortcuts/index.js
@@ -8,6 +8,7 @@ import { __ } from '@wordpress/i18n';
 
 function KeyboardShortcuts() {
 	const { redo, undo } = useDispatch( 'core' );
+	const { saveEditedWidgetAreas } = useDispatch( 'core/edit-widgets' );
 
 	useShortcut(
 		'core/edit-widgets/undo',
@@ -27,8 +28,18 @@ function KeyboardShortcuts() {
 		{ bindGlobal: true }
 	);
 
+	useShortcut(
+		'core/edit-widgets/save',
+		( event ) => {
+			event.preventDefault();
+			saveEditedWidgetAreas();
+		},
+		{ bindGlobal: true }
+	);
+
 	return null;
 }
+
 function KeyboardShortcutsRegister() {
 	// Registering the shortcuts
 	const { registerShortcut } = useDispatch( 'core/keyboard-shortcuts' );
@@ -50,6 +61,16 @@ function KeyboardShortcutsRegister() {
 			keyCombination: {
 				modifier: 'primaryShift',
 				character: 'z',
+			},
+		} );
+
+		registerShortcut( {
+			name: 'core/edit-widgets/save',
+			category: 'global',
+			description: __( 'Save your changes.' ),
+			keyCombination: {
+				modifier: 'primary',
+				character: 's',
 			},
 		} );
 	}, [ registerShortcut ] );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Fix #25817.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Go to the Widgets screen
2. Edit some widgets
3. Hit <kbd>Cmd</kbd> / <kbd>Ctrl</kbd> + <kbd>s</kbd> to save the changes
4. Observe that a **Widget saved.** toast showed on the bottom-left of the screen
5. Reload the page, the screen should be saved

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/7753001/95425731-52cf2f00-0977-11eb-9209-2e7da6ed4a56.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
