### PR TITLE
edit-site: migrate to builtin data controls 

### DIFF
--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -1,7 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { select, dispatch, apiFetch } from '@wordpress/data-controls';
+import { controls } from '@wordpress/data';
+import { apiFetch } from '@wordpress/data-controls';
 
 /**
  * Internal dependencies
@@ -58,7 +59,7 @@ export function setTemplate( templateId ) {
  * @return {Object} Action object used to set the current template.
  */
 export function* addTemplate( template ) {
-	const newTemplate = yield dispatch(
+	const newTemplate = yield controls.dispatch(
 		'core',
 		'saveEntityRecord',
 		'postType',
@@ -81,11 +82,8 @@ export function* removeTemplate( templateId ) {
 		path: `/wp/v2/templates/${ templateId }`,
 		method: 'DELETE',
 	} );
-	yield dispatch(
-		'core/edit-site',
-		'setPage',
-		yield select( 'core/edit-site', 'getPage' )
-	);
+	const page = yield controls.select( 'core/edit-site', 'getPage' );
+	yield controls.dispatch( 'core/edit-site', 'setPage', page );
 }
 
 /**
@@ -143,7 +141,12 @@ export function* showHomepage() {
 	const {
 		show_on_front: showOnFront,
 		page_on_front: frontpageId,
-	} = yield select( 'core', 'getEntityRecord', 'root', 'site' );
+	} = yield controls.resolveSelect(
+		'core',
+		'getEntityRecord',
+		'root',
+		'site'
+	);
 
 	const page = {
 		path: '/',

--- a/packages/edit-site/src/store/reducer.js
+++ b/packages/edit-site/src/store/reducer.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { flow } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { combineReducers } from '@wordpress/data';
@@ -14,37 +9,24 @@ import { combineReducers } from '@wordpress/data';
 import { PREFERENCES_DEFAULTS } from './defaults';
 
 /**
- * Higher-order reducer creator which provides the given initial state for the
- * original reducer.
- *
- * @param {*} initialState Initial state to provide to reducer.
- *
- * @return {Function} Higher-order reducer.
- */
-const createWithInitialState = ( initialState ) => ( reducer ) => {
-	return ( state = initialState, action ) => reducer( state, action );
-};
-
-/**
  * Reducer returning the user preferences.
  *
  * @param {Object}  state Current state.
- *
+ * @param {Object}  action Dispatched action.
  * @return {Object} Updated state.
  */
-export const preferences = flow( [
-	combineReducers,
-	createWithInitialState( PREFERENCES_DEFAULTS ),
-] )( {
-	features( state, action ) {
-		if ( action.type === 'TOGGLE_FEATURE' ) {
-			return {
-				...state,
-				[ action.feature ]: ! state[ action.feature ],
-			};
+export const preferences = combineReducers( {
+	features( state = PREFERENCES_DEFAULTS.features, action ) {
+		switch ( action.type ) {
+			case 'TOGGLE_FEATURE': {
+				return {
+					...state,
+					[ action.feature ]: ! state[ action.feature ],
+				};
+			}
+			default:
+				return state;
 		}
-
-		return state;
 	},
 } );
 

--- a/packages/edit-site/src/store/test/actions.js
+++ b/packages/edit-site/src/store/test/actions.js
@@ -56,7 +56,7 @@ describe( 'actions', () => {
 	} );
 
 	describe( 'removeTemplate', () => {
-		it( 'should yield the API_FETCH control and yield the SELECT control to set the page by yielding the DISPATCH control for the SET_PAGE action', () => {
+		it( 'should issue a REST request to delete the template, then read the current page and then set the page with an updated template list', () => {
 			const templateId = 1;
 			const page = { path: '/' };
 
@@ -69,7 +69,7 @@ describe( 'actions', () => {
 				},
 			} );
 			expect( it.next().value ).toEqual( {
-				type: '@@data/RESOLVE_SELECT',
+				type: '@@data/SELECT',
 				storeKey: 'core/edit-site',
 				selectorName: 'getPage',
 				args: [],


### PR DESCRIPTION
Migrates the `edit-site` package and its data store to use the built-in `select` and `dispatch` controls.

The `removeTemplate` action needs to do the _synchronous_ `select( 'core/edit-site' ).getPage()`, because the `getPage` selector doesn't have any resolver, and simply returns `state.page`. There is nothing asynchronous here that would need the _async_ control that was used previously.

The patch also does a drive-by simplification of the `preferences` reducer (cc @vindl)