### PR TITLE
[RNMobile][iOS] Fix for toolbar when hiding keybord with cmd + k (external one)

### DIFF
--- a/packages/components/src/mobile/keyboard-avoiding-view/index.ios.js
+++ b/packages/components/src/mobile/keyboard-avoiding-view/index.ios.js
@@ -76,9 +76,14 @@ export const KeyboardAvoidingView = ( {
 	}
 
 	function onKeyboardWillHide( { duration, startCoordinates } ) {
+		// The startCoordinates.height is set to wrong value when we use cmd + k for hide the keyboard (Have no idea why).
+		// Because of that the `setIsKeyboardOpened` is not invoked and the state of keyboard is wrong.
+		// The keyboardIsOpenBreakpoint use 100 as a fallback if the startCoordinates.height is too small (cmd + k case)
+		const keyboardIsOpenBreakpoint =
+			startCoordinates.height > 100 ? startCoordinates.height / 3 : 100;
 		const animatedListenerId = animatedHeight.addListener(
 			( { value } ) => {
-				if ( value < startCoordinates.height / 3 ) {
+				if ( value < keyboardIsOpenBreakpoint ) {
 					setIsKeyboardOpen( false );
 				}
 			}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
>There seems to be a regression that happens when selecting a paragraph block and pressing cmd+k to hide the keyboard in a simulator. I guess you can use an external keyboard to do the same on a real device. Seems to only happen on iOS 13.

![image](https://user-images.githubusercontent.com/16336501/95466741-f5d67780-097c-11eb-91a6-a5386c8b46f4.png)

## How has this been tested?
to reproduce you can use current develop (WPiOS or Gutenberg Demo) with an iOS 13 simulator with no home button:
- Select a paragraph block and the software keyboard is shown
- Close the software keyboard via cmd+k
- The toolbar should no stay behind the home button

## Screenshots <!-- if applicable -->

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
