### PR TITLE
block-directory: simplify the LOAD_ASSETS flow by making it an async function

### DIFF
--- a/packages/block-directory/src/store/controls.js
+++ b/packages/block-directory/src/store/controls.js
@@ -62,47 +62,36 @@ export function loadAssets( assets ) {
 }
 
 const controls = {
-	LOAD_ASSETS() {
+	async LOAD_ASSETS() {
 		/*
 		 * Fetch the current URL (post-new.php, or post.php?post=1&action=edit) and compare the
 		 * Javascript and CSS assets loaded between the pages. This imports the required assets
 		 * for the block into the current page while not requiring that we know them up-front.
 		 * In the future this can be improved by reliance upon block.json and/or a script-loader
-		 * dependancy API.
+		 * dependency API.
 		 */
-		return apiFetch( {
+		const response = await apiFetch( {
 			url: document.location.href,
 			parse: false,
-		} )
-			.then( ( response ) => response.text() )
-			.then( ( data ) => {
-				const doc = new window.DOMParser().parseFromString(
-					data,
-					'text/html'
-				);
+		} );
 
-				const newAssets = Array.from(
-					doc.querySelectorAll( 'link[rel="stylesheet"],script' )
-				).filter(
-					( asset ) =>
-						asset.id && ! document.getElementById( asset.id )
-				);
+		const data = await response.text();
 
-				return new Promise( async ( resolve, reject ) => {
-					for ( const i in newAssets ) {
-						try {
-							/*
-							 * Load each asset in order, as they may depend upon an earlier loaded script.
-							 * Stylesheets and Inline Scripts will resolve immediately upon insertion.
-							 */
-							await loadAsset( newAssets[ i ] );
-						} catch ( e ) {
-							reject( e );
-						}
-					}
-					resolve();
-				} );
-			} );
+		const doc = new window.DOMParser().parseFromString( data, 'text/html' );
+
+		const newAssets = Array.from(
+			doc.querySelectorAll( 'link[rel="stylesheet"],script' )
+		).filter(
+			( asset ) => asset.id && ! document.getElementById( asset.id )
+		);
+
+		/*
+		 * Load each asset in order, as they may depend upon an earlier loaded script.
+		 * Stylesheets and Inline Scripts will resolve immediately upon insertion.
+		 */
+		for ( const newAsset of newAssets ) {
+			await loadAsset( newAsset );
+		}
 	},
 };
 


### PR DESCRIPTION
Rewrites the `LOAD_ASSETS` control handler by converting it to an async function. That simplifies especially the async loop at the end that loads the missing assets.

Also fixes what I think is a bug: if one of the `loadAsset` calls failed, the surrounding promise was rejected by the `reject` call, but the loop continued to load the remaining assets! Even though their code can depend on the success of previous loads. After this patch, the loop terminates immediately on error.