### PR TITLE
Site Editor: Clear the active menu state when closing the sidebar

### DIFF
--- a/packages/edit-site/src/components/header/navigation-toggle/index.js
+++ b/packages/edit-site/src/components/header/navigation-toggle/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { Button, Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
@@ -31,9 +31,18 @@ function NavigationToggle( { icon, isOpen, onClick } ) {
 		};
 	}, [] );
 
+	const { setNavigationPanelActiveMenu } = useDispatch( 'core/edit-site' );
+
 	if ( ! isActive ) {
 		return null;
 	}
+
+	const handleClick = ( event ) => {
+		if ( isOpen ) {
+			setNavigationPanelActiveMenu();
+		}
+		onClick( event );
+	};
 
 	let buttonIcon = <Icon size="36px" icon={ wordpress } />;
 
@@ -60,7 +69,7 @@ function NavigationToggle( { icon, isOpen, onClick } ) {
 			<Button
 				className="edit-site-navigation-toggle__button has-icon"
 				label={ __( 'Toggle navigation' ) }
-				onClick={ onClick }
+				onClick={ handleClick }
 				showTooltip
 			>
 				{ buttonIcon }

--- a/packages/edit-site/src/components/header/navigation-toggle/index.js
+++ b/packages/edit-site/src/components/header/navigation-toggle/index.js
@@ -39,7 +39,7 @@ function NavigationToggle( { icon, isOpen, onClick } ) {
 
 	const handleClick = ( event ) => {
 		if ( isOpen ) {
-			setNavigationPanelActiveMenu();
+			setNavigationPanelActiveMenu( 'root' );
 		}
 		onClick( event );
 	};

--- a/packages/edit-site/src/components/header/navigation-toggle/test/index.js
+++ b/packages/edit-site/src/components/header/navigation-toggle/test/index.js
@@ -18,6 +18,9 @@ jest.mock( '@wordpress/data/src/components/use-select', () => {
 	const mock = jest.fn();
 	return mock;
 } );
+jest.mock( '@wordpress/data/src/components/use-dispatch', () => ( {
+	useDispatch: () => ( { setNavigationPanelActiveMenu: jest.fn() } ),
+} ) );
 
 jest.mock( '@wordpress/core-data' );
 

--- a/packages/edit-site/src/store/reducer.js
+++ b/packages/edit-site/src/store/reducer.js
@@ -182,7 +182,7 @@ export function homeTemplateId( state, action ) {
  *
  * @return {Object} Updated state.
  */
-function navigationPanelActiveMenu( state, action ) {
+function navigationPanelActiveMenu( state = 'root', action ) {
 	switch ( action.type ) {
 		case 'SET_NAVIGATION_PANEL_ACTIVE_MENU':
 			return action.menu;

--- a/packages/edit-site/src/store/reducer.js
+++ b/packages/edit-site/src/store/reducer.js
@@ -182,7 +182,7 @@ export function homeTemplateId( state, action ) {
  *
  * @return {Object} Updated state.
  */
-function navigationPanelActiveMenu( state = 'root', action ) {
+function navigationPanelActiveMenu( state, action ) {
 	switch ( action.type ) {
 		case 'SET_NAVIGATION_PANEL_ACTIVE_MENU':
 			return action.menu;


### PR DESCRIPTION
## Description

The Site Editor's navigation sidebar keeps its active menu state in the `edit-site` store.

Though, the state wasn't cleared when closing the sidebar, so reopening it would automatically enter whatever menu was left active before.

This PR clears the active menu state of the Site Editor sidebar when it's closed, so that reopening it will enter the root menu.

## How has this been tested?

- Enable the Site Editor experiment.
- Open the Site Editor.
- Toggle the sidebar (click on the top-left WP/site icon).
- Navigate into a nested menu.
- Close the sidebar (click on the same WP/site icon).
- Reopen the sidebar.
- It should start from the "root" menu, instead of the one left open before.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
