### PR TITLE
Add separate widgets endpoint

### DIFF
--- a/lib/class-wp-rest-sidebars-controller.php
+++ b/lib/class-wp-rest-sidebars-controller.php
@@ -271,9 +271,14 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 				$data[ $property_id ] = $property['default'];
 			}
 		}
+		
+		$context  = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data = $this->add_additional_fields_to_object( $data, $request );
+		$data = $this->filter_response_by_context( $data, $context );
 
-		$data     = $this->filter_response_by_context( $data, $request['context'] );
 		$response = rest_ensure_response( $data );
+
+		$response->add_links( $this->prepare_links( $sidebar ) );
 
 		/**
 		 * Filters a sidebar location returned from the REST API.
@@ -286,6 +291,28 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 		 * @param WP_REST_Request  $request  Request used to generate the response.
 		 */
 		return apply_filters( 'rest_prepare_sidebar', $response, $sidebar, $request );
+	}
+
+	/**
+	 * Prepares links for the request.
+	 *
+	 * @param Array $sidebar Sidebar.
+	 *
+	 * @return array Links for the given widget.
+	 */
+	protected function prepare_links( $sidebar ) {
+		return array(
+			'collection'               => array(
+				'href' => rest_url( sprintf( '%s/%s', $this->namespace, $this->rest_base ) ),
+			),
+			'self'                     => array(
+				'href' => rest_url( sprintf( '%s/%s/%s', $this->namespace, $this->rest_base, $sidebar['id'] ) ),
+			),
+			'https://api.w.org/widget' => array(
+				'href'       => add_query_arg( 'sidebar', $sidebar['id'], rest_url( sprintf( '%s/%s', '__experimental', 'widgets' ) ) ),
+				'embeddable' => true,
+			),
+		);
 	}
 
 	/**

--- a/lib/class-wp-rest-sidebars-controller.php
+++ b/lib/class-wp-rest-sidebars-controller.php
@@ -58,6 +58,9 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_items' ),
 					'permission_callback' => array( $this, 'permissions_check' ),
+					'args'                => array(
+						'context' => $this->get_context_param( array( 'default' => 'view' ) ),
+					),
 				),
 				'schema' => array( $this, 'get_public_item_schema' ),
 			)
@@ -73,13 +76,14 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 					'callback'            => array( $this, 'get_item' ),
 					'permission_callback' => array( $this, 'permissions_check' ),
 					'args'                => array(
-						'id' => array(
+						'id'      => array(
 							'description'       => __( 'The id of a registered sidebar', 'gutenberg' ),
 							'type'              => 'string',
 							'validate_callback' => function ( $id ) {
 								return $this->get_sidebar( $id )[0];
 							},
 						),
+						'context' => $this->get_context_param( array( 'default' => 'view' ) ),
 					),
 				),
 				array(
@@ -128,7 +132,9 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 		foreach ( (array) wp_get_sidebars_widgets() as $id => $widgets ) {
 			$sidebar = $this->get_sidebar( $id )[1];
 
-			$data[] = $this->prepare_item_for_response( $sidebar, $request )->get_data();
+			$data[] = $this->prepare_response_for_collection(
+				$this->prepare_item_for_response( $sidebar, $request )
+			);
 		}
 
 		return rest_ensure_response( $data );
@@ -169,6 +175,8 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 
 			$sidebars[ $request['id'] ] = $request['widgets'];
 		}
+
+		$request['context'] = 'edit';
 
 		return $this->prepare_item_for_response( $this->get_sidebar( $request['id'] ), $request );
 	}

--- a/lib/class-wp-rest-sidebars-controller.php
+++ b/lib/class-wp-rest-sidebars-controller.php
@@ -140,6 +140,8 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 			foreach ( $data['widgets'] as $j => $widget ) {
 				$response->data[ $i ]['widgets'][ $j ] = rest_do_request( '/wp/v2/widgets/' . $widget )->get_data();
 			}
+
+			$response->data[ $i ]['widgets'] = array_values( $response->data[ $i ]['widgets'] );
 		}
 
 		return $response;
@@ -220,6 +222,8 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 			foreach ( $response->data['widgets'] as $i => $widget ) {
 				$response->data['widgets'][ $i ] = $widgets[ $i ];
 			}
+
+			$response->data['widgets'] = array_values( $response->data['widgets'] );
 		}
 
 		return $response;

--- a/lib/class-wp-rest-sidebars-controller.php
+++ b/lib/class-wp-rest-sidebars-controller.php
@@ -34,7 +34,7 @@
 class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 
 	/**
-	 * Plugins controller constructor.
+	 * Sidebars controller constructor.
 	 *
 	 * @since 5.5.0
 	 */
@@ -77,7 +77,7 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 							'description'       => __( 'The id of a registered sidebar', 'gutenberg' ),
 							'type'              => 'string',
 							'validate_callback' => function ( $id ) {
-								return self::get_sidebar( $id )[0];
+								return $this->get_sidebar( $id )[0];
 							},
 						),
 					),
@@ -97,7 +97,7 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 	 * Checks if the user has permissions to make the request.
 	 *
 	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
-	 * @since 5.6.0
+	 * @since  5.6.0
 	 * @access public
 	 */
 	public function permissions_check() {
@@ -116,112 +116,17 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 		return true;
 	}
 
-
-	/**
-	 * Updates the sidebar.
-	 *
-	 * @param WP_REST_Request $request The request instance.
-	 *
-	 * @return WP_REST_Response
-	 * @global array $wp_registered_widget_updates
-	 */
-	public function update_item( $request ) {
-		global $wp_registered_widget_updates, $wp_registered_widgets;
-		$sidebar_id    = $request['id'];
-		$input_widgets = $request['widgets'];
-
-		// Initialize $numbers.
-		$numbers = array();
-		foreach ( $wp_registered_widget_updates as $id_base => $control ) {
-			if ( is_array( $control['callback'] ) ) {
-				$numbers[ $id_base ] = $control['callback'][0]->number + 1;
-			}
-		}
-
-		// Create and update widgets.
-		$sidebar_widgets_ids = array();
-		foreach ( $input_widgets as $input_widget ) {
-			ob_start();
-			if ( isset( $input_widget['id_base'] ) && isset( $wp_registered_widget_updates[ $input_widget['id_base'] ] ) ) {
-				// Class-based widget.
-				$update_control = $wp_registered_widget_updates[ $input_widget['id_base'] ];
-				if ( ! isset( $input_widget['id'] ) ) {
-					$number = $numbers[ $input_widget['id_base'] ] ++;
-					$id     = $input_widget['id_base'] . '-' . $number;
-
-					$input_widget['id']     = $id;
-					$input_widget['number'] = $number;
-				}
-				$field                      = 'widget-' . $input_widget['id_base'];
-				$number                     = $input_widget['number'];
-				$_POST                      = $input_widget;
-				$_POST[ $field ][ $number ] = wp_slash( $input_widget['settings'] );
-				call_user_func( $update_control['callback'] );
-				$update_control['callback'][0]->updated = false;
-
-				// Just because we saved new widget doesn't mean it was added to $wp_registered_widgets.
-				// Let's make sure it's there so that it's included in the response.
-				if ( ! isset( $wp_registered_widgets[ $input_widget['id'] ] ) ) {
-					$first_widget_id = substr( $input_widget['id'], 0, strrpos( $input_widget['id'], '-' ) ) . '-1';
-
-					if ( isset( $wp_registered_widgets[ $first_widget_id ] ) ) {
-						$wp_registered_widgets[ $input_widget['id'] ] = $wp_registered_widgets[ $first_widget_id ];
-						$widget_class                                 = get_class( $update_control['callback'][0] );
-						$new_object                                   = new $widget_class(
-							$input_widget['id_base'],
-							$input_widget['name'],
-							$input_widget['settings']
-						);
-						$new_object->_register();
-						$wp_registered_widgets[ $input_widget['id'] ]['callback'][0] = $new_object;
-					}
-				}
-			} else {
-				$registered_widget_id = null;
-				if ( isset( $wp_registered_widget_updates[ $input_widget['id'] ] ) ) {
-					$registered_widget_id = $input_widget['id'];
-				} else {
-					$numberless_id = substr( $input_widget['id'], 0, strrpos( $input_widget['id'], '-' ) );
-					if ( isset( $wp_registered_widget_updates[ $numberless_id ] ) ) {
-						$registered_widget_id = $numberless_id;
-					}
-				}
-
-				if ( $registered_widget_id ) {
-					// Old-style widget.
-					$update_control = $wp_registered_widget_updates[ $registered_widget_id ];
-					$_POST          = wp_slash( $input_widget['settings'] );
-					call_user_func( $update_control['callback'] );
-				}
-			}
-			ob_end_clean();
-
-			$sidebar_widgets_ids[] = $input_widget['id'];
-		}
-
-		// Update sidebar to only consist of the widgets we just processed.
-		$sidebars                = wp_get_sidebars_widgets();
-		$sidebars[ $sidebar_id ] = $sidebar_widgets_ids;
-		wp_set_sidebars_widgets( $sidebars );
-
-		$request = new WP_REST_Request( 'GET' );
-		$request->set_param( 'id', $sidebar_id );
-
-		return $this->get_item( $request );
-	}
-
 	/**
 	 * Returns a list of sidebars (active or inactive)
 	 *
 	 * @param WP_REST_Request $request The request instance.
 	 *
 	 * @return WP_REST_Response
-	 * @global array $wp_registered_sidebars
 	 */
 	public function get_items( $request ) {
 		$data = array();
 		foreach ( (array) wp_get_sidebars_widgets() as $id => $widgets ) {
-			$sidebar = self::get_sidebar( $id )[1];
+			$sidebar = $this->get_sidebar( $id )[1];
 
 			$data[] = $this->prepare_item_for_response( $sidebar, $request )->get_data();
 		}
@@ -237,9 +142,35 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response
 	 */
 	public function get_item( $request ) {
-		$sidebar = self::get_sidebar( $request['id'] )[1];
+		$sidebar = $this->get_sidebar( $request['id'] )[1];
 
 		return $this->prepare_item_for_response( $sidebar, $request );
+	}
+
+	/**
+	 * Updates the sidebar.
+	 *
+	 * @param WP_REST_Request $request The request instance.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function update_item( $request ) {
+		if ( isset( $request['widgets'] ) ) {
+			$sidebars = wp_get_sidebars_widgets();
+
+			foreach ( $sidebars as $sidebar_id => $widgets ) {
+				foreach ( $widgets as $i => $widget_id ) {
+					if ( in_array( $widget_id, $request['widgets'], true ) ) {
+						unset( $sidebars[ $sidebar_id ][ $i ] );
+						$sidebars['wp_inactive_widgets'][] = $widget_id;
+					}
+				}
+			}
+
+			$sidebars[ $request['id'] ] = $request['widgets'];
+		}
+
+		return $this->prepare_item_for_response( $this->get_sidebar( $request['id'] ), $request );
 	}
 
 	/**
@@ -250,9 +181,9 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 	 * @param string|int $id ID of the sidebar.
 	 *
 	 * @return array|null
-	 * @global array $wp_registered_sidebars
+	 * @global array     $wp_registered_sidebars
 	 */
-	public static function get_sidebar( $id ) {
+	protected function get_sidebar( $id ) {
 		global $wp_registered_sidebars;
 
 		if ( is_int( $id ) ) {
@@ -277,108 +208,10 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Returns a list of widgets for the given sidebar id
-	 *
-	 * @param string          $sidebar_id ID of the sidebar.
-	 * @param WP_REST_Request $request    Request object.
-	 *
-	 * @return array
-	 * @global array $wp_registered_widgets
-	 * @global array $wp_registered_sidebars
-	 */
-	public static function get_widgets( $sidebar_id, $request ) {
-		global $wp_registered_widgets, $wp_registered_sidebars, $wp_registered_widget_controls;
-
-		$widgets            = array();
-		$sidebars_widgets   = (array) wp_get_sidebars_widgets();
-		$registered_sidebar = isset( $wp_registered_sidebars[ $sidebar_id ] )
-			? $wp_registered_sidebars[ $sidebar_id ]
-			: (
-			'wp_inactive_widgets' === $sidebar_id ? array() : null
-			);
-
-		if ( null !== $registered_sidebar && isset( $sidebars_widgets[ $sidebar_id ] ) ) {
-			foreach ( $sidebars_widgets[ $sidebar_id ] as $widget_id ) {
-				// Just to be sure.
-				if ( isset( $wp_registered_widgets[ $widget_id ] ) ) {
-					$widget = $wp_registered_widgets[ $widget_id ];
-
-					// Get the widget output.
-					if ( is_callable( $widget['callback'] ) ) {
-						// @note: everything up to ob_start is taken from the dynamic_sidebar function.
-						$widget_parameters = array_merge(
-							array(
-								array_merge(
-									$registered_sidebar,
-									array(
-										'widget_id'   => $widget_id,
-										'widget_name' => $widget['name'],
-									)
-								),
-							),
-							(array) $widget['params']
-						);
-
-						$classname = '';
-						foreach ( (array) $widget['classname'] as $cn ) {
-							if ( is_string( $cn ) ) {
-								$classname .= '_' . $cn;
-							} elseif ( is_object( $cn ) ) {
-								$classname .= '_' . get_class( $cn );
-							}
-						}
-						$classname = ltrim( $classname, '_' );
-						if ( isset( $widget_parameters[0]['before_widget'] ) ) {
-							$widget_parameters[0]['before_widget'] = sprintf(
-								$widget_parameters[0]['before_widget'],
-								$widget_id,
-								$classname
-							);
-						}
-
-						ob_start();
-						call_user_func_array( $widget['callback'], $widget_parameters );
-						$widget['rendered'] = trim( ob_get_clean() );
-					}
-
-					if ( is_array( $widget['callback'] ) && isset( $widget['callback'][0] ) ) {
-						$instance               = $widget['callback'][0];
-						$widget['widget_class'] = get_class( $instance );
-						$widget['settings']     = static::get_sidebar_widget_instance(
-							$registered_sidebar,
-							$widget_id
-						);
-						$widget['number']       = (int) $widget['params'][0]['number'];
-						$widget['id_base']      = $instance->id_base;
-					}
-
-					if ( 'edit' === $request['context'] && isset( $wp_registered_widget_controls[ $widget_id ]['callback'] ) ) {
-						$control   = $wp_registered_widget_controls[ $widget_id ];
-						$arguments = array();
-						if ( ! empty( $widget['number'] ) ) {
-							$arguments[0] = array( 'number' => $widget['number'] );
-						}
-						ob_start();
-						call_user_func_array( $control['callback'], $arguments );
-						$widget['rendered_form'] = trim( ob_get_clean() );
-					}
-
-					unset( $widget['params'] );
-					unset( $widget['callback'] );
-
-					$widgets[] = $widget;
-				}
-			}
-		}
-
-		return $widgets;
-	}
-
-	/**
 	 * Prepare a single sidebar output for response
 	 *
 	 * @param array           $raw_sidebar Sidebar instance.
-	 * @param WP_REST_Request $request Request object.
+	 * @param WP_REST_Request $request     Request object.
 	 *
 	 * @return WP_REST_Response $data
 	 */
@@ -404,33 +237,22 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 
 		$fields = $this->get_fields_for_response( $request );
 		if ( rest_is_field_included( 'widgets', $fields ) ) {
-			$sidebar['widgets'] = self::get_widgets( $sidebar['id'], $request );
+			$widgets = wp_get_sidebars_widgets();
+
+			$sidebar['widgets'] = isset( $widgets[ $sidebar['id'] ] ) ? $widgets[ $sidebar['id'] ] : array();
 		}
 
 		$schema = $this->get_item_schema();
 		$data   = array();
 		foreach ( $schema['properties'] as $property_id => $property ) {
-			if ( isset( $sidebar[ $property_id ] ) && gettype( $sidebar[ $property_id ] ) === $property['type'] ) {
+			if ( isset( $sidebar[ $property_id ] ) && true === rest_validate_value_from_schema( $sidebar[ $property_id ], $property ) ) {
 				$data[ $property_id ] = $sidebar[ $property_id ];
 			} elseif ( isset( $property['default'] ) ) {
 				$data[ $property_id ] = $property['default'];
 			}
 		}
 
-		foreach ( $sidebar['widgets'] as $widget_id => $widget ) {
-			$widget_data = array();
-			foreach ( $schema['properties']['widgets']['items']['properties'] as $property_id => $property ) {
-				if ( isset( $widget[ $property_id ] ) && gettype( $widget[ $property_id ] ) === $property['type'] ) {
-					$widget_data[ $property_id ] = $widget[ $property_id ];
-				} elseif ( 'settings' === $property_id && isset( $widget[ $property_id ] ) && 'array' === gettype( $widget[ $property_id ] ) ) {
-					$widget_data[ $property_id ] = $widget['settings'];
-				} elseif ( isset( $property['default'] ) ) {
-					$widget_data[ $property_id ] = $property['default'];
-				}
-			}
-			$data['widgets'][ $widget_id ] = $widget_data;
-		}
-
+		$data     = $this->filter_response_by_context( $data, $request['context'] );
 		$response = rest_ensure_response( $data );
 
 		/**
@@ -440,8 +262,8 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 		 * returned.
 		 *
 		 * @param WP_REST_Response $response The response object.
-		 * @param object $sidebar The original status object.
-		 * @param WP_REST_Request $request Request used to generate the response.
+		 * @param object           $sidebar  The original status object.
+		 * @param WP_REST_Request  $request  Request used to generate the response.
 		 */
 		return apply_filters( 'rest_prepare_sidebar', $response, $sidebar, $request );
 	}
@@ -494,57 +316,7 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 					'description' => __( 'Nested widgets.', 'gutenberg' ),
 					'type'        => 'array',
 					'items'       => array(
-						'type'       => 'object',
-						'properties' => array(
-							'id'            => array(
-								'description' => __( 'Unique identifier for the widget.', 'gutenberg' ),
-								'type'        => 'string',
-								'context'     => array( 'view', 'edit', 'embed' ),
-							),
-							'id_base'       => array(
-								'description' => __( 'Type of widget for the object.', 'gutenberg' ),
-								'type'        => 'string',
-								'context'     => array( 'view', 'edit', 'embed' ),
-							),
-							'widget_class'  => array(
-								'description' => __( 'Class name of the widget implementation.', 'gutenberg' ),
-								'type'        => 'string',
-								'context'     => array( 'view', 'edit', 'embed' ),
-							),
-							'name'          => array(
-								'description' => __( 'Name of the widget.', 'gutenberg' ),
-								'type'        => 'string',
-								'context'     => array( 'view', 'edit', 'embed' ),
-							),
-							'description'   => array(
-								'description' => __( 'Description of the widget.', 'gutenberg' ),
-								'type'        => 'string',
-								'context'     => array( 'view', 'edit', 'embed' ),
-							),
-							'number'        => array(
-								'description' => __( 'Number of the widget.', 'gutenberg' ),
-								'type'        => 'integer',
-								'context'     => array( 'view', 'edit', 'embed' ),
-							),
-							'rendered'      => array(
-								'description' => __( 'HTML representation of the widget.', 'gutenberg' ),
-								'type'        => 'string',
-								'context'     => array( 'view', 'embed' ),
-								'readonly'    => true,
-							),
-							'rendered_form' => array(
-								'description' => __( 'HTML representation of the widget admin form.', 'gutenberg' ),
-								'type'        => 'string',
-								'context'     => array( 'edit' ),
-								'readonly'    => true,
-							),
-							'settings'      => array(
-								'description' => __( 'Settings of the widget.', 'gutenberg' ),
-								'type'        => 'object',
-								'context'     => array( 'view', 'edit', 'embed' ),
-								'default'     => array(),
-							),
-						),
+						'type' => 'string',
 					),
 					'default'     => array(),
 					'context'     => array( 'embed', 'view', 'edit' ),
@@ -556,80 +328,4 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 
 		return $this->add_additional_fields_schema( $this->schema );
 	}
-
-	/**
-	 * Retrieves a widget instance.
-	 *
-	 * @param array  $sidebar sidebar data available at $wp_registered_sidebars.
-	 * @param string $id Identifier of the widget instance.
-	 *
-	 * @return array Array containing the widget instance.
-	 * @since 5.7.0
-	 */
-	public static function get_sidebar_widget_instance( $sidebar, $id ) {
-		list( $object, $number, $name ) = static::get_widget_info( $id );
-		if ( ! $object ) {
-			return array();
-		}
-
-		$object->_set( $number );
-
-		$instances = $object->get_settings();
-		$instance  = $instances[ $number ];
-
-		$args = array_merge(
-			$sidebar,
-			array(
-				'widget_id'   => $id,
-				'widget_name' => $name,
-			)
-		);
-
-		/**
-		 * Filters the settings for a particular widget instance.
-		 *
-		 * Returning false will effectively short-circuit display of the widget.
-		 *
-		 * @param array $instance The current widget instance's settings.
-		 * @param WP_Widget $this The current widget instance.
-		 * @param array $args An array of default widget arguments.
-		 *
-		 * @since 2.8.0
-		 */
-		$instance = apply_filters( 'widget_display_callback', $instance, $object, $args );
-
-		if ( false === $instance ) {
-			return array();
-		}
-
-		return $instance;
-	}
-
-	/**
-	 * Given a widget id returns an array containing information about the widget.
-	 *
-	 * @param string $widget_id Identifier of the widget.
-	 *
-	 * @return array Array containing the the widget object, the number, and the name.
-	 * @since 5.7.0
-	 */
-	private static function get_widget_info( $widget_id ) {
-		global $wp_registered_widgets;
-
-		if (
-			! isset( $wp_registered_widgets[ $widget_id ]['callback'][0] ) ||
-			! isset( $wp_registered_widgets[ $widget_id ]['params'][0]['number'] ) ||
-			! isset( $wp_registered_widgets[ $widget_id ]['name'] ) ||
-			! ( $wp_registered_widgets[ $widget_id ]['callback'][0] instanceof WP_Widget )
-		) {
-			return array( null, null, null );
-		}
-
-		$object = $wp_registered_widgets[ $widget_id ]['callback'][0];
-		$number = $wp_registered_widgets[ $widget_id ]['params'][0]['number'];
-		$name   = $wp_registered_widgets[ $widget_id ]['name'];
-
-		return array( $object, $number, $name );
-	}
-
 }

--- a/lib/class-wp-rest-sidebars-controller.php
+++ b/lib/class-wp-rest-sidebars-controller.php
@@ -236,9 +236,14 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 		if ( isset( $wp_registered_sidebars[ $id ] ) ) {
 			$registered_sidebar = $wp_registered_sidebars[ $id ];
 
-			$sidebar['status']      = 'active';
-			$sidebar['name']        = isset( $registered_sidebar['name'] ) ? $registered_sidebar['name'] : '';
-			$sidebar['description'] = isset( $registered_sidebar['description'] ) ? $registered_sidebar['description'] : '';
+			$sidebar['status']        = 'active';
+			$sidebar['name']          = isset( $registered_sidebar['name'] ) ? $registered_sidebar['name'] : '';
+			$sidebar['description']   = isset( $registered_sidebar['description'] ) ? $registered_sidebar['description'] : '';
+			$sidebar['class']         = isset( $registered_sidebar['class'] ) ? $registered_sidebar['class'] : '';
+			$sidebar['before_widget'] = isset( $registered_sidebar['before_widget'] ) ? $registered_sidebar['before_widget'] : '';
+			$sidebar['after_widget']  = isset( $registered_sidebar['after_widget'] ) ? $registered_sidebar['after_widget'] : '';
+			$sidebar['before_title']  = isset( $registered_sidebar['before_title'] ) ? $registered_sidebar['before_title'] : '';
+			$sidebar['after_title']   = isset( $registered_sidebar['after_title'] ) ? $registered_sidebar['after_title'] : '';
 		} else {
 			$sidebar['status'] = 'inactive';
 		}
@@ -271,10 +276,10 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 				$data[ $property_id ] = $property['default'];
 			}
 		}
-		
-		$context  = ! empty( $request['context'] ) ? $request['context'] : 'view';
-		$data = $this->add_additional_fields_to_object( $data, $request );
-		$data = $this->filter_response_by_context( $data, $context );
+
+		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data    = $this->add_additional_fields_to_object( $data, $request );
+		$data    = $this->filter_response_by_context( $data, $context );
 
 		$response = rest_ensure_response( $data );
 
@@ -330,28 +335,63 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 			'title'      => 'sidebar',
 			'type'       => 'object',
 			'properties' => array(
-				'id'          => array(
+				'id'            => array(
 					'description' => __( 'ID of sidebar.', 'gutenberg' ),
 					'type'        => 'string',
 					'default'     => '',
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'name'        => array(
+				'name'          => array(
 					'description' => __( 'Unique name identifying the sidebar.', 'gutenberg' ),
 					'type'        => 'string',
 					'default'     => '',
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'description' => array(
+				'description'   => array(
 					'description' => __( 'Description of sidebar.', 'gutenberg' ),
 					'type'        => 'string',
 					'default'     => '',
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'status'      => array(
+				'class'         => array(
+					'description' => __( 'Extra CSS class to assign to the sidebar in the Widgets interface.', 'gutenberg' ),
+					'type'        => 'string',
+					'default'     => '',
+					'context'     => array( 'embed', 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'before_widget' => array(
+					'description' => __( 'HTML content to prepend to each widget\'s HTML output when assigned to this sidebar. Default is an opening list item element.', 'gutenberg' ),
+					'type'        => 'string',
+					'default'     => '',
+					'context'     => array( 'embed', 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'after_widget'  => array(
+					'description' => __( 'HTML content to append to each widget\'s HTML output when assigned to this sidebar. Default is a closing list item element.', 'gutenberg' ),
+					'type'        => 'string',
+					'default'     => '',
+					'context'     => array( 'embed', 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'before_title'  => array(
+					'description' => __( 'HTML content to prepend to the sidebar title when displayed. Default is an opening h2 element.', 'gutenberg' ),
+					'type'        => 'string',
+					'default'     => '',
+					'context'     => array( 'embed', 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'after_title'   => array(
+					'description' => __( 'HTML content to append to the sidebar title when displayed. Default is a closing h2 element.', 'gutenberg' ),
+					'type'        => 'string',
+					'default'     => '',
+					'context'     => array( 'embed', 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'status'        => array(
 					'description' => __( 'Status of sidebar.', 'gutenberg' ),
 					'type'        => 'string',
 					'enum'        => array( 'active', 'inactive' ),
@@ -359,7 +399,7 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'widgets'     => array(
+				'widgets'       => array(
 					'description' => __( 'Nested widgets.', 'gutenberg' ),
 					'type'        => 'array',
 					'items'       => array(

--- a/lib/class-wp-rest-sidebars-controller.php
+++ b/lib/class-wp-rest-sidebars-controller.php
@@ -228,7 +228,7 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response $data
 	 */
 	public function prepare_item_for_response( $raw_sidebar, $request ) {
-		global $wp_registered_sidebars;
+		global $wp_registered_sidebars, $wp_registered_widgets;
 
 		$id      = $raw_sidebar['id'];
 		$sidebar = array( 'id' => $id );
@@ -257,9 +257,7 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 			$sidebars = wp_get_sidebars_widgets();
 			$widgets  = array_filter(
 				isset( $sidebars[ $sidebar['id'] ] ) ? $sidebars[ $sidebar['id'] ] : array(),
-				function ( $widget_id ) {
-					global $wp_registered_widgets;
-
+				function ( $widget_id ) use ( $wp_registered_widgets ) {
 					return isset( $wp_registered_widgets[ $widget_id ] );
 				}
 			);

--- a/lib/class-wp-rest-sidebars-controller.php
+++ b/lib/class-wp-rest-sidebars-controller.php
@@ -258,7 +258,11 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 	public function get_items( $request ) {
 		$data = array();
 		foreach ( (array) wp_get_sidebars_widgets() as $id => $widgets ) {
-			list( , $sidebar ) = $this->get_sidebar( $id );
+			list( $exists, $sidebar ) = $this->get_sidebar( $id );
+
+			if ( ! $exists && 'wp_inactive_widgets' !== $id ) {
+				continue;
+			}
 
 			$data[] = $this->prepare_response_for_collection(
 				$this->prepare_item_for_response( $sidebar, $request )

--- a/lib/class-wp-rest-widgets-controller.php
+++ b/lib/class-wp-rest-widgets-controller.php
@@ -1,7 +1,12 @@
 <?php
+/**
+ * REST API: WP_REST_Widgets_Controller class
+ *
+ * @package Gutenberg
+ */
 
 /**
- * Class WP_REST_Widgets_Controller
+ * Core class representing a controller for widgets.
  */
 class WP_REST_Widgets_Controller extends WP_REST_Controller {
 
@@ -13,6 +18,9 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 		$this->rest_base = 'widgets';
 	}
 
+	/**
+	 * Registers the widget routes for the controller.
+	 */
 	public function register_routes() {
 		register_rest_route(
 			$this->namespace,
@@ -59,7 +67,7 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 					'permission_callback' => array( $this, 'delete_item_permissions_check' ),
 					'args'                => array(
 						'force' => array(
-							'description' => __( 'Whether to force removal of the widget, or move it to the inactive sidebar.' ),
+							'description' => __( 'Whether to force removal of the widget, or move it to the inactive sidebar.', 'gutenberg' ),
 							'type'        => 'boolean',
 						),
 					),
@@ -70,14 +78,34 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 		);
 	}
 
-	public function get_items_permissions_check( $request ) {
+	/**
+	 * Checks if a given request has access to get widgets.
+	 *
+	 * @since 5.6.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
+	 */
+	public function get_items_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		return $this->permissions_check();
 	}
 
+	/**
+	 * Retrieves a collection of widgets.
+	 *
+	 * @since 5.6.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
 	public function get_items( $request ) {
 		$prepared = array();
 
 		foreach ( wp_get_sidebars_widgets() as $sidebar_id => $widget_ids ) {
+			if ( isset( $request['sidebar'] ) && $sidebar_id !== $request['sidebar'] ) {
+				continue;
+			}
+
 			foreach ( $widget_ids as $widget_id ) {
 				$response = $this->prepare_item_for_response( compact( 'sidebar_id', 'widget_id' ), $request );
 
@@ -90,10 +118,26 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 		return new WP_REST_Response( $prepared );
 	}
 
-	public function get_item_permissions_check( $request ) {
+	/**
+	 * Checks if a given request has access to get a widget.
+	 *
+	 * @since 5.6.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
+	 */
+	public function get_item_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		return $this->permissions_check();
 	}
 
+	/**
+	 * Gets an individual widget.
+	 *
+	 * @since 5.6.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
 	public function get_item( $request ) {
 		$widget_id  = $request['id'];
 		$sidebar_id = $this->find_widgets_sidebar( $widget_id );
@@ -105,10 +149,26 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 		return $this->prepare_item_for_response( compact( 'sidebar_id', 'widget_id' ), $request );
 	}
 
-	public function create_item_permissions_check( $request ) {
+	/**
+	 * Checks if a given request has access to create widgets.
+	 *
+	 * @since 5.6.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
+	 */
+	public function create_item_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		return $this->permissions_check();
 	}
 
+	/**
+	 * Creates a widget.
+	 *
+	 * @since 5.6.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
 	public function create_item( $request ) {
 		$backup_post = $_POST;
 		$sidebar_id  = $request['sidebar'];
@@ -122,10 +182,26 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 		return $response;
 	}
 
-	public function update_item_permissions_check( $request ) {
+	/**
+	 * Checks if a given request has access to update widgets.
+	 *
+	 * @since 5.6.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
+	 */
+	public function update_item_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		return $this->permissions_check();
 	}
 
+	/**
+	 * Updates an existing widget.
+	 *
+	 * @since 5.6.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
 	public function update_item( $request ) {
 		$widget_id  = $request['id'];
 		$sidebar_id = $this->find_widgets_sidebar( $widget_id );
@@ -146,10 +222,26 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 		return $this->prepare_item_for_response( compact( 'sidebar_id', 'widget_id' ), $request );
 	}
 
-	public function delete_item_permissions_check( $request ) {
+	/**
+	 * Checks if a given request has access to delete widgets.
+	 *
+	 * @since 5.6.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
+	 */
+	public function delete_item_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		return $this->permissions_check();
 	}
 
+	/**
+	 * Deletes a widget.
+	 *
+	 * @since 5.6.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
 	public function delete_item( $request ) {
 		$widget_id  = $request['id'];
 		$sidebar_id = $this->find_widgets_sidebar( $widget_id );
@@ -175,6 +267,12 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 		return $prepared;
 	}
 
+	/**
+	 * Assigns a widget to the given sidebar.
+	 *
+	 * @param string $widget_id  The widget id to assign.
+	 * @param string $sidebar_id The sidebar id to assign to.
+	 */
 	protected function assign_to_sidebar( $widget_id, $sidebar_id ) {
 		$sidebars = wp_get_sidebars_widgets();
 
@@ -188,7 +286,9 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 			}
 		}
 
-		$sidebars[ $sidebar_id ][] = $widget_id;
+		if ( $sidebar_id ) {
+			$sidebars[ $sidebar_id ][] = $widget_id;
+		}
 
 		wp_set_sidebars_widgets( $sidebars );
 	}
@@ -231,7 +331,9 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * @param WP_REST_Request $request
+	 * Saves the widget in the request object.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
 	 *
 	 * @return string
 	 */
@@ -307,6 +409,15 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 		return $input_widget['id'];
 	}
 
+	/**
+	 * Prepares the widget for the REST response.
+	 *
+	 * @since 5.6.0
+	 *
+	 * @param array           $item    An array containing a widget_id and sidebar_id.
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
 	public function prepare_item_for_response( $item, $request ) {
 		global $wp_registered_widgets, $wp_registered_sidebars, $wp_registered_widget_controls;
 
@@ -314,7 +425,7 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 		$sidebar_id = $item['sidebar_id'];
 
 		if ( ! isset( $wp_registered_widgets[ $widget_id ] ) ) {
-			return new WP_Error( 'rest_invalid_widget', __( 'The requested widget is invalid.' ), array( 'status' => 500 ) );
+			return new WP_Error( 'rest_invalid_widget', __( 'The requested widget is invalid.', 'gutenberg' ), array( 'status' => 500 ) );
 		}
 
 		$fields = $this->get_fields_for_response( $request );
@@ -416,7 +527,6 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 	 * @param string $id      Identifier of the widget instance.
 	 *
 	 * @return array Array containing the widget instance.
-	 * @since 5.7.0
 	 */
 	protected function get_sidebar_widget_instance( $sidebar, $id ) {
 		list( $object, $number, $name ) = $this->get_widget_info( $id );
@@ -473,18 +583,30 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 		return array( $object, $number, $name );
 	}
 
+	/**
+	 * Gets the list of collection params.
+	 *
+	 * @since 5.6.0
+	 *
+	 * @return array[]
+	 */
 	public function get_collection_params() {
-		$params = array(
+		return array(
 			'context' => $this->get_context_param( array( 'default' => 'view' ) ),
 			'sidebar' => array(
-				'description' => __( 'The sidebar to return widgets for.' ),
+				'description' => __( 'The sidebar to return widgets for.', 'gutenberg' ),
 				'type'        => 'string',
 			),
 		);
-
-		return $params;
 	}
 
+	/**
+	 * Retrieves the widget's schema, conforming to JSON Schema.
+	 *
+	 * @since 5.6.0
+	 *
+	 * @return array Item schema data.
+	 */
 	public function get_item_schema() {
 		if ( $this->schema ) {
 			return $this->schema;

--- a/lib/class-wp-rest-widgets-controller.php
+++ b/lib/class-wp-rest-widgets-controller.php
@@ -14,7 +14,7 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 	 * Widgets controller constructor.
 	 */
 	public function __construct() {
-		$this->namespace = '__experimental';
+		$this->namespace = 'wp/v2';
 		$this->rest_base = 'widgets';
 	}
 
@@ -573,7 +573,7 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 	/**
 	 * Prepares links for the request.
 	 *
-	 * @param Array $prepared Widget.
+	 * @param array $prepared Widget.
 	 * @return array Links for the given widget.
 	 */
 	protected function prepare_links( $prepared ) {
@@ -585,7 +585,7 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 				'href' => rest_url( sprintf( '%s/%s/%s', $this->namespace, $this->rest_base, $prepared['id'] ) ),
 			),
 			'https://api.w.org/sidebar' => array(
-				'href' => rest_url( sprintf( '__experimental/sidebars/%s/', $prepared['sidebar'] ) ),
+				'href' => rest_url( sprintf( 'wp/v2/sidebars/%s/', $prepared['sidebar'] ) ),
 			),
 		);
 	}
@@ -610,7 +610,7 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 		$instance  = $instances[ $number ];
 
 		$args = array_merge(
-			$sidebar,
+			is_array( $sidebar ) ? $sidebar : array(),
 			array(
 				'widget_id'   => $id,
 				'widget_name' => $name,

--- a/lib/class-wp-rest-widgets-controller.php
+++ b/lib/class-wp-rest-widgets-controller.php
@@ -213,12 +213,16 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 		}
 
 		$backup_post = $_POST;
-		$this->save_widget( $request );
+
+		if ( isset( $request['settings'] ) ) {
+			$this->save_widget( $request );
+		}
+
 		$_POST = $backup_post;
 
 		if ( isset( $request['sidebar'] ) && $request['sidebar'] !== $sidebar_id ) {
-			$this->assign_to_sidebar( $widget_id, $sidebar_id );
 			$sidebar_id = $request['sidebar'];
+			$this->assign_to_sidebar( $widget_id, $sidebar_id );
 		}
 
 		$request['context'] = 'edit';
@@ -255,7 +259,8 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 		}
 
 		if ( $request['force'] ) {
-			$prepared = $this->prepare_item_for_response( compact( 'sidebar_id', 'widget_id' ), $request );
+			$request['context'] = 'edit';
+			$prepared           = $this->prepare_item_for_response( compact( 'sidebar_id', 'widget_id' ), $request );
 			$this->assign_to_sidebar( $widget_id, null );
 			$prepared->set_data(
 				array(
@@ -265,7 +270,13 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 			);
 		} else {
 			$this->assign_to_sidebar( $widget_id, 'wp_inactive_sidebar' );
-			$prepared = $this->prepare_item_for_response( compact( 'sidebar_id', 'widget_id' ), $request );
+			$prepared = $this->prepare_item_for_response(
+				array(
+					'sidebar_id' => 'wp_inactive_sidebar',
+					'widget_id'  => $widget_id,
+				),
+				$request
+			);
 		}
 
 		return $prepared;
@@ -449,7 +460,7 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 			'sidebar'       => $sidebar_id,
 			'widget_class'  => '',
 			'name'          => $widget['name'],
-			'description'   => $widget['description'],
+			'description'   => ! empty( $widget['description'] ) ? $widget['description'] : '',
 			'number'        => 0,
 			'rendered'      => '',
 			'rendered_form' => '',
@@ -661,7 +672,7 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 				'rendered'      => array(
 					'description' => __( 'HTML representation of the widget.', 'gutenberg' ),
 					'type'        => 'string',
-					'context'     => array( 'view', 'embed' ),
+					'context'     => array( 'view', 'edit', 'embed' ),
 					'readonly'    => true,
 				),
 				'rendered_form' => array(

--- a/lib/class-wp-rest-widgets-controller.php
+++ b/lib/class-wp-rest-widgets-controller.php
@@ -1,0 +1,558 @@
+<?php
+
+/**
+ * Class WP_REST_Widgets_Controller
+ */
+class WP_REST_Widgets_Controller extends WP_REST_Controller {
+
+	/**
+	 * Widgets controller constructor.
+	 */
+	public function __construct() {
+		$this->namespace = '__experimental';
+		$this->rest_base = 'widgets';
+	}
+
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => $this->get_collection_params(),
+				),
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'create_item' ),
+					'permission_callback' => array( $this, 'create_item_permissions_check' ),
+					'args'                => $this->get_endpoint_args_for_item_schema(),
+				),
+				'allow_batch' => true,
+				'schema'      => array( $this, 'get_public_item_schema' ),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base . '/(?P<id>[\w\-]+)',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+					'args'                => array(
+						'context' => $this->get_context_param( array( 'default' => 'view' ) ),
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'update_item' ),
+					'permission_callback' => array( $this, 'update_item_permissions_check' ),
+					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+				),
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'delete_item' ),
+					'permission_callback' => array( $this, 'delete_item_permissions_check' ),
+					'args'                => array(
+						'force' => array(
+							'description' => __( 'Whether to force removal of the widget, or move it to the inactive sidebar.' ),
+							'type'        => 'boolean',
+						),
+					),
+				),
+				'allow_batch' => true,
+				'schema'      => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	public function get_items_permissions_check( $request ) {
+		return $this->permissions_check();
+	}
+
+	public function get_items( $request ) {
+		$prepared = array();
+
+		foreach ( wp_get_sidebars_widgets() as $sidebar_id => $widget_ids ) {
+			foreach ( $widget_ids as $widget_id ) {
+				$response = $this->prepare_item_for_response( compact( 'sidebar_id', 'widget_id' ), $request );
+
+				if ( ! is_wp_error( $response ) ) {
+					$prepared[] = $this->prepare_response_for_collection( $response );
+				}
+			}
+		}
+
+		return new WP_REST_Response( $prepared );
+	}
+
+	public function get_item_permissions_check( $request ) {
+		return $this->permissions_check();
+	}
+
+	public function get_item( $request ) {
+		$widget_id  = $request['id'];
+		$sidebar_id = $this->find_widgets_sidebar( $widget_id );
+
+		if ( is_wp_error( $sidebar_id ) ) {
+			return $sidebar_id;
+		}
+
+		return $this->prepare_item_for_response( compact( 'sidebar_id', 'widget_id' ), $request );
+	}
+
+	public function create_item_permissions_check( $request ) {
+		return $this->permissions_check();
+	}
+
+	public function create_item( $request ) {
+		$backup_post = $_POST;
+		$sidebar_id  = $request['sidebar'];
+		$widget_id   = $this->save_widget( $request );
+		$_POST       = $backup_post;
+		$this->assign_to_sidebar( $widget_id, $sidebar_id );
+
+		$response = $this->prepare_item_for_response( compact( 'sidebar_id', 'widget_id' ), $request );
+		$response->set_status( 201 );
+
+		return $response;
+	}
+
+	public function update_item_permissions_check( $request ) {
+		return $this->permissions_check();
+	}
+
+	public function update_item( $request ) {
+		$widget_id  = $request['id'];
+		$sidebar_id = $this->find_widgets_sidebar( $widget_id );
+
+		if ( is_wp_error( $sidebar_id ) ) {
+			return $sidebar_id;
+		}
+
+		$backup_post = $_POST;
+		$this->save_widget( $request );
+		$_POST = $backup_post;
+
+		if ( isset( $request['sidebar'] ) && $request['sidebar'] !== $sidebar_id ) {
+			$this->assign_to_sidebar( $widget_id, $sidebar_id );
+			$sidebar_id = $request['sidebar'];
+		}
+
+		return $this->prepare_item_for_response( compact( 'sidebar_id', 'widget_id' ), $request );
+	}
+
+	public function delete_item_permissions_check( $request ) {
+		return $this->permissions_check();
+	}
+
+	public function delete_item( $request ) {
+		$widget_id  = $request['id'];
+		$sidebar_id = $this->find_widgets_sidebar( $widget_id );
+
+		if ( is_wp_error( $sidebar_id ) ) {
+			return $sidebar_id;
+		}
+
+		if ( $request['force'] ) {
+			$prepared = $this->prepare_item_for_response( compact( 'sidebar_id', 'widget_id' ), $request );
+			$this->assign_to_sidebar( $widget_id, null );
+			$prepared->set_data(
+				array(
+					'deleted'  => true,
+					'previous' => $prepared->get_data(),
+				)
+			);
+		} else {
+			$this->assign_to_sidebar( $widget_id, 'wp_inactive_sidebar' );
+			$prepared = $this->prepare_item_for_response( compact( 'sidebar_id', 'widget_id' ), $request );
+		}
+
+		return $prepared;
+	}
+
+	protected function assign_to_sidebar( $widget_id, $sidebar_id ) {
+		$sidebars = wp_get_sidebars_widgets();
+
+		foreach ( $sidebars as $maybe_sidebar_id => $widgets ) {
+			foreach ( $widgets as $i => $maybe_widget_id ) {
+				if ( $widget_id === $maybe_widget_id && $sidebar_id !== $maybe_sidebar_id ) {
+					unset( $sidebars[ $maybe_sidebar_id ][ $i ] );
+					// We could technically break 2 here, but continue looping in case the id is duplicated.
+					continue 2;
+				}
+			}
+		}
+
+		$sidebars[ $sidebar_id ][] = $widget_id;
+
+		wp_set_sidebars_widgets( $sidebars );
+	}
+
+	/**
+	 * Performs a permissions check for managing widgets.
+	 *
+	 * @return true|WP_Error
+	 */
+	protected function permissions_check() {
+		if ( ! current_user_can( 'edit_theme_options' ) ) {
+			return new WP_Error(
+				'rest_cannot_manage_widgets',
+				__( 'Sorry, you are not allowed to manage widgets on this site.', 'gutenberg' ),
+				array(
+					'status' => rest_authorization_required_code(),
+				)
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Finds the sidebar a widget belongs to.
+	 *
+	 * @param string $widget_id The widget id to search for.
+	 * @return string|WP_Error The found sidebar id, or a WP_Error instance if it does not exist.
+	 */
+	protected function find_widgets_sidebar( $widget_id ) {
+		foreach ( wp_get_sidebars_widgets() as $sidebar_id => $widget_ids ) {
+			foreach ( $widget_ids as $maybe_widget_id ) {
+				if ( $maybe_widget_id === $widget_id ) {
+					return (string) $sidebar_id;
+				}
+			}
+		}
+
+		return new WP_Error( 'rest_widget_not_found', __( 'No widget was found with that id.', 'gutenberg' ), array( 'status' => 404 ) );
+	}
+
+	/**
+	 * @param WP_REST_Request $request
+	 *
+	 * @return string
+	 */
+	protected function save_widget( $request ) {
+		global $wp_registered_widget_updates, $wp_registered_widgets;
+
+		// Initialize $numbers.
+		$numbers = array();
+		foreach ( $wp_registered_widget_updates as $id_base => $control ) {
+			if ( is_array( $control['callback'] ) ) {
+				$numbers[ $id_base ] = $control['callback'][0]->number + 1;
+			}
+		}
+
+		$input_widget = $request->get_params();
+
+		ob_start();
+		if ( isset( $input_widget['id_base'] ) && isset( $wp_registered_widget_updates[ $input_widget['id_base'] ] ) ) {
+			// Class-based widget.
+			$update_control = $wp_registered_widget_updates[ $input_widget['id_base'] ];
+			if ( ! isset( $input_widget['id'] ) ) {
+				$number = $numbers[ $input_widget['id_base'] ] ++;
+				$id     = $input_widget['id_base'] . '-' . $number;
+
+				$input_widget['id']     = $id;
+				$input_widget['number'] = $number;
+			}
+			$field                      = 'widget-' . $input_widget['id_base'];
+			$number                     = $input_widget['number'];
+			$_POST                      = $input_widget;
+			$_POST[ $field ][ $number ] = wp_slash( $input_widget['settings'] );
+			call_user_func( $update_control['callback'] );
+			$update_control['callback'][0]->updated = false;
+
+			// Just because we saved new widget doesn't mean it was added to $wp_registered_widgets.
+			// Let's make sure it's there so that it's included in the response.
+			if ( ! isset( $wp_registered_widgets[ $input_widget['id'] ] ) ) {
+				$first_widget_id = substr( $input_widget['id'], 0, strrpos( $input_widget['id'], '-' ) ) . '-1';
+
+				if ( isset( $wp_registered_widgets[ $first_widget_id ] ) ) {
+					$wp_registered_widgets[ $input_widget['id'] ] = $wp_registered_widgets[ $first_widget_id ];
+
+					$widget_class = get_class( $update_control['callback'][0] );
+					$new_object   = new $widget_class(
+						$input_widget['id_base'],
+						$input_widget['name'],
+						$input_widget['settings']
+					);
+					$new_object->_register();
+					$wp_registered_widgets[ $input_widget['id'] ]['callback'][0] = $new_object;
+				}
+			}
+		} else {
+			$registered_widget_id = null;
+			if ( isset( $wp_registered_widget_updates[ $input_widget['id'] ] ) ) {
+				$registered_widget_id = $input_widget['id'];
+			} else {
+				$numberless_id = substr( $input_widget['id'], 0, strrpos( $input_widget['id'], '-' ) );
+				if ( isset( $wp_registered_widget_updates[ $numberless_id ] ) ) {
+					$registered_widget_id = $numberless_id;
+				}
+			}
+
+			if ( $registered_widget_id ) {
+				// Old-style widget.
+				$update_control = $wp_registered_widget_updates[ $registered_widget_id ];
+				$_POST          = wp_slash( $input_widget['settings'] );
+				call_user_func( $update_control['callback'] );
+			}
+		}
+		ob_end_clean();
+
+		return $input_widget['id'];
+	}
+
+	public function prepare_item_for_response( $item, $request ) {
+		global $wp_registered_widgets, $wp_registered_sidebars, $wp_registered_widget_controls;
+
+		$widget_id  = $item['widget_id'];
+		$sidebar_id = $item['sidebar_id'];
+
+		if ( ! isset( $wp_registered_widgets[ $widget_id ] ) ) {
+			return new WP_Error( 'rest_invalid_widget', __( 'The requested widget is invalid.' ), array( 'status' => 500 ) );
+		}
+
+		$fields = $this->get_fields_for_response( $request );
+
+		if ( isset( $wp_registered_sidebars[ $sidebar_id ] ) ) {
+			$registered_sidebar = $wp_registered_sidebars[ $sidebar_id ];
+		} elseif ( 'wp_inactive_widgets' === $sidebar_id ) {
+			$registered_sidebar = array();
+		} else {
+			$registered_sidebar = null;
+		}
+
+		$widget   = $wp_registered_widgets[ $widget_id ];
+		$prepared = array(
+			'id'            => $widget_id,
+			'id_base'       => '',
+			'sidebar'       => $sidebar_id,
+			'widget_class'  => '',
+			'name'          => $widget['name'],
+			'description'   => $widget['description'],
+			'number'        => 0,
+			'rendered'      => '',
+			'rendered_form' => '',
+			'settings'      => array(),
+		);
+
+		// Get the widget output.
+		if ( is_callable( $widget['callback'] ) && rest_is_field_included( 'rendered', $fields ) ) {
+			// @note: everything up to ob_start is taken from the dynamic_sidebar function.
+			$widget_parameters = array_merge(
+				array(
+					array_merge(
+						$registered_sidebar,
+						array(
+							'widget_id'   => $widget_id,
+							'widget_name' => $widget['name'],
+						)
+					),
+				),
+				(array) $widget['params']
+			);
+
+			$classname = '';
+			foreach ( (array) $widget['classname'] as $cn ) {
+				if ( is_string( $cn ) ) {
+					$classname .= '_' . $cn;
+				} elseif ( is_object( $cn ) ) {
+					$classname .= '_' . get_class( $cn );
+				}
+			}
+			$classname = ltrim( $classname, '_' );
+			if ( isset( $widget_parameters[0]['before_widget'] ) ) {
+				$widget_parameters[0]['before_widget'] = sprintf(
+					$widget_parameters[0]['before_widget'],
+					$widget_id,
+					$classname
+				);
+			}
+
+			ob_start();
+			call_user_func_array( $widget['callback'], $widget_parameters );
+			$prepared['rendered'] = trim( ob_get_clean() );
+		}
+
+		if ( is_array( $widget['callback'] ) && isset( $widget['callback'][0] ) ) {
+			$instance                 = $widget['callback'][0];
+			$prepared['widget_class'] = get_class( $instance );
+			$prepared['settings']     = $this->get_sidebar_widget_instance(
+				$registered_sidebar,
+				$widget_id
+			);
+			$prepared['number']       = (int) $widget['params'][0]['number'];
+			$prepared['id_base']      = $instance->id_base;
+		}
+
+		if (
+			rest_is_field_included( 'rendered_form', $fields ) &&
+			isset( $wp_registered_widget_controls[ $widget_id ]['callback'] )
+		) {
+			$control   = $wp_registered_widget_controls[ $widget_id ];
+			$arguments = array();
+			if ( ! empty( $widget['number'] ) ) {
+				$arguments[0] = array( 'number' => $widget['number'] );
+			}
+			ob_start();
+			call_user_func_array( $control['callback'], $arguments );
+			$prepared['rendered_form'] = trim( ob_get_clean() );
+		}
+
+		$prepared = $this->filter_response_by_context( $prepared, $request['context'] );
+
+		return new WP_REST_Response( $prepared );
+	}
+
+	/**
+	 * Retrieves a widget instance.
+	 *
+	 * @param array  $sidebar sidebar data available at $wp_registered_sidebars.
+	 * @param string $id      Identifier of the widget instance.
+	 *
+	 * @return array Array containing the widget instance.
+	 * @since 5.7.0
+	 */
+	protected function get_sidebar_widget_instance( $sidebar, $id ) {
+		list( $object, $number, $name ) = $this->get_widget_info( $id );
+		if ( ! $object ) {
+			return array();
+		}
+
+		$object->_set( $number );
+
+		$instances = $object->get_settings();
+		$instance  = $instances[ $number ];
+
+		$args = array_merge(
+			$sidebar,
+			array(
+				'widget_id'   => $id,
+				'widget_name' => $name,
+			)
+		);
+
+		/** This filter is documented in wp-includes/class-wp-widget.php */
+		$instance = apply_filters( 'widget_display_callback', $instance, $object, $args );
+
+		if ( false === $instance ) {
+			return array();
+		}
+
+		return $instance;
+	}
+
+	/**
+	 * Given a widget id returns an array containing information about the widget.
+	 *
+	 * @param string $widget_id Identifier of the widget.
+	 *
+	 * @return array Array containing the the widget object, the number, and the name.
+	 */
+	protected function get_widget_info( $widget_id ) {
+		global $wp_registered_widgets;
+
+		if (
+			! isset( $wp_registered_widgets[ $widget_id ]['callback'][0] ) ||
+			! isset( $wp_registered_widgets[ $widget_id ]['params'][0]['number'] ) ||
+			! isset( $wp_registered_widgets[ $widget_id ]['name'] ) ||
+			! ( $wp_registered_widgets[ $widget_id ]['callback'][0] instanceof WP_Widget )
+		) {
+			return array( null, null, null );
+		}
+
+		$object = $wp_registered_widgets[ $widget_id ]['callback'][0];
+		$number = $wp_registered_widgets[ $widget_id ]['params'][0]['number'];
+		$name   = $wp_registered_widgets[ $widget_id ]['name'];
+
+		return array( $object, $number, $name );
+	}
+
+	public function get_collection_params() {
+		$params = array(
+			'context' => $this->get_context_param( array( 'default' => 'view' ) ),
+			'sidebar' => array(
+				'description' => __( 'The sidebar to return widgets for.' ),
+				'type'        => 'string',
+			),
+		);
+
+		return $params;
+	}
+
+	public function get_item_schema() {
+		if ( $this->schema ) {
+			return $this->schema;
+		}
+
+		$this->schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'widget',
+			'type'       => 'object',
+			'properties' => array(
+				'id'            => array(
+					'description' => __( 'Unique identifier for the widget.', 'gutenberg' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit', 'embed' ),
+				),
+				'id_base'       => array(
+					'description' => __( 'Type of widget for the object.', 'gutenberg' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit', 'embed' ),
+				),
+				'sidebar'       => array(
+					'description' => __( 'The sidebar the widget belongs to.', 'gutenberg' ),
+					'type'        => 'string',
+					'default'     => 'wp_inactive_widgets',
+					'required'    => true,
+					'context'     => array( 'view', 'edit', 'embed' ),
+				),
+				'widget_class'  => array(
+					'description' => __( 'Class name of the widget implementation.', 'gutenberg' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit', 'embed' ),
+				),
+				'name'          => array(
+					'description' => __( 'Name of the widget.', 'gutenberg' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit', 'embed' ),
+				),
+				'description'   => array(
+					'description' => __( 'Description of the widget.', 'gutenberg' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit', 'embed' ),
+				),
+				'number'        => array(
+					'description' => __( 'Number of the widget.', 'gutenberg' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit', 'embed' ),
+				),
+				'rendered'      => array(
+					'description' => __( 'HTML representation of the widget.', 'gutenberg' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'embed' ),
+					'readonly'    => true,
+				),
+				'rendered_form' => array(
+					'description' => __( 'HTML representation of the widget admin form.', 'gutenberg' ),
+					'type'        => 'string',
+					'context'     => array( 'edit' ),
+					'readonly'    => true,
+				),
+				'settings'      => array(
+					'description' => __( 'Settings of the widget.', 'gutenberg' ),
+					'type'        => 'object',
+					'context'     => array( 'view', 'edit', 'embed' ),
+					'default'     => array(),
+				),
+			),
+		);
+
+		return $this->schema;
+	}
+}

--- a/lib/class-wp-rest-widgets-controller.php
+++ b/lib/class-wp-rest-widgets-controller.php
@@ -380,7 +380,7 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 
 			// Just because we saved new widget doesn't mean it was added to $wp_registered_widgets.
 			// Let's make sure it's there so that it's included in the response.
-			if ( ! isset( $wp_registered_widgets[ $input_widget['id'] ] ) || $number === 1 ) {
+			if ( ! isset( $wp_registered_widgets[ $input_widget['id'] ] ) || 1 === $number ) {
 				$first_widget_id = substr( $input_widget['id'], 0, strrpos( $input_widget['id'], '-' ) ) . '-1';
 
 				if ( isset( $wp_registered_widgets[ $first_widget_id ] ) ) {

--- a/lib/class-wp-rest-widgets-controller.php
+++ b/lib/class-wp-rest-widgets-controller.php
@@ -176,6 +176,8 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 		$_POST       = $backup_post;
 		$this->assign_to_sidebar( $widget_id, $sidebar_id );
 
+		$request['context'] = 'edit';
+
 		$response = $this->prepare_item_for_response( compact( 'sidebar_id', 'widget_id' ), $request );
 		$response->set_status( 201 );
 
@@ -218,6 +220,8 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 			$this->assign_to_sidebar( $widget_id, $sidebar_id );
 			$sidebar_id = $request['sidebar'];
 		}
+
+		$request['context'] = 'edit';
 
 		return $this->prepare_item_for_response( compact( 'sidebar_id', 'widget_id' ), $request );
 	}

--- a/lib/class-wp-rest-widgets-controller.php
+++ b/lib/class-wp-rest-widgets-controller.php
@@ -679,7 +679,7 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 	 */
 	public function get_item_schema() {
 		if ( $this->schema ) {
-			return $this->schema;
+			return $this->add_additional_fields_schema( $this->schema );
 		}
 
 		$this->schema = array(
@@ -745,6 +745,6 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 			),
 		);
 
-		return $this->schema;
+		return $this->add_additional_fields_schema( $this->schema );
 	}
 }

--- a/lib/class-wp-rest-widgets-controller.php
+++ b/lib/class-wp-rest-widgets-controller.php
@@ -490,7 +490,7 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 		);
 
 		// Get the widget output.
-		if ( is_callable( $widget['callback'] ) && rest_is_field_included( 'rendered', $fields ) ) {
+		if ( is_callable( $widget['callback'] ) && rest_is_field_included( 'rendered', $fields ) && 'wp_inactive_widgets' !== $sidebar_id ) {
 			// @note: everything up to ob_start is taken from the dynamic_sidebar function.
 			$widget_parameters = array_merge(
 				array(

--- a/lib/load.php
+++ b/lib/load.php
@@ -35,6 +35,9 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	if ( ! class_exists( 'WP_REST_Sidebars_Controller' ) ) {
 		require_once dirname( __FILE__ ) . '/class-wp-rest-sidebars-controller.php';
 	}
+	if ( ! class_exists( 'WP_REST_Widgets_Controller' ) ) {
+		require_once dirname( __FILE__ ) . '/class-wp-rest-widgets-controller.php';
+	}
 	if ( ! class_exists( 'WP_REST_Block_Directory_Controller' ) ) {
 		require dirname( __FILE__ ) . '/class-wp-rest-block-directory-controller.php';
 	}

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -189,13 +189,16 @@ function gutenberg_register_plugins_endpoint() {
 add_action( 'rest_api_init', 'gutenberg_register_plugins_endpoint' );
 
 /**
- * Registers the Sidebars REST API routes.
+ * Registers the Sidebars & Widgets REST API routes.
  */
-function gutenberg_register_sidebars_endpoint() {
+function gutenberg_register_sidebars_and_widgets_endpoint() {
 	$sidebars = new WP_REST_Sidebars_Controller();
 	$sidebars->register_routes();
+
+	$widgets = new WP_REST_Widgets_Controller();
+	$widgets->register_routes();
 }
-add_action( 'rest_api_init', 'gutenberg_register_sidebars_endpoint' );
+add_action( 'rest_api_init', 'gutenberg_register_sidebars_and_widgets_endpoint' );
 
 /**
  * Registers the Batch REST API routes.

--- a/packages/edit-widgets/src/store/actions.js
+++ b/packages/edit-widgets/src/store/actions.js
@@ -88,7 +88,6 @@ export function* saveWidgetAreas( widgetAreas ) {
 				KIND,
 				POST_TYPE,
 				buildWidgetAreaPostId( widgetArea.id ),
-				{ deprecated: true }
 			);
 			const widgetsBlocks = post.blocks;
 			const newWidgets = widgetsBlocks.map( ( block ) => {
@@ -105,7 +104,6 @@ export function* saveWidgetAreas( widgetAreas ) {
 				widgetArea.id,
 				{
 					widgets: newWidgets,
-					deprecated: true,
 				}
 			);
 

--- a/packages/edit-widgets/src/store/actions.js
+++ b/packages/edit-widgets/src/store/actions.js
@@ -87,7 +87,7 @@ export function* saveWidgetAreas( widgetAreas ) {
 				'getEditedEntityRecord',
 				KIND,
 				POST_TYPE,
-				buildWidgetAreaPostId( widgetArea.id ),
+				buildWidgetAreaPostId( widgetArea.id )
 			);
 			const widgetsBlocks = post.blocks;
 			const newWidgets = widgetsBlocks.map( ( block ) => {

--- a/packages/edit-widgets/src/store/actions.js
+++ b/packages/edit-widgets/src/store/actions.js
@@ -87,7 +87,8 @@ export function* saveWidgetAreas( widgetAreas ) {
 				'getEditedEntityRecord',
 				KIND,
 				POST_TYPE,
-				buildWidgetAreaPostId( widgetArea.id )
+				buildWidgetAreaPostId( widgetArea.id ),
+				{ deprecated: true }
 			);
 			const widgetsBlocks = post.blocks;
 			const newWidgets = widgetsBlocks.map( ( block ) => {
@@ -102,7 +103,10 @@ export function* saveWidgetAreas( widgetAreas ) {
 				KIND,
 				WIDGET_AREA_ENTITY_TYPE,
 				widgetArea.id,
-				{ widgets: newWidgets }
+				{
+					widgets: newWidgets,
+					deprecated: true
+				}
 			);
 
 			yield* trySaveWidgetArea( widgetArea.id );

--- a/packages/edit-widgets/src/store/actions.js
+++ b/packages/edit-widgets/src/store/actions.js
@@ -105,7 +105,7 @@ export function* saveWidgetAreas( widgetAreas ) {
 				widgetArea.id,
 				{
 					widgets: newWidgets,
-					deprecated: true
+					deprecated: true,
 				}
 			);
 

--- a/packages/edit-widgets/src/store/utils.js
+++ b/packages/edit-widgets/src/store/utils.js
@@ -43,7 +43,7 @@ export const buildWidgetAreasPostId = () => `widget-areas`;
 export function buildWidgetAreasQuery() {
 	return {
 		per_page: -1,
-		deprecated: true
+		deprecated: true,
 	};
 }
 

--- a/packages/edit-widgets/src/store/utils.js
+++ b/packages/edit-widgets/src/store/utils.js
@@ -41,7 +41,10 @@ export const buildWidgetAreasPostId = () => `widget-areas`;
  * @return {Object} Query.
  */
 export function buildWidgetAreasQuery() {
-	return { per_page: -1 };
+	return {
+		per_page: -1,
+		deprecated: true
+	};
 }
 
 /**

--- a/packages/edit-widgets/src/store/utils.js
+++ b/packages/edit-widgets/src/store/utils.js
@@ -43,7 +43,6 @@ export const buildWidgetAreasPostId = () => `widget-areas`;
 export function buildWidgetAreasQuery() {
 	return {
 		per_page: -1,
-		deprecated: true,
 	};
 }
 

--- a/phpunit/class-rest-sidebars-controller-test.php
+++ b/phpunit/class-rest-sidebars-controller-test.php
@@ -261,84 +261,8 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 					'description' => '',
 					'status'      => 'active',
 					'widgets'     => array(
-						array(
-							'id'           => 'text-1',
-							'settings'     => array(
-								'text' => 'Custom text test',
-							),
-							'id_base'      => 'text',
-							'widget_class' => 'WP_Widget_Text',
-							'name'         => 'Text',
-							'description'  => 'Arbitrary text.',
-							'number'       => 1,
-							'rendered'     => '<div class="textwidget">Custom text test</div>',
-						),
-						array(
-							'id'           => 'rss-1',
-							'settings'     => array(
-								'title' => 'RSS test',
-							),
-							'id_base'      => 'rss',
-							'widget_class' => 'WP_Widget_RSS',
-							'name'         => 'RSS',
-							'description'  => 'Entries from any RSS or Atom feed.',
-							'number'       => 1,
-							'rendered'     => '',
-						),
-					),
-				),
-			),
-			$data
-		);
-	}
-
-	/**
-	 * Test a GET request in edit context. In particular, we expect rendered_form to be served correctly.
-	 */
-	public function test_get_items_active_sidebar_with_widgets_edit_context() {
-		$this->setup_widget(
-			'widget_text',
-			1,
-			array(
-				'text' => 'Custom text test',
-			)
-		);
-		$this->setup_sidebar(
-			'sidebar-1',
-			array(
-				'name' => 'Test sidebar',
-			),
-			array( 'text-1' )
-		);
-
-		$request            = new WP_REST_Request( 'GET', '/__experimental/sidebars' );
-		$request['context'] = 'edit';
-		$response           = rest_get_server()->dispatch( $request );
-		$data               = $response->get_data();
-		$this->assertEquals(
-			array(
-				array(
-					'id'          => 'sidebar-1',
-					'name'        => 'Test sidebar',
-					'description' => '',
-					'status'      => 'active',
-					'widgets'     => array(
-						array(
-							'id'            => 'text-1',
-							'settings'      => array(
-								'text' => 'Custom text test',
-							),
-							'id_base'       => 'text',
-							'widget_class'  => 'WP_Widget_Text',
-							'name'          => 'Text',
-							'description'   => 'Arbitrary text.',
-							'number'        => 1,
-							'rendered'      => '<div class="textwidget">Custom text test</div>',
-							'rendered_form' => '<input id="widget-text-1-title" name="widget-text[1][title]" class="title sync-input" type="hidden" value="">' . "\n" .
-																							'			<textarea id="widget-text-1-text" name="widget-text[1][text]" class="text sync-input" hidden>Custom text test</textarea>' . "\n" .
-																							'			<input id="widget-text-1-filter" name="widget-text[1][filter]" class="filter sync-input" type="hidden" value="on">' . "\n" .
-																							'			<input id="widget-text-1-visual" name="widget-text[1][visual]" class="visual sync-input" type="hidden" value="on">',
-						),
+						'text-1',
+						'rss-1',
 					),
 				),
 			),
@@ -447,6 +371,13 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 				'text' => 'Custom text test',
 			)
 		);
+		$this->setup_widget(
+			'widget_text',
+			2,
+			array(
+				'text' => 'Custom text test',
+			)
+		);
 		$this->setup_sidebar(
 			'sidebar-1',
 			array(
@@ -459,28 +390,8 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request->set_body_params(
 			array(
 				'widgets' => array(
-					array(
-						'id'           => 'text-1',
-						'settings'     => array(
-							'text' => 'Updated text test',
-						),
-						'id_base'      => 'text',
-						'widget_class' => 'WP_Widget_Text',
-						'name'         => 'Text',
-						'description'  => 'Arbitrary text.',
-						'number'       => 1,
-					),
-					array(
-						'id'           => 'text-2',
-						'settings'     => array(
-							'text' => 'Another text widget',
-						),
-						'id_base'      => 'text',
-						'widget_class' => 'WP_Widget_Text',
-						'name'         => 'Text',
-						'description'  => 'Arbitrary text.',
-						'number'       => 2,
-					),
+					'text-1',
+					'text-2',
 				),
 			)
 		);
@@ -493,112 +404,12 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 				'description' => '',
 				'status'      => 'active',
 				'widgets'     => array(
-					array(
-						'id'           => 'text-1',
-						'settings'     => array(
-							'text'   => 'Updated text test',
-							'title'  => '',
-							'filter' => false,
-						),
-						'id_base'      => 'text',
-						'widget_class' => 'WP_Widget_Text',
-						'name'         => 'Text',
-						'description'  => 'Arbitrary text.',
-						'number'       => 1,
-						'rendered'     => '<div class="textwidget">Updated text test</div>',
-					),
-					array(
-						'id'           => 'text-2',
-						'settings'     => array(
-							'text'   => 'Another text widget',
-							'title'  => '',
-							'filter' => false,
-						),
-						'id_base'      => 'text',
-						'widget_class' => 'WP_Widget_Text',
-						'name'         => 'Text',
-						'description'  => 'Arbitrary text.',
-						'number'       => 2,
-						'rendered'     => '<div class="textwidget">Another text widget</div>',
-					),
+					'text-1',
+					'text-2',
 				),
 			),
 			$data
 		);
-	}
-
-	/**
-	 * @group multisite
-	 */
-	public function test_store_html_as_admin() {
-		if ( is_multisite() ) {
-			$this->assertEquals(
-				'<div class="textwidget">alert(1)</div>',
-				$this->update_text_widget_with_raw_html( '<script>alert(1)</script>' )
-			);
-		} else {
-			$this->assertEquals(
-				'<div class="textwidget"><script>alert(1)</script></div>',
-				$this->update_text_widget_with_raw_html( '<script>alert(1)</script>' )
-			);
-		}
-	}
-
-	/**
-	 * @group multisite
-	 */
-	public function test_store_html_as_superadmin() {
-		wp_set_current_user( self::$superadmin_id );
-		if ( is_multisite() ) {
-			$this->assertEquals(
-				'<div class="textwidget"><script>alert(1)</script></div>',
-				$this->update_text_widget_with_raw_html( '<script>alert(1)</script>' )
-			);
-		} else {
-			$this->assertEquals(
-				'<div class="textwidget"><script>alert(1)</script></div>',
-				$this->update_text_widget_with_raw_html( '<script>alert(1)</script>' )
-			);
-		}
-	}
-
-	protected function update_text_widget_with_raw_html( $html ) {
-		$this->setup_widget(
-			'widget_text',
-			1,
-			array(
-				'text' => 'Custom text test',
-			)
-		);
-		$this->setup_sidebar(
-			'sidebar-1',
-			array(
-				'name' => 'Test sidebar',
-			),
-			array( 'text-1' )
-		);
-
-		$request = new WP_REST_Request( 'POST', '/__experimental/sidebars/sidebar-1' );
-		$request->set_body_params(
-			array(
-				'widgets' => array(
-					array(
-						'id'           => 'text-1',
-						'settings'     => array(
-							'text' => $html,
-						),
-						'id_base'      => 'text',
-						'widget_class' => 'WP_Widget_Text',
-						'name'         => 'Text',
-						'description'  => 'Arbitrary text.',
-						'number'       => 1,
-					),
-				),
-			)
-		);
-		$response = rest_get_server()->dispatch( $request );
-		$data     = $response->get_data();
-		return $data['widgets'][0]['rendered'];
 	}
 
 	/**
@@ -615,83 +426,6 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$this->do_test_update_item_legacy_widget( 'testwidget' );
 	}
 
-	/**
-	 *
-	 */
-	public function do_test_update_item_legacy_widget( $widget_id ) {
-		// @TODO: Use @dataProvider instead (it doesn't work with custom constructors like the one we have in this class)
-		wp_register_widget_control(
-			$widget_id,
-			'WP test widget',
-			function() {
-				$settings = get_option( 'widget_testwidget' );
-
-				// check if anything's been sent.
-				if ( isset( $_POST['update_testwidget'] ) ) {
-					$settings['id']    = $_POST['test_id'];
-					$settings['title'] = $_POST['test_title'];
-
-					update_option( 'widget_testwidget', $settings );
-				}
-			},
-			100,
-			200
-		);
-		wp_register_sidebar_widget(
-			$widget_id,
-			'WP test widget',
-			function() {
-				$settings = get_option( 'widget_testwidget' ) ? get_option( 'widget_testwidget' ) : array(
-					'id'    => '',
-					'title' => '',
-				);
-				echo '<h1>' . $settings['id'] . '</h1><span>' . $settings['title'] . '</span>';
-			}
-		);
-		$this->setup_sidebar(
-			'sidebar-1',
-			array(
-				'name' => 'Test sidebar',
-			),
-			array( $widget_id )
-		);
-
-		$request = new WP_REST_Request( 'POST', '/__experimental/sidebars/sidebar-1' );
-		$request->set_body_params(
-			array(
-				'widgets' => array(
-					array(
-						'id'       => $widget_id,
-						'name'     => 'WP test widget',
-						'settings' => array(
-							'test_id'           => 'My test id',
-							'test_title'        => 'My test title',
-							'update_testwidget' => true,
-						),
-					),
-				),
-			)
-		);
-		$response = rest_get_server()->dispatch( $request );
-		$data     = $response->get_data();
-		$this->assertEquals(
-			array(
-				'id'          => 'sidebar-1',
-				'name'        => 'Test sidebar',
-				'description' => '',
-				'status'      => 'active',
-				'widgets'     => array(
-					array(
-						'id'       => $widget_id,
-						'settings' => array(),
-						'rendered' => '<h1>My test id</h1><span>My test title</span>',
-						'name'     => 'WP test widget',
-					),
-				),
-			),
-			$data
-		);
-	}
 
 	/**
 	 *
@@ -740,18 +474,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 					'description' => '',
 					'status'      => 'active',
 					'widgets'     => array(
-						array(
-							'id'           => 'text-1',
-							'settings'     => array(
-								'text' => 'Custom text test',
-							),
-							'id_base'      => 'text',
-							'widget_class' => 'WP_Widget_Text',
-							'name'         => 'Text',
-							'description'  => 'Arbitrary text.',
-							'number'       => 1,
-							'rendered'     => '<div class="textwidget">Custom text test</div>',
-						),
+						'text-1',
 					),
 				),
 				array(
@@ -760,18 +483,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 					'description' => '',
 					'status'      => 'inactive',
 					'widgets'     => array(
-						array(
-							'id'           => 'rss-1',
-							'settings'     => array(
-								'title' => 'RSS test',
-							),
-							'id_base'      => 'rss',
-							'widget_class' => 'WP_Widget_RSS',
-							'name'         => 'RSS',
-							'description'  => 'Entries from any RSS or Atom feed.',
-							'number'       => 1,
-							'rendered'     => '',
-						),
+						'rss-1',
 					),
 				),
 			),
@@ -825,60 +537,6 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		);
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertErrorResponse( 'widgets_cannot_access', $response, 403 );
-	}
-
-	/**
-	 * Tests if the endpoint correctly handles "slashable" characters such as " or '.
-	 */
-	public function test_update_item_slashing() {
-		$this->setup_widget( 'widget_text', 1, array( 'text' => 'Custom text test' ) );
-		$this->setup_sidebar( 'sidebar-1', array( 'name' => 'Test sidebar' ), array( 'text-1', 'rss-1' ) );
-
-		$request = new WP_REST_Request( 'POST', '/__experimental/sidebars/sidebar-1' );
-		$request->set_body_params(
-			array(
-				'widgets' => array(
-					array(
-						'id'           => 'text-1',
-						'settings'     => array(
-							'text' => 'Updated \\" \\\' text test',
-						),
-						'id_base'      => 'text',
-						'widget_class' => 'WP_Widget_Text',
-						'name'         => 'Text',
-						'description'  => 'Arbitrary text.',
-						'number'       => 1,
-					),
-				),
-			)
-		);
-		$response = rest_get_server()->dispatch( $request );
-		$data     = $response->get_data();
-		$this->assertEquals(
-			array(
-				'id'          => 'sidebar-1',
-				'name'        => 'Test sidebar',
-				'description' => '',
-				'status'      => 'active',
-				'widgets'     => array(
-					array(
-						'id'           => 'text-1',
-						'settings'     => array(
-							'text'   => 'Updated \\" \\\' text test',
-							'title'  => '',
-							'filter' => false,
-						),
-						'id_base'      => 'text',
-						'widget_class' => 'WP_Widget_Text',
-						'name'         => 'Text',
-						'description'  => 'Arbitrary text.',
-						'number'       => 1,
-						'rendered'     => '<div class="textwidget">Updated \\" \\\' text test</div>',
-					),
-				),
-			),
-			$data
-		);
 	}
 
 	/**

--- a/phpunit/class-rest-sidebars-controller-test.php
+++ b/phpunit/class-rest-sidebars-controller-test.php
@@ -145,8 +145,8 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	 */
 	public function test_register_routes() {
 		$routes = rest_get_server()->get_routes();
-		$this->assertArrayHasKey( '/__experimental/sidebars', $routes );
-		$this->assertArrayHasKey( '/__experimental/sidebars/(?P<id>[\w-]+)', $routes );
+		$this->assertArrayHasKey( '/wp/v2/sidebars', $routes );
+		$this->assertArrayHasKey( '/wp/v2/sidebars/(?P<id>[\w-]+)', $routes );
 	}
 
 	/**
@@ -159,7 +159,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	 *
 	 */
 	public function test_get_items() {
-		$request  = new WP_REST_Request( 'GET', '/__experimental/sidebars' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/sidebars' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -171,7 +171,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	 */
 	public function test_get_items_no_permission() {
 		wp_set_current_user( 0 );
-		$request  = new WP_REST_Request( 'GET', '/__experimental/sidebars' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/sidebars' );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertErrorResponse( 'widgets_cannot_access', $response, 401 );
 	}
@@ -181,7 +181,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	 */
 	public function test_get_items_wrong_permission_author() {
 		wp_set_current_user( self::$author_id );
-		$request  = new WP_REST_Request( 'GET', '/__experimental/sidebars' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/sidebars' );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertErrorResponse( 'widgets_cannot_access', $response, 403 );
 	}
@@ -191,7 +191,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	 */
 	public function test_get_items_wrong_permission_subscriber() {
 		wp_set_current_user( self::$subscriber_id );
-		$request  = new WP_REST_Request( 'GET', '/__experimental/sidebars' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/sidebars' );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertErrorResponse( 'widgets_cannot_access', $response, 403 );
 	}
@@ -207,7 +207,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			)
 		);
 
-		$request  = new WP_REST_Request( 'GET', '/__experimental/sidebars' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/sidebars' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 		$data     = $this->remove_links( $data );
@@ -256,7 +256,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			array( 'text-1', 'rss-1' )
 		);
 
-		$request  = new WP_REST_Request( 'GET', '/__experimental/sidebars' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/sidebars' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 		$data     = $this->remove_links( $data );
@@ -293,7 +293,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			)
 		);
 
-		$request  = new WP_REST_Request( 'GET', '/__experimental/sidebars/sidebar-1' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/sidebars/sidebar-1' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 		$data     = $this->remove_links( $data );
@@ -326,7 +326,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			)
 		);
 
-		$request  = new WP_REST_Request( 'GET', '/__experimental/sidebars/sidebar-1' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/sidebars/sidebar-1' );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertErrorResponse( 'widgets_cannot_access', $response, 401 );
 	}
@@ -343,7 +343,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			)
 		);
 
-		$request  = new WP_REST_Request( 'GET', '/__experimental/sidebars/sidebar-1' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/sidebars/sidebar-1' );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertErrorResponse( 'widgets_cannot_access', $response, 403 );
 	}
@@ -360,7 +360,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			)
 		);
 
-		$request  = new WP_REST_Request( 'GET', '/__experimental/sidebars/sidebar-1' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/sidebars/sidebar-1' );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertErrorResponse( 'widgets_cannot_access', $response, 403 );
 	}
@@ -404,7 +404,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			array( 'text-1', 'rss-1' )
 		);
 
-		$request = new WP_REST_Request( 'PUT', '/__experimental/sidebars/sidebar-1' );
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/sidebars/sidebar-1' );
 		$request->set_body_params(
 			array(
 				'widgets' => array(
@@ -471,7 +471,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			)
 		);
 
-		$request = new WP_REST_Request( 'GET', '/__experimental/sidebars' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/sidebars' );
 		$request->set_param( 'context', 'view' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
@@ -517,7 +517,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	public function test_update_item_no_permission() {
 		wp_set_current_user( 0 );
 
-		$request = new WP_REST_Request( 'POST', '/__experimental/sidebars/sidebar-1' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/sidebars/sidebar-1' );
 		$request->set_body_params(
 			array(
 				'widgets' => array(),
@@ -533,7 +533,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	public function test_update_item_wrong_permission_author() {
 		wp_set_current_user( self::$author_id );
 
-		$request = new WP_REST_Request( 'POST', '/__experimental/sidebars/sidebar-1' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/sidebars/sidebar-1' );
 		$request->set_body_params(
 			array(
 				'widgets' => array(),
@@ -549,7 +549,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	public function test_update_item_wrong_permission_subscriber() {
 		wp_set_current_user( self::$subscriber_id );
 
-		$request = new WP_REST_Request( 'POST', '/__experimental/sidebars/sidebar-1' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/sidebars/sidebar-1' );
 		$request->set_body_params(
 			array(
 				'widgets' => array(),
@@ -576,7 +576,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	 */
 	public function test_get_item_schema() {
 		wp_set_current_user( self::$admin_id );
-		$request    = new WP_REST_Request( 'OPTIONS', '/__experimental/sidebars' );
+		$request    = new WP_REST_Request( 'OPTIONS', '/wp/v2/sidebars' );
 		$response   = rest_get_server()->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];

--- a/phpunit/class-rest-sidebars-controller-test.php
+++ b/phpunit/class-rest-sidebars-controller-test.php
@@ -210,7 +210,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request  = new WP_REST_Request( 'GET', '/__experimental/sidebars' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
-		unset( $data[0]['_links'] );
+		$data     = $this->remove_links( $data );
 		$this->assertEquals(
 			array(
 				array(
@@ -259,7 +259,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request  = new WP_REST_Request( 'GET', '/__experimental/sidebars' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
-		unset( $data[0]['_links'] );
+		$data     = $this->remove_links( $data );
 		$this->assertEquals(
 			array(
 				array(
@@ -296,7 +296,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request  = new WP_REST_Request( 'GET', '/__experimental/sidebars/sidebar-1' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
-		unset( $data[0]['_links'] );
+		$data     = $this->remove_links( $data );
 		$this->assertEquals(
 			array(
 				'id'            => 'sidebar-1',
@@ -415,7 +415,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		);
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
-		unset( $data[0]['_links'] );
+		$data     = $this->remove_links( $data );
 		$this->assertEquals(
 			array(
 				'id'            => 'sidebar-1',
@@ -475,8 +475,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request->set_param( 'context', 'view' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
-		unset( $data[0]['_links'] );
-		unset( $data[1]['_links'] );
+		$data     = $this->remove_links( $data );
 		$this->assertEquals(
 			array(
 				array(
@@ -593,5 +592,27 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( 'after_widget', $properties );
 		$this->assertArrayHasKey( 'before_title', $properties );
 		$this->assertArrayHasKey( 'after_title', $properties );
+	}
+
+	/**
+	 * Helper to remove links key.
+	 *
+	 * @param array $data Array of data.
+	 *
+	 * @return array
+	 */
+	protected function remove_links( $data ) {
+		if ( ! is_array( $data ) ) {
+			return $data;
+		}
+		$count = 0;
+		foreach ( $data as $item ) {
+			if ( isset( $item['_links'] ) ) {
+				unset( $data[ $count ]['_links'] );
+			}
+			$count ++;
+		}
+
+		return $data;
 	}
 }

--- a/phpunit/class-rest-sidebars-controller-test.php
+++ b/phpunit/class-rest-sidebars-controller-test.php
@@ -210,14 +210,20 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request  = new WP_REST_Request( 'GET', '/__experimental/sidebars' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
+		unset( $data[0]['_links'] );
 		$this->assertEquals(
 			array(
 				array(
-					'id'          => 'sidebar-1',
-					'name'        => 'Test sidebar',
-					'description' => '',
-					'status'      => 'active',
-					'widgets'     => array(),
+					'id'            => 'sidebar-1',
+					'name'          => 'Test sidebar',
+					'description'   => '',
+					'status'        => 'active',
+					'widgets'       => array(),
+					'class'         => '',
+					'before_widget' => '',
+					'after_widget'  => '',
+					'before_title'  => '',
+					'after_title'   => '',
 				),
 			),
 			$data
@@ -253,17 +259,23 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request  = new WP_REST_Request( 'GET', '/__experimental/sidebars' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
+		unset( $data[0]['_links'] );
 		$this->assertEquals(
 			array(
 				array(
-					'id'          => 'sidebar-1',
-					'name'        => 'Test sidebar',
-					'description' => '',
-					'status'      => 'active',
-					'widgets'     => array(
+					'id'            => 'sidebar-1',
+					'name'          => 'Test sidebar',
+					'description'   => '',
+					'status'        => 'active',
+					'widgets'       => array(
 						'text-1',
 						'rss-1',
 					),
+					'class'         => '',
+					'before_widget' => '',
+					'after_widget'  => '',
+					'before_title'  => '',
+					'after_title'   => '',
 				),
 			),
 			$data
@@ -284,13 +296,19 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request  = new WP_REST_Request( 'GET', '/__experimental/sidebars/sidebar-1' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
+		unset( $data[0]['_links'] );
 		$this->assertEquals(
 			array(
-				'id'          => 'sidebar-1',
-				'name'        => 'Test sidebar',
-				'description' => '',
-				'status'      => 'active',
-				'widgets'     => array(),
+				'id'            => 'sidebar-1',
+				'name'          => 'Test sidebar',
+				'description'   => '',
+				'status'        => 'active',
+				'widgets'       => array(),
+				'class'         => '',
+				'before_widget' => '',
+				'after_widget'  => '',
+				'before_title'  => '',
+				'after_title'   => '',
 			),
 			$data
 		);
@@ -397,16 +415,22 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		);
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
+		unset( $data[0]['_links'] );
 		$this->assertEquals(
 			array(
-				'id'          => 'sidebar-1',
-				'name'        => 'Test sidebar',
-				'description' => '',
-				'status'      => 'active',
-				'widgets'     => array(
+				'id'            => 'sidebar-1',
+				'name'          => 'Test sidebar',
+				'description'   => '',
+				'status'        => 'active',
+				'widgets'       => array(
 					'text-1',
 					'text-2',
 				),
+				'class'         => '',
+				'before_widget' => '',
+				'after_widget'  => '',
+				'before_title'  => '',
+				'after_title'   => '',
 			),
 			$data
 		);
@@ -451,25 +475,37 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request->set_param( 'context', 'view' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
+		unset( $data[0]['_links'] );
+		unset( $data[1]['_links'] );
 		$this->assertEquals(
 			array(
 				array(
-					'id'          => 'sidebar-1',
-					'name'        => 'Test sidebar',
-					'description' => '',
-					'status'      => 'active',
-					'widgets'     => array(
+					'id'            => 'sidebar-1',
+					'name'          => 'Test sidebar',
+					'description'   => '',
+					'status'        => 'active',
+					'widgets'       => array(
 						'text-1',
 					),
+					'class'         => '',
+					'before_widget' => '',
+					'after_widget'  => '',
+					'before_title'  => '',
+					'after_title'   => '',
 				),
 				array(
-					'id'          => 'wp_inactive_widgets',
-					'name'        => 'Inactive widgets',
-					'description' => '',
-					'status'      => 'inactive',
-					'widgets'     => array(
+					'id'            => 'wp_inactive_widgets',
+					'name'          => 'Inactive widgets',
+					'description'   => '',
+					'status'        => 'inactive',
+					'widgets'       => array(
 						'rss-1',
 					),
+					'class'         => '',
+					'before_widget' => '',
+					'after_widget'  => '',
+					'before_title'  => '',
+					'after_title'   => '',
 				),
 			),
 			$data
@@ -546,11 +582,16 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertEquals( 5, count( $properties ) );
+		$this->assertEquals( 10, count( $properties ) );
 		$this->assertArrayHasKey( 'id', $properties );
 		$this->assertArrayHasKey( 'name', $properties );
 		$this->assertArrayHasKey( 'description', $properties );
 		$this->assertArrayHasKey( 'status', $properties );
 		$this->assertArrayHasKey( 'widgets', $properties );
+		$this->assertArrayHasKey( 'class', $properties );
+		$this->assertArrayHasKey( 'before_widget', $properties );
+		$this->assertArrayHasKey( 'after_widget', $properties );
+		$this->assertArrayHasKey( 'before_title', $properties );
+		$this->assertArrayHasKey( 'after_title', $properties );
 	}
 }

--- a/phpunit/class-rest-sidebars-controller-test.php
+++ b/phpunit/class-rest-sidebars-controller-test.php
@@ -386,7 +386,7 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			array( 'text-1', 'rss-1' )
 		);
 
-		$request = new WP_REST_Request( 'POST', '/__experimental/sidebars/sidebar-1' );
+		$request = new WP_REST_Request( 'PUT', '/__experimental/sidebars/sidebar-1' );
 		$request->set_body_params(
 			array(
 				'widgets' => array(
@@ -411,21 +411,6 @@ class REST_Sidebars_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			$data
 		);
 	}
-
-	/**
-	 *
-	 */
-	public function test_update_item_legacy_widget_1() {
-		$this->do_test_update_item_legacy_widget( 'testwidget-1' );
-	}
-
-	/**
-	 *
-	 */
-	public function test_update_item_legacy_widget_2() {
-		$this->do_test_update_item_legacy_widget( 'testwidget' );
-	}
-
 
 	/**
 	 *

--- a/phpunit/class-rest-widgets-controller-test.php
+++ b/phpunit/class-rest-widgets-controller-test.php
@@ -827,7 +827,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 				'name'          => 'Text',
 				'description'   => 'Arbitrary text.',
 				'number'        => 1,
-				'rendered'      => '<div class="textwidget">Custom text test</div>',
+				'rendered'      => '',
 				'rendered_form' => '<input id="widget-text-1-title" name="widget-text[1][title]" class="title sync-input" type="hidden" value="">' . "\n" .
 								'			<textarea id="widget-text-1-text" name="widget-text[1][text]" class="text sync-input" hidden>Custom text test</textarea>' . "\n" .
 								'			<input id="widget-text-1-filter" name="widget-text[1][filter]" class="filter sync-input" type="hidden" value="on">' . "\n" .

--- a/phpunit/class-rest-widgets-controller-test.php
+++ b/phpunit/class-rest-widgets-controller-test.php
@@ -148,8 +148,8 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	 */
 	public function test_register_routes() {
 		$routes = rest_get_server()->get_routes();
-		$this->assertArrayHasKey( '/__experimental/widgets', $routes );
-		$this->assertArrayHasKey( '/__experimental/widgets/(?P<id>[\w\-]+)', $routes );
+		$this->assertArrayHasKey( '/wp/v2/widgets', $routes );
+		$this->assertArrayHasKey( '/wp/v2/widgets/(?P<id>[\w\-]+)', $routes );
 	}
 
 	/**
@@ -162,7 +162,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	 *
 	 */
 	public function test_get_items_no_widgets() {
-		$request  = new WP_REST_Request( 'GET', '/__experimental/widgets' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/widgets' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -174,7 +174,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	 */
 	public function test_get_items_no_permission() {
 		wp_set_current_user( 0 );
-		$request  = new WP_REST_Request( 'GET', '/__experimental/widgets' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/widgets' );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertErrorResponse( 'rest_cannot_manage_widgets', $response, 401 );
 	}
@@ -184,7 +184,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	 */
 	public function test_get_items_wrong_permission_author() {
 		wp_set_current_user( self::$author_id );
-		$request  = new WP_REST_Request( 'GET', '/__experimental/widgets' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/widgets' );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertErrorResponse( 'rest_cannot_manage_widgets', $response, 403 );
 	}
@@ -215,7 +215,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			array( 'text-1', 'rss-1' )
 		);
 
-		$request  = new WP_REST_Request( 'GET', '/__experimental/widgets' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/widgets' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 		$data     = $this->remove_links( $data );
@@ -271,7 +271,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			array( 'text-1' )
 		);
 
-		$request            = new WP_REST_Request( 'GET', '/__experimental/widgets' );
+		$request            = new WP_REST_Request( 'GET', '/wp/v2/widgets' );
 		$request['context'] = 'edit';
 		$response           = rest_get_server()->dispatch( $request );
 		$data               = $response->get_data();
@@ -319,7 +319,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			array( 'text-1' )
 		);
 
-		$request  = new WP_REST_Request( 'GET', '/__experimental/widgets/text-1' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/widgets/text-1' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 		$this->assertEqualSets(
@@ -361,7 +361,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			array( 'text-1' )
 		);
 
-		$request  = new WP_REST_Request( 'GET', '/__experimental/widgets/text-1' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/widgets/text-1' );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertErrorResponse( 'rest_cannot_manage_widgets', $response, 401 );
 	}
@@ -385,7 +385,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			)
 		);
 
-		$request  = new WP_REST_Request( 'GET', '/__experimental/widgets/text-1' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/widgets/text-1' );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertErrorResponse( 'rest_cannot_manage_widgets', $response, 403 );
 	}
@@ -401,7 +401,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			)
 		);
 
-		$request = new WP_REST_Request( 'POST', '/__experimental/widgets' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/widgets' );
 		$request->set_body_params(
 			array(
 				'sidebar'  => 'sidebar-1',
@@ -444,7 +444,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			)
 		);
 
-		$request = new WP_REST_Request( 'POST', '/__experimental/widgets' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/widgets' );
 		$request->set_body_params(
 			array(
 				'sidebar'  => 'sidebar-1',
@@ -488,7 +488,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			array( 'text-1', 'rss-1' )
 		);
 
-		$request = new WP_REST_Request( 'PUT', '/__experimental/widgets/text-1' );
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/widgets/text-1' );
 		$request->set_body_params(
 			array(
 				'id'           => 'text-1',
@@ -545,7 +545,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			array()
 		);
 
-		$request = new WP_REST_Request( 'PUT', '/__experimental/widgets/text-1' );
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/widgets/text-1' );
 		$request->set_body_params(
 			array(
 				'sidebar' => 'sidebar-2',
@@ -556,10 +556,10 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$this->assertNotWPError( $error, $error ? $error->get_error_message() : '' );
 		$this->assertEquals( 'sidebar-2', $response->get_data()['sidebar'] );
 
-		$sidebar1 = rest_do_request( '/__experimental/sidebars/sidebar-1' );
+		$sidebar1 = rest_do_request( '/wp/v2/sidebars/sidebar-1' );
 		$this->assertNotContains( 'text-1', $sidebar1->get_data()['widgets'] );
 
-		$sidebar2 = rest_do_request( '/__experimental/sidebars/sidebar-2' );
+		$sidebar2 = rest_do_request( '/wp/v2/sidebars/sidebar-2' );
 		$this->assertContains( 'text-1', $sidebar2->get_data()['widgets'] );
 	}
 
@@ -614,7 +614,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			array( 'text-1' )
 		);
 
-		$request = new WP_REST_Request( 'PUT', '/__experimental/widgets/text-1' );
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/widgets/text-1' );
 		$request->set_body_params(
 			array(
 				'id'           => 'text-1',
@@ -689,7 +689,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			array( $widget_id )
 		);
 
-		$request = new WP_REST_Request( 'PUT', '/__experimental/widgets/' . $widget_id );
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/widgets/' . $widget_id );
 		$request->set_body_params(
 			array(
 				'id'       => $widget_id,
@@ -727,7 +727,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	public function test_update_item_no_permission() {
 		wp_set_current_user( 0 );
 
-		$request = new WP_REST_Request( 'PUT', '/__experimental/sidebars/sidebar-1' );
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/sidebars/sidebar-1' );
 		$request->set_body_params(
 			array(
 				'widgets' => array(),
@@ -743,7 +743,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	public function test_update_item_wrong_permission_author() {
 		wp_set_current_user( self::$author_id );
 
-		$request = new WP_REST_Request( 'PUT', '/__experimental/sidebars/sidebar-1' );
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/sidebars/sidebar-1' );
 		$request->set_body_params(
 			array(
 				'widgets' => array(),
@@ -760,7 +760,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$this->setup_widget( 'widget_text', 1, array( 'text' => 'Custom text test' ) );
 		$this->setup_sidebar( 'sidebar-1', array( 'name' => 'Test sidebar' ), array( 'text-1', 'rss-1' ) );
 
-		$request = new WP_REST_Request( 'PUT', '/__experimental/widgets/text-1' );
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/widgets/text-1' );
 		$request->set_body_params(
 			array(
 				'id'           => 'text-1',
@@ -812,7 +812,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			array( 'text-1', 'rss-1' )
 		);
 
-		$request  = new WP_REST_Request( 'DELETE', '/__experimental/widgets/text-1' );
+		$request  = new WP_REST_Request( 'DELETE', '/wp/v2/widgets/text-1' );
 		$response = rest_do_request( $request );
 
 		$this->assertEqualSets(
@@ -856,7 +856,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			array( 'text-1', 'rss-1' )
 		);
 
-		$request = new WP_REST_Request( 'DELETE', '/__experimental/widgets/text-1' );
+		$request = new WP_REST_Request( 'DELETE', '/wp/v2/widgets/text-1' );
 		$request->set_query_params( array( 'force' => true ) );
 		$response = rest_do_request( $request );
 
@@ -886,7 +886,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			$response->get_data()
 		);
 
-		$response = rest_do_request( '/__experimental/widgets/text-1' );
+		$response = rest_do_request( '/wp/v2/widgets/text-1' );
 		$this->assertEquals( 404, $response->get_status() );
 	}
 
@@ -911,7 +911,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			array( 'text-1', 'rss-1' )
 		);
 
-		$request  = new WP_REST_Request( 'DELETE', '/__experimental/widgets/text-1' );
+		$request  = new WP_REST_Request( 'DELETE', '/wp/v2/widgets/text-1' );
 		$response = rest_do_request( $request );
 
 		$this->assertErrorResponse( 'rest_cannot_manage_widgets', $response, 401 );
@@ -938,7 +938,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			array( 'text-1', 'rss-1' )
 		);
 
-		$request  = new WP_REST_Request( 'DELETE', '/__experimental/widgets/text-1' );
+		$request  = new WP_REST_Request( 'DELETE', '/wp/v2/widgets/text-1' );
 		$response = rest_do_request( $request );
 
 		$this->assertErrorResponse( 'rest_cannot_manage_widgets', $response, 403 );
@@ -955,7 +955,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	 */
 	public function test_get_item_schema() {
 		wp_set_current_user( self::$admin_id );
-		$request    = new WP_REST_Request( 'OPTIONS', '/__experimental/widgets' );
+		$request    = new WP_REST_Request( 'OPTIONS', '/wp/v2/widgets' );
 		$response   = rest_get_server()->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];

--- a/phpunit/class-rest-widgets-controller-test.php
+++ b/phpunit/class-rest-widgets-controller-test.php
@@ -289,9 +289,9 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 					'number'        => 1,
 					'rendered'      => '<div class="textwidget">Custom text test</div>',
 					'rendered_form' => '<input id="widget-text-1-title" name="widget-text[1][title]" class="title sync-input" type="hidden" value="">' . "\n" .
-					                   '			<textarea id="widget-text-1-text" name="widget-text[1][text]" class="text sync-input" hidden>Custom text test</textarea>' . "\n" .
-					                   '			<input id="widget-text-1-filter" name="widget-text[1][filter]" class="filter sync-input" type="hidden" value="on">' . "\n" .
-					                   '			<input id="widget-text-1-visual" name="widget-text[1][visual]" class="visual sync-input" type="hidden" value="on">',
+									'			<textarea id="widget-text-1-text" name="widget-text[1][text]" class="text sync-input" hidden>Custom text test</textarea>' . "\n" .
+									'			<input id="widget-text-1-filter" name="widget-text[1][filter]" class="filter sync-input" type="hidden" value="on">' . "\n" .
+									'			<input id="widget-text-1-visual" name="widget-text[1][visual]" class="visual sync-input" type="hidden" value="on">',
 				),
 			),
 			$data
@@ -826,9 +826,9 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 				'number'        => 1,
 				'rendered'      => '<div class="textwidget">Custom text test</div>',
 				'rendered_form' => '<input id="widget-text-1-title" name="widget-text[1][title]" class="title sync-input" type="hidden" value="">' . "\n" .
-				                   '			<textarea id="widget-text-1-text" name="widget-text[1][text]" class="text sync-input" hidden>Custom text test</textarea>' . "\n" .
-				                   '			<input id="widget-text-1-filter" name="widget-text[1][filter]" class="filter sync-input" type="hidden" value="on">' . "\n" .
-				                   '			<input id="widget-text-1-visual" name="widget-text[1][visual]" class="visual sync-input" type="hidden" value="on">',
+								'			<textarea id="widget-text-1-text" name="widget-text[1][text]" class="text sync-input" hidden>Custom text test</textarea>' . "\n" .
+								'			<input id="widget-text-1-filter" name="widget-text[1][filter]" class="filter sync-input" type="hidden" value="on">' . "\n" .
+								'			<input id="widget-text-1-visual" name="widget-text[1][visual]" class="visual sync-input" type="hidden" value="on">',
 			),
 			$response->get_data()
 		);
@@ -874,9 +874,9 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 					'number'        => 1,
 					'rendered'      => '<div class="textwidget">Custom text test</div>',
 					'rendered_form' => '<input id="widget-text-1-title" name="widget-text[1][title]" class="title sync-input" type="hidden" value="">' . "\n" .
-					                   '			<textarea id="widget-text-1-text" name="widget-text[1][text]" class="text sync-input" hidden>Custom text test</textarea>' . "\n" .
-					                   '			<input id="widget-text-1-filter" name="widget-text[1][filter]" class="filter sync-input" type="hidden" value="on">' . "\n" .
-					                   '			<input id="widget-text-1-visual" name="widget-text[1][visual]" class="visual sync-input" type="hidden" value="on">',
+									'			<textarea id="widget-text-1-text" name="widget-text[1][text]" class="text sync-input" hidden>Custom text test</textarea>' . "\n" .
+									'			<input id="widget-text-1-filter" name="widget-text[1][filter]" class="filter sync-input" type="hidden" value="on">' . "\n" .
+									'			<input id="widget-text-1-visual" name="widget-text[1][visual]" class="visual sync-input" type="hidden" value="on">',
 
 				),
 			),

--- a/phpunit/class-rest-widgets-controller-test.php
+++ b/phpunit/class-rest-widgets-controller-test.php
@@ -286,9 +286,9 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 					'number'        => 1,
 					'rendered'      => '<div class="textwidget">Custom text test</div>',
 					'rendered_form' => '<input id="widget-text-1-title" name="widget-text[1][title]" class="title sync-input" type="hidden" value="">' . "\n" .
-					                   '			<textarea id="widget-text-1-text" name="widget-text[1][text]" class="text sync-input" hidden>Custom text test</textarea>' . "\n" .
-					                   '			<input id="widget-text-1-filter" name="widget-text[1][filter]" class="filter sync-input" type="hidden" value="on">' . "\n" .
-					                   '			<input id="widget-text-1-visual" name="widget-text[1][visual]" class="visual sync-input" type="hidden" value="on">',
+									'			<textarea id="widget-text-1-text" name="widget-text[1][text]" class="text sync-input" hidden>Custom text test</textarea>' . "\n" .
+									'			<input id="widget-text-1-filter" name="widget-text[1][filter]" class="filter sync-input" type="hidden" value="on">' . "\n" .
+									'			<input id="widget-text-1-visual" name="widget-text[1][visual]" class="visual sync-input" type="hidden" value="on">',
 				),
 			),
 			$data

--- a/phpunit/class-rest-widgets-controller-test.php
+++ b/phpunit/class-rest-widgets-controller-test.php
@@ -218,7 +218,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request  = new WP_REST_Request( 'GET', '/__experimental/widgets' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
-		$this->assertEquals(
+		$this->assertEqualSets(
 			array(
 				array(
 					'id'           => 'text-1',
@@ -274,7 +274,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request['context'] = 'edit';
 		$response           = rest_get_server()->dispatch( $request );
 		$data               = $response->get_data();
-		$this->assertEquals(
+		$this->assertEqualSets(
 			array(
 				array(
 					'id'            => 'text-1',
@@ -320,7 +320,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request  = new WP_REST_Request( 'GET', '/__experimental/widgets/text-1' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
-		$this->assertEquals(
+		$this->assertEqualSets(
 			array(
 				'id'           => 'text-1',
 				'sidebar'      => 'sidebar-1',
@@ -414,7 +414,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$this->assertEquals( 'text-1', $data['id'] );
 		$this->assertEquals( 'sidebar-1', $data['sidebar'] );
 		$this->assertEquals( 1, $data['number'] );
-		$this->assertEquals(
+		$this->assertEqualSets(
 			array(
 				'text'   => 'Updated text test',
 				'title'  => '',
@@ -457,7 +457,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$this->assertEquals( 'text-2', $data['id'] );
 		$this->assertEquals( 'sidebar-1', $data['sidebar'] );
 		$this->assertEquals( 2, $data['number'] );
-		$this->assertEquals(
+		$this->assertEqualSets(
 			array(
 				'text'   => 'Updated text test',
 				'title'  => '',
@@ -507,7 +507,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$this->assertEquals( 'text-1', $data['id'] );
 		$this->assertEquals( 'sidebar-1', $data['sidebar'] );
 		$this->assertEquals( 1, $data['number'] );
-		$this->assertEquals(
+		$this->assertEqualSets(
 			array(
 				'text'   => 'Updated text test',
 				'title'  => '',
@@ -701,7 +701,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		);
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
-		$this->assertEquals(
+		$this->assertEqualSets(
 			array(
 				'id'            => $widget_id,
 				'sidebar'       => 'sidebar-1',
@@ -775,7 +775,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
-		$this->assertEquals(
+		$this->assertEqualSets(
 			array(
 				'text'   => 'Updated \\" \\\' text test',
 				'title'  => '',
@@ -812,7 +812,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request  = new WP_REST_Request( 'DELETE', '/__experimental/widgets/text-1' );
 		$response = rest_do_request( $request );
 
-		$this->assertEquals(
+		$this->assertEqualSets(
 			array(
 				'id'            => 'text-1',
 				'sidebar'       => 'wp_inactive_widgets',
@@ -857,7 +857,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request->set_query_params( array( 'force' => true ) );
 		$response = rest_do_request( $request );
 
-		$this->assertEquals(
+		$this->assertEqualSets(
 			array(
 				'deleted'  => true,
 				'previous' => array(

--- a/phpunit/class-rest-widgets-controller-test.php
+++ b/phpunit/class-rest-widgets-controller-test.php
@@ -402,15 +402,11 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request = new WP_REST_Request( 'POST', '/__experimental/widgets' );
 		$request->set_body_params(
 			array(
-				'sidebar'      => 'sidebar-1',
-				'settings'     => array(
+				'sidebar'  => 'sidebar-1',
+				'settings' => array(
 					'text' => 'Updated text test',
 				),
-				'id_base'      => 'text',
-				'widget_class' => 'WP_Widget_Text',
-				'name'         => 'Text',
-				'description'  => 'Arbitrary text.',
-				'number'       => 1,
+				'id_base'  => 'text',
 			)
 		);
 		$response = rest_get_server()->dispatch( $request );
@@ -418,6 +414,49 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$this->assertEquals( 'text-1', $data['id'] );
 		$this->assertEquals( 'sidebar-1', $data['sidebar'] );
 		$this->assertEquals( 1, $data['number'] );
+		$this->assertEquals(
+			array(
+				'text'   => 'Updated text test',
+				'title'  => '',
+				'filter' => false,
+			),
+			$data['settings']
+		);
+	}
+
+	/**
+	 *
+	 */
+	public function test_create_item_second_instance() {
+		$this->setup_widget(
+			'widget_text',
+			1,
+			array(
+				'text' => 'Custom text test',
+			)
+		);
+		$this->setup_sidebar(
+			'sidebar-1',
+			array(
+				'name' => 'Test sidebar',
+			)
+		);
+
+		$request = new WP_REST_Request( 'POST', '/__experimental/widgets' );
+		$request->set_body_params(
+			array(
+				'sidebar'  => 'sidebar-1',
+				'settings' => array(
+					'text' => 'Updated text test',
+				),
+				'id_base'  => 'text',
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		$this->assertEquals( 'text-2', $data['id'] );
+		$this->assertEquals( 'sidebar-1', $data['sidebar'] );
+		$this->assertEquals( 2, $data['number'] );
 		$this->assertEquals(
 			array(
 				'text'   => 'Updated text test',
@@ -775,17 +814,21 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 
 		$this->assertEquals(
 			array(
-				'id'           => 'text-1',
-				'sidebar'      => 'wp_inactive_widgets',
-				'settings'     => array(
+				'id'            => 'text-1',
+				'sidebar'       => 'wp_inactive_widgets',
+				'settings'      => array(
 					'text' => 'Custom text test',
 				),
-				'id_base'      => 'text',
-				'widget_class' => 'WP_Widget_Text',
-				'name'         => 'Text',
-				'description'  => 'Arbitrary text.',
-				'number'       => 1,
-				'rendered'     => '<div class="textwidget">Custom text test</div>',
+				'id_base'       => 'text',
+				'widget_class'  => 'WP_Widget_Text',
+				'name'          => 'Text',
+				'description'   => 'Arbitrary text.',
+				'number'        => 1,
+				'rendered'      => '<div class="textwidget">Custom text test</div>',
+				'rendered_form' => '<input id="widget-text-1-title" name="widget-text[1][title]" class="title sync-input" type="hidden" value="">' . "\n" .
+				                   '			<textarea id="widget-text-1-text" name="widget-text[1][text]" class="text sync-input" hidden>Custom text test</textarea>' . "\n" .
+				                   '			<input id="widget-text-1-filter" name="widget-text[1][filter]" class="filter sync-input" type="hidden" value="on">' . "\n" .
+				                   '			<input id="widget-text-1-visual" name="widget-text[1][visual]" class="visual sync-input" type="hidden" value="on">',
 			),
 			$response->get_data()
 		);

--- a/phpunit/class-rest-widgets-controller-test.php
+++ b/phpunit/class-rest-widgets-controller-test.php
@@ -218,6 +218,8 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request  = new WP_REST_Request( 'GET', '/__experimental/widgets' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
+		unset( $data[0]['_links'] );
+		unset( $data[1]['_links'] );
 		$this->assertEqualSets(
 			array(
 				array(
@@ -274,6 +276,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request['context'] = 'edit';
 		$response           = rest_get_server()->dispatch( $request );
 		$data               = $response->get_data();
+		unset( $data[0]['_links'] );
 		$this->assertEqualSets(
 			array(
 				array(
@@ -701,7 +704,8 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		);
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
-		$this->assertEqualSets(
+		unset( $data[0]['_links'] );
+		$this->assertEquals(
 			array(
 				'id'            => $widget_id,
 				'sidebar'       => 'sidebar-1',

--- a/phpunit/class-rest-widgets-controller-test.php
+++ b/phpunit/class-rest-widgets-controller-test.php
@@ -218,8 +218,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request  = new WP_REST_Request( 'GET', '/__experimental/widgets' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
-		unset( $data[0]['_links'] );
-		unset( $data[1]['_links'] );
+		$data     = $this->remove_links( $data );
 		$this->assertEqualSets(
 			array(
 				array(
@@ -276,7 +275,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request['context'] = 'edit';
 		$response           = rest_get_server()->dispatch( $request );
 		$data               = $response->get_data();
-		unset( $data[0]['_links'] );
+		$data               = $this->remove_links( $data );
 		$this->assertEqualSets(
 			array(
 				array(
@@ -704,7 +703,7 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		);
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
-		unset( $data[0]['_links'] );
+		$data     = $this->remove_links( $data );
 		$this->assertEquals(
 			array(
 				'id'            => $widget_id,
@@ -972,5 +971,27 @@ class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( 'rendered', $properties );
 		$this->assertArrayHasKey( 'rendered_form', $properties );
 		$this->assertArrayHasKey( 'settings', $properties );
+	}
+
+	/**
+	 * Helper to remove links key.
+	 *
+	 * @param array $data Array of data.
+	 *
+	 * @return array
+	 */
+	protected function remove_links( $data ) {
+		if ( ! is_array( $data ) ) {
+			return $data;
+		}
+		$count = 0;
+		foreach ( $data as $item ) {
+			if ( isset( $item['_links'] ) ) {
+				unset( $data[ $count ]['_links'] );
+			}
+			$count ++;
+		}
+
+		return $data;
 	}
 }

--- a/phpunit/class-rest-widgets-controller-test.php
+++ b/phpunit/class-rest-widgets-controller-test.php
@@ -1,0 +1,926 @@
+<?php
+/**
+ * REST API: REST_Widgets_Controller_Test class
+ *
+ * @package    WordPress
+ * @subpackage REST_API
+ */
+
+/**
+ * Tests for REST API for Widgets.
+ *
+ * @see WP_Test_REST_Controller_Testcase
+ */
+class REST_Widgets_Controller_Test extends WP_Test_REST_Controller_Testcase {
+	/**
+	 * @var int
+	 */
+	public $menu_id;
+
+	/**
+	 * @var int
+	 */
+	protected static $superadmin_id;
+
+	/**
+	 * @var int
+	 */
+	protected static $admin_id;
+
+	/**
+	 * @var int
+	 */
+	protected static $admin_id_without_unfiltered_html;
+
+	/**
+	 * @var int
+	 */
+	protected static $editor_id;
+
+	/**
+	 * @var int
+	 */
+	protected static $subscriber_id;
+
+	/**
+	 * @var int
+	 */
+	protected static $author_id;
+
+	/**
+	 * @var int
+	 */
+	protected static $per_page = 50;
+
+	/**
+	 * Create fake data before our tests run.
+	 *
+	 * @param WP_UnitTest_Factory $factory Helper that lets us create fake data.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$superadmin_id = $factory->user->create(
+			array(
+				'role'       => 'administrator',
+				'user_login' => 'superadmin',
+			)
+		);
+		if ( is_multisite() ) {
+			update_site_option( 'site_admins', array( 'superadmin' ) );
+		}
+		self::$admin_id      = $factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+		self::$editor_id     = $factory->user->create(
+			array(
+				'role' => 'editor',
+			)
+		);
+		self::$author_id     = $factory->user->create(
+			array(
+				'role' => 'author',
+			)
+		);
+		self::$subscriber_id = $factory->user->create(
+			array(
+				'role' => 'subscriber',
+			)
+		);
+	}
+
+	/**
+	 *
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		wp_set_current_user( self::$admin_id );
+
+		// Unregister all widgets and sidebars.
+		global $wp_registered_sidebars, $_wp_sidebars_widgets;
+		$wp_registered_sidebars = array();
+		$_wp_sidebars_widgets   = array();
+		update_option( 'sidebars_widgets', array() );
+	}
+
+	private function setup_widget( $option_name, $number, $settings ) {
+		update_option(
+			$option_name,
+			array(
+				$number => $settings,
+			)
+		);
+	}
+
+	private function setup_sidebar( $id, $attrs = array(), $widgets = array() ) {
+		global $wp_registered_sidebars;
+		update_option(
+			'sidebars_widgets',
+			array(
+				$id => $widgets,
+			)
+		);
+		$wp_registered_sidebars[ $id ] = array_merge(
+			array(
+				'id'            => $id,
+				'before_widget' => '',
+				'after_widget'  => '',
+				'before_title'  => '',
+				'after_title'   => '',
+			),
+			$attrs
+		);
+
+		global $wp_registered_widgets;
+		foreach ( $wp_registered_widgets as $wp_registered_widget ) {
+			if ( is_array( $wp_registered_widget['callback'] ) ) {
+				$wp_registered_widget['callback'][0]->_register();
+			}
+		}
+	}
+
+	/**
+	 *
+	 */
+	public function test_register_routes() {
+		$routes = rest_get_server()->get_routes();
+		$this->assertArrayHasKey( '/__experimental/widgets', $routes );
+		$this->assertArrayHasKey( '/__experimental/widgets/(?P<id>[\w\-]+)', $routes );
+	}
+
+	/**
+	 *
+	 */
+	public function test_context_param() {
+	}
+
+	/**
+	 *
+	 */
+	public function test_get_items_no_widgets() {
+		$request  = new WP_REST_Request( 'GET', '/__experimental/widgets' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( array(), $data );
+	}
+
+	/**
+	 *
+	 */
+	public function test_get_items_no_permission() {
+		wp_set_current_user( 0 );
+		$request  = new WP_REST_Request( 'GET', '/__experimental/widgets' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_cannot_manage_widgets', $response, 401 );
+	}
+
+	/**
+	 *
+	 */
+	public function test_get_items_wrong_permission_author() {
+		wp_set_current_user( self::$author_id );
+		$request  = new WP_REST_Request( 'GET', '/__experimental/widgets' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_cannot_manage_widgets', $response, 403 );
+	}
+
+	/**
+	 *
+	 */
+	public function test_get_items() {
+		$this->setup_widget(
+			'widget_rss',
+			1,
+			array(
+				'title' => 'RSS test',
+			)
+		);
+		$this->setup_widget(
+			'widget_text',
+			1,
+			array(
+				'text' => 'Custom text test',
+			)
+		);
+		$this->setup_sidebar(
+			'sidebar-1',
+			array(
+				'name' => 'Test sidebar',
+			),
+			array( 'text-1', 'rss-1' )
+		);
+
+		$request  = new WP_REST_Request( 'GET', '/__experimental/widgets' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		$this->assertEquals(
+			array(
+				array(
+					'id'           => 'text-1',
+					'sidebar'      => 'sidebar-1',
+					'settings'     => array(
+						'text' => 'Custom text test',
+					),
+					'id_base'      => 'text',
+					'widget_class' => 'WP_Widget_Text',
+					'name'         => 'Text',
+					'description'  => 'Arbitrary text.',
+					'number'       => 1,
+					'rendered'     => '<div class="textwidget">Custom text test</div>',
+				),
+				array(
+					'id'           => 'rss-1',
+					'sidebar'      => 'sidebar-1',
+					'settings'     => array(
+						'title' => 'RSS test',
+					),
+					'id_base'      => 'rss',
+					'widget_class' => 'WP_Widget_RSS',
+					'name'         => 'RSS',
+					'description'  => 'Entries from any RSS or Atom feed.',
+					'number'       => 1,
+					'rendered'     => '',
+				),
+			),
+			$data
+		);
+	}
+
+	/**
+	 * Test a GET request in edit context. In particular, we expect rendered_form to be served correctly.
+	 */
+	public function test_get_items_edit_context() {
+		$this->setup_widget(
+			'widget_text',
+			1,
+			array(
+				'text' => 'Custom text test',
+			)
+		);
+		$this->setup_sidebar(
+			'sidebar-1',
+			array(
+				'name' => 'Test sidebar',
+			),
+			array( 'text-1' )
+		);
+
+		$request            = new WP_REST_Request( 'GET', '/__experimental/widgets' );
+		$request['context'] = 'edit';
+		$response           = rest_get_server()->dispatch( $request );
+		$data               = $response->get_data();
+		$this->assertEquals(
+			array(
+				array(
+					'id'            => 'text-1',
+					'sidebar'       => 'sidebar-1',
+					'settings'      => array(
+						'text' => 'Custom text test',
+					),
+					'id_base'       => 'text',
+					'widget_class'  => 'WP_Widget_Text',
+					'name'          => 'Text',
+					'description'   => 'Arbitrary text.',
+					'number'        => 1,
+					'rendered'      => '<div class="textwidget">Custom text test</div>',
+					'rendered_form' => '<input id="widget-text-1-title" name="widget-text[1][title]" class="title sync-input" type="hidden" value="">' . "\n" .
+					                   '			<textarea id="widget-text-1-text" name="widget-text[1][text]" class="text sync-input" hidden>Custom text test</textarea>' . "\n" .
+					                   '			<input id="widget-text-1-filter" name="widget-text[1][filter]" class="filter sync-input" type="hidden" value="on">' . "\n" .
+					                   '			<input id="widget-text-1-visual" name="widget-text[1][visual]" class="visual sync-input" type="hidden" value="on">',
+				),
+			),
+			$data
+		);
+	}
+
+	/**
+	 *
+	 */
+	public function test_get_item() {
+		$this->setup_widget(
+			'widget_text',
+			1,
+			array(
+				'text' => 'Custom text test',
+			)
+		);
+		$this->setup_sidebar(
+			'sidebar-1',
+			array(
+				'name' => 'Test sidebar',
+			)
+		);
+
+		$request  = new WP_REST_Request( 'GET', '/__experimental/widgets/text-1' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		$this->assertEquals(
+			array(
+				'id'           => 'text-1',
+				'sidebar'      => 'sidebar-1',
+				'settings'     => array(
+					'text' => 'Custom text test',
+				),
+				'id_base'      => 'text',
+				'widget_class' => 'WP_Widget_Text',
+				'name'         => 'Text',
+				'description'  => 'Arbitrary text.',
+				'number'       => 1,
+				'rendered'     => '<div class="textwidget">Custom text test</div>',
+			),
+			$data
+		);
+	}
+
+	/**
+	 *
+	 */
+	public function test_get_item_no_permission() {
+		$this->setup_widget(
+			'widget_text',
+			1,
+			array(
+				'text' => 'Custom text test',
+			)
+		);
+		$this->setup_sidebar(
+			'sidebar-1',
+			array(
+				'name' => 'Test sidebar',
+			)
+		);
+
+		$request  = new WP_REST_Request( 'GET', '/__experimental/widgets/text-1' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_cannot_manage_widgets', $response, 401 );
+	}
+
+	/**
+	 *
+	 */
+	public function test_get_item_wrong_permission_author() {
+		wp_set_current_user( self::$author_id );
+		$this->setup_widget(
+			'widget_text',
+			1,
+			array(
+				'text' => 'Custom text test',
+			)
+		);
+		$this->setup_sidebar(
+			'sidebar-1',
+			array(
+				'name' => 'Test sidebar',
+			)
+		);
+
+		$request  = new WP_REST_Request( 'GET', '/__experimental/widgets/text-1' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_cannot_manage_widgets', $response, 403 );
+	}
+
+	/**
+	 *
+	 */
+	public function test_create_item() {
+		$this->setup_sidebar(
+			'sidebar-1',
+			array(
+				'name' => 'Test sidebar',
+			),
+			array( 'rss-1' )
+		);
+
+		$request = new WP_REST_Request( 'POST', '/__experimental/widgets/' );
+		$request->set_body_params(
+			array(
+				'sidebar'      => 'sidebar-1',
+				'settings'     => array(
+					'text' => 'Updated text test',
+				),
+				'id_base'      => 'text',
+				'widget_class' => 'WP_Widget_Text',
+				'name'         => 'Text',
+				'description'  => 'Arbitrary text.',
+				'number'       => 1,
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		$this->assertEquals(
+			array(
+				'id'           => 'text-1',
+				'sidebar'      => 'sidebar-1',
+				'settings'     => array(
+					'text'   => 'Updated text test',
+					'title'  => '',
+					'filter' => false,
+				),
+				'id_base'      => 'text',
+				'widget_class' => 'WP_Widget_Text',
+				'name'         => 'Text',
+				'description'  => 'Arbitrary text.',
+				'number'       => 1,
+				'rendered'     => '<div class="textwidget">Updated text test</div>',
+			),
+			$data
+		);
+	}
+
+	/**
+	 *
+	 */
+	public function test_update_item() {
+		$this->setup_widget(
+			'widget_text',
+			1,
+			array(
+				'text' => 'Custom text test',
+			)
+		);
+		$this->setup_sidebar(
+			'sidebar-1',
+			array(
+				'name' => 'Test sidebar',
+			),
+			array( 'text-1', 'rss-1' )
+		);
+
+		$request = new WP_REST_Request( 'PUT', '/__experimental/widgets/text-1' );
+		$request->set_body_params(
+			array(
+				'id'           => 'text-1',
+				'sidebar'      => 'sidebar-1',
+				'settings'     => array(
+					'text' => 'Updated text test',
+				),
+				'id_base'      => 'text',
+				'widget_class' => 'WP_Widget_Text',
+				'name'         => 'Text',
+				'description'  => 'Arbitrary text.',
+				'number'       => 1,
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		$this->assertEquals(
+			array(
+				'id'           => 'text-1',
+				'sidebar'      => 'sidebar-1',
+				'settings'     => array(
+					'text'   => 'Updated text test',
+					'title'  => '',
+					'filter' => false,
+				),
+				'id_base'      => 'text',
+				'widget_class' => 'WP_Widget_Text',
+				'name'         => 'Text',
+				'description'  => 'Arbitrary text.',
+				'number'       => 1,
+				'rendered'     => '<div class="textwidget">Updated text test</div>',
+			),
+			$data
+		);
+	}
+
+	/**
+	 *
+	 */
+	public function test_update_item_reassign_sidebar() {
+		$this->setup_widget(
+			'widget_text',
+			1,
+			array(
+				'text' => 'Custom text test',
+			)
+		);
+		$this->setup_sidebar(
+			'sidebar-1',
+			array(
+				'name' => 'Test sidebar',
+			),
+			array( 'text-1', 'rss-1' )
+		);
+		$this->setup_sidebar(
+			'sidebar-2',
+			array(
+				'name' => 'Test sidebar',
+			),
+			array()
+		);
+
+		$request = new WP_REST_Request( 'PUT', '/__experimental/widgets/text-1' );
+		$request->set_body_params(
+			array(
+				'sidebar' => 'sidebar-1',
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertEquals( 'sidebar-2', $response->get_data()['sidebar'] );
+
+		$sidebar1 = rest_do_request( '/__experimental/sidebars/sidebar-1' );
+		$this->assertNotContains( 'text-1', $sidebar1->get_data()['widgets'] );
+
+		$sidebar2 = rest_do_request( '/__experimental/sidebars/sidebar-2' );
+		$this->assertContains( 'text-1', $sidebar2->get_data()['widgets'] );
+	}
+
+	/**
+	 * @group multisite
+	 */
+	public function test_store_html_as_admin() {
+		if ( is_multisite() ) {
+			$this->assertEquals(
+				'<div class="textwidget">alert(1)</div>',
+				$this->update_text_widget_with_raw_html( '<script>alert(1)</script>' )
+			);
+		} else {
+			$this->assertEquals(
+				'<div class="textwidget"><script>alert(1)</script></div>',
+				$this->update_text_widget_with_raw_html( '<script>alert(1)</script>' )
+			);
+		}
+	}
+
+	/**
+	 * @group multisite
+	 */
+	public function test_store_html_as_superadmin() {
+		wp_set_current_user( self::$superadmin_id );
+		if ( is_multisite() ) {
+			$this->assertEquals(
+				'<div class="textwidget"><script>alert(1)</script></div>',
+				$this->update_text_widget_with_raw_html( '<script>alert(1)</script>' )
+			);
+		} else {
+			$this->assertEquals(
+				'<div class="textwidget"><script>alert(1)</script></div>',
+				$this->update_text_widget_with_raw_html( '<script>alert(1)</script>' )
+			);
+		}
+	}
+
+	protected function update_text_widget_with_raw_html( $html ) {
+		$this->setup_widget(
+			'widget_text',
+			1,
+			array(
+				'text' => 'Custom text test',
+			)
+		);
+		$this->setup_sidebar(
+			'sidebar-1',
+			array(
+				'name' => 'Test sidebar',
+			),
+			array( 'text-1' )
+		);
+
+		$request = new WP_REST_Request( 'PUT', '/__experimental/widgets/text-1' );
+		$request->set_body_params(
+			array(
+				'id'           => 'text-1',
+				'settings'     => array(
+					'text' => $html,
+				),
+				'id_base'      => 'text',
+				'widget_class' => 'WP_Widget_Text',
+				'name'         => 'Text',
+				'description'  => 'Arbitrary text.',
+				'number'       => 1,
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		return $data['widgets'][0]['rendered'];
+	}
+
+	/**
+	 *
+	 */
+	public function test_update_item_legacy_widget_1() {
+		$this->do_test_update_item_legacy_widget( 'testwidget-1' );
+	}
+
+	/**
+	 *
+	 */
+	public function test_update_item_legacy_widget_2() {
+		$this->do_test_update_item_legacy_widget( 'testwidget' );
+	}
+
+	/**
+	 *
+	 */
+	public function do_test_update_item_legacy_widget( $widget_id ) {
+		// @TODO: Use @dataProvider instead (it doesn't work with custom constructors like the one we have in this class)
+		wp_register_widget_control(
+			$widget_id,
+			'WP test widget',
+			function () {
+				$settings = get_option( 'widget_testwidget' );
+
+				// check if anything's been sent.
+				if ( isset( $_POST['update_testwidget'] ) ) {
+					$settings['id']    = $_POST['test_id'];
+					$settings['title'] = $_POST['test_title'];
+
+					update_option( 'widget_testwidget', $settings );
+				}
+			},
+			100,
+			200
+		);
+		wp_register_sidebar_widget(
+			$widget_id,
+			'WP test widget',
+			function () {
+				$settings = get_option( 'widget_testwidget' ) ? get_option( 'widget_testwidget' ) : array(
+					'id'    => '',
+					'title' => '',
+				);
+				echo '<h1>' . $settings['id'] . '</h1><span>' . $settings['title'] . '</span>';
+			}
+		);
+		$this->setup_sidebar(
+			'sidebar-1',
+			array(
+				'name' => 'Test sidebar',
+			),
+			array( $widget_id )
+		);
+
+		$request = new WP_REST_Request( 'PUT', '/__experimental/widgets/' . $widget_id );
+		$request->set_body_params(
+			array(
+				'id'       => $widget_id,
+				'name'     => 'WP test widget',
+				'settings' => array(
+					'test_id'           => 'My test id',
+					'test_title'        => 'My test title',
+					'update_testwidget' => true,
+				),
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		$this->assertEquals(
+			array(
+				'id'       => $widget_id,
+				'sidebar'  => 'sidebar-1',
+				'settings' => array(),
+				'rendered' => '<h1>My test id</h1><span>My test title</span>',
+				'name'     => 'WP test widget',
+			),
+			$data
+		);
+	}
+
+	/**
+	 *
+	 */
+	public function test_update_item_no_permission() {
+		wp_set_current_user( 0 );
+
+		$request = new WP_REST_Request( 'PUT', '/__experimental/sidebars/sidebar-1' );
+		$request->set_body_params(
+			array(
+				'widgets' => array(),
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'widgets_cannot_access', $response, 401 );
+	}
+
+	/**
+	 *
+	 */
+	public function test_update_item_wrong_permission_author() {
+		wp_set_current_user( self::$author_id );
+
+		$request = new WP_REST_Request( 'PUT', '/__experimental/sidebars/sidebar-1' );
+		$request->set_body_params(
+			array(
+				'widgets' => array(),
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'widgets_cannot_access', $response, 403 );
+	}
+
+	/**
+	 * Tests if the endpoint correctly handles "slashable" characters such as " or '.
+	 */
+	public function test_update_item_slashing() {
+		$this->setup_widget( 'widget_text', 1, array( 'text' => 'Custom text test' ) );
+		$this->setup_sidebar( 'sidebar-1', array( 'name' => 'Test sidebar' ), array( 'text-1', 'rss-1' ) );
+
+		$request = new WP_REST_Request( 'PUT', '/__experimental/widgets/text-1' );
+		$request->set_body_params(
+			array(
+				'id'           => 'text-1',
+				'sidebar'      => 'sidebar-1',
+				'settings'     => array(
+					'text' => 'Updated \\" \\\' text test',
+				),
+				'id_base'      => 'text',
+				'widget_class' => 'WP_Widget_Text',
+				'name'         => 'Text',
+				'description'  => 'Arbitrary text.',
+				'number'       => 1,
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		$this->assertEquals(
+			array(
+				'id'           => 'text-1',
+				'sidebar'      => 'sidebar-1',
+				'settings'     => array(
+					'text'   => 'Updated \\" \\\' text test',
+					'title'  => '',
+					'filter' => false,
+				),
+				'id_base'      => 'text',
+				'widget_class' => 'WP_Widget_Text',
+				'name'         => 'Text',
+				'description'  => 'Arbitrary text.',
+				'number'       => 1,
+				'rendered'     => '<div class="textwidget">Updated \\" \\\' text test</div>',
+			),
+			$data
+		);
+	}
+
+	/**
+	 *
+	 */
+	public function test_delete_item() {
+		$this->setup_widget(
+			'widget_text',
+			1,
+			array(
+				'text' => 'Custom text test',
+			)
+		);
+		$this->setup_sidebar(
+			'sidebar-1',
+			array(
+				'name' => 'Test sidebar',
+			),
+			array( 'text-1', 'rss-1' )
+		);
+
+		$request  = new WP_REST_Request( 'DELETE', '/__experimental/widgets/text-1' );
+		$response = rest_do_request( $request );
+
+		$this->assertEquals(
+			array(
+				'id'           => 'text-1',
+				'sidebar'      => 'wp_inactive_widgets',
+				'settings'     => array(
+					'text' => 'Custom text test',
+				),
+				'id_base'      => 'text',
+				'widget_class' => 'WP_Widget_Text',
+				'name'         => 'Text',
+				'description'  => 'Arbitrary text.',
+				'number'       => 1,
+				'rendered'     => '<div class="textwidget">Custom text test</div>',
+			),
+			$response->get_data()
+		);
+	}
+
+	/**
+	 *
+	 */
+	public function test_delete_item_force() {
+		$this->setup_widget(
+			'widget_text',
+			1,
+			array(
+				'text' => 'Custom text test',
+			)
+		);
+		$this->setup_sidebar(
+			'sidebar-1',
+			array(
+				'name' => 'Test sidebar',
+			),
+			array( 'text-1', 'rss-1' )
+		);
+
+		$request = new WP_REST_Request( 'DELETE', '/__experimental/widgets/text-1' );
+		$request->set_query_params( array( 'force' => true ) );
+		$response = rest_do_request( $request );
+
+		$this->assertEquals(
+			array(
+				'deleted'  => true,
+				'previous' => array(
+
+					'id'           => 'text-1',
+					'sidebar'      => 'sidebar-1',
+					'settings'     => array(
+						'text' => 'Custom text test',
+					),
+					'id_base'      => 'text',
+					'widget_class' => 'WP_Widget_Text',
+					'name'         => 'Text',
+					'description'  => 'Arbitrary text.',
+					'number'       => 1,
+					'rendered'     => '<div class="textwidget">Custom text test</div>',
+				),
+			),
+			$response->get_data()
+		);
+
+		$response = rest_do_request( '/__experimental/widgets/text-1' );
+		$this->assertEquals( 404, $response->get_status() );
+	}
+
+	/**
+	 *
+	 */
+	public function test_delete_item_logged_out() {
+		$this->setup_widget(
+			'widget_text',
+			1,
+			array(
+				'text' => 'Custom text test',
+			)
+		);
+		$this->setup_sidebar(
+			'sidebar-1',
+			array(
+				'name' => 'Test sidebar',
+			),
+			array( 'text-1', 'rss-1' )
+		);
+
+		$request  = new WP_REST_Request( 'DELETE', '/__experimental/widgets/text-1' );
+		$response = rest_do_request( $request );
+
+		$this->assertErrorResponse( 'rest_cannot_manage_widgets', $response, 401 );
+	}
+
+	/**
+	 *
+	 */
+	public function test_delete_item_author() {
+		wp_set_current_user( self::$author_id );
+
+		$this->setup_widget(
+			'widget_text',
+			1,
+			array(
+				'text' => 'Custom text test',
+			)
+		);
+		$this->setup_sidebar(
+			'sidebar-1',
+			array(
+				'name' => 'Test sidebar',
+			),
+			array( 'text-1', 'rss-1' )
+		);
+
+		$request  = new WP_REST_Request( 'DELETE', '/__experimental/widgets/text-1' );
+		$response = rest_do_request( $request );
+
+		$this->assertErrorResponse( 'rest_cannot_manage_widgets', $response, 403 );
+	}
+
+	/**
+	 * The test_prepare_item() method does not exist for sidebar.
+	 */
+	public function test_prepare_item() {
+	}
+
+	/**
+	 *
+	 */
+	public function test_get_item_schema() {
+		wp_set_current_user( self::$admin_id );
+		$request    = new WP_REST_Request( 'OPTIONS', '/__experimental/widgets' );
+		$response   = rest_get_server()->dispatch( $request );
+		$data       = $response->get_data();
+		$properties = $data['schema']['properties'];
+
+		$this->assertEquals( 10, count( $properties ) );
+		$this->assertArrayHasKey( 'id', $properties );
+		$this->assertArrayHasKey( 'id_base', $properties );
+		$this->assertArrayHasKey( 'sidebar', $properties );
+		$this->assertArrayHasKey( 'widget_class', $properties );
+		$this->assertArrayHasKey( 'name', $properties );
+		$this->assertArrayHasKey( 'description', $properties );
+		$this->assertArrayHasKey( 'number', $properties );
+		$this->assertArrayHasKey( 'rendered', $properties );
+		$this->assertArrayHasKey( 'rendered_form', $properties );
+		$this->assertArrayHasKey( 'settings', $properties );
+	}
+}


### PR DESCRIPTION
## Description
This separates the widgets handling from sidebars into a dedicated widgets controller.

Fixes #25232.

## How has this been tested?
Automated tests in progress.

This will require changes to the client.

## Types of changes
Breaking change.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
