### PR TITLE
Fix gallery caption not centered in the front-end issue

### DIFF
--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -1,3 +1,10 @@
+.wp-block-gallery {
+
+	figcaption {
+		flex-grow: 1;
+	}
+}
+
 .wp-block-gallery,
 .blocks-gallery-grid {
 	display: flex;

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -1,10 +1,3 @@
-.wp-block-gallery {
-
-	figcaption {
-		flex-grow: 1;
-	}
-}
-
 .wp-block-gallery,
 .blocks-gallery-grid {
 	display: flex;
@@ -70,6 +63,10 @@
 				display: inline;
 			}
 		}
+	}
+
+	figcaption {
+		flex-grow: 1;
 	}
 
 	// Cropped


### PR DESCRIPTION
Fixes: #22188 

## Description
This PR will resolve the issue that occurs in the gallery. 

## How has this been tested? 
I have tested it on twenty twenty-one theme and twenty-twenty theme. It works as expected and also won't break any style required for backward compatibility.

## Screenshots <!-- if applicable -->

Editor Style:
![screenshot-guten local-2020 10 09-01_13_21](https://user-images.githubusercontent.com/25550562/95505892-b899d600-09cc-11eb-9138-1a2283295e5f.png)

Frontend Style:
![screenshot-guten local-2020 10 09-01_14_42](https://user-images.githubusercontent.com/25550562/95505999-e252fd00-09cc-11eb-95c2-d6202c013e48.png)


## Types of changes
Bug Fix - Non-breaking change.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
