### PR TITLE
Code example for requestToExternal

### DIFF
--- a/packages/dependency-extraction-webpack-plugin/README.md
+++ b/packages/dependency-extraction-webpack-plugin/README.md
@@ -194,18 +194,18 @@ If no string is returned, the script handle is assumed to be the same as the req
 
 ```js
 /**
- * Map 'my-module' request to 'my-module-script-handle'
+ * Map 'my-module' request to a global variable
  *
  * @param {string} request Requested module
  *
- * @return {(string|undefined)} Script global
+ * @return {(any|undefined)} Variable to map the requested module to
  */
-function requestToHandle( request ) {
+function requestToExternal( request ) {
 
   // Handle imports like `import myModule from 'my-module'`
   if ( request === 'my-module' ) {
-    // `my-module` depends on the script with the 'my-module-script-handle' handle.
-    return 'my-module-script-handle';
+    // MyModule is made available by another enqueued script or localised data.
+    return MyModule;
   }
 }
 


### PR DESCRIPTION
## Description
Correcting the code example for `requestToExternal` for **@wordpress/dependency-extraction-webpack-plugin**.

This needs to be updated here,
https://developer.wordpress.org/block-editor/packages/packages-dependency-extraction-webpack-plugin/

## How has this been tested?
Looked at the markdown renders.

## Types of changes
Documentation

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] ~I've updated all React Native files affected by any refactorings/renamings in this PR.~ <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
