### PR TITLE
Fix 9:16 aspect ratio styling

### DIFF
--- a/packages/block-library/src/embed/style.scss
+++ b/packages/block-library/src/embed/style.scss
@@ -74,8 +74,8 @@
 		padding-top: 100%; // 1 / 1 * 100
 	}
 
-	.wp-embed-aspect-9-6 .wp-block-embed__wrapper::before {
-		padding-top: 66.66%; // 6 / 9 * 100
+	.wp-embed-aspect-9-16 .wp-block-embed__wrapper::before {
+		padding-top: 177.77%; // 16 / 9 * 100
 	}
 
 	.wp-embed-aspect-1-2 .wp-block-embed__wrapper::before {


### PR DESCRIPTION
## Description

I noticed that even though there are these `ASPECT_RATIOS` defined:

https://github.com/WordPress/gutenberg/blob/78585d6935fee9020017d17383cef597b67c5703/packages/block-library/src/embed/constants.js#L1-L11

There was no style rule defined for `.wp-embed-aspect-9-16`. Instead there is apparently either an old style rule for `.wp-embed-aspect-9-16` or it was entered with a typo:

https://github.com/WordPress/gutenberg/blob/78585d6935fee9020017d17383cef597b67c5703/packages/block-library/src/embed/style.scss#L77-L79

This typo appears to have been introduced in #21599.

This is closely related to #18518. Since there is no style rule for `.wp-embed-aspect-9-16` in current Gutenberg, the fallback aspect ratio of 2:1 is used:

https://github.com/WordPress/gutenberg/blob/78585d6935fee9020017d17383cef597b67c5703/packages/block-library/src/embed/style.scss#L39-L43

When adding a Spotify block, the aspect ratio being detected is 9:16. Before the style rule is fixed, it gets the 2:1 fallback. But after the fix, the height gets quite excessive:

Before | After
-------|------
![image](https://user-images.githubusercontent.com/134745/95546868-82e9f280-09b6-11eb-8822-39c1973ad0f2.png) | ![image](https://user-images.githubusercontent.com/134745/95546988-cd6b6f00-09b6-11eb-9b8d-f9f7270b2a34.png)

The issue appears to be due to the Spotify `iframe` having a `height` that is just a little larger than the `width`:

```html
<iframe title="Spotify Embed: Cut To The Feeling (Kid Froopy Remix)" width="300" height="380" allowtransparency="true" frameborder="0" allow="encrypted-media" src="https://open.spotify.com/embed/album/4RuzGKLG99XctuBMBkFFOC"></iframe>
```

There appears to be a missing aspect ratio for 3:4 to invert the 4:3. This is not included in the scope of this PR.

## How has this been tested?

Add a Spotify embed, e.g. https://open.spotify.com/album/4RuzGKLG99XctuBMBkFFOC

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Fixing styles, which reveal a deeper issue with `getClassNames()` in the `embed/util.js`.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
