### PR TITLE
Performance: Remove transition on block selection indicator.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -144,8 +144,6 @@
 			// 2px outside.
 			box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color);
 			border-radius: $radius-block-ui - $border-width; // Border is outset, so so subtract the width to achieve correct radius.
-			transition: box-shadow 0.2s ease-out;
-			@include reduce-motion("transition");
 
 			// Windows High Contrast mode will show this outline.
 			outline: 2px solid transparent;
@@ -231,8 +229,6 @@
 		left: 0;
 		border-radius: $radius-block-ui;
 		box-shadow: 0 0 0 $border-width-focus transparent;
-		transition: box-shadow 0.1s ease-in;
-		@include reduce-motion("transition");
 	}
 
 	// Warnings


### PR DESCRIPTION
Although fading a box shadow should be performant, for whatever reason it feels clunky in the editor:

![before](https://user-images.githubusercontent.com/1204802/95552894-cde32480-0a0d-11eb-96cd-8cb322641e04.gif)

This PR simply removes the transition, making it feel much more responsive. I'm not finding myself missing the fade:

![after](https://user-images.githubusercontent.com/1204802/95552900-d0457e80-0a0d-11eb-8e60-43277d74f3d7.gif)


