### PR TITLE
Fix block editor example in storybook

### DIFF
--- a/packages/block-editor/src/hooks/font-size.js
+++ b/packages/block-editor/src/hooks/font-size.js
@@ -142,7 +142,7 @@ export function FontSizeEdit( props ) {
  */
 export function useIsFontSizeDisabled( { name: blockName } = {} ) {
 	const fontSizes = useEditorFeature( 'typography.fontSizes' );
-	const hasFontSizes = fontSizes.length;
+	const hasFontSizes = !! fontSizes?.length;
 
 	return (
 		! hasBlockSupport( blockName, FONT_SIZE_SUPPORT_KEY ) || ! hasFontSizes


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes #25975

This is a tiny fix for the `useIsFontSizeDisabled` hook, which didn't handle `fontSizes` being `undefined`. Also coerces the value to a boolean, as the function is documented to return values of that type.

The missing logic was causing the standalone block editor in the storybook to error as it doesn't have `fontSizes`.

## How has this been tested?
1. Checkout this branch and locally run `npm run storybook:dev`
2. Go to the Block Editor example
3. Try typing in the paragraph block

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
