### PR TITLE
Show all widget areas on widget screen

### DIFF
--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -85,7 +85,7 @@ function gutenberg_widgets_init( $hook ) {
 
 	$preload_paths = array(
 		array( '/wp/v2/media', 'OPTIONS' ),
-		'/__experimental/sidebars?context=edit',
+		'/__experimental/sidebars?context=edit&per_page=-1',
 	);
 	$preload_data  = array_reduce(
 		$preload_paths,

--- a/packages/edit-widgets/src/store/utils.js
+++ b/packages/edit-widgets/src/store/utils.js
@@ -41,7 +41,7 @@ export const buildWidgetAreasPostId = () => `widget-areas`;
  * @return {Object} Query.
  */
 export function buildWidgetAreasQuery() {
-	return {};
+	return { per_page: -1 };
 }
 
 /**


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes #25932, allows the widget screen to show all widget areas by appending `per_page=-1` to the query.

## How has this been tested?
Use the testing steps from #25932 which I've copied here:
1. Deactivate Gutenberg temporarily and install a [plugin like this](https://wordpress.org/plugins/custom-sidebars/) to create over 9 custom sidebars. If you already have over 9 sidebars, you can skip this step!
2. Enable and activate Gutenberg. 
3. Head to Appearance > Widgets.
4. See only 9 custom widget areas.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
