### PR TITLE
Fallback for dropcap when __experimentalFeatures is not present

### DIFF
--- a/packages/block-editor/src/components/use-editor-feature/index.js
+++ b/packages/block-editor/src/components/use-editor-feature/index.js
@@ -87,12 +87,15 @@ export default function useEditorFeature( featurePath ) {
 				return experimentalFeature;
 			}
 
-			// 3 - Fall back to block support.
+			// 3 - Fall back for typography.dropCap:
 			// This is only necessary to support typography.dropCap.
 			// when __experimentalFeatures are not present (core without plugin).
 			// To remove when __experimentalFeatures are ported to core.
-			const { getBlockSupport } = select( 'core/blocks' );
-			return getBlockSupport( blockName, featurePath );
+			if ( featurePath === 'typography.dropCap' ) {
+				return true;
+			}
+
+			return experimentalFeature;
 		},
 		[ blockName, featurePath ]
 	);

--- a/packages/block-editor/src/components/use-editor-feature/index.js
+++ b/packages/block-editor/src/components/use-editor-feature/index.js
@@ -81,7 +81,18 @@ export default function useEditorFeature( featurePath ) {
 			// such as core/heading or core/post-title.
 			const globalPath = `__experimentalFeatures.global.${ featurePath }`;
 			const blockPath = `__experimentalFeatures.${ blockName }.${ featurePath }`;
-			return get( settings, blockPath ) ?? get( settings, globalPath );
+			const experimentalFeature =
+				get( settings, blockPath ) ?? get( settings, globalPath );
+			if ( experimentalFeature !== undefined ) {
+				return experimentalFeature;
+			}
+
+			// 3 - Fall back to block support.
+			// This is only necessary to support typography.dropCap.
+			// when __experimentalFeatures are not present (core without plugin).
+			// To remove when __experimentalFeatures are ported to core.
+			const { getBlockSupport } = select( 'core/blocks' );
+			return getBlockSupport( blockName, featurePath );
 		},
 		[ blockName, featurePath ]
 	);

--- a/packages/block-editor/src/components/use-editor-feature/index.js
+++ b/packages/block-editor/src/components/use-editor-feature/index.js
@@ -91,11 +91,7 @@ export default function useEditorFeature( featurePath ) {
 			// This is only necessary to support typography.dropCap.
 			// when __experimentalFeatures are not present (core without plugin).
 			// To remove when __experimentalFeatures are ported to core.
-			if ( featurePath === 'typography.dropCap' ) {
-				return true;
-			}
-
-			return experimentalFeature;
+			return featurePath === 'typography.dropCap' ? true : undefined;
 		},
 		[ blockName, featurePath ]
 	);

--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -36,9 +36,6 @@
 		"fontSize": true,
 		"lineHeight": true,
 		"__experimentalSelector": "p",
-		"__unstablePasteTextInline": true,
-		"typography": {
-			"dropCap": true
-		}
+		"__unstablePasteTextInline": true
 	}
 }

--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -36,6 +36,9 @@
 		"fontSize": true,
 		"lineHeight": true,
 		"__experimentalSelector": "p",
-		"__unstablePasteTextInline": true
+		"__unstablePasteTextInline": true,
+		"typography": {
+			"dropCap": true
+		}
 	}
 }


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/issues/20588
Previously: https://github.com/WordPress/gutenberg/pull/24761, https://github.com/WordPress/gutenberg/pull/24932

This PR makes sure the dropCap feature is available for paragraph in contexts where `__experimentalFeatures` is not present (core without the plugin, given that `lib/global-styles.php` is not ported over).

## Test

Make sure theme.json still works as expected:

- Load a post with a paragraph and verify that the drop cap option is shown.
- Edit `lib/experimental-default-theme.json` and set `typography.dropCap` to `false` => load a post with a paragraph and verify that the drop cap option is not shown.

Make sure it works without any theme.json:

- Go to `lib/load.php` and comment the line `require dirname( __FILE__ ) . '/global-styles.php';`.
- Load a post with a paragraph and verify that the drop cap option is shown.
