### PR TITLE
Add no results placeholder in Query block

### DIFF
--- a/packages/block-library/src/query-loop/edit.js
+++ b/packages/block-library/src/query-loop/edit.js
@@ -99,7 +99,7 @@ export default function QueryLoopEdit( {
 	const blockProps = useBlockProps();
 
 	if ( ! posts?.length ) {
-		return <div { ...blockProps }> { __( 'No results found.' ) }</div>;
+		return <p { ...blockProps }> { __( 'No results found.' ) }</p>;
 	}
 
 	return (

--- a/packages/block-library/src/query-loop/edit.js
+++ b/packages/block-library/src/query-loop/edit.js
@@ -3,6 +3,7 @@
  */
 import { useState, useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
 import {
 	BlockContextProvider,
 	InnerBlocks,
@@ -96,6 +97,10 @@ export default function QueryLoopEdit( {
 		[ posts ]
 	);
 	const blockProps = useBlockProps();
+
+	if ( ! posts?.length ) {
+		return <div { ...blockProps }> { __( 'No results found.' ) }</div>;
+	}
 
 	return (
 		<div { ...blockProps }>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This PR adds to Query block a simple for now placeholder, when no results are found. This is needed because if no results are found and no other blocks exist, it shows nothing. Better design if needed will be in a follow up.
<!-- Please describe what you have changed or added -->

