### PR TITLE
Fix drop zone indicators for non blocks

### DIFF
--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -70,7 +70,6 @@ function Items( {
 			hasMultiSelection,
 			getGlobalBlockCount,
 			isTyping,
-			isDraggingBlocks,
 			__experimentalGetActiveBlockIdByBlockNames,
 		} = select( 'core/block-editor' );
 
@@ -88,7 +87,6 @@ function Items( {
 			enableAnimation:
 				! isTyping() &&
 				getGlobalBlockCount() <= BLOCK_ANIMATION_THRESHOLD,
-			isDraggingBlocks: isDraggingBlocks(),
 			activeEntityBlockId,
 		};
 	}
@@ -100,7 +98,6 @@ function Items( {
 		orientation,
 		hasMultiSelection,
 		enableAnimation,
-		isDraggingBlocks,
 		activeEntityBlockId,
 	} = useSelect( selector, [ rootClientId ] );
 
@@ -109,8 +106,7 @@ function Items( {
 		rootClientId,
 	} );
 
-	const isAppenderDropTarget =
-		dropTargetIndex === blockClientIds.length && isDraggingBlocks;
+	const isAppenderDropTarget = dropTargetIndex === blockClientIds.length;
 
 	return (
 		<>
@@ -119,8 +115,7 @@ function Items( {
 					? multiSelectedBlockClientIds.includes( clientId )
 					: selectedBlockClientId === clientId;
 
-				const isDropTarget =
-					dropTargetIndex === index && isDraggingBlocks;
+				const isDropTarget = dropTargetIndex === index;
 
 				return (
 					<AsyncModeProvider

--- a/packages/components/src/drop-zone/provider.js
+++ b/packages/components/src/drop-zone/provider.js
@@ -90,6 +90,8 @@ class DropZoneProvider extends Component {
 		const { defaultView } = ownerDocument;
 		defaultView.addEventListener( 'dragover', this.onDragOver );
 		defaultView.addEventListener( 'mouseup', this.resetDragState );
+		// The `dragend` event could be used for this, but only has partial
+		// support in firefox.
 		defaultView.addEventListener( 'keyup', this.onKeyUp );
 	}
 

--- a/packages/components/src/drop-zone/provider.js
+++ b/packages/components/src/drop-zone/provider.js
@@ -6,6 +6,7 @@ import { isEqual, find, some, filter, throttle, includes } from 'lodash';
 /**
  * WordPress dependencies
  */
+import { ESCAPE } from '@wordpress/keycodes';
 import { Component, createContext, createRef } from '@wordpress/element';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 
@@ -60,6 +61,7 @@ class DropZoneProvider extends Component {
 		// Event listeners
 		this.onDragOver = this.onDragOver.bind( this );
 		this.onDrop = this.onDrop.bind( this );
+		this.onKeyUp = this.onKeyUp.bind( this );
 		// Context methods so this component can receive data from consumers
 		this.addDropZone = this.addDropZone.bind( this );
 		this.removeDropZone = this.removeDropZone.bind( this );
@@ -88,6 +90,7 @@ class DropZoneProvider extends Component {
 		const { defaultView } = ownerDocument;
 		defaultView.addEventListener( 'dragover', this.onDragOver );
 		defaultView.addEventListener( 'mouseup', this.resetDragState );
+		defaultView.addEventListener( 'keyup', this.onKeyUp );
 	}
 
 	componentWillUnmount() {
@@ -95,6 +98,7 @@ class DropZoneProvider extends Component {
 		const { defaultView } = ownerDocument;
 		defaultView.removeEventListener( 'dragover', this.onDragOver );
 		defaultView.removeEventListener( 'mouseup', this.resetDragState );
+		defaultView.removeEventListener( 'keyup', this.onKeyUp );
 	}
 
 	addDropZone( dropZone ) {
@@ -224,6 +228,14 @@ class DropZoneProvider extends Component {
 	onDragOver( event ) {
 		this.toggleDraggingOverDocument( event, getDragEventType( event ) );
 		event.preventDefault();
+	}
+
+	onKeyUp( event ) {
+		const { isDraggingOverDocument } = this.state;
+		// If the user presses escape while dragging, cancel the drag.
+		if ( isDraggingOverDocument && event.keyCode === ESCAPE ) {
+			this.resetDragState();
+		}
 	}
 
 	onDrop( event ) {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
 #25317 ensured that when the user presses the `escape` key, the drop zone indicator for blocks is hidden.

The change had an unwanted side effects, drop zone indicators were only shown for blocks after that PR was merged. When dragging files or HTML, drop zone indicators were no longer shown because the change specifically checked for `isDraggingBlocks`.

This PR removes the `isDraggingBlocks` check, and implements separate handling for the `escape` key in the DropZone provider. 

While using the `escape` key works for blocks, it doesn't for files or HTML. I'm still looking into that, but it might be desirable to merge this fix for a regression, as it's still an improvement over what we had prior to #25317.

## How has this been tested?
**Blocks**
1. Drag a block into the editor canvas
2. Drop indicators should be displayed
3. Press escape
4. The drag event should be cancelled and the drop indicators shouldn't be displayed.

**Files**
1. Drag a file into the editor canvas
2. Drop indicators should be displayed
3. Press escape
4. The drag event should be cancelled and the drop indicators shouldn't be displayed. (note: this currently isn't working)

**HTML**
1. Drag HTML into the editor canvas (usually the easiest way to do this is to drag a link from one window into another).
2. Drop indicators should be displayed
3. Press escape
4. The drag event should be cancelled and the drop indicators shouldn't be displayed. (note: this currently isn't working)

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
