### PR TITLE
Uncollapse widget area when block is dragged over

### DIFF
--- a/packages/components/src/panel/body.js
+++ b/packages/components/src/panel/body.js
@@ -53,21 +53,23 @@ export function PanelBody(
 	scrollAfterOpenRef.current = scrollAfterOpen;
 	// Runs after initial render
 	useUpdateEffect( () => {
-		if ( isOpened && scrollAfterOpenRef.current ) {
+		if (
+			isOpened &&
+			scrollAfterOpenRef.current &&
+			nodeRef.current?.scrollIntoView
+		) {
 			/*
 			 * Scrolls the content into view when visible.
 			 * This improves the UX when there are multiple stacking <PanelBody />
 			 * components in a scrollable container.
 			 */
-			if ( nodeRef.current.scrollIntoView ) {
-				nodeRef.current.scrollIntoView( {
-					inline: 'nearest',
-					block: 'nearest',
-					behavior: scrollBehavior,
-				} );
-			}
+			nodeRef.current.scrollIntoView( {
+				inline: 'nearest',
+				block: 'nearest',
+				behavior: scrollBehavior,
+			} );
 		}
-	}, [ isOpened ] );
+	}, [ isOpened, scrollBehavior ] );
 
 	const classes = classnames( 'components-panel__body', className, {
 		'is-opened': isOpened,

--- a/packages/components/src/panel/body.js
+++ b/packages/components/src/panel/body.js
@@ -20,7 +20,16 @@ import Icon from '../icon';
 import { useControlledState, useUpdateEffect } from '../utils';
 
 export function PanelBody(
-	{ children, className, icon, initialOpen, onToggle = noop, opened, title },
+	{
+		children,
+		className,
+		icon,
+		initialOpen,
+		onToggle = noop,
+		opened,
+		title,
+		scrollAfterOpen = true,
+	},
 	ref
 ) {
 	const [ isOpened, setIsOpened ] = useControlledState( opened, {
@@ -39,9 +48,12 @@ export function PanelBody(
 		onToggle( next );
 	};
 
+	// Ref is used so that the effect does not re-run upon scrollAfterOpen changing value
+	const scrollAfterOpenRef = useRef();
+	scrollAfterOpenRef.current = scrollAfterOpen;
 	// Runs after initial render
 	useUpdateEffect( () => {
-		if ( isOpened ) {
+		if ( isOpened && scrollAfterOpenRef.current ) {
 			/*
 			 * Scrolls the content into view when visible.
 			 * This improves the UX when there are multiple stacking <PanelBody />
@@ -55,7 +67,7 @@ export function PanelBody(
 				} );
 			}
 		}
-	}, [ isOpened, scrollBehavior ] );
+	}, [ isOpened ] );
 
 	const classes = classnames( 'components-panel__body', className, {
 		'is-opened': isOpened,

--- a/packages/components/src/panel/index.js
+++ b/packages/components/src/panel/index.js
@@ -4,18 +4,23 @@
 import classnames from 'classnames';
 
 /**
+ * WordPress dependencies
+ */
+import { forwardRef } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import PanelHeader from './header';
 
-function Panel( { header, className, children } ) {
+function Panel( { header, className, children }, ref ) {
 	const classNames = classnames( className, 'components-panel' );
 	return (
-		<div className={ classNames }>
+		<div className={ classNames } ref={ ref }>
 			{ header && <PanelHeader label={ header } /> }
 			{ children }
 		</div>
 	);
 }
 
-export default Panel;
+export default forwardRef( Panel );

--- a/packages/edit-widgets/src/blocks/widget-area/edit/index.js
+++ b/packages/edit-widgets/src/blocks/widget-area/edit/index.js
@@ -73,7 +73,7 @@ export default function WidgetAreaEdit( {
 				{ ( { opened } ) => (
 					// This is required to ensure LegacyWidget blocks are not unmounted when the panel is collapsed.
 					// Unmounting legacy widgets may have unintended consequences (e.g. TinyMCE not being properly reinitialized)
-					<DisclosureContent visible={ opened } className="test">
+					<DisclosureContent visible={ opened }>
 						<EntityProvider
 							kind="root"
 							type="postType"

--- a/packages/edit-widgets/src/blocks/widget-area/edit/index.js
+++ b/packages/edit-widgets/src/blocks/widget-area/edit/index.js
@@ -6,6 +6,7 @@ import { DisclosureContent } from 'reakit/Disclosure';
 /**
  * WordPress dependencies
  */
+import { useCallback } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { EntityProvider } from '@wordpress/core-data';
 import { Panel, PanelBody } from '@wordpress/components';
@@ -20,36 +21,47 @@ export default function WidgetAreaEdit( {
 	className,
 	attributes: { id, name },
 } ) {
-	const isOpen = useSelect(
-		( select ) =>
-			select( 'core/edit-widgets' ).getIsWidgetAreaOpen( clientId ),
+	const { isOpen, isDraggingBlocks } = useSelect(
+		( select ) => ( {
+			isOpen: select( 'core/edit-widgets' ).getIsWidgetAreaOpen(
+				clientId
+			),
+			isDraggingBlocks: select( 'core/block-editor' ).isDraggingBlocks(),
+		} ),
 		[ clientId ]
 	);
 	const { setIsWidgetAreaOpen } = useDispatch( 'core/edit-widgets' );
+	const openOnDragOver = useCallback( () => {
+		if ( ! isOpen && isDraggingBlocks ) {
+			setIsWidgetAreaOpen( clientId, true );
+		}
+	}, [ clientId, isOpen, setIsWidgetAreaOpen, isDraggingBlocks ] );
 
 	return (
-		<Panel className={ className }>
-			<PanelBody
-				title={ name }
-				opened={ isOpen }
-				onToggle={ () => {
-					setIsWidgetAreaOpen( clientId, ! isOpen );
-				} }
-			>
-				{ ( { opened } ) => (
-					// This is required to ensure LegacyWidget blocks are not unmounted when the panel is collapsed.
-					// Unmounting legacy widgets may have unintended consequences (e.g. TinyMCE not being properly reinitialized)
-					<DisclosureContent visible={ opened }>
-						<EntityProvider
-							kind="root"
-							type="postType"
-							id={ `widget-area-${ id }` }
-						>
-							<WidgetAreaInnerBlocks />
-						</EntityProvider>
-					</DisclosureContent>
-				) }
-			</PanelBody>
-		</Panel>
+		<div onDragOver={ openOnDragOver }>
+			<Panel className={ className }>
+				<PanelBody
+					title={ name }
+					opened={ isOpen }
+					onToggle={ () => {
+						setIsWidgetAreaOpen( clientId, ! isOpen );
+					} }
+				>
+					{ ( { opened } ) => (
+						// This is required to ensure LegacyWidget blocks are not unmounted when the panel is collapsed.
+						// Unmounting legacy widgets may have unintended consequences (e.g. TinyMCE not being properly reinitialized)
+						<DisclosureContent visible={ opened }>
+							<EntityProvider
+								kind="root"
+								type="postType"
+								id={ `widget-area-${ id }` }
+							>
+								<WidgetAreaInnerBlocks />
+							</EntityProvider>
+						</DisclosureContent>
+					) }
+				</PanelBody>
+			</Panel>
+		</div>
 	);
 }

--- a/packages/edit-widgets/src/blocks/widget-area/edit/index.js
+++ b/packages/edit-widgets/src/blocks/widget-area/edit/index.js
@@ -6,7 +6,7 @@ import { DisclosureContent } from 'reakit/Disclosure';
 /**
  * WordPress dependencies
  */
-import { useCallback } from '@wordpress/element';
+import { useCallback, useRef } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { EntityProvider } from '@wordpress/core-data';
 import { Panel, PanelBody } from '@wordpress/components';
@@ -21,21 +21,22 @@ export default function WidgetAreaEdit( {
 	className,
 	attributes: { id, name },
 } ) {
-	const { isOpen, isDraggingBlocks } = useSelect(
-		( select ) => ( {
-			isOpen: select( 'core/edit-widgets' ).getIsWidgetAreaOpen(
-				clientId
-			),
-			isDraggingBlocks: select( 'core/block-editor' ).isDraggingBlocks(),
-		} ),
+	const isOpen = useSelect(
+		( select ) =>
+			select( 'core/edit-widgets' ).getIsWidgetAreaOpen( clientId ),
 		[ clientId ]
 	);
 	const { setIsWidgetAreaOpen } = useDispatch( 'core/edit-widgets' );
+
+	const scheduledForOpen = useRef( false );
 	const openOnDragOver = useCallback( () => {
-		if ( ! isOpen && isDraggingBlocks ) {
-			setIsWidgetAreaOpen( clientId, true );
+		if ( ! isOpen && ! scheduledForOpen.current ) {
+			scheduledForOpen.current = setTimeout( () => {
+				setIsWidgetAreaOpen( clientId, true );
+				scheduledForOpen.current = null;
+			}, 600 );
 		}
-	}, [ clientId, isOpen, setIsWidgetAreaOpen, isDraggingBlocks ] );
+	}, [ clientId, isOpen, setIsWidgetAreaOpen ] );
 
 	return (
 		<div onDragOver={ openOnDragOver }>

--- a/packages/edit-widgets/src/blocks/widget-area/edit/index.js
+++ b/packages/edit-widgets/src/blocks/widget-area/edit/index.js
@@ -43,21 +43,12 @@ export default function WidgetAreaEdit( {
 			return;
 		}
 
-		let timeout;
 		if ( isDraggingWithin && ! isOpen ) {
-			timeout = setTimeout( () => {
-				setOpen( true );
-				setOpenedWhileDragging( true );
-			}, 600 );
+			setOpen( true );
+			setOpenedWhileDragging( true );
 		} else if ( ! isDraggingWithin && isOpen && openedWhileDragging ) {
-			timeout = setTimeout( () => {
-				setOpen( false );
-			}, 100 );
+			setOpen( false );
 		}
-
-		return () => {
-			clearTimeout( timeout );
-		};
 	}, [ isOpen, isDragging, isDraggingWithin, openedWhileDragging ] );
 
 	return (

--- a/packages/edit-widgets/src/blocks/widget-area/edit/index.js
+++ b/packages/edit-widgets/src/blocks/widget-area/edit/index.js
@@ -68,6 +68,7 @@ export default function WidgetAreaEdit( {
 				onToggle={ () => {
 					setIsWidgetAreaOpen( clientId, ! isOpen );
 				} }
+				scrollAfterOpen={ ! isDragging }
 			>
 				{ ( { opened } ) => (
 					// This is required to ensure LegacyWidget blocks are not unmounted when the panel is collapsed.


### PR DESCRIPTION
## Description
Solves #25243

I wonder if we should add a timeout and some indication that the widget area is about to uncollapse @mapk ?

## How has this been tested?
1. Start dragging a block and move it over a collapsed widget area
1. Confirm it was uncollapsed

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
