### PR TITLE
block-directory: migrate the data-controls to builtin controls

### DIFF
--- a/packages/block-directory/src/store/actions.js
+++ b/packages/block-directory/src/store/actions.js
@@ -2,7 +2,8 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { apiFetch, dispatch, select } from '@wordpress/data-controls';
+import { controls } from '@wordpress/data';
+import { apiFetch } from '@wordpress/data-controls';
 
 /**
  * Internal dependencies
@@ -83,11 +84,11 @@ export function* installBlockType( block ) {
 		} );
 
 		yield loadAssets( assets );
-		const registeredBlocks = yield select( 'core/blocks', 'getBlockTypes' );
-		if (
-			! registeredBlocks.length ||
-			! registeredBlocks.filter( ( i ) => i.name === block.name ).length
-		) {
+		const registeredBlocks = yield controls.select(
+			'core/blocks',
+			'getBlockTypes'
+		);
+		if ( ! registeredBlocks.some( ( i ) => i.name === block.name ) ) {
 			throw new Error(
 				__( 'Error registering block. Try reloading the page.' )
 			);
@@ -141,7 +142,7 @@ export function* uninstallBlockType( block ) {
 		} );
 		yield removeInstalledBlockType( block );
 	} catch ( error ) {
-		yield dispatch(
+		yield controls.dispatch(
 			'core/notices',
 			'createErrorNotice',
 			error.message || __( 'An error occurred.' )

--- a/packages/block-directory/src/store/test/actions.js
+++ b/packages/block-directory/src/store/test/actions.js
@@ -81,7 +81,7 @@ describe( 'actions', () => {
 				args: [],
 				selectorName: 'getBlockTypes',
 				storeKey: 'core/blocks',
-				type: '@@data/RESOLVE_SELECT',
+				type: '@@data/SELECT',
 			} );
 
 			expect( generator.next( [ block ] ).value ).toEqual( {
@@ -143,7 +143,7 @@ describe( 'actions', () => {
 				args: [],
 				selectorName: 'getBlockTypes',
 				storeKey: 'core/blocks',
-				type: '@@data/RESOLVE_SELECT',
+				type: '@@data/SELECT',
 			} );
 
 			expect( generator.next( [ inactiveBlock ] ).value ).toEqual( {


### PR DESCRIPTION
Migrates the `block-directory` package to the builtin data controls introduced in #25362. Rather straightforward one, there are only two usages of `select`/`dispatch`.
