### PR TITLE
Fix template part theme identifier

### DIFF
--- a/lib/template-parts.php
+++ b/lib/template-parts.php
@@ -210,7 +210,7 @@ function filter_rest_wp_template_part_query( $args, $request ) {
 		);
 
 		// Ensure auto-drafts of all theme supplied template parts are created.
-		if ( wp_get_theme()->get( 'TextDomain' ) === $request['theme'] ) {
+		if ( wp_get_theme()->stylesheet === $request['theme'] ) {
 			/**
 			 * Finds all nested template part file paths in a theme's directory.
 			 *

--- a/packages/block-library/src/template-part/edit/selection/template-part-previews.js
+++ b/packages/block-library/src/template-part/edit/selection/template-part-previews.js
@@ -209,7 +209,8 @@ export default function TemplateParts( {
 				per_page: -1,
 			}
 		);
-		const currentTheme = select( 'core' ).getCurrentTheme()?.textdomain;
+		const currentTheme = select( 'core' ).getCurrentTheme()?.stylesheet;
+
 		const themeTemplateParts = select( 'core' ).getEntityRecords(
 			'postType',
 			'wp_template_part',

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -15,7 +15,6 @@
 function render_block_core_template_part( $attributes ) {
 	$content = null;
 
-
 	if ( ! empty( $attributes['postId'] ) && get_post_status( $attributes['postId'] ) ) {
 		// If we have a post ID and the post exists, which means this template part
 		// is user-customized, render the corresponding post content.

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -15,11 +15,12 @@
 function render_block_core_template_part( $attributes ) {
 	$content = null;
 
+
 	if ( ! empty( $attributes['postId'] ) && get_post_status( $attributes['postId'] ) ) {
 		// If we have a post ID and the post exists, which means this template part
 		// is user-customized, render the corresponding post content.
 		$content = get_post( $attributes['postId'] )->post_content;
-	} elseif ( isset( $attributes['theme'] ) && wp_get_theme()->get( 'TextDomain' ) === $attributes['theme'] ) {
+	} elseif ( isset( $attributes['theme'] ) && wp_get_theme()->stylesheet === $attributes['theme'] ) {
 		$template_part_query = new WP_Query(
 			array(
 				'post_type'      => 'wp_template_part',


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Update to use the themes `stylesheet` property instead of `textdomain`.  It was pointed out (https://github.com/WordPress/gutenberg/pull/25923#discussion_r501607268)  that while `textdomain` should generally be the same as `stylesheet`, `textdomain` could technically be omitted and `stylesheet` will be a more robust solution.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Smoke test template part seleection:

* Clean environment
* enable FSE
* enable a block based theme
* go to the post editor
* add the 'template part' block
* click "choose" and verify the theme's supplied template parts appear as options.
* select a template part and verify it is added to the post.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
