### PR TITLE
Block Editor: Fix null-unsafe access of fontSizes settings

### DIFF
--- a/packages/block-editor/src/hooks/font-size.js
+++ b/packages/block-editor/src/hooks/font-size.js
@@ -142,7 +142,7 @@ export function FontSizeEdit( props ) {
  */
 export function useIsFontSizeDisabled( { name: blockName } = {} ) {
 	const fontSizes = useEditorFeature( 'typography.fontSizes' );
-	const hasFontSizes = fontSizes.length;
+	const hasFontSizes = fontSizes && fontSizes.length;
 
 	return (
 		! hasBlockSupport( blockName, FONT_SIZE_SUPPORT_KEY ) || ! hasFontSizes


### PR DESCRIPTION
If the fontSizes settings is not set then the default returned by `useEditorFeature` is `undefined` causing `useIsFontSizeDisabled` to try to access `length` of `undefined`. This change makes the access of this setting null-safe.

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fix null-unsafe access of the `typography.fontSizes` setting.

## How has this been tested?
Tested by rendering a `BlockEditor` without passing the `fontSizes` setting.

## Types of changes
Bug-fix

Steps to reproduce bug:
1. Render a `BlockEditorProvider` without the `fontSizes` setting

Expected result:
This setting should be null-safe and not crash the editor when not provided.

Actual result:
The editor crashes.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
