### PR TITLE
Add width selector for button block

### DIFF
--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -54,7 +54,7 @@
 			"type": "string"
 		},
 		"width": {
-			"type": "number",
+			"type": "number"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -52,6 +52,9 @@
 		},
 		"gradient": {
 			"type": "string"
+		},
+		"width": {
+			"type": "number",
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -82,8 +82,8 @@ function WidthPanel( { selectedWidth, setAttributes } ) {
 	}
 
 	return (
-		<PanelBody title={ __( 'Width Settings' ) }>
-			<ButtonGroup aria-label={ __( 'Button Width' ) }>
+		<PanelBody title={ __( 'Width settings' ) }>
+			<ButtonGroup aria-label={ __( 'Button width' ) }>
 				{ [ 25, 50, 75, 100 ].map( ( widthValue ) => {
 					return (
 						<Button

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -237,7 +237,7 @@ function ButtonEdit( props ) {
 			<div
 				{ ...blockProps }
 				className={ classnames( blockProps.className, {
-					[ `wp-block-button__width-${ width }` ]: width,
+					[ `has-custom-width wp-block-button__width-${ width }` ]: width,
 				} ) }
 			>
 				<RichText

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -2,13 +2,14 @@
  * External dependencies
  */
 import classnames from 'classnames';
-
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { useCallback, useState } from '@wordpress/element';
 import {
+	Button,
+	ButtonGroup,
 	KeyboardShortcuts,
 	PanelBody,
 	RangeControl,
@@ -66,6 +67,29 @@ function BorderPanel( { borderRadius = '', setAttributes } ) {
 				allowReset
 				onChange={ setBorderRadius }
 			/>
+		</PanelBody>
+	);
+}
+
+function WidthPanel( { width, setAttributes } ) {
+	return (
+		<PanelBody title={ __( 'Width Settings' ) }>
+			<ButtonGroup aria-label={ __( 'Button Width' ) }>
+				{ [ 25, 50, 75, 100 ].map( ( widthValue ) => {
+					return (
+						<Button
+							key={ widthValue }
+							isSmall
+							isPrimary={ widthValue === width }
+							onClick={ () =>
+								setAttributes( { width: widthValue } )
+							}
+						>
+							{ widthValue }%
+						</Button>
+					);
+				} ) }
+			</ButtonGroup>
 		</PanelBody>
 	);
 }
@@ -168,6 +192,7 @@ function ButtonEdit( props ) {
 		rel,
 		text,
 		url,
+		width,
 	} = attributes;
 	const onSetLinkRel = useCallback(
 		( value ) => {
@@ -202,7 +227,12 @@ function ButtonEdit( props ) {
 	return (
 		<>
 			<ColorEdit { ...props } />
-			<div { ...blockProps }>
+			<div
+				{ ...blockProps }
+				className={ classnames( blockProps.className, {
+					[ `wp-block-button__width-${ width }` ]: width,
+				} ) }
+			>
 				<RichText
 					placeholder={ placeholder || __( 'Add text…' ) }
 					value={ text }
@@ -245,6 +275,7 @@ function ButtonEdit( props ) {
 					borderRadius={ borderRadius }
 					setAttributes={ setAttributes }
 				/>
+				<WidthPanel width={ width } setAttributes={ setAttributes } />
 				<PanelBody title={ __( 'Link settings' ) }>
 					<ToggleControl
 						label={ __( 'Open in new tab' ) }

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+
 /**
  * WordPress dependencies
  */
@@ -71,7 +72,15 @@ function BorderPanel( { borderRadius = '', setAttributes } ) {
 	);
 }
 
-function WidthPanel( { width, setAttributes } ) {
+function WidthPanel( { selectedWidth, setAttributes } ) {
+	function handleChange( newWidth ) {
+		// Check if we are toggling the width off
+		const width = selectedWidth === newWidth ? undefined : newWidth;
+
+		// Update attributes
+		setAttributes( { width } );
+	}
+
 	return (
 		<PanelBody title={ __( 'Width Settings' ) }>
 			<ButtonGroup aria-label={ __( 'Button Width' ) }>
@@ -80,10 +89,8 @@ function WidthPanel( { width, setAttributes } ) {
 						<Button
 							key={ widthValue }
 							isSmall
-							isPrimary={ widthValue === width }
-							onClick={ () =>
-								setAttributes( { width: widthValue } )
-							}
+							isPrimary={ widthValue === selectedWidth }
+							onClick={ () => handleChange( widthValue ) }
 						>
 							{ widthValue }%
 						</Button>
@@ -275,7 +282,10 @@ function ButtonEdit( props ) {
 					borderRadius={ borderRadius }
 					setAttributes={ setAttributes }
 				/>
-				<WidthPanel width={ width } setAttributes={ setAttributes } />
+				<WidthPanel
+					selectedWidth={ width }
+					setAttributes={ setAttributes }
+				/>
 				<PanelBody title={ __( 'Link settings' ) }>
 					<ToggleControl
 						label={ __( 'Open in new tab' ) }

--- a/packages/block-library/src/button/editor.scss
+++ b/packages/block-library/src/button/editor.scss
@@ -67,6 +67,16 @@
 	}
 }
 
+.wp-button-label__width {
+	.components-button-group {
+		display: block;
+	}
+
+	.components-base-control__field {
+		margin-bottom: 12px;
+	}
+}
+
 // Display "table" is used because the button container should only wrap the content and not takes the full width.
 div[data-type="core/button"] {
 	display: table;

--- a/packages/block-library/src/button/save.js
+++ b/packages/block-library/src/button/save.js
@@ -41,7 +41,7 @@ export default function save( { attributes, className } ) {
 	// A title will no longer be assigned for new or updated button block links.
 
 	const wrapperClasses = classnames( className, {
-		[ `wp-block-button__width-${ width }` ]: width,
+		[ `has-custom-width wp-block-button__width-${ width }` ]: width,
 	} );
 
 	return (

--- a/packages/block-library/src/button/save.js
+++ b/packages/block-library/src/button/save.js
@@ -14,7 +14,15 @@ import { RichText, useBlockProps } from '@wordpress/block-editor';
 import getColorAndStyleProps from './color-props';
 
 export default function save( { attributes } ) {
-	const { borderRadius, linkTarget, rel, text, title, url } = attributes;
+	const {
+		borderRadius,
+		linkTarget,
+		rel,
+		text,
+		title,
+		url,
+		width,
+	} = attributes;
 	const colorProps = getColorAndStyleProps( attributes );
 	const buttonClasses = classnames(
 		'wp-block-button__link',
@@ -23,7 +31,11 @@ export default function save( { attributes } ) {
 			'no-border-radius': borderRadius === 0,
 		}
 	);
+	const buttonWrapperStyle = {
+		width: width ? width + '%' : undefined,
+	};
 	const buttonStyle = {
+		width: width ? '100%' : undefined,
 		borderRadius: borderRadius ? borderRadius + 'px' : undefined,
 		...colorProps.style,
 	};
@@ -33,7 +45,7 @@ export default function save( { attributes } ) {
 	// A title will no longer be assigned for new or updated button block links.
 
 	return (
-		<div { ...useBlockProps.save() }>
+		<div { ...useBlockProps.save() } style={ buttonWrapperStyle }>
 			<RichText.Content
 				tagName="a"
 				className={ buttonClasses }

--- a/packages/block-library/src/button/save.js
+++ b/packages/block-library/src/button/save.js
@@ -13,7 +13,7 @@ import { RichText, useBlockProps } from '@wordpress/block-editor';
  */
 import getColorAndStyleProps from './color-props';
 
-export default function save( { attributes } ) {
+export default function save( { attributes, className } ) {
 	const {
 		borderRadius,
 		linkTarget,
@@ -31,11 +31,7 @@ export default function save( { attributes } ) {
 			'no-border-radius': borderRadius === 0,
 		}
 	);
-	const buttonWrapperStyle = {
-		width: width ? width + '%' : undefined,
-	};
 	const buttonStyle = {
-		width: width ? '100%' : undefined,
 		borderRadius: borderRadius ? borderRadius + 'px' : undefined,
 		...colorProps.style,
 	};
@@ -44,8 +40,12 @@ export default function save( { attributes } ) {
 	// if it had already been assigned, for the sake of backward-compatibility.
 	// A title will no longer be assigned for new or updated button block links.
 
+	const wrapperClasses = classnames( className, {
+		[ `wp-block-button__width-${ width }` ]: width,
+	} );
+
 	return (
-		<div { ...useBlockProps.save() } style={ buttonWrapperStyle }>
+		<div { ...useBlockProps.save( { className: wrapperClasses } ) }>
 			<RichText.Content
 				tagName="a"
 				className={ buttonClasses }

--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -34,32 +34,27 @@ $blocks-button__height: 3.1em;
 }
 
 .wp-block-button {
-	&.wp-block-button__width-25 {
-		width: 25%;
+	&.has-custom-width {
+		max-width: none;
 		.wp-block-button__link {
 			width: 100%;
 		}
+	}
+
+	&.wp-block-button__width-25 {
+		width: 25%;
 	}
 
 	&.wp-block-button__width-50 {
 		width: 50%;
-		.wp-block-button__link {
-			width: 100%;
-		}
 	}
 
 	&.wp-block-button__width-75 {
 		width: 75%;
-		.wp-block-button__link {
-			width: 100%;
-		}
 	}
 
 	&.wp-block-button__width-100 {
 		width: 100%;
-		.wp-block-button__link {
-			width: 100%;
-		}
 	}
 }
 

--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -35,7 +35,7 @@ $blocks-button__height: 3.1em;
 
 .wp-block-button {
 	&.wp-block-button__width-25 {
-		width: 25%;
+		flex: 0 0 25%;
 
 		.wp-block-button__link {
 			width: 100%;
@@ -43,7 +43,7 @@ $blocks-button__height: 3.1em;
 	}
 
 	&.wp-block-button__width-50 {
-		width: 50%;
+		flex: 0 0 50%;
 
 		.wp-block-button__link {
 			width: 100%;
@@ -51,7 +51,7 @@ $blocks-button__height: 3.1em;
 	}
 
 	&.wp-block-button__width-75 {
-		width: 75%;
+		flex: 0 0 75%;
 
 		.wp-block-button__link {
 			width: 100%;
@@ -59,7 +59,7 @@ $blocks-button__height: 3.1em;
 	}
 
 	&.wp-block-button__width-100 {
-		width: 100%;
+		flex: 0 0 100%;
 
 		.wp-block-button__link {
 			width: 100%;
@@ -75,7 +75,6 @@ $blocks-button__height: 3.1em;
 
 
 // the first selector is required for old buttons markup
-
 .wp-block-button.no-border-radius,
 .wp-block-button__link.no-border-radius {
 	border-radius: 0 !important;

--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -35,32 +35,28 @@ $blocks-button__height: 3.1em;
 
 .wp-block-button {
 	&.wp-block-button__width-25 {
-		flex: 0 0 25%;
-
+		width: 25%;
 		.wp-block-button__link {
 			width: 100%;
 		}
 	}
 
 	&.wp-block-button__width-50 {
-		flex: 0 0 50%;
-
+		width: 50%;
 		.wp-block-button__link {
 			width: 100%;
 		}
 	}
 
 	&.wp-block-button__width-75 {
-		flex: 0 0 75%;
-
+		width: 75%;
 		.wp-block-button__link {
 			width: 100%;
 		}
 	}
 
 	&.wp-block-button__width-100 {
-		flex: 0 0 100%;
-
+		width: 100%;
 		.wp-block-button__link {
 			width: 100%;
 		}

--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -33,6 +33,40 @@ $blocks-button__height: 3.1em;
 	}
 }
 
+.wp-block-button {
+	&.wp-block-button__width-25 {
+		width: 25%;
+
+		.wp-block-button__link {
+			width: 100%;
+		}
+	}
+
+	&.wp-block-button__width-50 {
+		width: 50%;
+
+		.wp-block-button__link {
+			width: 100%;
+		}
+	}
+
+	&.wp-block-button__width-75 {
+		width: 75%;
+
+		.wp-block-button__link {
+			width: 100%;
+		}
+	}
+
+	&.wp-block-button__width-100 {
+		width: 100%;
+
+		.wp-block-button__link {
+			width: 100%;
+		}
+	}
+}
+
 // the first selector is required for old buttons markup
 .wp-block-button.is-style-squared,
 .wp-block-button__link.wp-block-button.is-style-squared {

--- a/packages/block-library/src/buttons/editor.scss
+++ b/packages/block-library/src/buttons/editor.scss
@@ -13,6 +13,7 @@
 .wp-block[data-align="right"] > .wp-block-buttons {
 	display: flex;
 	justify-content: flex-end;
+	flex-wrap: wrap;
 }
 
 .wp-block-buttons > .block-list-appender {

--- a/packages/block-library/src/buttons/editor.scss
+++ b/packages/block-library/src/buttons/editor.scss
@@ -9,16 +9,12 @@
 }
 
 .wp-block[data-align="center"] > .wp-block-buttons {
-	display: flex;
 	align-items: center;
-	flex-wrap: wrap;
 	justify-content: center;
 }
 
 .wp-block[data-align="right"] > .wp-block-buttons {
-	display: flex;
 	justify-content: flex-end;
-	flex-wrap: wrap;
 }
 
 .wp-block-buttons > .block-list-appender {

--- a/packages/block-library/src/buttons/editor.scss
+++ b/packages/block-library/src/buttons/editor.scss
@@ -3,6 +3,11 @@
 	margin-left: 0;
 }
 
+.wp-block > .wp-block-buttons {
+	display: flex;
+	flex-wrap: wrap;
+}
+
 .wp-block[data-align="center"] > .wp-block-buttons {
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Issue #24705

Adds a width selector to the sidebar for the Button block, allowing the user to set their button to 25%, 50%, 75%, or 100% of the parent container.

By default, no percentage width is selected and the button width is determined as normal by the size of its content.

## Notes
_This is an alternative approach to #26045, which implements a width selector on the Button block using a new block support.__ This is related to issue #26368.

## How has this been tested?
Manually with the button block, using left, right, and center alignments.

1. Add a `Buttons` block to a post with one or more `Button`s
2. Select a `Button`
3. You should see a Width Settings section under the Inspector Controls, with options for 25, 50, 75, 100%.
4. Toggle a width option and verify that the correct inline style is applied to the block.
5. Save the post and view on the frontend.
6. Verify that the button is resized correctly in the saved post.

## Screenshots <!-- if applicable -->


![button_resize](https://user-images.githubusercontent.com/63313398/97051892-e0dd1500-1534-11eb-9502-afe3093d77e6.gif)


<img width="605" alt="Screen Shot 2020-10-09 at 1 58 03 PM" src="https://user-images.githubusercontent.com/63313398/95630894-82de0700-0a37-11eb-88d0-257aaa80570d.png">


## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
