### PR TITLE
Cover: Add repeated background option

### DIFF
--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -13,6 +13,10 @@
 			"type": "boolean",
 			"default": false
 		},
+		"isRepeated": {
+			"type": "boolean",
+			"default": false
+		},
 		"dimRatio": {
 			"type": "number",
 			"default": 50

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -8,7 +8,7 @@ import tinycolor from 'tinycolor2';
 /**
  * WordPress dependencies
  */
-import { useEffect, useRef, useState } from '@wordpress/element';
+import { Fragment, useEffect, useRef, useState } from '@wordpress/element';
 import {
 	BaseControl,
 	Button,
@@ -250,6 +250,7 @@ function CoverEdit( {
 		dimRatio,
 		focalPoint,
 		hasParallax,
+		isRepeated,
 		minHeight,
 		minHeightUnit,
 		style: styleAttribute,
@@ -267,6 +268,12 @@ function CoverEdit( {
 		setAttributes( {
 			hasParallax: ! hasParallax,
 			...( ! hasParallax ? { focalPoint: undefined } : {} ),
+		} );
+	};
+
+	const toggleIsRepeated = () => {
+		setAttributes( {
+			isRepeated: ! isRepeated,
 		} );
 	};
 
@@ -340,11 +347,19 @@ function CoverEdit( {
 				{ !! url && (
 					<PanelBody title={ __( 'Media settings' ) }>
 						{ isImageBackground && (
-							<ToggleControl
-								label={ __( 'Fixed background' ) }
-								checked={ hasParallax }
-								onChange={ toggleParallax }
-							/>
+							<Fragment>
+								<ToggleControl
+									label={ __( 'Fixed background' ) }
+									checked={ hasParallax }
+									onChange={ toggleParallax }
+								/>
+
+								<ToggleControl
+									label={ __( 'Repeated background' ) }
+									checked={ isRepeated }
+									onChange={ toggleIsRepeated }
+								/>
+							</Fragment>
 						) }
 						{ showFocalPointPicker && (
 							<FocalPointPicker
@@ -371,6 +386,7 @@ function CoverEdit( {
 										dimRatio: undefined,
 										focalPoint: undefined,
 										hasParallax: undefined,
+										isRepeated: undefined,
 									} )
 								}
 							>
@@ -489,6 +505,7 @@ function CoverEdit( {
 			'has-background-dim': dimRatio !== 0,
 			'is-transient': isBlogUrl,
 			'has-parallax': hasParallax,
+			'is-repeated': isRepeated,
 			[ overlayColor.class ]: overlayColor.class,
 			'has-background-gradient': gradientValue,
 			[ gradientClass ]: ! url && gradientClass,

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -316,7 +316,9 @@ function CoverEdit( {
 
 	const hasBackground = !! ( url || overlayColor.color || gradientValue );
 	const showFocalPointPicker =
-		isVideoBackground || ( isImageBackground && ! hasParallax );
+		isRepeated ||
+		isVideoBackground ||
+		( isImageBackground && ! hasParallax );
 
 	const controls = (
 		<>

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -316,9 +316,8 @@ function CoverEdit( {
 
 	const hasBackground = !! ( url || overlayColor.color || gradientValue );
 	const showFocalPointPicker =
-		isRepeated ||
 		isVideoBackground ||
-		( isImageBackground && ! hasParallax );
+		( isImageBackground && ( ! hasParallax || isRepeated ) );
 
 	const controls = (
 		<>

--- a/packages/block-library/src/cover/save.js
+++ b/packages/block-library/src/cover/save.js
@@ -35,6 +35,7 @@ export default function save( { attributes } ) {
 		dimRatio,
 		focalPoint,
 		hasParallax,
+		isRepeated,
 		overlayColor,
 		url,
 		minHeight: minHeightProp,
@@ -86,6 +87,7 @@ export default function save( { attributes } ) {
 		{
 			'has-background-dim': dimRatio !== 0,
 			'has-parallax': hasParallax,
+			'is-repeated': isRepeated,
 			'has-background-gradient': gradient || customGradient,
 			[ gradientClass ]: ! url && gradientClass,
 			'has-custom-content-position': ! isContentPositionCenter(

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -29,6 +29,11 @@
 		}
 	}
 
+	&.is-repeated {
+		background-repeat: repeat;
+		background-size: auto;
+	}
+
 	&.has-background-dim {
 		background-color: $black;
 


### PR DESCRIPTION
## Description

This PR adds the `Repeated Background` option to the `core/cover` block.

![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/77539/95655314-baeb5580-0adc-11eb-9e7e-1e0cd22706e7.gif)


## How has this been tested?

* Create a cover block
* Add an image as the background
* Open the Block settings sidebar
* Confirm you see the `Repeated Background` just below to `Fixed Background`



* Play with different combinations

## Screenshots <!-- if applicable -->

![image](https://user-images.githubusercontent.com/77539/95654348-d0a94c80-0ad5-11eb-818a-210b9f17c3a2.png)

![image](https://user-images.githubusercontent.com/77539/95654361-e3238600-0ad5-11eb-9145-56c505dc5a2e.png)


## [Video Demos](https://cloudup.com/i9ouIWrRslS)

| video 01 | video 02 |
----- |----
[<img src="https://user-images.githubusercontent.com/77539/95659276-53da9a80-0af6-11eb-9704-2491a706bfa5.png" width="400px" />](https://cloudup.com/iNfYd36IURA) | [<img src="https://user-images.githubusercontent.com/77539/95659241-0ceca500-0af6-11eb-9898-e4f1d0456f83.png" width="400px" />](https://cloudup.com/i9ouIWrRslS)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
