### PR TITLE
Move left sidebar state to redux

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -43,8 +43,6 @@ const interfaceLabels = {
 };
 
 function Editor() {
-	const [ leftSidebarContent, setLeftSidebarContent ] = useState( null );
-
 	const {
 		isFullscreenActive,
 		deviceType,
@@ -55,6 +53,7 @@ function Editor() {
 		page,
 		template,
 		select,
+		isNavigationOpen,
 	} = useSelect( ( _select ) => {
 		const {
 			isFeatureActive,
@@ -64,6 +63,7 @@ function Editor() {
 			getTemplatePartId,
 			getTemplateType,
 			getPage,
+			isNavigationOpened,
 		} = _select( 'core/edit-site' );
 		const _templateId = getTemplateId();
 		const _templatePartId = getTemplatePartId();
@@ -94,10 +94,11 @@ function Editor() {
 				: null,
 			select: _select,
 			entityId: _entityId,
+			isNavigationOpen: isNavigationOpened(),
 		};
 	}, [] );
 	const { editEntityRecord } = useDispatch( 'core' );
-	const { setPage } = useDispatch( 'core/edit-site' );
+	const { setPage, setIsInserterOpened } = useDispatch( 'core/edit-site' );
 
 	const inlineStyles = useResizeCanvas( deviceType );
 
@@ -153,8 +154,6 @@ function Editor() {
 		[ page?.context ]
 	);
 
-	const isNavigationOpen = leftSidebarContent === 'navigation';
-
 	useEffect( () => {
 		if ( isNavigationOpen ) {
 			document.body.classList.add( 'is-navigation-sidebar-open' );
@@ -162,9 +161,6 @@ function Editor() {
 			document.body.classList.remove( 'is-navigation-sidebar-open' );
 		}
 	}, [ isNavigationOpen ] );
-
-	const toggleLeftSidebarContent = ( value ) =>
-		setLeftSidebarContent( leftSidebarContent === value ? null : value );
 
 	return (
 		<>
@@ -214,14 +210,7 @@ function Editor() {
 												<InterfaceSkeleton
 													labels={ interfaceLabels }
 													leftSidebar={
-														<LeftSidebar
-															content={
-																leftSidebarContent
-															}
-															setContent={
-																setLeftSidebarContent
-															}
-														/>
+														<LeftSidebar />
 													}
 													sidebar={
 														sidebarIsOpened && (
@@ -232,23 +221,6 @@ function Editor() {
 														<Header
 															openEntitiesSavedStates={
 																openEntitiesSavedStates
-															}
-															isInserterOpen={
-																leftSidebarContent ===
-																'inserter'
-															}
-															onToggleInserter={ () =>
-																toggleLeftSidebarContent(
-																	'inserter'
-																)
-															}
-															isNavigationOpen={
-																isNavigationOpen
-															}
-															onToggleNavigation={ () =>
-																toggleLeftSidebarContent(
-																	'navigation'
-																)
 															}
 														/>
 													}
@@ -263,14 +235,8 @@ function Editor() {
 															<Popover.Slot name="block-toolbar" />
 															{ template && (
 																<BlockEditor
-																	setIsInserterOpen={ (
-																		isInserterOpen
-																	) =>
-																		setLeftSidebarContent(
-																			isInserterOpen
-																				? 'inserter'
-																				: null
-																		)
+																	setIsInserterOpen={
+																		setIsInserterOpened
 																	}
 																/>
 															) }

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -27,20 +27,20 @@ import RedoButton from './undo-redo/redo';
 import DocumentActions from './document-actions';
 import NavigationToggle from './navigation-toggle';
 
-export default function Header( {
-	openEntitiesSavedStates,
-	isInserterOpen,
-	onToggleInserter,
-	isNavigationOpen,
-	onToggleNavigation,
-} ) {
-	const { deviceType, hasFixedToolbar, template } = useSelect( ( select ) => {
+export default function Header( { openEntitiesSavedStates } ) {
+	const {
+		deviceType,
+		hasFixedToolbar,
+		template,
+		isNavigationOpen,
+		isInserterOpen,
+	} = useSelect( ( select ) => {
 		const {
 			__experimentalGetPreviewDeviceType,
 			isFeatureActive,
 			getTemplateId,
-			getTemplatePartId,
-			getTemplateType,
+			isNavigationOpened,
+			isInserterOpened,
 		} = select( 'core/edit-site' );
 		const { getEntityRecord } = select( 'core' );
 
@@ -48,15 +48,16 @@ export default function Header( {
 		return {
 			deviceType: __experimentalGetPreviewDeviceType(),
 			hasFixedToolbar: isFeatureActive( 'fixedToolbar' ),
-			templateId: _templateId,
 			template: getEntityRecord( 'postType', 'wp_template', _templateId ),
-			templatePartId: getTemplatePartId(),
-			templateType: getTemplateType(),
+			isNavigationOpen: isNavigationOpened(),
+			isInserterOpen: isInserterOpened(),
 		};
 	}, [] );
 
 	const {
 		__experimentalSetPreviewDeviceType: setPreviewDeviceType,
+		setIsInserterOpened,
+		setIsNavigationPanelOpened,
 	} = useDispatch( 'core/edit-site' );
 
 	const isLargeViewport = useViewportMatch( 'medium' );
@@ -69,7 +70,9 @@ export default function Header( {
 				<MainDashboardButton.Slot>
 					<NavigationToggle
 						isOpen={ isNavigationOpen }
-						onClick={ onToggleNavigation }
+						onClick={ () =>
+							setIsNavigationPanelOpened( ! isNavigationOpen )
+						}
 					/>
 				</MainDashboardButton.Slot>
 				<div className="edit-site-header__toolbar">
@@ -77,7 +80,9 @@ export default function Header( {
 						isPrimary
 						isPressed={ isInserterOpen }
 						className="edit-site-header-toolbar__inserter-toggle"
-						onClick={ onToggleInserter }
+						onClick={ () =>
+							setIsInserterOpened( ! isInserterOpen )
+						}
 						icon={ plus }
 						label={ _x(
 							'Add block',

--- a/packages/edit-site/src/components/header/navigation-toggle/index.js
+++ b/packages/edit-site/src/components/header/navigation-toggle/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { Button, Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
@@ -31,18 +31,9 @@ function NavigationToggle( { icon, isOpen, onClick } ) {
 		};
 	}, [] );
 
-	const { setNavigationPanelActiveMenu } = useDispatch( 'core/edit-site' );
-
 	if ( ! isActive ) {
 		return null;
 	}
-
-	const handleClick = ( event ) => {
-		if ( isOpen ) {
-			setNavigationPanelActiveMenu( 'root' );
-		}
-		onClick( event );
-	};
 
 	let buttonIcon = <Icon size="36px" icon={ wordpress } />;
 
@@ -69,7 +60,7 @@ function NavigationToggle( { icon, isOpen, onClick } ) {
 			<Button
 				className="edit-site-navigation-toggle__button has-icon"
 				label={ __( 'Toggle navigation' ) }
-				onClick={ handleClick }
+				onClick={ onClick }
 				showTooltip
 			>
 				{ buttonIcon }

--- a/packages/edit-site/src/components/left-sidebar/index.js
+++ b/packages/edit-site/src/components/left-sidebar/index.js
@@ -1,16 +1,37 @@
 /**
+ * WordPress dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+
+/**
  * Internal dependencies
  */
 import InserterPanel from './inserter-panel';
 import NavigationPanel from './navigation-panel';
 
-const LeftSidebar = ( { content, setContent } ) => {
-	if ( content === 'navigation' ) {
+const LeftSidebar = () => {
+	const { isNavigationOpen, isInserterOpen } = useSelect( ( select ) => {
+		const { isNavigationOpened, isInserterOpened } = select(
+			'core/edit-site'
+		);
+		return {
+			isNavigationOpen: isNavigationOpened(),
+			isInserterOpen: isInserterOpened(),
+		};
+	} );
+
+	const { setIsInserterOpened } = useDispatch( 'core/edit-site' );
+
+	if ( isNavigationOpen ) {
 		return <NavigationPanel />;
 	}
 
-	if ( content === 'inserter' ) {
-		return <InserterPanel closeInserter={ () => setContent( null ) } />;
+	if ( isInserterOpen ) {
+		return (
+			<InserterPanel
+				closeInserter={ () => setIsInserterOpened( false ) }
+			/>
+		);
 	}
 
 	return null;

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -173,3 +173,41 @@ export function setNavigationPanelActiveMenu( menu ) {
 		menu,
 	};
 }
+
+/**
+ * Opens the navigation panel and sets its active menu at the same time.
+ *
+ * @param {string} menu Identifies the menu to open.
+ */
+export function openNavigationPanelToMenu( menu ) {
+	return {
+		type: 'OPEN_NAVIGATION_PANEL_TO_MENU',
+		menu,
+	};
+}
+
+/**
+ * Sets whether the navigation panel should be open.
+ *
+ * @param {boolean} isOpen If true, opens the nav panel. If false, closes it. It
+ *                         does not toggle the state, but sets it directly.
+ */
+export function setIsNavigationPanelOpened( isOpen ) {
+	return {
+		type: 'SET_IS_NAVIGATION_PANEL_OPENED',
+		isOpen,
+	};
+}
+
+/**
+ * Sets whether the block inserter panel should be open.
+ *
+ * @param {boolean} isOpen If true, opens the inserter. If false, closes it. It
+ *                         does not toggle the state, but sets it directly.
+ */
+export function setIsInserterOpened( isOpen ) {
+	return {
+		type: 'SET_IS_INSERTER_OPENED',
+		isOpen,
+	};
+}

--- a/packages/edit-site/src/store/reducer.js
+++ b/packages/edit-site/src/store/reducer.js
@@ -226,12 +226,12 @@ export function navigationPanel(
  * @param {Object} state Current state.
  * @param {Object} action Dispatched action.
  */
-function blockInserterPanel( state = false, action ) {
+export function blockInserterPanel( state = false, action ) {
 	switch ( action.type ) {
 		case 'OPEN_NAVIGATION_PANEL_TO_MENU':
 			return false;
 		case 'SET_IS_NAVIGATION_PANEL_OPENED':
-			return action.isOpen ? false : state.isOpen;
+			return action.isOpen ? false : state;
 		case 'SET_IS_INSERTER_OPENED':
 			return action.isOpen;
 	}

--- a/packages/edit-site/src/store/reducer.js
+++ b/packages/edit-site/src/store/reducer.js
@@ -12,6 +12,7 @@ import { combineReducers } from '@wordpress/data';
  * Internal dependencies
  */
 import { PREFERENCES_DEFAULTS } from './defaults';
+import { MENU_ROOT } from '../components/left-sidebar/navigation-panel/constants';
 
 /**
  * Higher-order reducer creator which provides the given initial state for the
@@ -175,17 +176,64 @@ export function homeTemplateId( state, action ) {
 }
 
 /**
- * Reducer for navigation panel's active menu.
+ * Reducer for information about the navigation panel, such as its active menu
+ * and whether it should be opened or closed.
+ *
+ * Note: this reducer interacts with the block inserter panel reducer to make
+ * sure that only one of the two panels is open at the same time.
  *
  * @param {Object} state Current state.
  * @param {Object} action Dispatched action.
- *
- * @return {Object} Updated state.
  */
-function navigationPanelActiveMenu( state = 'root', action ) {
+export function navigationPanel(
+	state = { menu: MENU_ROOT, isOpen: false },
+	action
+) {
 	switch ( action.type ) {
 		case 'SET_NAVIGATION_PANEL_ACTIVE_MENU':
-			return action.menu;
+			return {
+				...state,
+				menu: action.menu,
+			};
+		case 'OPEN_NAVIGATION_PANEL_TO_MENU':
+			return {
+				...state,
+				isOpen: true,
+				menu: action.menu,
+			};
+		case 'SET_IS_NAVIGATION_PANEL_OPENED':
+			return {
+				...state,
+				menu: ! action.isOpen ? MENU_ROOT : state.menu, // Set menu to root when closing panel.
+				isOpen: action.isOpen,
+			};
+		case 'SET_IS_INSERTER_OPENED':
+			return {
+				...state,
+				menu: state.isOpen && action.isOpen ? MENU_ROOT : state.menu, // Set menu to root when closing panel.
+				isOpen: action.isOpen ? false : state.isOpen,
+			};
+	}
+	return state;
+}
+
+/**
+ * Reducer to set the block inserter panel open or closed.
+ *
+ * Note: this reducer interacts with the navigation panel reducer to make
+ * sure that only one of the two panels is open at the same time.
+ *
+ * @param {Object} state Current state.
+ * @param {Object} action Dispatched action.
+ */
+function blockInserterPanel( state = false, action ) {
+	switch ( action.type ) {
+		case 'OPEN_NAVIGATION_PANEL_TO_MENU':
+			return false;
+		case 'SET_IS_NAVIGATION_PANEL_OPENED':
+			return action.isOpen ? false : state.isOpen;
+		case 'SET_IS_INSERTER_OPENED':
+			return action.isOpen;
 	}
 	return state;
 }
@@ -199,5 +247,6 @@ export default combineReducers( {
 	templateType,
 	page,
 	homeTemplateId,
-	navigationPanelActiveMenu,
+	navigationPanel,
+	blockInserterPanel,
 } );

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -146,5 +146,27 @@ export function getPage( state ) {
  * @return {string} Active menu.
  */
 export function getNavigationPanelActiveMenu( state ) {
-	return state.navigationPanelActiveMenu;
+	return state.navigationPanel.menu;
+}
+
+/**
+ * Returns the current opened/closed state of the navigation panel.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {boolean} True if the navigation panel should be open; false if closed.
+ */
+export function isNavigationOpened( state ) {
+	return state.navigationPanel.isOpen;
+}
+
+/**
+ * Returns the current opened/closed state of the inserter panel.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {boolean} True if the inserter panel should be open; false if closed.
+ */
+export function isInserterOpened( state ) {
+	return state.blockInserterPanel;
 }

--- a/packages/edit-site/src/store/test/reducer.js
+++ b/packages/edit-site/src/store/test/reducer.js
@@ -14,8 +14,17 @@ import {
 	templatePartId,
 	templateType,
 	page,
+	navigationPanel,
+	blockInserterPanel,
 } from '../reducer';
 import { PREFERENCES_DEFAULTS } from '../defaults';
+
+import {
+	setNavigationPanelActiveMenu,
+	openNavigationPanelToMenu,
+	setIsNavigationPanelOpened,
+	setIsInserterOpened,
+} from '../actions';
 
 describe( 'state', () => {
 	describe( 'preferences()', () => {
@@ -180,6 +189,129 @@ describe( 'state', () => {
 					page: newPage,
 				} )
 			).toBe( newPage );
+		} );
+	} );
+
+	describe( 'navigationPanel()', () => {
+		it( 'should apply default state', () => {
+			expect( navigationPanel( undefined, {} ) ).toEqual( {
+				menu: 'root',
+				isOpen: false,
+			} );
+		} );
+
+		it( 'should default to returning the same state', () => {
+			const state = { test: 1 };
+			expect( navigationPanel( state, {} ) ).toBe( state );
+		} );
+
+		it( 'should set the active navigation panel', () => {
+			expect(
+				navigationPanel(
+					undefined,
+					setNavigationPanelActiveMenu( 'test-menu' )
+				)
+			).toEqual( {
+				isOpen: false,
+				menu: 'test-menu',
+			} );
+		} );
+
+		it( 'should be able to open the navigation panel to a menu', () => {
+			expect(
+				navigationPanel(
+					undefined,
+					openNavigationPanelToMenu( 'test-menu' )
+				)
+			).toEqual( {
+				isOpen: true,
+				menu: 'test-menu',
+			} );
+		} );
+
+		it( 'should be able to open the navigation panel', () => {
+			expect(
+				navigationPanel( undefined, setIsNavigationPanelOpened( true ) )
+			).toEqual( {
+				isOpen: true,
+				menu: 'root',
+			} );
+		} );
+
+		it( 'should change the menu to root when closing the panel', () => {
+			const state = navigationPanel(
+				undefined,
+				openNavigationPanelToMenu( 'test-menu' )
+			);
+
+			expect( state.menu ).toEqual( 'test-menu' );
+			expect(
+				navigationPanel( state, setIsNavigationPanelOpened( false ) )
+			).toEqual( {
+				isOpen: false,
+				menu: 'root',
+			} );
+		} );
+
+		it( 'should close the navigation panel when opening the inserter and change the menu to root', () => {
+			const state = navigationPanel(
+				undefined,
+				openNavigationPanelToMenu( 'test-menu' )
+			);
+
+			expect( state.menu ).toEqual( 'test-menu' );
+			expect(
+				navigationPanel( state, setIsInserterOpened( true ) )
+			).toEqual( {
+				isOpen: false,
+				menu: 'root',
+			} );
+		} );
+
+		it( 'should not change the state when closing the inserter', () => {
+			const state = navigationPanel(
+				undefined,
+				openNavigationPanelToMenu( 'test-menu' )
+			);
+
+			expect( state.menu ).toEqual( 'test-menu' );
+			expect(
+				navigationPanel( state, setIsInserterOpened( false ) )
+			).toEqual( state );
+		} );
+	} );
+
+	describe( 'blockInserterPanel()', () => {
+		it( 'should apply default state', () => {
+			expect( blockInserterPanel( undefined, {} ) ).toEqual( false );
+		} );
+
+		it( 'should default to returning the same state', () => {
+			expect( blockInserterPanel( true, {} ) ).toBe( true );
+		} );
+
+		it( 'should set the open state of the inserter panel', () => {
+			expect(
+				blockInserterPanel( false, setIsInserterOpened( true ) )
+			).toBe( true );
+			expect(
+				blockInserterPanel( true, setIsInserterOpened( false ) )
+			).toBe( false );
+		} );
+
+		it( 'should close the inserter when opening the nav panel', () => {
+			expect(
+				blockInserterPanel( true, openNavigationPanelToMenu( 'noop' ) )
+			).toBe( false );
+			expect(
+				blockInserterPanel( true, setIsNavigationPanelOpened( true ) )
+			).toBe( false );
+		} );
+
+		it( 'should not change the state when closing the nav panel', () => {
+			expect(
+				blockInserterPanel( true, setIsNavigationPanelOpened( false ) )
+			).toBe( true );
 		} );
 	} );
 } );

--- a/packages/edit-site/src/store/test/selectors.js
+++ b/packages/edit-site/src/store/test/selectors.js
@@ -10,6 +10,9 @@ import {
 	getTemplatePartId,
 	getTemplateType,
 	getPage,
+	getNavigationPanelActiveMenu,
+	isNavigationOpened,
+	isInserterOpened,
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -139,6 +142,37 @@ describe( 'selectors', () => {
 		it( 'returns the page object', () => {
 			const state = { page: {} };
 			expect( getPage( state ) ).toBe( state.page );
+		} );
+	} );
+
+	describe( 'getNavigationPanelActiveMenu', () => {
+		it( 'returns the current navigation menu', () => {
+			const state = {
+				navigationPanel: { menu: 'test-menu', isOpen: false },
+			};
+			expect( getNavigationPanelActiveMenu( state ) ).toBe( 'test-menu' );
+		} );
+	} );
+
+	describe( 'isNavigationOpened', () => {
+		it( 'returns the navigation panel isOpened state', () => {
+			const state = {
+				navigationPanel: { menu: 'test-menu', isOpen: false },
+			};
+			expect( isNavigationOpened( state ) ).toBe( false );
+			state.navigationPanel.isOpen = true;
+			expect( isNavigationOpened( state ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'isInserterOpened', () => {
+		it( 'returns the block inserter panel isOpened state', () => {
+			const state = {
+				blockInserterPanel: true,
+			};
+			expect( isInserterOpened( state ) ).toBe( true );
+			state.blockInserterPanel = false;
+			expect( isInserterOpened( state ) ).toBe( false );
 		} );
 	} );
 } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Instead of prop drilling the sidebar state, this tries moving it to redux, and it also tries separating "navigation" from "inserter" state. cc @Copons ([I think you mentioned this here](https://github.com/WordPress/gutenberg/pull/25884#discussion_r502366419).)

## How has this been tested?
1. test that the changes in #25957 still work (i.e. the menu should go back to root when closing the panel)
2. You can test that this is working by clicking the "view in navigation" button which is displayed in the template dropdown:

![2020-10-13 17 55 05](https://user-images.githubusercontent.com/6265975/95931283-8b0ead00-0d7d-11eb-8f45-8f3cc8a54f2a.gif)


## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
