### PR TITLE
Document Actions: Fix unexpected label wrapping

### DIFF
--- a/packages/edit-site/src/components/header/document-actions/style.scss
+++ b/packages/edit-site/src/components/header/document-actions/style.scss
@@ -11,8 +11,6 @@
 		flex-direction: row;
 		justify-content: center;
 		align-items: center;
-		transition: transform 0.2s;
-		@include reduce-motion(transition);
 	}
 
 	.edit-site-document-actions__title-wrapper > h1 {
@@ -24,6 +22,8 @@
 	.edit-site-document-actions__title {
 		font-size: $default-font-size;
 		font-weight: bold;
+		transition: transform 0.2s;
+		@include reduce-motion(transition);
 	}
 
 	.edit-site-document-actions__get-info {
@@ -34,19 +34,19 @@
 	.edit-site-document-actions__secondary-item {
 		font-size: $default-font-size;
 		opacity: 0;
-		transform: translateY(20px);
+		transform: translateY(0);
 		transition: transform 0.2s;
 		@include reduce-motion(transition);
 	}
 
 	&.has-secondary-label {
-		.edit-site-document-actions__title-wrapper {
-			transform: translateY(-12px);
-		}
+		transform: translateY(10px);
 
 		.edit-site-document-actions__title {
 			color: $gray-900;
 			font-weight: bold;
+			white-space: nowrap;
+			transform: translateY(-14px);
 
 			&.is-secondary-title-active {
 				color: $gray-700;
@@ -59,7 +59,7 @@
 			font-weight: normal;
 			opacity: 1;
 			white-space: nowrap;
-			transform: translateY(12px);
+			transform: translateY(-8px);
 
 			&.is-secondary-title-active {
 				color: $gray-900;

--- a/packages/edit-site/src/components/header/document-actions/style.scss
+++ b/packages/edit-site/src/components/header/document-actions/style.scss
@@ -45,7 +45,6 @@
 		}
 
 		.edit-site-document-actions__title {
-			position: absolute;
 			color: $gray-900;
 			font-weight: bold;
 

--- a/packages/edit-site/src/components/header/document-actions/style.scss
+++ b/packages/edit-site/src/components/header/document-actions/style.scss
@@ -3,9 +3,10 @@
 	flex-direction: column;
 	justify-content: center;
 	height: 100%;
-	// Flex items will, by default, refuse to shrink below a minimum intrinsic width. In
-	// order to shrink this flexbox item, and subsequently truncate child text, we set
-	// an explicit min-width. See https://dev.w3.org/csswg/css-flexbox/#min-size-auto
+	// Flex items will, by default, refuse to shrink below a minimum
+	// intrinsic width. In order to shrink this flexbox item, and
+	// subsequently truncate child text, we set an explicit min-width.
+	// See https://dev.w3.org/csswg/css-flexbox/#min-size-auto
 	min-width: 0;
 
 	.edit-site-document-actions__title-wrapper {

--- a/packages/edit-site/src/components/header/document-actions/style.scss
+++ b/packages/edit-site/src/components/header/document-actions/style.scss
@@ -13,6 +13,8 @@
 		flex-direction: row;
 		justify-content: center;
 		align-items: center;
+		transition: transform 0.2s;
+		@include reduce-motion(transition);
 
 		// See comment above about min-width
 		min-width: 0;
@@ -33,8 +35,6 @@
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
-		transition: transform 0.2s;
-		@include reduce-motion(transition);
 	}
 
 	.edit-site-document-actions__get-info {
@@ -57,10 +57,13 @@
 	&.has-secondary-label {
 		transform: translateY(10px);
 
+		.edit-site-document-actions__title-wrapper {
+			transform: translateY(-14px);
+		}
+
 		.edit-site-document-actions__title {
 			color: $gray-900;
 			font-weight: bold;
-			transform: translateY(-14px);
 
 			&.is-secondary-title-active {
 				color: $gray-700;

--- a/packages/edit-site/src/components/header/document-actions/style.scss
+++ b/packages/edit-site/src/components/header/document-actions/style.scss
@@ -3,6 +3,9 @@
 	flex-direction: column;
 	justify-content: center;
 	height: 100%;
+	// Flex items will, by default, refuse to shrink below a minimum intrinsic width. In
+	// order to shrink this flexbox item, and subsequently truncate child text, we set
+	// an explicit min-width. See https://dev.w3.org/csswg/css-flexbox/#min-size-auto
 	min-width: 0;
 
 	.edit-site-document-actions__title-wrapper {
@@ -10,6 +13,8 @@
 		flex-direction: row;
 		justify-content: center;
 		align-items: center;
+
+		// See comment above about min-width
 		min-width: 0;
 	}
 
@@ -17,6 +22,8 @@
 		display: flex;
 		justify-content: center;
 		margin: 0;
+
+		// See comment above about min-width
 		min-width: 0;
 	}
 

--- a/packages/edit-site/src/components/header/document-actions/style.scss
+++ b/packages/edit-site/src/components/header/document-actions/style.scss
@@ -1,27 +1,31 @@
 .edit-site-document-actions {
 	display: flex;
 	flex-direction: column;
-	align-items: center;
 	justify-content: center;
 	height: 100%;
-	position: relative;
+	min-width: 0;
 
 	.edit-site-document-actions__title-wrapper {
 		display: flex;
 		flex-direction: row;
 		justify-content: center;
 		align-items: center;
+		min-width: 0;
 	}
 
 	.edit-site-document-actions__title-wrapper > h1 {
 		display: flex;
 		justify-content: center;
 		margin: 0;
+		min-width: 0;
 	}
 
 	.edit-site-document-actions__title {
 		font-size: $default-font-size;
 		font-weight: bold;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
 		transition: transform 0.2s;
 		@include reduce-motion(transition);
 	}
@@ -36,6 +40,10 @@
 		opacity: 0;
 		transform: translateY(0);
 		transition: transform 0.2s;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		text-align: center;
 		@include reduce-motion(transition);
 	}
 
@@ -45,7 +53,6 @@
 		.edit-site-document-actions__title {
 			color: $gray-900;
 			font-weight: bold;
-			white-space: nowrap;
 			transform: translateY(-14px);
 
 			&.is-secondary-title-active {

--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -30,7 +30,7 @@
 // Keeps the document title centered when the sidebar is open
 body.is-navigation-sidebar-open {
 	.edit-site-header_start {
-		flex-basis: $nav-sidebar-width;
+		flex-basis: calc(#{$nav-sidebar-width} + 335px);
 	}
 }
 

--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -7,6 +7,8 @@
 
 	.edit-site-header_start,
 	.edit-site-header_end {
+		// The 335px flex basis and 0 flex-shrink prevents the left and
+		// right toolbar from collapsing when shrinking the viewport
 		flex: 1 0 335px;
 		display: flex;
 	}
@@ -16,9 +18,10 @@
 		align-items: center;
 		height: 100%;
 		flex-shrink: 1;
-		// Flex items will, by default, refuse to shrink below a minimum intrinsic width. In
-		// order to shrink this flexbox item, and subsequently truncate child text, we set
-		// an explicit min-width. See https://dev.w3.org/csswg/css-flexbox/#min-size-auto
+		// Flex items will, by default, refuse to shrink below a minimum
+		// intrinsic width. In order to shrink this flexbox item, and
+		// subsequently truncate child text, we set an explicit min-width.
+		// See https://dev.w3.org/csswg/css-flexbox/#min-size-auto
 		min-width: 0;
 	}
 

--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -16,6 +16,9 @@
 		align-items: center;
 		height: 100%;
 		flex-shrink: 1;
+		// Flex items will, by default, refuse to shrink below a minimum intrinsic width. In
+		// order to shrink this flexbox item, and subsequently truncate child text, we set
+		// an explicit min-width. See https://dev.w3.org/csswg/css-flexbox/#min-size-auto
 		min-width: 0;
 	}
 

--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -7,7 +7,7 @@
 
 	.edit-site-header_start,
 	.edit-site-header_end {
-		flex: 1;
+		flex: 1 0 335px;
 		display: flex;
 	}
 
@@ -15,6 +15,8 @@
 		display: flex;
 		align-items: center;
 		height: 100%;
+		flex-shrink: 1;
+		min-width: 0;
 	}
 
 	.edit-site-header_end {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
When the title in the document actions area is too long, it wraps very easily. This causes visual issues and overlaps with the template part title.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Enable the site editor locally
2. Navigate to the site editor
3. Modify the template title length in dev console to something with 15+ characters
4. Note that when selecting a template part, the template title does _not_ wrap
5. Ensure that the labels don't overlap other elements when the viewport is shrunk

## Screenshots <!-- if applicable -->
### Before
<img width="627" alt="Screen Shot 2020-10-07 at 8 06 06 PM" src="https://user-images.githubusercontent.com/6265975/95410468-e30a6700-08d8-11eb-805a-174b2b0612a1.png">

### After
![2020-10-09 18 21 39](https://user-images.githubusercontent.com/5414230/95642340-bed79300-0a5c-11eb-982c-f19627ac16af.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix for #25942

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
