### PR TITLE
[RN Mobile] - Fix UBE issue: cannot view or interact with the classic block on Jetpack sites

### DIFF
--- a/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergWebViewActivity.java
+++ b/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergWebViewActivity.java
@@ -226,12 +226,13 @@ public class GutenbergWebViewActivity extends AppCompatActivity {
 
     private void onGutenbergReady() {
         preventAutoSavesScript();
-        insertBlockScript();
         final Handler handler = new Handler();
         handler.postDelayed(() -> {
             // We want to make sure that page is loaded
             // with all elements before executing external JS
             injectOnGutenbergReadyExternalSources();
+            // Inject block content
+            insertBlockScript();
             // We need some extra time to hide all unwanted html elements
             // like NUX (new user experience) modal is.
             mForegroundView.postDelayed(() -> mForegroundView.setVisibility(View.INVISIBLE), 1500);


### PR DESCRIPTION
Fixes: [UBE issue: cannot view or interact with the classic block on Jetpack sites](https://github.com/wordpress-mobile/gutenberg-mobile/issues/2695)

Gutenberg mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2709

## How has this been tested?
1. On the web, create a post with a classic block on a Jetpack site (note: I used Jetpack 9.0.1 WordPress 5.5.1 in this test).
1. Save or publish the post.
1. In the app, open the post from the previous step in the block editor.
1. Tap on the classic block.
1. Tap on the classic block again.
1. Select the option to "Edit using the web editor."
1. Observe that you are able to load or interact with the classic block.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
