### PR TITLE
Info panel design force wrapping

### DIFF
--- a/packages/editor/src/components/table-of-contents/style.scss
+++ b/packages/editor/src/components/table-of-contents/style.scss
@@ -42,7 +42,7 @@
 }
 
 .table-of-contents__count {
-	flex-basis: 25%;
+	flex-basis: 33%;
 	display: flex;
 	flex-direction: column;
 	font-size: $default-font-size;


### PR DESCRIPTION

## Description
<!-- Please describe what you have changed or added -->
Force wrapping after 3 elements in the info panel.

This is a quick fix until we agree on the new design at https://github.com/WordPress/gutenberg/pull/25287

Related discussions:
* https://github.com/WordPress/gutenberg/pull/24823#issuecomment-683102201
* https://github.com/WordPress/gutenberg/pull/25287#issuecomment-706332483

## How has this been tested?
1. Edit an existing post or create a new one
2. Type a few words
3. Click on the (i) icon

## Screenshots
![image](https://user-images.githubusercontent.com/2256104/95719532-3e897b80-0c70-11eb-9e13-afd6dd5b6c23.png)

## Types of changes
Design

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
