### PR TITLE
Fix widget area title font

### DIFF
--- a/packages/edit-widgets/src/blocks/widget-area/editor.scss
+++ b/packages/edit-widgets/src/blocks/widget-area/editor.scss
@@ -1,9 +1,13 @@
 .wp-block[data-type="core/widget-area"] {
 	max-width: $widget-area-width;
 
-	// Remove default hover background in panel title. See #25752.
-	.components-panel__body > .components-panel__body-title:hover {
-		background: inherit;
+	.components-panel__body > .components-panel__body-title {
+		font-family: $default-font;
+
+		// Remove default hover background in panel title. See #25752.
+		&:hover {
+			background: inherit;
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Fix #25879.

Override the font for widget area titles.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Go to the Widgets screen
2. Observe that widget area titles have the UI font instead of the editor font

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/7753001/95719749-db650c80-0ca2-11eb-94f7-5edf3a1495bf.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
