### PR TITLE
Add Latest Pages - Query block variation

### DIFF
--- a/packages/block-library/src/query/index.js
+++ b/packages/block-library/src/query/index.js
@@ -9,6 +9,7 @@ import { __ } from '@wordpress/i18n';
 import metadata from './block.json';
 import edit from './edit';
 import save from './save';
+import variations from './variations';
 
 const { name } = metadata;
 export { metadata, name };
@@ -17,6 +18,7 @@ export const settings = {
 	title: __( 'Query' ),
 	edit,
 	save,
+	variations,
 };
 
 export { useQueryContext } from './edit';

--- a/packages/block-library/src/query/variations.js
+++ b/packages/block-library/src/query/variations.js
@@ -1,0 +1,19 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { page } from '@wordpress/icons';
+
+const variations = [
+	{
+		name: 'latest-pages',
+		title: 'Latest Pages',
+		icon: page,
+		keywords: [ __( 'pages' ) ],
+		description: __( 'Display a list of your most recent pages.' ),
+		attributes: {
+			query: { postType: 'page', order: 'desc', orderBy: 'date' },
+		},
+	},
+];
+export default variations;

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -56,10 +56,13 @@ export function createBlock( name, attributes = {}, innerBlocks = [] ) {
 		blockType.attributes,
 		( accumulator, schema, key ) => {
 			const value = attributes[ key ];
-
+			const hasDefault = schema.hasOwnProperty( 'default' );
 			if ( undefined !== value ) {
-				accumulator[ key ] = value;
-			} else if ( schema.hasOwnProperty( 'default' ) ) {
+				accumulator[ key ] =
+					schema.type === 'object' && hasDefault
+						? { ...schema.default, ...value }
+						: value;
+			} else if ( hasDefault ) {
 				accumulator[ key ] = schema.default;
 			}
 

--- a/packages/blocks/src/api/test/factory.js
+++ b/packages/blocks/src/api/test/factory.js
@@ -85,6 +85,54 @@ describe( 'block factory', () => {
 			expect( typeof block.clientId ).toBe( 'string' );
 		} );
 
+		it( 'should create a block respecting the defaults in an property with `object` type', () => {
+			registerBlockType( 'core/test-block', {
+				attributes: {
+					align: {
+						type: 'string',
+					},
+					includesDefault: {
+						type: 'boolean',
+						default: true,
+					},
+					includesFalseyDefault: {
+						type: 'number',
+						default: 0,
+					},
+					objectProp: {
+						type: 'object',
+						default: {
+							content: 'ping',
+							offset: 0,
+							level: 2,
+						},
+					},
+				},
+				category: 'text',
+				title: 'test block',
+			} );
+			const block = createBlock( 'core/test-block', {
+				align: 'left',
+				objectProp: { content: 'pong', level: 9 },
+			} );
+			expect( block ).toEqual(
+				expect.objectContaining( {
+					name: 'core/test-block',
+					innerBlocks: [],
+					attributes: {
+						includesDefault: true,
+						includesFalseyDefault: 0,
+						align: 'left',
+						objectProp: {
+							content: 'pong',
+							level: 9,
+							offset: 0,
+						},
+					},
+				} )
+			);
+		} );
+
 		it( 'should cast children and node source attributes with default undefined', () => {
 			registerBlockType( 'core/test-block', {
 				...defaultBlockSettings,

--- a/packages/e2e-tests/fixtures/blocks/core__embed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__embed.json
@@ -1,16 +1,16 @@
 [
-	{
-		"clientId": "_clientId_0",
-		"name": "core/embed",
-		"isValid": true,
-		"attributes": {
-			"url": "https://example.com/",
-			"caption": "Embedded content from an example URL",
-			"allowResponsive": true,
-			"responsive": false,
-			"previewable": true
-		},
-		"innerBlocks": [],
-		"originalContent": "<figure class=\"wp-block-embed\">\n    <div class=\"wp-block-embed__wrapper\">\n        https://example.com/\n    </div>\n    <figcaption>Embedded content from an example URL</figcaption>\n</figure>"
-	}
+    {
+        "clientId": "_clientId_0",
+        "name": "core/embed",
+        "isValid": true,
+        "attributes": {
+            "url": "https://example.com/",
+            "caption": "Embedded content from an example URL",
+            "allowResponsive": true,
+            "responsive": false,
+            "previewable": true
+        },
+        "innerBlocks": [],
+        "originalContent": "<figure class=\"wp-block-embed\">\n    <div class=\"wp-block-embed__wrapper\">\n        https://example.com/\n    </div>\n    <figcaption>Embedded content from an example URL</figcaption>\n</figure>"
+    }
 ]

--- a/packages/e2e-tests/fixtures/blocks/core__latest-posts.json
+++ b/packages/e2e-tests/fixtures/blocks/core__latest-posts.json
@@ -1,26 +1,26 @@
 [
-	{
-		"clientId": "_clientId_0",
-		"name": "core/latest-posts",
-		"isValid": true,
-		"attributes": {
-			"postsToShow": 5,
-			"displayPostContent": false,
-			"displayPostContentRadio": "excerpt",
-			"excerptLength": 55,
-			"displayAuthor": false,
-			"displayPostDate": false,
-			"postLayout": "list",
-			"columns": 3,
-			"order": "desc",
-			"orderBy": "date",
-			"displayFeaturedImage": false,
-			"featuredImageSizeSlug": "thumbnail",
-			"featuredImageSizeWidth": null,
-			"featuredImageSizeHeight": null,
-			"addLinkToFeaturedImage": false
-		},
-		"innerBlocks": [],
-		"originalContent": ""
-	}
+    {
+        "clientId": "_clientId_0",
+        "name": "core/latest-posts",
+        "isValid": true,
+        "attributes": {
+            "postsToShow": 5,
+            "displayPostContent": false,
+            "displayPostContentRadio": "excerpt",
+            "excerptLength": 55,
+            "displayAuthor": false,
+            "displayPostDate": false,
+            "postLayout": "list",
+            "columns": 3,
+            "order": "desc",
+            "orderBy": "date",
+            "displayFeaturedImage": false,
+            "featuredImageSizeSlug": "thumbnail",
+            "featuredImageSizeWidth": null,
+            "featuredImageSizeHeight": null,
+            "addLinkToFeaturedImage": false
+        },
+        "innerBlocks": [],
+        "originalContent": ""
+    }
 ]

--- a/packages/e2e-tests/fixtures/blocks/core__latest-posts__displayPostDate.json
+++ b/packages/e2e-tests/fixtures/blocks/core__latest-posts__displayPostDate.json
@@ -1,26 +1,26 @@
 [
-	{
-		"clientId": "_clientId_0",
-		"name": "core/latest-posts",
-		"isValid": true,
-		"attributes": {
-			"postsToShow": 5,
-			"displayPostContent": false,
-			"displayPostContentRadio": "excerpt",
-			"excerptLength": 55,
-			"displayAuthor": false,
-			"displayPostDate": true,
-			"postLayout": "list",
-			"columns": 3,
-			"order": "desc",
-			"orderBy": "date",
-			"displayFeaturedImage": false,
-			"featuredImageSizeSlug": "thumbnail",
-			"featuredImageSizeWidth": null,
-			"featuredImageSizeHeight": null,
-			"addLinkToFeaturedImage": false
-		},
-		"innerBlocks": [],
-		"originalContent": ""
-	}
+    {
+        "clientId": "_clientId_0",
+        "name": "core/latest-posts",
+        "isValid": true,
+        "attributes": {
+            "postsToShow": 5,
+            "displayPostContent": false,
+            "displayPostContentRadio": "excerpt",
+            "excerptLength": 55,
+            "displayAuthor": false,
+            "displayPostDate": true,
+            "postLayout": "list",
+            "columns": 3,
+            "order": "desc",
+            "orderBy": "date",
+            "displayFeaturedImage": false,
+            "featuredImageSizeSlug": "thumbnail",
+            "featuredImageSizeWidth": null,
+            "featuredImageSizeHeight": null,
+            "addLinkToFeaturedImage": false
+        },
+        "innerBlocks": [],
+        "originalContent": ""
+    }
 ]

--- a/packages/e2e-tests/fixtures/blocks/core__post-featured-image.json
+++ b/packages/e2e-tests/fixtures/blocks/core__post-featured-image.json
@@ -1,12 +1,12 @@
 [
-	{
-		"clientId": "_clientId_0",
-		"name": "core/post-featured-image",
-		"isValid": true,
-		"attributes": {
-			"isLink": false
-		},
-		"innerBlocks": [],
-		"originalContent": ""
-	}
+    {
+        "clientId": "_clientId_0",
+        "name": "core/post-featured-image",
+        "isValid": true,
+        "attributes": {
+            "isLink": false
+        },
+        "innerBlocks": [],
+        "originalContent": ""
+    }
 ]

--- a/packages/e2e-tests/fixtures/blocks/core__post-title.json
+++ b/packages/e2e-tests/fixtures/blocks/core__post-title.json
@@ -1,15 +1,15 @@
 [
-	{
-		"clientId": "_clientId_0",
-		"name": "core/post-title",
-		"isValid": true,
-		"attributes": {
-			"level": 2,
-			"isLink": false,
-			"linkTarget": "_self",
-			"rel": ""
-		},
-		"innerBlocks": [],
-		"originalContent": ""
-	}
+    {
+        "clientId": "_clientId_0",
+        "name": "core/post-title",
+        "isValid": true,
+        "attributes": {
+            "level": 2,
+            "isLink": false,
+            "rel": "",
+            "linkTarget": "_self"
+        },
+        "innerBlocks": [],
+        "originalContent": ""
+    }
 ]

--- a/packages/e2e-tests/fixtures/blocks/core__query.json
+++ b/packages/e2e-tests/fixtures/blocks/core__query.json
@@ -1,24 +1,24 @@
 [
-	{
-		"clientId": "_clientId_0",
-		"name": "core/query",
-		"isValid": true,
-		"attributes": {
-			"query": {
-				"perPage": null,
-				"pages": 1,
-				"offset": 0,
-				"postType": "post",
-				"categoryIds": [],
-				"tagIds": [],
-				"order": "desc",
-				"orderBy": "date",
-				"author": "",
-				"search": "",
-				"exclude": []
-			}
-		},
-		"innerBlocks": [],
-		"originalContent": ""
-	}
+    {
+        "clientId": "_clientId_0",
+        "name": "core/query",
+        "isValid": true,
+        "attributes": {
+            "query": {
+                "perPage": null,
+                "pages": 1,
+                "offset": 0,
+                "postType": "post",
+                "categoryIds": [],
+                "tagIds": [],
+                "order": "desc",
+                "orderBy": "date",
+                "author": "",
+                "search": "",
+                "exclude": []
+            }
+        },
+        "innerBlocks": [],
+        "originalContent": ""
+    }
 ]

--- a/packages/e2e-tests/fixtures/blocks/core__query.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__query.serialized.html
@@ -1,1 +1,1 @@
-<!-- wp:query /-->
+<!-- wp:query {"query":{"perPage":null,"pages":1,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[]}} /-->

--- a/packages/e2e-tests/fixtures/blocks/core__search.json
+++ b/packages/e2e-tests/fixtures/blocks/core__search.json
@@ -4,10 +4,10 @@
         "name": "core/search",
         "isValid": true,
         "attributes": {
-            "buttonPosition": "button-outside",
-            "buttonUseIcon": false,
+            "showLabel": true,
             "placeholder": "",
-            "showLabel": true
+            "buttonPosition": "button-outside",
+            "buttonUseIcon": false
         },
         "innerBlocks": [],
         "originalContent": ""

--- a/packages/e2e-tests/fixtures/blocks/core__search__custom-text.json
+++ b/packages/e2e-tests/fixtures/blocks/core__search__custom-text.json
@@ -4,12 +4,12 @@
         "name": "core/search",
         "isValid": true,
         "attributes": {
-            "buttonPosition": "button-outside",
             "label": "Custom label",
+            "showLabel": true,
             "placeholder": "Custom placeholder",
             "buttonText": "Custom button text",
-            "buttonUseIcon": false,
-            "showLabel": true
+            "buttonPosition": "button-outside",
+            "buttonUseIcon": false
         },
         "innerBlocks": [],
         "originalContent": ""

--- a/packages/e2e-tests/fixtures/blocks/core__social-links.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-links.json
@@ -4,8 +4,8 @@
         "name": "core/social-links",
         "isValid": true,
         "attributes": {
-			"openInNewTab": false
-		},
+            "openInNewTab": false
+        },
         "innerBlocks": [
             {
                 "clientId": "_clientId_0",


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This PR adds the first block variation in the `Query` block, which is the `Latest Pages`. Related section about block variations in the tracking issue: https://github.com/WordPress/gutenberg/issues/24762. 

In order to do this, I added some missing functionality in `createBlock` (Blocks API) to respect the default values of a property of type `object`. Previously it would overwrite the whole object, ignoring the rest default values. For example if we had in `block.json` an attribute like this:
```
"query": {
			"type": "object",
			"default": {
				"perPage": 3,
				"pages": 1
			}
		}  
```

and created a block with a single object's property set like this: `createBlock( 'test/block', { query: { perPage:10 } })`, it would result in keeping only the passed attributes, which in this case is `perPage`. The `pages` attribute would not be defined.

A final but not relevant thing this PR changes is some whitespaces differences that occurred during the regeneration of `fixtures`. The regeneration tool uses `spaces` and there were some handwritten with `tabs`.
<!-- Please describe what you have changed or added -->

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
