### PR TITLE
Site Editor: Navigation panel replace hardcoded menu strings with constants

### DIFF
--- a/packages/edit-site/src/components/left-sidebar/navigation-panel/constants.js
+++ b/packages/edit-site/src/components/left-sidebar/navigation-panel/constants.js
@@ -8,3 +8,10 @@ export const TEMPLATES_GENERAL = [
 ];
 
 export const TEMPLATES_POSTS = [ 'home', 'single' ];
+
+export const MENU_ROOT = 'root';
+export const MENU_TEMPLATE_PARTS = 'template-parts';
+export const MENU_TEMPLATES = 'templates';
+export const MENU_TEMPLATES_ALL = 'templates-all';
+export const MENU_TEMPLATES_PAGES = 'templates-pages';
+export const MENU_TEMPLATES_POSTS = 'templates-posts';

--- a/packages/edit-site/src/components/left-sidebar/navigation-panel/index.js
+++ b/packages/edit-site/src/components/left-sidebar/navigation-panel/index.js
@@ -17,6 +17,7 @@ import { __ } from '@wordpress/i18n';
  */
 import TemplatesMenu from './menus/templates';
 import TemplatePartsMenu from './menus/template-parts';
+import { MENU_ROOT, MENU_TEMPLATE_PARTS, MENU_TEMPLATES } from './constants';
 
 export const {
 	Fill: NavigationPanelPreviewFill,
@@ -68,7 +69,7 @@ const NavigationPanel = () => {
 				activeMenu={ activeMenu }
 				onActivateMenu={ setNavigationPanelActiveMenu }
 			>
-				{ activeMenu === 'root' && (
+				{ activeMenu === MENU_ROOT && (
 					<NavigationBackButton
 						backButtonLabel={ __( 'Dashboard' ) }
 						className="edit-site-navigation-panel__back-to-dashboard"
@@ -80,12 +81,12 @@ const NavigationPanel = () => {
 				<NavigationMenu title={ __( 'Theme' ) }>
 					<NavigationItem
 						title={ __( 'Templates' ) }
-						navigateToMenu="templates"
+						navigateToMenu={ MENU_TEMPLATES }
 					/>
 
 					<NavigationItem
 						title={ __( 'Template Parts' ) }
-						navigateToMenu="template-parts"
+						navigateToMenu={ MENU_TEMPLATE_PARTS }
 					/>
 
 					<TemplatesMenu onActivateItem={ setTemplate } />

--- a/packages/edit-site/src/components/left-sidebar/navigation-panel/menus/template-parts.js
+++ b/packages/edit-site/src/components/left-sidebar/navigation-panel/menus/template-parts.js
@@ -12,6 +12,7 @@ import {
  * Internal dependencies
  */
 import TemplateNavigationItems from '../template-navigation-items';
+import { MENU_ROOT, MENU_TEMPLATE_PARTS } from '../constants';
 
 export default function TemplatePartsMenu( { onActivateItem } ) {
 	const templateParts = useSelect( ( select ) => {
@@ -27,9 +28,9 @@ export default function TemplatePartsMenu( { onActivateItem } ) {
 
 	return (
 		<NavigationMenu
-			menu="template-parts"
+			menu={ MENU_TEMPLATE_PARTS }
 			title={ __( 'Template Parts' ) }
-			parentMenu="root"
+			parentMenu={ MENU_ROOT }
 		>
 			<TemplateNavigationItems
 				entityType="wp_template_part"

--- a/packages/edit-site/src/components/left-sidebar/navigation-panel/menus/templates-all.js
+++ b/packages/edit-site/src/components/left-sidebar/navigation-panel/menus/templates-all.js
@@ -8,13 +8,14 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import TemplateNavigationItems from '../template-navigation-items';
+import { MENU_TEMPLATES, MENU_TEMPLATES_ALL } from '../constants';
 
 export default function TemplatesAllMenu( { templates, onActivateItem } ) {
 	return (
 		<NavigationMenu
-			menu="templates-all"
+			menu={ MENU_TEMPLATES_ALL }
 			title={ __( 'All Templates' ) }
-			parentMenu="templates"
+			parentMenu={ MENU_TEMPLATES }
 		>
 			<TemplateNavigationItems
 				templates={ templates }

--- a/packages/edit-site/src/components/left-sidebar/navigation-panel/menus/templates-pages.js
+++ b/packages/edit-site/src/components/left-sidebar/navigation-panel/menus/templates-pages.js
@@ -11,6 +11,7 @@ import { __, _x } from '@wordpress/i18n';
  * Internal dependencies
  */
 import TemplateNavigationItems from '../template-navigation-items';
+import { MENU_TEMPLATES, MENU_TEMPLATES_PAGES } from '../constants';
 
 export default function TemplatesPagesMenu( { templates, onActivateItem } ) {
 	const defaultTemplate = templates?.find( ( { slug } ) => slug === 'page' );
@@ -20,9 +21,9 @@ export default function TemplatesPagesMenu( { templates, onActivateItem } ) {
 
 	return (
 		<NavigationMenu
-			menu="templates-pages"
+			menu={ MENU_TEMPLATES_PAGES }
 			title={ __( 'Pages' ) }
-			parentMenu="templates"
+			parentMenu={ MENU_TEMPLATES }
 		>
 			<NavigationGroup title={ _x( 'Specific', 'specific templates' ) }>
 				<TemplateNavigationItems

--- a/packages/edit-site/src/components/left-sidebar/navigation-panel/menus/templates-posts.js
+++ b/packages/edit-site/src/components/left-sidebar/navigation-panel/menus/templates-posts.js
@@ -11,7 +11,11 @@ import { __, _x } from '@wordpress/i18n';
  * Internal dependencies
  */
 import TemplateNavigationItems from '../template-navigation-items';
-import { TEMPLATES_POSTS } from '../constants';
+import {
+	MENU_TEMPLATES,
+	MENU_TEMPLATES_POSTS,
+	TEMPLATES_POSTS,
+} from '../constants';
 
 export default function TemplatePostsMenu( { templates, onActivateItem } ) {
 	const generalTemplates = templates?.find( ( { slug } ) =>
@@ -23,9 +27,9 @@ export default function TemplatePostsMenu( { templates, onActivateItem } ) {
 
 	return (
 		<NavigationMenu
-			menu="templates-posts"
+			menu={ MENU_TEMPLATES_POSTS }
 			title={ __( 'Posts' ) }
-			parentMenu="templates"
+			parentMenu={ MENU_TEMPLATES }
 		>
 			<NavigationGroup title={ _x( 'Specific', 'specific templates' ) }>
 				<TemplateNavigationItems

--- a/packages/edit-site/src/components/left-sidebar/navigation-panel/menus/templates.js
+++ b/packages/edit-site/src/components/left-sidebar/navigation-panel/menus/templates.js
@@ -13,7 +13,14 @@ import { __, _x } from '@wordpress/i18n';
 import TemplatesPagesMenu from './templates-pages';
 import TemplateNavigationItems from '../template-navigation-items';
 import TemplatePostsMenu from './templates-posts';
-import { TEMPLATES_GENERAL } from '../constants';
+import {
+	MENU_ROOT,
+	MENU_TEMPLATES,
+	MENU_TEMPLATES_ALL,
+	MENU_TEMPLATES_PAGES,
+	MENU_TEMPLATES_POSTS,
+	TEMPLATES_GENERAL,
+} from '../constants';
 import { useSelect } from '@wordpress/data';
 import TemplatesAllMenu from './templates-all';
 
@@ -33,20 +40,20 @@ export default function TemplatesMenu( { onActivateItem } ) {
 
 	return (
 		<NavigationMenu
-			menu="templates"
+			menu={ MENU_TEMPLATES }
 			title={ __( 'Templates' ) }
-			parentMenu="root"
+			parentMenu={ MENU_ROOT }
 		>
 			<NavigationItem
-				navigateToMenu="templates-all"
+				navigateToMenu={ MENU_TEMPLATES_ALL }
 				title={ _x( 'All', 'all templates' ) }
 			/>
 			<NavigationItem
-				navigateToMenu="templates-pages"
+				navigateToMenu={ MENU_TEMPLATES_PAGES }
 				title={ __( 'Pages' ) }
 			/>
 			<NavigationItem
-				navigateToMenu="templates-posts"
+				navigateToMenu={ MENU_TEMPLATES_POSTS }
 				title={ __( 'Posts' ) }
 			/>
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Replace all hardcoded strings of `menu` props with constants. Easier to import a constant rather than remembering all those strings 😄 

## How has this been tested?
Open Navigation panel and make sure you can navigate through all submenus

## Types of changes
Code Quality

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
