### PR TITLE
Tweak styles of the document actions area

### DIFF
--- a/packages/components/src/text/styles/text-mixins.js
+++ b/packages/components/src/text/styles/text-mixins.js
@@ -5,6 +5,7 @@ import { fontFamily } from './font-family';
 import css from './emotion-css';
 
 const fontWeightNormal = `font-weight: 400;`;
+const fontWeightMedium = `font-weight: 500;`;
 const fontWeightSemibold = `font-weight: 600;`;
 
 const title = `
@@ -74,8 +75,16 @@ const label = `
 	line-height: 16px;
 `;
 
+const sectionHeading = `
+	${ fontWeightMedium }
+	font-size: 11px;
+	line-height: 1.4;
+	text-transform: uppercase;
+	color: #757575; // $gray-700
+`;
+
 /**
- * @typedef {'title.large'|'title.medium'|'title.small'|'subtitle'|'subtitle.small'|'body'|'body.large'|'body.small'|'button'|'caption'|'label'} TextVariant
+ * @typedef {'title.large'|'title.medium'|'title.small'|'subtitle'|'subtitle.small'|'body'|'body.large'|'body.small'|'button'|'caption'|'label'|'sectionheading'} TextVariant
  */
 
 /**
@@ -133,6 +142,9 @@ const variant = ( variantName = 'body' ) => {
 
 		case 'label':
 			return label;
+
+		case 'sectionheading':
+			return sectionHeading;
 	}
 };
 

--- a/packages/components/src/text/styles/text-mixins.js
+++ b/packages/components/src/text/styles/text-mixins.js
@@ -3,6 +3,7 @@
  */
 import { fontFamily } from './font-family';
 import css from './emotion-css';
+import { G2 } from '../../utils/colors-values';
 
 const fontWeightNormal = `font-weight: 400;`;
 const fontWeightMedium = `font-weight: 500;`;
@@ -80,7 +81,7 @@ const sectionHeading = `
 	font-size: 11px;
 	line-height: 1.4;
 	text-transform: uppercase;
-	color: #757575; // $gray-700
+	color: ${ G2.gray[ 700 ] }
 `;
 
 /**

--- a/packages/edit-site/src/components/header/document-actions/index.js
+++ b/packages/edit-site/src/components/header/document-actions/index.js
@@ -12,7 +12,12 @@ import {
 	getBlockType,
 } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
-import { Dropdown, Button, VisuallyHidden } from '@wordpress/components';
+import {
+	Dropdown,
+	Button,
+	VisuallyHidden,
+	__experimentalText as Text,
+} from '@wordpress/components';
 import { chevronDown } from '@wordpress/icons';
 import { useRef } from '@wordpress/element';
 
@@ -97,17 +102,12 @@ export default function DocumentActions( {
 							entityLabel
 						) }
 					</VisuallyHidden>
-					<div
-						className={ classnames(
-							'edit-site-document-actions__title',
-							{
-								'is-active': isTitleActive,
-								'is-secondary-title-active': isActive,
-							}
-						) }
+					<Text
+						variant={ isTitleActive ? 'subtitle.small' : 'body' }
+						className="edit-site-document-actions__title"
 					>
 						{ entityTitle }
-					</div>
+					</Text>
 				</h1>
 				{ dropdownContent && ! isActive && (
 					<Dropdown
@@ -134,16 +134,12 @@ export default function DocumentActions( {
 					/>
 				) }
 			</div>
-			<div
-				className={ classnames(
-					'edit-site-document-actions__secondary-item',
-					{
-						'is-secondary-title-active': isActive,
-					}
-				) }
+			<Text
+				variant={ isActive ? 'subtitle.small' : 'body' }
+				className="edit-site-document-actions__secondary-item"
 			>
 				{ label ?? '' }
-			</div>
+			</Text>
 		</div>
 	);
 }

--- a/packages/edit-site/src/components/header/document-actions/index.js
+++ b/packages/edit-site/src/components/header/document-actions/index.js
@@ -64,11 +64,7 @@ export default function DocumentActions( {
 	entityLabel,
 	children: dropdownContent,
 } ) {
-	const { label, isActive } = useSecondaryText();
-
-	// Title is active when there is no secondary item, or when the secondary
-	// item is inactive.
-	const isTitleActive = ! label?.length || ! isActive;
+	const { label } = useSecondaryText();
 
 	// The title ref is passed to the popover as the anchorRef so that the
 	// dropdown is centered over the whole title area rather than just one
@@ -103,13 +99,13 @@ export default function DocumentActions( {
 						) }
 					</VisuallyHidden>
 					<Text
-						variant={ isTitleActive ? 'subtitle.small' : 'body' }
+						variant="subtitle.small"
 						className="edit-site-document-actions__title"
 					>
 						{ entityTitle }
 					</Text>
 				</h1>
-				{ dropdownContent && ! isActive && (
+				{ dropdownContent && (
 					<Dropdown
 						popoverProps={ {
 							anchorRef: titleRef.current,
@@ -135,7 +131,7 @@ export default function DocumentActions( {
 				) }
 			</div>
 			<Text
-				variant={ isActive ? 'subtitle.small' : 'body' }
+				variant="body"
 				className="edit-site-document-actions__secondary-item"
 			>
 				{ label ?? '' }

--- a/packages/edit-site/src/components/header/document-actions/style.scss
+++ b/packages/edit-site/src/components/header/document-actions/style.scss
@@ -31,8 +31,6 @@
 	}
 
 	.edit-site-document-actions__title {
-		font-size: $default-font-size;
-		font-weight: bold;
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
@@ -44,7 +42,6 @@
 	}
 
 	.edit-site-document-actions__secondary-item {
-		font-size: $default-font-size;
 		opacity: 0;
 		transform: translateY(0);
 		transition: transform 0.2s;
@@ -62,27 +59,10 @@
 			transform: translateY(-14px);
 		}
 
-		.edit-site-document-actions__title {
-			color: $gray-900;
-			font-weight: bold;
-
-			&.is-secondary-title-active {
-				color: $gray-700;
-				font-weight: normal;
-			}
-		}
-
 		.edit-site-document-actions__secondary-item {
-			color: $gray-700;
-			font-weight: normal;
 			opacity: 1;
 			white-space: nowrap;
 			transform: translateY(-8px);
-
-			&.is-secondary-title-active {
-				color: $gray-900;
-				font-weight: bold;
-			}
 		}
 	}
 }

--- a/packages/edit-site/src/components/header/document-actions/style.scss
+++ b/packages/edit-site/src/components/header/document-actions/style.scss
@@ -56,13 +56,12 @@
 		transform: translateY(10px);
 
 		.edit-site-document-actions__title-wrapper {
-			transform: translateY(-14px);
+			transform: translateY(-12px);
 		}
 
 		.edit-site-document-actions__secondary-item {
 			opacity: 1;
-			white-space: nowrap;
-			transform: translateY(-8px);
+			transform: translateY(-16px);
 		}
 	}
 }

--- a/packages/edit-site/src/components/header/document-actions/style.scss
+++ b/packages/edit-site/src/components/header/document-actions/style.scss
@@ -19,6 +19,10 @@
 
 		// See comment above about min-width
 		min-width: 0;
+
+		// Since part of the dropdown button width is blank space, visually,
+		// it looks off-center. This offsets that blank space.
+		margin-left: 12px;
 	}
 
 	.edit-site-document-actions__title-wrapper > h1 {
@@ -34,11 +38,6 @@
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
-	}
-
-	.edit-site-document-actions__get-info {
-		// Add a bit of margin for better spacing with title when focused.
-		margin-left: $grid-unit-05;
 	}
 
 	.edit-site-document-actions__secondary-item {

--- a/packages/edit-site/src/components/template-details/index.js
+++ b/packages/edit-site/src/components/template-details/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
+import { Button, __experimentalText as Text } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 
 /**
@@ -27,27 +27,37 @@ export default function TemplateDetails( { template, onClose } ) {
 	return (
 		<>
 			<div className="edit-site-template-details">
-				<p className="edit-site-template-details__heading">
+				<Text
+					variant="sectionheading"
+					className="edit-site-template-details__heading"
+				>
 					{ __( 'Template details' ) }
-				</p>
+				</Text>
 
 				{ title && (
-					<p>
+					<Text
+						variant="body"
+						className="edit-site-template-details__detail"
+					>
 						{ sprintf(
 							/* translators: %s: Name of the template. */
 							__( 'Name: %s' ),
 							title
 						) }
-					</p>
+					</Text>
 				) }
+
 				{ description && (
-					<p>
+					<Text
+						variant="body"
+						className="edit-site-template-details__detail"
+					>
 						{ sprintf(
 							/* translators: %s: Description of the template. */
 							__( 'Description: %s' ),
 							description
 						) }
-					</p>
+					</Text>
 				) }
 			</div>
 

--- a/packages/edit-site/src/components/template-details/index.js
+++ b/packages/edit-site/src/components/template-details/index.js
@@ -27,18 +27,12 @@ export default function TemplateDetails( { template, onClose } ) {
 	return (
 		<>
 			<div className="edit-site-template-details">
-				<Text
-					variant="sectionheading"
-					className="edit-site-template-details__heading"
-				>
+				<Text variant="sectionheading">
 					{ __( 'Template details' ) }
 				</Text>
 
 				{ title && (
-					<Text
-						variant="body"
-						className="edit-site-template-details__detail"
-					>
+					<Text variant="body">
 						{ sprintf(
 							/* translators: %s: Name of the template. */
 							__( 'Name: %s' ),
@@ -48,10 +42,7 @@ export default function TemplateDetails( { template, onClose } ) {
 				) }
 
 				{ description && (
-					<Text
-						variant="body"
-						className="edit-site-template-details__detail"
-					>
+					<Text variant="body">
 						{ sprintf(
 							/* translators: %s: Description of the template. */
 							__( 'Description: %s' ),

--- a/packages/edit-site/src/components/template-details/style.scss
+++ b/packages/edit-site/src/components/template-details/style.scss
@@ -1,14 +1,12 @@
 .edit-site-template-details {
 	padding: $grid-unit-15;
-}
-
-.edit-site-template-details__heading {
-	margin-top: $grid-unit-05;
-	margin-bottom: $grid-unit-15;
-	color: $gray-700;
-	text-transform: uppercase;
-	font-size: 11px;
-	font-weight: 500;
+	.edit-site-template-details__detail {
+		margin: $grid-unit-10 0;
+	}
+	.edit-site-template-details__heading {
+		margin-top: $grid-unit-05;
+		margin-bottom: $grid-unit-15;
+	}
 }
 
 .edit-site-template-details__show-all-button.components-button {

--- a/packages/edit-site/src/components/template-details/style.scss
+++ b/packages/edit-site/src/components/template-details/style.scss
@@ -1,11 +1,8 @@
 .edit-site-template-details {
-	padding: $grid-unit-15;
-	.edit-site-template-details__detail {
-		margin: $grid-unit-10 0;
-	}
-	.edit-site-template-details__heading {
-		margin-top: $grid-unit-05;
-		margin-bottom: $grid-unit-15;
+	margin: $grid-unit-10 $grid-unit-20;
+
+	p {
+		padding: $grid-unit-10 0;
 	}
 }
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

closes #26035

Tweaking the styles of the document actions area in the site editor. Would love to get the CSS into a final state here (cc @shaunandrews @jameskoster). I also tried using the `Text` component to handle font-related styles, and it's pretty nice to defer that work elsewhere.

I'm mostly unsure about padding and margin for the document actions _dropdown_ area.

Since this uses `Text`, the text style is a bit different in the header:

![2020-10-12 12 47 02](https://user-images.githubusercontent.com/6265975/95784662-1a866400-0c89-11eb-89ff-f797a1ac108f.gif)

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
