### PR TITLE
 Refactor document actions to handle template part titles

### DIFF
--- a/packages/edit-site/src/components/header/document-actions/index.js
+++ b/packages/edit-site/src/components/header/document-actions/index.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { sprintf, __ } from '@wordpress/i18n';
 import {
 	__experimentalGetBlockLabel as getBlockLabel,
 	getBlockType,
@@ -15,12 +15,6 @@ import { useSelect } from '@wordpress/data';
 import { Dropdown, Button, VisuallyHidden } from '@wordpress/components';
 import { chevronDown } from '@wordpress/icons';
 import { useRef } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
-import TemplateDetails from '../../template-details';
-import { getTemplateInfo } from '../../../utils';
 
 function getBlockDisplayText( block ) {
 	return block
@@ -50,8 +44,20 @@ function useSecondaryText() {
 	return {};
 }
 
-export default function DocumentActions( { template } ) {
-	const { title: documentTitle } = getTemplateInfo( template );
+/**
+ * @param {Object}   props             Props for the DocumentActions component.
+ * @param {string}   props.entityTitle The title to display.
+ * @param {string}   props.entityLabel A label to use for entity-related options.
+ *                                     E.g. "template" would be used for "edit
+ *                                     template" and "show template details".
+ * @param {Object[]} props.children    React component to use for the
+ *                                     information dropdown area.
+ */
+export default function DocumentActions( {
+	entityTitle,
+	entityLabel,
+	children: dropdownContent,
+} ) {
 	const { label, isActive } = useSecondaryText();
 
 	// Title is active when there is no secondary item, or when the secondary
@@ -69,7 +75,7 @@ export default function DocumentActions( { template } ) {
 				'has-secondary-label': !! label,
 			} ) }
 		>
-			{ documentTitle ? (
+			{ entityTitle ? (
 				<>
 					<div
 						ref={ titleRef }
@@ -77,7 +83,11 @@ export default function DocumentActions( { template } ) {
 					>
 						<h1>
 							<VisuallyHidden>
-								{ __( 'Edit template:' ) }
+								{ sprintf(
+									/* translators: %s: the entity being edited, like "template"*/
+									__( 'Edit %s:' ),
+									entityLabel
+								) }
 							</VisuallyHidden>
 							<div
 								className={ classnames(
@@ -88,10 +98,10 @@ export default function DocumentActions( { template } ) {
 									}
 								) }
 							>
-								{ documentTitle }
+								{ entityTitle }
 							</div>
 						</h1>
-						{ ! isActive && (
+						{ dropdownContent && ! isActive && (
 							<Dropdown
 								popoverProps={ {
 									anchorRef: titleRef.current,
@@ -104,12 +114,14 @@ export default function DocumentActions( { template } ) {
 										aria-expanded={ isOpen }
 										aria-haspopup="true"
 										onClick={ onToggle }
-										label={ __( 'Show template details' ) }
+										label={ sprintf(
+											/* translators: %s: the entity to see details about, like "template"*/
+											__( 'Show %s details' ),
+											entityLabel
+										) }
 									/>
 								) }
-								renderContent={ () => (
-									<TemplateDetails template={ template } />
-								) }
+								renderContent={ () => dropdownContent }
 							/>
 						) }
 					</div>

--- a/packages/edit-site/src/components/header/document-actions/index.js
+++ b/packages/edit-site/src/components/header/document-actions/index.js
@@ -69,77 +69,79 @@ export default function DocumentActions( {
 	// part of it.
 	const titleRef = useRef();
 
+	// Return a simple loading indicator until we have information to show.
+	if ( ! entityTitle ) {
+		return (
+			<div className="edit-site-document-actions">
+				{ __( 'Loading…' ) }
+			</div>
+		);
+	}
+
 	return (
 		<div
 			className={ classnames( 'edit-site-document-actions', {
 				'has-secondary-label': !! label,
 			} ) }
 		>
-			{ entityTitle ? (
-				<>
-					<div
-						ref={ titleRef }
-						className="edit-site-document-actions__title-wrapper"
-					>
-						<h1>
-							<VisuallyHidden>
-								{ sprintf(
-									/* translators: %s: the entity being edited, like "template"*/
-									__( 'Edit %s:' ),
-									entityLabel
-								) }
-							</VisuallyHidden>
-							<div
-								className={ classnames(
-									'edit-site-document-actions__title',
-									{
-										'is-active': isTitleActive,
-										'is-secondary-title-active': isActive,
-									}
-								) }
-							>
-								{ entityTitle }
-							</div>
-						</h1>
-						{ dropdownContent && ! isActive && (
-							<Dropdown
-								popoverProps={ {
-									anchorRef: titleRef.current,
-								} }
-								position="bottom center"
-								renderToggle={ ( { isOpen, onToggle } ) => (
-									<Button
-										className="edit-site-document-actions__get-info"
-										icon={ chevronDown }
-										aria-expanded={ isOpen }
-										aria-haspopup="true"
-										onClick={ onToggle }
-										label={ sprintf(
-											/* translators: %s: the entity to see details about, like "template"*/
-											__( 'Show %s details' ),
-											entityLabel
-										) }
-									/>
-								) }
-								renderContent={ () => dropdownContent }
-							/>
+			<div
+				ref={ titleRef }
+				className="edit-site-document-actions__title-wrapper"
+			>
+				<h1>
+					<VisuallyHidden>
+						{ sprintf(
+							/* translators: %s: the entity being edited, like "template"*/
+							__( 'Edit %s:' ),
+							entityLabel
 						) }
-					</div>
-
+					</VisuallyHidden>
 					<div
 						className={ classnames(
-							'edit-site-document-actions__secondary-item',
+							'edit-site-document-actions__title',
 							{
+								'is-active': isTitleActive,
 								'is-secondary-title-active': isActive,
 							}
 						) }
 					>
-						{ label ?? '' }
+						{ entityTitle }
 					</div>
-				</>
-			) : (
-				__( 'Loading…' )
-			) }
+				</h1>
+				{ dropdownContent && ! isActive && (
+					<Dropdown
+						popoverProps={ {
+							anchorRef: titleRef.current,
+						} }
+						position="bottom center"
+						renderToggle={ ( { isOpen, onToggle } ) => (
+							<Button
+								className="edit-site-document-actions__get-info"
+								icon={ chevronDown }
+								aria-expanded={ isOpen }
+								aria-haspopup="true"
+								onClick={ onToggle }
+								label={ sprintf(
+									/* translators: %s: the entity to see details about, like "template"*/
+									__( 'Show %s details' ),
+									entityLabel
+								) }
+							/>
+						) }
+						renderContent={ () => dropdownContent }
+					/>
+				) }
+			</div>
+			<div
+				className={ classnames(
+					'edit-site-document-actions__secondary-item',
+					{
+						'is-secondary-title-active': isActive,
+					}
+				) }
+			>
+				{ label ?? '' }
+			</div>
 		</div>
 	);
 }

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -22,32 +22,44 @@ import SaveButton from '../save-button';
 import UndoButton from './undo-redo/undo';
 import RedoButton from './undo-redo/redo';
 import DocumentActions from './document-actions';
+import TemplateDetails from '../template-details';
+import { getTemplateInfo } from '../../utils';
 
 export default function Header( { openEntitiesSavedStates } ) {
-	const { deviceType, hasFixedToolbar, template, isInserterOpen } = useSelect(
-		( select ) => {
-			const {
-				__experimentalGetPreviewDeviceType,
-				isFeatureActive,
-				getTemplateId,
-				isInserterOpened,
-			} = select( 'core/edit-site' );
-			const { getEntityRecord } = select( 'core' );
+	const {
+		deviceType,
+		hasFixedToolbar,
+		template,
+		templatePart,
+		templateType,
+		isInserterOpen,
+	} = useSelect( ( select ) => {
+		const {
+			__experimentalGetPreviewDeviceType,
+			isFeatureActive,
+			getTemplateId,
+			getTemplatePartId,
+			getTemplateType,
+			isInserterOpened,
+		} = select( 'core/edit-site' );
+		const { getEntityRecord } = select( 'core' );
 
-			const _templateId = getTemplateId();
-			return {
-				deviceType: __experimentalGetPreviewDeviceType(),
-				hasFixedToolbar: isFeatureActive( 'fixedToolbar' ),
-				template: getEntityRecord(
-					'postType',
-					'wp_template',
-					_templateId
-				),
-				isInserterOpen: isInserterOpened(),
-			};
-		},
-		[]
-	);
+		const templatePartId = getTemplatePartId();
+		const templateId = getTemplateId();
+
+		return {
+			deviceType: __experimentalGetPreviewDeviceType(),
+			hasFixedToolbar: isFeatureActive( 'fixedToolbar' ),
+			template: getEntityRecord( 'postType', 'wp_template', templateId ),
+			templatePart: getEntityRecord(
+				'postType',
+				'wp_template_part',
+				templatePartId
+			),
+			templateType: getTemplateType(),
+			isInserterOpen: isInserterOpened(),
+		};
+	}, [] );
 
 	const {
 		__experimentalSetPreviewDeviceType: setPreviewDeviceType,
@@ -57,6 +69,11 @@ export default function Header( { openEntitiesSavedStates } ) {
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const displayBlockToolbar =
 		! isLargeViewport || deviceType !== 'Desktop' || hasFixedToolbar;
+
+	let { title } = getTemplateInfo( template );
+	if ( 'wp_template_part' === templateType ) {
+		title = templatePart?.slug;
+	}
 
 	return (
 		<div className="edit-site-header">
@@ -88,7 +105,18 @@ export default function Header( { openEntitiesSavedStates } ) {
 			</div>
 
 			<div className="edit-site-header_center">
-				<DocumentActions template={ template } />
+				<DocumentActions
+					entityTitle={ title }
+					entityLabel={
+						templateType === 'wp_template'
+							? 'template'
+							: 'template part'
+					}
+				>
+					{ templateType === 'wp_template' && (
+						<TemplateDetails template={ template } />
+					) }
+				</DocumentActions>
 			</div>
 
 			<div className="edit-site-header_end">


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Resolves #25878. This refactors the `DocumentActions` component in the following ways:

1. Remove the prop for a `template` object
2. Add props for `entityTitle` and `entityLabel` so that the component can be used for generic entities.
3. Pass React `children` to the dropdown component so that the actions area is not tightly coupled to the content which could be shown there.

We then utilize these changes in the header component so that:
1. The `entityTitle` can changed based on the entity being edited (so it now shows the template part slug when zoomed into a template part).
2. Only render dropdown content when displaying a template so that we don't show a unnecessary content for the template part.

Visually, the only difference should be that when you switch to a template part in the sidebar, it now displays the template part slug as the document title.

## How has this been tested?
Locally in edit site.

## Screenshots <!-- if applicable -->
![2020-10-12 15 52 41](https://user-images.githubusercontent.com/6265975/95797182-aefdc000-0ca3-11eb-82d2-2989cdefcf81.gif)


## Types of changes
Enhancement

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
