### PR TITLE
editor: remove two unused registry controls

### DIFF
--- a/packages/editor/src/store/controls.js
+++ b/packages/editor/src/store/controls.js
@@ -1,29 +1,4 @@
 /**
- * WordPress dependencies
- */
-import { createRegistryControl } from '@wordpress/data';
-
-/**
- * Returns a control descriptor signalling to subscribe to the registry and
- * resolve the control promise only when the next state change occurs.
- *
- * @return {Object} Control descriptor.
- */
-export function awaitNextStateChange() {
-	return { type: 'AWAIT_NEXT_STATE_CHANGE' };
-}
-
-/**
- * Returns a control descriptor signalling to resolve with the current data
- * registry.
- *
- * @return {Object} Control descriptor.
- */
-export function getRegistry() {
-	return { type: 'GET_REGISTRY' };
-}
-
-/**
  * Function returning a sessionStorage key to set or retrieve a given post's
  * automatic session backup.
  *
@@ -62,15 +37,6 @@ export function localAutosaveClear( postId, isPostNew ) {
 }
 
 const controls = {
-	AWAIT_NEXT_STATE_CHANGE: createRegistryControl( ( registry ) => () =>
-		new Promise( ( resolve ) => {
-			const unsubscribe = registry.subscribe( () => {
-				unsubscribe();
-				resolve();
-			} );
-		} )
-	),
-	GET_REGISTRY: createRegistryControl( ( registry ) => () => registry ),
 	LOCAL_AUTOSAVE_SET( { postId, isPostNew, title, content, excerpt } ) {
 		localAutosaveSet( postId, isPostNew, title, content, excerpt );
 	},


### PR DESCRIPTION
Removes the `awaitNextStateChange` and `getRegistry` controls from the `editor` store. They are not used by any action.

They were added in #16402 when introducing support for attribute sources, and then refactored away in #17153.

With the data controls built into every store, I believe no control should ever need to use `createRegistryControl` again. The built-in data controls should provide all the functionality that is needed.