### PR TITLE
Fix drag and drop in empty widget area

### DIFF
--- a/packages/edit-widgets/src/blocks/widget-area/editor.scss
+++ b/packages/edit-widgets/src/blocks/widget-area/editor.scss
@@ -11,6 +11,15 @@
 	}
 }
 
+// Add some spacing above the inner blocks so that the block toolbar doesn't
+// overlap the panel header.
 .wp-block-widget-area > .components-panel__body > div > .block-editor-inner-blocks {
 	padding-top: $grid-unit-30;
+
+	// Ensure the widget area block lists have a minimum height so that it doesn't
+	// collapse to zero height when it has no blocks. When that happens the block
+	// can't be used as a drop target.
+	> .block-editor-block-list__layout {
+		min-height: $grid-unit-40;
+	}
 }

--- a/packages/edit-widgets/src/blocks/widget-area/editor.scss
+++ b/packages/edit-widgets/src/blocks/widget-area/editor.scss
@@ -11,6 +11,6 @@
 	}
 }
 
-.wp-block-widget-area > .components-panel__body > .block-editor-inner-blocks {
+.wp-block-widget-area > .components-panel__body > div > .block-editor-inner-blocks {
 	padding-top: $grid-unit-30;
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes #25911. 

The issue is that the Inner Blocks area being dragged into has collapsed to `0px` height. Since the Inner Blocks area represents the drop zone for blocks there was effectively no drop target.

This PR ensures there's a min-height on widget area inner blocks. The drop target is still not perfect, but it is at least possible now. 

Ideally the whole widget area block could act as a drop zone, I've documented in https://github.com/WordPress/gutenberg/issues/26049, but given I'm not sure of the feasibility of that, this seems like a good incremental fix.

## How has this been tested?
1. Ensure you have two widget area and make sure one is empty.
2. Try dragging a block from one widget area to another
3. Observe it works if you find the right spot.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
