### PR TITLE
Fix/wrong classes search block

### DIFF
--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -90,10 +90,10 @@ export default function SearchEdit( {
 			'button-only' === buttonPosition
 				? 'wp-block-search__button-only'
 				: undefined,
-			buttonUseIcon && 'no-button' !== buttonPosition
+			! buttonUseIcon && 'no-button' !== buttonPosition
 				? 'wp-block-search__text-button'
 				: undefined,
-			! buttonUseIcon && 'no-button' !== buttonPosition
+			buttonUseIcon && 'no-button' !== buttonPosition
 				? 'wp-block-search__icon-button'
 				: undefined
 		);

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -65,14 +65,14 @@ function render_block_core_search( $attributes ) {
 
 	if ( $show_button ) {
 		$button_internal_markup = '';
-		$button_classes = '';
+		$button_classes         = '';
 
 		if ( ! $use_icon_button ) {
 			if ( ! empty( $attributes['buttonText'] ) ) {
 				$button_internal_markup = $attributes['buttonText'];
 			}
 		} else {
-			$button_classes .= 'has-icon';
+			$button_classes        .= 'has-icon';
 			$button_internal_markup =
 				'<svg id="search-icon" class="search-icon" viewBox="0 0 24 24" width="24" height="24">
 			        <path d="M13.5 6C10.5 6 8 8.5 8 11.5c0 1.1.3 2.1.9 3l-3.4 3 1 1.1 3.4-2.9c1 .9 2.2 1.4 3.6 1.4 3 0 5.5-2.5 5.5-5.5C19 8.5 16.5 6 13.5 6zm0 9.5c-2.2 0-4-1.8-4-4s1.8-4 4-4 4 1.8 4 4-1.8 4-4 4z"></path>

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -65,20 +65,22 @@ function render_block_core_search( $attributes ) {
 
 	if ( $show_button ) {
 		$button_internal_markup = '';
+		$button_classes = '';
 
 		if ( ! $use_icon_button ) {
 			if ( ! empty( $attributes['buttonText'] ) ) {
 				$button_internal_markup = $attributes['buttonText'];
 			}
 		} else {
+			$button_classes .= 'has-icon';
 			$button_internal_markup =
-				'<svg id="search-icon" class="search-icon" viewBox="0 0 24 24">
+				'<svg id="search-icon" class="search-icon" viewBox="0 0 24 24" width="24" height="24">
 			        <path d="M13.5 6C10.5 6 8 8.5 8 11.5c0 1.1.3 2.1.9 3l-3.4 3 1 1.1 3.4-2.9c1 .9 2.2 1.4 3.6 1.4 3 0 5.5-2.5 5.5-5.5C19 8.5 16.5 6 13.5 6zm0 9.5c-2.2 0-4-1.8-4-4s1.8-4 4-4 4 1.8 4 4-1.8 4-4 4z"></path>
 			    </svg>';
 		}
 
 		$button_markup = sprintf(
-			'<button type="submit" class="wp-block-search__button">%s</button>',
+			'<button type="submit"class="wp-block-search__button ' . $button_classes . '">%s</button>',
 			$button_internal_markup
 		);
 	}


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
* Added missing width and height to the svg on the frontend
* Added `has-icon` class to the button when it's an icon isntead of text on the frontend (this was missing compared to the editor)
* Swapped the classes `wp-block-search__icon-button` and `wp-block-search__text-button` on the editor (they were correct on the frontend)

## How has this been tested?

* Create search blocks that have icon button on the different positions it can have it.
* Create search blocks that have text button on the different positions too.
* Check the frontend, the icon shouldn't be huge. 
* Check on the editor that when the block has an icon instead of text, the class `wp-block-search__icon-button` is applied. This doesn't have any visual impact, but it's needed for theming purposes.
* Check on the editor that when the block has an text instead of icon, the class `wp-block-search__text-button` is applied. This doesn't have any visual impact, but it's needed for theming purposes.

## Screenshots 

**Before:**

Editor:

<img width="723" alt="Screenshot 2020-10-13 at 10 50 01" src="https://user-images.githubusercontent.com/3593343/95844820-a5c72e80-0d49-11eb-9a04-683460f8b44d.png">

Frontend:

![Screenshot_2020-10-13 Search – gutenberg](https://user-images.githubusercontent.com/3593343/95844879-be374900-0d49-11eb-9faf-714bf3e77f1e.png)

**After**

Frontend:

<img width="677" alt="Screenshot 2020-10-13 at 11 41 58" src="https://user-images.githubusercontent.com/3593343/95844922-cee7bf00-0d49-11eb-97aa-640c9dd63424.png">



## Types of changes

Class changes and added width/height to svg that was missing. My changes bring the frontend result more in line with what the editor shows. 

Fixes #25902 

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
