### PR TITLE
Restrict legacy widget block to only being a child of widget area

### DIFF
--- a/packages/edit-widgets/src/blocks/legacy-widget/block.json
+++ b/packages/edit-widgets/src/blocks/legacy-widget/block.json
@@ -21,5 +21,8 @@
 	"supports": {
 		"html": false,
 		"customClassName": false
-	}
+	},
+	"parent": [
+		"core/widget-area"
+	]
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Closes #25834

As mentioned on #25834, legacy widgets currently don't support nesting anywhere other than within widget areas. This PR enforces that (potentially temporary) restriction by setting `core/widget-area` as the parent block for `core/legacy-widget`.

## How has this been tested?
1. Insert a parent block (Group, Columns, Media Text)
2. Try inserting a legacy widget block as a child block
3. Note that legacy widget is not available in the inserter
4. Try dragging a legacy widget into a parent block
5. Note the widget can't be moved into a nested context.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
