### PR TITLE
Make sure Global Styles CPT includes a theme reference

### DIFF
--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -141,7 +141,7 @@ function gutenberg_experimental_global_styles_get_user() {
 function gutenberg_experimental_global_styles_get_user_cpt( $should_create_cpt = false, $post_status_filter = array( 'publish' ) ) {
 	$user_cpt         = array();
 	$post_type_filter = 'wp_global_styles';
-	$post_name_filter = 'wp-global-styles-' . strtolower( wp_get_theme()->get( 'TextDomain' ) );
+	$post_name_filter = 'wp-global-styles-' . urlencode( wp_get_theme()->get_stylesheet() );
 	$recent_posts     = wp_get_recent_posts(
 		array(
 			'numberposts' => 1,


### PR DESCRIPTION
See conversation https://github.com/WordPress/gutenberg/pull/25923#discussion_r501327622

This fixes an issue by which themes that don't define a text-domain share and override each other's CPT data.

When creating the CPT for global styles, as the `post_name` identifier we use the theme text domain as a suffix such as `wp-global-styles-[text-domain]`. However, the text-domain is not a required field for a theme to work (it is a required file of a theme _that wants to be published in the themes directory_, though). Valid examples of themes that don't require a text-domain are: child themes that don't add new strings, local themes not distributed through any repository, and/or themes that don't need i18n.

In WordPress core, the canonical identifier for a theme is the `stylesheet` field within `WP_Theme` (`$theme->get_stylesheet()`). The [value](https://github.com/WordPress/wordpress-develop/blob/master/src/wp-includes/class-wp-theme.php#L206) of this field is the name of the theme directory within the theme root, which all themes need and is unique by default. In following [how core operates](https://github.com/WordPress/wordpress-develop/blob/master/src/wp-admin/includes/theme.php#L670), this PR changes the suffix added to the global styles CPT to be the `stylesheet` field instead.

## Considerations

If the text domain of a theme and the name of its directory are different, old user styles stored in the database will be ignored.
