### PR TITLE
Components: Remove size prop from Dashicon

### DIFF
--- a/packages/components/src/dashicon/index.js
+++ b/packages/components/src/dashicon/index.js
@@ -2,7 +2,6 @@
  * @typedef OwnProps
  *
  * @property {string} icon        Icon name
- * @property {number} [size=20]   Icon size
  * @property {string} [className] Class name
  */
 /** @typedef {import('react').ComponentPropsWithoutRef<'span'> & OwnProps} Props */
@@ -11,7 +10,7 @@
  * @param {Props} props
  * @return {JSX.Element} Element
  */
-function Dashicon( { icon, size = 20, className, ...extraProps } ) {
+function Dashicon( { icon, className, ...extraProps } ) {
 	const iconClass = [
 		'dashicon',
 		'dashicons',
@@ -21,19 +20,7 @@ function Dashicon( { icon, size = 20, className, ...extraProps } ) {
 		.filter( Boolean )
 		.join( ' ' );
 
-	return (
-		<span
-			className={ iconClass }
-			// Ignore reason: span attributes are the global attributes which do not include width/height
-			// See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span
-			// See https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes
-			// PR to remove: https://github.com/WordPress/gutenberg/pull/26067
-			// @ts-ignore
-			width={ size }
-			height={ size }
-			{ ...extraProps }
-		/>
-	);
+	return <span className={ iconClass } { ...extraProps } />;
 }
 
 export default Dashicon;

--- a/packages/components/src/icon/index.js
+++ b/packages/components/src/icon/index.js
@@ -15,22 +15,12 @@ import { SVG } from '@wordpress/primitives';
 import Dashicon from '../dashicon';
 
 function Icon( { icon = null, size, ...additionalProps } ) {
-	// Dashicons should be 20x20 by default.
-	const dashiconSize = size || 20;
-
 	if ( 'string' === typeof icon ) {
-		return (
-			<Dashicon
-				icon={ icon }
-				size={ dashiconSize }
-				{ ...additionalProps }
-			/>
-		);
+		return <Dashicon icon={ icon } { ...additionalProps } />;
 	}
 
 	if ( icon && Dashicon === icon.type ) {
 		return cloneElement( icon, {
-			size: dashiconSize,
 			...additionalProps,
 		} );
 	}

--- a/packages/components/src/icon/test/index.js
+++ b/packages/components/src/icon/test/index.js
@@ -38,20 +38,6 @@ describe( 'Icon', () => {
 		);
 	} );
 
-	it( 'renders a dashicon by slug and with a default size of 20', () => {
-		const wrapper = shallow( <Icon icon="format-image" /> );
-
-		expect( wrapper.find( 'Dashicon' ).prop( 'size' ) ).toBe( 20 );
-	} );
-
-	it( 'renders a dashicon by element and with a default size of 20', () => {
-		const wrapper = shallow(
-			<Icon icon={ <Dashicon icon="format-image" /> } />
-		);
-
-		expect( wrapper.find( 'Dashicon' ).prop( 'size' ) ).toBe( 20 );
-	} );
-
 	it( 'renders a function', () => {
 		const wrapper = shallow( <Icon icon={ () => <span /> } /> );
 
@@ -130,6 +116,11 @@ describe( 'Icon', () => {
 					// Custom logic for SVG elements tested separately.
 					//
 					// See: `renders an svg element and passes the size as its width and height`
+					return;
+				}
+
+				if ( [ 'dashicon', 'dashicon element' ].includes( label ) ) {
+					// `size` prop isn't passed through, since dashicon doesn't accept it.
 					return;
 				}
 


### PR DESCRIPTION
## Description
Found while working on #26066 with @sirreal.

`<span />` doesn't seem to actually accept `width` and `height` props: It is an inline element, and [its attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span) are the [global attributes]( https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes) which do not include width/height.

SO thread with some more info: https://stackoverflow.com/questions/2491068/does-height-and-width-not-apply-to-span

Thus, this PR removes those props, and the `size` prop that's used to set them.

## How has this been tested?
Do some smoke testing to verify that dashicons still work.

Furthermore, verify that unit tests pass:
```
npm run test-unit -- packages/components/src/icon/
```

## Types of changes
Bug fix/HTML standards compliance fix.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
