### PR TITLE
[RN Mobile] UBE - Inject css on both page visible and page started

### DIFF
--- a/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergWebViewActivity.java
+++ b/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergWebViewActivity.java
@@ -167,8 +167,7 @@ public class GutenbergWebViewActivity extends AppCompatActivity {
 
             @Override
             public void onPageCommitVisible(WebView view, String url) {
-                String injectCssScript = getFileContentFromAssets("gutenberg-web-single-block/inject-css.js");
-                evaluateJavaScript(injectCssScript);
+                injectCssScript();
 
                 long userId = getUserId();
                 if (userId != 0) {
@@ -189,6 +188,7 @@ public class GutenbergWebViewActivity extends AppCompatActivity {
 
             @Override
             public void onPageStarted(WebView view, String url, Bitmap favicon) {
+                injectCssScript();
                 injectOnPageLoadExternalSources();
                 super.onPageStarted(view, url, favicon);
             }
@@ -237,6 +237,11 @@ public class GutenbergWebViewActivity extends AppCompatActivity {
             // like NUX (new user experience) modal is.
             mForegroundView.postDelayed(() -> mForegroundView.setVisibility(View.INVISIBLE), 1500);
         }, 2000);
+    }
+
+    private void injectCssScript() {
+        String injectCssScript = getFileContentFromAssets("gutenberg-web-single-block/inject-css.js");
+        evaluateJavaScript(injectCssScript);
     }
 
     private void injectOnGutenbergReadyExternalSources() {

--- a/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergWebViewActivity.java
+++ b/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergWebViewActivity.java
@@ -90,7 +90,9 @@ public class GutenbergWebViewActivity extends AppCompatActivity {
                     }
                 }
                 else {
-                    mIsWebPageLoaded.compareAndSet(true, false);
+                    if (progress < 100) {
+                        mIsWebPageLoaded.compareAndSet(true, false);
+                    }
                     mProgressBar.setProgress(progress);
                 }
             }
@@ -244,12 +246,12 @@ public class GutenbergWebViewActivity extends AppCompatActivity {
     }
 
     private void onGutenbergReady() {
-        mIsGutenbergReady = true;
         preventAutoSavesScript();
         // Inject css when Gutenberg is ready
         injectCssScript();
         final Handler handler = new Handler();
         handler.postDelayed(() -> {
+            mIsGutenbergReady = true;
             // We want to make sure that page is loaded
             // with all elements before executing external JS
             injectOnGutenbergReadyExternalSources();


### PR DESCRIPTION
## How has this been tested?

Check WP Android fellow PR: https://github.com/wordpress-mobile/WordPress-Android/pull/13122

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
