### PR TITLE
Try: Make class and style tests less brittle.

### DIFF
--- a/phpunit/class-block-supported-styles-test.php
+++ b/phpunit/class-block-supported-styles-test.php
@@ -112,8 +112,14 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$style_list = $this->get_attribute_from_block( 'style', $styled_block );
 
 		$this->assertEquals( self::BLOCK_CONTENT, $content );
-		$this->assertEquals( $expected_classes, $class_list );
-		$this->assertEquals( $expected_styles, $style_list );
+		$this->assertEqualSets(
+			explode( ' ', $expected_classes ),
+			explode( ' ', $class_list )
+		);
+		$this->assertEquals(
+			array_map( 'trim', explode( ';', $expected_styles ) ),
+			array_map( 'trim', explode( ';', $style_list ) )
+		);
 	}
 
 	/**


### PR DESCRIPTION
Instead of relying on the exact order of classnames and style attributes,
split each string into an array and assert that they are equal sets which
ignores differences due to order.

This hopefully will fix the test failures occurring on `master`.