### PR TITLE
Add unsaved changes warning to widgets screen

### DIFF
--- a/packages/edit-widgets/src/components/layout/index.js
+++ b/packages/edit-widgets/src/components/layout/index.js
@@ -10,6 +10,7 @@ import { PluginArea } from '@wordpress/plugins';
 import WidgetAreasBlockEditorProvider from '../widget-areas-block-editor-provider';
 import Sidebar from '../sidebar';
 import Interface from './interface';
+import UnsavedChangesWarning from './unsaved-changes-warning';
 
 function Layout( { blockEditorSettings } ) {
 	return (
@@ -20,6 +21,7 @@ function Layout( { blockEditorSettings } ) {
 			<Sidebar />
 			<Popover.Slot />
 			<PluginArea />
+			<UnsavedChangesWarning />
 		</WidgetAreasBlockEditorProvider>
 	);
 }

--- a/packages/edit-widgets/src/components/layout/unsaved-changes-warning.js
+++ b/packages/edit-widgets/src/components/layout/unsaved-changes-warning.js
@@ -1,0 +1,52 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useEffect } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Warns the user if there are unsaved changes before leaving the editor.
+ * Compatible with Post Editor and Site Editor.
+ *
+ * @return {WPComponent} The component.
+ */
+export default function UnsavedChangesWarning() {
+	const isDirty = useSelect( ( select ) => {
+		return () => {
+			const { __experimentalGetDirtyEntityRecords } = select( 'core' );
+			const dirtyEntityRecords = __experimentalGetDirtyEntityRecords();
+			return dirtyEntityRecords.length > 0;
+		};
+	}, [] );
+
+	/**
+	 * Warns the user if there are unsaved changes before leaving the editor.
+	 *
+	 * @param {Event} event `beforeunload` event.
+	 *
+	 * @return {?string} Warning prompt message, if unsaved changes exist.
+	 */
+	const warnIfUnsavedChanges = ( event ) => {
+		// We need to call the selector directly in the listener to avoid race
+		// conditions with `BrowserURL` where `componentDidUpdate` gets the
+		// new value of `isEditedPostDirty` before this component does,
+		// causing this component to incorrectly think a trashed post is still dirty.
+		if ( isDirty() ) {
+			event.returnValue = __(
+				'You have unsaved changes. If you proceed, they will be lost.'
+			);
+			return event.returnValue;
+		}
+	};
+
+	useEffect( () => {
+		window.addEventListener( 'beforeunload', warnIfUnsavedChanges );
+
+		return () => {
+			window.removeEventListener( 'beforeunload', warnIfUnsavedChanges );
+		};
+	}, [] );
+
+	return null;
+}

--- a/packages/edit-widgets/src/components/layout/unsaved-changes-warning.js
+++ b/packages/edit-widgets/src/components/layout/unsaved-changes-warning.js
@@ -14,7 +14,7 @@ import { useSelect } from '@wordpress/data';
  * @return {WPComponent} The component.
  */
 export default function UnsavedChangesWarning() {
-	const isDirty = useSelect( ( select ) => {
+	const getIsDirty = useSelect( ( select ) => {
 		return () => {
 			const { __experimentalGetDirtyEntityRecords } = select( 'core' );
 			const dirtyEntityRecords = __experimentalGetDirtyEntityRecords();
@@ -35,7 +35,7 @@ export default function UnsavedChangesWarning() {
 			// conditions with `BrowserURL` where `componentDidUpdate` gets the
 			// new value of `isEditedPostDirty` before this component does,
 			// causing this component to incorrectly think a trashed post is still dirty.
-			if ( isDirty() ) {
+			if ( getIsDirty() ) {
 				event.returnValue = __(
 					'You have unsaved changes. If you proceed, they will be lost.'
 				);
@@ -48,7 +48,7 @@ export default function UnsavedChangesWarning() {
 		return () => {
 			window.removeEventListener( 'beforeunload', warnIfUnsavedChanges );
 		};
-	}, [ isDirty ] );
+	}, [ getIsDirty ] );
 
 	return null;
 }

--- a/packages/edit-widgets/src/components/layout/unsaved-changes-warning.js
+++ b/packages/edit-widgets/src/components/layout/unsaved-changes-warning.js
@@ -7,7 +7,9 @@ import { useSelect } from '@wordpress/data';
 
 /**
  * Warns the user if there are unsaved changes before leaving the editor.
- * Compatible with Post Editor and Site Editor.
+ *
+ * This is a duplicate of the component implemented in the editor package.
+ * Duplicated here as edit-widgets doesn't depend on editor.
  *
  * @return {WPComponent} The component.
  */

--- a/packages/edit-widgets/src/components/layout/unsaved-changes-warning.js
+++ b/packages/edit-widgets/src/components/layout/unsaved-changes-warning.js
@@ -22,33 +22,33 @@ export default function UnsavedChangesWarning() {
 		};
 	}, [] );
 
-	/**
-	 * Warns the user if there are unsaved changes before leaving the editor.
-	 *
-	 * @param {Event} event `beforeunload` event.
-	 *
-	 * @return {?string} Warning prompt message, if unsaved changes exist.
-	 */
-	const warnIfUnsavedChanges = ( event ) => {
-		// We need to call the selector directly in the listener to avoid race
-		// conditions with `BrowserURL` where `componentDidUpdate` gets the
-		// new value of `isEditedPostDirty` before this component does,
-		// causing this component to incorrectly think a trashed post is still dirty.
-		if ( isDirty() ) {
-			event.returnValue = __(
-				'You have unsaved changes. If you proceed, they will be lost.'
-			);
-			return event.returnValue;
-		}
-	};
-
 	useEffect( () => {
+		/**
+		 * Warns the user if there are unsaved changes before leaving the editor.
+		 *
+		 * @param {Event} event `beforeunload` event.
+		 *
+		 * @return {?string} Warning prompt message, if unsaved changes exist.
+		 */
+		const warnIfUnsavedChanges = ( event ) => {
+			// We need to call the selector directly in the listener to avoid race
+			// conditions with `BrowserURL` where `componentDidUpdate` gets the
+			// new value of `isEditedPostDirty` before this component does,
+			// causing this component to incorrectly think a trashed post is still dirty.
+			if ( isDirty() ) {
+				event.returnValue = __(
+					'You have unsaved changes. If you proceed, they will be lost.'
+				);
+				return event.returnValue;
+			}
+		};
+
 		window.addEventListener( 'beforeunload', warnIfUnsavedChanges );
 
 		return () => {
 			window.removeEventListener( 'beforeunload', warnIfUnsavedChanges );
 		};
-	}, [] );
+	}, [ isDirty ] );
 
 	return null;
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Closes #26076.

Adds the `UnsavedChangesWarning` component to the widgets screen.

I've copied this component from the `editor` package, since the widgets screen has no dependency on `editor` (see https://github.com/WordPress/gutenberg/pull/25859).

Potentially this component could be moved to `block-editor` to remove the duplication?

## How has this been tested?
1. Make changes to a block in the widget screen
2. Try to leave the screen
3. A confirm dialog should be shown
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
