### PR TITLE
Gallery block: use image caption as fallback for alt text.

### DIFF
--- a/packages/block-library/src/gallery/save.js
+++ b/packages/block-library/src/gallery/save.js
@@ -39,23 +39,17 @@ export default function save( { attributes } ) {
 							href = image.link;
 							break;
 					}
-					// The image should only have an aria-label if it's within a link and has no alt text.
-					const imageLabel =
-						! image.alt && image.caption && href
-							? image.caption
-							: null;
 
 					const img = (
 						<img
 							src={ image.url }
-							alt={ image.alt }
+							alt={ image.alt !== '' ? image.alt : image.caption }
 							data-id={ image.id }
 							data-full-url={ image.fullUrl }
 							data-link={ image.link }
 							className={
 								image.id ? `wp-image-${ image.id }` : null
 							}
-							aria-label={ imageLabel || null }
 						/>
 					);
 


### PR DESCRIPTION
## Description
Addresses [feedback](https://github.com/WordPress/gutenberg/pull/25560#issuecomment-703706634) on #25560. The image alt text will now fall back to the caption text, and `aria-label` is no longer used.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
