### PR TITLE
Add more CI status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![End-to-End Tests](https://github.com/WordPress/gutenberg/workflows/End-to-End%20Tests/badge.svg)](https://github.com/WordPress/gutenberg/actions?query=workflow%3A%22End-to-End+Tests%22+branch%3Amaster)
 [![Static Analysis (Linting, License, Type checks...)](https://github.com/WordPress/gutenberg/workflows/Static%20Analysis%20(Linting,%20License,%20Type%20checks...)/badge.svg)](https://github.com/WordPress/gutenberg/actions?query=workflow%3A%22Static+Analysis+%28Linting%2C+License%2C+Type+checks...%29%22+branch%3Amaster)
 [![Unit Tests](https://github.com/WordPress/gutenberg/workflows/Unit%20Tests/badge.svg)](https://github.com/WordPress/gutenberg/actions?query=workflow%3A%22Unit+Tests%22+branch%3Amaster)
-[![Storybook GitHub Pages](https://github.com/WordPress/gutenberg/workflows/Storybook%20GitHub%20Pages/badge.svg)](https://github.com/WordPress/gutenberg/actions?query=workflow%3A%22Storybook+GitHub+Pages%22+branch%3Amaster)
+[![Create Block](https://github.com/WordPress/gutenberg/workflows/Create%20Block/badge.svg)](https://github.com/WordPress/gutenberg/actions?query=workflow%3A%22Create+Block%22+branch%3Amaster)
 [![React Native E2E Tests (iOS)](https://github.com/WordPress/gutenberg/workflows/React%20Native%20E2E%20Tests%20(iOS)/badge.svg)](https://github.com/WordPress/gutenberg/actions?query=workflow%3A%22React+Native+E2E+Tests+%28iOS%29%22+branch%3Amaster)
 [![React Native E2E Tests (Android)](https://github.com/WordPress/gutenberg/workflows/React%20Native%20E2E%20Tests%20(Android)/badge.svg)](https://github.com/WordPress/gutenberg/actions?query=workflow%3A%22React+Native+E2E+Tests+%28Android%29%22+branch%3Amaster)
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,11 @@
 # Gutenberg
 
-[![Performances Tests](https://github.com/WordPress/gutenberg/workflows/Performances%20Tests/badge.svg)](https://github.com/WordPress/gutenberg/actions?query=workflow%3A%22Performances+Tests%22+branch%3Amaster)
 [![End-to-End Tests](https://github.com/WordPress/gutenberg/workflows/End-to-End%20Tests/badge.svg)](https://github.com/WordPress/gutenberg/actions?query=workflow%3A%22End-to-End+Tests%22+branch%3Amaster)
 [![Static Analysis (Linting, License, Type checks...)](https://github.com/WordPress/gutenberg/workflows/Static%20Analysis%20(Linting,%20License,%20Type%20checks...)/badge.svg)](https://github.com/WordPress/gutenberg/actions?query=workflow%3A%22Static+Analysis+%28Linting%2C+License%2C+Type+checks...%29%22+branch%3Amaster)
 [![Unit Tests](https://github.com/WordPress/gutenberg/workflows/Unit%20Tests/badge.svg)](https://github.com/WordPress/gutenberg/actions?query=workflow%3A%22Unit+Tests%22+branch%3Amaster)
-[![Create Block](https://github.com/WordPress/gutenberg/workflows/Create%20Block/badge.svg)](https://github.com/WordPress/gutenberg/actions?query=workflow%3A%22Create+Block%22+branch%3Amaster)
 [![Storybook GitHub Pages](https://github.com/WordPress/gutenberg/workflows/Storybook%20GitHub%20Pages/badge.svg)](https://github.com/WordPress/gutenberg/actions?query=workflow%3A%22Storybook+GitHub+Pages%22+branch%3Amaster)
 [![React Native E2E Tests (iOS)](https://github.com/WordPress/gutenberg/workflows/React%20Native%20E2E%20Tests%20(iOS)/badge.svg)](https://github.com/WordPress/gutenberg/actions?query=workflow%3A%22React+Native+E2E+Tests+%28iOS%29%22+branch%3Amaster)
 [![React Native E2E Tests (Android)](https://github.com/WordPress/gutenberg/workflows/React%20Native%20E2E%20Tests%20(Android)/badge.svg)](https://github.com/WordPress/gutenberg/actions?query=workflow%3A%22React+Native+E2E+Tests+%28Android%29%22+branch%3Amaster)
-[![Compressed Size](https://github.com/WordPress/gutenberg/workflows/Compressed%20Size/badge.svg)](https://github.com/WordPress/gutenberg/actions?query=workflow%3A%22Compressed+Size%22+branch%3Amaster)
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lerna.js.org)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # Gutenberg
 
+[![Performances Tests](https://github.com/WordPress/gutenberg/workflows/Performances%20Tests/badge.svg)](https://github.com/WordPress/gutenberg/actions?query=workflow%3A%22Performances+Tests%22+branch%3Amaster)
 [![End-to-End Tests](https://github.com/WordPress/gutenberg/workflows/End-to-End%20Tests/badge.svg)](https://github.com/WordPress/gutenberg/actions?query=workflow%3A%22End-to-End+Tests%22+branch%3Amaster)
+[![Static Analysis (Linting, License, Type checks...)](https://github.com/WordPress/gutenberg/workflows/Static%20Analysis%20(Linting,%20License,%20Type%20checks...)/badge.svg)](https://github.com/WordPress/gutenberg/actions?query=workflow%3A%22Static+Analysis+%28Linting%2C+License%2C+Type+checks...%29%22+branch%3Amaster)
+[![Unit Tests](https://github.com/WordPress/gutenberg/workflows/Unit%20Tests/badge.svg)](https://github.com/WordPress/gutenberg/actions?query=workflow%3A%22Unit+Tests%22+branch%3Amaster)
+[![Create Block](https://github.com/WordPress/gutenberg/workflows/Create%20Block/badge.svg)](https://github.com/WordPress/gutenberg/actions?query=workflow%3A%22Create+Block%22+branch%3Amaster)
+[![Storybook GitHub Pages](https://github.com/WordPress/gutenberg/workflows/Storybook%20GitHub%20Pages/badge.svg)](https://github.com/WordPress/gutenberg/actions?query=workflow%3A%22Storybook+GitHub+Pages%22+branch%3Amaster)
+[![React Native E2E Tests (iOS)](https://github.com/WordPress/gutenberg/workflows/React%20Native%20E2E%20Tests%20(iOS)/badge.svg)](https://github.com/WordPress/gutenberg/actions?query=workflow%3A%22React+Native+E2E+Tests+%28iOS%29%22+branch%3Amaster)
+[![React Native E2E Tests (Android)](https://github.com/WordPress/gutenberg/workflows/React%20Native%20E2E%20Tests%20(Android)/badge.svg)](https://github.com/WordPress/gutenberg/actions?query=workflow%3A%22React+Native+E2E+Tests+%28Android%29%22+branch%3Amaster)
+[![Compressed Size](https://github.com/WordPress/gutenberg/workflows/Compressed%20Size/badge.svg)](https://github.com/WordPress/gutenberg/actions?query=workflow%3A%22Compressed+Size%22+branch%3Amaster)
+
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lerna.js.org)
 
 ![Screenshot of the Gutenberg Editor, editing a post in WordPress](https://user-images.githubusercontent.com/1204802/73433964-2540d900-4346-11ea-94f3-5df2e9d876bc.png)


### PR DESCRIPTION
Added all the GitHub Actions workflow badges to the README. Seems a bit crowded now, any ideas about the layout appreciated!