### PR TITLE
[RNMobile] Prepare mobile columns for different units

### DIFF
--- a/packages/block-library/src/column/edit.native.js
+++ b/packages/block-library/src/column/edit.native.js
@@ -26,7 +26,6 @@ import { __ } from '@wordpress/i18n';
  */
 import styles from './editor.scss';
 import ColumnsPreview from './column-preview';
-import { getColumnWidths } from '../columns/utils';
 
 function ColumnEdit( {
 	attributes,
@@ -54,13 +53,11 @@ function ColumnEdit( {
 	}, [] );
 
 	const onWidthChange = ( width ) => {
-		setAttributes( {
-			width,
-		} );
+		setAttributes( { width: `${ width }%` } );
 	};
 
-	const columnWidths = Object.values(
-		getColumnWidths( columns, columnCount )
+	const columnWidths = columns.map(
+		( column ) => parseFloat( column.attributes.width ) || 100 / columnCount
 	);
 
 	if ( ! isSelected && ! hasChildren ) {

--- a/packages/block-library/src/columns/edit.native.js
+++ b/packages/block-library/src/columns/edit.native.js
@@ -30,7 +30,6 @@ import { columns } from '@wordpress/icons';
  */
 import variations from './variations';
 import styles from './editor.scss';
-import { getColumnWidths } from './utils';
 import ColumnsPreview from '../column/column-preview';
 
 /**
@@ -150,8 +149,9 @@ function ColumnsEditContainer( {
 	};
 
 	const getColumnsSliders = () => {
-		const columnWidths = Object.values(
-			getColumnWidths( innerColumns, columnCount )
+		const columnWidths = innerColumns.map(
+			( innerColumn ) =>
+				parseFloat( innerColumn.attributes.width ) || 100 / columnCount
 		);
 
 		return innerColumns.map( ( column, index ) => {
@@ -263,7 +263,7 @@ const ColumnsEditContainerWrapper = withDispatch(
 			const { updateBlockAttributes } = dispatch( 'core/block-editor' );
 
 			updateBlockAttributes( columnId, {
-				width: value,
+				width: `${ value }%`,
 			} );
 		},
 		updateBlockSettings( settings ) {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

After merging web feature related to introducing `UnitControl` in `Columns` block, we observed the crash when saving the post with columns block. That PR is a workaround to avoid the crash:

* mobile columns don't have any visual effect when changing their width, they are stacked in portrait mode or max 3 columns can be placed in a row in landscape mode (>480px)
* on mobile there is a possibility to change column width, but currently only in **percentages**

<!-- Please describe what you have changed or added -->

Adjust mobile columns for upcoming web feature.


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

* Open mobile app eg wp-ios
* Open draft post
* Switch to HTML mode
* Paste the code

```
<!-- wp:columns -->
<div class="wp-block-columns"><!-- wp:column {"width":"100%"} -->
<div class="wp-block-column" style="flex-basis:100%"><!-- wp:image {"id":2392,"sizeSlug":"large"} -->
<figure class="wp-block-image size-large"><img src="https://callstackhappiryuhome.files.wordpress.com/2020/10/pexels-photo-4595375.jpg?w=1024" alt="" class="wp-image-2392"/></figure>
<!-- /wp:image --></div>
<!-- /wp:column -->

<!-- wp:column {"width":"500em"} -->
<div class="wp-block-column" style="flex-basis:500em"><!-- wp:paragraph -->
<p>Lorem ipsum</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->
```

* Update / Save the post
* Switch to Visual Mode
* Expect to see two stacked column, first with picture, second with paragraph
* Switch again to HTML mode
* Replace `%` in first columns in favour of `rem` (_in width and flex-basis as well_)
* Update post
* Expect to see two **exactly the same** stacked column, first with picture, second with paragraph
* Open post preview
* Expect content is displayed properly
* Close preview
* Open column settings and change width using slider
* Save post
* Expect app mustn't crash

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [X] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
