### PR TITLE
Reusable blocks support for widgets editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17471,6 +17471,7 @@
 				"@wordpress/media-utils": "file:packages/media-utils",
 				"@wordpress/notices": "file:packages/notices",
 				"@wordpress/plugins": "file:packages/plugins",
+				"@wordpress/reusable-blocks": "file:packages/reusable-blocks",
 				"@wordpress/server-side-render": "file:packages/server-side-render",
 				"@wordpress/url": "file:packages/url",
 				"classnames": "^2.2.5",
@@ -46054,7 +46055,7 @@
 			"dependencies": {
 				"clone-deep": {
 					"version": "0.2.4",
-					"resolved": "http://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
+					"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
 					"integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
 					"dev": true,
 					"requires": {
@@ -46088,7 +46089,7 @@
 					"dependencies": {
 						"kind-of": {
 							"version": "2.0.1",
-							"resolved": "http://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
 							"integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
 							"dev": true,
 							"requires": {

--- a/packages/edit-widgets/package.json
+++ b/packages/edit-widgets/package.json
@@ -47,6 +47,7 @@
 		"@wordpress/media-utils": "file:../media-utils",
 		"@wordpress/notices": "file:../notices",
 		"@wordpress/plugins": "file:../plugins",
+		"@wordpress/reusable-blocks": "file:../reusable-blocks",
 		"@wordpress/server-side-render": "file:../server-side-render",
 		"@wordpress/url": "file:../url",
 		"classnames": "^2.2.5",

--- a/packages/edit-widgets/src/blocks/legacy-widget/block.json
+++ b/packages/edit-widgets/src/blocks/legacy-widget/block.json
@@ -23,7 +23,8 @@
 	},
 	"supports": {
 		"html": false,
-		"customClassName": false
+		"customClassName": false,
+		"reusable": false
 	},
 	"parent": [
 		"core/widget-area"

--- a/packages/edit-widgets/src/blocks/widget-area/block.json
+++ b/packages/edit-widgets/src/blocks/widget-area/block.json
@@ -13,6 +13,7 @@
 		"html": false,
 		"inserter": false,
 		"customClassName": false,
+		"reusable": false,
 		"__experimentalToolbar": false
 	}
 }

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
@@ -19,7 +19,7 @@ import {
 	BlockEditorKeyboardShortcuts,
 	__unstableEditorStyles as EditorStyles,
 } from '@wordpress/block-editor';
-import { ReusableBlocksButtons } from '@wordpress/reusable-blocks';
+import { ReusableBlocksMenuItems } from '@wordpress/reusable-blocks';
 
 /**
  * Internal dependencies
@@ -92,7 +92,7 @@ export default function WidgetAreasBlockEditorProvider( {
 							{ ...props }
 						>
 							{ children }
-							<ReusableBlocksButtons
+							<ReusableBlocksMenuItems
 								rootClientId={ widgetAreaId }
 							/>
 						</BlockEditorProvider>

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
@@ -27,6 +27,7 @@ import { ReusableBlocksButtons } from '@wordpress/reusable-blocks';
 import KeyboardShortcuts from '../keyboard-shortcuts';
 import { useEntityBlockEditor } from '@wordpress/core-data';
 import { buildWidgetAreasPostId, KIND, POST_TYPE } from '../../store/utils';
+import useLastSelectedWidgetArea from '../../hooks/use-last-selected-widget-area';
 
 export default function WidgetAreasBlockEditorProvider( {
 	blockEditorSettings,
@@ -66,6 +67,8 @@ export default function WidgetAreasBlockEditorProvider( {
 		};
 	}, [ blockEditorSettings, hasUploadPermissions, reusableBlocks ] );
 
+	const widgetAreaId = useLastSelectedWidgetArea();
+
 	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
 		KIND,
 		POST_TYPE,
@@ -89,7 +92,9 @@ export default function WidgetAreasBlockEditorProvider( {
 							{ ...props }
 						>
 							{ children }
-							<ReusableBlocksButtons />
+							<ReusableBlocksButtons
+								rootClientId={ widgetAreaId }
+							/>
 						</BlockEditorProvider>
 					</FocusReturnProvider>
 				</DropZoneProvider>

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
@@ -19,6 +19,7 @@ import {
 	BlockEditorKeyboardShortcuts,
 	__unstableEditorStyles as EditorStyles,
 } from '@wordpress/block-editor';
+import { ReusableBlocksButtons } from '@wordpress/reusable-blocks';
 
 /**
  * Internal dependencies
@@ -29,15 +30,22 @@ import { buildWidgetAreasPostId, KIND, POST_TYPE } from '../../store/utils';
 
 export default function WidgetAreasBlockEditorProvider( {
 	blockEditorSettings,
+	children,
 	...props
 } ) {
-	const { hasUploadPermissions } = useSelect( ( select ) => ( {
-		hasUploadPermissions: defaultTo(
-			select( 'core' ).canUser( 'create', 'media' ),
-			true
-		),
-		widgetAreas: select( 'core/edit-widgets' ).getWidgetAreas(),
-	} ) );
+	const { hasUploadPermissions, reusableBlocks } = useSelect(
+		( select ) => ( {
+			hasUploadPermissions: defaultTo(
+				select( 'core' ).canUser( 'create', 'media' ),
+				true
+			),
+			widgetAreas: select( 'core/edit-widgets' ).getWidgetAreas(),
+			reusableBlocks: select( 'core' ).getEntityRecords(
+				'postType',
+				'wp_block'
+			),
+		} )
+	);
 
 	const settings = useMemo( () => {
 		let mediaUploadBlockEditor;
@@ -52,10 +60,11 @@ export default function WidgetAreasBlockEditorProvider( {
 		}
 		return {
 			...blockEditorSettings,
+			__experimentalReusableBlocks: reusableBlocks,
 			mediaUpload: mediaUploadBlockEditor,
 			templateLock: 'all',
 		};
-	}, [ blockEditorSettings, hasUploadPermissions ] );
+	}, [ blockEditorSettings, hasUploadPermissions, reusableBlocks ] );
 
 	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
 		KIND,
@@ -78,7 +87,10 @@ export default function WidgetAreasBlockEditorProvider( {
 							settings={ settings }
 							useSubRegistry={ false }
 							{ ...props }
-						/>
+						>
+							{ children }
+							<ReusableBlocksButtons />
+						</BlockEditorProvider>
 					</FocusReturnProvider>
 				</DropZoneProvider>
 			</SlotFillProvider>

--- a/packages/edit-widgets/src/index.js
+++ b/packages/edit-widgets/src/index.js
@@ -11,6 +11,7 @@ import {
 	registerCoreBlocks,
 	__experimentalRegisterExperimentalCoreBlocks,
 } from '@wordpress/block-library';
+import '@wordpress/reusable-blocks';
 
 /**
  * Internal dependencies

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/index.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/index.js
@@ -9,10 +9,13 @@ import { withSelect } from '@wordpress/data';
 import ReusableBlockConvertButton from './reusable-block-convert-button';
 import ReusableBlockDeleteButton from './reusable-block-delete-button';
 
-function ReusableBlocksMenuItems( { clientIds } ) {
+function ReusableBlocksMenuItems( { clientIds, rootClientId } ) {
 	return (
 		<>
-			<ReusableBlockConvertButton clientIds={ clientIds } />
+			<ReusableBlockConvertButton
+				clientIds={ clientIds }
+				rootClientId={ rootClientId }
+			/>
 			{ clientIds.length === 1 && (
 				<ReusableBlockDeleteButton clientId={ clientIds[ 0 ] } />
 			) }

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
@@ -17,12 +17,15 @@ import { STORE_KEY } from '../../store/constants';
 /**
  * Menu control to convert block(s) to reusable block.
  *
- * @param {Object}   props           Component props.
- * @param {string[]} props.clientIds Client ids of selected blocks.
- *
+ * @param {Object}   props              Component props.
+ * @param {string[]} props.clientIds    Client ids of selected blocks.
+ * @param {string}   props.rootClientId ID of the currently selected top-level block.
  * @return {import('@wordpress/element').WPComponent} The menu control or null.
  */
-export default function ReusableBlockConvertButton( { clientIds } ) {
+export default function ReusableBlockConvertButton( {
+	clientIds,
+	rootClientId,
+} ) {
 	const canConvert = useSelect(
 		( select ) => {
 			const { canUser } = select( 'core' );
@@ -46,7 +49,7 @@ export default function ReusableBlockConvertButton( { clientIds } ) {
 				// Hide when this is already a reusable block.
 				! isReusable &&
 				// Hide when reusable blocks are disabled.
-				canInsertBlockType( 'core/block' ) &&
+				canInsertBlockType( 'core/block', rootClientId ) &&
 				blocks.every(
 					( block ) =>
 						// Guard against the case where a regular block has *just* been converted.


### PR DESCRIPTION
## Description
This PR brings the support for reusable blocks into the widgets editor.

## How has this been tested?
1. Go to widgets editor
1. Confirm you are able to add/remove/update reusable blocks just like in the post editor
1. Confirm the inserter shows the list of reusable blocks once you have at least one
1. Save widgets, confirm it worked as expected

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
