### PR TITLE
Update the registration examples to use apiVersion 2

### DIFF
--- a/docs/designers-developers/developers/internationalization.md
+++ b/docs/designers-developers/developers/internationalization.md
@@ -24,10 +24,11 @@ function myguten_block_init() {
     wp_register_script(
         'myguten-script',
         plugins_url( 'block.js', __FILE__ ),
-        array( 'wp-blocks', 'wp-element', 'wp-i18n' )
+        array( 'wp-blocks', 'wp-element', 'wp-i18n', 'wp-block-editor' )
     );
 
     register_block_type( 'myguten/simple', array(
+		'apiVersion' => 2,
         'editor_script' => 'myguten-script',
     ) );
 }
@@ -41,22 +42,28 @@ In your code, you can include the i18n functions. The most common function is **
 ```js
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
+import { useBlockProps } from '@wordpress/block-editor';
 
 registerBlockType( 'myguten/simple', {
+	apiVersion: 2,
 	title: __( 'Simple Block', 'myguten' ),
 	category: 'widgets',
 
 	edit: () => {
+		const blockProps = useBlockProps( { style: { color: 'red' } } );
+
 		return (
-			<p style="color:red">
+			<p {...blockProps}>
 				{ __( 'Hello World', 'myguten' ) }
 			</p>
 		);
 	},
 
 	save: () => {
+		const blockProps = useBlockProps.save( { style: { color: 'red' } } );
+
 		return (
-			<p style="color:red">
+			<p {...blockProps}>
 				{ __( 'Hello World', 'myguten' ) }
 			</p>
 		);
@@ -68,23 +75,27 @@ registerBlockType( 'myguten/simple', {
 const { __ } = wp.i18n;
 const el = wp.element.createElement;
 const { registerBlockType } = wp.blocks;
+const { useBlockProps } = wp.blockEditor;
 
 registerBlockType( 'myguten/simple', {
 	title: __( 'Simple Block', 'myguten' ),
 	category: 'widgets',
 
 	edit: function() {
+		const blockProps = useBlockProps( { style: { color: 'red' } } );
+		
 		return el(
 			'p',
-			{ style: { color: 'red' } },
+			blockProps,
 			__( 'Hello World', 'myguten' )
 		);
 	},
 
 	save: function() {
+		const blockProps = useBlockProps.save( { style: { color: 'red' } } );
 		return el(
 			'p',
-			{ style: { color: 'red' } },
+			blockProps,
 			__( 'Hello World', 'myguten' )
 		);
 	},

--- a/docs/designers-developers/developers/richtext.md
+++ b/docs/designers-developers/developers/richtext.md
@@ -29,7 +29,7 @@ There are a number of core blocks using the RichText component. The JavaScript e
 {% ESNext %}
 ```js
 import { registerBlockType } from '@wordpress/blocks';
-import { RichText } from '@wordpress/block-editor';
+import { useBlockProps, RichText } from '@wordpress/block-editor';
 
 registerBlockType( /* ... */, {
 	// ...
@@ -42,11 +42,13 @@ registerBlockType( /* ... */, {
 		},
 	},
 
-	edit( { className, attributes, setAttributes } ) {
+	edit( { attributes, setAttributes } ) {
+		const blockProps = useBlockProps();
+
 		return (
 			<RichText
+				{ ...blockProps }
 				tagName="h2" // The tag here is the element output and editable in the admin
-				className={ className }
 				value={ attributes.content } // Any existing content, either from the database or an attribute default
 				formattingControls={ [ 'bold', 'italic' ] } // Allow the content to be made bold or italic, but do not allow other formatting options
 				onChange={ ( content ) => setAttributes( { content } ) } // Store updated content as a block attribute
@@ -56,7 +58,9 @@ registerBlockType( /* ... */, {
 	},
 
 	save( { attributes } ) {
-		return <RichText.Content tagName="h2" value={ attributes.content } />; // Saves <h2>Content added in the editor...</h2> to the database for frontend display
+		const blockProps = useBlockProps.save();
+
+		return <RichText.Content { ...blockProps } tagName="h2" value={ attributes.content } />; // Saves <h2>Content added in the editor...</h2> to the database for frontend display
 	}
 } );
 ```
@@ -74,22 +78,25 @@ wp.blocks.registerBlockType( /* ... */, {
 	},
 
 	edit: function( props ) {
-		return wp.element.createElement( wp.editor.RichText, {
+		var blockProps = wp.blockEditor.useBlockProps();
+
+		return wp.element.createElement( wp.blockEditor.RichText, Object.assign( blockProps, {
 			tagName: 'h2',  // The tag here is the element output and editable in the admin
-			className: props.className,
 			value: props.attributes.content, // Any existing content, either from the database or an attribute default
 			formattingControls: [ 'bold', 'italic' ], // Allow the content to be made bold or italic, but do not allow other formatting options
 			onChange: function( content ) {
 				props.setAttributes( { content: content } ); // Store updated content as a block attribute
 			},
 			placeholder: __( 'Heading...' ), // Display this text before any content has been added by the user
-		} );
+		} ) );
 	},
 
 	save: function( props ) {
-		return wp.element.createElement( wp.editor.RichText.Content, {
+		var blockProps = wp.blockEditor.useBlockProps();
+
+		return wp.element.createElement( wp.blockEditor.RichText.Content, Object.assign( blockProps, {
 			tagName: 'h2', value: props.attributes.content // Saves <h2>Content added in the editor...</h2> to the database for frontend display
-		} );
+		} ) );
 	}
 } );
 ```

--- a/docs/designers-developers/developers/richtext.md
+++ b/docs/designers-developers/developers/richtext.md
@@ -92,7 +92,7 @@ wp.blocks.registerBlockType( /* ... */, {
 	},
 
 	save: function( props ) {
-		var blockProps = wp.blockEditor.useBlockProps();
+		var blockProps = wp.blockEditor.useBlockProps.save();
 
 		return wp.element.createElement( wp.blockEditor.RichText.Content, Object.assign( blockProps, {
 			tagName: 'h2', value: props.attributes.content // Saves <h2>Content added in the editor...</h2> to the database for frontend display

--- a/docs/designers-developers/developers/tutorials/block-tutorial/applying-styles-with-stylesheets.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/applying-styles-with-stylesheets.md
@@ -8,8 +8,11 @@ The editor will automatically generate a class name for each block type to simpl
 {% ESNext %}
 ```jsx
 import { registerBlockType } from '@wordpress/blocks';
+import { useBlockProps } from '@wordpress/block-editor';
 
 registerBlockType( 'gutenberg-examples/example-02-stylesheets', {
+	apiVersion: 2,
+
 	title: 'Example: Stylesheets',
 
 	icon: 'universal-access-alt',
@@ -18,43 +21,51 @@ registerBlockType( 'gutenberg-examples/example-02-stylesheets', {
 
 	example: {},
 
-	edit( { className } ) {
-		return <p className={ className }>Hello World, step 2 (from the editor, in green).</p>;
+	edit() {
+		const blockProps = useBlockProps();
+
+		return <p { ...blockProps }>Hello World, step 2 (from the editor, in green).</p>;
 	},
 
 	save() {
-		return <p>Hello World, step 2 (from the frontend, in red).</p>;
+		const blockProps = useBlockProps.save();
+
+		return <p { ...blockProps }>Hello World, step 2 (from the frontend, in red).</p>;
 	},
 } );
 ```
 {% ES5 %}
 ```js
-( function( blocks, element ) {
+( function( blocks, element, blockEditor ) {
 	var el = element.createElement;
 
 	blocks.registerBlockType( 'gutenberg-examples/example-02-stylesheets', {
+		apiVersion: 2,
 		title: 'Example: Stylesheets',
 		icon: 'universal-access-alt',
 		category: 'design',
 		example: {},
 		edit: function( props ) {
+			var blockProps = blockEditor.useBlockProps();
 			return el(
 				'p',
-				{ className: props.className },
+				blockProps,
 				'Hello World, step 2 (from the editor, in green).'
 			);
 		},
 		save: function() {
+			var blockProps = blockEditor.useBlockProps.save();
 			return el(
 				'p',
-				{},
+				blockProps,
 				'Hello World, step 2 (from the frontend, in red).'
 			);
 		},
 	} );
 }(
 	window.wp.blocks,
-	window.wp.element
+	window.wp.element,
+	window.wp.blockEditor,
 ) );
 ```
 {% end %}
@@ -120,6 +131,7 @@ function gutenberg_examples_02_register_block() {
 	);
 
 	register_block_type( 'gutenberg-examples/example-02-stylesheets', array(
+		'apiVersion' => 2,
 		'style' => 'gutenberg-examples-02',
 		'editor_style' => 'gutenberg-examples-02-editor',
 		'editor_script' => 'gutenberg-examples-02',

--- a/docs/designers-developers/developers/tutorials/block-tutorial/block-controls-toolbar-and-sidebar.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/block-controls-toolbar-and-sidebar.md
@@ -16,12 +16,14 @@ You can also customize the toolbar to include controls specific to your block ty
 import { registerBlockType } from '@wordpress/blocks';
 
 import {
+	useBlockProps,
 	RichText,
 	AlignmentToolbar,
 	BlockControls,
 } from '@wordpress/block-editor';
 
 registerBlockType( 'gutenberg-examples/example-04-controls-esnext', {
+	apiVersion: 2,
 	title: 'Example: Controls (esnext)',
 	icon: 'universal-access-alt',
 	category: 'design',
@@ -48,8 +50,9 @@ registerBlockType( 'gutenberg-examples/example-04-controls-esnext', {
 				content,
 				alignment,
 			},
-			className,
 		} = props;
+
+		const blockProps = useBlockProps();
 
 		const onChangeContent = ( newContent ) => {
 			props.setAttributes( { content: newContent } );
@@ -60,7 +63,7 @@ registerBlockType( 'gutenberg-examples/example-04-controls-esnext', {
 		};
 
 		return (
-			<div>
+			<div {...blockProps}>
 				{
 					<BlockControls>
 						<AlignmentToolbar
@@ -80,23 +83,28 @@ registerBlockType( 'gutenberg-examples/example-04-controls-esnext', {
 		);
 	},
 	save: ( props ) => {
+		const blockProps = useBlockProps.save();
+
 		return (
-			<RichText.Content
-				className={ `gutenberg-examples-align-${ props.attributes.alignment }` }
-				tagName="p"
-				value={ props.attributes.content }
-			/>
+			<div {...blockProps}>
+				<RichText.Content
+					className={ `gutenberg-examples-align-${ props.attributes.alignment }` }
+					tagName="p"
+					value={ props.attributes.content }
+				/>
+			</div>
 		);
 	},
 } );
 ```
 {% ES5 %}
 ```js
-( function( blocks, editor, element ) {
+( function( blocks, blockEditor, element ) {
 	var el = element.createElement;
-	var RichText = editor.RichText;
-	var AlignmentToolbar = editor.AlignmentToolbar;
-	var BlockControls = editor.BlockControls;
+	var RichText = blockEditor.RichText;
+	var AlignmentToolbar = blockEditor.AlignmentToolbar;
+	var BlockControls = blockEditor.BlockControls;
+	var useBlockProps = blockEditor.useBlockProps;
 
 	blocks.registerBlockType( 'gutenberg-examples/example-04-controls', {
 		title: 'Example: Controls',
@@ -123,6 +131,7 @@ registerBlockType( 'gutenberg-examples/example-04-controls-esnext', {
 		edit: function( props ) {
 			var content = props.attributes.content;
 			var alignment = props.attributes.alignment;
+			var blockProps = useBlockProps();
 
 			function onChangeContent( newContent ) {
 				props.setAttributes( { content: newContent } );
@@ -132,7 +141,9 @@ registerBlockType( 'gutenberg-examples/example-04-controls-esnext', {
 				props.setAttributes( { alignment: newAlignment === undefined ? 'none' : newAlignment } );
 			}
 
-			return [
+			return el( 
+				'div', 
+				blockProps, 
 				el(
 					BlockControls,
 					{ key: 'controls' },
@@ -150,25 +161,30 @@ registerBlockType( 'gutenberg-examples/example-04-controls-esnext', {
 						key: 'richtext',
 						tagName: 'p',
 						style: { textAlign: alignment },
-						className: props.className,
 						onChange: onChangeContent,
 						value: content,
 					}
 				),
-			];
+			);
 		},
 
 		save: function( props ) {
-			return el( RichText.Content, {
-				tagName: 'p',
-				className: 'gutenberg-examples-align-' + props.attributes.alignment,
-				value: props.attributes.content,
-			} );
+			var blockProps = useBlockProps.save();
+
+			return el( 
+				'div', 
+				blockProps, 
+				el( RichText.Content, {
+					tagName: 'p',
+					className: 'gutenberg-examples-align-' + props.attributes.alignment,
+					value: props.attributes.content,
+				} ) 
+			);
 		},
 	} );
 }(
 	window.wp.blocks,
-	window.wp.editor,
+	window.wp.blockEditor,
 	window.wp.element
 ) );
 ```

--- a/docs/designers-developers/developers/tutorials/block-tutorial/creating-dynamic-blocks.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/creating-dynamic-blocks.md
@@ -22,8 +22,10 @@ The following code example shows how to create a dynamic block that shows only t
 ```jsx
 import { registerBlockType } from '@wordpress/blocks';
 import { withSelect } from '@wordpress/data';
+import { useBlockProps } from '@wordpress/block-editor';
 
 registerBlockType( 'gutenberg-examples/example-dynamic', {
+	apiVersion: 2,
 	title: 'Example: last post',
 	icon: 'megaphone',
 	category: 'widgets',
@@ -32,31 +34,34 @@ registerBlockType( 'gutenberg-examples/example-dynamic', {
 		return {
 			posts: select( 'core' ).getEntityRecords( 'postType', 'post' ),
 		};
-	} )( ( { posts, className } ) => {
-		if ( ! posts ) {
-			return 'Loading...';
-		}
+	} )( ( { posts } ) => {
+		const blockProps = useBlockProps();
 
-		if ( posts && posts.length === 0 ) {
-			return 'No posts';
-		}
-
-		const post = posts[ 0 ];
-
-		return <a className={ className } href={ post.link }>
-			{ post.title.rendered }
-		</a>;
+		return (
+			<div { ...blockProps }>
+				{ ! posts && 'Loading' }
+				{ posts && posts.length === 0 && 'No Posts' }
+				{ posts && posts.length > 0 && (
+					<a href={ posts[ 0 ].link }>
+						{ posts[ 0 ].title.rendered }
+					</a>
+				) } 
+			</div>
+		)
+		
 	} ),
 } );
 ```
 {% ES5 %}
 ```js
-( function( blocks, element, data ) {
+( function( blocks, element, data, blockEditor ) {
 	var el = element.createElement,
 		registerBlockType = blocks.registerBlockType,
-		withSelect = data.withSelect;
+		withSelect = data.withSelect,
+		useBlockProps = blockEditor.useBlockProps;
 
 	registerBlockType( 'gutenberg-examples/example-dynamic', {
+		apiVersion: 2,
 		title: 'Example: last post',
 		icon: 'megaphone',
 		category: 'widgets',
@@ -65,20 +70,25 @@ registerBlockType( 'gutenberg-examples/example-dynamic', {
 				posts: select( 'core' ).getEntityRecords( 'postType', 'post' ),
 			};
 		} )( function( props ) {
+			var blockProps = useBlockProps();
+			var content;
 			if ( ! props.posts ) {
-				return 'Loading...';
+				content = 'Loading...';
+			} else if ( props.posts.length === 0 ) {
+				content = 'No posts';
+			} else {
+				var post = props.posts[ 0 ];
+				content = el(
+					'a',
+					{ href: post.link },
+					post.title.rendered
+				);
 			}
 
-			if ( props.posts.length === 0 ) {
-				return 'No posts';
-			}
-			var className = props.className;
-			var post = props.posts[ 0 ];
-
-			return el(
-				'a',
-				{ className: className, href: post.link },
-				post.title.rendered
+			return el( 
+				'div',
+				blockProps,
+				content
 			);
 		} ),
 	} );
@@ -86,6 +96,7 @@ registerBlockType( 'gutenberg-examples/example-dynamic', {
 	window.wp.blocks,
 	window.wp.element,
 	window.wp.data,
+	window.wp.blockEditor,
 ) );
 ```
 {% end %}
@@ -128,6 +139,7 @@ function gutenberg_examples_dynamic() {
 	);
 
 	register_block_type( 'gutenberg-examples/example-dynamic', array(
+		'apiVersion' => 2,
 		'editor_script' => 'gutenberg-examples-dynamic',
 		'render_callback' => 'gutenberg_examples_dynamic_render_callback'
 	) );
@@ -154,40 +166,52 @@ Gutenberg 2.8 added the [`<ServerSideRender>`](/packages/server-side-render/READ
 ```jsx
 import { registerBlockType } from '@wordpress/blocks';
 import ServerSideRender from '@wordpress/server-side-render';
+import { useBlockProps } from '@wordpress/block-editor';
 
 registerBlockType( 'gutenberg-examples/example-dynamic', {
+	apiVersion: 2,
 	title: 'Example: last post',
 	icon: 'megaphone',
 	category: 'widgets',
 
 	edit: function( props ) {
+		const blockProps = useBlockProps();
 		return (
-			<ServerSideRender
-				block="gutenberg-examples/example-dynamic"
-				attributes={ props.attributes }
-			/>
+			<div {...blockProps}>
+				<ServerSideRender
+					block="gutenberg-examples/example-dynamic"
+					attributes={ props.attributes }
+				/>
+			</div>
 		);
 	},
 } );
 ```
 {% ES5 %}
 ```js
-( function( blocks, element, serverSideRender ) {
+( function( blocks, element, serverSideRender, blockEditor ) {
 	var el = element.createElement,
 		registerBlockType = blocks.registerBlockType,
-		ServerSideRender = serverSideRender;
+		ServerSideRender = serverSideRender,
+		useBlockProps = blockEditor.useBlockProps;
 
 	registerBlockType( 'gutenberg-examples/example-dynamic', {
+		apiVersion: 2,
 		title: 'Example: last post',
 		icon: 'megaphone',
 		category: 'widgets',
 
 		edit: function( props ) {
+			var blockProps = useBlockProps();
 			return (
-				el( ServerSideRender, {
-					block: 'gutenberg-examples/example-dynamic',
-					attributes: props.attributes,
-				} )
+				el(
+					'div',
+					blockProps,
+					el( ServerSideRender, {
+						block: 'gutenberg-examples/example-dynamic',
+						attributes: props.attributes,
+					} )
+				)
 			);
 		},
 	} );
@@ -195,6 +219,7 @@ registerBlockType( 'gutenberg-examples/example-dynamic', {
 	window.wp.blocks,
 	window.wp.element,
 	window.wp.serverSideRender,
+	window.wp.blockEditor,
 ) );
 ```
 {% end %}

--- a/docs/designers-developers/developers/tutorials/block-tutorial/introducing-attributes-and-editable-fields.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/introducing-attributes-and-editable-fields.md
@@ -56,9 +56,10 @@ Here is the complete block definition for Example 03.
 {% ESNext %}
 ```jsx
 import { registerBlockType } from '@wordpress/blocks';
-import { RichText } from '@wordpress/block-editor';
+import { useBlockProps, RichText } from '@wordpress/block-editor';
 
 registerBlockType( 'gutenberg-examples/example-03-editable-esnext', {
+	apiVersion: 2,
 	title: 'Example: Editable (esnext)',
 	icon: 'universal-access-alt',
 	category: 'design',
@@ -76,30 +77,34 @@ registerBlockType( 'gutenberg-examples/example-03-editable-esnext', {
 	},
 	edit: ( props ) => {
 		const { attributes: { content }, setAttributes, className } = props;
+		const blockProps = useBlockProps();
 		const onChangeContent = ( newContent ) => {
 			setAttributes( { content: newContent } );
 		};
 		return (
 			<RichText
+				{ ...blockProps }
 				tagName="p"
-				className={ className }
 				onChange={ onChangeContent }
 				value={ content }
 			/>
 		);
 	},
 	save: ( props ) => {
-		return <RichText.Content tagName="p" value={ props.attributes.content } />;
+		const blockProps = useBlockProps.save();
+		return <RichText.Content { ...blockProps } tagName="p" value={ props.attributes.content } />;
 	},
 } );
 ```
 {% ES5 %}
 ```js
-( function( blocks, editor, element ) {
+( function( blocks, blockEditor, element ) {
 	var el = element.createElement;
-	var RichText = editor.RichText;
+	var RichText = blockEditor.RichText;
+	var useBlockProps = blockEditor.useBlockProps;
 
 	blocks.registerBlockType( 'gutenberg-examples/example-03-editable', {
+		apiVersion: 2,
 		title: 'Example: Editable',
 		icon: 'universal-access-alt',
 		category: 'design',
@@ -117,6 +122,7 @@ registerBlockType( 'gutenberg-examples/example-03-editable-esnext', {
 			},
 		},
 		edit: function( props ) {
+			var blockProps = useBlockProps();
 			var content = props.attributes.content;
 			function onChangeContent( newContent ) {
 				props.setAttributes( { content: newContent } );
@@ -124,24 +130,25 @@ registerBlockType( 'gutenberg-examples/example-03-editable-esnext', {
 
 			return el(
 				RichText,
-				{
+				Object.assign( blockProps, {
 					tagName: 'p',
-					className: props.className,
 					onChange: onChangeContent,
 					value: content,
-				}
+				} )
 			);
 		},
 
 		save: function( props ) {
-			return el( RichText.Content, {
-				tagName: 'p', value: props.attributes.content,
-			} );
+			var blockProps = useBlockProps.save();
+			return el( RichText.Content, Object.assign( blockProps, {
+				tagName: 'p', 
+				value: props.attributes.content,
+			} ) );
 		},
 	} );
 }(
 	window.wp.blocks,
-	window.wp.editor,
+	window.wp.blockEditor,
 	window.wp.element
 ) );
 ```

--- a/docs/designers-developers/developers/tutorials/block-tutorial/nested-blocks-inner-blocks.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/nested-blocks-inner-blocks.md
@@ -10,22 +10,26 @@ Here is the basic InnerBlocks usage.
 {% ESNext %}
 ```js
 import { registerBlockType } from '@wordpress/blocks';
-import { InnerBlocks } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
 registerBlockType( 'gutenberg-examples/example-06', {
 	// ...
 
-	edit: ( { className } ) => {
+	edit: () => {
+		const blockProps = useBlockProps();
+
 		return (
-			<div className={ className }>
+			<div { ...blockProps }>
 				<InnerBlocks />
 			</div>
 		);
 	},
 
-	save: ( { className } ) => {
+	save: () => {
+		const blockProps = useBlockProps.save();
+
 		return (
-			<div className={ className }>
+			<div { ...blockProps }>
 				<InnerBlocks.Content />
 			</div>
 		);
@@ -37,23 +41,28 @@ registerBlockType( 'gutenberg-examples/example-06', {
 ( function( blocks, element, blockEditor ) {
 	var el = element.createElement;
 	var InnerBlocks = blockEditor.InnerBlocks;
+	var useBlockProps = blockEditor.useBlockProps;
 
 	blocks.registerBlockType( 'gutenberg-examples/example-06', {
 		title: 'Example: Inner Blocks',
 		category: 'design',
 
-		edit: function( props ) {
+		edit: function() {
+			var blockProps = useBlockProps();
+
 			return el(
 				'div',
-				{ className: props.className },
+				blockProps,
 				el( InnerBlocks )
 			);
 		},
 
-		save: function( props ) {
+		save: function() {
+			var blockProps = useBlockProps.save();
+
 			return el(
 				'div',
-				{ className: props.className },
+				blockProps,
 				el( InnerBlocks.Content )
 			);
 		},

--- a/docs/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type.md
@@ -28,6 +28,7 @@ function gutenberg_examples_01_register_block() {
 	);
 
 	register_block_type( 'gutenberg-examples/example-01-basic-esnext', array(
+		'apiVersion' => 2,
 		'editor_script' => 'gutenberg-examples-01-esnext',
 	) );
 
@@ -51,6 +52,7 @@ With the script enqueued, let's look at the implementation of the block itself:
 {% ESNext %}
 ```jsx
 import { registerBlockType } from '@wordpress/blocks';
+import { useBlockProps } from '@wordpress/block-editor';
 
 const blockStyle = {
 	backgroundColor: '#900',
@@ -59,22 +61,28 @@ const blockStyle = {
 };
 
 registerBlockType( 'gutenberg-examples/example-01-basic-esnext', {
+	apiVersion: 2,
 	title: 'Example: Basic (esnext)',
 	icon: 'universal-access-alt',
 	category: 'design',
 	example: {},
 	edit() {
-		return <div style={ blockStyle }>Hello World, step 1 (from the editor).</div>;
+		const blockProps = useBlockProps( { style: blockStyle } );
+
+		return <div { ...blockProps }>Hello World, step 1 (from the editor).</div>;
 	},
 	save() {
-		return <div style={ blockStyle }>Hello World, step 1 (from the frontend).</div>;
+		const blockProps = useBlockProps.save( { style: blockStyle } );
+
+		return <div { ...blockProps }>Hello World, step 1 (from the frontend).</div>;
 	},
 } );
 ```
 {% ES5 %}
 ```js
-( function( blocks, element ) {
+( function( blocks, element, blockEditor ) {
 	var el = element.createElement;
+	var useBlockProps = blockEditor.useBlockProps;
 
 	var blockStyle = {
 		backgroundColor: '#900',
@@ -83,28 +91,32 @@ registerBlockType( 'gutenberg-examples/example-01-basic-esnext', {
 	};
 
 	blocks.registerBlockType( 'gutenberg-examples/example-01-basic', {
+		apiVersion: 2,
 		title: 'Example: Basic',
 		icon: 'universal-access-alt',
 		category: 'design',
 		example: {},
 		edit: function() {
+			var blockProps = useBlockProps( { style: blockStyle } );
 			return el(
 				'p',
-				{ style: blockStyle },
+				blockProps,
 				'Hello World, step 1 (from the editor).'
 			);
 		},
 		save: function() {
+			var blockProps = useBlockProps.save( { style: blockStyle } );
 			return el(
 				'p',
-				{ style: blockStyle },
+				blockProps,
 				'Hello World, step 1 (from the frontend).'
 			);
 		},
 	} );
 }(
 	window.wp.blocks,
-	window.wp.element
+	window.wp.element,
+	window.wp.blockEditor
 ) );
 ```
 {% end %}

--- a/docs/designers-developers/developers/tutorials/create-block/block-anatomy.md
+++ b/docs/designers-developers/developers/tutorials/create-block/block-anatomy.md
@@ -8,8 +8,10 @@ Here is the complete code for registering a block:
 
 ```js
 import { registerBlockType } from '@wordpress/blocks';
+import { useBlockProps } from '@wordpress/block-editor';
 
 registerBlockType( 'create-block/gutenpride', {
+	apiVersion: 2,
 	title: 'Gutenpride',
 	description: 'Example block.',
 	category: 'widgets',
@@ -20,11 +22,13 @@ registerBlockType( 'create-block/gutenpride', {
 	},
 
 	edit: () => {
-		return <div> Hello in Editor. </div>;
+		const blockProps = useBlockProps();
+		return <div { ...blockProps }> Hello in Editor. </div>;
 	},
 
 	save: () => {
-		return <div> Hello in Save.</div>;
+		const blockProps = useBlockProps.save();
+		return <div { ...blockProps }> Hello in Save.</div>;
 	},
 } );
 ```

--- a/docs/designers-developers/developers/tutorials/create-block/block-code.md
+++ b/docs/designers-developers/developers/tutorials/create-block/block-code.md
@@ -12,6 +12,7 @@ In the `gutenpride.php` file, the enqueue process is already setup from the gene
 
 ```php
 register_block_type( 'create-block/gutenpride', array(
+	'apiVersion' => 2,
     'editor_script' => 'create-block-gutenpride-block-editor',
     'editor_style'  => 'create-block-gutenpride-block-editor',
     'style'         => 'create-block-gutenpride-block',

--- a/docs/designers-developers/developers/tutorials/create-block/wp-plugin.md
+++ b/docs/designers-developers/developers/tutorials/create-block/wp-plugin.md
@@ -127,6 +127,7 @@ function create_block_gutenpride_block_init() {
 	);
 
 	register_block_type( 'create-block/gutenpride', array(
+		'apiVersion' => 2,
 		'editor_script' => 'create-block-gutenpride-block-editor',
 		'editor_style'  => 'create-block-gutenpride-block-editor',
 		'style'         => 'create-block-gutenpride-block',

--- a/docs/designers-developers/developers/tutorials/metabox/meta-block-3-add.md
+++ b/docs/designers-developers/developers/tutorials/metabox/meta-block-3-add.md
@@ -15,13 +15,15 @@ import { registerBlockType } from '@wordpress/blocks';
 import { TextControl } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useEntityProp } from '@wordpress/core-data';
+import { useBlockProps } from '@wordpress/block-editor';
 
 registerBlockType( 'myguten/meta-block', {
 	title: 'Meta Block',
 	icon: 'smiley',
 	category: 'text',
 
-	edit( { className, setAttributes, attributes } ) {
+	edit( { setAttributes, attributes } ) {
+		const blockProps = useBlockProps();
 		const postType = useSelect(
 			( select ) => select( 'core/editor' ).getCurrentPostType(),
 			[]
@@ -37,7 +39,7 @@ registerBlockType( 'myguten/meta-block', {
 		}
 
 		return (
-			<div className={ className }>
+			<div { ...blockProps }>
 				<TextControl
 					label="Meta Block Field"
 					value={ metaFieldValue }
@@ -62,6 +64,7 @@ registerBlockType( 'myguten/meta-block', {
 	var TextControl = wp.components.TextControl;
 	var useSelect = wp.data.useSelect;
 	var useEntityProp = wp.coreData.useEntityProp;
+	var useBlockProps = wp.blockEditor.useBlockProps;
 
 	registerBlockType( 'myguten/meta-block', {
 		title: 'Meta Block',
@@ -69,8 +72,7 @@ registerBlockType( 'myguten/meta-block', {
 		category: 'text',
 
 		edit: function( props ) {
-			var className = props.className;
-
+			var blockProps = useBlockProps();
 			var postType = useSelect(
 				function( select ) {
 					return select( 'core/editor' ).getCurrentPostType();
@@ -100,7 +102,7 @@ registerBlockType( 'myguten/meta-block', {
 
 			return el(
 				'div',
-				{ className: className },
+				blockProps,
 				el( TextControl, {
 					label: 'Meta Block Field',
 					value: metaFieldValue,

--- a/docs/designers-developers/developers/tutorials/metabox/meta-block-4-use-data.md
+++ b/docs/designers-developers/developers/tutorials/metabox/meta-block-4-use-data.md
@@ -36,6 +36,7 @@ function myguten_render_paragraph( $block_attributes, $content ) {
 }
 
 register_block_type( 'core/paragraph', array(
+	'apiVersion' => 2,
 	'render_callback' => 'myguten_render_paragraph',
 ) );
 ```

--- a/packages/block-editor/src/components/block-vertical-alignment-toolbar/README.md
+++ b/packages/block-editor/src/components/block-vertical-alignment-toolbar/README.md
@@ -15,6 +15,7 @@ import { registerBlockType } from '@wordpress/blocks';
 import {
 	BlockControls,
 	BlockVerticalAlignmentToolbar,
+	useBlockProps,
 } from '@wordpress/block-editor';
 
 registerBlockType( 'my-plugin/my-block', {
@@ -30,6 +31,7 @@ registerBlockType( 'my-plugin/my-block', {
 	},
 
 	edit( { attributes, setAttributes } ) {
+		const blockProps = useBlockProps();
 		
 		const { verticalAlignment } = attributes;
 
@@ -44,7 +46,7 @@ registerBlockType( 'my-plugin/my-block', {
 						value={ verticalAlignment }
 					/>
 				</BlockControls>
-				<div>
+				<div { ...blockProps }>
 					// your Block here
 				</div>
 			</>

--- a/packages/block-editor/src/components/inner-blocks/README.md
+++ b/packages/block-editor/src/components/inner-blocks/README.md
@@ -11,22 +11,26 @@ In a block's `edit` implementation, render `InnerBlocks`. Then, in the `save` im
 
 ```jsx
 import { registerBlockType } from '@wordpress/blocks';
-import { InnerBlocks } from '@wordpress/block-editor';
+import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 
 registerBlockType( 'my-plugin/my-block', {
 	// ...
 
-	edit( { className } ) {
+	edit() {
+		const blockProps = useBlockProps();
+
 		return (
-			<div className={ className }>
+			<div { ...blockProps }>
 				<InnerBlocks />
 			</div>
 		);
 	},
 
 	save() {
+		const blockProps = useBlockProps.save();
+
 		return (
-			<div>
+			<div { ...blockProps }>
 				<InnerBlocks.Content />
 			</div>
 		);

--- a/packages/block-editor/src/components/inspector-controls/README.md
+++ b/packages/block-editor/src/components/inspector-controls/README.md
@@ -13,7 +13,8 @@ var el = wp.element.createElement,
 	Fragment = wp.element.Fragment,
 	registerBlockType = wp.blocks.registerBlockType,
 	RichText = wp.editor.RichText,
-	InspectorControls = wp.editor.InspectorControls,
+	InspectorControls = wp.blockEditor.InspectorControls,
+	useBlockProps = wp.blockEditor.useBlockProps,
 	CheckboxControl = wp.components.CheckboxControl,
 	RadioControl = wp.components.RadioControl,
 	TextControl = wp.components.TextControl,
@@ -21,6 +22,8 @@ var el = wp.element.createElement,
 	SelectControl = wp.components.SelectControl;
 
 registerBlockType( 'my-plugin/inspector-controls-example', {
+	apiVersion: 2,
+
 	title: 'Inspector controls example',
 
 	icon: 'universal-access-alt',
@@ -53,6 +56,8 @@ registerBlockType( 'my-plugin/inspector-controls-example', {
 	},
 
 	edit: function( props ) {
+		var blockProps = useBlockProps();
+		
 		var content = props.attributes.content,
 			checkboxField = props.attributes.checkboxField,
 			radioField = props.attributes.radioField,
@@ -161,18 +166,19 @@ registerBlockType( 'my-plugin/inspector-controls-example', {
 				),
 				el(
 					RichText,
-					{
+					Object.assing( blockProps, {
 						key: 'editable',
 						tagName: 'p',
 						onChange: onChangeContent,
 						value: content
-					}
+					} )
 				)
 			)
 		);
 	},
 
 	save: function( props ) {
+		var blockProps  = useBlockProps.save();
 		var content = props.attributes.content,
 			checkboxField = props.attributes.checkboxField,
 			radioField = props.attributes.radioField,
@@ -182,7 +188,7 @@ registerBlockType( 'my-plugin/inspector-controls-example', {
 
 		return el(
 			'div',
-			null,
+			blockProps,
 			el(
 				RichText.Content,
 				{
@@ -236,19 +242,22 @@ registerBlockType( 'my-plugin/inspector-controls-example', {
 {% ESNext %}
 ```js
 import { registerBlockType } from '@wordpress/blocks';
-const {
+import {
 	CheckboxControl,
 	RadioControl,
 	TextControl,
 	ToggleControl,
-	SelectControl,
-} = wp.components;
-const {
+	SelectControl
+} from '@wordpress/components';
+import {
 	RichText,
 	InspectorControls,
-} = wp.editor;
+	useBlockProps
+} from '@wordpress/block-editor';
 
 registerBlockType( 'my-plugin/inspector-controls-example', {
+	apiVersion: 2,
+
 	title: 'Inspector controls example',
 
 	icon: 'universal-access-alt',
@@ -281,6 +290,7 @@ registerBlockType( 'my-plugin/inspector-controls-example', {
 	},
 
 	edit( { attributes, setAttributes } ) {
+		const blockProps = useBlockProps();
 		const { content, checkboxField, radioField, textField, toggleField, selectField } = attributes;
 
 		function onChangeContent( newContent ) {
@@ -360,6 +370,7 @@ registerBlockType( 'my-plugin/inspector-controls-example', {
 				</InspectorControls>
 
 				<RichText
+					{ ...blockProps }
 					key="editable"
 					tagName="p"
 					onChange={ onChangeContent }
@@ -371,9 +382,10 @@ registerBlockType( 'my-plugin/inspector-controls-example', {
 
 	save( { attributes } ) {
 		const { content, checkboxField, radioField, textField, toggleField, selectField } = attributes;
+		const blockProps = useBlockProps.save();
 
 		return (
-			<div>
+			<div { ...blockProps }>
 				<RichText.Content
 					value={ content }
 					tagName="p"

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -73,7 +73,7 @@ function random_image_enqueue_block_editor_assets() {
 	wp_enqueue_script(
 		'random-image-block',
 		plugins_url( 'block.js', __FILE__ ),
-		array( 'wp-blocks', 'wp-element' )
+		array( 'wp-blocks', 'wp-element', 'wp-block-editor', )
 	);
 }
 add_action( 'enqueue_block_editor_assets', 'random_image_enqueue_block_editor_assets' );
@@ -81,9 +81,10 @@ add_action( 'enqueue_block_editor_assets', 'random_image_enqueue_block_editor_as
 
 ```js
 // block.js
-( function( blocks, element ) {
+( function( blocks, element, blockEditor ) {
 	var el = element.createElement,
-		source = blocks.source;
+		source = blocks.source,
+		useBlockProps = blockEditor.useBlockProps;
 
 	function RandomImage( props ) {
 		var src = 'http://lorempixel.com/400/200/' + props.category;
@@ -95,6 +96,8 @@ add_action( 'enqueue_block_editor_assets', 'random_image_enqueue_block_editor_as
 	}
 
 	blocks.registerBlockType( 'myplugin/random-image', {
+		apiVersion: 2,
+
 		title: 'Random Image',
 
 		icon: 'format-image',
@@ -111,6 +114,7 @@ add_action( 'enqueue_block_editor_assets', 'random_image_enqueue_block_editor_as
 		},
 
 		edit: function( props ) {
+			var blockProps = useBlockProps();
 			var category = props.attributes.category,
 				children;
 
@@ -134,7 +138,7 @@ add_action( 'enqueue_block_editor_assets', 'random_image_enqueue_block_editor_as
 				)
 			);
 
-			return el( 'form', { onSubmit: setCategory }, children );
+			return el( 'form', Object.assing( blockProps, {  onSubmit: setCategory } ), children );
 		},
 
 		save: function( props ) {
@@ -143,7 +147,8 @@ add_action( 'enqueue_block_editor_assets', 'random_image_enqueue_block_editor_as
 	} );
 } )(
 	window.wp.blocks,
-	window.wp.element
+	window.wp.element,
+	window.wp.blockEditor
 );
 ```
 

--- a/packages/server-side-render/README.md
+++ b/packages/server-side-render/README.md
@@ -127,6 +127,7 @@ If you pass `attributes` to `ServerSideRender`, the block must also be registere
 register_block_type(
 	'core/archives',
 	array(
+		'apiVersion' => 2,
 		'attributes'      => array(
 			'showPostCounts'    => array(
 				'type'      => 'boolean',


### PR DESCRIPTION
This PR updates the block examples in our docs to use apiVersion: 2.

In addition to this PR, we'd need a few things:

 - An intro at the beginning of the registration docs to explain `useBlockProps`
 - A page dedicated to block api versions (like a changelog)
 - A migration guide from v1 to v2 (could serve as a dev note too)
 - A page dedicated to block supports flags.

I think we should create PRs for this and merge them together once we get close to the WordPress 5.6 release (to avoid confusing the developpers).