### PR TITLE
FullscreenMode: remove the is-fullscreen-mode CSS class from body on unmount

### DIFF
--- a/packages/interface/src/components/fullscreen-mode/index.js
+++ b/packages/interface/src/components/fullscreen-mode/index.js
@@ -22,6 +22,10 @@ export class FullscreenMode extends Component {
 		if ( this.isSticky ) {
 			document.body.classList.add( 'sticky-menu' );
 		}
+
+		if ( this.props.isActive ) {
+			document.body.classList.remove( 'is-fullscreen-mode' );
+		}
 	}
 
 	componentDidUpdate( prevProps ) {

--- a/packages/interface/src/components/fullscreen-mode/test/index.js
+++ b/packages/interface/src/components/fullscreen-mode/test/index.js
@@ -45,4 +45,25 @@ describe( 'FullscreenMode', () => {
 			true
 		);
 	} );
+
+	it( 'fullscreen mode to be removed from document body when component unmounted', () => {
+		// not present initially
+		expect( document.body.classList.contains( 'is-fullscreen-mode' ) ).toBe(
+			false
+		);
+
+		const mode = shallow( <FullscreenMode isActive /> );
+
+		// present after mounting with `isActive`
+		expect( document.body.classList.contains( 'is-fullscreen-mode' ) ).toBe(
+			true
+		);
+
+		mode.unmount();
+
+		// removed after unmounting
+		expect( document.body.classList.contains( 'is-fullscreen-mode' ) ).toBe(
+			false
+		);
+	} );
 } );


### PR DESCRIPTION
The `FullscreenMode` component adds the `is-fullscreen-mode` CSS class to `body` when mounted with `isActive={ true }`, adds and removes when the `isActive` prop changes, but _doesn't_ remove it when the component is unmounted.

This bug is not currently observable because the editor is always running in `wp-admin` context, mounted only once and never unmounted. As soon as the `FullscreenMode` component is used in a SPA with client-side router, unmounting on navigation to a different route would leave a stale `is-fullscreen-mode` class behind.