### PR TITLE
Limit block supports flag support to v2

### DIFF
--- a/lib/block-supports/index.php
+++ b/lib/block-supports/index.php
@@ -37,7 +37,7 @@ function gutenberg_apply_block_supports( $block_content, $block ) {
 
 	$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
 	// If no render_callback, assume styles have been previously handled.
-	if ( ! $block_type || ! $block_type->render_callback ) {
+	if ( ! $block_type || ! $block_type->apiVersion || ! $block_type->apiVersion < 2 || ! $block_type->render_callback ) {
 		return $block_content;
 	}
 

--- a/lib/block-supports/index.php
+++ b/lib/block-supports/index.php
@@ -37,7 +37,7 @@ function gutenberg_apply_block_supports( $block_content, $block ) {
 
 	$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
 	// If no render_callback, assume styles have been previously handled.
-	if ( ! $block_type || ! $block_type->apiVersion || ! $block_type->apiVersion < 2 || ! $block_type->render_callback ) {
+	if ( ! $block_type || ! property_exists( $block_type, 'api_version' ) || $block_type->api_version < 2 || ! $block_type->render_callback ) {
 		return $block_content;
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -46057,7 +46057,7 @@
 			"dependencies": {
 				"clone-deep": {
 					"version": "0.2.4",
-					"resolved": "http://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
+					"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
 					"integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
 					"dev": true,
 					"requires": {
@@ -46091,7 +46091,7 @@
 					"dependencies": {
 						"kind-of": {
 							"version": "2.0.1",
-							"resolved": "http://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
 							"integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
 							"dev": true,
 							"requires": {

--- a/packages/block-library/src/archives/index.php
+++ b/packages/block-library/src/archives/index.php
@@ -111,6 +111,7 @@ function register_block_core_archives() {
 	register_block_type_from_metadata(
 		__DIR__ . '/archives',
 		array(
+			'api_version'     => 2,
 			'render_callback' => 'render_block_core_archives',
 		)
 	);

--- a/packages/block-library/src/calendar/index.php
+++ b/packages/block-library/src/calendar/index.php
@@ -51,6 +51,7 @@ function register_block_core_calendar() {
 	register_block_type_from_metadata(
 		__DIR__ . '/calendar',
 		array(
+			'api_version'     => 2,
 			'render_callback' => 'render_block_core_calendar',
 		)
 	);

--- a/packages/block-library/src/categories/block.json
+++ b/packages/block-library/src/categories/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 2,
 	"name": "core/categories",
 	"category": "widgets",
 	"attributes": {

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -15,15 +15,15 @@ import {
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
-import { InspectorControls } from '@wordpress/block-editor';
+import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { pin } from '@wordpress/icons';
 
 export default function CategoriesEdit( {
 	attributes: { displayAsDropdown, showHierarchy, showPostCounts },
-	className,
 	setAttributes,
 } ) {
+	const blockProps = useBlockProps();
 	const selectId = useInstanceId( CategoriesEdit, 'blocks-category-select' );
 	const { categories, isRequesting } = useSelect( ( select ) => {
 		const { getEntityRecords } = select( 'core' );
@@ -150,16 +150,19 @@ export default function CategoriesEdit( {
 		return (
 			<>
 				{ inspectorControls }
-				<Placeholder icon={ pin } label={ __( 'Categories' ) }>
-					<Spinner />
-				</Placeholder>
+				<div { ...blockProps }>
+					<Placeholder icon={ pin } label={ __( 'Categories' ) }>
+						<Spinner />
+					</Placeholder>
+				</div>
 			</>
 		);
 	}
+
 	return (
 		<>
 			{ inspectorControls }
-			<div className={ className }>
+			<div { ...blockProps }>
 				{ displayAsDropdown
 					? renderCategoryDropdown()
 					: renderCategoryList() }

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -90,6 +90,7 @@ function register_block_core_categories() {
 	register_block_type_from_metadata(
 		__DIR__ . '/categories',
 		array(
+			'api_version'     => 2,
 			'render_callback' => 'render_block_core_categories',
 		)
 	);

--- a/packages/block-library/src/cover/index.php
+++ b/packages/block-library/src/cover/index.php
@@ -8,6 +8,8 @@
 /**
  * Supports `playsinline` attribute server side for `core/cover`.
  *
+ * @todo Remove this file once we bump the minimum supported version to WordPress 5.5.
+ *
  * @param array  $attributes The block attributes.
  * @param string $content HTML content of the block.
  *
@@ -28,6 +30,7 @@ function register_block_core_cover() {
 	register_block_type_from_metadata(
 		__DIR__ . '/cover',
 		array(
+			'api_version'     => 2,
 			'render_callback' => 'render_block_core_cover',
 		)
 	);

--- a/packages/block-library/src/latest-comments/block.json
+++ b/packages/block-library/src/latest-comments/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 2,
 	"name": "core/latest-comments",
 	"category": "widgets",
 	"attributes": {

--- a/packages/block-library/src/latest-comments/edit.js
+++ b/packages/block-library/src/latest-comments/edit.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { InspectorControls } from '@wordpress/block-editor';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import {
 	Disabled,
 	PanelBody,
@@ -31,6 +31,7 @@ export default function LatestComments( { attributes, setAttributes } ) {
 		displayDate,
 		displayExcerpt,
 	} = attributes;
+	const blockProps = useBlockProps();
 
 	return (
 		<>
@@ -71,12 +72,14 @@ export default function LatestComments( { attributes, setAttributes } ) {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<Disabled>
-				<ServerSideRender
-					block="core/latest-comments"
-					attributes={ attributes }
-				/>
-			</Disabled>
+			<div { ...blockProps }>
+				<Disabled>
+					<ServerSideRender
+						block="core/latest-comments"
+						attributes={ attributes }
+					/>
+				</Disabled>
+			</div>
 		</>
 	);
 }

--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -149,6 +149,7 @@ function register_block_core_latest_comments() {
 	register_block_type_from_metadata(
 		__DIR__ . '/latest-comments',
 		array(
+			'api_version'     => 2,
 			'render_callback' => 'render_block_core_latest_comments',
 		)
 	);

--- a/packages/block-library/src/latest-posts/block.json
+++ b/packages/block-library/src/latest-posts/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 2,
 	"name": "core/latest-posts",
 	"category": "widgets",
 	"attributes": {

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -28,6 +28,7 @@ import {
 	BlockAlignmentToolbar,
 	BlockControls,
 	__experimentalImageSizeControl as ImageSizeControl,
+	useBlockProps,
 } from '@wordpress/block-editor';
 import { withSelect } from '@wordpress/data';
 import { pin, list, grid } from '@wordpress/icons';
@@ -522,6 +523,16 @@ class LatestPostsEdit extends Component {
 	}
 }
 
+function LatestPostBlockWrapper( props ) {
+	const blockProps = useBlockProps();
+
+	return (
+		<div { ...blockProps }>
+			<LatestPostsEdit { ...props } />
+		</div>
+	);
+}
+
 export default withSelect( ( select, props ) => {
 	const {
 		featuredImageSizeSlug,
@@ -593,4 +604,4 @@ export default withSelect( ( select, props ) => {
 					return { ...post, featuredImageInfo };
 			  } ),
 	};
-} )( LatestPostsEdit );
+} )( LatestPostBlockWrapper );

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -185,6 +185,7 @@ function register_block_core_latest_posts() {
 	register_block_type_from_metadata(
 		__DIR__ . '/latest-posts',
 		array(
+			'api_version'     => 2,
 			'render_callback' => 'render_block_core_latest_posts',
 		)
 	);

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -217,6 +217,7 @@ function register_block_core_navigation_link() {
 	register_block_type_from_metadata(
 		__DIR__ . '/navigation-link',
 		array(
+			'api_version'     => 2,
 			'render_callback' => 'render_block_core_navigation_link',
 		)
 	);

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -161,6 +161,7 @@ function register_block_core_navigation() {
 	register_block_type_from_metadata(
 		__DIR__ . '/navigation',
 		array(
+			'api_version'     => 2,
 			'render_callback' => 'render_block_core_navigation',
 		)
 	);

--- a/packages/block-library/src/post-author/index.php
+++ b/packages/block-library/src/post-author/index.php
@@ -54,6 +54,7 @@ function register_block_core_post_author() {
 	register_block_type_from_metadata(
 		__DIR__ . '/post-author',
 		array(
+			'api_version'     => 2,
 			'render_callback' => 'render_block_core_post_author',
 		)
 	);

--- a/packages/block-library/src/post-comment-author/index.php
+++ b/packages/block-library/src/post-comment-author/index.php
@@ -28,6 +28,7 @@ function register_block_core_post_comment_author() {
 	register_block_type_from_metadata(
 		__DIR__ . '/post-comment-author',
 		array(
+			'api_version'     => 2,
 			'render_callback' => 'render_block_core_post_comment_author',
 		)
 	);

--- a/packages/block-library/src/post-comment-content/index.php
+++ b/packages/block-library/src/post-comment-content/index.php
@@ -28,6 +28,7 @@ function register_block_core_post_comment_content() {
 	register_block_type_from_metadata(
 		__DIR__ . '/post-comment-content',
 		array(
+			'api_version'     => 2,
 			'render_callback' => 'render_block_core_post_comment_content',
 		)
 	);

--- a/packages/block-library/src/post-comment-date/index.php
+++ b/packages/block-library/src/post-comment-date/index.php
@@ -35,6 +35,7 @@ function register_block_core_post_comment_date() {
 	register_block_type_from_metadata(
 		__DIR__ . '/post-comment-date',
 		array(
+			'api_version'     => 2,
 			'render_callback' => 'render_block_core_post_comment_date',
 		)
 	);

--- a/packages/block-library/src/post-comment/index.php
+++ b/packages/block-library/src/post-comment/index.php
@@ -11,7 +11,10 @@
  */
 function register_block_core_post_comment() {
 	register_block_type_from_metadata(
-		__DIR__ . '/post-comment'
+		__DIR__ . '/post-comment',
+		array(
+			'api_version' => 2,
+		)
 	);
 }
 add_action( 'init', 'register_block_core_post_comment' );

--- a/packages/block-library/src/post-comments-count/index.php
+++ b/packages/block-library/src/post-comments-count/index.php
@@ -37,6 +37,7 @@ function register_block_core_post_comments_count() {
 	register_block_type_from_metadata(
 		__DIR__ . '/post-comments-count',
 		array(
+			'api_version'     => 2,
 			'attributes'      => array(
 				'className' => array(
 					'type' => 'string',

--- a/packages/block-library/src/post-comments-form/index.php
+++ b/packages/block-library/src/post-comments-form/index.php
@@ -37,6 +37,7 @@ function register_block_core_post_comments_form() {
 	register_block_type_from_metadata(
 		__DIR__ . '/post-comments-form',
 		array(
+			'api_version'     => 2,
 			'render_callback' => 'render_block_core_post_comments_form',
 		)
 	);

--- a/packages/block-library/src/post-comments/index.php
+++ b/packages/block-library/src/post-comments/index.php
@@ -47,6 +47,7 @@ function register_block_core_post_comments() {
 	register_block_type_from_metadata(
 		__DIR__ . '/post-comments',
 		array(
+			'api_version'     => 2,
 			'render_callback' => 'render_block_core_post_comments',
 		)
 	);

--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -32,6 +32,7 @@ function register_block_core_post_content() {
 	register_block_type_from_metadata(
 		__DIR__ . '/post-content',
 		array(
+			'api_version'     => 2,
 			'render_callback' => 'render_block_core_post_content',
 		)
 	);

--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -35,6 +35,7 @@ function register_block_core_post_date() {
 	register_block_type_from_metadata(
 		__DIR__ . '/post-date',
 		array(
+			'api_version'     => 2,
 			'render_callback' => 'render_block_core_post_date',
 		)
 	);

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -55,6 +55,7 @@ function register_block_core_post_excerpt() {
 	register_block_type_from_metadata(
 		__DIR__ . '/post-excerpt',
 		array(
+			'api_version'     => 2,
 			'render_callback' => 'render_block_core_post_excerpt',
 		)
 	);

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -35,6 +35,7 @@ function register_block_core_post_featured_image() {
 	register_block_type_from_metadata(
 		__DIR__ . '/post-featured-image',
 		array(
+			'api_version'     => 2,
 			'render_callback' => 'render_block_core_post_featured_image',
 		)
 	);

--- a/packages/block-library/src/post-hierarchical-terms/index.php
+++ b/packages/block-library/src/post-hierarchical-terms/index.php
@@ -49,6 +49,7 @@ function register_block_core_post_hierarchical_terms() {
 	register_block_type_from_metadata(
 		__DIR__ . '/post-hierarchical-terms',
 		array(
+			'api_version'     => 2,
 			'render_callback' => 'render_block_core_post_hierarchical_terms',
 		)
 	);

--- a/packages/block-library/src/post-tags/index.php
+++ b/packages/block-library/src/post-tags/index.php
@@ -45,6 +45,7 @@ function register_block_core_post_tags() {
 	register_block_type_from_metadata(
 		__DIR__ . '/post-tags',
 		array(
+			'api_version'     => 2,
 			'render_callback' => 'render_block_core_post_tags',
 		)
 	);

--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -47,6 +47,7 @@ function register_block_core_post_title() {
 	register_block_type_from_metadata(
 		__DIR__ . '/post-title',
 		array(
+			'api_version'     => 2,
 			'render_callback' => 'render_block_core_post_title',
 		)
 	);

--- a/packages/block-library/src/query-loop/index.php
+++ b/packages/block-library/src/query-loop/index.php
@@ -82,6 +82,7 @@ function register_block_core_query_loop() {
 	register_block_type_from_metadata(
 		__DIR__ . '/query-loop',
 		array(
+			'api_version'       => 2,
 			'render_callback'   => 'render_block_core_query_loop',
 			'skip_inner_blocks' => true,
 		)

--- a/packages/block-library/src/query-pagination/index.php
+++ b/packages/block-library/src/query-pagination/index.php
@@ -43,6 +43,7 @@ function register_block_core_query_pagination() {
 	register_block_type_from_metadata(
 		__DIR__ . '/query-pagination',
 		array(
+			'api_version'     => 2,
 			'render_callback' => 'render_block_core_query_pagination',
 		)
 	);

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -10,7 +10,10 @@
  */
 function register_block_core_query() {
 	register_block_type_from_metadata(
-		__DIR__ . '/query'
+		__DIR__ . '/query',
+		array(
+			'api_version' => 2,
+		)
 	);
 }
 add_action( 'init', 'register_block_core_query' );

--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -98,6 +98,7 @@ function register_block_core_rss() {
 	register_block_type_from_metadata(
 		__DIR__ . '/rss',
 		array(
+			'api_version'     => 2,
 			'render_callback' => 'render_block_core_rss',
 		)
 	);

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -112,6 +112,7 @@ function register_block_core_search() {
 	register_block_type_from_metadata(
 		__DIR__ . '/search',
 		array(
+			'api_version'     => 2,
 			'render_callback' => 'render_block_core_search',
 		)
 	);

--- a/packages/block-library/src/shortcode/index.php
+++ b/packages/block-library/src/shortcode/index.php
@@ -24,6 +24,7 @@ function register_block_core_shortcode() {
 	register_block_type_from_metadata(
 		__DIR__ . '/shortcode',
 		array(
+			'api_version'     => 2,
 			'render_callback' => 'render_block_core_shortcode',
 		)
 	);

--- a/packages/block-library/src/site-logo/index.php
+++ b/packages/block-library/src/site-logo/index.php
@@ -47,6 +47,7 @@ function register_block_core_site_logo() {
 		register_block_type_from_metadata(
 			__DIR__ . '/site-logo',
 			array(
+				'api_version'     => 2,
 				'render_callback' => 'render_block_core_site_logo',
 			)
 		);

--- a/packages/block-library/src/site-tagline/index.php
+++ b/packages/block-library/src/site-tagline/index.php
@@ -29,6 +29,7 @@ function register_block_core_site_tagline() {
 	register_block_type_from_metadata(
 		__DIR__ . '/site-tagline',
 		array(
+			'api_version'     => 2,
 			'render_callback' => 'render_block_core_site_tagline',
 		)
 	);

--- a/packages/block-library/src/site-title/index.php
+++ b/packages/block-library/src/site-title/index.php
@@ -37,6 +37,7 @@ function register_block_core_site_title() {
 	register_block_type_from_metadata(
 		__DIR__ . '/site-title',
 		array(
+			'api_version'     => 2,
 			'render_callback' => 'render_block_core_site_title',
 		)
 	);

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -43,6 +43,7 @@ function register_block_core_social_link() {
 	register_block_type_from_metadata(
 		__DIR__ . '/social-link',
 		array(
+			'api_version'     => 2,
 			'render_callback' => 'render_block_core_social_link',
 		)
 	);

--- a/packages/block-library/src/tag-cloud/index.php
+++ b/packages/block-library/src/tag-cloud/index.php
@@ -44,6 +44,7 @@ function register_block_core_tag_cloud() {
 	register_block_type_from_metadata(
 		__DIR__ . '/tag-cloud',
 		array(
+			'api_version'     => 2,
 			'render_callback' => 'render_block_core_tag_cloud',
 		)
 	);

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -74,6 +74,7 @@ function register_block_core_template_part() {
 	register_block_type_from_metadata(
 		__DIR__ . '/template-part',
 		array(
+			'api_version'     => 2,
 			'render_callback' => 'render_block_core_template_part',
 		)
 	);

--- a/phpunit/class-block-supported-styles-test.php
+++ b/phpunit/class-block-supported-styles-test.php
@@ -147,6 +147,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	function test_named_color_support() {
 		$block_type_settings = array(
+			'apiVersion'      => 2,
 			'attributes'      => array(),
 			'supports'        => array(
 				'color' => true,
@@ -179,6 +180,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	function test_custom_color_support() {
 		$block_type_settings = array(
+			'apiVersion'      => 2,
 			'attributes'      => array(),
 			'supports'        => array(
 				'color' => true,
@@ -216,6 +218,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	function test_named_link_color_support() {
 		$block_type_settings = array(
+			'apiVersion'      => 2,
 			'attributes'      => array(),
 			'supports'        => array(
 				'color' => array(
@@ -247,6 +250,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	function test_custom_link_color_support() {
 		$block_type_settings = array(
+			'apiVersion'      => 2,
 			'attributes'      => array(),
 			'supports'        => array(
 				'color' => array(
@@ -278,6 +282,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	function test_named_gradient_support() {
 		$block_type_settings = array(
+			'apiVersion'      => 2,
 			'attributes'      => array(),
 			'supports'        => array(
 				'color' => array(
@@ -309,6 +314,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	function test_custom_gradient_support() {
 		$block_type_settings = array(
+			'apiVersion'      => 2,
 			'attributes'      => array(),
 			'supports'        => array(
 				'color' => array(
@@ -340,6 +346,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	function test_color_unsupported() {
 		$block_type_settings = array(
+			'apiVersion'      => 2,
 			'attributes'      => array(),
 			'supports'        => array(),
 			'render_callback' => true,
@@ -376,6 +383,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	function test_named_font_size() {
 		$block_type_settings = array(
+			'apiVersion'      => 2,
 			'attributes'      => array(),
 			'supports'        => array(
 				'fontSize' => true,
@@ -405,6 +413,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	function test_custom_font_size() {
 		$block_type_settings = array(
+			'apiVersion'      => 2,
 			'attributes'      => array(),
 			'supports'        => array(
 				'fontSize' => true,
@@ -434,6 +443,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	function test_font_size_unsupported() {
 		$block_type_settings = array(
+			'apiVersion'      => 2,
 			'attributes'      => array(),
 			'supports'        => array(),
 			'render_callback' => true,
@@ -462,6 +472,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	function test_line_height() {
 		$block_type_settings = array(
+			'apiVersion'      => 2,
 			'attributes'      => array(),
 			'supports'        => array(
 				'lineHeight' => true,
@@ -491,6 +502,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	function test_line_height_unsupported() {
 		$block_type_settings = array(
+			'apiVersion'      => 2,
 			'attributes'      => array(),
 			'supports'        => array(),
 			'render_callback' => true,
@@ -518,6 +530,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	function test_block_alignment() {
 		$block_type_settings = array(
+			'apiVersion'      => 2,
 			'attributes'      => array(),
 			'supports'        => array(
 				'align' => true,
@@ -547,6 +560,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	function test_block_alignment_unsupported() {
 		$block_type_settings = array(
+			'apiVersion'      => 2,
 			'attributes'      => array(),
 			'supports'        => array(),
 			'render_callback' => true,
@@ -574,6 +588,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	function test_all_supported() {
 		$block_type_settings = array(
+			'apiVersion'      => 2,
 			'attributes'      => array(),
 			'supports'        => array(
 				'color'      => array(
@@ -622,6 +637,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	function test_one_supported() {
 		$block_type_settings = array(
+			'apiVersion'      => 2,
 			'attributes'      => array(),
 			'supports'        => array(
 				'fontSize' => true,
@@ -663,6 +679,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	function test_render_callback_required() {
 		$block_type_settings = array(
+			'apiVersion' => 2,
 			'attributes' => array(),
 			'supports'   => array(
 				'align'      => true,
@@ -709,6 +726,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	function test_custom_classnames_support() {
 		$block_type_settings = array(
+			'apiVersion'      => 2,
 			'attributes'      => array(),
 			'supports'        => array(),
 			'render_callback' => true,
@@ -736,6 +754,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	function test_custom_classnames_support_opt_out() {
 		$block_type_settings = array(
+			'apiVersion'      => 2,
 			'attributes'      => array(),
 			'supports'        => array(
 				'customClassName' => false,
@@ -765,6 +784,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	function test_generatted_classnames_support_opt_out() {
 		$block_type_settings = array(
+			'apiVersion'      => 2,
 			'attributes'      => array(),
 			'supports'        => array(
 				'className' => false,
@@ -792,6 +812,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	public function test_render_block_suppresses_warnings_without_at_suppression() {
 		$block_type_settings = array(
+			'apiVersion'      => 2,
 			'attributes'      => array(),
 			'supports'        => array(),
 			'render_callback' => true,
@@ -831,7 +852,13 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 * block attributes are escaped correctly and safely.
 	 */
 	public function test_render_block_attribute() {
-		$this->register_block_type( 'core/example', array( 'render_callback' => true ) );
+		$this->register_block_type(
+			'core/example',
+			array(
+				'apiVersion'      => 2,
+				'render_callback' => true,
+			)
+		);
 
 		$block = array(
 			'blockName' => 'core/example',
@@ -875,6 +902,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$this->register_block_type(
 			'core/example',
 			array(
+				'apiVersion'      => 2,
 				'render_callback' => function( $attributes, $content ) {
 					return $content . '<div>Appended</div>';
 				},
@@ -907,6 +935,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$this->register_block_type(
 			'core/example',
 			array(
+				'apiVersion'      => 2,
 				'render_callback' => function() {
 					return 'This is rendered as just text.';
 				},

--- a/phpunit/class-block-supported-styles-test.php
+++ b/phpunit/class-block-supported-styles-test.php
@@ -147,7 +147,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	function test_named_color_support() {
 		$block_type_settings = array(
-			'apiVersion'      => 2,
+			'api_version'     => 2,
 			'attributes'      => array(),
 			'supports'        => array(
 				'color' => true,
@@ -180,7 +180,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	function test_custom_color_support() {
 		$block_type_settings = array(
-			'apiVersion'      => 2,
+			'api_version'     => 2,
 			'attributes'      => array(),
 			'supports'        => array(
 				'color' => true,
@@ -218,7 +218,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	function test_named_link_color_support() {
 		$block_type_settings = array(
-			'apiVersion'      => 2,
+			'api_version'     => 2,
 			'attributes'      => array(),
 			'supports'        => array(
 				'color' => array(
@@ -250,7 +250,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	function test_custom_link_color_support() {
 		$block_type_settings = array(
-			'apiVersion'      => 2,
+			'api_version'     => 2,
 			'attributes'      => array(),
 			'supports'        => array(
 				'color' => array(
@@ -282,7 +282,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	function test_named_gradient_support() {
 		$block_type_settings = array(
-			'apiVersion'      => 2,
+			'api_version'     => 2,
 			'attributes'      => array(),
 			'supports'        => array(
 				'color' => array(
@@ -314,7 +314,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	function test_custom_gradient_support() {
 		$block_type_settings = array(
-			'apiVersion'      => 2,
+			'api_version'     => 2,
 			'attributes'      => array(),
 			'supports'        => array(
 				'color' => array(
@@ -346,7 +346,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	function test_color_unsupported() {
 		$block_type_settings = array(
-			'apiVersion'      => 2,
+			'api_version'     => 2,
 			'attributes'      => array(),
 			'supports'        => array(),
 			'render_callback' => true,
@@ -383,7 +383,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	function test_named_font_size() {
 		$block_type_settings = array(
-			'apiVersion'      => 2,
+			'api_version'     => 2,
 			'attributes'      => array(),
 			'supports'        => array(
 				'fontSize' => true,
@@ -413,7 +413,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	function test_custom_font_size() {
 		$block_type_settings = array(
-			'apiVersion'      => 2,
+			'api_version'     => 2,
 			'attributes'      => array(),
 			'supports'        => array(
 				'fontSize' => true,
@@ -443,7 +443,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	function test_font_size_unsupported() {
 		$block_type_settings = array(
-			'apiVersion'      => 2,
+			'api_version'     => 2,
 			'attributes'      => array(),
 			'supports'        => array(),
 			'render_callback' => true,
@@ -472,7 +472,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	function test_line_height() {
 		$block_type_settings = array(
-			'apiVersion'      => 2,
+			'api_version'     => 2,
 			'attributes'      => array(),
 			'supports'        => array(
 				'lineHeight' => true,
@@ -502,7 +502,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	function test_line_height_unsupported() {
 		$block_type_settings = array(
-			'apiVersion'      => 2,
+			'api_version'     => 2,
 			'attributes'      => array(),
 			'supports'        => array(),
 			'render_callback' => true,
@@ -530,7 +530,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	function test_block_alignment() {
 		$block_type_settings = array(
-			'apiVersion'      => 2,
+			'api_version'     => 2,
 			'attributes'      => array(),
 			'supports'        => array(
 				'align' => true,
@@ -560,7 +560,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	function test_block_alignment_unsupported() {
 		$block_type_settings = array(
-			'apiVersion'      => 2,
+			'api_version'     => 2,
 			'attributes'      => array(),
 			'supports'        => array(),
 			'render_callback' => true,
@@ -588,7 +588,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	function test_all_supported() {
 		$block_type_settings = array(
-			'apiVersion'      => 2,
+			'api_version'     => 2,
 			'attributes'      => array(),
 			'supports'        => array(
 				'color'      => array(
@@ -637,7 +637,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	function test_one_supported() {
 		$block_type_settings = array(
-			'apiVersion'      => 2,
+			'api_version'     => 2,
 			'attributes'      => array(),
 			'supports'        => array(
 				'fontSize' => true,
@@ -679,9 +679,9 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	function test_render_callback_required() {
 		$block_type_settings = array(
-			'apiVersion' => 2,
-			'attributes' => array(),
-			'supports'   => array(
+			'api_version' => 2,
+			'attributes'  => array(),
+			'supports'    => array(
 				'align'      => true,
 				'color'      => array(
 					'gradients' => true,
@@ -726,7 +726,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	function test_custom_classnames_support() {
 		$block_type_settings = array(
-			'apiVersion'      => 2,
+			'api_version'     => 2,
 			'attributes'      => array(),
 			'supports'        => array(),
 			'render_callback' => true,
@@ -754,7 +754,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	function test_custom_classnames_support_opt_out() {
 		$block_type_settings = array(
-			'apiVersion'      => 2,
+			'api_version'     => 2,
 			'attributes'      => array(),
 			'supports'        => array(
 				'customClassName' => false,
@@ -784,7 +784,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	function test_generatted_classnames_support_opt_out() {
 		$block_type_settings = array(
-			'apiVersion'      => 2,
+			'api_version'     => 2,
 			'attributes'      => array(),
 			'supports'        => array(
 				'className' => false,
@@ -812,7 +812,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 */
 	public function test_render_block_suppresses_warnings_without_at_suppression() {
 		$block_type_settings = array(
-			'apiVersion'      => 2,
+			'api_version'     => 2,
 			'attributes'      => array(),
 			'supports'        => array(),
 			'render_callback' => true,
@@ -855,7 +855,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$this->register_block_type(
 			'core/example',
 			array(
-				'apiVersion'      => 2,
+				'api_version'     => 2,
 				'render_callback' => true,
 			)
 		);
@@ -902,7 +902,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$this->register_block_type(
 			'core/example',
 			array(
-				'apiVersion'      => 2,
+				'api_version'     => 2,
 				'render_callback' => function( $attributes, $content ) {
 					return $content . '<div>Appended</div>';
 				},
@@ -935,7 +935,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 		$this->register_block_type(
 			'core/example',
 			array(
-				'apiVersion'      => 2,
+				'api_version'     => 2,
 				'render_callback' => function() {
 					return 'This is rendered as just text.';
 				},


### PR DESCRIPTION
To avoid impacting existing dynamic blocks, this PRs only enable block supports server-side for blocks using apiVersion 2.