### PR TITLE
Try using virtualized list in Inserter

### DIFF
--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -62,6 +62,7 @@
 		"react-autosize-textarea": "^3.0.2",
 		"react-spring": "^8.0.19",
 		"react-transition-group": "^2.9.0",
+		"react-virtualized": "^9.22.2",
 		"reakit": "1.1.0",
 		"redux-multi": "^0.1.12",
 		"refx": "^3.0.0",

--- a/packages/block-editor/src/components/inserter/panel.js
+++ b/packages/block-editor/src/components/inserter/panel.js
@@ -3,19 +3,12 @@
  */
 import { Icon } from '@wordpress/components';
 
-function InserterPanel( { title, icon, children } ) {
+function InserterPanel( { title, icon } ) {
 	return (
-		<>
-			<div className="block-editor-inserter__panel-header">
-				<h2 className="block-editor-inserter__panel-title">
-					{ title }
-				</h2>
-				<Icon icon={ icon } />
-			</div>
-			<div className="block-editor-inserter__panel-content">
-				{ children }
-			</div>
-		</>
+		<div className="block-editor-inserter__panel-header">
+			<h2 className="block-editor-inserter__panel-title">{ title }</h2>
+			<Icon icon={ icon } />
+		</div>
 	);
 }
 

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -128,6 +128,8 @@ $block-inserter-tabs-height: 44px;
 	display: flex;
 	flex-direction: column;
 	margin-top: -$grid-unit-10;
+	height: 100%;
+	flex: 1;
 
 	.components-tab-panel__tabs {
 		position: sticky;
@@ -338,4 +340,18 @@ $block-inserter-tabs-height: 44px;
 	&:focus:not(:disabled) {
 		box-shadow: inset 0 0 0 $border-width-focus $gray-900, inset 0 0 0 2px $white;
 	}
+}
+
+.block-editor-inserter__content {
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+}
+
+.block-editor-inserter__block-list > div {
+	height: 100%;
+}
+
+.block-editor-block-types-list__list-item {
+	min-height: 108px;
 }


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/issues/26080

NOTE: This is just experimentation and looking forward to what everyone thinks about it. If it's something that we agree on then I'll refactor the code to make it production-ready! The design (padding) is a little bit off and some components don't really make sense anymore, those are something to do when this gets accepted.

## Description
Inserter is a long scrollable list of blocks. All the items in this list are rendered all the time which takes a significant time to mount (adds ~1300 DOM element). This exploration uses `react-virtualized` to turn the list into a virtualized list.

Virtualized list is a scrollable list that only renders the visible items. If you have 200 items in the list, but only 30 items are visible at the moment then only those will be mounted and rendered.

## Measurements 

My measurements are based on 4x CPU slowdown and 153 blocks in the `Inserter`. Measurement times are the time the `click` event on `Add block` (+ button in the top left corner) takes.

Times measured on `master` branch:

- 717ms
- 651ms
- 653ms
- 609ms
- 628ms

Times measured on this branch:

- 333ms
- 293ms
- 256ms
- 260ms
- 241ms
- 260ms
- 238ms

### Pros
- We only render the items that are visible which results in less DOM elements
- Inserter opens faster

### Cons
- If we are scrolling fast then it takes a little bit of time for the content to show up
- We need to make sure items' height is fixed. Block names can be long which means they get wrapped onto as many lines it needs to. We will need to fix this to 2 or 3 lines and hide the rest. This also results in some extra spacing between rows since we need to fix the height for each row.

## How has this been tested?
* Open block editor
* Click + button (add block) in the top left corner
* It should open faster

## Types of changes
Optimization

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
