### PR TITLE
Add types to CustomSelectControl

### DIFF
--- a/packages/components/src/custom-select-control/index.js
+++ b/packages/components/src/custom-select-control/index.js
@@ -13,6 +13,24 @@ import { Icon, check, chevronDown } from '@wordpress/icons';
  */
 import { Button, VisuallyHidden } from '../';
 
+/**
+ * @typedef CustomSelectControlOption
+ * @property {string} key Unique key for the option.
+ * @property {string} name The name of the option.
+ * @property {import('react').CSSProperties?} style Optional styles for the option.
+ * @property {string?} className Optional className to render on the option.
+ */
+
+/**
+ * @typedef Props
+ * @property {string} [className] Optional className
+ * @property {boolean} [hideLabelFromVision] Used to visually hide the label. It will always be visible to screen readers. Defaults to `false`
+ * @property {string} label The label for the control.
+ * @property {CustomSelectControlOption[]} options The options that can be chosen from.
+ * @property {import('downshift').UseSelectProps<CustomSelectControlOption>} [onChange] Function called with the control's internal state changes. The `selectedItem` property contains the next selected item.
+ * @property {CustomSelectControlOption} [value] Can be used to externally control the value of the control.
+ */
+
 const itemToString = ( item ) => item && item.name;
 // This is needed so that in Windows, where
 // the menu does not necessarily open on
@@ -52,6 +70,11 @@ const stateReducer = (
 			return changes;
 	}
 };
+
+/**
+ * @param {Props} props
+ * @return {JSX.Element} Element
+ */
 export default function CustomSelectControl( {
 	className,
 	hideLabelFromVision,

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -6,6 +6,7 @@
 	},
 	"references": [],
     "include": [
-		"src/dashicon/*"
+		"src/dashicon/*",
+		"src/custom-select-control/*"
 	],
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Adds JSDoc type annotations to the `CustomSelectControl` component

## How has this been tested?
I'm unsure how to test this.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
