### PR TITLE
Add template lock attribute to column and group

### DIFF
--- a/packages/block-library/src/column/block.json
+++ b/packages/block-library/src/column/block.json
@@ -11,6 +11,9 @@
 		},
 		"width": {
 			"type": "string"
+		},
+		"templateLock": {
+			"type": "string"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -22,7 +22,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 function ColumnEdit( {
-	attributes: { verticalAlignment, width },
+	attributes: { verticalAlignment, width, templateLock = false },
 	setAttributes,
 	clientId,
 } ) {
@@ -60,7 +60,7 @@ function ColumnEdit( {
 		style: width ? { flexBasis: width } : undefined,
 	} );
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
-		templateLock: false,
+		templateLock,
 		renderAppender: hasChildBlocks
 			? undefined
 			: InnerBlocks.ButtonBlockAppender,

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -6,6 +6,9 @@
 		"tagName": {
 			"type": "string",
 			"default": "div"
+		},
+		"templateLock": {
+			"type": "string"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -20,12 +20,13 @@ function GroupEdit( { attributes, clientId } ) {
 		[ clientId ]
 	);
 	const blockProps = useBlockProps();
-	const { tagName: TagName = 'div' } = attributes;
+	const { tagName: TagName = 'div', templateLock } = attributes;
 	const innerBlocksProps = useInnerBlocksProps(
 		{
 			className: 'wp-block-group__inner-container',
 		},
 		{
+			templateLock,
 			renderAppender: hasInnerBlocks
 				? undefined
 				: InnerBlocks.ButtonBlockAppender,

--- a/packages/e2e-tests/plugins/cpt-locking.php
+++ b/packages/e2e-tests/plugins/cpt-locking.php
@@ -69,7 +69,7 @@ function gutenberg_test_cpt_locking() {
 						array(
 							'core/paragraph',
 							array(
-								'placeholder' => 'Add a description343',
+								'placeholder' => 'Add a description',
 							),
 						),
 					),

--- a/packages/e2e-tests/plugins/cpt-locking.php
+++ b/packages/e2e-tests/plugins/cpt-locking.php
@@ -53,7 +53,7 @@ function gutenberg_test_cpt_locking() {
 		)
 	);
 	register_post_type(
-		'ul-post-ul-group',
+		'l-post-ul-group',
 		array(
 			'public'        => true,
 			'label'         => 'Locked Post Unlocked group',

--- a/packages/e2e-tests/plugins/cpt-locking.php
+++ b/packages/e2e-tests/plugins/cpt-locking.php
@@ -52,6 +52,82 @@ function gutenberg_test_cpt_locking() {
 			'template_lock' => false,
 		)
 	);
+	register_post_type(
+		'ul-post-ul-group',
+		array(
+			'public'        => true,
+			'label'         => 'Locked Post Unlocked group',
+			'show_in_rest'  => true,
+			'template'      => array(
+				array(
+					'core/group',
+					array(
+						'templateLock' => false,
+					),
+					array(
+						array( 'core/quote' ),
+						array(
+							'core/paragraph',
+							array(
+								'placeholder' => 'Add a description343',
+							),
+						),
+					),
+				),
+			),
+			'template_lock' => 'all',
+		)
+	);
+	register_post_type(
+		'l-post-l-group',
+		array(
+			'public'        => true,
+			'label'         => 'Locked Post Locked group',
+			'show_in_rest'  => true,
+			'template'      => array(
+				array(
+					'core/group',
+					array(
+						'templateLock' => 'all',
+					),
+					array(
+						array( 'core/quote' ),
+						array(
+							'core/paragraph',
+							array(
+								'placeholder' => 'Add a description',
+							),
+						),
+					),
+				),
+			),
+			'template_lock' => 'all',
+		)
+	);
+	register_post_type(
+		'l-post-i-group',
+		array(
+			'public'        => true,
+			'label'         => 'Locked Post Inherited group',
+			'show_in_rest'  => true,
+			'template'      => array(
+				array(
+					'core/group',
+					array(),
+					array(
+						array( 'core/quote' ),
+						array(
+							'core/paragraph',
+							array(
+								'placeholder' => 'Add a description',
+							),
+						),
+					),
+				),
+			),
+			'template_lock' => 'all',
+		)
+	);
 }
 
 add_action( 'init', 'gutenberg_test_cpt_locking' );

--- a/packages/e2e-tests/specs/editor/plugins/__snapshots__/cpt-locking.test.js.snap
+++ b/packages/e2e-tests/specs/editor/plugins/__snapshots__/cpt-locking.test.js.snap
@@ -36,6 +36,26 @@ exports[`cpt locking template_lock all should not error when deleting the cotent
 <!-- /wp:columns -->"
 `;
 
+exports[`cpt locking template_lock all unlocked group should allow blocks to be moved 1`] = `
+"<!-- wp:group {\\"templateLock\\":false} -->
+<div class=\\"wp-block-group\\"><div class=\\"wp-block-group__inner-container\\"><!-- wp:paragraph {\\"placeholder\\":\\"Add a description343\\"} -->
+<p>p1</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\"><p></p></blockquote>
+<!-- /wp:quote --></div></div>
+<!-- /wp:group -->"
+`;
+
+exports[`cpt locking template_lock all unlocked group should allow blocks to be removed 1`] = `
+"<!-- wp:group {\\"templateLock\\":false} -->
+<div class=\\"wp-block-group\\"><div class=\\"wp-block-group__inner-container\\"><!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\"><p></p></blockquote>
+<!-- /wp:quote --></div></div>
+<!-- /wp:group -->"
+`;
+
 exports[`cpt locking template_lock false should allow blocks to be inserted 1`] = `
 "<!-- wp:image -->
 <figure class=\\"wp-block-image\\"><img alt=\\"\\"/></figure>

--- a/packages/e2e-tests/specs/editor/plugins/__snapshots__/cpt-locking.test.js.snap
+++ b/packages/e2e-tests/specs/editor/plugins/__snapshots__/cpt-locking.test.js.snap
@@ -38,7 +38,7 @@ exports[`cpt locking template_lock all should not error when deleting the cotent
 
 exports[`cpt locking template_lock all unlocked group should allow blocks to be moved 1`] = `
 "<!-- wp:group {\\"templateLock\\":false} -->
-<div class=\\"wp-block-group\\"><div class=\\"wp-block-group__inner-container\\"><!-- wp:paragraph {\\"placeholder\\":\\"Add a description343\\"} -->
+<div class=\\"wp-block-group\\"><div class=\\"wp-block-group__inner-container\\"><!-- wp:paragraph {\\"placeholder\\":\\"Add a description\\"} -->
 <p>p1</p>
 <!-- /wp:paragraph -->
 

--- a/packages/e2e-tests/specs/editor/plugins/cpt-locking.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/cpt-locking.test.js
@@ -180,4 +180,67 @@ describe( 'cpt locking', () => {
 
 		it( 'should allow blocks to be moved', shouldAllowBlocksToBeMoved );
 	} );
+
+	describe( 'template_lock all unlocked group', () => {
+		beforeEach( async () => {
+			await createNewPost( {
+				postType: 'ul-post-ul-group',
+			} );
+		} );
+
+		it( 'should allow blocks to be removed', async () => {
+			await page.type(
+				'.block-editor-rich-text__editable[data-type="core/paragraph"]',
+				'p1'
+			);
+			await clickBlockToolbarButton( 'More options' );
+			const [ removeBlock ] = await page.$x(
+				'//button[contains(text(), "Remove block")]'
+			);
+			await removeBlock.click();
+			expect( await getEditedPostContent() ).toMatchSnapshot();
+		} );
+
+		it( 'should allow blocks to be moved', shouldAllowBlocksToBeMoved );
+	} );
+
+	describe( 'template_lock all locked group', () => {
+		beforeEach( async () => {
+			await createNewPost( {
+				postType: 'l-post-l-group',
+			} );
+		} );
+
+		it(
+			'should not allow blocks to be removed',
+			shouldNotAllowBlocksToBeRemoved
+		);
+
+		it( 'should not allow blocks to be moved', async () => {
+			await page.click(
+				'.block-editor-rich-text__editable[data-type="core/paragraph"]'
+			);
+			expect( await page.$( 'button[aria-label="Move up"]' ) ).toBeNull();
+		} );
+	} );
+
+	describe( 'template_lock all inherited group', () => {
+		beforeEach( async () => {
+			await createNewPost( {
+				postType: 'l-post-i-group',
+			} );
+		} );
+
+		it(
+			'should not allow blocks to be removed',
+			shouldNotAllowBlocksToBeRemoved
+		);
+
+		it( 'should not allow blocks to be moved', async () => {
+			await page.click(
+				'.block-editor-rich-text__editable[data-type="core/paragraph"]'
+			);
+			expect( await page.$( 'button[aria-label="Move up"]' ) ).toBeNull();
+		} );
+	} );
 } );

--- a/packages/e2e-tests/specs/editor/plugins/cpt-locking.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/cpt-locking.test.js
@@ -184,7 +184,7 @@ describe( 'cpt locking', () => {
 	describe( 'template_lock all unlocked group', () => {
 		beforeEach( async () => {
 			await createNewPost( {
-				postType: 'ul-post-ul-group',
+				postType: 'l-post-ul-group',
 			} );
 		} );
 


### PR DESCRIPTION
This PR adds a templateLock attribute to columns and group. When this attribute is set the locking of the blocks is set to the attribute value instead of relying on the inherited value.

This allows the locking of these blocks to be controlled by templates, patterns, etc.

supersedes: https://github.com/WordPress/gutenberg/pull/25869



## How has this been tested?
I verified now locking is not inherited by using sample cpt templates, and sample blocks with inner block templates.

I verified I could control the locking of the group block by using the templateLock attribute.
By pasting the following code on the code editor I verified that the first group block is not locked, while the second group block is locked.

```
<!-- wp:group -->
<div class="wp-block-group"><div class="wp-block-group__inner-container"><!-- wp:quote -->
<blockquote class="wp-block-quote"><p></p></blockquote>
<!-- /wp:quote --></div></div>
<!-- /wp:group -->

<!-- wp:group {"templateLock":"all"} -->
<div class="wp-block-group"><div class="wp-block-group__inner-container"><!-- wp:quote -->
<blockquote class="wp-block-quote"><p></p></blockquote>
<!-- /wp:quote --></div></div>
<!-- /wp:group -->
```

I verified I could control the locking of a column by pasting the following code on the code editor I verified column 1 is locked while the second column is not.

```
<!-- wp:columns -->
<div class="wp-block-columns"><!-- wp:column {"templateLock":"all"} -->
<div class="wp-block-column"><!-- wp:paragraph -->
<p>1</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"><!-- wp:paragraph -->
<p>2</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->
```
