### PR TITLE
Fix icons type annotation

### DIFF
--- a/packages/icons/src/icon/index.js
+++ b/packages/icons/src/icon/index.js
@@ -3,8 +3,7 @@
  */
 import { cloneElement } from '@wordpress/element';
 
-// Disable reason: JSDoc linter doesn't seem to parse the union (`&`) correctly.
-/** @typedef {{icon: JSX.Element, size?: number} & import('react').ComponentPropsWithoutRef<'SVG'>} IconProps */
+/** @typedef {{icon: JSX.Element, size?: number} & import('@wordpress/primitives').SVGProps} IconProps */
 
 /**
  * Return an SVG icon.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
From @sirreal:

> `'SVG'` isn’t something we can get the props for in `ComponentPropsWithoutRef<'SVG'>` — It would have to be the SVG component type or just the `SVGProps` like in the diff

`svg` would work better (or should) but doesn't actually, for whatever reason. The following _does_ work though (you can see that `className` for example will now show in the intellisense for `Icon`'s props.

## How has this been tested?
Tested using intellisense

## Screenshots <!-- if applicable -->
<img width="787" alt="VS Code's Intellisense showing all the expected attributes available now that the type is corrected" src="https://user-images.githubusercontent.com/24264157/96043308-987e7280-0e23-11eb-8a19-3a81b7873959.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
