### PR TITLE
Add dropdown button to view templates in sidebar

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -340,6 +340,6 @@ $block-inserter-tabs-height: 44px;
 	}
 
 	&:focus:not(:disabled) {
-		box-shadow: inset 0 0 0 $border-width-focus $gray-900, inset 0 0 0 2px $white;
+		box-shadow: inset 0 0 0 1.5px var(--wp-admin-theme-color), inset 0 0 0 3px #fff;
 	}
 }

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -335,6 +335,10 @@ $block-inserter-tabs-height: 44px;
 		color: $white;
 	}
 
+	&:active {
+		color: $gray-400;
+	}
+
 	&:focus:not(:disabled) {
 		box-shadow: inset 0 0 0 $border-width-focus $gray-900, inset 0 0 0 2px $white;
 	}

--- a/packages/edit-site/src/components/header/document-actions/index.js
+++ b/packages/edit-site/src/components/header/document-actions/index.js
@@ -129,6 +129,7 @@ export default function DocumentActions( {
 								) }
 							/>
 						) }
+						contentClassName="edit-site-document-actions__info-dropdown"
 						renderContent={ dropdownContent }
 					/>
 				) }

--- a/packages/edit-site/src/components/header/document-actions/index.js
+++ b/packages/edit-site/src/components/header/document-actions/index.js
@@ -50,8 +50,9 @@ function useSecondaryText() {
  * @param {string}   props.entityLabel A label to use for entity-related options.
  *                                     E.g. "template" would be used for "edit
  *                                     template" and "show template details".
- * @param {Object[]} props.children    React component to use for the
- *                                     information dropdown area.
+ * @param {Function} props.children    React component to use for the
+ *                                     information dropdown area. Should be a
+ *                                     function which accepts dropdown props.
  */
 export default function DocumentActions( {
 	entityTitle,
@@ -128,7 +129,7 @@ export default function DocumentActions( {
 								) }
 							/>
 						) }
-						renderContent={ () => dropdownContent }
+						renderContent={ dropdownContent }
 					/>
 				) }
 			</div>

--- a/packages/edit-site/src/components/header/document-actions/style.scss
+++ b/packages/edit-site/src/components/header/document-actions/style.scss
@@ -86,3 +86,7 @@
 		}
 	}
 }
+
+.edit-site-document-actions__info-dropdown > .components-popover__content > div {
+	padding: 0;
+}

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -113,9 +113,13 @@ export default function Header( { openEntitiesSavedStates } ) {
 							: 'template part'
 					}
 				>
-					{ templateType === 'wp_template' && (
-						<TemplateDetails template={ template } />
-					) }
+					{ templateType === 'wp_template' &&
+						( ( { onClose } ) => (
+							<TemplateDetails
+								template={ template }
+								onClose={ onClose }
+							/>
+						) ) }
 				</DocumentActions>
 			</div>
 

--- a/packages/edit-site/src/components/template-details/index.js
+++ b/packages/edit-site/src/components/template-details/index.js
@@ -25,32 +25,41 @@ export default function TemplateDetails( { template, onClose } ) {
 	};
 
 	return (
-		<div className="edit-site-template-details">
-			<p className="edit-site-template-details__heading">
-				{ __( 'Template details' ) }
-			</p>
+		<>
+			<div className="edit-site-template-details">
+				<p className="edit-site-template-details__heading">
+					{ __( 'Template details' ) }
+				</p>
 
-			{ title && (
-				<p>
-					{ sprintf(
-						/* translators: %s: Name of the template. */
-						__( 'Name: %s' ),
-						title
-					) }
-				</p>
-			) }
-			{ description && (
-				<p>
-					{ sprintf(
-						/* translators: %s: Description of the template. */
-						__( 'Description: %s' ),
-						description
-					) }
-				</p>
-			) }
-			<Button onClick={ showTemplateInSidebar } isLink>
-				{ __( 'View in navigation sidebar.' ) }
+				{ title && (
+					<p>
+						{ sprintf(
+							/* translators: %s: Name of the template. */
+							__( 'Name: %s' ),
+							title
+						) }
+					</p>
+				) }
+				{ description && (
+					<p>
+						{ sprintf(
+							/* translators: %s: Description of the template. */
+							__( 'Description: %s' ),
+							description
+						) }
+					</p>
+				) }
+			</div>
+
+			<Button
+				className="edit-site-template-details__show-all-button"
+				onClick={ showTemplateInSidebar }
+				aria-label={ __(
+					'Browse all templates. This will open the template menu in the navigation side panel.'
+				) }
+			>
+				{ __( 'Browse all templates' ) }
 			</Button>
-		</div>
+		</>
 	);
 }

--- a/packages/edit-site/src/components/template-details/index.js
+++ b/packages/edit-site/src/components/template-details/index.js
@@ -2,17 +2,27 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { getTemplateInfo } from '../../utils';
+import { MENU_TEMPLATES } from '../left-sidebar/navigation-panel/constants';
 
-export default function TemplateDetails( { template } ) {
+export default function TemplateDetails( { template, onClose } ) {
+	const { openNavigationPanelToMenu } = useDispatch( 'core/edit-site' );
 	if ( ! template ) {
 		return null;
 	}
+
 	const { title, description } = getTemplateInfo( template );
+
+	const showTemplateInSidebar = () => {
+		onClose();
+		openNavigationPanelToMenu( MENU_TEMPLATES );
+	};
 
 	return (
 		<div className="edit-site-template-details">
@@ -38,6 +48,9 @@ export default function TemplateDetails( { template } ) {
 					) }
 				</p>
 			) }
+			<Button onClick={ showTemplateInSidebar } isLink>
+				{ __( 'View in navigation sidebar.' ) }
+			</Button>
 		</div>
 	);
 }

--- a/packages/edit-site/src/components/template-details/index.js
+++ b/packages/edit-site/src/components/template-details/index.js
@@ -9,7 +9,7 @@ import { useDispatch } from '@wordpress/data';
  * Internal dependencies
  */
 import { getTemplateInfo } from '../../utils';
-import { MENU_TEMPLATES } from '../left-sidebar/navigation-panel/constants';
+import { MENU_TEMPLATES } from '../navigation-sidebar/navigation-panel/constants';
 
 export default function TemplateDetails( { template, onClose } ) {
 	const { openNavigationPanelToMenu } = useDispatch( 'core/edit-site' );

--- a/packages/edit-site/src/components/template-details/style.scss
+++ b/packages/edit-site/src/components/template-details/style.scss
@@ -1,5 +1,5 @@
 .edit-site-template-details {
-	margin: 0 $grid-unit-10;
+	padding: $grid-unit-15;
 }
 
 .edit-site-template-details__heading {
@@ -9,4 +9,21 @@
 	text-transform: uppercase;
 	font-size: 11px;
 	font-weight: 500;
+}
+
+.edit-site-template-details__show-all-button.components-button {
+	display: block;
+	background: $gray-900;
+	color: $white;
+	width: 100%;
+	height: ($button-size + $grid-unit-10);
+	border-radius: 0;
+
+	&:hover {
+		color: $white;
+	}
+
+	&:focus:not(:disabled) {
+		box-shadow: inset 0 0 0 $border-width-focus $gray-900, inset 0 0 0 2px $white;
+	}
 }

--- a/packages/edit-site/src/components/template-details/style.scss
+++ b/packages/edit-site/src/components/template-details/style.scss
@@ -23,6 +23,10 @@
 		color: $white;
 	}
 
+	&:active {
+		color: $gray-400;
+	}
+
 	&:focus:not(:disabled) {
 		box-shadow: inset 0 0 0 $border-width-focus $gray-900, inset 0 0 0 2px $white;
 	}

--- a/packages/edit-site/src/components/template-details/style.scss
+++ b/packages/edit-site/src/components/template-details/style.scss
@@ -28,6 +28,6 @@
 	}
 
 	&:focus:not(:disabled) {
-		box-shadow: inset 0 0 0 $border-width-focus $gray-900, inset 0 0 0 2px $white;
+		box-shadow: inset 0 0 0 1.5px var(--wp-admin-theme-color), inset 0 0 0 3px #fff;
 	}
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Adds a button to the template dropdown button which shows the template sidebar. Related: #21246. Resolves #25929. cc @mtias who proposed this idea

To do:
- [x] make sure keyboard focus goes to the nav sidebar (moved to follow up #26172)

## How has this been tested?
locally, in edit site. Test by opening the info area dropdown and clicking the button that shows up there.

## Screenshots <!-- if applicable -->
![2020-10-14 16 15 05](https://user-images.githubusercontent.com/6265975/96055361-ac809f00-0e38-11eb-9d1a-2ab5cc528c2f.gif)

<img width="326" alt="Screen Shot 2020-10-14 at 4 17 41 PM" src="https://user-images.githubusercontent.com/6265975/96055408-d33ed580-0e38-11eb-92bc-65f25eeb26fa.png">

## Types of changes
enhancement

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
