### PR TITLE
Cover block: improve overlay opacity handling

### DIFF
--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -314,6 +314,7 @@ function CoverEdit( {
 		}
 	}
 
+	const canDim = !! url && ( overlayColor.color || gradientValue );
 	const hasBackground = !! ( url || overlayColor.color || gradientValue );
 	const showFocalPointPicker =
 		isVideoBackground ||
@@ -425,7 +426,7 @@ function CoverEdit( {
 								},
 							] }
 						>
-							{ !! url && (
+							{ canDim && (
 								<RangeControl
 									label={ __( 'Opacity' ) }
 									value={ dimRatio }

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -437,6 +437,7 @@ function CoverEdit( {
 									}
 									min={ 0 }
 									max={ 100 }
+									step={ 10 }
 									required
 								/>
 							) }

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -53,9 +53,7 @@
 
 	@for $i from 1 through 10 {
 		&.has-background-dim.has-background-dim-#{ $i * 10 } {
-			&:not(.has-background-gradient)::before {
-				opacity: $i * 0.1;
-			}
+			&:not(.has-background-gradient)::before,
 			.wp-block-cover__gradient-background {
 				opacity: $i * 0.1;
 			}

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -34,13 +34,9 @@
 		background-size: auto;
 	}
 
-	&.has-background-dim {
-		background-color: $black;
-
-		&::before {
-			content: "";
-			background-color: inherit;
-		}
+	&.has-background-dim::before {
+		content: "";
+		background-color: inherit;
 	}
 
 	&.has-background-dim:not(.has-background-gradient)::before,


### PR DESCRIPTION
Fixes: #25290 which I believe was created by the change from #20904 as it moved the assignment of the black background color into a selector with greater specificity. That PR and its comments are also relevant here because in them an alternative fix was suggested by @jasmussen which is part of the changes in this PR. That is removing the styled fallback background color from the cover. (I'm not referring to it as the default background color because it's just styled and not part of the block attributes). The idea was discarded since it would "break" the dimming feature but if there's no background color or gradient set, that feature just shouldn't be available. Which is what has been done in this PR.

Besides that this gives the opacity range slider a `step` in accord with the available opacity styles 68419b4 and includes a very minor CSS optimization 0fb0fed. 

Note: I'd say part of the issue in #25290 is that the `has-background-dim` class is inappropriately applied to the block. I initially started on a fix by improving the logic for when that class is applied. However, that leads to block validation failures. If there's a way to handle the migration/upgrade of a block then that'd still be a nice thing to fix.

<details>
<summary>Screen recording demonstrating availability of opacity control only with application of background color (also stepped opacity increments)</summary>
<img src="https://user-images.githubusercontent.com/9000376/96157502-38d9a300-0ec7-11eb-8394-bcd542a4e5ac.gif">

Also worth noting that the background image used in that recording would not even be visible without the changes in this PR.
</details>


## How has this been tested?
WordPress 5.5.1, creating various Cover blocks with and without images and background colors.

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
