### PR TITLE
Minor updates to @wordpress/edit-widgets for easier Core integration

### DIFF
--- a/lib/widget-preview-template.php
+++ b/lib/widget-preview-template.php
@@ -34,7 +34,7 @@ if ( ! function_exists( 'wp_head' ) ) {
 		<?php
 		$registry = WP_Block_Type_Registry::get_instance();
 		$block    = $registry->get_registered( 'core/legacy-widget' );
-		echo $block->render( $_GET['widgetPreview'] );
+		echo $block->render( $_GET['widget-preview'] );
 		?>
 	</div><!-- #content -->
 </div><!-- #page -->

--- a/lib/widgets.php
+++ b/lib/widgets.php
@@ -268,22 +268,19 @@ function gutenberg_register_widgets() {
 add_action( 'widgets_init', 'gutenberg_register_widgets' );
 
 /**
- * Overwrites the template WordPress would use to render the currrent request,
- * to a widget preview template if widget-preview parameter was passed in the url.
- *
- * @param string $template Original template.
- *
- * @return string The original or the path of widget-preview-template.php file.
+ * Hook into before the widgets editor screen is loaded and, if widget-preview
+ * is set, render the requested preview of a legacy widget instead. This powers
+ * the Preview option in the Legacy Widget block.
  */
-function change_post_template_to_widget_preview( $template ) {
+function gutenberg_load_widget_preview_if_requested() {
 	if (
 		isset( $_GET['widget-preview'] ) &&
 		current_user_can( 'edit_theme_options' )
 	) {
-		add_filter( 'show_admin_bar', '__return_false' );
-		return dirname( __FILE__ ) . '/widget-preview-template.php';
+		define( 'IFRAME_REQUEST', true );
+		require_once dirname( __FILE__ ) . '/widget-preview-template.php';
+		exit;
 	}
-	return $template;
 }
-add_filter( 'template_include', 'change_post_template_to_widget_preview' );
+add_filter( 'load-appearance_page_gutenberg-widgets', 'gutenberg_load_widget_preview_if_requested' );
 

--- a/lib/widgets.php
+++ b/lib/widgets.php
@@ -271,7 +271,7 @@ add_action( 'widgets_init', 'gutenberg_register_widgets' );
 
 /**
  * Overwrites the template WordPress would use to render the currrent request,
- * to a widget preview template if widgetPreview parameter was passed in the url.
+ * to a widget preview template if widget-preview parameter was passed in the url.
  *
  * @param string $template Original template.
  *
@@ -279,7 +279,7 @@ add_action( 'widgets_init', 'gutenberg_register_widgets' );
  */
 function change_post_template_to_widget_preview( $template ) {
 	if (
-		isset( $_GET['widgetPreview'] ) &&
+		isset( $_GET['widget-preview'] ) &&
 		current_user_can( 'edit_theme_options' )
 	) {
 		add_filter( 'show_admin_bar', '__return_false' );

--- a/lib/widgets.php
+++ b/lib/widgets.php
@@ -158,8 +158,7 @@ function gutenberg_get_legacy_widget_settings() {
 		)
 	);
 
-	$has_permissions_to_manage_widgets = current_user_can( 'edit_theme_options' );
-	$available_legacy_widgets          = array();
+	$available_legacy_widgets = array();
 	global $wp_widget_factory;
 	if ( ! empty( $wp_widget_factory ) ) {
 		foreach ( $wp_widget_factory->widgets as $class => $widget_obj ) {
@@ -199,8 +198,7 @@ function gutenberg_get_legacy_widget_settings() {
 		}
 	}
 
-	$settings['hasPermissionsToManageWidgets'] = $has_permissions_to_manage_widgets;
-	$settings['availableLegacyWidgets']        = $available_legacy_widgets;
+	$settings['availableLegacyWidgets'] = $available_legacy_widgets;
 
 	return gutenberg_experiments_editor_settings( $settings );
 }

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -488,7 +488,6 @@ _Properties_
 -   _maxWidth_ `number`: Max width to constraint resizing
 -   _allowedBlockTypes_ `(boolean|Array)`: Allowed block types
 -   _hasFixedToolbar_ `boolean`: Whether or not the editor toolbar is fixed
--   _hasPermissionsToManageWidgets_ `boolean`: Whether or not the user is able to manage widgets.
 -   _focusMode_ `boolean`: Whether the focus mode is enabled or not
 -   _styles_ `Array`: Editor Styles
 -   _isRTL_ `boolean`: Whether the editor is in RTL mode

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -18,7 +18,6 @@ export const PREFERENCES_DEFAULTS = {
  * @property {number} maxWidth Max width to constraint resizing
  * @property {boolean|Array} allowedBlockTypes Allowed block types
  * @property {boolean} hasFixedToolbar Whether or not the editor toolbar is fixed
- * @property {boolean} hasPermissionsToManageWidgets Whether or not the user is able to manage widgets.
  * @property {boolean} focusMode Whether the focus mode is enabled or not
  * @property {Array} styles Editor Styles
  * @property {boolean} isRTL Whether the editor is in RTL mode
@@ -149,7 +148,6 @@ export const SETTINGS_DEFAULTS = {
 	allowedMimeTypes: null,
 
 	availableLegacyWidgets: {},
-	hasPermissionsToManageWidgets: false,
 	__experimentalCanUserUseUnfilteredHTML: false,
 	__experimentalBlockDirectory: false,
 	__experimentalEnableFullSiteEditing: false,

--- a/packages/edit-widgets/src/blocks/legacy-widget/edit/index.js
+++ b/packages/edit-widgets/src/blocks/legacy-widget/edit/index.js
@@ -23,7 +23,6 @@ import WidgetPreview from './widget-preview';
 function LegacyWidgetEdit( {
 	attributes,
 	availableLegacyWidgets,
-	hasPermissionsToManageWidgets,
 	prerenderedEditForm,
 	setAttributes,
 	widgetId,
@@ -57,7 +56,6 @@ function LegacyWidgetEdit( {
 		return (
 			<LegacyWidgetPlaceholder
 				availableLegacyWidgets={ availableLegacyWidgets }
-				hasPermissionsToManageWidgets={ hasPermissionsToManageWidgets }
 				onChangeWidget={ ( newWidget ) => {
 					const {
 						isReferenceWidget,
@@ -91,18 +89,6 @@ function LegacyWidgetEdit( {
 			</PanelBody>
 		</InspectorControls>
 	) : null;
-	if ( ! hasPermissionsToManageWidgets ) {
-		return (
-			<>
-				{ inspectorControls }
-				<WidgetPreview
-					className="wp-block-legacy-widget__preview"
-					widgetAreaId={ widgetAreaId }
-					attributes={ omit( attributes, 'widgetId' ) }
-				/>
-			</>
-		);
-	}
 
 	return (
 		<>
@@ -194,10 +180,7 @@ export default withSelect( ( select, { clientId, attributes } ) => {
 		clientId
 	);
 	const editorSettings = select( 'core/block-editor' ).getSettings();
-	const {
-		availableLegacyWidgets,
-		hasPermissionsToManageWidgets,
-	} = editorSettings;
+	const { availableLegacyWidgets } = editorSettings;
 
 	let WPWidget;
 	if ( widgetId && availableLegacyWidgets[ widgetId ] ) {
@@ -210,7 +193,6 @@ export default withSelect( ( select, { clientId, attributes } ) => {
 	}
 
 	return {
-		hasPermissionsToManageWidgets,
 		availableLegacyWidgets,
 		widgetId,
 		widgetAreaId: widgetArea?.id,

--- a/packages/edit-widgets/src/blocks/legacy-widget/edit/placeholder.js
+++ b/packages/edit-widgets/src/blocks/legacy-widget/edit/placeholder.js
@@ -15,7 +15,6 @@ import { brush } from '@wordpress/icons';
 export default function LegacyWidgetPlaceholder( {
 	availableLegacyWidgets,
 	currentWidget,
-	hasPermissionsToManageWidgets,
 	onChangeWidget,
 } ) {
 	const visibleLegacyWidgets = useMemo(
@@ -23,11 +22,7 @@ export default function LegacyWidgetPlaceholder( {
 		[ availableLegacyWidgets ]
 	);
 	let placeholderContent;
-	if ( ! hasPermissionsToManageWidgets ) {
-		placeholderContent = __(
-			"You don't have permissions to use widgets on this site."
-		);
-	} else if ( isEmpty( visibleLegacyWidgets ) ) {
+	if ( isEmpty( visibleLegacyWidgets ) ) {
 		placeholderContent = __( 'There are no widgets available.' );
 	} else {
 		placeholderContent = (

--- a/packages/edit-widgets/src/blocks/legacy-widget/edit/widget-preview.js
+++ b/packages/edit-widgets/src/blocks/legacy-widget/edit/widget-preview.js
@@ -16,9 +16,8 @@ function WidgetPreview( { widgetAreaId, attributes, hidden, ...props } ) {
 	const [ height, setHeight ] = useState( DEFAULT_HEIGHT );
 	const iframeRef = useRef();
 	const currentUrl = document.location.href;
-	const siteUrl = currentUrl.substr( 0, currentUrl.indexOf( 'wp-admin/' ) );
-	const iframeUrl = addQueryArgs( siteUrl, {
-		widgetPreview: {
+	const iframeUrl = addQueryArgs( currentUrl, {
+		'widget-preview': {
 			...attributes,
 			sidebarId: widgetAreaId,
 		},

--- a/packages/edit-widgets/src/index.js
+++ b/packages/edit-widgets/src/index.js
@@ -31,9 +31,9 @@ export function initialize( id, settings ) {
 	registerCoreBlocks();
 	if ( process.env.GUTENBERG_PHASE === 2 ) {
 		__experimentalRegisterExperimentalCoreBlocks( settings );
-		registerBlock( createLegacyWidget( settings ) );
-		registerBlock( widgetArea );
 	}
+	registerBlock( createLegacyWidget( settings ) );
+	registerBlock( widgetArea );
 	render(
 		<Layout blockEditorSettings={ settings } />,
 		document.getElementById( id )

--- a/packages/edit-widgets/src/style.scss
+++ b/packages/edit-widgets/src/style.scss
@@ -13,7 +13,8 @@ html.wp-toolbar {
 	background: $white;
 }
 
-body.appearance_page_gutenberg-widgets {
+body.appearance_page_gutenberg-widgets,
+body.widgets-php {
 	@include wp-admin-reset( ".blocks-widgets-container" );
 }
 

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -194,7 +194,6 @@ class EditorProvider extends Component {
 				'gradients',
 				'hasFixedToolbar',
 				'hasReducedUI',
-				'hasPermissionsToManageWidgets',
 				'imageEditing',
 				'imageSizes',
 				'imageDimensions',


### PR DESCRIPTION
Four smallish changes which will make it easier to add this package to Core (see https://github.com/WordPress/wordpress-develop/pull/603).

1. Update the CSS to target `body.widgets-php` as well as `body.appearance_page_gutenberg-widgets`. This is the class name that the screen will have in Core.

2. Have `@wordpress/edit-widgets` register the Legacy Widget block and the Widget Area block when `GUTENBERG_PHASE` is 1. This prevents those blocks from not being registered in Core.

3. Use `example.com/wp-admin/widgets.php?widget-preview=` instead of `example.com/?widgetPreview=` for Legacy Widget block previewing. This means that the code for handling this query param can be co-located with the rest of `widgets.php` in Core.

4. Remove `hasPermissionsToManageWidgets`. This isn't necessary as the Legacy Widget block is only ever registered in the widgets editor which can only be accessed when the logged-in user has permission to customise the site.

I've tested this by copying the built packages over into Core and running it against my WIP integration branch (https://github.com/WordPress/wordpress-develop/pull/603).

Need to test that these changes do not cause any regressions in the plugin, though.