### PR TITLE
Show the legacy widget name in list view

### DIFF
--- a/packages/edit-widgets/src/blocks/legacy-widget/block.json
+++ b/packages/edit-widgets/src/blocks/legacy-widget/block.json
@@ -8,6 +8,9 @@
 		"referenceWidgetName": {
 			"type": "string"
 		},
+		"name": {
+			"type": "string"
+		},
 		"idBase": {
 			"type": "string"
 		},

--- a/packages/edit-widgets/src/blocks/legacy-widget/index.js
+++ b/packages/edit-widgets/src/blocks/legacy-widget/index.js
@@ -40,6 +40,7 @@ export const create = ( editorSettings ) => {
 		name,
 		settings: {
 			...settings,
+			__experimentalLabel: ( { name: widgetName } ) => widgetName,
 			variations: legacyWidgetsToBlockVariations( legacyWidgets ),
 		},
 	};
@@ -66,13 +67,16 @@ function legacyWidgetToBlockVariation( className, widget ) {
 		name: className,
 		title: widget.name,
 	};
+
 	if ( widget.isReferenceWidget ) {
 		blockVariation.attributes = {
+			name: widget.name,
 			referenceWidgetName: className,
 			instance: {},
 		};
 	} else {
 		blockVariation.attributes = {
+			name: widget.name,
 			idBase: widget.id_base,
 			widgetClass: className,
 			instance: {},

--- a/packages/edit-widgets/src/store/transformers.js
+++ b/packages/edit-widgets/src/store/transformers.js
@@ -13,6 +13,7 @@ export function transformWidgetToBlock( widget ) {
 	}
 
 	const attributes = {
+		name: widget.name,
 		form: widget.form,
 		instance: widget.settings,
 		idBase: widget.id_base,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Closes #24940

Adds the `__experimentalLabel` prop to the legacy widget block. To show the widget name I had to add a `name` attribute to the block and ensure that gets set during block creation, but I think that's ok—as is the nature of the widget screen it's only used temporarily while widgets are in block form.

## How has this been tested?
1. Open the widget screen
2. Add various legacy widget blocks to widget areas.
3. Open List View and see the names

## Screenshots <!-- if applicable -->
<img width="249" alt="Screenshot 2020-10-15 at 12 32 06 pm" src="https://user-images.githubusercontent.com/677833/96077477-7ef03000-0ee2-11eb-925c-d733290afd1d.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
