### PR TITLE
Fix tabbing in widgets not triggering auto-scrolling

### DIFF
--- a/packages/edit-widgets/src/components/widget-areas-block-editor-content/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-content/index.js
@@ -5,10 +5,10 @@ import { Popover } from '@wordpress/components';
 import {
 	BlockList,
 	BlockEditorKeyboardShortcuts,
+	BlockSelectionClearer,
 	WritingFlow,
 	ObserveTyping,
 } from '@wordpress/block-editor';
-import { useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -17,15 +17,10 @@ import Notices from '../notices';
 import KeyboardShortcuts from '../keyboard-shortcuts';
 
 export default function WidgetAreasBlockEditorContent() {
-	const { clearSelectedBlock } = useDispatch( 'core/block-editor' );
-
 	return (
 		<>
-			<KeyboardShortcuts />
-			<BlockEditorKeyboardShortcuts />
 			<Notices />
-			<Popover.Slot name="block-toolbar" />
-			<div tabIndex="-1" onFocus={ clearSelectedBlock }>
+			<BlockSelectionClearer>
 				<div
 					className="editor-styles-wrapper"
 					onFocus={ ( event ) => {
@@ -35,13 +30,16 @@ export default function WidgetAreasBlockEditorContent() {
 						event.preventDefault();
 					} }
 				>
+					<KeyboardShortcuts />
+					<BlockEditorKeyboardShortcuts />
+					<Popover.Slot name="block-toolbar" />
 					<WritingFlow>
 						<ObserveTyping>
 							<BlockList className="edit-widgets-main-block-list" />
 						</ObserveTyping>
 					</WritingFlow>
 				</div>
-			</div>
+			</BlockSelectionClearer>
 		</>
 	);
 }

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-content/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-content/index.js
@@ -20,7 +20,7 @@ export default function WidgetAreasBlockEditorContent() {
 	return (
 		<BlockSelectionClearer>
 			<div
-				className="editor-styles-wrapper"
+				className="edit-widgets-block-editor editor-styles-wrapper"
 				onFocus={ ( event ) => {
 					// Stop propagation of the focus event to avoid the parent
 					// widget layout component catching the event and removing the selected area.

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-content/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-content/index.js
@@ -18,28 +18,26 @@ import KeyboardShortcuts from '../keyboard-shortcuts';
 
 export default function WidgetAreasBlockEditorContent() {
 	return (
-		<>
-			<Notices />
-			<BlockSelectionClearer>
-				<div
-					className="editor-styles-wrapper"
-					onFocus={ ( event ) => {
-						// Stop propagation of the focus event to avoid the parent
-						// widget layout component catching the event and removing the selected area.
-						event.stopPropagation();
-						event.preventDefault();
-					} }
-				>
-					<KeyboardShortcuts />
-					<BlockEditorKeyboardShortcuts />
-					<Popover.Slot name="block-toolbar" />
-					<WritingFlow>
-						<ObserveTyping>
-							<BlockList className="edit-widgets-main-block-list" />
-						</ObserveTyping>
-					</WritingFlow>
-				</div>
-			</BlockSelectionClearer>
-		</>
+		<BlockSelectionClearer>
+			<div
+				className="editor-styles-wrapper"
+				onFocus={ ( event ) => {
+					// Stop propagation of the focus event to avoid the parent
+					// widget layout component catching the event and removing the selected area.
+					event.stopPropagation();
+					event.preventDefault();
+				} }
+			>
+				<KeyboardShortcuts />
+				<BlockEditorKeyboardShortcuts />
+				<Notices />
+				<Popover.Slot name="block-toolbar" />
+				<WritingFlow>
+					<ObserveTyping>
+						<BlockList className="edit-widgets-main-block-list" />
+					</ObserveTyping>
+				</WritingFlow>
+			</div>
+		</BlockSelectionClearer>
 	);
 }

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-content/style.scss
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-content/style.scss
@@ -1,0 +1,3 @@
+.editor-styles-wrapper {
+	position: relative;
+}

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-content/style.scss
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-content/style.scss
@@ -1,3 +1,3 @@
-.editor-styles-wrapper {
+.edit-widgets-block-editor {
 	position: relative;
 }

--- a/packages/edit-widgets/src/style.scss
+++ b/packages/edit-widgets/src/style.scss
@@ -6,6 +6,7 @@
 @import "./components/sidebar/style.scss";
 @import "./components/notices/style.scss";
 @import "./components/layout/style.scss";
+@import "./components/widget-areas-block-editor-content/style.scss";
 
 // In order to use mix-blend-mode, this element needs to have an explicitly set background-color
 // We scope it to .wp-toolbar to be wp-admin only, to prevent bleed into other implementations


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Fix #25927.

It took me way more time than expected. It turns out, we just need to wrap the popover with an additional `position: relative` wrapper... 😞

We probably would want to add an e2e test in the future to prevent regression.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Go to the widgets screen
2. Open some widget areas until there's a scrollbar
3. Press <kbd>Tab</kbd> several times to tab through the widgets
4. Observe that when tabbing to an element below the viewport, the screen auto scrolls to it

## Screenshots <!-- if applicable -->
![Kapture 2020-10-15 at 13 18 44](https://user-images.githubusercontent.com/7753001/96080123-faed7680-0ee8-11eb-8c97-12093cd6a2c3.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
