### PR TITLE
PostCSS Plugins Preset: Update vulnerable dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7862,9 +7862,9 @@
 					}
 				},
 				"node-fetch": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-					"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+					"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
 				}
 			}
 		},
@@ -18139,7 +18139,7 @@
 				"@wordpress/base-styles": "file:packages/base-styles",
 				"@wordpress/postcss-themes": "file:packages/postcss-themes",
 				"autoprefixer": "^9.8.6",
-				"postcss-custom-properties": "^9.1.1"
+				"postcss-custom-properties": "^10.0.0"
 			}
 		},
 		"@wordpress/postcss-themes": {
@@ -38609,13 +38609,10 @@
 			"dev": true
 		},
 		"is-url-superb": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-url-superb/-/is-url-superb-3.0.0.tgz",
-			"integrity": "sha512-3faQP+wHCGDQT1qReM5zCPx2mxoal6DzbzquFlCYJLWyy4WPTved33ea2xFbX37z4NoriEwZGIYhFtx8RUB5wQ==",
-			"dev": true,
-			"requires": {
-				"url-regex": "^5.0.0"
-			}
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-url-superb/-/is-url-superb-4.0.0.tgz",
+			"integrity": "sha512-GI+WjezhPPcbM+tqE9LnmsY5qqjwHzTvjJ36wxYX5ujNXefSUJ/T17r5bqDV8yLhcgB59KTPNOc9O9cmHTPWsA==",
+			"dev": true
 		},
 		"is-utf8": {
 			"version": "0.2.1",
@@ -44210,9 +44207,9 @@
 			}
 		},
 		"kind-of": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
 		},
 		"klaw": {
 			"version": "1.3.1",
@@ -47028,9 +47025,9 @@
 			}
 		},
 		"minimist": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
 		},
 		"minimist-options": {
 			"version": "3.0.2",
@@ -47510,9 +47507,9 @@
 			}
 		},
 		"node-fetch": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-			"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
 		},
 		"node-fetch-npm": {
 			"version": "2.0.2",
@@ -50134,63 +50131,13 @@
 			}
 		},
 		"postcss-custom-properties": {
-			"version": "9.1.1",
-			"resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-9.1.1.tgz",
-			"integrity": "sha512-GVu+j7vwMTKUGhGXckYAFAAG5tTJUkSt8LuSyimtZdVVmdAEZYYqserkAgX8vwMhgGDPA4vJtWt7VgFxgiooDA==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-10.0.0.tgz",
+			"integrity": "sha512-55BPj5FudpCiPZzBaO+MOeqmwMDa+nV9/0QBJBfhZjYg6D9hE+rW9lpMBLTJoF4OTXnS5Po4yM1nMlgkPbCxFg==",
 			"dev": true,
 			"requires": {
 				"postcss": "^7.0.17",
-				"postcss-values-parser": "^3.0.5"
-			},
-			"dependencies": {
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "5.5.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-							"dev": true,
-							"requires": {
-								"has-flag": "^3.0.0"
-							}
-						}
-					}
-				},
-				"postcss": {
-					"version": "7.0.32",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
-					"integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
+				"postcss-values-parser": "^4.0.0"
 			}
 		},
 		"postcss-discard-comments": {
@@ -50911,15 +50858,14 @@
 			"integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU="
 		},
 		"postcss-values-parser": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-3.2.1.tgz",
-			"integrity": "sha512-SQ7/88VE9LhJh9gc27/hqnSU/aZaREVJcRVccXBmajgP2RkjdJzNyH/a9GCVMI5nsRhT0jC5HpUMwfkz81DVVg==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-4.0.0.tgz",
+			"integrity": "sha512-R9x2D87FcbhwXUmoCXJR85M1BLII5suXRuXibGYyBJ7lVDEpRIdKZh4+8q5S+/+A4m0IoG1U5tFw39asyhX/Hw==",
 			"dev": true,
 			"requires": {
 				"color-name": "^1.1.4",
-				"is-url-superb": "^3.0.0",
-				"postcss": "^7.0.5",
-				"url-regex": "^5.0.0"
+				"is-url-superb": "^4.0.0",
+				"postcss": "^7.0.5"
 			},
 			"dependencies": {
 				"color-name": {
@@ -59615,12 +59561,6 @@
 			"resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
 			"integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g="
 		},
-		"tlds": {
-			"version": "1.207.0",
-			"resolved": "https://registry.npmjs.org/tlds/-/tlds-1.207.0.tgz",
-			"integrity": "sha512-k7d7Q1LqjtAvhtEOs3yN14EabsNO8ZCoY6RESSJDB9lst3bTx3as/m1UuAeCKzYxiyhR1qq72ZPhpSf+qlqiwg==",
-			"dev": true
-		},
 		"tmp": {
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -60408,24 +60348,6 @@
 						"ajv": "^6.10.2",
 						"ajv-keywords": "^3.4.1"
 					}
-				}
-			}
-		},
-		"url-regex": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/url-regex/-/url-regex-5.0.0.tgz",
-			"integrity": "sha512-O08GjTiAFNsSlrUWfqF1jH0H1W3m35ZyadHrGv5krdnmPPoxP27oDTqux/579PtaroiSGm5yma6KT1mHFH6Y/g==",
-			"dev": true,
-			"requires": {
-				"ip-regex": "^4.1.0",
-				"tlds": "^1.203.0"
-			},
-			"dependencies": {
-				"ip-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.1.0.tgz",
-					"integrity": "sha512-pKnZpbgCTfH/1NLIlOduP/V+WRXzC2MOz3Qo8xmxk8C5GudJLgK5QyLVXOSWy3ParAH7Eemurl3xjv/WXYFvMA==",
-					"dev": true
 				}
 			}
 		},

--- a/packages/postcss-plugins-preset/CHANGELOG.md
+++ b/packages/postcss-plugins-preset/CHANGELOG.md
@@ -2,4 +2,10 @@
 
 ## Unreleased
 
+### Security
+
+-   Updated `postcss-custom-properties` dependency to `v10.0.0` that no longer contains vulnerable dependency `url-regex`.
+
+## 1.0.0 (2020-05-28)
+
 Initial release.

--- a/packages/postcss-plugins-preset/package.json
+++ b/packages/postcss-plugins-preset/package.json
@@ -32,7 +32,7 @@
 		"@wordpress/base-styles": "file:../base-styles",
 		"@wordpress/postcss-themes": "file:../postcss-themes",
 		"autoprefixer": "^9.8.6",
-		"postcss-custom-properties": "^9.1.1"
+		"postcss-custom-properties": "^10.0.0"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes #25731.

> The latest version of the npm package @wordpress/postcss-plugins-preset (1.4.1) depends on postcss-custom-properties@^9.1.1. This dependency, before version 10, contains a dependency tree which includes url-regex, a package now not maintained but known to have a ReDoS vulnerability.
> 
> Source 1: https://www.npmjs.com/advisories/1550
> Source 2: https://portswigger.net/daily-swig/unpatched-regex-bug-leaves-node-js-apps-open-to-redos-attacks
> 
> Versions of postcss-custom-properties from 10.0.0 onwards address this by updating dependencies such that url-regex is no longer included.

## How has this been tested?
I followed the update instructions shared by @jcush in #25731. To test it I went to `packages/postcss-plugins-preset` folder and executed `npm audit` which is the closest to installing the published version from npm.

## Types of changes

Security fix