### PR TITLE
Add legacy widget inspector card component

### DIFF
--- a/packages/edit-widgets/src/blocks/legacy-widget/edit/index.js
+++ b/packages/edit-widgets/src/blocks/legacy-widget/edit/index.js
@@ -7,7 +7,7 @@ import { get, omit } from 'lodash';
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
-import { Button, PanelBody, ToolbarGroup } from '@wordpress/components';
+import { Button, ToolbarGroup } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { withSelect } from '@wordpress/data';
 import { BlockControls, InspectorControls } from '@wordpress/block-editor';
@@ -19,6 +19,7 @@ import { update } from '@wordpress/icons';
 import LegacyWidgetEditHandler from './handler';
 import LegacyWidgetPlaceholder from './placeholder';
 import WidgetPreview from './widget-preview';
+import LegacyWidgetInspectorCard from './inspector-card';
 
 function LegacyWidgetEdit( {
 	attributes,
@@ -86,9 +87,12 @@ function LegacyWidgetEdit( {
 
 	const inspectorControls = WPWidget ? (
 		<InspectorControls>
-			<PanelBody title={ WPWidget.name }>
-				{ WPWidget.description }
-			</PanelBody>
+			<LegacyWidgetInspectorCard
+				name={ WPWidget.name }
+				description={ WPWidget.description }
+			/>
+			{ /* <PanelBody title={ WPWidget.name }>
+			</PanelBody> */ }
 		</InspectorControls>
 	) : null;
 	if ( ! hasPermissionsToManageWidgets ) {

--- a/packages/edit-widgets/src/blocks/legacy-widget/edit/index.js
+++ b/packages/edit-widgets/src/blocks/legacy-widget/edit/index.js
@@ -91,8 +91,6 @@ function LegacyWidgetEdit( {
 				name={ WPWidget.name }
 				description={ WPWidget.description }
 			/>
-			{ /* <PanelBody title={ WPWidget.name }>
-			</PanelBody> */ }
 		</InspectorControls>
 	) : null;
 	if ( ! hasPermissionsToManageWidgets ) {

--- a/packages/edit-widgets/src/blocks/legacy-widget/edit/inspector-card.js
+++ b/packages/edit-widgets/src/blocks/legacy-widget/edit/inspector-card.js
@@ -1,0 +1,18 @@
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+
+export default function LegacyWidgetInspectorCard( { name, description } ) {
+	return (
+		<div className="wp-block-legacy-widget-inspector-card">
+			<h3>
+				{
+					/* translators: %s: the name of the widget being viewed. */
+					sprintf( __( 'Widget: %s' ), name )
+				}
+			</h3>
+			<span>{ description }</span>
+		</div>
+	);
+}

--- a/packages/edit-widgets/src/blocks/legacy-widget/edit/inspector-card.js
+++ b/packages/edit-widgets/src/blocks/legacy-widget/edit/inspector-card.js
@@ -6,7 +6,7 @@ import { __, sprintf } from '@wordpress/i18n';
 export default function LegacyWidgetInspectorCard( { name, description } ) {
 	return (
 		<div className="wp-block-legacy-widget-inspector-card">
-			<h3>
+			<h3 className="wp-block-legacy-widget-inspector-card__name">
 				{
 					/* translators: %s: the name of the widget being viewed. */
 					sprintf( __( 'Widget: %s' ), name )

--- a/packages/edit-widgets/src/blocks/legacy-widget/editor.scss
+++ b/packages/edit-widgets/src/blocks/legacy-widget/editor.scss
@@ -42,9 +42,11 @@
 }
 
 .wp-block-legacy-widget-inspector-card {
-	padding: 0 $grid-unit-20 $grid-unit-20;
+	// Padding left = an icon, some margin and some padding
+	padding: 0 $grid-unit-20 $grid-unit-20 ( $icon-size + $grid-unit-40 + $grid-unit-05 );
 }
 
-.wp-block-legacy-widget-inspector-card__name {
+.interface-complementary-area .wp-block-legacy-widget-inspector-card__name {
+	margin: 0 0 5px;
 	font-weight: 500;
 }

--- a/packages/edit-widgets/src/blocks/legacy-widget/editor.scss
+++ b/packages/edit-widgets/src/blocks/legacy-widget/editor.scss
@@ -40,3 +40,7 @@
 	border: $border-width solid $gray-900;
 	border-radius: $radius-block-ui;
 }
+
+.wp-block-legacy-widget-inspector-card {
+	padding: 0 $grid-unit-20 $grid-unit-20;
+}

--- a/packages/edit-widgets/src/blocks/legacy-widget/editor.scss
+++ b/packages/edit-widgets/src/blocks/legacy-widget/editor.scss
@@ -44,3 +44,7 @@
 .wp-block-legacy-widget-inspector-card {
 	padding: 0 $grid-unit-20 $grid-unit-20;
 }
+
+.wp-block-legacy-widget-inspector-card__name {
+	font-weight: 500;
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Closes #24870

Improves how the details about the legacy widget are shown in the inspector:
<img width="285" alt="Screenshot 2020-10-15 at 4 42 50 pm" src="https://user-images.githubusercontent.com/677833/96099148-8117b600-0f05-11eb-9288-6587c57174e5.png">

This is a bit of a hybrid of some of the designs, as I don't think we realized the border at the top could be bypassed, and i know at the same time there was a desire to keep the description. Happy to iterate further on how it looks if we think further changes are needed.

## How has this been tested?
1. Open the widgets screen
2. Add some legacy widgets
3. Click on a legacy widget and view the sidebar.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
