### PR TITLE
Fix Cover width regression

### DIFF
--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -95,6 +95,7 @@
 	}
 
 	.wp-block-cover__inner-container {
+		width: 100%;
 		z-index: z-index(".wp-block-cover__inner-container");
 		color: $white;
 	}


### PR DESCRIPTION
In #25103 I introduced a regression to the cover block on the frontend (ironically in fixing another regression). This was kindly pointed out by @johnstonphilip in https://github.com/WordPress/gutenberg/pull/25103#issuecomment-708611178 and https://github.com/WordPress/gutenberg/pull/24523. Sorry about that.

This PR should address the regression, but also keep the fix for the initial issue (the width is now plainly `100%` rather than `calc(100% - 70px)`). 

Here's before and after for me in the editor:

<img width="1196" alt="Screenshot 2020-10-15 at 10 29 35" src="https://user-images.githubusercontent.com/1204802/96098011-ef428580-0ed1-11eb-8032-3a3e4ae41734.png">

Here's the frontend showing the width property present for the inner container:

<img width="1988" alt="Screenshot 2020-10-15 at 10 30 36" src="https://user-images.githubusercontent.com/1204802/96098042-f6699380-0ed1-11eb-963f-167e2723bbba.png">
