### PR TITLE
Block templates: Recognize and convert old or derivative block types to their canonical form

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -45,6 +45,7 @@ function gutenberg_reregister_core_block_types() {
 				'text-columns',
 				'verse',
 				'video',
+				'embed',
 			),
 			'block_names'   => array_merge(
 				array(

--- a/packages/blocks/src/api/parser.js
+++ b/packages/blocks/src/api/parser.js
@@ -395,14 +395,15 @@ export function getMigratedBlock( block, parsedAttributes ) {
 }
 
 /**
- * Convert derivative blocks to their canonical form. This function is used
+ * Convert legacy blocks to their canonical form. This function is used
  * both in the parser level for previous content and to convert such blocks
  * used in Custom Post Types templates.
  *
- * @param {string} name
- * @param {Object} attributes
+ * @param {string} name The block's name
+ * @param {Object} attributes The block's attributes
  */
-export function convertDerivativeBlocks( name, attributes ) {
+export function convertLegacyBlocks( name, attributes ) {
+	const newAttributes = { ...attributes };
 	// Convert 'core/cover-image' block in existing content to 'core/cover'.
 	if ( 'core/cover-image' === name ) {
 		name = 'core/cover';
@@ -417,7 +418,7 @@ export function convertDerivativeBlocks( name, attributes ) {
 	// canonical form 'core/social-link'.
 	if ( name && name.indexOf( 'core/social-link-' ) === 0 ) {
 		// Capture `social-link-wordpress` into `{"service":"wordpress"}`
-		attributes.service = name.substring( 17 );
+		newAttributes.service = name.substring( 17 );
 		name = 'core/social-link';
 	}
 
@@ -430,18 +431,18 @@ export function convertDerivativeBlocks( name, attributes ) {
 			speaker: 'speaker-deck',
 			polldaddy: 'crowdsignal',
 		};
-		attributes.providerNameSlug =
+		newAttributes.providerNameSlug =
 			providerSlug in deprecated
 				? deprecated[ providerSlug ]
 				: providerSlug;
 		// this is needed as the `responsive` attribute was passed
 		// in a different way before the refactoring to block variations
 		if ( ! [ 'amazon-kindle', 'wordpress' ].includes( providerSlug ) ) {
-			attributes.responsive = true;
+			newAttributes.responsive = true;
 		}
 		name = 'core/embed';
 	}
-	return { name, attributes };
+	return { name, attributes: newAttributes };
 }
 
 /**
@@ -468,7 +469,7 @@ export function createBlockWithFallback( blockNode ) {
 	// freeform content fallback.
 	let name = originalName || freeformContentFallbackBlock;
 
-	name = convertDerivativeBlocks( name, attributes ).name;
+	( { name, attributes } = convertLegacyBlocks( name, attributes ) );
 
 	// Fallback content may be upgraded from classic editor expecting implicit
 	// automatic paragraphs, so preserve them. Assumes wpautop is idempotent,

--- a/packages/blocks/src/api/parser.js
+++ b/packages/blocks/src/api/parser.js
@@ -395,29 +395,14 @@ export function getMigratedBlock( block, parsedAttributes ) {
 }
 
 /**
- * Creates a block with fallback to the unknown type handler.
+ * Convert derivative blocks to their canonical form. This function is used
+ * both in the parser level for previous content and to convert such blocks
+ * used in Custom Post Types templates.
  *
- * @param {Object} blockNode Parsed block node.
- *
- * @return {?Object} An initialized block object (if possible).
+ * @param {string} name
+ * @param {Object} attributes
  */
-export function createBlockWithFallback( blockNode ) {
-	const { blockName: originalName } = blockNode;
-	let { attrs: attributes, innerBlocks = [], innerHTML } = blockNode;
-	const { innerContent } = blockNode;
-	const freeformContentFallbackBlock = getFreeformContentHandlerName();
-	const unregisteredFallbackBlock =
-		getUnregisteredTypeHandlerName() || freeformContentFallbackBlock;
-
-	attributes = attributes || {};
-
-	// Trim content to avoid creation of intermediary freeform segments.
-	innerHTML = innerHTML.trim();
-
-	// Use type from block content if available. Otherwise, default to the
-	// freeform content fallback.
-	let name = originalName || freeformContentFallbackBlock;
-
+export function convertDerivativeBlocks( name, attributes ) {
 	// Convert 'core/cover-image' block in existing content to 'core/cover'.
 	if ( 'core/cover-image' === name ) {
 		name = 'core/cover';
@@ -456,6 +441,34 @@ export function createBlockWithFallback( blockNode ) {
 		}
 		name = 'core/embed';
 	}
+	return { name, attributes };
+}
+
+/**
+ * Creates a block with fallback to the unknown type handler.
+ *
+ * @param {Object} blockNode Parsed block node.
+ *
+ * @return {?Object} An initialized block object (if possible).
+ */
+export function createBlockWithFallback( blockNode ) {
+	const { blockName: originalName } = blockNode;
+	let { attrs: attributes, innerBlocks = [], innerHTML } = blockNode;
+	const { innerContent } = blockNode;
+	const freeformContentFallbackBlock = getFreeformContentHandlerName();
+	const unregisteredFallbackBlock =
+		getUnregisteredTypeHandlerName() || freeformContentFallbackBlock;
+
+	attributes = attributes || {};
+
+	// Trim content to avoid creation of intermediary freeform segments.
+	innerHTML = innerHTML.trim();
+
+	// Use type from block content if available. Otherwise, default to the
+	// freeform content fallback.
+	let name = originalName || freeformContentFallbackBlock;
+
+	name = convertDerivativeBlocks( name, attributes ).name;
 
 	// Fallback content may be upgraded from classic editor expecting implicit
 	// automatic paragraphs, so preserve them. Assumes wpautop is idempotent,

--- a/packages/blocks/src/api/parser.js
+++ b/packages/blocks/src/api/parser.js
@@ -401,6 +401,8 @@ export function getMigratedBlock( block, parsedAttributes ) {
  *
  * @param {string} name The block's name
  * @param {Object} attributes The block's attributes
+ *
+ * @return {Object} The block's name and attributes, changed accordingly if a match was found
  */
 export function convertLegacyBlocks( name, attributes ) {
 	const newAttributes = { ...attributes };

--- a/packages/blocks/src/api/templates.js
+++ b/packages/blocks/src/api/templates.js
@@ -11,7 +11,7 @@ import { renderToString } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { convertDerivativeBlocks } from './parser';
+import { convertLegacyBlocks } from './parser';
 import { createBlock } from './factory';
 import { getBlockType } from './registration';
 
@@ -111,7 +111,7 @@ export function synchronizeBlocksWithTemplate( blocks = [], template ) {
 			const {
 				name: blockName,
 				attributes: blockAttributes,
-			} = convertDerivativeBlocks( name, normalizedAttributes );
+			} = convertLegacyBlocks( name, normalizedAttributes );
 
 			return createBlock(
 				blockName,

--- a/packages/blocks/src/api/templates.js
+++ b/packages/blocks/src/api/templates.js
@@ -11,6 +11,7 @@ import { renderToString } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import { convertDerivativeBlocks } from './parser';
 import { createBlock } from './factory';
 import { getBlockType } from './registration';
 
@@ -107,9 +108,14 @@ export function synchronizeBlocksWithTemplate( blocks = [], template ) {
 				attributes
 			);
 
+			const {
+				name: blockName,
+				attributes: blockAttributes,
+			} = convertDerivativeBlocks( name, normalizedAttributes );
+
 			return createBlock(
-				name,
-				normalizedAttributes,
+				blockName,
+				blockAttributes,
 				synchronizeBlocksWithTemplate( [], innerBlocksTemplate )
 			);
 		}

--- a/packages/e2e-tests/plugins/custom-post-types.php
+++ b/packages/e2e-tests/plugins/custom-post-types.php
@@ -106,3 +106,27 @@ function hierarchical_without_title_cpt() {
 }
 add_action( 'init', 'hierarchical_without_title_cpt' );
 
+/**
+ * Registers a custom post type that includes a legacy block in `template`.
+ */
+function legacy_block_in_template_cpt() {
+	register_post_type(
+		'leg_block_in_tpl',
+		array(
+			'label'              => 'Legacy block in template',
+			'show_in_rest'       => true,
+			'public'             => true,
+			'publicly_queryable' => true,
+			'supports'           => array( 'title', 'editor', 'revisions' ),
+			'show_ui'            => true,
+			'show_in_menu'       => true,
+			'template'           => array(
+				array(
+					'core-embed/wordpress-tv',
+					array( 'className' => 'wordpress_video' ),
+				)
+			)
+		)
+	);
+}
+add_action( 'init', 'legacy_block_in_template_cpt' );

--- a/packages/e2e-tests/plugins/custom-post-types.php
+++ b/packages/e2e-tests/plugins/custom-post-types.php
@@ -124,8 +124,8 @@ function legacy_block_in_template_cpt() {
 				array(
 					'core-embed/wordpress-tv',
 					array( 'className' => 'wordpress_video' ),
-				)
-			)
+				),
+			),
 		)
 	);
 }

--- a/packages/e2e-tests/specs/editor/plugins/custom-post-types.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/custom-post-types.test.js
@@ -68,6 +68,7 @@ describe( 'Test Custom Post Types', () => {
 		await createNewPost( { postType: 'leg_block_in_tpl' } );
 		await page.click( '.block-editor-writing-flow' );
 		await page.keyboard.type( 'Hello there' );
+		await page.waitForSelector( '[data-type="core/embed"]' );
 		await publishPost();
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/plugins/custom-post-types.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/custom-post-types.test.js
@@ -64,4 +64,10 @@ describe( 'Test Custom Post Types', () => {
 		);
 		expect( selectedValue ).toEqual( valueToSelect );
 	} );
+	it( 'should create a cpt with a legacy block in its template without WSOD', async () => {
+		await createNewPost( { postType: 'leg_block_in_tpl' } );
+		await page.click( '.block-editor-writing-flow' );
+		await page.keyboard.type( 'Hello there' );
+		await publishPost();
+	} );
 } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes: https://github.com/WordPress/gutenberg/issues/26137

If a post type template contains a legacy block, like an `embed` for a specific platform (e.g. `core-embed/wordpress-tv`), the editor will crash with a WSOD when trying to create a new post.

Steps to reproduce exist in issue.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
