### PR TITLE
Global Styles sidebar (blocks tab): protect against not registered blocks

### DIFF
--- a/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
@@ -89,7 +89,14 @@ export default ( { identifier, title, icon, closeLabel } ) => {
 								 * as it's translatable and the block.json doesn't
 								 * have it yet.
 								 */
+
 								const blockType = getBlockType( blockName );
+								// Protect against blocks that aren't registered
+								// eg: widget-area
+								if ( blockType === undefined ) {
+									return blockType;
+								}
+
 								let panelTitle = blockType.title;
 								if (
 									'object' ===


### PR DESCRIPTION
This PR fixes a WSOD within the Global Styles sidebar (block tab) when a block type does not exist.
