### PR TITLE
Paragraph: avoid selector to improve performance

### DIFF
--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -19,17 +19,14 @@ import {
 } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import { formatLtr } from '@wordpress/icons';
 
 function getComputedStyle( node, pseudo ) {
 	return node.ownerDocument.defaultView.getComputedStyle( node, pseudo );
 }
 
-const querySelector = window.document.querySelector.bind( document );
-
 const name = 'core/paragraph';
-const PARAGRAPH_DROP_CAP_SELECTOR = 'p.has-drop-cap';
 
 function ParagraphRTLToolbar( { direction, setDirection } ) {
 	const isRTL = useSelect( ( select ) => {
@@ -56,38 +53,21 @@ function ParagraphRTLToolbar( { direction, setDirection } ) {
 	);
 }
 
-function useDropCap( isDropCap, fontSize, styleFontSize ) {
-	const isDisabled = ! useEditorFeature( 'typography.dropCap' );
+function useDropCapMinHeight( ref, isDisabled, dependencies ) {
+	const [ minHeight, setMinHeight ] = useState();
 
-	const [ minimumHeight, setMinimumHeight ] = useState();
-
-	const { fontSizes } = useSelect( ( select ) =>
-		select( 'core/block-editor' ).getSettings()
-	);
-
-	const fontSizeObject = getFontSize( fontSizes, fontSize, styleFontSize );
 	useEffect( () => {
 		if ( isDisabled ) {
+			setMinHeight();
 			return;
 		}
 
-		const element = querySelector( PARAGRAPH_DROP_CAP_SELECTOR );
-		if ( isDropCap && element ) {
-			setMinimumHeight(
-				getComputedStyle( element, 'first-letter' ).lineHeight
-			);
-		} else if ( minimumHeight ) {
-			setMinimumHeight( undefined );
-		}
-	}, [
-		isDisabled,
-		isDropCap,
-		minimumHeight,
-		setMinimumHeight,
-		fontSizeObject.size,
-	] );
+		setMinHeight(
+			getComputedStyle( ref.current, 'first-letter' ).lineHeight
+		);
+	}, [ isDisabled, ...dependencies ] );
 
-	return [ ! isDisabled, minimumHeight ];
+	return minHeight;
 }
 
 function ParagraphBlock( {
@@ -106,23 +86,25 @@ function ParagraphBlock( {
 		fontSize,
 		style,
 	} = attributes;
-	const [ isDropCapEnabled, dropCapMinimumHeight ] = useDropCap(
-		dropCap,
-		fontSize,
-		style?.fontSize
+	const isDropCapFeatureEnabled = useEditorFeature( 'typography.dropCap' );
+	const ref = useRef();
+	const inlineFontSize = style?.fontSize;
+	const size = useSelect(
+		( select ) => {
+			const { fontSizes } = select( 'core/block-editor' ).getSettings();
+			return getFontSize( fontSizes, fontSize, inlineFontSize ).size;
+		},
+		[ fontSize, inlineFontSize ]
 	);
-
-	const styles = {
-		direction,
-		minHeight: dropCapMinimumHeight,
-	};
-
+	const hasDropCap = isDropCapFeatureEnabled && dropCap;
+	const minHeight = useDropCapMinHeight( ref, ! hasDropCap, [ size ] );
 	const blockProps = useBlockProps( {
+		ref,
 		className: classnames( {
 			'has-drop-cap': dropCap,
 			[ `has-text-align-${ align }` ]: align,
 		} ),
-		style: styles,
+		style: { direction, minHeight },
 	} );
 
 	return (
@@ -141,8 +123,8 @@ function ParagraphBlock( {
 					}
 				/>
 			</BlockControls>
-			<InspectorControls>
-				{ isDropCapEnabled && (
+			{ isDropCapFeatureEnabled && (
+				<InspectorControls>
 					<PanelBody title={ __( 'Text settings' ) }>
 						<ToggleControl
 							label={ __( 'Drop cap' ) }
@@ -159,8 +141,8 @@ function ParagraphBlock( {
 							}
 						/>
 					</PanelBody>
-				) }
-			</InspectorControls>
+				</InspectorControls>
+			) }
 			<RichText
 				identifier="content"
 				tagName="p"


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

1. DOM querying can be avoided by using the ref.
2. `getComputedStyle` should only run if there's a drop cap, not on all paragraphs.
3. `useSelect` dependencies were missing.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
