### PR TITLE
Fix separator and spacer blocks after api v2 refactoring.

### DIFF
--- a/packages/block-library/src/separator/edit.js
+++ b/packages/block-library/src/separator/edit.js
@@ -16,18 +16,18 @@ import SeparatorSettings from './separator-settings';
 function SeparatorEdit( { color, setColor, className } ) {
 	return (
 		<>
-			<div { ...useBlockProps() }>
-				<HorizontalRule
-					className={ classnames( className, {
+			<HorizontalRule
+				{ ...useBlockProps( {
+					className: classnames( className, {
 						'has-background': color.color,
 						[ color.class ]: color.class,
-					} ) }
-					style={ {
+					} ),
+					style: {
 						backgroundColor: color.color,
 						color: color.color,
-					} }
-				/>
-			</div>
+					},
+				} ) }
+			/>
 			<SeparatorSettings color={ color } setColor={ setColor } />
 		</>
 	);

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -12,6 +12,7 @@ import { PanelBody, ResizableBox, RangeControl } from '@wordpress/components';
 import { compose, withInstanceId } from '@wordpress/compose';
 import { withDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
+import { View } from '@wordpress/primitives';
 
 const MIN_SPACER_HEIGHT = 1;
 const MAX_SPACER_HEIGHT = 500;
@@ -48,7 +49,7 @@ const SpacerEdit = ( {
 
 	return (
 		<>
-			<div { ...useBlockProps() }>
+			<View { ...useBlockProps() }>
 				<ResizableBox
 					className={ classnames(
 						'block-library-spacer__resize-container',
@@ -80,7 +81,7 @@ const SpacerEdit = ( {
 						isVisible: isResizing,
 					} }
 				/>
-			</div>
+			</View>
 			<InspectorControls>
 				<PanelBody title={ __( 'Spacer settings' ) }>
 					<RangeControl

--- a/packages/primitives/src/index.js
+++ b/packages/primitives/src/index.js
@@ -1,3 +1,4 @@
 export * from './svg';
 export * from './horizontal-rule';
 export * from './block-quotation';
+export * from './view';

--- a/packages/primitives/src/view/README.md
+++ b/packages/primitives/src/view/README.md
@@ -1,0 +1,3 @@
+# View
+
+A drop-in replacement for the div element that works across devices.

--- a/packages/primitives/src/view/index.js
+++ b/packages/primitives/src/view/index.js
@@ -1,0 +1,1 @@
+export const View = 'div';

--- a/packages/primitives/src/view/index.native.js
+++ b/packages/primitives/src/view/index.native.js
@@ -1,0 +1,4 @@
+/**
+ * External dependencies
+ */
+export { View } from 'react-native';


### PR DESCRIPTION
This also introduces the "View" primitive between mobile and web. The main question for me here is what props this primitive should accept. Implicitly here, it already accepts a bunch of web props (className, style, role, ref)  generated by useBlockProps but I guess the native version of useBlockProps could generate different ones (or we find a device-agnostic way to define these styles and properties).