### PR TITLE
Site editor: Rework navigation panel animations

### DIFF
--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -78,6 +78,7 @@ export default function Header( { openEntitiesSavedStates } ) {
 	return (
 		<div className="edit-site-header">
 			<div className="edit-site-header_start">
+				<div className="edit-site-header__navigation-panel-spacer"></div>
 				<div className="edit-site-header__toolbar">
 					<Button
 						isPrimary

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -78,7 +78,6 @@ export default function Header( { openEntitiesSavedStates } ) {
 	return (
 		<div className="edit-site-header">
 			<div className="edit-site-header_start">
-				<div className="edit-site-header__navigation-panel-spacer"></div>
 				<div className="edit-site-header__toolbar">
 					<Button
 						isPrimary

--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -6,6 +6,11 @@
 	box-sizing: border-box;
 	width: 100%;
 
+	padding-left: 60px;
+	transition: padding-left 20ms linear;
+	transition-delay: 80ms;
+	@include reduce-motion("transition");
+
 	.edit-site-header_start,
 	.edit-site-header_end {
 		flex: 1 0;
@@ -38,42 +43,16 @@
 	}
 }
 
-// This element is used to do the same transition as
-// the navigation sidebar. This element is at least
-// `$header-height` wide, when the navigation panel is
-// opened then it widens to the same width as the
-// navigation panel. While doing that, it also
-// moves itself to the left (negative `margin-left`)
-// to avoid content jumping
-.edit-site-header__navigation-panel-spacer {
-	min-width: $header-height;
-	transition: margin-left 100ms linear;
-	margin-left: 0;
-	@include reduce-motion("transition");
-}
-
-.edit-site-header__navigation-panel-spacer::before {
-	content: "";
-	display: block;
-	width: 0;
-	transition: width 100ms linear;
-	@include reduce-motion("transition");
-}
-
 // Keeps the document title centered when the sidebar is open
 body.is-navigation-sidebar-open {
 	.edit-site-header {
+		padding-left: 0;
+		transition: padding-left 20ms linear;
+		transition-delay: 0ms;
+
 		.edit-site-header_start {
 			flex-basis: $header-toolbar-min-width;
 		}
-	}
-
-	.edit-site-header__navigation-panel-spacer {
-		margin-left: -$nav-sidebar-width;
-	}
-
-	.edit-site-header__navigation-panel-spacer::before {
-		width: $nav-sidebar-width;
 	}
 }
 

--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -5,7 +5,6 @@
 	height: $header-height;
 	box-sizing: border-box;
 	width: 100%;
-	padding-left: $header-height;
 
 	.edit-site-header_start,
 	.edit-site-header_end {
@@ -39,14 +38,42 @@
 	}
 }
 
+// This element is used to do the same transition as
+// the navigation sidebar. This element is at least
+// `$header-height` wide, when the navigation panel is
+// opened then it widens to the same width as the
+// navigation panel. While doing that, it also
+// moves itself to the left (negative `margin-left`)
+// to avoid content jumping
+.edit-site-header__navigation-panel-spacer {
+	min-width: $header-height;
+	transition: margin-left 100ms linear;
+	margin-left: 0;
+	@include reduce-motion("transition");
+}
+
+.edit-site-header__navigation-panel-spacer::before {
+	content: "";
+	display: block;
+	width: 0;
+	transition: width 100ms linear;
+	@include reduce-motion("transition");
+}
+
 // Keeps the document title centered when the sidebar is open
 body.is-navigation-sidebar-open {
 	.edit-site-header {
-		padding-left: 0;
-
 		.edit-site-header_start {
 			flex-basis: $header-toolbar-min-width;
 		}
+	}
+
+	.edit-site-header__navigation-panel-spacer {
+		margin-left: -$nav-sidebar-width;
+	}
+
+	.edit-site-header__navigation-panel-spacer::before {
+		width: $nav-sidebar-width;
 	}
 }
 

--- a/packages/edit-site/src/components/navigation-sidebar/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/index.js
@@ -17,7 +17,7 @@ const NavigationSidebar = () => {
 	return (
 		<>
 			<NavigationToggle isOpen={ isNavigationOpen } />
-			{ isNavigationOpen && <NavigationPanel /> }
+			<NavigationPanel isOpen={ isNavigationOpen } />
 		</>
 	);
 };

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
@@ -17,7 +22,7 @@ export const {
 	Slot: NavigationPanelPreviewSlot,
 } = createSlotFill( 'EditSiteNavigationPanelPreview' );
 
-const NavigationPanel = () => {
+const NavigationPanel = ( { isOpen } ) => {
 	const [ contentActiveMenu, setContentActiveMenu ] = useState( MENU_ROOT );
 	const templatesActiveMenu = useSelect(
 		( select ) => select( 'core/edit-site' ).getNavigationPanelActiveMenu(),
@@ -25,14 +30,24 @@ const NavigationPanel = () => {
 	);
 
 	return (
-		<div className="edit-site-navigation-panel">
-			{ ( contentActiveMenu === MENU_ROOT ||
-				templatesActiveMenu !== MENU_ROOT ) && <TemplatesNavigation /> }
+		<div
+			className={ classnames( `edit-site-navigation-panel`, {
+				'is-open': isOpen,
+			} ) }
+		>
+			<div className="edit-site-navigation-panel__inner">
+				{ ( contentActiveMenu === MENU_ROOT ||
+					templatesActiveMenu !== MENU_ROOT ) && (
+					<TemplatesNavigation />
+				) }
 
-			{ ( templatesActiveMenu === MENU_ROOT ||
-				contentActiveMenu !== MENU_ROOT ) && (
-				<ContentNavigation onActivateMenu={ setContentActiveMenu } />
-			) }
+				{ ( templatesActiveMenu === MENU_ROOT ||
+					contentActiveMenu !== MENU_ROOT ) && (
+					<ContentNavigation
+						onActivateMenu={ setContentActiveMenu }
+					/>
+				) }
+			</div>
 
 			<NavigationPanelPreviewSlot />
 		</div>

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
@@ -24,10 +24,18 @@ export const {
 
 const NavigationPanel = ( { isOpen } ) => {
 	const [ contentActiveMenu, setContentActiveMenu ] = useState( MENU_ROOT );
-	const templatesActiveMenu = useSelect(
-		( select ) => select( 'core/edit-site' ).getNavigationPanelActiveMenu(),
-		[]
-	);
+	const { templatesActiveMenu, siteTitle } = useSelect( ( select ) => {
+		const { getNavigationPanelActiveMenu } = select( 'core/edit-site' );
+		const { getEntityRecord } = select( 'core' );
+
+		const siteData =
+			getEntityRecord( 'root', '__unstableBase', undefined ) || {};
+
+		return {
+			templatesActiveMenu: getNavigationPanelActiveMenu(),
+			siteTitle: siteData.name,
+		};
+	}, [] );
 
 	return (
 		<div
@@ -36,6 +44,12 @@ const NavigationPanel = ( { isOpen } ) => {
 			} ) }
 		>
 			<div className="edit-site-navigation-panel__inner">
+				<div className="edit-site-navigation-panel__site-title-container">
+					<div className="edit-site-navigation-panel__site-title">
+						{ siteTitle }
+					</div>
+				</div>
+
 				{ ( contentActiveMenu === MENU_ROOT ||
 					templatesActiveMenu !== MENU_ROOT ) && (
 					<TemplatesNavigation />

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
@@ -16,11 +16,27 @@
 	position: relative;
 	width: $nav-sidebar-width;
 	height: 100%;
-	padding-top: 61px;
 }
 
-.edit-site-navigation-panel.is-open .edit-site-navigation-panel__inner {
-	padding-top: 0;
+.edit-site-navigation-panel__site-title-container {
+	height: $header-height;
+	padding-left: $header-height;
+	margin: 0 $grid-unit-20 0 $grid-unit-10;
+	display: flex;
+	align-items: center;
+}
+
+.edit-site-navigation-panel__site-title {
+	font-style: normal;
+	font-weight: 600;
+	font-size: $default-font-size;
+	line-height: $default-line-height;
+	color: $gray-300;
+
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
 }
 
 .edit-site-navigation-panel__back-to-dashboard.components-button.is-tertiary {

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
@@ -1,18 +1,26 @@
 .edit-site-navigation-panel {
-	animation: edit-site-navigation-panel__slide-in 0.1s linear;
 	height: 100%;
-	width: $nav-sidebar-width;
+	position: relative;
+	width: 0;
+	overflow: hidden;
 	background: $gray-900;
-	@include reduce-motion("animation");
+	transition: width 100ms linear;
+	@include reduce-motion("transition");
+}
 
-	@keyframes edit-site-navigation-panel__slide-in {
-		from {
-			transform: translateX(-100%);
-		}
-		to {
-			transform: translateX(0%);
-		}
-	}
+.edit-site-navigation-panel.is-open {
+	width: $nav-sidebar-width;
+}
+
+.edit-site-navigation-panel__inner {
+	position: relative;
+	width: $nav-sidebar-width;
+	height: 100%;
+	padding-top: 61px;
+}
+
+.edit-site-navigation-panel.is-open .edit-site-navigation-panel__inner {
+	padding-top: 0;
 }
 
 .edit-site-navigation-panel__back-to-dashboard.components-button.is-tertiary {

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/index.js
@@ -7,29 +7,26 @@ import { __ } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
 
 function NavigationToggle( { icon, isOpen } ) {
-	const {
-		isActive,
-		isRequestingSiteIcon,
-		siteIconUrl,
-		siteTitle,
-	} = useSelect( ( select ) => {
-		const { isFeatureActive } = select( 'core/edit-site' );
-		const { getEntityRecord } = select( 'core' );
-		const { isResolving } = select( 'core/data' );
-		const siteData =
-			getEntityRecord( 'root', '__unstableBase', undefined ) || {};
+	const { isActive, isRequestingSiteIcon, siteIconUrl } = useSelect(
+		( select ) => {
+			const { isFeatureActive } = select( 'core/edit-site' );
+			const { getEntityRecord } = select( 'core' );
+			const { isResolving } = select( 'core/data' );
+			const siteData =
+				getEntityRecord( 'root', '__unstableBase', undefined ) || {};
 
-		return {
-			isActive: isFeatureActive( 'fullscreenMode' ),
-			isRequestingSiteIcon: isResolving( 'core', 'getEntityRecord', [
-				'root',
-				'__unstableBase',
-				undefined,
-			] ),
-			siteIconUrl: siteData.site_icon_url,
-			siteTitle: siteData.name,
-		};
-	}, [] );
+			return {
+				isActive: isFeatureActive( 'fullscreenMode' ),
+				isRequestingSiteIcon: isResolving( 'core', 'getEntityRecord', [
+					'root',
+					'__unstableBase',
+					undefined,
+				] ),
+				siteIconUrl: siteData.site_icon_url,
+			};
+		},
+		[]
+	);
 
 	const { setIsNavigationPanelOpened } = useDispatch( 'core/edit-site' );
 
@@ -67,12 +64,6 @@ function NavigationToggle( { icon, isOpen } ) {
 			>
 				{ buttonIcon }
 			</Button>
-
-			<div className="edit-site-navigation-toggle__site-title-container">
-				<div className="edit-site-navigation-toggle__site-title">
-					{ siteTitle }
-				</div>
-			</div>
 		</div>
 	);
 }

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/index.js
@@ -68,11 +68,11 @@ function NavigationToggle( { icon, isOpen } ) {
 				{ buttonIcon }
 			</Button>
 
-			{ isOpen && (
+			<div className="edit-site-navigation-toggle__site-title-container">
 				<div className="edit-site-navigation-toggle__site-title">
 					{ siteTitle }
 				</div>
-			) }
+			</div>
 		</div>
 	);
 }

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/style.scss
@@ -15,18 +15,7 @@
 
 .edit-site-navigation-toggle.is-open {
 	flex-shrink: 0;
-	height: $header-height + $border-width; // Cover header border
-	width: 300px;
 	position: static;
-
-	// Delay to sync with `NavigationPanel` animation
-	transition: width 80ms linear;
-	transition-delay: 20ms;
-	@include reduce-motion("transition");
-
-	.edit-site-navigation-toggle__button {
-		background: $gray-900;
-	}
 }
 
 .edit-site-navigation-toggle__button {
@@ -35,6 +24,7 @@
 	color: $white;
 	height: $header-height + $border-width; // Cover header border
 	width: $header-height;
+	z-index: 1;
 
 	&.has-icon {
 		min-width: $header-height;
@@ -57,6 +47,12 @@
 }
 
 .edit-site-navigation-toggle__site-title {
+	position: absolute;
+	top: 50%;
+	transform: translateY(-50%);
+	width: 300px;
+	left: $header-height;
+
 	font-style: normal;
 	font-weight: 600;
 	font-size: $default-font-size;
@@ -68,4 +64,21 @@
 	-webkit-line-clamp: 2;
 	-webkit-box-orient: vertical;
 	overflow: hidden;
+}
+
+.edit-site-navigation-toggle__site-title-container {
+	background: $gray-900;
+	position: absolute;
+	left: 0;
+	top: 0;
+	width: 0;
+	height: $header-height + $border-width;
+	overflow: hidden;
+	pointer-events: none;
+	transition: width 100ms linear;
+	@include reduce-motion("transition");
+}
+
+.edit-site-navigation-toggle.is-open .edit-site-navigation-toggle__site-title-container {
+	width: 300px;
 }

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/style.scss
@@ -13,11 +13,6 @@
 	}
 }
 
-.edit-site-navigation-toggle.is-open {
-	flex-shrink: 0;
-	position: static;
-}
-
 .edit-site-navigation-toggle__button {
 	align-items: center;
 	background: #23282e; // WP-admin gray.
@@ -44,41 +39,4 @@
 
 .edit-site-navigation-toggle__site-icon {
 	width: 36px;
-}
-
-.edit-site-navigation-toggle__site-title {
-	position: absolute;
-	top: 50%;
-	transform: translateY(-50%);
-	width: 300px;
-	left: $header-height;
-
-	font-style: normal;
-	font-weight: 600;
-	font-size: $default-font-size;
-	line-height: $default-line-height;
-	color: $gray-300;
-	margin: 0 $grid-unit-20 0 $grid-unit-10;
-
-	display: -webkit-box;
-	-webkit-line-clamp: 2;
-	-webkit-box-orient: vertical;
-	overflow: hidden;
-}
-
-.edit-site-navigation-toggle__site-title-container {
-	background: $gray-900;
-	position: absolute;
-	left: 0;
-	top: 0;
-	width: 0;
-	height: $header-height + $border-width;
-	overflow: hidden;
-	pointer-events: none;
-	transition: width 100ms linear;
-	@include reduce-motion("transition");
-}
-
-.edit-site-navigation-toggle.is-open .edit-site-navigation-toggle__site-title-container {
-	width: 300px;
 }

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/style.scss
@@ -15,7 +15,7 @@
 
 .edit-site-navigation-toggle__button {
 	align-items: center;
-	background: #23282e; // WP-admin gray.
+	background: $gray-900;
 	color: $white;
 	height: $header-height + $border-width; // Cover header border
 	width: $header-height;


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/26119

## Description
Reworks navigation panel animations. Instead of animation it uses transition which also let us have nice closing transition.

Known issues
* When closing the navigation sidebar, the header toolbar moves to the right by `60px`
* When opening the navigation sidebar, the drawer immediately takes up `60px` width and shows a grey outline

## How has this been tested?
* Open site editor
* Toggle navigation sidebar

## Screenshots <!-- if applicable -->
![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/2256104/96136968-55dc9900-0efc-11eb-89f4-e4f2f6902d28.gif)

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
