### PR TITLE
[Mobile] - Buttons block - Support content justification

### DIFF
--- a/packages/block-library/src/buttons/edit.native.js
+++ b/packages/block-library/src/buttons/edit.native.js
@@ -8,6 +8,7 @@ import { View } from 'react-native';
  * WordPress dependencies
  */
 import {
+	BlockControls,
 	__experimentalAlignmentHookSettingsProvider as AlignmentHookSettingsProvider,
 	InnerBlocks,
 } from '@wordpress/block-editor';
@@ -15,20 +16,23 @@ import { createBlock } from '@wordpress/blocks';
 import { useResizeObserver } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useState, useEffect, useRef } from '@wordpress/element';
+import { ToolbarGroup, ToolbarItem } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import { name as buttonBlockName } from '../button/';
 import styles from './editor.scss';
+import ContentJustificationDropdown from './content-justification-dropdown';
 
 const ALLOWED_BLOCKS = [ buttonBlockName ];
 const BUTTONS_TEMPLATE = [ [ 'core/button' ] ];
 
 export default function ButtonsEdit( {
-	attributes: { align },
+	attributes: { contentJustification },
 	clientId,
 	isSelected,
+	setAttributes,
 } ) {
 	const [ resizeObserver, sizes ] = useResizeObserver();
 	const [ maxWidth, setMaxWidth ] = useState( 0 );
@@ -89,6 +93,12 @@ export default function ButtonsEdit( {
 		selectBlock( insertedBlock.clientId );
 	}, 200 );
 
+	function onChangeContentJustification( updatedValue ) {
+		setAttributes( {
+			contentJustification: updatedValue,
+		} );
+	}
+
 	const renderFooterAppender = useRef( () => (
 		<View style={ styles.appenderContainer }>
 			<InnerBlocks.ButtonBlockAppender
@@ -104,24 +114,40 @@ export default function ButtonsEdit( {
 	};
 
 	return (
-		<AlignmentHookSettingsProvider value={ alignmentHooksSetting }>
-			{ resizeObserver }
-			<InnerBlocks
-				allowedBlocks={ ALLOWED_BLOCKS }
-				template={ BUTTONS_TEMPLATE }
-				renderFooterAppender={
-					shouldRenderFooterAppender && renderFooterAppender.current
-				}
-				orientation="horizontal"
-				horizontalAlignment={ align }
-				onDeleteBlock={
-					shouldDelete ? () => removeBlock( clientId ) : undefined
-				}
-				onAddBlock={ onAddNextButton }
-				parentWidth={ maxWidth }
-				marginHorizontal={ spacing }
-				marginVertical={ spacing }
-			/>
-		</AlignmentHookSettingsProvider>
+		<>
+			<BlockControls>
+				<ToolbarGroup>
+					<ToolbarItem>
+						{ ( toggleProps ) => (
+							<ContentJustificationDropdown
+								toggleProps={ toggleProps }
+								value={ contentJustification }
+								onChange={ onChangeContentJustification }
+							/>
+						) }
+					</ToolbarItem>
+				</ToolbarGroup>
+			</BlockControls>
+			<AlignmentHookSettingsProvider value={ alignmentHooksSetting }>
+				{ resizeObserver }
+				<InnerBlocks
+					allowedBlocks={ ALLOWED_BLOCKS }
+					template={ BUTTONS_TEMPLATE }
+					renderFooterAppender={
+						shouldRenderFooterAppender &&
+						renderFooterAppender.current
+					}
+					orientation="horizontal"
+					horizontalAlignment={ contentJustification }
+					onDeleteBlock={
+						shouldDelete ? () => removeBlock( clientId ) : undefined
+					}
+					onAddBlock={ onAddNextButton }
+					parentWidth={ maxWidth }
+					marginHorizontal={ spacing }
+					marginVertical={ spacing }
+				/>
+			</AlignmentHookSettingsProvider>
+		</>
 	);
 }


### PR DESCRIPTION
## Description
This PR is a continuation of https://github.com/WordPress/gutenberg/pull/23168 adding support of content justification and the `ContentJustificationDropdown` for mobile.

## How has this been tested?
- Open the demo app
- Add a Buttons block
- Add at least two buttons
- Select the block
- **Expect** to see two options in the Toolbar, **Alignment**, and **Content justification**.
- Change the alignment to full-width
- **Expect** to see the block in full-width
- Change the content justification to different options
- **Expect** to see the alignment of the blocks change within the Buttons block

## Screenshots <!-- if applicable -->

ContentJustificationDropdown | ToolbarItem
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/96152469-defbcc00-0f0c-11eb-83c2-a9fb7471021c.gif" width="250" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/96152447-da371800-0f0c-11eb-9100-eb113c6dde0a.png" width="250" /></kbd> 

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
