### PR TITLE
[RN Mobile] Ube cannot view or interact with the classic block on jetpack sites

### DIFF
--- a/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergWebViewActivity.java
+++ b/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergWebViewActivity.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import android.graphics.Bitmap;
 import android.os.Bundle;
 import android.os.Handler;
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
@@ -52,10 +53,10 @@ public class GutenbergWebViewActivity extends AppCompatActivity {
     private final Runnable mWebPageLoadedRunnable = new Runnable() {
         @Override public void run() {
             if (!mIsWebPageLoaded.getAndSet(true)) {
+                mProgressBar.setVisibility(View.GONE);
                 // We want to insert block content
                 // only if gutenberg is ready
                 if (mIsGutenbergReady) {
-                    mProgressBar.setVisibility(View.GONE);
                     final Handler handler = new Handler();
                     handler.postDelayed(() -> {
                         // Insert block content
@@ -355,6 +356,12 @@ public class GutenbergWebViewActivity extends AppCompatActivity {
         });
 
         super.finish();
+    }
+
+    @Override
+    protected void onDestroy() {
+        mWebPageLoadedHandler.removeCallbacks(mWebPageLoadedRunnable);
+        super.onDestroy();
     }
 
     public class WPWebKit {

--- a/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergWebViewActivity.java
+++ b/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/GutenbergWebViewActivity.java
@@ -100,6 +100,9 @@ public class GutenbergWebViewActivity extends AppCompatActivity {
                     mWebPageLoadedHandler.postDelayed(mWebPageLoadedRunnable, 1500);
                 } else {
                     mIsWebPageLoaded.compareAndSet(true, false);
+                    if (mProgressBar.getVisibility() == View.GONE) {
+                        mProgressBar.setVisibility(View.VISIBLE);
+                    }
                     mProgressBar.setProgress(progress);
                 }
             }


### PR DESCRIPTION
Even if we have fixed this issue [UBE issue: cannot view or interact with the classic block on Jetpack sites](https://github.com/wordpress-mobile/gutenberg-mobile/issues/2695)
we still had a problem on some devices, like `Galaxy Tab S3` @cameronvoell.

This PR proposes a new fix that should work for every scenario on every Android device.

Gutenberg mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2730

## How has this been tested?
1. On the web, create a post with a classic block on a Jetpack site (note: I used Jetpack 9.0.1 WordPress 5.5.1 in this test).
1. Save or publish the post.
1. In the app, open the post from the previous step in the block editor.
1. Tap on the classic block.
1. Tap on the classic block again.
1. Select the option to "Edit using the web editor."
1. Observe that you are able to load or interact with the classic block.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
