### PR TITLE
Gutenberg: Improve I18n types

### DIFF
--- a/packages/i18n/src/create-i18n.js
+++ b/packages/i18n/src/create-i18n.js
@@ -22,19 +22,69 @@ const DEFAULT_LOCALE_DATA = {
 	},
 };
 
+/* eslint-disable jsdoc/valid-types */
+/**
+ * @typedef {(data?: LocaleData, domain?: string)=>void} SetLocaleData
+ * Merges locale data into the Tannin instance by domain. Accepts data in a
+ * Jed-formatted JSON object shape.
+ *
+ * @see http://messageformat.github.io/Jed/
+ */
+/**
+ * @typedef {(text: string, domain?: string) => string} __
+ *
+ * Retrieve the translation of text.
+ *
+ * @see https://developer.wordpress.org/reference/functions/__/
+ */
+/**
+ * @typedef {(text: string, context: string, domain?: string) => string} _x
+ *
+ * Retrieve translated string with gettext context.
+ *
+ * @see https://developer.wordpress.org/reference/functions/_x/
+ */
+/**
+ * @typedef {(single: string, plural: string, number: number, domain?: string) => string} _n
+ *
+ * Translates and retrieves the singular or plural form based on the supplied
+ * number.
+ *
+ * @see https://developer.wordpress.org/reference/functions/_n/
+ */
+/**
+ * @typedef {(single: string, plural: string, number: number, context: string, domain?: string) => string} _nx
+ *
+ * Translates and retrieves the singular or plural form based on the supplied
+ * number, with gettext context.
+ *
+ * @see https://developer.wordpress.org/reference/functions/_nx/
+ */
+/**
+ * @typedef {() => boolean} IsRtl
+ *
+ * Check if current locale is RTL.
+ *
+ * **RTL (Right To Left)** is a locale property indicating that text is written from right to left.
+ * For example, the `he` locale (for Hebrew) specifies right-to-left. Arabic (ar) is another common
+ * language written RTL. The opposite of RTL, LTR (Left To Right) is used in other languages,
+ * including English (`en`, `en-US`, `en-GB`, etc.), Spanish (`es`), and French (`fr`).
+ */
+/* eslint-enable jsdoc/valid-types */
+
 /**
  * An i18n instance
  *
- * @typedef {Object} I18n
- * @property {Function} setLocaleData Merges locale data into the Tannin instance by domain. Accepts data in a
- *                                    Jed-formatted JSON object shape.
- * @property {Function} __            Retrieve the translation of text.
- * @property {Function} _x            Retrieve translated string with gettext context.
- * @property {Function} _n            Translates and retrieves the singular or plural form based on the supplied
- *                                    number.
- * @property {Function} _nx           Translates and retrieves the singular or plural form based on the supplied
- *                                    number, with gettext context.
- * @property {Function} isRTL         Check if current locale is RTL.
+ * @typedef I18n
+ * @property {SetLocaleData} setLocaleData Merges locale data into the Tannin instance by domain. Accepts data in a
+ *                                         Jed-formatted JSON object shape.
+ * @property {__} __                       Retrieve the translation of text.
+ * @property {_x} _x                       Retrieve translated string with gettext context.
+ * @property {_n} _n                       Translates and retrieves the singular or plural form based on the supplied
+ *                                         number.
+ * @property {_nx} _nx                     Translates and retrieves the singular or plural form based on the supplied
+ *                                         number, with gettext context.
+ * @property {IsRtl} isRTL                 Check if current locale is RTL.
  */
 
 /**
@@ -52,15 +102,7 @@ export const createI18n = ( initialData, initialDomain ) => {
 	 */
 	const tannin = new Tannin( {} );
 
-	/**
-	 * Merges locale data into the Tannin instance by domain. Accepts data in a
-	 * Jed-formatted JSON object shape.
-	 *
-	 * @see http://messageformat.github.io/Jed/
-	 *
-	 * @param {LocaleData} [data]   Locale data configuration.
-	 * @param {string}     [domain] Domain for which configuration applies.
-	 */
+	/** @type {SetLocaleData} */
 	const setLocaleData = ( data, domain = 'default' ) => {
 		tannin.data[ domain ] = {
 			...DEFAULT_LOCALE_DATA,
@@ -105,82 +147,27 @@ export const createI18n = ( initialData, initialDomain ) => {
 		return tannin.dcnpgettext( domain, context, single, plural, number );
 	};
 
-	/**
-	 * Retrieve the translation of text.
-	 *
-	 * @see https://developer.wordpress.org/reference/functions/__/
-	 *
-	 * @param {string} text     Text to translate.
-	 * @param {string} [domain] Domain to retrieve the translated text.
-	 *
-	 * @return {string} Translated text.
-	 */
+	/** @type {__} */
 	const __ = ( text, domain ) => {
 		return dcnpgettext( domain, undefined, text );
 	};
 
-	/**
-	 * Retrieve translated string with gettext context.
-	 *
-	 * @see https://developer.wordpress.org/reference/functions/_x/
-	 *
-	 * @param {string} text     Text to translate.
-	 * @param {string} context  Context information for the translators.
-	 * @param {string} [domain] Domain to retrieve the translated text.
-	 *
-	 * @return {string} Translated context string without pipe.
-	 */
+	/** @type {_x} */
 	const _x = ( text, context, domain ) => {
 		return dcnpgettext( domain, context, text );
 	};
 
-	/**
-	 * Translates and retrieves the singular or plural form based on the supplied
-	 * number.
-	 *
-	 * @see https://developer.wordpress.org/reference/functions/_n/
-	 *
-	 * @param {string} single   The text to be used if the number is singular.
-	 * @param {string} plural   The text to be used if the number is plural.
-	 * @param {number} number   The number to compare against to use either the
-	 *                          singular or plural form.
-	 * @param {string} [domain] Domain to retrieve the translated text.
-	 *
-	 * @return {string} The translated singular or plural form.
-	 */
+	/** @type {_n} */
 	const _n = ( single, plural, number, domain ) => {
 		return dcnpgettext( domain, undefined, single, plural, number );
 	};
 
-	/**
-	 * Translates and retrieves the singular or plural form based on the supplied
-	 * number, with gettext context.
-	 *
-	 * @see https://developer.wordpress.org/reference/functions/_nx/
-	 *
-	 * @param {string} single   The text to be used if the number is singular.
-	 * @param {string} plural   The text to be used if the number is plural.
-	 * @param {number} number   The number to compare against to use either the
-	 *                          singular or plural form.
-	 * @param {string} context  Context information for the translators.
-	 * @param {string} [domain] Domain to retrieve the translated text.
-	 *
-	 * @return {string} The translated singular or plural form.
-	 */
+	/** @type {_nx} */
 	const _nx = ( single, plural, number, context, domain ) => {
 		return dcnpgettext( domain, context, single, plural, number );
 	};
 
-	/**
-	 * Check if current locale is RTL.
-	 *
-	 * **RTL (Right To Left)** is a locale property indicating that text is written from right to left.
-	 * For example, the `he` locale (for Hebrew) specifies right-to-left. Arabic (ar) is another common
-	 * language written RTL. The opposite of RTL, LTR (Left To Right) is used in other languages,
-	 * including English (`en`, `en-US`, `en-GB`, etc.), Spanish (`es`), and French (`fr`).
-	 *
-	 * @return {boolean} Whether locale is RTL.
-	 */
+	/** @type {IsRtl} */
 	const isRTL = () => {
 		return 'rtl' === _x( 'ltr', 'text direction' );
 	};

--- a/packages/i18n/src/create-i18n.js
+++ b/packages/i18n/src/create-i18n.js
@@ -24,7 +24,7 @@ const DEFAULT_LOCALE_DATA = {
 
 /* eslint-disable jsdoc/valid-types */
 /**
- * @typedef {(data?: LocaleData, domain?: string)=>void} SetLocaleData
+ * @typedef {(data?: LocaleData, domain?: string) => void} SetLocaleData
  * Merges locale data into the Tannin instance by domain. Accepts data in a
  * Jed-formatted JSON object shape.
  *


### PR DESCRIPTION
##  Description

Improve the types of translation methods for `@wordpress/i18n`. They were all `Function` which is much more generic. Now they are the full function types with parameters and returns.

<details>
<summary>Diff in typings</summary>

```diff
diff --git a/build-types/create-i18n.d.ts b/../create-i18n.d.ts
index 240c96ea15..cd3d7b4c93 100644
--- a/build-types/create-i18n.d.ts
+++ b/../create-i18n.d.ts
@@ -2,6 +2,38 @@ export function createI18n(initialData?: Record<string, any> | undefined, initia
 export type LocaleData = {
     [x: string]: any;
 };
+/**
+ * Merges locale data into the Tannin instance by domain. Accepts data in a
+ * Jed-formatted JSON object shape.
+ */
+export type SetLocaleData = (data?: Record<string, any> | undefined, domain?: string | undefined) => void;
+/**
+ * Retrieve the translation of text.
+ */
+export type __ = (text: string, domain?: string | undefined) => string;
+/**
+ * Retrieve translated string with gettext context.
+ */
+export type _x = (text: string, context: string, domain?: string | undefined) => string;
+/**
+ * Translates and retrieves the singular or plural form based on the supplied
+ * number.
+ */
+export type _n = (single: string, plural: string, number: number, domain?: string | undefined) => string;
+/**
+ * Translates and retrieves the singular or plural form based on the supplied
+ * number, with gettext context.
+ */
+export type _nx = (single: string, plural: string, number: number, context: string, domain?: string | undefined) => string;
+/**
+ * Check if current locale is RTL.
+ *
+ * **RTL (Right To Left)** is a locale property indicating that text is written from right to left.
+ * For example, the `he` locale (for Hebrew) specifies right-to-left. Arabic (ar) is another common
+ * language written RTL. The opposite of RTL, LTR (Left To Right) is used in other languages,
+ * including English (`en`, `en-US`, `en-GB`, etc.), Spanish (`es`), and French (`fr`).
+ */
+export type IsRtl = () => boolean;
 /**
  * An i18n instance
  */
@@ -10,28 +42,28 @@ export type I18n = {
      * Merges locale data into the Tannin instance by domain. Accepts data in a
      * Jed-formatted JSON object shape.
      */
-    setLocaleData: Function;
+    setLocaleData: SetLocaleData;
     /**
      * Retrieve the translation of text.
      */
-    __: Function;
+    __: __;
     /**
      * Retrieve translated string with gettext context.
      */
-    _x: Function;
+    _x: _x;
     /**
      * Translates and retrieves the singular or plural form based on the supplied
      * number.
      */
-    _n: Function;
+    _n: _n;
     /**
      * Translates and retrieves the singular or plural form based on the supplied
      * number, with gettext context.
      */
-    _nx: Function;
+    _nx: _nx;
     /**
      * Check if current locale is RTL.
      */
-    isRTL: Function;
+    isRTL: IsRtl;
 };
 //# sourceMappingURL=create-i18n.d.ts.map
\ No newline at end of file
```

</details>

## How has this been tested?

Tests and typechecking pass.

## Types of changes
New feature: Improved types.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
