### PR TITLE
Add types to Tip

### DIFF
--- a/packages/components/src/tip/index.js
+++ b/packages/components/src/tip/index.js
@@ -5,7 +5,7 @@ import { SVG, Path } from '@wordpress/primitives';
 
 /**
  * @typedef Props
- * @property {import('@wordpress/element').WPNode} children Children to render in the tip.
+ * @property {import('react').ReactNode} children Children to render in the tip.
  */
 
 /**

--- a/packages/components/src/tip/index.js
+++ b/packages/components/src/tip/index.js
@@ -1,8 +1,17 @@
 /**
- * Internal dependencies
+ * WordPress dependencies
  */
-import { SVG, Path } from '../';
+import { SVG, Path } from '@wordpress/primitives';
 
+/**
+ * @typedef Props
+ * @property {import('@wordpress/element').WPNode} children Children to render in the tip.
+ */
+
+/**
+ * @param {Props} props
+ * @return {JSX.Element} Element
+ */
 function Tip( props ) {
 	return (
 		<div className="components-tip">

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -2,11 +2,8 @@
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",
-		"declarationDir": "build-types",
+		"declarationDir": "build-types"
 	},
-	"references": [],
-    "include": [
-		"src/dashicon/*",
-		"src/tip/*"
-	],
+	"references": [ { "path": "../primitives" } ],
+	"include": [ "src/dashicon/*", "src/tip/*" ]
 }

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -6,6 +6,7 @@
 	},
 	"references": [],
     "include": [
-		"src/dashicon/*"
+		"src/dashicon/*",
+		"src/tip/*"
 	],
 }

--- a/packages/element/src/react.js
+++ b/packages/element/src/react.js
@@ -41,6 +41,12 @@ import { isString } from 'lodash';
  */
 
 /**
+ * Object containing a React node.
+ *
+ * @typedef {import('react').ReactNode} WPNode
+ */
+
+/**
  * Object containing a React synthetic event.
  *
  * @typedef {import('react').SyntheticEvent} WPSyntheticEvent

--- a/packages/element/src/react.js
+++ b/packages/element/src/react.js
@@ -41,12 +41,6 @@ import { isString } from 'lodash';
  */
 
 /**
- * Object containing a React node.
- *
- * @typedef {import('react').ReactNode} WPNode
- */
-
-/**
  * Object containing a React synthetic event.
  *
  * @typedef {import('react').SyntheticEvent} WPSyntheticEvent


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
* Add missing `ReactNode` type to be able to properly type `children`
* Type the `Tip` component

## How has this been tested?
Local typecheck.

## Types of changes
New types.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->

/cc @sirreal 