### PR TITLE
Add types to shortcut

### DIFF
--- a/packages/components/src/shortcut/index.js
+++ b/packages/components/src/shortcut/index.js
@@ -1,8 +1,19 @@
 /**
  * External dependencies
  */
-import { isString, isObject } from 'lodash';
+import { isString } from 'lodash';
 
+/** @typedef {string | { display: string, ariaLabel: string }} Shortcut */
+/**
+ * @typedef Props
+ * @property {Shortcut} shortcut Shortcut configuration
+ * @property {string} [className] Classname
+ */
+
+/**
+ * @param {Props} props Props
+ * @return {JSX.Element | null} Element
+ */
 function Shortcut( { shortcut, className } ) {
 	if ( ! shortcut ) {
 		return null;
@@ -13,9 +24,7 @@ function Shortcut( { shortcut, className } ) {
 
 	if ( isString( shortcut ) ) {
 		displayText = shortcut;
-	}
-
-	if ( isObject( shortcut ) ) {
+	} else {
 		displayText = shortcut.display;
 		ariaLabel = shortcut.ariaLabel;
 	}

--- a/packages/components/src/shortcut/index.js
+++ b/packages/components/src/shortcut/index.js
@@ -12,7 +12,7 @@ import { isString, isObject } from 'lodash';
 
 /**
  * @param {Props} props Props
- * @return {import('react').ReactNode} Element
+ * @return {JSX.Element | null} Element
  */
 function Shortcut( { shortcut, className } ) {
 	if ( ! shortcut ) {

--- a/packages/components/src/shortcut/index.js
+++ b/packages/components/src/shortcut/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isString } from 'lodash';
+import { isString, isObject } from 'lodash';
 
 /** @typedef {string | { display: string, ariaLabel: string }} Shortcut */
 /**
@@ -24,7 +24,9 @@ function Shortcut( { shortcut, className } ) {
 
 	if ( isString( shortcut ) ) {
 		displayText = shortcut;
-	} else {
+	}
+
+	if ( isObject( shortcut ) ) {
 		displayText = shortcut.display;
 		ariaLabel = shortcut.ariaLabel;
 	}

--- a/packages/components/src/shortcut/index.js
+++ b/packages/components/src/shortcut/index.js
@@ -12,7 +12,7 @@ import { isString } from 'lodash';
 
 /**
  * @param {Props} props Props
- * @return {JSX.Element | null} Element
+ * @return {import('react').ReactNode} Element
  */
 function Shortcut( { shortcut, className } ) {
 	if ( ! shortcut ) {

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -5,5 +5,5 @@
 		"declarationDir": "build-types"
 	},
 	"references": [ { "path": "../primitives" } ],
-	"include": [ "src/dashicon/*", "src/tip/*" ]
+	"include": [ "src/dashicon/*", "src/shortcut/*", "src/tip/*" ]
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Add types to `Shortcut` and update type-refinements in the component.

## How has this been tested?
Local typecheck.

## Types of changes
Type updates.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->

/cc @sirreal 