### PR TITLE
Try typing animate

### DIFF
--- a/packages/components/src/animate/index.js
+++ b/packages/components/src/animate/index.js
@@ -4,46 +4,40 @@
 import classnames from 'classnames';
 
 /**
- * @typedef {'top' | 'top left' | 'top right' | 'bottom' | 'bottom left' | 'bottom right'} AppearOrigin
+ * WordPress dependencies
  */
-/**
- * @typedef {'appear' | 'loading' | 'slide-in'} Type
- */
-/**
- * @typedef {'left' | 'right'} SlideInOrigin
- */
+import deprecated from '@wordpress/deprecated';
 
 /**
- * @param {Type} type The animation type
+ * @typedef {'top' | 'top left' | 'top right' | 'middle' | 'middle left' | 'middle right' | 'bottom' | 'bottom left' | 'bottom right'} AppearOrigin
+ * @typedef {'left' | 'right'} SlideInOrigin
+ * @typedef {{type: 'appear'; origin?: AppearOrigin}} AppearOptions
+ * @typedef {{type: 'slide-in'; origin?: SlideInOrigin}} SlideInOptions
+ * @typedef {{type: 'loading'}} LoadingOptions
+ * @typedef {AppearOptions|SlideInOptions|LoadingOptions} UseAnimateOptions
+ */
+
+/* eslint-disable jsdoc/valid-types */
+/**
+ * @param {UseAnimateOptions['type']} type The animation type
  * @return {'top'|'left'} Default origin
  */
 function getDefaultOrigin( type ) {
 	return type === 'appear' ? 'top' : 'left';
 }
+/* eslint-enable jsdoc/valid-types */
 
 /**
- * @typedef AppearOptions
- * @property {'appear'} type The type of animation.
- * @property {AppearOrigin} origin The origin of the appearance.
- */
-
-/**
- * @typedef SlideInOptions
- * @property {'slide-in'} type The type of animation.
- * @property {SlideInOrigin} origin The origin of the appearance.
- */
-
-/**
- * @typedef LoadingOptions
- * @property {'loading'} type The type of animation.
- * @property {never} origin .
- */
-
-/**
- * @param {AppearOptions | SlideInOptions | LoadingOptions} options
+ * @param {UseAnimateOptions} options
  * @return {string | undefined} Classname that applies the animations
  */
-export function useAnimate( { type, origin = getDefaultOrigin( type ) } ) {
+export function useAnimate( { type } ) {
+	if ( type === 'loading' ) {
+		return classnames( 'components-animate__loading' );
+	}
+
+	const origin = getDefaultOrigin( type );
+
 	if ( type === 'appear' ) {
 		const [ yAxis, xAxis = 'center' ] = origin.split( ' ' );
 		return classnames( 'components-animate__appear', {
@@ -59,61 +53,29 @@ export function useAnimate( { type, origin = getDefaultOrigin( type ) } ) {
 		);
 	}
 
-	if ( type === 'loading' ) {
-		return classnames( 'components-animate__loading' );
-	}
-
 	return undefined;
 }
 
 /**
- * @typedef AppearPropsOptions
- * @property {AppearOrigin} origin The origin of the appearance.
+ *
+ * @todo Remove options when deprecated handling has been removed.
+ *
+ * @param {{options?: any; children: (props: {className?: string})=> JSX.Element;} & UseAnimateOptions} props
+ * @return {JSX.Element} Element
  */
-
-/**
- * @typedef SlideInPropsOptions
- * @property {SlideInOrigin} origin The origin of the appearance.
- */
-
-/**
- * @typedef ChildrenProps
- * @property {string} className Classnames for the animation.
- */
-
-/**
- * @callback children
- * @param {ChildrenProps} props
- * @return {JSX.Element}
- */
-
-/**
- * @typedef AppearProps
- * @property {'appear'} type The animation type.
- * @property {AppearPropsOptions} options Options for the animation.
- * @property {children} children Children as a function.
- */
-
-/**
- * @typedef SlideInProps
- * @property {'slide-in'} type The animation type.
- * @property {SlideInPropsOptions} options Options for the animation.
- * @property {children} children Children as a function.
- */
-
-/**
- * @typedef LoadingProps
- * @property {'loading'} type The animation type.
- * @property {never} options Unused options
- * @property {children} children Children as a function.
- */
-
-/**
- * @param {AppearProps | SlideInProps | LoadingProps} props Props.
- * @return {JSX.Element} Element.
- */
-export default function Animate( { type, options, children } ) {
+export default function Animate( {
+	type,
+	options: _deprecatedOptions,
+	children,
+	...options
+} ) {
+	if ( Boolean( _deprecatedOptions ) ) {
+		deprecated( '<Animate> options prop', {
+			version: '9.3',
+			hint: 'Pass options directly as props instead.',
+		} );
+	}
 	return children( {
-		className: useAnimate( { type, ...( options || {} ) } ),
+		className: useAnimate( { type, ..._deprecatedOptions, ...options } ),
 	} );
 }

--- a/packages/components/src/animate/index.js
+++ b/packages/components/src/animate/index.js
@@ -3,10 +3,46 @@
  */
 import classnames from 'classnames';
 
+/**
+ * @typedef {'top' | 'top left' | 'top right' | 'bottom' | 'bottom left' | 'bottom right'} AppearOrigin
+ */
+/**
+ * @typedef {'appear' | 'loading' | 'slide-in'} Type
+ */
+/**
+ * @typedef {'left' | 'right'} SlideInOrigin
+ */
+
+/**
+ * @param {Type} type The animation type
+ * @return {'top'|'left'} Default origin
+ */
 function getDefaultOrigin( type ) {
 	return type === 'appear' ? 'top' : 'left';
 }
 
+/**
+ * @typedef AppearOptions
+ * @property {'appear'} type The type of animation.
+ * @property {AppearOrigin} origin The origin of the appearance.
+ */
+
+/**
+ * @typedef SlideInOptions
+ * @property {'slide-in'} type The type of animation.
+ * @property {SlideInOrigin} origin The origin of the appearance.
+ */
+
+/**
+ * @typedef LoadingOptions
+ * @property {'loading'} type The type of animation.
+ * @property {never} origin .
+ */
+
+/**
+ * @param {AppearOptions | SlideInOptions | LoadingOptions} options
+ * @return {string | undefined} Classname that applies the animations
+ */
 export function useAnimate( { type, origin = getDefaultOrigin( type ) } ) {
 	if ( type === 'appear' ) {
 		const [ yAxis, xAxis = 'center' ] = origin.split( ' ' );
@@ -26,10 +62,58 @@ export function useAnimate( { type, origin = getDefaultOrigin( type ) } ) {
 	if ( type === 'loading' ) {
 		return classnames( 'components-animate__loading' );
 	}
+
+	return undefined;
 }
 
-export default function Animate( { type, options = {}, children } ) {
+/**
+ * @typedef AppearPropsOptions
+ * @property {AppearOrigin} origin The origin of the appearance.
+ */
+
+/**
+ * @typedef SlideInPropsOptions
+ * @property {SlideInOrigin} origin The origin of the appearance.
+ */
+
+/**
+ * @typedef ChildrenProps
+ * @property {string} className Classnames for the animation.
+ */
+
+/**
+ * @callback children
+ * @param {ChildrenProps} props
+ * @return {JSX.Element}
+ */
+
+/**
+ * @typedef AppearProps
+ * @property {'appear'} type The animation type.
+ * @property {AppearPropsOptions} options Options for the animation.
+ * @property {children} children Children as a function.
+ */
+
+/**
+ * @typedef SlideInProps
+ * @property {'slide-in'} type The animation type.
+ * @property {SlideInPropsOptions} options Options for the animation.
+ * @property {children} children Children as a function.
+ */
+
+/**
+ * @typedef LoadingProps
+ * @property {'loading'} type The animation type.
+ * @property {never} options Unused options
+ * @property {children} children Children as a function.
+ */
+
+/**
+ * @param {AppearProps | SlideInProps | LoadingProps} props Props.
+ * @return {JSX.Element} Element.
+ */
+export default function Animate( { type, options, children } ) {
 	return children( {
-		className: useAnimate( { type, ...options } ),
+		className: useAnimate( { type, ...( options || {} ) } ),
 	} );
 }

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -2,10 +2,8 @@
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",
-		"declarationDir": "build-types",
+		"declarationDir": "build-types"
 	},
 	"references": [],
-    "include": [
-		"src/dashicon/*"
-	],
+	"include": [ "src/animate/*", "src/dashicon/*" ]
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Try typing `Animate`. Keyword _try_. The types do not work at the moment. I think we won't be able to do as advanced/helpful typing for this component as we have in the `.d.ts` file for it. @sirreal @ockham do y'all have any ideas about how to better approach this? Should I just simplify the types?

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
