### PR TITLE
Allow tranform to Columns from a single block

### DIFF
--- a/packages/block-library/src/columns/transforms.js
+++ b/packages/block-library/src/columns/transforms.js
@@ -30,7 +30,7 @@ const transforms = {
 				);
 			},
 			isMatch: ( { length: selectedBlocksLength } ) =>
-				selectedBlocksLength > 1 &&
+				selectedBlocksLength &&
 				selectedBlocksLength <= MAXIMUM_SELECTED_BLOCKS,
 		},
 	],

--- a/packages/e2e-tests/specs/editor/various/block-switcher.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-switcher.test.js
@@ -31,6 +31,7 @@ describe( 'Block Switcher', () => {
 				'Quote',
 				'Heading',
 				'Pullquote',
+				'Columns',
 			] )
 		);
 	} );
@@ -69,6 +70,7 @@ describe( 'Block Switcher', () => {
 				'core/paragraph',
 				'core/group',
 				'core/heading',
+				'core/columns',
 			].map( ( block ) => wp.blocks.unregisterBlockType( block ) );
 		} );
 
@@ -85,7 +87,7 @@ describe( 'Block Switcher', () => {
 
 	describe( 'Conditional tranformation options', () => {
 		describe( 'Columns tranforms', () => {
-			it( 'Should show Columns block only if selected blocks are between limits (2-6)', async () => {
+			it( 'Should show Columns block only if selected blocks are between limits (1-6)', async () => {
 				await insertBlock( 'List' );
 				await page.keyboard.type( 'List content' );
 				await insertBlock( 'Heading' );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Since a new `Columns` variation was added here: https://github.com/WordPress/gutenberg/pull/24065
We should allow the transformation to a single selected block to a Columns block. 
<!-- Please describe what you have changed or added -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
