### PR TITLE
Site Editor: Fix height of Navigation panel and make it scrollable

### DIFF
--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
@@ -59,17 +59,18 @@ const NavigationPanel = ( { isOpen } ) => {
 					</div>
 				</div>
 
-				{ ( contentActiveMenu === MENU_ROOT ||
-					templatesActiveMenu !== MENU_ROOT ) && (
-					<TemplatesNavigation />
-				) }
-
-				{ ( templatesActiveMenu === MENU_ROOT ||
-					contentActiveMenu !== MENU_ROOT ) && (
-					<ContentNavigation
-						onActivateMenu={ setContentActiveMenu }
-					/>
-				) }
+				<div className="edit-site-navigation-panel__scroll-container">
+					{ ( contentActiveMenu === MENU_ROOT ||
+						templatesActiveMenu !== MENU_ROOT ) && (
+						<TemplatesNavigation />
+					) }
+					{ ( templatesActiveMenu === MENU_ROOT ||
+						contentActiveMenu !== MENU_ROOT ) && (
+						<ContentNavigation
+							onActivateMenu={ setContentActiveMenu }
+						/>
+					) }
+				</div>
 			</div>
 
 			<NavigationPanelPreviewSlot />

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
@@ -21,9 +21,15 @@
 	position: relative;
 	width: $nav-sidebar-width;
 	height: 100%;
+	padding-top: $header-height;
+	overflow: hidden;
 }
 
 .edit-site-navigation-panel__site-title-container {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
 	height: $header-height;
 	padding-left: $header-height;
 	margin: 0 $grid-unit-20 0 $grid-unit-10;
@@ -42,6 +48,12 @@
 	-webkit-line-clamp: 2;
 	-webkit-box-orient: vertical;
 	overflow: hidden;
+}
+
+.edit-site-navigation-panel__scroll-container {
+	overflow-x: hidden;
+	overflow-y: auto;
+	height: 100%;
 }
 
 .edit-site-navigation-panel__back-to-dashboard.components-button.is-tertiary {

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
@@ -21,15 +21,10 @@
 	position: relative;
 	width: $nav-sidebar-width;
 	height: 100%;
-	padding-top: $header-height;
 	overflow: hidden;
 }
 
 .edit-site-navigation-panel__site-title-container {
-	position: absolute;
-	top: 0;
-	left: 0;
-	width: 100%;
 	height: $header-height;
 	padding-left: $header-height;
 	margin: 0 $grid-unit-20 0 $grid-unit-10;

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
@@ -6,6 +6,11 @@
 	background: $gray-900;
 	transition: width 100ms linear;
 	@include reduce-motion("transition");
+
+	// Footer is visible from medium so we subtract footer's height
+	@include break-medium() {
+		height: calc(100% - #{$button-size-small + $border-width});
+	}
 }
 
 .edit-site-navigation-panel.is-open {

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
@@ -48,7 +48,7 @@
 .edit-site-navigation-panel__scroll-container {
 	overflow-x: hidden;
 	overflow-y: auto;
-	height: 100%;
+	height: calc(100% - #{$header-height});
 }
 
 .edit-site-navigation-panel__back-to-dashboard.components-button.is-tertiary {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->
Fixes: https://github.com/WordPress/gutenberg/issues/26120

## Description
Add a scroll container and makes sure the site title stick to the top. Also subtracts the footer's height from the navigation panel's height so it doesn't "go below" the footer.


## How has this been tested?
- Open site editor
- Open navigation panel
- In devtools copy-paste one of the menus (Templates or Content) as many times as you need to make the container overflow
- Or just resize your browser / use devtools to reduce the height of the viewport

## Screenshots <!-- if applicable -->
![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/2256104/96235602-4bbda780-0f9b-11eb-9f68-a7d1a5118ad7.gif)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
