### PR TITLE
Fix Site Tagline block's text alignment

### DIFF
--- a/packages/block-library/src/site-tagline/edit.js
+++ b/packages/block-library/src/site-tagline/edit.js
@@ -37,14 +37,14 @@ export default function SiteTaglineEdit( { attributes, setAttributes } ) {
 
 			<RichText
 				allowedFormats={ [] }
-				className={ classnames( {
-					[ `has-text-align-${ textAlign }` ]: textAlign,
-				} ) }
 				onChange={ setSiteTagline }
 				placeholder={ __( 'Site Tagline' ) }
 				tagName="p"
 				value={ siteTagline }
 				{ ...blockProps }
+				className={ classnames( blockProps.className, {
+					[ `has-text-align-${ textAlign }` ]: textAlign,
+				} ) }
 			/>
 		</>
 	);

--- a/packages/block-library/src/site-tagline/edit.js
+++ b/packages/block-library/src/site-tagline/edit.js
@@ -22,8 +22,11 @@ export default function SiteTaglineEdit( { attributes, setAttributes } ) {
 		'site',
 		'description'
 	);
-	const blockProps = useBlockProps();
-
+	const blockProps = useBlockProps( {
+		className: classnames( {
+			[ `has-text-align-${ textAlign }` ]: textAlign,
+		} ),
+	} );
 	return (
 		<>
 			<BlockControls>
@@ -42,9 +45,6 @@ export default function SiteTaglineEdit( { attributes, setAttributes } ) {
 				tagName="p"
 				value={ siteTagline }
 				{ ...blockProps }
-				className={ classnames( blockProps.className, {
-					[ `has-text-align-${ textAlign }` ]: textAlign,
-				} ) }
 			/>
 		</>
 	);

--- a/packages/block-library/src/site-tagline/index.js
+++ b/packages/block-library/src/site-tagline/index.js
@@ -15,6 +15,7 @@ export { metadata, name };
 
 export const settings = {
 	title: __( 'Site Tagline' ),
+	description: __( 'In a few words, what this site is about.' ),
 	keywords: [ __( 'description' ) ],
 	icon,
 	edit,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This PR fixes `Site Tagline` block's text alignment. It also adds a small description to the block.

<img width="404" alt="Captura de ecrã 2020-10-20, às 16 57 56" src="https://user-images.githubusercontent.com/150562/96612283-7d18d900-12f5-11eb-8a43-3f36c208bdc9.png">


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
