### PR TITLE
Writing flow: fix in-between inserter for aligned blocks

### DIFF
--- a/packages/block-editor/src/components/block-list/insertion-point.js
+++ b/packages/block-editor/src/components/block-list/insertion-point.js
@@ -189,14 +189,22 @@ export default function InsertionPoint( { children, containerRef } ) {
 
 		const rect = event.target.getBoundingClientRect();
 		const offset = event.clientY - rect.top;
-		const element = Array.from( event.target.children ).find(
-			( blockEl ) => {
-				return blockEl.offsetTop > offset;
-			}
-		);
+		let element = Array.from( event.target.children ).find( ( blockEl ) => {
+			return blockEl.offsetTop > offset;
+		} );
 
 		if ( ! element ) {
 			return;
+		}
+
+		// The block may be in an alignment wrapper, so check the first direct
+		// child if the element has no ID.
+		if ( ! element.id ) {
+			element = element.firstElementChild;
+
+			if ( ! element ) {
+				return;
+			}
 		}
 
 		const clientId = element.id.slice( 'block-'.length );

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/writing-flow.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/writing-flow.test.js.snap
@@ -238,6 +238,16 @@ exports[`Writing Flow should not delete surrounding space when deleting a word w
 <!-- /wp:paragraph -->"
 `;
 
+exports[`Writing Flow should not have a dead zone above an aligned block 1`] = `
+"<!-- wp:paragraph -->
+<p>1</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:image {\\"align\\":\\"wide\\"} -->
+<figure class=\\"wp-block-image alignwide\\"><img alt=\\"\\"/></figure>
+<!-- /wp:image -->"
+`;
+
 exports[`Writing Flow should not have a dead zone between blocks (lower) 1`] = `
 "<!-- wp:paragraph -->
 <p>1</p>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

Currently, there's no in-between inserter and click capture before aligned blocks.

<img width="865" alt="Screenshot 2020-10-16 at 13 59 39" src="https://user-images.githubusercontent.com/4710635/96250758-0065c200-0fb8-11eb-854e-24ae8195b3a6.png">


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
