### PR TITLE
Minor iterations to grouping for preferences panel

### DIFF
--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -57,11 +57,6 @@ export function PreferencesModal( { isModalActive, isViewable, closeModal } ) {
 					) }
 					label={ __( 'Show most used blocks' ) }
 				/>
-				<EnableFeature
-					featureName="showIconLabels"
-					help={ __( 'Shows text instead of icons in toolbar.' ) }
-					label={ __( 'Display button labels' ) }
-				/>
 			</Section>
 			<Section title={ __( 'Keyboard' ) }>
 				<EnableFeature
@@ -73,11 +68,6 @@ export function PreferencesModal( { isModalActive, isViewable, closeModal } ) {
 				/>
 			</Section>
 			<Section title={ __( 'Appearance' ) }>
-				<EnableFeature
-					featureName="themeStyles"
-					help={ __( 'Make the editor look like your theme.' ) }
-					label={ __( 'Use theme styles' ) }
-				/>
 				<EnableFeature
 					featureName="reducedUI"
 					help={ __(
@@ -91,6 +81,16 @@ export function PreferencesModal( { isModalActive, isViewable, closeModal } ) {
 						'Highlights the current block and fades other content.'
 					) }
 					label={ __( 'Spotlight mode' ) }
+				/>
+				<EnableFeature
+					featureName="showIconLabels"
+					help={ __( 'Shows text instead of icons in toolbar.' ) }
+					label={ __( 'Display button labels' ) }
+				/>
+				<EnableFeature
+					featureName="themeStyles"
+					help={ __( 'Make the editor look like your theme.' ) }
+					label={ __( 'Use theme styles' ) }
 				/>
 			</Section>
 			<Section

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
@@ -18,11 +18,6 @@ exports[`PreferencesModal should match snapshot when the modal is active 1`] = `
       help="Places the most frequent blocks in the block library."
       label="Show most used blocks"
     />
-    <WithSelect(WithDispatch(BaseOption))
-      featureName="showIconLabels"
-      help="Shows text instead of icons in toolbar."
-      label="Display button labels"
-    />
   </Section>
   <Section
     title="Keyboard"
@@ -37,11 +32,6 @@ exports[`PreferencesModal should match snapshot when the modal is active 1`] = `
     title="Appearance"
   >
     <WithSelect(WithDispatch(BaseOption))
-      featureName="themeStyles"
-      help="Make the editor look like your theme."
-      label="Use theme styles"
-    />
-    <WithSelect(WithDispatch(BaseOption))
       featureName="reducedUI"
       help="Compacts options and outlines in the toolbar."
       label="Reduce the interface"
@@ -50,6 +40,16 @@ exports[`PreferencesModal should match snapshot when the modal is active 1`] = `
       featureName="focusMode"
       help="Highlights the current block and fades other content."
       label="Spotlight mode"
+    />
+    <WithSelect(WithDispatch(BaseOption))
+      featureName="showIconLabels"
+      help="Shows text instead of icons in toolbar."
+      label="Display button labels"
+    />
+    <WithSelect(WithDispatch(BaseOption))
+      featureName="themeStyles"
+      help="Make the editor look like your theme."
+      label="Use theme styles"
     />
   </Section>
   <Section


### PR DESCRIPTION
This responds to feedback on #25837 and iterates the grouping of the changes to the preferences panel. There have been quite a few changes for this release, but the grouping wasn't really modified. This small PR responds to the feedback by @mtias to adjust the grouping.

The iterations included in this are:

- Moves button labels to appearance
- Moves theme styles at bottom of appearance group

![image](https://user-images.githubusercontent.com/253067/96252592-1cfafd80-0faa-11eb-8208-88a8def6a230.png)

This doesn't respond to the suggestion of iteration the keyboard section. What that section could or couldn't become feels like a more in-depth discussion. For example, it could flourish into an accessibility section such as Slack, Apple and many other applications. However, that feels like it needs more time than a few days before a release, so perhaps another issue should have that discussion. If that's a wrong assessment, I am very happy to work up an iteration on that based on feedback.

I would love general feedback on this and really like a code review. Ideally, this would slide in under the wire for the release, but I understand if that is too late now to do so. I am labelling and cc'ing in @tellthemachines just incase for things like test passing.