### PR TITLE
Add loading message to Query block while fetching results

### DIFF
--- a/packages/block-library/src/query-loop/edit.js
+++ b/packages/block-library/src/query-loop/edit.js
@@ -3,7 +3,7 @@
  */
 import { useState, useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import {
 	BlockContextProvider,
 	InnerBlocks,
@@ -42,11 +42,10 @@ export default function QueryLoopEdit( {
 	const [ { page } ] = useQueryContext() || queryContext || [ {} ];
 	const [ activeBlockContext, setActiveBlockContext ] = useState();
 
-	const { posts, blocks, postTypeName } = useSelect(
+	const { posts, blocks } = useSelect(
 		( select ) => {
-			const { getEntityRecords, getPostType } = select( 'core' );
+			const { getEntityRecords } = select( 'core' );
 			const { getBlocks } = select( 'core/block-editor' );
-			const postTypeObject = getPostType( postType );
 			const query = {
 				offset: perPage ? perPage * ( page - 1 ) + offset : 0,
 				categories: categoryIds,
@@ -69,7 +68,6 @@ export default function QueryLoopEdit( {
 			return {
 				posts: getEntityRecords( 'postType', postType, query ),
 				blocks: getBlocks( clientId ),
-				postTypeName: postTypeObject?.labels?.name || 'Posts',
 			};
 		},
 		[
@@ -99,14 +97,7 @@ export default function QueryLoopEdit( {
 	const blockProps = useBlockProps();
 
 	if ( ! posts ) {
-		return (
-			<p { ...blockProps }>
-				{
-					// translators: %s: Name of Post Type (plural) that is loading e.g: "Posts".
-					sprintf( __( 'Loading %s…' ), postTypeName )
-				}
-			</p>
-		);
+		return <p { ...blockProps }>{ __( 'Loading…' ) }</p>;
 	}
 
 	if ( ! posts.length ) {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This PR adds a loading message to Query block while fetching results. 

Part of: https://github.com/WordPress/gutenberg/issues/26189.
<!-- Please describe what you have changed or added -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
