### PR TITLE
Try useAnimate for all <Animate /> cases, lightening the React tree

### DIFF
--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -12,7 +12,7 @@ import { useEffect, useRef, useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import Animate from '../animate';
+import { useAnimate } from '../animate';
 import { ROOT_MENU } from './constants';
 import { NavigationContext } from './context';
 import { NavigationUI } from './styles/navigation-styles';
@@ -61,27 +61,23 @@ export default function Navigation( {
 	};
 
 	const classes = classnames( 'components-navigation', className );
+	const animateClassName = useAnimate( {
+		type: 'slide-in',
+		origin: slideOrigin,
+	} );
 
 	return (
 		<NavigationUI className={ classes }>
-			<Animate
+			<div
 				key={ menu }
-				type="slide-in"
-				options={ { origin: slideOrigin } }
+				className={ classnames( {
+					[ animateClassName ]: isMounted.current && slideOrigin,
+				} ) }
 			>
-				{ ( { className: animateClassName } ) => (
-					<div
-						className={ classnames( {
-							[ animateClassName ]:
-								isMounted.current && slideOrigin,
-						} ) }
-					>
-						<NavigationContext.Provider value={ context }>
-							{ children }
-						</NavigationContext.Provider>
-					</div>
-				) }
-			</Animate>
+				<NavigationContext.Provider value={ context }>
+					{ children }
+				</NavigationContext.Provider>
+			</div>
 		</NavigationUI>
 	);
 }

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -29,7 +29,7 @@ import Button from '../button';
 import ScrollLock from '../scroll-lock';
 import IsolatedEventContainer from '../isolated-event-container';
 import { Slot, Fill, useSlot } from '../slot-fill';
-import Animate from '../animate';
+import { useAnimate } from '../animate';
 
 const FocusManaged = withConstrainedTabbing(
 	withFocusReturn( ( { children } ) => children )
@@ -529,57 +529,55 @@ const Popover = ( {
 		onClickOutside( clickEvent );
 	}
 
+	const animateClassName = useAnimate( {
+		type: animate && animateOrigin ? 'appear' : null,
+		origin: animateOrigin,
+	} );
+
 	// Disable reason: We care to capture the _bubbled_ events from inputs
 	// within popover as inferring close intent.
 
 	let content = (
 		<PopoverDetectOutside onFocusOutside={ handleOnFocusOutside }>
-			<Animate
-				type={ animate && animateOrigin ? 'appear' : null }
-				options={ { origin: animateOrigin } }
-			>
-				{ ( { className: animateClassName } ) => (
-					<IsolatedEventContainer
-						className={ classnames(
-							'components-popover',
-							className,
-							animateClassName,
-							{
-								'is-expanded': isExpanded,
-								'is-without-arrow': noArrow,
-								'is-alternate': isAlternate,
-							}
-						) }
-						{ ...contentProps }
-						onKeyDown={ maybeClose }
-						ref={ containerRef }
-					>
-						{ isExpanded && <ScrollLock /> }
-						{ isExpanded && (
-							<div className="components-popover__header">
-								<span className="components-popover__header-title">
-									{ headerTitle }
-								</span>
-								<Button
-									className="components-popover__close"
-									icon={ close }
-									onClick={ onClose }
-								/>
-							</div>
-						) }
-						<div
-							ref={ contentRef }
-							className="components-popover__content"
-							tabIndex="-1"
-						>
-							<div style={ { position: 'relative' } }>
-								{ containerResizeListener }
-								{ children }
-							</div>
-						</div>
-					</IsolatedEventContainer>
+			<IsolatedEventContainer
+				className={ classnames(
+					'components-popover',
+					className,
+					animateClassName,
+					{
+						'is-expanded': isExpanded,
+						'is-without-arrow': noArrow,
+						'is-alternate': isAlternate,
+					}
 				) }
-			</Animate>
+				{ ...contentProps }
+				onKeyDown={ maybeClose }
+				ref={ containerRef }
+			>
+				{ isExpanded && <ScrollLock /> }
+				{ isExpanded && (
+					<div className="components-popover__header">
+						<span className="components-popover__header-title">
+							{ headerTitle }
+						</span>
+						<Button
+							className="components-popover__close"
+							icon={ close }
+							onClick={ onClose }
+						/>
+					</div>
+				) }
+				<div
+					ref={ contentRef }
+					className="components-popover__content"
+					tabIndex="-1"
+				>
+					<div style={ { position: 'relative' } }>
+						{ containerResizeListener }
+						{ children }
+					</div>
+				</div>
+			</IsolatedEventContainer>
 		</PopoverDetectOutside>
 	);
 

--- a/packages/editor/src/components/post-saved-state/index.js
+++ b/packages/editor/src/components/post-saved-state/index.js
@@ -6,7 +6,10 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Animate, Button } from '@wordpress/components';
+import {
+	__unstableUseAnimate as useAnimate,
+	Button,
+} from '@wordpress/components';
 import { usePrevious, useViewportMatch } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
@@ -97,6 +100,8 @@ export default function PostSavedState( {
 		return () => clearTimeout( timeoutId );
 	}, [ isSaving ] );
 
+	const animateClassName = useAnimate( { type: 'loading' } );
+
 	if ( isSaving ) {
 		// TODO: Classes generation should be common across all return
 		// paths of this function, including proper naming convention for
@@ -106,14 +111,10 @@ export default function PostSavedState( {
 		} );
 
 		return (
-			<Animate type="loading">
-				{ ( { className: animateClassName } ) => (
-					<span className={ classnames( classes, animateClassName ) }>
-						<Icon icon={ cloud } />
-						{ isAutosaving ? __( 'Autosaving' ) : __( 'Saving' ) }
-					</span>
-				) }
-			</Animate>
+			<span className={ classnames( classes, animateClassName ) }>
+				<Icon icon={ cloud } />
+				{ isAutosaving ? __( 'Autosaving' ) : __( 'Saving' ) }
+			</span>
 		);
 	}
 

--- a/packages/interface/src/components/complementary-area/index.js
+++ b/packages/interface/src/components/complementary-area/index.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Animate, Button, Panel, Slot, Fill } from '@wordpress/components';
+import { Button, Panel, Slot, Fill } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { check, starEmpty, starFilled } from '@wordpress/icons';
@@ -27,9 +27,7 @@ function ComplementaryAreaSlot( { scope, ...props } ) {
 function ComplementaryAreaFill( { scope, children, className } ) {
 	return (
 		<Fill name={ `ComplementaryArea/${ scope }` }>
-			<Animate type="slide-in" options={ { origin: 'left' } }>
-				{ () => <div className={ className }>{ children }</div> }
-			</Animate>
+			<div className={ className }>{ children }</div>
 		</Fill>
 	);
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

This hook was introduces (as unstable) in #26063, but it seems good to have for all instances where `<Animate />` is currently used. There's no good reason for this to be a component.

Should we mark the hooks stable? Should we deprecate the component?
Should it remain in the `components` package? I think it still makes sense here since it provides a class, and it's mostly used in the package.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
