### PR TITLE
[RNMobile] Fix appender to add new buttons when a Button is selected no longer showing

### DIFF
--- a/packages/block-library/src/buttons/edit.native.js
+++ b/packages/block-library/src/buttons/edit.native.js
@@ -32,7 +32,6 @@ export default function ButtonsEdit( {
 } ) {
 	const [ resizeObserver, sizes ] = useResizeObserver();
 	const [ maxWidth, setMaxWidth ] = useState( 0 );
-	const shouldRenderFooterAppender = isSelected || isInnerButtonSelected;
 	const { marginLeft: spacing } = styles.spacing;
 
 	const { getBlockOrder, isInnerButtonSelected, shouldDelete } = useSelect(
@@ -102,6 +101,8 @@ export default function ButtonsEdit( {
 	const alignmentHooksSetting = {
 		isEmbedButton: true,
 	};
+
+	const shouldRenderFooterAppender = isSelected || isInnerButtonSelected;
 
 	return (
 		<AlignmentHookSettingsProvider value={ alignmentHooksSetting }>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes appender to add new buttons (when a Button is selected) is no longer showing described here: https://github.com/WordPress/gutenberg/pull/25636#issuecomment-709997047. 
Condition `const shouldRenderFooterAppender = isSelected || isInnerButtonSelected;` should be place after `isInnerButtonSelected` to avoid `undefined` value.

## How has this been tested?

* Open a post
* Add `Buttons` block
* Expect inline appender is visible
* Go one level up and have focused `Buttons` block
* Expect inline appender is visible in the same place as before



<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

<img width="492" alt="Screenshot 2020-10-16 at 14 46 03" src="https://user-images.githubusercontent.com/22746080/96259741-52a9e180-0fbe-11eb-9430-da0535208fe1.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [X] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
