### PR TITLE
TextControl: Forward refs

### DIFF
--- a/packages/components/src/text-control/index.js
+++ b/packages/components/src/text-control/index.js
@@ -2,25 +2,50 @@
  * WordPress dependencies
  */
 import { useInstanceId } from '@wordpress/compose';
+import { forwardRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import BaseControl from '../base-control';
 
-export default function TextControl( {
-	label,
-	hideLabelFromVision,
-	value,
-	help,
-	className,
-	onChange,
-	type = 'text',
-	...props
-} ) {
+/**
+ * @typedef OwnProps
+ * @property {string} label Label for the control.
+ * @property {boolean} [hideLabelFromVision] Whether to accessibly hide the label.
+ * @property {string} value Value of the input.
+ * @property {string} [help] Optional help text for the control.
+ * @property {string} [className] Classname passed to BaseControl wrapper
+ * @property {(value: string) => void} onChange Handle changes.
+ * @property {string} [type='text'] Type of the input.
+ */
+
+/** @typedef {OwnProps & import('react').ComponentProps<'input'>} Props */
+
+/**
+ *
+ * @param {Props} props Props
+ * @param {import('react').Ref<HTMLInputElement>} [ref]
+ */
+function TextControl(
+	{
+		label,
+		hideLabelFromVision,
+		value,
+		help,
+		className,
+		onChange,
+		type = 'text',
+		...props
+	},
+	ref
+) {
 	const instanceId = useInstanceId( TextControl );
 	const id = `inspector-text-control-${ instanceId }`;
-	const onChangeValue = ( event ) => onChange( event.target.value );
+	const onChangeValue = (
+		/** @type {import('react').ChangeEvent<HTMLInputElement>} */
+		event
+	) => onChange( event.target.value );
 
 	return (
 		<BaseControl
@@ -37,8 +62,11 @@ export default function TextControl( {
 				value={ value }
 				onChange={ onChangeValue }
 				aria-describedby={ !! help ? id + '__help' : undefined }
+				ref={ ref }
 				{ ...props }
 			/>
 		</BaseControl>
 	);
 }
+
+export default forwardRef( TextControl );

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -4,7 +4,11 @@
 		"rootDir": "src",
 		"declarationDir": "build-types"
 	},
-	"references": [ { "path": "../hooks" }, { "path": "../primitives" } ],
+	"references": [
+		{ "path": "../element" },
+		{ "path": "../hooks" },
+		{ "path": "../primitives" }
+	],
 	"include": [
 		"src/base-control/**/*",
 		"src/dashicon/**/*",


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Adds fowarding refs to `TextControl` allowing consumers to get a handle on the inner `input`. This is the standard for component libraries wrapping form elements: https://reactjs.org/docs/forwarding-refs.html

I also updated the JSDocs but did not activate type checking for this component as `compose` is still untyped. /cc @sirreal Is this the right thing to do here?

## How has this been tested?
Manually tested in storybook.

## Types of changes
Non-breaking changes.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
