### PR TITLE
Block Supports: Avoid PHP warnings on libxml < 2.7.8

### DIFF
--- a/lib/block-supports/index.php
+++ b/lib/block-supports/index.php
@@ -63,7 +63,13 @@ function gutenberg_apply_block_supports( $block_content, $block ) {
 		. $block_content
 		. '</body></html>';
 
-	$success = $dom->loadHTML( $wrapped_block_html, LIBXML_HTML_NODEFDTD | LIBXML_COMPACT );
+	$options = LIBXML_COMPACT;
+
+	// LIBXML_HTML_NODEFDTD is only available in libxml 2.7.8+.
+	if ( defined( 'LIBXML_HTML_NODEFDTD' ) ) {
+		$options |= constant( 'LIBXML_HTML_NODEFDTD' );
+	}
+	$success = $dom->loadHTML( $wrapped_block_html, $options );
 
 	// Clear errors and reset the use_errors setting.
 	libxml_clear_errors();


### PR DESCRIPTION
Only include `LIBXML_HTML_NODEFDTD` as a `loadHTML()` option if it is defined.

Fix ported from the AMP WordPress Plugin:
https://github.com/ampproject/amp-wp/pull/4486/files
(amp-wp is GPLv2: https://github.com/ampproject/amp-wp/blob/develop/LICENSE)

Props @schlessera.
See #25122.

## Description
Only include `LIBXML_HTML_NODEFDTD` as a `loadHTML()` option if it is defined.

## How has this been tested?
- Ran the included automated tests locally in the Gutenberg Docker environment.
- Added this change into the equivalent current place on core, then ran the core automated tests at GoDaddy. It solves the issue with warnings there.

## Types of changes
This is a bug fix to avoid PHP warnings when PHP is compiled with libxml < 2.7.8

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [X] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
