### PR TITLE
Fix: Post schedule label showing wrong time if site and user timezones did not match

### DIFF
--- a/packages/editor/src/components/post-schedule/label.js
+++ b/packages/editor/src/components/post-schedule/label.js
@@ -2,14 +2,14 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { dateI18n, __experimentalGetSettings } from '@wordpress/date';
+import { format, __experimentalGetSettings } from '@wordpress/date';
 import { withSelect } from '@wordpress/data';
 
 export function PostScheduleLabel( { date, isFloating } ) {
 	const settings = __experimentalGetSettings();
 
 	return date && ! isFloating
-		? dateI18n(
+		? format(
 				`${ settings.formats.date } ${ settings.formats.time }`,
 				date
 		  )


### PR DESCRIPTION
Fixes: https://core.trac.wordpress.org/ticket/50949#comment:29

Previously the issue happened just on the core but if the Gutenberg plugin was installed the issue did not happen.
Recently the issue started appearing also with Gutenberg installed. That happened after PR https://github.com/WordPress/gutenberg/pull/22866 was merged.
On PR https://github.com/WordPress/gutenberg/pull/22866 it is referred that core already used a higher version of moment-timezone than the one previously used on Gutenberg. That explains why previously the issue happened on the core but not on Gutenberg.

It seems the update is not the issue in fact it seems before the update there was a bug in the library that made our code work well.

The date we have in select( 'core/editor' ).getEditedPostAttribute( 'date' ) is on the timezone of the website and does not needs any conversion. We just want to format it in a pretty way to show it to the user. The function dateI18n that was previously being used assumes the date is in a different timezone and then changes the time to the site time zone making the time appear wrong because the time was already in that timezone.

What I did was instead of calling dateI18n just use format because we just want to format the date given that it is already on the site timezone.

The component DateTime was showing the correct date and that component was just doing format calls packages/components/src/date-time/time.js, so this change makes PostScheduleLabel consistent with that.


## How has this been tested?
Se your test website to a timezone that is different from the one on your computer.
On master Create a post and publish it verify the date shown as publishing date on the document sidebar is not correct (according to the website timezone). Click the date and open the post scheduler to verify the date there is correct according to the site time zone.
On this branch repeat the previous step and verify the post publish date now shows the correct date.

