### PR TITLE
Global Styles: Use block settings on the block panels.

### DIFF
--- a/packages/edit-site/src/components/editor/utils.js
+++ b/packages/edit-site/src/components/editor/utils.js
@@ -1,3 +1,12 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
 /* Supporting data */
 export const GLOBAL_CONTEXT = 'global';
 export const PRESET_CATEGORIES = {
@@ -20,3 +29,15 @@ export const fromPx = ( value ) => {
 };
 
 export const toPx = ( value ) => ( value ? value + 'px' : value );
+
+export function useEditorFeature( featurePath, blockName = GLOBAL_CONTEXT ) {
+	const settings = useSelect( ( select ) => {
+		return select( 'core/edit-site' ).getSettings();
+	} );
+	return (
+		get(
+			settings,
+			`__experimentalFeatures.${ blockName }.${ featurePath }`
+		) ?? get( settings, `__experimentalFeatures.global.${ featurePath }` )
+	);
+}

--- a/packages/edit-site/src/components/editor/utils.js
+++ b/packages/edit-site/src/components/editor/utils.js
@@ -38,6 +38,10 @@ export function useEditorFeature( featurePath, blockName = GLOBAL_CONTEXT ) {
 		get(
 			settings,
 			`__experimentalFeatures.${ blockName }.${ featurePath }`
-		) ?? get( settings, `__experimentalFeatures.global.${ featurePath }` )
+		) ??
+		get(
+			settings,
+			`__experimentalFeatures.${ GLOBAL_CONTEXT }.${ featurePath }`
+		)
 	);
 }

--- a/packages/edit-site/src/components/sidebar/color-panel.js
+++ b/packages/edit-site/src/components/sidebar/color-panel.js
@@ -7,7 +7,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { LINK_COLOR } from '../editor/utils';
+import { LINK_COLOR, useEditorFeature } from '../editor/utils';
 import ColorPalettePanel from './color-palette-panel';
 
 export default ( {
@@ -17,6 +17,13 @@ export default ( {
 	getSetting,
 	setSetting,
 } ) => {
+	const colors = useEditorFeature( 'color.palette', name );
+	const disableCustomColors = ! useEditorFeature( 'color.custom', name );
+	const gradients = useEditorFeature( 'color.gradients', name );
+	const disableCustomGradients = ! useEditorFeature(
+		'color.customGradient',
+		name
+	);
 	if (
 		! supports.includes( 'color' ) &&
 		! supports.includes( 'backgrounColor' ) &&
@@ -74,11 +81,14 @@ export default ( {
 			label: __( 'Link color' ),
 		} );
 	}
-
 	return (
 		<PanelColorGradientSettings
 			title={ __( 'Color' ) }
 			settings={ settings }
+			colors={ colors }
+			gradients={ gradients }
+			disableCustomColors={ disableCustomColors }
+			disableCustomGradients={ disableCustomGradients }
 		>
 			<ColorPalettePanel
 				key={ 'color-palette-panel-' + name }

--- a/packages/edit-site/src/components/sidebar/typography-panel.js
+++ b/packages/edit-site/src/components/sidebar/typography-panel.js
@@ -1,20 +1,26 @@
 /**
  * WordPress dependencies
  */
-import { FontSizePicker, LineHeightControl } from '@wordpress/block-editor';
-import { PanelBody } from '@wordpress/components';
+import { LineHeightControl } from '@wordpress/block-editor';
+import { PanelBody, FontSizePicker } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { fromPx, toPx } from '../editor/utils';
+import { fromPx, toPx, useEditorFeature } from '../editor/utils';
 
 export default ( {
 	context: { supports, name },
 	getStyleProperty,
 	setStyleProperty,
 } ) => {
+	const fontSizes = useEditorFeature( 'typography.fontSizes', name );
+	const disableCustomFontSizes = ! useEditorFeature(
+		'typography.customFontSize',
+		name
+	);
+
 	if (
 		! supports.includes( 'fontSize' ) &&
 		! supports.includes( 'lineHeight' )
@@ -30,6 +36,8 @@ export default ( {
 					onChange={ ( value ) =>
 						setStyleProperty( name, 'fontSize', toPx( value ) )
 					}
+					fontSizes={ fontSizes }
+					disableCustomFontSizes={ disableCustomFontSizes }
 				/>
 			) }
 			{ supports.includes( 'lineHeight' ) && (


### PR DESCRIPTION
Currently, on the pannels of each block, we don't use the settings for that block.
So for example, if the paragraph has a specific color palette when we go to the paragraph settings on GloboStyles as options for text and background color we don't see that palette and we just see the global one.

This PR fixes that and makes sure the settings used are the ones of the block whose styles we are editing.


## How has this been tested?
Open the global styles sidebar.
Go to the paragraph block settings.
Add a block specific color palette for the paragraph.
Verify the background and text color options show the new user-defined palette instead of the global one.