### PR TITLE
Global styles: Add preset classes generation on the client side.

### DIFF
--- a/packages/edit-site/src/components/editor/global-styles-renderer.js
+++ b/packages/edit-site/src/components/editor/global-styles-renderer.js
@@ -11,7 +11,11 @@ import { __EXPERIMENTAL_STYLE_PROPERTY as STYLE_PROPERTY } from '@wordpress/bloc
 /**
  * Internal dependencies
  */
-import { PRESET_CATEGORIES, LINK_COLOR_DECLARATION } from './utils';
+import {
+	PRESET_CATEGORIES,
+	PRESET_CLASSES,
+	LINK_COLOR_DECLARATION,
+} from './utils';
 
 export const mergeTrees = ( baseData, userData ) => {
 	// Deep clone from base data.
@@ -86,6 +90,31 @@ export default ( blockData, tree ) => {
 	};
 
 	/**
+	 * Transform given preset tree into a set of preset class declarations.
+	 *
+	 * @param {string} blockSelector
+	 * @param {Object} blockPresets
+	 * @return {string} CSS declarations for the preset classes.
+	 */
+	const getBlockPresetClasses = ( blockSelector, blockPresets ) => {
+		return reduce(
+			PRESET_CLASSES,
+			( declarations, { path, key, property }, classSuffix ) => {
+				const presets = get( blockPresets, path, [] );
+				presets.forEach( ( preset ) => {
+					const slug = preset.slug;
+					const value = preset[ key ];
+					const classSelectorToUse = `.has-${ slug }-${ classSuffix }`;
+					const selectorToUse = `${ blockSelector }${ classSelectorToUse }`;
+					declarations += `${ selectorToUse } {${ property }: ${ value };}\n`;
+				} );
+				return declarations;
+			},
+			''
+		);
+	};
+
+	/**
 	 * Transform given preset tree into a set of style declarations.
 	 *
 	 * @param {Object} blockPresets
@@ -157,6 +186,9 @@ export default ( blockData, tree ) => {
 			...getBlockPresetsDeclarations( tree[ context ].settings ),
 			...getCustomDeclarations( tree[ context ].settings.custom ),
 		];
+		styles.push(
+			getBlockPresetClasses( blockSelector, tree[ context ].settings )
+		);
 		if ( blockDeclarations.length > 0 ) {
 			styles.push(
 				`${ blockSelector } { ${ blockDeclarations.join( ';' ) } }`

--- a/packages/edit-site/src/components/editor/utils.js
+++ b/packages/edit-site/src/components/editor/utils.js
@@ -5,6 +5,21 @@ export const PRESET_CATEGORIES = {
 	gradient: { path: [ 'color', 'gradients' ], key: 'gradient' },
 	fontSize: { path: [ 'typography', 'fontSizes' ], key: 'size' },
 };
+export const PRESET_CLASSES = {
+	color: { ...PRESET_CATEGORIES.color, property: 'color' },
+	'background-color': {
+		...PRESET_CATEGORIES.color,
+		property: 'background-color',
+	},
+	'gradient-background': {
+		...PRESET_CATEGORIES.gradient,
+		property: 'background',
+	},
+	'font-size': {
+		...PRESET_CATEGORIES.fontSize,
+		property: 'font-size',
+	},
+};
 export const LINK_COLOR = '--wp--style--color--link';
 export const LINK_COLOR_DECLARATION = `a { color: var(${ LINK_COLOR }, #00e); }`;
 


### PR DESCRIPTION
This PR adds the preset class declaration to the client-side as part of the global style mechanism.
The user is able to add and edit colors, so we need to generate the classes for the presets dynamically.




## How has this been tested?
As a user, I edited some color palettes.
Using the browser dev tools I verified the styles included the correct classes for these colors.