### PR TITLE
blocks.getSaveElement example usage

### DIFF
--- a/docs/designers-developers/developers/filters/block-filters.md
+++ b/docs/designers-developers/developers/filters/block-filters.md
@@ -156,6 +156,67 @@ A filter that applies to the result of a block's `save` function. This filter is
 
 The filter's callback receives an element, a block type and the block attributes as arguments. It should return an element.
 
+_Example:_
+
+Adding a `<code>` element.
+
+{% codetabs %}
+{% ESNext %}
+```js
+const { cloneElement } = wp.element;
+
+function addCodeElement( element, blockType, attributes ) {
+	if ( blockType.name !== "core/paragraph" ) {
+		return element;
+	}
+
+	return cloneElement(
+		// The saved element
+		element,
+		// Overwrite props here
+		{},
+		// Original content (children)
+		element.props.children,
+		// Any additional content
+		<code>My code</code>
+	);
+};
+
+wp.hooks.addFilter(
+	'blocks.getSaveContent.extraProps',
+	'my-plugin/add-code-element',
+	addCodeElement
+);
+```
+{% ES5 %}
+```js
+var el = wp.element.createElement;
+
+function addCodeElement( element, blockType, attributes ) {
+	if ( blockType.name !== "core/paragraph" ) {
+		return element;
+	}
+
+	return wp.element.cloneElement(
+		// The saved element
+		element,
+		// Overwrite props here
+		{},
+		// Original content (children)
+		element.props.children,
+		// Any additional content
+		el( 'code', {}, 'My code' )
+	);
+};
+
+wp.hooks.addFilter(
+	'blocks.getSaveContent.extraProps',
+	'my-plugin/add-code-element',
+	addCodeElement
+);
+```
+{% end %}
+
 #### `blocks.getSaveContent.extraProps`
 
 A filter that applies to all blocks returning a WP Element in the `save` function. This filter is used to add extra props to the root element of the `save` function. For example: to add a className, an id, or any valid prop for this element.


### PR DESCRIPTION
Happened to need this for my project so thought I'd add example for this.

I have tested the ES5 version and adapted ESX from that.

```js
var el = wp.element.createElement;

function addCodeElement( element, blockType, attributes ) {
	if ( blockType.name !== "core/paragraph" ) {
		return element;
	}
	return wp.element.cloneElement(
		// The saved element
		element,
		// Overwrite props here
		{},
		// Original content (children)
		element.props.children,
		// Any additional content
		el( 'code', {}, 'My code' )
	);
};
wp.hooks.addFilter(
	'blocks.getSaveContent.extraProps',
	'my-plugin/add-code-element',
	addCodeElement
);
```

Old PR #8470

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

Example usage for `blocks.getSaveElement` hook.

## How has this been tested?
Tested locally with a cover block.

## Types of changes
Code examples added in markdown file.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] ~I've updated all React Native files affected by any refactorings/renamings in this PR.~ <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
