### PR TITLE
Update URLs used for embeds in testing to use media that is evergreen

### DIFF
--- a/packages/block-library/src/embed/test/index.js
+++ b/packages/block-library/src/embed/test/index.js
@@ -42,8 +42,8 @@ describe( 'utils', () => {
 
 	describe( 'findMoreSuitableBlock', () => {
 		test( 'findMoreSuitableBlock matches a URL to a block name', () => {
-			const twitterURL = 'https://twitter.com/notnownikki';
-			const youtubeURL = 'https://www.youtube.com/watch?v=bNnfuvC1LlU';
+			const twitterURL = 'https://twitter.com/WordPress';
+			const youtubeURL = 'https://www.youtube.com/watch?v=72xdCU__XCk';
 			const unknownURL = 'https://example.com/';
 
 			expect( findMoreSuitableBlock( twitterURL ) ).toEqual(
@@ -110,7 +110,7 @@ describe( 'utils', () => {
 	describe( 'createUpgradedEmbedBlock', () => {
 		describe( 'do not create new block', () => {
 			it( 'when block type does not exist', () => {
-				const youtubeURL = 'https://www.youtube.com/watch?v=dQw4w';
+				const youtubeURL = 'https://www.youtube.com/watch?v=72xdCU';
 
 				unregisterBlockType( DEFAULT_EMBED_BLOCK );
 
@@ -129,7 +129,7 @@ describe( 'utils', () => {
 			} );
 
 			it( 'when block variation does not exist', () => {
-				const youtubeURL = 'https://www.youtube.com/watch?v=dQw4w';
+				const youtubeURL = 'https://www.youtube.com/watch?v=72xdCU';
 
 				unregisterBlockVariation( DEFAULT_EMBED_BLOCK, 'youtube' );
 
@@ -152,7 +152,7 @@ describe( 'utils', () => {
 		} );
 
 		it( 'should return a YouTube embed block when given a YouTube URL', () => {
-			const youtubeURL = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+			const youtubeURL = 'https://www.youtube.com/watch?v=72xdCU__XCk';
 
 			const result = createUpgradedEmbedBlock( {
 				attributes: { url: youtubeURL },

--- a/packages/block-library/src/shortcode/test/edit.native.js
+++ b/packages/block-library/src/shortcode/test/edit.native.js
@@ -23,7 +23,7 @@ describe( 'Shortcode', () => {
 			<Shortcode
 				attributes={ {
 					text:
-						'[youtube https://www.youtube.com/watch?v=ssfHW5lwFZg]',
+						'[youtube https://www.youtube.com/watch?v=72xdCU__XCk]',
 				} }
 			/>
 		);
@@ -31,7 +31,7 @@ describe( 'Shortcode', () => {
 		const textInput = testInstance.findByType( TextInput );
 		expect( textInput ).toBeTruthy();
 		expect( textInput.props.value ).toBe(
-			'[youtube https://www.youtube.com/watch?v=ssfHW5lwFZg]'
+			'[youtube https://www.youtube.com/watch?v=72xdCU__XCk]'
 		);
 	} );
 } );

--- a/packages/components/src/card/stories/media.js
+++ b/packages/components/src/card/stories/media.js
@@ -94,7 +94,7 @@ export const iframeEmbed = () => {
 				<iframe
 					width="560"
 					height="315"
-					src="https://www.youtube.com/embed/zGP6zk7jcrQ"
+					src="https://www.youtube.com/embed/72xdCU__XCk"
 					frameBorder="0"
 					allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
 					allowFullScreen

--- a/packages/core-data/src/test/reducer.js
+++ b/packages/core-data/src/test/reducer.js
@@ -344,12 +344,12 @@ describe( 'embedPreviews()', () => {
 		const originalState = deepFreeze( {} );
 		const state = embedPreviews( originalState, {
 			type: 'RECEIVE_EMBED_PREVIEW',
-			url: 'http://twitter.com/notnownikki',
+			url: 'http://twitter.com/WordPress',
 			preview: { data: 42 },
 		} );
 
 		expect( state ).toEqual( {
-			'http://twitter.com/notnownikki': { data: 42 },
+			'http://twitter.com/WordPress': { data: 42 },
 		} );
 	} );
 } );

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -80,7 +80,7 @@ describe( 'getEntityRecords', () => {
 describe( 'getEmbedPreview', () => {
 	const SUCCESSFUL_EMBED_RESPONSE = { data: '<p>some html</p>' };
 	const UNEMBEDDABLE_RESPONSE = false;
-	const EMBEDDABLE_URL = 'http://twitter.com/notnownikki';
+	const EMBEDDABLE_URL = 'http://twitter.com/WordPress';
 	const UNEMBEDDABLE_URL = 'http://example.com/';
 
 	it( 'yields with fetched embed preview', async () => {

--- a/packages/e2e-tests/specs/editor/plugins/innerblocks-locking-all-embed.js
+++ b/packages/e2e-tests/specs/editor/plugins/innerblocks-locking-all-embed.js
@@ -13,9 +13,9 @@ import {
 
 const MOCK_RESPONSES = [
 	{
-		match: createEmbeddingMatcher( 'https://twitter.com/wordpress' ),
+		match: createEmbeddingMatcher( 'https://twitter.com/WordPress' ),
 		onRequestMatch: createJSONResponse( {
-			url: 'https://twitter.com/wordpress',
+			url: 'https://twitter.com/WordPress',
 			html: '<p>Mock success response.</p>',
 			type: 'rich',
 			provider_name: 'Twitter',
@@ -48,7 +48,7 @@ describe( 'Embed block inside a locked all parent', () => {
 		await page.waitForSelector( embedInputSelector );
 		await page.click( embedInputSelector );
 		// This URL should not have a trailing slash.
-		await page.keyboard.type( 'https://twitter.com/wordpress' );
+		await page.keyboard.type( 'https://twitter.com/WordPress' );
 		await page.keyboard.press( 'Enter' );
 		// The twitter block should appear correctly.
 		await page.waitForSelector( 'figure.wp-block-embed' );

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/embedding.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/embedding.test.js.snap
@@ -15,9 +15,9 @@ https://twitter.com/wooyaygutenberg123454312
 `;
 
 exports[`Embedding content should render embeds in the correct state 1`] = `
-"<!-- wp:embed {\\"url\\":\\"https://twitter.com/notnownikki\\",\\"type\\":\\"rich\\",\\"providerNameSlug\\":\\"twitter\\",\\"responsive\\":true,\\"className\\":\\"\\"} -->
+"<!-- wp:embed {\\"url\\":\\"https://twitter.com/WordPress\\",\\"type\\":\\"rich\\",\\"providerNameSlug\\":\\"twitter\\",\\"responsive\\":true,\\"className\\":\\"\\"} -->
 <figure class=\\"wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter\\"><div class=\\"wp-block-embed__wrapper\\">
-https://twitter.com/notnownikki
+https://twitter.com/WordPress
 </div></figure>
 <!-- /wp:embed -->
 
@@ -33,9 +33,9 @@ https://wordpress.org/gutenberg/handbook/
 </div></figure>
 <!-- /wp:embed -->
 
-<!-- wp:embed {\\"url\\":\\"https://twitter.com/thatbunty\\"} -->
+<!-- wp:embed {\\"url\\":\\"https://twitter.com/WordPress\\"} -->
 <figure class=\\"wp-block-embed\\"><div class=\\"wp-block-embed__wrapper\\">
-https://twitter.com/thatbunty
+https://twitter.com/WordPress
 </div></figure>
 <!-- /wp:embed -->
 
@@ -45,9 +45,9 @@ https://wordpress.org/gutenberg/handbook/block-api/attributes/
 </div></figure>
 <!-- /wp:embed -->
 
-<!-- wp:embed {\\"url\\":\\"https://www.youtube.com/watch?v=lXMskKTw3Bc\\",\\"type\\":\\"video\\",\\"providerNameSlug\\":\\"youtube\\",\\"responsive\\":true,\\"className\\":\\"wp-embed-aspect-16-9 wp-has-aspect-ratio\\"} -->
+<!-- wp:embed {\\"url\\":\\"https://www.youtube.com/watch?v=72xdCU__XCk\\",\\"type\\":\\"video\\",\\"providerNameSlug\\":\\"youtube\\",\\"responsive\\":true,\\"className\\":\\"wp-embed-aspect-16-9 wp-has-aspect-ratio\\"} -->
 <figure class=\\"wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio\\"><div class=\\"wp-block-embed__wrapper\\">
-https://www.youtube.com/watch?v=lXMskKTw3Bc
+https://www.youtube.com/watch?v=72xdCU__XCk
 </div></figure>
 <!-- /wp:embed -->
 
@@ -59,9 +59,9 @@ https://cloudup.com/cQFlxqtY4ob
 `;
 
 exports[`Embedding content should retry embeds that could not be embedded with trailing slashes, without the trailing slashes 1`] = `
-"<!-- wp:embed {\\"url\\":\\"https://twitter.com/notnownikki/\\",\\"type\\":\\"rich\\",\\"providerNameSlug\\":\\"embed-handler\\",\\"responsive\\":true,\\"className\\":\\"\\"} -->
+"<!-- wp:embed {\\"url\\":\\"https://twitter.com/WordPress/\\",\\"type\\":\\"rich\\",\\"providerNameSlug\\":\\"embed-handler\\",\\"responsive\\":true,\\"className\\":\\"\\"} -->
 <figure class=\\"wp-block-embed is-type-rich is-provider-embed-handler wp-block-embed-embed-handler\\"><div class=\\"wp-block-embed__wrapper\\">
-https://twitter.com/notnownikki/
+https://twitter.com/WordPress/
 </div></figure>
 <!-- /wp:embed -->"
 `;

--- a/packages/e2e-tests/specs/editor/various/embedding.test.js
+++ b/packages/e2e-tests/specs/editor/various/embedding.test.js
@@ -25,7 +25,7 @@ const MOCK_EMBED_WORDPRESS_SUCCESS_RESPONSE = {
 };
 
 const MOCK_EMBED_RICH_SUCCESS_RESPONSE = {
-	url: 'https://twitter.com/notnownikki',
+	url: 'https://twitter.com/WordPress',
 	html: '<p>Mock success response.</p>',
 	type: 'rich',
 	provider_name: 'Twitter',
@@ -34,7 +34,7 @@ const MOCK_EMBED_RICH_SUCCESS_RESPONSE = {
 };
 
 const MOCK_EMBED_VIDEO_SUCCESS_RESPONSE = {
-	url: 'https://www.youtube.com/watch?v=lXMskKTw3Bc',
+	url: 'https://www.youtube.com/watch?v=72xdCU__XCk',
 	html: '<iframe width="16" height="9"></iframe>',
 	type: 'video',
 	provider_name: 'YouTube',
@@ -61,7 +61,7 @@ const MOCK_EMBED_IMAGE_SUCCESS_RESPONSE = {
 };
 
 const MOCK_BAD_EMBED_PROVIDER_RESPONSE = {
-	url: 'https://twitter.com/thatbunty',
+	url: 'https://twitter.com/WordPress',
 	html: false,
 	provider_name: 'Embed Provider',
 	version: '1.0',
@@ -70,7 +70,7 @@ const MOCK_BAD_EMBED_PROVIDER_RESPONSE = {
 const MOCK_CANT_EMBED_RESPONSE = {
 	provider_name: 'Embed Handler',
 	html:
-		'<a href="https://twitter.com/wooyaygutenberg123454312">https://twitter.com/wooyaygutenberg123454312</a>',
+		'<a href="https://twitter.com/wooyaygutenberg123454312">https://twitter.com/WordPress</a>',
 };
 
 const MOCK_BAD_WORDPRESS_RESPONSE = {
@@ -105,7 +105,7 @@ const MOCK_RESPONSES = [
 	},
 	{
 		match: createEmbeddingMatcher(
-			'https://www.youtube.com/watch?v=lXMskKTw3Bc'
+			'https://www.youtube.com/watch?v=72xdCU__XCk'
 		),
 		onRequestMatch: createJSONResponse( MOCK_EMBED_VIDEO_SUCCESS_RESPONSE ),
 	},
@@ -126,15 +126,15 @@ const MOCK_RESPONSES = [
 		onRequestMatch: createJSONResponse( MOCK_EMBED_RICH_SUCCESS_RESPONSE ),
 	},
 	{
-		match: createEmbeddingMatcher( 'https://twitter.com/notnownikki' ),
+		match: createEmbeddingMatcher( 'https://twitter.com/WordPress' ),
 		onRequestMatch: createJSONResponse( MOCK_EMBED_RICH_SUCCESS_RESPONSE ),
 	},
 	{
-		match: createEmbeddingMatcher( 'https://twitter.com/notnownikki/' ),
+		match: createEmbeddingMatcher( 'https://twitter.com/WordPress/' ),
 		onRequestMatch: createJSONResponse( MOCK_CANT_EMBED_RESPONSE ),
 	},
 	{
-		match: createEmbeddingMatcher( 'https://twitter.com/thatbunty' ),
+		match: createEmbeddingMatcher( 'https://twitter.com/WordPress' ),
 		onRequestMatch: createJSONResponse( MOCK_BAD_EMBED_PROVIDER_RESPONSE ),
 	},
 	{
@@ -170,7 +170,7 @@ describe( 'Embedding content', () => {
 
 	it( 'should render embeds in the correct state', async () => {
 		// Valid embed. Should render valid figure element.
-		await insertEmbed( 'https://twitter.com/notnownikki' );
+		await insertEmbed( 'https://twitter.com/WordPress' );
 		await page.waitForSelector( 'figure.wp-block-embed' );
 
 		// Valid provider; invalid content. Should render failed, edit state.
@@ -187,9 +187,9 @@ describe( 'Embedding content', () => {
 
 		// Provider whose oembed API has gone wrong. Should render failed, edit
 		// state.
-		await insertEmbed( 'https://twitter.com/thatbunty' );
+		await insertEmbed( 'https://twitter.com/WordPress' );
 		await page.waitForSelector(
-			'input[value="https://twitter.com/thatbunty"]'
+			'input[value="https://twitter.com/WordPress"]'
 		);
 
 		// WordPress content that can be embedded. Should render valid figure
@@ -201,7 +201,7 @@ describe( 'Embedding content', () => {
 
 		// Video content. Should render valid figure element, and include the
 		// aspect ratio class.
-		await insertEmbed( 'https://www.youtube.com/watch?v=lXMskKTw3Bc' );
+		await insertEmbed( 'https://www.youtube.com/watch?v=72xdCU__XCk' );
 		await page.waitForSelector(
 			'figure.wp-block-embed.is-type-video.wp-embed-aspect-16-9'
 		);
@@ -228,7 +228,7 @@ describe( 'Embedding content', () => {
 	} );
 
 	it( 'should retry embeds that could not be embedded with trailing slashes, without the trailing slashes', async () => {
-		await insertEmbed( 'https://twitter.com/notnownikki/' );
+		await insertEmbed( 'https://twitter.com/WordPress/' );
 		// The twitter block should appear correctly.
 		await page.waitForSelector( 'figure.wp-block-embed' );
 		expect( await getEditedPostContent() ).toMatchSnapshot();

--- a/packages/e2e-tests/specs/local/demo.test.js
+++ b/packages/e2e-tests/specs/local/demo.test.js
@@ -9,7 +9,7 @@ import {
 } from '@wordpress/e2e-test-utils';
 
 const MOCK_VIMEO_RESPONSE = {
-	url: 'https://vimeo.com/22439234',
+	url: 'https://vimeo.com/76979871',
 	html: '<iframe width="16" height="9"></iframe>',
 	type: 'video',
 	provider_name: 'Vimeo',
@@ -21,7 +21,7 @@ describe( 'new editor state', () => {
 	beforeAll( async () => {
 		await setUpResponseMocking( [
 			{
-				match: createEmbeddingMatcher( 'https://vimeo.com/22439234' ),
+				match: createEmbeddingMatcher( 'https://vimeo.com/76979871' ),
 				onRequestMatch: createJSONResponse( MOCK_VIMEO_RESPONSE ),
 			},
 		] );

--- a/post-content.php
+++ b/post-content.php
@@ -145,9 +145,9 @@
 <p><?php _e( 'Any block can opt into these alignments. The embed block has them also, and is responsive out of the box:', 'gutenberg' ); ?></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:embed {"url":"https://vimeo.com/22439234","type":"video","providerNameSlug":"vimeo","align":"wide","className":"wp-has-aspect-ratio wp-embed-aspect-16-9","responsive":true} -->
+<!-- wp:embed {"url":"https://vimeo.com/76979871","type":"video","providerNameSlug":"vimeo","align":"wide","className":"wp-has-aspect-ratio wp-embed-aspect-16-9","responsive":true} -->
 <figure class="wp-block-embed-vimeo alignwide wp-block-embed is-type-video is-provider-vimeo wp-has-aspect-ratio wp-embed-aspect-16-9"><div class="wp-block-embed__wrapper">
-https://vimeo.com/22439234
+https://vimeo.com/76979871
 </div></figure>
 <!-- /wp:embed -->
 

--- a/test/integration/blocks-raw-handling.test.js
+++ b/test/integration/blocks-raw-handling.test.js
@@ -79,7 +79,7 @@ describe( 'Blocks raw handling', () => {
 						transform: () => {
 							return createBlock( 'core/embed', {
 								url:
-									'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+									'https://www.youtube.com/watch?v=72xdCU__XCk',
 							} );
 						},
 					},


### PR DESCRIPTION
Update URLs used for embeds in testing to use media that is consistent with core and is unlikely to be removed which would cause testing failures.

Carrying an update from core being introduced in 5.6 via [[coreRevision49117]](https://core.trac.wordpress.org/changeset/49117)/[core#51487](https://core.trac.wordpress.org/ticket/51487#comment:8) that originally spawned in [core#46986](https://core.trac.wordpress.org/ticket/46986) and was discussed in [meta#5467](https://meta.trac.wordpress.org/ticket/5467).

> Instead of using WordPress test accounts, could we instead fall back onto using a video uploaded by the embed company instead?
> For example, for Vimeo, anything from Vimeo Staff https://vimeo.com/staff or the test video from https://player.vimeo.com/embed should be safe to use going forward. edit: The player embed page actually has a bunch of test videos with various states, such as not-embeddable, hosted by official vimeo test accounts, seems perfect for this use-case.
> Having official WordPress accounts for every embed platform is not going to be viable from a management perspective IMHO, and having accounts everywhere with only a single W logo video doesn't lead to a super great experience when it ends up in search results.
> Where WordPress does have a use for the service (Such as Youtube) using one of our uploads such as a release video does make sense though.

This ticket is to update those urls to use the youtube suggested video and the one from the Vimeo embed tutorial.
Youtube - https://www.youtube.com/watch?v=72xdCU__XCk
Vimeo - https://vimeo.com/76979871
Twitter - https://www.twitter.com/WordPress

I didn't touch Soundcloud or Instagram as I wasn't sure what media would be best evergreen there and unlikely to be deleted. Maybe one of their sample media, will delve further.

I will also look to update the documentation here;
https://github.com/WordPress/gutenberg/blob/master/docs/contributors/testing-overview.md#end-to-end-testing
Similar to what was done in the core handbook here;
https://make.wordpress.org/core/handbook/testing/automated-testing/

Leaving in draft and will check off the items below when done.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
