### PR TITLE
Block wrapper: reduce context

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -577,7 +577,6 @@ _Parameters_
 
 -   _props_ `Object`: Optional. Props to pass to the element. Must contain the ref if one is defined.
 -   _options_ `Object`: Options for internal use only.
--   _options.\_\_unstableIsHtml_ `boolean`: 
 
 _Returns_
 

--- a/packages/block-editor/src/components/block-edit/context.js
+++ b/packages/block-editor/src/components/block-edit/context.js
@@ -13,7 +13,7 @@ const Context = createContext( {
 	isSelected: false,
 	focusedElement: null,
 	setFocusedElement: noop,
-	clientId: null,
+	clientId: undefined,
 } );
 const { Provider } = Context;
 

--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -19,7 +19,10 @@ import { ENTER, BACKSPACE, DELETE } from '@wordpress/keycodes';
 import { __, sprintf } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import deprecated from '@wordpress/deprecated';
-import { __unstableGetBlockProps as getBlockProps } from '@wordpress/blocks';
+import {
+	__unstableGetBlockProps as getBlockProps,
+	getBlockType,
+} from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -76,7 +79,6 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 			const {
 				getBlockMode,
 				getBlockName,
-				getBlockType,
 				getBlockRootClientId,
 				getBlockIndex,
 				isBlockSelected,

--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -30,8 +30,9 @@ import {
 import { isInsideRootBlock } from '../../utils/dom';
 import useMovingAnimation from '../use-moving-animation';
 import { Context, SetBlockNodes } from './root-container';
-import { BlockListBlockContext } from './block';
+import { BlockWrapperPropsContext } from './block';
 import ELEMENTS from './block-wrapper-elements';
+import { useBlockEditContext } from '../block-edit';
 
 /**
  * If the block count exceeds the threshold, we disable the reordering animation
@@ -48,21 +49,19 @@ const BLOCK_ANIMATION_THRESHOLD = 200;
  * also pass any other props through this hook, and they will be merged and
  * returned.
  *
- * @param {Object}  props   Optional. Props to pass to the element. Must contain
- *                          the ref if one is defined.
- * @param {Object}  options Options for internal use only.
- * @param {boolean} options.__unstableIsHtml
+ * @param {Object} props   Optional. Props to pass to the element. Must contain
+ * the ref if one is defined.
+ * @param {Object} options Options for internal use only.
  *
  * @return {Object} Props to pass to the element to mark as a block.
  */
-export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
+export function useBlockProps( props = {}, options = {} ) {
+	const { clientId = options.clientId } = useBlockEditContext();
 	const fallbackRef = useRef();
 	const ref = props.ref || fallbackRef;
 	const onSelectionStart = useContext( Context );
 	const setBlockNodes = useContext( SetBlockNodes );
-	const { clientId, className, wrapperProps = {} } = useContext(
-		BlockListBlockContext
-	);
+	const wrapperProps = useContext( BlockWrapperPropsContext );
 	const {
 		rootClientId,
 		mode,
@@ -325,7 +324,8 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		};
 	}, [ isNavigationMode, isHovered, setHovered ] );
 
-	const htmlSuffix = mode === 'html' && ! __unstableIsHtml ? '-visual' : '';
+	const htmlSuffix =
+		mode === 'html' && ! options.__unstableIsHtml ? '-visual' : '';
 
 	return {
 		...wrapperProps,
@@ -338,12 +338,9 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		'data-block': clientId,
 		'data-type': name,
 		'data-title': blockTitle,
-		className: classnames(
-			className,
-			props.className,
-			wrapperProps.className,
-			{ 'is-hovered': isHovered }
-		),
+		className: classnames( props.className, wrapperProps.className, {
+			'is-hovered': isHovered,
+		} ),
 		style: { ...wrapperProps.style, ...props.style },
 	};
 }

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -81,12 +81,8 @@ function BlockListBlock( {
 	isFocusMode,
 	isLocked,
 	clientId,
-	rootClientId,
 	isSelected,
 	isMultiSelected,
-	isPartOfMultiSelection,
-	isFirstMultiSelected,
-	isLastMultiSelected,
 	isTypingWithinBlock,
 	isAncestorOfSelectedBlock,
 	isSelectionEnabled,
@@ -100,8 +96,6 @@ function BlockListBlock( {
 	onInsertBlocksAfter,
 	onMerge,
 	toggleSelection,
-	index,
-	enableAnimation,
 	activeEntityBlockId,
 } ) {
 	// In addition to withSelect, we should favor using useSelect in this
@@ -207,18 +201,7 @@ function BlockListBlock( {
 
 	const value = {
 		clientId,
-		rootClientId,
-		isSelected,
-		isFirstMultiSelected,
-		isLastMultiSelected,
-		isPartOfMultiSelection,
-		enableAnimation,
-		index,
 		className: wrapperClassName,
-		isLocked,
-		name,
-		mode,
-		blockTitle: blockType.title,
 		wrapperProps: omit( wrapperProps, [ 'data-align' ] ),
 	};
 	const memoizedValue = useMemo( () => value, Object.values( value ) );
@@ -267,10 +250,8 @@ const applyWithSelect = withSelect(
 	( select, { clientId, rootClientId, isLargeViewport } ) => {
 		const {
 			isBlockSelected,
-			isAncestorMultiSelected,
 			isBlockMultiSelected,
 			isFirstMultiSelectedBlock,
-			getLastMultiSelectedBlockClientId,
 			isTyping,
 			getBlockMode,
 			isSelectionEnabled,
@@ -297,19 +278,12 @@ const applyWithSelect = withSelect(
 		// the state. It happens now because the order in withSelect rendering
 		// is not correct.
 		const { name, attributes, isValid } = block || {};
-		const isFirstMultiSelected = isFirstMultiSelectedBlock( clientId );
 
 		// Do not add new properties here, use `useSelect` instead to avoid
 		// leaking new props to the public API (editor.BlockListBlock filter).
 		return {
 			isMultiSelected: isBlockMultiSelected( clientId ),
-			isPartOfMultiSelection:
-				isBlockMultiSelected( clientId ) ||
-				isAncestorMultiSelected( clientId ),
-			isFirstMultiSelected,
-			isLastMultiSelected:
-				getLastMultiSelectedBlockClientId() === clientId,
-			multiSelectedClientIds: isFirstMultiSelected
+			multiSelectedClientIds: isFirstMultiSelectedBlock( clientId )
 				? getMultiSelectedBlockClientIds()
 				: undefined,
 

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -24,12 +24,6 @@ import useBlockDropZone from '../use-block-drop-zone';
  */
 const appenderNodesMap = new Map();
 
-/**
- * If the block count exceeds the threshold, we disable the reordering animation
- * to avoid laginess.
- */
-const BLOCK_ANIMATION_THRESHOLD = 200;
-
 function BlockList(
 	{ className, placeholder, rootClientId, renderAppender },
 	ref
@@ -73,8 +67,6 @@ function Items( {
 			getSelectedBlockClientId,
 			getMultiSelectedBlockClientIds,
 			hasMultiSelection,
-			getGlobalBlockCount,
-			isTyping,
 			isDraggingBlocks,
 			__experimentalGetActiveBlockIdByBlockNames,
 		} = select( 'core/block-editor' );
@@ -90,9 +82,6 @@ function Items( {
 			multiSelectedBlockClientIds: getMultiSelectedBlockClientIds(),
 			orientation: getBlockListSettings( rootClientId )?.orientation,
 			hasMultiSelection: hasMultiSelection(),
-			enableAnimation:
-				! isTyping() &&
-				getGlobalBlockCount() <= BLOCK_ANIMATION_THRESHOLD,
 			isDraggingBlocks: isDraggingBlocks(),
 			activeEntityBlockId,
 		};
@@ -104,7 +93,6 @@ function Items( {
 		multiSelectedBlockClientIds,
 		orientation,
 		hasMultiSelection,
-		enableAnimation,
 		isDraggingBlocks,
 		activeEntityBlockId,
 	} = useSelect( selector, [ rootClientId ] );
@@ -137,9 +125,9 @@ function Items( {
 							clientId={ clientId }
 							// This prop is explicitely computed and passed down
 							// to avoid being impacted by the async mode
-							// otherwise there might be a small delay to trigger the animation.
+							// otherwise there might be a small delay to trigger
+							// the animation.
 							index={ index }
-							enableAnimation={ enableAnimation }
 							className={ classnames( {
 								'is-drop-target': isDropTarget,
 								'is-dropping-horizontally':


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

The block props hooks should be getting this data from the store instead of through context.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
