### PR TITLE
Fix design of color/gradient controls in editor panel

### DIFF
--- a/packages/block-editor/src/components/colors-gradients/style.scss
+++ b/packages/block-editor/src/components/colors-gradients/style.scss
@@ -23,4 +23,26 @@
 	&.is-opened &__panel-title .component-color-indicator {
 		display: none;
 	}
+
+	// Must equal $color-palette-circle-size from:
+	// @wordpress/components/src/circular-option-picker/style.scss
+	$swatch-size: 28px;
+
+	// Optimize fit of six swatches per line using calc() to create variable
+	// spacing that mimics a "justified/space-between" layout and works with
+	// or without scrollbars
+	@media screen and (min-width: $break-medium) {
+		// Overrides the default negative margin
+		.components-circular-option-picker__swatches {
+			margin-right: 0;
+		}
+		// Figures the spacing
+		.components-circular-option-picker__option-wrapper {
+			margin-right: calc((100% - (#{$swatch-size} * 6)) / 5);
+		}
+		// Removes the right margin on every sixth swatch
+		.components-circular-option-picker__option-wrapper:nth-child(6n + 6) {
+			margin-right: 0;
+		}
+	}
 }

--- a/packages/components/src/angle-picker-control/index.js
+++ b/packages/components/src/angle-picker-control/index.js
@@ -13,13 +13,10 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import BaseControl from '../base-control';
-import { FlexBlock } from '../flex';
+import { FlexBlock, FlexItem } from '../flex';
 import NumberControl from '../number-control';
 import AngleCircle from './angle-circle';
-import {
-	Root,
-	NumberControlWrapper,
-} from './styles/angle-picker-control-styles';
+import { Root } from './styles/angle-picker-control-styles';
 
 export default function AnglePickerControl( {
 	className,
@@ -52,8 +49,8 @@ export default function AnglePickerControl( {
 			label={ label }
 			{ ...props }
 		>
-			<Root gap={ 3 }>
-				<NumberControlWrapper>
+			<Root>
+				<FlexBlock>
 					<NumberControl
 						className="components-angle-picker-control__input-field"
 						id={ id }
@@ -63,14 +60,14 @@ export default function AnglePickerControl( {
 						step="1"
 						value={ value }
 					/>
-				</NumberControlWrapper>
-				<FlexBlock>
+				</FlexBlock>
+				<FlexItem>
 					<AngleCircle
 						aria-hidden="true"
 						value={ value }
 						onChange={ onChange }
 					/>
-				</FlexBlock>
+				</FlexItem>
 			</Root>
 		</BaseControl>
 	);

--- a/packages/components/src/angle-picker-control/index.js
+++ b/packages/components/src/angle-picker-control/index.js
@@ -7,6 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { useInstanceId } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -22,10 +23,11 @@ import {
 
 export default function AnglePickerControl( {
 	className,
+	hideLabelFromVision,
 	id: idProp,
-	value,
+	label = __( 'Angle' ),
 	onChange,
-	label,
+	value,
 	...props
 } ) {
 	const instanceId = useInstanceId(
@@ -45,6 +47,7 @@ export default function AnglePickerControl( {
 	return (
 		<BaseControl
 			className={ classes }
+			hideLabelFromVision={ hideLabelFromVision }
 			id={ id }
 			label={ label }
 			{ ...props }

--- a/packages/components/src/angle-picker-control/styles/angle-picker-control-styles.js
+++ b/packages/components/src/angle-picker-control/styles/angle-picker-control-styles.js
@@ -6,17 +6,13 @@ import styled from '@emotion/styled';
 /**
  * Internal dependencies
  */
-import { Flex, FlexItem } from '../../flex';
+import { Flex } from '../../flex';
 import { color } from '../../utils/style-mixins';
 
 const CIRCLE_SIZE = 30;
 
 export const Root = styled( Flex )`
 	max-width: 200px;
-`;
-
-export const NumberControlWrapper = styled( FlexItem )`
-	width: 80px;
 `;
 
 export const CircleRoot = styled.div`

--- a/packages/components/src/circular-option-picker/style.scss
+++ b/packages/components/src/circular-option-picker/style.scss
@@ -4,16 +4,16 @@ $color-palette-circle-spacing: 12px;
 .components-circular-option-picker {
 	display: inline-block;
 	width: 100%;
-	margin-right: -10px;
 
 	.components-circular-option-picker__custom-clear-wrapper {
 		display: flex;
 		justify-content: flex-end;
 	}
 
-	// Account for scrollbar or no scrollbar.
+	// Effectively negates the end swatch spacing to keep the swatches
+	// from wrapping before necessary.
 	.components-circular-option-picker__swatches {
-		margin-right: -$grid-unit-20;
+		margin-right: -$color-palette-circle-spacing;
 	}
 }
 
@@ -21,7 +21,7 @@ $color-palette-circle-spacing: 12px;
 	display: inline-block;
 	height: $color-palette-circle-size;
 	width: $color-palette-circle-size;
-	margin-right: $color-palette-circle-spacing + $grid-unit-05;
+	margin-right: $color-palette-circle-spacing;
 	margin-bottom: $color-palette-circle-spacing;
 	vertical-align: top;
 	transform: scale(1);

--- a/packages/components/src/custom-gradient-picker/index.js
+++ b/packages/components/src/custom-gradient-picker/index.js
@@ -13,7 +13,7 @@ import { __ } from '@wordpress/i18n';
  */
 import AnglePickerControl from '../angle-picker-control';
 import CustomGradientBar from './custom-gradient-bar';
-import { Flex, FlexItem } from '../flex';
+import { Flex } from '../flex';
 import SelectControl from '../select-control';
 import { getGradientParsed } from './utils';
 import { serializeGradient } from './serializer';
@@ -22,7 +22,10 @@ import {
 	HORIZONTAL_GRADIENT_ORIENTATION,
 	GRADIENT_OPTIONS,
 } from './constants';
-import { SelectWrapper } from './styles/custom-gradient-picker-styles';
+import {
+	AccessoryWrapper,
+	SelectWrapper,
+} from './styles/custom-gradient-picker-styles';
 
 const GradientAnglePicker = ( { gradientAST, hasGradient, onChange } ) => {
 	const angle = get(
@@ -86,6 +89,7 @@ const GradientTypePicker = ( { gradientAST, hasGradient, onChange } ) => {
 		<SelectControl
 			className="components-custom-gradient-picker__type-picker"
 			label={ __( 'Type' ) }
+			labelPosition={ 'side' }
 			onChange={ handleOnChange }
 			options={ GRADIENT_OPTIONS }
 			value={ hasGradient && type }
@@ -110,15 +114,15 @@ export default function CustomGradientPicker( { value, onChange } ) {
 						onChange={ onChange }
 					/>
 				</SelectWrapper>
-				{ type === 'linear-gradient' && (
-					<FlexItem>
+				<AccessoryWrapper>
+					{ type === 'linear-gradient' && (
 						<GradientAnglePicker
 							gradientAST={ gradientAST }
 							hasGradient={ hasGradient }
 							onChange={ onChange }
 						/>
-					</FlexItem>
-				) }
+					) }
+				</AccessoryWrapper>
 			</Flex>
 		</div>
 	);

--- a/packages/components/src/custom-gradient-picker/index.js
+++ b/packages/components/src/custom-gradient-picker/index.js
@@ -43,8 +43,9 @@ const GradientAnglePicker = ( { gradientAST, hasGradient, onChange } ) => {
 	};
 	return (
 		<AnglePickerControl
-			value={ hasGradient ? angle : '' }
+			hideLabelFromVision
 			onChange={ onAngleChange }
+			value={ hasGradient ? angle : '' }
 		/>
 	);
 };

--- a/packages/components/src/custom-gradient-picker/styles/custom-gradient-picker-styles.js
+++ b/packages/components/src/custom-gradient-picker/styles/custom-gradient-picker-styles.js
@@ -5,8 +5,12 @@ import styled from '@emotion/styled';
 /**
  * Internal dependencies
  */
-import { FlexItem } from '../../flex';
+import { FlexBlock } from '../../flex';
 
-export const SelectWrapper = styled( FlexItem )`
-	width: 110px;
+export const SelectWrapper = styled( FlexBlock )`
+	flex-grow: 5;
+`;
+
+export const AccessoryWrapper = styled( FlexBlock )`
+	flex-grow: 4;
 `;


### PR DESCRIPTION
#23802 had a lot of good improvements and this follows up on that addressing three issues.

1. Since it was merged the default position of labels in `SelectControl` changed #25427, throwing the alignment off in `CustomGradienPicker`.

2. The change to make the swatches align on the right side with their neighboring controls https://github.com/WordPress/gutenberg/pull/23802#issuecomment-681867143 currently only works when there is no scrollbar on the settings sidebar and can be improved to work with or without scrollbars.

3. The "dial" of the `AnglePickerControl` was able to push out of alignment (to the right) when the settings sidebar has a scrollbar.

All of the above can be noted in the "before" screen capture below.

Before | After
----|----
![color-gradient-panel-before](https://user-images.githubusercontent.com/9000376/96390293-d43d7300-1168-11eb-87e8-c4305fadff86.png) | ![color-gradient-panel-after](https://user-images.githubusercontent.com/9000376/96390388-3bf3be00-1169-11eb-881a-03aab1073979.png)

<details>
<summary>After screen recording comparing settings sidebar with and without overflow</summary>
<img src="https://user-images.githubusercontent.com/9000376/96390494-d6ec9800-1169-11eb-8ffe-e95a0b1ea7d0.gif">
</details>

<details>
<summary>Before screen recording comparing settings sidebar with and without overflow</summary>
<img src="https://user-images.githubusercontent.com/9000376/96390516-e66be100-1169-11eb-90a0-2972279f25a7.gif">
</details>

An aside is the `AnglePickerControl` gets a default label which according to its readme it already had. 

## How has this been tested?
Wordpress 5.5.1, Chrome 85
Resolutions from 280 to 1440.

## Types of changes
Non-breaking design fixes
Accessibility fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
