### PR TITLE
[Widgets Editor] Add "Browse all" option to the inserter

### DIFF
--- a/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
@@ -12,7 +12,7 @@ import {
 	FocusReturnProvider,
 } from '@wordpress/components';
 import { uploadMedia } from '@wordpress/media-utils';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import {
 	BlockEditorProvider,
@@ -47,6 +47,7 @@ export default function WidgetAreasBlockEditorProvider( {
 			),
 		} )
 	);
+	const { setIsInserterOpened } = useDispatch( 'core/edit-widgets' );
 
 	const settings = useMemo( () => {
 		let mediaUploadBlockEditor;
@@ -64,8 +65,14 @@ export default function WidgetAreasBlockEditorProvider( {
 			__experimentalReusableBlocks: reusableBlocks,
 			mediaUpload: mediaUploadBlockEditor,
 			templateLock: 'all',
+			__experimentalSetIsInserterOpened: setIsInserterOpened,
 		};
-	}, [ blockEditorSettings, hasUploadPermissions, reusableBlocks ] );
+	}, [
+		blockEditorSettings,
+		hasUploadPermissions,
+		reusableBlocks,
+		setIsInserterOpened,
+	] );
 
 	const widgetAreaId = useLastSelectedWidgetArea();
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Fix #26023.

Add the "Browse all" button to the quick inline inserter in Widgets Editor.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Go to Widgets Editor
2. Select any widget area, and click the inline appender
3. Observe that there's a "Browse all" button in the quick inserter
4. Clicking on the button will open the global inserter on the left

## Screenshots <!-- if applicable -->
![Kapture 2020-10-19 at 12 32 12](https://user-images.githubusercontent.com/7753001/96402012-757b0680-1207-11eb-8f43-710e7b0ffb8c.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
