### PR TITLE
Use ToolbarButtons instead of Buttons in the Legacy Widget block's toolbar

### DIFF
--- a/packages/edit-widgets/src/blocks/legacy-widget/edit/index.js
+++ b/packages/edit-widgets/src/blocks/legacy-widget/edit/index.js
@@ -7,7 +7,11 @@ import { get, isEmpty, omit, pickBy } from 'lodash';
  * WordPress dependencies
  */
 import { useCallback, useMemo, useState } from '@wordpress/element';
-import { Button, Placeholder, ToolbarGroup } from '@wordpress/components';
+import {
+	ToolbarButton,
+	Placeholder,
+	ToolbarGroup,
+} from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { withSelect } from '@wordpress/data';
 import {
@@ -105,7 +109,7 @@ function LegacyWidgetEdit( {
 			<BlockControls>
 				<ToolbarGroup>
 					{ WPWidget && ! WPWidget.isHidden && (
-						<Button
+						<ToolbarButton
 							onClick={ onResetWidget }
 							label={ __( 'Change widget' ) }
 							icon={ update }
@@ -113,20 +117,20 @@ function LegacyWidgetEdit( {
 					) }
 					{ hasEditForm && (
 						<>
-							<Button
+							<ToolbarButton
 								className="components-tab-button"
 								isPressed={ ! isPreview }
 								onClick={ () => setIsPreview( false ) }
 							>
 								<span>{ __( 'Edit' ) }</span>
-							</Button>
-							<Button
+							</ToolbarButton>
+							<ToolbarButton
 								className="components-tab-button"
 								isPressed={ isPreview }
 								onClick={ () => setIsPreview( true ) }
 							>
 								<span>{ __( 'Preview' ) }</span>
-							</Button>
+							</ToolbarButton>
 						</>
 					) }
 				</ToolbarGroup>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
When testing the widget screen I noticed the block toolbar for the Legacy Widget Block doesn't use a Roving Tab Index. The toolbar instead has a tab stop for each button.

This is caused by the block using `Button` components instead of `ToolbarButton` components. This PR switches over the component. There's no visual change.

## How has this been tested?
1. Navigate to the widgets screen.
2. Add a legacy widget block
3. Shift+Tab to the block toolbar
4. Observe the first item is focused (on `master` the last item is focused)
5. Use left/right arrow keys to navigate to around the toolbar.
6. Use left/right arrow keys to focus the 'Edit' button
7. Press Tab, observe focus is moved back to the block (on `master` the preview button is focused)

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
