### PR TITLE
Fix align order in heading block

### DIFF
--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -21,7 +21,7 @@
 		}
 	},
 	"supports": {
-		"align": [ "full", "wide" ],
+		"align": [ "wide", "full" ],
 		"anchor": true,
 		"className": false,
 		"color": {


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/pull/25917#issuecomment-711160360

https://github.com/WordPress/gutenberg/pull/25917 landed support for align in the heading block. However, the order of the options was "Full" and then "Wide" which didn't follow the existing order in other blocks (wide, and then full).

