### PR TITLE
Fix responsive embeds on widget screen

### DIFF
--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -41,6 +41,16 @@ function gutenberg_widgets_init( $hook ) {
 		return;
 	}
 
+	$current_screen = get_current_screen();
+	/**
+	 * Make the WP Screen object aware that this is a block editor page.
+	 * Since custom blocks check whether the screen is_block_editor,
+	 * this is required for custom blocks to be loaded and for responsive embeds
+	 * to work.
+	 * See wp_enqueue_registered_block_scripts_and_styles in wp-includes/script-loader.php
+	 */
+	$current_screen->is_block_editor( true );
+
 	$initializer_name = 'initialize';
 
 	// Media settings.

--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -143,3 +143,15 @@ function gutenberg_widgets_editor_load_block_editor_scripts_and_styles( $is_bloc
 
 add_filter( 'should_load_block_editor_scripts_and_styles', 'gutenberg_widgets_editor_load_block_editor_scripts_and_styles' );
 
+/**
+ * Show responsive embeds correctly on the widgets screen by adding the wp-embed-responsive class.
+ *
+ * @param string $classes existing admin body classes.
+ *
+ * @return string admin body classes including the wp-embed-responsive class.
+ */
+function gutenberg_widgets_editor_add_responsive_embed_body_class( $classes ) {
+	return "$classes wp-embed-responsive";
+}
+
+add_filter( 'admin_body_class', 'gutenberg_widgets_editor_add_responsive_embed_body_class' );

--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -136,20 +136,3 @@ function gutenberg_widgets_init( $hook ) {
 	wp_enqueue_style( 'wp-format-library' );
 }
 add_action( 'admin_enqueue_scripts', 'gutenberg_widgets_init' );
-
-/**
- * Tells the script loader to load the scripts and styles of custom block on widgets editor screen.
- *
- * @param bool $is_block_editor_screen Current decision about loading block assets.
- * @return bool Filtered decision about loading block assets.
- */
-function gutenberg_widgets_editor_load_block_editor_scripts_and_styles( $is_block_editor_screen ) {
-	if ( is_callable( 'get_current_screen' ) && 'appearance_page_gutenberg-widgets' === get_current_screen()->base ) {
-		return true;
-	}
-
-	return $is_block_editor_screen;
-}
-
-add_filter( 'should_load_block_editor_scripts_and_styles', 'gutenberg_widgets_editor_load_block_editor_scripts_and_styles' );
-

--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -41,16 +41,6 @@ function gutenberg_widgets_init( $hook ) {
 		return;
 	}
 
-	$current_screen = get_current_screen();
-	/**
-	 * Make the WP Screen object aware that this is a block editor page.
-	 * Since custom blocks check whether the screen is_block_editor,
-	 * this is required for custom blocks to be loaded and for responsive embeds
-	 * to work.
-	 * See wp_enqueue_registered_block_scripts_and_styles in wp-includes/script-loader.php
-	 */
-	$current_screen->is_block_editor( true );
-
 	$initializer_name = 'initialize';
 
 	// Media settings.
@@ -136,3 +126,20 @@ function gutenberg_widgets_init( $hook ) {
 	wp_enqueue_style( 'wp-format-library' );
 }
 add_action( 'admin_enqueue_scripts', 'gutenberg_widgets_init' );
+
+/**
+ * Tells the script loader to load the scripts and styles of custom block on widgets editor screen.
+ *
+ * @param bool $is_block_editor_screen Current decision about loading block assets.
+ * @return bool Filtered decision about loading block assets.
+ */
+function gutenberg_widgets_editor_load_block_editor_scripts_and_styles( $is_block_editor_screen ) {
+	if ( is_callable( 'get_current_screen' ) && 'appearance_page_gutenberg-widgets' === get_current_screen()->base ) {
+		return true;
+	}
+
+	return $is_block_editor_screen;
+}
+
+add_filter( 'should_load_block_editor_scripts_and_styles', 'gutenberg_widgets_editor_load_block_editor_scripts_and_styles' );
+


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes #26104

WordPress keeps some internal state to determine whether the current screen is a block editor. Setting this to true has the side effect of enabling responsive embeds in the editor, solving the issues seen in #26104:
https://github.com/WordPress/wordpress-develop/blob/master/src/wp-admin/admin-header.php#L192-L199

## How has this been tested?
1. Paste a youtube link into a widget area on the widget screen
2. The video should eventually appear and be playable within the editor

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
