### PR TITLE
Block Editor: Ensure Align options are always in the same order

### DIFF
--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -59,7 +59,9 @@ export function getValidAlignments(
 ) {
 	let validAlignments;
 	if ( Array.isArray( blockAlign ) ) {
-		validAlignments = blockAlign;
+		validAlignments = ALL_ALIGNMENTS.filter( ( value ) =>
+			blockAlign.includes( value )
+		);
 	} else if ( blockAlign === true ) {
 		// `true` includes all alignments...
 		validAlignments = ALL_ALIGNMENTS;

--- a/packages/block-editor/src/hooks/test/align.js
+++ b/packages/block-editor/src/hooks/test/align.js
@@ -74,6 +74,18 @@ describe( 'align', () => {
 			] );
 		} );
 
+		it( 'should return all aligns sorted when provided in the random order', () => {
+			expect(
+				getValidAlignments( [
+					'full',
+					'right',
+					'center',
+					'wide',
+					'left',
+				] )
+			).toEqual( [ 'left', 'center', 'right', 'wide', 'full' ] );
+		} );
+
 		it( 'should return all aligns if block defines align support as true', () => {
 			expect( getValidAlignments( true ) ).toEqual( [
 				'left',
@@ -83,7 +95,6 @@ describe( 'align', () => {
 				'full',
 			] );
 		} );
-
 		it( 'should return all aligns except wide if wide align explicitly false on the block', () => {
 			expect( getValidAlignments( true, false, true ) ).toEqual( [
 				'left',


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Follow-up for #26260 and the following comment from myself:

> Would it be possible to fo a follow-up that ensures the same order no matter what you set in `supports`?

## How has this been tested?
Unit tests


## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
