### PR TITLE
Editor: refactor PostFormatPanel to use React hooks.

### DIFF
--- a/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
@@ -6,15 +6,21 @@ import { find, get, includes } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
-import { ifCondition, compose } from '@wordpress/compose';
-import { withDispatch, withSelect } from '@wordpress/data';
 import { Button, PanelBody } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { POST_FORMATS } from '../post-format';
+
+const getSuggestion = ( supportedFormats, suggestedPostFormat ) => {
+	const formats = POST_FORMATS.filter( ( format ) =>
+		includes( supportedFormats, format.id )
+	);
+	return find( formats, ( format ) => format.id === suggestedPostFormat );
+};
 
 const PostFormatSuggestion = ( {
 	suggestedPostFormat,
@@ -26,13 +32,39 @@ const PostFormatSuggestion = ( {
 	</Button>
 );
 
-const PostFormatPanel = ( { suggestion, onUpdatePostFormat } ) => {
+export default function PostFormatPanel() {
+	const { currentPostFormat, suggestion } = useSelect( ( select ) => {
+		const { getEditedPostAttribute, getSuggestedPostFormat } = select(
+			'core/editor'
+		);
+		const supportedFormats = get(
+			select( 'core' ).getThemeSupports(),
+			[ 'formats' ],
+			[]
+		);
+		return {
+			currentPostFormat: getEditedPostAttribute( 'format' ),
+			suggestion: getSuggestion(
+				supportedFormats,
+				getSuggestedPostFormat()
+			),
+		};
+	}, [] );
+
+	const { editPost } = useDispatch( 'core/editor' );
+
+	const onUpdatePostFormat = ( format ) => editPost( { format } );
+
 	const panelBodyTitle = [
 		__( 'Suggestion:' ),
 		<span className="editor-post-publish-panel__link" key="label">
 			{ __( 'Use a post format' ) }
 		</span>,
 	];
+
+	if ( ! suggestion || suggestion.id === currentPostFormat ) {
+		return null;
+	}
 
 	return (
 		<PanelBody initialOpen={ false } title={ panelBodyTitle }>
@@ -54,40 +86,4 @@ const PostFormatPanel = ( { suggestion, onUpdatePostFormat } ) => {
 			</p>
 		</PanelBody>
 	);
-};
-
-const getSuggestion = ( supportedFormats, suggestedPostFormat ) => {
-	const formats = POST_FORMATS.filter( ( format ) =>
-		includes( supportedFormats, format.id )
-	);
-	return find( formats, ( format ) => format.id === suggestedPostFormat );
-};
-
-export default compose(
-	withSelect( ( select ) => {
-		const { getEditedPostAttribute, getSuggestedPostFormat } = select(
-			'core/editor'
-		);
-		const supportedFormats = get(
-			select( 'core' ).getThemeSupports(),
-			[ 'formats' ],
-			[]
-		);
-		return {
-			currentPostFormat: getEditedPostAttribute( 'format' ),
-			suggestion: getSuggestion(
-				supportedFormats,
-				getSuggestedPostFormat()
-			),
-		};
-	} ),
-	withDispatch( ( dispatch ) => ( {
-		onUpdatePostFormat( postFormat ) {
-			dispatch( 'core/editor' ).editPost( { format: postFormat } );
-		},
-	} ) ),
-	ifCondition(
-		( { suggestion, currentPostFormat } ) =>
-			suggestion && suggestion.id !== currentPostFormat
-	)
-)( PostFormatPanel );
+}


### PR DESCRIPTION
## Description
Refactors the `PostFormatPanel` component in the `editor` package to use React hooks.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
