### PR TITLE
Improve documentation for dateI18n. Standardise way to output date. Add function dateI18nAddTimezone.

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -22,7 +22,10 @@ import {
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 import { __, sprintf } from '@wordpress/i18n';
-import { dateI18n, format, __experimentalGetSettings } from '@wordpress/date';
+import {
+	__experimentalGetSettings,
+	dateI18nAddTimezone,
+} from '@wordpress/date';
 import {
 	InspectorControls,
 	BlockAlignmentToolbar,
@@ -550,12 +553,18 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 									) }
 								</div>
 							) }
-							{ displayPostDate && post.date_gmt && (
+							{ displayPostDate && post.date && (
 								<time
-									dateTime={ format( 'c', post.date_gmt ) }
+									dateTime={ dateI18nAddTimezone(
+										'c',
+										post.date
+									) }
 									className="wp-block-latest-posts__post-date"
 								>
-									{ dateI18n( dateFormat, post.date_gmt ) }
+									{ dateI18nAddTimezone(
+										dateFormat,
+										post.date
+									) }
 								</time>
 							) }
 							{ displayPostContent &&

--- a/packages/block-library/src/post-comment-date/edit.js
+++ b/packages/block-library/src/post-comment-date/edit.js
@@ -2,7 +2,10 @@
  * WordPress dependencies
  */
 import { useEntityProp } from '@wordpress/core-data';
-import { __experimentalGetSettings, dateI18n } from '@wordpress/date';
+import {
+	__experimentalGetSettings,
+	dateI18nAddTimezone,
+} from '@wordpress/date';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { PanelBody, CustomSelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -18,7 +21,7 @@ export default function Edit( { attributes, context, setAttributes } ) {
 	const formatOptions = Object.values( settings.formats ).map(
 		( formatOption ) => ( {
 			key: formatOption,
-			name: dateI18n( formatOption, date ),
+			name: dateI18nAddTimezone( formatOption, date ),
 		} )
 	);
 	const resolvedFormat = format || siteDateFormat || settings.formats.date;
@@ -45,8 +48,13 @@ export default function Edit( { attributes, context, setAttributes } ) {
 			</InspectorControls>
 
 			<div { ...blockProps }>
-				<time dateTime={ dateI18n( 'c', date ) }>
-					{ dateI18n( resolvedFormat, date ) }
+				<time
+					dateTime={ dateI18nAddTimezone(
+						'c',
+						dateI18nAddTimezone( date )
+					) }
+				>
+					{ dateI18nAddTimezone( resolvedFormat, date ) }
 				</time>
 			</div>
 		</>

--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -8,7 +8,10 @@ import classnames from 'classnames';
  */
 import { useEntityProp } from '@wordpress/core-data';
 import { useState } from '@wordpress/element';
-import { __experimentalGetSettings, dateI18n } from '@wordpress/date';
+import {
+	__experimentalGetSettings,
+	dateI18nAddTimezone,
+} from '@wordpress/date';
 import {
 	AlignmentToolbar,
 	BlockControls,
@@ -52,7 +55,7 @@ export default function PostDateEdit( { attributes, context, setAttributes } ) {
 	const formatOptions = Object.values( settings.formats ).map(
 		( formatOption ) => ( {
 			key: formatOption,
-			name: dateI18n( formatOption, date ),
+			name: dateI18nAddTimezone( formatOption, date ),
 		} )
 	);
 	const resolvedFormat = format || siteFormat || settings.formats.date;
@@ -107,8 +110,8 @@ export default function PostDateEdit( { attributes, context, setAttributes } ) {
 
 			<div { ...blockProps }>
 				{ date && (
-					<time dateTime={ dateI18n( 'c', date ) }>
-						{ dateI18n( resolvedFormat, date ) }
+					<time dateTime={ dateI18nAddTimezone( 'c', date ) }>
+						{ dateI18nAddTimezone( resolvedFormat, date ) }
 
 						{ isPickerOpen && (
 							<Popover

--- a/packages/date/README.md
+++ b/packages/date/README.md
@@ -39,6 +39,15 @@ _Returns_
 
 Formats a date (like `wp_date()` in PHP), translating it into site's locale.
 
+If the date string specifies a timezone e.g.: 2020-10-16T12:36:00.00-04:00
+the date is assumed to be in that timezone. If the date does not contain a
+timezone, the date is considered to be in the user's local timezone.
+Dates are converted to the site timezone before being formatted. If a date
+comes from WordPress API's it is already on the website timezone, but if we
+this function the function assume the date is in user timezone and when
+changing to WordPress timzone the time will change. If the date comes from
+the WordPress API's the date is string that not refers a timezone but is on the
+WordPress timezone, for these cases `dateI18nAddTimezone`should be should be used instead.
 Backward Compatibility Notice: if `timezone` is set to `true`, the function
 behaves like `gmdateI18n`.
 
@@ -51,6 +60,33 @@ _Parameters_
 
 -   _dateFormat_ `string`: PHP-style formatting string. See php.net/date.
 -   _dateValue_ `(Date|string|null)`: Date object or string, parsable by moment.js.
+-   _timezone_ `(string|number|boolean|null)`: Timezone to output result in or a UTC offset. Defaults to timezone from site. Notice: `boolean` is effectively deprecated, but still supported for backward compatibility reasons.
+
+_Returns_
+
+-   `string`: Formatted date.
+
+<a name="dateI18nAddTimezone" href="#dateI18nAddTimezone">#</a> **dateI18nAddTimezone**
+
+Formats a date (like `wp_date()` in PHP), translating it into site's locale.
+
+If the date string specifies a timezone e.g.: 2020-10-16T12:36:00.00+01:00
+the date is assumed to be in that timezone. And then the date is changed to
+the website timezone. If the date does not contain a timezone like the dates
+from the WordPress API, the date is considered to be in the website timezone.
+For most cases where a date comes from the WordPress API, and we just want to
+format that date in a given way without chaning timezone this is the recommended
+function to use.
+
+_Related_
+
+-   <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>
+-   <https://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC>
+
+_Parameters_
+
+-   _dateFormat_ `string`: PHP-style formatting string. See php.net/date.
+-   _dateValue_ `(Date|string|Moment|null)`: Date object or string, parsable by moment.js.
 -   _timezone_ `(string|number|boolean|null)`: Timezone to output result in or a UTC offset. Defaults to timezone from site. Notice: `boolean` is effectively deprecated, but still supported for backward compatibility reasons.
 
 _Returns_

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -544,6 +544,15 @@ export function gmdate( dateFormat, dateValue = new Date() ) {
 /**
  * Formats a date (like `wp_date()` in PHP), translating it into site's locale.
  *
+ * If the date string specifies a timezone e.g.: 2020-10-16T12:36:00.00-04:00
+ * the date is assumed to be in that timezone. If the date does not contain a
+ * timezone, the date is considered to be in the user's local timezone.
+ * Dates are converted to the site timezone before being formatted. If a date
+ * comes from WordPress API's it is already on the website timezone, but if we
+ * this function the function assume the date is in user timezone and when
+ * changing to WordPress timzone the time will change. If the date comes from
+ * the WordPress API's the date is string that not refers a timezone but is on the
+ * WordPress timezone, for these cases `dateI18nAddTimezone`should be should be used instead.
  * Backward Compatibility Notice: if `timezone` is set to `true`, the function
  * behaves like `gmdateI18n`.
  *
@@ -587,6 +596,42 @@ export function dateI18n( dateFormat, dateValue = new Date(), timezone ) {
 			},
 		}
 	);
+}
+
+/**
+ * Formats a date (like `wp_date()` in PHP), translating it into site's locale.
+ *
+ * If the date string specifies a timezone e.g.: 2020-10-16T12:36:00.00+01:00
+ * the date is assumed to be in that timezone. And then the date is changed to
+ * the website timezone. If the date does not contain a timezone like the dates
+ * from the WordPress API, the date is considered to be in the website timezone.
+ * For most cases where a date comes from the WordPress API, and we just want to
+ * format that date in a given way without chaning timezone this is the recommended
+ * function to use.
+ *
+ * @param {string}                     dateFormat PHP-style formatting string.
+ *                                                See php.net/date.
+ * @param {Date|string|Moment|null}    dateValue  Date object or string, parsable by
+ *                                                moment.js.
+ * @param {string|number|boolean|null} timezone   Timezone to output result in or a
+ *                                                UTC offset. Defaults to timezone from
+ *                                                site. Notice: `boolean` is effectively
+ *                                                deprecated, but still supported for
+ *                                                backward compatibility reasons.
+ *
+ * @see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+ * @see https://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC
+ *
+ * @return {string} Formatted date.
+ */
+export function dateI18nAddTimezone(
+	dateFormat,
+	dateValue = new Date(),
+	timezone = WP_ZONE
+) {
+	const dateMoment = momentLib.tz( dateValue, timezone );
+	dateMoment.locale( settings.l10n.locale );
+	return format( dateFormat, dateMoment );
 }
 
 /**

--- a/packages/date/src/test/index.js
+++ b/packages/date/src/test/index.js
@@ -5,6 +5,7 @@ import {
 	__experimentalGetSettings,
 	date as dateNoI18n,
 	dateI18n,
+	dateI18nAddTimezone,
 	getDate,
 	gmdate,
 	gmdateI18n,
@@ -830,5 +831,48 @@ describe( 'Moment.js Localization', () => {
 
 		// Restore default settings
 		setSettings( settings );
+	} );
+	describe( 'Function dateI18nAddTimezone', () => {
+		it( 'should add the website timezone to a date string without timezone and not change the time', () => {
+			const settings = __experimentalGetSettings();
+
+			// Simulate different timezone
+			setSettings( {
+				...settings,
+				timezone: { offset: -4, string: 'America/New_York' },
+			} );
+
+			expect( dateI18nAddTimezone( 'c', '2019-01-18T12:00:00' ) ).toBe(
+				'2019-01-18T12:00:00-04:00'
+			);
+		} );
+
+		it( 'should add the timezone parameter to a date string without timezone and not change the time', () => {
+			const settings = __experimentalGetSettings();
+
+			// Simulate different timezone
+			setSettings( {
+				...settings,
+				timezone: { offset: -4, string: 'America/New_York' },
+			} );
+
+			expect(
+				dateI18nAddTimezone( 'c', '2019-01-18T12:00:00', 'Japan' )
+			).toBe( '2019-01-18T12:00:00+09:00' );
+		} );
+
+		it( 'should convert a date that has a timezone to the website timezone before formatting', () => {
+			const settings = __experimentalGetSettings();
+
+			// Simulate different timezone
+			setSettings( {
+				...settings,
+				timezone: { offset: -4, string: 'America/New_York' },
+			} );
+
+			expect(
+				dateI18nAddTimezone( 'c', '2019-01-18T12:00:00+01:00' )
+			).toBe( '2019-01-18T07:00:00-04:00' );
+		} );
 	} );
 } );

--- a/packages/editor/src/components/post-schedule/label.js
+++ b/packages/editor/src/components/post-schedule/label.js
@@ -2,9 +2,10 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-
-import { dateI18n, __experimentalGetSettings } from '@wordpress/date';
-
+import {
+	dateI18nAddTimezone,
+	__experimentalGetSettings,
+} from '@wordpress/date';
 import { withSelect } from '@wordpress/data';
 
 export function PostScheduleLabel( { date, isFloating } ) {
@@ -14,7 +15,7 @@ export function PostScheduleLabel( { date, isFloating } ) {
 
 	const settings = __experimentalGetSettings();
 
-	return dateI18n(
+	return dateI18nAddTimezone(
 		`${ settings.formats.date } ${ settings.formats.time }`,
 		date
 	);


### PR DESCRIPTION
This PR improves documentation for dateI18n.
Checks the codebase and standardizes the ways we output dates, mostly relying on wp.date. dateI18nAddTimezone now. This change fixes an issue that packages/block-library/src/post-date/edit.js and packages/block-library/src/post-comment-date/edit.js had similar to the one fixed in https://github.com/WordPress/gutenberg/pull/26212.

We also fix an issue that was present in multiple blocks when outputting in a format that has a timezone representation (e.g., the 'c' format very used to output time HTML elements). The timezone used was the local one instead of the WordPress one, and the value was converted to the website timezone, making the time wrong because the date was already on the website timezone.
What we needed to output time HTML elements and to general date formats, in general, is a function that receives the time in the WordPress timezone (but whose time does not specify the timezone) adds the WordPress timezone keeping the same hours.
E.g., if we receive a string "2020-10-16T14:36:58", the website is on -4 UTC offset, and the user is on +2 UTC offset when applied the "c" format we want to output:
`2020-10-16T14:36:58-04:00`

If we call `wp.date.format('c', '2020-10-16T14:36:58');` we get `2020-10-16T14:36:58+02:00. The hours are not changed; that's why the fix in https://github.com/WordPress/gutenberg/pull/26212 worked, but the timezone specified is not correct. It is the user timezone, and it should be the website timezone. Browsers would announce the time on the time elements incorrectly.


If we call `wp.date.dateI18n('c', '2020-10-16T14:36:58');` we get `2020-10-16T08:36:58-04:00`. The output is on the website timezone but the hours are not correct because they were converted without need.

If we call `wp.date.dateI18nAddTimezone('c', '2020-10-16T14:36:58');` we get the correct output `2020-10-16T14:36:58-04:00`.


## How has this been tested?
On the browser console, I made some tests to wp.date.dateI18nAddTimezone calls and verified the results were the expected ones.
I added the latest posts block, post date block, and post comment date blocks. And I verified the time element they output (using the browser inspector) is in the website timezone and matches exactly what is output on the frontend by the server. Previously the outputs between server and client did not match.