### PR TITLE
Add a document explaining the different block API versions

### DIFF
--- a/docs/designers-developers/developers/block-api/versions.md
+++ b/docs/designers-developers/developers/block-api/versions.md
@@ -1,0 +1,12 @@
+# Block API Versions
+
+This document lists the changes made between the different API versions.
+
+## Version 2 (>= WordPress 5.6)
+
+- Moves the responsibility to render the block element wrapper in the editor to the block author using the `useBlockProps()` hook.
+- Generates classnames and styles are not added automatically to the saved markup for static blocks, block authors are required to explicitely use `useBlockProps.save()` in their `save` functions to retrieve the generated classes and styles to apply on the block wrapper.
+
+## Version 1
+
+Initial version.

--- a/docs/designers-developers/developers/block-api/versions.md
+++ b/docs/designers-developers/developers/block-api/versions.md
@@ -4,8 +4,8 @@ This document lists the changes made between the different API versions.
 
 ## Version 2 (>= WordPress 5.6)
 
-- Moves the responsibility to render the block element wrapper in the editor to the block author using the `useBlockProps()` hook.
-- Generates classnames and styles are not added automatically to the saved markup for static blocks, block authors are required to explicitely use `useBlockProps.save()` in their `save` functions to retrieve the generated classes and styles to apply on the block wrapper.
+- To render the block element wrapper for the block's `edit` implementation, the block author must use the `useBlockProps()` hook.
+- The generated class names and styles are no longer added automatically to the saved markup for static blocks when `save` is processed. To include them, the block author must explicitly use `useBlockProps.save()` and add to their block wrapper.
 
 ## Version 1
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -156,6 +156,12 @@
 		"parent": "block-api"
 	},
 	{
+		"title": "Block API Versions",
+		"slug": "versions",
+		"markdown_source": "../docs/designers-developers/developers/block-api/versions.md",
+		"parent": "block-api"
+	},
+	{
 		"title": "Filter Reference",
 		"slug": "filters",
 		"markdown_source": "../docs/designers-developers/developers/filters/README.md",

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -26,7 +26,8 @@
 			{ "docs/designers-developers/developers/block-api/block-transforms.md": [] },
 			{ "docs/designers-developers/developers/block-api/block-templates.md": [] },
 			{ "docs/designers-developers/developers/block-api/block-patterns.md": [] },
-			{ "docs/designers-developers/developers/block-api/block-annotations.md": [] }
+			{ "docs/designers-developers/developers/block-api/block-annotations.md": [] },
+			{ "docs/designers-developers/developers/block-api/versions.md": [] }
 		] },
 		{ "docs/designers-developers/developers/filters/README.md": [
 			{ "docs/designers-developers/developers/filters/block-filters.md": [] },


### PR DESCRIPTION
Related to #26100 

This PR adds a "changelog" for block API versions.