### PR TITLE
Pass all extra attributes down in get_block_wrapper_attributes

### DIFF
--- a/lib/class-wp-block-supports.php
+++ b/lib/class-wp-block-supports.php
@@ -8,7 +8,7 @@
 /**
  * Class encapsulating and implementing Block Supports.
  *
- * @private
+ * @access private
  */
 class WP_Block_Supports {
 

--- a/lib/class-wp-block-supports.php
+++ b/lib/class-wp-block-supports.php
@@ -173,6 +173,12 @@ function get_block_wrapper_attributes( $extra_attributes = array() ) {
 		$attributes[ $attribute_name ] = $extra_attributes[ $attribute_name ] . ' ' . $new_attributes[ $attribute_name ];
 	}
 
+	foreach ( $extra_attributes as $attribute_name => $value ) {
+		if ( ! in_array( $attribute_name, $attributes_to_merge, true ) ) {
+			$attributes[ $attribute_name ] = $value;
+		}
+	}
+
 	if ( empty( $attributes ) ) {
 		return '';
 	}


### PR DESCRIPTION
To match developer expectations, the extra attributes are passed down to the caller of `get_block_wrapper_attributes`. Also this implementation is more future proof to potential support for other attributes in "block-supports".

Related here https://github.com/WordPress/gutenberg/pull/26192#discussion_r507660647