### PR TITLE
Warn about using core/batch-processing store

### DIFF
--- a/packages/edit-widgets/README.md
+++ b/packages/edit-widgets/README.md
@@ -4,6 +4,10 @@ Widgets Page Module for WordPress.
 
 > This package is meant to be used only with WordPress core. Feel free to use it in your own project but please keep in mind that it might never get fully documented.
 
+## Batch processing
+
+This package contains the first version of what may eventually become `@wordpress/batch-processing` package. Once imported, `core/__experimental-batch-processing` store gets registered. As the name says - it is highly experimental and considered a private API for now.
+
 ## Installation
 
 Install the module

--- a/packages/edit-widgets/src/store/actions.js
+++ b/packages/edit-widgets/src/store/actions.js
@@ -181,7 +181,7 @@ export function* saveWidgetArea( widgetAreaId ) {
 	}
 
 	const batch = yield dispatch(
-		'core/batch-processing',
+		'core/__experimental-batch-processing',
 		'processBatch',
 		'WIDGETS_API_FETCH',
 		'default'

--- a/packages/edit-widgets/src/store/batch-processing/constants.js
+++ b/packages/edit-widgets/src/store/batch-processing/constants.js
@@ -1,7 +1,7 @@
 /**
  * Module Constants
  */
-export const MODULE_KEY = 'core/batch-processing';
+export const MODULE_KEY = 'core/__experimental-batch-processing';
 
 export const BATCH_MAX_SIZE = 20;
 

--- a/packages/edit-widgets/src/store/batch-support.js
+++ b/packages/edit-widgets/src/store/batch-support.js
@@ -57,7 +57,7 @@ function shoehornBatchSupport() {
 		) {
 			// Wait for any batch requests already in progress
 			await Promise.all(
-				select( 'core/batch-processing' ).getPromises(
+				select( 'core/__experimental-batch-processing' ).getPromises(
 					'WIDGETS_API_FETCH'
 				)
 			);
@@ -65,7 +65,7 @@ function shoehornBatchSupport() {
 		return next( options );
 	} );
 
-	dispatch( 'core/batch-processing' ).registerProcessor(
+	dispatch( 'core/__experimental-batch-processing' ).registerProcessor(
 		'WIDGETS_API_FETCH',
 		batchProcessor
 	);
@@ -77,11 +77,9 @@ function isWidgetsEndpoint( path ) {
 }
 
 function addToBatch( request ) {
-	return dispatch( 'core/batch-processing' ).enqueueItemAndWaitForResults(
-		'WIDGETS_API_FETCH',
-		'default',
-		request
-	);
+	return dispatch(
+		'core/__experimental-batch-processing'
+	).enqueueItemAndWaitForResults( 'WIDGETS_API_FETCH', 'default', request );
 }
 
 async function batchProcessor( requests, transaction ) {


### PR DESCRIPTION
## Description
https://github.com/WordPress/gutenberg/pull/26164 added an experimental batch-processing utilities. They are a private API and should not be used outside of `edit-widgets` package just yet. This PR adds a warning to the code.

## How has this been tested?
Confirm saving widgets still works after applying this PR

## Types of changes
Non-breaking change 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
