### PR TITLE
Fix for current_parsed_blocks value when block has inner blocks

### DIFF
--- a/lib/class-wp-block.php
+++ b/lib/class-wp-block.php
@@ -203,6 +203,7 @@ class WP_Block {
 	 */
 	public function render( $options = array() ) {
 		global $post;
+		global $current_parsed_block;
 		$options = array_replace(
 			array(
 				'dynamic' => true,
@@ -216,9 +217,14 @@ class WP_Block {
 		if ( ! $options['dynamic'] || empty( $this->block_type->skip_inner_blocks ) ) {
 			$index = 0;
 			foreach ( $this->inner_content as $chunk ) {
-				$block_content .= is_string( $chunk ) ?
-					$chunk :
-					$this->inner_blocks[ $index++ ]->render();
+				if ( is_string( $chunk ) ) {
+					$block_content .= $chunk;
+				} else {
+					$parent_parsed_block = $current_parsed_block;
+					$current_parsed_block = $this->inner_blocks[ $index ]->parsed_block;
+					$block_content .= $this->inner_blocks[ $index++ ]->render();
+					$current_parsed_block = $parent_parsed_block;
+				}
 			}
 		}
 

--- a/lib/class-wp-block.php
+++ b/lib/class-wp-block.php
@@ -220,9 +220,9 @@ class WP_Block {
 				if ( is_string( $chunk ) ) {
 					$block_content .= $chunk;
 				} else {
-					$parent_parsed_block = $current_parsed_block;
+					$parent_parsed_block  = $current_parsed_block;
 					$current_parsed_block = $this->inner_blocks[ $index ]->parsed_block;
-					$block_content .= $this->inner_blocks[ $index++ ]->render();
+					$block_content       .= $this->inner_blocks[ $index++ ]->render();
 					$current_parsed_block = $parent_parsed_block;
 				}
 			}


### PR DESCRIPTION
In https://github.com/WordPress/gutenberg/pull/26192 we refactored the block supports mechanism. It works by holding a global `$current_parsed_blocks` reference that it uses to determine the attributes that it needs to add to blocks.

However, when a block has inner blocks, that reference isn't updated so inner blocks end up inheriting the parent's properties (style and classes).

## How to test

This is what I've done:

- In your WordPress environment, patch the `wp-includes/class-wp-block.php` class with the contents of this PR.
- Create a post that adds the social links block. Publish.
- Verify that the individual social links (the `li` elements) don't have the `wp-social-links` class attached. It should be present in the parent (`ul` element).
