### PR TITLE
Make batch opt-in more expressive.

### DIFF
--- a/lib/class-wp-rest-batch-controller.php
+++ b/lib/class-wp-rest-batch-controller.php
@@ -133,10 +133,11 @@ class WP_REST_Batch_Controller {
 				if ( isset( $handler['allow_batch'] ) ) {
 					$allow_batch = $handler['allow_batch'];
 				} else {
-					$allow_batch = ! empty( rest_get_server()->get_route_options( $route )['allow_batch'] );
+					$route_options = rest_get_server()->get_route_options( $route );
+					$allow_batch   = isset( $route_options['allow_batch'] ) ? $route_options['allow_batch'] : false;
 				}
 
-				if ( ! $allow_batch ) {
+				if ( ! is_array( $allow_batch ) || empty( $allow_batch['__experimental'] ) ) {
 					$error = new WP_Error(
 						'rest_batch_not_allowed',
 						__( 'The requested route does not support batch requests.', 'gutenberg' ),

--- a/lib/class-wp-rest-menu-items-controller.php
+++ b/lib/class-wp-rest-menu-items-controller.php
@@ -44,7 +44,7 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 					'permission_callback' => array( $this, 'create_item_permissions_check' ),
 					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::CREATABLE ),
 				),
-				'allow_batch' => true,
+				'allow_batch' => array( '__experimental' => true ),
 				'schema'      => array( $this, 'get_public_item_schema' ),
 			)
 		);
@@ -93,7 +93,7 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 						),
 					),
 				),
-				'allow_batch' => true,
+				'allow_batch' => array( '__experimental' => true ),
 				'schema'      => array( $this, 'get_public_item_schema' ),
 			)
 		);

--- a/lib/class-wp-rest-widgets-controller.php
+++ b/lib/class-wp-rest-widgets-controller.php
@@ -38,7 +38,7 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 					'permission_callback' => array( $this, 'create_item_permissions_check' ),
 					'args'                => $this->get_endpoint_args_for_item_schema(),
 				),
-				'allow_batch' => true,
+				'allow_batch' => array( '__experimental' => true ),
 				'schema'      => array( $this, 'get_public_item_schema' ),
 			)
 		);
@@ -72,7 +72,7 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 						),
 					),
 				),
-				'allow_batch' => true,
+				'allow_batch' => array( '__experimental' => true ),
 				'schema'      => array( $this, 'get_public_item_schema' ),
 			)
 		);


### PR DESCRIPTION
## Description
This let's people opt-in to a specific version of batching, and allows us to
introduce in the future further flags to customize behavior.

## How has this been tested?
Manually tested.

## Types of changes
Breaking change to `__experimental` feature.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
