### PR TITLE
Stabilize batching endpoint as v1.

### DIFF
--- a/lib/class-wp-rest-batch-controller.php
+++ b/lib/class-wp-rest-batch-controller.php
@@ -243,7 +243,7 @@ class WP_REST_Batch_Controller {
 		$responses = array();
 
 		foreach ( $requests as $request ) {
-			if ( 0 !== strpos( $request->get_route(), '/__experimental' ) ) {
+			if ( 0 !== strpos( $request->get_route(), '/__experimental' ) && 0 !== strpos( $request->get_route(), '/wp/v2/widgets' ) ) {
 				$error       = new WP_Error(
 					'rest_batch_not_allowed',
 					__( 'The requested route does not support batch requests.', 'gutenberg' ),

--- a/lib/class-wp-rest-batch-controller.php
+++ b/lib/class-wp-rest-batch-controller.php
@@ -20,7 +20,7 @@ class WP_REST_Batch_Controller {
 	 */
 	public function register_routes() {
 		register_rest_route(
-			'__experimental',
+			'v1',
 			'batch',
 			array(
 				'callback'            => array( $this, 'serve_batch_request' ),
@@ -137,7 +137,7 @@ class WP_REST_Batch_Controller {
 					$allow_batch   = isset( $route_options['allow_batch'] ) ? $route_options['allow_batch'] : false;
 				}
 
-				if ( ! is_array( $allow_batch ) || empty( $allow_batch['__experimental'] ) ) {
+				if ( ! is_array( $allow_batch ) || empty( $allow_batch['v1'] ) ) {
 					$error = new WP_Error(
 						'rest_batch_not_allowed',
 						__( 'The requested route does not support batch requests.', 'gutenberg' ),

--- a/lib/class-wp-rest-menu-items-controller.php
+++ b/lib/class-wp-rest-menu-items-controller.php
@@ -44,7 +44,7 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 					'permission_callback' => array( $this, 'create_item_permissions_check' ),
 					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::CREATABLE ),
 				),
-				'allow_batch' => array( '__experimental' => true ),
+				'allow_batch' => array( 'v1' => true ),
 				'schema'      => array( $this, 'get_public_item_schema' ),
 			)
 		);
@@ -93,7 +93,7 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 						),
 					),
 				),
-				'allow_batch' => array( '__experimental' => true ),
+				'allow_batch' => array( 'v1' => true ),
 				'schema'      => array( $this, 'get_public_item_schema' ),
 			)
 		);

--- a/lib/class-wp-rest-widgets-controller.php
+++ b/lib/class-wp-rest-widgets-controller.php
@@ -38,7 +38,7 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 					'permission_callback' => array( $this, 'create_item_permissions_check' ),
 					'args'                => $this->get_endpoint_args_for_item_schema(),
 				),
-				'allow_batch' => array( '__experimental' => true ),
+				'allow_batch' => array( 'v1' => true ),
 				'schema'      => array( $this, 'get_public_item_schema' ),
 			)
 		);
@@ -72,7 +72,7 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 						),
 					),
 				),
-				'allow_batch' => array( '__experimental' => true ),
+				'allow_batch' => array( 'v1' => true ),
 				'schema'      => array( $this, 'get_public_item_schema' ),
 			)
 		);

--- a/packages/edit-widgets/src/store/batch-support.js
+++ b/packages/edit-widgets/src/store/batch-support.js
@@ -92,7 +92,7 @@ async function batchProcessor( requests, transaction ) {
 	}
 
 	const response = await apiFetch( {
-		path: '/__experimental/batch',
+		path: '/v1/batch',
 		method: 'POST',
 		data: {
 			validation: 'require-all-validate',

--- a/phpunit/class-rest-batch-controller-test.php
+++ b/phpunit/class-rest-batch-controller-test.php
@@ -121,7 +121,7 @@ class REST_Batch_Controller_Test extends WP_Test_REST_TestCase {
 			)
 		);
 
-		$request = new WP_REST_Request( 'POST', '/__experimental/batch' );
+		$request = new WP_REST_Request( 'POST', '/v1/batch' );
 		$request->set_body_params(
 			array(
 				'requests' => array(
@@ -144,7 +144,7 @@ class REST_Batch_Controller_Test extends WP_Test_REST_TestCase {
 	public function test_batch_pre_validation() {
 		wp_set_current_user( self::$administrator_id );
 
-		$request = new WP_REST_Request( 'POST', '/__experimental/batch' );
+		$request = new WP_REST_Request( 'POST', '/v1/batch' );
 		$request->set_body_params(
 			array(
 				'validation' => 'require-all-validate',
@@ -191,7 +191,7 @@ class REST_Batch_Controller_Test extends WP_Test_REST_TestCase {
 	public function test_batch_create() {
 		wp_set_current_user( self::$administrator_id );
 
-		$request = new WP_REST_Request( 'POST', '/__experimental/batch' );
+		$request = new WP_REST_Request( 'POST', '/v1/batch' );
 		$request->set_body_params(
 			array(
 				'requests' => array(


### PR DESCRIPTION
## Description
Stabilizes the batch endpoint as `v1` instead of `__experimental` as per discussion in #core: https://wordpress.slack.com/archives/C02RQBWTW/p1603137625395000

## How has this been tested?
Manually tested.

## Types of changes
Breaking change of experimental API.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
