### PR TITLE
Navigation Panel - ensure focus when menu changes.

### DIFF
--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
@@ -37,9 +37,11 @@ const NavigationPanel = ( { isOpen } ) => {
 		};
 	}, [] );
 
-	const menuRef = useRef();
+	// Ensures focus is moved to the panel area when it is activated
+	// from a separate component (such as document actions in the header).
+	const panelRef = useRef();
 	useEffect( () => {
-		menuRef.current.focus();
+		panelRef.current.focus();
 	}, [ templatesActiveMenu ] );
 
 	return (
@@ -47,7 +49,7 @@ const NavigationPanel = ( { isOpen } ) => {
 			className={ classnames( `edit-site-navigation-panel`, {
 				'is-open': isOpen,
 			} ) }
-			ref={ menuRef }
+			ref={ panelRef }
 			tabIndex="-1"
 		>
 			<div className="edit-site-navigation-panel__inner">

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { useState, useEffect, useRef } from '@wordpress/element';
 import { createSlotFill } from '@wordpress/components';
 
 /**
@@ -37,11 +37,18 @@ const NavigationPanel = ( { isOpen } ) => {
 		};
 	}, [] );
 
+	const menuRef = useRef();
+	useEffect( () => {
+		menuRef.current.focus();
+	}, [ templatesActiveMenu ] );
+
 	return (
 		<div
 			className={ classnames( `edit-site-navigation-panel`, {
 				'is-open': isOpen,
 			} ) }
+			ref={ menuRef }
+			tabIndex="-1"
 		>
 			<div className="edit-site-navigation-panel__inner">
 				<div className="edit-site-navigation-panel__site-title-container">


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
As described in #26172: opening a menu in the nav sidebar should move focus to this component.  Here, we ensure focus is added to the navigation panel wrapper div whenever the active menu changes.

This should create no observable change in the standard use of the navigation panel component.  Selecting a menu and pressing 'tab' after this change should behave exactly the same as before.  However, when we trigger a menu to open from outside the navigation panel (like document actions in the header) this will properly move the focus to the nav panel as expected as opposed to keeping focus in the document actions dropdown.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Tested on local docker environment.

1. Test the keyboard flow within the Navigation panel before and after this change.  Verify it works the same.
2. Test opening the panel from document-actions in the header.
   * Open the dropdown from the template name in the document actions header.
   * Select 'Browse all templates'
   * Verify focus is in the expected place as observed in step 1. (Press 'tab' and it should highlight the first option in the navigation panel)

## Screenshots <!-- if applicable -->
![move-focus](https://user-images.githubusercontent.com/28742426/96512814-0c0eee00-122f-11eb-876d-f78441f13183.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
