### PR TITLE
Delete widgets that have been removed from all sidebars.

### DIFF
--- a/packages/edit-widgets/src/store/reducer.js
+++ b/packages/edit-widgets/src/store/reducer.js
@@ -25,6 +25,14 @@ export function mapping( state, action ) {
 		return newMapping;
 	}
 
+	if ( type === 'REMOVE_WIDGET_ID_FOR_CLIENT_ID' ) {
+		const newMapping = {
+			...state,
+		};
+		delete newMapping[ action.widgetId ];
+		return newMapping;
+	}
+
 	return state || {};
 }
 


### PR DESCRIPTION
## Description
After the widget areas have been saved, delete any widgets that had their blocks removed.

## How has this been tested?
Manually tested.

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
