### PR TITLE
Sort post formats alphabetically by translated name.

### DIFF
--- a/packages/editor/src/components/post-format/index.js
+++ b/packages/editor/src/components/post-format/index.js
@@ -16,18 +16,30 @@ import { useInstanceId } from '@wordpress/compose';
  */
 import PostFormatCheck from './check';
 
+// All WP post formats, sorted alphabetically by translated name.
 export const POST_FORMATS = [
 	{ id: 'aside', caption: __( 'Aside' ) },
+	{ id: 'audio', caption: __( 'Audio' ) },
+	{ id: 'chat', caption: __( 'Chat' ) },
 	{ id: 'gallery', caption: __( 'Gallery' ) },
-	{ id: 'link', caption: __( 'Link' ) },
 	{ id: 'image', caption: __( 'Image' ) },
+	{ id: 'link', caption: __( 'Link' ) },
 	{ id: 'quote', caption: __( 'Quote' ) },
 	{ id: 'standard', caption: __( 'Standard' ) },
 	{ id: 'status', caption: __( 'Status' ) },
 	{ id: 'video', caption: __( 'Video' ) },
-	{ id: 'audio', caption: __( 'Audio' ) },
-	{ id: 'chat', caption: __( 'Chat' ) },
-];
+].sort( ( a, b ) => {
+	const normalizedA = a.caption.toUpperCase();
+	const normalizedB = b.caption.toUpperCase();
+
+	if ( normalizedA < normalizedB ) {
+		return -1;
+	}
+	if ( normalizedA > normalizedB ) {
+		return 1;
+	}
+	return 0;
+} );
 
 export default function PostFormat() {
 	const instanceId = useInstanceId( PostFormat );


### PR DESCRIPTION
## Description
This PR updates the `POST_FORMATS` array in packages/editor/src/components/post-format/index.js to sort the formats alphabetically by localized name. (Previously, the post formats were in a seemingly random order that seems to have been copy-pasted from [here](https://developer.wordpress.org/themes/functionality/post-formats/#supported-formats).)

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/19592990/96524487-0b318880-123e-11eb-9aca-4a4416e5336c.png)

### After
![image](https://user-images.githubusercontent.com/19592990/96524667-885cfd80-123e-11eb-9526-970cbdb27eb6.png)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
