### PR TITLE
Mobile - Heading block - Disable full-width/wide alignment

### DIFF
--- a/packages/components/src/mobile/utils/alignments.native.js
+++ b/packages/components/src/mobile/utils/alignments.native.js
@@ -3,7 +3,7 @@ export const WIDE_ALIGNMENTS = {
 		wide: 'wide',
 		full: 'full',
 	},
-	excludeBlocks: [ 'core/columns' ],
+	excludeBlocks: [ 'core/columns', 'core/heading' ],
 };
 
 export const ALIGNMENT_BREAKPOINTS = {


### PR DESCRIPTION
## Description
This PR disables full-width/wide alignment support for the Heading block on **mobile** after being introduced in this [PR](https://github.com/WordPress/gutenberg/pull/25917).

## How has this been tested?
- Open the demo app
- Add a Heading block
- **Expect** to see that there are no full-width/wide alignment options in the toolbar

## Screenshots <!-- if applicable -->
Before | After
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/96554078-54252380-12b6-11eb-8cf7-324cb945d216.png" width="250" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/96554092-57201400-12b6-11eb-9642-aa3c418c3d6a.png" width="250" /></kbd> 

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
