### PR TITLE
Fix archives block render function

### DIFF
--- a/packages/block-library/src/archives/index.php
+++ b/packages/block-library/src/archives/index.php
@@ -88,16 +88,17 @@ function render_block_core_archives( $attributes ) {
 
 	$classnames = esc_attr( $class );
 
+	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classnames ) );
+
 	if ( empty( $archives ) ) {
 
 		return sprintf(
-			'<div class="%1$s">%2$s</div>',
-			$classnames,
+			'<div %1$s>%2$s</div>',
+			$wrapper_attributes,
 			__( 'No archives to show.' )
 		);
 	}
 
-	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classnames ) );
 
 	return sprintf(
 		'<ul %1$s>%2$s</ul>',

--- a/packages/block-library/src/archives/index.php
+++ b/packages/block-library/src/archives/index.php
@@ -91,14 +91,12 @@ function render_block_core_archives( $attributes ) {
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classnames ) );
 
 	if ( empty( $archives ) ) {
-
 		return sprintf(
 			'<div %1$s>%2$s</div>',
 			$wrapper_attributes,
 			__( 'No archives to show.' )
 		);
 	}
-
 
 	return sprintf(
 		'<ul %1$s>%2$s</ul>',


### PR DESCRIPTION
While working on the Core patch to update the packages. I noticed that the wrapper attributes are not being applied properly in all situations (no results). This addresses that.  