### PR TITLE
Try: get_block_wrapper_attributes without global

### DIFF
--- a/lib/class-wp-block-supports.php
+++ b/lib/class-wp-block-supports.php
@@ -67,46 +67,11 @@ class WP_Block_Supports {
 	 * Generates an array of HTML attributes, such as classes, by applying to
 	 * the given block all of the features that the block supports.
 	 *
-	 * @param  array $parsed_block Block as parsed from content.
+	 * @param  string $block_name The name of the block to be processed.
+	 * @param  array  $block_attributes The attributes of the block to be processed.
 	 * @return array               Array of HTML attributes.
 	 */
-	public function apply_block_supports( $parsed_block ) {
-		$block_attributes = $parsed_block['attrs'];
-		$block_type       = WP_Block_Type_Registry::get_instance()->get_registered(
-			$parsed_block['blockName']
-		);
-
-		// If no render_callback, assume styles have been previously handled.
-		if ( ! $block_type || empty( $block_type ) ) {
-			return array();
-		}
-
-		$output = array();
-		foreach ( $this->block_supports as $name => $block_support_config ) {
-			if ( ! isset( $block_support_config['apply'] ) ) {
-				continue;
-			}
-
-			$new_attributes = call_user_func(
-				$block_support_config['apply'],
-				$block_type,
-				$block_attributes
-			);
-
-			if ( ! empty( $new_attributes ) ) {
-				foreach ( $new_attributes as $attribute_name => $attribute_value ) {
-					if ( empty( $output[ $attribute_name ] ) ) {
-						$output[ $attribute_name ] = $attribute_value;
-					} else {
-						$output[ $attribute_name ] .= " $attribute_value";
-					}
-				}
-			}
-		}
-		return $output;
-	}
-
-	public function apply_block_supports_without_global( $block_name, $block_attributes ) {
+	public function apply_block_supports( $block_name, $block_attributes ) {
 		$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block_name );
 
 		// If no render_callback, assume styles have been previously handled.
@@ -172,70 +137,14 @@ class WP_Block_Supports {
  * Generates a string of attributes by applying to the current block being
  * rendered all of the features that the block supports.
  *
- * @param array $extra_attributes Optional. Extra attributes to render on the block wrapper.
+ * @param string $block_name The name of the block to be processed.
+ * @param array  $block_attributes The attributes of the block to be processed.
+ * @param array  $extra_attributes Optional. Extra attributes to render on the block wrapper.
  *
  * @return string String of HTML classes.
  */
-function get_block_wrapper_attributes( $extra_attributes = array() ) {
-	error_log( 'WITH' );
-	global $current_parsed_block;
-	$new_attributes = WP_Block_Supports::get_instance()->apply_block_supports( $current_parsed_block );
-
-	if ( empty( $new_attributes ) && empty( $extra_attributes ) ) {
-		return '';
-	}
-
-	// This is hardcoded on purpose.
-	// We only support a fixed list of attributes.
-	$attributes_to_merge = array( 'style', 'class' );
-	$attributes          = array();
-	foreach ( $attributes_to_merge as $attribute_name ) {
-		if ( empty( $new_attributes[ $attribute_name ] ) && empty( $extra_attributes[ $attribute_name ] ) ) {
-			continue;
-		}
-
-		if ( empty( $new_attributes[ $attribute_name ] ) ) {
-			$attributes[ $attribute_name ] = $extra_attributes[ $attribute_name ];
-			continue;
-		}
-
-		if ( empty( $extra_attributes[ $attribute_name ] ) ) {
-			$attributes[ $attribute_name ] = $new_attributes[ $attribute_name ];
-			continue;
-		}
-
-		$attributes[ $attribute_name ] = $extra_attributes[ $attribute_name ] . ' ' . $new_attributes[ $attribute_name ];
-	}
-
-	foreach ( $extra_attributes as $attribute_name => $value ) {
-		if ( ! in_array( $attribute_name, $attributes_to_merge, true ) ) {
-			$attributes[ $attribute_name ] = $value;
-		}
-	}
-
-	if ( empty( $attributes ) ) {
-		return '';
-	}
-
-	$normalized_attributes = array();
-	foreach ( $attributes as $key => $value ) {
-		$normalized_attributes[] = $key . '="' . esc_attr( $value ) . '"';
-	}
-
-	return implode( ' ', $normalized_attributes );
-}
-
-/**
- * Generates a string of attributes by applying to the current block being
- * rendered all of the features that the block supports.
- *
- * @param array $extra_attributes Optional. Extra attributes to render on the block wrapper.
- *
- * @return string String of HTML classes.
- */
-function get_block_wrapper_attributes_without_global( $block_name, $block_attributes, $extra_attributes = array() ) {
-	error_log( 'WITHOUT' );
-	$new_attributes = WP_Block_Supports::get_instance()->apply_block_supports_without_global( $block_name, $block_attributes );
+function get_block_wrapper_attributes( $block_name, $block_attributes, $extra_attributes = array() ) {
+	$new_attributes = WP_Block_Supports::get_instance()->apply_block_supports( $block_name, $block_attributes );
 
 	if ( empty( $new_attributes ) && empty( $extra_attributes ) ) {
 		return '';

--- a/lib/class-wp-block-supports.php
+++ b/lib/class-wp-block-supports.php
@@ -103,6 +103,39 @@ class WP_Block_Supports {
 				}
 			}
 		}
+		return $output;
+	}
+
+	public function apply_block_supports_without_global( $block_name, $block_attributes ) {
+		$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block_name );
+
+		// If no render_callback, assume styles have been previously handled.
+		if ( ! $block_type || empty( $block_type ) ) {
+			return array();
+		}
+
+		$output = array();
+		foreach ( $this->block_supports as $name => $block_support_config ) {
+			if ( ! isset( $block_support_config['apply'] ) ) {
+				continue;
+			}
+
+			$new_attributes = call_user_func(
+				$block_support_config['apply'],
+				$block_type,
+				$block_attributes
+			);
+
+			if ( ! empty( $new_attributes ) ) {
+				foreach ( $new_attributes as $attribute_name => $attribute_value ) {
+					if ( empty( $output[ $attribute_name ] ) ) {
+						$output[ $attribute_name ] = $attribute_value;
+					} else {
+						$output[ $attribute_name ] .= " $attribute_value";
+					}
+				}
+			}
+		}
 
 		return $output;
 	}
@@ -144,8 +177,65 @@ class WP_Block_Supports {
  * @return string String of HTML classes.
  */
 function get_block_wrapper_attributes( $extra_attributes = array() ) {
+	error_log( 'WITH' );
 	global $current_parsed_block;
 	$new_attributes = WP_Block_Supports::get_instance()->apply_block_supports( $current_parsed_block );
+
+	if ( empty( $new_attributes ) && empty( $extra_attributes ) ) {
+		return '';
+	}
+
+	// This is hardcoded on purpose.
+	// We only support a fixed list of attributes.
+	$attributes_to_merge = array( 'style', 'class' );
+	$attributes          = array();
+	foreach ( $attributes_to_merge as $attribute_name ) {
+		if ( empty( $new_attributes[ $attribute_name ] ) && empty( $extra_attributes[ $attribute_name ] ) ) {
+			continue;
+		}
+
+		if ( empty( $new_attributes[ $attribute_name ] ) ) {
+			$attributes[ $attribute_name ] = $extra_attributes[ $attribute_name ];
+			continue;
+		}
+
+		if ( empty( $extra_attributes[ $attribute_name ] ) ) {
+			$attributes[ $attribute_name ] = $new_attributes[ $attribute_name ];
+			continue;
+		}
+
+		$attributes[ $attribute_name ] = $extra_attributes[ $attribute_name ] . ' ' . $new_attributes[ $attribute_name ];
+	}
+
+	foreach ( $extra_attributes as $attribute_name => $value ) {
+		if ( ! in_array( $attribute_name, $attributes_to_merge, true ) ) {
+			$attributes[ $attribute_name ] = $value;
+		}
+	}
+
+	if ( empty( $attributes ) ) {
+		return '';
+	}
+
+	$normalized_attributes = array();
+	foreach ( $attributes as $key => $value ) {
+		$normalized_attributes[] = $key . '="' . esc_attr( $value ) . '"';
+	}
+
+	return implode( ' ', $normalized_attributes );
+}
+
+/**
+ * Generates a string of attributes by applying to the current block being
+ * rendered all of the features that the block supports.
+ *
+ * @param array $extra_attributes Optional. Extra attributes to render on the block wrapper.
+ *
+ * @return string String of HTML classes.
+ */
+function get_block_wrapper_attributes_without_global( $block_name, $block_attributes, $extra_attributes = array() ) {
+	error_log( 'WITHOUT' );
+	$new_attributes = WP_Block_Supports::get_instance()->apply_block_supports_without_global( $block_name, $block_attributes );
 
 	if ( empty( $new_attributes ) && empty( $extra_attributes ) ) {
 		return '';

--- a/lib/class-wp-block.php
+++ b/lib/class-wp-block.php
@@ -203,7 +203,6 @@ class WP_Block {
 	 */
 	public function render( $options = array() ) {
 		global $post;
-		global $current_parsed_block;
 		$options = array_replace(
 			array(
 				'dynamic' => true,
@@ -217,14 +216,9 @@ class WP_Block {
 		if ( ! $options['dynamic'] || empty( $this->block_type->skip_inner_blocks ) ) {
 			$index = 0;
 			foreach ( $this->inner_content as $chunk ) {
-				if ( is_string( $chunk ) ) {
-					$block_content .= $chunk;
-				} else {
-					$parent_parsed_block  = $current_parsed_block;
-					$current_parsed_block = $this->inner_blocks[ $index ]->parsed_block;
-					$block_content       .= $this->inner_blocks[ $index++ ]->render();
-					$current_parsed_block = $parent_parsed_block;
-				}
+				$block_content .= is_string( $chunk ) ?
+					$chunk :
+					$this->inner_blocks[ $index++ ]->render();
 			}
 		}
 

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -366,18 +366,11 @@ function gutenberg_replace_default_block_categories( $default_categories ) {
 }
 add_filter( 'block_categories', 'gutenberg_replace_default_block_categories' );
 
-global $current_parsed_block;
-$current_parsed_block = array(
-	'blockName'  => null,
-	'attributes' => null,
-);
-
 /**
  * Shim that hooks into `pre_render_block` so as to override `render_block` with
  * a function that assigns block context.
  *
  * The context handling can be removed when plugin support requires WordPress 5.5.0+.
- * The global current_parsed_block assignment can be removed when plugin support requires WordPress 5.6.0+.
  *
  * @see https://core.trac.wordpress.org/ticket/49927
  * @see https://core.trac.wordpress.org/changeset/48243
@@ -389,7 +382,6 @@ $current_parsed_block = array(
  */
 function gutenberg_render_block_with_assigned_block_context( $pre_render, $parsed_block ) {
 	global $post, $wp_query;
-	global $current_parsed_block;
 
 	/*
 	 * If a non-null value is provided, a filter has run at an earlier priority
@@ -398,8 +390,6 @@ function gutenberg_render_block_with_assigned_block_context( $pre_render, $parse
 	if ( null !== $pre_render ) {
 		return $pre_render;
 	}
-
-	$current_parsed_block = $parsed_block;
 
 	$source_block = $parsed_block;
 

--- a/packages/block-library/src/archives/index.php
+++ b/packages/block-library/src/archives/index.php
@@ -10,7 +10,9 @@
  *
  * @see WP_Widget_Archives
  *
- * @param array $attributes The block attributes.
+ * @param Array   $attributes The block attributes.
+ * @param String  $content InnerBlocks content of the Block.
+ * @param WPBlock $block Block object.
  *
  * @return string Returns the post content with archives added.
  */

--- a/packages/block-library/src/archives/index.php
+++ b/packages/block-library/src/archives/index.php
@@ -14,7 +14,7 @@
  *
  * @return string Returns the post content with archives added.
  */
-function render_block_core_archives( $attributes ) {
+function render_block_core_archives( $attributes, $content, $block ) {
 	$show_post_count = ! empty( $attributes['showPostCounts'] );
 
 	$class = '';
@@ -97,7 +97,11 @@ function render_block_core_archives( $attributes ) {
 		);
 	}
 
-	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classnames ) );
+	$wrapper_attributes = get_block_wrapper_attributes(
+		$block->name,
+		$attributes,
+		array( 'class' => $classnames )
+	);
 
 	return sprintf(
 		'<ul %1$s>%2$s</ul>',

--- a/packages/block-library/src/calendar/index.php
+++ b/packages/block-library/src/calendar/index.php
@@ -8,7 +8,9 @@
 /**
  * Renders the `core/calendar` block on server.
  *
- * @param array $attributes The block attributes.
+ * @param Array   $attributes The block attributes.
+ * @param String  $content InnerBlocks content of the Block.
+ * @param WPBlock $block Block object.
  *
  * @return string Returns the block content.
  */

--- a/packages/block-library/src/calendar/index.php
+++ b/packages/block-library/src/calendar/index.php
@@ -12,7 +12,7 @@
  *
  * @return string Returns the block content.
  */
-function render_block_core_calendar( $attributes ) {
+function render_block_core_calendar( $attributes, $content, $block ) {
 	global $monthnum, $year;
 
 	$previous_monthnum = $monthnum;
@@ -31,7 +31,10 @@ function render_block_core_calendar( $attributes ) {
 		}
 	}
 
-	$wrapper_attributes = get_block_wrapper_attributes();
+	$wrapper_attributes = get_block_wrapper_attributes(
+		$block->name,
+		$attributes
+	);
 	$output             = sprintf(
 		'<div %1$s>%2$s</div>',
 		$wrapper_attributes,

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -8,7 +8,9 @@
 /**
  * Renders the `core/categories` block on server.
  *
- * @param array $attributes The block attributes.
+ * @param Array   $attributes The block attributes.
+ * @param String  $content InnerBlocks content of the Block.
+ * @param WPBlock $block Block object.
  *
  * @return string Returns the categories list/dropdown markup.
  */

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -12,7 +12,7 @@
  *
  * @return string Returns the categories list/dropdown markup.
  */
-function render_block_core_categories( $attributes ) {
+function render_block_core_categories( $attributes, $content, $block ) {
 	static $block_id = 0;
 	$block_id++;
 
@@ -47,7 +47,11 @@ function render_block_core_categories( $attributes ) {
 		$type           = 'list';
 	}
 
-	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => "wp-block-categories-{$type}" ) );
+	$wrapper_attributes = get_block_wrapper_attributes(
+		$block->name,
+		$attributes,
+		array( 'class' => "wp-block-categories-{$type}" )
+	);
 
 	return sprintf(
 		$wrapper_markup,

--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -36,11 +36,13 @@ function wp_latest_comments_draft_or_post_title( $post = 0 ) {
 /**
  * Renders the `core/latest-comments` block on server.
  *
- * @param array $attributes The block attributes.
+ * @param Array   $attributes The block attributes.
+ * @param String  $content InnerBlocks content of the Block.
+ * @param WPBlock $block Block object.
  *
  * @return string Returns the post content with latest comments added.
  */
-function render_block_core_latest_comments( $attributes = array() ) {
+function render_block_core_latest_comments( $attributes = array(), $content, $block ) {
 	// This filter is documented in wp-includes/widgets/class-wp-widget-recent-comments.php.
 	$comments = get_comments(
 		apply_filters(
@@ -129,7 +131,11 @@ function render_block_core_latest_comments( $attributes = array() ) {
 	if ( empty( $comments ) ) {
 		$classnames[] = 'no-comments';
 	}
-	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => implode( ' ', $classnames ) ) );
+	$wrapper_attributes = get_block_wrapper_attributes(
+		$block->name,
+		$attributes,
+		array( 'class' => implode( ' ', $classnames ) )
+	);
 
 	return ! empty( $comments ) ? sprintf(
 		'<ol %1$s>%2$s</ol>',

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -28,11 +28,13 @@ function block_core_latest_posts_get_excerpt_length() {
 /**
  * Renders the `core/latest-posts` block on server.
  *
- * @param array $attributes The block attributes.
+ * @param Array   $attributes The block attributes.
+ * @param String  $content InnerBlocks content of the Block.
+ * @param WPBlock $block Block object.
  *
  * @return string Returns the post content with latest posts added.
  */
-function render_block_core_latest_posts( $attributes ) {
+function render_block_core_latest_posts( $attributes, $content, $block ) {
 	global $post, $block_core_latest_posts_excerpt_length;
 
 	$args = array(
@@ -171,7 +173,11 @@ function render_block_core_latest_posts( $attributes ) {
 		$class .= ' has-author';
 	}
 
-	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $class ) );
+	$wrapper_attributes = get_block_wrapper_attributes(
+		$block->name,
+		$attributes,
+		array( 'class' => $class )
+	);
 
 	return sprintf(
 		'<ul %1$s>%2$s</ul>',

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -97,8 +97,8 @@ function block_core_navigation_link_render_submenu_icon() {
 /**
  * Renders the `core/navigation-link` block.
  *
- * @param array $attributes The block attributes.
- * @param array $content The saved content.
+ * @param array   $attributes The block attributes.
+ * @param array   $content The saved content.
  * @param WPBlock $block The parsed block.
  *
  * @return string Returns the post content with the legacy widget added.

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -99,7 +99,7 @@ function block_core_navigation_link_render_submenu_icon() {
  *
  * @param array $attributes The block attributes.
  * @param array $content The saved content.
- * @param array $block The parsed block.
+ * @param WPBlock $block The parsed block.
  *
  * @return string Returns the post content with the legacy widget added.
  */
@@ -128,6 +128,8 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 	};
 
 	$wrapper_attributes = get_block_wrapper_attributes(
+		$block->name,
+		$attributes,
 		array(
 			'class' => $css_classes . ( $has_submenu ? ' has-child' : '' ) .
 				( $is_active ? ' current-menu-item' : '' ),

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -99,7 +99,7 @@ function block_core_navigation_render_submenu_icon() {
  *
  * @param array $attributes The block attributes.
  * @param array $content The saved content.
- * @param array $block The parsed block.
+ * @param WPBlock $block The parsed block.
  *
  * @return string Returns the post content with the legacy widget added.
  */
@@ -140,6 +140,8 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	}
 
 	$wrapper_attributes = get_block_wrapper_attributes(
+		$block->name,
+		$attributes,
 		array(
 			'class' => implode( ' ', $classes ),
 			'style' => $colors['inline_styles'] . $font_sizes['inline_styles'],

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -97,8 +97,8 @@ function block_core_navigation_render_submenu_icon() {
 /**
  * Renders the `core/navigation` block on server.
  *
- * @param array $attributes The block attributes.
- * @param array $content The saved content.
+ * @param array   $attributes The block attributes.
+ * @param array   $content The saved content.
  * @param WPBlock $block The parsed block.
  *
  * @return string Returns the post content with the legacy widget added.

--- a/packages/block-library/src/post-author/index.php
+++ b/packages/block-library/src/post-author/index.php
@@ -35,7 +35,11 @@ function render_block_core_post_author( $attributes, $content, $block ) {
 		isset( $attributes['textAlign'] ) ? array( 'has-text-align-' . $attributes['textAlign'] ) : array()
 	);
 
-	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => implode( ' ', $classes ) ) );
+	$wrapper_attributes = get_block_wrapper_attributes(
+		$block->name,
+		$attributes,
+		array( 'class' => implode( ' ', $classes ) )
+	);
 
 	return sprintf( '<div %1$s>', $wrapper_attributes ) .
 	( ! empty( $attributes['showAvatar'] ) ? '<div class="wp-block-post-author__avatar">' . $avatar . '</div>' : '' ) .

--- a/packages/block-library/src/post-comment-author/index.php
+++ b/packages/block-library/src/post-comment-author/index.php
@@ -18,7 +18,10 @@ function render_block_core_post_comment_author( $attributes, $content, $block ) 
 		return '';
 	}
 
-	$wrapper_attributes = get_block_wrapper_attributes();
+	$wrapper_attributes = get_block_wrapper_attributes(
+		$block->name,
+		$attributes
+	);
 
 	return sprintf(
 		'<div %1$s>%2$s</div>',

--- a/packages/block-library/src/post-comment-content/index.php
+++ b/packages/block-library/src/post-comment-content/index.php
@@ -17,7 +17,10 @@ function render_block_core_post_comment_content( $attributes, $content, $block )
 	if ( ! isset( $block->context['commentId'] ) ) {
 		return '';
 	}
-	$wrapper_attributes = get_block_wrapper_attributes();
+	$wrapper_attributes = get_block_wrapper_attributes(
+		$block->name,
+		$attributes
+	);
 	return sprintf(
 		'<div %1$s>%2$s</div>',
 		$wrapper_attributes,

--- a/packages/block-library/src/post-comment-date/index.php
+++ b/packages/block-library/src/post-comment-date/index.php
@@ -18,7 +18,10 @@ function render_block_core_post_comment_date( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$wrapper_attributes = get_block_wrapper_attributes();
+	$wrapper_attributes = get_block_wrapper_attributes(
+		$block->name,
+		$attributes
+	);
 	return sprintf(
 		'<div %1$s><time datetime="%2$s">%3$s</time></div>',
 		$wrapper_attributes,

--- a/packages/block-library/src/post-comments-count/index.php
+++ b/packages/block-library/src/post-comments-count/index.php
@@ -23,7 +23,11 @@ function render_block_core_post_comments_count( $attributes, $content, $block ) 
 		$classes .= 'has-text-align-' . $attributes['textAlign'];
 	}
 
-	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );
+	$wrapper_attributes = get_block_wrapper_attributes(
+		$block->name,
+		$attributes,
+		array( 'class' => $classes )
+	);
 	return sprintf(
 		'<div class="%1$s">%2$s</div>',
 		$wrapper_attributes,

--- a/packages/block-library/src/post-comments-form/index.php
+++ b/packages/block-library/src/post-comments-form/index.php
@@ -26,7 +26,11 @@ function render_block_core_post_comments_form( $attributes, $content, $block ) {
 	ob_start();
 	comment_form( array(), $block->context['postId'] );
 	$form               = ob_get_clean();
-	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );
+	$wrapper_attributes = get_block_wrapper_attributes(
+		$block->name,
+		$attributes,
+		array( 'class' => $classes )
+	);
 
 	return sprintf( '<div %1$s>%2$s</div>', $wrapper_attributes, $form );
 }

--- a/packages/block-library/src/post-comments/index.php
+++ b/packages/block-library/src/post-comments/index.php
@@ -36,7 +36,11 @@ function render_block_core_post_comments( $attributes, $content, $block ) {
 		$classes .= 'has-text-align-' . $attributes['textAlign'];
 	}
 
-	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );
+	$wrapper_attributes = get_block_wrapper_attributes(
+		$block->name,
+		$attributes,
+		array( 'class' => $classes )
+	);
 	$output             = sprintf( '<div %1$s>', $wrapper_attributes ) . ob_get_clean() . '</div>';
 	return $output;
 }

--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -21,7 +21,8 @@ function render_block_core_post_content( $attributes, $content, $block ) {
 	$wrapper_attributes = get_block_wrapper_attributes(
 		$block->name,
 		$attributes,
-		array( 'class' => 'entry-content' ) );
+		array( 'class' => 'entry-content' )
+	);
 
 	return (
 		'<div ' . $wrapper_attributes . '>' .

--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -18,7 +18,10 @@ function render_block_core_post_content( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'entry-content' ) );
+	$wrapper_attributes = get_block_wrapper_attributes(
+		$block->name,
+		$attributes,
+		array( 'class' => 'entry-content' ) );
 
 	return (
 		'<div ' . $wrapper_attributes . '>' .

--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -19,7 +19,11 @@ function render_block_core_post_date( $attributes, $content, $block ) {
 	}
 
 	$align_class_name   = empty( $attributes['textAlign'] ) ? '' : "has-text-align-{$attributes['textAlign']}";
-	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $align_class_name ) );
+	$wrapper_attributes = get_block_wrapper_attributes(
+		$block->name,
+		$attributes,
+		array( 'class' => $align_class_name )
+	);
 
 	return sprintf(
 		'<div %1$s><time datetime="%2$s">%3$s</time></div>',

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -32,7 +32,11 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	if ( isset( $attributes['textAlign'] ) ) {
 		$classes .= 'has-text-align-' . $attributes['textAlign'];
 	}
-	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );
+	$wrapper_attributes = get_block_wrapper_attributes(
+		$block->name,
+		$attributes,
+		array( 'class' => $classes )
+	);
 
 	$output = sprintf( '<div %1$s>', esc_attr( $wrapper_attributes ) ) . '<p class="wp-block-post-excerpt__excerpt">' . get_the_excerpt( $block->context['postId'] );
 	if ( ! isset( $attributes['showMoreOnNewLine'] ) || $attributes['showMoreOnNewLine'] ) {

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -25,7 +25,10 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 		$featured_image = sprintf( '<a href="%1s">%2s</a>', get_the_permalink( $post_ID ), $featured_image );
 	}
 
-	$wrapper_attributes = get_block_wrapper_attributes();
+	$wrapper_attributes = get_block_wrapper_attributes(
+		$block->name,
+		$attributes
+	);
 
 	return '<p ' . $wrapper_attributes . '>' . $featured_image . '</p>';
 }

--- a/packages/block-library/src/post-hierarchical-terms/index.php
+++ b/packages/block-library/src/post-hierarchical-terms/index.php
@@ -34,7 +34,11 @@ function render_block_core_post_hierarchical_terms( $attributes, $content, $bloc
 		);
 	}
 	$terms_links        = trim( $terms_links, ' | ' );
-	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $align_class_name ) );
+	$wrapper_attributes = get_block_wrapper_attributes(
+		$block->name,
+		$attributes,
+		array( 'class' => $align_class_name )
+	);
 
 	return sprintf(
 		'<div %1$s>%2$s</div>',

--- a/packages/block-library/src/post-tags/index.php
+++ b/packages/block-library/src/post-tags/index.php
@@ -25,7 +25,11 @@ function render_block_core_post_tags( $attributes, $content, $block ) {
 			$classes .= 'has-text-align-' . $attributes['textAlign'];
 		}
 
-		$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );
+		$wrapper_attributes = get_block_wrapper_attributes(
+			$block->name,
+			$attributes,
+			array( 'class' => $classes )
+		);
 		$output             = sprintf( '<div %1$s>', $wrapper_attributes );
 
 		foreach ( $post_tags as $tag ) {

--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -31,7 +31,11 @@ function render_block_core_post_title( $attributes, $content, $block ) {
 	if ( isset( $attributes['isLink'] ) && $attributes['isLink'] ) {
 		$title = sprintf( '<a href="%1s" target="%2s" rel="%3s">%4s</a>', get_the_permalink( $post_ID ), $attributes['linkTarget'], $attributes['rel'], $title );
 	}
-	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $align_class_name ) );
+	$wrapper_attributes = get_block_wrapper_attributes(
+		$block->name,
+		$attributes,
+		array( 'class' => $align_class_name )
+	);
 
 	return sprintf(
 		'<%1$s %2$s>%3$s</%1$s>',

--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -8,11 +8,13 @@
 /**
  * Renders the `core/rss` block on server.
  *
- * @param array $attributes The block attributes.
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
  *
  * @return string Returns the block content with received rss items.
  */
-function render_block_core_rss( $attributes ) {
+function render_block_core_rss( $attributes, $content, $block ) {
 	$rss = fetch_feed( $attributes['feedURL'] );
 
 	if ( is_wp_error( $rss ) ) {
@@ -87,7 +89,11 @@ function render_block_core_rss( $attributes ) {
 	if ( isset( $attributes['columns'] ) && 'grid' === $attributes['blockLayout'] ) {
 		$classnames[] = 'columns-' . $attributes['columns'];
 	}
-	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => implode( ' ', $classnames ) ) );
+	$wrapper_attributes = get_block_wrapper_attributes(
+		$block->name,
+		$attributes,
+		array( 'class' => implode( ' ', $classnames ) )
+	);
 
 	return sprintf( '<ul %s>%s</ul>', $wrapper_attributes, $list_items );
 }

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -8,11 +8,13 @@
 /**
  * Dynamically renders the `core/search` block.
  *
- * @param array $attributes The block attributes.
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
  *
  * @return string The search block markup.
  */
-function render_block_core_search( $attributes ) {
+function render_block_core_search( $attributes, $content, $block ) {
 	static $instance_id = 0;
 
 	// Older versions of the Search block defaulted the label and buttonText
@@ -96,7 +98,11 @@ function render_block_core_search( $attributes ) {
 		$width_styles,
 		$input_markup . $button_markup
 	);
-	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classnames ) );
+	$wrapper_attributes = get_block_wrapper_attributes(
+		$block->name,
+		$attributes,
+		array( 'class' => $classnames )
+	);
 
 	return sprintf(
 		'<form role="search" method="get" action="%s" %s>%s</form>',

--- a/packages/block-library/src/site-logo/index.php
+++ b/packages/block-library/src/site-logo/index.php
@@ -8,11 +8,13 @@
 /**
  * Renders the `core/site-logo` block on the server.
  *
- * @param array $attributes The block attributes.
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
  *
  * @return string The render.
  */
-function render_block_core_site_logo( $attributes ) {
+function render_block_core_site_logo( $attributes, $content, $block ) {
 	$adjust_width_height_filter = function ( $image ) use ( $attributes ) {
 		if ( empty( $attributes['width'] ) ) {
 			return $image;
@@ -32,7 +34,11 @@ function render_block_core_site_logo( $attributes ) {
 		$classnames[] = "align{$attributes['align']}";
 	}
 
-	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => implode( ' ', $classnames ) ) );
+	$wrapper_attributes = get_block_wrapper_attributes(
+		$block->name,
+		$attributes,
+		array( 'class' => implode( ' ', $classnames ) )
+	);
 	$html               = sprintf( '<div %s><a href="' . get_bloginfo( 'url' ) . '" rel="home" title="' . get_bloginfo( 'name' ) . '">%s</a></div>', $wrapper_attributes, $custom_logo );
 	remove_filter( 'wp_get_attachment_image_src', $adjust_width_height_filter );
 	return $html;

--- a/packages/block-library/src/site-tagline/index.php
+++ b/packages/block-library/src/site-tagline/index.php
@@ -8,13 +8,19 @@
 /**
  * Renders the `core/site-tagline` block on the server.
  *
- * @param array $attributes The block attributes.
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
  *
  * @return string The render.
  */
-function render_block_core_site_tagline( $attributes ) {
+function render_block_core_site_tagline( $attributes, $content, $block ) {
 	$align_class_name   = empty( $attributes['textAlign'] ) ? '' : "has-text-align-{$attributes['textAlign']}";
-	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $align_class_name ) );
+	$wrapper_attributes = get_block_wrapper_attributes(
+		$block->name,
+		$attributes,
+		array( 'class' => $align_class_name )
+	);
 
 	return sprintf(
 		'<p %1$s>%2$s</p>',

--- a/packages/block-library/src/site-title/index.php
+++ b/packages/block-library/src/site-title/index.php
@@ -8,11 +8,13 @@
 /**
  * Renders the `core/site-title` block on the server.
  *
- * @param array $attributes The block attributes.
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
  *
  * @return string The render.
  */
-function render_block_core_site_title( $attributes ) {
+function render_block_core_site_title( $attributes, $content, $block ) {
 	$tag_name         = 'h1';
 	$align_class_name = empty( $attributes['textAlign'] ) ? '' : "has-text-align-{$attributes['textAlign']}";
 
@@ -21,7 +23,11 @@ function render_block_core_site_title( $attributes ) {
 	}
 
 	$link               = sprintf( '<a href="%1$s" rel="home">%2$s</a>', get_bloginfo( 'url' ), get_bloginfo( 'name' ) );
-	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $align_class_name ) );
+	$wrapper_attributes = get_block_wrapper_attributes(
+		$block->name,
+		$attributes,
+		array( 'class' => $align_class_name )
+	);
 
 	return sprintf(
 		'<%1$s %2$s>%3$s</%1$s>',

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -33,7 +33,7 @@ function render_block_core_social_link( $attributes, $content, $block ) {
 	}
 
 	$icon               = block_core_social_link_get_icon( $service );
-	$wrapper_attributes = get_block_wrapper_attributes_without_global(
+	$wrapper_attributes = get_block_wrapper_attributes(
 		$block->name,
 		$attributes,
 		array( 'class' => 'wp-social-link wp-social-link-' . $service . $class_name )

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -33,7 +33,11 @@ function render_block_core_social_link( $attributes, $content, $block ) {
 	}
 
 	$icon               = block_core_social_link_get_icon( $service );
-	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'wp-social-link wp-social-link-' . $service . $class_name ) );
+	$wrapper_attributes = get_block_wrapper_attributes_without_global(
+		$block->name,
+		$attributes,
+		array( 'class' => 'wp-social-link wp-social-link-' . $service . $class_name )
+	);
 
 	return '<li ' . $wrapper_attributes . '><a href="' . esc_url( $url ) . '" aria-label="' . esc_attr( $label ) . '" ' . $attribute . '> ' . $icon . '</a></li>';
 }

--- a/packages/block-library/src/tag-cloud/index.php
+++ b/packages/block-library/src/tag-cloud/index.php
@@ -8,11 +8,13 @@
 /**
  * Renders the `core/tag-cloud` block on server.
  *
- * @param array $attributes The block attributes.
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
  *
  * @return string Returns the tag cloud for selected taxonomy.
  */
-function render_block_core_tag_cloud( $attributes ) {
+function render_block_core_tag_cloud( $attributes, $content, $block ) {
 	$args      = array(
 		'echo'       => false,
 		'taxonomy'   => $attributes['taxonomy'],
@@ -31,7 +33,10 @@ function render_block_core_tag_cloud( $attributes ) {
 		);
 	}
 
-	$wrapper_attributes = get_block_wrapper_attributes();
+	$wrapper_attributes = get_block_wrapper_attributes(
+		$block->name,
+		$attributes
+	);
 
 	return sprintf(
 		'<p %1$s>%2$s</p>',

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -8,11 +8,13 @@
 /**
  * Renders the `core/template-part` block on the server.
  *
- * @param array $attributes The block attributes.
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
  *
  * @return string The render.
  */
-function render_block_core_template_part( $attributes ) {
+function render_block_core_template_part( $attributes, $content, $block ) {
 	$content = null;
 
 	if ( ! empty( $attributes['postId'] ) && get_post_status( $attributes['postId'] ) ) {
@@ -63,7 +65,10 @@ function render_block_core_template_part( $attributes ) {
 	}
 	$content            = do_shortcode( $content );
 	$html_tag           = esc_attr( $attributes['tagName'] );
-	$wrapper_attributes = get_block_wrapper_attributes();
+	$wrapper_attributes = get_block_wrapper_attributes(
+		$block->name,
+		$attributes
+	);
 
 	return "<$html_tag $wrapper_attributes>" . str_replace( ']]>', ']]&gt;', $content ) . "</$html_tag>";
 }

--- a/phpunit/class-block-supported-styles-test.php
+++ b/phpunit/class-block-supported-styles-test.php
@@ -97,7 +97,7 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	 * @param WPBlock $block Block to render.
 	 */
 	private function render_example_block( $block ) {
-		$wrapper_attributes   = get_block_wrapper_attributes(
+		$wrapper_attributes = get_block_wrapper_attributes(
 			$block->name,
 			$block->attributes,
 			array(

--- a/phpunit/class-block-supported-styles-test.php
+++ b/phpunit/class-block-supported-styles-test.php
@@ -94,12 +94,12 @@ class Block_Supported_Styles_Test extends WP_UnitTestCase {
 	/**
 	 * Returns the rendered output for the current block.
 	 *
-	 * @param array $block Block to render.
+	 * @param WPBlock $block Block to render.
 	 */
 	private function render_example_block( $block ) {
-		global $current_parsed_block;
-		$current_parsed_block = $block;
 		$wrapper_attributes   = get_block_wrapper_attributes(
+			$block->name,
+			$block->attributes,
 			array(
 				'class' => 'foo-bar-class',
 				'style' => 'test: style;',


### PR DESCRIPTION
Alternative to https://github.com/WordPress/gutenberg/pull/26344

This refactors the `get_block_wrapper_attributes` to get the data it needs from the parameters instead of the `current_parsed_block` global.

It fixes an issue with updating the `current_parsed_block` global value with inner blocks for the plugin, in accordance to what we did for WP core at https://github.com/WordPress/gutenberg/pull/26291 (ported over at https://github.com/WordPress/wordpress-develop/pull/626).