### PR TITLE
Change replaceInnerBlocks updateSelection property to false

### DIFF
--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -1250,7 +1250,7 @@ _Parameters_
 
 -   _rootClientId_ `string`: Client ID of the block whose InnerBlocks will re replaced.
 -   _blocks_ `Array<Object>`: Block objects to insert as new InnerBlocks
--   _updateSelection_ `?boolean`: If true block selection will be updated. If false, block selection will not change. Defaults to true.
+-   _updateSelection_ `?boolean`: If true block selection will be updated. If false, block selection will not change. Defaults to false.
 
 _Returns_
 

--- a/packages/block-editor/src/components/block-variation-picker/index.native.js
+++ b/packages/block-editor/src/components/block-variation-picker/index.native.js
@@ -68,8 +68,7 @@ function BlockVariationPicker( { isVisible, onClose, clientId, variations } ) {
 	const onVariationSelect = ( variation ) => {
 		replaceInnerBlocks(
 			clientId,
-			createBlocksFromInnerBlocksTemplate( variation.innerBlocks ),
-			false
+			createBlocksFromInnerBlocksTemplate( variation.innerBlocks )
 		);
 		onClose();
 	};

--- a/packages/block-editor/src/components/inner-blocks/README.md
+++ b/packages/block-editor/src/components/inner-blocks/README.md
@@ -102,7 +102,7 @@ The previous example creates an InnerBlocks area containing two columns one with
 
 ### `templateInsertUpdatesSelection`
 * **Type:** `Boolean`
-* **Default:** `true`
+* **Default:** `false`
 
 If true when child blocks in the template are inserted the selection is updated.
 If false the selection should not be updated when child blocks specified in the template are inserted.

--- a/packages/block-editor/src/components/provider/test/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/test/use-block-sync.js
@@ -97,8 +97,7 @@ describe( 'useBlockSync hook', () => {
 		expect( onInput ).not.toHaveBeenCalled();
 		expect( replaceInnerBlocks ).toHaveBeenCalledWith(
 			'test', // It should use the given client ID.
-			fakeBlocks, // It should use the controlled blocks value.
-			false // It shoudl not update the selection state.
+			fakeBlocks // It should use the controlled blocks value.
 		);
 
 		const testBlocks = [
@@ -119,11 +118,7 @@ describe( 'useBlockSync hook', () => {
 		expect( onChange ).not.toHaveBeenCalled();
 		expect( onInput ).not.toHaveBeenCalled();
 		expect( resetBlocks ).not.toHaveBeenCalled();
-		expect( replaceInnerBlocks ).toHaveBeenCalledWith(
-			'test',
-			testBlocks,
-			false
-		);
+		expect( replaceInnerBlocks ).toHaveBeenCalledWith( 'test', testBlocks );
 	} );
 
 	it( 'does not add the controlled blocks to the block-editor store if the store already contains them', async () => {
@@ -315,7 +310,7 @@ describe( 'useBlockSync hook', () => {
 			);
 		} );
 
-		expect( replaceInnerBlocks ).toHaveBeenCalledWith( 'test', [], false );
+		expect( replaceInnerBlocks ).toHaveBeenCalledWith( 'test', [] );
 		expect( onChange ).not.toHaveBeenCalled();
 		expect( onInput ).not.toHaveBeenCalled();
 	} );

--- a/packages/block-editor/src/components/provider/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/use-block-sync.js
@@ -96,7 +96,7 @@ export default function useBlockSync( {
 		if ( clientId ) {
 			setHasControlledInnerBlocks( clientId, true );
 			__unstableMarkNextChangeAsNotPersistent();
-			replaceInnerBlocks( clientId, controlledBlocks, false );
+			replaceInnerBlocks( clientId, controlledBlocks );
 		} else {
 			resetBlocks( controlledBlocks );
 		}

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -668,7 +668,7 @@ export function removeBlock( clientId, selectPrevious ) {
 export function replaceInnerBlocks(
 	rootClientId,
 	blocks,
-	updateSelection = true
+	updateSelection = false
 ) {
 	return {
 		type: 'REPLACE_INNER_BLOCKS',

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -661,7 +661,7 @@ export function removeBlock( clientId, selectPrevious ) {
  *
  * @param {string}   rootClientId    Client ID of the block whose InnerBlocks will re replaced.
  * @param {Object[]} blocks          Block objects to insert as new InnerBlocks
- * @param {?boolean} updateSelection If true block selection will be updated. If false, block selection will not change. Defaults to true.
+ * @param {?boolean} updateSelection If true block selection will be updated. If false, block selection will not change. Defaults to false.
  *
  * @return {Object} Action object.
  */

--- a/packages/block-editor/src/store/test/actions.js
+++ b/packages/block-editor/src/store/test/actions.js
@@ -1100,17 +1100,17 @@ describe( 'actions', () => {
 				blocks: [ block ],
 				rootClientId: 'root',
 				time: expect.any( Number ),
-				updateSelection: true,
+				updateSelection: false,
 			} );
 		} );
 
-		it( 'should return the REPLACE_INNER_BLOCKS action with updateSelection false', () => {
-			expect( replaceInnerBlocks( 'root', [ block ], false ) ).toEqual( {
+		it( 'should return the REPLACE_INNER_BLOCKS action with updateSelection true', () => {
+			expect( replaceInnerBlocks( 'root', [ block ], true ) ).toEqual( {
 				type: 'REPLACE_INNER_BLOCKS',
 				blocks: [ block ],
 				rootClientId: 'root',
 				time: expect.any( Number ),
-				updateSelection: false,
+				updateSelection: true,
 			} );
 		} );
 	} );

--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -39,6 +39,7 @@ function ButtonsEdit( {
 			type: 'default',
 			alignments: [],
 		},
+		templateInsertUpdatesSelection: true,
 	} );
 	return (
 		<>

--- a/packages/block-library/src/buttons/edit.native.js
+++ b/packages/block-library/src/buttons/edit.native.js
@@ -137,7 +137,7 @@ export default function ButtonsEdit( {
 				marginHorizontal={ spacing }
 				marginVertical={ spacing }
 				__experimentalLayout={ { type: 'default', alignments: [] } }
-				templateInsertUpdatesSelection={ true }
+				templateInsertUpdatesSelection
 			/>
 		</>
 	);

--- a/packages/block-library/src/buttons/edit.native.js
+++ b/packages/block-library/src/buttons/edit.native.js
@@ -137,6 +137,7 @@ export default function ButtonsEdit( {
 				marginHorizontal={ spacing }
 				marginVertical={ spacing }
 				__experimentalLayout={ { type: 'default', alignments: [] } }
+				templateInsertUpdatesSelection={ true }
 			/>
 		</>
 	);

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -195,7 +195,7 @@ const ColumnsEditContainerWrapper = withDispatch(
 				}
 			}
 
-			replaceInnerBlocks( clientId, innerBlocks, false );
+			replaceInnerBlocks( clientId, innerBlocks );
 		},
 	} )
 )( ColumnsEditContainer );
@@ -235,7 +235,8 @@ function Placeholder( { clientId, name, setAttributes } ) {
 							clientId,
 							createBlocksFromInnerBlocksTemplate(
 								nextVariation.innerBlocks
-							)
+							),
+							true
 						);
 					}
 				} }

--- a/packages/block-library/src/columns/edit.native.js
+++ b/packages/block-library/src/columns/edit.native.js
@@ -311,7 +311,7 @@ const ColumnsEditContainerWrapper = withDispatch(
 				);
 			}
 
-			replaceInnerBlocks( clientId, innerBlocks, false );
+			replaceInnerBlocks( clientId, innerBlocks );
 		},
 		onAddNextColumn: () => {
 			const { clientId } = ownProps;

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -453,7 +453,10 @@ function CoverEdit( {
 		{
 			className: 'wp-block-cover__inner-container',
 		},
-		{ template: INNER_BLOCKS_TEMPLATE }
+		{
+			template: INNER_BLOCKS_TEMPLATE,
+			templateInsertUpdatesSelection: true,
+		}
 	);
 
 	if ( ! hasBackground ) {

--- a/packages/block-library/src/cover/edit.native.js
+++ b/packages/block-library/src/cover/edit.native.js
@@ -516,7 +516,7 @@ const Cover = ( {
 			>
 				<InnerBlocks
 					template={ INNER_BLOCKS_TEMPLATE }
-					templateInsertUpdatesSelection={ true }
+					templateInsertUpdatesSelection
 				/>
 			</View>
 

--- a/packages/block-library/src/cover/edit.native.js
+++ b/packages/block-library/src/cover/edit.native.js
@@ -514,7 +514,10 @@ const Cover = ( {
 				pointerEvents="box-none"
 				style={ [ styles.content, { minHeight: CONTAINER_HEIGHT } ] }
 			>
-				<InnerBlocks template={ INNER_BLOCKS_TEMPLATE } />
+				<InnerBlocks
+					template={ INNER_BLOCKS_TEMPLATE }
+					templateInsertUpdatesSelection={ true }
+				/>
 			</View>
 
 			<View pointerEvents="none" style={ styles.overlayContainer }>

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -286,13 +286,8 @@ function MediaTextEdit( { attributes, isSelected, setAttributes } ) {
 	} );
 
 	const innerBlocksProps = useInnerBlocksProps(
-		{
-			className: 'wp-block-media-text__content',
-		},
-		{
-			template: TEMPLATE,
-			templateInsertUpdatesSelection: false,
-		}
+		{ className: 'wp-block-media-text__content' },
+		{ template: TEMPLATE }
 	);
 
 	return (

--- a/packages/block-library/src/media-text/edit.native.js
+++ b/packages/block-library/src/media-text/edit.native.js
@@ -379,10 +379,7 @@ class MediaTextEdit extends Component {
 							...innerBlockContainerStyle,
 						} }
 					>
-						<InnerBlocks
-							template={ TEMPLATE }
-							templateInsertUpdatesSelection={ false }
-						/>
+						<InnerBlocks template={ TEMPLATE } />
 					</View>
 				</View>
 			</>

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -213,7 +213,8 @@ export default compose( [
 				}
 				dispatch( 'core/block-editor' ).replaceInnerBlocks(
 					clientId,
-					blocks
+					blocks,
+					true
 				);
 			},
 		};

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -69,7 +69,6 @@ function Navigation( {
 				isSelected
 					? InnerBlocks.DefaultAppender
 					: false,
-			templateInsertUpdatesSelection: false,
 			__experimentalAppenderTagName: 'li',
 			__experimentalCaptureToolbars: true,
 			// Template lock set to false here so that the Nav

--- a/packages/block-library/src/query-loop/edit.js
+++ b/packages/block-library/src/query-loop/edit.js
@@ -122,10 +122,7 @@ export default function QueryLoopEdit( {
 					>
 						{ blockContext ===
 						( activeBlockContext || blockContexts[ 0 ] ) ? (
-							<InnerBlocks
-								template={ TEMPLATE }
-								templateInsertUpdatesSelection={ false }
-							/>
+							<InnerBlocks template={ TEMPLATE } />
 						) : (
 							<BlockPreview
 								blocks={ blocks }

--- a/packages/block-library/src/query/edit/index.js
+++ b/packages/block-library/src/query/edit/index.js
@@ -66,10 +66,7 @@ export function QueryContent( {
 			</BlockControls>
 			<div { ...blockProps }>
 				<QueryProvider>
-					<InnerBlocks
-						template={ TEMPLATE }
-						templateInsertUpdatesSelection={ false }
-					/>
+					<InnerBlocks template={ TEMPLATE } />
 				</QueryProvider>
 			</div>
 		</>

--- a/packages/e2e-tests/plugins/block-context/index.js
+++ b/packages/e2e-tests/plugins/block-context/index.js
@@ -32,6 +32,7 @@
 				el( InnerBlocks, {
 					template: [ [ 'gutenberg/test-context-consumer', {} ] ],
 					templateLock: 'all',
+					templateInsertUpdatesSelection: true,
 				} )
 			);
 		},

--- a/packages/e2e-tests/plugins/inner-blocks-templates/index.js
+++ b/packages/e2e-tests/plugins/inner-blocks-templates/index.js
@@ -1,4 +1,4 @@
-( function() {
+( function () {
 	var registerBlockType = wp.blocks.registerBlockType;
 	var createBlock = wp.blocks.createBlock;
 	var el = wp.element.createElement;
@@ -24,7 +24,7 @@
 		],
 	];
 
-	var save = function() {
+	var save = function () {
 		return el( InnerBlocks.Content );
 	};
 
@@ -33,7 +33,7 @@
 		icon: 'cart',
 		category: 'text',
 
-		edit: function( props ) {
+		edit: function ( props ) {
 			return el( InnerBlocks, {
 				template: TEMPLATE,
 			} );
@@ -47,7 +47,7 @@
 		icon: 'cart',
 		category: 'text',
 
-		edit: function( props ) {
+		edit: function ( props ) {
 			return el( InnerBlocks, {
 				template: TEMPLATE,
 				templateLock: 'all',
@@ -62,9 +62,10 @@
 		icon: 'cart',
 		category: 'text',
 
-		edit: function( props ) {
+		edit: function ( props ) {
 			return el( InnerBlocks, {
 				template: TEMPLATE_PARAGRAPH_PLACEHOLDER,
+				templateInsertUpdatesSelection: true,
 			} );
 		},
 
@@ -86,7 +87,7 @@
 						'test/test-inner-blocks-locking-all',
 						'test/test-inner-blocks-paragraph-placeholder',
 					],
-					transform: function( attributes, innerBlocks ) {
+					transform: function ( attributes, innerBlocks ) {
 						return createBlock(
 							'test/test-inner-blocks-transformer-target',
 							attributes,
@@ -99,7 +100,7 @@
 				{
 					type: 'block',
 					blocks: [ 'test/i-dont-exist' ],
-					transform: function( attributes, innerBlocks ) {
+					transform: function ( attributes, innerBlocks ) {
 						return createBlock(
 							'test/test-inner-blocks-transformer-target',
 							attributes,
@@ -110,7 +111,7 @@
 			],
 		},
 
-		edit: function( props ) {
+		edit: function ( props ) {
 			return el( InnerBlocks, {
 				template: TEMPLATE,
 			} );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Based on this comment: https://github.com/WordPress/gutenberg/pull/26267#pullrequestreview-511686901

This PR changes the default value of action `replaceInnerBlocks`'s `updateSelection` property to `false`. This change propagates to changing the default value of `InnerBlock`'s `templateInsertUpdatesSelection` to `false` as well.

This change affects whether the selection is updated or not, when child blocks in the template are inserted.

Most blocks that use `InnerBlocks` would set this as `false`, thus making this change the preferred default value.


 
<!-- Please describe what you have changed or added -->

## How has this been tested?
### Affected blocks:
- Query
- Columns
- Column
- Navigation
- Media & Text
- Buttons
- Cover

### Hooks
- useBlockSync

### Native files/Blocks/Components changed
- Media & Text
- BlockVariationPicker
- Columns
- Buttons
- Cover

You can test this by creating the above affected blocks on master and the on this branch. Block `focus` should be identical.


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
