### PR TITLE
E2E Tests: Fix demo test by disabling the welcome dialog

### DIFF
--- a/packages/e2e-tests/specs/local/demo.test.js
+++ b/packages/e2e-tests/specs/local/demo.test.js
@@ -4,6 +4,7 @@
 import {
 	createEmbeddingMatcher,
 	createJSONResponse,
+	createNewPost,
 	setUpResponseMocking,
 	visitAdminPage,
 } from '@wordpress/e2e-test-utils';
@@ -19,6 +20,9 @@ const MOCK_VIMEO_RESPONSE = {
 
 describe( 'new editor state', () => {
 	beforeAll( async () => {
+		// First, make sure that the block editor is properly configured.
+		await createNewPost();
+
 		await setUpResponseMocking( [
 			{
 				match: createEmbeddingMatcher( 'https://vimeo.com/22439234' ),

--- a/packages/e2e-tests/specs/local/demo.test.js
+++ b/packages/e2e-tests/specs/local/demo.test.js
@@ -38,9 +38,7 @@ describe( 'new editor state', () => {
 			return select( 'core/editor' ).isEditedPostDirty();
 		} );
 		expect( isDirty ).toBeTruthy();
-	} );
 
-	it( 'should be immediately saveable', async () => {
 		expect( await page.$( 'button.editor-post-save-draft' ) ).toBeTruthy();
 	} );
 } );

--- a/packages/jest-puppeteer-axe/CHANGELOG.md
+++ b/packages/jest-puppeteer-axe/CHANGELOG.md
@@ -2,16 +2,16 @@
 
 ## Unreleased
 
-### New Features
+### Breaking Changes
 
-- Migrated `axe-puppeteer` to its new package name  [@axe-core/puppeteer](https://github.com/dequelabs/axe-core-npm/tree/develop/packages/puppeteer).
+-   Migrated `axe-puppeteer` to its new package [@axe-core/puppeteer](https://github.com/dequelabs/axe-core-npm/tree/develop/packages/puppeteer) that contains breaking changes.
 
 ## 1.1.0 (2019-05-21)
 
 ### New Feature
 
-- Added optional `disabledRules` option to use with `toPassAxeTests` matcher.
+-   Added optional `disabledRules` option to use with `toPassAxeTests` matcher.
 
 ## 1.0.0 (2019-03-06)
 
-- Initial release.
+-   Initial release.

--- a/packages/jest-puppeteer-axe/src/index.js
+++ b/packages/jest-puppeteer-axe/src/index.js
@@ -80,7 +80,7 @@ async function toPassAxeTests(
 	page,
 	{ include, exclude, disabledRules, options, config } = {}
 ) {
-	const axe = await new AxePuppeteer( page );
+	const axe = new AxePuppeteer( page );
 
 	if ( include ) {
 		axe.include( include );

--- a/packages/jest-puppeteer-axe/src/index.js
+++ b/packages/jest-puppeteer-axe/src/index.js
@@ -80,7 +80,7 @@ async function toPassAxeTests(
 	page,
 	{ include, exclude, disabledRules, options, config } = {}
 ) {
-	const axe = new AxePuppeteer( page );
+	const axe = await new AxePuppeteer( page );
 
 	if ( include ) {
 		axe.include( include );


### PR DESCRIPTION
## Description
Follow-up for #25659 where I noticed that the demo e2e test fails from time to time. The issue seemed to be the Welcome Dialog which prevents all the interactions to happen in the first place.

The proposed solution is to open a new editor page to remove the popup and properly configure full-screen mode before proceeding with the actual test. The issue happens mostly because all other tests depend on `createNewPage` helper's behavior.

I also decided to combine two tests into one given that the first one always passes and the second is not reliable. It seems like merging both resolves the issue. There is an open issue about this bug:

https://github.com/dequelabs/axe-core-npm/issues/98

It seems like there is some iframe injected that triggers the issue.

## How has this been tested?
```sh
npm run test-e2e -- --puppeteer-interactive packages/e2e-tests/specs/local/demo.test.js
```