### PR TITLE
Update global styles reference preset variables on colors and gradients

### DIFF
--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -567,7 +567,16 @@ function gutenberg_experimental_global_styles_flatten_styles_tree( $styles ) {
 	foreach ( $mappings as $key => $path ) {
 		$value = gutenberg_experimental_get( $styles, $path, null );
 		if ( null !== $value ) {
-			$result[ $key ] = $value;
+			$variable_reference_prefix               = 'var:';
+			$variable_path_separator_token_attribute = '|';
+			$variable_path_separator_token_style     = '--';
+			$variable_reference_prefix_length        = strlen( $variable_reference_prefix );
+			if ( strncmp( $value, $variable_reference_prefix, $variable_reference_prefix_length ) === 0 ) {
+				$variable       = str_replace( $variable_path_separator_token_attribute, $variable_path_separator_token_style, substr( $value, $variable_reference_prefix_length ) );
+				$result[ $key ] = "var(--wp--$variable)";
+			} else {
+				$result[ $key ] = $value;
+			}
 		}
 	}
 	return $result;

--- a/packages/edit-site/src/components/editor/global-styles-renderer.js
+++ b/packages/edit-site/src/components/editor/global-styles-renderer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, kebabCase, reduce } from 'lodash';
+import { get, kebabCase, reduce, startsWith } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -51,6 +51,20 @@ export const mergeTrees = ( baseData, userData ) => {
 	return mergedTree;
 };
 
+function compileStyleValue( uncompiledValue ) {
+	const VARIABLE_REFERENCE_PREFIX = 'var:';
+	const VARIABLE_PATH_SEPARATOR_TOKEN_ATTRIBUTE = '|';
+	const VARIABLE_PATH_SEPARATOR_TOKEN_STYLE = '--';
+	if ( startsWith( uncompiledValue, VARIABLE_REFERENCE_PREFIX ) ) {
+		const variable = uncompiledValue
+			.slice( VARIABLE_REFERENCE_PREFIX.length )
+			.split( VARIABLE_PATH_SEPARATOR_TOKEN_ATTRIBUTE )
+			.join( VARIABLE_PATH_SEPARATOR_TOKEN_STYLE );
+		return `var(--wp--${ variable })`;
+	}
+	return uncompiledValue;
+}
+
 export default ( blockData, tree ) => {
 	const styles = [];
 	// Can this be converted to a context, as the global context?
@@ -74,9 +88,8 @@ export default ( blockData, tree ) => {
 				get( blockStyles, STYLE_PROPERTY[ key ], false )
 			) {
 				declarations.push(
-					`${ cssProperty }: ${ get(
-						blockStyles,
-						STYLE_PROPERTY[ key ]
+					`${ cssProperty }: ${ compileStyleValue(
+						get( blockStyles, STYLE_PROPERTY[ key ] )
 					) }`
 				);
 			}

--- a/packages/edit-site/src/components/editor/utils.js
+++ b/packages/edit-site/src/components/editor/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
+import { get, find } from 'lodash';
 /**
  * WordPress dependencies
  */
@@ -44,4 +44,37 @@ export function useEditorFeature( featurePath, blockName = GLOBAL_CONTEXT ) {
 			`__experimentalFeatures.${ GLOBAL_CONTEXT }.${ featurePath }`
 		)
 	);
+}
+
+export function getPresetVariable( presetCategory, presets, value ) {
+	if ( ! value ) {
+		return;
+	}
+	const presetData = PRESET_CATEGORIES[ presetCategory ];
+	const { key } = presetData;
+	const presetObject = find( presets, ( preset ) => {
+		return preset[ key ] === value;
+	} );
+	return (
+		presetObject && `var:preset|${ presetCategory }|${ presetObject.slug }`
+	);
+}
+
+export function getPresetValueFromVariable(
+	presetCategory,
+	presets,
+	variable
+) {
+	if ( ! variable ) {
+		return;
+	}
+	const slug = variable.slice( variable.lastIndexOf( '|' ) + 1 );
+	const presetObject = find( presets, ( preset ) => {
+		return preset.slug === slug;
+	} );
+	if ( presetObject ) {
+		const presetData = PRESET_CATEGORIES[ presetCategory ];
+		const { key } = presetData;
+		return presetObject[ key ];
+	}
 }

--- a/packages/edit-site/src/components/sidebar/color-panel.js
+++ b/packages/edit-site/src/components/sidebar/color-panel.js
@@ -7,7 +7,12 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { LINK_COLOR, useEditorFeature } from '../editor/utils';
+import {
+	LINK_COLOR,
+	useEditorFeature,
+	getPresetValueFromVariable,
+	getPresetVariable,
+} from '../editor/utils';
 import ColorPalettePanel from './color-palette-panel';
 
 export default ( {
@@ -36,29 +41,52 @@ export default ( {
 	const settings = [];
 
 	if ( supports.includes( 'color' ) ) {
+		const color = getStyleProperty( name, 'color' );
 		settings.push( {
-			colorValue: getStyleProperty( name, 'color' ),
+			colorValue:
+				getPresetValueFromVariable( 'color', colors, color ) || color,
 			onColorChange: ( value ) =>
-				setStyleProperty( name, 'color', value ),
+				setStyleProperty(
+					name,
+					'color',
+					getPresetVariable( 'color', colors, value ) || value
+				),
 			label: __( 'Text color' ),
 		} );
 	}
 
 	let backgroundSettings = {};
 	if ( supports.includes( 'backgroundColor' ) ) {
+		const backgroundColor = getStyleProperty( name, 'backgroundColor' );
 		backgroundSettings = {
-			colorValue: getStyleProperty( name, 'backgroundColor' ),
+			colorValue:
+				getPresetValueFromVariable(
+					'color',
+					colors,
+					backgroundColor
+				) || backgroundColor,
 			onColorChange: ( value ) =>
-				setStyleProperty( name, 'backgroundColor', value ),
+				setStyleProperty(
+					name,
+					'backgroundColor',
+					getPresetVariable( 'color', colors, value ) || value
+				),
 		};
 	}
 
 	let gradientSettings = {};
 	if ( supports.includes( 'background' ) ) {
+		const gradient = getStyleProperty( name, 'background' );
 		gradientSettings = {
-			gradientValue: getStyleProperty( name, 'background' ),
+			gradientValue:
+				getPresetValueFromVariable( 'gradient', gradients, gradient ) ||
+				gradient,
 			onGradientChange: ( value ) =>
-				setStyleProperty( name, 'background', value ),
+				setStyleProperty(
+					name,
+					'background',
+					getPresetVariable( 'gradient', gradients, value ) || value
+				),
 		};
 	}
 
@@ -74,10 +102,16 @@ export default ( {
 	}
 
 	if ( supports.includes( LINK_COLOR ) ) {
+		const color = getStyleProperty( name, LINK_COLOR );
 		settings.push( {
-			colorValue: getStyleProperty( name, LINK_COLOR ),
+			colorValue:
+				getPresetValueFromVariable( 'color', colors, color ) || color,
 			onColorChange: ( value ) =>
-				setStyleProperty( name, LINK_COLOR, value ),
+				setStyleProperty(
+					name,
+					LINK_COLOR,
+					getPresetVariable( 'color', colors, value ) || value
+				),
 			label: __( 'Link color' ),
 		} );
 	}


### PR DESCRIPTION
This PR updates global styles to reference preset by varaibles instead of value.

Previously if we had a color palette with a color name blue and value #00f, and we applied a background color to the paragraphs the output would be:
p { background-color: #00f };
not the ouput is:
p { background-color: var(--wp-preset--color-blue) };

So if the color blue is changed the background color of the paragraph also changes automatically.

The presets for font sizes don't use this yet because of the pending issue related to units.


## How has this been tested?
I added a paragraph block.
I used global styles and created a custom color palette for paragraphs.
I applied on of the colors as the paragraph background color.
I changed the color value using the color palette editor, and I verified the background colors of the paragraphs also changed.