### PR TITLE
Check if the API method on WP_REST_Server is callable

### DIFF
--- a/lib/class-wp-rest-batch-controller.php
+++ b/lib/class-wp-rest-batch-controller.php
@@ -110,7 +110,7 @@ class WP_REST_Batch_Controller {
 			$requests[] = $single_request;
 		}
 
-		if ( ! method_exists( rest_get_server(), 'match_request_to_handler' ) ) {
+		if ( ! is_callable( array( rest_get_server(), 'match_request_to_handler' ) ) ) {
 			return $this->polyfill_batching( $requests );
 		}
 


### PR DESCRIPTION
## Description
This will fix a fatal error for people running the plugin on Trunk.

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
