### PR TITLE
Process settings only once in edit-site

### DIFF
--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -87,8 +87,7 @@ function gutenberg_get_editor_styles() {
  * @param string $hook Page.
  */
 function gutenberg_edit_site_init( $hook ) {
-	global $current_screen;
-	global $post;
+	global $current_screen, $post;
 
 	if ( ! gutenberg_is_edit_site_page( $hook ) ) {
 		return;

--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -88,6 +88,7 @@ function gutenberg_get_editor_styles() {
  */
 function gutenberg_edit_site_init( $hook ) {
 	global $current_screen;
+	global $post;
 
 	if ( ! gutenberg_is_edit_site_page( $hook ) ) {
 		return;

--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -137,11 +137,6 @@ function gutenberg_edit_site_init( $hook ) {
 	$settings['styles'] = gutenberg_get_editor_styles();
 	$settings           = gutenberg_experimental_global_styles_settings( $settings );
 
-	// This is so other parts of the code can hook their own settings.
-	// Example: Global Styles.
-	global $post;
-	$settings = apply_filters( 'block_editor_settings', $settings, $post );
-
 	// Preload block editor paths.
 	// most of these are copied from edit-forms-blocks.php.
 	$preload_paths = array(

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -975,5 +975,5 @@ function gutenberg_experimental_global_styles_register_cpt() {
 }
 
 add_action( 'init', 'gutenberg_experimental_global_styles_register_cpt' );
-add_action( 'wp_enqueue_scripts', 'gutenberg_experimental_global_styles_enqueue_assets' );
 add_filter( 'block_editor_settings', 'gutenberg_experimental_global_styles_settings' );
+add_action( 'wp_enqueue_scripts', 'gutenberg_experimental_global_styles_enqueue_assets' );

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -976,5 +976,4 @@ function gutenberg_experimental_global_styles_register_cpt() {
 
 add_action( 'init', 'gutenberg_experimental_global_styles_register_cpt' );
 add_action( 'wp_enqueue_scripts', 'gutenberg_experimental_global_styles_enqueue_assets' );
-// This is to hook into the edit-post (block-editor store)
 add_filter( 'block_editor_settings', 'gutenberg_experimental_global_styles_settings' );

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -975,5 +975,6 @@ function gutenberg_experimental_global_styles_register_cpt() {
 }
 
 add_action( 'init', 'gutenberg_experimental_global_styles_register_cpt' );
-add_filter( 'block_editor_settings', 'gutenberg_experimental_global_styles_settings' );
 add_action( 'wp_enqueue_scripts', 'gutenberg_experimental_global_styles_enqueue_assets' );
+// This is to hook into the edit-post (block-editor store)
+add_filter( 'block_editor_settings', 'gutenberg_experimental_global_styles_settings' );


### PR DESCRIPTION
We are processing Global Styles twice in the edit-site screen. This PR removes the duplication and follows the same standards as in the other screens, this is, use `gutenberg_experimental_global_styles_settings` to get the settings instead of hooking into the `block_editor_setting` filter.