### PR TITLE
Navigation Component: Add Support for RTL Languages

### DIFF
--- a/packages/components/src/navigation/back-button/index.js
+++ b/packages/components/src/navigation/back-button/index.js
@@ -14,7 +14,7 @@ import { Icon, chevronLeft, chevronRight } from '@wordpress/icons';
  */
 import { useNavigationContext } from '../context';
 import { MenuBackButtonUI } from '../styles/navigation-styles';
-import { useRTL } from '../../utils/rtl';
+import { getRTL } from '../../utils/rtl';
 
 function NavigationBackButton(
 	{ backButtonLabel, className, href, onClick, parentMenu },
@@ -34,11 +34,12 @@ function NavigationBackButton(
 			onClick( event );
 		}
 
+		const animationDirection = getRTL() ? 'left' : 'right';
 		if ( parentMenu && ! event.defaultPrevented ) {
-			setActiveMenu( parentMenu, 'right' );
+			setActiveMenu( parentMenu, animationDirection );
 		}
 	};
-	const icon = useRTL() ? chevronRight : chevronLeft;
+	const icon = getRTL() ? chevronRight : chevronLeft;
 	return (
 		<MenuBackButtonUI
 			className={ classes }

--- a/packages/components/src/navigation/back-button/index.js
+++ b/packages/components/src/navigation/back-button/index.js
@@ -2,19 +2,19 @@
  * External dependencies
  */
 import classnames from 'classnames';
-
 /**
  * WordPress dependencies
  */
 import { forwardRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Icon, chevronLeft } from '@wordpress/icons';
+import { Icon, chevronLeft, chevronRight } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import { useNavigationContext } from '../context';
 import { MenuBackButtonUI } from '../styles/navigation-styles';
+import { useRTL } from '../../utils/rtl';
 
 function NavigationBackButton(
 	{ backButtonLabel, className, href, onClick, parentMenu },
@@ -38,7 +38,7 @@ function NavigationBackButton(
 			setActiveMenu( parentMenu, 'right' );
 		}
 	};
-
+	const icon = useRTL() ? chevronRight : chevronLeft;
 	return (
 		<MenuBackButtonUI
 			className={ classes }
@@ -47,10 +47,9 @@ function NavigationBackButton(
 			ref={ ref }
 			onClick={ handleOnClick }
 		>
-			<Icon icon={ chevronLeft } />
+			<Icon icon={ icon } />
 			{ backButtonLabel || parentMenuTitle || __( 'Back' ) }
 		</MenuBackButtonUI>
 	);
 }
-
 export default forwardRef( NavigationBackButton );

--- a/packages/components/src/navigation/group/index.js
+++ b/packages/components/src/navigation/group/index.js
@@ -15,12 +15,14 @@ import { useState } from '@wordpress/element';
 import { NavigationGroupContext } from './context';
 import { GroupTitleUI } from '../styles/navigation-styles';
 import { useNavigationContext } from '../context';
+import { useRTL } from '../../utils/rtl';
 
 export default function NavigationGroup( { children, className, title } ) {
 	const [ groupId ] = useState( uniqueId( 'group-' ) );
 	const {
 		navigationTree: { items },
 	} = useNavigationContext();
+	const isRTL = useRTL();
 
 	const context = { group: groupId };
 
@@ -45,6 +47,7 @@ export default function NavigationGroup( { children, className, title } ) {
 						className="components-navigation__group-title"
 						id={ groupTitleId }
 						variant="caption"
+						isRTL={ isRTL }
 					>
 						{ title }
 					</GroupTitleUI>

--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -17,6 +17,7 @@ import { ROOT_MENU } from './constants';
 import { NavigationContext } from './context';
 import { NavigationUI } from './styles/navigation-styles';
 import { useCreateNavigationTree } from './use-create-navigation-tree';
+import { useRTL } from '../utils/rtl';
 
 export default function Navigation( {
 	activeItem,
@@ -28,8 +29,9 @@ export default function Navigation( {
 	const [ menu, setMenu ] = useState( activeMenu );
 	const [ slideOrigin, setSlideOrigin ] = useState();
 	const navigationTree = useCreateNavigationTree();
+	const defaultSlideOrigin = useRTL() ? 'right' : 'left';
 
-	const setActiveMenu = ( menuId, slideInOrigin = 'left' ) => {
+	const setActiveMenu = ( menuId, slideInOrigin = defaultSlideOrigin ) => {
 		if ( ! navigationTree.getMenu( menuId ) ) {
 			return;
 		}

--- a/packages/components/src/navigation/item/index.js
+++ b/packages/components/src/navigation/item/index.js
@@ -67,6 +67,7 @@ export default function NavigationItem( props ) {
 						<ItemTitleUI
 							className="components-navigation__item-title"
 							variant="body.small"
+							isRTL={ isRTL }
 							as="span"
 						>
 							{ title }

--- a/packages/components/src/navigation/item/index.js
+++ b/packages/components/src/navigation/item/index.js
@@ -75,7 +75,10 @@ export default function NavigationItem( props ) {
 					) }
 
 					{ badge && (
-						<ItemBadgeUI className="components-navigation__item-badge">
+						<ItemBadgeUI
+							className="components-navigation__item-badge"
+							isRTL={ isRTL }
+						>
 							{ badge }
 						</ItemBadgeUI>
 					) }

--- a/packages/components/src/navigation/item/index.js
+++ b/packages/components/src/navigation/item/index.js
@@ -8,7 +8,7 @@ import { noop, uniqueId } from 'lodash';
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
-import { Icon, chevronRight } from '@wordpress/icons';
+import { Icon, chevronLeft, chevronRight } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -17,6 +17,7 @@ import Button from '../../button';
 import { useNavigationContext } from '../context';
 import { useNavigationTreeItem } from './use-navigation-tree-item';
 import { ItemBadgeUI, ItemTitleUI, ItemUI } from '../styles/navigation-styles';
+import { useRTL } from '../../utils/rtl';
 
 export default function NavigationItem( props ) {
 	const {
@@ -39,6 +40,7 @@ export default function NavigationItem( props ) {
 		navigationTree,
 		setActiveMenu,
 	} = useNavigationContext();
+	const isRTL = useRTL();
 
 	if ( ! navigationTree.getItem( itemId )?._isVisible ) {
 		return null;
@@ -55,6 +57,7 @@ export default function NavigationItem( props ) {
 
 		onClick( event );
 	};
+	const icon = isRTL ? chevronLeft : chevronRight;
 
 	return (
 		<ItemUI className={ classes }>
@@ -76,7 +79,7 @@ export default function NavigationItem( props ) {
 						</ItemBadgeUI>
 					) }
 
-					{ navigateToMenu && <Icon icon={ chevronRight } /> }
+					{ navigateToMenu && <Icon icon={ icon } /> }
 				</Button>
 			) }
 		</ItemUI>

--- a/packages/components/src/navigation/menu/menu-title.js
+++ b/packages/components/src/navigation/menu/menu-title.js
@@ -18,6 +18,7 @@ import {
 } from '../styles/navigation-styles';
 import { useNavigationMenuContext } from './context';
 import { SEARCH_FOCUS_DELAY } from '../constants';
+import { useRTL } from '../../utils/rtl';
 
 export default function NavigationMenuTitle( {
 	hasSearch,
@@ -29,6 +30,7 @@ export default function NavigationMenuTitle( {
 	const [ isSearching, setIsSearching ] = useState( false );
 	const { menu } = useNavigationMenuContext();
 	const searchButtonRef = useRef();
+	const isRTL = useRTL();
 
 	if ( ! title ) {
 		return null;
@@ -55,6 +57,7 @@ export default function NavigationMenuTitle( {
 					as="h2"
 					className="components-navigation__menu-title-heading"
 					variant="title.small"
+					isRTL={ isRTL }
 				>
 					<span id={ menuTitleId }>{ title }</span>
 

--- a/packages/components/src/navigation/stories/style.css
+++ b/packages/components/src/navigation/stories/style.css
@@ -14,6 +14,12 @@
 	fill: #949494;
 	margin-right: 8px;
 }
+
+:root[dir="rtl"] .navigation-story__wordpress-icon svg {
+	fill: #949494;
+	margin-right: 0;
+	margin-left: 8px;
+}
 .navigation-story__wordpress-icon:hover svg {
 	fill: #ddd;
 }

--- a/packages/components/src/navigation/styles/navigation-styles.js
+++ b/packages/components/src/navigation/styles/navigation-styles.js
@@ -169,7 +169,8 @@ export const ItemUI = styled.li`
 `;
 
 export const ItemBadgeUI = styled.span`
-	margin-left: 8px;
+	margin-left: ${ ( props ) => ( props.isRTL ? '0' : '8px' ) };
+	margin-right: ${ ( props ) => ( props.isRTL ? '8px' : '0' ) };
 	display: inline-flex;
 	padding: 4px 12px;
 	border-radius: 2px;

--- a/packages/components/src/navigation/styles/navigation-styles.js
+++ b/packages/components/src/navigation/styles/navigation-styles.js
@@ -61,7 +61,10 @@ export const MenuTitleHeadingUI = styled( Text )`
 	display: flex;
 	justify-content: space-between;
 	margin-bottom: ${ space( 1 ) };
-	padding: ${ space( 0.5 ) } 0 ${ space( 0.5 ) } ${ space( 2 ) };
+	padding: ${ ( props ) =>
+		props.isRTL
+			? `${ space( 0.5 ) } ${ space( 2 ) } ${ space( 0.5 ) } 0`
+			: `${ space( 0.5 ) } 0 ${ space( 0.5 ) } ${ space( 2 ) }` };
 `;
 
 export const MenuTitleActionsUI = styled.span`
@@ -126,7 +129,9 @@ export const MenuTitleSearchUI = styled.div`
 export const GroupTitleUI = styled( Text )`
 	margin-top: 8px;
 	padding: ${ ( props ) =>
-		props.isRTL ? '4px 16px 4px 0' : '4px 0 4px 16px' };
+		props.isRTL
+			? `${ space( 0.5 ) } ${ space( 2 ) } ${ space( 0.5 ) } 0`
+			: `${ space( 0.5 ) } 0 ${ space( 0.5 ) } ${ space( 2 ) }` };
 	text-transform: uppercase;
 	color: ${ G2.gray[ 100 ] };
 `;
@@ -169,8 +174,8 @@ export const ItemUI = styled.li`
 `;
 
 export const ItemBadgeUI = styled.span`
-	margin-left: ${ ( props ) => ( props.isRTL ? '0' : '8px' ) };
-	margin-right: ${ ( props ) => ( props.isRTL ? '8px' : '0' ) };
+	margin-left: ${ ( props ) => ( props.isRTL ? '0' : space( 1 ) ) };
+	margin-right: ${ ( props ) => ( props.isRTL ? space( 1 ) : '0' ) };
 	display: inline-flex;
 	padding: 4px 12px;
 	border-radius: 2px;

--- a/packages/components/src/navigation/styles/navigation-styles.js
+++ b/packages/components/src/navigation/styles/navigation-styles.js
@@ -186,7 +186,6 @@ export const ItemBadgeUI = styled.span`
 	${ reduceMotion( 'animation' ) };
 `;
 
-export const ItemTitleUI = styled( Text )`
-	margin-right: auto;
-	text-align: left;
-`;
+export const ItemTitleUI = styled( Text )( ( props ) =>
+	props.isRTL ? { marginLeft: 'auto' } : { marginRight: 'auto' }
+);

--- a/packages/components/src/navigation/styles/navigation-styles.js
+++ b/packages/components/src/navigation/styles/navigation-styles.js
@@ -125,7 +125,8 @@ export const MenuTitleSearchUI = styled.div`
 
 export const GroupTitleUI = styled( Text )`
 	margin-top: 8px;
-	padding: 4px 0 4px 16px;
+	padding: ${ ( props ) =>
+		props.isRTL ? '4px 16px 4px 0' : '4px 0 4px 16px' };
 	text-transform: uppercase;
 	color: ${ G2.gray[ 100 ] };
 `;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->
Paired programmed with @mattwiebe for these code changes

## Description
<!-- Please describe what you have changed or added -->
There are several arrow symbol and navigation items that need to be adjusted (or even moved) according to the RTL directions.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
**Site Editor**
1. Enable the site editor locally
2. Set the navigation language to one that requires an RTL view (arabic, hebrew, etc.)
3. Navigate to the site editor
4. Ensure that the UI and animations mirror the sidebar for LTR languages (english, spanish, etc.)

**Storybook**
1. Navigate to a local copy of the Gutenberg repo in a terminal shell
2. Run `yarn storybook:dev`
3. In the left sidebar, select the Navigation component
4. Use the chrome dev tools inspector and select an area near the example navigation component
5. Add the dir="rtl" attribute to the HTML element of the iframe
6. Verify that RTL language support works as expected

## Screenshots <!-- if applicable -->
### Before
![2020-10-20 13 49 15](https://user-images.githubusercontent.com/5414230/96642613-3ddd8e80-12db-11eb-8a51-42437d2ec5ef.gif)

### After
![2020-10-20 16 38 58](https://user-images.githubusercontent.com/5414230/96655702-f7942980-12f2-11eb-8d5c-3b2c81ab8dbb.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Fixes https://github.com/WordPress/gutenberg/issues/25997

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
