### PR TITLE
Fix Twenty Twenty One related e2e test failures

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,6 +1,8 @@
 {
-	"core": "WordPress/WordPress",
-	"plugins": [ "." ],
+	"core": "WordPress/WordPress#master",
+	"plugins": [
+		"."
+	],
 	"env": {
 		"tests": {
 			"mappings": {

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,5 +1,5 @@
 {
-	"core": "WordPress/WordPress#master",
+	"core": "WordPress/WordPress",
 	"plugins": [
 		"."
 	],

--- a/packages/e2e-tests/experimental-features.js
+++ b/packages/e2e-tests/experimental-features.js
@@ -50,6 +50,16 @@ export const navigationPanel = {
 		}
 	},
 
+	async close() {
+		const isOpen = !! ( await page.$(
+			'.edit-site-navigation-toggle.is-open'
+		) );
+
+		if ( isOpen ) {
+			await page.click( '.edit-site-navigation-toggle__button' );
+		}
+	},
+
 	async isRoot() {
 		const isBackToDashboardButtonVisible = !! ( await page.$(
 			'.edit-site-navigation-panel .edit-site-navigation-panel__back-to-dashboard'

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/adding-patterns.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/adding-patterns.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`adding blocks should insert a block pattern 1`] = `
+exports[`adding patterns should insert a block pattern 1`] = `
 "<!-- wp:buttons {\\"align\\":\\"center\\"} -->
 <div class=\\"wp-block-buttons aligncenter\\"><!-- wp:button {\\"borderRadius\\":2,\\"style\\":{\\"color\\":{\\"background\\":\\"#ba0c49\\",\\"text\\":\\"#fffffa\\"}}} -->
 <div class=\\"wp-block-button\\"><a class=\\"wp-block-button__link has-text-color has-background\\" style=\\"border-radius:2px;background-color:#ba0c49;color:#fffffa\\">Download now</a></div>

--- a/packages/e2e-tests/specs/editor/various/adding-patterns.test.js
+++ b/packages/e2e-tests/specs/editor/various/adding-patterns.test.js
@@ -9,7 +9,7 @@ import {
 
 /** @typedef {import('puppeteer').ElementHandle} ElementHandle */
 
-describe( 'adding blocks', () => {
+describe( 'adding patterns', () => {
 	beforeEach( async () => {
 		await createNewPost();
 	} );

--- a/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
@@ -17,6 +17,21 @@ async function openBlockNavigator() {
 	);
 }
 
+async function tabToColumnsControl() {
+	let isColumnsControl = false;
+	do {
+		await page.keyboard.press( 'Tab' );
+		isColumnsControl = await page.evaluate( () => {
+			const activeElement = document.activeElement;
+			return (
+				activeElement.tagName === 'INPUT' &&
+				activeElement.attributes.getNamedItem( 'aria-label' ).value ===
+					'Columns'
+			);
+		} );
+	} while ( ! isColumnsControl );
+}
+
 describe( 'Navigating the block hierarchy', () => {
 	beforeEach( async () => {
 		await createNewPost();
@@ -94,7 +109,7 @@ describe( 'Navigating the block hierarchy', () => {
 		await pressKeyWithModifier( 'ctrl', '`' );
 		await pressKeyWithModifier( 'ctrl', '`' );
 		await pressKeyWithModifier( 'ctrl', '`' );
-		await pressKeyTimes( 'Tab', 5 );
+		await tabToColumnsControl();
 
 		// Tweak the columns count by increasing it by one.
 		await page.keyboard.press( 'ArrowRight' );

--- a/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
+++ b/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
@@ -305,12 +305,22 @@ describe( 'Multi-block selection', () => {
 		await clickBlockAppender();
 		await page.keyboard.type( '1' );
 		await page.keyboard.press( 'Enter' );
-		await page.keyboard.type( '/cover' );
+		await page.keyboard.type( '/group' );
 		await page.waitForXPath(
-			`//*[contains(@class, "components-autocomplete__result") and contains(@class, "is-selected") and contains(text(), 'Cover')]`
+			`//*[contains(@class, "components-autocomplete__result") and contains(@class, "is-selected") and contains(text(), 'Group')]`
 		);
 		await page.keyboard.press( 'Enter' );
-		await page.click( '.components-circular-option-picker__option' );
+
+		const groupAppender = await page.waitForSelector(
+			'.block-editor-button-block-appender'
+		);
+		await groupAppender.click();
+
+		const paragraphBlockButton = await page.waitForSelector(
+			'.editor-block-list-item-paragraph'
+		);
+		await paragraphBlockButton.click();
+
 		await page.keyboard.type( '2' );
 
 		const [ coord1, coord2 ] = await page.evaluate( () => {
@@ -319,6 +329,7 @@ describe( 'Multi-block selection', () => {
 			);
 			const rect1 = elements[ 0 ].getBoundingClientRect();
 			const rect2 = elements[ 1 ].getBoundingClientRect();
+
 			return [
 				{
 					x: rect1.x + rect1.width / 2,

--- a/packages/e2e-tests/specs/editor/various/typewriter.test.js
+++ b/packages/e2e-tests/specs/editor/various/typewriter.test.js
@@ -152,23 +152,26 @@ describe( 'TypeWriter', () => {
 
 		let count = 0;
 
-		// Create blocks until the the typewriter effect kicks in.
+		// Create blocks until the the typewriter effect kicks in, create at
+		// least 10 blocks to properly test the .
 		while (
-			await page.evaluate(
+			( await page.evaluate(
 				() =>
 					wp.dom.getScrollContainer( document.activeElement )
 						.scrollTop === 0
-			)
+			) ) ||
+			count < 10
 		) {
 			await page.keyboard.press( 'Enter' );
 			count++;
 		}
 
 		// Scroll the active element to the very bottom of the scroll container,
-		// then scroll 20px down, so the caret is partially hidden.
+		// then scroll up, so the caret is partially hidden.
 		await page.evaluate( () => {
 			document.activeElement.scrollIntoView( false );
-			wp.dom.getScrollContainer( document.activeElement ).scrollTop -= 20;
+			wp.dom.getScrollContainer( document.activeElement ).scrollTop -=
+				document.activeElement.offsetHeight + 10;
 		} );
 
 		const bottomPostition = await getCaretPosition();
@@ -194,10 +197,11 @@ describe( 'TypeWriter', () => {
 		}
 
 		// Scroll the active element to the very top of the scroll container,
-		// then scroll 10px down, so the caret is partially hidden.
+		// then scroll down, so the caret is partially hidden.
 		await page.evaluate( () => {
 			document.activeElement.scrollIntoView();
-			wp.dom.getScrollContainer( document.activeElement ).scrollTop += 20;
+			wp.dom.getScrollContainer( document.activeElement ).scrollTop +=
+				document.activeElement.offsetHeight + 10;
 		} );
 
 		const topPostition = await getCaretPosition();

--- a/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
@@ -238,6 +238,12 @@ describe( 'Multi-entity save flow', () => {
 			await navigationPanel.backToRoot();
 			await navigationPanel.navigate( 'Templates' );
 			await navigationPanel.clickItemByText( 'Front page' );
+			await navigationPanel.close();
+
+			// Click the first block so that the template part inserts in the right place.
+			const firstBlock = await page.$( '.wp-block' );
+
+			await firstBlock.click();
 
 			// Insert a new template part placeholder.
 			await insertBlock( 'Template Part' );

--- a/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
@@ -242,7 +242,6 @@ describe( 'Multi-entity save flow', () => {
 
 			// Click the first block so that the template part inserts in the right place.
 			const firstBlock = await page.$( '.wp-block' );
-
 			await firstBlock.click();
 
 			// Insert a new template part placeholder.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Attempts at fixing failing end to end tests. 

Some of these are failing because the theme in the testing environment is now Twenty Twenty One. Some of the assumptions made in tests are now wrong:

- `Navigating the block hierarchy › should navigate block hierarchy using only the keyboard` - this test was assuming that the column count RangeControl would be 5 tab stops into the columns block's inspector controls. But Twenty Twenty One adds some block styles to columns, so the test has now been updated to press tab until the column count RangeControl is focused.
- `TypeWriter › should scroll caret into view from the top` - harder to track down, but I think this was failing because the paragraph font size in Twenty Twenty One is slightly larger. The page wasn't scrolling enough to take this into account.
- `Multi-block selection › should select by dragging into nested block` - I think this is similar to the above, the paragraph inside the cover block is half off-screen, seems like enough so that dragging to it doesn't work correctly, but not enough for the browser to scroll to it. I switched to a group block, but an alternative could be to scroll down after inserting the cover.

There were two that I haven't been able to reproduce locally:
- `adding patterns › should insert a block pattern` - This may be happening because patterns load in asynchronously and the test is moving too quickly.
- `adding blocks › Should insert content using the placeholder and the regular inserter` - Couldn't spot any potential issues, but it has been failing in `master`.