### PR TITLE
Fix block supports for inner blocks

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -518,3 +518,14 @@ function gutenberg_override_reusable_block_post_type_labels() {
 	);
 }
 add_filter( 'post_type_labels_wp_block', 'gutenberg_override_reusable_block_post_type_labels', 10, 0 );
+
+function gutenberg_check_render_callback( $args, $block_name ){
+	if ( NULL !== $args['render_callback'] ) {
+		$block_render_callback = $args['render_callback'];
+		$args['render_callback'] = function( $attributes, $content, $block ) use ( $block_render_callback ) {
+			return $block_render_callback( $attributes, $content, $block );
+		};
+	}
+	return $args;
+}
+add_filter( 'register_block_type_args', 'gutenberg_check_render_callback', 10, 2 );

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -530,9 +530,9 @@ $current_parsed_block = array(
  * @param array $args Block attributes.
  * @return array Block attributes.
  */
-function gutenberg_current_parsed_block_tracking( $args ){
-	if ( NULL !== $args['render_callback'] ) {
-		$block_render_callback = $args['render_callback'];
+function gutenberg_current_parsed_block_tracking( $args ) {
+	if ( null !== $args['render_callback'] ) {
+		$block_render_callback   = $args['render_callback'];
 		$args['render_callback'] = function( $attributes, $content, $block ) use ( $block_render_callback ) {
 			global $current_parsed_block;
 			$parent_parsed_block  = $current_parsed_block;

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -523,7 +523,12 @@ function gutenberg_check_render_callback( $args, $block_name ){
 	if ( NULL !== $args['render_callback'] ) {
 		$block_render_callback = $args['render_callback'];
 		$args['render_callback'] = function( $attributes, $content, $block ) use ( $block_render_callback ) {
-			return $block_render_callback( $attributes, $content, $block );
+			global $current_parsed_block;
+			$parent_parsed_block  = $current_parsed_block;
+			$current_parsed_block = $block->parsed_block;
+			$result               = $block_render_callback( $attributes, $content, $block );
+			$current_parsed_block = $parent_parsed_block;
+			return $result;
 		};
 	}
 	return $args;

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -366,18 +366,11 @@ function gutenberg_replace_default_block_categories( $default_categories ) {
 }
 add_filter( 'block_categories', 'gutenberg_replace_default_block_categories' );
 
-global $current_parsed_block;
-$current_parsed_block = array(
-	'blockName'  => null,
-	'attributes' => null,
-);
-
 /**
  * Shim that hooks into `pre_render_block` so as to override `render_block` with
  * a function that assigns block context.
  *
  * The context handling can be removed when plugin support requires WordPress 5.5.0+.
- * The global current_parsed_block assignment can be removed when plugin support requires WordPress 5.6.0+.
  *
  * @see https://core.trac.wordpress.org/ticket/49927
  * @see https://core.trac.wordpress.org/changeset/48243
@@ -389,7 +382,6 @@ $current_parsed_block = array(
  */
 function gutenberg_render_block_with_assigned_block_context( $pre_render, $parsed_block ) {
 	global $post, $wp_query;
-	global $current_parsed_block;
 
 	/*
 	 * If a non-null value is provided, a filter has run at an earlier priority
@@ -398,8 +390,6 @@ function gutenberg_render_block_with_assigned_block_context( $pre_render, $parse
 	if ( null !== $pre_render ) {
 		return $pre_render;
 	}
-
-	$current_parsed_block = $parsed_block;
 
 	$source_block = $parsed_block;
 
@@ -519,7 +509,28 @@ function gutenberg_override_reusable_block_post_type_labels() {
 }
 add_filter( 'post_type_labels_wp_block', 'gutenberg_override_reusable_block_post_type_labels', 10, 0 );
 
-function gutenberg_check_render_callback( $args, $block_name ){
+global $current_parsed_block;
+$current_parsed_block = array(
+	'blockName'  => null,
+	'attributes' => null,
+);
+
+/**
+ * Wraps the render_callback of dynamic blocks to keep track
+ * of the current block being rendered via a global variable
+ * called $current_parsed_block.
+ *
+ * This is for get_block_wrapper_attributes to get access
+ * to the runtime data of the block being rendered.
+ *
+ * This shim can be removed when the plugin requires WordPress 5.6.
+ *
+ * @since 9.2.1
+ *
+ * @param array $args Block attributes.
+ * @return array Block attributes.
+ */
+function gutenberg_current_parsed_block_tracking( $args ){
 	if ( NULL !== $args['render_callback'] ) {
 		$block_render_callback = $args['render_callback'];
 		$args['render_callback'] = function( $attributes, $content, $block ) use ( $block_render_callback ) {
@@ -533,4 +544,4 @@ function gutenberg_check_render_callback( $args, $block_name ){
 	}
 	return $args;
 }
-add_filter( 'register_block_type_args', 'gutenberg_check_render_callback', 10, 2 );
+add_filter( 'register_block_type_args', 'gutenberg_current_parsed_block_tracking' );


### PR DESCRIPTION
Alternative to https://github.com/WordPress/gutenberg/pull/26311

It fixes an issue with updating the `current_parsed_block` global value with inner blocks for the plugin, in accordance to what we did for WP core at https://github.com/WordPress/gutenberg/pull/26291 (ported over at https://github.com/WordPress/wordpress-develop/pull/626).