### PR TITLE
Fix the RTL test snapshots

### DIFF
--- a/packages/e2e-tests/specs/editor/various/__snapshots__/rtl.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/rtl.test.js.snap
@@ -8,11 +8,11 @@ exports[`RTL should arrow navigate 1`] = `
 
 exports[`RTL should arrow navigate between blocks 1`] = `
 "<!-- wp:paragraph -->
-<p>٠</p>
+<p>٠<br>١</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p><br>١١٠<br><br>٢</p>
+<p>٠<br>١<br>٢</p>
 <!-- /wp:paragraph -->"
 `;
 
@@ -24,11 +24,7 @@ exports[`RTL should merge backward 1`] = `
 
 exports[`RTL should merge forward 1`] = `
 "<!-- wp:paragraph -->
-<p>٠</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p></p>
+<p>٠١</p>
 <!-- /wp:paragraph -->"
 `;
 


### PR DESCRIPTION
For some reason, this PR introduced new snapshots for the RTL tests https://github.com/WordPress/gutenberg/pull/22213 
The problem is, these snapshots are wrong. that's not what we expect there.
I expect this PR is going to break the RTL tests but we should try to find why the result doesn't match the snapshot and not just use broken snapshots.