### PR TITLE
Movers: Small positioning refactor.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -550,18 +550,6 @@
 	.block-editor-block-mover:not(.is-horizontal) {
 		// Position SVGs.
 		.block-editor-block-mover-button {
-			&.is-up-button {
-				svg {
-					margin-top: 2px;
-				}
-			}
-
-			&.is-down-button {
-				svg {
-					margin-bottom: 3px;
-				}
-			}
-
 			&:focus::before {
 				left: 0 !important;
 				min-width: 0;

--- a/packages/block-editor/src/components/block-mover/style.scss
+++ b/packages/block-editor/src/components/block-mover/style.scss
@@ -64,10 +64,16 @@
 
 	// Position the icons correctly.
 	@include break-small() {
+		.components-toolbar-group .block-editor-block-mover-button,
+		.components-toolbar .block-editor-block-mover-button {
+			margin: 0 auto 0 0;
+		}
+
+		// Up button.
 		.components-toolbar-group .block-editor-block-mover-button.is-up-button,
 		.components-toolbar .block-editor-block-mover-button.is-up-button {
 			svg {
-				margin-bottom: -$grid-unit-10;
+				top: 5px;
 			}
 
 			// Focus style.
@@ -77,10 +83,11 @@
 			}
 		}
 
+		// Down button.
 		.components-toolbar-group .block-editor-block-mover-button.is-down-button,
 		.components-toolbar .block-editor-block-mover-button.is-down-button {
 			svg {
-				margin-top: -$grid-unit-10;
+				bottom: 5px;
 			}
 
 			// Focus style.


### PR DESCRIPTION
This PR changes the CSS for positioning the arrow SVGs inside the mover buttons.

In testing this PR, you should ideally not see any difference before and after. But there are some special instances, and I haven't narrowed down exactly what makes this happen, the mover arrows get offset by 1 pixel, probably due to browser rounding issues. 

The CSS refactor in this PR _should_ make that a thing of the past.

Before (in some rare cases):

<img width="187" alt="before" src="https://user-images.githubusercontent.com/1204802/96711318-a7be6c80-139d-11eb-927d-53b1f12b239d.png">

After:

<img width="406" alt="after" src="https://user-images.githubusercontent.com/1204802/96711323-aab95d00-139d-11eb-916b-b84e83c469f6.png">

Gif comparing the two
![rounding](https://user-images.githubusercontent.com/1204802/96711341-b0af3e00-139d-11eb-82a5-2a77b9d1f11e.gif)
