### PR TITLE
Try: Wider vanilla column width.

### DIFF
--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -71,7 +71,7 @@ $shadow-modal: 0 3px 30px rgba($black, 0.2);
  */
 
 $sidebar-width: 280px;
-$content-width: 580px; // This is optimized for 70 characters.
+$content-width: 840px;
 $widget-area-width: 700px;
 
 /**


### PR DESCRIPTION
One commont point of frustration that's been voiced with the block editor, is the thin main column of text to write in. This one:

<img width="1474" alt="before" src="https://user-images.githubusercontent.com/1204802/96716252-1226db00-13a5-11eb-8297-ae31e99c8c3a.png">

When the initial width was decided upon, it was chosen for readability and to emphasize wide and full-wide images. But most modern themes today, provide an editor style that customizes this default width, and if by updating the vanilla styles we can improve the writing experience for older themes, that seems like a good small win. This PR changes that width to 840px, which still allows for visible wide and fullwide images:

<img width="1474" alt="after" src="https://user-images.githubusercontent.com/1204802/96716417-4ac6b480-13a5-11eb-8695-28cabda36d33.png">

I'd love to do more with the default style, such as improve the font. But starting with the main column width feels like a good first step.