### PR TITLE
Block Library: Fix archive block classes (#26349)

### DIFF
--- a/phpunit/block-library/class-test-archives.php
+++ b/phpunit/block-library/class-test-archives.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Test the server-side rendering of the `core/archives` block.
+ *
+ * @package Gutenberg
+ */
+
+class Archives_Test extends WP_UnitTestCase {
+	/**
+	 * Create a shared post fixture, so that the block can return the desired markup.
+	 *
+	 * @param WP_UnitTest_Factory $factory Fixture factory singleton.
+	 */
+	public static function wpSetupBeforeClass( $factory ) {
+		$factory->post->create();
+	}
+
+	/**
+	 * Verify the block output when no posts are found.
+	 */
+	public function test_no_posts_found() {
+		// The shared fixture is published, so modifying the SQL query used by `wp_get_archives()` will make it seem
+		// like there are no posts to show.
+		add_filter(
+			'getarchives_where',
+			function( $sql_where ) {
+				return str_replace( 'publish', 'private', $sql_where );
+			}
+		);
+
+		$this->assertDiscardWhitespace(
+			'<div class="wp-block-archives wp-block-archives-list">No archives to show.</div>',
+			render_block_core_archives(
+				array(
+					'displayAsDropdown' => false,
+					'showPostCounts'    => false,
+				)
+			)
+		);
+	}
+
+	/**
+	 * Verify the block classes with the default attributes.
+	 */
+	public function test_default_block_classes_output() {
+		$this->assertContains(
+			'<ul class="wp-block-archives wp-block-archives-list">',
+			render_block_core_archives(
+				array(
+					'displayAsDropdown' => false,
+					'showPostCounts'    => false,
+				)
+			)
+		);
+	}
+
+	/**
+	 * Verify the block classes with the when displaying as a dropdown.
+	 */
+	public function test_display_as_dropdown_block_classes_output() {
+		$this->assertContains(
+			'<div class="wp-block-archives wp-block-archives-dropdown">',
+			render_block_core_archives(
+				array(
+					'displayAsDropdown' => true,
+					'showPostCounts'    => false,
+				)
+			)
+		);
+	}
+}


### PR DESCRIPTION
## Description

Issue #26349 describes how Archive blocks have an extra space before the first class. So currently the output is `class=" wp-block-archives-list wp-block-archives"`.

By using an array for constructing classes instead of string concatenation, this issue can be avoided.

This PR also fixes the escaping to always be late, and adds PHP unit tests for good measure.

## How has this been tested?
- PHP unit test.
- Manual test:
  - Open the post editor and add an Archives block.
  - View the post on the frontend and note the classes have no prepended space anymore.

## Types of changes

Bug fix, no breaking changes.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
