### PR TITLE
Update Version in WordPress doc to include 5.6

### DIFF
--- a/docs/contributors/versions-in-wordpress.md
+++ b/docs/contributors/versions-in-wordpress.md
@@ -6,6 +6,7 @@ If anything looks incorrect here, please bring it up in #core-editor in [WordPre
 
 | Gutenberg Versions | WordPress Version |
 | ------------------ | ----------------- |
+| 8.5.1-9.2            | 5.6             |
 | 7.6-8.5            | 5.5.1             |
 | 7.6-8.5            | 5.5               |
 | 6.6-7.5            | 5.4.2             |


### PR DESCRIPTION
I haven't yet included 5.5.2 as it's unclear to me if a minor release is still slated to happen. I will update this once more if so!

