### PR TITLE
Block widget: Set container classname dynamically depending on block

### DIFF
--- a/packages/e2e-tests/specs/widgets/adding-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/adding-widgets.test.js
@@ -163,10 +163,10 @@ describe( 'Widgets screen', () => {
 		const serializedWidgetAreas = await getSerializedWidgetAreas();
 		expect( serializedWidgetAreas ).toMatchInlineSnapshot( `
 		Object {
-		  "sidebar-1": "<div class=\\"widget widget_block\\"><div class=\\"widget-content\\">
+		  "sidebar-1": "<div class=\\"widget widget_block widget_text\\"><div class=\\"widget-content\\">
 		<p>First Paragraph</p>
 		</div></div>
-		<div class=\\"widget widget_block\\"><div class=\\"widget-content\\">
+		<div class=\\"widget widget_block widget_text\\"><div class=\\"widget-content\\">
 		<p>Second Paragraph</p>
 		</div></div>",
 		}
@@ -295,13 +295,13 @@ describe( 'Widgets screen', () => {
 		const serializedWidgetAreas = await getSerializedWidgetAreas();
 		expect( serializedWidgetAreas ).toMatchInlineSnapshot( `
 		Object {
-		  "sidebar-1": "<div class=\\"widget widget_block\\"><div class=\\"widget-content\\">
+		  "sidebar-1": "<div class=\\"widget widget_block widget_text\\"><div class=\\"widget-content\\">
 		<p>First Paragraph</p>
 		</div></div>
 		<div class=\\"widget widget_block\\"><div class=\\"widget-content\\">
 		<h2>My Heading</h2>
 		</div></div>
-		<div class=\\"widget widget_block\\"><div class=\\"widget-content\\">
+		<div class=\\"widget widget_block widget_text\\"><div class=\\"widget-content\\">
 		<p>Second Paragraph</p>
 		</div></div>",
 		}
@@ -379,10 +379,10 @@ describe( 'Widgets screen', () => {
 		const serializedWidgetAreas = await getSerializedWidgetAreas();
 		expect( serializedWidgetAreas ).toMatchInlineSnapshot( `
 		Object {
-		  "sidebar-1": "<div class=\\"widget widget_block\\"><div class=\\"widget-content\\">
+		  "sidebar-1": "<div class=\\"widget widget_block widget_text\\"><div class=\\"widget-content\\">
 		<p>First Paragraph</p>
 		</div></div>
-		<div class=\\"widget widget_block\\"><div class=\\"widget-content\\">
+		<div class=\\"widget widget_block widget_text\\"><div class=\\"widget-content\\">
 		<p>First Paragraph</p>
 		</div></div>",
 		}


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/25822.

Updates `WP_Widget_Block` to dynamically set the classname used in the block widget's container HTML. This way, if a block widget contains a block that has an equivalent legacy widget, we can display that legacy widget's class name.

This lessens the likelihood that a theme's CSS styles need to be updated to work correctly with a block widget.

A new `widget_block_dynamic_classname` filter has also been added. This lets third parties do something similar for their blocks and complements the existing `widgets_to_exclude_from_legacy_widget_block` filter.

### An example

To illustrate, this is how the **Archives widget** renders in a sidebar today:

```html
<div class="widget widget_archive">
	<div class="widget-content">
		<ul>
			<li><a href="https://test.local/2020/08/">August 2020</a></li>
			<li><a href="https://test.local/2020/07/">July 2020</a></li>
		</ul>
	</div>
</div>
```

And this is how the **Archives block** renders in a sidebar today:

```html
<div class="widget widget_block">
	<div class="widget-content">
		<ul class="wp-block-archives-list wp-block-archives">
			<li><a href="http://localhost:8889/?m=202009">September 2020</a></li>
			<li><a href="http://localhost:8889/?m=202004">April 2020</a></li>
		</ul>
	</div>
</div>
```

With this change, the Archives block renders like so:

```html
<div class="widget widget_block widget_archive">
	<div class="widget-content">
		<ul class="wp-block-archives-list wp-block-archives">
			<li><a href="http://localhost:8889/?m=202009">September 2020</a></li>
			<li><a href="http://localhost:8889/?m=202004">April 2020</a></li>
		</ul>
	</div>
</div>
```

Note the addition of the `widget_archive` classname.

### To test

1. Go to Appearance → Widgets
1. Add an e.g. Search block
1. Preview the frontend. Notice that `widget_search` appears in the markup surrounding the Search block