### PR TITLE
Fix image block centering when resizing to a smaller size

### DIFF
--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -2,6 +2,15 @@ figure.wp-block-image:not(.wp-block) {
 	margin: 0;
 }
 
+figure.wp-block {
+	// Because blocks have margin left/right of `auto`, the figure should
+	// stay full-size so it doesn't unexpectedly center when the image inside
+	// it is resized to smaller proportions.
+	// This is needed specifically for the image block because the figure has
+	// `display: table` so the default behavior is for its width to collapse.
+	width: 100%;
+}
+
 .wp-block-image {
 	position: relative;
 

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -52,6 +52,19 @@ figure.wp-block-image:not(.wp-block) {
 	}
 }
 
+.wp-block[data-align="left"],
+.wp-block[data-align="center"],
+.wp-block[data-align="right"] {
+	> .wp-block-image {
+		display: table;
+
+		> figcaption {
+			display: table-caption;
+			caption-side: bottom;
+		}
+	}
+}
+
 .wp-block[data-align="left"] > .wp-block-image {
 	margin-right: 1em;
 	margin-left: 0;

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -2,15 +2,6 @@ figure.wp-block-image:not(.wp-block) {
 	margin: 0;
 }
 
-figure.wp-block {
-	// Because blocks have margin left/right of `auto`, the figure should
-	// stay full-size so it doesn't unexpectedly center when the image inside
-	// it is resized to smaller proportions.
-	// This is needed specifically for the image block because the figure has
-	// `display: table` so the default behavior is for its width to collapse.
-	width: 100%;
-}
-
 .wp-block-image {
 	position: relative;
 

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -18,8 +18,7 @@
 
 	.alignleft,
 	.alignright,
-	.aligncenter,
-	&.is-resized {
+	.aligncenter {
 		display: table;
 
 		> figcaption {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes #23986

When resizing an image to be smaller, the block was unexpectedly centering.

The wrapping `figure` for the image block is set to `display: table`. When its contents are resized to a smaller size this wrapper's width collapses to its content size. At the same time blocks have `auto` left and right margin, so the image ends up centered.

The fix I've applied is to add `with: 100%` to the figure so that it behave more like `display: block`.

## How has this been tested?
1. Add an image block
2. Make it smaller
3. The image should stay left aligned
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
