### PR TITLE
Query block: Expose initial templates as block variations

### DIFF
--- a/packages/block-library/src/query/edit/query-placeholder.js
+++ b/packages/block-library/src/query/edit/query-placeholder.js
@@ -1,0 +1,55 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+import {
+	useBlockProps,
+	__experimentalBlockVariationPicker,
+} from '@wordpress/block-editor';
+import { createBlocksFromInnerBlocksTemplate } from '@wordpress/blocks';
+
+const QueryPlaceholder = ( { clientId, name, setAttributes } ) => {
+	const { blockType, defaultVariation, variations } = useSelect(
+		( select ) => {
+			const {
+				getBlockVariations,
+				getBlockType,
+				getDefaultBlockVariation,
+			} = select( 'core/blocks' );
+
+			return {
+				blockType: getBlockType( name ),
+				defaultVariation: getDefaultBlockVariation( name, 'block' ),
+				variations: getBlockVariations( name, 'block' ),
+			};
+		},
+		[ name ]
+	);
+	const { replaceInnerBlocks } = useDispatch( 'core/block-editor' );
+	const blockProps = useBlockProps();
+	return (
+		<div { ...blockProps }>
+			<__experimentalBlockVariationPicker
+				icon={ blockType?.icon?.src }
+				label={ blockType?.title }
+				variations={ variations }
+				onSelect={ ( nextVariation = defaultVariation ) => {
+					if ( nextVariation.attributes ) {
+						setAttributes( nextVariation.attributes );
+					}
+					if ( nextVariation.innerBlocks ) {
+						replaceInnerBlocks(
+							clientId,
+							createBlocksFromInnerBlocksTemplate(
+								nextVariation.innerBlocks
+							),
+							false
+						);
+					}
+				} }
+			/>
+		</div>
+	);
+};
+
+export default QueryPlaceholder;

--- a/packages/block-library/src/query/icons.js
+++ b/packages/block-library/src/query/icons.js
@@ -1,0 +1,30 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, SVG } from '@wordpress/components';
+
+export const titleDate = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 34 30">
+		<Path d="M34 0H0v3h34V0zM12 5H0v1h12V5zM0 17h12v1H0v-1zm34-5H0v3h34v-3zM0 29h12v1H0v-1zm34-5H0v3h34v-3z" />
+	</SVG>
+);
+
+export const titleExcerpt = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 34 30">
+		<Path d="M34 0H0v3h34V0zm-4 5H0v1h30V5zm4 3H0v1h34V8zM0 11h30v1H0v-1zm0 12h30v1H0v-1zm34 3H0v1h34v-1zM0 29h30v1H0v-1zm34-11H0v3h34v-3z" />
+	</SVG>
+);
+
+export const titleDateExcerpt = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 34 30">
+		<Path d="M34 0H0v3h34V0zM12 5H0v1h12V5zm22 3H0v1h34V8zM0 11h34v1H0v-1zm0 12h12v1H0v-1zm34 3H0v1h34v-1zM0 29h34v1H0v-1zm34-11H0v3h34v-3z" />
+	</SVG>
+);
+
+export const titleContent = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 34 30">
+		<Path d="M0 5h30v1H0zM0 17h30v1H0zM0 11h30v1H0zM0 23h30v1H0zM0 8h34v1H0zM0 20h34v1H0zM0 14h34v1H0zM0 26h34v1H0zM0 29h34v1H0zM0 0h34v3H0z" />
+	</SVG>
+);
+
+export default { titleDate, titleExcerpt, titleDateExcerpt, titleContent };

--- a/packages/block-library/src/query/icons.js
+++ b/packages/block-library/src/query/icons.js
@@ -4,25 +4,25 @@
 import { Path, SVG } from '@wordpress/components';
 
 export const titleDate = (
-	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 34 30">
-		<Path d="M34 0H0v3h34V0zM12 5H0v1h12V5zM0 17h12v1H0v-1zm34-5H0v3h34v-3zM0 29h12v1H0v-1zm34-5H0v3h34v-3z" />
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+  		<Path d="M41 9H7v3h34V9zm-22 5H7v1h12v-1zM7 26h12v1H7v-1zm34-5H7v3h34v-3zM7 38h12v1H7v-1zm34-5H7v3h34v-3z" />
 	</SVG>
 );
 
 export const titleExcerpt = (
-	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 34 30">
-		<Path d="M34 0H0v3h34V0zm-4 5H0v1h30V5zm4 3H0v1h34V8zM0 11h30v1H0v-1zm0 12h30v1H0v-1zm34 3H0v1h34v-1zM0 29h30v1H0v-1zm34-11H0v3h34v-3z" />
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+  		<Path d="M41 9H7v3h34V9zm-4 5H7v1h30v-1zm4 3H7v1h34v-1zM7 20h30v1H7v-1zm0 12h30v1H7v-1zm34 3H7v1h34v-1zM7 38h30v1H7v-1zm34-11H7v3h34v-3z" />
 	</SVG>
 );
 
 export const titleDateExcerpt = (
-	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 34 30">
-		<Path d="M34 0H0v3h34V0zM12 5H0v1h12V5zm22 3H0v1h34V8zM0 11h34v1H0v-1zm0 12h12v1H0v-1zm34 3H0v1h34v-1zM0 29h34v1H0v-1zm34-11H0v3h34v-3z" />
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+  		<Path d="M41 9H7v3h34V9zm-22 5H7v1h12v-1zm22 3H7v1h34v-1zM7 20h34v1H7v-1zm0 12h12v1H7v-1zm34 3H7v1h34v-1zM7 38h34v1H7v-1zm34-11H7v3h34v-3z" />
 	</SVG>
 );
 
 export const imageDateTitle = (
-	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 34 30">
-		<Path d="M0 0h34v6H0V0zm12 8H0v1h12V8zm18 3H0v1h30v-1zm0 18H0v1h30v-1zM0 26h12v1H0v-1zm34-8H0v6h34v-6z" />
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+  		<Path d="M7 9h34v6H7V9zm12 8H7v1h12v-1zm18 3H7v1h30v-1zm0 18H7v1h30v-1zM7 35h12v1H7v-1zm34-8H7v6h34v-6z" />
 	</SVG>
 );

--- a/packages/block-library/src/query/icons.js
+++ b/packages/block-library/src/query/icons.js
@@ -21,10 +21,8 @@ export const titleDateExcerpt = (
 	</SVG>
 );
 
-export const titleContent = (
+export const imageDateTitle = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 34 30">
-		<Path d="M0 5h30v1H0zM0 17h30v1H0zM0 11h30v1H0zM0 23h30v1H0zM0 8h34v1H0zM0 20h34v1H0zM0 14h34v1H0zM0 26h34v1H0zM0 29h34v1H0zM0 0h34v3H0z" />
+		<Path d="M0 0h34v6H0V0zm12 8H0v1h12V8zm18 3H0v1h30v-1zm0 18H0v1h30v-1zM0 26h12v1H0v-1zm34-8H0v6h34v-6z" />
 	</SVG>
 );
-
-export default { titleDate, titleExcerpt, titleDateExcerpt, titleContent };

--- a/packages/block-library/src/query/icons.js
+++ b/packages/block-library/src/query/icons.js
@@ -5,24 +5,24 @@ import { Path, SVG } from '@wordpress/components';
 
 export const titleDate = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
-  		<Path d="M41 9H7v3h34V9zm-22 5H7v1h12v-1zM7 26h12v1H7v-1zm34-5H7v3h34v-3zM7 38h12v1H7v-1zm34-5H7v3h34v-3z" />
+		<Path d="M41 9H7v3h34V9zm-22 5H7v1h12v-1zM7 26h12v1H7v-1zm34-5H7v3h34v-3zM7 38h12v1H7v-1zm34-5H7v3h34v-3z" />
 	</SVG>
 );
 
 export const titleExcerpt = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
-  		<Path d="M41 9H7v3h34V9zm-4 5H7v1h30v-1zm4 3H7v1h34v-1zM7 20h30v1H7v-1zm0 12h30v1H7v-1zm34 3H7v1h34v-1zM7 38h30v1H7v-1zm34-11H7v3h34v-3z" />
+		<Path d="M41 9H7v3h34V9zm-4 5H7v1h30v-1zm4 3H7v1h34v-1zM7 20h30v1H7v-1zm0 12h30v1H7v-1zm34 3H7v1h34v-1zM7 38h30v1H7v-1zm34-11H7v3h34v-3z" />
 	</SVG>
 );
 
 export const titleDateExcerpt = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
-  		<Path d="M41 9H7v3h34V9zm-22 5H7v1h12v-1zm22 3H7v1h34v-1zM7 20h34v1H7v-1zm0 12h12v1H7v-1zm34 3H7v1h34v-1zM7 38h34v1H7v-1zm34-11H7v3h34v-3z" />
+		<Path d="M41 9H7v3h34V9zm-22 5H7v1h12v-1zm22 3H7v1h34v-1zM7 20h34v1H7v-1zm0 12h12v1H7v-1zm34 3H7v1h34v-1zM7 38h34v1H7v-1zm34-11H7v3h34v-3z" />
 	</SVG>
 );
 
 export const imageDateTitle = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
-  		<Path d="M7 9h34v6H7V9zm12 8H7v1h12v-1zm18 3H7v1h30v-1zm0 18H7v1h30v-1zM7 35h12v1H7v-1zm34-8H7v6h34v-6z" />
+		<Path d="M7 9h34v6H7V9zm12 8H7v1h12v-1zm18 3H7v1h30v-1zm0 18H7v1h30v-1zM7 35h12v1H7v-1zm34-8H7v6h34v-6z" />
 	</SVG>
 );

--- a/packages/block-library/src/query/index.js
+++ b/packages/block-library/src/query/index.js
@@ -9,6 +9,7 @@ import { __ } from '@wordpress/i18n';
 import metadata from './block.json';
 import edit from './edit';
 import save from './save';
+import variations from './variations';
 
 const { name } = metadata;
 export { metadata, name };
@@ -17,6 +18,7 @@ export const settings = {
 	title: __( 'Query' ),
 	edit,
 	save,
+	variations,
 };
 
 export { useQueryContext } from './edit';

--- a/packages/block-library/src/query/index.js
+++ b/packages/block-library/src/query/index.js
@@ -16,6 +16,7 @@ export { metadata, name };
 
 export const settings = {
 	title: __( 'Query' ),
+	description: __( 'Displays a list of entities as a result of a query.' ),
 	edit,
 	save,
 	variations,

--- a/packages/block-library/src/query/index.js
+++ b/packages/block-library/src/query/index.js
@@ -16,7 +16,7 @@ export { metadata, name };
 
 export const settings = {
 	title: __( 'Query' ),
-	description: __( 'Displays a list of entities as a result of a query.' ),
+	description: __( 'Displays a list of posts as a result of a query.' ),
 	edit,
 	save,
 	variations,

--- a/packages/block-library/src/query/variations.js
+++ b/packages/block-library/src/query/variations.js
@@ -2,13 +2,22 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { heading, paragraph, list } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import {
+	titleDate,
+	titleExcerpt,
+	titleDateExcerpt,
+	titleContent,
+} from './icons';
 
 const variations = [
 	{
 		name: 'title-date',
 		title: __( 'Title and Date' ),
-		icon: list,
+		icon: titleDate,
 		innerBlocks: [
 			[
 				'core/query-loop',
@@ -19,14 +28,14 @@ const variations = [
 		scope: [ 'block' ],
 	},
 	{
-		name: 'title-image',
-		title: __( 'Title and Featured Image' ),
-		icon: heading,
+		name: 'title-excerpt',
+		title: __( 'Title and Excerpt' ),
+		icon: titleExcerpt,
 		innerBlocks: [
 			[
 				'core/query-loop',
 				{},
-				[ [ 'core/post-title' ], [ 'core/post-featured-image' ] ],
+				[ [ 'core/post-title' ], [ 'core/post-excerpt' ] ],
 			],
 		],
 		scope: [ 'block' ],
@@ -34,7 +43,7 @@ const variations = [
 	{
 		name: 'title-date-excerpt',
 		title: __( 'Title, Date and Excerpt' ),
-		icon: paragraph,
+		icon: titleDateExcerpt,
 		innerBlocks: [
 			[
 				'core/query-loop',
@@ -44,6 +53,19 @@ const variations = [
 					[ 'core/post-date' ],
 					[ 'core/post-excerpt' ],
 				],
+			],
+		],
+		scope: [ 'block' ],
+	},
+	{
+		name: 'title-content',
+		title: __( 'Title and Content' ),
+		icon: titleContent,
+		innerBlocks: [
+			[
+				'core/query-loop',
+				{},
+				[ [ 'core/post-title' ], [ 'core/post-content' ] ],
 			],
 		],
 		scope: [ 'block' ],

--- a/packages/block-library/src/query/variations.js
+++ b/packages/block-library/src/query/variations.js
@@ -1,0 +1,53 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { heading, paragraph, list } from '@wordpress/icons';
+
+const variations = [
+	{
+		name: 'title-date',
+		title: __( 'Title and Date' ),
+		icon: list,
+		innerBlocks: [
+			[
+				'core/query-loop',
+				{},
+				[ [ 'core/post-title' ], [ 'core/post-date' ] ],
+			],
+		],
+		scope: [ 'block' ],
+	},
+	{
+		name: 'title-image',
+		title: __( 'Title and Featured Image' ),
+		icon: heading,
+		innerBlocks: [
+			[
+				'core/query-loop',
+				{},
+				[ [ 'core/post-title' ], [ 'core/post-featured-image' ] ],
+			],
+		],
+		scope: [ 'block' ],
+	},
+	{
+		name: 'title-date-excerpt',
+		title: __( 'Title, Date and Excerpt' ),
+		icon: paragraph,
+		innerBlocks: [
+			[
+				'core/query-loop',
+				{},
+				[
+					[ 'core/post-title' ],
+					[ 'core/post-date' ],
+					[ 'core/post-excerpt' ],
+				],
+			],
+		],
+		scope: [ 'block' ],
+	},
+];
+
+export default variations;

--- a/packages/block-library/src/query/variations.js
+++ b/packages/block-library/src/query/variations.js
@@ -10,7 +10,7 @@ import {
 	titleDate,
 	titleExcerpt,
 	titleDateExcerpt,
-	titleContent,
+	imageDateTitle,
 } from './icons';
 
 const variations = [
@@ -58,14 +58,18 @@ const variations = [
 		scope: [ 'block' ],
 	},
 	{
-		name: 'title-content',
-		title: __( 'Title and Content' ),
-		icon: titleContent,
+		name: 'image-date-title',
+		title: __( 'Image, Date and Title ' ),
+		icon: imageDateTitle,
 		innerBlocks: [
 			[
 				'core/query-loop',
 				{},
-				[ [ 'core/post-title' ], [ 'core/post-content' ] ],
+				[
+					[ 'core/post-featured-image' ],
+					[ 'core/post-date' ],
+					[ 'core/post-title' ],
+				],
 			],
 		],
 		scope: [ 'block' ],


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Resolves: https://github.com/WordPress/gutenberg/issues/26194

This PR expose initial templates like `Title and Excerpt`, `Title and Featured Image` as block variations of the `Query` block.
For now it uses the `Placeholder` pattern like `Columns` and these variations are not exposed in the inserter.



## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
