### PR TITLE
Upgrade webpack to version 5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,8 +48,7 @@
 		"@babel/compat-data": {
 			"version": "7.12.7",
 			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.12.7.tgz",
-			"integrity": "sha512-YaxPMGs/XIWtYqrdEOZOCPsVWfEoriXopnsz3/i7apYPXQ3698UFhS6dVT1KN5qOsWmVgw/FOrmQgpRaZayGsw==",
-			"dev": true
+			"integrity": "sha512-YaxPMGs/XIWtYqrdEOZOCPsVWfEoriXopnsz3/i7apYPXQ3698UFhS6dVT1KN5qOsWmVgw/FOrmQgpRaZayGsw=="
 		},
 		"@babel/core": {
 			"version": "7.12.9",
@@ -160,7 +159,6 @@
 			"version": "7.12.5",
 			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.12.5.tgz",
 			"integrity": "sha512-+qH6NrscMolUlzOYngSBMIOQpKUGPPsc61Bu5W10mg84LxZ7cmvnBHzARKbDoFxVvqqAbj6Tg6N7bSrWSPXMyw==",
-			"dev": true,
 			"requires": {
 				"@babel/compat-data": "^7.12.5",
 				"@babel/helper-validator-option": "^7.12.1",
@@ -171,8 +169,7 @@
 				"semver": {
 					"version": "5.7.1",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 				}
 			}
 		},
@@ -252,7 +249,6 @@
 			"version": "7.10.4",
 			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.10.4.tgz",
 			"integrity": "sha512-wljroF5PgCk2juF69kanHVs6vrLwIPNp6DLD+Lrl3hoQ3PpPPikaDRNFA+0t81NOoMt2DL6WW/mdU8k4k6ZzuA==",
-			"dev": true,
 			"requires": {
 				"@babel/types": "^7.10.4"
 			}
@@ -355,8 +351,7 @@
 		"@babel/helper-validator-option": {
 			"version": "7.12.1",
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.1.tgz",
-			"integrity": "sha512-YpJabsXlJVWP0USHjnC/AQDTLlZERbON577YUVO/wLpqyj6HAtVYnWaQaN0iUN+1/tWn3c+uKKXjRut5115Y2A==",
-			"dev": true
+			"integrity": "sha512-YpJabsXlJVWP0USHjnC/AQDTLlZERbON577YUVO/wLpqyj6HAtVYnWaQaN0iUN+1/tWn3c+uKKXjRut5115Y2A=="
 		},
 		"@babel/helper-wrap-function": {
 			"version": "7.12.3",
@@ -418,7 +413,6 @@
 			"version": "7.12.1",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.12.1.tgz",
 			"integrity": "sha512-d+/o30tJxFxrA1lhzJqiUcEJdI6jKlNregCv5bASeGf2Q4MXmnwH7viDo7nhx1/ohf09oaH8j1GVYG/e3Yqk6A==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4",
 				"@babel/helper-remap-async-to-generator": "^7.12.1",
@@ -449,7 +443,6 @@
 			"version": "7.12.1",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.12.1.tgz",
 			"integrity": "sha512-a4rhUSZFuq5W8/OO8H7BL5zspjnc1FLd9hlOxIK/f7qG4a0qsqk8uvF/ywgBA8/OmjsapjpvaEOYItfGG1qIvQ==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4",
 				"@babel/plugin-syntax-dynamic-import": "^7.8.0"
@@ -468,7 +461,6 @@
 			"version": "7.12.1",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.12.1.tgz",
 			"integrity": "sha512-6CThGf0irEkzujYS5LQcjBx8j/4aQGiVv7J9+2f7pGfxqyKh3WnmVJYW3hdrQjyksErMGBPQrCnHfOtna+WLbw==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4",
 				"@babel/plugin-syntax-export-namespace-from": "^7.8.3"
@@ -478,7 +470,6 @@
 			"version": "7.12.1",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.12.1.tgz",
 			"integrity": "sha512-GoLDUi6U9ZLzlSda2Df++VSqDJg3CG+dR0+iWsv6XRw1rEq+zwt4DirM9yrxW6XWaTpmai1cWJLMfM8qQJf+yw==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4",
 				"@babel/plugin-syntax-json-strings": "^7.8.0"
@@ -488,7 +479,6 @@
 			"version": "7.12.1",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.12.1.tgz",
 			"integrity": "sha512-k8ZmVv0JU+4gcUGeCDZOGd0lCIamU/sMtIiX3UWnUc5yzgq6YUGyEolNYD+MLYKfSzgECPcqetVcJP9Afe/aCA==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4",
 				"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
@@ -507,7 +497,6 @@
 			"version": "7.12.7",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.12.7.tgz",
 			"integrity": "sha512-8c+uy0qmnRTeukiGsjLGy6uVs/TFjJchGXUeBqlG4VWYOdJWkhhVPdQ3uHwbmalfJwv2JsV0qffXP4asRfL2SQ==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4",
 				"@babel/plugin-syntax-numeric-separator": "^7.10.4"
@@ -546,7 +535,6 @@
 			"version": "7.12.1",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.12.1.tgz",
 			"integrity": "sha512-mwZ1phvH7/NHK6Kf8LP7MYDogGV+DKB1mryFOEwx5EBNQrosvIczzZFTUmWaeujd5xT6G1ELYWUz3CutMhjE1w==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-create-class-features-plugin": "^7.12.1",
 				"@babel/helper-plugin-utils": "^7.10.4"
@@ -556,7 +544,6 @@
 			"version": "7.12.1",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.12.1.tgz",
 			"integrity": "sha512-MYq+l+PvHuw/rKUz1at/vb6nCnQ2gmJBNaM62z0OgH7B2W1D9pvkpYtlti9bGtizNIU1K3zm4bZF9F91efVY0w==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-create-regexp-features-plugin": "^7.12.1",
 				"@babel/helper-plugin-utils": "^7.10.4"
@@ -566,7 +553,6 @@
 			"version": "7.8.4",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
 			"integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.0"
 			}
@@ -617,7 +603,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
 			"integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3"
 			}
@@ -643,7 +628,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
 			"integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.0"
 			}
@@ -660,7 +644,6 @@
 			"version": "7.10.4",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
 			"integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
@@ -677,7 +660,6 @@
 			"version": "7.10.4",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
 			"integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
@@ -710,7 +692,6 @@
 			"version": "7.12.1",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.12.1.tgz",
 			"integrity": "sha512-i7ooMZFS+a/Om0crxZodrTzNEPJHZrlMVGMTEpFAj6rYY/bKCddB0Dk/YxfPuYXOopuhKk/e1jV6h+WUU9XN3A==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
@@ -799,7 +780,6 @@
 			"version": "7.12.1",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.12.1.tgz",
 			"integrity": "sha512-B2pXeRKoLszfEW7J4Hg9LoFaWEbr/kzo3teWHmtFCszjRNa/b40f9mfeqZsIDLLt/FjwQ6pz/Gdlwy85xNckBA==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-create-regexp-features-plugin": "^7.12.1",
 				"@babel/helper-plugin-utils": "^7.10.4"
@@ -809,7 +789,6 @@
 			"version": "7.12.1",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.12.1.tgz",
 			"integrity": "sha512-iRght0T0HztAb/CazveUpUQrZY+aGKKaWXMJ4uf9YJtqxSUe09j3wteztCUDRHs+SRAL7yMuFqUsLoAKKzgXjw==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
@@ -869,7 +848,6 @@
 			"version": "7.12.1",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.12.1.tgz",
 			"integrity": "sha512-tDW8hMkzad5oDtzsB70HIQQRBiTKrhfgwC/KkJeGsaNFTdWhKNt/BiE8c5yj19XiGyrxpbkOfH87qkNg1YGlOQ==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-module-transforms": "^7.12.1",
 				"@babel/helper-plugin-utils": "^7.10.4",
@@ -880,7 +858,6 @@
 					"version": "2.3.3",
 					"resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
 					"integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
-					"dev": true,
 					"requires": {
 						"object.assign": "^4.1.0"
 					}
@@ -912,7 +889,6 @@
 			"version": "7.12.1",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.12.1.tgz",
 			"integrity": "sha512-Hn7cVvOavVh8yvW6fLwveFqSnd7rbQN3zJvoPNyNaQSvgfKmDBO9U1YL9+PCXGRlZD9tNdWTy5ACKqMuzyn32Q==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-hoist-variables": "^7.10.4",
 				"@babel/helper-module-transforms": "^7.12.1",
@@ -925,7 +901,6 @@
 					"version": "2.3.3",
 					"resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
 					"integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
-					"dev": true,
 					"requires": {
 						"object.assign": "^4.1.0"
 					}
@@ -936,7 +911,6 @@
 			"version": "7.12.1",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.12.1.tgz",
 			"integrity": "sha512-aEIubCS0KHKM0zUos5fIoQm+AZUMt1ZvMpqz0/H5qAQ7vWylr9+PLYurT+Ic7ID/bKLd4q8hDovaG3Zch2uz5Q==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-module-transforms": "^7.12.1",
 				"@babel/helper-plugin-utils": "^7.10.4"
@@ -946,7 +920,6 @@
 			"version": "7.12.1",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.12.1.tgz",
 			"integrity": "sha512-tB43uQ62RHcoDp9v2Nsf+dSM8sbNodbEicbQNA53zHz8pWUhsgHSJCGpt7daXxRydjb0KnfmB+ChXOv3oADp1Q==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-create-regexp-features-plugin": "^7.12.1"
 			}
@@ -955,7 +928,6 @@
 			"version": "7.12.1",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.12.1.tgz",
 			"integrity": "sha512-+eW/VLcUL5L9IvJH7rT1sT0CzkdUTvPrXC2PXTn/7z7tXLBuKvezYbGdxD5WMRoyvyaujOq2fWoKl869heKjhw==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
@@ -997,7 +969,6 @@
 			"version": "7.12.1",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.12.1.tgz",
 			"integrity": "sha512-KOHd0tIRLoER+J+8f9DblZDa1fLGPwaaN1DI1TVHuQFOpjHV22C3CUB3obeC4fexHY9nx+fH0hQNvLFFfA1mxA==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
@@ -1025,7 +996,6 @@
 			"version": "7.12.7",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.12.7.tgz",
 			"integrity": "sha512-Rs3ETtMtR3VLXFeYRChle5SsP/P9Jp/6dsewBQfokDSzKJThlsuFcnzLTDRALiUmTC48ej19YD9uN1mupEeEDg==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-builder-react-jsx-experimental": "^7.12.4",
 				"@babel/helper-plugin-utils": "^7.10.4",
@@ -1036,7 +1006,6 @@
 			"version": "7.12.1",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.12.1.tgz",
 			"integrity": "sha512-FbpL0ieNWiiBB5tCldX17EtXgmzeEZjFrix72rQYeq9X6nUK38HCaxexzVQrZWXanxKJPKVVIU37gFjEQYkPkA==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
@@ -1053,7 +1022,6 @@
 			"version": "7.12.1",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.12.1.tgz",
 			"integrity": "sha512-RqeaHiwZtphSIUZ5I85PEH19LOSzxfuEazoY7/pWASCAIBuATQzpSVD+eT6MebeeZT2F4eSL0u4vw6n4Nm0Mjg==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.10.4",
 				"@babel/helper-plugin-utils": "^7.10.4"
@@ -1071,7 +1039,6 @@
 			"version": "7.12.1",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.12.1.tgz",
 			"integrity": "sha512-pOnUfhyPKvZpVyBHhSBoX8vfA09b7r00Pmm1sH+29ae2hMTKVmSp4Ztsr8KBKjLjx17H0eJqaRC3bR2iThM54A==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
@@ -1131,7 +1098,6 @@
 			"version": "7.12.1",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.12.1.tgz",
 			"integrity": "sha512-EPGgpGy+O5Kg5pJFNDKuxt9RdmTgj5sgrus2XVeMp/ZIbOESadgILUbm50SNpghOh3/6yrbsH+NB5+WJTmsA7Q==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
@@ -1150,7 +1116,6 @@
 			"version": "7.12.1",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.12.1.tgz",
 			"integrity": "sha512-I8gNHJLIc7GdApm7wkVnStWssPNbSRMPtgHdmH3sRM1zopz09UWPS4x5V4n1yz/MIWTVnJ9sp6IkuXdWM4w+2Q==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
@@ -1168,7 +1133,6 @@
 			"version": "7.12.7",
 			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.12.7.tgz",
 			"integrity": "sha512-OnNdfAr1FUQg7ksb7bmbKoby4qFOHw6DKWWUNB9KqnnCldxhxJlP+21dpyaWFmf2h0rTbOkXJtAGevY3XW1eew==",
-			"dev": true,
 			"requires": {
 				"@babel/compat-data": "^7.12.7",
 				"@babel/helper-compilation-targets": "^7.12.5",
@@ -1242,7 +1206,6 @@
 					"version": "3.8.1",
 					"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.8.1.tgz",
 					"integrity": "sha512-a16TLmy9NVD1rkjUGbwuyWkiDoN0FDpAwrfLONvHFQx0D9k7J9y0srwMT8QP/Z6HE3MIFaVynEeYwZwPX1o5RQ==",
-					"dev": true,
 					"requires": {
 						"browserslist": "^4.15.0",
 						"semver": "7.0.0"
@@ -1251,16 +1214,14 @@
 						"semver": {
 							"version": "7.0.0",
 							"resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-							"integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
-							"dev": true
+							"integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A=="
 						}
 					}
 				},
 				"semver": {
 					"version": "5.7.1",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 				}
 			}
 		},
@@ -1278,7 +1239,6 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.4.tgz",
 			"integrity": "sha512-J36NhwnfdzpmH41M1DrnkkgAqhZaqr/NBdPfQ677mLzlaXo+oDiv1deyCDtgAhz8p328otdob0Du7+xgHGZbKg==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
@@ -1291,7 +1251,6 @@
 			"version": "7.12.7",
 			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.12.7.tgz",
 			"integrity": "sha512-wKeTdnGUP5AEYCYQIMeXMMwU7j+2opxrG0WzuZfxuuW9nhKvvALBjl67653CWamZJVefuJGI219G591RSldrqQ==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4",
 				"@babel/plugin-transform-react-display-name": "^7.12.1",
@@ -1714,8 +1673,7 @@
 		"@emotion/weak-memoize": {
 			"version": "0.2.5",
 			"resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
-			"integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==",
-			"dev": true
+			"integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
 		},
 		"@evocateur/libnpmaccess": {
 			"version": "3.1.2",
@@ -7652,179 +7610,21 @@
 					"integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
 					"dev": true
 				},
-				"@webassemblyjs/ast": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
-					"integrity": "sha512-C6wW5L+b7ogSDVqymbkkvuW9kruN//YisMED04xzeBBqjHa2FYnmvOlS6Xj68xWQRgWvI9cIglsjFowH/RJyEA==",
-					"dev": true,
+				"@types/reach__router": {
+					"version": "1.3.5",
+					"resolved": "https://registry.npmjs.org/@types/reach__router/-/reach__router-1.3.5.tgz",
+					"integrity": "sha512-h0NbqXN/tJuBY/xggZSej1SKQEstbHO7J/omt1tYoFGmj3YXOodZKbbqD4mNDh7zvEGYd7YFrac1LTtAr3xsYQ==",
 					"requires": {
-						"@webassemblyjs/helper-module-context": "1.9.0",
-						"@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-						"@webassemblyjs/wast-parser": "1.9.0"
+						"@types/history": "*",
+						"@types/react": "*"
 					}
 				},
-				"@webassemblyjs/floating-point-hex-parser": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.9.0.tgz",
-					"integrity": "sha512-TG5qcFsS8QB4g4MhrxK5TqfdNe7Ey/7YL/xN+36rRjl/BlGE/NcBvJcqsRgCP6Z92mRE+7N50pRIi8SmKUbcQA==",
-					"dev": true
-				},
-				"@webassemblyjs/helper-api-error": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.0.tgz",
-					"integrity": "sha512-NcMLjoFMXpsASZFxJ5h2HZRcEhDkvnNFOAKneP5RbKRzaWJN36NC4jqQHKwStIhGXu5mUWlUUk7ygdtrO8lbmw==",
-					"dev": true
-				},
-				"@webassemblyjs/helper-buffer": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.9.0.tgz",
-					"integrity": "sha512-qZol43oqhq6yBPx7YM3m9Bv7WMV9Eevj6kMi6InKOuZxhw+q9hOkvq5e/PpKSiLfyetpaBnogSbNCfBwyB00CA==",
-					"dev": true
-				},
-				"@webassemblyjs/helper-code-frame": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.9.0.tgz",
-					"integrity": "sha512-ERCYdJBkD9Vu4vtjUYe8LZruWuNIToYq/ME22igL+2vj2dQ2OOujIZr3MEFvfEaqKoVqpsFKAGsRdBSBjrIvZA==",
-					"dev": true,
+				"@types/react-syntax-highlighter": {
+					"version": "11.0.4",
+					"resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.4.tgz",
+					"integrity": "sha512-9GfTo3a0PHwQeTVoqs0g5bS28KkSY48pp5659wA+Dp4MqceDEa8EHBqrllJvvtyusszyJhViUEap0FDvlk/9Zg==",
 					"requires": {
-						"@webassemblyjs/wast-printer": "1.9.0"
-					}
-				},
-				"@webassemblyjs/helper-fsm": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.9.0.tgz",
-					"integrity": "sha512-OPRowhGbshCb5PxJ8LocpdX9Kl0uB4XsAjl6jH/dWKlk/mzsANvhwbiULsaiqT5GZGT9qinTICdj6PLuM5gslw==",
-					"dev": true
-				},
-				"@webassemblyjs/helper-module-context": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.9.0.tgz",
-					"integrity": "sha512-MJCW8iGC08tMk2enck1aPW+BE5Cw8/7ph/VGZxwyvGbJwjktKkDK7vy7gAmMDx88D7mhDTCNKAW5tED+gZ0W8g==",
-					"dev": true,
-					"requires": {
-						"@webassemblyjs/ast": "1.9.0"
-					}
-				},
-				"@webassemblyjs/helper-wasm-bytecode": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.0.tgz",
-					"integrity": "sha512-R7FStIzyNcd7xKxCZH5lE0Bqy+hGTwS3LJjuv1ZVxd9O7eHCedSdrId/hMOd20I+v8wDXEn+bjfKDLzTepoaUw==",
-					"dev": true
-				},
-				"@webassemblyjs/helper-wasm-section": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.9.0.tgz",
-					"integrity": "sha512-XnMB8l3ek4tvrKUUku+IVaXNHz2YsJyOOmz+MMkZvh8h1uSJpSen6vYnw3IoQ7WwEuAhL8Efjms1ZWjqh2agvw==",
-					"dev": true,
-					"requires": {
-						"@webassemblyjs/ast": "1.9.0",
-						"@webassemblyjs/helper-buffer": "1.9.0",
-						"@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-						"@webassemblyjs/wasm-gen": "1.9.0"
-					}
-				},
-				"@webassemblyjs/ieee754": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.9.0.tgz",
-					"integrity": "sha512-dcX8JuYU/gvymzIHc9DgxTzUUTLexWwt8uCTWP3otys596io0L5aW02Gb1RjYpx2+0Jus1h4ZFqjla7umFniTg==",
-					"dev": true,
-					"requires": {
-						"@xtuc/ieee754": "^1.2.0"
-					}
-				},
-				"@webassemblyjs/leb128": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.9.0.tgz",
-					"integrity": "sha512-ENVzM5VwV1ojs9jam6vPys97B/S65YQtv/aanqnU7D8aSoHFX8GyhGg0CMfyKNIHBuAVjy3tlzd5QMMINa7wpw==",
-					"dev": true,
-					"requires": {
-						"@xtuc/long": "4.2.2"
-					}
-				},
-				"@webassemblyjs/utf8": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.9.0.tgz",
-					"integrity": "sha512-GZbQlWtopBTP0u7cHrEx+73yZKrQoBMpwkGEIqlacljhXCkVM1kMQge/Mf+csMJAjEdSwhOyLAS0AoR3AG5P8w==",
-					"dev": true
-				},
-				"@webassemblyjs/wasm-edit": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.9.0.tgz",
-					"integrity": "sha512-FgHzBm80uwz5M8WKnMTn6j/sVbqilPdQXTWraSjBwFXSYGirpkSWE2R9Qvz9tNiTKQvoKILpCuTjBKzOIm0nxw==",
-					"dev": true,
-					"requires": {
-						"@webassemblyjs/ast": "1.9.0",
-						"@webassemblyjs/helper-buffer": "1.9.0",
-						"@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-						"@webassemblyjs/helper-wasm-section": "1.9.0",
-						"@webassemblyjs/wasm-gen": "1.9.0",
-						"@webassemblyjs/wasm-opt": "1.9.0",
-						"@webassemblyjs/wasm-parser": "1.9.0",
-						"@webassemblyjs/wast-printer": "1.9.0"
-					}
-				},
-				"@webassemblyjs/wasm-gen": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.9.0.tgz",
-					"integrity": "sha512-cPE3o44YzOOHvlsb4+E9qSqjc9Qf9Na1OO/BHFy4OI91XDE14MjFN4lTMezzaIWdPqHnsTodGGNP+iRSYfGkjA==",
-					"dev": true,
-					"requires": {
-						"@webassemblyjs/ast": "1.9.0",
-						"@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-						"@webassemblyjs/ieee754": "1.9.0",
-						"@webassemblyjs/leb128": "1.9.0",
-						"@webassemblyjs/utf8": "1.9.0"
-					}
-				},
-				"@webassemblyjs/wasm-opt": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.9.0.tgz",
-					"integrity": "sha512-Qkjgm6Anhm+OMbIL0iokO7meajkzQD71ioelnfPEj6r4eOFuqm4YC3VBPqXjFyyNwowzbMD+hizmprP/Fwkl2A==",
-					"dev": true,
-					"requires": {
-						"@webassemblyjs/ast": "1.9.0",
-						"@webassemblyjs/helper-buffer": "1.9.0",
-						"@webassemblyjs/wasm-gen": "1.9.0",
-						"@webassemblyjs/wasm-parser": "1.9.0"
-					}
-				},
-				"@webassemblyjs/wasm-parser": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.9.0.tgz",
-					"integrity": "sha512-9+wkMowR2AmdSWQzsPEjFU7njh8HTO5MqO8vjwEHuM+AMHioNqSBONRdr0NQQ3dVQrzp0s8lTcYqzUdb7YgELA==",
-					"dev": true,
-					"requires": {
-						"@webassemblyjs/ast": "1.9.0",
-						"@webassemblyjs/helper-api-error": "1.9.0",
-						"@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-						"@webassemblyjs/ieee754": "1.9.0",
-						"@webassemblyjs/leb128": "1.9.0",
-						"@webassemblyjs/utf8": "1.9.0"
-					}
-				},
-				"@webassemblyjs/wast-parser": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.9.0.tgz",
-					"integrity": "sha512-qsqSAP3QQ3LyZjNC/0jBJ/ToSxfYJ8kYyuiGvtn/8MK89VrNEfwj7BPQzJVHi0jGTRK2dGdJ5PRqhtjzoww+bw==",
-					"dev": true,
-					"requires": {
-						"@webassemblyjs/ast": "1.9.0",
-						"@webassemblyjs/floating-point-hex-parser": "1.9.0",
-						"@webassemblyjs/helper-api-error": "1.9.0",
-						"@webassemblyjs/helper-code-frame": "1.9.0",
-						"@webassemblyjs/helper-fsm": "1.9.0",
-						"@xtuc/long": "4.2.2"
-					}
-				},
-				"@webassemblyjs/wast-printer": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.9.0.tgz",
-					"integrity": "sha512-2J0nE95rHXHyQ24cWjMKJ1tqB/ds8z/cyeOZxJhcb+rW+SQASVjuznUSmdz5GpVJTzU8JkhYut0D3siFDD6wsA==",
-					"dev": true,
-					"requires": {
-						"@webassemblyjs/ast": "1.9.0",
-						"@webassemblyjs/wast-parser": "1.9.0",
-						"@xtuc/long": "4.2.2"
+						"@types/react": "*"
 					}
 				},
 				"ajv": {
@@ -8831,179 +8631,122 @@
 						}
 					}
 				},
-				"@webassemblyjs/ast": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
-					"integrity": "sha512-C6wW5L+b7ogSDVqymbkkvuW9kruN//YisMED04xzeBBqjHa2FYnmvOlS6Xj68xWQRgWvI9cIglsjFowH/RJyEA==",
-					"dev": true,
+				"@storybook/theming": {
+					"version": "6.0.21",
+					"resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.0.21.tgz",
+					"integrity": "sha512-n97DfB9kG6WrV1xBGDyeQibTrh8pBBCp3dSL3UTGH+KX3C2+4sm6QHlTgyekbi5FrbFEbnuZOKAS3YbLVONsRQ==",
 					"requires": {
-						"@webassemblyjs/helper-module-context": "1.9.0",
-						"@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-						"@webassemblyjs/wast-parser": "1.9.0"
+						"@emotion/core": "^10.0.20",
+						"@emotion/styled": "^10.0.17",
+						"core-js": "^3.0.1",
+						"deep-object-diff": "^1.1.0",
+						"emotion-theming": "^10.0.19",
+						"global": "^4.3.2",
+						"memoizerific": "^1.11.3",
+						"polished": "^3.4.4"
 					}
 				},
-				"@webassemblyjs/floating-point-hex-parser": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.9.0.tgz",
-					"integrity": "sha512-TG5qcFsS8QB4g4MhrxK5TqfdNe7Ey/7YL/xN+36rRjl/BlGE/NcBvJcqsRgCP6Z92mRE+7N50pRIi8SmKUbcQA==",
-					"dev": true
+				"@svgr/babel-plugin-add-jsx-attribute": {
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-5.4.0.tgz",
+					"integrity": "sha512-ZFf2gs/8/6B8PnSofI0inYXr2SDNTDScPXhN7k5EqD4aZ3gi6u+rbmZHVB8IM3wDyx8ntKACZbtXSm7oZGRqVg=="
 				},
-				"@webassemblyjs/helper-api-error": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.0.tgz",
-					"integrity": "sha512-NcMLjoFMXpsASZFxJ5h2HZRcEhDkvnNFOAKneP5RbKRzaWJN36NC4jqQHKwStIhGXu5mUWlUUk7ygdtrO8lbmw==",
-					"dev": true
+				"@svgr/babel-plugin-remove-jsx-attribute": {
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-5.4.0.tgz",
+					"integrity": "sha512-yaS4o2PgUtwLFGTKbsiAy6D0o3ugcUhWK0Z45umJ66EPWunAz9fuFw2gJuje6wqQvQWOTJvIahUwndOXb7QCPg=="
 				},
-				"@webassemblyjs/helper-buffer": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.9.0.tgz",
-					"integrity": "sha512-qZol43oqhq6yBPx7YM3m9Bv7WMV9Eevj6kMi6InKOuZxhw+q9hOkvq5e/PpKSiLfyetpaBnogSbNCfBwyB00CA==",
-					"dev": true
+				"@svgr/babel-plugin-svg-dynamic-title": {
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-5.4.0.tgz",
+					"integrity": "sha512-zSOZH8PdZOpuG1ZVx/cLVePB2ibo3WPpqo7gFIjLV9a0QsuQAzJiwwqmuEdTaW2pegyBE17Uu15mOgOcgabQZg=="
 				},
-				"@webassemblyjs/helper-code-frame": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.9.0.tgz",
-					"integrity": "sha512-ERCYdJBkD9Vu4vtjUYe8LZruWuNIToYq/ME22igL+2vj2dQ2OOujIZr3MEFvfEaqKoVqpsFKAGsRdBSBjrIvZA==",
-					"dev": true,
+				"@svgr/babel-plugin-svg-em-dimensions": {
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-5.4.0.tgz",
+					"integrity": "sha512-cPzDbDA5oT/sPXDCUYoVXEmm3VIoAWAPT6mSPTJNbQaBNUuEKVKyGH93oDY4e42PYHRW67N5alJx/eEol20abw=="
+				},
+				"@svgr/babel-plugin-transform-react-native-svg": {
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-5.4.0.tgz",
+					"integrity": "sha512-3eYP/SaopZ41GHwXma7Rmxcv9uRslRDTY1estspeB1w1ueZWd/tPlMfEOoccYpEMZU3jD4OU7YitnXcF5hLW2Q=="
+				},
+				"@svgr/babel-plugin-transform-svg-component": {
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-5.4.0.tgz",
+					"integrity": "sha512-zLl4Fl3NvKxxjWNkqEcpdSOpQ3LGVH2BNFQ6vjaK6sFo2IrSznrhURIPI0HAphKiiIwNYjAfE0TNoQDSZv0U9A=="
+				},
+				"@svgr/babel-preset": {
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/@svgr/babel-preset/-/babel-preset-5.4.0.tgz",
+					"integrity": "sha512-Gyx7cCxua04DBtyILTYdQxeO/pwfTBev6+eXTbVbxe4HTGhOUW6yo7PSbG2p6eJMl44j6XSequ0ZDP7bl0nu9A==",
 					"requires": {
-						"@webassemblyjs/wast-printer": "1.9.0"
+						"@svgr/babel-plugin-add-jsx-attribute": "^5.4.0",
+						"@svgr/babel-plugin-remove-jsx-attribute": "^5.4.0",
+						"@svgr/babel-plugin-remove-jsx-empty-expression": "^5.0.1",
+						"@svgr/babel-plugin-replace-jsx-attribute-value": "^5.0.1",
+						"@svgr/babel-plugin-svg-dynamic-title": "^5.4.0",
+						"@svgr/babel-plugin-svg-em-dimensions": "^5.4.0",
+						"@svgr/babel-plugin-transform-react-native-svg": "^5.4.0",
+						"@svgr/babel-plugin-transform-svg-component": "^5.4.0"
 					}
 				},
-				"@webassemblyjs/helper-fsm": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.9.0.tgz",
-					"integrity": "sha512-OPRowhGbshCb5PxJ8LocpdX9Kl0uB4XsAjl6jH/dWKlk/mzsANvhwbiULsaiqT5GZGT9qinTICdj6PLuM5gslw==",
-					"dev": true
-				},
-				"@webassemblyjs/helper-module-context": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.9.0.tgz",
-					"integrity": "sha512-MJCW8iGC08tMk2enck1aPW+BE5Cw8/7ph/VGZxwyvGbJwjktKkDK7vy7gAmMDx88D7mhDTCNKAW5tED+gZ0W8g==",
-					"dev": true,
+				"@svgr/core": {
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/@svgr/core/-/core-5.4.0.tgz",
+					"integrity": "sha512-hWGm1DCCvd4IEn7VgDUHYiC597lUYhFau2lwJBYpQWDirYLkX4OsXu9IslPgJ9UpP7wsw3n2Ffv9sW7SXJVfqQ==",
 					"requires": {
-						"@webassemblyjs/ast": "1.9.0"
+						"@svgr/plugin-jsx": "^5.4.0"
 					}
 				},
-				"@webassemblyjs/helper-wasm-bytecode": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.0.tgz",
-					"integrity": "sha512-R7FStIzyNcd7xKxCZH5lE0Bqy+hGTwS3LJjuv1ZVxd9O7eHCedSdrId/hMOd20I+v8wDXEn+bjfKDLzTepoaUw==",
-					"dev": true
-				},
-				"@webassemblyjs/helper-wasm-section": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.9.0.tgz",
-					"integrity": "sha512-XnMB8l3ek4tvrKUUku+IVaXNHz2YsJyOOmz+MMkZvh8h1uSJpSen6vYnw3IoQ7WwEuAhL8Efjms1ZWjqh2agvw==",
-					"dev": true,
+				"@svgr/hast-util-to-babel-ast": {
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-5.4.0.tgz",
+					"integrity": "sha512-+U0TZZpPsP2V1WvVhqAOSTk+N+CjYHdZx+x9UBa1eeeZDXwH8pt0CrQf2+SvRl/h2CAPRFkm+Ey96+jKP8Bsgg==",
 					"requires": {
-						"@webassemblyjs/ast": "1.9.0",
-						"@webassemblyjs/helper-buffer": "1.9.0",
-						"@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-						"@webassemblyjs/wasm-gen": "1.9.0"
+						"@babel/types": "^7.9.5"
 					}
 				},
-				"@webassemblyjs/ieee754": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.9.0.tgz",
-					"integrity": "sha512-dcX8JuYU/gvymzIHc9DgxTzUUTLexWwt8uCTWP3otys596io0L5aW02Gb1RjYpx2+0Jus1h4ZFqjla7umFniTg==",
-					"dev": true,
+				"@svgr/plugin-jsx": {
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/@svgr/plugin-jsx/-/plugin-jsx-5.4.0.tgz",
+					"integrity": "sha512-SGzO4JZQ2HvGRKDzRga9YFSqOqaNrgLlQVaGvpZ2Iht2gwRp/tq+18Pvv9kS9ZqOMYgyix2LLxZMY1LOe9NPqw==",
 					"requires": {
-						"@xtuc/ieee754": "^1.2.0"
+						"@babel/core": "^7.7.5",
+						"@svgr/babel-preset": "^5.4.0",
+						"@svgr/hast-util-to-babel-ast": "^5.4.0",
+						"svg-parser": "^2.0.2"
 					}
 				},
-				"@webassemblyjs/leb128": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.9.0.tgz",
-					"integrity": "sha512-ENVzM5VwV1ojs9jam6vPys97B/S65YQtv/aanqnU7D8aSoHFX8GyhGg0CMfyKNIHBuAVjy3tlzd5QMMINa7wpw==",
-					"dev": true,
+				"@svgr/plugin-svgo": {
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/@svgr/plugin-svgo/-/plugin-svgo-5.4.0.tgz",
+					"integrity": "sha512-3Cgv3aYi1l6SHyzArV9C36yo4kgwVdF3zPQUC6/aCDUeXAofDYwE5kk3e3oT5ZO2a0N3lB+lLGvipBG6lnG8EA==",
 					"requires": {
-						"@xtuc/long": "4.2.2"
+						"merge-deep": "^3.0.2"
 					}
 				},
-				"@webassemblyjs/utf8": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.9.0.tgz",
-					"integrity": "sha512-GZbQlWtopBTP0u7cHrEx+73yZKrQoBMpwkGEIqlacljhXCkVM1kMQge/Mf+csMJAjEdSwhOyLAS0AoR3AG5P8w==",
-					"dev": true
-				},
-				"@webassemblyjs/wasm-edit": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.9.0.tgz",
-					"integrity": "sha512-FgHzBm80uwz5M8WKnMTn6j/sVbqilPdQXTWraSjBwFXSYGirpkSWE2R9Qvz9tNiTKQvoKILpCuTjBKzOIm0nxw==",
-					"dev": true,
+				"@svgr/webpack": {
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/@svgr/webpack/-/webpack-5.4.0.tgz",
+					"integrity": "sha512-LjepnS/BSAvelnOnnzr6Gg0GcpLmnZ9ThGFK5WJtm1xOqdBE/1IACZU7MMdVzjyUkfFqGz87eRE4hFaSLiUwYg==",
 					"requires": {
-						"@webassemblyjs/ast": "1.9.0",
-						"@webassemblyjs/helper-buffer": "1.9.0",
-						"@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-						"@webassemblyjs/helper-wasm-section": "1.9.0",
-						"@webassemblyjs/wasm-gen": "1.9.0",
-						"@webassemblyjs/wasm-opt": "1.9.0",
-						"@webassemblyjs/wasm-parser": "1.9.0",
-						"@webassemblyjs/wast-printer": "1.9.0"
+						"@babel/core": "^7.9.0",
+						"@babel/plugin-transform-react-constant-elements": "^7.9.0",
+						"@babel/preset-env": "^7.9.5",
+						"@babel/preset-react": "^7.9.4",
+						"@svgr/core": "^5.4.0",
+						"@svgr/plugin-jsx": "^5.4.0",
+						"@svgr/plugin-svgo": "^5.4.0"
 					}
 				},
-				"@webassemblyjs/wasm-gen": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.9.0.tgz",
-					"integrity": "sha512-cPE3o44YzOOHvlsb4+E9qSqjc9Qf9Na1OO/BHFy4OI91XDE14MjFN4lTMezzaIWdPqHnsTodGGNP+iRSYfGkjA==",
-					"dev": true,
+				"@types/reach__router": {
+					"version": "1.3.5",
+					"resolved": "https://registry.npmjs.org/@types/reach__router/-/reach__router-1.3.5.tgz",
+					"integrity": "sha512-h0NbqXN/tJuBY/xggZSej1SKQEstbHO7J/omt1tYoFGmj3YXOodZKbbqD4mNDh7zvEGYd7YFrac1LTtAr3xsYQ==",
 					"requires": {
-						"@webassemblyjs/ast": "1.9.0",
-						"@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-						"@webassemblyjs/ieee754": "1.9.0",
-						"@webassemblyjs/leb128": "1.9.0",
-						"@webassemblyjs/utf8": "1.9.0"
-					}
-				},
-				"@webassemblyjs/wasm-opt": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.9.0.tgz",
-					"integrity": "sha512-Qkjgm6Anhm+OMbIL0iokO7meajkzQD71ioelnfPEj6r4eOFuqm4YC3VBPqXjFyyNwowzbMD+hizmprP/Fwkl2A==",
-					"dev": true,
-					"requires": {
-						"@webassemblyjs/ast": "1.9.0",
-						"@webassemblyjs/helper-buffer": "1.9.0",
-						"@webassemblyjs/wasm-gen": "1.9.0",
-						"@webassemblyjs/wasm-parser": "1.9.0"
-					}
-				},
-				"@webassemblyjs/wasm-parser": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.9.0.tgz",
-					"integrity": "sha512-9+wkMowR2AmdSWQzsPEjFU7njh8HTO5MqO8vjwEHuM+AMHioNqSBONRdr0NQQ3dVQrzp0s8lTcYqzUdb7YgELA==",
-					"dev": true,
-					"requires": {
-						"@webassemblyjs/ast": "1.9.0",
-						"@webassemblyjs/helper-api-error": "1.9.0",
-						"@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-						"@webassemblyjs/ieee754": "1.9.0",
-						"@webassemblyjs/leb128": "1.9.0",
-						"@webassemblyjs/utf8": "1.9.0"
-					}
-				},
-				"@webassemblyjs/wast-parser": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.9.0.tgz",
-					"integrity": "sha512-qsqSAP3QQ3LyZjNC/0jBJ/ToSxfYJ8kYyuiGvtn/8MK89VrNEfwj7BPQzJVHi0jGTRK2dGdJ5PRqhtjzoww+bw==",
-					"dev": true,
-					"requires": {
-						"@webassemblyjs/ast": "1.9.0",
-						"@webassemblyjs/floating-point-hex-parser": "1.9.0",
-						"@webassemblyjs/helper-api-error": "1.9.0",
-						"@webassemblyjs/helper-code-frame": "1.9.0",
-						"@webassemblyjs/helper-fsm": "1.9.0",
-						"@xtuc/long": "4.2.2"
-					}
-				},
-				"@webassemblyjs/wast-printer": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.9.0.tgz",
-					"integrity": "sha512-2J0nE95rHXHyQ24cWjMKJ1tqB/ds8z/cyeOZxJhcb+rW+SQASVjuznUSmdz5GpVJTzU8JkhYut0D3siFDD6wsA==",
-					"dev": true,
-					"requires": {
-						"@webassemblyjs/ast": "1.9.0",
-						"@webassemblyjs/wast-parser": "1.9.0",
-						"@xtuc/long": "4.2.2"
+						"@types/history": "*",
+						"@types/react": "*"
 					}
 				},
 				"anymatch": {
@@ -10050,14 +9793,12 @@
 		"@svgr/babel-plugin-remove-jsx-empty-expression": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-5.0.1.tgz",
-			"integrity": "sha512-LA72+88A11ND/yFIMzyuLRSMJ+tRKeYKeQ+mR3DcAZ5I4h5CPWN9AHyUzJbWSYp/u2u0xhmgOe0+E41+GjEueA==",
-			"dev": true
+			"integrity": "sha512-LA72+88A11ND/yFIMzyuLRSMJ+tRKeYKeQ+mR3DcAZ5I4h5CPWN9AHyUzJbWSYp/u2u0xhmgOe0+E41+GjEueA=="
 		},
 		"@svgr/babel-plugin-replace-jsx-attribute-value": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-5.0.1.tgz",
-			"integrity": "sha512-PoiE6ZD2Eiy5mK+fjHqwGOS+IXX0wq/YDtNyIgOrc6ejFnxN4b13pRpiIPbtPwHEc+NT2KCjteAcq33/F1Y9KQ==",
-			"dev": true
+			"integrity": "sha512-PoiE6ZD2Eiy5mK+fjHqwGOS+IXX0wq/YDtNyIgOrc6ejFnxN4b13pRpiIPbtPwHEc+NT2KCjteAcq33/F1Y9KQ=="
 		},
 		"@svgr/babel-plugin-svg-dynamic-title": {
 			"version": "5.0.1",
@@ -10806,8 +10547,7 @@
 		"@types/history": {
 			"version": "4.7.8",
 			"resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.8.tgz",
-			"integrity": "sha512-S78QIYirQcUoo6UJZx9CSP0O2ix9IaeAXwQi26Rhr/+mg7qqPy8TzaxHSUut7eGjL8WmLccT7/MXf304WjqHcA==",
-			"dev": true
+			"integrity": "sha512-S78QIYirQcUoo6UJZx9CSP0O2ix9IaeAXwQi26Rhr/+mg7qqPy8TzaxHSUut7eGjL8WmLccT7/MXf304WjqHcA=="
 		},
 		"@types/html-minifier-terser": {
 			"version": "5.1.1",
@@ -11525,6 +11265,29 @@
 				"@webassemblyjs/wast-parser": "1.9.0",
 				"@xtuc/long": "4.2.2"
 			}
+		},
+		"@webpack-cli/info": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.1.0.tgz",
+			"integrity": "sha512-uNWSdaYHc+f3LdIZNwhdhkjjLDDl3jP2+XBqAq9H8DjrJUvlOKdP8TNruy1yEaDfgpAIgbSAN7pye4FEHg9tYQ==",
+			"dev": true,
+			"requires": {
+				"envinfo": "^7.7.3"
+			},
+			"dependencies": {
+				"envinfo": {
+					"version": "7.7.3",
+					"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.7.3.tgz",
+					"integrity": "sha512-46+j5QxbPWza0PB1i15nZx0xQ4I/EfQxg9J8Had3b408SV63nEtor2e+oiY63amTo9KTuh2a3XLObNwduxYwwA==",
+					"dev": true
+				}
+			}
+		},
+		"@webpack-cli/serve": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.1.0.tgz",
+			"integrity": "sha512-7RfnMXCpJ/NThrhq4gYQYILB18xWyoQcBey81oIyVbmgbc6m5ZHHyFK+DyH7pLHJf0p14MxL4mTsoPAgBSTpIg==",
+			"dev": true
 		},
 		"@wordpress/a11y": {
 			"version": "file:packages/a11y",
@@ -20979,6 +20742,12 @@
 			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
 			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
 		},
+		"array-back": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
+			"integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg==",
+			"dev": true
+		},
 		"array-differ": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-2.1.0.tgz",
@@ -23003,7 +22772,6 @@
 			"version": "4.15.0",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.15.0.tgz",
 			"integrity": "sha512-IJ1iysdMkGmjjYeRlDU8PQejVwxvVO5QOfXH7ylW31GO6LwNRSmm/SgRXtNsEXqMLl2e+2H5eEJ7sfynF8TCaQ==",
-			"dev": true,
 			"requires": {
 				"caniuse-lite": "^1.0.30001164",
 				"colorette": "^1.2.1",
@@ -23015,32 +22783,27 @@
 				"caniuse-lite": {
 					"version": "1.0.30001165",
 					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001165.tgz",
-					"integrity": "sha512-8cEsSMwXfx7lWSUMA2s08z9dIgsnR5NAqjXP23stdsU3AUWkCr/rr4s4OFtHXn5XXr6+7kam3QFVoYyXNPdJPA==",
-					"dev": true
+					"integrity": "sha512-8cEsSMwXfx7lWSUMA2s08z9dIgsnR5NAqjXP23stdsU3AUWkCr/rr4s4OFtHXn5XXr6+7kam3QFVoYyXNPdJPA=="
 				},
 				"colorette": {
 					"version": "1.2.1",
 					"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
-					"integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
-					"dev": true
+					"integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw=="
 				},
 				"electron-to-chromium": {
 					"version": "1.3.619",
 					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.619.tgz",
-					"integrity": "sha512-WFGatwtk7Fw0QcKCZzfGD72hvbcXV8kLY8aFuj0Ip0QRnOtyLYMsc+wXbSjb2w4lk1gcAeNU1/lQ20A+tvuypQ==",
-					"dev": true
+					"integrity": "sha512-WFGatwtk7Fw0QcKCZzfGD72hvbcXV8kLY8aFuj0Ip0QRnOtyLYMsc+wXbSjb2w4lk1gcAeNU1/lQ20A+tvuypQ=="
 				},
 				"escalade": {
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-					"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-					"dev": true
+					"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
 				},
 				"node-releases": {
 					"version": "1.1.67",
 					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.67.tgz",
-					"integrity": "sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg==",
-					"dev": true
+					"integrity": "sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg=="
 				}
 			}
 		},
@@ -24115,6 +23878,31 @@
 			"resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.8.tgz",
 			"integrity": "sha512-PM54PkseWbiiD/mMsbvW351/u+dafwTJ0ye2qB60G1aGQP9j3xK2gmMDc+R34L3nDtx4qMCitXT75mkbkGJDLw=="
 		},
+		"command-line-usage": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.1.tgz",
+			"integrity": "sha512-F59pEuAR9o1SF/bD0dQBDluhpT4jJQNWUHEuVBqpDmCUo6gPjCi+m9fCWnWZVR/oG6cMTUms4h+3NPl74wGXvA==",
+			"dev": true,
+			"requires": {
+				"array-back": "^4.0.1",
+				"chalk": "^2.4.2",
+				"table-layout": "^1.0.1",
+				"typical": "^5.2.0"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				}
+			}
+		},
 		"commander": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-4.1.0.tgz",
@@ -24992,8 +24780,7 @@
 		"core-js": {
 			"version": "3.6.4",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
-			"integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==",
-			"dev": true
+			"integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw=="
 		},
 		"core-js-pure": {
 			"version": "3.2.1",
@@ -25874,8 +25661,7 @@
 		"deep-object-diff": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/deep-object-diff/-/deep-object-diff-1.1.0.tgz",
-			"integrity": "sha512-b+QLs5vHgS+IoSNcUE4n9HP2NwcHj7aqnJWsjPtuG75Rh5TOaGt0OjAYInh77d5T16V5cRDC+Pw/6ZZZiETBGw==",
-			"dev": true
+			"integrity": "sha512-b+QLs5vHgS+IoSNcUE4n9HP2NwcHj7aqnJWsjPtuG75Rh5TOaGt0OjAYInh77d5T16V5cRDC+Pw/6ZZZiETBGw=="
 		},
 		"deepmerge": {
 			"version": "1.5.2",
@@ -26155,12 +25941,6 @@
 			"requires": {
 				"repeat-string": "^1.5.4"
 			}
-		},
-		"detect-file": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
-			"integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
-			"dev": true
 		},
 		"detect-indent": {
 			"version": "5.0.0",
@@ -26560,7 +26340,6 @@
 			"version": "10.0.27",
 			"resolved": "https://registry.npmjs.org/emotion-theming/-/emotion-theming-10.0.27.tgz",
 			"integrity": "sha512-MlF1yu/gYh8u+sLUqA0YuA9JX0P4Hb69WlKc/9OLo+WCXuX6sy/KoIa+qJimgmr2dWqnypYKYPX37esjDBbhdw==",
-			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.5.5",
 				"@emotion/weak-memoize": "0.2.5",
@@ -26571,7 +26350,6 @@
 					"version": "3.3.2",
 					"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
 					"integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-					"dev": true,
 					"requires": {
 						"react-is": "^16.7.0"
 					}
@@ -26611,13 +26389,13 @@
 			}
 		},
 		"enhanced-resolve": {
-			"version": "5.4.1",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.4.1.tgz",
-			"integrity": "sha512-4GbyIMzYktTFoRSmkbgZ1LU+RXwf4AQ8Z+rSuuh1dC8plp0PPeaWvx6+G4hh4KnUJ48VoxKbNyA1QQQIUpXjYA==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.4.0.tgz",
+			"integrity": "sha512-ZmqfWURB2lConOBM1JdCVfPyMRv5RdKWktLXO6123p97ovVm2CLBgw9t5MBj3jJWA6eHyOeIws9iJQoGFR4euQ==",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.2.4",
-				"tapable": "^2.2.0"
+				"tapable": "^2.0.0"
 			},
 			"dependencies": {
 				"graceful-fs": {
@@ -26630,6 +26408,23 @@
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.0.tgz",
 					"integrity": "sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw==",
+					"dev": true
+				}
+			}
+		},
+		"enquirer": {
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+			"integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+			"dev": true,
+			"requires": {
+				"ansi-colors": "^4.1.1"
+			},
+			"dependencies": {
+				"ansi-colors": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+					"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
 					"dev": true
 				}
 			}
@@ -28609,8 +28404,7 @@
 		"esutils": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-			"dev": true
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
 		},
 		"etag": {
 			"version": "1.8.1",
@@ -29914,63 +29708,6 @@
 				}
 			}
 		},
-		"findup-sync": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
-			"integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
-			"dev": true,
-			"requires": {
-				"detect-file": "^1.0.0",
-				"is-glob": "^4.0.0",
-				"micromatch": "^3.0.4",
-				"resolve-dir": "^1.0.1"
-			},
-			"dependencies": {
-				"expand-tilde": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-					"integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
-					"dev": true,
-					"requires": {
-						"homedir-polyfill": "^1.0.1"
-					}
-				},
-				"global-modules": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
-					"integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
-					"dev": true,
-					"requires": {
-						"global-prefix": "^1.0.1",
-						"is-windows": "^1.0.1",
-						"resolve-dir": "^1.0.0"
-					}
-				},
-				"global-prefix": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
-					"integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
-					"dev": true,
-					"requires": {
-						"expand-tilde": "^2.0.2",
-						"homedir-polyfill": "^1.0.1",
-						"ini": "^1.3.4",
-						"is-windows": "^1.0.1",
-						"which": "^1.2.14"
-					}
-				},
-				"resolve-dir": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
-					"integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
-					"dev": true,
-					"requires": {
-						"expand-tilde": "^2.0.0",
-						"global-modules": "^1.0.0"
-					}
-				}
-			}
-		},
 		"flat-cache": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
@@ -30032,7 +29769,6 @@
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-			"dev": true,
 			"requires": {
 				"for-in": "^1.0.1"
 			}
@@ -37666,8 +37402,7 @@
 		"lazy-cache": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-			"dev": true
+			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
 		},
 		"lazy-universal-dotenv": {
 			"version": "3.0.1",
@@ -39565,7 +39300,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.2.tgz",
 			"integrity": "sha512-T7qC8kg4Zoti1cFd8Cr0M+qaZfOwjlPDEdZIIPPB2JZctjaPM4fX+i7HOId69tAti2fvO6X5ldfYUONDODsrkA==",
-			"dev": true,
 			"requires": {
 				"arr-union": "^3.1.0",
 				"clone-deep": "^0.2.4",
@@ -39576,7 +39310,6 @@
 					"version": "0.2.4",
 					"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
 					"integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
-					"dev": true,
 					"requires": {
 						"for-own": "^0.1.3",
 						"is-plain-object": "^2.0.1",
@@ -39589,7 +39322,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -39598,7 +39330,6 @@
 					"version": "0.1.2",
 					"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
 					"integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.1",
 						"kind-of": "^2.0.1",
@@ -39610,7 +39341,6 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
 							"integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
-							"dev": true,
 							"requires": {
 								"is-buffer": "^1.0.2"
 							}
@@ -39618,8 +39348,7 @@
 						"lazy-cache": {
 							"version": "0.2.7",
 							"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
-							"integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
-							"dev": true
+							"integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
 						}
 					}
 				}
@@ -40792,7 +40521,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
 			"integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
-			"dev": true,
 			"requires": {
 				"for-in": "^0.1.3",
 				"is-extendable": "^0.1.1"
@@ -40801,8 +40529,7 @@
 				"for-in": {
 					"version": "0.1.8",
 					"resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
-					"integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE=",
-					"dev": true
+					"integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE="
 				}
 			}
 		},
@@ -41062,12 +40789,6 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
 			"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
-		},
-		"neo-async": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-			"dev": true
 		},
 		"nested-error-stacks": {
 			"version": "2.1.0",
@@ -43423,7 +43144,6 @@
 			"version": "3.6.7",
 			"resolved": "https://registry.npmjs.org/polished/-/polished-3.6.7.tgz",
 			"integrity": "sha512-b4OViUOihwV0icb9PHmWbR+vPqaSzSAEbgLskvb7ANPATVXGiYv/TQFHQo65S53WU9i5EQ1I03YDOJW7K0bmYg==",
-			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.9.2"
 			}
@@ -47618,6 +47338,12 @@
 				"strip-indent": "^2.0.0"
 			}
 		},
+		"reduce-flatten": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
+			"integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==",
+			"dev": true
+		},
 		"redux": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/redux/-/redux-4.0.0.tgz",
@@ -51339,8 +51065,7 @@
 		"svg-parser": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
-			"integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==",
-			"dev": true
+			"integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ=="
 		},
 		"svg-tags": {
 			"version": "1.0.0",
@@ -51796,6 +51521,18 @@
 						"ansi-regex": "^5.0.0"
 					}
 				}
+			}
+		},
+		"table-layout": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.1.tgz",
+			"integrity": "sha512-dEquqYNJiGwY7iPfZ3wbXDI944iqanTSchrACLL2nOB+1r+h1Nzu2eH+DuPPvWvm5Ry7iAPeFlgEtP5bIp5U7Q==",
+			"dev": true,
+			"requires": {
+				"array-back": "^4.0.1",
+				"deep-extend": "~0.6.0",
+				"typical": "^5.2.0",
+				"wordwrapjs": "^4.0.0"
 			}
 		},
 		"tannin": {
@@ -52840,6 +52577,12 @@
 			"integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
 			"dev": true
 		},
+		"typical": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+			"integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+			"dev": true
+		},
 		"ua-parser-js": {
 			"version": "0.7.18",
 			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
@@ -53626,9 +53369,9 @@
 			}
 		},
 		"watchpack": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.1.0.tgz",
-			"integrity": "sha512-UjgD1mqjkG99+3lgG36at4wPnUXNvis2v1utwTgQ43C22c4LD71LsYMExdWXh4HZ+RmW+B0t1Vrg2GpXAkTOQw==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.0.1.tgz",
+			"integrity": "sha512-vO8AKGX22ZRo6PiOFM9dC0re8IcKh8Kd/aH2zeqUc6w4/jBGlTy2P7fTC6ekT0NjVeGjgU2dGC5rNstKkeLEQg==",
 			"dev": true,
 			"requires": {
 				"glob-to-regexp": "^0.4.1",
@@ -53756,10 +53499,47 @@
 					"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
 					"dev": true
 				},
+				"browserslist": {
+					"version": "4.15.0",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.15.0.tgz",
+					"integrity": "sha512-IJ1iysdMkGmjjYeRlDU8PQejVwxvVO5QOfXH7ylW31GO6LwNRSmm/SgRXtNsEXqMLl2e+2H5eEJ7sfynF8TCaQ==",
+					"dev": true,
+					"requires": {
+						"caniuse-lite": "^1.0.30001164",
+						"colorette": "^1.2.1",
+						"electron-to-chromium": "^1.3.612",
+						"escalade": "^3.1.1",
+						"node-releases": "^1.1.67"
+					}
+				},
+				"caniuse-lite": {
+					"version": "1.0.30001165",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001165.tgz",
+					"integrity": "sha512-8cEsSMwXfx7lWSUMA2s08z9dIgsnR5NAqjXP23stdsU3AUWkCr/rr4s4OFtHXn5XXr6+7kam3QFVoYyXNPdJPA==",
+					"dev": true
+				},
+				"colorette": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
+					"integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
+					"dev": true
+				},
 				"commander": {
 					"version": "2.20.3",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
 					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+					"dev": true
+				},
+				"electron-to-chromium": {
+					"version": "1.3.616",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.616.tgz",
+					"integrity": "sha512-CI8L38UN2BEnqXw3/oRIQTmde0LiSeqWSRlPA42ZTYgJQ8fYenzAM2Z3ni+jtILTcrs5aiXZCGJ96Pm+3/yGyQ==",
+					"dev": true
+				},
+				"escalade": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+					"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
 					"dev": true
 				},
 				"eslint-scope": {
@@ -53862,19 +53642,31 @@
 					"dev": true
 				},
 				"mime-db": {
-					"version": "1.45.0",
-					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
-					"integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==",
+					"version": "1.44.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+					"integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
 					"dev": true
 				},
 				"mime-types": {
-					"version": "2.1.28",
-					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
-					"integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
+					"version": "2.1.27",
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+					"integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
 					"dev": true,
 					"requires": {
-						"mime-db": "1.45.0"
+						"mime-db": "1.44.0"
 					}
+				},
+				"neo-async": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+					"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+					"dev": true
+				},
+				"node-releases": {
+					"version": "1.1.67",
+					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.67.tgz",
+					"integrity": "sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg==",
+					"dev": true
 				},
 				"p-limit": {
 					"version": "3.1.0",
@@ -53928,6 +53720,12 @@
 					"requires": {
 						"randombytes": "^2.1.0"
 					}
+				},
+				"source-list-map": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
+					"integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==",
+					"dev": true
 				},
 				"source-map": {
 					"version": "0.6.1",
@@ -53991,6 +53789,16 @@
 						"serialize-javascript": "^5.0.1",
 						"source-map": "^0.6.1",
 						"terser": "^5.3.8"
+					}
+				},
+				"webpack-sources": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-2.2.0.tgz",
+					"integrity": "sha512-bQsA24JLwcnWGArOKUxYKhX3Mz/nK1Xf6hxullKERyktjNMC4x8koOeaDNTA2fEJ09BdWLbM/iTW0ithREUP0w==",
+					"dev": true,
+					"requires": {
+						"source-list-map": "^2.0.1",
+						"source-map": "^0.6.1"
 					}
 				}
 			}
@@ -54104,227 +53912,92 @@
 			}
 		},
 		"webpack-cli": {
-			"version": "3.3.11",
-			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.11.tgz",
-			"integrity": "sha512-dXlfuml7xvAFwYUPsrtQAA9e4DOe58gnzSxhgrO/ZM/gyXTBowrsYeubyN4mqGhYdpXMFNyQ6emjJS9M7OBd4g==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.1.0.tgz",
+			"integrity": "sha512-NdhxXMZmoik62Y05t0h1y65LjBM7BwFPq311ihXuMM3RY6dlc4KkCTyHLzTuBEc+bqq6d3xh+CWmU0xRexNJBA==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.4.2",
-				"cross-spawn": "6.0.5",
-				"enhanced-resolve": "4.1.0",
-				"findup-sync": "3.0.0",
-				"global-modules": "2.0.0",
-				"import-local": "2.0.0",
-				"interpret": "1.2.0",
-				"loader-utils": "1.2.3",
-				"supports-color": "6.1.0",
-				"v8-compile-cache": "2.0.3",
-				"yargs": "13.2.4"
+				"@webpack-cli/info": "^1.0.2",
+				"@webpack-cli/serve": "^1.0.1",
+				"ansi-escapes": "^4.3.1",
+				"colorette": "^1.2.1",
+				"command-line-usage": "^6.1.0",
+				"commander": "^6.0.0",
+				"enquirer": "^2.3.4",
+				"execa": "^4.0.0",
+				"import-local": "^3.0.2",
+				"interpret": "^2.0.0",
+				"rechoir": "^0.7.0",
+				"v8-compile-cache": "^2.1.0",
+				"webpack-merge": "^4.2.2"
 			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+				"ansi-escapes": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+					"integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+					"dev": true,
+					"requires": {
+						"type-fest": "^0.11.0"
+					}
+				},
+				"colorette": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
+					"integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
 					"dev": true
 				},
-				"big.js": {
-					"version": "5.2.2",
-					"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-					"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+				"commander": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+					"integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
 					"dev": true
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "5.5.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-							"dev": true,
-							"requires": {
-								"has-flag": "^3.0.0"
-							}
-						}
-					}
-				},
-				"cliui": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-					"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-					"dev": true,
-					"requires": {
-						"string-width": "^3.1.0",
-						"strip-ansi": "^5.2.0",
-						"wrap-ansi": "^5.1.0"
-					}
-				},
-				"cross-spawn": {
-					"version": "6.0.5",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-					"dev": true,
-					"requires": {
-						"nice-try": "^1.0.4",
-						"path-key": "^2.0.1",
-						"semver": "^5.5.0",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
-					}
-				},
-				"enhanced-resolve": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
-					"integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"memory-fs": "^0.4.0",
-						"tapable": "^1.0.0"
-					}
-				},
-				"execa": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-					"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-					"dev": true,
-					"requires": {
-						"cross-spawn": "^6.0.0",
-						"get-stream": "^4.0.0",
-						"is-stream": "^1.1.0",
-						"npm-run-path": "^2.0.0",
-						"p-finally": "^1.0.0",
-						"signal-exit": "^3.0.0",
-						"strip-eof": "^1.0.0"
-					}
 				},
 				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"get-caller-file": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-					"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-					"dev": true
-				},
-				"get-stream": {
 					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
 					"dev": true,
 					"requires": {
-						"pump": "^3.0.0"
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
 					}
 				},
-				"interpret": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
-					"integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
-					"dev": true
-				},
-				"invert-kv": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-					"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
-					"dev": true
-				},
-				"json5": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+				"import-local": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
+					"integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
 					"dev": true,
 					"requires": {
-						"minimist": "^1.2.0"
-					}
-				},
-				"lcid": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-					"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
-					"dev": true,
-					"requires": {
-						"invert-kv": "^2.0.0"
-					}
-				},
-				"loader-utils": {
-					"version": "1.2.3",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
-					"integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
-					"dev": true,
-					"requires": {
-						"big.js": "^5.2.2",
-						"emojis-list": "^2.0.0",
-						"json5": "^1.0.1"
+						"pkg-dir": "^4.2.0",
+						"resolve-cwd": "^3.0.0"
 					}
 				},
 				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
 					"dev": true,
 					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"mem": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
-					"integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
-					"dev": true,
-					"requires": {
-						"map-age-cleaner": "^0.1.1",
-						"mimic-fn": "^2.0.0",
-						"p-is-promise": "^2.0.0"
-					}
-				},
-				"mimic-fn": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-					"dev": true
-				},
-				"os-locale": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-					"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
-					"dev": true,
-					"requires": {
-						"execa": "^1.0.0",
-						"lcid": "^2.0.0",
-						"mem": "^4.0.0"
+						"p-locate": "^4.1.0"
 					}
 				},
 				"p-limit": {
-					"version": "2.2.2",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-					"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
 					"dev": true,
 					"requires": {
 						"p-try": "^2.0.0"
 					}
 				},
 				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
 					"dev": true,
 					"requires": {
-						"p-limit": "^2.0.0"
+						"p-limit": "^2.2.0"
 					}
 				},
 				"p-try": {
@@ -54333,98 +54006,66 @@
 					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 					"dev": true
 				},
-				"pump": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-					"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-					"dev": true,
-					"requires": {
-						"end-of-stream": "^1.1.0",
-						"once": "^1.3.1"
-					}
-				},
-				"require-main-filename": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-					"dev": true
-				},
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				},
-				"string-width": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^7.0.1",
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				},
-				"v8-compile-cache": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz",
-					"integrity": "sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==",
-					"dev": true
-				},
-				"wrap-ansi": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-					"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.0",
-						"string-width": "^3.0.0",
-						"strip-ansi": "^5.0.0"
-					}
-				},
-				"y18n": {
+				"path-exists": {
 					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
 					"dev": true
 				},
-				"yargs": {
-					"version": "13.2.4",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.4.tgz",
-					"integrity": "sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==",
+				"path-parse": {
+					"version": "1.0.6",
+					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+					"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+					"dev": true
+				},
+				"pkg-dir": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+					"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
 					"dev": true,
 					"requires": {
-						"cliui": "^5.0.0",
-						"find-up": "^3.0.0",
-						"get-caller-file": "^2.0.1",
-						"os-locale": "^3.1.0",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^2.0.0",
-						"set-blocking": "^2.0.0",
-						"string-width": "^3.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^4.0.0",
-						"yargs-parser": "^13.1.0"
+						"find-up": "^4.0.0"
 					}
+				},
+				"rechoir": {
+					"version": "0.7.0",
+					"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.0.tgz",
+					"integrity": "sha512-ADsDEH2bvbjltXEP+hTIAmeFekTFK0V2BTxMkok6qILyAJEXV0AFfoWcAq4yfll5VdIMd/RVXq0lR+wQi5ZU3Q==",
+					"dev": true,
+					"requires": {
+						"resolve": "^1.9.0"
+					}
+				},
+				"resolve": {
+					"version": "1.19.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+					"integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+					"dev": true,
+					"requires": {
+						"is-core-module": "^2.1.0",
+						"path-parse": "^1.0.6"
+					}
+				},
+				"resolve-cwd": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+					"integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+					"dev": true,
+					"requires": {
+						"resolve-from": "^5.0.0"
+					}
+				},
+				"resolve-from": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+					"dev": true
+				},
+				"type-fest": {
+					"version": "0.11.0",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+					"integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+					"dev": true
 				}
 			}
 		},
@@ -54535,6 +54176,15 @@
 					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
 					"dev": true
 				}
+			}
+		},
+		"webpack-merge": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.2.tgz",
+			"integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
+			"dev": true,
+			"requires": {
+				"lodash": "^4.17.15"
 			}
 		},
 		"webpack-sources": {
@@ -54788,6 +54438,16 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
 			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+		},
+		"wordwrapjs": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.0.tgz",
+			"integrity": "sha512-Svqw723a3R34KvsMgpjFBYCgNOSdcW3mQFK4wIfhGQhtaFVOJmdYoXgi63ne3dTlWgatVcUc7t4HtQ/+bUVIzQ==",
+			"dev": true,
+			"requires": {
+				"reduce-flatten": "^2.0.0",
+				"typical": "^5.0.0"
+			}
 		},
 		"worker-farm": {
 			"version": "1.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10742,6 +10742,16 @@
 				"@types/json-schema": "*"
 			}
 		},
+		"@types/eslint-scope": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.0.tgz",
+			"integrity": "sha512-O/ql2+rrCUe2W2rs7wMR+GqPRcgB6UiqN5RhrR5xruFlY7l9YLMn0ZkDzjoHLeiFkR8MCQZVudUuuvQ2BLC9Qw==",
+			"dev": true,
+			"requires": {
+				"@types/eslint": "*",
+				"@types/estree": "*"
+			}
+		},
 		"@types/estree": {
 			"version": "0.0.44",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.44.tgz",
@@ -11342,178 +11352,177 @@
 			}
 		},
 		"@webassemblyjs/ast": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
-			"integrity": "sha512-aJMfngIZ65+t71C3y2nBBg5FFG0Okt9m0XEgWZ7Ywgn1oMAT8cNwx00Uv1cQyHtidq0Xn94R4TAywO+LCQ+ZAQ==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
+			"integrity": "sha512-C6wW5L+b7ogSDVqymbkkvuW9kruN//YisMED04xzeBBqjHa2FYnmvOlS6Xj68xWQRgWvI9cIglsjFowH/RJyEA==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/helper-module-context": "1.8.5",
-				"@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-				"@webassemblyjs/wast-parser": "1.8.5"
+				"@webassemblyjs/helper-module-context": "1.9.0",
+				"@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+				"@webassemblyjs/wast-parser": "1.9.0"
 			}
 		},
 		"@webassemblyjs/floating-point-hex-parser": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.5.tgz",
-			"integrity": "sha512-9p+79WHru1oqBh9ewP9zW95E3XAo+90oth7S5Re3eQnECGq59ly1Ri5tsIipKGpiStHsUYmY3zMLqtk3gTcOtQ==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.9.0.tgz",
+			"integrity": "sha512-TG5qcFsS8QB4g4MhrxK5TqfdNe7Ey/7YL/xN+36rRjl/BlGE/NcBvJcqsRgCP6Z92mRE+7N50pRIi8SmKUbcQA==",
 			"dev": true
 		},
 		"@webassemblyjs/helper-api-error": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.5.tgz",
-			"integrity": "sha512-Za/tnzsvnqdaSPOUXHyKJ2XI7PDX64kWtURyGiJJZKVEdFOsdKUCPTNEVFZq3zJ2R0G5wc2PZ5gvdTRFgm81zA==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.0.tgz",
+			"integrity": "sha512-NcMLjoFMXpsASZFxJ5h2HZRcEhDkvnNFOAKneP5RbKRzaWJN36NC4jqQHKwStIhGXu5mUWlUUk7ygdtrO8lbmw==",
 			"dev": true
 		},
 		"@webassemblyjs/helper-buffer": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.5.tgz",
-			"integrity": "sha512-Ri2R8nOS0U6G49Q86goFIPNgjyl6+oE1abW1pS84BuhP1Qcr5JqMwRFT3Ah3ADDDYGEgGs1iyb1DGX+kAi/c/Q==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.9.0.tgz",
+			"integrity": "sha512-qZol43oqhq6yBPx7YM3m9Bv7WMV9Eevj6kMi6InKOuZxhw+q9hOkvq5e/PpKSiLfyetpaBnogSbNCfBwyB00CA==",
 			"dev": true
 		},
 		"@webassemblyjs/helper-code-frame": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.8.5.tgz",
-			"integrity": "sha512-VQAadSubZIhNpH46IR3yWO4kZZjMxN1opDrzePLdVKAZ+DFjkGD/rf4v1jap744uPVU6yjL/smZbRIIJTOUnKQ==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.9.0.tgz",
+			"integrity": "sha512-ERCYdJBkD9Vu4vtjUYe8LZruWuNIToYq/ME22igL+2vj2dQ2OOujIZr3MEFvfEaqKoVqpsFKAGsRdBSBjrIvZA==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/wast-printer": "1.8.5"
+				"@webassemblyjs/wast-printer": "1.9.0"
 			}
 		},
 		"@webassemblyjs/helper-fsm": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.5.tgz",
-			"integrity": "sha512-kRuX/saORcg8se/ft6Q2UbRpZwP4y7YrWsLXPbbmtepKr22i8Z4O3V5QE9DbZK908dh5Xya4Un57SDIKwB9eow==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.9.0.tgz",
+			"integrity": "sha512-OPRowhGbshCb5PxJ8LocpdX9Kl0uB4XsAjl6jH/dWKlk/mzsANvhwbiULsaiqT5GZGT9qinTICdj6PLuM5gslw==",
 			"dev": true
 		},
 		"@webassemblyjs/helper-module-context": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.8.5.tgz",
-			"integrity": "sha512-/O1B236mN7UNEU4t9X7Pj38i4VoU8CcMHyy3l2cV/kIF4U5KoHXDVqcDuOs1ltkac90IM4vZdHc52t1x8Yfs3g==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.9.0.tgz",
+			"integrity": "sha512-MJCW8iGC08tMk2enck1aPW+BE5Cw8/7ph/VGZxwyvGbJwjktKkDK7vy7gAmMDx88D7mhDTCNKAW5tED+gZ0W8g==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.8.5",
-				"mamacro": "^0.0.3"
+				"@webassemblyjs/ast": "1.9.0"
 			}
 		},
 		"@webassemblyjs/helper-wasm-bytecode": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.5.tgz",
-			"integrity": "sha512-Cu4YMYG3Ddl72CbmpjU/wbP6SACcOPVbHN1dI4VJNJVgFwaKf1ppeFJrwydOG3NDHxVGuCfPlLZNyEdIYlQ6QQ==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.0.tgz",
+			"integrity": "sha512-R7FStIzyNcd7xKxCZH5lE0Bqy+hGTwS3LJjuv1ZVxd9O7eHCedSdrId/hMOd20I+v8wDXEn+bjfKDLzTepoaUw==",
 			"dev": true
 		},
 		"@webassemblyjs/helper-wasm-section": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.8.5.tgz",
-			"integrity": "sha512-VV083zwR+VTrIWWtgIUpqfvVdK4ff38loRmrdDBgBT8ADXYsEZ5mPQ4Nde90N3UYatHdYoDIFb7oHzMncI02tA==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.9.0.tgz",
+			"integrity": "sha512-XnMB8l3ek4tvrKUUku+IVaXNHz2YsJyOOmz+MMkZvh8h1uSJpSen6vYnw3IoQ7WwEuAhL8Efjms1ZWjqh2agvw==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.8.5",
-				"@webassemblyjs/helper-buffer": "1.8.5",
-				"@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-				"@webassemblyjs/wasm-gen": "1.8.5"
+				"@webassemblyjs/ast": "1.9.0",
+				"@webassemblyjs/helper-buffer": "1.9.0",
+				"@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+				"@webassemblyjs/wasm-gen": "1.9.0"
 			}
 		},
 		"@webassemblyjs/ieee754": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.8.5.tgz",
-			"integrity": "sha512-aaCvQYrvKbY/n6wKHb/ylAJr27GglahUO89CcGXMItrOBqRarUMxWLJgxm9PJNuKULwN5n1csT9bYoMeZOGF3g==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.9.0.tgz",
+			"integrity": "sha512-dcX8JuYU/gvymzIHc9DgxTzUUTLexWwt8uCTWP3otys596io0L5aW02Gb1RjYpx2+0Jus1h4ZFqjla7umFniTg==",
 			"dev": true,
 			"requires": {
 				"@xtuc/ieee754": "^1.2.0"
 			}
 		},
 		"@webassemblyjs/leb128": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.8.5.tgz",
-			"integrity": "sha512-plYUuUwleLIziknvlP8VpTgO4kqNaH57Y3JnNa6DLpu/sGcP6hbVdfdX5aHAV716pQBKrfuU26BJK29qY37J7A==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.9.0.tgz",
+			"integrity": "sha512-ENVzM5VwV1ojs9jam6vPys97B/S65YQtv/aanqnU7D8aSoHFX8GyhGg0CMfyKNIHBuAVjy3tlzd5QMMINa7wpw==",
 			"dev": true,
 			"requires": {
 				"@xtuc/long": "4.2.2"
 			}
 		},
 		"@webassemblyjs/utf8": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.8.5.tgz",
-			"integrity": "sha512-U7zgftmQriw37tfD934UNInokz6yTmn29inT2cAetAsaU9YeVCveWEwhKL1Mg4yS7q//NGdzy79nlXh3bT8Kjw==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.9.0.tgz",
+			"integrity": "sha512-GZbQlWtopBTP0u7cHrEx+73yZKrQoBMpwkGEIqlacljhXCkVM1kMQge/Mf+csMJAjEdSwhOyLAS0AoR3AG5P8w==",
 			"dev": true
 		},
 		"@webassemblyjs/wasm-edit": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.8.5.tgz",
-			"integrity": "sha512-A41EMy8MWw5yvqj7MQzkDjU29K7UJq1VrX2vWLzfpRHt3ISftOXqrtojn7nlPsZ9Ijhp5NwuODuycSvfAO/26Q==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.9.0.tgz",
+			"integrity": "sha512-FgHzBm80uwz5M8WKnMTn6j/sVbqilPdQXTWraSjBwFXSYGirpkSWE2R9Qvz9tNiTKQvoKILpCuTjBKzOIm0nxw==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.8.5",
-				"@webassemblyjs/helper-buffer": "1.8.5",
-				"@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-				"@webassemblyjs/helper-wasm-section": "1.8.5",
-				"@webassemblyjs/wasm-gen": "1.8.5",
-				"@webassemblyjs/wasm-opt": "1.8.5",
-				"@webassemblyjs/wasm-parser": "1.8.5",
-				"@webassemblyjs/wast-printer": "1.8.5"
+				"@webassemblyjs/ast": "1.9.0",
+				"@webassemblyjs/helper-buffer": "1.9.0",
+				"@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+				"@webassemblyjs/helper-wasm-section": "1.9.0",
+				"@webassemblyjs/wasm-gen": "1.9.0",
+				"@webassemblyjs/wasm-opt": "1.9.0",
+				"@webassemblyjs/wasm-parser": "1.9.0",
+				"@webassemblyjs/wast-printer": "1.9.0"
 			}
 		},
 		"@webassemblyjs/wasm-gen": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.5.tgz",
-			"integrity": "sha512-BCZBT0LURC0CXDzj5FXSc2FPTsxwp3nWcqXQdOZE4U7h7i8FqtFK5Egia6f9raQLpEKT1VL7zr4r3+QX6zArWg==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.9.0.tgz",
+			"integrity": "sha512-cPE3o44YzOOHvlsb4+E9qSqjc9Qf9Na1OO/BHFy4OI91XDE14MjFN4lTMezzaIWdPqHnsTodGGNP+iRSYfGkjA==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.8.5",
-				"@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-				"@webassemblyjs/ieee754": "1.8.5",
-				"@webassemblyjs/leb128": "1.8.5",
-				"@webassemblyjs/utf8": "1.8.5"
+				"@webassemblyjs/ast": "1.9.0",
+				"@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+				"@webassemblyjs/ieee754": "1.9.0",
+				"@webassemblyjs/leb128": "1.9.0",
+				"@webassemblyjs/utf8": "1.9.0"
 			}
 		},
 		"@webassemblyjs/wasm-opt": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.5.tgz",
-			"integrity": "sha512-HKo2mO/Uh9A6ojzu7cjslGaHaUU14LdLbGEKqTR7PBKwT6LdPtLLh9fPY33rmr5wcOMrsWDbbdCHq4hQUdd37Q==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.9.0.tgz",
+			"integrity": "sha512-Qkjgm6Anhm+OMbIL0iokO7meajkzQD71ioelnfPEj6r4eOFuqm4YC3VBPqXjFyyNwowzbMD+hizmprP/Fwkl2A==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.8.5",
-				"@webassemblyjs/helper-buffer": "1.8.5",
-				"@webassemblyjs/wasm-gen": "1.8.5",
-				"@webassemblyjs/wasm-parser": "1.8.5"
+				"@webassemblyjs/ast": "1.9.0",
+				"@webassemblyjs/helper-buffer": "1.9.0",
+				"@webassemblyjs/wasm-gen": "1.9.0",
+				"@webassemblyjs/wasm-parser": "1.9.0"
 			}
 		},
 		"@webassemblyjs/wasm-parser": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.8.5.tgz",
-			"integrity": "sha512-pi0SYE9T6tfcMkthwcgCpL0cM9nRYr6/6fjgDtL6q/ZqKHdMWvxitRi5JcZ7RI4SNJJYnYNaWy5UUrHQy998lw==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.9.0.tgz",
+			"integrity": "sha512-9+wkMowR2AmdSWQzsPEjFU7njh8HTO5MqO8vjwEHuM+AMHioNqSBONRdr0NQQ3dVQrzp0s8lTcYqzUdb7YgELA==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.8.5",
-				"@webassemblyjs/helper-api-error": "1.8.5",
-				"@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-				"@webassemblyjs/ieee754": "1.8.5",
-				"@webassemblyjs/leb128": "1.8.5",
-				"@webassemblyjs/utf8": "1.8.5"
+				"@webassemblyjs/ast": "1.9.0",
+				"@webassemblyjs/helper-api-error": "1.9.0",
+				"@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+				"@webassemblyjs/ieee754": "1.9.0",
+				"@webassemblyjs/leb128": "1.9.0",
+				"@webassemblyjs/utf8": "1.9.0"
 			}
 		},
 		"@webassemblyjs/wast-parser": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.8.5.tgz",
-			"integrity": "sha512-daXC1FyKWHF1i11obK086QRlsMsY4+tIOKgBqI1lxAnkp9xe9YMcgOxm9kLe+ttjs5aWV2KKE1TWJCN57/Btsg==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.9.0.tgz",
+			"integrity": "sha512-qsqSAP3QQ3LyZjNC/0jBJ/ToSxfYJ8kYyuiGvtn/8MK89VrNEfwj7BPQzJVHi0jGTRK2dGdJ5PRqhtjzoww+bw==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.8.5",
-				"@webassemblyjs/floating-point-hex-parser": "1.8.5",
-				"@webassemblyjs/helper-api-error": "1.8.5",
-				"@webassemblyjs/helper-code-frame": "1.8.5",
-				"@webassemblyjs/helper-fsm": "1.8.5",
+				"@webassemblyjs/ast": "1.9.0",
+				"@webassemblyjs/floating-point-hex-parser": "1.9.0",
+				"@webassemblyjs/helper-api-error": "1.9.0",
+				"@webassemblyjs/helper-code-frame": "1.9.0",
+				"@webassemblyjs/helper-fsm": "1.9.0",
 				"@xtuc/long": "4.2.2"
 			}
 		},
 		"@webassemblyjs/wast-printer": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.8.5.tgz",
-			"integrity": "sha512-w0U0pD4EhlnvRyeJzBqaVSJAo9w/ce7/WPogeXLzGkO6hzhr4GnQIZ4W4uUt5b9ooAaXPtnXlj0gzsXEOUNYMg==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.9.0.tgz",
+			"integrity": "sha512-2J0nE95rHXHyQ24cWjMKJ1tqB/ds8z/cyeOZxJhcb+rW+SQASVjuznUSmdz5GpVJTzU8JkhYut0D3siFDD6wsA==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.8.5",
-				"@webassemblyjs/wast-parser": "1.8.5",
+				"@webassemblyjs/ast": "1.9.0",
+				"@webassemblyjs/wast-parser": "1.9.0",
 				"@xtuc/long": "4.2.2"
 			}
 		},
@@ -12619,9 +12628,9 @@
 				"terser-webpack-plugin": "^3.0.3",
 				"thread-loader": "^2.1.3",
 				"url-loader": "^3.0.0",
-				"webpack": "^4.42.0",
+				"webpack": "^5.10.0",
 				"webpack-bundle-analyzer": "^4.2.0",
-				"webpack-cli": "^3.3.11",
+				"webpack-cli": "^4.1.0",
 				"webpack-livereload-plugin": "^2.3.0",
 				"webpack-sources": "^2.2.0"
 			}
@@ -26602,25 +26611,26 @@
 			}
 		},
 		"enhanced-resolve": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.1.tgz",
-			"integrity": "sha512-98p2zE+rL7/g/DzMHMTF4zZlCgeVdJ7yr6xzEpJRYwFYrGi9ANdn5DnJURg6RpBkyk60XYDnWIv51VfIhfNGuA==",
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.4.1.tgz",
+			"integrity": "sha512-4GbyIMzYktTFoRSmkbgZ1LU+RXwf4AQ8Z+rSuuh1dC8plp0PPeaWvx6+G4hh4KnUJ48VoxKbNyA1QQQIUpXjYA==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"memory-fs": "^0.5.0",
-				"tapable": "^1.0.0"
+				"graceful-fs": "^4.2.4",
+				"tapable": "^2.2.0"
 			},
 			"dependencies": {
-				"memory-fs": {
-					"version": "0.5.0",
-					"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
-					"integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
-					"dev": true,
-					"requires": {
-						"errno": "^0.1.3",
-						"readable-stream": "^2.0.1"
-					}
+				"graceful-fs": {
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+					"dev": true
+				},
+				"tapable": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.0.tgz",
+					"integrity": "sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw==",
+					"dev": true
 				}
 			}
 		},
@@ -38844,12 +38854,6 @@
 				"tmpl": "1.0.x"
 			}
 		},
-		"mamacro": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/mamacro/-/mamacro-0.0.3.tgz",
-			"integrity": "sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA==",
-			"dev": true
-		},
 		"map-age-cleaner": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.2.tgz",
@@ -41060,9 +41064,9 @@
 			"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
 		},
 		"neo-async": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.5.1.tgz",
-			"integrity": "sha512-3KL3fvuRkZ7s4IFOMfztb7zJp3QaVWnBeGoJlgB38XnCRPj/0tLzzLG5IB8NYOHbJ8g8UGrgZv44GLDk6CxTxA==",
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
 			"dev": true
 		},
 		"nested-error-stacks": {
@@ -53622,14 +53626,21 @@
 			}
 		},
 		"watchpack": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
-			"integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.1.0.tgz",
+			"integrity": "sha512-UjgD1mqjkG99+3lgG36at4wPnUXNvis2v1utwTgQ43C22c4LD71LsYMExdWXh4HZ+RmW+B0t1Vrg2GpXAkTOQw==",
 			"dev": true,
 			"requires": {
-				"chokidar": "^2.0.2",
-				"graceful-fs": "^4.1.2",
-				"neo-async": "^2.5.0"
+				"glob-to-regexp": "^0.4.1",
+				"graceful-fs": "^4.1.2"
+			},
+			"dependencies": {
+				"glob-to-regexp": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+					"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+					"dev": true
+				}
 			}
 		},
 		"watchpack-chokidar2": {
@@ -53678,122 +53689,133 @@
 			"dev": true
 		},
 		"webpack": {
-			"version": "4.42.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.42.0.tgz",
-			"integrity": "sha512-EzJRHvwQyBiYrYqhyjW9AqM90dE4+s1/XtCfn7uWg6cS72zH+2VPFAlsnW0+W0cDi0XRjNKUMoJtpSi50+Ph6w==",
+			"version": "5.10.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.10.0.tgz",
+			"integrity": "sha512-P0bHAXmIz0zsNcHNLqFmLY1ZtrT+jtBr7FqpuDtA2o7GiHC+zBsfhgK7SmJ1HG7BAEb3G9JoMdSVi7mEDvG3Zg==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.8.5",
-				"@webassemblyjs/helper-module-context": "1.8.5",
-				"@webassemblyjs/wasm-edit": "1.8.5",
-				"@webassemblyjs/wasm-parser": "1.8.5",
-				"acorn": "^6.2.1",
-				"ajv": "^6.10.2",
-				"ajv-keywords": "^3.4.1",
+				"@types/eslint-scope": "^3.7.0",
+				"@types/estree": "^0.0.45",
+				"@webassemblyjs/ast": "1.9.0",
+				"@webassemblyjs/helper-module-context": "1.9.0",
+				"@webassemblyjs/wasm-edit": "1.9.0",
+				"@webassemblyjs/wasm-parser": "1.9.0",
+				"acorn": "^8.0.4",
+				"browserslist": "^4.14.5",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^4.1.0",
-				"eslint-scope": "^4.0.3",
+				"enhanced-resolve": "^5.3.1",
+				"eslint-scope": "^5.1.1",
+				"events": "^3.2.0",
+				"glob-to-regexp": "^0.4.1",
+				"graceful-fs": "^4.2.4",
 				"json-parse-better-errors": "^1.0.2",
-				"loader-runner": "^2.4.0",
-				"loader-utils": "^1.2.3",
-				"memory-fs": "^0.4.1",
-				"micromatch": "^3.1.10",
-				"mkdirp": "^0.5.1",
-				"neo-async": "^2.6.1",
-				"node-libs-browser": "^2.2.1",
-				"schema-utils": "^1.0.0",
-				"tapable": "^1.1.3",
-				"terser-webpack-plugin": "^1.4.3",
-				"watchpack": "^1.6.0",
-				"webpack-sources": "^1.4.1"
+				"loader-runner": "^4.1.0",
+				"mime-types": "^2.1.27",
+				"neo-async": "^2.6.2",
+				"pkg-dir": "^5.0.0",
+				"schema-utils": "^3.0.0",
+				"tapable": "^2.1.1",
+				"terser-webpack-plugin": "^5.0.3",
+				"watchpack": "^2.0.0",
+				"webpack-sources": "^2.1.1"
 			},
 			"dependencies": {
+				"@types/estree": {
+					"version": "0.0.45",
+					"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.45.tgz",
+					"integrity": "sha512-jnqIUKDUqJbDIUxm0Uj7bnlMnRm1T/eZ9N+AVMqhPgzrba2GhGG5o/jCTwmdPK709nEZsGoMzXEDUjcXHa3W0g==",
+					"dev": true
+				},
+				"@types/json-schema": {
+					"version": "7.0.6",
+					"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
+					"integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
+					"dev": true
+				},
 				"acorn": {
-					"version": "6.4.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
-					"integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
+					"version": "8.0.4",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.0.4.tgz",
+					"integrity": "sha512-XNP0PqF1XD19ZlLKvB7cMmnZswW4C/03pRHgirB30uSJTaS3A3V1/P4sS3HPvFmjoriPCJQs+JDSbm4bL1TxGQ==",
 					"dev": true
 				},
-				"big.js": {
-					"version": "5.2.2",
-					"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-					"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-					"dev": true
-				},
-				"bluebird": {
-					"version": "3.7.2",
-					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-					"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-					"dev": true
-				},
-				"cacache": {
-					"version": "12.0.4",
-					"resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
-					"integrity": "sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==",
+				"ajv": {
+					"version": "6.12.6",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+					"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 					"dev": true,
 					"requires": {
-						"bluebird": "^3.5.5",
-						"chownr": "^1.1.1",
-						"figgy-pudding": "^3.5.1",
-						"glob": "^7.1.4",
-						"graceful-fs": "^4.1.15",
-						"infer-owner": "^1.0.3",
-						"lru-cache": "^5.1.1",
-						"mississippi": "^3.0.0",
-						"mkdirp": "^0.5.1",
-						"move-concurrently": "^1.0.1",
-						"promise-inflight": "^1.0.1",
-						"rimraf": "^2.6.3",
-						"ssri": "^6.0.1",
-						"unique-filename": "^1.1.1",
-						"y18n": "^4.0.0"
+						"fast-deep-equal": "^3.1.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
 					}
 				},
-				"chownr": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-					"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+				"ajv-keywords": {
+					"version": "3.5.2",
+					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+					"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
 					"dev": true
 				},
-				"emojis-list": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-					"integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+				"commander": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
 					"dev": true
 				},
-				"find-cache-dir": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
-					"integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+				"eslint-scope": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+					"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
 					"dev": true,
 					"requires": {
-						"commondir": "^1.0.1",
-						"make-dir": "^2.0.0",
-						"pkg-dir": "^3.0.0"
+						"esrecurse": "^4.3.0",
+						"estraverse": "^4.1.1"
 					}
+				},
+				"esrecurse": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+					"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+					"dev": true,
+					"requires": {
+						"estraverse": "^5.2.0"
+					},
+					"dependencies": {
+						"estraverse": {
+							"version": "5.2.0",
+							"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+							"integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+							"dev": true
+						}
+					}
+				},
+				"events": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
+					"integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==",
+					"dev": true
+				},
+				"fast-deep-equal": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+					"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+					"dev": true
 				},
 				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+					"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
 					"dev": true,
 					"requires": {
-						"locate-path": "^3.0.0"
+						"locate-path": "^6.0.0",
+						"path-exists": "^4.0.0"
 					}
 				},
-				"glob": {
-					"version": "7.1.6",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-					"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-					"dev": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
+				"glob-to-regexp": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+					"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+					"dev": true
 				},
 				"graceful-fs": {
 					"version": "4.2.4",
@@ -53801,147 +53823,107 @@
 					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
 					"dev": true
 				},
-				"json5": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-					"dev": true,
-					"requires": {
-						"minimist": "^1.2.0"
-					}
-				},
-				"loader-utils": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-					"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
-					"dev": true,
-					"requires": {
-						"big.js": "^5.2.2",
-						"emojis-list": "^3.0.0",
-						"json5": "^1.0.1"
-					}
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"lru-cache": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-					"dev": true,
-					"requires": {
-						"yallist": "^3.0.2"
-					}
-				},
-				"make-dir": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-					"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-					"dev": true,
-					"requires": {
-						"pify": "^4.0.1",
-						"semver": "^5.6.0"
-					}
-				},
-				"mississippi": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
-					"integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
-					"dev": true,
-					"requires": {
-						"concat-stream": "^1.5.0",
-						"duplexify": "^3.4.2",
-						"end-of-stream": "^1.1.0",
-						"flush-write-stream": "^1.0.0",
-						"from2": "^2.1.0",
-						"parallel-transform": "^1.1.0",
-						"pump": "^3.0.0",
-						"pumpify": "^1.3.3",
-						"stream-each": "^1.1.0",
-						"through2": "^2.0.0"
-					}
-				},
-				"neo-async": {
-					"version": "2.6.1",
-					"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-					"integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 					"dev": true
 				},
-				"p-limit": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+				"jest-worker": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
+					"integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
 					"dev": true,
 					"requires": {
-						"p-try": "^2.0.0"
+						"@types/node": "*",
+						"merge-stream": "^2.0.0",
+						"supports-color": "^7.0.0"
+					}
+				},
+				"loader-runner": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.1.0.tgz",
+					"integrity": "sha512-oR4lB4WvwFoC70ocraKhn5nkKSs23t57h9udUgw8o0iH8hMXeEoRuUgfcvgUwAJ1ZpRqBvcou4N2SMvM1DwMrA==",
+					"dev": true
+				},
+				"locate-path": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+					"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^5.0.0"
+					}
+				},
+				"merge-stream": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+					"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+					"dev": true
+				},
+				"mime-db": {
+					"version": "1.45.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
+					"integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==",
+					"dev": true
+				},
+				"mime-types": {
+					"version": "2.1.28",
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
+					"integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
+					"dev": true,
+					"requires": {
+						"mime-db": "1.45.0"
+					}
+				},
+				"p-limit": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+					"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+					"dev": true,
+					"requires": {
+						"yocto-queue": "^0.1.0"
 					}
 				},
 				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+					"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
 					"dev": true,
 					"requires": {
-						"p-limit": "^2.0.0"
+						"p-limit": "^3.0.2"
 					}
 				},
-				"p-try": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-					"dev": true
-				},
-				"pify": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
 					"dev": true
 				},
 				"pkg-dir": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+					"integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+					"dev": true,
+					"requires": {
+						"find-up": "^5.0.0"
+					}
+				},
+				"schema-utils": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-					"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
+					"integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
 					"dev": true,
 					"requires": {
-						"find-up": "^3.0.0"
+						"@types/json-schema": "^7.0.6",
+						"ajv": "^6.12.5",
+						"ajv-keywords": "^3.5.2"
 					}
-				},
-				"pump": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-					"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-					"dev": true,
-					"requires": {
-						"end-of-stream": "^1.1.0",
-						"once": "^1.3.1"
-					}
-				},
-				"rimraf": {
-					"version": "2.7.1",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
 				},
 				"serialize-javascript": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
-					"integrity": "sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==",
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
+					"integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
 					"dev": true,
 					"requires": {
 						"randombytes": "^2.1.0"
@@ -53953,68 +53935,63 @@
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
 				},
-				"ssri": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-					"integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+				"source-map-support": {
+					"version": "0.5.19",
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+					"integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
 					"dev": true,
 					"requires": {
-						"figgy-pudding": "^3.5.1"
+						"buffer-from": "^1.0.0",
+						"source-map": "^0.6.0"
+					}
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
 					}
 				},
 				"tapable": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
-					"integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.0.tgz",
+					"integrity": "sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw==",
 					"dev": true
+				},
+				"terser": {
+					"version": "5.5.1",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-5.5.1.tgz",
+					"integrity": "sha512-6VGWZNVP2KTUcltUQJ25TtNjx/XgdDsBDKGt8nN0MpydU36LmbPPcMBd2kmtZNNGVVDLg44k7GKeHHj+4zPIBQ==",
+					"dev": true,
+					"requires": {
+						"commander": "^2.20.0",
+						"source-map": "~0.7.2",
+						"source-map-support": "~0.5.19"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.7.3",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+							"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+							"dev": true
+						}
+					}
 				},
 				"terser-webpack-plugin": {
-					"version": "1.4.4",
-					"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.4.tgz",
-					"integrity": "sha512-U4mACBHIegmfoEe5fdongHESNJWqsGU+W0S/9+BmYGVQDw1+c2Ow05TpMhxjPK1sRb7cuYq1BPl1e5YHJMTCqA==",
+					"version": "5.0.3",
+					"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.0.3.tgz",
+					"integrity": "sha512-zFdGk8Lh9ZJGPxxPE6jwysOlATWB8GMW8HcfGULWA/nPal+3VdATflQvSBSLQJRCmYZnfFJl6vkRTiwJGNgPiQ==",
 					"dev": true,
 					"requires": {
-						"cacache": "^12.0.2",
-						"find-cache-dir": "^2.1.0",
-						"is-wsl": "^1.1.0",
-						"schema-utils": "^1.0.0",
-						"serialize-javascript": "^3.1.0",
+						"jest-worker": "^26.6.1",
+						"p-limit": "^3.0.2",
+						"schema-utils": "^3.0.0",
+						"serialize-javascript": "^5.0.1",
 						"source-map": "^0.6.1",
-						"terser": "^4.1.2",
-						"webpack-sources": "^1.4.0",
-						"worker-farm": "^1.7.0"
+						"terser": "^5.3.8"
 					}
-				},
-				"unique-filename": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
-					"integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
-					"dev": true,
-					"requires": {
-						"unique-slug": "^2.0.0"
-					}
-				},
-				"webpack-sources": {
-					"version": "1.4.3",
-					"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
-					"integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
-					"dev": true,
-					"requires": {
-						"source-list-map": "^2.0.0",
-						"source-map": "~0.6.1"
-					}
-				},
-				"y18n": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-					"dev": true
-				},
-				"yallist": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-					"dev": true
 				}
 			}
 		},
@@ -55216,6 +55193,12 @@
 			"requires": {
 				"fd-slicer": "~1.0.1"
 			}
+		},
+		"yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"dev": true
 		},
 		"zip-stream": {
 			"version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -107,8 +107,6 @@
 		"@types/sprintf-js": "1.1.2",
 		"@types/tinycolor2": "1.4.2",
 		"@types/uuid": "8.3.0",
-		"@types/webpack": "4.41.16",
-		"@types/webpack-sources": "0.1.7",
 		"@wordpress/babel-plugin-import-jsx-pragma": "file:packages/babel-plugin-import-jsx-pragma",
 		"@wordpress/babel-plugin-makepot": "file:packages/babel-plugin-makepot",
 		"@wordpress/babel-preset-default": "file:packages/babel-preset-default",
@@ -198,7 +196,7 @@
 		"typescript": "4.0.3",
 		"uuid": "8.3.0",
 		"wd": "1.12.1",
-		"webpack": "4.42.0",
+		"webpack": "5.10.0",
 		"webpack-bundle-analyzer": "4.2.0",
 		"worker-farm": "1.7.0"
 	},

--- a/packages/custom-templated-path-webpack-plugin/package.json
+++ b/packages/custom-templated-path-webpack-plugin/package.json
@@ -31,7 +31,7 @@
 		"escape-string-regexp": "^1.0.5"
 	},
 	"peerDependencies": {
-		"webpack": "^4.0.0"
+		"webpack": "^4.0.0 || ^5.0.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
+++ b/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Webpack \`combine-assets\` should produce expected output: Asset file should match snapshot 1`] = `"<?php return array('fileA.js' => array('dependencies' => array('lodash', 'wp-blob'), 'version' => 'a3da22ced6876ec052d2861d383960fc'), 'fileB.js' => array('dependencies' => array('wp-token-list'), 'version' => '1a2b3802cc39dc1a607ecc4d0b23fcb0'));"`;
+exports[`Webpack \`combine-assets\` should produce expected output: Asset file should match snapshot 1`] = `"<?php return array('fileA.js' => array('dependencies' => array('lodash', 'wp-blob'), 'version' => 'c1a0364500c80987c940e1d047a1f440'), 'fileB.js' => array('dependencies' => array('wp-token-list'), 'version' => '371032d1471df7da2912fa1cd5474f64'));"`;
 
 exports[`Webpack \`combine-assets\` should produce expected output: External modules should match snapshot 1`] = `
 Array [
@@ -28,7 +28,7 @@ Array [
 ]
 `;
 
-exports[`Webpack \`dynamic-import\` should produce expected output: Asset file should match snapshot 1`] = `"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => 'd5c613274c346f46e16ab4d320fc01e6');"`;
+exports[`Webpack \`dynamic-import\` should produce expected output: Asset file should match snapshot 1`] = `"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '6beab7b6d11b0d5aa173d6c30876cf75');"`;
 
 exports[`Webpack \`dynamic-import\` should produce expected output: External modules should match snapshot 1`] = `
 Array [
@@ -48,7 +48,7 @@ Array [
 ]
 `;
 
-exports[`Webpack \`function-output-filename\` should produce expected output: Asset file should match snapshot 1`] = `"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => 'f6dc46e27c3a9e7338ed4fa9fdf8f606');"`;
+exports[`Webpack \`function-output-filename\` should produce expected output: Asset file should match snapshot 1`] = `"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => 'b3f0507c52ecec25e3fd43e9c24a2686');"`;
 
 exports[`Webpack \`function-output-filename\` should produce expected output: External modules should match snapshot 1`] = `
 Array [
@@ -68,15 +68,15 @@ Array [
 ]
 `;
 
-exports[`Webpack \`no-default\` should produce expected output: Asset file should match snapshot 1`] = `"<?php return array('dependencies' => array(), 'version' => '0a2f4c4cfbc33dde065a2e4be1e6337c');"`;
+exports[`Webpack \`no-default\` should produce expected output: Asset file should match snapshot 1`] = `"<?php return array('dependencies' => array(), 'version' => '8496c3a9f730be0cb9c1d98a4dccf779');"`;
 
 exports[`Webpack \`no-default\` should produce expected output: External modules should match snapshot 1`] = `Array []`;
 
-exports[`Webpack \`no-deps\` should produce expected output: Asset file should match snapshot 1`] = `"<?php return array('dependencies' => array(), 'version' => 'e8e65570823ee9206bdada3a0f11b610');"`;
+exports[`Webpack \`no-deps\` should produce expected output: Asset file should match snapshot 1`] = `"<?php return array('dependencies' => array(), 'version' => 'edf63f92d4912e4dc86233ff82ab4eff');"`;
 
 exports[`Webpack \`no-deps\` should produce expected output: External modules should match snapshot 1`] = `Array []`;
 
-exports[`Webpack \`output-format-json\` should produce expected output: Asset file should match snapshot 1`] = `"{\\"dependencies\\":[\\"lodash\\"],\\"version\\":\\"aeb5066a5e17aea01932c77baf342372\\"}"`;
+exports[`Webpack \`output-format-json\` should produce expected output: Asset file should match snapshot 1`] = `"{\\"dependencies\\":[\\"lodash\\"],\\"version\\":\\"0cc76fc6a71a3027053c3fe635f4026a\\"}"`;
 
 exports[`Webpack \`output-format-json\` should produce expected output: External modules should match snapshot 1`] = `
 Array [
@@ -88,7 +88,7 @@ Array [
 ]
 `;
 
-exports[`Webpack \`overrides\` should produce expected output: Asset file should match snapshot 1`] = `"<?php return array('dependencies' => array('wp-blob', 'wp-script-handle-for-rxjs', 'wp-url'), 'version' => '67d711ce8940ddb82e7f264f61a5a3d9');"`;
+exports[`Webpack \`overrides\` should produce expected output: Asset file should match snapshot 1`] = `"<?php return array('dependencies' => array('wp-blob', 'wp-script-handle-for-rxjs', 'wp-url'), 'version' => '18b6bab716b493f09a08360d4a7da0e4');"`;
 
 exports[`Webpack \`overrides\` should produce expected output: External modules should match snapshot 1`] = `
 Array [
@@ -124,7 +124,7 @@ Array [
 ]
 `;
 
-exports[`Webpack \`wordpress\` should produce expected output: Asset file should match snapshot 1`] = `"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '202b3ce17cfd72799ce45e7efa04d83c');"`;
+exports[`Webpack \`wordpress\` should produce expected output: Asset file should match snapshot 1`] = `"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => 'b3f0507c52ecec25e3fd43e9c24a2686');"`;
 
 exports[`Webpack \`wordpress\` should produce expected output: External modules should match snapshot 1`] = `
 Array [
@@ -144,7 +144,7 @@ Array [
 ]
 `;
 
-exports[`Webpack \`wordpress-require\` should produce expected output: Asset file should match snapshot 1`] = `"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '47b0c1540a1caf08b8931e4a4328db04');"`;
+exports[`Webpack \`wordpress-require\` should produce expected output: Asset file should match snapshot 1`] = `"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => 'f6db2e391b22a13b164814dfb5842d3f');"`;
 
 exports[`Webpack \`wordpress-require\` should produce expected output: External modules should match snapshot 1`] = `
 Array [

--- a/packages/library-export-default-webpack-plugin/package.json
+++ b/packages/library-export-default-webpack-plugin/package.json
@@ -33,7 +33,7 @@
 		"webpack-sources": "^1.1.0"
 	},
 	"peerDependencies": {
-		"webpack": "^4.0.0"
+		"webpack": "^4.0.0 || ^5.0.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Breaking Changes
 
--   The peer `jest` dependency has been updated from requiring `>=25` to requiring `>=26` (see [Breaking Changes](https://jestjs.io/blog/2020/05/05/jest-26), [#27956](https://github.com/WordPress/gutenberg/pull/27956)).
+-   The bundled `jest` dependency has been updated to the next major version `^26.6.3` (see [Breaking Changes](https://jestjs.io/blog/2020/05/05/jest-26), [#27956](https://github.com/WordPress/gutenberg/pull/27956)).
+-   The bundled `webpack` dependency has been updated to the next major version `^5.10.0` (see [Breaking Changes](https://webpack.js.org/migrate/5/), [#26382](https://github.com/WordPress/gutenberg/pull/26382)).
 -   The bundled `@wordpress/eslint-plugin` dependency has been updated to the next major version `^8.0.0`. There are new ESLint rules enabled in the recommended config used by `lint-js` command.
 -   The bundled `stylelint-config-wordpress` dependency has been replaced with `@wordpress/stylelint-config` (#27810)[https://github.com/WordPress/gutenberg/pull/27810].
 

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -48,6 +48,7 @@ const cssLoaders = [
 
 const config = {
 	mode,
+	target: 'browserslist',
 	entry: {
 		index: path.resolve( process.cwd(), 'src', 'index.js' ),
 	},

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -71,9 +71,9 @@
 		"terser-webpack-plugin": "^3.0.3",
 		"thread-loader": "^2.1.3",
 		"url-loader": "^3.0.0",
-		"webpack": "^4.42.0",
+		"webpack": "^5.10.0",
 		"webpack-bundle-analyzer": "^4.2.0",
-		"webpack-cli": "^3.3.11",
+		"webpack-cli": "^4.1.0",
 		"webpack-livereload-plugin": "^2.3.0",
 		"webpack-sources": "^2.2.0"
 	},

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -87,6 +87,7 @@ module.exports = {
 		],
 	},
 	mode,
+	target: 'browserslist',
 	entry: gutenbergPackages.reduce( ( memo, packageName ) => {
 		const name = camelCaseDash( packageName );
 		memo[ name ] = `./packages/${ packageName }`;


### PR DESCRIPTION
Closes https://github.com/WordPress/gutenberg/issues/21647.

This is a draft PR that upgrades webpack to version 5. There are 18 small commits that make independent changes that are needed. Most can be merged as separate PRs, to make things compatible between v4 and v5 before actually doing the upgrade.

Migration guide:
https://webpack.js.org/migrate/5/

Cc @scinos who's also interested in webpack 5 but is not a member of this repo, so I cannot add him as a reviewer 🙂 