### PR TITLE
FSE: allow themes to live in a sub directory

### DIFF
--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -19,7 +19,7 @@ function render_block_core_template_part( $attributes ) {
 		// If we have a post ID and the post exists, which means this template part
 		// is user-customized, render the corresponding post content.
 		$content = get_post( $attributes['postId'] )->post_content;
-	} elseif ( isset( $attributes['theme'] ) && basename( wp_get_theme()->stylesheet ) === $attributes['theme'] ) {
+	} elseif ( isset( $attributes['theme'] ) && basename( wp_get_theme()->get_stylesheet() ) === $attributes['theme'] ) {
 		$template_part_query = new WP_Query(
 			array(
 				'post_type'      => 'wp_template_part',

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -19,7 +19,7 @@ function render_block_core_template_part( $attributes ) {
 		// If we have a post ID and the post exists, which means this template part
 		// is user-customized, render the corresponding post content.
 		$content = get_post( $attributes['postId'] )->post_content;
-	} elseif ( isset( $attributes['theme'] ) && wp_get_theme()->stylesheet === $attributes['theme'] ) {
+	} elseif ( isset( $attributes['theme'] ) && basename( wp_get_theme()->stylesheet ) === $attributes['theme'] ) {
 		$template_part_query = new WP_Query(
 			array(
 				'post_type'      => 'wp_template_part',


### PR DESCRIPTION
## Description
When block based themes aren't in the `themes` directory the template parts don't show - instead you get "Template Part Not Found".

This changes the way we look for the template parts so that it works even if the theme is in a sub directory.

## How has this been tested?
- Add an experimental block based theme to a sub directory of themes and activate it
- Enable the FSE experiment
- Check that the header and footer templates load correctly

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
