### PR TITLE
Update node-watch to 0.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47910,9 +47910,9 @@
 			}
 		},
 		"node-watch": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.6.0.tgz",
-			"integrity": "sha512-XAgTL05z75ptd7JSVejH1a2Dm1zmXYhuDr9l230Qk6Z7/7GPcnAs/UyJJ4ggsXSvWil8iOzwQLW0zuGUvHpG8g==",
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.7.0.tgz",
+			"integrity": "sha512-OOBiglke5SlRQT5WYfwXTmYqTfXjcTNBHpalyHLtLxDpQYVpVRkJqabcch1kmwJsjV/J4OZuzEafeb4soqtFZA==",
 			"dev": true
 		},
 		"nodegit": {

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
 		"mkdirp": "0.5.1",
 		"nock": "12.0.3",
 		"node-sass": "4.13.1",
-		"node-watch": "0.6.0",
+		"node-watch": "0.7.0",
 		"patch-package": "6.2.2",
 		"postcss": "7.0.32",
 		"postcss-loader": "3.0.0",


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

Filesystem watching wasn't working for me on Linux. Updating to the latest version of `node-watch` fixed the issue for me.

OS: Arch Linux x86_64
Kernel: 5.4.72-1-lts

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

`npm run dev` on Linux runs incremental build when file is changed.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Bug Fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
