### PR TITLE
Fix composite role warnings triggered by template part previews.

### DIFF
--- a/packages/block-library/src/template-part/edit/selection/template-part-previews.js
+++ b/packages/block-library/src/template-part/edit/selection/template-part-previews.js
@@ -60,7 +60,7 @@ function TemplatePartItem( {
 	return (
 		<CompositeItem
 			className="wp-block-template-part__selection-preview-item"
-			role="listitem"
+			role="option"
 			onClick={ onClick }
 			onKeyDown={ ( event ) => {
 				if ( ENTER === event.keyCode || SPACE === event.keyCode ) {
@@ -238,7 +238,7 @@ export default function TemplateParts( {
 		return (
 			<Composite
 				{ ...composite }
-				role="list"
+				role="listbox"
 				aria-label={ __( 'List of template parts' ) }
 			>
 				<TemplatePartSearchResults
@@ -255,7 +255,7 @@ export default function TemplateParts( {
 	return (
 		<Composite
 			{ ...composite }
-			role="list"
+			role="listbox"
 			aria-label={ __( 'List of template parts' ) }
 		>
 			<TemplatePartsByTheme


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
This fixes the console warning for composite elements requiring a valid 'role' that comes from the template-part-previews component.  The roles have been updated from list/listitem to listbox/option which is more consistent with other sections of the project where composite is used (such as the inserter list/items).  This change removes the warning that was triggered.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
* Enable FSE experiment.
* Open the template part previews selection component (either by adding a template part block, or using the dropdown on an existing template-part block's toolbar).
* Verify there are no longer composite/role warnings triggered in the console.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
