### PR TITLE
Fix autosave e2e tests

### DIFF
--- a/packages/e2e-tests/specs/editor/various/autosave.test.js
+++ b/packages/e2e-tests/specs/editor/various/autosave.test.js
@@ -124,42 +124,6 @@ describe( 'autosave', () => {
 		);
 	} );
 
-	it( 'should clear sessionStorage upon user logout', async () => {
-		await clickBlockAppender();
-		await page.keyboard.type( 'before save' );
-		await saveDraft();
-
-		// Fake local autosave
-		await page.evaluate(
-			( postId ) =>
-				window.sessionStorage.setItem(
-					`wp-autosave-block-editor-post-${ postId }`,
-					JSON.stringify( {
-						post_title: 'A',
-						content: 'B',
-						excerpt: 'C',
-					} )
-				),
-			await getCurrentPostId()
-		);
-		expect(
-			await page.evaluate( () => window.sessionStorage.length )
-		).toBe( 1 );
-
-		await Promise.all( [
-			page.waitForSelector( '#wp-admin-bar-logout', { visible: true } ),
-			page.hover( '#wp-admin-bar-my-account' ),
-		] );
-		await Promise.all( [
-			page.waitForNavigation(),
-			page.click( '#wp-admin-bar-logout' ),
-		] );
-
-		expect(
-			await page.evaluate( () => window.sessionStorage.length )
-		).toBe( 0 );
-	} );
-
 	it( "shouldn't contaminate other posts", async () => {
 		await clickBlockAppender();
 		await page.keyboard.type( 'before save' );
@@ -336,6 +300,42 @@ describe( 'autosave', () => {
 			( element ) => element.innerText
 		);
 		expect( notice ).toContain( AUTOSAVE_NOTICE_REMOTE );
+	} );
+
+	it( 'should clear sessionStorage upon user logout', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( 'before save' );
+		await saveDraft();
+
+		// Fake local autosave
+		await page.evaluate(
+			( postId ) =>
+				window.sessionStorage.setItem(
+					`wp-autosave-block-editor-post-${ postId }`,
+					JSON.stringify( {
+						post_title: 'A',
+						content: 'B',
+						excerpt: 'C',
+					} )
+				),
+			await getCurrentPostId()
+		);
+		expect(
+			await page.evaluate( () => window.sessionStorage.length )
+		).toBe( 1 );
+
+		await Promise.all( [
+			page.waitForSelector( '#wp-admin-bar-logout', { visible: true } ),
+			page.hover( '#wp-admin-bar-my-account' ),
+		] );
+		await Promise.all( [
+			page.waitForNavigation(),
+			page.click( '#wp-admin-bar-logout' ),
+		] );
+
+		expect(
+			await page.evaluate( () => window.sessionStorage.length )
+		).toBe( 0 );
 	} );
 
 	afterEach( async () => {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Current failures in `autosave` e2e tests are caused by a specific test that `logs out` the user and that makes the test to visit the `login` page. There, a request is happening and fails (logs in console) making any subsequent test fail.

For now, I just moved that test at the end and it resolves this issue temporarily.

The root for this might be in some recent changes (3 days ago) in password generation in `core`. 

The request is coming from here: https://github.com/WordPress/WordPress/blob/c575f66422d8288dbe478c7717df9f5685be0f80/wp-admin/js/user-profile.js#L150

That file changed 3 days ago in this commit: https://github.com/WordPress/WordPress/commit/daa977c495e73bb2b85a517e464c16fd4f2d3233 and might be probably related.

