### PR TITLE
Port changes from core PR

### DIFF
--- a/lib/class-wp-block-supports.php
+++ b/lib/class-wp-block-supports.php
@@ -215,7 +215,8 @@ function wp_block_supports_track_block_to_render( $args ) {
 			//
 			// See:
 			// - https://core.trac.wordpress.org/ticket/49927
-			// - commit 910de8f6890c87f93359c6f2edc6c27b9a3f3292 at wordpress-develop
+			// - commit 910de8f6890c87f93359c6f2edc6c27b9a3f3292 at wordpress-develop.
+			//
 			if ( null !== $block ) {
 				$parent_block                       = WP_Block_Supports::$block_to_render;
 				WP_Block_Supports::$block_to_render = $block->parsed_block;

--- a/lib/class-wp-block-supports.php
+++ b/lib/class-wp-block-supports.php
@@ -209,7 +209,7 @@ function get_block_wrapper_attributes( $extra_attributes = array() ) {
 function wp_block_supports_track_block_to_render( $args ) {
 	if ( is_callable( $args['render_callback'] ) ) {
 		$block_render_callback   = $args['render_callback'];
-		$args['render_callback'] = function( $attributes, $content, $block ) use ( $block_render_callback ) {
+		$args['render_callback'] = function( $attributes, $content, $block = null ) use ( $block_render_callback ) {
 			// Check for null for back compatibility with WP_Block_Type->render
 			// which is unused since the introduction of WP_Block class.
 			//

--- a/lib/class-wp-block-supports.php
+++ b/lib/class-wp-block-supports.php
@@ -216,16 +216,16 @@ function wp_block_supports_track_block_to_render( $args ) {
 			// See:
 			// - https://core.trac.wordpress.org/ticket/49927
 			// - commit 910de8f6890c87f93359c6f2edc6c27b9a3f3292 at wordpress-develop.
-			//
-			if ( null !== $block ) {
-				$parent_block                       = WP_Block_Supports::$block_to_render;
-				WP_Block_Supports::$block_to_render = $block->parsed_block;
-				$result                             = $block_render_callback( $attributes, $content, $block );
-				WP_Block_Supports::$block_to_render = $parent_block;
-				return $result;
-			} else {
+
+			if ( null === $block ) {
 				return $block_render_callback( $attributes, $content );
 			}
+
+			$parent_block                       = WP_Block_Supports::$block_to_render;
+			WP_Block_Supports::$block_to_render = $block->parsed_block;
+			$result                             = $block_render_callback( $attributes, $content, $block );
+			WP_Block_Supports::$block_to_render = $parent_block;
+			return $result;
 		};
 	}
 	return $args;


### PR DESCRIPTION
This PR ports the changes done while preparing the block supports class to be ported to core. See https://github.com/WordPress/wordpress-develop/pull/640

Specifically, this adds the following checks:

- Only attaches the wrapper if the existing render_callback is a callable (before, only checked for null).
- Only updates the current block to be rendered if the closure receives a not `null` WP_Block. This is because there are some dead paths in core that are still used by tests, so we need to cover against that as well. See [this comment](https://github.com/WordPress/wordpress-develop/pull/640/commits/c61fff865781191a4eee63493181e3e3f726c6f7) for context.

## How to test

- Create a new post with the social links block and publish.
- Go to the front-end and verify that the class `wp-block-social-links` is attached to the root element (ul) and not the children (li).
