### PR TITLE
Mobile Stories block - unit tests for BlockMediaUpdateProgress

### DIFF
--- a/packages/block-editor/src/components/block-media-update-progress/index.native.js
+++ b/packages/block-editor/src/components/block-media-update-progress/index.native.js
@@ -153,7 +153,7 @@ export class BlockMediaUpdateProgress extends React.Component {
 	}
 
 	mediaSaveStateReset( payload ) {
-		this.setState( { isUploadInProgress: false, isUploadFailed: false } );
+		this.setState( { isSaveInProgress: false, isSaveFailed: false } );
 		if ( this.props.onMediaSaveStateReset ) {
 			this.props.onMediaSaveStateReset( payload );
 		}

--- a/packages/block-editor/src/components/block-media-update-progress/test/index.native.js
+++ b/packages/block-editor/src/components/block-media-update-progress/test/index.native.js
@@ -81,7 +81,7 @@ const localMediaFiles = [
 	{
 		alt: '',
 		caption: '',
-		id: 2,
+		id: '2',
 		link: '',
 		mime: 'image/jpeg',
 		type: 'image',
@@ -90,7 +90,7 @@ const localMediaFiles = [
 	{
 		alt: '',
 		caption: '',
-		id: 3,
+		id: '3',
 		link: '',
 		mime: 'image/jpeg',
 		type: 'image',

--- a/packages/block-editor/src/components/block-media-update-progress/test/index.native.js
+++ b/packages/block-editor/src/components/block-media-update-progress/test/index.native.js
@@ -303,7 +303,7 @@ describe( 'BlockMediaUpdateProgress component', () => {
 		const wrapper = shallow(
 			<BlockMediaUpdateProgress
 				onFinishMediaSaveWithSuccess={ onFinishMediaSaveWithSuccess }
-				mediaFiles={ localMediaFiles }
+				mediaFiles={ tempMediaFiles }
 				renderContent={ () => {} }
 			/>
 		);
@@ -338,7 +338,7 @@ describe( 'BlockMediaUpdateProgress component', () => {
 		const wrapper = shallow(
 			<BlockMediaUpdateProgress
 				onFinishMediaSaveWithFailure={ onFinishMediaSaveWithFailure }
-				mediaFiles={ localMediaFiles }
+				mediaFiles={ tempMediaFiles }
 				renderContent={ () => {} }
 			/>
 		);
@@ -374,7 +374,7 @@ describe( 'BlockMediaUpdateProgress component', () => {
 		const wrapper = shallow(
 			<BlockMediaUpdateProgress
 				onMediaSaveStateReset={ onMediaSaveStateReset }
-				mediaFiles={ localMediaFiles }
+				mediaFiles={ tempMediaFiles }
 				renderContent={ () => {} }
 			/>
 		);
@@ -409,7 +409,7 @@ describe( 'BlockMediaUpdateProgress component', () => {
 		const wrapper = shallow(
 			<BlockMediaUpdateProgress
 				onFinalSaveResult={ onFinalSaveResult }
-				mediaFiles={ localMediaFiles }
+				mediaFiles={ tempMediaFiles }
 				renderContent={ () => {} }
 			/>
 		);
@@ -444,7 +444,7 @@ describe( 'BlockMediaUpdateProgress component', () => {
 		const wrapper = shallow(
 			<BlockMediaUpdateProgress
 				onFinalSaveResult={ onFinalSaveResult }
-				mediaFiles={ localMediaFiles }
+				mediaFiles={ tempMediaFiles }
 				renderContent={ () => {} }
 			/>
 		);
@@ -480,7 +480,7 @@ describe( 'BlockMediaUpdateProgress component', () => {
 		const wrapper = shallow(
 			<BlockMediaUpdateProgress
 				onMediaIdChanged={ onMediaIdChanged }
-				mediaFiles={ localMediaFiles }
+				mediaFiles={ tempMediaFiles }
 				renderContent={ () => {} }
 			/>
 		);

--- a/packages/block-editor/src/components/block-media-update-progress/test/index.native.js
+++ b/packages/block-editor/src/components/block-media-update-progress/test/index.native.js
@@ -52,8 +52,8 @@ jest.mock( '@wordpress/react-native-bridge', () => {
 	};
 } );
 
-const MEDIA_ID_LOCAL = 2;
-const MEDIA_ID_TEMP = 'tempid-0-1';
+const MEDIAID_LOCAL = 2;
+const MEDIAID_TEMP = 'tempid-0-1';
 
 const tempMediaFiles = [
 	{
@@ -109,7 +109,7 @@ describe( 'BlockMediaUpdateProgress component', () => {
 		const progress = 10;
 		const payload = {
 			state: MEDIA_UPLOAD_STATE_UPLOADING,
-			mediaId: MEDIA_ID_LOCAL,
+			mediaId: MEDIAID_LOCAL,
 			progress,
 		};
 
@@ -158,11 +158,11 @@ describe( 'BlockMediaUpdateProgress component', () => {
 		const progress = 10;
 		const payloadSuccess = {
 			state: MEDIA_UPLOAD_STATE_SUCCEEDED,
-			mediaId: MEDIA_ID_LOCAL,
+			mediaId: MEDIAID_LOCAL,
 		};
 		const payloadUploading = {
 			state: MEDIA_UPLOAD_STATE_UPLOADING,
-			mediaId: MEDIA_ID_LOCAL,
+			mediaId: MEDIAID_LOCAL,
 			progress,
 		};
 
@@ -195,11 +195,11 @@ describe( 'BlockMediaUpdateProgress component', () => {
 		const progress = 10;
 		const payloadFail = {
 			state: MEDIA_UPLOAD_STATE_FAILED,
-			mediaId: MEDIA_ID_LOCAL,
+			mediaId: MEDIAID_LOCAL,
 		};
 		const payloadUploading = {
 			state: MEDIA_UPLOAD_STATE_UPLOADING,
-			mediaId: MEDIA_ID_LOCAL,
+			mediaId: MEDIAID_LOCAL,
 			progress,
 		};
 
@@ -233,11 +233,11 @@ describe( 'BlockMediaUpdateProgress component', () => {
 		const progress = 10;
 		const payloadReset = {
 			state: MEDIA_UPLOAD_STATE_RESET,
-			mediaId: MEDIA_ID_LOCAL,
+			mediaId: MEDIAID_LOCAL,
 		};
 		const payloadUploading = {
 			state: MEDIA_UPLOAD_STATE_UPLOADING,
-			mediaId: MEDIA_ID_LOCAL,
+			mediaId: MEDIAID_LOCAL,
 			progress,
 		};
 
@@ -289,11 +289,11 @@ describe( 'BlockMediaUpdateProgress component', () => {
 		const progress = 10;
 		const payloadSuccess = {
 			state: MEDIA_SAVE_STATE_SUCCEEDED,
-			mediaId: MEDIA_ID_TEMP, // while saving, we have a tempid key
+			mediaId: MEDIAID_TEMP, // while saving, we have a tempid key
 		};
 		const payloadSaving = {
 			state: MEDIA_SAVE_STATE_SAVING,
-			mediaId: MEDIA_ID_TEMP, // while saving, we have a tempid key
+			mediaId: MEDIAID_TEMP, // while saving, we have a tempid key
 			progress,
 		};
 
@@ -324,11 +324,11 @@ describe( 'BlockMediaUpdateProgress component', () => {
 		const progress = 10;
 		const payloadFail = {
 			state: MEDIA_SAVE_STATE_FAILED,
-			mediaId: MEDIA_ID_TEMP, // while saving, we have a tempid key
+			mediaId: MEDIAID_TEMP, // while saving, we have a tempid key
 		};
 		const payloadSaving = {
 			state: MEDIA_SAVE_STATE_SAVING,
-			mediaId: MEDIA_ID_TEMP, // while saving, we have a tempid key
+			mediaId: MEDIAID_TEMP, // while saving, we have a tempid key
 			progress,
 		};
 
@@ -360,11 +360,11 @@ describe( 'BlockMediaUpdateProgress component', () => {
 		const progress = 10;
 		const payloadReset = {
 			state: MEDIA_SAVE_STATE_RESET,
-			mediaId: MEDIA_ID_TEMP, // while saving, we have a tempid key
+			mediaId: MEDIAID_TEMP, // while saving, we have a tempid key
 		};
 		const payloadSaving = {
 			state: MEDIA_SAVE_STATE_SAVING,
-			mediaId: MEDIA_ID_TEMP, // while saving, we have a tempid key
+			mediaId: MEDIAID_TEMP, // while saving, we have a tempid key
 			progress,
 		};
 
@@ -394,12 +394,12 @@ describe( 'BlockMediaUpdateProgress component', () => {
 		const progress = 10;
 		const payloadFail = {
 			state: MEDIA_SAVE_FINAL_STATE_RESULT,
-			mediaId: MEDIA_ID_TEMP, // while saving, we have a tempid key
+			mediaId: MEDIAID_TEMP, // while saving, we have a tempid key
 			success: false,
 		};
 		const payloadSaving = {
 			state: MEDIA_SAVE_STATE_SAVING,
-			mediaId: MEDIA_ID_TEMP, // while saving, we have a tempid key
+			mediaId: MEDIAID_TEMP, // while saving, we have a tempid key
 			progress,
 		};
 
@@ -429,12 +429,12 @@ describe( 'BlockMediaUpdateProgress component', () => {
 		const progress = 10;
 		const payloadSuccess = {
 			state: MEDIA_SAVE_FINAL_STATE_RESULT,
-			mediaId: MEDIA_ID_TEMP, // while saving, we have a tempid key
+			mediaId: MEDIAID_TEMP, // while saving, we have a tempid key
 			success: true,
 		};
 		const payloadSaving = {
 			state: MEDIA_SAVE_STATE_SAVING,
-			mediaId: MEDIA_ID_TEMP, // while saving, we have a tempid key
+			mediaId: MEDIAID_TEMP, // while saving, we have a tempid key
 			progress,
 		};
 
@@ -464,13 +464,13 @@ describe( 'BlockMediaUpdateProgress component', () => {
 		const progress = 10;
 		const payloadMediaIdChange = {
 			state: MEDIA_SAVE_MEDIAID_CHANGED,
-			mediaId: MEDIA_ID_TEMP, // while saving, we have a tempid key
-			newId: MEDIA_ID_LOCAL,
+			mediaId: MEDIAID_TEMP, // while saving, we have a tempid key
+			newId: MEDIAID_LOCAL,
 			mediaUrl: 'file:///folder/someimage.jpg',
 		};
 		const payloadSaving = {
 			state: MEDIA_SAVE_STATE_SAVING,
-			mediaId: MEDIA_ID_TEMP, // while saving, we have a tempid key
+			mediaId: MEDIAID_TEMP, // while saving, we have a tempid key
 			progress,
 		};
 

--- a/packages/block-editor/src/components/block-media-update-progress/test/index.native.js
+++ b/packages/block-editor/src/components/block-media-update-progress/test/index.native.js
@@ -314,7 +314,7 @@ describe( 'BlockMediaUpdateProgress component', () => {
 
 		sendMediaSave( payloadSuccess );
 
-		expect( wrapper.instance().state.c ).toEqual( false );
+		expect( wrapper.instance().state.isUploadInProgress ).toEqual( false );
 		expect( onFinishMediaSaveWithSuccess ).toHaveBeenCalledTimes( 1 );
 		expect( onFinishMediaSaveWithSuccess ).toHaveBeenCalledWith(
 			payloadSuccess

--- a/packages/block-editor/src/components/block-media-update-progress/test/index.native.js
+++ b/packages/block-editor/src/components/block-media-update-progress/test/index.native.js
@@ -1,0 +1,236 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * WordPress dependencies
+ */
+import { sendMediaUpload } from '@wordpress/react-native-bridge';
+
+/**
+ * Internal dependencies
+ */
+import {
+	BlockMediaUpdateProgress,
+	MEDIA_UPLOAD_STATE_UPLOADING,
+	MEDIA_UPLOAD_STATE_SUCCEEDED,
+	MEDIA_UPLOAD_STATE_FAILED,
+	MEDIA_UPLOAD_STATE_RESET,
+} from '../';
+
+jest.mock( '@wordpress/react-native-bridge', () => {
+	const callUploadCallback = ( payload ) => {
+		this.uploadCallBack( payload );
+	};
+	const subscribeMediaUpload = ( callback ) => {
+		this.uploadCallBack = callback;
+	};
+	const mediaSources = {
+		deviceCamera: 'DEVICE_CAMERA',
+		deviceLibrary: 'DEVICE_MEDIA_LIBRARY',
+		siteMediaLibrary: 'SITE_MEDIA_LIBRARY',
+	};
+	return {
+		subscribeMediaUpload,
+		sendMediaUpload: callUploadCallback,
+		mediaSources,
+	};
+} );
+
+// const MEDIA_ID_REMOTE = 123;
+const MEDIA_ID_LOCAL = 2;
+// const MEDIA_ID_TEMP = 'tempid-0-1';
+
+// const tempMediaFiles = [{'alt':'','caption':'','id':'tempid-0-1','link':'','mime':'image/jpeg','type':'image','url':''},
+// {'alt':'','caption':'','id':'tempid-0-2','link':'','mime':'image/jpeg','type':'image','url':''}];
+
+const localMediaFiles = [
+	{
+		alt: '',
+		caption: '',
+		id: 2,
+		link: '',
+		mime: 'image/jpeg',
+		type: 'image',
+		url: '',
+	},
+	{
+		alt: '',
+		caption: '',
+		id: 3,
+		link: '',
+		mime: 'image/jpeg',
+		type: 'image',
+		url: '',
+	},
+];
+
+// const remoteMediaFiles = [{'alt':'','caption':'','id':122,'link':'','mime':'image/jpeg','type':'image','url':''},
+// {'alt':'','caption':'','id':123,'link':'','mime':'image/jpeg','type':'image','url':''}];
+
+describe( 'BlockMediaUpdateProgress component', () => {
+	it( 'renders without crashing', () => {
+		const wrapper = shallow(
+			<BlockMediaUpdateProgress renderContent={ () => {} } />
+		);
+		expect( wrapper ).toBeTruthy();
+	} );
+
+	it( 'upload: listens media upload progress for local file', () => {
+		const progress = 10;
+		const payload = {
+			state: MEDIA_UPLOAD_STATE_UPLOADING,
+			mediaId: MEDIA_ID_LOCAL,
+			progress,
+		};
+
+		const onUpdateMediaProgress = jest.fn();
+
+		const wrapper = shallow(
+			<BlockMediaUpdateProgress
+				onUpdateMediaProgress={ onUpdateMediaProgress }
+				mediaFiles={ localMediaFiles }
+				renderContent={ () => {} }
+			/>
+		);
+
+		sendMediaUpload( payload );
+
+		expect( wrapper.instance().state.progress ).toEqual( progress );
+		expect( wrapper.instance().state.isUploadInProgress ).toEqual( true );
+		expect( wrapper.instance().state.isUploadFailed ).toEqual( false );
+		expect( onUpdateMediaProgress ).toHaveBeenCalledTimes( 1 );
+		expect( onUpdateMediaProgress ).toHaveBeenCalledWith( payload );
+	} );
+
+	it( 'upload does not get affected by unrelated media uploads', () => {
+		const payload = {
+			state: MEDIA_UPLOAD_STATE_UPLOADING,
+			mediaId: 432, // id not belonging to assigned mediaFiles collection in test
+			progress: 20,
+		};
+		const onUpdateMediaProgress = jest.fn();
+		const wrapper = shallow(
+			<BlockMediaUpdateProgress
+				onUpdateMediaProgress={ onUpdateMediaProgress }
+				mediaFiles={ localMediaFiles }
+				renderContent={ () => {} }
+			/>
+		);
+
+		sendMediaUpload( payload );
+
+		expect( wrapper.instance().state.progress ).toEqual( 0 );
+		expect( onUpdateMediaProgress ).toHaveBeenCalledTimes( 0 );
+	} );
+
+	it( 'upload: listens media upload success', () => {
+		const progress = 10;
+		const payloadSuccess = {
+			state: MEDIA_UPLOAD_STATE_SUCCEEDED,
+			mediaId: MEDIA_ID_LOCAL,
+		};
+		const payloadUploading = {
+			state: MEDIA_UPLOAD_STATE_UPLOADING,
+			mediaId: MEDIA_ID_LOCAL,
+			progress,
+		};
+
+		const onFinishMediaUploadWithSuccess = jest.fn();
+
+		const wrapper = shallow(
+			<BlockMediaUpdateProgress
+				onFinishMediaUploadWithSuccess={
+					onFinishMediaUploadWithSuccess
+				}
+				mediaFiles={ localMediaFiles }
+				renderContent={ () => {} }
+			/>
+		);
+
+		sendMediaUpload( payloadUploading );
+
+		expect( wrapper.instance().state.progress ).toEqual( progress );
+
+		sendMediaUpload( payloadSuccess );
+
+		expect( wrapper.instance().state.isUploadInProgress ).toEqual( false );
+		expect( onFinishMediaUploadWithSuccess ).toHaveBeenCalledTimes( 1 );
+		expect( onFinishMediaUploadWithSuccess ).toHaveBeenCalledWith(
+			payloadSuccess
+		);
+	} );
+
+	it( 'upload: listens media upload fail', () => {
+		const progress = 10;
+		const payloadFail = {
+			state: MEDIA_UPLOAD_STATE_FAILED,
+			mediaId: MEDIA_ID_LOCAL,
+		};
+		const payloadUploading = {
+			state: MEDIA_UPLOAD_STATE_UPLOADING,
+			mediaId: MEDIA_ID_LOCAL,
+			progress,
+		};
+
+		const onFinishMediaUploadWithFailure = jest.fn();
+
+		const wrapper = shallow(
+			<BlockMediaUpdateProgress
+				onFinishMediaUploadWithFailure={
+					onFinishMediaUploadWithFailure
+				}
+				mediaFiles={ localMediaFiles }
+				renderContent={ () => {} }
+			/>
+		);
+
+		sendMediaUpload( payloadUploading );
+
+		expect( wrapper.instance().state.progress ).toEqual( progress );
+
+		sendMediaUpload( payloadFail );
+
+		expect( wrapper.instance().state.isUploadInProgress ).toEqual( false );
+		expect( wrapper.instance().state.isUploadFailed ).toEqual( true );
+		expect( onFinishMediaUploadWithFailure ).toHaveBeenCalledTimes( 1 );
+		expect( onFinishMediaUploadWithFailure ).toHaveBeenCalledWith(
+			payloadFail
+		);
+	} );
+
+	it( 'upload: listens media upload reset', () => {
+		const progress = 10;
+		const payloadReset = {
+			state: MEDIA_UPLOAD_STATE_RESET,
+			mediaId: MEDIA_ID_LOCAL,
+		};
+		const payloadUploading = {
+			state: MEDIA_UPLOAD_STATE_UPLOADING,
+			mediaId: MEDIA_ID_LOCAL,
+			progress,
+		};
+
+		const onMediaUploadStateReset = jest.fn();
+
+		const wrapper = shallow(
+			<BlockMediaUpdateProgress
+				onMediaUploadStateReset={ onMediaUploadStateReset }
+				mediaFiles={ localMediaFiles }
+				renderContent={ () => {} }
+			/>
+		);
+
+		sendMediaUpload( payloadUploading );
+
+		expect( wrapper.instance().state.progress ).toEqual( progress );
+
+		sendMediaUpload( payloadReset );
+
+		expect( wrapper.instance().state.isUploadInProgress ).toEqual( false );
+		expect( wrapper.instance().state.isUploadFailed ).toEqual( false );
+		expect( onMediaUploadStateReset ).toHaveBeenCalledTimes( 1 );
+		expect( onMediaUploadStateReset ).toHaveBeenCalledWith( payloadReset );
+	} );
+} );

--- a/packages/block-editor/src/components/block-media-update-progress/test/index.native.js
+++ b/packages/block-editor/src/components/block-media-update-progress/test/index.native.js
@@ -114,11 +114,11 @@ describe( 'BlockMediaUpdateProgress component', () => {
 			progress,
 		};
 
-		const onUpdateMediaProgress = jest.fn();
+		const onUpdateMediaUploadProgress = jest.fn();
 
 		const wrapper = shallow(
 			<BlockMediaUpdateProgress
-				onUpdateMediaProgress={ onUpdateMediaProgress }
+				onUpdateMediaUploadProgress={ onUpdateMediaUploadProgress }
 				mediaFiles={ localMediaFiles }
 				renderContent={ () => {} }
 			/>
@@ -129,8 +129,8 @@ describe( 'BlockMediaUpdateProgress component', () => {
 		expect( wrapper.instance().state.progress ).toEqual( progress );
 		expect( wrapper.instance().state.isUploadInProgress ).toEqual( true );
 		expect( wrapper.instance().state.isUploadFailed ).toEqual( false );
-		expect( onUpdateMediaProgress ).toHaveBeenCalledTimes( 1 );
-		expect( onUpdateMediaProgress ).toHaveBeenCalledWith( payload );
+		expect( onUpdateMediaUploadProgress ).toHaveBeenCalledTimes( 1 );
+		expect( onUpdateMediaUploadProgress ).toHaveBeenCalledWith( payload );
 	} );
 
 	// UPLOAD tests
@@ -140,10 +140,10 @@ describe( 'BlockMediaUpdateProgress component', () => {
 			mediaId: 432, // id not belonging to assigned mediaFiles collection in test
 			progress: 20,
 		};
-		const onUpdateMediaProgress = jest.fn();
+		const onUpdateMediaUploadProgress = jest.fn();
 		const wrapper = shallow(
 			<BlockMediaUpdateProgress
-				onUpdateMediaProgress={ onUpdateMediaProgress }
+				onUpdateMediaUploadProgress={ onUpdateMediaUploadProgress }
 				mediaFiles={ localMediaFiles }
 				renderContent={ () => {} }
 			/>
@@ -152,7 +152,7 @@ describe( 'BlockMediaUpdateProgress component', () => {
 		sendMediaUpload( payload );
 
 		expect( wrapper.instance().state.progress ).toEqual( 0 );
-		expect( onUpdateMediaProgress ).toHaveBeenCalledTimes( 0 );
+		expect( onUpdateMediaUploadProgress ).toHaveBeenCalledTimes( 0 );
 	} );
 
 	it( 'upload: listens media upload success', () => {

--- a/packages/block-editor/src/components/block-media-update-progress/test/index.native.js
+++ b/packages/block-editor/src/components/block-media-update-progress/test/index.native.js
@@ -52,7 +52,6 @@ jest.mock( '@wordpress/react-native-bridge', () => {
 	};
 } );
 
-// const MEDIA_ID_REMOTE = 123;
 const MEDIA_ID_LOCAL = 2;
 const MEDIA_ID_TEMP = 'tempid-0-1';
 

--- a/packages/block-editor/src/components/block-media-update-progress/test/index.native.js
+++ b/packages/block-editor/src/components/block-media-update-progress/test/index.native.js
@@ -106,7 +106,7 @@ describe( 'BlockMediaUpdateProgress component', () => {
 		expect( wrapper ).toBeTruthy();
 	} );
 
-	it( 'upload: listens media upload progress for local file', () => {
+	it( 'upload: onUpdateMediaUploadProgress is called when a progress update payload is received', () => {
 		const progress = 10;
 		const payload = {
 			state: MEDIA_UPLOAD_STATE_UPLOADING,
@@ -155,7 +155,7 @@ describe( 'BlockMediaUpdateProgress component', () => {
 		expect( onUpdateMediaUploadProgress ).toHaveBeenCalledTimes( 0 );
 	} );
 
-	it( 'upload: listens media upload success', () => {
+	it( 'upload: onFinishMediaUploadWithSuccess is called when a success payload is received', () => {
 		const progress = 10;
 		const payloadSuccess = {
 			state: MEDIA_UPLOAD_STATE_SUCCEEDED,
@@ -192,7 +192,7 @@ describe( 'BlockMediaUpdateProgress component', () => {
 		);
 	} );
 
-	it( 'upload: listens media upload fail', () => {
+	it( 'upload: onFinishMediaUploadWithFailure is called when a failed payload is received', () => {
 		const progress = 10;
 		const payloadFail = {
 			state: MEDIA_UPLOAD_STATE_FAILED,
@@ -230,7 +230,7 @@ describe( 'BlockMediaUpdateProgress component', () => {
 		);
 	} );
 
-	it( 'upload: listens media upload reset', () => {
+	it( 'upload: onMediaUploadStateReset is called when a reset payload is received', () => {
 		const progress = 10;
 		const payloadReset = {
 			state: MEDIA_UPLOAD_STATE_RESET,
@@ -265,7 +265,7 @@ describe( 'BlockMediaUpdateProgress component', () => {
 	} );
 
 	// SAVE tests
-	it( 'save does not get affected by unrelated media uploads', () => {
+	it( 'save does not get affected by unrelated media save events', () => {
 		const payload = {
 			state: MEDIA_SAVE_STATE_SAVING,
 			mediaId: 'tempid-432', // id not belonging to assigned mediaFiles collection in test
@@ -286,7 +286,7 @@ describe( 'BlockMediaUpdateProgress component', () => {
 		expect( onUpdateMediaSaveProgress ).toHaveBeenCalledTimes( 0 );
 	} );
 
-	it( 'save: listens media save success', () => {
+	it( 'save: onFinishMediaSaveWithSuccess is called when a success payload is received', () => {
 		const progress = 10;
 		const payloadSuccess = {
 			state: MEDIA_SAVE_STATE_SUCCEEDED,
@@ -321,7 +321,7 @@ describe( 'BlockMediaUpdateProgress component', () => {
 		);
 	} );
 
-	it( 'save: listens media save fail', () => {
+	it( 'save: onFinishMediaSaveWithFailure is called when a failed payload is received', () => {
 		const progress = 10;
 		const payloadFail = {
 			state: MEDIA_SAVE_STATE_FAILED,
@@ -357,7 +357,7 @@ describe( 'BlockMediaUpdateProgress component', () => {
 		);
 	} );
 
-	it( 'save: listens media save reset', () => {
+	it( 'save: onMediaSaveStateReset is called when a reset payload is received', () => {
 		const progress = 10;
 		const payloadReset = {
 			state: MEDIA_SAVE_STATE_RESET,
@@ -391,7 +391,7 @@ describe( 'BlockMediaUpdateProgress component', () => {
 		expect( onMediaSaveStateReset ).toHaveBeenCalledWith( payloadReset );
 	} );
 
-	it( 'save: listens total media save result, with result: fail', () => {
+	it( 'save: onFinalSaveResult is called with fail result when fail result is received', () => {
 		const progress = 10;
 		const payloadFail = {
 			state: MEDIA_SAVE_FINAL_STATE_RESULT,
@@ -426,7 +426,7 @@ describe( 'BlockMediaUpdateProgress component', () => {
 		expect( onFinalSaveResult ).toHaveBeenCalledWith( payloadFail );
 	} );
 
-	it( 'save: listens total media save result, with result: success', () => {
+	it( 'save: onFinalSaveResult is called with success result when success result is received', () => {
 		const progress = 10;
 		const payloadSuccess = {
 			state: MEDIA_SAVE_FINAL_STATE_RESULT,

--- a/packages/block-editor/src/components/block-media-update-progress/test/index.native.js
+++ b/packages/block-editor/src/components/block-media-update-progress/test/index.native.js
@@ -6,7 +6,7 @@ import { shallow } from 'enzyme';
 /**
  * WordPress dependencies
  */
-import { sendMediaUpload } from '@wordpress/react-native-bridge';
+import { sendMediaUpload, sendMediaSave } from '@wordpress/react-native-bridge';
 
 /**
  * Internal dependencies
@@ -17,14 +17,26 @@ import {
 	MEDIA_UPLOAD_STATE_SUCCEEDED,
 	MEDIA_UPLOAD_STATE_FAILED,
 	MEDIA_UPLOAD_STATE_RESET,
+	MEDIA_SAVE_STATE_SAVING,
+	MEDIA_SAVE_STATE_SUCCEEDED,
+	MEDIA_SAVE_STATE_FAILED,
+	MEDIA_SAVE_STATE_RESET,
+	MEDIA_SAVE_FINAL_STATE_RESULT,
+	MEDIA_SAVE_MEDIAID_CHANGED,
 } from '../';
 
 jest.mock( '@wordpress/react-native-bridge', () => {
 	const callUploadCallback = ( payload ) => {
 		this.uploadCallBack( payload );
 	};
+	const callSaveCallback = ( payload ) => {
+		this.saveCallBack( payload );
+	};
 	const subscribeMediaUpload = ( callback ) => {
 		this.uploadCallBack = callback;
+	};
+	const subscribeMediaSave = ( callback ) => {
+		this.saveCallBack = callback;
 	};
 	const mediaSources = {
 		deviceCamera: 'DEVICE_CAMERA',
@@ -33,17 +45,37 @@ jest.mock( '@wordpress/react-native-bridge', () => {
 	};
 	return {
 		subscribeMediaUpload,
+		subscribeMediaSave,
 		sendMediaUpload: callUploadCallback,
+		sendMediaSave: callSaveCallback,
 		mediaSources,
 	};
 } );
 
 // const MEDIA_ID_REMOTE = 123;
 const MEDIA_ID_LOCAL = 2;
-// const MEDIA_ID_TEMP = 'tempid-0-1';
+const MEDIA_ID_TEMP = 'tempid-0-1';
 
-// const tempMediaFiles = [{'alt':'','caption':'','id':'tempid-0-1','link':'','mime':'image/jpeg','type':'image','url':''},
-// {'alt':'','caption':'','id':'tempid-0-2','link':'','mime':'image/jpeg','type':'image','url':''}];
+const tempMediaFiles = [
+	{
+		alt: '',
+		caption: '',
+		id: 'tempid-0-1',
+		link: '',
+		mime: 'image/jpeg',
+		type: 'image',
+		url: '',
+	},
+	{
+		alt: '',
+		caption: '',
+		id: 'tempid-0-2',
+		link: '',
+		mime: 'image/jpeg',
+		type: 'image',
+		url: '',
+	},
+];
 
 const localMediaFiles = [
 	{
@@ -65,9 +97,6 @@ const localMediaFiles = [
 		url: '',
 	},
 ];
-
-// const remoteMediaFiles = [{'alt':'','caption':'','id':122,'link':'','mime':'image/jpeg','type':'image','url':''},
-// {'alt':'','caption':'','id':123,'link':'','mime':'image/jpeg','type':'image','url':''}];
 
 describe( 'BlockMediaUpdateProgress component', () => {
 	it( 'renders without crashing', () => {
@@ -104,6 +133,7 @@ describe( 'BlockMediaUpdateProgress component', () => {
 		expect( onUpdateMediaProgress ).toHaveBeenCalledWith( payload );
 	} );
 
+	// UPLOAD tests
 	it( 'upload does not get affected by unrelated media uploads', () => {
 		const payload = {
 			state: MEDIA_UPLOAD_STATE_UPLOADING,
@@ -232,5 +262,240 @@ describe( 'BlockMediaUpdateProgress component', () => {
 		expect( wrapper.instance().state.isUploadFailed ).toEqual( false );
 		expect( onMediaUploadStateReset ).toHaveBeenCalledTimes( 1 );
 		expect( onMediaUploadStateReset ).toHaveBeenCalledWith( payloadReset );
+	} );
+
+	// SAVE tests
+	it( 'save does not get affected by unrelated media uploads', () => {
+		const payload = {
+			state: MEDIA_SAVE_STATE_SAVING,
+			mediaId: 'tempid-432', // id not belonging to assigned mediaFiles collection in test
+			progress: 20,
+		};
+		const onUpdateMediaSaveProgress = jest.fn();
+		const wrapper = shallow(
+			<BlockMediaUpdateProgress
+				onUpdateMediaSaveProgress={ onUpdateMediaSaveProgress }
+				mediaFiles={ tempMediaFiles }
+				renderContent={ () => {} }
+			/>
+		);
+
+		sendMediaSave( payload );
+
+		expect( wrapper.instance().state.progress ).toEqual( 0 );
+		expect( onUpdateMediaSaveProgress ).toHaveBeenCalledTimes( 0 );
+	} );
+
+	it( 'save: listens media save success', () => {
+		const progress = 10;
+		const payloadSuccess = {
+			state: MEDIA_SAVE_STATE_SUCCEEDED,
+			mediaId: MEDIA_ID_TEMP, // while saving, we have a tempid key
+		};
+		const payloadSaving = {
+			state: MEDIA_SAVE_STATE_SAVING,
+			mediaId: MEDIA_ID_TEMP, // while saving, we have a tempid key
+			progress,
+		};
+
+		const onFinishMediaSaveWithSuccess = jest.fn();
+
+		const wrapper = shallow(
+			<BlockMediaUpdateProgress
+				onFinishMediaSaveWithSuccess={ onFinishMediaSaveWithSuccess }
+				mediaFiles={ localMediaFiles }
+				renderContent={ () => {} }
+			/>
+		);
+
+		sendMediaSave( payloadSaving );
+
+		expect( wrapper.instance().state.progress ).toEqual( progress );
+
+		sendMediaSave( payloadSuccess );
+
+		expect( wrapper.instance().state.c ).toEqual( false );
+		expect( onFinishMediaSaveWithSuccess ).toHaveBeenCalledTimes( 1 );
+		expect( onFinishMediaSaveWithSuccess ).toHaveBeenCalledWith(
+			payloadSuccess
+		);
+	} );
+
+	it( 'save: listens media save fail', () => {
+		const progress = 10;
+		const payloadFail = {
+			state: MEDIA_SAVE_STATE_FAILED,
+			mediaId: MEDIA_ID_TEMP, // while saving, we have a tempid key
+		};
+		const payloadSaving = {
+			state: MEDIA_SAVE_STATE_SAVING,
+			mediaId: MEDIA_ID_TEMP, // while saving, we have a tempid key
+			progress,
+		};
+
+		const onFinishMediaSaveWithFailure = jest.fn();
+
+		const wrapper = shallow(
+			<BlockMediaUpdateProgress
+				onFinishMediaSaveWithFailure={ onFinishMediaSaveWithFailure }
+				mediaFiles={ localMediaFiles }
+				renderContent={ () => {} }
+			/>
+		);
+
+		sendMediaSave( payloadSaving );
+
+		expect( wrapper.instance().state.progress ).toEqual( progress );
+
+		sendMediaSave( payloadFail );
+
+		expect( wrapper.instance().state.isSaveInProgress ).toEqual( false );
+		expect( wrapper.instance().state.isSaveFailed ).toEqual( true );
+		expect( onFinishMediaSaveWithFailure ).toHaveBeenCalledTimes( 1 );
+		expect( onFinishMediaSaveWithFailure ).toHaveBeenCalledWith(
+			payloadFail
+		);
+	} );
+
+	it( 'save: listens media save reset', () => {
+		const progress = 10;
+		const payloadReset = {
+			state: MEDIA_SAVE_STATE_RESET,
+			mediaId: MEDIA_ID_TEMP, // while saving, we have a tempid key
+		};
+		const payloadSaving = {
+			state: MEDIA_SAVE_STATE_SAVING,
+			mediaId: MEDIA_ID_TEMP, // while saving, we have a tempid key
+			progress,
+		};
+
+		const onMediaSaveStateReset = jest.fn();
+
+		const wrapper = shallow(
+			<BlockMediaUpdateProgress
+				onMediaSaveStateReset={ onMediaSaveStateReset }
+				mediaFiles={ localMediaFiles }
+				renderContent={ () => {} }
+			/>
+		);
+
+		sendMediaSave( payloadSaving );
+
+		expect( wrapper.instance().state.progress ).toEqual( progress );
+
+		sendMediaSave( payloadReset );
+
+		expect( wrapper.instance().state.isSaveInProgress ).toEqual( false );
+		expect( wrapper.instance().state.isSaveFailed ).toEqual( false );
+		expect( onMediaSaveStateReset ).toHaveBeenCalledTimes( 1 );
+		expect( onMediaSaveStateReset ).toHaveBeenCalledWith( payloadReset );
+	} );
+
+	it( 'save: listens total media save result, with result: fail', () => {
+		const progress = 10;
+		const payloadFail = {
+			state: MEDIA_SAVE_FINAL_STATE_RESULT,
+			mediaId: MEDIA_ID_TEMP, // while saving, we have a tempid key
+			success: false,
+		};
+		const payloadSaving = {
+			state: MEDIA_SAVE_STATE_SAVING,
+			mediaId: MEDIA_ID_TEMP, // while saving, we have a tempid key
+			progress,
+		};
+
+		const onFinalSaveResult = jest.fn();
+
+		const wrapper = shallow(
+			<BlockMediaUpdateProgress
+				onFinalSaveResult={ onFinalSaveResult }
+				mediaFiles={ localMediaFiles }
+				renderContent={ () => {} }
+			/>
+		);
+
+		sendMediaSave( payloadSaving );
+
+		expect( wrapper.instance().state.progress ).toEqual( progress );
+
+		sendMediaSave( payloadFail );
+
+		expect( wrapper.instance().state.isSaveInProgress ).toEqual( false );
+		expect( wrapper.instance().state.isSaveFailed ).toEqual( true );
+		expect( onFinalSaveResult ).toHaveBeenCalledTimes( 1 );
+		expect( onFinalSaveResult ).toHaveBeenCalledWith( payloadFail );
+	} );
+
+	it( 'save: listens total media save result, with result: success', () => {
+		const progress = 10;
+		const payloadSuccess = {
+			state: MEDIA_SAVE_FINAL_STATE_RESULT,
+			mediaId: MEDIA_ID_TEMP, // while saving, we have a tempid key
+			success: true,
+		};
+		const payloadSaving = {
+			state: MEDIA_SAVE_STATE_SAVING,
+			mediaId: MEDIA_ID_TEMP, // while saving, we have a tempid key
+			progress,
+		};
+
+		const onFinalSaveResult = jest.fn();
+
+		const wrapper = shallow(
+			<BlockMediaUpdateProgress
+				onFinalSaveResult={ onFinalSaveResult }
+				mediaFiles={ localMediaFiles }
+				renderContent={ () => {} }
+			/>
+		);
+
+		sendMediaSave( payloadSaving );
+
+		expect( wrapper.instance().state.progress ).toEqual( progress );
+
+		sendMediaSave( payloadSuccess );
+
+		expect( wrapper.instance().state.isSaveInProgress ).toEqual( false );
+		expect( wrapper.instance().state.isSaveFailed ).toEqual( false );
+		expect( onFinalSaveResult ).toHaveBeenCalledTimes( 1 );
+		expect( onFinalSaveResult ).toHaveBeenCalledWith( payloadSuccess );
+	} );
+
+	it( 'save: listens to mediaId change and passes it up', () => {
+		const progress = 10;
+		const payloadMediaIdChange = {
+			state: MEDIA_SAVE_MEDIAID_CHANGED,
+			mediaId: MEDIA_ID_TEMP, // while saving, we have a tempid key
+			newId: MEDIA_ID_LOCAL,
+			mediaUrl: 'file:///folder/someimage.jpg',
+		};
+		const payloadSaving = {
+			state: MEDIA_SAVE_STATE_SAVING,
+			mediaId: MEDIA_ID_TEMP, // while saving, we have a tempid key
+			progress,
+		};
+
+		const onMediaIdChanged = jest.fn();
+
+		const wrapper = shallow(
+			<BlockMediaUpdateProgress
+				onMediaIdChanged={ onMediaIdChanged }
+				mediaFiles={ localMediaFiles }
+				renderContent={ () => {} }
+			/>
+		);
+
+		sendMediaSave( payloadSaving );
+
+		expect( wrapper.instance().state.progress ).toEqual( progress );
+
+		sendMediaSave( payloadMediaIdChange );
+
+		expect( wrapper.instance().state.isSaveInProgress ).toEqual( false );
+		expect( wrapper.instance().state.isSaveFailed ).toEqual( false );
+		expect( wrapper.instance().state.isUploadInProgress ).toEqual( false );
+		expect( wrapper.instance().state.isUploadFailed ).toEqual( false );
+		expect( onMediaIdChanged ).toHaveBeenCalledTimes( 1 );
+		expect( onMediaIdChanged ).toHaveBeenCalledWith( payloadMediaIdChange );
 	} );
 } );

--- a/packages/block-editor/src/components/block-media-update-progress/test/index.native.js
+++ b/packages/block-editor/src/components/block-media-update-progress/test/index.native.js
@@ -314,7 +314,7 @@ describe( 'BlockMediaUpdateProgress component', () => {
 
 		sendMediaSave( payloadSuccess );
 
-		expect( wrapper.instance().state.isUploadInProgress ).toEqual( false );
+		expect( wrapper.instance().state.isSaveInProgress ).toEqual( false );
 		expect( onFinishMediaSaveWithSuccess ).toHaveBeenCalledTimes( 1 );
 		expect( onFinishMediaSaveWithSuccess ).toHaveBeenCalledWith(
 			payloadSuccess


### PR DESCRIPTION
Adds unit tests for the BlockMediaUpdateProgress component introduced in https://github.com/WordPress/gutenberg/pull/25242

Based on pre-existing tests for MediaUploadProgress component, and adapted to our own `mediaFiles` collection use cases.