### PR TITLE
Update dropdown-menu and button to allow text buttons

### DIFF
--- a/packages/components/src/button/index.js
+++ b/packages/components/src/button/index.js
@@ -40,6 +40,7 @@ export function Button( props, ref ) {
 		shortcut,
 		label,
 		children,
+		text,
 		__experimentalIsFocusable: isFocusable,
 		...additionalProps
 	} = props;
@@ -111,6 +112,7 @@ export function Button( props, ref ) {
 			ref={ ref }
 		>
 			{ icon && <Icon icon={ icon } size={ iconSize } /> }
+			{ ! icon && text && <span>{ text }</span> }
 			{ children }
 		</Tag>
 	);

--- a/packages/components/src/button/index.js
+++ b/packages/components/src/button/index.js
@@ -112,7 +112,7 @@ export function Button( props, ref ) {
 			ref={ ref }
 		>
 			{ icon && <Icon icon={ icon } size={ iconSize } /> }
-			{ ! icon && text && <span>{ text }</span> }
+			{ text && <>{ text }</> }
 			{ children }
 		</Tag>
 	);

--- a/packages/components/src/dropdown-menu/index.js
+++ b/packages/components/src/dropdown-menu/index.js
@@ -43,6 +43,7 @@ function DropdownMenu( {
 	toggleProps,
 	menuProps,
 	disableOpenOnArrowDown = false,
+	text,
 	// The following props exist for backward compatibility.
 	menuLabel,
 	position,
@@ -129,6 +130,7 @@ function DropdownMenu( {
 						aria-haspopup="true"
 						aria-expanded={ isOpen }
 						label={ label }
+						text={ text }
 						showTooltip={ toggleProps?.showTooltip ?? true }
 					>
 						{ mergedToggleProps.children }


### PR DESCRIPTION
## Description

In support of Social links size option (#25921) this PR adds the ability to show a dropdown-menu button with icon and/or text. Previously, you would need to create a custom control using the lower-level Dropdown component, for example the Replace image toolbar.

## How has this been tested?

1. Confirm once applied nothing changes in existing DropdownMenus

2. Alter a DropdownMenu component being used to include the additional text prop

For example, update `packages/block-editor/src/components/rich-text/format-toolbar/index.js` and add a text prop, for example:

```
<DropdownMenu
	icon={ chevronDown }
	text={ __( 'More' ) }
...
```

You can test text-only buttons by setting `icon={ null }`

## Screenshots

![dropdown-menu-more](https://user-images.githubusercontent.com/45363/97030863-4371e900-1514-11eb-8a30-610405c6be29.gif)



## Types of changes

- Adds text prop to DropdownMenu and Button components
- Adds rendering of text fragment if specified in Button component


## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
