### PR TITLE
Turn off autocomplete for token input.

### DIFF
--- a/packages/components/src/form-token-field/token-input.js
+++ b/packages/components/src/form-token-field/token-input.js
@@ -57,6 +57,7 @@ class TokenInput extends Component {
 					className,
 					'components-form-token-field__input'
 				) }
+				autoComplete="off"
 				role="combobox"
 				aria-expanded={ isExpanded }
 				aria-autocomplete="list"


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Adds the `autocomplete="off"` attribute to the TokenInput, used by the `ComboboxControl`. Fixes an issue noted in https://github.com/WordPress/gutenberg/issues/26077#issuecomment-715366166.

## How has this been tested?
Tested user field with and without the attribute.

## Screenshots <!-- if applicable -->
Without `autocomplete="off"` chrome offers to fill the input (the dark 'admin'), obscuring the actual selector:
![image](https://user-images.githubusercontent.com/2676022/97035770-0c0b3880-1524-11eb-8be4-d7b884d7c545.png)

With `autocomplete="off"` selector works as expected:
![image](https://user-images.githubusercontent.com/2676022/97035796-1af1eb00-1524-11eb-8f6d-6b9871069370.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
