### PR TITLE
Docs: Fix minor formatting issue likely caused due to a merge

### DIFF
--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -120,10 +120,7 @@ If so, you need to instruct Apache to allow following such links:
 
 Tools like MAMP tend to configure MySQL to use ports other than the default 3306, often preferring 8889. This may throw off WP-CLI, which will fail after trying to connect to the database. To remedy this, edit `wp-config.php` and change the `DB_HOST` constant from `define( 'DB_HOST', 'localhost' )` to `define( 'DB_HOST', '127.0.0.1:8889' )`.
 
-## On A Remote Server
-=======
 ### On A Remote Server
->>>>>>> Docs: Refresh Getting Started guide
 
 You can use a remote server in development by building locally and then uploading the built files as a plugin to the remote server.
 


### PR DESCRIPTION

## Description

Fixes a minor formatting issue that was likely caused due to a merge conflict.

## How has this been tested?

Documentation, confirm formatting is correct.

