### PR TITLE
Edit Site: prevent inserter overscroll

### DIFF
--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -110,6 +110,8 @@ html.interface-interface-skeleton__html-container {
 .interface-interface-skeleton__left-sidebar {
 	@include break-medium() {
 		border-right: $border-width solid $gray-200;
+		overflow: hidden; // prevent overscroll
+		padding-bottom: 24px; // compensate for breadcrumb footer
 	}
 }
 

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -61,6 +61,11 @@ html.interface-interface-skeleton__html-container {
 	// it is added, it should take care of the issue.
 	// See also: https://drafts.csswg.org/css-overscroll/
 	overscroll-behavior-y: none;
+
+	// Footer overlap prevention
+	@include break-medium() {
+		padding-bottom: $button-size-small + $border-width;
+	}
 }
 
 .interface-interface-skeleton__content {
@@ -111,7 +116,6 @@ html.interface-interface-skeleton__html-container {
 	@include break-medium() {
 		border-right: $border-width solid $gray-200;
 		overflow: hidden; // prevent overscroll
-		padding-bottom: 24px; // compensate for breadcrumb footer
 	}
 }
 


### PR DESCRIPTION
## Description
This just adds some `overflow: hidden` to `.interface-interface-skeleton__left-sidebar` to prevent it overflowing when open. It seems a bit too simple and may break something else, but since I believe we're already expecting overflows to be hidden (as in #26424), I hope there aren't any larger issues.

BONUS: the block inserter tip at the bottom is no longer cut off

fixes https://github.com/WordPress/gutenberg/issues/26428

## How has this been tested?
* Open Site Editor
* Open the Inserter sidebar
* See if there's a giant white space when you scroll down to the bottom of the Site Editor proper (not just the Inserter itself)
* See if the tooltip

## Screenshots <!-- if applicable -->

### Before
<img width="1301" alt="Screen Shot 2020-10-23 at 16 34 10" src="https://user-images.githubusercontent.com/195089/97056022-97e58a80-154d-11eb-9948-b0f1e181afcf.png">
^ Colorized green by me, normally white. Note the double scrollbars.

### After
<img width="1299" alt="Screen Shot 2020-10-23 at 16 30 28" src="https://user-images.githubusercontent.com/195089/97055755-13930780-154d-11eb-933e-3b55cc48f14a.png">

## Types of changes

Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
