### PR TITLE
E2E Tests: Fix Meta Boxes Test

### DIFF
--- a/packages/e2e-tests/specs/editor/plugins/meta-boxes.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/meta-boxes.test.js
@@ -60,7 +60,7 @@ describe( 'Meta boxes', () => {
 		await page.waitForNavigation();
 
 		// Check the the dynamic block appears.
-		await page.waitForSelector( '.wp-block-latest-posts' );
+		await page.waitForSelector( '.wp-block-latest-posts__list' );
 	} );
 
 	it( 'Should render the excerpt in meta based on post content if no explicit excerpt exists', async () => {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
It looks like the removal of this [shim](https://github.com/WordPress/gutenberg/pull/26356/files#diff-83705774c15f7e3df5b54b2096fe476721e8b962ba319a8e7dc46d7b9b0b27b4L511-L547) in `lib/compat.php` in this [PR](https://github.com/WordPress/gutenberg/pull/26356) is causing an e2e spec failure. 

`Meta boxes › Should render dynamic blocks when the meta box uses the excerpt for front end rendering`

As @talldan mentions [here](https://github.com/WordPress/gutenberg/pull/26356#issuecomment-716312970), the latest posts block no longer has a `.wp-block-latest-posts` classname on its wrapper. What's odd is that, although the classname doesn't exist in an e2e testing environment, it does appear in the development environment. I'm unsure of the cause, but while we search for the cause, I attempt to introduce this **temporary** fix.

The intention of the failing spec is to ensure that the latest posts block is rendered at all, so I modify the selector that identifies the block (because it is, after all, still being rendered).

Other alternatives seem to be:
- reverting @nosolosw 's PR 
- temporarily disabling the spec
- reintroducing [the shim](https://github.com/WordPress/gutenberg/pull/26356/files#diff-83705774c15f7e3df5b54b2096fe476721e8b962ba319a8e7dc46d7b9b0b27b4L511-L547)
- addressing the underlying issue (I'm still not certain of the cause)

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
