### PR TITLE
Inserter: Fix 'Browse All' in Quick Inserter

### DIFF
--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -160,16 +160,22 @@ _Returns_
 
 <a name="getBlockInsertionPoint" href="#getBlockInsertionPoint">#</a> **getBlockInsertionPoint**
 
-Returns the insertion point, the index at which the new inserted block would
-be placed. Defaults to the last index.
+Returns the insertion point. This will be:
+
+1) The insertion point manually set using setInsertionPoint() or
+   showInsertionPoint(); or
+2) The point after the current block selection, if there is a selection; or
+3) The point at the end of the block list.
+
+Components like <Inserter> will default to inserting blocks at this point.
 
 _Parameters_
 
--   _state_ `Object`: Editor state.
+-   _state_ `Object`: Global application state.
 
 _Returns_
 
--   `Object`: Insertion point object with `rootClientId`, `index`.
+-   `Object`: Insertion point object with `rootClientId`, `index`, `isVisible`.
 
 <a name="getBlockListSettings" href="#getBlockListSettings">#</a> **getBlockListSettings**
 
@@ -812,7 +818,8 @@ _Returns_
 
 <a name="isBlockInsertionPointVisible" href="#isBlockInsertionPointVisible">#</a> **isBlockInsertionPointVisible**
 
-Returns true if we should show the block insertion point.
+Whether or not the insertion point should be shown to users. This is set
+using showInsertionPoint() or hideInsertionPoint().
 
 _Parameters_
 
@@ -820,7 +827,7 @@ _Parameters_
 
 _Returns_
 
--   `?boolean`: Whether the insertion point is visible or not.
+-   `?boolean`: Whether the insertion point should be shown.
 
 <a name="isBlockMultiSelected" href="#isBlockMultiSelected">#</a> **isBlockMultiSelected**
 
@@ -1048,7 +1055,7 @@ _Parameters_
 
 <a name="hideInsertionPoint" href="#hideInsertionPoint">#</a> **hideInsertionPoint**
 
-Returns an action object hiding the insertion point.
+Hides the insertion point for users.
 
 _Returns_
 
@@ -1351,6 +1358,21 @@ _Parameters_
 -   _clientId_ `string`: The block's clientId.
 -   _hasControlledInnerBlocks_ `boolean`: True if the block's inner blocks are controlled.
 
+<a name="setInsertionPoint" href="#setInsertionPoint">#</a> **setInsertionPoint**
+
+Sets the insertion point without showing it to users.
+
+Components like <Inserter> will default to inserting blocks at this point.
+
+_Parameters_
+
+-   _rootClientId_ `?string`: Optional root client ID of block list on which to insert.
+-   _index_ `?number`: Index at which block should be inserted.
+
+_Returns_
+
+-   `Object`: Action object.
+
 <a name="setNavigationMode" href="#setNavigationMode">#</a> **setNavigationMode**
 
 Generators that triggers an action used to enable or disable the navigation mode.
@@ -1373,8 +1395,9 @@ _Returns_
 
 <a name="showInsertionPoint" href="#showInsertionPoint">#</a> **showInsertionPoint**
 
-Returns an action object used in signalling that the insertion point should
-be shown.
+Sets the insertion point and shows it to users.
+
+Components like <Inserter> will default to inserting blocks at this point.
 
 _Parameters_
 

--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -1386,8 +1386,8 @@ Components like <Inserter> will default to inserting blocks at this point.
 
 _Parameters_
 
--   _rootClientId_ `?string`: Optional root client ID of block list on which to insert.
--   _index_ `?number`: Index at which block should be inserted.
+-   _rootClientId_ `?string`: Root client ID of block list in which to insert. Use `undefined` for the root block list.
+-   _index_ `number`: Index at which block should be inserted.
 
 _Returns_
 

--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -1358,21 +1358,6 @@ _Parameters_
 -   _clientId_ `string`: The block's clientId.
 -   _hasControlledInnerBlocks_ `boolean`: True if the block's inner blocks are controlled.
 
-<a name="setInsertionPoint" href="#setInsertionPoint">#</a> **setInsertionPoint**
-
-Sets the insertion point without showing it to users.
-
-Components like <Inserter> will default to inserting blocks at this point.
-
-_Parameters_
-
--   _rootClientId_ `?string`: Optional root client ID of block list on which to insert.
--   _index_ `?number`: Index at which block should be inserted.
-
-_Returns_
-
--   `Object`: Action object.
-
 <a name="setNavigationMode" href="#setNavigationMode">#</a> **setNavigationMode**
 
 Generators that triggers an action used to enable or disable the navigation mode.

--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -175,7 +175,7 @@ _Parameters_
 
 _Returns_
 
--   `Object`: Insertion point object with `rootClientId`, `index`, `isVisible`.
+-   `Object`: Insertion point object with `rootClientId` and `index`.
 
 <a name="getBlockListSettings" href="#getBlockListSettings">#</a> **getBlockListSettings**
 

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -12,7 +12,7 @@ import { speak } from '@wordpress/a11y';
  * @property {string=}   rootClientId        If set, insertion will be into the
  *                                           block with this ID.
  * @property {number=}   insertionIndex      If set, insertion will be into this
- *                                           explciit position.
+ *                                           explicit position.
  * @property {string=}   clientId            If set, insertion will be after the
  *                                           block with this ID.
  * @property {boolean=}  isAppender          Whether the inserter is an appender

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -75,10 +75,9 @@ function useInsertionPoint( {
 			} else {
 				// Otherwise, we're in "auto mode" where the insertion point is
 				// decided by getBlockInsertionPoint().
-
-				_destinationRootClientId = getBlockInsertionPoint()
-					.rootClientId;
-				_destinationIndex = getBlockInsertionPoint().index;
+				const insertionPoint = getBlockInsertionPoint();
+				_destinationRootClientId = insertionPoint.rootClientId;
+				_destinationIndex = insertionPoint.index;
 			}
 
 			return {

--- a/packages/block-editor/src/components/inserter/quick-inserter.js
+++ b/packages/block-editor/src/components/inserter/quick-inserter.js
@@ -154,18 +154,14 @@ export default function QuickInserter( {
 		[ filterValue, patterns ]
 	);
 
-	const setInserterIsOpened = useSelect(
-		( select ) =>
-			select( 'core/block-editor' ).getSettings()
+	const { setInserterIsOpened, blockIndex } = useSelect( ( select ) => {
+		const { getSettings, getBlockIndex } = select( 'core/block-editor' );
+		return {
+			setInserterIsOpened: getSettings()
 				.__experimentalSetIsInserterOpened,
-		[]
-	);
-
-	const previousBlockClientId = useSelect(
-		( select ) =>
-			select( 'core/block-editor' ).getPreviousBlockClientId( clientId ),
-		[ clientId ]
-	);
+			blockIndex: getBlockIndex( clientId, rootClientId ),
+		};
+	}, [] );
 
 	useEffect( () => {
 		if ( setInserterIsOpened ) {
@@ -173,7 +169,7 @@ export default function QuickInserter( {
 		}
 	}, [ setInserterIsOpened ] );
 
-	const { selectBlock } = useDispatch( 'core/block-editor' );
+	const { setInsertionPoint } = useDispatch( 'core/block-editor' );
 
 	// Announce search results on change
 	useEffect( () => {
@@ -189,17 +185,9 @@ export default function QuickInserter( {
 		debouncedSpeak( resultsFoundMessage );
 	}, [ filterValue, debouncedSpeak ] );
 
-	// When clicking Browse All select the appropriate block so as
-	// the insertion point can work as expected
 	const onBrowseAll = () => {
-		// We have to select the previous block because the menu inserter
-		// inserts the new block after the selected one.
-		// Ideally, this selection shouldn't focus the block to avoid the setTimeout.
-		selectBlock( previousBlockClientId );
-		// eslint-disable-next-line @wordpress/react-no-unsafe-timeout
-		setTimeout( () => {
-			setInserterIsOpened( true );
-		} );
+		setInsertionPoint( rootClientId, blockIndex );
+		setInserterIsOpened( true );
 	};
 
 	// Disable reason (no-autofocus): The inserter menu is a modal display, not one which

--- a/packages/block-editor/src/components/inserter/quick-inserter.js
+++ b/packages/block-editor/src/components/inserter/quick-inserter.js
@@ -174,7 +174,7 @@ export default function QuickInserter( {
 		}
 	}, [ setInserterIsOpened ] );
 
-	const { setInsertionPoint } = useDispatch( 'core/block-editor' );
+	const { __unstableSetInsertionPoint } = useDispatch( 'core/block-editor' );
 
 	// Announce search results on change
 	useEffect( () => {
@@ -191,7 +191,7 @@ export default function QuickInserter( {
 	}, [ filterValue, debouncedSpeak ] );
 
 	const onBrowseAll = () => {
-		setInsertionPoint( rootClientId, blockIndex );
+		__unstableSetInsertionPoint( rootClientId, blockIndex );
 		setInserterIsOpened( true );
 	};
 

--- a/packages/block-editor/src/components/inserter/quick-inserter.js
+++ b/packages/block-editor/src/components/inserter/quick-inserter.js
@@ -154,14 +154,19 @@ export default function QuickInserter( {
 		[ filterValue, patterns ]
 	);
 
-	const { setInserterIsOpened, blockIndex } = useSelect( ( select ) => {
-		const { getSettings, getBlockIndex } = select( 'core/block-editor' );
-		return {
-			setInserterIsOpened: getSettings()
-				.__experimentalSetIsInserterOpened,
-			blockIndex: getBlockIndex( clientId, rootClientId ),
-		};
-	}, [] );
+	const { setInserterIsOpened, blockIndex } = useSelect(
+		( select ) => {
+			const { getSettings, getBlockIndex } = select(
+				'core/block-editor'
+			);
+			return {
+				setInserterIsOpened: getSettings()
+					.__experimentalSetIsInserterOpened,
+				blockIndex: getBlockIndex( clientId, rootClientId ),
+			};
+		},
+		[ clientId, rootClientId ]
+	);
 
 	useEffect( () => {
 		if ( setInserterIsOpened ) {

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -523,8 +523,28 @@ export function* insertBlocks(
 }
 
 /**
- * Returns an action object used in signalling that the insertion point should
- * be shown.
+ * Sets the insertion point without showing it to users.
+ *
+ * Components like <Inserter> will default to inserting blocks at this point.
+ *
+ * @param {?string} rootClientId Optional root client ID of block list on
+ *                               which to insert.
+ * @param {?number} index        Index at which block should be inserted.
+ *
+ * @return {Object} Action object.
+ */
+export function setInsertionPoint( rootClientId, index ) {
+	return {
+		type: 'SET_INSERTION_POINT',
+		rootClientId,
+		index,
+	};
+}
+
+/**
+ * Sets the insertion point and shows it to users.
+ *
+ * Components like <Inserter> will default to inserting blocks at this point.
  *
  * @param {?string} rootClientId Optional root client ID of block list on
  *                               which to insert.
@@ -541,7 +561,7 @@ export function showInsertionPoint( rootClientId, index ) {
 }
 
 /**
- * Returns an action object hiding the insertion point.
+ * Hides the insertion point for users.
  *
  * @return {Object} Action object.
  */

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -533,7 +533,7 @@ export function* insertBlocks(
  *
  * @return {Object} Action object.
  */
-export function setInsertionPoint( rootClientId, index ) {
+export function __unstableSetInsertionPoint( rootClientId, index ) {
 	return {
 		type: 'SET_INSERTION_POINT',
 		rootClientId,

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -527,9 +527,10 @@ export function* insertBlocks(
  *
  * Components like <Inserter> will default to inserting blocks at this point.
  *
- * @param {?string} rootClientId Optional root client ID of block list on
- *                               which to insert.
- * @param {?number} index        Index at which block should be inserted.
+ * @param {?string} rootClientId Root client ID of block list in which to
+ *                               insert. Use `undefined` for the root block
+ *                               list.
+ * @param {number} index         Index at which block should be inserted.
  *
  * @return {Object} Action object.
  */
@@ -546,9 +547,10 @@ export function __unstableSetInsertionPoint( rootClientId, index ) {
  *
  * Components like <Inserter> will default to inserting blocks at this point.
  *
- * @param {?string} rootClientId Optional root client ID of block list on
- *                               which to insert.
- * @param {?number} index        Index at which block should be inserted.
+ * @param {?string} rootClientId Root client ID of block list in which to
+ *                               insert. Use `undefined` for the root block
+ *                               list.
+ * @param {number} index         Index at which block should be inserted.
  *
  * @return {Object} Action object.
  */

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1379,11 +1379,25 @@ export function blocksMode( state = {}, action ) {
  */
 export function insertionPoint( state = null, action ) {
 	switch ( action.type ) {
-		case 'SHOW_INSERTION_POINT':
+		case 'SET_INSERTION_POINT': {
 			const { rootClientId, index } = action;
-			return { rootClientId, index };
+			return { rootClientId, index, isVisible: false };
+		}
+
+		case 'SHOW_INSERTION_POINT': {
+			const { rootClientId, index } = action;
+			return { rootClientId, index, isVisible: true };
+		}
 
 		case 'HIDE_INSERTION_POINT':
+			return state ? { ...state, isVisible: false } : state;
+
+		case 'CLEAR_SELECTED_BLOCK':
+		case 'SELECT_BLOCK':
+		case 'REPLACE_INNER_BLOCKS':
+		case 'INSERT_BLOCKS':
+		case 'REMOVE_BLOCKS':
+		case 'REPLACE_BLOCKS':
 			return null;
 	}
 

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1381,7 +1381,9 @@ export function insertionPoint( state = null, action ) {
 	switch ( action.type ) {
 		case 'SET_INSERTION_POINT': {
 			const { rootClientId, index } = action;
-			return { rootClientId, index, isVisible: false };
+			return state
+				? { ...state, rootClientId, index }
+				: { rootClientId, index };
 		}
 
 		case 'SHOW_INSERTION_POINT': {

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1400,7 +1400,7 @@ function resetInsertionPoint( state, action, defaultValue ) {
  *
  * @return {Object} Updated state.
  */
-export function insertionPoint( state = {}, action ) {
+export function insertionPoint( state = null, action ) {
 	switch ( action.type ) {
 		case 'SET_INSERTION_POINT':
 		case 'SHOW_INSERTION_POINT': {
@@ -1409,7 +1409,7 @@ export function insertionPoint( state = {}, action ) {
 		}
 	}
 
-	return resetInsertionPoint( state, action, {} );
+	return resetInsertionPoint( state, action, null );
 }
 
 /**

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1378,7 +1378,6 @@ export function blocksMode( state = {}, action ) {
  */
 function resetInsertionPoint( state, action, defaultValue ) {
 	switch ( action.type ) {
-		case 'HIDE_INSERTION_POINT':
 		case 'CLEAR_SELECTED_BLOCK':
 		case 'SELECT_BLOCK':
 		case 'REPLACE_INNER_BLOCKS':
@@ -1424,6 +1423,8 @@ export function insertionPointVisibility( state = false, action ) {
 	switch ( action.type ) {
 		case 'SHOW_INSERTION_POINT':
 			return true;
+		case 'HIDE_INSERTION_POINT':
+			return false;
 	}
 
 	return resetInsertionPoint( state, action, false );

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1368,42 +1368,65 @@ export function blocksMode( state = {}, action ) {
 }
 
 /**
- * Reducer returning the block insertion point visibility, either null if there
- * is not an explicit insertion point assigned, or an object of its `index` and
- * `rootClientId`.
+ * A helper for resetting the insertion point state.
  *
- * @param {Object} state  Current state.
- * @param {Object} action Dispatched action.
+ * @param {Object} state        Current state.
+ * @param {Object} action       Dispatched action.
+ * @param {*}      defaultValue The default value for the reducer.
  *
- * @return {Object} Updated state.
+ * @return {*} Either the default value if a reset is required, or the state.
  */
-export function insertionPoint( state = null, action ) {
+function resetInsertionPoint( state, action, defaultValue ) {
 	switch ( action.type ) {
-		case 'SET_INSERTION_POINT': {
-			const { rootClientId, index } = action;
-			return state
-				? { ...state, rootClientId, index }
-				: { rootClientId, index };
-		}
-
-		case 'SHOW_INSERTION_POINT': {
-			const { rootClientId, index } = action;
-			return { rootClientId, index, isVisible: true };
-		}
-
 		case 'HIDE_INSERTION_POINT':
-			return state ? { ...state, isVisible: false } : state;
-
 		case 'CLEAR_SELECTED_BLOCK':
 		case 'SELECT_BLOCK':
 		case 'REPLACE_INNER_BLOCKS':
 		case 'INSERT_BLOCKS':
 		case 'REMOVE_BLOCKS':
 		case 'REPLACE_BLOCKS':
-			return null;
+			return defaultValue;
 	}
 
 	return state;
+}
+
+/**
+ * Reducer returning the insertion point position, consisting of the
+ * rootClientId and an index.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+export function insertionPoint( state = {}, action ) {
+	switch ( action.type ) {
+		case 'SET_INSERTION_POINT':
+		case 'SHOW_INSERTION_POINT': {
+			const { rootClientId, index } = action;
+			return { rootClientId, index };
+		}
+	}
+
+	return resetInsertionPoint( state, action, {} );
+}
+
+/**
+ * Reducer returning the visibility of the insertion point.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+export function insertionPointVisibility( state = false, action ) {
+	switch ( action.type ) {
+		case 'SHOW_INSERTION_POINT':
+			return true;
+	}
+
+	return resetInsertionPoint( state, action, false );
 }
 
 /**
@@ -1674,6 +1697,7 @@ export default combineReducers( {
 	blocksMode,
 	blockListSettings,
 	insertionPoint,
+	insertionPointVisibility,
 	template,
 	settings,
 	preferences,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1138,12 +1138,19 @@ export function isCaretWithinFormattedText( state ) {
 }
 
 /**
- * Returns the insertion point, the index at which the new inserted block would
- * be placed. Defaults to the last index.
+ * Returns the insertion point. This will be:
  *
- * @param {Object} state Editor state.
+ * 1) The insertion point manually set using setInsertionPoint() or
+ *    showInsertionPoint(); or
+ * 2) The point after the current block selection, if there is a selection; or
+ * 3) The point at the end of the block list.
  *
- * @return {Object} Insertion point object with `rootClientId`, `index`.
+ * Components like <Inserter> will default to inserting blocks at this point.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {Object} Insertion point object with `rootClientId`, `index`,
+ *                  `isVisible`.
  */
 export function getBlockInsertionPoint( state ) {
 	let rootClientId, index;
@@ -1162,18 +1169,19 @@ export function getBlockInsertionPoint( state ) {
 		index = getBlockOrder( state ).length;
 	}
 
-	return { rootClientId, index };
+	return { rootClientId, index, isVisible: false };
 }
 
 /**
- * Returns true if we should show the block insertion point.
+ * Whether or not the insertion point should be shown to users. This is set
+ * using showInsertionPoint() or hideInsertionPoint().
  *
  * @param {Object} state Global application state.
  *
- * @return {?boolean} Whether the insertion point is visible or not.
+ * @return {?boolean} Whether the insertion point should be shown.
  */
 export function isBlockInsertionPointVisible( state ) {
-	return state.insertionPoint !== null;
+	return !! state.insertionPoint?.isVisible;
 }
 
 /**

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1149,8 +1149,7 @@ export function isCaretWithinFormattedText( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @return {Object} Insertion point object with `rootClientId`, `index`,
- *                  `isVisible`.
+ * @return {Object} Insertion point object with `rootClientId` and `index`.
  */
 export function getBlockInsertionPoint( state ) {
 	let rootClientId, index;
@@ -1169,7 +1168,7 @@ export function getBlockInsertionPoint( state ) {
 		index = getBlockOrder( state ).length;
 	}
 
-	return { rootClientId, index, isVisible: false };
+	return { rootClientId, index };
 }
 
 /**
@@ -1181,7 +1180,7 @@ export function getBlockInsertionPoint( state ) {
  * @return {?boolean} Whether the insertion point should be shown.
  */
 export function isBlockInsertionPointVisible( state ) {
-	return !! state.insertionPoint?.isVisible;
+	return state.insertionPointVisibility;
 }
 
 /**

--- a/packages/block-editor/src/store/test/actions.js
+++ b/packages/block-editor/src/store/test/actions.js
@@ -24,6 +24,7 @@ import {
 	resetBlocks,
 	selectBlock,
 	selectPreviousBlock,
+	setInsertionPoint,
 	showInsertionPoint,
 	startMultiSelect,
 	startTyping,
@@ -699,10 +700,28 @@ describe( 'actions', () => {
 		} );
 	} );
 
+	describe( 'setInsertionPoint', () => {
+		it( 'should return the SET_INSERTION_POINT action', () => {
+			expect( setInsertionPoint() ).toEqual( {
+				type: 'SET_INSERTION_POINT',
+			} );
+			expect( setInsertionPoint( 'rootClientId', 2 ) ).toEqual( {
+				type: 'SET_INSERTION_POINT',
+				rootClientId: 'rootClientId',
+				index: 2,
+			} );
+		} );
+	} );
+
 	describe( 'showInsertionPoint', () => {
 		it( 'should return the SHOW_INSERTION_POINT action', () => {
 			expect( showInsertionPoint() ).toEqual( {
 				type: 'SHOW_INSERTION_POINT',
+			} );
+			expect( showInsertionPoint( 'rootClientId', 2 ) ).toEqual( {
+				type: 'SHOW_INSERTION_POINT',
+				rootClientId: 'rootClientId',
+				index: 2,
 			} );
 		} );
 	} );

--- a/packages/block-editor/src/store/test/actions.js
+++ b/packages/block-editor/src/store/test/actions.js
@@ -24,7 +24,7 @@ import {
 	resetBlocks,
 	selectBlock,
 	selectPreviousBlock,
-	setInsertionPoint,
+	__unstableSetInsertionPoint,
 	showInsertionPoint,
 	startMultiSelect,
 	startTyping,
@@ -700,16 +700,18 @@ describe( 'actions', () => {
 		} );
 	} );
 
-	describe( 'setInsertionPoint', () => {
+	describe( '__unstableSetInsertionPoint', () => {
 		it( 'should return the SET_INSERTION_POINT action', () => {
-			expect( setInsertionPoint() ).toEqual( {
+			expect( __unstableSetInsertionPoint() ).toEqual( {
 				type: 'SET_INSERTION_POINT',
 			} );
-			expect( setInsertionPoint( 'rootClientId', 2 ) ).toEqual( {
-				type: 'SET_INSERTION_POINT',
-				rootClientId: 'rootClientId',
-				index: 2,
-			} );
+			expect( __unstableSetInsertionPoint( 'rootClientId', 2 ) ).toEqual(
+				{
+					type: 'SET_INSERTION_POINT',
+					rootClientId: 'rootClientId',
+					index: 2,
+				}
+			);
 		} );
 	} );
 

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -2023,6 +2023,20 @@ describe( 'state', () => {
 
 		it( 'should set insertion point', () => {
 			const state = insertionPoint( null, {
+				type: 'SET_INSERTION_POINT',
+				rootClientId: 'clientId1',
+				index: 0,
+			} );
+
+			expect( state ).toEqual( {
+				rootClientId: 'clientId1',
+				index: 0,
+				isVisible: false,
+			} );
+		} );
+
+		it( 'should show insertion point', () => {
+			const state = insertionPoint( null, {
 				type: 'SHOW_INSERTION_POINT',
 				rootClientId: 'clientId1',
 				index: 0,
@@ -2031,16 +2045,42 @@ describe( 'state', () => {
 			expect( state ).toEqual( {
 				rootClientId: 'clientId1',
 				index: 0,
+				isVisible: true,
 			} );
 		} );
 
-		it( 'should clear the insertion point', () => {
+		it( 'should hide the insertion point', () => {
 			const original = deepFreeze( {
 				rootClientId: 'clientId1',
 				index: 0,
+				isVisible: true,
 			} );
 			const state = insertionPoint( original, {
 				type: 'HIDE_INSERTION_POINT',
+			} );
+
+			expect( state ).toEqual( {
+				rootClientId: 'clientId1',
+				index: 0,
+				isVisible: false,
+			} );
+		} );
+
+		it.each( [
+			'CLEAR_SELECTED_BLOCK',
+			'SELECT_BLOCK',
+			'REPLACE_INNER_BLOCKS',
+			'INSERT_BLOCKS',
+			'REMOVE_BLOCKS',
+			'REPLACE_BLOCKS',
+		] )( 'should clear the insertion point on %s', ( type ) => {
+			const original = deepFreeze( {
+				rootClientId: 'clientId1',
+				index: 0,
+				isVisible: true,
+			} );
+			const state = insertionPoint( original, {
+				type,
 			} );
 
 			expect( state ).toBe( null );

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -30,6 +30,7 @@ import {
 	preferences,
 	blocksMode,
 	insertionPoint,
+	insertionPointVisibility,
 	template,
 	blockListSettings,
 	lastBlockAttributesChange,
@@ -2015,90 +2016,83 @@ describe( 'state', () => {
 	} );
 
 	describe( 'insertionPoint', () => {
-		it( 'should default to null', () => {
+		it( 'defaults to {}', () => {
 			const state = insertionPoint( undefined, {} );
 
-			expect( state ).toBe( null );
+			expect( state ).toEqual( {} );
 		} );
 
-		it( 'should set insertion point', () => {
-			const state = insertionPoint( null, {
-				type: 'SET_INSERTION_POINT',
-				rootClientId: 'clientId1',
-				index: 0,
-			} );
+		it.each( [ 'SET_INSERTION_POINT', 'SHOW_INSERTION_POINT' ] )(
+			'sets the insertion point on %s',
+			( type ) => {
+				const original = deepFreeze( {
+					rootClientId: 'clientId1',
+					index: 0,
+				} );
 
-			expect( state ).toEqual( {
-				rootClientId: 'clientId1',
-				index: 0,
-			} );
-		} );
+				const expectedNewState = {
+					rootClientId: 'clientId2',
+					index: 1,
+				};
 
-		it( 'should not modify isVisible when setting insertion point', () => {
-			const currentState = { isVisible: true };
+				const state = insertionPoint( original, {
+					type,
+					...expectedNewState,
+				} );
 
-			const state = insertionPoint( currentState, {
-				type: 'SET_INSERTION_POINT',
-				rootClientId: 'clientId1',
-				index: 0,
-			} );
-
-			expect( state ).toEqual( {
-				isVisible: true,
-				rootClientId: 'clientId1',
-				index: 0,
-			} );
-		} );
-
-		it( 'should show insertion point', () => {
-			const state = insertionPoint( null, {
-				type: 'SHOW_INSERTION_POINT',
-				rootClientId: 'clientId1',
-				index: 0,
-			} );
-
-			expect( state ).toEqual( {
-				rootClientId: 'clientId1',
-				index: 0,
-				isVisible: true,
-			} );
-		} );
-
-		it( 'should hide the insertion point', () => {
-			const original = deepFreeze( {
-				rootClientId: 'clientId1',
-				index: 0,
-				isVisible: true,
-			} );
-			const state = insertionPoint( original, {
-				type: 'HIDE_INSERTION_POINT',
-			} );
-
-			expect( state ).toEqual( {
-				rootClientId: 'clientId1',
-				index: 0,
-				isVisible: false,
-			} );
-		} );
+				expect( state ).toEqual( expectedNewState );
+			}
+		);
 
 		it.each( [
+			'HIDE_INSERTION_POINT',
 			'CLEAR_SELECTED_BLOCK',
 			'SELECT_BLOCK',
 			'REPLACE_INNER_BLOCKS',
 			'INSERT_BLOCKS',
 			'REMOVE_BLOCKS',
 			'REPLACE_BLOCKS',
-		] )( 'should clear the insertion point on %s', ( type ) => {
+		] )( 'resets the insertion point on %s', ( type ) => {
 			const original = deepFreeze( {
 				rootClientId: 'clientId1',
 				index: 0,
-				isVisible: true,
 			} );
 			const state = insertionPoint( original, {
 				type,
 			} );
 
-			expect( state ).toBe( null );
+			expect( state ).toEqual( {} );
+		} );
+	} );
+
+	describe( 'insertionPointVisibility', () => {
+		it( 'defaults to `false`', () => {
+			const state = insertionPointVisibility( undefined, {} );
+			expect( state ).toBe( false );
+		} );
+
+		it( 'shows the insertion point', () => {
+			const state = insertionPointVisibility( false, {
+				type: 'SHOW_INSERTION_POINT',
+			} );
+
+			expect( state ).toBe( true );
+		} );
+
+		it.each( [
+			'HIDE_INSERTION_POINT',
+			'CLEAR_SELECTED_BLOCK',
+			'SELECT_BLOCK',
+			'REPLACE_INNER_BLOCKS',
+			'INSERT_BLOCKS',
+			'REMOVE_BLOCKS',
+			'REPLACE_BLOCKS',
+		] )( 'resets the insertion point on %s to `false`', ( type ) => {
+			const state = insertionPointVisibility( true, {
+				type,
+			} );
+
+			expect( state ).toBe( false );
 		} );
 	} );
 

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -2016,10 +2016,10 @@ describe( 'state', () => {
 	} );
 
 	describe( 'insertionPoint', () => {
-		it( 'defaults to {}', () => {
+		it( 'defaults to `null`', () => {
 			const state = insertionPoint( undefined, {} );
 
-			expect( state ).toEqual( {} );
+			expect( state ).toEqual( null );
 		} );
 
 		it.each( [ 'SET_INSERTION_POINT', 'SHOW_INSERTION_POINT' ] )(
@@ -2052,7 +2052,7 @@ describe( 'state', () => {
 			'INSERT_BLOCKS',
 			'REMOVE_BLOCKS',
 			'REPLACE_BLOCKS',
-		] )( 'resets the insertion point on %s', ( type ) => {
+		] )( 'resets the insertion point to `null` on %s', ( type ) => {
 			const original = deepFreeze( {
 				rootClientId: 'clientId1',
 				index: 0,
@@ -2061,7 +2061,7 @@ describe( 'state', () => {
 				type,
 			} );
 
-			expect( state ).toEqual( {} );
+			expect( state ).toEqual( null );
 		} );
 	} );
 

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -2031,7 +2031,22 @@ describe( 'state', () => {
 			expect( state ).toEqual( {
 				rootClientId: 'clientId1',
 				index: 0,
-				isVisible: false,
+			} );
+		} );
+
+		it( 'should not modify isVisible when setting insertion point', () => {
+			const currentState = { isVisible: true };
+
+			const state = insertionPoint( currentState, {
+				type: 'SET_INSERTION_POINT',
+				rootClientId: 'clientId1',
+				index: 0,
+			} );
+
+			expect( state ).toEqual( {
+				isVisible: true,
+				rootClientId: 'clientId1',
+				index: 0,
 			} );
 		} );
 

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -2045,7 +2045,6 @@ describe( 'state', () => {
 		);
 
 		it.each( [
-			'HIDE_INSERTION_POINT',
 			'CLEAR_SELECTED_BLOCK',
 			'SELECT_BLOCK',
 			'REPLACE_INNER_BLOCKS',
@@ -2087,7 +2086,7 @@ describe( 'state', () => {
 			'INSERT_BLOCKS',
 			'REMOVE_BLOCKS',
 			'REPLACE_BLOCKS',
-		] )( 'resets the insertion point on %s to `false`', ( type ) => {
+		] )( 'sets the insertion point on %s to `false`', ( type ) => {
 			const state = insertionPointVisibility( true, {
 				type,
 			} );

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -2020,12 +2020,14 @@ describe( 'selectors', () => {
 				insertionPoint: {
 					rootClientId: undefined,
 					index: 0,
+					isVisible: true,
 				},
 			};
 
 			expect( getBlockInsertionPoint( state ) ).toEqual( {
 				rootClientId: undefined,
 				index: 0,
+				isVisible: true,
 			} );
 		} );
 
@@ -2054,6 +2056,7 @@ describe( 'selectors', () => {
 			expect( getBlockInsertionPoint( state ) ).toEqual( {
 				rootClientId: undefined,
 				index: 1,
+				isVisible: false,
 			} );
 		} );
 
@@ -2086,6 +2089,7 @@ describe( 'selectors', () => {
 			expect( getBlockInsertionPoint( state ) ).toEqual( {
 				rootClientId: 'clientId1',
 				index: 1,
+				isVisible: false,
 			} );
 		} );
 
@@ -2118,6 +2122,7 @@ describe( 'selectors', () => {
 			expect( getBlockInsertionPoint( state ) ).toEqual( {
 				rootClientId: undefined,
 				index: 2,
+				isVisible: false,
 			} );
 		} );
 
@@ -2150,6 +2155,7 @@ describe( 'selectors', () => {
 			expect( getBlockInsertionPoint( state ) ).toEqual( {
 				rootClientId: undefined,
 				index: 2,
+				isVisible: false,
 			} );
 		} );
 	} );
@@ -2163,11 +2169,24 @@ describe( 'selectors', () => {
 			expect( isBlockInsertionPointVisible( state ) ).toBe( false );
 		} );
 
-		it( 'should return true if assigned insertion point', () => {
+		it( 'should return false if insertion point is set to not show', () => {
 			const state = {
 				insertionPoint: {
 					rootClientId: undefined,
 					index: 5,
+					isVisible: false,
+				},
+			};
+
+			expect( isBlockInsertionPointVisible( state ) ).toBe( false );
+		} );
+
+		it( 'should return true if insertion point is set to show', () => {
+			const state = {
+				insertionPoint: {
+					rootClientId: undefined,
+					index: 5,
+					isVisible: true,
 				},
 			};
 

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -2020,14 +2020,12 @@ describe( 'selectors', () => {
 				insertionPoint: {
 					rootClientId: undefined,
 					index: 0,
-					isVisible: true,
 				},
 			};
 
 			expect( getBlockInsertionPoint( state ) ).toEqual( {
 				rootClientId: undefined,
 				index: 0,
-				isVisible: true,
 			} );
 		} );
 
@@ -2056,7 +2054,6 @@ describe( 'selectors', () => {
 			expect( getBlockInsertionPoint( state ) ).toEqual( {
 				rootClientId: undefined,
 				index: 1,
-				isVisible: false,
 			} );
 		} );
 
@@ -2089,7 +2086,6 @@ describe( 'selectors', () => {
 			expect( getBlockInsertionPoint( state ) ).toEqual( {
 				rootClientId: 'clientId1',
 				index: 1,
-				isVisible: false,
 			} );
 		} );
 
@@ -2122,7 +2118,6 @@ describe( 'selectors', () => {
 			expect( getBlockInsertionPoint( state ) ).toEqual( {
 				rootClientId: undefined,
 				index: 2,
-				isVisible: false,
 			} );
 		} );
 
@@ -2155,27 +2150,14 @@ describe( 'selectors', () => {
 			expect( getBlockInsertionPoint( state ) ).toEqual( {
 				rootClientId: undefined,
 				index: 2,
-				isVisible: false,
 			} );
 		} );
 	} );
 
 	describe( 'isBlockInsertionPointVisible', () => {
-		it( 'should return false if no assigned insertion point', () => {
-			const state = {
-				insertionPoint: null,
-			};
-
-			expect( isBlockInsertionPointVisible( state ) ).toBe( false );
-		} );
-
 		it( 'should return false if insertion point is set to not show', () => {
 			const state = {
-				insertionPoint: {
-					rootClientId: undefined,
-					index: 5,
-					isVisible: false,
-				},
+				insertionPointVisibility: false,
 			};
 
 			expect( isBlockInsertionPointVisible( state ) ).toBe( false );
@@ -2183,11 +2165,7 @@ describe( 'selectors', () => {
 
 		it( 'should return true if insertion point is set to show', () => {
 			const state = {
-				insertionPoint: {
-					rootClientId: undefined,
-					index: 5,
-					isVisible: true,
-				},
+				insertionPointVisibility: true,
 			};
 
 			expect( isBlockInsertionPointVisible( state ) ).toBe( true );

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/adding-blocks.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/adding-blocks.test.js.snap
@@ -53,6 +53,18 @@ lines preserved[/myshortcode]
 <!-- /wp:shortcode -->"
 `;
 
+exports[`adding blocks inserts a block in proper place after having clicked \`Browse All\` from block appender 1`] = `
+"<!-- wp:group -->
+<div class=\\"wp-block-group\\"><div class=\\"wp-block-group__inner-container\\"><!-- wp:paragraph -->
+<p>Paragraph inside group</p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:group -->
+
+<!-- wp:paragraph -->
+<p>Paragraph after group</p>
+<!-- /wp:paragraph -->"
+`;
+
 exports[`adding blocks inserts a block in proper place after having clicked \`Browse All\` from inline inserter 1`] = `
 "<!-- wp:paragraph -->
 <p>First paragraph</p>

--- a/packages/e2e-tests/specs/editor/various/adding-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/adding-blocks.test.js
@@ -297,4 +297,19 @@ describe( 'adding blocks', () => {
 		expect( indicatorRect.x ).toBe( paragraphRect.x );
 		expect( indicatorRect.y > paragraphRect.y ).toBe( true );
 	} );
+
+	// Check for regression of https://github.com/WordPress/gutenberg/issues/24403
+	it( 'inserts a block in proper place after having clicked `Browse All` from block appender', async () => {
+		await insertBlock( 'Group' );
+		await insertBlock( 'Paragraph' );
+		await page.keyboard.type( 'Paragraph after group' );
+		await page.click( '[data-type="core/group"] [aria-label="Add block"]' );
+		const browseAll = await page.waitForXPath(
+			'//button[text()="Browse all"]'
+		);
+		await browseAll.click();
+		await insertBlock( 'Paragraph' );
+		await page.keyboard.type( 'Paragraph inside group' );
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/24403.
Related to https://github.com/WordPress/gutenberg/pull/24285.

![insertion-point](https://user-images.githubusercontent.com/612155/97139169-02950100-17ae-11eb-89cc-22e089fcad6e.gif)

Maintain the insertion point in `@wordpress/block-editor` state when moving from the Quick Inserter to the Inserter.

This fixes a bug (https://github.com/WordPress/gutenberg/issues/24403) where the insertion point is wrong after clicking a block appender (e.g. in a Columns block) and selecting _Browse All_.

Care is taken to not regress a previous bug (https://github.com/WordPress/gutenberg/issues/24262) where the insertion point was wrong after clicking an inline insertion button and selecting _Browse All_.

I re-used the existing `insertionPoint` state tree so as to minimise the amount of new actions and selectors needed. This means we have three insertion point actions:

- `setInsertionPoint`: Sets where the inserter will default to inserting blocks.
- `showInsertionPoint`: Sets where the inserter will default to inserting blocks and display this to the user.
- `hideInsertionPoint`: Hides the insertion point from the user.

The insertion point is cleared when block selection changes. This is needed for the Site Editor where the Inserter is persistent.

### Testing

A regression E2E test has been added. This complements the one added in https://github.com/WordPress/gutenberg/pull/24396.

The manual flows that I checked are:

1. Create a new post.
1. Insert a Columns block with a paragraph in the first column.
1. Insert a block at the end of the post.
1. Click the block appender in the empty column.
1. Select _Browse All_.
1. Click on a block. It should be inserted into the empty column.
1. Click on the inline inserter that appears when you hover over the paragraph in the first column.
1. Select _Browse All_.
1. Click on a block. It should be inserted into the first column.

And:

1. Go to the experimental site editor.
1. Hover over a block and click on the inline inserter button that appears.
1. Select _Browse All_.
1. Click on a block. It should be inserted into the location you clicked on.
1. Hover over a block and click on the inline inserter button that appears.
1. Select _Browse All_.
1. Select a different block somewhere else in the page.
1. Click on a block. It should be inserted after the block you selected.