### PR TITLE
Polish search button, fix line-height.

### DIFF
--- a/packages/block-library/src/search/editor.scss
+++ b/packages/block-library/src/search/editor.scss
@@ -7,29 +7,14 @@
 		padding: $grid-unit-05;
 	}
 
-	.wp-block-search__input,
-	&.wp-block-search__button-inside .wp-block-search__inside-wrapper {
-		border-radius: $radius-block-ui;
-		border: 1px solid $gray-600;
-		color: $dark-gray-placeholder;
-		font-family: $default-font;
-		font-size: $default-font-size;
-		background-color: $white;
-
-		&:focus {
-			outline: none;
-		}
-	}
-
 	.wp-block-search__button {
-		background: #f7f7f7;
-		border-radius: $radius-block-ui;
-		border: 1px solid #ccc;
-		box-shadow: inset 0 -1px 0 #ccc;
-		font-family: $default-font;
-		font-size: $default-font-size;
-		padding: 6px 10px;
-		color: #32373c;
+		height: auto;
+		border-radius: initial;
+
+		// This needs high specificity because it otherwise inherits styles from `components-button`.
+		&.wp-block-search__button.wp-block-search__button {
+			padding: 6px 10px;
+		}
 	}
 
 	&__components-button-group {

--- a/packages/block-library/src/search/editor.scss
+++ b/packages/block-library/src/search/editor.scss
@@ -12,6 +12,7 @@
 		border-radius: initial;
 
 		// This needs high specificity because it otherwise inherits styles from `components-button`.
+		// stylelint-disable-line no-duplicate-selectors
 		&.wp-block-search__button.wp-block-search__button {
 			padding: 6px 10px;
 		}

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -1,4 +1,17 @@
 .wp-block-search {
+
+	.wp-block-search__button {
+		background: #f7f7f7;
+		border: 1px solid #ccc;
+		padding: 6px 10px;
+		color: #32373c;
+
+
+		&.has-icon {
+			line-height: 0;
+		}
+	}
+
 	.wp-block-search__inside-wrapper {
 		display: flex;
 		flex: auto;

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -5,10 +5,16 @@
 		border: 1px solid #ccc;
 		padding: 6px 10px;
 		color: #32373c;
-
+		margin-left: 0.625em;
+		word-break: normal;
 
 		&.has-icon {
 			line-height: 0;
+		}
+
+		svg {
+			min-width: 1.5em;
+			min-height: 1.5em;
 		}
 	}
 
@@ -27,16 +33,6 @@
 		flex-grow: 1;
 		min-width: 3em;
 		border: 1px solid $gray-600;
-	}
-
-	.wp-block-search__button {
-		margin-left: 0.625em;
-		word-break: normal;
-
-		svg {
-			min-width: 1.5em;
-			min-height: 1.5em;
-		}
 	}
 
 	&.wp-block-search__button-only {


### PR DESCRIPTION
This PR polishes the search block to have simpler CSS and to look more alike frontend and editor. Before, the editor had a special button style only used for this. This PR makes it look _almost_ the same frontend and backend.

Editor:

<img width="1094" alt="Screenshot 2020-10-26 at 10 14 31" src="https://user-images.githubusercontent.com/1204802/97154755-934eeb00-1774-11eb-8e96-2371c189d169.png">

Frontend:

<img width="1142" alt="Screenshot 2020-10-26 at 10 14 36" src="https://user-images.githubusercontent.com/1204802/97154761-9649db80-1774-11eb-93db-fb3803afc03d.png">

Additionally, it adds a line-height property to the button, which benefits themes, as reported by @jffng here: https://github.com/WordPress/twentytwentyone/pull/673#issuecomment-715482961