### PR TITLE
Create Block: Update the list of categories to pick from

### DIFF
--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Update the list of available block categories to align with changes introduced in WordPress 5.0.
+-   Set the minimum required version of WordPress to 5.0 to ensure that block is correctly registered with new block categories.
+
 ## 0.16.0 (2020-06-25)
 
 ### New Feature

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Breaking Changes
 
--   Update the list of available block categories to align with changes introduced in WordPress 5.0.
--   Set the minimum required version of WordPress to 5.0 to ensure that block is correctly registered with new block categories.
+-   Update the list of available block categories to align with changes introduced in WordPress 5.5.0 (https://make.wordpress.org/core/2020/07/30/block-api-updates-in-5-5/).
+-   Set the minimum required version of WordPress to 5.5.0 to ensure that block is correctly registered with new block categories.
 
 ## 0.16.0 (2020-06-25)
 

--- a/packages/create-block/lib/prompts.js
+++ b/packages/create-block/lib/prompts.js
@@ -70,7 +70,7 @@ const category = {
 	type: 'list',
 	name: 'category',
 	message: 'The category name to help users browse and discover your block:',
-	choices: [ 'common', 'embed', 'formatting', 'layout', 'widgets' ],
+	choices: [ 'text', 'media', 'design', 'widgets', 'embed' ],
 };
 
 const author = {

--- a/packages/create-block/lib/templates/es5/readme.txt.mustache
+++ b/packages/create-block/lib/templates/es5/readme.txt.mustache
@@ -3,8 +3,8 @@
 Contributors:      {{author}}
 {{/author}}
 Tags:              block
-Requires at least: 5.3.2
-Tested up to:      5.4.1
+Requires at least: 5.5.0
+Tested up to:      5.5.1
 Stable tag:        {{version}}
 Requires PHP:      7.0.0
 {{#license}}

--- a/packages/create-block/lib/templates/esnext/readme.txt.mustache
+++ b/packages/create-block/lib/templates/esnext/readme.txt.mustache
@@ -3,8 +3,8 @@
 Contributors:      {{author}}
 {{/author}}
 Tags:              block
-Requires at least: 5.3.2
-Tested up to:      5.4.1
+Requires at least: 5.5.0
+Tested up to:      5.5.1
 Stable tag:        {{version}}
 Requires PHP:      7.0.0
 {{#license}}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Closes #22848.
Follows-up #19279.

> It's possible now to register blocks without providing the category. It became optional in #22280.
> 
> In addition to that, there is now a refined list of categories as of #19279:
> 
> - Text
> - Media
> - Design
> - Widgets (Unchanged)
> - Embeds (Unchanged)
> - Reusable (Unchanged) – set only by the user using UI



## How has this been tested?
Scaffold a block with `npx wp-create-block`, and activate it in WordPress 5.5.0 or higher. It should work as before. During the scaffolding process please make sure that only new categories are listed.

## Types of changes
Breaking change for `@wordpress/create-block` as the minimum WordPress version required becomes now 5.5.0.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
