### PR TITLE
Scripts: Teach all the tools to skip `vendor` folder

### DIFF
--- a/packages/jest-preset-default/CHANGELOG.md
+++ b/packages/jest-preset-default/CHANGELOG.md
@@ -2,31 +2,34 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Ignore `/vendor` folder when searching for tests.
+
 ## 6.0.0 (2020-04-15)
 
 ### Breaking Changes
 
-- The peer `jest` dependency has been updated from requiring `>=24` to requiring `>=25` (see [Breaking Changes](https://jestjs.io/blog/2020/01/21/jest-25), [#20766](https://github.com/WordPress/gutenberg/pull/20766)).
-- This package requires now `node` v10.0.0 or later ([#20766](https://github.com/WordPress/gutenberg/pull/20766)).
+-   The peer `jest` dependency has been updated from requiring `>=24` to requiring `>=25` (see [Breaking Changes](https://jestjs.io/blog/2020/01/21/jest-25), [#20766](https://github.com/WordPress/gutenberg/pull/20766)).
+-   This package requires now `node` v10.0.0 or later ([#20766](https://github.com/WordPress/gutenberg/pull/20766)).
 
 ## 5.4.0 (2020-02-04)
 
 ### Bug Fixes
 
-- Use `require.resolve()` instead of `<rootDir>` to resolve `jest` config files according to the NodeJS lookup algorithm. ([#19957](https://github.com/WordPress/gutenberg/pull/19957))
+-   Use `require.resolve()` instead of `<rootDir>` to resolve `jest` config files according to the NodeJS lookup algorithm. ([#19957](https://github.com/WordPress/gutenberg/pull/19957))
 
 ## 5.3.1 (2020-01-01)
 
 ### Bug Fixes
 
-- Fix preset file extension for inclusion in NPM deployments. ([#19306](https://github.com/WordPress/gutenberg/pull/19306)).
+-   Fix preset file extension for inclusion in NPM deployments. ([#19306](https://github.com/WordPress/gutenberg/pull/19306)).
 
 ## 5.3.0 (2019-12-20)
 
 ### New Features
 
-- Added support to collapse or omit successful test results from Travis CI builds ([#16744](https://github.com/WordPress/gutenberg/issues/16744))
-
+-   Added support to collapse or omit successful test results from Travis CI builds ([#16744](https://github.com/WordPress/gutenberg/issues/16744))
 
 ## 5.2.0 (2019-11-15)
 
@@ -34,29 +37,29 @@
 
 ### Bug Fixes
 
-- Add `wordpress` folder to the list of ignored paths ([#17296](https://github.com/WordPress/gutenberg/pull/17296)).
+-   Add `wordpress` folder to the list of ignored paths ([#17296](https://github.com/WordPress/gutenberg/pull/17296)).
 
 ## 5.0.0 (2019-08-29)
 
 ### Breaking Changes
 
-- Files with `.spec.js` suffix are no longer matched as test files by default.
+-   Files with `.spec.js` suffix are no longer matched as test files by default.
 
 ### New Features
 
-- Align `testMatch` config option with Jest and allow test files with `.ts` suffix.
+-   Align `testMatch` config option with Jest and allow test files with `.ts` suffix.
 
 ## 4.0.0 (2019-03-06)
 
 ### Breaking Changes
 
-- The bundled `jest` dependency has been updated from requiring `^23.6.0` to requiring `^24.1.0` (see [Breaking Changes](https://jestjs.io/blog/2019/01/25/jest-24-refreshing-polished-typescript-friendly#breaking-changes), [#13922](https://github.com/WordPress/gutenberg/pull/13922)).
-- The bundled `jest-enzyme` dependency has been removed completely ([#13922](https://github.com/WordPress/gutenberg/pull/13922)).
+-   The bundled `jest` dependency has been updated from requiring `^23.6.0` to requiring `^24.1.0` (see [Breaking Changes](https://jestjs.io/blog/2019/01/25/jest-24-refreshing-polished-typescript-friendly#breaking-changes), [#13922](https://github.com/WordPress/gutenberg/pull/13922)).
+-   The bundled `jest-enzyme` dependency has been removed completely ([#13922](https://github.com/WordPress/gutenberg/pull/13922)).
 
 ### Internal
 
-- The bundled `enzyme` dependency has been updated from requiring `^3.7.0` to requiring `^3.9.0` ([#13922](https://github.com/WordPress/gutenberg/pull/13922)).
-- The bundled `enzyme-adapter-react-16` dependency has been updated from requiring `^1.6.0` to requiring `^1.10.0` ([#13922](https://github.com/WordPress/gutenberg/pull/13922)).
+-   The bundled `enzyme` dependency has been updated from requiring `^3.7.0` to requiring `^3.9.0` ([#13922](https://github.com/WordPress/gutenberg/pull/13922)).
+-   The bundled `enzyme-adapter-react-16` dependency has been updated from requiring `^1.6.0` to requiring `^1.10.0` ([#13922](https://github.com/WordPress/gutenberg/pull/13922)).
 
 ## 3.0.3 (2018-11-20)
 
@@ -68,27 +71,27 @@
 
 ### Breaking Change
 
-- Remove coverage support.
+-   Remove coverage support.
 
 ## 2.0.0 (2018-07-12)
 
 ### Breaking Change
 
-- Updated code to work with Babel 7 ([#7832](https://github.com/WordPress/gutenberg/pull/7832))
+-   Updated code to work with Babel 7 ([#7832](https://github.com/WordPress/gutenberg/pull/7832))
 
 ### Internal
 
-- Moved `@WordPress/packages` repository to `@WordPress/gutenberg` ([#7805](https://github.com/WordPress/gutenberg/pull/7805))
+-   Moved `@WordPress/packages` repository to `@WordPress/gutenberg` ([#7805](https://github.com/WordPress/gutenberg/pull/7805))
 
 ## 1.0.6 (2018-05-18)
 
 ### Polish
 
-- Fix: Standardized `package.json` format ([#119](https://github.com/WordPress/packages/pull/119))
+-   Fix: Standardized `package.json` format ([#119](https://github.com/WordPress/packages/pull/119))
 
 ## 1.0.5 (2018-03-22)
 
 ### Polish
 
-- Docs: Wrap filename in backticks ([#89](https://github.com/WordPress/packages/pull/89))
-- Add `jest-preset` keyword to `jest-preset-default` package ([#92](https://github.com/WordPress/packages/pull/92))
+-   Docs: Wrap filename in backticks ([#89](https://github.com/WordPress/packages/pull/89))
+-   Add `jest-preset` keyword to `jest-preset-default` package ([#92](https://github.com/WordPress/packages/pull/92))

--- a/packages/jest-preset-default/jest-preset.js
+++ b/packages/jest-preset-default/jest-preset.js
@@ -21,7 +21,11 @@ module.exports = {
 		'**/test/*.[jt]s',
 		'**/?(*.)test.[jt]s',
 	],
-	testPathIgnorePatterns: [ '/node_modules/', '<rootDir>/wordpress/' ],
+	testPathIgnorePatterns: [
+		'/node_modules/',
+		'<rootDir>/vendor/',
+		'<rootDir>/wordpress/',
+	],
 	timers: 'fake',
 	transform: {
 		'^.+\\.[jt]sx?$': require.resolve( 'babel-jest' ),

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Ignore `/vendor` folder when searching for files to lint or format.
+
 ## 12.1.0 (2020-07-07)
 
 ### Enhancements

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -150,7 +150,7 @@ This is how you execute the script with presented setup:
 
 When you run commands similar to the `npm run format:js:src` example above, you can provide a file, a directory, or `glob` syntax or any combination of them.
 
-By default, files located in `build` and `node_modules` folders are ignored.
+By default, files located in `build`, `node_modules`, `vendor` and `wordpress` folders are ignored.
 
 ### `lint-js`
 
@@ -174,7 +174,7 @@ This is how you execute the script with presented setup:
 
 When you run commands similar to the `npm run lint:js:src` example above, you can provide a file, a directory, or `glob` syntax or any combination of them. See [more examples](https://eslint.org/docs/user-guide/command-line-interface).
 
-By default, files located in `build` and `node_modules` folders are ignored.
+By default, files located in `build`, `node_modules`, `vendor` and `wordpress` folders are ignored.
 
 #### Advanced information
 
@@ -202,7 +202,7 @@ This is how you execute those scripts using the presented setup:
 
 When you run commands similar to the `npm run lint:pkg-json:src` example above, you can provide one or multiple directories to scan as well. See [more examples](https://github.com/tclindner/npm-package-json-lint/blob/HEAD/README.md#examples).
 
-By default, files located in `build` and `node_modules` folders are ignored.
+By default, files located in `build`, `node_modules`, `vendor` and `wordpress` folders are ignored.
 
 #### Advanced information
 
@@ -226,7 +226,7 @@ This is how you execute the script with presented setup:
 
 -   `npm run lint:md:docs` - lints markdown files in the entire project’s directories.
 
-By default, files located in `build` and `node_modules` folders are ignored.
+By default, files located in `build`, `node_modules`, `vendor` and `wordpress` folders are ignored.
 
 #### Advanced information
 
@@ -250,7 +250,7 @@ This is how you execute the script with presented setup:
 
 -   `npm run lint:md:js` - lints markdown files in the entire project’s directories.
 
-By default, files located in `build` and `node_modules` folders are ignored.
+By default, files located in `build`, `node_modules`, `vendor` and `wordpress` folders are ignored.
 
 #### Advanced information
 
@@ -278,7 +278,7 @@ This is how you execute the script with presented setup:
 
 When you run commands similar to the `npm run lint:css:src` example above, be sure to include the quotation marks around file globs. This ensures that you can use the powers of [globby](https://github.com/sindresorhus/globby) (like the `**` globstar) regardless of your shell. See [more examples](https://github.com/stylelint/stylelint/blob/HEAD/docs/user-guide/cli.md#examples).
 
-By default, files located in `build` and `node_modules` folders are ignored.
+By default, files located in `build`, `node_modules`, `vendor` and `wordpress` folders are ignored.
 
 #### Advanced information
 

--- a/packages/scripts/config/.eslintignore
+++ b/packages/scripts/config/.eslintignore
@@ -1,3 +1,4 @@
 build
 node_modules
+vendor
 wordpress

--- a/packages/scripts/config/.npmpackagejsonlintignore
+++ b/packages/scripts/config/.npmpackagejsonlintignore
@@ -1,4 +1,5 @@
 # By default, all `node_modules` are ignored.
 
 build
+vendor
 wordpress

--- a/packages/scripts/config/.stylelintignore
+++ b/packages/scripts/config/.stylelintignore
@@ -1,4 +1,5 @@
 # By default, all `node_modules` are ignored.
 
 build
+vendor
 wordpress


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes #24295.

> If you have a vendor folder, from composer, `wp-scripts lint-md-docs` will lint all the readmes, etc.

The same change has been applied to:
- Jest preset default, i.e. unit tests
- ESLint related tasks
- Prettier task
- Stylelint task

## How has this been tested?

1. Remove the override in Gutenber repo: `.eslintignore` (that lists `vendor` as well).
2. Make sure that all tools that depend on `.eslitignore` ignore `vendor` folder from composer.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
