### PR TITLE
Rewrite sideEffects flags to use only positive patterns

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -308,17 +308,4 @@ If your package includes a few files with side effects, you can list them instea
 }
 ```
 
-Many `@wordpress` UI-focused packages rely on side effects for registering blocks, plugins, and data stores. To reduce maintenance costs, it may be preferable to opt for an inverse glob strategy, where you instead list the paths where side effects are *not* present, leaving the bundler to assume that everything else might have them. This results in a glob with multiple roots (to match `@wordpress` package structure) and one or more excluded directories.
-
-Here is an example where we declare that the `components` and `utils` directories are side effect-free:
-
-```json
-{
-	"name": "package",
-	"sideEffects": [
-		"!((src|build|build-module)/(components|utils)/**)"
-	],
-}
-```
-
 Please consult the [side effects documentation](./side-effects.md) for more information on identifying and declaring side effects.

--- a/packages/block-directory/package.json
+++ b/packages/block-directory/package.json
@@ -21,10 +21,6 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"react-native": "src/index",
-	"sideEffects": [
-		"build-style/**",
-		"!((src|build|build-module)/components/**)"
-	],
 	"dependencies": {
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/api-fetch": "file:../api-fetch",

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -24,7 +24,7 @@
 	"react-native": "src/index",
 	"sideEffects": [
 		"build-style/**",
-		"!((src|build|build-module)/(components|utils)/**)"
+		"{src,build,build-module}/{index.js,store/index.js,hooks/**}"
 	],
 	"dependencies": {
 		"@babel/runtime": "^7.11.2",

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -24,6 +24,7 @@
 	"react-native": "src/index",
 	"sideEffects": [
 		"build-style/**",
+		"src/**/*.scss",
 		"{src,build,build-module}/{index.js,store/index.js,hooks/**}"
 	],
 	"dependencies": {

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -22,7 +22,8 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"sideEffects": [
-		"build-style/**"
+		"build-style/**",
+		"src/**/*.scss"
 	],
 	"dependencies": {
 		"@babel/runtime": "^7.11.2",

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -22,7 +22,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"sideEffects": [
-		"!((src|build|build-module)/api/**)"
+		"{src,build,build-module}/{index.js,store/index.js}"
 	],
 	"dependencies": {
 		"@babel/runtime": "^7.11.2",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -22,7 +22,8 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"sideEffects": [
-		"build-style/**"
+		"build-style/**",
+		"src/**/*.scss"
 	],
 	"dependencies": {
 		"@babel/runtime": "^7.11.2",

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -23,7 +23,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"sideEffects": [
-		"(src|build|build-module)/index.js"
+		"{src,build,build-module}/index.js"
 	],
 	"dependencies": {
 		"@babel/runtime": "^7.11.2",

--- a/packages/edit-navigation/package.json
+++ b/packages/edit-navigation/package.json
@@ -23,10 +23,6 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"react-native": "src/index",
-	"sideEffects": [
-		"build-style/**",
-		"!((src|build|build-module)/components/**)"
-	],
 	"dependencies": {
 		"@babel/runtime": "^7.11.2",
 		"@wordpress/api-fetch": "file:../api-fetch",

--- a/packages/edit-post/package.json
+++ b/packages/edit-post/package.json
@@ -22,10 +22,6 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"react-native": "src/index",
-	"sideEffects": [
-		"build-style/**",
-		"!((src|build|build-module)/(components|utils)/**)"
-	],
 	"dependencies": {
 		"@babel/runtime": "^7.11.2",
 		"@wordpress/a11y": "file:../a11y",

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -22,10 +22,6 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"react-native": "src/index",
-	"sideEffects": [
-		"build-style/**",
-		"!((src|build|build-module)/components/**)"
-	],
 	"dependencies": {
 		"@babel/runtime": "^7.11.2",
 		"@wordpress/a11y": "file:../a11y",

--- a/packages/edit-widgets/package.json
+++ b/packages/edit-widgets/package.json
@@ -22,10 +22,6 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"react-native": "src/index",
-	"sideEffects": [
-		"build-style/**",
-		"!((src|build|build-module)/components/**)"
-	],
 	"dependencies": {
 		"@babel/runtime": "^7.11.2",
 		"@wordpress/api-fetch": "file:../api-fetch",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -23,6 +23,7 @@
 	"react-native": "src/index",
 	"sideEffects": [
 		"build-style/**",
+		"src/**/*.scss",
 		"{src,build,build-module}/{index.js,store/index.js,hooks/**}"
 	],
 	"dependencies": {

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -23,7 +23,7 @@
 	"react-native": "src/index",
 	"sideEffects": [
 		"build-style/**",
-		"!((src|build|build-module)/(components|utils)/**)"
+		"{src,build,build-module}/{index.js,store/index.js,hooks/**}"
 	],
 	"dependencies": {
 		"@babel/runtime": "^7.11.2",

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -24,7 +24,7 @@
 	"react-native": "src/index",
 	"sideEffects": [
 		"build-style/**",
-		"!((src|build|build-module)/components/**)"
+		"{src,build,build-module}/{index.js,store/index.js}"
 	],
 	"dependencies": {
 		"@babel/runtime": "^7.11.2",

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -24,6 +24,7 @@
 	"react-native": "src/index",
 	"sideEffects": [
 		"build-style/**",
+		"src/**/*.scss",
 		"{src,build,build-module}/{index.js,store/index.js}"
 	],
 	"dependencies": {

--- a/packages/nux/package.json
+++ b/packages/nux/package.json
@@ -23,6 +23,7 @@
 	"react-native": "src/index",
 	"sideEffects": [
 		"build-style/**",
+		"src/**/*.scss",
 		"{src,build,build-module}/{index.js,store/index.js}"
 	],
 	"dependencies": {

--- a/packages/nux/package.json
+++ b/packages/nux/package.json
@@ -23,7 +23,7 @@
 	"react-native": "src/index",
 	"sideEffects": [
 		"build-style/**",
-		"!((src|build|build-module)/components/**)"
+		"{src,build,build-module}/{index.js,store/index.js}"
 	],
 	"dependencies": {
 		"@babel/runtime": "^7.11.2",

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -22,7 +22,9 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"react-native": "src/index",
-	"sideEffects": false,
+	"sideEffects": [
+		"src/**/*.scss"
+	],
 	"types": "build-types",
 	"dependencies": {
 		"@babel/runtime": "^7.11.2",

--- a/packages/reusable-blocks/package.json
+++ b/packages/reusable-blocks/package.json
@@ -22,8 +22,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"sideEffects": [
-		"build-style/**",
-		"!((src|build|build-module)/(components|utils)/**)"
+		"{src,build,build-module}/{index.js,store/index.js}"
 	],
 	"dependencies": {
 		"@wordpress/block-editor": "file:../block-editor",

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -22,7 +22,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"sideEffects": [
-		"!((src|build|build-module)/component/**)"
+		"{src,build,build-module}/{index.js,store/index.js}"
 	],
 	"dependencies": {
 		"@babel/runtime": "^7.11.2",

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -22,6 +22,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"sideEffects": [
+		"src/**/*.scss",
 		"{src,build,build-module}/{index.js,store/index.js}"
 	],
 	"dependencies": {

--- a/packages/side-effects.md
+++ b/packages/side-effects.md
@@ -86,19 +86,3 @@ If it has a few files with side effects, it can list them:
 ```
 
 This allows the bundler to assume that only the modules that were declared have side effects, and *nothing else does*. Of course, this means that we need to be careful to include everything that *does* have side effects, or problems can arise in applications that make use of the package.
-
-## The approach in `@wordpress`
-
-In order to reduce maintenance cost and minimize the chance of breakage, we opted for using inverse globs for a number of `@wordpress` packages, where we list the paths that *do not* include side effects, leaving the bundler to assume that everything else does. Here's an example:
-
-```json
-{
-	"sideEffects": [
-		"!((src|build|build-module)/(components|utils)/**)"
-	],
-}
-```
-
-The above means that the bundler should assume that anything outside the `components` and `utils` directories contains side effects, and nothing in those directories does. These directories can be inside of a `src`, `build`, or `build-module` top-level directory in the package, due to the way `@wordpress` packages are built.
-
-This approach should guarantee that everything in `components` and `utils` can be tree-shaken. It will only potentially cause problems if one of the files in there uses side effects, which would be a bad practice for a component or utility file.


### PR DESCRIPTION
Since v5, webpack [doesn't support extended globs](https://github.com/webpack/webpack/issues/11779) in the `sideEffects` flag, which also include the `!` operator to negate glob conditions. We therefore need to rewrite our patterns to be positive 🙂 

There are several categories of packages and side effects in the Gutenberg repo, and the set of used combinations is rather small:

- some packages are not libraries that would have many exports to use by consumers, but are apps or plugins that have one entrypoint function (usually called like `initialize()`). They don't need to declare any side effects, as it's expected to bundle and use the entire package. Examples are `edit-post`, `edit-site`, `edit-navigation`, `edit-widgets`. In the Gutenberg plugin, they are used by PHP pages that load the script and then call, e.g., `window.wp.editWidgets.initialize()`. Then there's the `block-directory` plugin that is initialized simply by loading the script. From these packages, I removed the existing `sideEffects` declarations from `package.json`. The flag defaults to `sideEffects: true`, as desired.

- some packages register a data store. Then the files that have side effects are `store/index.js` (contains the `registerStore` call) and `index.js` (contains the `import './store'` call, which is itself a side effect that needs to be declared)

- some packages install hooks (actions or filters). That usualy adds `hooks/**` as side-effectful, and also the root `index.js` that does `import './hooks'`

- some packages have `*.scss` files in their sources and produce a `build-style` directory. This directory needs to be declared as side-effectful.

I'm not sure whether we need to declare `src/**/*.scss`, too. These files are every directly imported only by the React Native code. I don't know how that is bundled.

**Todo:**
- update the documentation. So far, I only removed the obsolete parts and didn't replace them with anything new.
- check that we are declaring styles correctly. I'm unsure about what's needed here. Who is importing the files from `build-style` and do they need them declared as side-effectful?

This PR is a spinoff from the big webpack 5 upgrade branch in #26382.