### PR TITLE
Chore: Ensure WordPress packages share the same hoisted dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,23 +46,10 @@
 			}
 		},
 		"@babel/compat-data": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.9.0.tgz",
-			"integrity": "sha512-zeFQrr+284Ekvd9e7KAX954LkapWiOmQtsfHirhxqfdlX6MEC32iRE+pqUGlYIBchdevaCwvzxWGSy/YBNI85g==",
-			"dev": true,
-			"requires": {
-				"browserslist": "^4.9.1",
-				"invariant": "^2.2.4",
-				"semver": "^5.5.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				}
-			}
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.12.1.tgz",
+			"integrity": "sha512-725AQupWJZ8ba0jbKceeFblZTY90McUBWMwHhkFQ9q1zKPJ95GUktljFcgcsIVwRnTnRKlcYzfiNImg5G9m6ZQ==",
+			"dev": true
 		},
 		"@babel/core": {
 			"version": "7.11.6",
@@ -301,18 +288,44 @@
 			}
 		},
 		"@babel/helper-builder-react-jsx": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.9.0.tgz",
-			"integrity": "sha512-weiIo4gaoGgnhff54GQ3P5wsUQmnSwpkvU0r6ZHq6TzoSzKy4JxHEgnxNytaKbov2a9z/CVNyzliuCOUPEX3Jw==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.10.4.tgz",
+			"integrity": "sha512-5nPcIZ7+KKDxT1427oBivl9V9YTal7qk0diccnh7RrcgrT/pGFOjgGw1dgryyx1GvHEpXVfoDF6Ak3rTiWh8Rg==",
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.8.3",
-				"@babel/types": "^7.9.0"
+				"@babel/helper-annotate-as-pure": "^7.10.4",
+				"@babel/types": "^7.10.4"
+			},
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz",
+					"integrity": "sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==",
+					"requires": {
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+					"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
+				},
+				"@babel/types": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.1.tgz",
+					"integrity": "sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==",
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-builder-react-jsx-experimental": {
 			"version": "7.9.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.9.0.tgz",
 			"integrity": "sha512-3xJEiyuYU4Q/Ar9BsHisgdxZsRlsShMe90URZ0e6przL26CCs8NJbDoxH94kKT17PcxlMhsCAwZd90evCo26VQ==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.8.3",
 				"@babel/helper-module-imports": "^7.8.3",
@@ -320,22 +333,17 @@
 			}
 		},
 		"@babel/helper-compilation-targets": {
-			"version": "7.8.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.8.7.tgz",
-			"integrity": "sha512-4mWm8DCK2LugIS+p1yArqvG1Pf162upsIsjE7cNBjez+NjliQpVhj20obE520nao0o14DaTnFJv+Fw5a0JpoUw==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.12.1.tgz",
+			"integrity": "sha512-jtBEif7jsPwP27GPHs06v4WBV0KrE8a/P7n0N0sSvHn2hwUCYnolP/CLmz51IzAW4NlN+HuoBtb9QcwnRo9F/g==",
 			"dev": true,
 			"requires": {
-				"@babel/compat-data": "^7.8.6",
-				"browserslist": "^4.9.1",
-				"invariant": "^2.2.4",
-				"levenary": "^1.1.1",
+				"@babel/compat-data": "^7.12.1",
+				"@babel/helper-validator-option": "^7.12.1",
+				"browserslist": "^4.12.0",
 				"semver": "^5.5.0"
 			},
 			"dependencies": {
-				"leven": {
-					"version": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
-					"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="
-				},
 				"semver": {
 					"version": "5.7.1",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -405,12 +413,31 @@
 			}
 		},
 		"@babel/helper-hoist-variables": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.8.3.tgz",
-			"integrity": "sha512-ky1JLOjcDUtSc+xkt0xhYff7Z6ILTAHKmZLHPxAhOP0Nd77O+3nCsd6uSVYur6nJnCI029CrNbYlc0LoPfAPQg==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.10.4.tgz",
+			"integrity": "sha512-wljroF5PgCk2juF69kanHVs6vrLwIPNp6DLD+Lrl3hoQ3PpPPikaDRNFA+0t81NOoMt2DL6WW/mdU8k4k6ZzuA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.8.3"
+				"@babel/types": "^7.10.4"
+			},
+			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+					"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+					"dev": true
+				},
+				"@babel/types": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.1.tgz",
+					"integrity": "sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
@@ -537,6 +564,12 @@
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.0.tgz",
 			"integrity": "sha512-6G8bQKjOh+of4PV/ThDm/rRqlU7+IGoJuofpagU5GlEl29Vv0RGqqt86ZGRV8ZuSOY3o+8yXl5y782SMcG7SHw=="
 		},
+		"@babel/helper-validator-option": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.1.tgz",
+			"integrity": "sha512-YpJabsXlJVWP0USHjnC/AQDTLlZERbON577YUVO/wLpqyj6HAtVYnWaQaN0iUN+1/tWn3c+uKKXjRut5115Y2A==",
+			"dev": true
+		},
 		"@babel/helper-wrap-function": {
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.8.3.tgz",
@@ -595,14 +628,139 @@
 			}
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.8.3.tgz",
-			"integrity": "sha512-NZ9zLv848JsV3hs8ryEh7Uaz/0KsmPLqv0+PdkDJL1cJy0K4kOCFa8zc1E3mp+RHPQcpdfb/6GovEsW4VDrOMw==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.12.1.tgz",
+			"integrity": "sha512-d+/o30tJxFxrA1lhzJqiUcEJdI6jKlNregCv5bASeGf2Q4MXmnwH7viDo7nhx1/ohf09oaH8j1GVYG/e3Yqk6A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3",
-				"@babel/helper-remap-async-to-generator": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-remap-async-to-generator": "^7.12.1",
 				"@babel/plugin-syntax-async-generators": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.10.4"
+					}
+				},
+				"@babel/helper-annotate-as-pure": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz",
+					"integrity": "sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+					"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.10.4",
+						"@babel/template": "^7.10.4",
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+					"integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-plugin-utils": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+					"integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+					"dev": true
+				},
+				"@babel/helper-remap-async-to-generator": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.12.1.tgz",
+					"integrity": "sha512-9d0KQCRM8clMPcDwo8SevNs+/9a8yWVVmaE80FGJcEP8N1qToREmWEGnBn8BUlJhYRFz6fqxeRL1sl5Ogsed7A==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-annotate-as-pure": "^7.10.4",
+						"@babel/helper-wrap-function": "^7.10.4",
+						"@babel/types": "^7.12.1"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+					"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+					"dev": true
+				},
+				"@babel/helper-wrap-function": {
+					"version": "7.12.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.12.3.tgz",
+					"integrity": "sha512-Cvb8IuJDln3rs6tzjW3Y8UeelAOdnpB8xtQ4sme2MSZ9wOxrbThporC0y/EtE16VAtoyEfLM404Xr1e0OOp+ow==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-function-name": "^7.10.4",
+						"@babel/template": "^7.10.4",
+						"@babel/traverse": "^7.10.4",
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+					"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.12.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.3.tgz",
+					"integrity": "sha512-kFsOS0IbsuhO5ojF8Hc8z/8vEIOkylVBrjiZUbLTE3XFe0Qi+uu6HjzQixkFaqr0ZPAMZcBVxEwmsnsLPZ2Xsw==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+					"integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.10.4",
+						"@babel/parser": "^7.10.4",
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/types": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.1.tgz",
+					"integrity": "sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				}
 			}
 		},
 		"@babel/plugin-proposal-class-properties": {
@@ -821,13 +979,21 @@
 			}
 		},
 		"@babel/plugin-proposal-dynamic-import": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.8.3.tgz",
-			"integrity": "sha512-NyaBbyLFXFLT9FP+zk0kYlUlA8XtCUbehs67F0nnEg7KICgMc2mNkIeu9TYhKzyXMkrapZFwAhXLdnt4IYHy1w==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.12.1.tgz",
+			"integrity": "sha512-a4rhUSZFuq5W8/OO8H7BL5zspjnc1FLd9hlOxIK/f7qG4a0qsqk8uvF/ywgBA8/OmjsapjpvaEOYItfGG1qIvQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.10.4",
 				"@babel/plugin-syntax-dynamic-import": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+					"integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/plugin-proposal-export-default-from": {
@@ -858,13 +1024,21 @@
 			}
 		},
 		"@babel/plugin-proposal-json-strings": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.8.3.tgz",
-			"integrity": "sha512-KGhQNZ3TVCQG/MjRbAUwuH+14y9q0tpxs1nWWs3pbSleRdDro9SAMMDyye8HhY1gqZ7/NqIc8SKhya0wRDgP1Q==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.12.1.tgz",
+			"integrity": "sha512-GoLDUi6U9ZLzlSda2Df++VSqDJg3CG+dR0+iWsv6XRw1rEq+zwt4DirM9yrxW6XWaTpmai1cWJLMfM8qQJf+yw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.10.4",
 				"@babel/plugin-syntax-json-strings": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+					"integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/plugin-proposal-logical-assignment-operators": {
@@ -904,13 +1078,30 @@
 			}
 		},
 		"@babel/plugin-proposal-numeric-separator": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.8.3.tgz",
-			"integrity": "sha512-jWioO1s6R/R+wEHizfaScNsAx+xKgwTLNXSh7tTC4Usj3ItsPEhYkEpU4h+lpnBwq7NBVOJXfO6cRFYcX69JUQ==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.12.1.tgz",
+			"integrity": "sha512-MR7Ok+Af3OhNTCxYVjJZHS0t97ydnJZt/DbR4WISO39iDnhiD8XHrY12xuSJ90FFEGjir0Fzyyn7g/zY6hxbxA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3",
-				"@babel/plugin-syntax-numeric-separator": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/plugin-syntax-numeric-separator": "^7.10.4"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+					"integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+					"dev": true
+				},
+				"@babel/plugin-syntax-numeric-separator": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+					"integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.10.4"
+					}
+				}
 			}
 		},
 		"@babel/plugin-proposal-object-rest-spread": {
@@ -1306,12 +1497,20 @@
 			}
 		},
 		"@babel/plugin-syntax-top-level-await": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.8.3.tgz",
-			"integrity": "sha512-kwj1j9lL/6Wd0hROD3b/OZZ7MSrZLqqn9RAZ5+cYYsflQ9HZBIKCUkr3+uL1MEJ1NePiUbf98jjiMQSv0NMR9g==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.12.1.tgz",
+			"integrity": "sha512-i7ooMZFS+a/Om0crxZodrTzNEPJHZrlMVGMTEpFAj6rYY/bKCddB0Dk/YxfPuYXOopuhKk/e1jV6h+WUU9XN3A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+					"integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/plugin-syntax-typescript": {
@@ -1406,12 +1605,20 @@
 			}
 		},
 		"@babel/plugin-transform-duplicate-keys": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.8.3.tgz",
-			"integrity": "sha512-s8dHiBUbcbSgipS4SMFuWGqCvyge5V2ZeAWzR6INTVC3Ltjig/Vw1G2Gztv0vU/hRG9X8IvKvYdoksnUfgXOEQ==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.12.1.tgz",
+			"integrity": "sha512-iRght0T0HztAb/CazveUpUQrZY+aGKKaWXMJ4uf9YJtqxSUe09j3wteztCUDRHs+SRAL7yMuFqUsLoAKKzgXjw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+					"integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/plugin-transform-exponentiation-operator": {
@@ -1466,14 +1673,239 @@
 			}
 		},
 		"@babel/plugin-transform-modules-amd": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.9.0.tgz",
-			"integrity": "sha512-vZgDDF003B14O8zJy0XXLnPH4sg+9X5hFBBGN1V+B2rgrB+J2xIypSN6Rk9imB2hSTHQi5OHLrFWsZab1GMk+Q==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.12.1.tgz",
+			"integrity": "sha512-tDW8hMkzad5oDtzsB70HIQQRBiTKrhfgwC/KkJeGsaNFTdWhKNt/BiE8c5yj19XiGyrxpbkOfH87qkNg1YGlOQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "^7.9.0",
-				"@babel/helper-plugin-utils": "^7.8.3",
-				"babel-plugin-dynamic-import-node": "^2.3.0"
+				"@babel/helper-module-transforms": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"babel-plugin-dynamic-import-node": "^2.3.3"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.10.4"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.1.tgz",
+					"integrity": "sha512-DB+6rafIdc9o72Yc3/Ph5h+6hUjeOp66pF0naQBgUFFuPqzQwIlPTm3xZR7YNvduIMtkDIj2t21LSQwnbCrXvg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.1",
+						"jsesc": "^2.5.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+					"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.10.4",
+						"@babel/template": "^7.10.4",
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+					"integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz",
+					"integrity": "sha512-k0CIe3tXUKTRSoEx1LQEPFU9vRQfqHtl+kf8eNnDqb4AUJEy5pz6aIiog+YWtVm2jpggjS1laH68bPsR+KWWPQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.1"
+					}
+				},
+				"@babel/helper-module-imports": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.1.tgz",
+					"integrity": "sha512-ZeC1TlMSvikvJNy1v/wPIazCu3NdOwgYZLIkmIyAsGhqkNpiDoQQRmaCK8YP4Pq3GPTLPV9WXaPCJKvx06JxKA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.1"
+					}
+				},
+				"@babel/helper-module-transforms": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
+					"integrity": "sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-imports": "^7.12.1",
+						"@babel/helper-replace-supers": "^7.12.1",
+						"@babel/helper-simple-access": "^7.12.1",
+						"@babel/helper-split-export-declaration": "^7.11.0",
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"@babel/template": "^7.10.4",
+						"@babel/traverse": "^7.12.1",
+						"@babel/types": "^7.12.1",
+						"lodash": "^4.17.19"
+					}
+				},
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
+					"integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-plugin-utils": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+					"integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+					"dev": true
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.1.tgz",
+					"integrity": "sha512-zJjTvtNJnCFsCXVi5rUInstLd/EIVNmIKA1Q9ynESmMBWPWd+7sdR+G4/wdu+Mppfep0XLyG2m7EBPvjCeFyrw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.12.1",
+						"@babel/helper-optimise-call-expression": "^7.10.4",
+						"@babel/traverse": "^7.12.1",
+						"@babel/types": "^7.12.1"
+					}
+				},
+				"@babel/helper-simple-access": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
+					"integrity": "sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.1"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.11.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+					"integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.11.0"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+					"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+					"dev": true
+				},
+				"@babel/highlight": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+					"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.12.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.3.tgz",
+					"integrity": "sha512-kFsOS0IbsuhO5ojF8Hc8z/8vEIOkylVBrjiZUbLTE3XFe0Qi+uu6HjzQixkFaqr0ZPAMZcBVxEwmsnsLPZ2Xsw==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+					"integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.10.4",
+						"@babel/parser": "^7.10.4",
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.1.tgz",
+					"integrity": "sha512-MA3WPoRt1ZHo2ZmoGKNqi20YnPt0B1S0GTZEPhhd+hw2KGUzBlHuVunj6K4sNuK+reEvyiPwtp0cpaqLzJDmAw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.10.4",
+						"@babel/generator": "^7.12.1",
+						"@babel/helper-function-name": "^7.10.4",
+						"@babel/helper-split-export-declaration": "^7.11.0",
+						"@babel/parser": "^7.12.1",
+						"@babel/types": "^7.12.1",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.19"
+					}
+				},
+				"@babel/types": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.1.tgz",
+					"integrity": "sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"babel-plugin-dynamic-import-node": {
+					"version": "2.3.3",
+					"resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+					"integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
+					"dev": true,
+					"requires": {
+						"object.assign": "^4.1.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"debug": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
@@ -1488,43 +1920,555 @@
 			}
 		},
 		"@babel/plugin-transform-modules-systemjs": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.9.0.tgz",
-			"integrity": "sha512-FsiAv/nao/ud2ZWy4wFacoLOm5uxl0ExSQ7ErvP7jpoihLR6Cq90ilOFyX9UXct3rbtKsAiZ9kFt5XGfPe/5SQ==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.12.1.tgz",
+			"integrity": "sha512-Hn7cVvOavVh8yvW6fLwveFqSnd7rbQN3zJvoPNyNaQSvgfKmDBO9U1YL9+PCXGRlZD9tNdWTy5ACKqMuzyn32Q==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-hoist-variables": "^7.8.3",
-				"@babel/helper-module-transforms": "^7.9.0",
-				"@babel/helper-plugin-utils": "^7.8.3",
-				"babel-plugin-dynamic-import-node": "^2.3.0"
+				"@babel/helper-hoist-variables": "^7.10.4",
+				"@babel/helper-module-transforms": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-validator-identifier": "^7.10.4",
+				"babel-plugin-dynamic-import-node": "^2.3.3"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.10.4"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.1.tgz",
+					"integrity": "sha512-DB+6rafIdc9o72Yc3/Ph5h+6hUjeOp66pF0naQBgUFFuPqzQwIlPTm3xZR7YNvduIMtkDIj2t21LSQwnbCrXvg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.1",
+						"jsesc": "^2.5.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+					"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.10.4",
+						"@babel/template": "^7.10.4",
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+					"integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz",
+					"integrity": "sha512-k0CIe3tXUKTRSoEx1LQEPFU9vRQfqHtl+kf8eNnDqb4AUJEy5pz6aIiog+YWtVm2jpggjS1laH68bPsR+KWWPQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.1"
+					}
+				},
+				"@babel/helper-module-imports": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.1.tgz",
+					"integrity": "sha512-ZeC1TlMSvikvJNy1v/wPIazCu3NdOwgYZLIkmIyAsGhqkNpiDoQQRmaCK8YP4Pq3GPTLPV9WXaPCJKvx06JxKA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.1"
+					}
+				},
+				"@babel/helper-module-transforms": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
+					"integrity": "sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-imports": "^7.12.1",
+						"@babel/helper-replace-supers": "^7.12.1",
+						"@babel/helper-simple-access": "^7.12.1",
+						"@babel/helper-split-export-declaration": "^7.11.0",
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"@babel/template": "^7.10.4",
+						"@babel/traverse": "^7.12.1",
+						"@babel/types": "^7.12.1",
+						"lodash": "^4.17.19"
+					}
+				},
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
+					"integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-plugin-utils": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+					"integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+					"dev": true
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.1.tgz",
+					"integrity": "sha512-zJjTvtNJnCFsCXVi5rUInstLd/EIVNmIKA1Q9ynESmMBWPWd+7sdR+G4/wdu+Mppfep0XLyG2m7EBPvjCeFyrw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.12.1",
+						"@babel/helper-optimise-call-expression": "^7.10.4",
+						"@babel/traverse": "^7.12.1",
+						"@babel/types": "^7.12.1"
+					}
+				},
+				"@babel/helper-simple-access": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
+					"integrity": "sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.1"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.11.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+					"integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.11.0"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+					"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+					"dev": true
+				},
+				"@babel/highlight": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+					"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.12.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.3.tgz",
+					"integrity": "sha512-kFsOS0IbsuhO5ojF8Hc8z/8vEIOkylVBrjiZUbLTE3XFe0Qi+uu6HjzQixkFaqr0ZPAMZcBVxEwmsnsLPZ2Xsw==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+					"integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.10.4",
+						"@babel/parser": "^7.10.4",
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.1.tgz",
+					"integrity": "sha512-MA3WPoRt1ZHo2ZmoGKNqi20YnPt0B1S0GTZEPhhd+hw2KGUzBlHuVunj6K4sNuK+reEvyiPwtp0cpaqLzJDmAw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.10.4",
+						"@babel/generator": "^7.12.1",
+						"@babel/helper-function-name": "^7.10.4",
+						"@babel/helper-split-export-declaration": "^7.11.0",
+						"@babel/parser": "^7.12.1",
+						"@babel/types": "^7.12.1",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.19"
+					}
+				},
+				"@babel/types": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.1.tgz",
+					"integrity": "sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"babel-plugin-dynamic-import-node": {
+					"version": "2.3.3",
+					"resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+					"integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
+					"dev": true,
+					"requires": {
+						"object.assign": "^4.1.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"debug": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/plugin-transform-modules-umd": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.9.0.tgz",
-			"integrity": "sha512-uTWkXkIVtg/JGRSIABdBoMsoIeoHQHPTL0Y2E7xf5Oj7sLqwVsNXOkNk0VJc7vF0IMBsPeikHxFjGe+qmwPtTQ==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.12.1.tgz",
+			"integrity": "sha512-aEIubCS0KHKM0zUos5fIoQm+AZUMt1ZvMpqz0/H5qAQ7vWylr9+PLYurT+Ic7ID/bKLd4q8hDovaG3Zch2uz5Q==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "^7.9.0",
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-module-transforms": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.10.4"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.1.tgz",
+					"integrity": "sha512-DB+6rafIdc9o72Yc3/Ph5h+6hUjeOp66pF0naQBgUFFuPqzQwIlPTm3xZR7YNvduIMtkDIj2t21LSQwnbCrXvg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.1",
+						"jsesc": "^2.5.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+					"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.10.4",
+						"@babel/template": "^7.10.4",
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+					"integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz",
+					"integrity": "sha512-k0CIe3tXUKTRSoEx1LQEPFU9vRQfqHtl+kf8eNnDqb4AUJEy5pz6aIiog+YWtVm2jpggjS1laH68bPsR+KWWPQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.1"
+					}
+				},
+				"@babel/helper-module-imports": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.1.tgz",
+					"integrity": "sha512-ZeC1TlMSvikvJNy1v/wPIazCu3NdOwgYZLIkmIyAsGhqkNpiDoQQRmaCK8YP4Pq3GPTLPV9WXaPCJKvx06JxKA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.1"
+					}
+				},
+				"@babel/helper-module-transforms": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
+					"integrity": "sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-imports": "^7.12.1",
+						"@babel/helper-replace-supers": "^7.12.1",
+						"@babel/helper-simple-access": "^7.12.1",
+						"@babel/helper-split-export-declaration": "^7.11.0",
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"@babel/template": "^7.10.4",
+						"@babel/traverse": "^7.12.1",
+						"@babel/types": "^7.12.1",
+						"lodash": "^4.17.19"
+					}
+				},
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
+					"integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-plugin-utils": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+					"integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+					"dev": true
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.1.tgz",
+					"integrity": "sha512-zJjTvtNJnCFsCXVi5rUInstLd/EIVNmIKA1Q9ynESmMBWPWd+7sdR+G4/wdu+Mppfep0XLyG2m7EBPvjCeFyrw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.12.1",
+						"@babel/helper-optimise-call-expression": "^7.10.4",
+						"@babel/traverse": "^7.12.1",
+						"@babel/types": "^7.12.1"
+					}
+				},
+				"@babel/helper-simple-access": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
+					"integrity": "sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.1"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.11.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+					"integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.11.0"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+					"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+					"dev": true
+				},
+				"@babel/highlight": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+					"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.12.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.3.tgz",
+					"integrity": "sha512-kFsOS0IbsuhO5ojF8Hc8z/8vEIOkylVBrjiZUbLTE3XFe0Qi+uu6HjzQixkFaqr0ZPAMZcBVxEwmsnsLPZ2Xsw==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+					"integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.10.4",
+						"@babel/parser": "^7.10.4",
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.1.tgz",
+					"integrity": "sha512-MA3WPoRt1ZHo2ZmoGKNqi20YnPt0B1S0GTZEPhhd+hw2KGUzBlHuVunj6K4sNuK+reEvyiPwtp0cpaqLzJDmAw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.10.4",
+						"@babel/generator": "^7.12.1",
+						"@babel/helper-function-name": "^7.10.4",
+						"@babel/helper-split-export-declaration": "^7.11.0",
+						"@babel/parser": "^7.12.1",
+						"@babel/types": "^7.12.1",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.19"
+					}
+				},
+				"@babel/types": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.1.tgz",
+					"integrity": "sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"debug": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/plugin-transform-named-capturing-groups-regex": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.8.3.tgz",
-			"integrity": "sha512-f+tF/8UVPU86TrCb06JoPWIdDpTNSGGcAtaD9mLP0aYGA0OS0j7j7DHJR0GTFrUZPUU6loZhbsVZgTh0N+Qdnw==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.12.1.tgz",
+			"integrity": "sha512-tB43uQ62RHcoDp9v2Nsf+dSM8sbNodbEicbQNA53zHz8pWUhsgHSJCGpt7daXxRydjb0KnfmB+ChXOv3oADp1Q==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-regexp-features-plugin": "^7.8.3"
+				"@babel/helper-create-regexp-features-plugin": "^7.12.1"
+			},
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz",
+					"integrity": "sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-create-regexp-features-plugin": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.12.1.tgz",
+					"integrity": "sha512-rsZ4LGvFTZnzdNZR5HZdmJVuXK8834R5QkF3WvcnBhrlVtF0HSIUC6zbreL9MgjTywhKokn8RIYRiq99+DLAxA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-annotate-as-pure": "^7.10.4",
+						"@babel/helper-regex": "^7.10.4",
+						"regexpu-core": "^4.7.1"
+					}
+				},
+				"@babel/helper-regex": {
+					"version": "7.10.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.10.5.tgz",
+					"integrity": "sha512-68kdUAzDrljqBrio7DYAEgCoJHxppJOERHOgOrDN7WjOzP0ZQ1LsSDRXcemzVZaLvjaJsJEESb6qt+znNuENDg==",
+					"dev": true,
+					"requires": {
+						"lodash": "^4.17.19"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+					"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+					"dev": true
+				},
+				"@babel/types": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.1.tgz",
+					"integrity": "sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"regexpu-core": {
+					"version": "4.7.1",
+					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.1.tgz",
+					"integrity": "sha512-ywH2VUraA44DZQuRKzARmw6S66mr48pQVva4LBeRhcOltJ6hExvWly5ZjFLYo67xbIxb6W1q4bAGtgfEl20zfQ==",
+					"dev": true,
+					"requires": {
+						"regenerate": "^1.4.0",
+						"regenerate-unicode-properties": "^8.2.0",
+						"regjsgen": "^0.5.1",
+						"regjsparser": "^0.6.4",
+						"unicode-match-property-ecmascript": "^1.0.4",
+						"unicode-match-property-value-ecmascript": "^1.2.0"
+					}
+				}
 			}
 		},
 		"@babel/plugin-transform-new-target": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.8.3.tgz",
-			"integrity": "sha512-QuSGysibQpyxexRyui2vca+Cmbljo8bcRckgzYV4kRIsHpVeyeC3JDO63pY+xFZ6bWOBn7pfKZTqV4o/ix9sFw==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.12.1.tgz",
+			"integrity": "sha512-+eW/VLcUL5L9IvJH7rT1sT0CzkdUTvPrXC2PXTn/7z7tXLBuKvezYbGdxD5WMRoyvyaujOq2fWoKl869heKjhw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+					"integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/plugin-transform-object-assign": {
@@ -1579,14 +2523,62 @@
 			}
 		},
 		"@babel/plugin-transform-react-jsx": {
-			"version": "7.9.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.9.4.tgz",
-			"integrity": "sha512-Mjqf3pZBNLt854CK0C/kRuXAnE6H/bo7xYojP+WGtX8glDGSibcwnsWwhwoSuRg0+EBnxPC1ouVnuetUIlPSAw==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.10.4.tgz",
+			"integrity": "sha512-L+MfRhWjX0eI7Js093MM6MacKU4M6dnCRa/QPDwYMxjljzSCzzlzKzj9Pk4P3OtrPcxr2N3znR419nr3Xw+65A==",
 			"requires": {
-				"@babel/helper-builder-react-jsx": "^7.9.0",
-				"@babel/helper-builder-react-jsx-experimental": "^7.9.0",
-				"@babel/helper-plugin-utils": "^7.8.3",
-				"@babel/plugin-syntax-jsx": "^7.8.3"
+				"@babel/helper-builder-react-jsx": "^7.10.4",
+				"@babel/helper-builder-react-jsx-experimental": "^7.10.4",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/plugin-syntax-jsx": "^7.10.4"
+			},
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz",
+					"integrity": "sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==",
+					"requires": {
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-builder-react-jsx-experimental": {
+					"version": "7.12.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.12.4.tgz",
+					"integrity": "sha512-AjEa0jrQqNk7eDQOo0pTfUOwQBMF+xVqrausQwT9/rTKy0g04ggFNaJpaE09IQMn9yExluigWMJcj0WC7bq+Og==",
+					"requires": {
+						"@babel/helper-annotate-as-pure": "^7.10.4",
+						"@babel/helper-module-imports": "^7.12.1",
+						"@babel/types": "^7.12.1"
+					}
+				},
+				"@babel/helper-module-imports": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.1.tgz",
+					"integrity": "sha512-ZeC1TlMSvikvJNy1v/wPIazCu3NdOwgYZLIkmIyAsGhqkNpiDoQQRmaCK8YP4Pq3GPTLPV9WXaPCJKvx06JxKA==",
+					"requires": {
+						"@babel/types": "^7.12.1"
+					}
+				},
+				"@babel/helper-plugin-utils": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+					"integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+					"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
+				},
+				"@babel/types": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.1.tgz",
+					"integrity": "sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==",
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/plugin-transform-react-jsx-development": {
@@ -1628,25 +2620,61 @@
 			}
 		},
 		"@babel/plugin-transform-reserved-words": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.8.3.tgz",
-			"integrity": "sha512-mwMxcycN3omKFDjDQUl+8zyMsBfjRFr0Zn/64I41pmjv4NJuqcYlEtezwYtw9TFd9WR1vN5kiM+O0gMZzO6L0A==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.12.1.tgz",
+			"integrity": "sha512-pOnUfhyPKvZpVyBHhSBoX8vfA09b7r00Pmm1sH+29ae2hMTKVmSp4Ztsr8KBKjLjx17H0eJqaRC3bR2iThM54A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+					"integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/plugin-transform-runtime": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.9.0.tgz",
-			"integrity": "sha512-pUu9VSf3kI1OqbWINQ7MaugnitRss1z533436waNXp+0N3ur3zfut37sXiQMxkuCF4VUjwZucen/quskCh7NHw==",
+			"version": "7.11.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.11.5.tgz",
+			"integrity": "sha512-9aIoee+EhjySZ6vY5hnLjigHzunBlscx9ANKutkeWTJTx6m5Rbq6Ic01tLvO54lSusR+BxV7u4UDdCmXv5aagg==",
 			"requires": {
-				"@babel/helper-module-imports": "^7.8.3",
-				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/helper-module-imports": "^7.10.4",
+				"@babel/helper-plugin-utils": "^7.10.4",
 				"resolve": "^1.8.1",
 				"semver": "^5.5.1"
 			},
 			"dependencies": {
+				"@babel/helper-module-imports": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.1.tgz",
+					"integrity": "sha512-ZeC1TlMSvikvJNy1v/wPIazCu3NdOwgYZLIkmIyAsGhqkNpiDoQQRmaCK8YP4Pq3GPTLPV9WXaPCJKvx06JxKA==",
+					"requires": {
+						"@babel/types": "^7.12.1"
+					}
+				},
+				"@babel/helper-plugin-utils": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+					"integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+					"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
+				},
+				"@babel/types": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.1.tgz",
+					"integrity": "sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==",
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
 				"semver": {
 					"version": "5.7.1",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -1689,12 +2717,20 @@
 			}
 		},
 		"@babel/plugin-transform-typeof-symbol": {
-			"version": "7.8.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.8.4.tgz",
-			"integrity": "sha512-2QKyfjGdvuNfHsb7qnBBlKclbD4CfshH2KvDabiijLMGXPHJXGxtDzwIF7bQP+T0ysw8fYTtxPafgfs/c1Lrqg==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.12.1.tgz",
+			"integrity": "sha512-EPGgpGy+O5Kg5pJFNDKuxt9RdmTgj5sgrus2XVeMp/ZIbOESadgILUbm50SNpghOh3/6yrbsH+NB5+WJTmsA7Q==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+					"integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/plugin-transform-typescript": {
@@ -1734,76 +2770,736 @@
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.9.0.tgz",
-			"integrity": "sha512-712DeRXT6dyKAM/FMbQTV/FvRCms2hPCx+3weRjZ8iQVQWZejWWk1wwG6ViWMyqb/ouBbGOl5b6aCk0+j1NmsQ==",
+			"version": "7.11.5",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.11.5.tgz",
+			"integrity": "sha512-kXqmW1jVcnB2cdueV+fyBM8estd5mlNfaQi6lwLgRwCby4edpavgbFhiBNjmWA3JpB/yZGSISa7Srf+TwxDQoA==",
 			"dev": true,
 			"requires": {
-				"@babel/compat-data": "^7.9.0",
-				"@babel/helper-compilation-targets": "^7.8.7",
-				"@babel/helper-module-imports": "^7.8.3",
-				"@babel/helper-plugin-utils": "^7.8.3",
-				"@babel/plugin-proposal-async-generator-functions": "^7.8.3",
-				"@babel/plugin-proposal-dynamic-import": "^7.8.3",
-				"@babel/plugin-proposal-json-strings": "^7.8.3",
-				"@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
-				"@babel/plugin-proposal-numeric-separator": "^7.8.3",
-				"@babel/plugin-proposal-object-rest-spread": "^7.9.0",
-				"@babel/plugin-proposal-optional-catch-binding": "^7.8.3",
-				"@babel/plugin-proposal-optional-chaining": "^7.9.0",
-				"@babel/plugin-proposal-unicode-property-regex": "^7.8.3",
+				"@babel/compat-data": "^7.11.0",
+				"@babel/helper-compilation-targets": "^7.10.4",
+				"@babel/helper-module-imports": "^7.10.4",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/plugin-proposal-async-generator-functions": "^7.10.4",
+				"@babel/plugin-proposal-class-properties": "^7.10.4",
+				"@babel/plugin-proposal-dynamic-import": "^7.10.4",
+				"@babel/plugin-proposal-export-namespace-from": "^7.10.4",
+				"@babel/plugin-proposal-json-strings": "^7.10.4",
+				"@babel/plugin-proposal-logical-assignment-operators": "^7.11.0",
+				"@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.4",
+				"@babel/plugin-proposal-numeric-separator": "^7.10.4",
+				"@babel/plugin-proposal-object-rest-spread": "^7.11.0",
+				"@babel/plugin-proposal-optional-catch-binding": "^7.10.4",
+				"@babel/plugin-proposal-optional-chaining": "^7.11.0",
+				"@babel/plugin-proposal-private-methods": "^7.10.4",
+				"@babel/plugin-proposal-unicode-property-regex": "^7.10.4",
 				"@babel/plugin-syntax-async-generators": "^7.8.0",
+				"@babel/plugin-syntax-class-properties": "^7.10.4",
 				"@babel/plugin-syntax-dynamic-import": "^7.8.0",
+				"@babel/plugin-syntax-export-namespace-from": "^7.8.3",
 				"@babel/plugin-syntax-json-strings": "^7.8.0",
+				"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
 				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
-				"@babel/plugin-syntax-numeric-separator": "^7.8.0",
+				"@babel/plugin-syntax-numeric-separator": "^7.10.4",
 				"@babel/plugin-syntax-object-rest-spread": "^7.8.0",
 				"@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
 				"@babel/plugin-syntax-optional-chaining": "^7.8.0",
-				"@babel/plugin-syntax-top-level-await": "^7.8.3",
-				"@babel/plugin-transform-arrow-functions": "^7.8.3",
-				"@babel/plugin-transform-async-to-generator": "^7.8.3",
-				"@babel/plugin-transform-block-scoped-functions": "^7.8.3",
-				"@babel/plugin-transform-block-scoping": "^7.8.3",
-				"@babel/plugin-transform-classes": "^7.9.0",
-				"@babel/plugin-transform-computed-properties": "^7.8.3",
-				"@babel/plugin-transform-destructuring": "^7.8.3",
-				"@babel/plugin-transform-dotall-regex": "^7.8.3",
-				"@babel/plugin-transform-duplicate-keys": "^7.8.3",
-				"@babel/plugin-transform-exponentiation-operator": "^7.8.3",
-				"@babel/plugin-transform-for-of": "^7.9.0",
-				"@babel/plugin-transform-function-name": "^7.8.3",
-				"@babel/plugin-transform-literals": "^7.8.3",
-				"@babel/plugin-transform-member-expression-literals": "^7.8.3",
-				"@babel/plugin-transform-modules-amd": "^7.9.0",
-				"@babel/plugin-transform-modules-commonjs": "^7.9.0",
-				"@babel/plugin-transform-modules-systemjs": "^7.9.0",
-				"@babel/plugin-transform-modules-umd": "^7.9.0",
-				"@babel/plugin-transform-named-capturing-groups-regex": "^7.8.3",
-				"@babel/plugin-transform-new-target": "^7.8.3",
-				"@babel/plugin-transform-object-super": "^7.8.3",
-				"@babel/plugin-transform-parameters": "^7.8.7",
-				"@babel/plugin-transform-property-literals": "^7.8.3",
-				"@babel/plugin-transform-regenerator": "^7.8.7",
-				"@babel/plugin-transform-reserved-words": "^7.8.3",
-				"@babel/plugin-transform-shorthand-properties": "^7.8.3",
-				"@babel/plugin-transform-spread": "^7.8.3",
-				"@babel/plugin-transform-sticky-regex": "^7.8.3",
-				"@babel/plugin-transform-template-literals": "^7.8.3",
-				"@babel/plugin-transform-typeof-symbol": "^7.8.4",
-				"@babel/plugin-transform-unicode-regex": "^7.8.3",
+				"@babel/plugin-syntax-top-level-await": "^7.10.4",
+				"@babel/plugin-transform-arrow-functions": "^7.10.4",
+				"@babel/plugin-transform-async-to-generator": "^7.10.4",
+				"@babel/plugin-transform-block-scoped-functions": "^7.10.4",
+				"@babel/plugin-transform-block-scoping": "^7.10.4",
+				"@babel/plugin-transform-classes": "^7.10.4",
+				"@babel/plugin-transform-computed-properties": "^7.10.4",
+				"@babel/plugin-transform-destructuring": "^7.10.4",
+				"@babel/plugin-transform-dotall-regex": "^7.10.4",
+				"@babel/plugin-transform-duplicate-keys": "^7.10.4",
+				"@babel/plugin-transform-exponentiation-operator": "^7.10.4",
+				"@babel/plugin-transform-for-of": "^7.10.4",
+				"@babel/plugin-transform-function-name": "^7.10.4",
+				"@babel/plugin-transform-literals": "^7.10.4",
+				"@babel/plugin-transform-member-expression-literals": "^7.10.4",
+				"@babel/plugin-transform-modules-amd": "^7.10.4",
+				"@babel/plugin-transform-modules-commonjs": "^7.10.4",
+				"@babel/plugin-transform-modules-systemjs": "^7.10.4",
+				"@babel/plugin-transform-modules-umd": "^7.10.4",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^7.10.4",
+				"@babel/plugin-transform-new-target": "^7.10.4",
+				"@babel/plugin-transform-object-super": "^7.10.4",
+				"@babel/plugin-transform-parameters": "^7.10.4",
+				"@babel/plugin-transform-property-literals": "^7.10.4",
+				"@babel/plugin-transform-regenerator": "^7.10.4",
+				"@babel/plugin-transform-reserved-words": "^7.10.4",
+				"@babel/plugin-transform-shorthand-properties": "^7.10.4",
+				"@babel/plugin-transform-spread": "^7.11.0",
+				"@babel/plugin-transform-sticky-regex": "^7.10.4",
+				"@babel/plugin-transform-template-literals": "^7.10.4",
+				"@babel/plugin-transform-typeof-symbol": "^7.10.4",
+				"@babel/plugin-transform-unicode-escapes": "^7.10.4",
+				"@babel/plugin-transform-unicode-regex": "^7.10.4",
 				"@babel/preset-modules": "^0.1.3",
-				"@babel/types": "^7.9.0",
-				"browserslist": "^4.9.1",
+				"@babel/types": "^7.11.5",
+				"browserslist": "^4.12.0",
 				"core-js-compat": "^3.6.2",
 				"invariant": "^2.2.2",
 				"levenary": "^1.1.1",
 				"semver": "^5.5.0"
 			},
 			"dependencies": {
-				"leven": {
-					"version": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
-					"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="
+				"@babel/code-frame": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.10.4"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.1.tgz",
+					"integrity": "sha512-DB+6rafIdc9o72Yc3/Ph5h+6hUjeOp66pF0naQBgUFFuPqzQwIlPTm3xZR7YNvduIMtkDIj2t21LSQwnbCrXvg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.1",
+						"jsesc": "^2.5.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-annotate-as-pure": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz",
+					"integrity": "sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-builder-binary-assignment-operator-visitor": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.10.4.tgz",
+					"integrity": "sha512-L0zGlFrGWZK4PbT8AszSfLTM5sDU1+Az/En9VrdT8/LmEiJt4zXt+Jve9DCAnQcbqDhCI+29y/L93mrDzddCcg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-explode-assignable-expression": "^7.10.4",
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-create-class-features-plugin": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.12.1.tgz",
+					"integrity": "sha512-hkL++rWeta/OVOBTRJc9a5Azh5mt5WgZUGAKMD8JM141YsE08K//bp1unBBieO6rUKkIPyUE0USQ30jAy3Sk1w==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-function-name": "^7.10.4",
+						"@babel/helper-member-expression-to-functions": "^7.12.1",
+						"@babel/helper-optimise-call-expression": "^7.10.4",
+						"@babel/helper-replace-supers": "^7.12.1",
+						"@babel/helper-split-export-declaration": "^7.10.4"
+					}
+				},
+				"@babel/helper-create-regexp-features-plugin": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.12.1.tgz",
+					"integrity": "sha512-rsZ4LGvFTZnzdNZR5HZdmJVuXK8834R5QkF3WvcnBhrlVtF0HSIUC6zbreL9MgjTywhKokn8RIYRiq99+DLAxA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-annotate-as-pure": "^7.10.4",
+						"@babel/helper-regex": "^7.10.4",
+						"regexpu-core": "^4.7.1"
+					}
+				},
+				"@babel/helper-define-map": {
+					"version": "7.10.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.10.5.tgz",
+					"integrity": "sha512-fMw4kgFB720aQFXSVaXr79pjjcW5puTCM16+rECJ/plGS+zByelE8l9nCpV1GibxTnFVmUuYG9U8wYfQHdzOEQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-function-name": "^7.10.4",
+						"@babel/types": "^7.10.5",
+						"lodash": "^4.17.19"
+					}
+				},
+				"@babel/helper-explode-assignable-expression": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.12.1.tgz",
+					"integrity": "sha512-dmUwH8XmlrUpVqgtZ737tK88v07l840z9j3OEhCLwKTkjlvKpfqXVIZ0wpK3aeOxspwGrf/5AP5qLx4rO3w5rA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.1"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+					"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.10.4",
+						"@babel/template": "^7.10.4",
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+					"integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz",
+					"integrity": "sha512-k0CIe3tXUKTRSoEx1LQEPFU9vRQfqHtl+kf8eNnDqb4AUJEy5pz6aIiog+YWtVm2jpggjS1laH68bPsR+KWWPQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.1"
+					}
+				},
+				"@babel/helper-module-imports": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.1.tgz",
+					"integrity": "sha512-ZeC1TlMSvikvJNy1v/wPIazCu3NdOwgYZLIkmIyAsGhqkNpiDoQQRmaCK8YP4Pq3GPTLPV9WXaPCJKvx06JxKA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.1"
+					}
+				},
+				"@babel/helper-module-transforms": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
+					"integrity": "sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-imports": "^7.12.1",
+						"@babel/helper-replace-supers": "^7.12.1",
+						"@babel/helper-simple-access": "^7.12.1",
+						"@babel/helper-split-export-declaration": "^7.11.0",
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"@babel/template": "^7.10.4",
+						"@babel/traverse": "^7.12.1",
+						"@babel/types": "^7.12.1",
+						"lodash": "^4.17.19"
+					}
+				},
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
+					"integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-plugin-utils": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+					"integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+					"dev": true
+				},
+				"@babel/helper-regex": {
+					"version": "7.10.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.10.5.tgz",
+					"integrity": "sha512-68kdUAzDrljqBrio7DYAEgCoJHxppJOERHOgOrDN7WjOzP0ZQ1LsSDRXcemzVZaLvjaJsJEESb6qt+znNuENDg==",
+					"dev": true,
+					"requires": {
+						"lodash": "^4.17.19"
+					}
+				},
+				"@babel/helper-remap-async-to-generator": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.12.1.tgz",
+					"integrity": "sha512-9d0KQCRM8clMPcDwo8SevNs+/9a8yWVVmaE80FGJcEP8N1qToREmWEGnBn8BUlJhYRFz6fqxeRL1sl5Ogsed7A==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-annotate-as-pure": "^7.10.4",
+						"@babel/helper-wrap-function": "^7.10.4",
+						"@babel/types": "^7.12.1"
+					}
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.1.tgz",
+					"integrity": "sha512-zJjTvtNJnCFsCXVi5rUInstLd/EIVNmIKA1Q9ynESmMBWPWd+7sdR+G4/wdu+Mppfep0XLyG2m7EBPvjCeFyrw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.12.1",
+						"@babel/helper-optimise-call-expression": "^7.10.4",
+						"@babel/traverse": "^7.12.1",
+						"@babel/types": "^7.12.1"
+					}
+				},
+				"@babel/helper-simple-access": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
+					"integrity": "sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.1"
+					}
+				},
+				"@babel/helper-skip-transparent-expression-wrappers": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.12.1.tgz",
+					"integrity": "sha512-Mf5AUuhG1/OCChOJ/HcADmvcHM42WJockombn8ATJG3OnyiSxBK/Mm5x78BQWvmtXZKHgbjdGL2kin/HOLlZGA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.1"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.11.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+					"integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.11.0"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+					"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+					"dev": true
+				},
+				"@babel/helper-wrap-function": {
+					"version": "7.12.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.12.3.tgz",
+					"integrity": "sha512-Cvb8IuJDln3rs6tzjW3Y8UeelAOdnpB8xtQ4sme2MSZ9wOxrbThporC0y/EtE16VAtoyEfLM404Xr1e0OOp+ow==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-function-name": "^7.10.4",
+						"@babel/template": "^7.10.4",
+						"@babel/traverse": "^7.10.4",
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+					"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.12.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.3.tgz",
+					"integrity": "sha512-kFsOS0IbsuhO5ojF8Hc8z/8vEIOkylVBrjiZUbLTE3XFe0Qi+uu6HjzQixkFaqr0ZPAMZcBVxEwmsnsLPZ2Xsw==",
+					"dev": true
+				},
+				"@babel/plugin-proposal-class-properties": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.12.1.tgz",
+					"integrity": "sha512-cKp3dlQsFsEs5CWKnN7BnSHOd0EOW8EKpEjkoz1pO2E5KzIDNV9Ros1b0CnmbVgAGXJubOYVBOGCT1OmJwOI7w==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-create-class-features-plugin": "^7.12.1",
+						"@babel/helper-plugin-utils": "^7.10.4"
+					}
+				},
+				"@babel/plugin-proposal-nullish-coalescing-operator": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.12.1.tgz",
+					"integrity": "sha512-nZY0ESiaQDI1y96+jk6VxMOaL4LPo/QDHBqL+SF3/vl6dHkTwHlOI8L4ZwuRBHgakRBw5zsVylel7QPbbGuYgg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.10.4",
+						"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
+					}
+				},
+				"@babel/plugin-proposal-object-rest-spread": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.12.1.tgz",
+					"integrity": "sha512-s6SowJIjzlhx8o7lsFx5zmY4At6CTtDvgNQDdPzkBQucle58A6b/TTeEBYtyDgmcXjUTM+vE8YOGHZzzbc/ioA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.10.4",
+						"@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+						"@babel/plugin-transform-parameters": "^7.12.1"
+					}
+				},
+				"@babel/plugin-proposal-optional-catch-binding": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.12.1.tgz",
+					"integrity": "sha512-hFvIjgprh9mMw5v42sJWLI1lzU5L2sznP805zeT6rySVRA0Y18StRhDqhSxlap0oVgItRsB6WSROp4YnJTJz0g==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.10.4",
+						"@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
+					}
+				},
+				"@babel/plugin-proposal-optional-chaining": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.12.1.tgz",
+					"integrity": "sha512-c2uRpY6WzaVDzynVY9liyykS+kVU+WRZPMPYpkelXH8KBt1oXoI89kPbZKKG/jDT5UK92FTW2fZkZaJhdiBabw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.10.4",
+						"@babel/helper-skip-transparent-expression-wrappers": "^7.12.1",
+						"@babel/plugin-syntax-optional-chaining": "^7.8.0"
+					}
+				},
+				"@babel/plugin-proposal-unicode-property-regex": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.12.1.tgz",
+					"integrity": "sha512-MYq+l+PvHuw/rKUz1at/vb6nCnQ2gmJBNaM62z0OgH7B2W1D9pvkpYtlti9bGtizNIU1K3zm4bZF9F91efVY0w==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-create-regexp-features-plugin": "^7.12.1",
+						"@babel/helper-plugin-utils": "^7.10.4"
+					}
+				},
+				"@babel/plugin-syntax-class-properties": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.1.tgz",
+					"integrity": "sha512-U40A76x5gTwmESz+qiqssqmeEsKvcSyvtgktrm0uzcARAmM9I1jR221f6Oq+GmHrcD+LvZDag1UTOTe2fL3TeA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.10.4"
+					}
+				},
+				"@babel/plugin-syntax-logical-assignment-operators": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+					"integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.10.4"
+					}
+				},
+				"@babel/plugin-syntax-numeric-separator": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+					"integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.10.4"
+					}
+				},
+				"@babel/plugin-transform-arrow-functions": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.12.1.tgz",
+					"integrity": "sha512-5QB50qyN44fzzz4/qxDPQMBCTHgxg3n0xRBLJUmBlLoU/sFvxVWGZF/ZUfMVDQuJUKXaBhbupxIzIfZ6Fwk/0A==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.10.4"
+					}
+				},
+				"@babel/plugin-transform-async-to-generator": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.12.1.tgz",
+					"integrity": "sha512-SDtqoEcarK1DFlRJ1hHRY5HvJUj5kX4qmtpMAm2QnhOlyuMC4TMdCRgW6WXpv93rZeYNeLP22y8Aq2dbcDRM1A==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-imports": "^7.12.1",
+						"@babel/helper-plugin-utils": "^7.10.4",
+						"@babel/helper-remap-async-to-generator": "^7.12.1"
+					}
+				},
+				"@babel/plugin-transform-block-scoped-functions": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.12.1.tgz",
+					"integrity": "sha512-5OpxfuYnSgPalRpo8EWGPzIYf0lHBWORCkj5M0oLBwHdlux9Ri36QqGW3/LR13RSVOAoUUMzoPI/jpE4ABcHoA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.10.4"
+					}
+				},
+				"@babel/plugin-transform-block-scoping": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.1.tgz",
+					"integrity": "sha512-zJyAC9sZdE60r1nVQHblcfCj29Dh2Y0DOvlMkcqSo0ckqjiCwNiUezUKw+RjOCwGfpLRwnAeQ2XlLpsnGkvv9w==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.10.4"
+					}
+				},
+				"@babel/plugin-transform-classes": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.12.1.tgz",
+					"integrity": "sha512-/74xkA7bVdzQTBeSUhLLJgYIcxw/dpEpCdRDiHgPJ3Mv6uC11UhjpOhl72CgqbBCmt1qtssCyB2xnJm1+PFjog==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-annotate-as-pure": "^7.10.4",
+						"@babel/helper-define-map": "^7.10.4",
+						"@babel/helper-function-name": "^7.10.4",
+						"@babel/helper-optimise-call-expression": "^7.10.4",
+						"@babel/helper-plugin-utils": "^7.10.4",
+						"@babel/helper-replace-supers": "^7.12.1",
+						"@babel/helper-split-export-declaration": "^7.10.4",
+						"globals": "^11.1.0"
+					}
+				},
+				"@babel/plugin-transform-computed-properties": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.12.1.tgz",
+					"integrity": "sha512-vVUOYpPWB7BkgUWPo4C44mUQHpTZXakEqFjbv8rQMg7TC6S6ZhGZ3otQcRH6u7+adSlE5i0sp63eMC/XGffrzg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.10.4"
+					}
+				},
+				"@babel/plugin-transform-destructuring": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.12.1.tgz",
+					"integrity": "sha512-fRMYFKuzi/rSiYb2uRLiUENJOKq4Gnl+6qOv5f8z0TZXg3llUwUhsNNwrwaT/6dUhJTzNpBr+CUvEWBtfNY1cw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.10.4"
+					}
+				},
+				"@babel/plugin-transform-dotall-regex": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.12.1.tgz",
+					"integrity": "sha512-B2pXeRKoLszfEW7J4Hg9LoFaWEbr/kzo3teWHmtFCszjRNa/b40f9mfeqZsIDLLt/FjwQ6pz/Gdlwy85xNckBA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-create-regexp-features-plugin": "^7.12.1",
+						"@babel/helper-plugin-utils": "^7.10.4"
+					}
+				},
+				"@babel/plugin-transform-exponentiation-operator": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.12.1.tgz",
+					"integrity": "sha512-7tqwy2bv48q+c1EHbXK0Zx3KXd2RVQp6OC7PbwFNt/dPTAV3Lu5sWtWuAj8owr5wqtWnqHfl2/mJlUmqkChKug==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-builder-binary-assignment-operator-visitor": "^7.10.4",
+						"@babel/helper-plugin-utils": "^7.10.4"
+					}
+				},
+				"@babel/plugin-transform-for-of": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.12.1.tgz",
+					"integrity": "sha512-Zaeq10naAsuHo7heQvyV0ptj4dlZJwZgNAtBYBnu5nNKJoW62m0zKcIEyVECrUKErkUkg6ajMy4ZfnVZciSBhg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.10.4"
+					}
+				},
+				"@babel/plugin-transform-function-name": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.12.1.tgz",
+					"integrity": "sha512-JF3UgJUILoFrFMEnOJLJkRHSk6LUSXLmEFsA23aR2O5CSLUxbeUX1IZ1YQ7Sn0aXb601Ncwjx73a+FVqgcljVw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-function-name": "^7.10.4",
+						"@babel/helper-plugin-utils": "^7.10.4"
+					}
+				},
+				"@babel/plugin-transform-literals": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.12.1.tgz",
+					"integrity": "sha512-+PxVGA+2Ag6uGgL0A5f+9rklOnnMccwEBzwYFL3EUaKuiyVnUipyXncFcfjSkbimLrODoqki1U9XxZzTvfN7IQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.10.4"
+					}
+				},
+				"@babel/plugin-transform-member-expression-literals": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.12.1.tgz",
+					"integrity": "sha512-1sxePl6z9ad0gFMB9KqmYofk34flq62aqMt9NqliS/7hPEpURUCMbyHXrMPlo282iY7nAvUB1aQd5mg79UD9Jg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.10.4"
+					}
+				},
+				"@babel/plugin-transform-modules-commonjs": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.12.1.tgz",
+					"integrity": "sha512-dY789wq6l0uLY8py9c1B48V8mVL5gZh/+PQ5ZPrylPYsnAvnEMjqsUXkuoDVPeVK+0VyGar+D08107LzDQ6pag==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-transforms": "^7.12.1",
+						"@babel/helper-plugin-utils": "^7.10.4",
+						"@babel/helper-simple-access": "^7.12.1",
+						"babel-plugin-dynamic-import-node": "^2.3.3"
+					}
+				},
+				"@babel/plugin-transform-object-super": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.12.1.tgz",
+					"integrity": "sha512-AvypiGJH9hsquNUn+RXVcBdeE3KHPZexWRdimhuV59cSoOt5kFBmqlByorAeUlGG2CJWd0U+4ZtNKga/TB0cAw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.10.4",
+						"@babel/helper-replace-supers": "^7.12.1"
+					}
+				},
+				"@babel/plugin-transform-parameters": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.12.1.tgz",
+					"integrity": "sha512-xq9C5EQhdPK23ZeCdMxl8bbRnAgHFrw5EOC3KJUsSylZqdkCaFEXxGSBuTSObOpiiHHNyb82es8M1QYgfQGfNg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.10.4"
+					}
+				},
+				"@babel/plugin-transform-property-literals": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.12.1.tgz",
+					"integrity": "sha512-6MTCR/mZ1MQS+AwZLplX4cEySjCpnIF26ToWo942nqn8hXSm7McaHQNeGx/pt7suI1TWOWMfa/NgBhiqSnX0cQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.10.4"
+					}
+				},
+				"@babel/plugin-transform-regenerator": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.12.1.tgz",
+					"integrity": "sha512-gYrHqs5itw6i4PflFX3OdBPMQdPbF4bj2REIUxlMRUFk0/ZOAIpDFuViuxPjUL7YC8UPnf+XG7/utJvqXdPKng==",
+					"dev": true,
+					"requires": {
+						"regenerator-transform": "^0.14.2"
+					}
+				},
+				"@babel/plugin-transform-shorthand-properties": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.12.1.tgz",
+					"integrity": "sha512-GFZS3c/MhX1OusqB1MZ1ct2xRzX5ppQh2JU1h2Pnfk88HtFTM+TWQqJNfwkmxtPQtb/s1tk87oENfXJlx7rSDw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.10.4"
+					}
+				},
+				"@babel/plugin-transform-spread": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.12.1.tgz",
+					"integrity": "sha512-vuLp8CP0BE18zVYjsEBZ5xoCecMK6LBMMxYzJnh01rxQRvhNhH1csMMmBfNo5tGpGO+NhdSNW2mzIvBu3K1fng==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.10.4",
+						"@babel/helper-skip-transparent-expression-wrappers": "^7.12.1"
+					}
+				},
+				"@babel/plugin-transform-sticky-regex": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.12.1.tgz",
+					"integrity": "sha512-CiUgKQ3AGVk7kveIaPEET1jNDhZZEl1RPMWdTBE1799bdz++SwqDHStmxfCtDfBhQgCl38YRiSnrMuUMZIWSUQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.10.4",
+						"@babel/helper-regex": "^7.10.4"
+					}
+				},
+				"@babel/plugin-transform-template-literals": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.12.1.tgz",
+					"integrity": "sha512-b4Zx3KHi+taXB1dVRBhVJtEPi9h1THCeKmae2qP0YdUHIFhVjtpqqNfxeVAa1xeHVhAy4SbHxEwx5cltAu5apw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.10.4"
+					}
+				},
+				"@babel/plugin-transform-unicode-regex": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.12.1.tgz",
+					"integrity": "sha512-SqH4ClNngh/zGwHZOOQMTD+e8FGWexILV+ePMyiDJttAWRh5dhDL8rcl5lSgU3Huiq6Zn6pWTMvdPAb21Dwdyg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-create-regexp-features-plugin": "^7.12.1",
+						"@babel/helper-plugin-utils": "^7.10.4"
+					}
+				},
+				"@babel/template": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+					"integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.10.4",
+						"@babel/parser": "^7.10.4",
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.1.tgz",
+					"integrity": "sha512-MA3WPoRt1ZHo2ZmoGKNqi20YnPt0B1S0GTZEPhhd+hw2KGUzBlHuVunj6K4sNuK+reEvyiPwtp0cpaqLzJDmAw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.10.4",
+						"@babel/generator": "^7.12.1",
+						"@babel/helper-function-name": "^7.10.4",
+						"@babel/helper-split-export-declaration": "^7.11.0",
+						"@babel/parser": "^7.12.1",
+						"@babel/types": "^7.12.1",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.19"
+					}
+				},
+				"@babel/types": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.1.tgz",
+					"integrity": "sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"babel-plugin-dynamic-import-node": {
+					"version": "2.3.3",
+					"resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+					"integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
+					"dev": true,
+					"requires": {
+						"object.assign": "^4.1.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"debug": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				},
+				"regexpu-core": {
+					"version": "4.7.1",
+					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.1.tgz",
+					"integrity": "sha512-ywH2VUraA44DZQuRKzARmw6S66mr48pQVva4LBeRhcOltJ6hExvWly5ZjFLYo67xbIxb6W1q4bAGtgfEl20zfQ==",
+					"dev": true,
+					"requires": {
+						"regenerate": "^1.4.0",
+						"regenerate-unicode-properties": "^8.2.0",
+						"regjsgen": "^0.5.1",
+						"regjsparser": "^0.6.4",
+						"unicode-match-property-ecmascript": "^1.0.4",
+						"unicode-match-property-value-ecmascript": "^1.2.0"
+					}
 				},
 				"semver": {
 					"version": "5.7.1",
@@ -1954,17 +3650,17 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.9.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
-			"integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+			"version": "7.11.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+			"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
 			},
 			"dependencies": {
 				"regenerator-runtime": {
-					"version": "0.13.5",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-					"integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+					"version": "0.13.7",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
 				}
 			}
 		},
@@ -6266,6 +7962,15 @@
 					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
 					"dev": true
 				},
+				"query-string": {
+					"version": "6.13.6",
+					"resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.6.tgz",
+					"integrity": "sha512-/WWZ7d9na6s2wMEGdVCVgKWE9Rt7nYyNIf7k8xmHXcesPMlEzicWo3lbYwHyA4wBktI2KrXxxZeACLbE84hvSQ==",
+					"requires": {
+						"decode-uri-component": "^0.2.0",
+						"split-on-first": "^1.0.0"
+					}
+				},
 				"semver": {
 					"version": "5.7.1",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -7917,9 +9622,9 @@
 					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
 				},
 				"query-string": {
-					"version": "6.13.6",
-					"resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.6.tgz",
-					"integrity": "sha512-/WWZ7d9na6s2wMEGdVCVgKWE9Rt7nYyNIf7k8xmHXcesPMlEzicWo3lbYwHyA4wBktI2KrXxxZeACLbE84hvSQ==",
+					"version": "6.13.1",
+					"resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.1.tgz",
+					"integrity": "sha512-RfoButmcK+yCta1+FuU8REvisx1oEzhMKwhLUNcepQTPGcNMp1sIqjnfCtfnvGSQZQEhaBHvccujtWoUV3TTbA==",
 					"requires": {
 						"decode-uri-component": "^0.2.0",
 						"split-on-first": "^1.0.0",
@@ -15288,9 +16993,9 @@
 			"dev": true
 		},
 		"@types/uuid": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-7.0.2.tgz",
-			"integrity": "sha512-8Ly3zIPTnT0/8RCU6Kg/G3uTICf9sRwYOpUzSIM3503tLIKcnJPRuinHhXngJUy2MntrEf6dlpOHXJju90Qh5w==",
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
+			"integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
 			"dev": true
 		},
 		"@types/vfile": {
@@ -15702,21 +17407,6 @@
 				"@babel/runtime": "^7.11.2",
 				"@wordpress/dom-ready": "file:packages/dom-ready",
 				"@wordpress/i18n": "file:packages/i18n"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/annotations": {
@@ -15729,22 +17419,7 @@
 				"@wordpress/rich-text": "file:packages/rich-text",
 				"lodash": "^4.17.19",
 				"rememo": "^3.0.0",
-				"uuid": "^7.0.2"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
+				"uuid": "^8.3.0"
 			}
 		},
 		"@wordpress/api-fetch": {
@@ -15753,42 +17428,12 @@
 				"@babel/runtime": "^7.11.2",
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/url": "file:packages/url"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/autop": {
 			"version": "file:packages/autop",
 			"requires": {
 				"@babel/runtime": "^7.11.2"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/babel-plugin-import-jsx-pragma": {
@@ -15802,23 +17447,6 @@
 				"@babel/runtime": "^7.11.2",
 				"gettext-parser": "^1.3.1",
 				"lodash": "^4.17.19"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
-					"dev": true
-				}
 			}
 		},
 		"@wordpress/babel-preset-default": {
@@ -15835,904 +17463,6 @@
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/warning": "file:packages/warning",
 				"core-js": "^3.6.4"
-			},
-			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-					"dev": true,
-					"requires": {
-						"@babel/highlight": "^7.10.4"
-					}
-				},
-				"@babel/compat-data": {
-					"version": "7.11.0",
-					"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.11.0.tgz",
-					"integrity": "sha512-TPSvJfv73ng0pfnEOh17bYMPQbI95+nGWc71Ss4vZdRBHTDqmM9Z8ZV4rYz8Ks7sfzc95n30k6ODIq5UGnXcYQ==",
-					"dev": true,
-					"requires": {
-						"browserslist": "^4.12.0",
-						"invariant": "^2.2.4",
-						"semver": "^5.5.0"
-					}
-				},
-				"@babel/helper-annotate-as-pure": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz",
-					"integrity": "sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.10.4"
-					}
-				},
-				"@babel/helper-builder-binary-assignment-operator-visitor": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.10.4.tgz",
-					"integrity": "sha512-L0zGlFrGWZK4PbT8AszSfLTM5sDU1+Az/En9VrdT8/LmEiJt4zXt+Jve9DCAnQcbqDhCI+29y/L93mrDzddCcg==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-explode-assignable-expression": "^7.10.4",
-						"@babel/types": "^7.10.4"
-					}
-				},
-				"@babel/helper-builder-react-jsx": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.10.4.tgz",
-					"integrity": "sha512-5nPcIZ7+KKDxT1427oBivl9V9YTal7qk0diccnh7RrcgrT/pGFOjgGw1dgryyx1GvHEpXVfoDF6Ak3rTiWh8Rg==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-annotate-as-pure": "^7.10.4",
-						"@babel/types": "^7.10.4"
-					}
-				},
-				"@babel/helper-builder-react-jsx-experimental": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.11.5.tgz",
-					"integrity": "sha512-Vc4aPJnRZKWfzeCBsqTBnzulVNjABVdahSPhtdMD3Vs80ykx4a87jTHtF/VR+alSrDmNvat7l13yrRHauGcHVw==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-annotate-as-pure": "^7.10.4",
-						"@babel/helper-module-imports": "^7.10.4",
-						"@babel/types": "^7.11.5"
-					}
-				},
-				"@babel/helper-compilation-targets": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.10.4.tgz",
-					"integrity": "sha512-a3rYhlsGV0UHNDvrtOXBg8/OpfV0OKTkxKPzIplS1zpx7CygDcWWxckxZeDd3gzPzC4kUT0A4nVFDK0wGMh4MQ==",
-					"dev": true,
-					"requires": {
-						"@babel/compat-data": "^7.10.4",
-						"browserslist": "^4.12.0",
-						"invariant": "^2.2.4",
-						"levenary": "^1.1.1",
-						"semver": "^5.5.0"
-					}
-				},
-				"@babel/helper-create-class-features-plugin": {
-					"version": "7.10.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.10.5.tgz",
-					"integrity": "sha512-0nkdeijB7VlZoLT3r/mY3bUkw3T8WG/hNw+FATs/6+pG2039IJWjTYL0VTISqsNHMUTEnwbVnc89WIJX9Qed0A==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-function-name": "^7.10.4",
-						"@babel/helper-member-expression-to-functions": "^7.10.5",
-						"@babel/helper-optimise-call-expression": "^7.10.4",
-						"@babel/helper-plugin-utils": "^7.10.4",
-						"@babel/helper-replace-supers": "^7.10.4",
-						"@babel/helper-split-export-declaration": "^7.10.4"
-					}
-				},
-				"@babel/helper-create-regexp-features-plugin": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.10.4.tgz",
-					"integrity": "sha512-2/hu58IEPKeoLF45DBwx3XFqsbCXmkdAay4spVr2x0jYgRxrSNp+ePwvSsy9g6YSaNDcKIQVPXk1Ov8S2edk2g==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-annotate-as-pure": "^7.10.4",
-						"@babel/helper-regex": "^7.10.4",
-						"regexpu-core": "^4.7.0"
-					}
-				},
-				"@babel/helper-define-map": {
-					"version": "7.10.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.10.5.tgz",
-					"integrity": "sha512-fMw4kgFB720aQFXSVaXr79pjjcW5puTCM16+rECJ/plGS+zByelE8l9nCpV1GibxTnFVmUuYG9U8wYfQHdzOEQ==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-function-name": "^7.10.4",
-						"@babel/types": "^7.10.5",
-						"lodash": "^4.17.19"
-					}
-				},
-				"@babel/helper-explode-assignable-expression": {
-					"version": "7.11.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.11.4.tgz",
-					"integrity": "sha512-ux9hm3zR4WV1Y3xXxXkdG/0gxF9nvI0YVmKVhvK9AfMoaQkemL3sJpXw+Xbz65azo8qJiEz2XVDUpK3KYhH3ZQ==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.10.4"
-					}
-				},
-				"@babel/helper-function-name": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-					"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-get-function-arity": "^7.10.4",
-						"@babel/template": "^7.10.4",
-						"@babel/types": "^7.10.4"
-					}
-				},
-				"@babel/helper-get-function-arity": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-					"integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.10.4"
-					}
-				},
-				"@babel/helper-hoist-variables": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.10.4.tgz",
-					"integrity": "sha512-wljroF5PgCk2juF69kanHVs6vrLwIPNp6DLD+Lrl3hoQ3PpPPikaDRNFA+0t81NOoMt2DL6WW/mdU8k4k6ZzuA==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.10.4"
-					}
-				},
-				"@babel/helper-member-expression-to-functions": {
-					"version": "7.11.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
-					"integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.11.0"
-					}
-				},
-				"@babel/helper-module-imports": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
-					"integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.10.4"
-					}
-				},
-				"@babel/helper-module-transforms": {
-					"version": "7.11.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
-					"integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-module-imports": "^7.10.4",
-						"@babel/helper-replace-supers": "^7.10.4",
-						"@babel/helper-simple-access": "^7.10.4",
-						"@babel/helper-split-export-declaration": "^7.11.0",
-						"@babel/template": "^7.10.4",
-						"@babel/types": "^7.11.0",
-						"lodash": "^4.17.19"
-					}
-				},
-				"@babel/helper-optimise-call-expression": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
-					"integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.10.4"
-					}
-				},
-				"@babel/helper-plugin-utils": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
-					"integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
-					"dev": true
-				},
-				"@babel/helper-regex": {
-					"version": "7.10.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.10.5.tgz",
-					"integrity": "sha512-68kdUAzDrljqBrio7DYAEgCoJHxppJOERHOgOrDN7WjOzP0ZQ1LsSDRXcemzVZaLvjaJsJEESb6qt+znNuENDg==",
-					"dev": true,
-					"requires": {
-						"lodash": "^4.17.19"
-					}
-				},
-				"@babel/helper-remap-async-to-generator": {
-					"version": "7.11.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.11.4.tgz",
-					"integrity": "sha512-tR5vJ/vBa9wFy3m5LLv2faapJLnDFxNWff2SAYkSE4rLUdbp7CdObYFgI7wK4T/Mj4UzpjPwzR8Pzmr5m7MHGA==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-annotate-as-pure": "^7.10.4",
-						"@babel/helper-wrap-function": "^7.10.4",
-						"@babel/template": "^7.10.4",
-						"@babel/types": "^7.10.4"
-					}
-				},
-				"@babel/helper-replace-supers": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
-					"integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-member-expression-to-functions": "^7.10.4",
-						"@babel/helper-optimise-call-expression": "^7.10.4",
-						"@babel/traverse": "^7.10.4",
-						"@babel/types": "^7.10.4"
-					}
-				},
-				"@babel/helper-simple-access": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
-					"integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
-					"dev": true,
-					"requires": {
-						"@babel/template": "^7.10.4",
-						"@babel/types": "^7.10.4"
-					}
-				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.11.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
-					"integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.11.0"
-					}
-				},
-				"@babel/helper-validator-identifier": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-					"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
-					"dev": true
-				},
-				"@babel/helper-wrap-function": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.10.4.tgz",
-					"integrity": "sha512-6py45WvEF0MhiLrdxtRjKjufwLL1/ob2qDJgg5JgNdojBAZSAKnAjkyOCNug6n+OBl4VW76XjvgSFTdaMcW0Ug==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-function-name": "^7.10.4",
-						"@babel/template": "^7.10.4",
-						"@babel/traverse": "^7.10.4",
-						"@babel/types": "^7.10.4"
-					}
-				},
-				"@babel/highlight": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-					"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.4",
-						"chalk": "^2.0.0",
-						"js-tokens": "^4.0.0"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
-					"integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
-					"dev": true
-				},
-				"@babel/plugin-proposal-async-generator-functions": {
-					"version": "7.10.5",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.10.5.tgz",
-					"integrity": "sha512-cNMCVezQbrRGvXJwm9fu/1sJj9bHdGAgKodZdLqOQIpfoH3raqmRPBM17+lh7CzhiKRRBrGtZL9WcjxSoGYUSg==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.10.4",
-						"@babel/helper-remap-async-to-generator": "^7.10.4",
-						"@babel/plugin-syntax-async-generators": "^7.8.0"
-					}
-				},
-				"@babel/plugin-proposal-class-properties": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.10.4.tgz",
-					"integrity": "sha512-vhwkEROxzcHGNu2mzUC0OFFNXdZ4M23ib8aRRcJSsW8BZK9pQMD7QB7csl97NBbgGZO7ZyHUyKDnxzOaP4IrCg==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-create-class-features-plugin": "^7.10.4",
-						"@babel/helper-plugin-utils": "^7.10.4"
-					}
-				},
-				"@babel/plugin-proposal-dynamic-import": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.10.4.tgz",
-					"integrity": "sha512-up6oID1LeidOOASNXgv/CFbgBqTuKJ0cJjz6An5tWD+NVBNlp3VNSBxv2ZdU7SYl3NxJC7agAQDApZusV6uFwQ==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.10.4",
-						"@babel/plugin-syntax-dynamic-import": "^7.8.0"
-					}
-				},
-				"@babel/plugin-proposal-json-strings": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.10.4.tgz",
-					"integrity": "sha512-fCL7QF0Jo83uy1K0P2YXrfX11tj3lkpN7l4dMv9Y9VkowkhkQDwFHFd8IiwyK5MZjE8UpbgokkgtcReH88Abaw==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.10.4",
-						"@babel/plugin-syntax-json-strings": "^7.8.0"
-					}
-				},
-				"@babel/plugin-proposal-nullish-coalescing-operator": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.10.4.tgz",
-					"integrity": "sha512-wq5n1M3ZUlHl9sqT2ok1T2/MTt6AXE0e1Lz4WzWBr95LsAZ5qDXe4KnFuauYyEyLiohvXFMdbsOTMyLZs91Zlw==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.10.4",
-						"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
-					}
-				},
-				"@babel/plugin-proposal-numeric-separator": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.10.4.tgz",
-					"integrity": "sha512-73/G7QoRoeNkLZFxsoCCvlg4ezE4eM+57PnOqgaPOozd5myfj7p0muD1mRVJvbUWbOzD+q3No2bWbaKy+DJ8DA==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.10.4",
-						"@babel/plugin-syntax-numeric-separator": "^7.10.4"
-					}
-				},
-				"@babel/plugin-proposal-object-rest-spread": {
-					"version": "7.11.0",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.11.0.tgz",
-					"integrity": "sha512-wzch41N4yztwoRw0ak+37wxwJM2oiIiy6huGCoqkvSTA9acYWcPfn9Y4aJqmFFJ70KTJUu29f3DQ43uJ9HXzEA==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.10.4",
-						"@babel/plugin-syntax-object-rest-spread": "^7.8.0",
-						"@babel/plugin-transform-parameters": "^7.10.4"
-					}
-				},
-				"@babel/plugin-proposal-optional-catch-binding": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.10.4.tgz",
-					"integrity": "sha512-LflT6nPh+GK2MnFiKDyLiqSqVHkQnVf7hdoAvyTnnKj9xB3docGRsdPuxp6qqqW19ifK3xgc9U5/FwrSaCNX5g==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.10.4",
-						"@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
-					}
-				},
-				"@babel/plugin-proposal-optional-chaining": {
-					"version": "7.11.0",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.11.0.tgz",
-					"integrity": "sha512-v9fZIu3Y8562RRwhm1BbMRxtqZNFmFA2EG+pT2diuU8PT3H6T/KXoZ54KgYisfOFZHV6PfvAiBIZ9Rcz+/JCxA==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.10.4",
-						"@babel/helper-skip-transparent-expression-wrappers": "^7.11.0",
-						"@babel/plugin-syntax-optional-chaining": "^7.8.0"
-					}
-				},
-				"@babel/plugin-proposal-unicode-property-regex": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.10.4.tgz",
-					"integrity": "sha512-H+3fOgPnEXFL9zGYtKQe4IDOPKYlZdF1kqFDQRRb8PK4B8af1vAGK04tF5iQAAsui+mHNBQSAtd2/ndEDe9wuA==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-create-regexp-features-plugin": "^7.10.4",
-						"@babel/helper-plugin-utils": "^7.10.4"
-					}
-				},
-				"@babel/plugin-syntax-class-properties": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.10.4.tgz",
-					"integrity": "sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.10.4"
-					}
-				},
-				"@babel/plugin-syntax-logical-assignment-operators": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
-					"integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.10.4"
-					}
-				},
-				"@babel/plugin-syntax-numeric-separator": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
-					"integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.10.4"
-					}
-				},
-				"@babel/plugin-syntax-top-level-await": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.10.4.tgz",
-					"integrity": "sha512-ni1brg4lXEmWyafKr0ccFWkJG0CeMt4WV1oyeBW6EFObF4oOHclbkj5cARxAPQyAQ2UTuplJyK4nfkXIMMFvsQ==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.10.4"
-					}
-				},
-				"@babel/plugin-transform-arrow-functions": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.10.4.tgz",
-					"integrity": "sha512-9J/oD1jV0ZCBcgnoFWFq1vJd4msoKb/TCpGNFyyLt0zABdcvgK3aYikZ8HjzB14c26bc7E3Q1yugpwGy2aTPNA==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.10.4"
-					}
-				},
-				"@babel/plugin-transform-async-to-generator": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.10.4.tgz",
-					"integrity": "sha512-F6nREOan7J5UXTLsDsZG3DXmZSVofr2tGNwfdrVwkDWHfQckbQXnXSPfD7iO+c/2HGqycwyLST3DnZ16n+cBJQ==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-module-imports": "^7.10.4",
-						"@babel/helper-plugin-utils": "^7.10.4",
-						"@babel/helper-remap-async-to-generator": "^7.10.4"
-					}
-				},
-				"@babel/plugin-transform-block-scoped-functions": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.10.4.tgz",
-					"integrity": "sha512-WzXDarQXYYfjaV1szJvN3AD7rZgZzC1JtjJZ8dMHUyiK8mxPRahynp14zzNjU3VkPqPsO38CzxiWO1c9ARZ8JA==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.10.4"
-					}
-				},
-				"@babel/plugin-transform-block-scoping": {
-					"version": "7.11.1",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.11.1.tgz",
-					"integrity": "sha512-00dYeDE0EVEHuuM+26+0w/SCL0BH2Qy7LwHuI4Hi4MH5gkC8/AqMN5uWFJIsoXZrAphiMm1iXzBw6L2T+eA0ew==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.10.4"
-					}
-				},
-				"@babel/plugin-transform-classes": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.10.4.tgz",
-					"integrity": "sha512-2oZ9qLjt161dn1ZE0Ms66xBncQH4In8Sqw1YWgBUZuGVJJS5c0OFZXL6dP2MRHrkU/eKhWg8CzFJhRQl50rQxA==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-annotate-as-pure": "^7.10.4",
-						"@babel/helper-define-map": "^7.10.4",
-						"@babel/helper-function-name": "^7.10.4",
-						"@babel/helper-optimise-call-expression": "^7.10.4",
-						"@babel/helper-plugin-utils": "^7.10.4",
-						"@babel/helper-replace-supers": "^7.10.4",
-						"@babel/helper-split-export-declaration": "^7.10.4",
-						"globals": "^11.1.0"
-					}
-				},
-				"@babel/plugin-transform-computed-properties": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.10.4.tgz",
-					"integrity": "sha512-JFwVDXcP/hM/TbyzGq3l/XWGut7p46Z3QvqFMXTfk6/09m7xZHJUN9xHfsv7vqqD4YnfI5ueYdSJtXqqBLyjBw==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.10.4"
-					}
-				},
-				"@babel/plugin-transform-destructuring": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.10.4.tgz",
-					"integrity": "sha512-+WmfvyfsyF603iPa6825mq6Qrb7uLjTOsa3XOFzlYcYDHSS4QmpOWOL0NNBY5qMbvrcf3tq0Cw+v4lxswOBpgA==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.10.4"
-					}
-				},
-				"@babel/plugin-transform-dotall-regex": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.10.4.tgz",
-					"integrity": "sha512-ZEAVvUTCMlMFAbASYSVQoxIbHm2OkG2MseW6bV2JjIygOjdVv8tuxrCTzj1+Rynh7ODb8GivUy7dzEXzEhuPaA==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-create-regexp-features-plugin": "^7.10.4",
-						"@babel/helper-plugin-utils": "^7.10.4"
-					}
-				},
-				"@babel/plugin-transform-duplicate-keys": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.10.4.tgz",
-					"integrity": "sha512-GL0/fJnmgMclHiBTTWXNlYjYsA7rDrtsazHG6mglaGSTh0KsrW04qml+Bbz9FL0LcJIRwBWL5ZqlNHKTkU3xAA==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.10.4"
-					}
-				},
-				"@babel/plugin-transform-exponentiation-operator": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.10.4.tgz",
-					"integrity": "sha512-S5HgLVgkBcRdyQAHbKj+7KyuWx8C6t5oETmUuwz1pt3WTWJhsUV0WIIXuVvfXMxl/QQyHKlSCNNtaIamG8fysw==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-builder-binary-assignment-operator-visitor": "^7.10.4",
-						"@babel/helper-plugin-utils": "^7.10.4"
-					}
-				},
-				"@babel/plugin-transform-for-of": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.10.4.tgz",
-					"integrity": "sha512-ItdQfAzu9AlEqmusA/65TqJ79eRcgGmpPPFvBnGILXZH975G0LNjP1yjHvGgfuCxqrPPueXOPe+FsvxmxKiHHQ==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.10.4"
-					}
-				},
-				"@babel/plugin-transform-function-name": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.10.4.tgz",
-					"integrity": "sha512-OcDCq2y5+E0dVD5MagT5X+yTRbcvFjDI2ZVAottGH6tzqjx/LKpgkUepu3hp/u4tZBzxxpNGwLsAvGBvQ2mJzg==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-function-name": "^7.10.4",
-						"@babel/helper-plugin-utils": "^7.10.4"
-					}
-				},
-				"@babel/plugin-transform-literals": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.10.4.tgz",
-					"integrity": "sha512-Xd/dFSTEVuUWnyZiMu76/InZxLTYilOSr1UlHV+p115Z/Le2Fi1KXkJUYz0b42DfndostYlPub3m8ZTQlMaiqQ==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.10.4"
-					}
-				},
-				"@babel/plugin-transform-member-expression-literals": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.10.4.tgz",
-					"integrity": "sha512-0bFOvPyAoTBhtcJLr9VcwZqKmSjFml1iVxvPL0ReomGU53CX53HsM4h2SzckNdkQcHox1bpAqzxBI1Y09LlBSw==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.10.4"
-					}
-				},
-				"@babel/plugin-transform-modules-amd": {
-					"version": "7.10.5",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.10.5.tgz",
-					"integrity": "sha512-elm5uruNio7CTLFItVC/rIzKLfQ17+fX7EVz5W0TMgIHFo1zY0Ozzx+lgwhL4plzl8OzVn6Qasx5DeEFyoNiRw==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-module-transforms": "^7.10.5",
-						"@babel/helper-plugin-utils": "^7.10.4",
-						"babel-plugin-dynamic-import-node": "^2.3.3"
-					}
-				},
-				"@babel/plugin-transform-modules-commonjs": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.10.4.tgz",
-					"integrity": "sha512-Xj7Uq5o80HDLlW64rVfDBhao6OX89HKUmb+9vWYaLXBZOma4gA6tw4Ni1O5qVDoZWUV0fxMYA0aYzOawz0l+1w==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-module-transforms": "^7.10.4",
-						"@babel/helper-plugin-utils": "^7.10.4",
-						"@babel/helper-simple-access": "^7.10.4",
-						"babel-plugin-dynamic-import-node": "^2.3.3"
-					}
-				},
-				"@babel/plugin-transform-modules-systemjs": {
-					"version": "7.10.5",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.10.5.tgz",
-					"integrity": "sha512-f4RLO/OL14/FP1AEbcsWMzpbUz6tssRaeQg11RH1BP/XnPpRoVwgeYViMFacnkaw4k4wjRSjn3ip1Uw9TaXuMw==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-hoist-variables": "^7.10.4",
-						"@babel/helper-module-transforms": "^7.10.5",
-						"@babel/helper-plugin-utils": "^7.10.4",
-						"babel-plugin-dynamic-import-node": "^2.3.3"
-					}
-				},
-				"@babel/plugin-transform-modules-umd": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.10.4.tgz",
-					"integrity": "sha512-mohW5q3uAEt8T45YT7Qc5ws6mWgJAaL/8BfWD9Dodo1A3RKWli8wTS+WiQ/knF+tXlPirW/1/MqzzGfCExKECA==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-module-transforms": "^7.10.4",
-						"@babel/helper-plugin-utils": "^7.10.4"
-					}
-				},
-				"@babel/plugin-transform-named-capturing-groups-regex": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.10.4.tgz",
-					"integrity": "sha512-V6LuOnD31kTkxQPhKiVYzYC/Jgdq53irJC/xBSmqcNcqFGV+PER4l6rU5SH2Vl7bH9mLDHcc0+l9HUOe4RNGKA==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-create-regexp-features-plugin": "^7.10.4"
-					}
-				},
-				"@babel/plugin-transform-new-target": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.10.4.tgz",
-					"integrity": "sha512-YXwWUDAH/J6dlfwqlWsztI2Puz1NtUAubXhOPLQ5gjR/qmQ5U96DY4FQO8At33JN4XPBhrjB8I4eMmLROjjLjw==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.10.4"
-					}
-				},
-				"@babel/plugin-transform-object-super": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.10.4.tgz",
-					"integrity": "sha512-5iTw0JkdRdJvr7sY0vHqTpnruUpTea32JHmq/atIWqsnNussbRzjEDyWep8UNztt1B5IusBYg8Irb0bLbiEBCQ==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.10.4",
-						"@babel/helper-replace-supers": "^7.10.4"
-					}
-				},
-				"@babel/plugin-transform-parameters": {
-					"version": "7.10.5",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.10.5.tgz",
-					"integrity": "sha512-xPHwUj5RdFV8l1wuYiu5S9fqWGM2DrYc24TMvUiRrPVm+SM3XeqU9BcokQX/kEUe+p2RBwy+yoiR1w/Blq6ubw==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-get-function-arity": "^7.10.4",
-						"@babel/helper-plugin-utils": "^7.10.4"
-					}
-				},
-				"@babel/plugin-transform-property-literals": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.10.4.tgz",
-					"integrity": "sha512-ofsAcKiUxQ8TY4sScgsGeR2vJIsfrzqvFb9GvJ5UdXDzl+MyYCaBj/FGzXuv7qE0aJcjWMILny1epqelnFlz8g==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.10.4"
-					}
-				},
-				"@babel/plugin-transform-react-jsx": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.10.4.tgz",
-					"integrity": "sha512-L+MfRhWjX0eI7Js093MM6MacKU4M6dnCRa/QPDwYMxjljzSCzzlzKzj9Pk4P3OtrPcxr2N3znR419nr3Xw+65A==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-builder-react-jsx": "^7.10.4",
-						"@babel/helper-builder-react-jsx-experimental": "^7.10.4",
-						"@babel/helper-plugin-utils": "^7.10.4",
-						"@babel/plugin-syntax-jsx": "^7.10.4"
-					}
-				},
-				"@babel/plugin-transform-regenerator": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.10.4.tgz",
-					"integrity": "sha512-3thAHwtor39A7C04XucbMg17RcZ3Qppfxr22wYzZNcVIkPHfpM9J0SO8zuCV6SZa265kxBJSrfKTvDCYqBFXGw==",
-					"dev": true,
-					"requires": {
-						"regenerator-transform": "^0.14.2"
-					}
-				},
-				"@babel/plugin-transform-reserved-words": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.10.4.tgz",
-					"integrity": "sha512-hGsw1O6Rew1fkFbDImZIEqA8GoidwTAilwCyWqLBM9f+e/u/sQMQu7uX6dyokfOayRuuVfKOW4O7HvaBWM+JlQ==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.10.4"
-					}
-				},
-				"@babel/plugin-transform-runtime": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.11.5.tgz",
-					"integrity": "sha512-9aIoee+EhjySZ6vY5hnLjigHzunBlscx9ANKutkeWTJTx6m5Rbq6Ic01tLvO54lSusR+BxV7u4UDdCmXv5aagg==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-module-imports": "^7.10.4",
-						"@babel/helper-plugin-utils": "^7.10.4",
-						"resolve": "^1.8.1",
-						"semver": "^5.5.1"
-					}
-				},
-				"@babel/plugin-transform-shorthand-properties": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.10.4.tgz",
-					"integrity": "sha512-AC2K/t7o07KeTIxMoHneyX90v3zkm5cjHJEokrPEAGEy3UCp8sLKfnfOIGdZ194fyN4wfX/zZUWT9trJZ0qc+Q==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.10.4"
-					}
-				},
-				"@babel/plugin-transform-spread": {
-					"version": "7.11.0",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.11.0.tgz",
-					"integrity": "sha512-UwQYGOqIdQJe4aWNyS7noqAnN2VbaczPLiEtln+zPowRNlD+79w3oi2TWfYe0eZgd+gjZCbsydN7lzWysDt+gw==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.10.4",
-						"@babel/helper-skip-transparent-expression-wrappers": "^7.11.0"
-					}
-				},
-				"@babel/plugin-transform-sticky-regex": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.10.4.tgz",
-					"integrity": "sha512-Ddy3QZfIbEV0VYcVtFDCjeE4xwVTJWTmUtorAJkn6u/92Z/nWJNV+mILyqHKrUxXYKA2EoCilgoPePymKL4DvQ==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.10.4",
-						"@babel/helper-regex": "^7.10.4"
-					}
-				},
-				"@babel/plugin-transform-template-literals": {
-					"version": "7.10.5",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.10.5.tgz",
-					"integrity": "sha512-V/lnPGIb+KT12OQikDvgSuesRX14ck5FfJXt6+tXhdkJ+Vsd0lDCVtF6jcB4rNClYFzaB2jusZ+lNISDk2mMMw==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-annotate-as-pure": "^7.10.4",
-						"@babel/helper-plugin-utils": "^7.10.4"
-					}
-				},
-				"@babel/plugin-transform-typeof-symbol": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.10.4.tgz",
-					"integrity": "sha512-QqNgYwuuW0y0H+kUE/GWSR45t/ccRhe14Fs/4ZRouNNQsyd4o3PG4OtHiIrepbM2WKUBDAXKCAK/Lk4VhzTaGA==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.10.4"
-					}
-				},
-				"@babel/plugin-transform-unicode-regex": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.10.4.tgz",
-					"integrity": "sha512-wNfsc4s8N2qnIwpO/WP2ZiSyjfpTamT2C9V9FDH/Ljub9zw6P3SjkXcFmc0RQUt96k2fmIvtla2MMjgTwIAC+A==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-create-regexp-features-plugin": "^7.10.4",
-						"@babel/helper-plugin-utils": "^7.10.4"
-					}
-				},
-				"@babel/preset-env": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.11.5.tgz",
-					"integrity": "sha512-kXqmW1jVcnB2cdueV+fyBM8estd5mlNfaQi6lwLgRwCby4edpavgbFhiBNjmWA3JpB/yZGSISa7Srf+TwxDQoA==",
-					"dev": true,
-					"requires": {
-						"@babel/compat-data": "^7.11.0",
-						"@babel/helper-compilation-targets": "^7.10.4",
-						"@babel/helper-module-imports": "^7.10.4",
-						"@babel/helper-plugin-utils": "^7.10.4",
-						"@babel/plugin-proposal-async-generator-functions": "^7.10.4",
-						"@babel/plugin-proposal-class-properties": "^7.10.4",
-						"@babel/plugin-proposal-dynamic-import": "^7.10.4",
-						"@babel/plugin-proposal-export-namespace-from": "^7.10.4",
-						"@babel/plugin-proposal-json-strings": "^7.10.4",
-						"@babel/plugin-proposal-logical-assignment-operators": "^7.11.0",
-						"@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.4",
-						"@babel/plugin-proposal-numeric-separator": "^7.10.4",
-						"@babel/plugin-proposal-object-rest-spread": "^7.11.0",
-						"@babel/plugin-proposal-optional-catch-binding": "^7.10.4",
-						"@babel/plugin-proposal-optional-chaining": "^7.11.0",
-						"@babel/plugin-proposal-private-methods": "^7.10.4",
-						"@babel/plugin-proposal-unicode-property-regex": "^7.10.4",
-						"@babel/plugin-syntax-async-generators": "^7.8.0",
-						"@babel/plugin-syntax-class-properties": "^7.10.4",
-						"@babel/plugin-syntax-dynamic-import": "^7.8.0",
-						"@babel/plugin-syntax-export-namespace-from": "^7.8.3",
-						"@babel/plugin-syntax-json-strings": "^7.8.0",
-						"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
-						"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
-						"@babel/plugin-syntax-numeric-separator": "^7.10.4",
-						"@babel/plugin-syntax-object-rest-spread": "^7.8.0",
-						"@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
-						"@babel/plugin-syntax-optional-chaining": "^7.8.0",
-						"@babel/plugin-syntax-top-level-await": "^7.10.4",
-						"@babel/plugin-transform-arrow-functions": "^7.10.4",
-						"@babel/plugin-transform-async-to-generator": "^7.10.4",
-						"@babel/plugin-transform-block-scoped-functions": "^7.10.4",
-						"@babel/plugin-transform-block-scoping": "^7.10.4",
-						"@babel/plugin-transform-classes": "^7.10.4",
-						"@babel/plugin-transform-computed-properties": "^7.10.4",
-						"@babel/plugin-transform-destructuring": "^7.10.4",
-						"@babel/plugin-transform-dotall-regex": "^7.10.4",
-						"@babel/plugin-transform-duplicate-keys": "^7.10.4",
-						"@babel/plugin-transform-exponentiation-operator": "^7.10.4",
-						"@babel/plugin-transform-for-of": "^7.10.4",
-						"@babel/plugin-transform-function-name": "^7.10.4",
-						"@babel/plugin-transform-literals": "^7.10.4",
-						"@babel/plugin-transform-member-expression-literals": "^7.10.4",
-						"@babel/plugin-transform-modules-amd": "^7.10.4",
-						"@babel/plugin-transform-modules-commonjs": "^7.10.4",
-						"@babel/plugin-transform-modules-systemjs": "^7.10.4",
-						"@babel/plugin-transform-modules-umd": "^7.10.4",
-						"@babel/plugin-transform-named-capturing-groups-regex": "^7.10.4",
-						"@babel/plugin-transform-new-target": "^7.10.4",
-						"@babel/plugin-transform-object-super": "^7.10.4",
-						"@babel/plugin-transform-parameters": "^7.10.4",
-						"@babel/plugin-transform-property-literals": "^7.10.4",
-						"@babel/plugin-transform-regenerator": "^7.10.4",
-						"@babel/plugin-transform-reserved-words": "^7.10.4",
-						"@babel/plugin-transform-shorthand-properties": "^7.10.4",
-						"@babel/plugin-transform-spread": "^7.11.0",
-						"@babel/plugin-transform-sticky-regex": "^7.10.4",
-						"@babel/plugin-transform-template-literals": "^7.10.4",
-						"@babel/plugin-transform-typeof-symbol": "^7.10.4",
-						"@babel/plugin-transform-unicode-escapes": "^7.10.4",
-						"@babel/plugin-transform-unicode-regex": "^7.10.4",
-						"@babel/preset-modules": "^0.1.3",
-						"@babel/types": "^7.11.5",
-						"browserslist": "^4.12.0",
-						"core-js-compat": "^3.6.2",
-						"invariant": "^2.2.2",
-						"levenary": "^1.1.1",
-						"semver": "^5.5.0"
-					}
-				},
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"@babel/template": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
-					"integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.10.4",
-						"@babel/parser": "^7.10.4",
-						"@babel/types": "^7.10.4"
-					}
-				},
-				"@babel/types": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-					"integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.4",
-						"lodash": "^4.17.19",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"babel-plugin-dynamic-import-node": {
-					"version": "2.3.3",
-					"resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
-					"integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
-					"dev": true,
-					"requires": {
-						"object.assign": "^4.1.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"globals": {
-					"version": "11.12.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-					"dev": true
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
-					"dev": true
-				},
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				}
 			}
 		},
 		"@wordpress/base-styles": {
@@ -16743,26 +17473,12 @@
 			"version": "file:packages/blob",
 			"requires": {
 				"@babel/runtime": "^7.11.2"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/block-directory": {
 			"version": "file:packages/block-directory",
 			"requires": {
+				"@babel/runtime": "^7.11.2",
 				"@wordpress/a11y": "file:packages/a11y",
 				"@wordpress/api-fetch": "file:packages/api-fetch",
 				"@wordpress/block-editor": "file:packages/block-editor",
@@ -16827,21 +17543,6 @@
 				"rememo": "^3.0.0",
 				"tinycolor2": "^1.4.1",
 				"traverse": "^0.6.6"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/block-library": {
@@ -16884,42 +17585,12 @@
 				"react-easy-crop": "^3.0.0",
 				"reakit": "1.1.0",
 				"tinycolor2": "^1.4.1"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/block-serialization-default-parser": {
 			"version": "file:packages/block-serialization-default-parser",
 			"requires": {
 				"@babel/runtime": "^7.11.2"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/block-serialization-spec-parser": {
@@ -16953,22 +17624,7 @@
 				"showdown": "^1.9.1",
 				"simple-html-tokenizer": "^0.5.7",
 				"tinycolor2": "^1.4.1",
-				"uuid": "^7.0.2"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
+				"uuid": "^8.3.0"
 			}
 		},
 		"@wordpress/browserslist-config": {
@@ -17013,22 +17669,7 @@
 				"reakit": "^1.1.0",
 				"rememo": "^3.0.0",
 				"tinycolor2": "^1.4.1",
-				"uuid": "^7.0.2"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
+				"uuid": "^8.3.0"
 			}
 		},
 		"@wordpress/compose": {
@@ -17043,21 +17684,6 @@
 				"mousetrap": "^1.6.5",
 				"react-resize-aware": "^3.0.1",
 				"use-memo-one": "^1.1.1"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/core-data": {
@@ -17076,21 +17702,6 @@
 				"equivalent-key-map": "^0.2.2",
 				"lodash": "^4.17.19",
 				"rememo": "^3.0.0"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/create-block": {
@@ -17133,26 +17744,12 @@
 				"redux": "^4.0.0",
 				"turbo-combine-reducers": "^1.0.2",
 				"use-memo-one": "^1.1.1"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/data-controls": {
 			"version": "file:packages/data-controls",
 			"requires": {
+				"@babel/runtime": "^7.11.2",
 				"@wordpress/api-fetch": "file:packages/api-fetch",
 				"@wordpress/data": "file:packages/data"
 			}
@@ -17163,29 +17760,6 @@
 				"@babel/runtime": "^7.11.2",
 				"moment": "^2.22.1",
 				"moment-timezone": "^0.5.31"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"moment-timezone": {
-					"version": "0.5.31",
-					"resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.31.tgz",
-					"integrity": "sha512-+GgHNg8xRhMXfEbv81iDtrVeTcWt0kWmTEY1XQK14dICTXnWJnT0dxdlPspwqF3keKMVPXwayEsk1DI0AA/jdA==",
-					"requires": {
-						"moment": ">= 2.9.0"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/dependency-extraction-webpack-plugin": {
@@ -17202,21 +17776,6 @@
 			"requires": {
 				"@babel/runtime": "^7.11.2",
 				"@wordpress/hooks": "file:packages/hooks"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/docgen": {
@@ -17238,42 +17797,12 @@
 			"requires": {
 				"@babel/runtime": "^7.11.2",
 				"lodash": "^4.17.19"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/dom-ready": {
 			"version": "file:packages/dom-ready",
 			"requires": {
 				"@babel/runtime": "^7.11.2"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/e2e-test-utils": {
@@ -17285,23 +17814,6 @@
 				"@wordpress/url": "file:packages/url",
 				"lodash": "^4.17.19",
 				"node-fetch": "^2.6.0"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
-					"dev": true
-				}
 			}
 		},
 		"@wordpress/e2e-tests": {
@@ -17316,7 +17828,7 @@
 				"chalk": "^4.0.0",
 				"expect-puppeteer": "^4.4.0",
 				"lodash": "^4.17.19",
-				"uuid": "^7.0.2"
+				"uuid": "^8.3.0"
 			}
 		},
 		"@wordpress/edit-navigation": {
@@ -17345,22 +17857,7 @@
 				"classnames": "^2.2.5",
 				"lodash": "^4.17.19",
 				"rememo": "^3.0.0",
-				"uuid": "^7.0.2"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
+				"uuid": "^8.3.0"
 			}
 		},
 		"@wordpress/edit-post": {
@@ -17397,21 +17894,6 @@
 				"memize": "^1.1.0",
 				"refx": "^3.0.0",
 				"rememo": "^3.0.0"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/edit-site": {
@@ -17447,21 +17929,6 @@
 				"jszip": "^3.2.2",
 				"lodash": "^4.17.19",
 				"rememo": "^3.0.0"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/edit-widgets": {
@@ -17494,27 +17961,7 @@
 				"lodash": "^4.17.19",
 				"reakit": "^1.1.0",
 				"rememo": "^3.0.0",
-				"uuid": "^8.3.1"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				},
-				"uuid": {
-					"version": "8.3.1",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
-					"integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg=="
-				}
+				"uuid": "^8.3.0"
 			}
 		},
 		"@wordpress/editor": {
@@ -17556,21 +18003,6 @@
 				"redux-optimist": "^1.0.0",
 				"refx": "^3.0.0",
 				"rememo": "^3.0.0"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/element": {
@@ -17583,21 +18015,6 @@
 				"lodash": "^4.17.19",
 				"react": "^16.13.1",
 				"react-dom": "^16.13.1"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/env": {
@@ -17622,21 +18039,6 @@
 			"version": "file:packages/escape-html",
 			"requires": {
 				"@babel/runtime": "^7.11.2"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/eslint-plugin": {
@@ -17656,61 +18058,6 @@
 				"globals": "^12.0.0",
 				"prettier": "npm:wp-prettier@2.0.5",
 				"requireindex": "^1.2.0"
-			},
-			"dependencies": {
-				"cosmiconfig": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
-					"integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
-					"dev": true,
-					"requires": {
-						"@types/parse-json": "^4.0.0",
-						"import-fresh": "^3.2.1",
-						"parse-json": "^5.0.0",
-						"path-type": "^4.0.0",
-						"yaml": "^1.10.0"
-					}
-				},
-				"import-fresh": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
-					"integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
-					"dev": true,
-					"requires": {
-						"parent-module": "^1.0.0",
-						"resolve-from": "^4.0.0"
-					}
-				},
-				"parse-json": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.1.tgz",
-					"integrity": "sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1",
-						"lines-and-columns": "^1.1.6"
-					}
-				},
-				"path-type": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-					"dev": true
-				},
-				"resolve-from": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-					"dev": true
-				},
-				"yaml": {
-					"version": "1.10.0",
-					"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
-					"integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
-					"dev": true
-				}
 			}
 		},
 		"@wordpress/format-library": {
@@ -17730,63 +18077,18 @@
 				"@wordpress/rich-text": "file:packages/rich-text",
 				"@wordpress/url": "file:packages/url",
 				"lodash": "^4.17.19"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/hooks": {
 			"version": "file:packages/hooks",
 			"requires": {
 				"@babel/runtime": "^7.11.2"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/html-entities": {
 			"version": "file:packages/html-entities",
 			"requires": {
 				"@babel/runtime": "^7.11.2"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/i18n": {
@@ -17798,21 +18100,6 @@
 				"memize": "^1.1.0",
 				"sprintf-js": "^1.1.1",
 				"tannin": "^1.2.0"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/icons": {
@@ -17821,21 +18108,6 @@
 				"@babel/runtime": "^7.11.2",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/primitives": "file:packages/primitives"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/interface": {
@@ -17850,42 +18122,12 @@
 				"@wordpress/plugins": "file:packages/plugins",
 				"classnames": "^2.2.5",
 				"lodash": "^4.17.19"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/is-shallow-equal": {
 			"version": "file:packages/is-shallow-equal",
 			"requires": {
 				"@babel/runtime": "^7.11.2"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/jest-console": {
@@ -17895,23 +18137,6 @@
 				"@babel/runtime": "^7.11.2",
 				"jest-matcher-utils": "^25.3.0",
 				"lodash": "^4.17.19"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
-					"dev": true
-				}
 			}
 		},
 		"@wordpress/jest-preset-default": {
@@ -17932,23 +18157,6 @@
 			"requires": {
 				"@axe-core/puppeteer": "^4.0.0",
 				"@babel/runtime": "^7.11.2"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
-					"dev": true
-				}
 			}
 		},
 		"@wordpress/keyboard-shortcuts": {
@@ -17961,21 +18169,6 @@
 				"@wordpress/keycodes": "file:packages/keycodes",
 				"lodash": "^4.17.19",
 				"rememo": "^3.0.0"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/keycodes": {
@@ -17984,21 +18177,6 @@
 				"@babel/runtime": "^7.11.2",
 				"@wordpress/i18n": "file:packages/i18n",
 				"lodash": "^4.17.19"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/lazy-import": {
@@ -18028,21 +18206,6 @@
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/i18n": "file:packages/i18n",
 				"lodash": "^4.17.19"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/media-utils": {
@@ -18054,21 +18217,6 @@
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/i18n": "file:packages/i18n",
 				"lodash": "^4.17.19"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/notices": {
@@ -18078,21 +18226,6 @@
 				"@wordpress/a11y": "file:packages/a11y",
 				"@wordpress/data": "file:packages/data",
 				"lodash": "^4.17.19"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/npm-package-json-lint-config": {
@@ -18112,21 +18245,6 @@
 				"@wordpress/icons": "file:packages/icons",
 				"lodash": "^4.17.19",
 				"rememo": "^3.0.0"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/plugins": {
@@ -18138,21 +18256,6 @@
 				"@wordpress/hooks": "file:packages/hooks",
 				"@wordpress/icons": "file:packages/icons",
 				"lodash": "^4.17.19"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/postcss-plugins-preset": {
@@ -18182,42 +18285,12 @@
 				"@babel/runtime": "^7.11.2",
 				"@wordpress/element": "file:packages/element",
 				"classnames": "^2.2.5"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/priority-queue": {
 			"version": "file:packages/priority-queue",
 			"requires": {
 				"@babel/runtime": "^7.11.2"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/project-management-automation": {
@@ -18227,23 +18300,6 @@
 				"@actions/core": "^1.0.0",
 				"@actions/github": "^1.0.0",
 				"@babel/runtime": "^7.11.2"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
-					"dev": true
-				}
 			}
 		},
 		"@wordpress/react-native-aztec": {
@@ -18334,21 +18390,6 @@
 				"is-promise": "^4.0.0",
 				"lodash": "^4.17.19",
 				"rungen": "^0.3.2"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/reusable-blocks": {
@@ -18365,21 +18406,6 @@
 				"@wordpress/icons": "file:packages/icons",
 				"@wordpress/notices": "file:packages/notices",
 				"lodash": "^4.17.19"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/rich-text": {
@@ -18397,21 +18423,6 @@
 				"lodash": "^4.17.19",
 				"memize": "^1.1.0",
 				"rememo": "^3.0.0"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/scripts": {
@@ -18475,21 +18486,6 @@
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/url": "file:packages/url",
 				"lodash": "^4.17.19"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/shortcode": {
@@ -18498,21 +18494,6 @@
 				"@babel/runtime": "^7.11.2",
 				"lodash": "^4.17.19",
 				"memize": "^1.1.0"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/token-list": {
@@ -18520,21 +18501,6 @@
 			"requires": {
 				"@babel/runtime": "^7.11.2",
 				"lodash": "^4.17.19"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/url": {
@@ -18544,21 +18510,6 @@
 				"lodash": "^4.17.19",
 				"qs": "^6.5.2",
 				"react-native-url-polyfill": "^1.1.2"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/viewport": {
@@ -18568,21 +18519,6 @@
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/data": "file:packages/data",
 				"lodash": "^4.17.19"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@wordpress/warning": {
@@ -18593,21 +18529,6 @@
 			"requires": {
 				"@babel/runtime": "^7.11.2",
 				"lodash": "^4.17.19"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.11.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-					"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@xtuc/ieee754": {
@@ -30483,23 +30404,57 @@
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
 		"cosmiconfig": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.5.tgz",
-			"integrity": "sha512-94j37OtvxS5w7qr7Ta6dt67tWdnOxigBVN4VnSxNXFez9o18PGQ0D33SchKP17r9LAcWVTYV72G6vDayAUBFIg==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
+			"integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
+			"dev": true,
 			"requires": {
-				"is-directory": "^0.3.1",
-				"js-yaml": "^3.9.0",
-				"parse-json": "^4.0.0"
+				"@types/parse-json": "^4.0.0",
+				"import-fresh": "^3.2.1",
+				"parse-json": "^5.0.0",
+				"path-type": "^4.0.0",
+				"yaml": "^1.10.0"
 			},
 			"dependencies": {
-				"parse-json": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+				"import-fresh": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+					"integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+					"dev": true,
 					"requires": {
-						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1"
+						"parent-module": "^1.0.0",
+						"resolve-from": "^4.0.0"
 					}
+				},
+				"parse-json": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+					"integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"error-ex": "^1.3.1",
+						"json-parse-even-better-errors": "^2.3.0",
+						"lines-and-columns": "^1.1.6"
+					}
+				},
+				"path-type": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+					"dev": true
+				},
+				"resolve-from": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+					"dev": true
+				},
+				"yaml": {
+					"version": "1.10.0",
+					"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
+					"integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
+					"dev": true
 				}
 			}
 		},
@@ -30930,6 +30885,40 @@
 				"cssnano-preset-default": "^4.0.7",
 				"is-resolvable": "^1.0.0",
 				"postcss": "^7.0.0"
+			},
+			"dependencies": {
+				"cosmiconfig": {
+					"version": "5.2.1",
+					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+					"integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+					"dev": true,
+					"requires": {
+						"import-fresh": "^2.0.0",
+						"is-directory": "^0.3.1",
+						"js-yaml": "^3.13.1",
+						"parse-json": "^4.0.0"
+					}
+				},
+				"import-fresh": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+					"integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+					"dev": true,
+					"requires": {
+						"caller-path": "^2.0.0",
+						"resolve-from": "^3.0.0"
+					}
+				},
+				"parse-json": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+					"dev": true,
+					"requires": {
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1"
+					}
+				}
 			}
 		},
 		"cssnano-preset-default": {
@@ -46594,6 +46583,37 @@
 				"metro-cache": "^0.56.4",
 				"metro-core": "^0.56.4",
 				"pretty-format": "^24.7.0"
+			},
+			"dependencies": {
+				"cosmiconfig": {
+					"version": "5.2.1",
+					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+					"integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+					"requires": {
+						"import-fresh": "^2.0.0",
+						"is-directory": "^0.3.1",
+						"js-yaml": "^3.13.1",
+						"parse-json": "^4.0.0"
+					}
+				},
+				"import-fresh": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+					"integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+					"requires": {
+						"caller-path": "^2.0.0",
+						"resolve-from": "^3.0.0"
+					}
+				},
+				"parse-json": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+					"requires": {
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1"
+					}
+				}
 			}
 		},
 		"metro-core": {
@@ -47252,6 +47272,14 @@
 			"version": "2.22.1",
 			"resolved": "https://registry.npmjs.org/moment/-/moment-2.22.1.tgz",
 			"integrity": "sha512-shJkRTSebXvsVqk56I+lkb2latjBs8I+pc2TzWc545y2iFnSjm7Wg0QMh+ZWcdSLQyGEau5jI8ocnmkyTgr9YQ=="
+		},
+		"moment-timezone": {
+			"version": "0.5.31",
+			"resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.31.tgz",
+			"integrity": "sha512-+GgHNg8xRhMXfEbv81iDtrVeTcWt0kWmTEY1XQK14dICTXnWJnT0dxdlPspwqF3keKMVPXwayEsk1DI0AA/jdA==",
+			"requires": {
+				"moment": ">= 2.9.0"
+			}
 		},
 		"moo": {
 			"version": "0.4.3",
@@ -50310,6 +50338,40 @@
 			"requires": {
 				"cosmiconfig": "^5.0.0",
 				"import-cwd": "^2.0.0"
+			},
+			"dependencies": {
+				"cosmiconfig": {
+					"version": "5.2.1",
+					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+					"integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+					"dev": true,
+					"requires": {
+						"import-fresh": "^2.0.0",
+						"is-directory": "^0.3.1",
+						"js-yaml": "^3.13.1",
+						"parse-json": "^4.0.0"
+					}
+				},
+				"import-fresh": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+					"integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+					"dev": true,
+					"requires": {
+						"caller-path": "^2.0.0",
+						"resolve-from": "^3.0.0"
+					}
+				},
+				"parse-json": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+					"dev": true,
+					"requires": {
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1"
+					}
+				}
 			}
 		},
 		"postcss-loader": {
@@ -60500,9 +60562,9 @@
 			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
 		},
 		"uuid": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.2.tgz",
-			"integrity": "sha512-vy9V/+pKG+5ZTYKf+VcphF5Oc6EFiu3W8Nv3P3zIh0EqVI80ZxOzuPfe9EHjkFNvf8+xuTHVeei4Drydlx4zjw=="
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
+			"integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ=="
 		},
 		"v8-compile-cache": {
 			"version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
 		"@types/requestidlecallback": "0.3.1",
 		"@types/semver": "7.2.0",
 		"@types/sprintf-js": "1.1.2",
-		"@types/uuid": "7.0.2",
+		"@types/uuid": "8.3.0",
 		"@types/webpack": "4.41.16",
 		"@types/webpack-sources": "0.1.7",
 		"@wordpress/babel-plugin-import-jsx-pragma": "file:packages/babel-plugin-import-jsx-pragma",
@@ -197,7 +197,7 @@
 		"stylelint-config-wordpress": "17.0.0",
 		"terser-webpack-plugin": "3.0.3",
 		"typescript": "4.0.3",
-		"uuid": "7.0.2",
+		"uuid": "8.3.0",
 		"wd": "1.12.1",
 		"webpack": "4.42.0",
 		"worker-farm": "1.7.0"

--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -29,7 +29,7 @@
 		"@wordpress/rich-text": "file:../rich-text",
 		"lodash": "^4.17.19",
 		"rememo": "^3.0.0",
-		"uuid": "^7.0.2"
+		"uuid": "^8.3.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/block-directory/package.json
+++ b/packages/block-directory/package.json
@@ -22,6 +22,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
+		"@babel/runtime": "^7.11.2",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/block-editor": "file:../block-editor",

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -46,7 +46,7 @@
 		"showdown": "^1.9.1",
 		"simple-html-tokenizer": "^0.5.7",
 		"tinycolor2": "^1.4.1",
-		"uuid": "^7.0.2"
+		"uuid": "^8.3.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -61,7 +61,7 @@
 		"reakit": "^1.1.0",
 		"rememo": "^3.0.0",
 		"tinycolor2": "^1.4.1",
-		"uuid": "^7.0.2"
+		"uuid": "^8.3.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/data-controls/package.json
+++ b/packages/data-controls/package.json
@@ -23,6 +23,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
+		"@babel/runtime": "^7.11.2",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/data": "file:../data"
 	},

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -31,7 +31,7 @@
 		"chalk": "^4.0.0",
 		"expect-puppeteer": "^4.4.0",
 		"lodash": "^4.17.19",
-		"uuid": "^7.0.2"
+		"uuid": "^8.3.0"
 	},
 	"peerDependencies": {
 		"jest": ">=24",

--- a/packages/edit-navigation/package.json
+++ b/packages/edit-navigation/package.json
@@ -47,7 +47,7 @@
 		"classnames": "^2.2.5",
 		"lodash": "^4.17.19",
 		"rememo": "^3.0.0",
-		"uuid": "^7.0.2"
+		"uuid": "^8.3.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/edit-widgets/package.json
+++ b/packages/edit-widgets/package.json
@@ -50,7 +50,7 @@
 		"lodash": "^4.17.19",
 		"reakit": "^1.1.0",
 		"rememo": "^3.0.0",
-		"uuid": "^8.3.1"
+		"uuid": "^8.3.0"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This PR ensures that all WordPress packages use the same dependencies. It changes the following:
- all packages use now "uuid" in version "8.3.0"
- "@babel/runtime" is set to "7.11.2" for the whole project
- Gutenberg project installs the same version of Babel helpers and plugins as `@wordpress/babel-preset-default`