### PR TITLE
Polish shortcode block.

### DIFF
--- a/packages/block-library/src/shortcode/editor.scss
+++ b/packages/block-library/src/shortcode/editor.scss
@@ -1,25 +1,10 @@
-.wp-block-shortcode {
-	display: flex;
-	flex-direction: column;
-	padding: $block-padding;
-	font-size: $default-font-size;
-	font-family: $default-font;
-	margin-bottom: $default-block-margin;
-
-	label {
-		display: flex;
-		align-items: center;
-		white-space: nowrap;
-		font-weight: 600;
-		flex-shrink: 0;
-	}
-
+[data-type="core/shortcode"] {
 	.block-editor-plain-text {
 		max-height: 250px;
 	}
 
-	.dashicon {
-		margin-right: $grid-unit-10;
+	&.components-placeholder {
+		min-height: 0;
 	}
 }
 


### PR DESCRIPTION
Shortcode block had unused CSS. This fixes and polishes it.

Before:

<img width="1059" alt="Screenshot 2020-10-26 at 14 26 35" src="https://user-images.githubusercontent.com/1204802/97178889-6e6c6f00-1798-11eb-86a3-bf6db355aa47.png">

After:

<img width="787" alt="Screenshot 2020-10-26 at 14 34 08" src="https://user-images.githubusercontent.com/1204802/97178895-70cec900-1798-11eb-8948-8817aa7a4b0a.png">

Fixes #26410.