### PR TITLE
Storybook: fix broken BlockDraggable story

### DIFF
--- a/packages/block-editor/src/components/block-draggable/stories/index.js
+++ b/packages/block-editor/src/components/block-draggable/stories/index.js
@@ -1,15 +1,16 @@
 /**
- * WordPress dependencies
- */
-import { wordpress } from '@wordpress/icons';
-
-/**
  * Internal dependencies
  */
-import { BlockDraggableChip } from '../draggable-chip';
+import BlockDraggableChip from '../draggable-chip';
 
 export default { title: 'BlockEditor/BlockDraggable' };
 
 export const _default = () => {
-	return <BlockDraggableChip icon={ wordpress } label="WordPress" />;
+	// create a wrapper box for the absolutely-positioned child component
+	const wrapperStyle = { margin: '24px 0', position: 'relative' };
+	return (
+		<div style={ wrapperStyle }>
+			<BlockDraggableChip clientIds={ [ 1, 2 ] } />
+		</div>
+	);
 };


### PR DESCRIPTION
Fixes a story for the `BlockDraggableChip` component that is currently broken:

<img width="1144" alt="Screenshot 2020-10-26 at 13 53 11" src="https://user-images.githubusercontent.com/664258/97178581-f605ae00-1797-11eb-9eb6-13e423849ca9.png">

There were several issues, ordered by most serious first:
- the component is exported from its module as default export, but was imported as named `{ BlockDraggableChip }`. That's `undefined` though.
- the component gets the wrong props. `clientIds` is the only required, others (`label`, `icon`) are not supported at all. I'm providing array with two dummy IDs, to avoid needing to create and populate a `core/block-editor` store
- to see the component well in the story, a wrapper `div` with 24px margin is needed. Without that, the negative margins will shift the component partially out of view.

The result after the patch:
<img width="412" alt="Screenshot 2020-10-26 at 14 28 17" src="https://user-images.githubusercontent.com/664258/97179032-a1aefe00-1798-11eb-85cd-a6ee9a2d9e33.png">
