### PR TITLE
ColorIndicator: Use CSS-in-JS

### DIFF
--- a/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
+++ b/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
@@ -1,24 +1,36 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ColorPaletteControl matches the snapshot 1`] = `
-.emotion-2 {
+.emotion-4 {
   font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
   font-size: 13px;
 }
 
-.emotion-0 {
+.emotion-2 {
   margin-bottom: 8px;
 }
 
-.components-panel__row .emotion-0 {
+.components-panel__row .emotion-2 {
   margin-bottom: inherit;
 }
 
+.emotion-0 {
+  width: 25px;
+  height: 16px;
+  margin-left: 0.8rem;
+  border: 1px solid #dadada;
+  display: inline-block;
+}
+
+.emotion-0 + .emotion-0 {
+  margin-left: 0.5rem;
+}
+
 <div
-  className="components-base-control block-editor-color-gradient-control emotion-2 emotion-3"
+  className="components-base-control block-editor-color-gradient-control emotion-4 emotion-5"
 >
   <div
-    className="components-base-control__field emotion-0 emotion-1"
+    className="components-base-control__field emotion-2 emotion-3"
   >
     <fieldset>
       <legend>
@@ -31,7 +43,7 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
             Test Color
             <span
               aria-label="(Color: #f00)"
-              className="component-color-indicator"
+              className="component-color-indicator emotion-0 emotion-1"
               style={
                 Object {
                   "background": "#f00",

--- a/packages/components/src/color-indicator/index.js
+++ b/packages/components/src/color-indicator/index.js
@@ -3,8 +3,13 @@
  */
 import classnames from 'classnames';
 
+/**
+ * Internal dependencies
+ */
+import { StyledColorIndicator } from './styles/color-indicator-styles';
+
 const ColorIndicator = ( { className, colorValue, ...props } ) => (
-	<span
+	<StyledColorIndicator
 		className={ classnames( 'component-color-indicator', className ) }
 		style={ { background: colorValue } }
 		{ ...props }

--- a/packages/components/src/color-indicator/stories/index.js
+++ b/packages/components/src/color-indicator/stories/index.js
@@ -17,3 +17,14 @@ export const _default = () => {
 	const color = text( 'Color', '#0073aa' );
 	return <ColorIndicator colorValue={ color } />;
 };
+
+export const neighbors = () => {
+	const color = text( 'Color', '#0073aa' );
+	return (
+		<div>
+			<ColorIndicator colorValue={ color } />
+			<ColorIndicator colorValue={ color } />
+			<ColorIndicator colorValue={ color } />
+		</div>
+	);
+};

--- a/packages/components/src/color-indicator/styles/color-indicator-styles.js
+++ b/packages/components/src/color-indicator/styles/color-indicator-styles.js
@@ -1,4 +1,9 @@
-.component-color-indicator {
+/**
+ * External dependencies
+ */
+import styled from '@emotion/styled';
+
+export const StyledColorIndicator = styled.span`
 	width: 25px;
 	height: 16px;
 	margin-left: 0.8rem;
@@ -8,4 +13,4 @@
 	& + & {
 		margin-left: 0.5rem;
 	}
-}
+`;

--- a/packages/components/src/color-indicator/test/__snapshots__/index.js.snap
+++ b/packages/components/src/color-indicator/test/__snapshots__/index.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ColorIndicator matches the snapshot 1`] = `
-<span
+<StyledColorIndicator
   aria-label="sample label"
   className="component-color-indicator"
   style={

--- a/packages/components/src/style.scss
+++ b/packages/components/src/style.scss
@@ -5,7 +5,6 @@
 @import "./checkbox-control/style.scss";
 @import "./circular-option-picker/style.scss";
 @import "./color-edit/style.scss";
-@import "./color-indicator/style.scss";
 @import "./color-picker/style.scss";
 @import "./combobox-control/style.scss";
 @import "./custom-gradient-picker/style.scss";


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Use CSS-in-JS for `ColorIndicator`.

This does _not_ adjust anything to do with native styles. @ItsJonQ is there something we should do about that or just leave them alone for now?

## How has this been tested?
Verified no changes in storybook and in Gutenberg itself.

<img width="287" alt="Captura de Tela 2020-10-27 às 08 08 45" src="https://user-images.githubusercontent.com/24264157/97321023-ab357600-182b-11eb-8e88-ff7c2c9de80a.png">

## Types of changes
Non-breaking CSS-in-JS changes. Existing classnames are preserved to ensure existing targeting of the component continues to work.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
