### PR TITLE
Add: Support for other units and CSS properties in Font Size presets

### DIFF
--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -334,6 +334,12 @@ function gutenberg_experimental_global_styles_get_theme_support_settings() {
 			$theme_settings['global']['settings']['typography'] = array();
 		}
 		$theme_settings['global']['settings']['typography']['fontSizes'] = array();
+		// Back-compatibility for presets without units.
+		foreach ( $theme_font_sizes[0] as &$font_size ) {
+			if ( is_numeric( $font_size['size'] ) ) {
+				$font_size['size'] = $font_size['size'] . 'px';
+			}
+		}
 		$theme_settings['global']['settings']['typography']['fontSizes'] = $theme_font_sizes[0];
 	}
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 - Introduce `Navigation` component as `__experimentalNavigation` for displaying a hierarchy of items.
 
+
+### Breaking Change
+
+- Introduce support for other units and advanced CSS properties on `FontSizePicker`. Provided the value passed to the `FontSizePicker` is a string or one of the size options passed is a string, onChange will start to be called with a string value instead of a number. On WordPress usage, font size options are now automatically converted to strings with the default "px" unit added.
+
 ## 10.0.0 (2020-07-07)
 
 ### Breaking Change

--- a/packages/components/src/font-size-picker/README.md
+++ b/packages/components/src/font-size-picker/README.md
@@ -68,7 +68,7 @@ If no value exists, this prop defines the starting position for the font size pi
 ### fontSizes
 
 An array of font size objects. The object should contain properties size, name, and slug.
-The property `size` contains a number with the font size value, in `px`.
+The property `size` contains a number with the font size value, in `px` or a string specifying the font size CSS property that should be used eg: "13px", "1em", or "clamp(12px, 5vw, 100px)".
 The `name` property includes a label for that font size e.g.: `Small`.
 The `slug` property is a string with a unique identifier for the font size. Used for the class generation process.
 
@@ -89,7 +89,7 @@ If onChange is called without any parameter, it should reset the value, attendin
 
 The current font size value.
 
-- Type: `Number`
+- Type: `Number | String`
 - Required: No
 
 ### withSlider


### PR DESCRIPTION
This PR makes sure themes can use font size values on font size presets that are not in pixels.
Some examples are "2rem", "1em", or "clamp(12px, 5vw, 100px)". Any valid CSS property for font size is accepted on the preset.

The font size preset was the only preset whose value was not a valid CSS property e.g: it used "13" as a value and "13" is an invalid property while "13px" is a valid property. This causes problems on https://github.com/WordPress/gutenberg/pull/26319 because if we try to reference a variable containing the font size preset the variable is not valid. So this PR includes functionality that if the font size preset is a number automatically adds the pixel unit e.g: "13" -> "13px". This is only done on existing font size presets added with add_theme_supports, for the font sizes passed via theme.json we assume they pass valid CSS properties.


When a font size preset is selected that is not in pixels the font size component shows the custom field as empty and correctly shows the selected preset. I guess the UI of the component should be improved to deal with other units besides pixes and to allow a free form input version where the user can type something like "clamp(12px, 5vw, 100px)" or change a little bit the advanced preset. But than can be done in a follow up PR. cc: @ItsJonQ as someone that is involved in UI work and worked with unit selection before.

## Description
<!-- Please describe what you have changed or added -->

## How has this been tested?
I tested 2019 and 2020 themes and verified the font size presets were still applied and font size selection still worked as expected.
I tested the global styles theme with the following typography settings:
```
			"typography": {
				"customLineHeight": true,
				"fontSizes": [
					{
					  "name": "x-small",
					  "slug": "x-small",
					  "size": "1rem"
					},
					{
					  "name": "small",
					  "slug": "small",
					  "size": "2em"
					},
					{
						"name": "normal",
						"slug": "normal",
						"size": "15px"
					},
					{
						"name": "Fluid",
						"slug": "fluid",
						"size": "clamp(12px, 5vw, 100px)"
					}
				]
			}
```
I verified all the presets worked as expected.
