### PR TITLE
Latest Posts: Bring back classname on post list

### DIFF
--- a/packages/block-library/src/latest-posts/block.json
+++ b/packages/block-library/src/latest-posts/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 2,
 	"name": "core/latest-posts",
 	"category": "widgets",
 	"attributes": {

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -400,7 +400,15 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 		</InspectorControls>
 	);
 
-	const blockProps = useBlockProps();
+	const blockProps = useBlockProps( {
+		className: classnames( {
+			'wp-block-latest-posts__list': true,
+			'is-grid': postLayout === 'grid',
+			'has-dates': displayPostDate,
+			'has-author': displayAuthor,
+			[ `columns-${ columns }` ]: postLayout === 'grid',
+		} ),
+	} );
 
 	const hasPosts = Array.isArray( latestPosts ) && latestPosts.length;
 	if ( ! hasPosts ) {
@@ -442,20 +450,12 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 	const dateFormat = __experimentalGetSettings().formats.date;
 
 	return (
-		<div { ...blockProps }>
+		<>
 			{ inspectorControls }
 			<BlockControls>
 				<ToolbarGroup controls={ layoutControls } />
 			</BlockControls>
-			<ul
-				className={ classnames( {
-					'wp-block-latest-posts__list': true,
-					'is-grid': postLayout === 'grid',
-					'has-dates': displayPostDate,
-					'has-author': displayAuthor,
-					[ `columns-${ columns }` ]: postLayout === 'grid',
-				} ) }
-			>
+			<ul { ...blockProps }>
 				{ displayPosts.map( ( post, i ) => {
 					const titleTrimmed = invoke( post, [
 						'title',
@@ -585,6 +585,6 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 					);
 				} ) }
 			</ul>
-		</div>
+		</>
 	);
 }

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -52,11 +52,7 @@ const USERS_LIST_QUERY = {
 	per_page: -1,
 };
 
-export default function LatestPostsEdit( {
-	attributes,
-	setAttributes,
-	className,
-} ) {
+export default function LatestPostsEdit( { attributes, setAttributes } ) {
 	const {
 		postsToShow,
 		order,
@@ -452,7 +448,7 @@ export default function LatestPostsEdit( {
 				<ToolbarGroup controls={ layoutControls } />
 			</BlockControls>
 			<ul
-				className={ classnames( className, {
+				className={ classnames( {
 					'wp-block-latest-posts__list': true,
 					'is-grid': postLayout === 'grid',
 					'has-dates': displayPostDate,

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -52,7 +52,11 @@ const USERS_LIST_QUERY = {
 	per_page: -1,
 };
 
-export default function LatestPostsEdit( { attributes, setAttributes } ) {
+export default function LatestPostsEdit( {
+	attributes,
+	setAttributes,
+	className,
+} ) {
 	const {
 		postsToShow,
 		order,
@@ -448,7 +452,7 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 				<ToolbarGroup controls={ layoutControls } />
 			</BlockControls>
 			<ul
-				className={ classnames( {
+				className={ classnames( className, {
 					'wp-block-latest-posts__list': true,
 					'is-grid': postLayout === 'grid',
 					'has-dates': displayPostDate,


### PR DESCRIPTION
## Description
Fixes #26445. In https://github.com/WordPress/gutenberg/pull/26122 the Latest Posts edit component was refactored away from a class, which meant that the `this.props.className` was removed. This breaks latest posts styling, since themes rely on the `.wp-block-latest-posts` class to style. This is most obvious when you try to switch to grid style.

This PR simply adds the class back to the `ul`. I tried passing a props arg to `useBlockProps`, but since the classname needs to be on the `ul` (not the `div`, where `useBlockProps` is), this simple change works better.

## How has this been tested?

I tested with Twenty Twenty-One and Twenty Nineteen, both were broken (not showing posts in a grid, had bullet points) before this change.

Test by adding a Latest Posts block to your site, and making sure it looks the same on the frontend and editor.

## Screenshots

These are both in the editor. Everything's fine on the frontend.

Before:
![Screen Shot 2020-10-26 at 5 09 12 PM](https://user-images.githubusercontent.com/541093/97228932-fa3cc600-17ad-11eb-85c0-ad4edb9db47d.png)

After:
![Screen Shot 2020-10-26 at 5 02 34 PM](https://user-images.githubusercontent.com/541093/97228886-eb561380-17ad-11eb-8523-f2069b5b4666.png)

## Types of changes

Bug fix (non-breaking change which fixes an issue)
