### PR TITLE
Update glossary to include more block based terminology

### DIFF
--- a/docs/designers-developers/glossary.md
+++ b/docs/designers-developers/glossary.md
@@ -22,11 +22,11 @@
 <dt>Block name</dt>
 <dd>A unique identifier for a block type, consisting of a plugin-specific namespace and a short label describing the block's intent. e.g. <code>core/image</code></dd>
 
-<dt>Block Template</dt>
-<dd>Templates are HTML files of block markup that map to templates from the standard WordPress template hierarchy, for example index, single or archive. This helps control the front-end defaults of a site that are not edited via the Page Editor or the Post Editor. </dd>
+<dt>Block Templates</dt>
+<dd> A template is a pre-defined arrangement of blocks, possibly with predefined attributes or placeholder content. You can provide a template for a post type, to give users a starting point when creating a new piece of content, or inside a custom block with the <code>InnerBlocks</code> component. At their core, templates are simply HTML files of block markup that map to templates from the standard WordPress template hierarchy, for example index, single or archive. This helps control the front-end defaults of a site that are not edited via the Page Editor or the Post Editor. See the <a href="../../developers/block-api/block-templates/">templates documentation</a> for more information. </dd>
 
-<dt>Block Template Part</dt>
-<dd>Building on Block Templates, these parts help set structure like a Footer or Header that one typically sees in a WordPress site. With Full Site Editing and block based themes, users can create their own arbitrary Template Parts, save those in the database for their site, and re-use them throughout their site.</dd>
+<dt>Block Template Parts</dt>
+<dd>Building on Block Templates, these parts help set structure for reusable items like a Footer or Header that one typically sees in a WordPress site. They are primarily site structure and are never to be mixed with the post content editor. With Full Site Editing and block based themes, users can create their own arbitrary Template Parts, save those in the database for their site, and re-use them throughout their site. Template parts are equivalent – in blocks – of theme template parts. They are generally defined by a theme first, carry some semantic meaning (could be swapped between themes such as a header), and can only be inserted in the site editor context (within “templates”). </dd>
 
 <dt>Patterns</dt>
 <dd>Patterns are predefined layouts of blocks that can be inserted as starter content that are meant to be changed by the user every time. Once inserted, they exist as a local save and are not global.</dd>
@@ -69,11 +69,5 @@
 
 <dt>Toolbar</dt>
 <dd>A set of button controls. In the context of a block, usually referring to the toolbar of block controls shown above the selected block.</dd>
-
-<dt>Template</dt>
-<dd> A template is a pre-defined arrangement of blocks, possibly with predefined attributes or placeholder content. You can provide a template for a post type, to give users a starting point when creating a new piece of content, or inside a custom block with the <code>InnerBlocks</code> component. See the <a href="../../developers/block-api/block-templates/">templates documentation</a> for more information.</dd>
-
-<dt>Template part</dt>
-<dd>Template parts are equivalent – in blocks – of theme template parts. They are generally defined by a theme first. They carry some semantic meaning (could be swapped between themes such as a header) and can only be inserted in the site editor context (within “templates”). They are primarily site structure and are never to be mixed with the post content editor. </dd>
 
 </dl>

--- a/docs/designers-developers/glossary.md
+++ b/docs/designers-developers/glossary.md
@@ -10,6 +10,9 @@
 <dt>Block</dt>
 <dd>The abstract term used to describe units of markup that, composed together, form the content or layout of a webpage. The idea combines concepts of what in WordPress today we achieve with shortcodes, custom HTML, and embed discovery into a single consistent API and user experience.</dd>
 
+<dt>Block Based Theme</dt>
+<dd>A theme built in block forward way that allows Full Site Editing to work. The core of a block-based theme are its block templates and block template parts. To date, block-based theme templates have been HTML files of block markup that map to templates from the standard WordPress template hierarchy. </dd>
+
 <dt>Block categories</dt>
 <dd>These are not a WordPress taxonomy, but instead used internally to sort blocks in the Block Library.</dd>
 
@@ -18,6 +21,12 @@
 
 <dt>Block name</dt>
 <dd>A unique identifier for a block type, consisting of a plugin-specific namespace and a short label describing the block's intent. e.g. <code>core/image</code></dd>
+
+<dt>Block Template</dt>
+<dd>Templates are HTML files of block markup that map to templates from the standard WordPress template hierarchy, for example index, single or archive. This helps control the front-end defaults of a site that are not edited via the Page Editor or the Post Editor. </dd>
+
+<dt>Block Template Part</dt>
+<dd>Building on Block Templates, these parts help set structure like a Footer or Header that one typically sees in a WordPress site. With Full Site Editing and block based themes, users can create their own arbitrary Template Parts, save those in the database for their site, and re-use them throughout their site.</dd>
 
 <dt>Patterns</dt>
 <dd>Patterns are predefined layouts of blocks that can be inserted as starter content that are meant to be changed by the user every time. Once inserted, they exist as a local save and are not global.</dd>
@@ -30,6 +39,9 @@
 
 <dt>Dynamic block</dt>
 <dd>A type of block where the content of which may change and cannot be determined at the time of saving a post, instead calculated any time the post is shown on the front of a site. These blocks may save fallback content or no content at all in their JavaScript implementation, instead deferring to a PHP block implementation for runtime rendering.</dd>
+
+<dt>Full Site Editing </dt>
+<dd>This refers to a collection of features that ultimately allows users to edit their entire website using blocks as the starting point. This feature set includes everything from block patterns to global styles to templates to design tools for blocks (and more). Currently, it's still in an experimental phase.</dd>
 
 <dt>Inspector</dt>
 <dd>Deprecated term. See <a href="#settings-sidebar">Settings Sidebar.</a></dd>


### PR DESCRIPTION
Offering this update to include the terms Block Based Themes, Block Templates, Block Template Parts, and Full Site Editing since these are increasingly becoming necessary terms to refer to in the wider community. Happy to have any of this rephrased as others see fit. cc @kjellr in particular for the block based theme specific terms.