### PR TITLE
Dark mode UI updates

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -208,6 +208,10 @@
 	color: #555;
 	font-size: $default-font-size;
 	text-align: center;
+
+	.is-dark-theme & {
+		color: $light-gray-placeholder;
+	}
 }
 
 

--- a/packages/block-editor/src/components/button-block-appender/style.scss
+++ b/packages/block-editor/src/components/button-block-appender/style.scss
@@ -9,7 +9,13 @@
 	color: $gray-900;
 	box-shadow: inset 0 0 0 $border-width $gray-900;
 
+	.is-dark-theme & {
+		color: $light-gray-placeholder;
+		box-shadow: inset 0 0 0 $border-width $light-gray-placeholder;
+	}
+
 	&:hover {
+		color: var(--wp-admin-theme-color);
 		box-shadow: inset 0 0 0 $border-width var(--wp-admin-theme-color);
 	}
 


### PR DESCRIPTION
Fixes #26479. 
Provides a dark mode color for caption placeholders as seen in Gallery and Table blocks. 
Adds a dark mode color for the block appender button as seen in the Columns block. 

## How has this been tested?
Tested locally.

## Screenshots 

**Gutenberg Starter Theme**
![Screen Shot 2020-10-26 at 4 43 14 PM](https://user-images.githubusercontent.com/617986/97240310-2c98f400-17ab-11eb-8506-bfefca136d2f.png)

**Twenty Twenty One**
I'm not sure why the Columns block appender buttons and the Verse block's placeholder text doesn't show correctly in this theme. Anyone have any ideas?

![2021](https://user-images.githubusercontent.com/617986/97240356-4afeef80-17ab-11eb-84c2-621eec9d12f6.png)


## Types of changes
CSS changes.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
