### PR TITLE
Fix block inserter WSOD when an empty reusable block exists

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1697,7 +1697,11 @@ export const __experimentalGetParsedReusableBlock = createSelector(
 
 		// Only reusableBlock.content.raw should be used here, `reusableBlock.content` is a
 		// workaround until #22127 is fixed.
-		return parse( reusableBlock.content.raw || reusableBlock.content );
+		return parse(
+			typeof reusableBlock.content.raw === 'string'
+				? reusableBlock.content.raw
+				: reusableBlock.content
+		);
 	},
 	( state ) => [ getReusableBlocks( state ) ]
 );


### PR DESCRIPTION
Problem: when a user has an empty reusable block (e.g. the post content is an empty string), the block inserter selector passes the content object instead of the content string into the parser. This causes an editor WSOD.

The fix is to check for a string instead of a truthy value. The old truthy check doesn't work for empty strings because empty strings are falsey. 

This error happens on _any post_, even if it does not use reusabel blocks. This is because the inserter always attempts to load the reusable blocks so the user can preview them.
 
To test:
1. create a reusable block
2. go to the reusable block post editor via manage reusable blocks
3. delete all blocks from the reusable block. It should be completely empty.
4. Go to any post on your site in Gutenberg.
5. Click the inserter button.

Previous behavior:
6. The editor crashes to a WSOD.

Fixed behavior:
6. The inserter opens.

closes #26485