### PR TITLE
Reusable Blocks: Make the number retrieved from the API unlimited

### DIFF
--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -323,7 +323,8 @@ export default compose( [
 			selectionEnd: getEditorSelectionEnd(),
 			reusableBlocks: select( 'core' ).getEntityRecords(
 				'postType',
-				'wp_block'
+				'wp_block',
+				{ 'per_page': -1 }
 			),
 			hasUploadPermissions: defaultTo(
 				canUser( 'create', 'media' ),

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -324,7 +324,7 @@ export default compose( [
 			reusableBlocks: select( 'core' ).getEntityRecords(
 				'postType',
 				'wp_block',
-				{ 'per_page': -1 }
+				{ per_page: -1 }
 			),
 			hasUploadPermissions: defaultTo(
 				canUser( 'create', 'media' ),


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This is to fix #26352. Having no limit seems like it could be risky, but
there are a number of other places in the codebase where all entities
are returned in one call to the API, including categories, which could
return a similar amount of data to this.

## How has this been tested?
* I created 11 reusable blocks
* When using the master branch, if I try to insert the first reusable block I created into a new post, it's not available in the block inserter
* With this branch, all reusable blocks are available in the block inserter

It seems you only get the 10 most recently created reusable blocks currently.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Fixes #26352

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
