### PR TITLE
Fix Block preview vertical offset.

### DIFF
--- a/packages/block-editor/src/components/block-preview/style.scss
+++ b/packages/block-editor/src/components/block-preview/style.scss
@@ -15,45 +15,44 @@
 		padding: 0;
 		margin: 0;
 	}
-}
 
-.block-editor-block-preview__content {
-	// This element receives inline styles for width, height, and transform-scale.
-	// Those inline styles are calculated to fit a perfect thumbnail.
+	.block-editor-block-preview__content {
+		// This element receives inline styles for width, height, and transform-scale.
+		// Those inline styles are calculated to fit a perfect thumbnail.
 
-	// Position above the padding.
-	position: absolute;
+		// Position above the padding.
+		position: absolute;
 
-	// Vertical alignment. It works with the transform: translate(-50%, -50%)`,
-	top: 0;
-	left: 0;
+		// Vertical alignment. It works with the transform: translate(-50%, -50%)`,
+		top: 0;
+		left: 0;
 
-	// Important to set the origin.
-	transform-origin: top left;
+		// Important to set the origin.
+		transform-origin: top left;
 
-	// Resetting paddings, margins, and other.
+		// Resetting paddings, margins, and other.
 
-	text-align: initial;
-	margin: 0;
-	overflow: visible;
-	min-height: auto;
+		text-align: initial;
+		margin: 0;
+		overflow: visible;
+		min-height: auto;
 
-	.block-editor-block-list__insertion-point,
-	.block-editor-block-drop-zone,
-	.reusable-block-indicator,
-	.block-list-appender {
-		display: none;
-	}
+		.block-editor-block-list__insertion-point,
+		.block-editor-block-drop-zone,
+		.reusable-block-indicator,
+		.block-list-appender {
+			display: none;
+		}
 
-	// Reset default editor padding
-	.block-editor-block-list__layout.is-root-container {
-		padding-left: 0;
-		padding-right: 0;
+		// Reset default editor padding
+		.block-editor-block-list__layout.is-root-container {
+			padding-left: 0;
+			padding-right: 0;
 
-		> .wp-block[data-align="full"] {
-			margin-left: 0;
-			margin-right: 0;
+			> .wp-block[data-align="full"] {
+				margin-left: 0;
+				margin-right: 0;
+			}
 		}
 	}
 }
-


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
There is a vertical offset in block previews that seems to be caused by the `position: relative` style of the `Disabled` component overwriting the specificity of the `position: absolute` style of the content of the `BlockPreview` component:

![Screen Shot 2020-10-26 at 8 30 33 PM](https://user-images.githubusercontent.com/28742426/97242402-3120d500-17ca-11eb-87e4-67af3015f27c.png)
![Screen Shot 2020-10-26 at 8 30 42 PM](https://user-images.githubusercontent.com/28742426/97242409-32ea9880-17ca-11eb-8364-6705ee8ad266.png)

This creates some previews with extra space at the top, content cut short, or even completely blank in some circumstances:

![Screen Shot 2020-10-26 at 8 38 56 PM](https://user-images.githubusercontent.com/28742426/97242906-6d086a00-17cb-11eb-8be0-e5a858a82e29.png)


![Screen Shot 2020-10-26 at 8 28 37 PM](https://user-images.githubusercontent.com/28742426/97242322-f028c080-17c9-11eb-8b01-1e29d2097b7b.png)

![Screen Shot 2020-10-26 at 8 29 02 PM](https://user-images.githubusercontent.com/28742426/97242324-f28b1a80-17c9-11eb-8f0c-252611b13a4f.png)

Nesting the `content` styles definitions inside the `container` for the `BlockPreview` component fixes this:

![Screen Shot 2020-10-26 at 8 38 35 PM](https://user-images.githubusercontent.com/28742426/97242915-71cd1e00-17cb-11eb-87af-cc7b8ccca546.png)


![Screen Shot 2020-10-26 at 8 32 49 PM](https://user-images.githubusercontent.com/28742426/97242530-7e04ab80-17ca-11eb-8754-9d23068a6b75.png)

![Screen Shot 2020-10-26 at 8 33 00 PM](https://user-images.githubusercontent.com/28742426/97242531-7e9d4200-17ca-11eb-8872-987589d66742.png)


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Tested previews in:
* The block inserter.
* Site Editor Navigation Sidebar
* Template Part selection previews
Verify previews look as expected.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
