### PR TITLE
Add the option to convert a template part to regular blocks.

### DIFF
--- a/packages/edit-site/src/components/template-part-converter/convert-to-regular.js
+++ b/packages/edit-site/src/components/template-part-converter/convert-to-regular.js
@@ -1,0 +1,33 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+import { BlockSettingsMenuControls } from '@wordpress/block-editor';
+import { MenuItem } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+export default function ConvertToRegularBlocks( { clientId } ) {
+	const { innerBlocks } = useSelect(
+		( select ) =>
+			select( 'core/block-editor' ).__unstableGetBlockWithBlockTree(
+				clientId
+			),
+		[ clientId ]
+	);
+	const { replaceBlocks } = useDispatch( 'core/block-editor' );
+
+	return (
+		<BlockSettingsMenuControls>
+			{ ( { onClose } ) => (
+				<MenuItem
+					onClick={ () => {
+						replaceBlocks( clientId, innerBlocks );
+						onClose();
+					} }
+				>
+					{ __( 'Convert to regular blocks' ) }
+				</MenuItem>
+			) }
+		</BlockSettingsMenuControls>
+	);
+}

--- a/packages/edit-site/src/components/template-part-converter/convert-to-regular.js
+++ b/packages/edit-site/src/components/template-part-converter/convert-to-regular.js
@@ -25,7 +25,7 @@ export default function ConvertToRegularBlocks( { clientId } ) {
 						onClose();
 					} }
 				>
-					{ __( 'Convert to regular blocks' ) }
+					{ __( 'Detach blocks from template part.' ) }
 				</MenuItem>
 			) }
 		</BlockSettingsMenuControls>

--- a/packages/edit-site/src/components/template-part-converter/convert-to-regular.js
+++ b/packages/edit-site/src/components/template-part-converter/convert-to-regular.js
@@ -25,7 +25,7 @@ export default function ConvertToRegularBlocks( { clientId } ) {
 						onClose();
 					} }
 				>
-					{ __( 'Detach blocks from template part.' ) }
+					{ __( 'Detach blocks from template part' ) }
 				</MenuItem>
 			) }
 		</BlockSettingsMenuControls>

--- a/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
+++ b/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
@@ -1,0 +1,40 @@
+/**
+ * WordPress dependencies
+ */
+import { useDispatch } from '@wordpress/data';
+import { BlockSettingsMenuControls } from '@wordpress/block-editor';
+import { MenuItem } from '@wordpress/components';
+import { createBlock } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+
+export default function ConvertToTemplatePart( { clientIds, blocks } ) {
+	const { replaceBlocks } = useDispatch( 'core/block-editor' );
+
+	return (
+		<BlockSettingsMenuControls>
+			{ ( { onClose } ) => (
+				<MenuItem
+					onClick={ () => {
+						replaceBlocks(
+							clientIds,
+							createBlock(
+								'core/template-part',
+								{},
+								blocks.map( ( block ) =>
+									createBlock(
+										block.name,
+										block.attributes,
+										block.innerBlocks
+									)
+								)
+							)
+						);
+						onClose();
+					} }
+				>
+					{ __( 'Make template part' ) }
+				</MenuItem>
+			) }
+		</BlockSettingsMenuControls>
+	);
+}

--- a/packages/edit-site/src/components/template-part-converter/index.js
+++ b/packages/edit-site/src/components/template-part-converter/index.js
@@ -1,11 +1,13 @@
 /**
  * WordPress dependencies
  */
-import { useSelect, useDispatch } from '@wordpress/data';
-import { BlockSettingsMenuControls } from '@wordpress/block-editor';
-import { MenuItem } from '@wordpress/components';
-import { createBlock } from '@wordpress/blocks';
-import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import ConvertToRegularBlocks from './convert-to-regular';
+import ConvertToTemplatePart from './convert-to-template-part';
 
 export default function TemplatePartConverter() {
 	const { clientIds, blocks } = useSelect( ( select ) => {
@@ -18,38 +20,11 @@ export default function TemplatePartConverter() {
 			blocks: getBlocksByClientId( selectedBlockClientIds ),
 		};
 	} );
-	const { replaceBlocks } = useDispatch( 'core/block-editor' );
 
-	// Avoid transforming a single `core/template-part` block.
+	// Allow converting a single template part to standard blocks.
 	if ( blocks.length === 1 && blocks[ 0 ]?.name === 'core/template-part' ) {
-		return null;
+		return <ConvertToRegularBlocks clientId={ clientIds[ 0 ] } />;
 	}
 
-	return (
-		<BlockSettingsMenuControls>
-			{ ( { onClose } ) => (
-				<MenuItem
-					onClick={ () => {
-						replaceBlocks(
-							clientIds,
-							createBlock(
-								'core/template-part',
-								{},
-								blocks.map( ( block ) =>
-									createBlock(
-										block.name,
-										block.attributes,
-										block.innerBlocks
-									)
-								)
-							)
-						);
-						onClose();
-					} }
-				>
-					{ __( 'Make template part' ) }
-				</MenuItem>
-			) }
-		</BlockSettingsMenuControls>
-	);
+	return <ConvertToTemplatePart clientIds={ clientIds } blocks={ blocks } />;
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Recently we added the ability to convert selected blocks into a Template Part (#20445), modeled after the reusable blocks flow:

![Screen Shot 2020-10-26 at 9 12 36 PM](https://user-images.githubusercontent.com/28742426/97244976-629c9f00-17d0-11eb-8ac0-8a289ac3060b.png)

Reusable blocks also has the option to convert back to regular blocks:

![Screen Shot 2020-10-26 at 9 11 22 PM](https://user-images.githubusercontent.com/28742426/97245010-72b47e80-17d0-11eb-8468-4626fef4bc18.png)

Similarly, we could the option to convert a single template part to regular blocks:

![Screen Shot 2020-10-26 at 9 12 14 PM](https://user-images.githubusercontent.com/28742426/97245033-819b3100-17d0-11eb-9ed1-c4114e0a7dbf.png)

This PR enables this functionality.  Is this something that makes sense for the Template Part flow? cc @mtias 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Select a template part and try to convert it to standard blocks as shown in the screenshot above.  Verify this works as expected.
Also verify the 'convert to template part' flow continues to work as expected.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
