### PR TITLE
[Heading Block] Fix double alignment controls in toolbar

### DIFF
--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -3,7 +3,7 @@
 	"name": "core/heading",
 	"category": "text",
 	"attributes": {
-		"align": {
+		"textAlign": {
 			"type": "string"
 		},
 		"content": {

--- a/packages/block-library/src/heading/deprecated.js
+++ b/packages/block-library/src/heading/deprecated.js
@@ -82,16 +82,13 @@ const deprecated = [
 		},
 		attributes: { ...blockAttributes },
 		isEligible: ( { align } ) => TEXT_ALIGN_OPTIONS.includes( align ),
-		migrate: ( { align, ...rest } ) => {
-			delete rest.className;
-			return { ...rest, textAlign: align };
-		},
+		migrate: migrateTextAlign,
 		save( { attributes } ) {
-			const { textAlign, content, level } = attributes;
+			const { align, content, level } = attributes;
 			const TagName = 'h' + level;
 
 			const className = classnames( {
-				[ `has-text-align-${ textAlign }` ]: textAlign,
+				[ `has-text-align-${ align }` ]: align,
 			} );
 
 			return (

--- a/packages/block-library/src/heading/deprecated.js
+++ b/packages/block-library/src/heading/deprecated.js
@@ -56,7 +56,23 @@ const TEXT_ALIGN_OPTIONS = [ 'left', 'right', 'center' ];
 
 const deprecated = [
 	{
-		supports: blockSupports,
+		supports: {
+			className: false,
+			anchor: true,
+			align: [ 'wide', 'full' ],
+			color: { link: true },
+			fontSize: true,
+			lineHeight: true,
+			__experimentalSelector: {
+				'core/heading/h1': 'h1',
+				'core/heading/h2': 'h2',
+				'core/heading/h3': 'h3',
+				'core/heading/h4': 'h4',
+				'core/heading/h5': 'h5',
+				'core/heading/h6': 'h6',
+			},
+			__unstablePasteTextInline: true,
+		},
 		attributes: { ...blockAttributes },
 		isEligible: ( { align } ) => TEXT_ALIGN_OPTIONS.includes( align ),
 		migrate: ( { align, ...rest } ) => {

--- a/packages/block-library/src/heading/deprecated.js
+++ b/packages/block-library/src/heading/deprecated.js
@@ -52,6 +52,8 @@ const migrateCustomColors = ( attributes ) => {
 	};
 };
 
+const TEXT_ALIGN_OPTIONS = [ 'left', 'right', 'center' ];
+
 const migrateTextAlign = ( attributes ) => {
 	const { align, ...rest } = attributes;
 	return TEXT_ALIGN_OPTIONS.includes( align )
@@ -59,14 +61,12 @@ const migrateTextAlign = ( attributes ) => {
 		: attributes;
 };
 
-const TEXT_ALIGN_OPTIONS = [ 'left', 'right', 'center' ];
-
 const deprecated = [
 	{
 		supports: {
-			className: false,
-			anchor: true,
 			align: [ 'wide', 'full' ],
+			anchor: true,
+			className: false,
 			color: { link: true },
 			fontSize: true,
 			lineHeight: true,
@@ -80,7 +80,7 @@ const deprecated = [
 			},
 			__unstablePasteTextInline: true,
 		},
-		attributes: { ...blockAttributes },
+		attributes: blockAttributes,
 		isEligible: ( { align } ) => TEXT_ALIGN_OPTIONS.includes( align ),
 		migrate: migrateTextAlign,
 		save( { attributes } ) {

--- a/packages/block-library/src/heading/deprecated.js
+++ b/packages/block-library/src/heading/deprecated.js
@@ -7,7 +7,11 @@ import { omit } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { getColorClassName, RichText } from '@wordpress/block-editor';
+import {
+	getColorClassName,
+	RichText,
+	useBlockProps,
+} from '@wordpress/block-editor';
 
 const blockSupports = {
 	className: false,
@@ -48,7 +52,31 @@ const migrateCustomColors = ( attributes ) => {
 	};
 };
 
+const TEXT_ALIGN_OPTIONS = [ 'left', 'right', 'center' ];
+
 const deprecated = [
+	{
+		supports: blockSupports,
+		attributes: { ...blockAttributes },
+		isEligible: ( { align } ) => TEXT_ALIGN_OPTIONS.includes( align ),
+		migrate: ( { align, ...rest } ) => {
+			return { ...rest, textAlign: align };
+		},
+		save( { attributes } ) {
+			const { textAlign, content, level } = attributes;
+			const TagName = 'h' + level;
+
+			const className = classnames( {
+				[ `has-text-align-${ textAlign }` ]: textAlign,
+			} );
+
+			return (
+				<TagName { ...useBlockProps.save( { className } ) }>
+					<RichText.Content value={ content } />
+				</TagName>
+			);
+		},
+	},
 	{
 		supports: blockSupports,
 		attributes: {

--- a/packages/block-library/src/heading/deprecated.js
+++ b/packages/block-library/src/heading/deprecated.js
@@ -52,6 +52,13 @@ const migrateCustomColors = ( attributes ) => {
 	};
 };
 
+const migrateTextAlign = ( attributes ) => {
+	const { align, ...rest } = attributes;
+	return TEXT_ALIGN_OPTIONS.includes( align )
+		? { ...rest, textAlign: align }
+		: attributes;
+};
+
 const TEXT_ALIGN_OPTIONS = [ 'left', 'right', 'center' ];
 
 const deprecated = [
@@ -75,9 +82,7 @@ const deprecated = [
 		},
 		attributes: { ...blockAttributes },
 		isEligible: ( { align } ) => TEXT_ALIGN_OPTIONS.includes( align ),
-		migrate: ( { align, ...rest } ) => {
-			return { ...rest, textAlign: align };
-		},
+		migrate: migrateTextAlign,
 		save( { attributes } ) {
 			const { textAlign, content, level } = attributes;
 			const TagName = 'h' + level;
@@ -104,9 +109,8 @@ const deprecated = [
 				type: 'string',
 			},
 		},
-		migrate: ( { align, ...rest } ) => {
-			return migrateCustomColors( { ...rest, textAlign: align } );
-		},
+		migrate: ( attributes ) =>
+			migrateCustomColors( migrateTextAlign( attributes ) ),
 		save( { attributes } ) {
 			const {
 				textAlign,
@@ -147,9 +151,8 @@ const deprecated = [
 				type: 'string',
 			},
 		},
-		migrate: ( { align, ...rest } ) => {
-			return migrateCustomColors( { ...rest, textAlign: align } );
-		},
+		migrate: ( attributes ) =>
+			migrateCustomColors( migrateTextAlign( attributes ) ),
 		save( { attributes } ) {
 			const {
 				textAlign,
@@ -191,9 +194,8 @@ const deprecated = [
 				type: 'string',
 			},
 		},
-		migrate: ( { align, ...rest } ) => {
-			return migrateCustomColors( { ...rest, textAlign: align } );
-		},
+		migrate: ( attributes ) =>
+			migrateCustomColors( migrateTextAlign( attributes ) ),
 		save( { attributes } ) {
 			const {
 				textAlign,

--- a/packages/block-library/src/heading/deprecated.js
+++ b/packages/block-library/src/heading/deprecated.js
@@ -82,7 +82,10 @@ const deprecated = [
 		},
 		attributes: { ...blockAttributes },
 		isEligible: ( { align } ) => TEXT_ALIGN_OPTIONS.includes( align ),
-		migrate: migrateTextAlign,
+		migrate: ( { align, ...rest } ) => {
+			delete rest.className;
+			return { ...rest, textAlign: align };
+		},
 		save( { attributes } ) {
 			const { textAlign, content, level } = attributes;
 			const TagName = 'h' + level;
@@ -113,7 +116,7 @@ const deprecated = [
 			migrateCustomColors( migrateTextAlign( attributes ) ),
 		save( { attributes } ) {
 			const {
-				textAlign,
+				align,
 				content,
 				customTextColor,
 				level,
@@ -126,7 +129,7 @@ const deprecated = [
 			const className = classnames( {
 				[ textClass ]: textClass,
 				'has-text-color': textColor || customTextColor,
-				[ `has-text-align-${ textAlign }` ]: textAlign,
+				[ `has-text-align-${ align }` ]: align,
 			} );
 
 			return (
@@ -155,7 +158,7 @@ const deprecated = [
 			migrateCustomColors( migrateTextAlign( attributes ) ),
 		save( { attributes } ) {
 			const {
-				textAlign,
+				align,
 				content,
 				customTextColor,
 				level,
@@ -167,7 +170,7 @@ const deprecated = [
 
 			const className = classnames( {
 				[ textClass ]: textClass,
-				[ `has-text-align-${ textAlign }` ]: textAlign,
+				[ `has-text-align-${ align }` ]: align,
 			} );
 
 			return (
@@ -198,7 +201,7 @@ const deprecated = [
 			migrateCustomColors( migrateTextAlign( attributes ) ),
 		save( { attributes } ) {
 			const {
-				textAlign,
+				align,
 				level,
 				content,
 				textColor,
@@ -217,7 +220,7 @@ const deprecated = [
 					className={ className ? className : undefined }
 					tagName={ tagName }
 					style={ {
-						textAlign,
+						textAlign: align,
 						color: textClass ? undefined : customTextColor,
 					} }
 					value={ content }

--- a/packages/block-library/src/heading/deprecated.js
+++ b/packages/block-library/src/heading/deprecated.js
@@ -104,10 +104,12 @@ const deprecated = [
 				type: 'string',
 			},
 		},
-		migrate: migrateCustomColors,
+		migrate: ( { align, ...rest } ) => {
+			return migrateCustomColors( { ...rest, textAlign: align } );
+		},
 		save( { attributes } ) {
 			const {
-				align,
+				textAlign,
 				content,
 				customTextColor,
 				level,
@@ -120,7 +122,7 @@ const deprecated = [
 			const className = classnames( {
 				[ textClass ]: textClass,
 				'has-text-color': textColor || customTextColor,
-				[ `has-text-align-${ align }` ]: align,
+				[ `has-text-align-${ textAlign }` ]: textAlign,
 			} );
 
 			return (
@@ -145,10 +147,12 @@ const deprecated = [
 				type: 'string',
 			},
 		},
-		migrate: migrateCustomColors,
+		migrate: ( { align, ...rest } ) => {
+			return migrateCustomColors( { ...rest, textAlign: align } );
+		},
 		save( { attributes } ) {
 			const {
-				align,
+				textAlign,
 				content,
 				customTextColor,
 				level,
@@ -160,7 +164,7 @@ const deprecated = [
 
 			const className = classnames( {
 				[ textClass ]: textClass,
-				[ `has-text-align-${ align }` ]: align,
+				[ `has-text-align-${ textAlign }` ]: textAlign,
 			} );
 
 			return (
@@ -187,10 +191,12 @@ const deprecated = [
 				type: 'string',
 			},
 		},
-		migrate: migrateCustomColors,
+		migrate: ( { align, ...rest } ) => {
+			return migrateCustomColors( { ...rest, textAlign: align } );
+		},
 		save( { attributes } ) {
 			const {
-				align,
+				textAlign,
 				level,
 				content,
 				textColor,
@@ -209,7 +215,7 @@ const deprecated = [
 					className={ className ? className : undefined }
 					tagName={ tagName }
 					style={ {
-						textAlign: align,
+						textAlign,
 						color: textClass ? undefined : customTextColor,
 					} }
 					value={ content }

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -28,11 +28,11 @@ function HeadingEdit( {
 	onReplace,
 	mergedStyle,
 } ) {
-	const { align, content, level, placeholder } = attributes;
+	const { textAlign, content, level, placeholder } = attributes;
 	const tagName = 'h' + level;
 	const blockProps = useBlockProps( {
 		className: classnames( {
-			[ `has-text-align-${ align }` ]: align,
+			[ `has-text-align-${ textAlign }` ]: textAlign,
 		} ),
 		style: mergedStyle,
 	} );
@@ -49,9 +49,9 @@ function HeadingEdit( {
 					/>
 				</ToolbarGroup>
 				<AlignmentToolbar
-					value={ align }
+					value={ textAlign }
 					onChange={ ( nextAlign ) => {
-						setAttributes( { align: nextAlign } );
+						setAttributes( { textAlign: nextAlign } );
 					} }
 				/>
 			</BlockControls>
@@ -74,7 +74,7 @@ function HeadingEdit( {
 				onReplace={ onReplace }
 				onRemove={ () => onReplace( [] ) }
 				placeholder={ placeholder || __( 'Write heading…' ) }
-				textAlign={ align }
+				textAlign={ textAlign }
 				{ ...blockProps }
 			/>
 		</>

--- a/packages/block-library/src/heading/save.js
+++ b/packages/block-library/src/heading/save.js
@@ -9,11 +9,11 @@ import classnames from 'classnames';
 import { RichText, useBlockProps } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
-	const { align, content, level } = attributes;
+	const { textAlign, content, level } = attributes;
 	const TagName = 'h' + level;
 
 	const className = classnames( {
-		[ `has-text-align-${ align }` ]: align,
+		[ `has-text-align-${ textAlign }` ]: textAlign,
 	} );
 
 	return (

--- a/packages/e2e-tests/fixtures/blocks/core__heading__deprecated-1.json
+++ b/packages/e2e-tests/fixtures/blocks/core__heading__deprecated-1.json
@@ -4,9 +4,9 @@
         "name": "core/heading",
         "isValid": true,
         "attributes": {
-            "align": "right",
             "content": "A picture is worth a thousand words, or so the saying goes",
-            "level": 3
+            "level": 3,
+            "textAlign": "right"
         },
         "innerBlocks": [],
         "originalContent": "<h3 style=\"text-align:right\">A picture is worth a thousand words, or so the saying goes</h3>"

--- a/packages/e2e-tests/fixtures/blocks/core__heading__deprecated-1.json
+++ b/packages/e2e-tests/fixtures/blocks/core__heading__deprecated-1.json
@@ -2,11 +2,11 @@
     {
         "clientId": "_clientId_0",
         "name": "core/heading",
-        "isValid": true,
+        "isValid": false,
         "attributes": {
-            "align": "right",
             "content": "A picture is worth a thousand words, or so the saying goes",
-            "level": 3
+            "level": 3,
+            "align": "right"
         },
         "innerBlocks": [],
         "originalContent": "<h3 style=\"text-align:right\">A picture is worth a thousand words, or so the saying goes</h3>"

--- a/packages/e2e-tests/fixtures/blocks/core__heading__deprecated-1.json
+++ b/packages/e2e-tests/fixtures/blocks/core__heading__deprecated-1.json
@@ -2,11 +2,11 @@
     {
         "clientId": "_clientId_0",
         "name": "core/heading",
-        "isValid": false,
+        "isValid": true,
         "attributes": {
+            "align": "right",
             "content": "A picture is worth a thousand words, or so the saying goes",
-            "level": 3,
-            "align": "right"
+            "level": 3
         },
         "innerBlocks": [],
         "originalContent": "<h3 style=\"text-align:right\">A picture is worth a thousand words, or so the saying goes</h3>"

--- a/packages/e2e-tests/fixtures/blocks/core__heading__deprecated-1.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__heading__deprecated-1.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:heading {"align":"right","level":3} -->
+<!-- wp:heading {"textAlign":"right","level":3} -->
 <h3 class="has-text-align-right">A picture is worth a thousand words, or so the saying goes</h3>
 <!-- /wp:heading -->

--- a/packages/e2e-tests/fixtures/blocks/core__heading__deprecated-1.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__heading__deprecated-1.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:heading {"level":3,"align":"right"} -->
-<h3 style="text-align:right">A picture is worth a thousand words, or so the saying goes</h3>
+<!-- wp:heading {"align":"right","level":3} -->
+<h3 class="has-text-align-right">A picture is worth a thousand words, or so the saying goes</h3>
 <!-- /wp:heading -->

--- a/packages/e2e-tests/fixtures/blocks/core__heading__deprecated-1.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__heading__deprecated-1.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:heading {"align":"right","level":3} -->
-<h3 class="has-text-align-right">A picture is worth a thousand words, or so the saying goes</h3>
+<!-- wp:heading {"level":3,"align":"right"} -->
+<h3 style="text-align:right">A picture is worth a thousand words, or so the saying goes</h3>
 <!-- /wp:heading -->

--- a/packages/e2e-tests/fixtures/blocks/core__heading__deprecated-4.html
+++ b/packages/e2e-tests/fixtures/blocks/core__heading__deprecated-4.html
@@ -1,0 +1,4 @@
+<!-- wp:heading {"textColor":"accent","align":"center"} -->
+<h2 class="has-accent-color has-text-color has-text-align-center">Text</h2>
+<!-- /wp:heading -->
+

--- a/packages/e2e-tests/fixtures/blocks/core__heading__deprecated-4.json
+++ b/packages/e2e-tests/fixtures/blocks/core__heading__deprecated-4.json
@@ -1,0 +1,15 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "core/heading",
+        "isValid": true,
+        "attributes": {
+            "content": "Text",
+            "level": 2,
+            "textColor": "accent",
+            "textAlign": "center"
+        },
+        "innerBlocks": [],
+        "originalContent": "<h2 class=\"has-accent-color has-text-color has-text-align-center\">Text</h2>"
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__heading__deprecated-4.parsed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__heading__deprecated-4.parsed.json
@@ -1,0 +1,23 @@
+[
+    {
+        "blockName": "core/heading",
+        "attrs": {
+            "textColor": "accent",
+            "align": "center"
+        },
+        "innerBlocks": [],
+        "innerHTML": "\n<h2 class=\"has-accent-color has-text-color has-text-align-center\">Text</h2>\n",
+        "innerContent": [
+            "\n<h2 class=\"has-accent-color has-text-color has-text-align-center\">Text</h2>\n"
+        ]
+    },
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n\n",
+        "innerContent": [
+            "\n\n"
+        ]
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__heading__deprecated-4.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__heading__deprecated-4.serialized.html
@@ -1,0 +1,3 @@
+<!-- wp:heading {"textAlign":"center","textColor":"accent"} -->
+<h2 class="has-text-align-center has-accent-color has-text-color">Text</h2>
+<!-- /wp:heading -->

--- a/packages/e2e-tests/fixtures/blocks/core__heading_align-textalign.html
+++ b/packages/e2e-tests/fixtures/blocks/core__heading_align-textalign.html
@@ -1,0 +1,3 @@
+<!-- wp:heading {"textAlign":"center","align":"wide"} -->
+<h2 class="alignwide has-text-align-center">Text</h2>
+<!-- /wp:heading -->

--- a/packages/e2e-tests/fixtures/blocks/core__heading_align-textalign.json
+++ b/packages/e2e-tests/fixtures/blocks/core__heading_align-textalign.json
@@ -1,0 +1,15 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "core/heading",
+        "isValid": true,
+        "attributes": {
+            "textAlign": "center",
+            "content": "Text",
+            "level": 2,
+            "align": "wide"
+        },
+        "innerBlocks": [],
+        "originalContent": "<h2 class=\"alignwide has-text-align-center\">Text</h2>"
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__heading_align-textalign.parsed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__heading_align-textalign.parsed.json
@@ -1,0 +1,23 @@
+[
+    {
+        "blockName": "core/heading",
+        "attrs": {
+            "textAlign": "center",
+            "align": "wide"
+        },
+        "innerBlocks": [],
+        "innerHTML": "\n<h2 class=\"alignwide has-text-align-center\">Text</h2>\n",
+        "innerContent": [
+            "\n<h2 class=\"alignwide has-text-align-center\">Text</h2>\n"
+        ]
+    },
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n",
+        "innerContent": [
+            "\n"
+        ]
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__heading_align-textalign.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__heading_align-textalign.serialized.html
@@ -1,0 +1,3 @@
+<!-- wp:heading {"textAlign":"center","align":"wide"} -->
+<h2 class="alignwide has-text-align-center">Text</h2>
+<!-- /wp:heading -->


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes: https://github.com/WordPress/gutenberg/issues/26335

After #25917 was merged, the block alignment toolbar is automatically added to the Heading block toolbar, and it controls the `align` attribute. This attribute was already in use for text alignment, so now there are two controls which both control `align`.

This PR renames the previous `align` attribute used for text alignment to `textAlign` and handles the deprecated block.

Steps to reproduce are on the issue. Basically just add a `heading` block and try to add both `text-align` and `block-align` from its Toolbar.
<!-- Please describe what you have changed or added -->

## How has this been tested?
1. Create some headings from master with different alignments, both text and block.
2. In this branch go to edit the same post and see that there are no errors and the migration works.
3. Also test that both alignments are supported now.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
