### PR TITLE
Hooks: Use own instance's `doAction` for built-in hooks

### DIFF
--- a/packages/hooks/CHANGELOG.md
+++ b/packages/hooks/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Include TypeScript type declarations ([#26430](https://github.com/WordPress/gutenberg/pull/26430))
 
+### Bug Fix
+
+- Fix: Use own instance's `doAction` method for built-in `hookAdded` and `hookRemoved` hooks ([#26498](https://github.com/WordPress/gutenberg/pull/26498))
+
 ## 2.6.0 (2019-08-29)
 
 ### New Feature

--- a/packages/hooks/src/createAddHook.js
+++ b/packages/hooks/src/createAddHook.js
@@ -3,7 +3,6 @@
  */
 import validateNamespace from './validateNamespace.js';
 import validateHookName from './validateHookName.js';
-import { doAction } from './';
 
 /**
  * @callback AddHook
@@ -91,7 +90,13 @@ function createAddHook( hooks ) {
 		}
 
 		if ( hookName !== 'hookAdded' ) {
-			doAction( 'hookAdded', hookName, namespace, callback, priority );
+			this.doAction(
+				'hookAdded',
+				hookName,
+				namespace,
+				callback,
+				priority
+			);
 		}
 	};
 }

--- a/packages/hooks/src/createCurrentHook.js
+++ b/packages/hooks/src/createCurrentHook.js
@@ -3,13 +3,19 @@
  * currently running hook, or `null` if no hook of the given type is currently
  * running.
  *
- * @param  {import('.').Hooks} hooks Stored hooks, keyed by hook name.
+ * @param  {import('.').Hooks}    hooks Hooks instance.
+ * @param  {import('.').StoreKey} storeKey
  *
  * @return {() => string | null} Function that returns the current hook name or null.
  */
-function createCurrentHook( hooks ) {
+function createCurrentHook( hooks, storeKey ) {
 	return function currentHook() {
-		return hooks.__current[ hooks.__current.length - 1 ]?.name ?? null;
+		const hooksStore = hooks[ storeKey ];
+
+		return (
+			hooksStore.__current[ hooksStore.__current.length - 1 ]?.name ??
+			null
+		);
 	};
 }
 

--- a/packages/hooks/src/createDidHook.js
+++ b/packages/hooks/src/createDidHook.js
@@ -17,18 +17,21 @@ import validateHookName from './validateHookName.js';
  * Returns a function which, when invoked, will return the number of times a
  * hook has been called.
  *
- * @param  {import('.').Hooks} hooks Stored hooks, keyed by hook name.
+ * @param  {import('.').Hooks}    hooks Hooks instance.
+ * @param  {import('.').StoreKey} storeKey
  *
  * @return {DidHook} Function that returns a hook's call count.
  */
-function createDidHook( hooks ) {
+function createDidHook( hooks, storeKey ) {
 	return function didHook( hookName ) {
+		const hooksStore = hooks[ storeKey ];
+
 		if ( ! validateHookName( hookName ) ) {
 			return;
 		}
 
-		return hooks[ hookName ] && hooks[ hookName ].runs
-			? hooks[ hookName ].runs
+		return hooksStore[ hookName ] && hooksStore[ hookName ].runs
+			? hooksStore[ hookName ].runs
 			: 0;
 	};
 }

--- a/packages/hooks/src/createDoingHook.js
+++ b/packages/hooks/src/createDoingHook.js
@@ -12,21 +12,24 @@
  * Returns a function which, when invoked, will return whether a hook is
  * currently being executed.
  *
- * @param  {import('.').Hooks} hooks Stored hooks, keyed by hook name.
+ * @param  {import('.').Hooks}    hooks Hooks instance.
+ * @param  {import('.').StoreKey} storeKey
  *
  * @return {DoingHook} Function that returns whether a hook is currently
  *                     being executed.
  */
-function createDoingHook( hooks ) {
+function createDoingHook( hooks, storeKey ) {
 	return function doingHook( hookName ) {
+		const hooksStore = hooks[ storeKey ];
+
 		// If the hookName was not passed, check for any current hook.
 		if ( 'undefined' === typeof hookName ) {
-			return 'undefined' !== typeof hooks.__current[ 0 ];
+			return 'undefined' !== typeof hooksStore.__current[ 0 ];
 		}
 
 		// Return the __current hook.
-		return hooks.__current[ 0 ]
-			? hookName === hooks.__current[ 0 ].name
+		return hooksStore.__current[ 0 ]
+			? hookName === hooksStore.__current[ 0 ].name
 			: false;
 	};
 }

--- a/packages/hooks/src/createHasHook.js
+++ b/packages/hooks/src/createHasHook.js
@@ -13,24 +13,27 @@
  * Returns a function which, when invoked, will return whether any handlers are
  * attached to a particular hook.
  *
- * @param  {import('.').Hooks} hooks Stored hooks, keyed by hook name.
+ * @param  {import('.').Hooks}    hooks Hooks instance.
+ * @param  {import('.').StoreKey} storeKey
  *
  * @return {HasHook} Function that returns whether any handlers are
  *                   attached to a particular hook and optional namespace.
  */
-function createHasHook( hooks ) {
+function createHasHook( hooks, storeKey ) {
 	return function hasHook( hookName, namespace ) {
+		const hooksStore = hooks[ storeKey ];
+
 		// Use the namespace if provided.
 		if ( 'undefined' !== typeof namespace ) {
 			return (
-				hookName in hooks &&
-				hooks[ hookName ].handlers.some(
+				hookName in hooksStore &&
+				hooksStore[ hookName ].handlers.some(
 					( hook ) => hook.namespace === namespace
 				)
 			);
 		}
 
-		return hookName in hooks;
+		return hookName in hooksStore;
 	};
 }
 

--- a/packages/hooks/src/createHooks.js
+++ b/packages/hooks/src/createHooks.js
@@ -13,32 +13,33 @@ import createDidHook from './createDidHook';
  * Returns an instance of the hooks object.
  */
 function createHooks() {
-	/** @type {import('.').Hooks} */
+	/** @type {import('.').Store} */
 	const actions = Object.create( null );
-	/** @type {import('.').Hooks} */
+	/** @type {import('.').Store} */
 	const filters = Object.create( null );
 	actions.__current = [];
 	filters.__current = [];
 
+	/** @type {import('.').Hooks} */
 	const hooks = Object.create( null );
 
 	Object.assign( hooks, {
-		addAction: createAddHook( actions ).bind( hooks ),
-		addFilter: createAddHook( filters ).bind( hooks ),
-		removeAction: createRemoveHook( actions ).bind( hooks ),
-		removeFilter: createRemoveHook( filters ).bind( hooks ),
-		hasAction: createHasHook( actions ),
-		hasFilter: createHasHook( filters ),
-		removeAllActions: createRemoveHook( actions, true ).bind( hooks ),
-		removeAllFilters: createRemoveHook( filters, true ).bind( hooks ),
-		doAction: createRunHook( actions ),
-		applyFilters: createRunHook( filters, true ),
-		currentAction: createCurrentHook( actions ),
-		currentFilter: createCurrentHook( filters ),
-		doingAction: createDoingHook( actions ),
-		doingFilter: createDoingHook( filters ),
-		didAction: createDidHook( actions ),
-		didFilter: createDidHook( filters ),
+		addAction: createAddHook( hooks, 'actions' ),
+		addFilter: createAddHook( hooks, 'filters' ),
+		removeAction: createRemoveHook( hooks, 'actions' ),
+		removeFilter: createRemoveHook( hooks, 'filters' ),
+		hasAction: createHasHook( hooks, 'actions' ),
+		hasFilter: createHasHook( hooks, 'filters' ),
+		removeAllActions: createRemoveHook( hooks, 'actions', true ),
+		removeAllFilters: createRemoveHook( hooks, 'filters', true ),
+		doAction: createRunHook( hooks, 'actions' ),
+		applyFilters: createRunHook( hooks, 'filters', true ),
+		currentAction: createCurrentHook( hooks, 'actions' ),
+		currentFilter: createCurrentHook( hooks, 'filters' ),
+		doingAction: createDoingHook( hooks, 'actions' ),
+		doingFilter: createDoingHook( hooks, 'filters' ),
+		didAction: createDidHook( hooks, 'actions' ),
+		didFilter: createDidHook( hooks, 'filters' ),
 		actions,
 		filters,
 	} );

--- a/packages/hooks/src/createHooks.js
+++ b/packages/hooks/src/createHooks.js
@@ -20,15 +20,17 @@ function createHooks() {
 	actions.__current = [];
 	filters.__current = [];
 
-	return {
-		addAction: createAddHook( actions ),
-		addFilter: createAddHook( filters ),
-		removeAction: createRemoveHook( actions ),
-		removeFilter: createRemoveHook( filters ),
+	const hooks = Object.create( null );
+
+	Object.assign( hooks, {
+		addAction: createAddHook( actions ).bind( hooks ),
+		addFilter: createAddHook( filters ).bind( hooks ),
+		removeAction: createRemoveHook( actions ).bind( hooks ),
+		removeFilter: createRemoveHook( filters ).bind( hooks ),
 		hasAction: createHasHook( actions ),
 		hasFilter: createHasHook( filters ),
-		removeAllActions: createRemoveHook( actions, true ),
-		removeAllFilters: createRemoveHook( filters, true ),
+		removeAllActions: createRemoveHook( actions, true ).bind( hooks ),
+		removeAllFilters: createRemoveHook( filters, true ).bind( hooks ),
 		doAction: createRunHook( actions ),
 		applyFilters: createRunHook( filters, true ),
 		currentAction: createCurrentHook( actions ),
@@ -39,7 +41,9 @@ function createHooks() {
 		didFilter: createDidHook( filters ),
 		actions,
 		filters,
-	};
+	} );
+
+	return hooks;
 }
 
 export default createHooks;

--- a/packages/hooks/src/createHooks.js
+++ b/packages/hooks/src/createHooks.js
@@ -10,41 +10,50 @@ import createDoingHook from './createDoingHook';
 import createDidHook from './createDidHook';
 
 /**
+ * Internal class for constructing hooks. Use `createHooks()` function
+ *
+ * Note, it is necessary to expose this class to make its type public.
+ *
+ * @private
+ */
+export class _Hooks {
+	constructor() {
+		/** @type {import('.').Store} actions */
+		this.actions = Object.create( null );
+		this.actions.__current = [];
+
+		/** @type {import('.').Store} filters */
+		this.filters = Object.create( null );
+		this.filters.__current = [];
+
+		this.addAction = createAddHook( this, 'actions' );
+		this.addFilter = createAddHook( this, 'filters' );
+		this.removeAction = createRemoveHook( this, 'actions' );
+		this.removeFilter = createRemoveHook( this, 'filters' );
+		this.hasAction = createHasHook( this, 'actions' );
+		this.hasFilter = createHasHook( this, 'filters' );
+		this.removeAllActions = createRemoveHook( this, 'actions', true );
+		this.removeAllFilters = createRemoveHook( this, 'filters', true );
+		this.doAction = createRunHook( this, 'actions' );
+		this.applyFilters = createRunHook( this, 'filters', true );
+		this.currentAction = createCurrentHook( this, 'actions' );
+		this.currentFilter = createCurrentHook( this, 'filters' );
+		this.doingAction = createDoingHook( this, 'actions' );
+		this.doingFilter = createDoingHook( this, 'filters' );
+		this.didAction = createDidHook( this, 'actions' );
+		this.didFilter = createDidHook( this, 'filters' );
+	}
+}
+
+/** @typedef {_Hooks} Hooks */
+
+/**
  * Returns an instance of the hooks object.
+ *
+ * @return {Hooks} A Hooks instance.
  */
 function createHooks() {
-	/** @type {import('.').Store} */
-	const actions = Object.create( null );
-	/** @type {import('.').Store} */
-	const filters = Object.create( null );
-	actions.__current = [];
-	filters.__current = [];
-
-	/** @type {import('.').Hooks} */
-	const hooks = Object.create( null );
-
-	Object.assign( hooks, {
-		addAction: createAddHook( hooks, 'actions' ),
-		addFilter: createAddHook( hooks, 'filters' ),
-		removeAction: createRemoveHook( hooks, 'actions' ),
-		removeFilter: createRemoveHook( hooks, 'filters' ),
-		hasAction: createHasHook( hooks, 'actions' ),
-		hasFilter: createHasHook( hooks, 'filters' ),
-		removeAllActions: createRemoveHook( hooks, 'actions', true ),
-		removeAllFilters: createRemoveHook( hooks, 'filters', true ),
-		doAction: createRunHook( hooks, 'actions' ),
-		applyFilters: createRunHook( hooks, 'filters', true ),
-		currentAction: createCurrentHook( hooks, 'actions' ),
-		currentFilter: createCurrentHook( hooks, 'filters' ),
-		doingAction: createDoingHook( hooks, 'actions' ),
-		doingFilter: createDoingHook( hooks, 'filters' ),
-		didAction: createDidHook( hooks, 'actions' ),
-		didFilter: createDidHook( hooks, 'filters' ),
-		actions,
-		filters,
-	} );
-
-	return hooks;
+	return new _Hooks();
 }
 
 export default createHooks;

--- a/packages/hooks/src/createRemoveHook.js
+++ b/packages/hooks/src/createRemoveHook.js
@@ -3,7 +3,6 @@
  */
 import validateNamespace from './validateNamespace.js';
 import validateHookName from './validateHookName.js';
-import { doAction } from './';
 
 /**
  * @callback RemoveHook
@@ -74,8 +73,9 @@ function createRemoveHook( hooks, removeAll = false ) {
 				}
 			}
 		}
+
 		if ( hookName !== 'hookRemoved' ) {
-			doAction( 'hookRemoved', hookName, namespace );
+			this.doAction( 'hookRemoved', hookName, namespace );
 		}
 
 		return handlersRemoved;

--- a/packages/hooks/src/createRunHook.js
+++ b/packages/hooks/src/createRunHook.js
@@ -3,30 +3,33 @@
  * registered to a hook of the specified type, optionally returning the final
  * value of the call chain.
  *
- * @param  {import('.').Hooks} hooks                  Stored hooks, keyed by hook name.
- * @param  {boolean}           [returnFirstArg=false] Whether each hook callback is expected to
- *                                                    return its first argument.
+ * @param  {import('.').Hooks}    hooks Hooks instance.
+ * @param  {import('.').StoreKey} storeKey
+ * @param  {boolean}              [returnFirstArg=false] Whether each hook callback is expected to
+ *                                                       return its first argument.
  *
  * @return {(hookName:string, ...args: unknown[]) => unknown} Function that runs hook callbacks.
  */
-function createRunHook( hooks, returnFirstArg = false ) {
+function createRunHook( hooks, storeKey, returnFirstArg = false ) {
 	return function runHooks( hookName, ...args ) {
-		if ( ! hooks[ hookName ] ) {
-			hooks[ hookName ] = {
+		const hooksStore = hooks[ storeKey ];
+
+		if ( ! hooksStore[ hookName ] ) {
+			hooksStore[ hookName ] = {
 				handlers: [],
 				runs: 0,
 			};
 		}
 
-		hooks[ hookName ].runs++;
+		hooksStore[ hookName ].runs++;
 
-		const handlers = hooks[ hookName ].handlers;
+		const handlers = hooksStore[ hookName ].handlers;
 
 		// The following code is stripped from production builds.
 		if ( 'production' !== process.env.NODE_ENV ) {
 			// Handle any 'all' hooks registered.
-			if ( 'hookAdded' !== hookName && hooks.all ) {
-				handlers.push( ...hooks.all.handlers );
+			if ( 'hookAdded' !== hookName && hooksStore.all ) {
+				handlers.push( ...hooksStore.all.handlers );
 			}
 		}
 
@@ -39,7 +42,7 @@ function createRunHook( hooks, returnFirstArg = false ) {
 			currentIndex: 0,
 		};
 
-		hooks.__current.push( hookInfo );
+		hooksStore.__current.push( hookInfo );
 
 		while ( hookInfo.currentIndex < handlers.length ) {
 			const handler = handlers[ hookInfo.currentIndex ];
@@ -52,7 +55,7 @@ function createRunHook( hooks, returnFirstArg = false ) {
 			hookInfo.currentIndex++;
 		}
 
-		hooks.__current.pop();
+		hooksStore.__current.pop();
 
 		if ( returnFirstArg ) {
 			return args[ 0 ];

--- a/packages/hooks/src/index.js
+++ b/packages/hooks/src/index.js
@@ -16,7 +16,6 @@ import createHooks from './createHooks';
  * @typedef Hook
  * @property {Handler[]} handlers Array of handlers
  * @property {number}    runs     Run counter
- *
  */
 
 /**
@@ -26,7 +25,15 @@ import createHooks from './createHooks';
  */
 
 /**
- * @typedef {Record<string, Hook> & {__current: Current[]}} Hooks
+ * @typedef {Record<string, Hook> & {__current: Current[]}} Store
+ */
+
+/**
+ * @typedef {'actions' | 'filters'} StoreKey
+ */
+
+/**
+ * @typedef {Record<string, Function> & Record<StoreKey, Store>} Hooks
  */
 
 const {

--- a/packages/hooks/src/index.js
+++ b/packages/hooks/src/index.js
@@ -33,7 +33,7 @@ import createHooks from './createHooks';
  */
 
 /**
- * @typedef {Record<string, Function> & Record<StoreKey, Store>} Hooks
+ * @typedef {import('./createHooks').Hooks} Hooks
  */
 
 const {

--- a/packages/hooks/src/test/index.test.js
+++ b/packages/hooks/src/test/index.test.js
@@ -742,6 +742,23 @@ test( 'adding an action triggers a hookAdded action passing all callback details
 		actionA,
 		9
 	);
+
+	// Private instance.
+	const hooksPrivateInstance = createHooks();
+
+	removeAction( 'hookAdded', 'my_callback' );
+	hookAddedSpy.mockClear();
+
+	hooksPrivateInstance.addAction( 'hookAdded', 'my_callback', hookAddedSpy );
+	hooksPrivateInstance.addAction( 'testAction', 'my_callback2', actionA, 9 );
+
+	expect( hookAddedSpy ).toHaveBeenCalledTimes( 1 );
+	expect( hookAddedSpy ).toHaveBeenCalledWith(
+		'testAction',
+		'my_callback2',
+		actionA,
+		9
+	);
 } );
 
 test( 'adding a filter triggers a hookAdded action passing all callback details', () => {
@@ -750,6 +767,23 @@ test( 'adding a filter triggers a hookAdded action passing all callback details'
 	setupActionListener( 'hookAdded', hookAddedSpy );
 
 	addFilter( 'testFilter', 'my_callback3', filterA, 8 );
+	expect( hookAddedSpy ).toHaveBeenCalledTimes( 1 );
+	expect( hookAddedSpy ).toHaveBeenCalledWith(
+		'testFilter',
+		'my_callback3',
+		filterA,
+		8
+	);
+
+	// Private instance.
+	const hooksPrivateInstance = createHooks();
+
+	removeAction( 'hookAdded', 'my_callback' );
+	hookAddedSpy.mockClear();
+
+	hooksPrivateInstance.addAction( 'hookAdded', 'my_callback', hookAddedSpy );
+	hooksPrivateInstance.addFilter( 'testFilter', 'my_callback3', filterA, 8 );
+
 	expect( hookAddedSpy ).toHaveBeenCalledTimes( 1 );
 	expect( hookAddedSpy ).toHaveBeenCalledWith(
 		'testFilter',
@@ -772,6 +806,27 @@ test( 'removing an action triggers a hookRemoved action passing all callback det
 		'testAction',
 		'my_callback2'
 	);
+
+	// Private instance.
+	const hooksPrivateInstance = createHooks();
+
+	removeAction( 'hookRemoved', 'my_callback' );
+	hookRemovedSpy.mockClear();
+
+	hooksPrivateInstance.addAction(
+		'hookRemoved',
+		'my_callback',
+		hookRemovedSpy
+	);
+
+	hooksPrivateInstance.addAction( 'testAction', 'my_callback2', actionA, 9 );
+	hooksPrivateInstance.removeAction( 'testAction', 'my_callback2' );
+
+	expect( hookRemovedSpy ).toHaveBeenCalledTimes( 1 );
+	expect( hookRemovedSpy ).toHaveBeenCalledWith(
+		'testAction',
+		'my_callback2'
+	);
 } );
 
 test( 'removing a filter triggers a hookRemoved action passing all callback details', () => {
@@ -781,6 +836,27 @@ test( 'removing a filter triggers a hookRemoved action passing all callback deta
 
 	addFilter( 'testFilter', 'my_callback3', filterA, 8 );
 	removeFilter( 'testFilter', 'my_callback3' );
+
+	expect( hookRemovedSpy ).toHaveBeenCalledTimes( 1 );
+	expect( hookRemovedSpy ).toHaveBeenCalledWith(
+		'testFilter',
+		'my_callback3'
+	);
+
+	// Private instance.
+	const hooksPrivateInstance = createHooks();
+
+	removeAction( 'hookRemoved', 'my_callback' );
+	hookRemovedSpy.mockClear();
+
+	hooksPrivateInstance.addAction(
+		'hookRemoved',
+		'my_callback',
+		hookRemovedSpy
+	);
+
+	hooksPrivateInstance.addFilter( 'testFilter', 'my_callback3', filterA, 8 );
+	hooksPrivateInstance.removeFilter( 'testFilter', 'my_callback3' );
 
 	expect( hookRemovedSpy ).toHaveBeenCalledTimes( 1 );
 	expect( hookRemovedSpy ).toHaveBeenCalledWith(


### PR DESCRIPTION
## Description
Hooks are currently using `doAction` from the shared global instance to trigger the built-in hooks `hookAdded` and `hookRemoved`. This PR binds the methods for adding and removing hooks to their own hooks instance so that they use `doAction` from the given instance for the said built-in hooks.

## How has this been tested?
Tests pass successfully.

## Types of changes
Bug fix: Use own instance's `doAction` method to trigger built-in `hookAdded` and `hookRemoved` hooks.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
