### PR TITLE
Support for custom setting of fontSize & padding on a button

### DIFF
--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -59,6 +59,10 @@
 		"align": true,
 		"alignWide": false,
 		"reusable": false,
-		"__experimentalSelector": ".wp-block-button > a"
+		"__experimentalSelector": ".wp-block-button > a",
+		"spacing": {
+			"padding": true
+		},
+		"fontSize": true
 	}
 }

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -17,12 +17,14 @@ import {
 	ToolbarButton,
 	ToolbarGroup,
 	Popover,
+	__experimentalBoxControl as BoxControl,
 } from '@wordpress/components';
 import {
 	BlockControls,
 	InspectorControls,
 	RichText,
 	useBlockProps,
+	getFontSizeClass,
 	__experimentalLinkControl as LinkControl,
 	__experimentalUseEditorFeature as useEditorFeature,
 } from '@wordpress/block-editor';
@@ -42,6 +44,7 @@ const MAX_BORDER_RADIUS_VALUE = 50;
 const INITIAL_BORDER_RADIUS_POSITION = 5;
 
 const EMPTY_ARRAY = [];
+const { __Visualizer: BoxControlVisualizer } = BoxControl;
 
 function BorderPanel( { borderRadius = '', setAttributes } ) {
 	const initialBorderRadius = borderRadius;
@@ -199,10 +202,21 @@ function ButtonEdit( props ) {
 	const colorProps = getColorAndStyleProps( attributes, colors, true );
 	const blockProps = useBlockProps();
 
+	// The passed className for fontSize shouldn't be applied on the div, only on the text field
+	const wrapperClassNames = blockProps.className.replace(
+		getFontSizeClass( attributes.fontSize ),
+		''
+	);
+	const { style, ...otherBlockProps } = blockProps;
+
 	return (
 		<>
 			<ColorEdit { ...props } />
-			<div { ...blockProps }>
+			<div { ...otherBlockProps } className={ wrapperClassNames }>
+				<BoxControlVisualizer
+					values={ attributes.style?.spacing?.padding }
+					showValues={ attributes.style?.visualizers?.padding }
+				/>
 				<RichText
 					placeholder={ placeholder || __( 'Add text…' ) }
 					value={ text }
@@ -221,6 +235,7 @@ function ButtonEdit( props ) {
 							? borderRadius + 'px'
 							: undefined,
 						...colorProps.style,
+						...style,
 					} }
 					onSplit={ ( value ) =>
 						createBlock( 'core/button', {

--- a/packages/block-library/src/button/save.js
+++ b/packages/block-library/src/button/save.js
@@ -6,7 +6,11 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { RichText, useBlockProps } from '@wordpress/block-editor';
+import {
+	RichText,
+	useBlockProps,
+	getFontSizeClass,
+} from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -14,18 +18,32 @@ import { RichText, useBlockProps } from '@wordpress/block-editor';
 import getColorAndStyleProps from './color-props';
 
 export default function save( { attributes } ) {
-	const { borderRadius, linkTarget, rel, text, title, url } = attributes;
+	const {
+		borderRadius,
+		linkTarget,
+		rel,
+		text,
+		title,
+		url,
+		fontSize,
+	} = attributes;
 	const colorProps = getColorAndStyleProps( attributes );
 	const buttonClasses = classnames(
 		'wp-block-button__link',
 		colorProps.className,
+		getFontSizeClass( fontSize ),
 		{
 			'no-border-radius': borderRadius === 0,
 		}
 	);
+
+	const blockProps = useBlockProps.save();
+	const { style, ...otherBlockProps } = blockProps;
+
 	const buttonStyle = {
 		borderRadius: borderRadius ? borderRadius + 'px' : undefined,
 		...colorProps.style,
+		...style,
 	};
 
 	// The use of a `title` attribute here is soft-deprecated, but still applied
@@ -33,7 +51,7 @@ export default function save( { attributes } ) {
 	// A title will no longer be assigned for new or updated button block links.
 
 	return (
-		<div { ...useBlockProps.save() }>
+		<div { ...otherBlockProps }>
 			<RichText.Content
 				tagName="a"
 				className={ buttonClasses }


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
#20967 Adds a way to control the font size and padding of buttons block
Font size can be one of the defined values in the dropdown or a custom value
Padding is a custom value with shown visualizers when editing it.

## How has this been tested?
Manually by adding the button block. Changes should be applied on the block and visualized when saving the post. 

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
Settings Panel:
![Screenshot 2020-10-26 at 15 05 14](https://user-images.githubusercontent.com/6911590/97300055-97573780-185e-11eb-915a-62e45842bfc1.png)

Custom padding and font-size on a button:
![Screenshot 2020-10-26 at 15 03 47](https://user-images.githubusercontent.com/6911590/97300104-a807ad80-185e-11eb-80fc-7b8199e12eb0.png)
![Screenshot 2020-10-27 at 13 50 32](https://user-images.githubusercontent.com/6911590/97300117-adfd8e80-185e-11eb-9af3-3545be5abf85.png)
Example on a saved post preview:
![Screenshot 2020-10-27 at 14 28 36](https://user-images.githubusercontent.com/6911590/97301685-bf479a80-1860-11eb-9717-0eb2c14e3acd.png)
## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
New feature (non-breaking change which adds functionality)
Adds control for the button font-size & padding
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
