### PR TITLE
webpack: replace legacy namedChunks/namedModules options with chunkIds/moduleIds

### DIFF
--- a/packages/dependency-extraction-webpack-plugin/test/build.js
+++ b/packages/dependency-extraction-webpack-plugin/test/build.js
@@ -34,8 +34,8 @@ describe.each( configFixtures )( 'Webpack `%s`', ( configCase ) => {
 					mode: 'production',
 					optimization: {
 						minimize: false,
-						namedChunks: true,
-						namedModules: true,
+						chunkIds: 'named',
+						moduleIds: 'named',
 					},
 					output: {},
 				},


### PR DESCRIPTION
webpack 5 removes support for `namedModules` and `namedChunks` options. This PR replaces them with newer options that have the same meaning and are supported both in v4 and v5.

The affected webpack config is used by `dependency-extraction-webpack-plugin` tests.

Spinoff from #26382 -- one of the parts that are zero-risk and can be merged independently.