### PR TITLE
wp-env: Add support for custom WP_HOME port

### DIFF
--- a/packages/env/lib/config/config.js
+++ b/packages/env/lib/config/config.js
@@ -259,7 +259,12 @@ function withOverrides( config ) {
 				const baseUrl = new URL(
 					config.env[ envKey ].config[ configKey ]
 				);
-				baseUrl.port = config.env[ envKey ].port;
+
+				// Don't overwrite the port of WP_HOME when set.
+				if ( ! ( configKey === 'WP_HOME' && !! baseUrl.port ) ) {
+					baseUrl.port = config.env[ envKey ].port;
+				}
+
 				config.env[ envKey ].config[ configKey ] = baseUrl.toString();
 			} catch ( error ) {
 				throw new ValidationError(

--- a/packages/env/lib/config/test/config.js
+++ b/packages/env/lib/config/test/config.js
@@ -731,6 +731,42 @@ describe( 'readConfig', () => {
 			} );
 		} );
 
+		it( 'should not overwrite port number for WP_HOME if set', async () => {
+			readFile.mockImplementation( () =>
+				Promise.resolve(
+					JSON.stringify( {
+						port: 1000,
+						testsPort: 2000,
+						config: {
+							WP_HOME: 'http://localhost:3000/',
+						},
+					} )
+				)
+			);
+			const config = await readConfig( '.wp-env.json' );
+			// Custom port is overriden while testsPort gets the deault value.
+			expect( config ).toMatchObject( {
+				env: {
+					development: {
+						port: 1000,
+						config: {
+							WP_TESTS_DOMAIN: 'http://localhost:1000/',
+							WP_SITEURL: 'http://localhost:1000/',
+							WP_HOME: 'http://localhost:3000/',
+						},
+					},
+					tests: {
+						port: 2000,
+						config: {
+							WP_TESTS_DOMAIN: 'http://localhost:2000/',
+							WP_SITEURL: 'http://localhost:2000/',
+							WP_HOME: 'http://localhost:3000/',
+						},
+					},
+				},
+			} );
+		} );
+
 		it( 'should throw an error if the port number environment variable is invalid', async () => {
 			readFile.mockImplementation( () =>
 				Promise.resolve( JSON.stringify( {} ) )


### PR DESCRIPTION
## Description
This checks for whether a custom port has been set for `WP_HOME` in the .wp-env.json file before appending the environment's to support local environments where the front end needs to be pointed at another port (e.g., a headless app).

Adds unit test.

## How has this been tested?
Added unit tests. Also testing this config locally and ensured that the "Site Address (URL)" setting in Settings > General reflects the port that was set in my .wp-env.json file.

## Types of changes
New feature (non-breaking change which adds functionality).
Resolves #26481.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
