### PR TITLE
Deprecate the data controls after all usages were updated

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17154,7 +17154,8 @@
 			"version": "file:packages/data-controls",
 			"requires": {
 				"@wordpress/api-fetch": "file:packages/api-fetch",
-				"@wordpress/data": "file:packages/data"
+				"@wordpress/data": "file:packages/data",
+				"@wordpress/deprecated": "file:packages/deprecated"
 			}
 		},
 		"@wordpress/date": {

--- a/packages/data-controls/package.json
+++ b/packages/data-controls/package.json
@@ -24,7 +24,8 @@
 	"react-native": "src/index",
 	"dependencies": {
 		"@wordpress/api-fetch": "file:../api-fetch",
-		"@wordpress/data": "file:../data"
+		"@wordpress/data": "file:../data",
+		"@wordpress/deprecated": "file:../deprecated"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/data-controls/src/index.js
+++ b/packages/data-controls/src/index.js
@@ -3,8 +3,7 @@
  */
 import triggerFetch from '@wordpress/api-fetch';
 import { controls as dataControls } from '@wordpress/data';
-// TODO: mark the deprecated controls after all Gutenberg usages are removed
-// import deprecated from '@wordpress/deprecated';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Dispatches a control action for triggering an api fetch call.
@@ -39,9 +38,9 @@ export function apiFetch( request ) {
  * @param {Array} args Arguments passed without change to the `@wordpress/data` control.
  */
 export function select( ...args ) {
-	// deprecated( '`select` control in `@wordpress/data-controls`', {
-	// 	alternative: 'built-in `resolveSelect` control in `@wordpress/data`',
-	// } );
+	deprecated( '`select` control in `@wordpress/data-controls`', {
+		alternative: 'built-in `resolveSelect` control in `@wordpress/data`',
+	} );
 
 	return dataControls.resolveSelect( ...args );
 }
@@ -53,9 +52,9 @@ export function select( ...args ) {
  * @param {Array} args Arguments passed without change to the `@wordpress/data` control.
  */
 export function syncSelect( ...args ) {
-	// deprecated( '`syncSelect` control in `@wordpress/data-controls`', {
-	// 	alternative: 'built-in `select` control in `@wordpress/data`',
-	// } );
+	deprecated( '`syncSelect` control in `@wordpress/data-controls`', {
+		alternative: 'built-in `select` control in `@wordpress/data`',
+	} );
 
 	return dataControls.select( ...args );
 }
@@ -67,9 +66,9 @@ export function syncSelect( ...args ) {
  * @param {Array} args Arguments passed without change to the `@wordpress/data` control.
  */
 export function dispatch( ...args ) {
-	// deprecated( '`dispatch` control in `@wordpress/data-controls`', {
-	// 	alternative: 'built-in `dispatch` control in `@wordpress/data`',
-	// } );
+	deprecated( '`dispatch` control in `@wordpress/data-controls`', {
+		alternative: 'built-in `dispatch` control in `@wordpress/data`',
+	} );
 
 	return dataControls.dispatch( ...args );
 }


### PR DESCRIPTION
Marks the `select`, `syncSelect` and `dispatch` exports from `@wordpress/data-controls` as deprecated. Since #25362 they are built-in into every data store and don't need a separate package to work.

We needed to postpone the actual deprecation until all usages in Gutenberg monorepo packages were removed. That happened in #25993, #25990, #25949, #25773 and #25772. That work is now finished.