### PR TITLE
Update the .is-dark-theme UI for Quote and Pullquote blocks

### DIFF
--- a/packages/block-library/src/pullquote/theme.scss
+++ b/packages/block-library/src/pullquote/theme.scss
@@ -4,6 +4,12 @@
 	margin-bottom: 1.75em;
 	color: #555;
 
+	.is-dark-theme & {
+		border-top: 4px solid $light-gray-placeholder;
+		border-bottom: 4px solid $light-gray-placeholder;
+		color: $light-gray-placeholder;
+	}
+
 	cite,
 	footer,
 	&__citation {
@@ -11,5 +17,9 @@
 		text-transform: uppercase;
 		font-size: 0.8125em;
 		font-style: normal;
+
+		.is-dark-theme & {
+			color: $light-gray-placeholder;
+		}
 	}
 }

--- a/packages/block-library/src/quote/theme.scss
+++ b/packages/block-library/src/quote/theme.scss
@@ -3,6 +3,10 @@
 	margin: 0 0 1.75em 0;
 	padding-left: 1em;
 
+	.is-dark-theme & {
+		border-left: 0.25em solid $light-gray-placeholder;
+	}
+
 	cite,
 	footer,
 	&__citation {
@@ -11,6 +15,10 @@
 		margin-top: 1em;
 		position: relative;
 		font-style: normal;
+
+		.is-dark-theme & {
+			color: $light-gray-placeholder;
+		}
 	}
 
 	&.has-text-align-right {


### PR DESCRIPTION
Fixes #16732. 
Updates the UI on Quote and Pullquote blocks for dark themes. This includes the borders and citations.

## How has this been tested?
Tested locally.

## Screenshots 

**Quote block before**
![quote-before](https://user-images.githubusercontent.com/617986/97330257-3f580b00-1835-11eb-8574-78c90cb40802.png)

**Quote block after**
![quote-after](https://user-images.githubusercontent.com/617986/97330271-44b55580-1835-11eb-89e6-5db73433e6b7.png)

**Pullquote block before**
![pull-before](https://user-images.githubusercontent.com/617986/97330286-4bdc6380-1835-11eb-9beb-141fa5e1f3e9.png)

**Pullquote block after**
![pull-after](https://user-images.githubusercontent.com/617986/97330302-5139ae00-1835-11eb-9444-e6a560d492ac.png)


## Types of changes
CSS changes.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
