### PR TITLE
Centered text on Nextpage block

### DIFF
--- a/packages/block-library/src/nextpage/editor.scss
+++ b/packages/block-library/src/nextpage/editor.scss
@@ -1,5 +1,6 @@
 .block-editor-block-list__block[data-type="core/nextpage"] {
 	max-width: 100%;
+	text-align: center;
 	margin-top: $default-block-margin;
 	margin-bottom: $default-block-margin;
 }
@@ -13,7 +14,6 @@
 	> span {
 		font-size: $default-font-size;
 		position: relative;
-		display: inline-block;
 		text-transform: uppercase;
 		font-weight: 600;
 		font-family: $default-font;


### PR DESCRIPTION
Centered the text on the Nextpage block. The problem was noticeable on dark themes.

## How has this been tested?
Tested locally.

## Screenshots 

**Before**
![break-before](https://user-images.githubusercontent.com/617986/97348315-33774380-184b-11eb-9e54-9dd84064ce77.png)

**After**
![break-after](https://user-images.githubusercontent.com/617986/97348328-37a36100-184b-11eb-8fb6-c5a00aad35a0.png)


## Types of changes
CSS changes.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
