### PR TITLE
Cleanup PHP Codesniffer warnings and enable fail

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
 	},
 	"scripts": {
 		"format": "phpcbf --standard=phpcs.xml.dist --report-summary --report-source",
-		"lint": "phpcs --standard=phpcs.xml.dist --runtime-set ignore_warnings_on_exit 1",
+		"lint": "phpcs --standard=phpcs.xml.dist",
 		"test": "phpunit",
 		"test:watch": "phpunit-watcher watch < /dev/tty"
 	}

--- a/lib/widgets.php
+++ b/lib/widgets.php
@@ -56,8 +56,6 @@ function gutenberg_use_widgets_block_editor() {
  * @return array Legacy widget settings.
  */
 function gutenberg_get_legacy_widget_settings() {
-	global $wp_widget_factory;
-
 	$settings = array();
 
 	$widget_types_to_hide_from_legacy_widget_block = apply_filters(

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -106,11 +106,11 @@ function render_classic_location_menu( $location, $attributes ) {
 
 	return wp_nav_menu(
 		array(
-			'theme_location'   => $location,
-			'container'        => '',
-			'items_wrap'       => '%3$s',
-			'fallback_cb'      => false,
-			'echo'             => false,
+			'theme_location' => $location,
+			'container'      => '',
+			'items_wrap'     => '%3$s',
+			'fallback_cb'    => false,
+			'echo'           => false,
 		)
 	);
 }


### PR DESCRIPTION
## Description

In #26472 a flag was added to the lint command to not fail on warnings, it was failing on instances of Unused Variables.

This PR fixes the unused variables in the code and removes flag 

- Removes flag ignore warnings in composer.json
- Fixes Unused variable warnings

Closes #26490 

## How has this been tested?

Setup: `composer install`

Baseline:
1. Remove flag from composer.json lint command
2. Run `npm run lint-php`, confirm warnings

Confirm:
1. Apply change.
2. Run `npm run lint-php`

If you are not running Docker, you can call: `./vendor/squizlabs/php_codesniffer/bin/phpcs --standard=phpcs.xml.dist`

## Types of changes

- Clean up lint errors
