### PR TITLE
Site Editor: Rename left sidebar → block library

### DIFF
--- a/packages/block-editor/src/components/block-icon/README.md
+++ b/packages/block-editor/src/components/block-icon/README.md
@@ -1,6 +1,6 @@
 # Block Icon
 
-The BlockIcon component provides an icon for blocks in different places in the editor: the toolbar of a selected block, the placeholders of certain blocks (gallery, image), the block insertion panel of the editor or the left sidebar.
+The BlockIcon component provides an icon for blocks in different places in the editor: the toolbar of a selected block, the placeholders of certain blocks (gallery, image), the block insertion panel of the editor or the secondary sidebar.
 
 The rendered an [Icon](https://github.com/WordPress/gutenberg/tree/master/packages/components/src/icon) component with default styles.
 
@@ -26,4 +26,4 @@ const MyBlockIcon = () => <BlockIcon icon={ icon } />
 
 ## Related components
 
-Block Editor components are components that can be used to compose the UI of your block editor. Thus, they can only be used under a [`BlockEditorProvider`](https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/provider/README.md) in the components tree. 
+Block Editor components are components that can be used to compose the UI of your block editor. Thus, they can only be used under a [`BlockEditorProvider`](https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/provider/README.md) in the components tree.

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -53,7 +53,7 @@ import ActionsPanel from './actions-panel';
 import PopoverWrapper from './popover-wrapper';
 
 const interfaceLabels = {
-	leftSidebar: __( 'Block library' ),
+	secondarySidebar: __( 'Block library' ),
 	/* translators: accessibility text for the editor top bar landmark region. */
 	header: __( 'Editor top bar' ),
 	/* translators: accessibility text for the editor content landmark region. */
@@ -149,7 +149,7 @@ function Layout() {
 	}, [ isInserterOpened, isHugeViewport ] );
 
 	// Local state for save panel.
-	// Note 'thruthy' callback implies an open panel.
+	// Note 'truthy' callback implies an open panel.
 	const [
 		entitiesSavedStatesCallback,
 		setEntitiesSavedStatesCallback,
@@ -185,7 +185,7 @@ function Layout() {
 							}
 						/>
 					}
-					leftSidebar={
+					secondarySidebar={
 						mode === 'visual' &&
 						isInserterOpened && (
 							<PopoverWrapper

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -42,7 +42,7 @@ import GlobalStylesProvider from './global-styles-provider';
 import NavigationSidebar from '../navigation-sidebar';
 
 const interfaceLabels = {
-	leftSidebar: __( 'Block Library' ),
+	secondarySidebar: __( 'Block Library' ),
 	drawer: __( 'Navigation Sidebar' ),
 };
 
@@ -221,7 +221,7 @@ function Editor() {
 													drawer={
 														<NavigationSidebar />
 													}
-													leftSidebar={
+													secondarySidebar={
 														isInserterOpen ? (
 															<div className="edit-site-editor__inserter-panel">
 																<div className="edit-site-editor__inserter-panel-header">

--- a/packages/edit-widgets/src/components/layout/interface.js
+++ b/packages/edit-widgets/src/components/layout/interface.js
@@ -59,7 +59,7 @@ function Interface( { blockEditorSettings } ) {
 		<InterfaceSkeleton
 			labels={ interfaceLabels }
 			header={ <Header /> }
-			leftSidebar={
+			secondarySidebar={
 				isInserterOpened && (
 					<PopoverWrapper
 						className="edit-widgets-layout__inserter-panel-popover-wrapper"

--- a/packages/interface/src/components/interface-skeleton/index.js
+++ b/packages/interface/src/components/interface-skeleton/index.js
@@ -28,7 +28,7 @@ function InterfaceSkeleton( {
 	footer,
 	header,
 	sidebar,
-	leftSidebar,
+	secondarySidebar,
 	content,
 	drawer,
 	actions,
@@ -44,8 +44,8 @@ function InterfaceSkeleton( {
 		header: __( 'Header' ),
 		/* translators: accessibility text for the content landmark region. */
 		body: __( 'Content' ),
-		/* translators: accessibility text for the left sidebar landmark region. */
-		leftSidebar: __( 'Left sidebar' ),
+		/* translators: accessibility text for the secondary sidebar landmark region. */
+		secondarySidebar: __( 'Block Library' ),
 		/* translators: accessibility text for the settings landmark region. */
 		sidebar: __( 'Settings' ),
 		/* translators: accessibility text for the publish landmark region. */
@@ -84,14 +84,14 @@ function InterfaceSkeleton( {
 					</div>
 				) }
 				<div className="interface-interface-skeleton__body">
-					{ !! leftSidebar && (
+					{ !! secondarySidebar && (
 						<div
-							className="interface-interface-skeleton__left-sidebar"
+							className="interface-interface-skeleton__secondary-sidebar"
 							role="region"
-							aria-label={ mergedLabels.leftSidebar }
+							aria-label={ mergedLabels.secondarySidebar }
 							tabIndex="-1"
 						>
-							{ leftSidebar }
+							{ secondarySidebar }
 						</div>
 					) }
 					<div

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -85,7 +85,7 @@ html.interface-interface-skeleton__html-container {
 
 }
 
-.interface-interface-skeleton__left-sidebar,
+.interface-interface-skeleton__secondary-sidebar,
 .interface-interface-skeleton__sidebar {
 	display: block;
 	flex-shrink: 0;
@@ -113,7 +113,7 @@ html.interface-interface-skeleton__html-container {
 	}
 }
 
-.interface-interface-skeleton__left-sidebar {
+.interface-interface-skeleton__secondary-sidebar {
 	@include break-medium() {
 		border-right: $border-width solid $gray-200;
 	}


### PR DESCRIPTION
## Description
Rename **Left Sidebar** to **Secondary Sidebar** to be more semantic and descriptive of function rather than location.

Fixes https://github.com/WordPress/gutenberg/issues/25616

## How has this been tested?
* No lint/build errors
* Edit Site screen still works
* Edit Post screen still works

## Types of changes
Renaming. What could go wrong?

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
