### PR TITLE
Improves the alt text copy for images

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -302,7 +302,7 @@ export default function Image( {
 							<>
 								<ExternalLink href="https://www.w3.org/WAI/tutorials/images/decision-tree">
 									{ __(
-										'Describe the purpose of the image'
+										'Alt text explains the purpose of an image, giving context to visitors with vision impairments.'
 									) }
 								</ExternalLink>
 								{ __(

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -300,14 +300,14 @@ export default function Image( {
 						onChange={ updateAlt }
 						help={
 							<>
+							{ __(
+								'Alt Text explains an image\'s purpose, giving context to visitors with vision impairments.'
+							) }
 								<ExternalLink href="https://www.w3.org/WAI/tutorials/images/decision-tree">
 									{ __(
-										'Alt Text explains an image\'s purpose, giving context to visitors with vision impairments.'
+										"Learn more."
 									) }
 								</ExternalLink>
-								{ __(
-									'Leave empty if the image is purely decorative.'
-								) }
 							</>
 						}
 					/>

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -302,7 +302,7 @@ export default function Image( {
 							<>
 								<ExternalLink href="https://www.w3.org/WAI/tutorials/images/decision-tree">
 									{ __(
-										'Alt text explains the purpose of an image, giving context to visitors with vision impairments.'
+										'Alt Text explains an image\'s purpose, giving context to visitors with vision impairments.'
 									) }
 								</ExternalLink>
 								{ __(


### PR DESCRIPTION
This PR brings the copy in from #19068 and iterates alt text on images to be a little more explanatory.

Here is what the result is:

![image](https://user-images.githubusercontent.com/253067/97359642-f9cb2a80-1894-11eb-8488-d2f857259825.png)

What I am looking for specifically is feedback around the following:

- The copy contents. In seeing this PR it is a lot visually for a link. What should be split or could?
- What should have a link?
- Should we keep the link out?