### PR TITLE
Configure e2e tests to bail and skip experiments

### DIFF
--- a/package.json
+++ b/package.json
@@ -245,6 +245,7 @@
 		"test-e2e": "wp-scripts test-e2e --config packages/e2e-tests/jest.config.js",
 		"test-e2e:debug": "wp-scripts --inspect-brk test-e2e --config packages/e2e-tests/jest.config.js --puppeteer-devtools",
 		"test-e2e:watch": "npm run test-e2e -- --watch",
+		"test-e2e:experiments": "wp-scripts test-e2e --config packages/e2e-tests/jest.experiments.config.js",
 		"test-performance": "wp-scripts test-e2e --config packages/e2e-tests/jest.performance.config.js",
 		"test-php": "npm run lint-php && npm run test-unit-php",
 		"test-unit": "wp-scripts test-unit-js --config test/unit/jest.config.js",

--- a/packages/e2e-tests/jest.config.js
+++ b/packages/e2e-tests/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
 	...require( '@wordpress/scripts/config/jest-e2e.config' ),
+	bail: true,
 	setupFiles: [ '<rootDir>/config/gutenberg-phase.js' ],
 	setupFilesAfterEnv: [
 		'<rootDir>/config/setup-test-framework.js',
@@ -10,6 +11,7 @@ module.exports = {
 	testPathIgnorePatterns: [
 		'/node_modules/',
 		'<rootDir>/wordpress/',
+		'e2e-tests/specs/experiments/',
 		'e2e-tests/specs/performance/',
 	],
 };

--- a/packages/e2e-tests/jest.experiments.config.js
+++ b/packages/e2e-tests/jest.experiments.config.js
@@ -1,0 +1,18 @@
+module.exports = {
+	...require( '@wordpress/scripts/config/jest-e2e.config' ),
+	bail: true,
+	setupFiles: [ '<rootDir>/config/gutenberg-phase.js' ],
+	setupFilesAfterEnv: [
+		'<rootDir>/config/setup-test-framework.js',
+		'@wordpress/jest-console',
+		'@wordpress/jest-puppeteer-axe',
+		'expect-puppeteer',
+	],
+	testPathIgnorePatterns: [
+		'/node_modules/',
+		'<rootDir>/wordpress/',
+		'e2e-tests/specs/editor/', // covered in default config
+		'e2e-tests/specs/local/',  // covered in default config
+		'e2e-tests/specs/performance/',
+	],
+};

--- a/packages/e2e-tests/jest.experiments.config.js
+++ b/packages/e2e-tests/jest.experiments.config.js
@@ -12,7 +12,7 @@ module.exports = {
 		'/node_modules/',
 		'<rootDir>/wordpress/',
 		'e2e-tests/specs/editor/', // covered in default config
-		'e2e-tests/specs/local/',  // covered in default config
+		'e2e-tests/specs/local/', // covered in default config
 		'e2e-tests/specs/performance/',
 	],
 };


### PR DESCRIPTION
## Description

Adjust e2e test config to help speed up and improve reliability.

- Add `bail: true` to config, why keep running if it hits a failure, just exit early and save everyone time.

- Do we need to run e2e tests on experiments for CI by default?

- Add new `npm run test-e2e:experiments` to just run experiments e2e tests


## How has this been tested?

- Confirm `npm run test-e2e` stops after first failure
- Confirm `npm run test-e2e` does not run experiments tests
- Confirm `npm run test-e2e:experiments` runs experiments e2e tests

## Types of changes

- e2e test config changes
