### PR TITLE
Mobile stories block: hide behind feature flag

### DIFF
--- a/packages/edit-post/src/editor.native.js
+++ b/packages/edit-post/src/editor.native.js
@@ -26,7 +26,7 @@ class Editor extends Component {
 	constructor( props ) {
 		super( ...arguments );
 
-		if ( !__DEV__ ) {
+		if ( ! __DEV__ ) {
 			this.props.hideBlockTypes( [ 'jetpack/story' ] );
 		}
 

--- a/packages/edit-post/src/editor.native.js
+++ b/packages/edit-post/src/editor.native.js
@@ -26,6 +26,10 @@ class Editor extends Component {
 	constructor( props ) {
 		super( ...arguments );
 
+		if ( !__DEV__ ) {
+			this.props.hideBlockTypes( [ 'jetpack/story' ] );
+		}
+
 		if ( props.initialHtmlModeEnabled && props.mode === 'visual' ) {
 			// enable html mode if the initial mode the parent wants it but we're not already in it
 			this.props.switchEditorMode( 'text' );
@@ -56,6 +60,11 @@ class Editor extends Component {
 
 		// Omit hidden block types if exists and non-empty.
 		if ( size( hiddenBlockTypes ) > 0 ) {
+			if ( settings.allowedBlockTypes === undefined ) {
+				// if no specific flags for allowedBlockTypes are set, assume `true`
+				// meaning allow all block types
+				settings.allowedBlockTypes = true;
+			}
 			// Defer to passed setting for `allowedBlockTypes` if provided as
 			// anything other than `true` (where `true` is equivalent to allow
 			// all block types).
@@ -189,10 +198,13 @@ export default compose( [
 		};
 	} ),
 	withDispatch( ( dispatch ) => {
-		const { switchEditorMode } = dispatch( 'core/edit-post' );
+		const { switchEditorMode, hideBlockTypes } = dispatch(
+			'core/edit-post'
+		);
 
 		return {
 			switchEditorMode,
+			hideBlockTypes,
 		};
 	} ),
 ] )( Editor );

--- a/packages/edit-post/src/editor.native.js
+++ b/packages/edit-post/src/editor.native.js
@@ -26,10 +26,6 @@ class Editor extends Component {
 	constructor( props ) {
 		super( ...arguments );
 
-		if ( ! __DEV__ && this.props.capabilities.stories !== true ) {
-			this.props.hideBlockTypes( [ 'jetpack/story' ] );
-		}
-
 		if ( props.initialHtmlModeEnabled && props.mode === 'visual' ) {
 			// enable html mode if the initial mode the parent wants it but we're not already in it
 			this.props.switchEditorMode( 'text' );
@@ -198,13 +194,9 @@ export default compose( [
 		};
 	} ),
 	withDispatch( ( dispatch ) => {
-		const { switchEditorMode, hideBlockTypes } = dispatch(
-			'core/edit-post'
-		);
-
+		const { switchEditorMode } = dispatch( 'core/edit-post' );
 		return {
 			switchEditorMode,
-			hideBlockTypes,
 		};
 	} ),
 ] )( Editor );

--- a/packages/edit-post/src/editor.native.js
+++ b/packages/edit-post/src/editor.native.js
@@ -26,7 +26,7 @@ class Editor extends Component {
 	constructor( props ) {
 		super( ...arguments );
 
-		if ( ! __DEV__ && this.props.capabilities.stories !== true) {
+		if ( ! __DEV__ && this.props.capabilities.stories !== true ) {
 			this.props.hideBlockTypes( [ 'jetpack/story' ] );
 		}
 

--- a/packages/edit-post/src/editor.native.js
+++ b/packages/edit-post/src/editor.native.js
@@ -26,7 +26,7 @@ class Editor extends Component {
 	constructor( props ) {
 		super( ...arguments );
 
-		if ( ! __DEV__ ) {
+		if ( ! __DEV__ && this.props.capabilities.stories !== true) {
 			this.props.hideBlockTypes( [ 'jetpack/story' ] );
 		}
 

--- a/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/GutenbergProps.kt
+++ b/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/GutenbergProps.kt
@@ -3,7 +3,7 @@ package org.wordpress.mobile.WPAndroidGlue
 import android.os.Bundle
 
 data class GutenbergProps @JvmOverloads constructor(
-    val enableStories: Boolean,
+    val enableMediaFilesCollectionBlocks: Boolean,
     val enableMentions: Boolean,
     val enableUnsupportedBlockEditor: Boolean,
     val canEnableUnsupportedBlockEditor: Boolean,
@@ -38,7 +38,7 @@ data class GutenbergProps @JvmOverloads constructor(
 
     fun getUpdatedCapabilitiesProps() = Bundle().apply {
         putBoolean(PROP_CAPABILITIES_MENTIONS, enableMentions)
-        putBoolean(PROP_CAPABILITIES_STORIES, enableStories)
+        putBoolean(PROP_CAPABILITIES_MEDIAFILES_COLLECTION_BLOCK, enableMediaFilesCollectionBlocks)
         putBoolean(PROP_CAPABILITIES_UNSUPPORTED_BLOCK_EDITOR, enableUnsupportedBlockEditor)
         putBoolean(PROP_CAPABILITIES_CAN_ENABLE_UNSUPPORTED_BLOCK_EDITOR, canEnableUnsupportedBlockEditor)
         putBoolean(PROP_CAPABILITIES_MODAL_LAYOUT_PICKER, isModalLayoutPickerEnabled)
@@ -66,7 +66,7 @@ data class GutenbergProps @JvmOverloads constructor(
         private const val PROP_EDITOR_MODE_EDITOR = "editor"
 
         const val PROP_CAPABILITIES = "capabilities"
-        const val PROP_CAPABILITIES_STORIES = "stories"
+        const val PROP_CAPABILITIES_MEDIAFILES_COLLECTION_BLOCK = "mediaFilesCollectionBlock"
         const val PROP_CAPABILITIES_MENTIONS = "mentions"
         const val PROP_CAPABILITIES_UNSUPPORTED_BLOCK_EDITOR = "unsupportedBlockEditor"
         const val PROP_CAPABILITIES_CAN_ENABLE_UNSUPPORTED_BLOCK_EDITOR = "canEnableUnsupportedBlockEditor"

--- a/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/GutenbergProps.kt
+++ b/packages/react-native-bridge/android/src/main/java/org/wordpress/mobile/WPAndroidGlue/GutenbergProps.kt
@@ -3,6 +3,7 @@ package org.wordpress.mobile.WPAndroidGlue
 import android.os.Bundle
 
 data class GutenbergProps @JvmOverloads constructor(
+    val enableStories: Boolean,
     val enableMentions: Boolean,
     val enableUnsupportedBlockEditor: Boolean,
     val canEnableUnsupportedBlockEditor: Boolean,
@@ -37,6 +38,7 @@ data class GutenbergProps @JvmOverloads constructor(
 
     fun getUpdatedCapabilitiesProps() = Bundle().apply {
         putBoolean(PROP_CAPABILITIES_MENTIONS, enableMentions)
+        putBoolean(PROP_CAPABILITIES_STORIES, enableStories)
         putBoolean(PROP_CAPABILITIES_UNSUPPORTED_BLOCK_EDITOR, enableUnsupportedBlockEditor)
         putBoolean(PROP_CAPABILITIES_CAN_ENABLE_UNSUPPORTED_BLOCK_EDITOR, canEnableUnsupportedBlockEditor)
         putBoolean(PROP_CAPABILITIES_MODAL_LAYOUT_PICKER, isModalLayoutPickerEnabled)
@@ -64,6 +66,7 @@ data class GutenbergProps @JvmOverloads constructor(
         private const val PROP_EDITOR_MODE_EDITOR = "editor"
 
         const val PROP_CAPABILITIES = "capabilities"
+        const val PROP_CAPABILITIES_STORIES = "stories"
         const val PROP_CAPABILITIES_MENTIONS = "mentions"
         const val PROP_CAPABILITIES_UNSUPPORTED_BLOCK_EDITOR = "unsupportedBlockEditor"
         const val PROP_CAPABILITIES_CAN_ENABLE_UNSUPPORTED_BLOCK_EDITOR = "canEnableUnsupportedBlockEditor"

--- a/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
+++ b/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
@@ -14,7 +14,7 @@ public struct MediaInfo {
 
 /// Definition of capabilities to enable in the Block Editor
 public enum Capabilities: String {
-    case stories
+    case mediaFilesCollectionBlock
     case mentions
     case unsupportedBlockEditor
     case canEnableUnsupportedBlockEditor
@@ -118,10 +118,10 @@ extension RCTLogLevel {
 }
 
 public enum GutenbergUserEvent {
-    
+
     case editorSessionTemplateApply(_ template: String)
     case editorSessionTemplatePreview(_ template: String)
-    
+
     init?(event: String, properties:[AnyHashable: Any]?) {
         switch event {
         case "editor_session_template_apply":
@@ -211,7 +211,7 @@ public protocol GutenbergBridgeDelegate: class {
     /// Tells the delegate to display the media editor from a given URL
     ///
     func gutenbergDidRequestMediaEditor(with mediaUrl: URL, callback: @escaping MediaPickerDidPickMediaCallback)
-    
+
     /// Tells the delegate that the editor needs to log a custom event
     /// - Parameter event: The event key to be logged
     func gutenbergDidLogUserEvent(_ event: GutenbergUserEvent)
@@ -225,9 +225,9 @@ public protocol GutenbergBridgeDelegate: class {
 
     /// Tells the delegate that the editor requested to show the tooltip
     func gutenbergDidRequestStarterPageTemplatesTooltipShown() -> Bool
-    
+
     /// Tells the delegate that the editor requested to set the tooltip's visibility
-    /// - Parameter tooltipShown: Tooltip's visibility value    
+    /// - Parameter tooltipShown: Tooltip's visibility value
     func gutenbergDidRequestSetStarterPageTemplatesTooltipShown(_ tooltipShown: Bool)
 
     func gutenbergDidSendButtonPressedAction(_ buttonType: Gutenberg.ActionButtonType)

--- a/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
+++ b/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
@@ -14,6 +14,7 @@ public struct MediaInfo {
 
 /// Definition of capabilities to enable in the Block Editor
 public enum Capabilities: String {
+    case stories
     case mentions
     case unsupportedBlockEditor
     case canEnableUnsupportedBlockEditor


### PR DESCRIPTION
Uses `hideBlockTypes` from `core/edit-post` to hide the Story block when the feature flag from the host app is not present.

Related PRs:
- Gutenberg mobile https://github.com/wordpress-mobile/gutenberg-mobile/pull/2762
- WPAndroid PR: https://github.com/wordpress-mobile/WordPress-Android/pull/13245