### PR TITLE
Restore underlines on is-tertiary buttons

### DIFF
--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -120,6 +120,7 @@
 		&:hover:not(:disabled) {
 			color: var(--wp-admin-theme-color-darker-10);
 			box-shadow: inset 0 0 0 $border-width var(--wp-admin-theme-color-darker-10);
+			text-decoration: none;
 		}
 
 		&:disabled,
@@ -131,6 +132,7 @@
 			opacity: 1;
 			box-shadow: none;
 			outline: none;
+			text-decoration: none;
 		}
 	}
 
@@ -155,6 +157,7 @@
 		color: var(--wp-admin-theme-color);
 		background: transparent;
 		padding: 6px; // This reduces the horizontal padding on tertiary/text buttons, so as to space them optically.
+		text-decoration: underline;
 
 		.dashicon {
 			display: inline-block;
@@ -169,6 +172,7 @@
 	&.is-destructive {
 		color: $alert-red;
 		box-shadow: inset 0 0 0 $border-width $alert-red;
+		text-decoration: none;
 
 		&:hover:not(:disabled) {
 			color: darken($alert-red, 20%);


### PR DESCRIPTION
## Description
Closes #23890.

Restores the underline to the tertiary button styles in the editor.

## How has this been tested?
Tested on lastest versions of Firefox, Chrome and Safari in macOs.

## Screenshots 

<img width="1054" alt="Screen Shot 2020-10-27 at 15 56 16" src="https://user-images.githubusercontent.com/3276087/97367973-a72b4780-186f-11eb-9dd8-89530e676c06.png">

---

<img width="1055" alt="Screen Shot 2020-10-27 at 16 09 18" src="https://user-images.githubusercontent.com/3276087/97367988-ab576500-186f-11eb-9f56-566b4f748d6d.png">

---

<img width="1054" alt="Screen Shot 2020-10-27 at 15 56 16" src="https://user-images.githubusercontent.com/3276087/97368003-b01c1900-186f-11eb-8ad9-f13a180e1da1.png">

---

![2020-10-27 16-03-30 2020-10-27 16_05_08](https://user-images.githubusercontent.com/3276087/97368017-b3170980-186f-11eb-82f3-d81670b9d966.gif)

---


## Types of changes
CSS and visual changes.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
