### PR TITLE
Try fixing/stabilizing allowed blocks test

### DIFF
--- a/packages/e2e-test-utils/src/create-new-post.js
+++ b/packages/e2e-test-utils/src/create-new-post.js
@@ -58,5 +58,7 @@ export async function createNewPost( {
 				.dispatch( 'core/edit-post' )
 				.toggleFeature( 'fullscreenMode' )
 		);
+
+		await page.waitForSelector( 'body:not(.is-fullscreen-mode)' );
 	}
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Currently the following test is failing intermittently:
```
Allowed Blocks Filter › should restrict the allowed blocks in the inserter

    TimeoutError: waiting for selector ".block-editor-inserter__search-input,input.block-editor-inserter__search" failed: timeout 30000ms exceeded
```

It feels like the only way the `waitForSelector` call for the search input would fail is if the inserter fails to open. Looking at the code there's no conditional rendering of the search input, it should always be present when the block library panel is open.

From observing the test I noticed that full-screen mode is always disabled at the start of the test. My current theory is that sometimes the page layout shifts just as the 'Add Block' button is supposed to be clicked, causing the click to miss its target. This change waits for the `is-fullscreen-mode` class to be removed. Bit of a stab in the dark, though.

