### PR TITLE
Mobile: Add canUser checks to media components

### DIFF
--- a/packages/block-editor/src/components/media-upload/index.native.js
+++ b/packages/block-editor/src/components/media-upload/index.native.js
@@ -20,6 +20,8 @@ import {
 	video,
 	wordpress,
 } from '@wordpress/icons';
+import { withSelect } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
 
 export const MEDIA_TYPE_IMAGE = 'image';
 export const MEDIA_TYPE_VIDEO = 'video';
@@ -98,7 +100,10 @@ export class MediaUpload extends React.Component {
 			siteLibrarySource,
 		];
 
-		return internalSources.concat( this.state.otherMediaOptions );
+		if ( this.props.hasMediaUpload ) {
+			return internalSources.concat( this.state.otherMediaOptions );
+		}
+		return [ siteLibrarySource ]; // You can only use the media that ia already there
 	}
 
 	getMediaOptionsItems() {
@@ -209,4 +214,10 @@ export class MediaUpload extends React.Component {
 	}
 }
 
-export default MediaUpload;
+export default compose(
+	withSelect( ( select ) => {
+		return {
+			hasMediaUpload: !! select( 'core' ).canUser( 'create', 'media' ),
+		};
+	} )
+)( MediaUpload );

--- a/packages/components/src/mobile/media-edit/index.native.js
+++ b/packages/components/src/mobile/media-edit/index.native.js
@@ -13,6 +13,8 @@ import {
 	requestMediaEditor,
 	mediaSources,
 } from '@wordpress/react-native-bridge';
+import { withSelect } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
 
 export const MEDIA_TYPE_IMAGE = 'image';
 
@@ -32,7 +34,7 @@ const replaceOption = {
 	types: [ MEDIA_TYPE_IMAGE ],
 };
 
-export class MediaEdit extends React.Component {
+class MediaEditClass extends React.Component {
 	constructor( props ) {
 		super( props );
 		this.onPickerPresent = this.onPickerPresent.bind( this );
@@ -44,10 +46,15 @@ export class MediaEdit extends React.Component {
 	}
 
 	getMediaOptionsItems() {
-		const { pickerOptions, openReplaceMediaOptions, source } = this.props;
+		const {
+			pickerOptions,
+			openReplaceMediaOptions,
+			source,
+			hasMediaUpload,
+		} = this.props;
 
 		return compact( [
-			source?.uri && editOption,
+			source?.uri && hasMediaUpload && editOption,
 			openReplaceMediaOptions && replaceOption,
 			...( pickerOptions ? pickerOptions : [] ),
 		] );
@@ -123,4 +130,13 @@ export class MediaEdit extends React.Component {
 	}
 }
 
+const MediaEdit = compose(
+	withSelect( ( select ) => {
+		return {
+			hasMediaUpload: !! select( 'core' ).canUser( 'create', 'media' ),
+		};
+	} )
+)( MediaEditClass );
+
+export { MediaEdit };
 export default MediaEdit;

--- a/packages/react-native-editor/src/api-fetch-setup.js
+++ b/packages/react-native-editor/src/api-fetch-setup.js
@@ -13,7 +13,11 @@ const SUPPORTED_ENDPOINTS = [
 const setTimeoutPromise = ( delay ) =>
 	new Promise( ( resolve ) => setTimeout( resolve, delay ) );
 
-const fetchHandler = ( { path }, retries = 20, retryCount = 1 ) => {
+const fetchHandler = (
+	{ path, parse = true },
+	retries = 20,
+	retryCount = 1
+) => {
 	if ( ! isPathSupported( path ) ) {
 		return Promise.reject( `Unsupported path: ${ path }` );
 	}
@@ -23,7 +27,16 @@ const fetchHandler = ( { path }, retries = 20, retryCount = 1 ) => {
 	const parseResponse = ( response ) => {
 		if ( typeof response === 'string' ) {
 			response = JSON.parse( response );
+			if ( ! parse ) {
+				// Create the expected response object.
+				return new Response( response.body, {
+					status: response.statusCode,
+					headers: response.headers,
+				} );
+			}
+			return response.body;
 		}
+
 		return response;
 	};
 


### PR DESCRIPTION
## Description
Currently we don't check for canUser permissions (more specifically media upload permissions) before we display UI that lets them do that. Instead we show them an error message after the api returns that they can't upload an image for example. 

In order to fix this we needed to update the network layer on the native side ([Android FluxC](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1739 )) and iOS (coming soon) to return more then just the body of the response. 

## How has this been tested?
Testing prerequisites. 
- Set a user to be a contributor on one site.
- Set the same user as an admin, editor or author on a different site.

Apply the https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1739 
To your local Android build. 

On the site where you are a contributor. 
1. Check the different blocks that let you add Media (Image, Video, Gallery, Media-Text) note that you only the see the choice to use the WordPress Media. 
2. When a Image is selected note that you can only replace the image and not edit it.

On a site that you are a (admin, editor or author) 
1. Check that the different blocks that let you add Media (Image, Video, Gallery, Media-Text) note that you can add images for more then just WordPress Media.
2. 2. When a Image is selected note that you can  replace and edit the the image as expected.

## Screenshots <!-- if applicable -->
New Popover choice to only Choose the image from the WordPress Media. 
<img width="300" src="https://user-images.githubusercontent.com/115071/97914817-54391080-1d05-11eb-89a4-67e729b6f763.png" />

New popover choose to only replace image. 
<img width="300" src="https://user-images.githubusercontent.com/115071/97914787-45525e00-1d05-11eb-9366-09f2ab2951f5.png" />

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
