### PR TITLE
Ensure editor footer remains at the bottom of the screen when navigating regions

### DIFF
--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -148,6 +148,13 @@ html.interface-interface-skeleton__html-container {
 	background-color: $white;
 	z-index: z-index(".interface-interface-skeleton__footer");
 
+	// When the navigate regions shortcut is used it applies position: relative
+	// to regions. The footer should always stay stuck to the bottom though, so
+	// override using a more specific selector with position: fixed.
+	.is-focusing-regions &[role="region"] {
+		position: fixed;
+	}
+
 	// On Mobile the footer is hidden
 	display: none;
 	@include break-medium() {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes  #26532

When using <kbd>Ctrl + `</kbd> to navigate regions, the footer suddenly takes up more than half the screen on desktop sized browsers.

It's caused by `position: relative` being applied to regions:
https://github.com/WordPress/gutenberg/blob/5060734d4cf0002cc0f4d0c02bfd7e86b6de7d1a/packages/components/src/higher-order/navigate-regions/style.scss#L2

The footer uses `position: fixed` to stick to the bottom of the screen, so `relative` suddenly overrides that.

The two potential solutions are:
- Remove `position: relative` from navigate regions
- Override `position: relative` just for the footer.

I've gone with the second solution as I don't know what implications the first might have.

## How has this been tested?
1. Open the editor and press Ctrl + `
2. The page layout shouldn't change

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
