### PR TITLE
FSE - Follow-up to #25995: Use `WP_Theme::get_stylesheet` instead of the private property.

### DIFF
--- a/lib/template-parts.php
+++ b/lib/template-parts.php
@@ -210,7 +210,7 @@ function filter_rest_wp_template_part_query( $args, $request ) {
 		);
 
 		// Ensure auto-drafts of all theme supplied template parts are created.
-		if ( wp_get_theme()->stylesheet === $request['theme'] ) {
+		if ( wp_get_theme()->get_stylesheet() === $request['theme'] ) {
 			/**
 			 * Finds all nested template part file paths in a theme's directory.
 			 *


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
As noted in [this comment](https://github.com/WordPress/gutenberg/pull/25995/files#r504983933) on PR #25995, the `WP_Theme::get_stylesheet()` method should be used instead of of accessing the private property.

Code like `wp_get_theme()->stylesheet` only works because it is implemented as part of the `__get()` method. PHP IDE's and code analysis tools will flag this as a pattern to avoid.

## How has this been tested?
Manually tested by verifying that template parts are still correctly being displayed on the frontend.

## Types of changes
PHP code style enhancement.