### PR TITLE
Take into account existing settings for back compatibility

### DIFF
--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -257,84 +257,114 @@ function gutenberg_experimental_global_styles_get_core() {
 /**
  * Returns the theme presets registered via add_theme_support, if any.
  *
+ * @param array $settings Existing settings passed to the editor.
+ *
  * @return array Config that adheres to the theme.json schema.
  */
-function gutenberg_experimental_global_styles_get_theme_support_settings() {
+function gutenberg_experimental_global_styles_get_existing_theme_settings( $settings ) {
 	$theme_settings                       = array();
 	$theme_settings['global']             = array();
 	$theme_settings['global']['settings'] = array();
 
-	// Deprecated theme supports.
-	if ( get_theme_support( 'disable-custom-colors' ) ) {
+	// STEP 1: port settings that are already processed by core
+	// and could had been filtered by any 3rd party.
+
+	if ( array_key_exists( 'disableCustomColors', $settings ) && $settings['disableCustomColors'] ) {
 		if ( ! isset( $theme_settings['global']['settings']['color'] ) ) {
 			$theme_settings['global']['settings']['color'] = array();
 		}
 		$theme_settings['global']['settings']['color']['custom'] = false;
+		unset( $settings['disableCustomColors'] );
 	}
-	if ( get_theme_support( 'disable-custom-gradients' ) ) {
+
+	if ( array_key_exists( 'disableCustomGradients', $settings ) && $settings['disableCustomGradients'] ) {
 		if ( ! isset( $theme_settings['global']['settings']['color'] ) ) {
 			$theme_settings['global']['settings']['color'] = array();
 		}
 		$theme_settings['global']['settings']['color']['customGradient'] = false;
+		unset( $settings['disableCustomGradients'] );
 	}
-	if ( get_theme_support( 'disable-custom-font-sizes' ) ) {
+
+	if ( array_key_exists( 'disableCustomFontSizes', $settings ) && $settings['disableCustomFontSizes'] ) {
 		if ( ! isset( $theme_settings['global']['settings']['typography'] ) ) {
 			$theme_settings['global']['settings']['typography'] = array();
 		}
 		$theme_settings['global']['settings']['typography']['customFontSize'] = false;
+		unset( $settings['disableCustomFontSizes'] );
 	}
-	if ( get_theme_support( 'custom-line-height' ) ) {
+
+	if ( array_key_exists( 'enableCustomLineHeight', $settings ) && $settings['enableCustomLineHeight'] ) {
 		if ( ! isset( $theme_settings['global']['settings']['typography'] ) ) {
 			$theme_settings['global']['settings']['typography'] = array();
 		}
 		$theme_settings['global']['settings']['typography']['customLineHeight'] = true;
+		unset( $settings['enableCustomLineHeight'] );
 	}
+
+	if ( array_key_exists( 'enableCustomUnits', $settings ) && $settings['enableCustomUnits'] ) {
+		if ( ! isset( $theme_settings['global']['settings']['spacing'] ) ) {
+			$theme_settings['global']['settings']['spacing'] = array();
+		}
+		$custom_units = true === $settings['enableCustomLineHeight'] ? array( 'px', 'em', 'rem', 'vh', 'vw' ) : $settings['enableCustomUnits'];
+		$theme_settings['global']['settings']['spacing'] ['units'] = $custom_units;
+		unset( $settings['enableCustomUnits'] );
+	}
+
+	if (
+		array_key_exists( 'colors', $settings ) &&
+		is_array( $settings['colors'] ) &&
+		! empty( $settings['colors'] )
+	) {
+		if ( ! isset( $theme_settings['global']['settings']['color'] ) ) {
+			$theme_settings['global']['settings']['color'] = array();
+		}
+		$theme_settings['global']['settings']['color']['palette'] = array();
+		$theme_settings['global']['settings']['color']['palette'] = $settings['colors'];
+		unset( $settings['colors'] );
+	}
+
+	if (
+		array_key_exists( 'gradients', $settings ) &&
+		is_array( $settings['gradients'] ) &&
+		! empty( $settings['gradients'] )
+	) {
+		if ( ! isset( $theme_settings['global']['settings']['color'] ) ) {
+			$theme_settings['global']['settings']['color'] = array();
+		}
+		$theme_settings['global']['settings']['color']['gradients'] = array();
+		$theme_settings['global']['settings']['color']['gradients'] = $settings['gradients'];
+		unset( $settings['gradients'] );
+	}
+
+	if (
+		array_key_exists( 'fontSizes', $settings ) &&
+		is_array( $settings['fontSizes'] ) &&
+		! empty( $settings['fontSizes'] )
+	) {
+		if ( ! isset( $theme_settings['global']['settings']['typography'] ) ) {
+			$theme_settings['global']['settings']['typography'] = array();
+		}
+		$theme_settings['global']['settings']['typography']['fontSizes'] = array();
+		$theme_settings['global']['settings']['typography']['fontSizes'] = $settings['fontSizes'];
+		unset( $settings['fontSizes'] );
+	}
+
+	// STEP 2: process settings that weren't ported to core,
+	// so there wasn't an existing prior setting value for them,
+	// hence we query directly for theme support.
+
 	if ( get_theme_support( 'custom-spacing' ) ) {
 		if ( ! isset( $theme_settings['global']['settings']['spacing'] ) ) {
 			$theme_settings['global']['settings']['spacing'] = array();
 		}
 		$theme_settings['global']['settings']['spacing']['custom'] = true;
 	}
+
 	if ( get_theme_support( 'experimental-link-color' ) ) {
 		if ( ! isset( $theme_settings['global']['settings']['color'] ) ) {
 			$theme_settings['global']['settings']['color'] = array();
 		}
 		$theme_settings['global']['settings']['color']['link'] = true;
-	}
-
-	$custom_units_theme_support = get_theme_support( 'custom-units' );
-	if ( $custom_units_theme_support ) {
-		if ( ! isset( $theme_settings['global']['settings']['spacing'] ) ) {
-			$theme_settings['global']['settings']['spacing'] = array();
-		}
-		$theme_settings['global']['settings']['spacing'] ['units'] = true === $custom_units_theme_support ? array( 'px', 'em', 'rem', 'vh', 'vw' ) : $custom_units_theme_support;
-	}
-
-	$theme_colors = get_theme_support( 'editor-color-palette' );
-	if ( ! empty( $theme_colors[0] ) ) {
-		if ( ! isset( $theme_settings['global']['settings']['color'] ) ) {
-			$theme_settings['global']['settings']['color'] = array();
-		}
-		$theme_settings['global']['settings']['color']['palette'] = array();
-		$theme_settings['global']['settings']['color']['palette'] = $theme_colors[0];
-	}
-
-	$theme_gradients = get_theme_support( 'editor-gradient-presets' );
-	if ( ! empty( $theme_gradients[0] ) ) {
-		if ( ! isset( $theme_settings['global']['settings']['color'] ) ) {
-			$theme_settings['global']['settings']['color'] = array();
-		}
-		$theme_settings['global']['settings']['color']['gradients'] = array();
-		$theme_settings['global']['settings']['color']['gradients'] = $theme_gradients[0];
-	}
-
-	$theme_font_sizes = get_theme_support( 'editor-font-sizes' );
-	if ( ! empty( $theme_font_sizes[0] ) ) {
-		if ( ! isset( $theme_settings['global']['settings']['typography'] ) ) {
-			$theme_settings['global']['settings']['typography'] = array();
-		}
-		$theme_settings['global']['settings']['typography']['fontSizes'] = array();
-		$theme_settings['global']['settings']['typography']['fontSizes'] = $theme_font_sizes[0];
 	}
 
 	return $theme_settings;
@@ -343,14 +373,13 @@ function gutenberg_experimental_global_styles_get_theme_support_settings() {
 /**
  * Returns the theme's origin config.
  *
- * It also fetches the existing presets the theme declared via add_theme_support
- * and uses them if the theme hasn't declared any via theme.json.
+ * @param array $fallback Optional theme settings to fall back to
+ *                        if there's no value for them in the theme.json.
  *
  * @return array Config that adheres to the theme.json schema.
  */
-function gutenberg_experimental_global_styles_get_theme() {
-	$theme_support_settings = gutenberg_experimental_global_styles_get_theme_support_settings();
-	$theme_config           = gutenberg_experimental_global_styles_get_from_file(
+function gutenberg_experimental_global_styles_get_theme( $fallback = array() ) {
+	$theme_config = gutenberg_experimental_global_styles_get_from_file(
 		locate_template( 'experimental-theme.json' )
 	);
 
@@ -368,7 +397,7 @@ function gutenberg_experimental_global_styles_get_theme() {
 	 *
 	 */
 	$theme_config = gutenberg_experimental_global_styles_merge_trees(
-		$theme_support_settings,
+		$fallback,
 		$theme_config
 	);
 
@@ -840,11 +869,14 @@ function gutenberg_experimental_global_styles_normalize_schema( $tree ) {
  * Takes data from the different origins (core, theme, and user)
  * and returns the merged result.
  *
+ * @param array $theme_settings_fallback Optional theme settings to fall back to
+ *              if there's no value for them in the theme.json.
+ *
  * @return array Merged trees
  */
-function gutenberg_experimental_global_styles_get_merged_origins() {
+function gutenberg_experimental_global_styles_get_merged_origins( $theme_settings_fallback = array() ) {
 	$core  = gutenberg_experimental_global_styles_get_core();
-	$theme = gutenberg_experimental_global_styles_get_theme();
+	$theme = gutenberg_experimental_global_styles_get_theme( $theme_settings_fallback );
 	$user  = gutenberg_experimental_global_styles_get_user();
 
 	return gutenberg_experimental_global_styles_merge_trees( $core, $theme, $user );
@@ -895,21 +927,12 @@ function gutenberg_experimental_global_styles_get_editor_settings( $config ) {
  * @return array New block editor settings
  */
 function gutenberg_experimental_global_styles_settings( $settings ) {
-	$merged = gutenberg_experimental_global_styles_get_merged_origins();
+	$theme_settings = gutenberg_experimental_global_styles_get_existing_theme_settings( $settings );
+	$merged         = gutenberg_experimental_global_styles_get_merged_origins( $theme_settings );
 
 	// STEP 1: ADD FEATURES
-	// These need to be added to settings always.
-	// We also need to unset the deprecated settings defined by core.
+	// These need to be added for any editor.
 	$settings['__experimentalFeatures'] = gutenberg_experimental_global_styles_get_editor_settings( $merged );
-
-	unset( $settings['colors'] );
-	unset( $settings['gradients'] );
-	unset( $settings['fontSizes'] );
-	unset( $settings['disableCustomColors'] );
-	unset( $settings['disableCustomGradients'] );
-	unset( $settings['disableCustomFontSizes'] );
-	unset( $settings['enableCustomLineHeight'] );
-	unset( $settings['enableCustomUnits'] );
 
 	// STEP 2 - IF EDIT-SITE, ADD DATA REQUIRED FOR GLOBAL STYLES SIDEBAR
 	// The client needs some information to be able to access/update the user styles.
@@ -926,7 +949,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 		$settings['__experimentalGlobalStylesContexts']     = gutenberg_experimental_global_styles_get_block_data();
 		$settings['__experimentalGlobalStylesBaseStyles']   = gutenberg_experimental_global_styles_merge_trees(
 			gutenberg_experimental_global_styles_get_core(),
-			gutenberg_experimental_global_styles_get_theme()
+			gutenberg_experimental_global_styles_get_theme( $theme_settings )
 		);
 	} else {
 		// STEP 3 - OTHERWISE, ADD STYLES
@@ -975,5 +998,6 @@ function gutenberg_experimental_global_styles_register_cpt() {
 }
 
 add_action( 'init', 'gutenberg_experimental_global_styles_register_cpt' );
-add_filter( 'block_editor_settings', 'gutenberg_experimental_global_styles_settings' );
 add_action( 'wp_enqueue_scripts', 'gutenberg_experimental_global_styles_enqueue_assets' );
+// We want it to be the last of the filters applied, hence the PHP_INT_MAX.
+add_filter( 'block_editor_settings', 'gutenberg_experimental_global_styles_settings', PHP_INT_MAX );


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/26537

## To Do

- Make it work for edit-site.
- Review other editors.

## How to test

- Activate a theme that doesn't have support for line height.
- Filter the editor settings to enable line height. For example, paste this code in global-styles.php

```php
function gs_set_custom_line_height( $settings ) {
	$settings['enableCustomLineHeight'] = true;
	return $settings;
}
add_filter('block_editor_settings', 'gs_set_custom_line_height');
```

The expected result is that the line height control should be enabled in any of the editors (post, site, etc). It isn't in the `master` branch.