### PR TITLE
Update Version in WordPress doc for 5.5.2 and 5.6

### DIFF
--- a/docs/contributors/versions-in-wordpress.md
+++ b/docs/contributors/versions-in-wordpress.md
@@ -6,7 +6,8 @@ If anything looks incorrect here, please bring it up in #core-editor in [WordPre
 
 | Gutenberg Versions | WordPress Version |
 | ------------------ | ----------------- |
-| 8.5.1-9.2            | 5.6             |
+| 8.6-9.2            | 5.6             |
+| 8.6-9.2            | 5.5.2             |
 | 7.6-8.5            | 5.5.1             |
 | 7.6-8.5            | 5.5               |
 | 6.6-7.5            | 5.4.2             |

--- a/docs/contributors/versions-in-wordpress.md
+++ b/docs/contributors/versions-in-wordpress.md
@@ -7,7 +7,8 @@ If anything looks incorrect here, please bring it up in #core-editor in [WordPre
 | Gutenberg Versions | WordPress Version |
 | ------------------ | ----------------- |
 | 8.6-9.2            | 5.6             |
-| 8.6-9.2            | 5.5.2             |
+| 7.6-8.5            | 5.5.3             |
+| 7.6-8.5            | 5.5.2             |
 | 7.6-8.5            | 5.5.1             |
 | 7.6-8.5            | 5.5               |
 | 6.6-7.5            | 5.4.2             |


### PR DESCRIPTION
An additional update to cover 5.5.2 and 5.6. I made a slight change to what was shared previously for 5.6 to remove the patch release mention (8.5.1) since those releases are for bug fixes that are cherry picked into the prior release.