### PR TITLE
Add taxonomy field to categories block

### DIFF
--- a/packages/block-library/src/categories/block.json
+++ b/packages/block-library/src/categories/block.json
@@ -3,6 +3,10 @@
 	"name": "core/categories",
 	"category": "widgets",
 	"attributes": {
+		"taxonomy": {
+			"type": "string",
+			"default": "category"
+		},
 		"displayAsDropdown": {
 			"type": "boolean",
 			"default": false

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -23,7 +23,7 @@ import { pin } from '@wordpress/icons';
 function CategoriesEdit( {
 	attributes: { taxonomy, displayAsDropdown, showHierarchy, showPostCounts },
 	setAttributes,
-	taxonomies
+	taxonomies,
 } ) {
 	const selectId = useInstanceId( CategoriesEdit, 'blocks-category-select' );
 	const { categories, isRequesting } = useSelect( ( select ) => {

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -17,7 +17,7 @@ function render_block_core_categories( $attributes ) {
 	$block_id++;
 
 	$args = array(
-		'taxonomy'     => empty($attributes['taxonomy']) ? 'category' : $attributes['taxonomy'],
+		'taxonomy'     => empty( $attributes['taxonomy'] ) ? 'category' : $attributes['taxonomy'],
 		'echo'         => false,
 		'hierarchical' => ! empty( $attributes['showHierarchy'] ),
 		'orderby'      => 'name',

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -17,6 +17,7 @@ function render_block_core_categories( $attributes ) {
 	$block_id++;
 
 	$args = array(
+		'taxonomy'     => empty($attributes['taxonomy']) ? 'category' : $attributes['taxonomy'],
 		'echo'         => false,
 		'hierarchical' => ! empty( $attributes['showHierarchy'] ),
 		'orderby'      => 'name',

--- a/packages/e2e-tests/fixtures/blocks/core__categories.json
+++ b/packages/e2e-tests/fixtures/blocks/core__categories.json
@@ -6,7 +6,8 @@
         "attributes": {
             "displayAsDropdown": false,
             "showHierarchy": false,
-            "showPostCounts": false
+            "showPostCounts": false,
+            "taxonomy": "category"
         },
         "innerBlocks": [],
         "originalContent": ""

--- a/packages/e2e-tests/fixtures/blocks/core__categories.parsed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__categories.parsed.json
@@ -4,7 +4,8 @@
         "attrs": {
             "showPostCounts": false,
             "displayAsDropdown": false,
-            "showHierarchy": false
+            "showHierarchy": false,
+            "taxonomy": "category"
         },
         "innerBlocks": [],
         "innerHTML": "",


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Adding a taxonomy selector the the Categories block.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Setup with Docker environment and tested in browser.

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/162595/97505096-7281c380-1935-11eb-9344-65f0c6a08716.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Adds taxonomy selector field in the inspector panel.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->

## TODO:
- I was not able to figure out how to make the preview re-render after changing the taxonomy
- The `build_dropdown_script_block_core_categories()` function will need to be updated so that redirects to other taxonomies will work

This is incomplete, but hopefully a start that someone can fill in the last details.