### PR TITLE
Fix dirty template and template parts on template creation.

### DIFF
--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -34,9 +34,8 @@ export default function TemplatePartEdit( {
 	const postId = useTemplatePartPost( _postId, slug, theme );
 
 	// Set the post ID, once found, so that edits persist,
-	// but wait until the third inner blocks change,
-	// because the first 2 are just the template part
-	// content loading.
+	// but wait until the inner blocks have loaded to allow
+	// new edits to trigger this.
 	const { innerBlocks, entityRecordEdits } = useSelect(
 		( select ) => {
 			const { getBlocks } = select( 'core/block-editor' );

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -27,7 +27,6 @@ export default function TemplatePartEdit( {
 	setAttributes,
 	clientId,
 } ) {
-	const initialPostId = useRef( _postId );
 	const initialSlug = useRef( slug );
 	const initialTheme = useRef( theme );
 
@@ -56,30 +55,22 @@ export default function TemplatePartEdit( {
 	const { editEntityRecord } = useDispatch( 'core' );
 	const [ areInnerBlocksLoaded, setAreInnerBlocksLoaded ] = useState( false );
 	useEffect( () => {
-		if (
-			! areInnerBlocksLoaded &&
-			postId !== null &&
-			postId !== undefined &&
-			innerBlocks === entityRecordEdits?.blocks
-		) {
-			// Another option than using entityRecordEdits is to get the entityRecord
-			// parse its content into blocks, then compare.
-			setAreInnerBlocksLoaded( true );
-			return;
-		}
+		if ( postId !== null && postId !== undefined ) {
+			if ( ! areInnerBlocksLoaded ) {
+				// Another option than using entityRecordEdits is to get the entityRecord
+				// parse its content into blocks, then compare.
+				if ( innerBlocks === entityRecordEdits?.blocks ) {
+					setAreInnerBlocksLoaded( true );
+				}
+				return;
+			}
 
-		if (
-			areInnerBlocksLoaded &&
-			( _postId === null || _postId === undefined ) &&
-			( initialPostId.current === undefined ||
-				initialPostId.current === null ) &&
-			postId !== undefined &&
-			postId !== null
-		) {
-			setAttributes( { postId } );
-			editEntityRecord( 'postType', 'wp_template_part', postId, {
-				status: 'publish',
-			} );
+			if ( _postId === null || _postId === undefined ) {
+				setAttributes( { postId } );
+				editEntityRecord( 'postType', 'wp_template_part', postId, {
+					status: 'publish',
+				} );
+			}
 		}
 	}, [ innerBlocks, entityRecordEdits?.blocks ] );
 

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -29,6 +29,7 @@ export default function TemplatePartEdit( {
 } ) {
 	const initialSlug = useRef( slug );
 	const initialTheme = useRef( theme );
+	const initialContent = useRef();
 
 	// Resolve the post ID if not set, and load its post.
 	const postId = useTemplatePartPost( _postId, slug, theme );
@@ -53,24 +54,26 @@ export default function TemplatePartEdit( {
 		[ clientId, postId ]
 	);
 	const { editEntityRecord } = useDispatch( 'core' );
-	const initialContent = useRef();
+
 	useEffect( () => {
-		if ( postId === null || postId === undefined ) {
+		if (
+			postId === null ||
+			postId === undefined ||
+			( _postId !== null && _postId !== undefined )
+		) {
 			return;
 		}
 
+		const innerContent = serialize( innerBlocks );
+
 		if ( ! initialContent.current ) {
-			const innerContent = serialize( innerBlocks );
 			if ( innerContent === expectedContent ) {
 				initialContent.current = innerContent;
 			}
 			return;
 		}
 
-		if (
-			( _postId === null || _postId === undefined ) &&
-			initialContent.current !== serialize( innerBlocks )
-		) {
+		if ( initialContent.current !== innerContent ) {
 			setAttributes( { postId } );
 			editEntityRecord( 'postType', 'wp_template_part', postId, {
 				status: 'publish',

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -67,7 +67,7 @@ export default function TemplatePartEdit( {
 
 		const innerContent = serialize( innerBlocks );
 
-		// If we havent set initialContent, the block hasn't loaded.
+		// If we havent set initialContent, check if innerBlocks are loaded.
 		if ( ! initialContent.current ) {
 			// If the content of innerBlocks and the content from entity match,
 			// then we can consider innerBlocks as loaded and set initialContent.

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useRef, useEffect, useState } from '@wordpress/element';
+import { useRef, useEffect } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { BlockControls, useBlockProps } from '@wordpress/block-editor';
 import {
@@ -53,20 +53,24 @@ export default function TemplatePartEdit( {
 		[ clientId, postId ]
 	);
 	const { editEntityRecord } = useDispatch( 'core' );
-	const [ areInnerBlocksLoaded, setAreInnerBlocksLoaded ] = useState( false );
+	const initialContent = useRef();
 	useEffect( () => {
 		if ( postId === null || postId === undefined ) {
 			return;
 		}
 
-		if ( ! areInnerBlocksLoaded ) {
-			if ( serialize( innerBlocks ) === expectedContent ) {
-				setAreInnerBlocksLoaded( true );
+		if ( ! initialContent.current ) {
+			const innerContent = serialize( innerBlocks );
+			if ( innerContent === expectedContent ) {
+				initialContent.current = innerContent;
 			}
 			return;
 		}
 
-		if ( _postId === null || _postId === undefined ) {
+		if (
+			( _postId === null || _postId === undefined ) &&
+			initialContent.current !== serialize( innerBlocks )
+		) {
 			setAttributes( { postId } );
 			editEntityRecord( 'postType', 'wp_template_part', postId, {
 				status: 'publish',

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -33,7 +33,7 @@ export default function TemplatePartEdit( {
 	// Resolve the post ID if not set, and load its post.
 	const postId = useTemplatePartPost( _postId, slug, theme );
 
-	// Set the post ID, once found, so that edits persist,
+	// Set the postId attribute if it did not exist,
 	// but wait until the inner blocks have loaded to allow
 	// new edits to trigger this.
 	const { innerBlocks, entityRecordEdits } = useSelect(
@@ -54,22 +54,22 @@ export default function TemplatePartEdit( {
 	const { editEntityRecord } = useDispatch( 'core' );
 	const [ areInnerBlocksLoaded, setAreInnerBlocksLoaded ] = useState( false );
 	useEffect( () => {
-		if ( postId !== null && postId !== undefined ) {
-			if ( ! areInnerBlocksLoaded ) {
-				// Another option than using entityRecordEdits is to get the entityRecord
-				// parse its content into blocks, then compare.
-				if ( innerBlocks === entityRecordEdits?.blocks ) {
-					setAreInnerBlocksLoaded( true );
-				}
-				return;
-			}
+		if ( postId === null || postId === undefined ) {
+			return;
+		}
 
-			if ( _postId === null || _postId === undefined ) {
-				setAttributes( { postId } );
-				editEntityRecord( 'postType', 'wp_template_part', postId, {
-					status: 'publish',
-				} );
+		if ( ! areInnerBlocksLoaded ) {
+			if ( innerBlocks === entityRecordEdits?.blocks ) {
+				setAreInnerBlocksLoaded( true );
 			}
+			return;
+		}
+
+		if ( _postId === null || _postId === undefined ) {
+			setAttributes( { postId } );
+			editEntityRecord( 'postType', 'wp_template_part', postId, {
+				status: 'publish',
+			} );
 		}
 	}, [ innerBlocks, entityRecordEdits?.blocks ] );
 

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -34,7 +34,7 @@ export default function TemplatePartEdit( {
 	// Resolve the post ID if not set, and load its post.
 	const postId = useTemplatePartPost( _postId, slug, theme );
 
-	// Set the postId attribute if it did not exist,
+	// Set the postId block attribute if it did not exist,
 	// but wait until the inner blocks have loaded to allow
 	// new edits to trigger this.
 	const { innerBlocks, expectedContent } = useSelect(
@@ -54,8 +54,9 @@ export default function TemplatePartEdit( {
 		[ clientId, postId ]
 	);
 	const { editEntityRecord } = useDispatch( 'core' );
-
 	useEffect( () => {
+		// If postId (entity) has not resolved or _postId (block attr) is set,
+		// then we have no need for this effect.
 		if (
 			postId === null ||
 			postId === undefined ||
@@ -66,13 +67,21 @@ export default function TemplatePartEdit( {
 
 		const innerContent = serialize( innerBlocks );
 
+		// If we havent set initialContent, the block hasn't loaded.
 		if ( ! initialContent.current ) {
+			// If the content of innerBlocks and the content from entity match,
+			// then we can consider innerBlocks as loaded and set initialContent.
 			if ( innerContent === expectedContent ) {
 				initialContent.current = innerContent;
 			}
+			// Continue to return early until this effect is triggered
+			// with innerBlocks already loaded (as denoted by initialContent being set).
 			return;
 		}
 
+		// After initialContent is set and the content is updated, we can set the
+		// postId block attribute and set the post status to 'publish'.
+		// After this is done the hook will no longer run due to the first return above.
 		if ( initialContent.current !== innerContent ) {
 			setAttributes( { postId } );
 			editEntityRecord( 'postType', 'wp_template_part', postId, {

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -12,7 +12,7 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { chevronUp, chevronDown } from '@wordpress/icons';
-
+import { serialize } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
@@ -36,17 +36,18 @@ export default function TemplatePartEdit( {
 	// Set the postId attribute if it did not exist,
 	// but wait until the inner blocks have loaded to allow
 	// new edits to trigger this.
-	const { innerBlocks, entityRecordEdits } = useSelect(
+	const { innerBlocks, expectedContent } = useSelect(
 		( select ) => {
 			const { getBlocks } = select( 'core/block-editor' );
-			const { getEntityRecordEdits } = select( 'core' );
+			const entityRecord = select( 'core' ).getEntityRecord(
+				'postType',
+				'wp_template_part',
+				postId
+			);
+
 			return {
 				innerBlocks: getBlocks( clientId ),
-				entityRecordEdits: getEntityRecordEdits(
-					'postType',
-					'wp_template_part',
-					postId
-				),
+				expectedContent: entityRecord?.content.raw,
 			};
 		},
 		[ clientId, postId ]
@@ -59,7 +60,7 @@ export default function TemplatePartEdit( {
 		}
 
 		if ( ! areInnerBlocksLoaded ) {
-			if ( innerBlocks === entityRecordEdits?.blocks ) {
+			if ( serialize( innerBlocks ) === expectedContent ) {
 				setAreInnerBlocksLoaded( true );
 			}
 			return;
@@ -71,7 +72,7 @@ export default function TemplatePartEdit( {
 				status: 'publish',
 			} );
 		}
-	}, [ innerBlocks, entityRecordEdits?.blocks ] );
+	}, [ innerBlocks, expectedContent ] );
 
 	const blockProps = useBlockProps();
 

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -57,11 +57,7 @@ export default function TemplatePartEdit( {
 	useEffect( () => {
 		// If postId (entity) has not resolved or _postId (block attr) is set,
 		// then we have no need for this effect.
-		if (
-			postId === null ||
-			postId === undefined ||
-			( _postId !== null && _postId !== undefined )
-		) {
+		if ( ! postId || _postId ) {
 			return;
 		}
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
This PR fixes a bug where creating a new Template from the navigation sidebar in the site editor loads the template with all the un-customized theme supplied template-parts dirtied and upgraded to 'publish' status.  

This bug is fixed by refactoring the `useEffect` in the template part block to rely on inner blocks changing from when they were initially loaded, as opposed to the previous implementation of relying on a magic number of innerBlocks updates.  Previously, the first 2 innerBlocks updates were ignored and the 3rd innerBlocks update would assume a user editing the contents of the template part to trigger `setAttribute( postId )` and `editEntityRecord` to upgrade status to `publish`.  2 seems to be a magic number that worked for loading an existing template in the site editor, but it seems this does not work for the new template creation flow.  Instead of allowing this to happen on the n-th update, we allow it to happen on the 1st update to innerBlocks content after innerBlocks are considered to be loaded.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
In the Site Editor:
* Load a template that references **non-customized theme supplied template parts**.
   * Verify the template parts (and template) are not dirty when loaded.
* Edit a block inside a template part.
   * Verify the template part (and template) is now dirtied by checking the entities in the save flow.
* **Without saving the updates to the template and template part**, reload the site editor.
* Create a template from the navigation sidebar.
   * Verify the template-parts (and template) do not load dirty by checking the entities in the save flow.
* Edit a block inside a template part.
   * Verify the template part (and template) is now dirtied by checking the entities in the save flow.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
