### PR TITLE
[WIP] Gallery Block: Update child images from gallery settings

### DIFF
--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -23,6 +23,9 @@
 			"type": "boolean",
 			"default": true
 		},
+		"linkTarget": {
+			"type": "string"
+		},
 		"linkTo": {
 			"type": "string"
 		},

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -234,9 +234,9 @@ function GalleryEdit( props ) {
 		} );
 	}
 
-	// function updateImagesSize( newSizeSlug ) {
-	// 	// Needs applying to child images somehow
-	// }
+	function updateImagesSize( newSizeSlug ) {
+		setAttributes( { sizeSlug: newSizeSlug } );
+	}
 
 	useEffect( () => {
 		if (
@@ -348,7 +348,7 @@ function GalleryEdit( props ) {
 							label={ __( 'Image size' ) }
 							value={ sizeSlug }
 							options={ imageSizeOptions }
-							// onChange={ updateImagesSize }
+							onChange={ updateImagesSize }
 						/>
 					) }
 					{ dirtyImageOptions && (

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -15,7 +15,7 @@ import {
 /**
  * WordPress dependencies
  */
-import { compose, usePrevious } from '@wordpress/compose';
+import { compose } from '@wordpress/compose';
 import {
 	Button,
 	ButtonGroup,
@@ -90,8 +90,15 @@ function GalleryEdit( props ) {
 		'core/block-editor'
 	);
 
-	const previousOptions = usePrevious( { linkTarget, linkTo, sizeSlug } );
+	const currentImageOptions = { linkTarget, linkTo, sizeSlug };
+
 	const [ images, setImages ] = useState( [] );
+	const [ imageSettings, setImageSettings ] = useState( currentImageOptions );
+	const [ dirtyImageOptions, setDirtyImageOptions ] = useState( false );
+
+	useEffect( () => {
+		setDirtyImageOptions( ! isEqual( currentImageOptions, imageSettings ) );
+	}, [ currentImageOptions, imageSettings ] );
 
 	const getBlock = useSelect( ( select ) => {
 		return select( 'core/block-editor' ).getBlock;
@@ -232,6 +239,8 @@ function GalleryEdit( props ) {
 			);
 			updateBlockAttributes( block.clientId, newAttributes );
 		} );
+		setDirtyImageOptions( false );
+		setImageSettings( currentImageOptions );
 	}
 
 	function updateImagesSize( newSizeSlug ) {
@@ -304,10 +313,6 @@ function GalleryEdit( props ) {
 	const imageSizeOptions = getImagesSizeOptions();
 	const shouldShowSizeOptions = hasImages && ! isEmpty( imageSizeOptions );
 	const hasLinkTo = linkTo && linkTo !== 'none';
-	const currentOptions = { linkTarget, linkTo, sizeSlug };
-	// Not working...multiple re-renders ruins usePrevious determination of dirty.
-	const dirtyImageOptions =
-		true || ! isEqual( previousOptions, currentOptions );
 
 	return (
 		<>

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -15,8 +15,10 @@ import {
 /**
  * WordPress dependencies
  */
-import { compose } from '@wordpress/compose';
+import { compose, usePrevious } from '@wordpress/compose';
 import {
+	Button,
+	ButtonGroup,
 	PanelBody,
 	SelectControl,
 	ToggleControl,
@@ -35,6 +37,7 @@ import { createBlock } from '@wordpress/blocks';
  */
 import { sharedIcon } from './shared-icon';
 import { defaultColumnsNumber, pickRelevantMediaFiles } from './shared';
+import { getNewImageAttributes } from './utils';
 import Gallery from './gallery';
 import {
 	LINK_DESTINATION_ATTACHMENT,
@@ -75,6 +78,7 @@ function GalleryEdit( props ) {
 	} = props;
 
 	const {
+		linkTarget,
 		linkTo,
 		columns = defaultColumnsNumber( images ),
 		sizeSlug,
@@ -86,15 +90,19 @@ function GalleryEdit( props ) {
 		'core/block-editor'
 	);
 
+	const previousOptions = usePrevious( { linkTarget, linkTo, sizeSlug } );
 	const [ images, setImages ] = useState( [] );
 
 	const getBlock = useSelect( ( select ) => {
 		return select( 'core/block-editor' ).getBlock;
 	}, [] );
 
+	const getMedia = useSelect( ( select ) => {
+		return select( 'core' ).getMedia;
+	}, [] );
+
 	const imageSizing = useSelect(
 		( select ) => {
-			const { getMedia } = select( 'core' );
 			const { getSettings } = select( 'core/block-editor' );
 			const { imageSizes } = getSettings();
 
@@ -147,7 +155,9 @@ function GalleryEdit( props ) {
 		[ isSelected, images ]
 	);
 
-	const { replaceInnerBlocks } = useDispatch( 'core/block-editor' );
+	const { replaceInnerBlocks, updateBlockAttributes } = useDispatch(
+		'core/block-editor'
+	);
 
 	// function onRemoveImage( index ) {
 	// 	// need to update columns attribute at this point maybe?
@@ -196,6 +206,10 @@ function GalleryEdit( props ) {
 			: __( 'Thumbnails are not cropped.' );
 	}
 
+	function toggleOpenInNewTab() {
+		setAttributes( { linkTarget: linkTarget ? undefined : '_blank' } );
+	}
+
 	function getImagesSizeOptions() {
 		return map(
 			filter( imageSizing.imageSizes, ( { slug } ) =>
@@ -203,6 +217,21 @@ function GalleryEdit( props ) {
 			),
 			( { name, slug } ) => ( { value: slug, label: name } )
 		);
+	}
+
+	function applyImageOptions( { forceUpdate } ) {
+		getBlock( clientId ).innerBlocks.forEach( ( block ) => {
+			const image = block.attributes.id
+				? getMedia( block.attributes.id )
+				: null;
+			const newAttributes = getNewImageAttributes(
+				attributes,
+				block.attributes,
+				image,
+				forceUpdate
+			);
+			updateBlockAttributes( block.clientId, newAttributes );
+		} );
 	}
 
 	// function updateImagesSize( newSizeSlug ) {
@@ -274,6 +303,11 @@ function GalleryEdit( props ) {
 
 	const imageSizeOptions = getImagesSizeOptions();
 	const shouldShowSizeOptions = hasImages && ! isEmpty( imageSizeOptions );
+	const hasLinkTo = linkTo && linkTo !== 'none';
+	const currentOptions = { linkTarget, linkTo, sizeSlug };
+	// Not working...multiple re-renders ruins usePrevious determination of dirty.
+	const dirtyImageOptions =
+		true || ! isEqual( previousOptions, currentOptions );
 
 	return (
 		<>
@@ -290,7 +324,6 @@ function GalleryEdit( props ) {
 							required
 						/>
 					) }
-
 					<ToggleControl
 						label={ __( 'Crop images' ) }
 						checked={ !! imageCrop }
@@ -303,6 +336,13 @@ function GalleryEdit( props ) {
 						onChange={ setLinkTo }
 						options={ linkOptions }
 					/>
+					{ hasLinkTo && (
+						<ToggleControl
+							label={ __( 'Open in new tab' ) }
+							checked={ linkTarget === '_blank' }
+							onChange={ toggleOpenInNewTab }
+						/>
+					) }
 					{ shouldShowSizeOptions && (
 						<SelectControl
 							label={ __( 'Image size' ) }
@@ -310,6 +350,26 @@ function GalleryEdit( props ) {
 							options={ imageSizeOptions }
 							// onChange={ updateImagesSize }
 						/>
+					) }
+					{ dirtyImageOptions && (
+						<ButtonGroup>
+							<Button
+								isSmall
+								onClick={ () =>
+									applyImageOptions( { forceUpdate: true } )
+								}
+							>
+								{ __( 'Apply to all images' ) }
+							</Button>
+							<Button
+								isSmall
+								onClick={ () =>
+									applyImageOptions( { forceUpdate: false } )
+								}
+							>
+								{ __( 'Apply only as fallback' ) }
+							</Button>
+						</ButtonGroup>
 					) }
 				</PanelBody>
 			</InspectorControls>

--- a/packages/block-library/src/gallery/utils.js
+++ b/packages/block-library/src/gallery/utils.js
@@ -83,7 +83,7 @@ export function getNewImageAttributes(
 		return {
 			...getHrefAndDestination( image, parentOptions.linkTo ),
 			...getLinkTargetSettings( parentOptions.linkTarget, attributes ),
-			sizeSlug,
+			sizeSlug: parentOptions.sizeSlug,
 		};
 	}
 

--- a/packages/block-library/src/gallery/utils.js
+++ b/packages/block-library/src/gallery/utils.js
@@ -1,0 +1,119 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import {
+	LINK_DESTINATION_ATTACHMENT,
+	LINK_DESTINATION_MEDIA,
+	LINK_DESTINATION_NONE,
+} from './constants';
+import { getUpdatedLinkTargetSettings as getLinkTargetSettings } from '../image/utils';
+
+/**
+ * Determines new href and linkDestination values for an image block from the
+ * supplied Gallery link destination.
+ *
+ * @param {Object} image       Gallery image.
+ * @param {string} destination Gallery's selected link destination.
+ * @return {Object}            New attributes to assign to image block.
+ */
+export function getHrefAndDestination( image, destination ) {
+	// Need to determine the URL that the selected destination maps to.
+	// Gutenberg and WordPress use different constants so the new link
+	// destination also needs to be tweaked.
+	switch ( destination ) {
+		case LINK_DESTINATION_MEDIA:
+			return {
+				href: image?.source_url, // eslint-disable-line camelcase
+				linkDestination: 'media',
+			};
+		case LINK_DESTINATION_ATTACHMENT:
+			return {
+				href: image?.link,
+				linkDestination: 'attachment',
+			};
+		case LINK_DESTINATION_NONE:
+			return {
+				href: undefined,
+				linkDestination: LINK_DESTINATION_NONE,
+			};
+	}
+
+	return {};
+}
+
+/**
+ * Determines new Image block attributes affected by a change in Gallery image
+ * size selection.
+ *
+ * @param {Object} image Media file object for gallery image.
+ * @param {string} size  Gallery's selected size slug to apply.
+ */
+export function getImageSizeAttributes( image, size ) {
+	const url = get( image, [ 'media_details', 'sizes', size, 'source_url' ] );
+
+	if ( url ) {
+		return { url, width: undefined, height: undefined, sizeSlug: size };
+	}
+
+	return {};
+}
+
+/**
+ * Determine new attribute values for an Image block based on Gallery settings
+ * and user's choice to apply for all gallery images or only as a fallback if
+ * the image block doesn't have a value set.
+ *
+ * @param {Object} parentOptions Gallery attributes for linkTo, linkTarget & sizeSlug.
+ * @param {Object} attributes    Image block attributes.
+ * @param {Object} image         Media object for block's image.
+ * @param {boolean} forceUpdate  Whether to force the Image block updates or only as a fallback.
+ */
+export function getNewImageAttributes(
+	parentOptions,
+	attributes,
+	image,
+	forceUpdate
+) {
+	if ( forceUpdate ) {
+		return {
+			...getHrefAndDestination( image, parentOptions.linkTo ),
+			...getLinkTargetSettings( parentOptions.linkTarget, attributes ),
+			sizeSlug,
+		};
+	}
+
+	// Not forcing update so we need to determine which attributes to set.
+	const { linkDestination, linkTarget, sizeSlug } = attributes;
+	let newAttributes = {};
+
+	// Set linkDestination if image's is not set or is 'none'.
+	if ( ! linkDestination || linkDestination === 'none' ) {
+		newAttributes = {
+			...newAttributes,
+			...getHrefAndDestination( image, parentOptions.linkTo ),
+		};
+	}
+
+	// Set linkTarget if parent sets it and image does not.
+	if ( parentOptions.linkTarget && linkTarget !== '_blank' ) {
+		newAttributes = {
+			...newAttributes,
+			...getLinkTargetSettings( parentOptions.linkTarget, attributes ),
+		};
+	}
+
+	// Set image size slug if it isn't set.
+	if ( ! sizeSlug ) {
+		newAttributes = {
+			...newAttributes,
+			...getImageSizeAttributes( image, parentOptions.sizeSlug ),
+		};
+	}
+
+	return newAttributes;
+}


### PR DESCRIPTION
# Work in Progress!

## Description
As part of the efforts to refactor the Gallery block to use core image blocks, we need a new method to passing along gallery level settings to the individual images. These settings include:

* Link Destination (Media file or Attachment page)
* Whether to open image link in new tab
* Image size

This is an alternative approach to https://github.com/WordPress/gutenberg/pull/26415 which leveraged hooks in the image block to pick up changes in the gallery's settings.

Any deprecations, transforms and migrations will be addressed once an approach has been decided upon.

## Issues still to be resolved

* Core image blocks store the attributes we intend to update within the saved markup and have them extracted. This prevents us from a very simple fallback to whatever is in the gallery provided block context.

* If the attributes on the image are updated from the gallery context once, there is currently no means to distinguish at a later point in time if the value set originally came from the gallery context and could/should be overwritten by a subsequent change to the gallery's setting.

* Current UI for gallery level settings is not very intuitive, needs work and design input once we have a better understanding of what is required.

* WordPress' constants for link destinations differ from Gutenberg's, so that could be tidied up.

* Idea was to have the apply buttons only show when gallery settings were changed. Re-rendering of the gallery is currently preventing comparing previous values to determine the dirty state. This needs fixing but may not be required depending on what direction is decided on for the UI.

## How has this been tested?
Manually.

#### Testing Instructions

1. Checkout this PR branch
2. Add a Gallery and images to a post
3. Select a couple of images in the gallery and update their link destination, target and/or url.
4. Select the gallery and change the destination
5. Click "apply only as fallback" button beneath the gallery options
6. Select images you did not edit and check they have the relevant destination etc
7. Select the images you modified before changing the gallery and ensure they kept their settings
8. Reselect the gallery and now click the "Apply to all images" button
9. Select the images you modified and confirm their settings were overridden by the gallery's settings

## Screenshots <!-- if applicable -->

#### Before hiding/showing "apply" buttons
![GalleryToImageSettings](https://user-images.githubusercontent.com/60436221/97515523-eb882600-19dc-11eb-8ae5-ad5b26e07ae4.gif)

#### After hiding/showing "apply" buttons
![GalleryToImageSettings](https://user-images.githubusercontent.com/60436221/97538799-babfe500-1a0c-11eb-897e-812804c4cf31.gif)


## Types of changes
* New feature
* Breaking Change

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->