### PR TITLE
Try: Cover default-overlay color regression fix.

### DIFF
--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -155,6 +155,12 @@
 	}
 }
 
+// This is unscoped to the Cover block to reduce specificity.
+// This allows theme colors override the specific color.
+.has-background-dim {
+	background-color: $black;
+}
+
 .wp-block-cover__video-background {
 	position: absolute;
 	top: 50%;


### PR DESCRIPTION
Possibly fixes #26545.

The Cover block is most of the time, used as a photo with a dim black overlay to ensure text on top is readable. This is augmented by the fact the block has a classname, "has-background-dim". However this regressed, and no dimming was applied until you explicitly set a color:

![before](https://user-images.githubusercontent.com/1204802/97550062-77945080-19d1-11eb-892e-0c68e89813b7.gif)

This both causes a less than optimal default state of the block, but also affects every existing cover block published.

The regression happened to fix #25290, and the issue boils down to this:

`.wp-block-cover.has-background-dim { ... }` has higher specificity than `.has-contrast-yellow-background-color`. So previously, users could simply not choose the color of the overlay at all:

<img width="470" alt="Screenshot 2020-10-29 at 10 22 33" src="https://user-images.githubusercontent.com/1204802/97550372-e5407c80-19d1-11eb-9f6b-6ccc3c57f4f3.png">

As far as I can tell, there are only two ways of fixing this.

1. Reducing the specificity of `has-background-dim`
2. Increasing the specificity of every custom theme color.

This PR does the former, and in doing so fixes the issue so that by default, there's a background dim, but if a user chooses a different color, that color works too:

![after](https://user-images.githubusercontent.com/1204802/97550500-099c5900-19d2-11eb-86b3-152baf4aabcd.gif)

The obvious downside is that `has-background-dim` is now totally unscoped, and affects any element with this class. But as far as I can tell, only the Cover block uses this class. 

I'd love your thoughts on which of the two approaches above you would prefer.