### PR TITLE
Add a note to import default-custom-properties.

### DIFF
--- a/packages/base-styles/README.md
+++ b/packages/base-styles/README.md
@@ -23,6 +23,7 @@ In your application's SCSS file, include styles like so:
 @import "node_modules/@wordpress/base-styles/breakpoints";
 @import "node_modules/@wordpress/base-styles/animations";
 @import "node_modules/@wordpress/base-styles/z-index";
+@import 'node_modules/@wordpress/base-styles/default-custom-properties';
 ```
 
 If you use [Webpack](https://webpack.js.org/) for your SCSS pipeline, you can use `~` to resolve to `node_modules`:


### PR DESCRIPTION
This is especially important for npm package consumer. Without this knowledge, the consuming website will not have the --wp-admin-theme-color at :root.

## Description

Add documentation for `@import 'node_modules/@wordpress/base-styles/default-custom-properties'`.

## How has this been tested?

This is just a documentation change. No test required.

This is related to an issue and its pull request in the WooCommerce Admin repository, [Issue #5449](https://github.com/woocommerce/woocommerce-admin/issues/5449#issuecomment-718051052) and [PR #5491](https://github.com/woocommerce/woocommerce-admin/pull/5491), which is related to Gutenberg's [PR #24408](https://github.com/WordPress/gutenberg/pull/24408) and [PR #24890](https://github.com/WordPress/gutenberg/pull/24890).

## Types of changes

Documentation update.

## Checklist:

Not applicable, so I tick the below check boxes. 

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
