### PR TITLE
Try: Windows 10 high contrast mode improvements.

### DIFF
--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -32,7 +32,7 @@
 		box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color);
 
 		// Windows High Contrast mode will show this outline, but not the box-shadow.
-		outline: 1px solid transparent;
+		outline: 3px solid transparent;
 	}
 
 	/**
@@ -45,6 +45,9 @@
 		color: $white;
 		text-decoration: none;
 		text-shadow: none;
+
+		// Show the boundary of the button, in High Contrast Mode.
+		outline: 1px solid transparent;
 
 		&:hover:not(:disabled) {
 			background: var(--wp-admin-theme-color-darker-10);
@@ -59,9 +62,6 @@
 
 		&:focus:not(:disabled) {
 			box-shadow: inset 0 0 0 1px $white, 0 0 0 $border-width-focus var(--wp-admin-theme-color);
-
-			// Windows High Contrast mode will show this outline, but not the box-shadow.
-			outline: 1px solid transparent;
 		}
 
 		&:disabled,
@@ -73,6 +73,7 @@
 			background: var(--wp-admin-theme-color);
 			border-color: var(--wp-admin-theme-color);
 			opacity: 1;
+			outline: none;
 
 			&:focus:enabled {
 				box-shadow:
@@ -106,6 +107,9 @@
 
 	&.is-secondary,
 	&.is-tertiary {
+		// Show the boundary of the button, in High Contrast Mode.
+		outline: 1px solid transparent;
+
 		&:active:not(:disabled) {
 			background: $gray-300;
 			color: var(--wp-admin-theme-color-darker-10);
@@ -125,6 +129,7 @@
 			transform: none;
 			opacity: 1;
 			box-shadow: none;
+			outline: none;
 		}
 	}
 
@@ -154,9 +159,6 @@
 			display: inline-block;
 			flex: 0 0 auto;
 		}
-
-		// Windows High Contrast mode.
-		outline: 1px dotted transparent;
 	}
 
 	/**

--- a/packages/components/src/select-control/styles/select-control-styles.js
+++ b/packages/components/src/select-control/styles/select-control-styles.js
@@ -69,7 +69,6 @@ export const Select = styled.select`
 		color: ${ color( 'black' ) };
 		display: block;
 		margin: 0;
-		outline: none;
 		width: 100%;
 
 		${ disabledStyles };


### PR DESCRIPTION
Windows 10 high contrast mode removes all background colors and box shadows, and instead makes fully opaque any property set on `outline` or `border`. 

This is a great trick to provide tailormade focus styles for that mode specifically, without affecting the default styles.

In that vein, this PR does a few things:

- Unifies the button styles, as the differentiation doesn't bring a lot of value in high contrast mode.
- It adds a more clear focus style for said buttons.
- It fixes an issue with the custom select box, that did not have a focus style.

Screenshot showing that the regular base UI is unaffected:

<img width="352" alt="Screenshot 2020-10-29 at 12 36 41" src="https://user-images.githubusercontent.com/1204802/97563612-97cd0b00-19e3-11eb-8486-a4386495c69f.png">

<img width="280" alt="Screenshot 2020-10-29 at 12 36 36" src="https://user-images.githubusercontent.com/1204802/97563618-9996ce80-19e3-11eb-9777-687453743e40.png">

Screenshot of the improved high contrast mode:

<img width="639" alt="Screenshot 2020-10-29 at 12 37 40" src="https://user-images.githubusercontent.com/1204802/97563633-a0254600-19e3-11eb-871b-9edb8da3f92c.png">
