### PR TITLE
Cover block: Restore default overlay background

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- Fix a regression ([#26545](https://github.com/WordPress/gutenberg/pull/26545)]) where the Cover block lost its default background overlay color
+  ([#26569](https://github.com/WordPress/gutenberg/pull/26569)]).
+
 ## 2.23.0 (2020-09-03)
 
 ### Enhancement

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Bug Fixes
 
-- Fix a regression ([#26545](https://github.com/WordPress/gutenberg/pull/26545)]) where the Cover block lost its default background overlay color
-  ([#26569](https://github.com/WordPress/gutenberg/pull/26569)]).
+- Fix a regression ([#26545](https://github.com/WordPress/gutenberg/pull/26545)) where the Cover block lost its default background overlay color
+  ([#26569](https://github.com/WordPress/gutenberg/pull/26569)).
 
 ## 2.23.0 (2020-09-03)
 

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -314,6 +314,7 @@ function CoverEdit( {
 		}
 	}
 
+	const canDim = !! url && ( overlayColor.color || gradientValue );
 	const hasBackground = !! ( url || overlayColor.color || gradientValue );
 	const showFocalPointPicker =
 		isVideoBackground ||
@@ -425,7 +426,7 @@ function CoverEdit( {
 								},
 							] }
 						>
-							{ !! url && (
+							{ canDim && (
 								<RangeControl
 									label={ __( 'Opacity' ) }
 									value={ dimRatio }

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -314,7 +314,6 @@ function CoverEdit( {
 		}
 	}
 
-	const canDim = !! url && ( overlayColor.color || gradientValue );
 	const hasBackground = !! ( url || overlayColor.color || gradientValue );
 	const showFocalPointPicker =
 		isVideoBackground ||
@@ -426,7 +425,7 @@ function CoverEdit( {
 								},
 							] }
 						>
-							{ canDim && (
+							{ !! url && (
 								<RangeControl
 									label={ __( 'Opacity' ) }
 									value={ dimRatio }

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -34,6 +34,20 @@
 		background-size: auto;
 	}
 
+	/**
+	 * Set a default background color for has-background-dim _unless_ it includes another
+	 * background-color class (e.g. has-green-background-color). The presence of another
+	 * background-color class implies that another style will provide the background color
+	 * for the overlay.
+	 *
+	 * See:
+	 *   - Issue with background color specificity: https://github.com/WordPress/gutenberg/issues/26545
+	 *   - Issue with alternative fix: https://github.com/WordPress/gutenberg/issues/26545
+	 */
+	&.has-background-dim:not([class*="-background-color"]) {
+		background-color: $black;
+	}
+
 	&.has-background-dim::before {
 		content: "";
 		background-color: inherit;


### PR DESCRIPTION
## Description

The default Cover block overlay background was removed. This changed the
style of existing blocks on existing sites.

Restore the default background in such a way that it does not conflict
with theme-provided background-color styles and there is no need to
artificially add extra specificity.

Fixes https://github.com/WordPress/gutenberg/issues/26545
Closes https://github.com/WordPress/gutenberg/pull/26564 (superseded)

## How has this been tested?

Try to reproduce this issue: https://github.com/WordPress/gutenberg/issues/26545

Be sure that the issue described in https://github.com/WordPress/gutenberg/issues/25290 is no longer present.

There appear to be problems with the Docker registry so I'm unable to easily test this with wp-env. I did manually apply the changes via developer tools and they seem to fix the issue.


## Types of changes
Bug fix

Fix a regression where the Cover block lost its default background overlay color (https://github.com/WordPress/gutenberg/issues/26545).

