### PR TITLE
Resolve per-entity resolvers after receiving a list of records

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,7 +1,7 @@
 {
 	"core": "WordPress/WordPress",
 	"plugins": [
-		"."
+		".", "./test-plugins/core-data"
 	],
 	"themes": [ "WordPress/theme-experiments/twentytwentyone-blocks" ],
 	"env": {

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,7 +1,7 @@
 {
 	"core": "WordPress/WordPress",
 	"plugins": [
-		".", "./test-plugins/core-data"
+		"."
 	],
 	"themes": [ "WordPress/theme-experiments/twentytwentyone-blocks" ],
 	"env": {

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -173,12 +173,24 @@ export function* getEntityRecords( kind, name, query = {} ) {
 	}
 
 	yield receiveEntityRecords( kind, name, records, query );
-	for ( const record of records ) {
-		yield {
-			type: 'FINISH_RESOLUTION',
-			selectorName: 'getEntityRecord',
-			args: [ kind, name, record.id ],
-		};
+	// When requesting all fields, the list of results can be used to
+	// resolve the `getEntityRecord` selector in addition to `getEntityRecords`.
+	// See https://github.com/WordPress/gutenberg/pull/26575
+	if ( ! query?._fields ) {
+		for ( const record of records ) {
+			if ( record.id ) {
+				yield {
+					type: 'START_RESOLUTION',
+					selectorName: 'getEntityRecord',
+					args: [ kind, name, record.id ],
+				};
+				yield {
+					type: 'FINISH_RESOLUTION',
+					selectorName: 'getEntityRecord',
+					args: [ kind, name, record.id ],
+				};
+			}
+		}
 	}
 }
 

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -173,6 +173,13 @@ export function* getEntityRecords( kind, name, query = {} ) {
 	}
 
 	yield receiveEntityRecords( kind, name, records, query );
+	for ( const record of records ) {
+		yield {
+			type: 'FINISH_RESOLUTION',
+			selectorName: 'getEntityRecord',
+			args: [ kind, name, record.id ],
+		};
+	}
 }
 
 getEntityRecords.shouldInvalidate = ( action, kind, name ) => {

--- a/packages/core-data/src/test/integration.js
+++ b/packages/core-data/src/test/integration.js
@@ -1,0 +1,110 @@
+/**
+ * WordPress dependencies
+ */
+import { createRegistry, controls } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { receiveEntityRecords } from '../actions';
+import * as selectors from '../selectors';
+import * as resolvers from '../resolvers';
+
+// Mock to prevent calling window.fetch in test environment
+jest.mock( '@wordpress/data-controls', () => {
+	return {
+		apiFetch: jest.fn(),
+	};
+} );
+import { apiFetch } from '@wordpress/data-controls';
+
+describe( 'receiveEntityRecord', () => {
+	function createTestRegistry( getEntityRecord ) {
+		const registry = createRegistry();
+		const initialState = {
+			entities: {
+				data: {},
+			},
+		};
+		registry.registerStore( 'core', {
+			selectors: {
+				getEntitiesByKind: () => [
+					{ name: 'postType', kind: 'root', baseURL: '/wp/v2/types' },
+					{ name: 'postType', kind: 'root', baseURL: '/wp/v2/types' },
+				],
+			},
+			reducer: () => ( {} ),
+		} );
+		registry.registerStore( 'test/resolution', {
+			actions: {
+				receiveEntityRecords,
+				*getEntityRecords( ...args ) {
+					return yield controls.resolveSelect(
+						'test/resolution',
+						'getEntityRecords',
+						...args
+					);
+				},
+				*getEntityRecord( ...args ) {
+					return yield controls.resolveSelect(
+						'test/resolution',
+						'getEntityRecord',
+						...args
+					);
+				},
+			},
+			reducer: ( state = initialState ) => {
+				return state;
+			},
+			selectors: {
+				getEntityRecord: selectors.getEntityRecord,
+				getEntityRecords: selectors.getEntityRecords,
+			},
+			resolvers: {
+				getEntityRecord,
+				getEntityRecords: resolvers.getEntityRecords,
+			},
+		} );
+		return registry;
+	}
+
+	const runPromise = async ( promise ) => {
+		jest.runAllTimers();
+		await promise;
+	};
+
+	beforeEach( async () => {
+		jest.useFakeTimers();
+	} );
+
+	it( 'should not trigger a resolver when the requested record is available via receiveEntityRecords.', async () => {
+		const getEntityRecord = jest.fn();
+		const registry = createTestRegistry( getEntityRecord );
+
+		// Trigger resolution of postType records
+		apiFetch.mockImplementation( () => ( {
+			2: { slug: 'test', id: 2 },
+		} ) );
+		await runPromise(
+			registry
+				.dispatch( 'test/resolution' )
+				.getEntityRecords( 'root', 'postType' )
+		);
+
+		// Select record with id = 2, it is available and should trigger the resolver
+		await runPromise(
+			registry
+				.dispatch( 'test/resolution' )
+				.getEntityRecord( 'root', 'postType', 2 )
+		);
+		expect( getEntityRecord ).not.toHaveBeenCalled();
+
+		// Select record with id = 4, it is not available and should not trigger the resolver
+		await runPromise(
+			registry
+				.dispatch( 'test/resolution' )
+				.getEntityRecord( 'root', 'postType', 4 )
+		);
+		expect( getEntityRecord ).toHaveBeenCalled();
+	} );
+} );


### PR DESCRIPTION
## Description

**The problem**: calling `saveEntityRecord()` triggers a number of per-entity GET requests:

<img width="595" alt="Zrzut ekranu 2020-10-29 o 17 12 38" src="https://user-images.githubusercontent.com/205419/97601026-fe651f80-1a09-11eb-876d-a97fdb13bae4.png">

The cause is described in https://github.com/WordPress/gutenberg/issues/26325:

> saveEntityRecord() calls getRawEntityRecord(), which doesn't consider the record with a specific id to be resolved even though a list of records from /wp/v2/books was loaded earlier on. Instead, a resolver is triggered, and an explicit GET request is issued to /wp/v2/books/1 

This PR proposes resolving all per-entity resolvers after receiving the list of records. 

## How has this been tested?
1. Go to the new widgets editor
1. Make any change and click save
1. Confirm there is no burst of GET requests following the save

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
