### PR TITLE
i10n backport for WordPress 5.5.2

### DIFF
--- a/packages/block-editor/src/components/block-mover/index.js
+++ b/packages/block-editor/src/components/block-mover/index.js
@@ -17,7 +17,7 @@ import {
 import { getBlockType } from '@wordpress/blocks';
 import { useState } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
-import { _n } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -44,6 +44,9 @@ function BlockMover( {
 		return null;
 	}
 
+	const dragHandleLabel =
+		clientIds.length === 1 ? __( 'Drag block' ) : __( 'Drag blocks' );
+
 	// We emulate a disabled state because forcefully applying the `disabled`
 	// attribute on the buttons while it has focus causes the screen to change
 	// to an unfocused state (body as active element) without firing blur on,
@@ -65,11 +68,7 @@ function BlockMover( {
 							icon={ dragHandle }
 							className="block-editor-block-mover__drag-handle"
 							aria-hidden="true"
-							label={ _n(
-								'Drag block',
-								'Drag blocks',
-								clientIds.length
-							) }
+							label={ dragHandleLabel }
 							// Should not be able to tab to drag handle as this
 							// button can only be used with a pointer device.
 							tabIndex="-1"

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -6,7 +6,7 @@ import { castArray, flow, noop } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __, _n } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import {
 	DropdownMenu,
 	MenuGroup,
@@ -74,6 +74,9 @@ export function BlockSettingsDropdown( {
 			: noop,
 		[ __experimentalSelectBlock ]
 	);
+
+	const removeBlockLabel =
+		count === 1 ? __( 'Remove block' ) : __( 'Remove blocks' );
 
 	return (
 		<BlockActions
@@ -191,11 +194,7 @@ export function BlockSettingsDropdown( {
 										) }
 										shortcut={ shortcuts.remove }
 									>
-										{ _n(
-											'Remove block',
-											'Remove blocks',
-											count
-										) }
+										{ removeBlockLabel }
 									</MenuItem>
 								) }
 							</MenuGroup>


### PR DESCRIPTION
Backport of https://github.com/WordPress/gutenberg/pull/26565 for WordPress 5.5.2.