### PR TITLE
Site Editor: restore block inserter previews

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -276,6 +276,7 @@ $block-inserter-tabs-height: 44px;
 	border-top: $border-width solid $gray-300;
 	padding: $grid-unit-20;
 	flex-shrink: 0;
+	position: relative; // prevents overscroll when block library is open
 }
 
 .block-editor-inserter__manage-reusable-blocks-container {

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -115,7 +115,6 @@ html.interface-interface-skeleton__html-container {
 .interface-interface-skeleton__left-sidebar {
 	@include break-medium() {
 		border-right: $border-width solid $gray-200;
-		overflow: hidden; // prevent overscroll
 	}
 }
 


### PR DESCRIPTION


<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
The fix in #26432 accidentally broke block previews in the Inserter due to a naïve use of `overflow: hidden` to fix the overscroll with the block library open in the site editor.

A little testing revealed that the `.components-visually-hidden` element inside `.block-editor-inserter__tips` might be at the root of causing a browser bug due to its odd combination of styles. Trusty `position: relative` stabilized the rendering context and there was once again peace in the land.

## How has this been tested?
Ensuring block previews appear again when hovering over a block in the block library

## Types of changes
Bug fix

