### PR TITLE
Removes extra fullstop from preferences

### DIFF
--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -64,7 +64,7 @@ export function PreferencesModal( { isModalActive, isViewable, closeModal } ) {
 					help={ __(
 						'Aids screen readers by stopping text caret from leaving blocks.'
 					) }
-					label={ __( 'Contain text cursor inside block.' ) }
+					label={ __( 'Contain text cursor inside block' ) }
 				/>
 			</Section>
 			<Section title={ __( 'Appearance' ) }>

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
@@ -25,7 +25,7 @@ exports[`PreferencesModal should match snapshot when the modal is active 1`] = `
     <WithSelect(WithDispatch(BaseOption))
       featureName="keepCaretInsideBlock"
       help="Aids screen readers by stopping text caret from leaving blocks."
-      label="Contain text cursor inside block."
+      label="Contain text cursor inside block"
     />
   </Section>
   <Section


### PR DESCRIPTION
There was an extra fullstop on one preferences option ("Contain text..."), this simply removes it.

**Before:**

![before](https://user-images.githubusercontent.com/253067/97629885-ac7ec280-1a26-11eb-8ee0-51ded919f40b.png)


**After:**

![image](https://user-images.githubusercontent.com/253067/97629939-bbfe0b80-1a26-11eb-857b-4f40ff7ac8fc.png)
