### PR TITLE
Ignore error when axe core fails to inject into blank iframes

### DIFF
--- a/packages/e2e-tests/config/setup-test-framework.js
+++ b/packages/e2e-tests/config/setup-test-framework.js
@@ -154,8 +154,10 @@ function observeConsoleLogging() {
 		// - https://github.com/WordPress/gutenberg/pull/26527
 		// - https://github.com/WordPress/gutenberg/pull/26535
 		if (
-			text.includes(
-				'Failed to inject axe-core into frame (about:blank)'
+			message.args.some( ( argument ) =>
+				argument?.includes(
+					'Failed to inject axe-core into frame (about:blank)'
+				)
 			)
 		) {
 			return;

--- a/packages/e2e-tests/config/setup-test-framework.js
+++ b/packages/e2e-tests/config/setup-test-framework.js
@@ -145,6 +145,22 @@ function observeConsoleLogging() {
 			return;
 		}
 
+		// Ignore axe core errors about injections into blank iframes
+		// See the following tickets for details:
+		// - https://github.com/dequelabs/axe-puppeteer/issues/25
+		// - https://github.com/dequelabs/axe-core-npm/issues/98
+		//
+		// Previous attempts to solve:
+		// - https://github.com/WordPress/gutenberg/pull/26527
+		// - https://github.com/WordPress/gutenberg/pull/26535
+		if (
+			text.includes(
+				'Failed to inject axe-core into frame (about:blank)'
+			)
+		) {
+			return;
+		}
+
 		const logFunction = OBSERVED_CONSOLE_MESSAGE_TYPES[ type ];
 
 		// As of Puppeteer 1.6.1, `message.text()` wrongly returns an object of


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Previously #26527, #26535

Axe core tests fail intermittently:
```
Template Part › Template part placeholder › Should insert template part when preview is selected

    expect(jest.fn()).not.toHaveErrored(expected)

    Expected mock function not to be called but it was called with:
    ["Failed to inject axe-core into frame (about:blank)"],["Failed to inject axe-core into frame (about:blank)"]
```
This occurs when axe attempts to inject scripts into iframes created by the react-resize-aware utility in the `useResizeObserver` hook, mostly when tests briefly interact with block previews.

This PR adds the error message to our list of exceptions for things that will fail tests.

Axe itself won't fail tests when this injection fails, so it seems we're being stricter than Axe:
https://github.com/dequelabs/axe-core-npm/blob/1f06cb67e2bbbf1922fd9d2e6bcee74f092cfa1c/packages/puppeteer/src/axePuppeteer.ts#L67-L69

## How has this been tested?
CI tests should regularly pass.
