### PR TITLE
Scripts: Fix error in ignore-emit-webpack-plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18448,7 +18448,7 @@
 				"dir-glob": "^3.0.1",
 				"eslint": "^7.1.0",
 				"eslint-plugin-markdown": "^1.0.2",
-				"ignore-emit-webpack-plugin": "^2.0.2",
+				"ignore-emit-webpack-plugin": "2.0.3",
 				"jest": "^25.3.0",
 				"jest-puppeteer": "^4.4.0",
 				"markdownlint": "^0.18.0",
@@ -37521,9 +37521,9 @@
 			"dev": true
 		},
 		"ignore-emit-webpack-plugin": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/ignore-emit-webpack-plugin/-/ignore-emit-webpack-plugin-2.0.2.tgz",
-			"integrity": "sha512-mlwNY4ocAFJ+gzvIdbWdF2nPszE5CdZYJBvI38XEJnW2/qV7kA5HenzGE0XdS4nzoSqEIj268y2y4K6WTLFm8Q==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/ignore-emit-webpack-plugin/-/ignore-emit-webpack-plugin-2.0.3.tgz",
+			"integrity": "sha512-ahTYD5KZ3DiZG9goS8NCxBaPEfXsPLH5JeWKmFTThD8lsPen6R4tLnWcN/mrksK5cDqyxOzmRL12feJQZjffuA==",
 			"dev": true
 		},
 		"ignore-walk": {

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Ignore `/vendor` folder when searching for files to lint or format.
 
+### Bug Fixes
+
+-   Temporary pin `ignore-emit-webpack-plugin` to the version `2.0.3` to fix a known issue with version `2.0.4` ([GitHub issue](https://github.com/mrbar42/ignore-emit-webpack-plugin/issues/17)).
+
 ## 12.1.0 (2020-07-07)
 
 ### Enhancements

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -50,7 +50,7 @@
 		"dir-glob": "^3.0.1",
 		"eslint": "^7.1.0",
 		"eslint-plugin-markdown": "^1.0.2",
-		"ignore-emit-webpack-plugin": "^2.0.2",
+		"ignore-emit-webpack-plugin": "2.0.3",
 		"jest": "^25.3.0",
 		"jest-puppeteer": "^4.4.0",
 		"markdownlint": "^0.18.0",


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes #26547 - the issue in `@wordpress/scripts` with `build` command:

> I have a problem with npx @wordpress/create-block. When I run it I get this error:

> Compiling block.
> (node:21) UnhandledPromiseRejectionWarning: Error: Command failed with exit code 1: npm run build
> /home/stampirl/code/wordpress/hero-slider/node_modules/ignore-emit-webpack-plugin/index.js:64
>                 compilation.hooks.processAssets.tap({
>                                                 ^
> 
> TypeError: Cannot read property 'tap' of undefined

I followed the suggestion from @ryelle:

> Looks like the issue is with ignore-emit-webpack-plugin@2.0.4 mrbar42/ignore-emit-webpack-plugin#17 — it should be fixed if we pin the dependency in @wordpress/scripts to 2.0.3, until they fix it.

That was confirmed by @cdwieber:

> +1, I was able to pin the dependency to 2.0.3 in our plugin's package.json, and that allowed us to run the build script successfully.

## How has this been tested?

Execute `npx wp-scripts build`.