### PR TITLE
Disable customizer and widgets from FSE

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -70,7 +70,11 @@ function gutenberg_menu() {
 	if ( gutenberg_is_fse_theme() ) {
 		add_menu_page(
 			__( 'Site Editor (beta)', 'gutenberg' ),
-			__( 'Site Editor <span class="awaiting-mod">beta</span>', 'gutenberg' ),
+			sprintf(
+				/* translators: %s: "beta" label. */
+				__( 'Site Editor %s', 'gutenberg' ),
+				'<span class="awaiting-mod">' . __( 'beta', 'gutenberg' ) . '</span>'
+			),
 			'edit_theme_options',
 			'gutenberg-edit-site',
 			'gutenberg_edit_site_page',

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -70,7 +70,7 @@ function gutenberg_menu() {
 	if ( gutenberg_is_fse_theme() ) {
 		add_menu_page(
 			__( 'Site Editor (beta)', 'gutenberg' ),
-			__( 'Site Editor (beta)', 'gutenberg' ),
+			__( 'Site Editor <span class="awaiting-mod">beta</span>', 'gutenberg' ),
 			'edit_theme_options',
 			'gutenberg-edit-site',
 			'gutenberg_edit_site_page',

--- a/lib/full-site-editing.php
+++ b/lib/full-site-editing.php
@@ -78,7 +78,7 @@ function gutenberg_menu_order( $menu_order ) {
 		'gutenberg-edit-site' => array_search( 'themes.php', $menu_order, true ),
 	);
 
-	// traverse through the new positions and move.
+	// Traverse through the new positions and move
 	// the items if found in the original menu_positions.
 	foreach ( $new_positions as $value => $new_index ) {
 		$current_index = array_search( $value, $menu_order, true );

--- a/lib/full-site-editing.php
+++ b/lib/full-site-editing.php
@@ -28,3 +28,64 @@ function gutenberg_full_site_editing_notice() {
 	<?php
 }
 add_action( 'admin_notices', 'gutenberg_full_site_editing_notice' );
+
+/**
+ * Removes legacy pages from FSE themes.
+ */
+function gutenberg_remove_legacy_pages() {
+	if ( ! gutenberg_is_fse_theme() ) {
+		return;
+	}
+
+	global $submenu;
+	if ( isset( $submenu['themes.php'] ) ) {
+		$indexes_to_remove = array();
+		foreach ( $submenu['themes.php'] as $index => $menu_item ) {
+			if (
+				false !== strpos( $menu_item[2], 'customize.php' ) ||
+				false !== strpos( $menu_item[2], 'gutenberg-widgets' )
+			) {
+				$indexes_to_remove[] = $index;
+			}
+		}
+
+		foreach ( $indexes_to_remove as $index ) {
+			unset( $submenu['themes.php'][ $index ] );
+		}
+	}
+}
+
+add_action( 'admin_menu', 'gutenberg_remove_legacy_pages' );
+
+/**
+ * Activates the 'menu_order' filter and then hooks into 'menu_order'
+ */
+add_filter( 'custom_menu_order', '__return_true' );
+add_filter( 'menu_order', 'gutenberg_menu_order' );
+
+/**
+ * Filters WordPress default menu order
+ *
+ * @param array $menu_order Menu Order.
+ */
+function gutenberg_menu_order( $menu_order ) {
+	if ( ! gutenberg_is_fse_theme() ) {
+		return;
+	}
+
+	$new_positions = array(
+		// Position the site editor before the appearnce menu.
+		'gutenberg-edit-site' => array_search( 'themes.php', $menu_order, true ),
+	);
+
+	// traverse through the new positions and move.
+	// the items if found in the original menu_positions.
+	foreach ( $new_positions as $value => $new_index ) {
+		$current_index = array_search( $value, $menu_order, true );
+		if ( $current_index ) {
+			$out = array_splice( $menu_order, $current_index, 1 );
+			array_splice( $menu_order, $new_index, 0, $out );
+		}
+	}
+	return $menu_order;
+}


### PR DESCRIPTION
Builds on top of #26500 

This PR cleans wp-admin a bit for FSE themes:

 - It disables the widgets and the customizer screens
 - It moves the Site Editor screen before the "Appearance" menu and clarify its beta status.

<img width="1123" alt="Capture d’écran 2020-10-30 à 12 12 54 PM" src="https://user-images.githubusercontent.com/272444/97698909-97974300-1aa9-11eb-9080-69f309225d37.png">
