### PR TITLE
Unify the inserter search UI

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-tab.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab.js
@@ -7,43 +7,15 @@ import { fromPairs } from 'lodash';
  * WordPress dependencies
  */
 import { useMemo, useCallback, useEffect } from '@wordpress/element';
-import { __, _x } from '@wordpress/i18n';
+import { _x } from '@wordpress/i18n';
 import { useAsyncList } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
-import InserterPanel from './panel';
 import PatternInserterPanel from './pattern-panel';
-import { searchItems } from './search-items';
-import InserterNoResults from './no-results';
 import usePatternsState from './hooks/use-patterns-state';
 import BlockPatternList from '../block-patterns-list';
-
-function BlockPatternsSearchResults( { filterValue, onInsert } ) {
-	const [ allPatterns, , onClick ] = usePatternsState( onInsert );
-
-	const filteredPatterns = useMemo(
-		() => searchItems( allPatterns, filterValue ),
-		[ filterValue, allPatterns ]
-	);
-
-	const currentShownPatterns = useAsyncList( filteredPatterns );
-
-	if ( filterValue ) {
-		return !! filteredPatterns.length ? (
-			<InserterPanel title={ __( 'Search Results' ) }>
-				<BlockPatternList
-					shownPatterns={ currentShownPatterns }
-					blockPatterns={ filteredPatterns }
-					onClickPattern={ onClick }
-				/>
-			</InserterPanel>
-		) : (
-			<InserterNoResults />
-		);
-	}
-}
 
 function BlockPatternsCategory( {
 	onInsert,
@@ -148,18 +120,8 @@ function BlockPatternsCategory( {
 	);
 }
 
-function BlockPatternsTabs( {
-	onInsert,
-	onClickCategory,
-	filterValue,
-	selectedCategory,
-} ) {
-	return filterValue ? (
-		<BlockPatternsSearchResults
-			onInsert={ onInsert }
-			filterValue={ filterValue }
-		/>
-	) : (
+function BlockPatternsTabs( { onInsert, onClickCategory, selectedCategory } ) {
+	return (
 		<BlockPatternsCategory
 			selectedCategory={ selectedCategory }
 			onInsert={ onInsert }

--- a/packages/block-editor/src/components/inserter/block-types-tab.js
+++ b/packages/block-editor/src/components/inserter/block-types-tab.js
@@ -1,21 +1,12 @@
 /**
  * External dependencies
  */
-import {
-	map,
-	findIndex,
-	flow,
-	sortBy,
-	groupBy,
-	isEmpty,
-	orderBy,
-} from 'lodash';
+import { map, findIndex, flow, sortBy, groupBy, orderBy } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-import { __, _x, _n, sprintf } from '@wordpress/i18n';
-import { withSpokenMessages } from '@wordpress/components';
+import { __, _x } from '@wordpress/i18n';
 import { useMemo, useEffect } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 
@@ -24,10 +15,7 @@ import { useSelect } from '@wordpress/data';
  */
 import BlockTypesList from '../block-types-list';
 import ChildBlocks from './child-blocks';
-import __experimentalInserterMenuExtension from '../inserter-menu-extension';
-import { searchBlockItems } from './search-items';
 import InserterPanel from './panel';
-import InserterNoResults from './no-results';
 import useBlockTypesState from './hooks/use-block-types-state';
 
 const getBlockNamespace = ( item ) => item.name.split( '/' )[ 0 ];
@@ -38,8 +26,6 @@ export function BlockTypesTab( {
 	rootClientId,
 	onInsert,
 	onHover,
-	filterValue,
-	debouncedSpeak,
 	showMostUsedBlocks,
 } ) {
 	const [ items, categories, collections, onSelectItem ] = useBlockTypesState(
@@ -58,10 +44,6 @@ export function BlockTypesTab( {
 		[ rootClientId ]
 	);
 
-	const filteredItems = useMemo( () => {
-		return searchBlockItems( items, categories, collections, filterValue );
-	}, [ filterValue, items, categories, collections ] );
-
 	const suggestedItems = useMemo( () => {
 		return orderBy( items, [ 'frecency' ], [ 'desc' ] ).slice(
 			0,
@@ -70,8 +52,8 @@ export function BlockTypesTab( {
 	}, [ items ] );
 
 	const uncategorizedItems = useMemo( () => {
-		return filteredItems.filter( ( item ) => ! item.category );
-	}, [ filteredItems ] );
+		return items.filter( ( item ) => ! item.category );
+	}, [ items ] );
 
 	const itemsPerCategory = useMemo( () => {
 		const getCategoryIndex = ( item ) => {
@@ -88,14 +70,14 @@ export function BlockTypesTab( {
 				),
 			( itemList ) => sortBy( itemList, getCategoryIndex ),
 			( itemList ) => groupBy( itemList, 'category' )
-		)( filteredItems );
-	}, [ filteredItems, categories ] );
+		)( items );
+	}, [ items, categories ] );
 
 	const itemsPerCollection = useMemo( () => {
 		// Create a new Object to avoid mutating collection.
 		const result = { ...collections };
 		Object.keys( collections ).forEach( ( namespace ) => {
-			result[ namespace ] = filteredItems.filter(
+			result[ namespace ] = items.filter(
 				( item ) => getBlockNamespace( item ) === namespace
 			);
 			if ( result[ namespace ].length === 0 ) {
@@ -104,22 +86,10 @@ export function BlockTypesTab( {
 		} );
 
 		return result;
-	}, [ filteredItems, collections ] );
+	}, [ items, collections ] );
 
 	// Hide block preview on unmount.
 	useEffect( () => () => onHover( null ), [] );
-
-	// Announce search results on change.
-	useEffect( () => {
-		const resultsFoundMessage = sprintf(
-			/* translators: %d: number of results. */
-			_n( '%d result found.', '%d results found.', filteredItems.length ),
-			filteredItems.length
-		);
-		debouncedSpeak( resultsFoundMessage );
-	}, [ filterValue, debouncedSpeak ] );
-
-	const hasItems = ! isEmpty( filteredItems );
 
 	return (
 		<div>
@@ -129,7 +99,7 @@ export function BlockTypesTab( {
 						// Pass along every block, as useBlockTypesState() and
 						// getInserterItems() will have already filtered out
 						// non-child blocks.
-						items={ filteredItems }
+						items={ items }
 						onSelect={ onSelectItem }
 						onHover={ onHover }
 						label={ __( 'Child Blocks' ) }
@@ -139,8 +109,7 @@ export function BlockTypesTab( {
 
 			{ showMostUsedBlocks &&
 				! hasChildItems &&
-				!! suggestedItems.length &&
-				! filterValue && (
+				!! suggestedItems.length && (
 					<InserterPanel title={ _x( 'Most used', 'blocks' ) }>
 						<BlockTypesList
 							items={ suggestedItems }
@@ -209,27 +178,8 @@ export function BlockTypesTab( {
 						</InserterPanel>
 					);
 				} ) }
-
-			<__experimentalInserterMenuExtension.Slot
-				fillProps={ {
-					onSelect: onSelectItem,
-					onHover,
-					filterValue,
-					hasItems,
-				} }
-			>
-				{ ( fills ) => {
-					if ( fills.length ) {
-						return fills;
-					}
-					if ( ! hasItems ) {
-						return <InserterNoResults />;
-					}
-					return null;
-				} }
-			</__experimentalInserterMenuExtension.Slot>
 		</div>
 	);
 }
 
-export default withSpokenMessages( BlockTypesTab );
+export default BlockTypesTab;

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -16,6 +16,7 @@ import InserterPreviewPanel from './preview-panel';
 import BlockTypesTab from './block-types-tab';
 import BlockPatternsTabs from './block-patterns-tab';
 import ReusableBlocksTab from './reusable-blocks-tab';
+import InserterSearchResults from './search-results';
 import useInsertionPoint from './hooks/use-insertion-point';
 import InserterTabs from './tabs';
 
@@ -31,7 +32,6 @@ function InserterMenu( {
 	showInserterHelpPanel,
 	showMostUsedBlocks,
 } ) {
-	const [ activeTab, setActiveTab ] = useState( 'blocks' );
 	const [ filterValue, setFilterValue ] = useState( '' );
 	const [ hoveredItem, setHoveredItem ] = useState( null );
 	const [ selectedPatternCategory, setSelectedPatternCategory ] = useState(
@@ -100,7 +100,6 @@ function InserterMenu( {
 					rootClientId={ destinationRootClientId }
 					onInsert={ onInsert }
 					onHover={ onHover }
-					filterValue={ filterValue }
 					showMostUsedBlocks={ showMostUsedBlocks }
 				/>
 			</div>
@@ -118,7 +117,6 @@ function InserterMenu( {
 	const patternsTab = (
 		<BlockPatternsTabs
 			onInsert={ onInsertPattern }
-			filterValue={ filterValue }
 			onClickCategory={ onClickPatternCategory }
 			selectedCategory={ selectedPatternCategory }
 		/>
@@ -129,21 +127,8 @@ function InserterMenu( {
 			rootClientId={ destinationRootClientId }
 			onInsert={ onInsert }
 			onHover={ onHover }
-			filterValue={ filterValue }
 		/>
 	);
-
-	const searchFormPlaceholder = () => {
-		if ( activeTab === 'reusable' ) {
-			return __( 'Search for a reusable block' );
-		}
-
-		if ( activeTab === 'patterns' ) {
-			return __( 'Search for a pattern' );
-		}
-
-		return __( 'Search for a block' );
-	};
 
 	// Disable reason (no-autofocus): The inserter menu is a modal display, not one which
 	// is always visible, and one which already incurs this behavior of autoFocus via
@@ -166,13 +151,25 @@ function InserterMenu( {
 							setFilterValue( value );
 						} }
 						value={ filterValue }
-						placeholder={ searchFormPlaceholder() }
+						placeholder={ __( 'Search' ) }
 					/>
-					{ ( showPatterns || hasReusableBlocks ) && (
+					{ !! filterValue && (
+						<InserterSearchResults
+							filterValue={ filterValue }
+							onSelect={ onSelect }
+							rootClientId={ rootClientId }
+							clientId={ clientId }
+							isAppender={ isAppender }
+							selectBlockOnInsert={
+								__experimentalSelectBlockOnInsert
+							}
+							showBlockDirectory
+						/>
+					) }
+					{ ! filterValue && ( showPatterns || hasReusableBlocks ) && (
 						<InserterTabs
 							showPatterns={ showPatterns }
 							showReusableBlocks={ hasReusableBlocks }
-							onSelect={ setActiveTab }
 						>
 							{ ( tab ) => {
 								if ( tab.name === 'blocks' ) {
@@ -184,7 +181,10 @@ function InserterMenu( {
 							} }
 						</InserterTabs>
 					) }
-					{ ! showPatterns && ! hasReusableBlocks && blocksTab }
+					{ ! filterValue &&
+						! showPatterns &&
+						! hasReusableBlocks &&
+						blocksTab }
 				</div>
 			</div>
 			{ showInserterHelpPanel && hoveredItem && (

--- a/packages/block-editor/src/components/inserter/quick-inserter.js
+++ b/packages/block-editor/src/components/inserter/quick-inserter.js
@@ -1,32 +1,25 @@
 /**
  * External dependencies
  */
-import { orderBy } from 'lodash';
 import classnames from 'classnames';
 
 /**
  * WordPress dependencies
  */
-import { useState, useMemo, useEffect } from '@wordpress/element';
-import { __, _n, sprintf } from '@wordpress/i18n';
-import { VisuallyHidden, Button } from '@wordpress/components';
+import { useState, useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { LEFT, RIGHT, UP, DOWN, BACKSPACE, ENTER } from '@wordpress/keycodes';
-import { useDebounce } from '@wordpress/compose';
-import { speak } from '@wordpress/a11y';
 
 /**
  * Internal dependencies
  */
-import BlockTypesList from '../block-types-list';
-import BlockPatternsList from '../block-patterns-list';
 import InserterSearchForm from './search-form';
-import InserterPanel from './panel';
-import InserterNoResults from './no-results';
+import InserterSearchResults from './search-results';
 import useInsertionPoint from './hooks/use-insertion-point';
 import usePatternsState from './hooks/use-patterns-state';
 import useBlockTypesState from './hooks/use-block-types-state';
-import { searchBlockItems, searchItems } from './search-items';
 
 const SEARCH_THRESHOLD = 6;
 const SHOWN_BLOCK_TYPES = 6;
@@ -42,69 +35,6 @@ const preventArrowKeysPropagation = ( event ) => {
 };
 const stopKeyPropagation = ( event ) => event.stopPropagation();
 
-function QuickInserterList( {
-	blockTypes,
-	blockPatterns,
-	onSelectBlockType,
-	onSelectBlockPattern,
-	onHover,
-} ) {
-	const shownBlockTypes = useMemo(
-		() =>
-			orderBy( blockTypes, [ 'frecency' ], [ 'desc' ] ).slice(
-				0,
-				SHOWN_BLOCK_TYPES
-			),
-		[ blockTypes ]
-	);
-	const shownBlockPatterns = useMemo(
-		() => blockPatterns.slice( 0, SHOWN_BLOCK_PATTERNS ),
-		[ blockTypes ]
-	);
-	return (
-		<div className="block-editor-inserter__quick-inserter-results">
-			{ ! shownBlockTypes.length && ! shownBlockPatterns.length && (
-				<InserterNoResults />
-			) }
-
-			{ !! shownBlockTypes.length && (
-				<InserterPanel
-					title={
-						<VisuallyHidden>{ __( 'Blocks' ) }</VisuallyHidden>
-					}
-				>
-					<BlockTypesList
-						items={ shownBlockTypes }
-						onSelect={ onSelectBlockType }
-						onHover={ onHover }
-						label={ __( 'Blocks' ) }
-					/>
-				</InserterPanel>
-			) }
-
-			{ !! shownBlockTypes.length && !! shownBlockPatterns.length && (
-				<div className="block-editor-inserter__quick-inserter-separator" />
-			) }
-
-			{ !! shownBlockPatterns.length && (
-				<InserterPanel
-					title={
-						<VisuallyHidden>{ __( 'Blocks' ) }</VisuallyHidden>
-					}
-				>
-					<div className="block-editor-inserter__quick-inserter-patterns">
-						<BlockPatternsList
-							shownPatterns={ shownBlockPatterns }
-							blockPatterns={ shownBlockPatterns }
-							onClickPattern={ onSelectBlockPattern }
-						/>
-					</div>
-				</InserterPanel>
-			) }
-		</div>
-	);
-}
-
 export default function QuickInserter( {
 	onSelect,
 	rootClientId,
@@ -112,47 +42,25 @@ export default function QuickInserter( {
 	isAppender,
 	selectBlockOnInsert,
 } ) {
-	const debouncedSpeak = useDebounce( speak, 500 );
 	const [ filterValue, setFilterValue ] = useState( '' );
-	const [
-		destinationRootClientId,
-		onInsertBlocks,
-		onToggleInsertionPoint,
-	] = useInsertionPoint( {
+	const [ destinationRootClientId, onInsertBlocks ] = useInsertionPoint( {
 		onSelect,
 		rootClientId,
 		clientId,
 		isAppender,
 		selectBlockOnInsert,
 	} );
-	const [
-		blockTypes,
-		blockTypeCategories,
-		blockTypeCollections,
-		onSelectBlockType,
-	] = useBlockTypesState( destinationRootClientId, onInsertBlocks );
-	const [ patterns, , onSelectBlockPattern ] = usePatternsState(
+	const [ blockTypes ] = useBlockTypesState(
+		destinationRootClientId,
 		onInsertBlocks
 	);
+
+	const [ patterns ] = usePatternsState( onInsertBlocks );
 	const showPatterns =
 		! destinationRootClientId && patterns.length && !! filterValue;
 	const showSearch =
 		( showPatterns && patterns.length > SEARCH_THRESHOLD ) ||
 		blockTypes.length > SEARCH_THRESHOLD;
-
-	const filteredBlockTypes = useMemo( () => {
-		return searchBlockItems(
-			blockTypes,
-			blockTypeCategories,
-			blockTypeCollections,
-			filterValue
-		);
-	}, [ filterValue, blockTypes, blockTypeCategories, blockTypeCollections ] );
-
-	const filteredBlockPatterns = useMemo(
-		() => searchItems( patterns, filterValue ),
-		[ filterValue, patterns ]
-	);
 
 	const { setInserterIsOpened, blockIndex } = useSelect(
 		( select ) => {
@@ -176,20 +84,8 @@ export default function QuickInserter( {
 
 	const { __unstableSetInsertionPoint } = useDispatch( 'core/block-editor' );
 
-	// Announce search results on change
-	useEffect( () => {
-		if ( ! filterValue ) {
-			return;
-		}
-		const count = filteredBlockTypes.length + filteredBlockPatterns.length;
-		const resultsFoundMessage = sprintf(
-			/* translators: %d: number of results. */
-			_n( '%d result found.', '%d results found.', count ),
-			count
-		);
-		debouncedSpeak( resultsFoundMessage );
-	}, [ filterValue, debouncedSpeak ] );
-
+	// When clicking Browse All select the appropriate block so as
+	// the insertion point can work as expected
 	const onBrowseAll = () => {
 		__unstableSetInsertionPoint( rootClientId, blockIndex );
 		setInserterIsOpened( true );
@@ -220,13 +116,18 @@ export default function QuickInserter( {
 				/>
 			) }
 
-			<QuickInserterList
-				blockTypes={ filteredBlockTypes }
-				blockPatterns={ showPatterns ? filteredBlockPatterns : [] }
-				onSelectBlockPattern={ onSelectBlockPattern }
-				onSelectBlockType={ onSelectBlockType }
-				onHover={ onToggleInsertionPoint }
-			/>
+			<div className="block-editor-inserter__quick-inserter-results">
+				<InserterSearchResults
+					filterValue={ filterValue }
+					onSelect={ onSelect }
+					rootClientId={ rootClientId }
+					clientId={ clientId }
+					isAppender={ isAppender }
+					selectBlockOnInsert={ selectBlockOnInsert }
+					maxBlockPatterns={ showPatterns ? SHOWN_BLOCK_PATTERNS : 0 }
+					maxBlockTypes={ SHOWN_BLOCK_TYPES }
+				/>
+			</div>
 
 			{ setInserterIsOpened && (
 				<Button

--- a/packages/block-editor/src/components/inserter/reusable-blocks-tab.js
+++ b/packages/block-editor/src/components/inserter/reusable-blocks-tab.js
@@ -1,77 +1,39 @@
 /**
  * WordPress dependencies
  */
-import { withSpokenMessages } from '@wordpress/components';
-import { useMemo, useEffect } from '@wordpress/element';
-import { __, _n, sprintf } from '@wordpress/i18n';
+import { useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
  */
 import BlockTypesList from '../block-types-list';
-import { searchBlockItems } from './search-items';
 import InserterPanel from './panel';
 import InserterNoResults from './no-results';
 import useBlockTypesState from './hooks/use-block-types-state';
 
-function ReusableBlocksList( {
-	debouncedSpeak,
-	filterValue,
-	onHover,
-	onInsert,
-	rootClientId,
-} ) {
-	const [ items, categories, collections, onSelectItem ] = useBlockTypesState(
+function ReusableBlocksList( { onHover, onInsert, rootClientId } ) {
+	const [ items, , , onSelectItem ] = useBlockTypesState(
 		rootClientId,
 		onInsert
 	);
 
 	const filteredItems = useMemo( () => {
-		const reusableItems = items.filter(
-			( { category } ) => category === 'reusable'
-		);
-
-		if ( ! filterValue ) {
-			return reusableItems;
-		}
-		return searchBlockItems(
-			reusableItems,
-			categories,
-			collections,
-			filterValue
-		);
-	}, [ filterValue, items, categories, collections ] );
-
-	// Announce search results on change.
-	useEffect( () => {
-		const resultsFoundMessage = sprintf(
-			/* translators: %d: number of results. */
-			_n( '%d result found.', '%d results found.', filteredItems.length ),
-			filteredItems.length
-		);
-		debouncedSpeak( resultsFoundMessage );
-	}, [ filterValue, debouncedSpeak ] );
+		return items.filter( ( { category } ) => category === 'reusable' );
+	}, [ items ] );
 
 	if ( filteredItems.length === 0 ) {
 		return <InserterNoResults />;
 	}
 
 	return (
-		<InserterPanel
-			title={
-				filterValue ? __( 'Search Results' ) : __( 'Reusable blocks' )
-			}
-		>
+		<InserterPanel title={ __( 'Reusable blocks' ) }>
 			<BlockTypesList
 				items={ filteredItems }
 				onSelect={ onSelectItem }
 				onHover={ onHover }
-				label={
-					filterValue
-						? __( 'Search Results' )
-						: __( 'Reusable blocks' )
-				}
+				label={ __( 'Reusable blocks' ) }
 			/>
 		</InserterPanel>
 	);
@@ -85,23 +47,13 @@ function ReusableBlocksList( {
  * @param {?string}  props.rootClientId   Client id of block to insert into.
  * @param {Function} props.onInsert       Callback to run when item is inserted.
  * @param {Function} props.onHover        Callback to run when item is hovered.
- * @param {?string}  props.filterValue    Search term.
- * @param {Function} props.debouncedSpeak Debounced speak function.
  *
  * @return {WPComponent} The component.
  */
-export function ReusableBlocksTab( {
-	rootClientId,
-	onInsert,
-	onHover,
-	filterValue,
-	debouncedSpeak,
-} ) {
+export function ReusableBlocksTab( { rootClientId, onInsert, onHover } ) {
 	return (
 		<>
 			<ReusableBlocksList
-				debouncedSpeak={ debouncedSpeak }
-				filterValue={ filterValue }
 				onHover={ onHover }
 				onInsert={ onInsert }
 				rootClientId={ rootClientId }
@@ -120,4 +72,4 @@ export function ReusableBlocksTab( {
 	);
 }
 
-export default withSpokenMessages( ReusableBlocksTab );
+export default ReusableBlocksTab;

--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -1,0 +1,173 @@
+/**
+ * External dependencies
+ */
+import { orderBy, isEmpty } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { useMemo, useEffect } from '@wordpress/element';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { VisuallyHidden } from '@wordpress/components';
+import { useDebounce } from '@wordpress/compose';
+import { speak } from '@wordpress/a11y';
+
+/**
+ * Internal dependencies
+ */
+import BlockTypesList from '../block-types-list';
+import BlockPatternsList from '../block-patterns-list';
+import __experimentalInserterMenuExtension from '../inserter-menu-extension';
+import InserterPanel from './panel';
+import InserterNoResults from './no-results';
+import useInsertionPoint from './hooks/use-insertion-point';
+import usePatternsState from './hooks/use-patterns-state';
+import useBlockTypesState from './hooks/use-block-types-state';
+import { searchBlockItems, searchItems } from './search-items';
+
+function InserterSearchResults( {
+	filterValue,
+	onSelect,
+	rootClientId,
+	clientId,
+	isAppender,
+	selectBlockOnInsert,
+	maxBlockPatterns,
+	maxBlockTypes,
+	showBlockDirectory = false,
+} ) {
+	const debouncedSpeak = useDebounce( speak, 500 );
+
+	const [
+		destinationRootClientId,
+		onInsertBlocks,
+		onToggleInsertionPoint,
+	] = useInsertionPoint( {
+		onSelect,
+		rootClientId,
+		clientId,
+		isAppender,
+		selectBlockOnInsert,
+	} );
+	const [
+		blockTypes,
+		blockTypeCategories,
+		blockTypeCollections,
+		onSelectBlockType,
+	] = useBlockTypesState( destinationRootClientId, onInsertBlocks );
+	const [ patterns, , onSelectBlockPattern ] = usePatternsState(
+		onInsertBlocks
+	);
+
+	const filteredBlockTypes = useMemo( () => {
+		const results = searchBlockItems(
+			orderBy( blockTypes, [ 'frecency' ], [ 'desc' ] ),
+			blockTypeCategories,
+			blockTypeCollections,
+			filterValue
+		);
+
+		return maxBlockTypes !== undefined
+			? results.slice( 0, maxBlockTypes )
+			: results;
+	}, [
+		filterValue,
+		blockTypes,
+		blockTypeCategories,
+		blockTypeCollections,
+		maxBlockTypes,
+	] );
+
+	const filteredBlockPatterns = useMemo( () => {
+		const results = searchItems( patterns, filterValue );
+		return maxBlockPatterns !== undefined
+			? results.slice( 0, maxBlockPatterns )
+			: results;
+	}, [ filterValue, patterns, maxBlockPatterns ] );
+
+	// Announce search results on change
+	useEffect( () => {
+		if ( ! filterValue ) {
+			return;
+		}
+		const count = filteredBlockTypes.length + filteredBlockPatterns.length;
+		const resultsFoundMessage = sprintf(
+			/* translators: %d: number of results. */
+			_n( '%d result found.', '%d results found.', count ),
+			count
+		);
+		debouncedSpeak( resultsFoundMessage );
+	}, [ filterValue, debouncedSpeak ] );
+
+	const hasItems =
+		! isEmpty( filteredBlockTypes ) || ! isEmpty( filteredBlockPatterns );
+
+	return (
+		<>
+			{ ! filteredBlockTypes.length && ! filteredBlockPatterns.length && (
+				<InserterNoResults />
+			) }
+
+			{ !! filteredBlockTypes.length && (
+				<InserterPanel
+					title={
+						<VisuallyHidden>{ __( 'Blocks' ) }</VisuallyHidden>
+					}
+				>
+					<BlockTypesList
+						items={ filteredBlockTypes }
+						onSelect={ onSelectBlockType }
+						onHover={ onToggleInsertionPoint }
+						label={ __( 'Blocks' ) }
+					/>
+				</InserterPanel>
+			) }
+
+			{ !! filteredBlockTypes.length &&
+				!! filteredBlockPatterns.length && (
+					<div className="block-editor-inserter__quick-inserter-separator" />
+				) }
+
+			{ !! filteredBlockPatterns.length && (
+				<InserterPanel
+					title={
+						<VisuallyHidden>
+							{ __( 'Block Patterns' ) }
+						</VisuallyHidden>
+					}
+				>
+					<div className="block-editor-inserter__quick-inserter-patterns">
+						<BlockPatternsList
+							shownPatterns={ filteredBlockPatterns }
+							blockPatterns={ filteredBlockPatterns }
+							onClickPattern={ onSelectBlockPattern }
+						/>
+					</div>
+				</InserterPanel>
+			) }
+
+			{ showBlockDirectory && (
+				<__experimentalInserterMenuExtension.Slot
+					fillProps={ {
+						onSelect: onSelectBlockType,
+						onHover: onToggleInsertionPoint,
+						filterValue,
+						hasItems,
+					} }
+				>
+					{ ( fills ) => {
+						if ( fills.length ) {
+							return fills;
+						}
+						if ( ! hasItems ) {
+							return <InserterNoResults />;
+						}
+						return null;
+					} }
+				</__experimentalInserterMenuExtension.Slot>
+			) }
+		</>
+	);
+}
+
+export default InserterSearchResults;

--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -104,9 +104,7 @@ function InserterSearchResults( {
 
 	return (
 		<>
-			{ ! filteredBlockTypes.length && ! filteredBlockPatterns.length && (
-				<InserterNoResults />
-			) }
+			{ ! showBlockDirectory && ! hasItems && <InserterNoResults /> }
 
 			{ !! filteredBlockTypes.length && (
 				<InserterPanel

--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -9,7 +9,7 @@ import { orderBy, isEmpty } from 'lodash';
 import { useMemo, useEffect } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { VisuallyHidden } from '@wordpress/components';
-import { useDebounce } from '@wordpress/compose';
+import { useDebounce, useAsyncList } from '@wordpress/compose';
 import { speak } from '@wordpress/a11y';
 
 /**
@@ -99,6 +99,8 @@ function InserterSearchResults( {
 		debouncedSpeak( resultsFoundMessage );
 	}, [ filterValue, debouncedSpeak ] );
 
+	const currentShownPatterns = useAsyncList( filteredBlockPatterns );
+
 	const hasItems =
 		! isEmpty( filteredBlockTypes ) || ! isEmpty( filteredBlockPatterns );
 
@@ -136,7 +138,7 @@ function InserterSearchResults( {
 				>
 					<div className="block-editor-inserter__quick-inserter-patterns">
 						<BlockPatternsList
-							shownPatterns={ filteredBlockPatterns }
+							shownPatterns={ currentShownPatterns }
 							blockPatterns={ filteredBlockPatterns }
 							onClickPattern={ onSelectBlockPattern }
 						/>

--- a/packages/block-editor/src/components/inserter/test/block-types-tab.js
+++ b/packages/block-editor/src/components/inserter/test/block-types-tab.js
@@ -56,20 +56,6 @@ const initializeAllClosedMenuState = ( propOverrides ) => {
 	return result;
 };
 
-const assertNoResultsMessageToBePresent = ( element ) => {
-	const noResultsMessage = element.querySelector(
-		'.block-editor-inserter__no-results'
-	);
-	expect( noResultsMessage.textContent ).toEqual( 'No results found.' );
-};
-
-const assertNoResultsMessageNotToBePresent = ( element ) => {
-	const noResultsMessage = element.querySelector(
-		'.block-editor-inserter__no-results'
-	);
-	expect( noResultsMessage ).toBe( null );
-};
-
 describe( 'InserterMenu', () => {
 	beforeEach( () => {
 		debouncedSpeak.mockClear();
@@ -98,8 +84,6 @@ describe( 'InserterMenu', () => {
 		);
 
 		expect( visibleBlocks ).toBe( null );
-
-		assertNoResultsMessageToBePresent( container );
 	} );
 
 	it( 'should show items from the embed category in the embed tab', () => {
@@ -118,8 +102,6 @@ describe( 'InserterMenu', () => {
 		expect( blocks ).toHaveLength( 2 );
 		expect( blocks[ 0 ].textContent ).toBe( 'YouTube' );
 		expect( blocks[ 1 ].textContent ).toBe( 'A Paragraph Embed' );
-
-		assertNoResultsMessageNotToBePresent( container );
 	} );
 
 	it( 'should show the common category blocks', () => {
@@ -139,8 +121,6 @@ describe( 'InserterMenu', () => {
 		expect( blocks[ 0 ].textContent ).toBe( 'Paragraph' );
 		expect( blocks[ 1 ].textContent ).toBe( 'Advanced Paragraph' );
 		expect( blocks[ 2 ].textContent ).toBe( 'Some Other Block' );
-
-		assertNoResultsMessageNotToBePresent( container );
 	} );
 
 	it( 'displays child blocks UI when root block has child blocks', () => {
@@ -153,8 +133,6 @@ describe( 'InserterMenu', () => {
 		);
 
 		expect( childBlocksContent ).not.toBeNull();
-
-		assertNoResultsMessageNotToBePresent( container );
 	} );
 
 	it( 'should disable items with `isDisabled`', () => {
@@ -168,82 +146,5 @@ describe( 'InserterMenu', () => {
 
 		expect( disabledBlocks ).toHaveLength( 1 );
 		expect( disabledBlocks[ 0 ].textContent ).toBe( 'More' );
-	} );
-
-	it( 'should allow searching for items', () => {
-		const { container } = render(
-			<InserterBlockList filterValue="paragraph" />
-		);
-
-		const matchingCategories = container.querySelectorAll(
-			'.block-editor-inserter__panel-title'
-		);
-
-		expect( matchingCategories ).toHaveLength( 3 );
-		expect( matchingCategories[ 0 ].textContent ).toBe( 'Text' );
-		expect( matchingCategories[ 1 ].textContent ).toBe( 'Embeds' );
-		expect( matchingCategories[ 2 ].textContent ).toBe( 'Core' ); // "Core" namespace collection
-
-		const blocks = container.querySelectorAll(
-			'.block-editor-block-types-list__item-title'
-		);
-
-		// There are five buttons present for 3 total distinct results. The
-		// additional two account for the collection results (repeated).
-		expect( blocks ).toHaveLength( 5 );
-		expect( debouncedSpeak ).toHaveBeenCalledWith( '3 results found.' );
-
-		// Default block results.
-		expect( blocks[ 0 ].textContent ).toBe( 'Paragraph' );
-		expect( blocks[ 1 ].textContent ).toBe( 'Advanced Paragraph' );
-		expect( blocks[ 2 ].textContent ).toBe( 'A Paragraph Embed' );
-
-		// Collection results.
-		expect( blocks[ 3 ].textContent ).toBe( 'Paragraph' );
-		expect( blocks[ 4 ].textContent ).toBe( 'Advanced Paragraph' );
-
-		assertNoResultsMessageNotToBePresent( container );
-	} );
-
-	it( 'should speak after any change in search term', () => {
-		// The search result count should always be announced any time the user
-		// changes the search term, even if it results in the same count.
-		//
-		// See: https://github.com/WordPress/gutenberg/pull/22279#discussion_r423317161
-		const { rerender } = render(
-			<InserterBlockList filterValue="Advanced Para" />
-		);
-
-		rerender( <InserterBlockList filterValue="Advanced Paragraph" /> );
-		rerender( <InserterBlockList filterValue="Advanced Paragraph" /> );
-
-		expect( debouncedSpeak ).toHaveBeenCalledTimes( 2 );
-		expect( debouncedSpeak.mock.calls[ 0 ][ 0 ] ).toBe( '1 result found.' );
-		expect( debouncedSpeak.mock.calls[ 1 ][ 0 ] ).toBe( '1 result found.' );
-	} );
-
-	it( 'should trim whitespace of search terms', () => {
-		const { container } = render(
-			<InserterBlockList filterValue=" paragraph" />
-		);
-
-		const matchingCategories = container.querySelectorAll(
-			'.block-editor-inserter__panel-title'
-		);
-
-		expect( matchingCategories ).toHaveLength( 3 );
-		expect( matchingCategories[ 0 ].textContent ).toBe( 'Text' );
-		expect( matchingCategories[ 1 ].textContent ).toBe( 'Embeds' );
-
-		const blocks = container.querySelectorAll(
-			'.block-editor-block-types-list__item-title'
-		);
-
-		expect( blocks ).toHaveLength( 5 );
-		expect( blocks[ 0 ].textContent ).toBe( 'Paragraph' );
-		expect( blocks[ 1 ].textContent ).toBe( 'Advanced Paragraph' );
-		expect( blocks[ 2 ].textContent ).toBe( 'A Paragraph Embed' );
-
-		assertNoResultsMessageNotToBePresent( container );
 	} );
 } );

--- a/packages/block-editor/src/components/inserter/test/reusable-blocks-tab.js
+++ b/packages/block-editor/src/components/inserter/test/reusable-blocks-tab.js
@@ -50,20 +50,6 @@ const initializeAllClosedMenuState = ( propOverrides ) => {
 	return result;
 };
 
-const assertNoResultsMessageToBePresent = ( element ) => {
-	const noResultsMessage = element.querySelector(
-		'.block-editor-inserter__no-results'
-	);
-	expect( noResultsMessage.textContent ).toEqual( 'No results found.' );
-};
-
-const assertNoResultsMessageNotToBePresent = ( element ) => {
-	const noResultsMessage = element.querySelector(
-		'.block-editor-inserter__no-results'
-	);
-	expect( noResultsMessage ).toBe( null );
-};
-
 describe( 'InserterMenu', () => {
 	beforeEach( () => {
 		debouncedSpeak.mockClear();
@@ -92,8 +78,6 @@ describe( 'InserterMenu', () => {
 		);
 
 		expect( visibleBlocks ).toBe( null );
-
-		assertNoResultsMessageToBePresent( container );
 	} );
 
 	it( 'should list reusable blocks', () => {
@@ -104,41 +88,6 @@ describe( 'InserterMenu', () => {
 
 		expect( blocks ).toHaveLength( 1 );
 		expect( blocks[ 0 ].textContent ).toBe( 'My reusable block' );
-
-		assertNoResultsMessageNotToBePresent( container );
-	} );
-
-	it( 'should allow searching for reusable blocks by title', () => {
-		const { container } = render(
-			<InserterBlockList filterValue="my reusable" />
-		);
-
-		const blocks = container.querySelectorAll(
-			'.block-editor-block-types-list__item-title'
-		);
-
-		expect( blocks ).toHaveLength( 1 );
-		expect( debouncedSpeak ).toHaveBeenCalledWith( '1 result found.' );
-		expect( blocks[ 0 ].textContent ).toBe( 'My reusable block' );
-
-		assertNoResultsMessageNotToBePresent( container );
-	} );
-
-	it( 'should speak after any change in search term', () => {
-		// The search result count should always be announced any time the user
-		// changes the search term, even if it results in the same count.
-		//
-		// See: https://github.com/WordPress/gutenberg/pull/22279#discussion_r423317161
-		const { rerender } = render(
-			<InserterBlockList filterValue="my reusab" />
-		);
-
-		rerender( <InserterBlockList filterValue="my reusable" /> );
-		rerender( <InserterBlockList filterValue="my reusable" /> );
-
-		expect( debouncedSpeak ).toHaveBeenCalledTimes( 2 );
-		expect( debouncedSpeak.mock.calls[ 0 ][ 0 ] ).toBe( '1 result found.' );
-		expect( debouncedSpeak.mock.calls[ 1 ][ 0 ] ).toBe( '1 result found.' );
 	} );
 
 	it( 'should trim whitespace of search terms', () => {
@@ -152,7 +101,5 @@ describe( 'InserterMenu', () => {
 
 		expect( blocks ).toHaveLength( 1 );
 		expect( blocks[ 0 ].textContent ).toBe( 'My reusable block' );
-
-		assertNoResultsMessageNotToBePresent( container );
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/plugins/block-directory-add.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/block-directory-add.test.js
@@ -168,7 +168,7 @@ describe( 'adding blocks from block directory', () => {
 
 		const selectorContent = await page.evaluate(
 			() =>
-				document.querySelector( '.block-editor-inserter__block-list' )
+				document.querySelector( '.block-editor-inserter__main-area' )
 					.innerHTML
 		);
 		expect( selectorContent ).toContain( 'has-no-results' );

--- a/packages/e2e-tests/specs/editor/plugins/block-icons.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/block-icons.test.js
@@ -12,7 +12,7 @@ import {
 } from '@wordpress/e2e-test-utils';
 
 const INSERTER_BUTTON_SELECTOR =
-	'.block-editor-inserter__block-list .block-editor-block-types-list__item';
+	'.block-editor-inserter__main-area .block-editor-block-types-list__item';
 const INSERTER_ICON_WRAPPER_SELECTOR = `${ INSERTER_BUTTON_SELECTOR } .block-editor-block-types-list__item-icon`;
 const INSERTER_ICON_SELECTOR = `${ INSERTER_BUTTON_SELECTOR } .block-editor-block-icon`;
 const INSPECTOR_ICON_SELECTOR = '.edit-post-sidebar .block-editor-block-icon';

--- a/packages/e2e-tests/specs/editor/various/adding-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/adding-blocks.test.js
@@ -259,6 +259,10 @@ describe( 'adding blocks', () => {
 			inserterMenuInputSelector
 		);
 		inserterMenuSearchInput.type( 'cover' );
+		// We need to wait a bit after typing otherwise we might an "early" result
+		// that is going to be "detached" when trying to click on it
+		// eslint-disable-next-line no-restricted-syntax
+		await page.waitFor( 100 );
 		const coverBlock = await page.waitForSelector(
 			'.block-editor-block-types-list .editor-block-list-item-cover'
 		);

--- a/packages/e2e-tests/specs/editor/various/adding-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/adding-blocks.test.js
@@ -276,10 +276,12 @@ describe( 'adding blocks', () => {
 		await insertBlock( 'Paragraph' );
 		await page.keyboard.type( 'First paragraph' );
 		await insertBlock( 'Image' );
+		await showBlockToolbar();
 		const paragraphBlock = await page.$(
 			'p[aria-label="Paragraph block"]'
 		);
 		paragraphBlock.click();
+		await showBlockToolbar();
 
 		// Open the global inserter and search for the Heading block.
 		await searchForBlock( 'Heading' );

--- a/packages/e2e-tests/specs/editor/various/adding-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/adding-blocks.test.js
@@ -275,6 +275,11 @@ describe( 'adding blocks', () => {
 		// First insert a random Paragraph.
 		await insertBlock( 'Paragraph' );
 		await page.keyboard.type( 'First paragraph' );
+		await insertBlock( 'Image' );
+		const paragraphBlock = await page.$(
+			'p[aria-label="Paragraph block"]'
+		);
+		paragraphBlock.click();
 
 		// Open the global inserter and search for the Heading block.
 		await searchForBlock( 'Heading' );
@@ -291,10 +296,6 @@ describe( 'adding blocks', () => {
 			'.block-editor-block-list__insertion-point-indicator'
 		);
 		const indicatorRect = await indicator.boundingBox();
-
-		const paragraphBlock = await page.$(
-			'p[aria-label="Paragraph block"]'
-		);
 		const paragraphRect = await paragraphBlock.boundingBox();
 
 		// The blue line indicator should be below the last block.


### PR DESCRIPTION
This PR makes the search behavior of the global inserter works similarly to the quick inserter (canvas inserter):

 - Search work across tabs (no separation between patterns, block types...)
 - Patterns shows up in two columns
 - Simplifies the code a lot (as shown by the removed code)

<img width="356" alt="Capture d’écran 2020-10-30 à 1 23 48 PM" src="https://user-images.githubusercontent.com/272444/97704892-7b000880-1ab3-11eb-88d8-939d6c1464ce.png">
