### PR TITLE
Allow adding a header by typing /h1, /h2 etc

### DIFF
--- a/packages/block-library/src/heading/transforms.js
+++ b/packages/block-library/src/heading/transforms.js
@@ -67,6 +67,16 @@ const transforms = {
 				} );
 			},
 		} ) ),
+		...[ 1, 2, 3, 4, 5, 6 ].map( ( level ) => ( {
+			type: 'enter',
+			regExp: new RegExp( `^/h${ level }$` ),
+			transform( content ) {
+				return createBlock( name, {
+					level,
+					content,
+				} );
+			},
+		} ) ),
 	],
 	to: [
 		{

--- a/packages/block-library/src/heading/transforms.js
+++ b/packages/block-library/src/heading/transforms.js
@@ -69,7 +69,7 @@ const transforms = {
 		} ) ),
 		...[ 1, 2, 3, 4, 5, 6 ].map( ( level ) => ( {
 			type: 'enter',
-			regExp: new RegExp( `^/h${ level }$` ),
+			regExp: new RegExp( `^/(h|H)${ level }$` ),
 			transform( content ) {
 				return createBlock( name, {
 					level,


### PR DESCRIPTION
## Description
Currently users can add a header by typing `###` followed by a space.
This PR adds the same behavior for `/h1` to `/h6` followed by enter/return.

## To test:
Typing `/h4` + enter/return should create a new block with `level:4`. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
