### PR TITLE
File Block: Copy url button is moved to Block toolbar

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Fix a regression ([#26545](https://github.com/WordPress/gutenberg/pull/26545)) where the Cover block lost its default background overlay color
   ([#26569](https://github.com/WordPress/gutenberg/pull/26569)).
 
+### Enhancement
+
+- File Block: Copy url button is moved to Block toolbar
+
 ## 2.23.0 (2020-09-03)
 
 ### Enhancement

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Enhancement
 
-- File Block: Copy url button is moved to Block toolbar
+- File Block: Copy url button is moved to Block toolbar.
 
 ## 2.23.0 (2020-09-03)
 

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -185,7 +185,6 @@ function FileEdit( {
 					<ToolbarItem
 						as={ ClipboardButton }
 						text={ href }
-						className={ 'wp-block-file__copy-url-button' }
 						onCopy={ confirmCopyURL }
 						onFinishCopy={ resetCopyConfirmation }
 						disabled={ isBlobURL( href ) }

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -11,6 +11,8 @@ import {
 	__unstableUseAnimate as useAnimate,
 	ClipboardButton,
 	withNotices,
+	ToolbarGroup,
+	ToolbarItem,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import {
@@ -171,13 +173,28 @@ function FileEdit( {
 				} }
 			/>
 			<BlockControls>
-				<MediaReplaceFlow
-					mediaId={ id }
-					mediaURL={ href }
-					accept="*"
-					onSelect={ onSelectFile }
-					onError={ onUploadError }
-				/>
+				<ToolbarGroup>
+					<ToolbarItem
+						as={ MediaReplaceFlow }
+						mediaId={ id }
+						mediaURL={ href }
+						accept="*"
+						onSelect={ onSelectFile }
+						onError={ onUploadError }
+					/>
+					<ToolbarItem
+						as={ ClipboardButton }
+						text={ href }
+						className={ 'wp-block-file__copy-url-button' }
+						onCopy={ confirmCopyURL }
+						onFinishCopy={ resetCopyConfirmation }
+						disabled={ isBlobURL( href ) }
+					>
+						{ showCopyConfirmation
+							? __( 'Copied!' )
+							: __( 'Copy URL' ) }
+					</ToolbarItem>
+				</ToolbarGroup>
 			</BlockControls>
 			<div { ...blockProps }>
 				<div className={ 'wp-block-file__content-wrapper' }>
@@ -214,20 +231,6 @@ function FileEdit( {
 						</div>
 					) }
 				</div>
-				{ isSelected && (
-					<ClipboardButton
-						isSecondary
-						text={ href }
-						className={ 'wp-block-file__copy-url-button' }
-						onCopy={ confirmCopyURL }
-						onFinishCopy={ resetCopyConfirmation }
-						disabled={ isBlobURL( href ) }
-					>
-						{ showCopyConfirmation
-							? __( 'Copied!' )
-							: __( 'Copy URL' ) }
-					</ClipboardButton>
-				) }
 			</div>
 		</>
 	);

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -12,7 +12,7 @@ import {
 	ClipboardButton,
 	withNotices,
 	ToolbarGroup,
-	ToolbarItem,
+	ToolbarButton,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import {
@@ -174,16 +174,15 @@ function FileEdit( {
 			/>
 			<BlockControls>
 				<ToolbarGroup>
-					<ToolbarItem
-						as={ MediaReplaceFlow }
+					<MediaReplaceFlow
 						mediaId={ id }
 						mediaURL={ href }
 						accept="*"
 						onSelect={ onSelectFile }
 						onError={ onUploadError }
 					/>
-					<ToolbarItem
-						as={ ClipboardButton }
+					<ClipboardButton
+						as={ ToolbarButton }
 						text={ href }
 						onCopy={ confirmCopyURL }
 						onFinishCopy={ resetCopyConfirmation }
@@ -192,7 +191,7 @@ function FileEdit( {
 						{ showCopyConfirmation
 							? __( 'Copied!' )
 							: __( 'Copy URL' ) }
-					</ToolbarItem>
+					</ClipboardButton>
 				</ToolbarGroup>
 			</BlockControls>
 			<div { ...blockProps }>

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -9,7 +9,6 @@ import classnames from 'classnames';
 import { getBlobByURL, isBlobURL, revokeBlobURL } from '@wordpress/blob';
 import {
 	__unstableUseAnimate as useAnimate,
-	ClipboardButton,
 	withNotices,
 	ToolbarGroup,
 	ToolbarButton,
@@ -23,7 +22,8 @@ import {
 	RichText,
 	useBlockProps,
 } from '@wordpress/block-editor';
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect, useState, useRef } from '@wordpress/element';
+import { useCopyOnClick } from '@wordpress/compose';
 import { __, _x } from '@wordpress/i18n';
 import { file as icon } from '@wordpress/icons';
 
@@ -32,13 +32,22 @@ import { file as icon } from '@wordpress/icons';
  */
 import FileBlockInspector from './inspector';
 
-function FileEdit( {
-	isSelected,
-	attributes,
-	setAttributes,
-	noticeUI,
-	noticeOperations,
-} ) {
+function ClipboardToolbarButton( { text, disabled } ) {
+	const ref = useRef();
+	const hasCopied = useCopyOnClick( ref, text );
+
+	return (
+		<ToolbarButton
+			className="components-clipboard-toolbar-button"
+			ref={ ref }
+			disabled={ disabled }
+		>
+			{ hasCopied ? __( 'Copied!' ) : __( 'Copy URL' ) }
+		</ToolbarButton>
+	);
+}
+
+function FileEdit( { attributes, setAttributes, noticeUI, noticeOperations } ) {
 	const {
 		id,
 		fileName,
@@ -49,7 +58,6 @@ function FileEdit( {
 		downloadButtonText,
 	} = attributes;
 	const [ hasError, setHasError ] = useState( false );
-	const [ showCopyConfirmation, setShowCopyConfirmation ] = useState( false );
 	const { media, mediaUpload } = useSelect(
 		( select ) => ( {
 			media:
@@ -84,10 +92,6 @@ function FileEdit( {
 		}
 	}, [] );
 
-	useEffect( () => {
-		setShowCopyConfirmation( false );
-	}, [ isSelected ] );
-
 	function onSelectFile( newMedia ) {
 		if ( newMedia && newMedia.url ) {
 			setHasError( false );
@@ -104,14 +108,6 @@ function FileEdit( {
 		setHasError( true );
 		noticeOperations.removeAllNotices();
 		noticeOperations.createErrorNotice( message );
-	}
-
-	function confirmCopyURL() {
-		setShowCopyConfirmation( true );
-	}
-
-	function resetCopyConfirmation() {
-		setShowCopyConfirmation( false );
 	}
 
 	function changeLinkDestinationOption( newHref ) {
@@ -181,17 +177,10 @@ function FileEdit( {
 						onSelect={ onSelectFile }
 						onError={ onUploadError }
 					/>
-					<ClipboardButton
-						as={ ToolbarButton }
+					<ClipboardToolbarButton
 						text={ href }
-						onCopy={ confirmCopyURL }
-						onFinishCopy={ resetCopyConfirmation }
 						disabled={ isBlobURL( href ) }
-					>
-						{ showCopyConfirmation
-							? __( 'Copied!' )
-							: __( 'Copy URL' ) }
-					</ClipboardButton>
+					/>
 				</ToolbarGroup>
 			</BlockControls>
 			<div { ...blockProps }>

--- a/packages/block-library/src/file/editor.scss
+++ b/packages/block-library/src/file/editor.scss
@@ -21,8 +21,4 @@
 		display: inline-block;
 		margin-left: 0.75em;
 	}
-
-	.wp-block-file__copy-url-button {
-		margin-left: 1em;
-	}
 }

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## Unreleased
 
 - Introduce `Navigation` component as `__experimentalNavigation` for displaying a hierarchy of items.
-- ClipBoardButton: add `as: Component` props so the Button Component can be overridden, this change is made so we can use is as ToolbarButton.
 
 ### Breaking Change
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Introduce `Navigation` component as `__experimentalNavigation` for displaying a hierarchy of items.
-
+- ClipBoardButton: add `as: Component` props so the Button Component can be overridden, this change is made so we can use is as ToolbarButton.
 
 ### Breaking Change
 

--- a/packages/components/src/clipboard-button/index.js
+++ b/packages/components/src/clipboard-button/index.js
@@ -15,6 +15,7 @@ import { useCopyOnClick } from '@wordpress/compose';
 import Button from '../button';
 
 export default function ClipboardButton( {
+	as: Component = Button,
 	className,
 	children,
 	onCopy,
@@ -52,13 +53,13 @@ export default function ClipboardButton( {
 	};
 
 	return (
-		<Button
+		<Component
 			{ ...buttonProps }
 			className={ classes }
 			ref={ ref }
 			onCopy={ focusOnCopyEventTarget }
 		>
 			{ children }
-		</Button>
+		</Component>
 	);
 }

--- a/packages/components/src/clipboard-button/index.js
+++ b/packages/components/src/clipboard-button/index.js
@@ -15,7 +15,6 @@ import { useCopyOnClick } from '@wordpress/compose';
 import Button from '../button';
 
 export default function ClipboardButton( {
-	as: Component = Button,
 	className,
 	children,
 	onCopy,
@@ -53,13 +52,13 @@ export default function ClipboardButton( {
 	};
 
 	return (
-		<Component
+		<Button
 			{ ...buttonProps }
 			className={ classes }
 			ref={ ref }
 			onCopy={ focusOnCopyEventTarget }
 		>
 			{ children }
-		</Component>
+		</Button>
 	);
 }

--- a/packages/e2e-tests/specs/local/demo.test.js
+++ b/packages/e2e-tests/specs/local/demo.test.js
@@ -39,6 +39,8 @@ describe( 'new editor state', () => {
 		} );
 		expect( isDirty ).toBeTruthy();
 
+		await page.waitForSelector( 'button.editor-post-save-draft' );
+
 		expect( await page.$( 'button.editor-post-save-draft' ) ).toBeTruthy();
 	} );
 } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->
closes #26328
## Description
<!-- Please describe what you have changed or added -->
As mentioned in issue #26328 the **copy url** button in the **file block** is editor only element. so in the PR i moved the **copy url button** to the **block toolbar**.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
### Before
![image](https://user-images.githubusercontent.com/4710635/96619013-ef91b500-1305-11eb-9721-23968bd4a0ff.png)
### After
![image](https://user-images.githubusercontent.com/15234847/97716313-bf93a000-1ac3-11eb-8be5-4ecb23998c96.png)

## Types of changes
### Enhancement
 - File Block: Copy url button is moved to Block toolbar
## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
