### PR TITLE
Fix: Font size picker regression on edit site global styles

### DIFF
--- a/packages/edit-site/src/components/editor/utils.js
+++ b/packages/edit-site/src/components/editor/utils.js
@@ -17,19 +17,6 @@ export const PRESET_CATEGORIES = {
 export const LINK_COLOR = '--wp--style--color--link';
 export const LINK_COLOR_DECLARATION = `a { color: var(${ LINK_COLOR }, #00e); }`;
 
-/* Helpers for unit processing */
-export const fromPx = ( value ) => {
-	switch ( typeof value ) {
-		case 'string':
-			return +value.replace( 'px', '' );
-		case 'number':
-		default:
-			return value;
-	}
-};
-
-export const toPx = ( value ) => ( value ? value + 'px' : value );
-
 export function useEditorFeature( featurePath, blockName = GLOBAL_CONTEXT ) {
 	const settings = useSelect( ( select ) => {
 		return select( 'core/edit-site' ).getSettings();

--- a/packages/edit-site/src/components/sidebar/typography-panel.js
+++ b/packages/edit-site/src/components/sidebar/typography-panel.js
@@ -8,7 +8,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { fromPx, toPx, useEditorFeature } from '../editor/utils';
+import { useEditorFeature } from '../editor/utils';
 
 export default ( {
 	context: { supports, name },
@@ -32,9 +32,9 @@ export default ( {
 		<PanelBody title={ __( 'Typography' ) } initialOpen={ true }>
 			{ supports.includes( 'fontSize' ) && (
 				<FontSizePicker
-					value={ fromPx( getStyleProperty( name, 'fontSize' ) ) }
+					value={ getStyleProperty( name, 'fontSize' ) }
 					onChange={ ( value ) =>
-						setStyleProperty( name, 'fontSize', toPx( value ) )
+						setStyleProperty( name, 'fontSize', value )
 					}
 					fontSizes={ fontSizes }
 					disableCustomFontSizes={ disableCustomFontSizes }


### PR DESCRIPTION
Fixes a regression where font size picker is not working as expected on global styles.
Regressed in https://github.com/WordPress/gutenberg/pull/26475.


Now the handling of pixel values is done at the component level so we need to remove some logic from global styles.

More details of the regression available at https://github.com/WordPress/gutenberg/pull/26475#issuecomment-719546022


## How has this been tested?
I verified the font size picker worked as expected on the global styles sidebar.
