### PR TITLE
Chore: Remove anonymous components from global styles sidebar

### DIFF
--- a/packages/edit-site/src/components/sidebar/color-palette-panel.js
+++ b/packages/edit-site/src/components/sidebar/color-palette-panel.js
@@ -7,7 +7,11 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-export default ( { contextName, getSetting, setSetting } ) => {
+export default function ColorPalettePanel( {
+	contextName,
+	getSetting,
+	setSetting,
+} ) {
 	const colors = getSetting( contextName, 'color.palette' );
 	let emptyUI;
 	if ( colors === undefined ) {
@@ -37,4 +41,4 @@ export default ( { contextName, getSetting, setSetting } ) => {
 			emptyUI={ emptyUI }
 		/>
 	);
-};
+}

--- a/packages/edit-site/src/components/sidebar/color-panel.js
+++ b/packages/edit-site/src/components/sidebar/color-panel.js
@@ -10,13 +10,13 @@ import { __ } from '@wordpress/i18n';
 import { LINK_COLOR, useEditorFeature } from '../editor/utils';
 import ColorPalettePanel from './color-palette-panel';
 
-export default ( {
+export default function ColorPanel( {
 	context: { supports, name },
 	getStyleProperty,
 	setStyleProperty,
 	getSetting,
 	setSetting,
-} ) => {
+} ) {
 	const colors = useEditorFeature( 'color.palette', name );
 	const disableCustomColors = ! useEditorFeature( 'color.custom', name );
 	const gradients = useEditorFeature( 'color.gradients', name );
@@ -98,4 +98,4 @@ export default ( {
 			/>
 		</PanelColorGradientSettings>
 	);
-};
+}

--- a/packages/edit-site/src/components/sidebar/default-sidebar.js
+++ b/packages/edit-site/src/components/sidebar/default-sidebar.js
@@ -6,7 +6,7 @@ import {
 	ComplementaryAreaMoreMenuItem,
 } from '@wordpress/interface';
 
-export default ( {
+export default function DefaultSidebar( {
 	className,
 	identifier,
 	title,
@@ -14,7 +14,7 @@ export default ( {
 	children,
 	closeLabel,
 	header,
-} ) => {
+} ) {
 	return (
 		<>
 			<ComplementaryArea
@@ -37,4 +37,4 @@ export default ( {
 			</ComplementaryAreaMoreMenuItem>
 		</>
 	);
-};
+}

--- a/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
@@ -22,7 +22,12 @@ import { GLOBAL_CONTEXT } from '../editor/utils';
 import TypographyPanel from './typography-panel';
 import ColorPanel from './color-panel';
 
-export default ( { identifier, title, icon, closeLabel } ) => {
+export default function GlobalStylesSidebar( {
+	identifier,
+	title,
+	icon,
+	closeLabel,
+} ) {
 	const {
 		contexts,
 		getStyleProperty,
@@ -178,4 +183,4 @@ export default ( { identifier, title, icon, closeLabel } ) => {
 			</TabPanel>
 		</DefaultSidebar>
 	);
-};
+}

--- a/packages/edit-site/src/components/sidebar/typography-panel.js
+++ b/packages/edit-site/src/components/sidebar/typography-panel.js
@@ -10,11 +10,11 @@ import { __ } from '@wordpress/i18n';
  */
 import { useEditorFeature } from '../editor/utils';
 
-export default ( {
+export default function TypographyPanel( {
 	context: { supports, name },
 	getStyleProperty,
 	setStyleProperty,
-} ) => {
+} ) {
 	const fontSizes = useEditorFeature( 'typography.fontSizes', name );
 	const disableCustomFontSizes = ! useEditorFeature(
 		'typography.customFontSize',
@@ -50,4 +50,4 @@ export default ( {
 			) }
 		</PanelBody>
 	);
-};
+}


### PR DESCRIPTION
Using anonymous components makes things harder to debug as the component names do not appear on the react dev tools.
