### PR TITLE
Site Editor: reorder template creation dropdown

### DIFF
--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/new-template-dropdown.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/new-template-dropdown.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { map, omit, reduce } from 'lodash';
+import { map, filter, includes } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -20,10 +20,7 @@ import { Icon, plus } from '@wordpress/icons';
  * Internal dependencies
  */
 import getClosestAvailableTemplate from '../../../utils/get-closest-available-template';
-import {
-	TEMPLATES_DEFAULT_DETAILS,
-	TEMPLATES_DEFAULT_ORDER,
-} from '../../../utils/get-template-info/constants';
+import { TEMPLATES_DEFAULT_DETAILS } from '../../../utils/get-template-info/constants';
 
 export default function NewTemplateDropdown() {
 	const templates = useSelect(
@@ -49,21 +46,11 @@ export default function NewTemplateDropdown() {
 		} );
 	};
 
-	const missingTemplates = omit(
-		TEMPLATES_DEFAULT_DETAILS,
-		map( templates, 'slug' )
-	);
+	const existingTemplateSlugs = map( templates, 'slug' );
 
-	const orderedMissingTemplates = reduce(
-		TEMPLATES_DEFAULT_ORDER,
-		( result = [], slug ) => {
-			if ( missingTemplates[ slug ] ) {
-				const template = missingTemplates[ slug ];
-				template.slug = slug;
-				result.push( template );
-			}
-			return result;
-		}
+	const missingTemplates = filter(
+		TEMPLATES_DEFAULT_DETAILS,
+		( template ) => ! includes( existingTemplateSlugs, template.slug )
 	);
 
 	return (
@@ -84,7 +71,7 @@ export default function NewTemplateDropdown() {
 				<NavigableMenu>
 					<MenuGroup label={ __( 'Add Template' ) }>
 						{ map(
-							orderedMissingTemplates,
+							missingTemplates,
 							( { title, description, slug } ) => (
 								<MenuItem
 									info={ description }

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/new-template-dropdown.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/new-template-dropdown.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { map, omit } from 'lodash';
+import { map, omit, reduce } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -20,7 +20,10 @@ import { Icon, plus } from '@wordpress/icons';
  * Internal dependencies
  */
 import getClosestAvailableTemplate from '../../../utils/get-closest-available-template';
-import { TEMPLATES_DEFAULT_DETAILS } from '../../../utils/get-template-info/constants';
+import {
+	TEMPLATES_DEFAULT_DETAILS,
+	TEMPLATES_DEFAULT_ORDER,
+} from '../../../utils/get-template-info/constants';
 
 export default function NewTemplateDropdown() {
 	const templates = useSelect(
@@ -51,6 +54,18 @@ export default function NewTemplateDropdown() {
 		map( templates, 'slug' )
 	);
 
+	const orderedMissingTemplates = reduce(
+		TEMPLATES_DEFAULT_ORDER,
+		( result = [], slug ) => {
+			if ( missingTemplates[ slug ] ) {
+				const template = missingTemplates[ slug ];
+				template.slug = slug;
+				result.push( template );
+			}
+			return result;
+		}
+	);
+
 	return (
 		<DropdownMenu
 			className="edit-site-navigation-panel__new-template-dropdown"
@@ -69,8 +84,8 @@ export default function NewTemplateDropdown() {
 				<NavigableMenu>
 					<MenuGroup label={ __( 'Add Template' ) }>
 						{ map(
-							missingTemplates,
-							( { title, description }, slug ) => (
+							orderedMissingTemplates,
+							( { title, description, slug } ) => (
 								<MenuItem
 									info={ description }
 									key={ slug }

--- a/packages/edit-site/src/utils/get-template-info/constants.js
+++ b/packages/edit-site/src/utils/get-template-info/constants.js
@@ -48,3 +48,18 @@ export const TEMPLATES_DEFAULT_DETAILS = {
 		description: __( 'Template for single posts' ),
 	},
 };
+
+/**
+ * This is the default order of perceived importance for creating templates
+ */
+export const TEMPLATES_DEFAULT_ORDER = [
+	'front-page',
+	'index',
+	'home',
+	'page',
+	'singular',
+	'single',
+	'archive',
+	'search',
+	'404',
+];

--- a/packages/edit-site/src/utils/get-template-info/constants.js
+++ b/packages/edit-site/src/utils/get-template-info/constants.js
@@ -3,63 +3,55 @@
  */
 import { __, _x } from '@wordpress/i18n';
 
-export const TEMPLATES_DEFAULT_DETAILS = {
-	// General
-	'front-page': {
+/**
+ * Default template details, ordered by perceived importance
+ */
+export const TEMPLATES_DEFAULT_DETAILS = [
+	{
+		slug: 'front-page',
 		title: _x( 'Front Page', 'template name' ),
 		description: __(
 			'Front page template, whether it displays the blog posts index or a static page'
 		),
 	},
-	archive: {
-		title: _x( 'Archive', 'template name' ),
-		description: __( 'Generic archive template' ),
-	},
-	singular: {
-		title: _x( 'Singular', 'template name' ),
-		description: __( 'Default template for both single posts and pages' ),
-	},
-	index: {
+	{
+		slug: 'index',
 		title: _x( 'Index', 'template name' ),
 		description: __( 'Default template' ),
 	},
-	search: {
-		title: _x( 'Search Results', 'template name' ),
-		description: __( 'Search results template' ),
-	},
-	'404': {
-		title: _x( '404 (Not Found)', 'template name' ),
-		description: __( 'Template for "not found" errors' ),
-	},
-
-	// Pages
-	page: {
-		title: __( 'Single Page' ),
-		description: __( 'Template for single pages' ),
-	},
-
-	// Posts
-	home: {
+	{
+		slug: 'home',
 		title: __( 'Home Page' ),
 		description: __( 'Template for the latest blog posts' ),
 	},
-	single: {
+	{
+		slug: 'page',
+		title: __( 'Single Page' ),
+		description: __( 'Template for single pages' ),
+	},
+	{
+		slug: 'singular',
+		title: _x( 'Singular', 'template name' ),
+		description: __( 'Default template for both single posts and pages' ),
+	},
+	{
+		slug: 'single',
 		title: __( 'Single Post' ),
 		description: __( 'Template for single posts' ),
 	},
-};
-
-/**
- * This is the default order of perceived importance for creating templates
- */
-export const TEMPLATES_DEFAULT_ORDER = [
-	'front-page',
-	'index',
-	'home',
-	'page',
-	'singular',
-	'single',
-	'archive',
-	'search',
-	'404',
+	{
+		slug: 'archive',
+		title: _x( 'Archive', 'template name' ),
+		description: __( 'Generic archive template' ),
+	},
+	{
+		slug: 'search',
+		title: _x( 'Search Results', 'template name' ),
+		description: __( 'Search results template' ),
+	},
+	{
+		slug: '404',
+		title: _x( '404 (Not Found)', 'template name' ),
+		description: __( 'Template for "not found" errors' ),
+	},
 ];

--- a/packages/edit-site/src/utils/get-template-info/index.js
+++ b/packages/edit-site/src/utils/get-template-info/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { find } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import { TEMPLATES_DEFAULT_DETAILS } from './constants';
@@ -15,7 +20,7 @@ export default function getTemplateInfo( template ) {
 		return {};
 	}
 	const { title: defaultTitle, description: defaultDescription } =
-		TEMPLATES_DEFAULT_DETAILS[ template.slug ] ?? {};
+		find( TEMPLATES_DEFAULT_DETAILS, { slug: template?.slug } ) ?? {};
 
 	let title = template?.title?.rendered ?? template.slug;
 	if ( title !== template.slug ) {

--- a/packages/edit-site/src/utils/get-template-info/test/index.js
+++ b/packages/edit-site/src/utils/get-template-info/test/index.js
@@ -2,6 +2,10 @@
  * Internal dependencies
  */
 import getTemplateInfo from '../';
+import {
+	TEMPLATES_DEFAULT_DETAILS,
+	TEMPLATES_DEFAULT_ORDER,
+} from '../constants';
 
 describe( 'get template info', () => {
 	it( 'should return an empty object if no template is passed', () => {
@@ -67,5 +71,11 @@ describe( 'get template info', () => {
 		).toMatchSnapshot();
 
 		expect( getTemplateInfo( {} ) ).toMatchSnapshot();
+	} );
+
+	it( 'should have the same templates in TEMPLATES_DEFAULT_DETAILS and TEMPLATES_DEFAULT_ORDER', () => {
+		expect( Object.keys( TEMPLATES_DEFAULT_DETAILS ).sort() ).toEqual(
+			TEMPLATES_DEFAULT_ORDER.sort()
+		);
 	} );
 } );

--- a/packages/edit-site/src/utils/get-template-info/test/index.js
+++ b/packages/edit-site/src/utils/get-template-info/test/index.js
@@ -2,10 +2,6 @@
  * Internal dependencies
  */
 import getTemplateInfo from '../';
-import {
-	TEMPLATES_DEFAULT_DETAILS,
-	TEMPLATES_DEFAULT_ORDER,
-} from '../constants';
 
 describe( 'get template info', () => {
 	it( 'should return an empty object if no template is passed', () => {
@@ -71,11 +67,5 @@ describe( 'get template info', () => {
 		).toMatchSnapshot();
 
 		expect( getTemplateInfo( {} ) ).toMatchSnapshot();
-	} );
-
-	it( 'should have the same templates in TEMPLATES_DEFAULT_DETAILS and TEMPLATES_DEFAULT_ORDER', () => {
-		expect( Object.keys( TEMPLATES_DEFAULT_DETAILS ).sort() ).toEqual(
-			TEMPLATES_DEFAULT_ORDER.sort()
-		);
 	} );
 } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Reorder items in template creation dropdown by perceived importance 

Before this, the 404 template would appear first, based on the way keyed objects are sorted alphabetically.

Fixes #26543 

## How has this been tested?

* Open Site Editor
* Open Navigation Sidebar
* Click "Templates"
* Click the "Add" plus sign
* Note that 404 does not appear first (it should appear last)

## Screenshots

Before:
<img width="264" alt="Screen Shot 2020-10-30 at 14 00 11" src="https://user-images.githubusercontent.com/195089/97746412-4478bc80-1ab8-11eb-98e4-3af867d659f1.png">

After:
<img width="263" alt="Screen Shot 2020-10-30 at 13 58 39" src="https://user-images.githubusercontent.com/195089/97746298-1dba8600-1ab8-11eb-9cf9-b8ab6d221249.png">

## Types of changes
Feature improvement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
