### PR TITLE
ComboboxControl: updated component to deburr options labels before filter

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Introduce `Navigation` component as `__experimentalNavigation` for displaying a hierarchy of items.
 
+### Enhancements
+- ComboboxControl: Deburr option labels before filter
+
 ### Breaking Change
 
 - Introduce support for other units and advanced CSS properties on `FontSizePicker`. Provided the value passed to the `FontSizePicker` is a string or one of the size options passed is a string, onChange will start to be called with a string value instead of a number. On WordPress usage, font size options are now automatically converted to strings with the default "px" unit added.

--- a/packages/components/src/combobox-control/index.js
+++ b/packages/components/src/combobox-control/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-
+import { deburr } from 'lodash';
 /**
  * WordPress dependencies
  */
@@ -49,7 +49,9 @@ function ComboboxControl( {
 		const containsMatch = [];
 		const match = inputValue.toLocaleLowerCase();
 		options.forEach( ( option ) => {
-			const index = option.label.toLocaleLowerCase().indexOf( match );
+			const index = deburr( option.label )
+				.toLocaleLowerCase()
+				.indexOf( match );
 			if ( index === 0 ) {
 				startsWithMatch.push( option );
 			} else if ( index > 0 ) {

--- a/packages/components/src/combobox-control/index.js
+++ b/packages/components/src/combobox-control/index.js
@@ -47,7 +47,7 @@ function ComboboxControl( {
 	const matchingSuggestions = useMemo( () => {
 		const startsWithMatch = [];
 		const containsMatch = [];
-		const match = inputValue.toLocaleLowerCase();
+		const match = deburr( inputValue.toLocaleLowerCase() );
 		options.forEach( ( option ) => {
 			const index = deburr( option.label )
 				.toLocaleLowerCase()

--- a/packages/components/src/combobox-control/stories/index.js
+++ b/packages/components/src/combobox-control/stories/index.js
@@ -276,17 +276,8 @@ function ComboboxControlWithState() {
 				onChange={ setValue }
 				label="Select a country"
 				options={ filteredOptions }
-				onFilterValueChange={ ( filter ) =>
-					setFilteredOptions(
-						countries
-							.filter( ( country ) =>
-								country.name
-									.toLowerCase()
-									.startsWith( filter.toLowerCase() )
-							)
-							.slice( 0, 20 )
-							.map( mapCountryOption )
-					)
+				onFilterValueChange={ () =>
+					setFilteredOptions( countries.map( mapCountryOption ) )
 				}
 			/>
 			<p>Value: { value }</p>


### PR DESCRIPTION
closes #25953

## Description
This PR ComboboxControl is updated to Deburr options labels before filter. as requested in issue #25953

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/15234847/97750273-c258ba00-1af0-11eb-9107-71eacfafbb64.png)

### After
![image](https://user-images.githubusercontent.com/15234847/97750312-d3093000-1af0-11eb-91d6-6872624d0f2f.png)

## Types of changes
### Enhancements
- ComboboxControl: Deburr options labels before filter

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.