### PR TITLE
Stop propagation on `withConstrainedTabbing`

### DIFF
--- a/packages/components/src/higher-order/with-constrained-tabbing/index.js
+++ b/packages/components/src/higher-order/with-constrained-tabbing/index.js
@@ -30,6 +30,12 @@ const withConstrainedTabbing = createHigherOrderComponent(
 				const firstTabbable = tabbables[ 0 ];
 				const lastTabbable = tabbables[ tabbables.length - 1 ];
 
+				if ( tabbables.includes( event.target ) ) {
+					// Stops nested withConstrainedTabbing components from always focusing
+					// the outermost component.
+					event.stopPropagation();
+				}
+
 				if ( event.shiftKey && event.target === firstTabbable ) {
 					event.preventDefault();
 					lastTabbable.focus();


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

Fixes #26115

Nested `withConstrainedTabbing` components were causing focus to more to the outermost parent component, for example, in the custom text color options from the paragraph toolbar.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Try tabbing through nested popovers such as Paragraph > More rich text controls > Text color > Custom color.

## Screenshots <!-- if applicable -->

Before:
![color-picker-before](https://user-images.githubusercontent.com/5129775/97756445-7d1c9400-1ac0-11eb-81ac-b6f0000a2c39.gif)

After:
![color-picker-after](https://user-images.githubusercontent.com/5129775/97756452-80b01b00-1ac0-11eb-94ba-0b45f4cb2848.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Bug Fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
