### PR TITLE
Fix Nav Panel template part bugs (and failing template part e2e for "cannot find 'header'")

### DIFF
--- a/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
@@ -26,6 +26,7 @@ const visitSiteEditor = async () => {
 		page: 'gutenberg-edit-site',
 	} ).slice( 1 );
 	await visitAdminPage( 'admin.php', query );
+	await page.waitForSelector( '.edit-site-visual-editor' );
 };
 
 const clickTemplateItem = async ( menus, itemName ) => {

--- a/packages/edit-site/src/components/navigation-sidebar/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/index.js
@@ -23,8 +23,12 @@ export default function NavigationSidebar() {
 	return (
 		<>
 			<NavigationToggle isOpen={ isNavigationOpen } />
-			<NavigationPanel isOpen={ isNavigationOpen } />
-			<NavigationPanelPreviewSlot />
+			{ isNavigationOpen && (
+				<>
+					<NavigationPanel isOpen={ isNavigationOpen } />
+					<NavigationPanelPreviewSlot />
+				</>
+			) }
 		</>
 	);
 }

--- a/packages/edit-site/src/components/navigation-sidebar/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/index.js
@@ -3,6 +3,7 @@
  */
 import { createSlotFill } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -20,10 +21,17 @@ export default function NavigationSidebar() {
 		return select( 'core/edit-site' ).isNavigationOpened();
 	} );
 
+	// Don't mount navigation panel until it is triggered.
+	// This prevents bugs as noted in #26613.
+	// We can revert this once the underlying bugs are fixed.
+	const [ hasOpened, setHasOpened ] = useState( false );
 	return (
 		<>
-			<NavigationToggle isOpen={ isNavigationOpen } />
-			{ isNavigationOpen && (
+			<NavigationToggle
+				isOpen={ isNavigationOpen }
+				setHasOpened={ setHasOpened }
+			/>
+			{ hasOpened && (
 				<>
 					<NavigationPanel isOpen={ isNavigationOpen } />
 					<NavigationPanelPreviewSlot />

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/index.js
@@ -6,7 +6,7 @@ import { Button, Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
 
-function NavigationToggle( { icon, isOpen } ) {
+function NavigationToggle( { icon, isOpen, setHasOpened } ) {
 	const { isActive, isRequestingSiteIcon, siteIconUrl } = useSelect(
 		( select ) => {
 			const { isFeatureActive } = select( 'core/edit-site' );
@@ -29,6 +29,10 @@ function NavigationToggle( { icon, isOpen } ) {
 	);
 
 	const { setIsNavigationPanelOpened } = useDispatch( 'core/edit-site' );
+	const onClick = () => {
+		setHasOpened( true );
+		setIsNavigationPanelOpened( ! isOpen );
+	};
 
 	if ( ! isActive ) {
 		return null;
@@ -59,7 +63,7 @@ function NavigationToggle( { icon, isOpen } ) {
 			<Button
 				className="edit-site-navigation-toggle__button has-icon"
 				label={ __( 'Toggle navigation' ) }
-				onClick={ () => setIsNavigationPanelOpened( ! isOpen ) }
+				onClick={ onClick }
 				showTooltip
 			>
 				{ buttonIcon }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
This PR prevents the Navigation Panel from mounting until it is first opened.  This seems to fix two bugs: the nav panel sometimes failing to show any template parts and sometimes causing duplicate auto-drafts to be created.

When loading the site editor from a fresh state, the Template Parts shown in the navigation panel are inconsistent.  On any given fresh attempt we see one of the following:
1. No template parts listed.
   * This causes an e2e test failure in template parts (timeout trying to select 'header').
2. Template parts listed as expected.
3. Template parts listed with duplicate auto-drafts (2 headers and 2 footers).

While there is not a fundamental problem with how the Navigation Panel is currently implemented, this implementation seems to be bringing out other bugs in the underlying infrastructure.

### No template parts listed
Since the Nav Panel is always mounted in the interface skeleton, its query for template parts is triggered immediately.  The `useSelect` to retrieve template parts sometimes returns with no results.  For whatever reason, this never updates after the template parts are actually created (some issue with the core-data cache not updating when expected?).  Opening the template parts selection previews (which also uses `useSelect` to retrieve template parts in the same way) from the toolbar dropdown of an existing template part will show the templates as expected.  After creating a new template part in the editor, the nav panel updates and shows all template parts as expected.

### Template parts created with duplicates.
Since the Nav Panel's query for template parts is triggered immediately, template part auto drafting is triggered twice almost simultaneously.  Once by the editor loading, and once by the nav panel's query.  Even though the function to create auto-drafts is written to check for an existing auto-draft before creating one, sometimes this near simultaneous call of the function will not see the auto drafts that the other is creating and will result in triggering creation of the same template part twice.

With this change of only mounting the Nav Panel when it is toggled open, neither of the above problems are observed.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
As noted the behaviors are not consistent, so it may take a handful of attempts to verify that the bug exists on master and that this fixes it.

Manual flow:
* Clean your environment (I have been using `npx wp-env clean all`).
* Enable FSE and a block based theme.
* Load the site editor and open the navigation panel.
* Repeat the above 3 steps multiple times and verify the nav panel always shows the template parts with no duplicates.

E2E testing:
* Running the e2e tests for template-parts should never fail due to not finding 'header'.

CI:
* Lets also run the admin tests on this PR a handful of times and verify the template-parts test does not fail due to not finding 'header'.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
