### PR TITLE
Fix: Visual regression on the color palette editor

### DIFF
--- a/packages/components/src/color-edit/style.scss
+++ b/packages/components/src/color-edit/style.scss
@@ -1,7 +1,8 @@
 .components-color-edit__color-option-main-area {
 	display: flex;
 	align-items: center;
-	.components-circular-option-picker__option-wrapper {
+	div.components-circular-option-picker__option-wrapper {
+		display: block;
 		margin: $grid-unit-10;
 	}
 }


### PR DESCRIPTION
Fixes a visual regression caused as a side effect of other CSS changes.

## Screenshots <!-- if applicable -->
Before:
![image](https://user-images.githubusercontent.com/11271197/97761442-a0b1ff80-1afd-11eb-946b-9ed1a6d677e2.png)

After:
![image](https://user-images.githubusercontent.com/11271197/97761448-a576b380-1afd-11eb-9485-8a4a54994141.png)
