### PR TITLE
Correct the docblock for the `widget_comments_args` filter

### DIFF
--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -41,8 +41,8 @@ function wp_latest_comments_draft_or_post_title( $post = 0 ) {
  * @return string Returns the post content with latest comments added.
  */
 function render_block_core_latest_comments( $attributes = array() ) {
-	// This filter is documented in wp-includes/widgets/class-wp-widget-recent-comments.php.
 	$comments = get_comments(
+		// This filter is documented in wp-includes/widgets/class-wp-widget-recent-comments.php.
 		apply_filters(
 			'widget_comments_args',
 			array(


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
The docblock for this filter is not in the correct place. This means that libraries that scan WordPress core for actions and filters (including WP Parser on developer.wordpress.org) see this filter twice.

## How has this been tested?
This has been tested by running the [wp-hooks](https://github.com/johnbillion/wp-hooks) action and filter documentation generator over WordPress core with this change in place and verifying that the filter only appears once.

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
