### PR TITLE
Refactored Gallery: Update application of gallery settings on images

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -9,7 +9,6 @@ import { toString, isEqual, isEmpty, find } from 'lodash';
 import { compose } from '@wordpress/compose';
 import {
 	Button,
-	ButtonGroup,
 	PanelBody,
 	SelectControl,
 	ToggleControl,
@@ -28,7 +27,7 @@ import { createBlock } from '@wordpress/blocks';
  */
 import { sharedIcon } from './shared-icon';
 import { defaultColumnsNumber, pickRelevantMediaFiles } from './shared';
-import { getHrefAndDestination, getNewImageAttributes } from './utils';
+import { getHrefAndDestination, getImageSizeAttributes } from './utils';
 import { getUpdatedLinkTargetSettings } from '../image/utils';
 import Gallery from './gallery';
 import {
@@ -188,21 +187,24 @@ function GalleryEdit( props ) {
 		setAttributes( { linkTarget: linkTarget ? undefined : '_blank' } );
 	}
 
-	function applyImageOptions( { forceUpdate } ) {
+	function applyImageOptions() {
 		getBlock( clientId ).innerBlocks.forEach( ( block ) => {
 			const image = block.attributes.id
 				? find( images, { id: block.attributes.id } )
 				: null;
-			const newAttributes = getNewImageAttributes(
-				attributes,
-				block.attributes,
-				image.imageData,
-				forceUpdate
-			);
-			updateBlockAttributes( block.clientId, newAttributes );
+
+			updateBlockAttributes( block.clientId, {
+				...getHrefAndDestination( image.imageData, linkTo ),
+				...getUpdatedLinkTargetSettings( linkTarget, block.attributes ),
+				...getImageSizeAttributes( image.imageData, sizeSlug ),
+			} );
 		} );
 		setDirtyImageOptions( false );
 		setImageSettings( currentImageOptions );
+	}
+
+	function cancelImageOptions() {
+		setAttributes( imageSettings );
 	}
 
 	function updateImagesSize( newSizeSlug ) {
@@ -320,24 +322,18 @@ function GalleryEdit( props ) {
 						/>
 					) }
 					{ dirtyImageOptions && (
-						<ButtonGroup>
-							<Button
-								isSmall
-								onClick={ () =>
-									applyImageOptions( { forceUpdate: true } )
-								}
-							>
+						<div className={ 'gallery-settings-buttons' }>
+							<Button isPrimary onClick={ applyImageOptions }>
 								{ __( 'Apply to all images' ) }
 							</Button>
 							<Button
-								isSmall
-								onClick={ () =>
-									applyImageOptions( { forceUpdate: false } )
-								}
+								className={ 'cancel-apply-to-images' }
+								isLink
+								onClick={ cancelImageOptions }
 							>
-								{ __( 'Apply only as fallback' ) }
+								{ __( 'Cancel' ) }
 							</Button>
-						</ButtonGroup>
+						</div>
 					) }
 				</PanelBody>
 			</InspectorControls>

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -128,3 +128,9 @@ figure.wp-block-gallery {
 	margin-top: -9px;
 	margin-left: -9px;
 }
+
+.gallery-settings-buttons {
+	.components-button:first-child {
+		margin-right: 8px;
+	}
+}

--- a/packages/block-library/src/gallery/utils.js
+++ b/packages/block-library/src/gallery/utils.js
@@ -11,6 +11,11 @@ import {
 	LINK_DESTINATION_MEDIA,
 	LINK_DESTINATION_NONE,
 } from './constants';
+import {
+	LINK_DESTINATION_ATTACHMENT as IMAGE_LINK_DESTINATION_ATTACHMENT,
+	LINK_DESTINATION_MEDIA as IMAGE_LINK_DESTINATION_MEDIA,
+	LINK_DESTINATION_NONE as IMAGE_LINK_DESTINATION_NONE,
+} from '../image/constants';
 import { getUpdatedLinkTargetSettings as getLinkTargetSettings } from '../image/utils';
 
 /**
@@ -28,18 +33,18 @@ export function getHrefAndDestination( image, destination ) {
 	switch ( destination ) {
 		case LINK_DESTINATION_MEDIA:
 			return {
-				href: image?.source_url, // eslint-disable-line camelcase
-				linkDestination: 'media',
+				href: image?.source_url || image?.url, // eslint-disable-line camelcase
+				linkDestination: IMAGE_LINK_DESTINATION_MEDIA,
 			};
 		case LINK_DESTINATION_ATTACHMENT:
 			return {
 				href: image?.link,
-				linkDestination: 'attachment',
+				linkDestination: IMAGE_LINK_DESTINATION_ATTACHMENT,
 			};
 		case LINK_DESTINATION_NONE:
 			return {
 				href: undefined,
-				linkDestination: LINK_DESTINATION_NONE,
+				linkDestination: IMAGE_LINK_DESTINATION_NONE,
 			};
 	}
 

--- a/packages/block-library/src/gallery/utils.js
+++ b/packages/block-library/src/gallery/utils.js
@@ -16,7 +16,6 @@ import {
 	LINK_DESTINATION_MEDIA as IMAGE_LINK_DESTINATION_MEDIA,
 	LINK_DESTINATION_NONE as IMAGE_LINK_DESTINATION_NONE,
 } from '../image/constants';
-import { getUpdatedLinkTargetSettings as getLinkTargetSettings } from '../image/utils';
 
 /**
  * Determines new href and linkDestination values for an image block from the
@@ -66,59 +65,4 @@ export function getImageSizeAttributes( image, size ) {
 	}
 
 	return {};
-}
-
-/**
- * Determine new attribute values for an Image block based on Gallery settings
- * and user's choice to apply for all gallery images or only as a fallback if
- * the image block doesn't have a value set.
- *
- * @param {Object} parentOptions Gallery attributes for linkTo, linkTarget & sizeSlug.
- * @param {Object} attributes    Image block attributes.
- * @param {Object} image         Media object for block's image.
- * @param {boolean} forceUpdate  Whether to force the Image block updates or only as a fallback.
- */
-export function getNewImageAttributes(
-	parentOptions,
-	attributes,
-	image,
-	forceUpdate
-) {
-	if ( forceUpdate ) {
-		return {
-			...getHrefAndDestination( image, parentOptions.linkTo ),
-			...getLinkTargetSettings( parentOptions.linkTarget, attributes ),
-			sizeSlug: parentOptions.sizeSlug,
-		};
-	}
-
-	// Not forcing update so we need to determine which attributes to set.
-	const { linkDestination, linkTarget, sizeSlug } = attributes;
-	let newAttributes = {};
-
-	// Set linkDestination if image's is not set or is 'none'.
-	if ( ! linkDestination || linkDestination === 'none' ) {
-		newAttributes = {
-			...newAttributes,
-			...getHrefAndDestination( image, parentOptions.linkTo ),
-		};
-	}
-
-	// Set linkTarget if parent sets it and image does not.
-	if ( parentOptions.linkTarget && linkTarget !== '_blank' ) {
-		newAttributes = {
-			...newAttributes,
-			...getLinkTargetSettings( parentOptions.linkTarget, attributes ),
-		};
-	}
-
-	// Set image size slug if it isn't set.
-	if ( ! sizeSlug ) {
-		newAttributes = {
-			...newAttributes,
-			...getImageSizeAttributes( image, parentOptions.sizeSlug ),
-		};
-	}
-
-	return newAttributes;
 }


### PR DESCRIPTION
## Description
- Fixes application of selected gallery settings when adding images to the gallery
- Updates the approach to applying gallery settings to child images
  - It now simply overwrites an image's settings
  - UI has been updated to reflect this change, there are now  "Apply to all images" and "Cancel" buttons

## How has this been tested?
Manually.

#### Testing Instructions
1. Add a gallery including images to a post
2. Select the gallery and change the image related settings e.g. link destination, size etc.
3. Click the cancel button
4. Select the individual images in the gallery and ensure their settings weren't changed
5. Reselect the gallery and change image related settings again
6. Click the "Apply to all images" butotn
7. Check the individual images again but this time ensure their settings now match the gallery selections made.

## Screenshots <!-- if applicable -->
![GalleryUpdates](https://user-images.githubusercontent.com/60436221/97851019-874cc580-1d40-11eb-9093-10fd733da67e.gif)

## Types of changes
Continued refactoring and bug fix.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
