### PR TITLE
Provide a minimum of code wrapping for the code block.

### DIFF
--- a/packages/block-library/src/code/style.scss
+++ b/packages/block-library/src/code/style.scss
@@ -1,0 +1,5 @@
+// Provide a minimum of overflow handling.
+.wp-block-code code {
+	white-space: pre-wrap;
+	overflow-wrap: break-word;
+}

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -8,6 +8,7 @@
 @import "./buttons/style.scss";
 @import "./calendar/style.scss";
 @import "./categories/style.scss";
+@import "./code/style.scss";
 @import "./columns/style.scss";
 @import "./cover/style.scss";
 @import "./embed/style.scss";


### PR DESCRIPTION
Fixes #26600. 

I'm not entirely sure what might have caused this, but #26600 suggests that a recent change casued text in the code block to stop wrapping. I'm not sure what that might be, the only recent change is #26347 and that doesn't look like it would've caused anything. 

But in any case, this PR explicitly allows code to break words and wrap:

<img width="1247" alt="Screenshot 2020-11-02 at 10 36 25" src="https://user-images.githubusercontent.com/1204802/97853004-cd316b80-1cf7-11eb-82f2-893121df7db7.png">

Right now it does that in the `style.scss` file which loads for every code block. That's a big opinionated change to the block, so it needs a bit sanity check.

On the flipside, if we move those rules to `theme.scss`, very few themes will actually benefit from this change. But I'm happy to do so if that's desired. Let me know your thoughts!