### PR TITLE
Restore opacity controls

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+- Fix a regression where the Cover would not show opacity controls for the default overlay color ([#26625](https://github.com/WordPress/gutenberg/pull/26625)).
 - Fix a regression ([#26545](https://github.com/WordPress/gutenberg/pull/26545)) where the Cover block lost its default background overlay color
   ([#26569](https://github.com/WordPress/gutenberg/pull/26569)).
 

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -314,7 +314,6 @@ function CoverEdit( {
 		}
 	}
 
-	const canDim = !! url && ( overlayColor.color || gradientValue );
 	const hasBackground = !! ( url || overlayColor.color || gradientValue );
 	const showFocalPointPicker =
 		isVideoBackground ||
@@ -426,7 +425,7 @@ function CoverEdit( {
 								},
 							] }
 						>
-							{ canDim && (
+							{ !! url && (
 								<RangeControl
 									label={ __( 'Opacity' ) }
 									value={ dimRatio }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

Restore opacity controls for Cover block with default background overlay.

https://github.com/WordPress/gutenberg/pull/26133 removed the default Cover block overlay and the opacity controls. https://github.com/WordPress/gutenberg/pull/26569 restored the background overlay but not the opacity controls. This restores the opacity controls as [suggested by](https://github.com/WordPress/gutenberg/pull/26569#issuecomment-718833367) @stokesman [and others](https://github.com/WordPress/gutenberg/pull/26569#pullrequestreview-521019822) in https://github.com/WordPress/gutenberg/pull/26569.

## How has this been tested?

Confirm that a new Cover block with background color selected includes the opacity controls.

## Screenshots

Notice the *Opacity* controls in the sidebar are present with this change.

### Before
![Screen Shot 2020-11-02 at 11 05 09](https://user-images.githubusercontent.com/841763/97855693-6ada6a00-1cfb-11eb-8910-d3b997fa7e7c.png)

### After
![Screen Shot 2020-11-02 at 11 05 48](https://user-images.githubusercontent.com/841763/97855697-6dd55a80-1cfb-11eb-9f06-44e103cdfd42.png)


## Types of changes
Bug fix: Restore missing opacity controls to the Cover block with no background selected.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
