### PR TITLE
Testing: Remove axe verification executed after every test case

### DIFF
--- a/packages/e2e-tests/config/setup-test-framework.js
+++ b/packages/e2e-tests/config/setup-test-framework.js
@@ -175,54 +175,6 @@ function observeConsoleLogging() {
 }
 
 /**
- * Runs Axe tests when the block editor is found on the current page.
- *
- * @return {?Promise} Promise resolving once Axe texts are finished.
- */
-async function runAxeTestsForBlockEditor() {
-	if ( ! ( await page.$( '.block-editor' ) ) ) {
-		return;
-	}
-
-	await expect( page ).toPassAxeTests( {
-		// Temporary disabled rules to enable initial integration.
-		// See: https://github.com/WordPress/gutenberg/pull/15018.
-		disabledRules: [
-			'aria-allowed-role',
-			'aria-allowed-attr',
-			'aria-hidden-focus',
-			'aria-input-field-name',
-			'aria-valid-attr-value',
-			'button-name',
-			'color-contrast',
-			'dlitem',
-			'duplicate-id',
-			'label',
-			'landmark-one-main',
-			'link-name',
-			'listitem',
-			'region',
-			'aria-required-children',
-			'aria-required-parent',
-			'frame-title',
-		],
-		exclude: [
-			// Ignores elements created by metaboxes.
-			'.edit-post-layout__metaboxes',
-			// Ignores elements created by TinyMCE.
-			'.mce-container',
-			// These properties were not included in the 1.1 spec
-			// through error, they should be allowed on role="row":
-			// https://github.com/w3c/aria/issues/558
-			'[role="treegrid"] [aria-posinset]',
-			'[role="treegrid"] [aria-setsize]',
-			// Ignore block previews.
-			'.block-editor-block-preview__content',
-		],
-	} );
-}
-
-/**
  * Simulate slow network or throttled CPU if provided via environment variables.
  */
 async function simulateAdverseConditions() {
@@ -271,7 +223,6 @@ beforeAll( async () => {
 } );
 
 afterEach( async () => {
-	await runAxeTestsForBlockEditor();
 	await setupBrowser();
 } );
 


### PR DESCRIPTION
Nothing serious here, I just want to see the impact on the jobs.