### PR TITLE
Do not invalidate the entity record during optimistic update in saveEntityRecord

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -502,7 +502,8 @@ export function* saveEntityRecord(
 				name,
 				{ ...persistedEntity, ...data },
 				undefined,
-				true
+				// This must be false or it will trigger a GET request in parallel to the PUT/POST below
+				false
 			);
 
 			updatedRecord = yield apiFetch( {

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -92,7 +92,9 @@ describe( 'saveEntityRecord', () => {
 			'__experimentalGetEntityRecordNoResolver'
 		);
 		expect( fulfillment.next().value.type ).toBe( '@@data/SELECT' );
-		expect( fulfillment.next().value.type ).toBe( 'RECEIVE_ITEMS' );
+		const receiveItems = fulfillment.next().value;
+		expect( receiveItems.type ).toBe( 'RECEIVE_ITEMS' );
+		expect( receiveItems.invalidateCache ).toBe( false );
 		const { value: apiFetchAction } = fulfillment.next( {} );
 		expect( apiFetchAction.request ).toEqual( {
 			path: '/wp/v2/posts',
@@ -132,7 +134,9 @@ describe( 'saveEntityRecord', () => {
 		expect( fulfillment.next().value.type ).toBe( '@@data/SELECT' );
 		expect( fulfillment.next().value.type ).toBe( '@@data/SELECT' );
 		expect( fulfillment.next().value.type ).toBe( '@@data/SELECT' );
-		expect( fulfillment.next().value.type ).toBe( 'RECEIVE_ITEMS' );
+		const receiveItems = fulfillment.next().value;
+		expect( receiveItems.type ).toBe( 'RECEIVE_ITEMS' );
+		expect( receiveItems.invalidateCache ).toBe( false );
 		const { value: apiFetchAction } = fulfillment.next( {} );
 		expect( apiFetchAction.request ).toEqual( {
 			path: '/wp/v2/posts/10',


### PR DESCRIPTION
## Description
As seen in https://github.com/WordPress/gutenberg/issues/26325, invalidating the cache during an optimistic update may cause a GET request in the next tick. When that GET is resolved, it will update the state. If the timing lines up badly, it will overwrite the results of the POST. This PR flips the `invalidateCache` argument to `false` to prevent this race condition from happening. The GET will be triggered only after the POST/PUT request is finished (successfully or not).

Related to https://github.com/WordPress/gutenberg/issues/26325

## How has this been tested?
1. Confirm all tests passed.
2. Go to the widgets editor, click save, confirm all the GET requests are started only after the POST/PUT is finished.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
