### PR TITLE
Add inserter performance measures

### DIFF
--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -31,6 +31,7 @@ const config = require( '../config' );
  * @property {number[]} type             Average type time.
  * @property {number[]} focus            Average block selection time.
  * @property {number[]} inserterOpen     Average time to open global inserter.
+ * @property {number[]} inserterHover    Average time to move mouse between two block item in the inserter.
  */
 
 /**
@@ -46,6 +47,9 @@ const config = require( '../config' );
  * @property {number} inserterOpen     Average time to open global inserter.
  * @property {number} minInserterOpen  Min time to open global inserter.
  * @property {number} maxInserterOpen  Max time to open global inserter.
+ * @property {number} inserterHover     Average time to move mouse between two block item in the inserter.
+ * @property {number} minInserterHover  Min time to move mouse between two block item in the inserter.
+ * @property {number} maxInserterHover  Max time to move mouse between two block item in the inserter.
  */
 /**
  * @typedef WPFormattedPerformanceResults
@@ -60,6 +64,9 @@ const config = require( '../config' );
  * @property {string=} inserterOpen     Average time to open global inserter.
  * @property {string=} minInserterOpen  Min time to open global inserter.
  * @property {string=} maxInserterOpen  Max time to open global inserter.
+ * @property {string=} inserterHover     Average time to move mouse between two block item in the inserter.
+ * @property {string=} minInserterHover  Min time to move mouse between two block item in the inserter.
+ * @property {string=} maxInserterHover  Max time to move mouse between two block item in the inserter.
  */
 
 /**
@@ -119,6 +126,9 @@ function curateResults( results ) {
 		inserterOpen: average( results.inserterOpen ),
 		minInserterOpen: Math.min( ...results.inserterOpen ),
 		maxInserterOpen: Math.max( ...results.inserterOpen ),
+		inserterHover: average( results.inserterHover ),
+		minInserterHover: Math.min( ...results.inserterHover ),
+		maxInserterHover: Math.max( ...results.inserterHover ),
 	};
 }
 
@@ -179,6 +189,9 @@ async function runTestSuite( testSuite, performanceTestDirectory ) {
 			inserterOpen: results.map( ( r ) => r.inserterOpen ),
 			minInserterOpen: results.map( ( r ) => r.minInserterOpen ),
 			maxInserterOpen: results.map( ( r ) => r.maxInserterOpen ),
+			inserterHover: results.map( ( r ) => r.inserterHover ),
+			minInserterHover: results.map( ( r ) => r.minInserterHover ),
+			maxInserterHover: results.map( ( r ) => r.maxInserterHover ),
 		},
 		median
 	);

--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -294,7 +294,21 @@ async function runPerformanceTests( branches, options ) {
 	log( '\n>> 🎉 Results.\n' );
 	for ( const testSuite of testSuites ) {
 		log( `\n>> ${ testSuite }\n` );
-		console.table( results[ testSuite ] );
+
+		/** @type {Record<string, Record<string, string>>} */
+		const invertedResult = {};
+		Object.entries( results[ testSuite ] ).reduce(
+			( acc, [ key, val ] ) => {
+				for ( const entry of Object.keys( val ) ) {
+					if ( ! acc[ entry ] ) acc[ entry ] = {};
+					// @ts-ignore
+					acc[ entry ][ key ] = val[ entry ];
+				}
+				return acc;
+			},
+			invertedResult
+		);
+		console.table( invertedResult );
 	}
 }
 

--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -37,16 +37,16 @@ const config = require( '../config' );
 /**
  * @typedef WPPerformanceResults
  *
- * @property {number} load             Load Time.
- * @property {number} type             Average type time.
- * @property {number} minType          Minium type time.
- * @property {number} maxType          Maximum type time.
- * @property {number} focus            Average block selection time.
- * @property {number} minFocus         Min block selection time.
- * @property {number} maxFocus         Max block selection time.
- * @property {number} inserterOpen     Average time to open global inserter.
- * @property {number} minInserterOpen  Min time to open global inserter.
- * @property {number} maxInserterOpen  Max time to open global inserter.
+ * @property {number} load              Load Time.
+ * @property {number} type              Average type time.
+ * @property {number} minType           Minium type time.
+ * @property {number} maxType           Maximum type time.
+ * @property {number} focus             Average block selection time.
+ * @property {number} minFocus          Min block selection time.
+ * @property {number} maxFocus          Max block selection time.
+ * @property {number} inserterOpen      Average time to open global inserter.
+ * @property {number} minInserterOpen   Min time to open global inserter.
+ * @property {number} maxInserterOpen   Max time to open global inserter.
  * @property {number} inserterHover     Average time to move mouse between two block item in the inserter.
  * @property {number} minInserterHover  Min time to move mouse between two block item in the inserter.
  * @property {number} maxInserterHover  Max time to move mouse between two block item in the inserter.
@@ -54,16 +54,16 @@ const config = require( '../config' );
 /**
  * @typedef WPFormattedPerformanceResults
  *
- * @property {string=} load             Load Time.
- * @property {string=} type             Average type time.
- * @property {string=} minType          Minium type time.
- * @property {string=} maxType          Maximum type time.
- * @property {string=} focus            Average block selection time.
- * @property {string=} minFocus         Min block selection time.
- * @property {string=} maxFocus         Max block selection time.
- * @property {string=} inserterOpen     Average time to open global inserter.
- * @property {string=} minInserterOpen  Min time to open global inserter.
- * @property {string=} maxInserterOpen  Max time to open global inserter.
+ * @property {string=} load              Load Time.
+ * @property {string=} type              Average type time.
+ * @property {string=} minType           Minium type time.
+ * @property {string=} maxType           Maximum type time.
+ * @property {string=} focus             Average block selection time.
+ * @property {string=} minFocus          Min block selection time.
+ * @property {string=} maxFocus          Max block selection time.
+ * @property {string=} inserterOpen      Average time to open global inserter.
+ * @property {string=} minInserterOpen   Min time to open global inserter.
+ * @property {string=} maxInserterOpen   Max time to open global inserter.
  * @property {string=} inserterHover     Average time to move mouse between two block item in the inserter.
  * @property {string=} minInserterHover  Min time to move mouse between two block item in the inserter.
  * @property {string=} maxInserterHover  Max time to move mouse between two block item in the inserter.

--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -30,6 +30,7 @@ const config = require( '../config' );
  * @property {number[]} load             Load Time.
  * @property {number[]} type             Average type time.
  * @property {number[]} focus            Average block selection time.
+ * @property {number[]} inserterOpen     Average time to open global inserter.
  */
 
 /**
@@ -42,6 +43,9 @@ const config = require( '../config' );
  * @property {number} focus            Average block selection time.
  * @property {number} minFocus         Min block selection time.
  * @property {number} maxFocus         Max block selection time.
+ * @property {number} inserterOpen     Average time to open global inserter.
+ * @property {number} minInserterOpen  Min time to open global inserter.
+ * @property {number} maxInserterOpen  Max time to open global inserter.
  */
 /**
  * @typedef WPFormattedPerformanceResults
@@ -53,6 +57,9 @@ const config = require( '../config' );
  * @property {string=} focus            Average block selection time.
  * @property {string=} minFocus         Min block selection time.
  * @property {string=} maxFocus         Max block selection time.
+ * @property {string=} inserterOpen     Average time to open global inserter.
+ * @property {string=} minInserterOpen  Min time to open global inserter.
+ * @property {string=} maxInserterOpen  Max time to open global inserter.
  */
 
 /**
@@ -109,6 +116,9 @@ function curateResults( results ) {
 		focus: average( results.focus ),
 		minFocus: Math.min( ...results.focus ),
 		maxFocus: Math.max( ...results.focus ),
+		inserterOpen: average( results.inserterOpen ),
+		minInserterOpen: Math.min( ...results.inserterOpen ),
+		maxInserterOpen: Math.max( ...results.inserterOpen ),
 	};
 }
 
@@ -166,6 +176,9 @@ async function runTestSuite( testSuite, performanceTestDirectory ) {
 			focus: results.map( ( r ) => r.focus ),
 			minFocus: results.map( ( r ) => r.minFocus ),
 			maxFocus: results.map( ( r ) => r.maxFocus ),
+			inserterOpen: results.map( ( r ) => r.inserterOpen ),
+			minInserterOpen: results.map( ( r ) => r.minInserterOpen ),
+			maxInserterOpen: results.map( ( r ) => r.maxInserterOpen ),
 		},
 		median
 	);

--- a/packages/e2e-tests/config/performance-reporter.js
+++ b/packages/e2e-tests/config/performance-reporter.js
@@ -28,7 +28,9 @@ class PerformanceReporter {
 		}
 
 		const results = readFileSync( filepath, 'utf8' );
-		const { load, type, focus } = JSON.parse( results );
+		const { load, type, focus, inserterOpen, inserterHover } = JSON.parse(
+			results
+		);
 
 		if ( load && load.length ) {
 			// eslint-disable-next-line no-console
@@ -60,6 +62,36 @@ Slowest time to select a block: ${ success(
 			) }
 Fastest time to select a block: ${ success(
 				round( Math.min( ...focus ) ) + 'ms'
+			) }` );
+		}
+
+		if ( inserterOpen && inserterOpen.length ) {
+			// eslint-disable-next-line no-console
+			console.log( `
+${ title( 'Opening Global Inserter Performance:' ) }
+Average time to open global inserter: ${ success(
+				round( average( inserterOpen ) ) + 'ms'
+			) }
+Slowest time to open global inserter: ${ success(
+				round( Math.max( ...inserterOpen ) ) + 'ms'
+			) }
+Fastest time to open global inserter: ${ success(
+				round( Math.min( ...inserterOpen ) ) + 'ms'
+			) }` );
+		}
+
+		if ( inserterHover && inserterHover.length ) {
+			// eslint-disable-next-line no-console
+			console.log( `
+${ title( 'Inserter Block Item Hover Performance:' ) }
+Average time to move mouse between two block item in the inserter: ${ success(
+				round( average( inserterHover ) ) + 'ms'
+			) }
+Slowest time to move mouse between two block item in the inserter: ${ success(
+				round( Math.max( ...inserterHover ) ) + 'ms'
+			) }
+Fastest time to move mouse between two block item in the inserter: ${ success(
+				round( Math.min( ...inserterHover ) ) + 'ms'
 			) }` );
 		}
 

--- a/packages/e2e-tests/specs/performance/site-editor.test.js
+++ b/packages/e2e-tests/specs/performance/site-editor.test.js
@@ -34,6 +34,8 @@ describe( 'Site Editor Performance', () => {
 			load: [],
 			type: [],
 			focus: [],
+			inserterOpen: [],
+			inserterHover: [],
 		};
 
 		await visitAdminPage(


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Add two new performance measurements:

* Time to open global inserter
* Time to move mouse between two block items in the inserter

## How has this been tested?
`npm run test-performance`

## Screenshots
![image](https://user-images.githubusercontent.com/2256104/97880095-05996f80-1d21-11eb-9c4b-0d36995835da.png)

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
