### PR TITLE
Allow editing of extracted excerpt

### DIFF
--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -103,16 +103,12 @@ function PostExcerptEditor( {
 						! showMoreOnNewLine &&
 						'wp-block-post-excerpt__excerpt is-inline'
 					}
-					placeholder={ postContentExcerpt }
 					value={
 						excerpt ||
-						( isSelected
-							? ''
-							: postContentExcerpt ||
-							  __( 'No post excerpt found' ) )
+						postContentExcerpt ||
+						( isSelected ? '' : __( 'No post excerpt found' ) )
 					}
 					onChange={ setExcerpt }
-					keepPlaceholderOnFocus
 				/>
 				{ ! showMoreOnNewLine && ' ' }
 				{ showMoreOnNewLine ? (


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Resolves: https://github.com/WordPress/gutenberg/issues/26585

In `Post Excerpt` block if the post hasn't a value in the `excerpt` field, it shows a created excerpt which is extracted from `post content`. Now if a user clicks to edit the content from an extracted excerpt, they have to create a new one from scratch.

This PR allows to edit this extracted excerpt if you want to change it. After the update any change in the excerpt is synced with the excerpt field in the respective post.
<!-- Please describe what you have changed or added -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
