### PR TITLE
Update the order of settings and filters in the sidebar

### DIFF
--- a/packages/block-library/src/query/edit/query-inspector-controls.js
+++ b/packages/block-library/src/query/edit/query-inspector-controls.js
@@ -134,13 +134,30 @@ export default function QueryInspectorControls( { query, setQuery } ) {
 	] );
 	return (
 		<InspectorControls>
-			<PanelBody title={ __( 'Filtering and Sorting' ) }>
+			<PanelBody title={ __( 'Settings' ) }>
 				<SelectControl
 					options={ postTypesSelectOptions }
 					value={ postType }
 					label={ __( 'Post Type' ) }
 					onChange={ onPostTypeChange }
 				/>
+				<QueryControls
+					{ ...{ order, orderBy, selectedAuthorId, authorList } }
+					onOrderChange={ ( value ) => setQuery( { order: value } ) }
+					onOrderByChange={ ( value ) =>
+						setQuery( { orderBy: value } )
+					}
+				/>
+				{ showSticky && (
+					<SelectControl
+						label={ __( 'Sticky posts' ) }
+						options={ stickyOptions }
+						value={ sticky }
+						onChange={ ( value ) => setQuery( { sticky: value } ) }
+					/>
+				) }
+			</PanelBody>
+			<PanelBody title={ __( 'Filters' ) }>
 				{ showCategories && categories?.terms?.length > 0 && (
 					<FormTokenField
 						label={ __( 'Categories' ) }
@@ -167,10 +184,6 @@ export default function QueryInspectorControls( { query, setQuery } ) {
 				) }
 				<QueryControls
 					{ ...{ order, orderBy, selectedAuthorId, authorList } }
-					onOrderChange={ ( value ) => setQuery( { order: value } ) }
-					onOrderByChange={ ( value ) =>
-						setQuery( { orderBy: value } )
-					}
 					onAuthorChange={ ( value ) =>
 						setQuery( {
 							author: value !== '' ? +value : undefined,
@@ -178,18 +191,10 @@ export default function QueryInspectorControls( { query, setQuery } ) {
 					}
 				/>
 				<TextControl
-					label={ __( 'Search' ) }
+					label={ __( 'Keyword' ) }
 					value={ querySearch }
 					onChange={ setQuerySearch }
 				/>
-				{ showSticky && (
-					<SelectControl
-						label={ __( 'Sticky posts' ) }
-						options={ stickyOptions }
-						value={ sticky }
-						onChange={ ( value ) => setQuery( { sticky: value } ) }
-					/>
-				) }
 			</PanelBody>
 		</InspectorControls>
 	);

--- a/packages/block-library/src/query/edit/query-inspector-controls.js
+++ b/packages/block-library/src/query/edit/query-inspector-controls.js
@@ -142,7 +142,7 @@ export default function QueryInspectorControls( { query, setQuery } ) {
 					onChange={ onPostTypeChange }
 				/>
 				<QueryControls
-					{ ...{ order, orderBy, selectedAuthorId, authorList } }
+					{ ...{ order, orderBy } }
 					onOrderChange={ ( value ) => setQuery( { order: value } ) }
 					onOrderByChange={ ( value ) =>
 						setQuery( { orderBy: value } )
@@ -183,7 +183,7 @@ export default function QueryInspectorControls( { query, setQuery } ) {
 					/>
 				) }
 				<QueryControls
-					{ ...{ order, orderBy, selectedAuthorId, authorList } }
+					{ ...{ selectedAuthorId, authorList } }
 					onAuthorChange={ ( value ) =>
 						setQuery( {
 							author: value !== '' ? +value : undefined,


### PR DESCRIPTION
Fixes #26646. Groups the settings and filters in different panels and still maintains visibility based on post type.

## How has this been tested?
Tested locally.

## Screenshots

**Before**
![before](https://user-images.githubusercontent.com/617986/97936115-69c33000-1d2f-11eb-9666-6fad62cc4138.png)

**After**
![after](https://user-images.githubusercontent.com/617986/97936120-6def4d80-1d2f-11eb-8bc9-6719e4bacda9.png)


## Types of changes


## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
