### PR TITLE
Show user's name when a post is being taken over

### DIFF
--- a/packages/editor/src/components/post-locked-modal/index.js
+++ b/packages/editor/src/components/post-locked-modal/index.js
@@ -96,6 +96,7 @@ class PostLockedModal extends Component {
 				isTakeover: true,
 				user: {
 					avatar: received.lock_error.avatar_src,
+					text: received.lock_error.text,
 				},
 			} );
 		} else if ( received.new_lock ) {
@@ -143,7 +144,7 @@ class PostLockedModal extends Component {
 			return null;
 		}
 
-		const userDisplayName = user.name;
+		const userTakeoverText = user.text;
 		const userAvatar = user.avatar;
 
 		const unlockUrl = addQueryArgs( 'post.php', {
@@ -180,13 +181,12 @@ class PostLockedModal extends Component {
 				{ !! isTakeover && (
 					<div>
 						<div>
-							{ userDisplayName
+							{ userTakeoverText
 								? sprintf(
-										/* translators: %s: user's display name */
 										__(
-											'%s now has editing control of this post. Don’t worry, your changes up to this moment have been saved.'
+											'%s Don’t worry, your changes up to this moment have been saved.'
 										),
-										userDisplayName
+										userTakeoverText
 								  )
 								: __(
 										'Another user now has editing control of this post. Don’t worry, your changes up to this moment have been saved.'


### PR DESCRIPTION
## Description
Use the `text` property returned by the heartbeat API to show the name of the user taking over a post. See #26645 

## How has this been tested?
Tested code change in my local running WordPress 5.3

## Screenshots

Previous behavior:

![Screen Shot 2020-11-02 at 7 58 59 PM](https://user-images.githubusercontent.com/1427716/97936952-355d6d00-1d4b-11eb-9725-07d704001ffa.png)

After fix:

![Screen Shot 2020-11-02 at 8 40 03 PM](https://user-images.githubusercontent.com/1427716/97937084-a00ea880-1d4b-11eb-84dd-1c9829c6dceb.png)


## Types of changes
Bug Fix - the `name` property is never given by the Heartbeat API; this uses the `text` property instead.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
