### PR TITLE
 Build Tooling: Rebuild stylesheets when imported styles are modified

### DIFF
--- a/bin/packages/build.js
+++ b/bin/packages/build.js
@@ -32,30 +32,32 @@ function getPackageName( file ) {
 }
 
 /**
- * Finds all stylesheet entry points that have import statements
- * that include styles from a given file
+ * Finds all stylesheet entry points that contain import statements
+ * that include the given file name
  *
  * @param  {string} file File name
  * @return {Array}       List of entry points that import the styles from the file
  */
-function findEntryPointsThatImportFile( file ) {
+function findStyleEntriesThatImportFile( file ) {
 	const entriesWithImport = stylesheetEntryPoints.reduce(
 		( acc, entryPoint ) => {
 			const content = fs.readFileSync( entryPoint, 'utf8' );
+
+			// Returns all import statements from a stylesheet
 			const importStatements = content
 				.toString()
 				.match( /@import "(.*?)"/g );
 
 			const packageName = getPackageName( file );
-			const re = new RegExp( packageName, 'g' );
+			const regex = new RegExp( packageName, 'g' );
 
-			const fileIsImported =
+			const fileIsImportedInStyleEntry =
 				importStatements &&
-				importStatements.find( ( importedFile ) =>
-					importedFile.match( re )
+				importStatements.find( ( importStatement ) =>
+					importStatement.match( regex )
 				);
 
-			if ( fileIsImported ) {
+			if ( fileIsImportedInStyleEntry ) {
 				acc.push( entryPoint );
 			}
 
@@ -97,11 +99,11 @@ function createStyleEntryTransform() {
 
 			// Find other stylesheets that need to be rebuilt because
 			// they import the styles that are being transformed
-			const entryPoints = await findEntryPointsThatImportFile( file );
+			const styleEntries = findStyleEntriesThatImportFile( file );
 
-			// Rebuild stylesheets that import the styles being updated
-			if ( entryPoints.length ) {
-				entryPoints.forEach( ( entry ) => stream.push( entry ) );
+			// Rebuild stylesheets that import the styles being transformed
+			if ( styleEntries.length ) {
+				styleEntries.forEach( ( entry ) => stream.push( entry ) );
 				callback();
 			} else {
 				packages.add( packageName );

--- a/bin/packages/build.js
+++ b/bin/packages/build.js
@@ -29,16 +29,6 @@ function getPackageName( file ) {
 	return path.relative( PACKAGES_DIR, file ).split( path.sep )[ 0 ];
 }
 
-/**
- * Determine if a file is a sass stylesheet
- *
- * @param  {string} file File name
- * @return {boolean} Is a stylesheet
- */
-function isSassStylesheet( file ) {
-	return path.extname( file ) === '.scss';
-}
-
 function findEntriesThatImportFile( file ) {
 	const entriesWithImport = allEntries.reduce( ( acc, entry ) => {
 		const content = fs.readFileSync( entry, 'utf8' );
@@ -76,7 +66,7 @@ function createStyleEntryTransform() {
 		objectMode: true,
 		async transform( file, encoding, callback ) {
 			// Only stylesheets are subject to this transform.
-			if ( ! isSassStylesheet( file ) ) {
+			if ( path.extname( file ) !== '.scss' ) {
 				this.push( file );
 				callback();
 				return;

--- a/bin/packages/build.js
+++ b/bin/packages/build.js
@@ -49,7 +49,7 @@ function findStyleEntriesThatImportFile( file ) {
 				.match( /@import "(.*?)"/g );
 
 			const packageName = getPackageName( file );
-			const regex = new RegExp( packageName, 'g' );
+			const regex = new RegExp( `/${ packageName }/`, 'g' );
 
 			const fileIsImportedInStyleEntry =
 				importStatements &&
@@ -97,6 +97,12 @@ function createStyleEntryTransform() {
 				return;
 			}
 
+			packages.add( packageName );
+			const entries = await glob(
+				path.resolve( PACKAGES_DIR, packageName, 'src/*.scss' )
+			);
+			entries.forEach( ( entry ) => this.push( entry ) );
+
 			// Find other stylesheets that need to be rebuilt because
 			// they import the styles that are being transformed
 			const styleEntries = findStyleEntriesThatImportFile( file );
@@ -104,15 +110,9 @@ function createStyleEntryTransform() {
 			// Rebuild stylesheets that import the styles being transformed
 			if ( styleEntries.length ) {
 				styleEntries.forEach( ( entry ) => stream.push( entry ) );
-				callback();
-			} else {
-				packages.add( packageName );
-				const entries = await glob(
-					path.resolve( PACKAGES_DIR, packageName, 'src/*.scss' )
-				);
-				entries.forEach( ( entry ) => this.push( entry ) );
-				callback();
 			}
+
+			callback();
 		},
 	} );
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
The local dev environment wasn't reloading style updates properly when modifying stylesheets that were separate (but imported) by another package.

Ex. Updates to styles in the interface package were not being propagated to the site editor stylesheet ([which imports interface package styles](https://github.com/WordPress/gutenberg/blob/fb1cc0e8cec5c55c17de72b13a13214beb6fe602/packages/edit-site/src/style.scss#L1), and should, theoretically, update as well)

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Set up a local dev environment for Gutenberg
2. Set up the local WordPress instance with Docker (`npx wp-env start`)
3. Run `npm run dev`
5. Navigate to the site editor
6. Open up the block inserter
7. Note that the background color of the block inserter is white
8. Update styles in `packages/interface/src/components/interface-skeleton/style.scss:98` and change the background-color to something notable, like purple
9. Refresh the page after waiting some period for the stylesheets to rebuild
10. Note that the background color of the block inserter is now purple
11. Open `packages/interface/build-style/style.css:317` and `packages/edit-site/build-style/style.css:317`. These are the transpiled stylesheets that should reflect up to date styling changes. Confirm that the background color has been updated to purple in both of these files.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix for #26669 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
