### PR TITLE
FSE: Enhance multiple saved entities titles

### DIFF
--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -134,10 +134,10 @@ function* loadPostTypeEntities() {
 			},
 			mergedEdits: { meta: true },
 			getTitle( record ) {
-				if ( name === 'wp_template_part' || name === 'wp_template' ) {
+				if ( [ 'wp_template_part', 'wp_template' ].includes( name ) ) {
 					return startCase( record.slug );
 				}
-				return get( record, [ 'title', 'rendered' ], record.id );
+				return record?.title?.renderd || record?.title || record.id;
 			},
 		};
 	} );

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -280,7 +280,7 @@ export const __experimentalGetDirtyEntityRecords = createSelector(
 								entityRecord[
 									entity.key || DEFAULT_ENTITY_KEY
 								],
-							title: entity?.getTitle( entityRecord ) || '',
+							title: entity?.getTitle?.( entityRecord ) || '',
 							name,
 							kind,
 						} );

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -280,9 +280,7 @@ export const __experimentalGetDirtyEntityRecords = createSelector(
 								entityRecord[
 									entity.key || DEFAULT_ENTITY_KEY
 								],
-							title: ! entity.getTitle
-								? ''
-								: entity.getTitle( entityRecord ),
+							title: entity?.getTitle( entityRecord ) || '',
 							name,
 							kind,
 						} );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This falls under the umbrella of FSE.

When you make changes in FSE, you can review the changed entities by clicking the 'update' button and then `review changes`.

Now, when you make changes in Post Blocks that enable editing, like `Post Excerpt`, in the `review changes` section it shows the `ID` which is just unintuitive and non descriptive.

This PR shows the title.

I'm not really sure if the place I chose is the best one, so feedback would be good. I have comments in `diff`.



## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
