### PR TITLE
Document should be specified for getBlockDOMNode

### DIFF
--- a/packages/block-editor/src/components/block-list/block-popover.js
+++ b/packages/block-editor/src/components/block-list/block-popover.js
@@ -27,6 +27,7 @@ import BlockSelectionButton from './block-selection-button';
 import BlockContextualToolbar from './block-contextual-toolbar';
 import Inserter from '../inserter';
 import { BlockNodes } from './root-container';
+import { getBlockDOMNode } from '../../utils/dom';
 
 function selector( select ) {
 	const {
@@ -119,12 +120,12 @@ function BlockPopover( {
 
 	let node = blockNodes[ clientId ];
 
-	if ( capturingClientId ) {
-		node = document.getElementById( 'block-' + capturingClientId );
-	}
-
 	if ( ! node ) {
 		return null;
+	}
+
+	if ( capturingClientId ) {
+		node = getBlockDOMNode( capturingClientId, node.ownerDocument );
 	}
 
 	let anchorRef = node;

--- a/packages/block-editor/src/components/block-list/insertion-point.js
+++ b/packages/block-editor/src/components/block-list/insertion-point.js
@@ -56,9 +56,10 @@ function InsertionPointInserter( {
 			return;
 		}
 
+		const { ownerDocument } = containerRef.current;
 		const targetRect = target.getBoundingClientRect();
 		const isReverse = clientY < targetRect.top + targetRect.height / 2;
-		const blockNode = getBlockDOMNode( clientId );
+		const blockNode = getBlockDOMNode( clientId, ownerDocument );
 		const container = isReverse ? containerRef.current : blockNode;
 		const closest =
 			getClosestTabbable( blockNode, true, container ) || blockNode;
@@ -109,7 +110,8 @@ function InsertionPointPopover( {
 	const appenderNodesMap = useContext( AppenderNodesContext );
 	const element = useMemo( () => {
 		if ( clientId ) {
-			return getBlockDOMNode( clientId );
+			const { ownerDocument } = containerRef.current;
+			return getBlockDOMNode( clientId, ownerDocument );
 		}
 
 		// Can't find the element, might be at the end of the block list, or inside an empty block list.

--- a/packages/block-editor/src/components/block-list/use-multi-selection.js
+++ b/packages/block-editor/src/components/block-list/use-multi-selection.js
@@ -102,7 +102,10 @@ export default function useMultiSelection( ref ) {
 			const selection = defaultView.getSelection();
 
 			if ( selection.rangeCount && ! selection.isCollapsed ) {
-				const blockNode = getBlockDOMNode( selectedBlockClientId );
+				const blockNode = getBlockDOMNode(
+					selectedBlockClientId,
+					ownerDocument
+				);
 				const { startContainer, endContainer } = selection.getRangeAt(
 					0
 				);
@@ -129,8 +132,8 @@ export default function useMultiSelection( ref ) {
 		const start = multiSelectedBlockClientIds[ 0 ];
 		const end = multiSelectedBlockClientIds[ length - 1 ];
 
-		let startNode = getBlockDOMNode( start );
-		let endNode = getBlockDOMNode( end );
+		let startNode = getBlockDOMNode( start, ownerDocument );
+		let endNode = getBlockDOMNode( end, ownerDocument );
 
 		const selection = defaultView.getSelection();
 		const range = ownerDocument.createRange();

--- a/packages/block-editor/src/components/multi-select-scroll-into-view/index.js
+++ b/packages/block-editor/src/components/multi-select-scroll-into-view/index.js
@@ -6,7 +6,7 @@ import scrollIntoView from 'dom-scroll-into-view';
 /**
  * WordPress dependencies
  */
-import { useEffect } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { getScrollContainer } from '@wordpress/dom';
 
@@ -37,13 +37,15 @@ export default function MultiSelectScrollIntoView() {
 		selector,
 		[]
 	);
+	const ref = useRef();
 
 	useEffect( () => {
 		if ( ! selectionEnd || isMultiSelecting || ! isMultiSelection ) {
 			return;
 		}
 
-		const extentNode = getBlockDOMNode( selectionEnd );
+		const { ownerDocument } = ref.current;
+		const extentNode = getBlockDOMNode( selectionEnd, ownerDocument );
 
 		if ( ! extentNode ) {
 			return;
@@ -62,5 +64,5 @@ export default function MultiSelectScrollIntoView() {
 		} );
 	}, [ isMultiSelection, selectionEnd, isMultiSelecting ] );
 
-	return null;
+	return <div ref={ ref } />;
 }

--- a/packages/block-editor/src/components/skip-to-selected-block/index.js
+++ b/packages/block-editor/src/components/skip-to-selected-block/index.js
@@ -12,7 +12,10 @@ import { getBlockDOMNode } from '../../utils/dom';
 
 const SkipToSelectedBlock = ( { selectedBlockClientId } ) => {
 	const onClick = () => {
-		const selectedBlockElement = getBlockDOMNode( selectedBlockClientId );
+		const selectedBlockElement = getBlockDOMNode(
+			selectedBlockClientId,
+			document
+		);
 		selectedBlockElement.focus();
 	};
 

--- a/packages/block-editor/src/components/writing-flow/focus-capture.js
+++ b/packages/block-editor/src/components/writing-flow/focus-capture.js
@@ -80,7 +80,10 @@ const FocusCapture = forwardRef(
 
 			// If there is a selected block, move focus to the first or last
 			// tabbable element depending on the direction.
-			const wrapper = getBlockDOMNode( selectedClientId );
+			const wrapper = getBlockDOMNode(
+				selectedClientId,
+				ref.current.ownerDocument
+			);
 
 			if ( isReverse ) {
 				const tabbables = focus.tabbable.find( wrapper );

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -305,12 +305,14 @@ export default function WritingFlow( { children } ) {
 	function onMouseDown( event ) {
 		verticalRect.current = null;
 
+		const { ownerDocument } = event.target;
+
 		// Clicking inside a selected block should exit navigation mode and block moving mode.
 		if (
 			isNavigationMode &&
 			selectedBlockClientId &&
 			isInsideRootBlock(
-				getBlockDOMNode( selectedBlockClientId ),
+				getBlockDOMNode( selectedBlockClientId, ownerDocument ),
 				event.target
 			)
 		) {
@@ -417,6 +419,8 @@ export default function WritingFlow( { children } ) {
 		const hasModifier =
 			isShift || event.ctrlKey || event.altKey || event.metaKey;
 		const isNavEdge = isVertical ? isVerticalEdge : isHorizontalEdge;
+		const { ownerDocument } = container.current;
+		const { defaultView } = ownerDocument;
 
 		// In navigation mode, tab and arrows navigate from block to block.
 		if ( isNavigationMode ) {
@@ -489,7 +493,10 @@ export default function WritingFlow( { children } ) {
 					event.preventDefault();
 					selectBlock( focusedBlockUid );
 				} else if ( isTab && selectedBlockClientId ) {
-					const wrapper = getBlockDOMNode( selectedBlockClientId );
+					const wrapper = getBlockDOMNode(
+						selectedBlockClientId,
+						ownerDocument
+					);
 					let nextTabbable;
 
 					if ( navigateDown ) {
@@ -517,7 +524,10 @@ export default function WritingFlow( { children } ) {
 		// Navigation mode (press Esc), to navigate through blocks.
 		if ( selectedBlockClientId ) {
 			if ( isTab ) {
-				const wrapper = getBlockDOMNode( selectedBlockClientId );
+				const wrapper = getBlockDOMNode(
+					selectedBlockClientId,
+					ownerDocument
+				);
 
 				if ( isShift ) {
 					if ( target === wrapper ) {
@@ -558,9 +568,6 @@ export default function WritingFlow( { children } ) {
 
 			return;
 		}
-
-		const { ownerDocument } = container.current;
-		const { defaultView } = ownerDocument;
 
 		// When presing any key other than up or down, the initial vertical
 		// position must ALWAYS be reset. The vertical position is saved so it

--- a/packages/block-editor/src/hooks/color-panel.js
+++ b/packages/block-editor/src/hooks/color-panel.js
@@ -29,7 +29,7 @@ export default function ColorPanel( {
 			return;
 		}
 
-		const colorsDetectionElement = getBlockDOMNode( clientId );
+		const colorsDetectionElement = getBlockDOMNode( clientId, document );
 		if ( ! colorsDetectionElement ) {
 			return;
 		}

--- a/packages/block-editor/src/utils/dom.js
+++ b/packages/block-editor/src/utils/dom.js
@@ -3,24 +3,26 @@
  * if exists. As much as possible, this helper should be avoided, and used only
  * in cases where isolated behaviors need remote access to a block node.
  *
- * @param {string} clientId Block client ID.
+ * @param {string}   clientId Block client ID.
+ * @param {Document} doc      Document to search.
  *
  * @return {Element?} Block DOM node.
  */
-export function getBlockDOMNode( clientId ) {
-	return document.getElementById( 'block-' + clientId );
+export function getBlockDOMNode( clientId, doc ) {
+	return doc.getElementById( 'block-' + clientId );
 }
 
 /**
  * Returns the preview container DOM node for a given block client ID, or
  * undefined if the container cannot be determined.
  *
- * @param {string} clientId Block client ID.
+ * @param {string}   clientId Block client ID.
+ * @param {Document} doc      Document to search.
  *
  * @return {Node|undefined} Preview container DOM node.
  */
-export function getBlockPreviewContainerDOMNode( clientId ) {
-	const domNode = getBlockDOMNode( clientId );
+export function getBlockPreviewContainerDOMNode( clientId, doc ) {
+	const domNode = getBlockDOMNode( clientId, doc );
 
 	if ( ! domNode ) {
 		return;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

PR is split out from the iframe PRs.
This function is just an internal function, so it's fine to change.
We should not assume that the block node will be rendered in the top document node.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
