### PR TITLE
Remove `useMemo` in Query inspector controls

### DIFF
--- a/packages/block-library/src/query/edit/query-inspector-controls.js
+++ b/packages/block-library/src/query/edit/query-inspector-controls.js
@@ -25,6 +25,12 @@ import { useEffect, useState, useCallback, useMemo } from '@wordpress/element';
 import { getTermsInfo } from '../utils';
 import { MAX_FETCHED_TERMS } from '../constants';
 
+const stickyOptions = [
+	{ label: __( 'Include' ), value: '' },
+	{ label: __( 'Exclude' ), value: 'exclude' },
+	{ label: __( 'Only' ), value: 'only' },
+];
+
 export default function QueryInspectorControls( { query, setQuery } ) {
 	const {
 		order,
@@ -124,11 +130,6 @@ export default function QueryInspectorControls( { query, setQuery } ) {
 		onChangeDebounced();
 		return onChangeDebounced.cancel;
 	}, [ querySearch, onChangeDebounced ] );
-	const stickyOptions = [
-		{ label: __( 'Include' ), value: '' },
-		{ label: __( 'Exclude' ), value: 'exclude' },
-		{ label: __( 'Only' ), value: 'only' },
-	];
 	return (
 		<InspectorControls>
 			<PanelBody title={ __( 'Filtering and Sorting' ) }>

--- a/packages/block-library/src/query/edit/query-inspector-controls.js
+++ b/packages/block-library/src/query/edit/query-inspector-controls.js
@@ -124,14 +124,14 @@ export default function QueryInspectorControls( { query, setQuery } ) {
 		onChangeDebounced();
 		return onChangeDebounced.cancel;
 	}, [ querySearch, onChangeDebounced ] );
-	const stickyOptions = useMemo( () => [
-		{
-			label: __( 'Include' ),
-			value: '',
-		},
-		{ label: __( 'Exclude' ), value: 'exclude' },
-		{ label: __( 'Only' ), value: 'only' },
-	] );
+	const stickyOptions = useMemo(
+		() => [
+			{ label: __( 'Include' ), value: '' },
+			{ label: __( 'Exclude' ), value: 'exclude' },
+			{ label: __( 'Only' ), value: 'only' },
+		],
+		[]
+	);
 	return (
 		<InspectorControls>
 			<PanelBody title={ __( 'Filtering and Sorting' ) }>

--- a/packages/block-library/src/query/edit/query-inspector-controls.js
+++ b/packages/block-library/src/query/edit/query-inspector-controls.js
@@ -124,14 +124,11 @@ export default function QueryInspectorControls( { query, setQuery } ) {
 		onChangeDebounced();
 		return onChangeDebounced.cancel;
 	}, [ querySearch, onChangeDebounced ] );
-	const stickyOptions = useMemo(
-		() => [
-			{ label: __( 'Include' ), value: '' },
-			{ label: __( 'Exclude' ), value: 'exclude' },
-			{ label: __( 'Only' ), value: 'only' },
-		],
-		[]
-	);
+	const stickyOptions = [
+		{ label: __( 'Include' ), value: '' },
+		{ label: __( 'Exclude' ), value: 'exclude' },
+		{ label: __( 'Only' ), value: 'only' },
+	];
 	return (
 		<InspectorControls>
 			<PanelBody title={ __( 'Filtering and Sorting' ) }>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This PR just adds the missing dependencies for `useMemo` in Query inspector controls.