### PR TITLE
[Mobile] - InnerBlocks - Support for LayoutProvider

### DIFF
--- a/packages/block-editor/src/components/inner-blocks/index.native.js
+++ b/packages/block-editor/src/components/inner-blocks/index.native.js
@@ -20,6 +20,7 @@ import BlockList from '../block-list';
 import { useBlockEditContext } from '../block-edit/context';
 import useBlockSync from '../provider/use-block-sync';
 import { BlockContextProvider } from '../block-context';
+import { defaultLayout, LayoutProvider } from './layout';
 
 /**
  * InnerBlocks is a component which allows a single block to have multiple blocks
@@ -49,6 +50,7 @@ function UncontrolledInnerBlocks( props ) {
 		marginHorizontal,
 		horizontalAlignment,
 		filterInnerBlocks,
+		__experimentalLayout: layout = defaultLayout,
 	} = props;
 
 	const block = useSelect(
@@ -91,9 +93,11 @@ function UncontrolledInnerBlocks( props ) {
 		const context = getBlockContext( block.attributes, blockType );
 
 		blockList = (
-			<BlockContextProvider value={ context }>
-				{ blockList }
-			</BlockContextProvider>
+			<LayoutProvider value={ layout }>
+				<BlockContextProvider value={ context }>
+					{ blockList }
+				</BlockContextProvider>
+			</LayoutProvider>
 		);
 	}
 

--- a/packages/block-editor/src/hooks/align.native.js
+++ b/packages/block-editor/src/hooks/align.native.js
@@ -12,6 +12,8 @@ import { WIDE_ALIGNMENTS } from '@wordpress/components';
 
 const ALIGNMENTS = [ 'left', 'center', 'right' ];
 
+export * from './align.js';
+
 // Used to filter out blocks that don't support wide/full alignment on mobile
 addFilter(
 	'blocks.registerBlockType',


### PR DESCRIPTION
`Gutenberg Mobile PR` -> https://github.com/wordpress-mobile/gutenberg-mobile/pull/2775

## Description
This PR fixes a mobile regression after [this feature](https://github.com/WordPress/gutenberg/pull/26380/files) got introduced for the web editor. With those changes, the block alignment toolbar stopped showing but this PR fixes that.

## How has this been tested?
- Open the app with metro running
- Add a Group block
- **Expect** to see the block alignment option in the toolbar
- Change the alignment to wide/full-width
- **Expect** the block to adjust to the selected alignment

## Screenshots <!-- if applicable -->
Before | After
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/97995500-e107cb00-1de6-11eb-9f0e-8d0a007f881e.png" width="250" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/97995425-c7668380-1de6-11eb-9c0f-7602c5bab32c.png" width="250" /></kbd> 

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
