### PR TITLE
[Concurrency issues] More integration tests

### DIFF
--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -56,13 +56,14 @@ const entityActions = defaultEntities.reduce( ( result, entity ) => {
 	return result;
 }, {} );
 
-registerStore( REDUCER_KEY, {
+export const storeConfig = {
 	reducer,
 	controls,
 	actions: { ...actions, ...entityActions, ...locksActions },
 	selectors: { ...selectors, ...entitySelectors, ...locksSelectors },
 	resolvers: { ...resolvers, ...entityResolvers },
-} );
+};
+registerStore( REDUCER_KEY, storeConfig );
 
 export { default as EntityProvider } from './entity-provider';
 export * from './entity-provider';

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -196,17 +196,18 @@ export function* getEntityRecords( kind, name, query = {} ) {
 		// resolve the `getEntityRecord` selector in addition to `getEntityRecords`.
 		// See https://github.com/WordPress/gutenberg/pull/26575
 		if ( ! query?._fields ) {
+			const key = entity.key || DEFAULT_ENTITY_KEY;
 			for ( const record of records ) {
-				if ( record.id ) {
+				if ( record[ key ] ) {
 					yield {
 						type: 'START_RESOLUTION',
 						selectorName: 'getEntityRecord',
-						args: [ kind, name, record.id ],
+						args: [ kind, name, record[ key ] ],
 					};
 					yield {
 						type: 'FINISH_RESOLUTION',
 						selectorName: 'getEntityRecord',
-						args: [ kind, name, record.id ],
+						args: [ kind, name, record[ key ] ],
 					};
 				}
 			}

--- a/packages/core-data/src/test/integration.js
+++ b/packages/core-data/src/test/integration.js
@@ -132,7 +132,7 @@ describe( 'receiveEntityRecord', () => {
 		);
 		jest.runAllTimers();
 
-		// Select record with id = 2, it is available and should not trigger the resolver
+		// Select record with id = test-1, it is available and should not trigger the resolver
 		await runPromise(
 			registry
 				.dispatch( 'test/resolution' )
@@ -140,7 +140,7 @@ describe( 'receiveEntityRecord', () => {
 		);
 		expect( getEntityRecord ).not.toHaveBeenCalled();
 
-		// Select record with id = 4, it is not available and should trigger the resolver
+		// Select record with id = test-2, it is not available and should trigger the resolver
 		await runPromise(
 			registry
 				.dispatch( 'test/resolution' )
@@ -246,9 +246,12 @@ describe( 'saveEntityRecord', () => {
 		jest.runAllTimers();
 		expect( triggerFetch ).toBeCalledTimes( 0 );
 
-		// Calling a selector after the save is finished should trigger a GET request
+		// Calling the selector after the save is finished should trigger a resolver and a GET request
 		registry.select( 'core' ).getEntityRecords( 'root', 'postType' );
 		jest.runAllTimers();
 		expect( triggerFetch ).toBeCalledTimes( 1 );
+		expect( triggerFetch ).toBeCalledWith( {
+			path: '/wp/v2/types?context=edit',
+		} );
 	} );
 } );

--- a/packages/core-data/src/test/integration.js
+++ b/packages/core-data/src/test/integration.js
@@ -103,16 +103,15 @@ describe( 'receiveEntityRecord', () => {
 		await runPromise(
 			registry
 				.dispatch( 'test/resolution' )
-				.getEntityRecords( 'root', 'postType' )
+				.getEntityRecords( 'root', 'site' )
 		);
 		jest.runAllTimers();
-		await runPendingPromises();
 
 		// Select record with id = 2, it is available and should not trigger the resolver
 		await runPromise(
 			registry
 				.dispatch( 'test/resolution' )
-				.getEntityRecord( 'root', 'postType', 2 )
+				.getEntityRecord( 'root', 'site', 2 )
 		);
 		expect( getEntityRecord ).not.toHaveBeenCalled();
 
@@ -120,7 +119,7 @@ describe( 'receiveEntityRecord', () => {
 		await runPromise(
 			registry
 				.dispatch( 'test/resolution' )
-				.getEntityRecord( 'root', 'postType', 4 )
+				.getEntityRecord( 'root', 'site', 4 )
 		);
 		expect( getEntityRecord ).toHaveBeenCalled();
 	} );
@@ -136,7 +135,7 @@ describe( 'receiveEntityRecord', () => {
 		await runPromise(
 			registry
 				.dispatch( 'test/resolution' )
-				.getEntityRecords( 'root', 'template' )
+				.getEntityRecords( 'root', 'taxonomy' )
 		);
 		jest.runAllTimers();
 
@@ -144,7 +143,7 @@ describe( 'receiveEntityRecord', () => {
 		await runPromise(
 			registry
 				.dispatch( 'test/resolution' )
-				.getEntityRecord( 'root', 'template', 'test-1' )
+				.getEntityRecord( 'root', 'taxonomy', 'test-1' )
 		);
 		expect( getEntityRecord ).not.toHaveBeenCalled();
 
@@ -152,7 +151,7 @@ describe( 'receiveEntityRecord', () => {
 		await runPromise(
 			registry
 				.dispatch( 'test/resolution' )
-				.getEntityRecord( 'root', 'template', 'test-2' )
+				.getEntityRecord( 'root', 'taxonomy', 'test-2' )
 		);
 		expect( getEntityRecord ).toHaveBeenCalled();
 	} );

--- a/packages/core-data/src/test/integration.js
+++ b/packages/core-data/src/test/integration.js
@@ -6,11 +6,10 @@ import { createRegistry, controls } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { receiveEntityRecords } from '../actions';
+import * as actions from '../actions';
 import * as selectors from '../selectors';
 import * as resolvers from '../resolvers';
-import * as locksActions from '../locks/actions';
-import * as locksSelectors from '../locks/selectors';
+import { storeConfig as coreStoreConfig } from '../';
 
 // Mock to prevent calling window.fetch in test environment
 jest.mock( '@wordpress/data-controls', () => {
@@ -20,7 +19,23 @@ jest.mock( '@wordpress/data-controls', () => {
 		apiFetch: jest.fn(),
 	};
 } );
+const { apiFetch: actualApiFetch } = jest.requireActual(
+	'@wordpress/data-controls'
+);
 import { apiFetch } from '@wordpress/data-controls';
+
+jest.mock( '@wordpress/api-fetch', () => {
+	return {
+		__esModule: true,
+		default: jest.fn(),
+	};
+} );
+import triggerFetch from '@wordpress/api-fetch';
+
+const runPromise = async ( promise ) => {
+	jest.runAllTimers();
+	await promise;
+};
 
 describe( 'receiveEntityRecord', () => {
 	function createTestRegistry( getEntityRecord ) {
@@ -30,22 +45,10 @@ describe( 'receiveEntityRecord', () => {
 				data: {},
 			},
 		};
-		registry.registerStore( 'core', {
-			actions: {
-				...locksActions,
-			},
-			selectors: {
-				getEntitiesByKind: () => [
-					{ name: 'postType', kind: 'root', baseURL: '/wp/v2/types' },
-					{ name: 'postType', kind: 'root', baseURL: '/wp/v2/types' },
-				],
-				...locksSelectors,
-			},
-			reducer: () => ( { locks: { requests: [], children: {} } } ),
-		} );
+		registry.registerStore( 'core', coreStoreConfig );
 		registry.registerStore( 'test/resolution', {
 			actions: {
-				receiveEntityRecords,
+				receiveEntityRecords: actions.receiveEntityRecords,
 				*getEntityRecords( ...args ) {
 					return yield controls.resolveSelect(
 						'test/resolution',
@@ -76,16 +79,13 @@ describe( 'receiveEntityRecord', () => {
 		return registry;
 	}
 
-	const runPromise = async ( promise ) => {
-		jest.runAllTimers();
-		await promise;
-	};
-
 	beforeEach( async () => {
+		apiFetch.mockReset();
+		triggerFetch.mockReset();
 		jest.useFakeTimers();
 	} );
 
-	it( 'should not trigger a resolver when the requested record is available via receiveEntityRecords.', async () => {
+	it( 'should not trigger a resolver when the requested record is available via receiveEntityRecords (default entity key).', async () => {
 		const getEntityRecord = jest.fn();
 		const registry = createTestRegistry( getEntityRecord );
 
@@ -98,8 +98,9 @@ describe( 'receiveEntityRecord', () => {
 				.dispatch( 'test/resolution' )
 				.getEntityRecords( 'root', 'postType' )
 		);
+		jest.runAllTimers();
 
-		// Select record with id = 2, it is available and should trigger the resolver
+		// Select record with id = 2, it is available and should not trigger the resolver
 		await runPromise(
 			registry
 				.dispatch( 'test/resolution' )
@@ -107,12 +108,147 @@ describe( 'receiveEntityRecord', () => {
 		);
 		expect( getEntityRecord ).not.toHaveBeenCalled();
 
-		// Select record with id = 4, it is not available and should not trigger the resolver
+		// Select record with id = 4, it is not available and should trigger the resolver
 		await runPromise(
 			registry
 				.dispatch( 'test/resolution' )
 				.getEntityRecord( 'root', 'postType', 4 )
 		);
 		expect( getEntityRecord ).toHaveBeenCalled();
+	} );
+
+	it( 'should not trigger a resolver when the requested record is available via receiveEntityRecords (non-default entity key).', async () => {
+		const getEntityRecord = jest.fn();
+		const registry = createTestRegistry( getEntityRecord );
+
+		// Trigger resolution of postType records
+		apiFetch.mockImplementation( () => ( {
+			'test-1': { slug: 'test-1', id: 2 },
+		} ) );
+		await runPromise(
+			registry
+				.dispatch( 'test/resolution' )
+				.getEntityRecords( 'root', 'template' )
+		);
+		jest.runAllTimers();
+
+		// Select record with id = 2, it is available and should not trigger the resolver
+		await runPromise(
+			registry
+				.dispatch( 'test/resolution' )
+				.getEntityRecord( 'root', 'template', 'test-1' )
+		);
+		expect( getEntityRecord ).not.toHaveBeenCalled();
+
+		// Select record with id = 4, it is not available and should trigger the resolver
+		await runPromise(
+			registry
+				.dispatch( 'test/resolution' )
+				.getEntityRecord( 'root', 'template', 'test-2' )
+		);
+		expect( getEntityRecord ).toHaveBeenCalled();
+	} );
+} );
+
+describe( 'saveEntityRecord', () => {
+	function createTestRegistry() {
+		const registry = createRegistry();
+		registry.registerStore( 'core', coreStoreConfig );
+		return registry;
+	}
+
+	beforeEach( async () => {
+		apiFetch.mockReset();
+		triggerFetch.mockReset();
+		jest.useFakeTimers( 'modern' );
+	} );
+
+	it( 'should not trigger any GET requests until POST/PUT is finished.', async () => {
+		const registry = createTestRegistry();
+		// Fetch post types from the API {{{
+		apiFetch.mockImplementation( () => ( {
+			'post-1': { slug: 'post-1' },
+		} ) );
+
+		// Trigger fetch
+		registry.select( 'core' ).getEntityRecords( 'root', 'postType' );
+		jest.runAllTimers();
+		await Promise.resolve().then( () => jest.runAllTimers() );
+		expect( apiFetch ).toBeCalledTimes( 1 );
+		expect( apiFetch ).toBeCalledWith( {
+			path: '/wp/v2/types?context=edit',
+		} );
+
+		// Select fetched results, there should be no subsequent request
+		apiFetch.mockReset();
+		const results = registry
+			.select( 'core' )
+			.getEntityRecords( 'root', 'postType' );
+		expect( apiFetch ).toBeCalledTimes( 0 );
+		jest.runAllTimers();
+		expect( apiFetch ).toBeCalledTimes( 0 );
+		expect( results ).toHaveLength( 1 );
+		expect( results[ 0 ].slug ).toBe( 'post-1' );
+		// }}} Fetch post types from the API
+
+		// Save changes
+		apiFetch.mockClear();
+		apiFetch.mockImplementation( actualApiFetch );
+		let resolvePromise;
+		triggerFetch.mockImplementation( function () {
+			return new Promise( ( resolve ) => {
+				resolvePromise = resolve;
+			} );
+		} );
+		const savePromise = registry
+			.dispatch( 'core' )
+			.saveEntityRecord( 'root', 'postType', {
+				slug: 'post-1',
+				newField: 'a',
+			} );
+		jest.runAllTimers();
+
+		// There should ONLY be a single hanging API call (PUT) by this point.
+		// If there have been any other requests, it is a race condition of some sorts,
+		// e.g. a resolution was triggered before the save was finished.
+		expect( triggerFetch ).toBeCalledTimes( 1 );
+		expect( triggerFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				method: 'PUT',
+				path: '/wp/v2/types/post-1',
+				data: expect.objectContaining( {
+					newField: 'a',
+					slug: 'post-1',
+				} ),
+			} )
+		);
+		triggerFetch.mockClear();
+		apiFetch.mockClear();
+
+		// The PUT is still hanging, let's call a selector now and make sure it won't trigger
+		// any requests
+		registry.select( 'core' ).getEntityRecords( 'root', 'postType' );
+		jest.runAllTimers();
+		expect( triggerFetch ).toBeCalledTimes( 0 );
+
+		// Now that all timers are exhausted, let's resolve the PUT request and wait until the
+		// save is complete
+		resolvePromise( { newField: 'a', slug: 'post-1' } );
+
+		// Run selector and make sure it doesn't trigger any requests just yet
+		registry.select( 'core' ).getEntityRecords( 'root', 'postType' );
+		jest.runAllTimers();
+		expect( triggerFetch ).toBeCalledTimes( 0 );
+
+		const newRecord = await savePromise;
+		expect( newRecord ).toEqual( { newField: 'a', slug: 'post-1' } );
+		// There should be no other API calls just because saving succeeded
+		jest.runAllTimers();
+		expect( triggerFetch ).toBeCalledTimes( 0 );
+
+		// Calling a selector after the save is finished should trigger a GET request
+		registry.select( 'core' ).getEntityRecords( 'root', 'postType' );
+		jest.runAllTimers();
+		expect( triggerFetch ).toBeCalledTimes( 1 );
 	} );
 } );

--- a/packages/core-data/src/test/integration.js
+++ b/packages/core-data/src/test/integration.js
@@ -37,6 +37,13 @@ const runPromise = async ( promise ) => {
 	await promise;
 };
 
+const runPendingPromises = async () => {
+	jest.runAllTimers();
+	const p = new Promise( ( resolve ) => setTimeout( resolve ) );
+	jest.runAllTimers();
+	await p;
+};
+
 describe( 'receiveEntityRecord', () => {
 	function createTestRegistry( getEntityRecord ) {
 		const registry = createRegistry();
@@ -99,6 +106,7 @@ describe( 'receiveEntityRecord', () => {
 				.getEntityRecords( 'root', 'postType' )
 		);
 		jest.runAllTimers();
+		await runPendingPromises();
 
 		// Select record with id = 2, it is available and should not trigger the resolver
 		await runPromise(
@@ -206,7 +214,7 @@ describe( 'saveEntityRecord', () => {
 				slug: 'post-1',
 				newField: 'a',
 			} );
-		jest.runAllTimers();
+		await runPendingPromises();
 
 		// There should ONLY be a single hanging API call (PUT) by this point.
 		// If there have been any other requests, it is a race condition of some sorts,
@@ -248,7 +256,7 @@ describe( 'saveEntityRecord', () => {
 
 		// Calling the selector after the save is finished should trigger a resolver and a GET request
 		registry.select( 'core' ).getEntityRecords( 'root', 'postType' );
-		jest.runAllTimers();
+		await runPendingPromises();
 		expect( triggerFetch ).toBeCalledTimes( 1 );
 		expect( triggerFetch ).toBeCalledWith( {
 			path: '/wp/v2/types?context=edit',

--- a/packages/data-controls/src/index.js
+++ b/packages/data-controls/src/index.js
@@ -109,9 +109,7 @@ export const awaitPromise = function ( promise ) {
  * store.
  */
 export const controls = {
-	AWAIT_PROMISE: async ( { promise } ) => {
-		return await promise;
-	},
+	AWAIT_PROMISE: ( { promise } ) => promise,
 	API_FETCH( { request } ) {
 		return triggerFetch( request );
 	},


### PR DESCRIPTION
## Description
Following up on https://github.com/WordPress/gutenberg/pull/26627#issuecomment-721043279, this PR adds more tests to make sure the code won't regress over time. Writing these tests I also caught an issue with entity key resolution - it always used `id` instead of the correct one for given entity. Fix and test case are included in this PR.

cc @youknowriad 

## How has this been tested?
Confirm all the tests pass

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
