### PR TITLE
Windows: Use wp-env instead of file location

### DIFF
--- a/package.json
+++ b/package.json
@@ -267,7 +267,7 @@
 		"playground:build": "npm run storybook:build",
 		"playground:dev": "echo \"Please use storybook:dev instead.\"",
 		"env": "wp-scripts env",
-		"wp-env": "packages/env/bin/wp-env"
+		"wp-env": "wp-env"
 	},
 	"husky": {
 		"hooks": {


### PR DESCRIPTION

## Description

The `wp-env` command in package.json points to `packages/env/bin/wp-env` 

This does not work when running: `npm run wp-env CMD` on Windows.

```
> npm run wp-env stop

> gutenberg@9.3.0-rc.1 wp-env C:\Users\mkaz\src\wp\gutenberg
> packages/env/bin/wp-env "stop"

'packages' is not recognized as an internal or external command,
operable program or batch file.
npm ERR! code ELIFECYCLE
```

Changing to `wp-env` will use the proper npm binary location for the package.

## How has this been tested?

1. Run `npm run wp-env stop` on Windows (not WSL). Confirm error.

2. Apply patch, run command again, confirm it works.


## Types of changes

Updates wp-env command in package.json

