### PR TITLE
Update Query block's toolbar settings

### DIFF
--- a/packages/block-library/src/query/edit/query-toolbar.js
+++ b/packages/block-library/src/query/edit/query-toolbar.js
@@ -5,7 +5,6 @@ import {
 	ToolbarGroup,
 	Dropdown,
 	ToolbarButton,
-	RangeControl,
 	BaseControl,
 	__experimentalNumberControl as NumberControl,
 } from '@wordpress/components';
@@ -29,7 +28,7 @@ export default function QueryToolbar( { query, setQuery } ) {
 						<BaseControl>
 							<NumberControl
 								__unstableInputWidth="60px"
-								label={ __( 'Items per Page' ) }
+								label={ __( 'Items per page' ) }
 								labelPosition="edge"
 								min={ 1 }
 								max={ 100 }
@@ -44,7 +43,7 @@ export default function QueryToolbar( { query, setQuery } ) {
 						<BaseControl>
 							<NumberControl
 								__unstableInputWidth="60px"
-								label={ __( 'Offset' ) }
+								label={ __( 'Offset the first item' ) }
 								labelPosition="edge"
 								min={ 0 }
 								max={ 100 }
@@ -54,17 +53,6 @@ export default function QueryToolbar( { query, setQuery } ) {
 								step="1"
 								value={ query.offset }
 								isDragEnabled={ false }
-							/>
-						</BaseControl>
-						<BaseControl>
-							<RangeControl
-								label={ __( 'Number of Pages' ) }
-								min={ 1 }
-								allowReset
-								value={ query.pages }
-								onChange={ ( value ) =>
-									setQuery( { pages: value ?? -1 } )
-								}
 							/>
 						</BaseControl>
 					</>


### PR DESCRIPTION
See #26550. Removes number of pages from toolbar. 
Aligns input labels with design direction. 
Still need to include Pagination block by default. Without the "number of pages" input, we can't get the Pagination block to show correctly, so this will need to be fixed by including the block by default.
Also need to include helper text for the "Offset" input.

cc @ntsekouras 

## How has this been tested?
Tested locally. 

## Screenshots 

**Before**
![Screen Shot 2020-11-03 at 1 45 58 PM](https://user-images.githubusercontent.com/617986/98043931-ed862680-1dda-11eb-891e-d864c2252c58.png)

**After**
![Screen Shot 2020-11-03 at 1 46 43 PM](https://user-images.githubusercontent.com/617986/98043990-07276e00-1ddb-11eb-9034-5044d321991b.png)



## Types of changes
Removed rangeControl from toolbar settings.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
