### PR TITLE
Gallery: Remove caption fallback for alt attribute

### DIFF
--- a/packages/block-library/src/gallery/save.js
+++ b/packages/block-library/src/gallery/save.js
@@ -40,7 +40,7 @@ export default function save( { attributes } ) {
 					const img = (
 						<img
 							src={ image.url }
-							alt={ image.alt !== '' ? image.alt : image.caption }
+							alt={ image.alt }
 							data-id={ image.id }
 							data-full-url={ image.fullUrl }
 							data-link={ image.link }


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/26549.
Alternative to https://github.com/WordPress/gutenberg/pull/26574, which is somewhat controversial (see [discussion](https://github.com/WordPress/gutenberg/pull/26574#discussion_r516429003)).
Effectively reverts #26082. Might require a follow-up for improved a11y.

## Description
When a gallery image's `alt` attribute value is empty, we use what's in the `caption` prop to fill it out. The issue is that `caption` can contain links, whereas the `alt` attribute should not contain any HTML. This PR removes the fallback -- if the image has no `alt` text set, the `alt` attribute will be empty.

## How has this been tested?
Manually:
1. Add the Image Gallery block.
2. Add some images.
3. Fill the caption with some text and a link.
4. Preview the site and inspect the image element.
5. See that the `alt` attribute is empty.

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.