### PR TITLE
Revert "Fix #22892 and print classnames in spacer block on editor sid…

### DIFF
--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -23,7 +23,6 @@ const SpacerEdit = ( {
 	setAttributes,
 	onResizeStart,
 	onResizeStop,
-	className,
 } ) => {
 	const [ isResizing, setIsResizing ] = useState( false );
 	const { height } = attributes;
@@ -53,7 +52,6 @@ const SpacerEdit = ( {
 			<View { ...useBlockProps() }>
 				<ResizableBox
 					className={ classnames(
-						className,
 						'block-library-spacer__resize-container',
 						{
 							'is-selected': isSelected,


### PR DESCRIPTION
This reverts #23235 as this PR is not needed anymore per this comment https://github.com/WordPress/gutenberg/pull/23235#issuecomment-721043962