### PR TITLE
Update material lib to v1.2.1

### DIFF
--- a/packages/react-native-bridge/android/build.gradle
+++ b/packages/react-native-bridge/android/build.gradle
@@ -146,7 +146,7 @@ dependencies {
     // For animated GIF support
     implementation 'com.facebook.fresco:animated-gif:2.0.0'
 
-    implementation 'com.google.android.material:material:1.1.0'
+    implementation 'com.google.android.material:material:1.2.1'
 
     if (rootProject.ext.buildGutenbergFromSource) {
         println "using gutenberg from source"


### PR DESCRIPTION
## Description
This PR updates material library version from 1.1.0 to 1.2.1. 

## How has this been tested?
I've tested several flows in WPAndroid including adding images, adding videos, adding other blocks, basic navigation and more. WPAndroid was using v 1.2.0 through a transitive dependency for some time so the udpate from 1.2.0->1.2.1 is minor ([here is a change list](https://github.com/material-components/material-components-android/releases/tag/1.2.1)).

I've tested the changes on an Emulator api 30 and api 28.

## Types of changes
Library update -> it's not a breaking change. WPAndroid will use v1.2.1 no matter what is specified in this repo.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
