### PR TITLE
Try: Use currentColor to design quote blocks

### DIFF
--- a/packages/block-library/src/pullquote/theme.scss
+++ b/packages/block-library/src/pullquote/theme.scss
@@ -1,25 +1,15 @@
 .wp-block-pullquote {
-	border-top: 4px solid #555;
-	border-bottom: 4px solid #555;
+	border-top: 4px solid currentColor;
+	border-bottom: 4px solid currentColor;
 	margin-bottom: 1.75em;
-	color: #555;
-
-	.is-dark-theme & {
-		border-top: 4px solid $light-gray-placeholder;
-		border-bottom: 4px solid $light-gray-placeholder;
-		color: $light-gray-placeholder;
-	}
+	color: currentColor;
 
 	cite,
 	footer,
 	&__citation {
-		color: #555;
+		color: currentColor;
 		text-transform: uppercase;
 		font-size: 0.8125em;
 		font-style: normal;
-
-		.is-dark-theme & {
-			color: $light-gray-placeholder;
-		}
 	}
 }

--- a/packages/block-library/src/quote/theme.scss
+++ b/packages/block-library/src/quote/theme.scss
@@ -1,29 +1,21 @@
 .wp-block-quote {
-	border-left: 0.25em solid $black;
+	border-left: 0.25em solid currentColor;
 	margin: 0 0 1.75em 0;
 	padding-left: 1em;
-
-	.is-dark-theme & {
-		border-left: 0.25em solid $light-gray-placeholder;
-	}
 
 	cite,
 	footer,
 	&__citation {
-		color: #555;
+		color: currentColor;
 		font-size: 0.8125em;
 		margin-top: 1em;
 		position: relative;
 		font-style: normal;
-
-		.is-dark-theme & {
-			color: $light-gray-placeholder;
-		}
 	}
 
 	&.has-text-align-right {
 		border-left: none;
-		border-right: 0.25em solid $black;
+		border-right: 0.25em solid currentColor;
 		padding-left: 0;
 		padding-right: 1em;
 	}


### PR DESCRIPTION
This PR reverts changes in #26510 and resurrects changes in #25358. It changes Quote and Pullquote blocks to use `currentColor` to colorize both the content and citation fields, ensuring that it's legible in the editor, and on the frontend:

![currentcolor](https://user-images.githubusercontent.com/1204802/98091669-03045a80-1e86-11eb-912d-4ea0cd42758e.gif)

There is also #26686 as an alternative to this one. The benefit of this PR is that it fixes both the issue with input field placeholder legibility, and also makes both quote blocks more useful in dark themes. 
