### PR TITLE
Try: Use placeholder state to ensure legibility of quote block citation

### DIFF
--- a/packages/block-library/src/pullquote/editor.scss
+++ b/packages/block-library/src/pullquote/editor.scss
@@ -29,3 +29,8 @@
 .wp-block-pullquote .wp-block-pullquote__citation {
 	color: inherit;
 }
+
+// Colorize the placeholder state to be legible.
+.is-dark-theme [data-type="core/pullquote"] [data-rich-text-placeholder] {
+	color: $white;
+}

--- a/packages/block-library/src/pullquote/theme.scss
+++ b/packages/block-library/src/pullquote/theme.scss
@@ -4,12 +4,6 @@
 	margin-bottom: 1.75em;
 	color: #555;
 
-	.is-dark-theme & {
-		border-top: 4px solid $light-gray-placeholder;
-		border-bottom: 4px solid $light-gray-placeholder;
-		color: $light-gray-placeholder;
-	}
-
 	cite,
 	footer,
 	&__citation {
@@ -17,9 +11,5 @@
 		text-transform: uppercase;
 		font-size: 0.8125em;
 		font-style: normal;
-
-		.is-dark-theme & {
-			color: $light-gray-placeholder;
-		}
 	}
 }

--- a/packages/block-library/src/quote/editor.scss
+++ b/packages/block-library/src/quote/editor.scss
@@ -1,3 +1,7 @@
 .wp-block-quote__citation {
 	font-size: $default-font-size;
 }
+
+.is-dark-theme .wp-block-quote__citation ::placeholder {
+	color: $light-gray-placeholder;
+}

--- a/packages/block-library/src/quote/theme.scss
+++ b/packages/block-library/src/quote/theme.scss
@@ -3,10 +3,6 @@
 	margin: 0 0 1.75em 0;
 	padding-left: 1em;
 
-	.is-dark-theme & {
-		border-left: 0.25em solid $light-gray-placeholder;
-	}
-
 	cite,
 	footer,
 	&__citation {
@@ -15,10 +11,6 @@
 		margin-top: 1em;
 		position: relative;
 		font-style: normal;
-
-		.is-dark-theme & {
-			color: $light-gray-placeholder;
-		}
 	}
 
 	&.has-text-align-right {
@@ -37,4 +29,9 @@
 	&.is-large {
 		border: none;
 	}
+}
+
+// Colorize the placeholder state to be legible.
+.is-dark-theme [data-type="core/quote"] [data-rich-text-placeholder] {
+	color: $white;
 }


### PR DESCRIPTION
Alternative to #26684, which is probably less impactful. 

Changes the placeholder colors in quote block input fields, so that they are legible in themes that register themselves as dark:

![placeholder](https://user-images.githubusercontent.com/1204802/98093381-27613680-1e88-11eb-835a-2202165a1905.gif)

We should only merge one of the two PRs. This one has the benefit of fixing the issue without changing any of the quote block CSS that is possibly in wide usage at the moment. The downside is, and as is also highlighted by the initial ticket, the opinionated styles for both quotes simply don't work very well in dark themes. 