### PR TITLE
Updating some native mobile UI tests

### DIFF
--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-paragraph.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-paragraph.test.js
@@ -9,7 +9,6 @@ import {
 	clickMiddleOfElement,
 	clickBeginningOfElement,
 	stopDriver,
-	swipeUp,
 	isAndroid,
 } from './helpers/utils';
 import testData from './helpers/test-data';

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-paragraph.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-paragraph.test.js
@@ -163,7 +163,6 @@ describe( 'Gutenberg Editor tests for Paragraph Block', () => {
 		await editorPage.sendTextToParagraphBlock( 1, testData.longText );
 
 		for ( let i = 3; i > 0; i-- ) {
-			await swipeUp( driver );
 			await editorPage.removeBlockAtPosition( paragraphBlockName, i );
 		}
 	} );

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-paste.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-paste.test.js
@@ -69,6 +69,10 @@ describe( 'Gutenberg Editor paste tests', () => {
 
 		// create another paragraph block
 		await editorPage.addNewBlock( paragraphBlockName );
+		if ( isAndroid() ) {
+			// On Andrdoid 10 a new auto-suggestion popup is appearing to let the user paste text recently put in the clipboard. Let's dismiss it.
+			await editorPage.dismissAndroidClipboardSmartSuggestion();
+		}
 		const paragraphBlockElement2 = await editorPage.getBlockAtPosition(
 			paragraphBlockName,
 			2
@@ -110,6 +114,10 @@ describe( 'Gutenberg Editor paste tests', () => {
 
 		// create another paragraph block
 		await editorPage.addNewBlock( paragraphBlockName );
+		if ( isAndroid() ) {
+			// On Andrdoid 10 a new auto-suggestion popup is appearing to let the user paste text recently put in the clipboard. Let's dismiss it.
+			await editorPage.dismissAndroidClipboardSmartSuggestion();
+		}
 		const paragraphBlockElement2 = await editorPage.getBlockAtPosition(
 			paragraphBlockName,
 			2

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -167,6 +167,20 @@ export default class EditorPage {
 		await hideKeyboardToolbarButton.click();
 	}
 
+	async dismissAndroidClipboardSmartSuggestion() {
+		if ( ! isAndroid() ) {
+			return;
+		}
+
+		const dismissClipboardSmartSuggestionLocator = `//*[@${ this.accessibilityIdXPathAttrib }="Dismiss Smart Suggestion"]`;
+		const smartSuggestions = await this.driver.elementsByXPath(
+			dismissClipboardSmartSuggestionLocator
+		);
+		if ( smartSuggestions.length !== 0 ) {
+			smartSuggestions[ 0 ].click();
+		}
+	}
+
 	// =========================
 	// Block toolbar functions
 	// =========================


### PR DESCRIPTION
## Description
PR to update some native mobile UI tests that fail locally.

## How has this been tested?
Locally on an Android 10 device (Pixel 2 XL) via issuing `npm run test:e2e:android:local` and on an iOS v14.1 simulator via `npm run test:e2e:ios:local`.

## Types of changes
* swipeUp not needed; performed via removeBlockAtPosition on Android
* **Dismissing** Android 10's clipboard paste auto-suggestion popup so the test can continue as it was. Here's a screenshot of how that popup looks:

<img src="https://user-images.githubusercontent.com/1032913/98236281-c874ed80-1f6b-11eb-9080-0161f511a8fa.jpg" width="300px"/>
The updated code is dismissing the popup by looking for the `Dismiss Smart Suggestion` content-description and tapping on it.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
