### PR TITLE
Throttle useSelect calls

### DIFF
--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -192,8 +192,11 @@ export default function useSelect( _mapSelect, deps ) {
 		} );
 
 		return () => {
-			clearTimeout( throttleRef.current );
-			throttleRef.current = null;
+			if ( throttleRef.current ) {
+				clearTimeout( throttleRef.current );
+				throttleRef.current = null;
+				onStoreChange();
+			}
 			isMountedAndNotUnsubscribing.current = false;
 			unsubscribe();
 			renderQueue.flush( queueContext );

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -193,6 +193,7 @@ export default function useSelect( _mapSelect, deps ) {
 
 		return () => {
 			clearTimeout( throttleRef.current );
+			throttleRef.current = null;
 			isMountedAndNotUnsubscribing.current = false;
 			unsubscribe();
 			renderQueue.flush( queueContext );

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -161,6 +161,10 @@ export default function useSelect( _mapSelect, deps ) {
 			}
 		};
 
+		// A single dispatch() call may cause multiple store changes in a very brief
+		// period of time. There is little value in recomputing selector in response
+		// to every atomic update. Throttling ensures this doesn't happen more often
+		// than once in THROTTLE_MS milliseconds.
 		const throttledOnStoreChange = () => {
 			if ( throttleRef.current ) {
 				return;


### PR DESCRIPTION
## Description
I added a `console.log` statement to `onStoreChange();` and opened the post editor. Then, I typed a _single letter_:

<img width="236" alt="Zrzut ekranu 2020-11-4 o 16 10 41" src="https://user-images.githubusercontent.com/205419/98128603-627b5e00-1eb8-11eb-803f-81c71240451d.png">

Uh-oh!

Then I did the same with this PR applied:

<img width="177" alt="Zrzut ekranu 2020-11-4 o 16 15 30" src="https://user-images.githubusercontent.com/205419/98129084-fea56500-1eb8-11eb-8fdc-e981ee4d71b1.png">

Still not perfect, but much better!

## How has this been tested?
Confirm all the tests pass

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
