### PR TITLE
Navigation block: Fix the text color for links in the navigation block

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -1,7 +1,7 @@
 // Default background and font color
 .wp-block-navigation:not(.has-background) .wp-block-navigation__container {
 	.wp-block-navigation-link:not(.has-text-color) {
-		color: $gray-900;
+		color: inherit;
 	}
 	.wp-block-navigation__container {
 		background-color: $white;

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -1,9 +1,7 @@
 // Default background and font color
 .wp-block-navigation:not(.has-background) .wp-block-navigation__container {
-	.wp-block-navigation-link:not(.has-text-color) {
-		color: inherit;
-	}
 	.wp-block-navigation__container {
+		color: $gray-900;
 		background-color: $white;
 	}
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This fixes the color of links inside the navigation block. On the front end the navigation links inherit their color, so they should in the editor too.

There's an underlying issue which I can't get to the bottom of here. In the editor the `li` elements have the class `wp-block-navigation-link` but in the output they don't. I think we should add this but I haven't yet worked out how...

## How has this been tested?
Locally with the latest Gutenburg and the Rivington theme.

## Screenshots <!-- if applicable -->
Before:
<img width="830" alt="Screenshot 2020-11-04 at 15 29 52" src="https://user-images.githubusercontent.com/275961/98135256-85f1d900-1eb7-11eb-941e-38a55404020b.png">

After:
<img width="821" alt="Screenshot 2020-11-04 at 15 29 40" src="https://user-images.githubusercontent.com/275961/98135266-88543300-1eb7-11eb-9e23-fa8b0b54676c.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
