### PR TITLE
Site Editor: Replace incorrect `find` with `filter` in the sidebar

### DIFF
--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/templates-posts.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/templates-posts.js
@@ -23,7 +23,7 @@ import {
 } from '../constants';
 
 export default function TemplatesPostsMenu( { templates } ) {
-	const generalTemplates = templates?.find( ( { slug } ) =>
+	const generalTemplates = templates?.filter( ( { slug } ) =>
 		TEMPLATES_POSTS.includes( slug )
 	);
 	const specificTemplates = templates?.filter( ( { slug } ) =>


### PR DESCRIPTION
## Description

This PR fixes what appears to be a simple copy-paste typo (compare it to the [templates pages menu](https://github.com/WordPress/gutenberg/blob/09d43d6b0f6bb795bd974079352483af208680bc/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/templates-pages.js#L22)).

Using `find` on a dynamically fetched list can produce unexpected behaviour (on top of returning the incorrect value), which propagates to the rendered `map`, causing plenty of duplicated keys (e.g. `wp_template-undefined`).

## How has this been tested?

- Open the Site Editor, and open the browser console.
- The sidebar should be mounted and its content loaded behind the scenes, but just to be sure, try opening it anyway.
- Check that there are no "duplicated key" errors reported inside `NavigationGroup`.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
