### PR TITLE
Fix: Font size picker does not correctly handles big font sizes.

### DIFF
--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -21,6 +21,7 @@ import VisuallyHidden from '../visually-hidden';
 
 const DEFAULT_FONT_SIZE = 'default';
 const CUSTOM_FONT_SIZE = 'custom';
+const MAX_FONT_SIZE_DISPLAY = '25px';
 
 function getSelectValueFromFontSize( fontSizes, value ) {
 	if ( value ) {
@@ -45,7 +46,9 @@ function getSelectOptions( optionsArray, disableCustomFontSizes ) {
 		key: option.slug,
 		name: option.name,
 		size: option.size,
-		style: { fontSize: option.size },
+		style: {
+			fontSize: `min( ${ option.size }, ${ MAX_FONT_SIZE_DISPLAY } )`,
+		},
 	} ) );
 }
 


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/25862

Makes the font size picker selector not render any font size with a size bigger than 25px.

Before:
![image](https://user-images.githubusercontent.com/11271197/98154562-e3445500-1ecc-11eb-8a0b-8b22f2961040.png)

After:

![image](https://user-images.githubusercontent.com/11271197/98154609-f1927100-1ecc-11eb-9a8f-7d921fdfd51d.png)
