### PR TITLE
Fix: Preset colors don't work on button block style outline

### DIFF
--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -73,11 +73,15 @@ $blocks-button__height: 3.1em;
 
 .is-style-outline > .wp-block-button__link,
 .wp-block-button__link.is-style-outline {
-	background-color: transparent;
 	border: 2px solid;
 }
 
 .is-style-outline > .wp-block-button__link:not(.has-text-color),
 .wp-block-button__link.is-style-outline:not(.has-text-color) {
 	color: #32373c;
+}
+
+.is-style-outline > .wp-block-button__link:not(.has-background),
+.wp-block-button__link.is-style-outline:not(.has-background) {
+	background-color: transparent;
 }


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/24625

## How has this been tested?
I added a buttons block.
I set the style of the button to outline.
I added a preset background color and a preset text color.
I published the post and verified on the frontend of the website the colors appear as expected. (on master they don't appear).