### PR TITLE
Full Site Editing: Use template and template parts entities titles

### DIFF
--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -135,9 +135,13 @@ function* loadPostTypeEntities() {
 			mergedEdits: { meta: true },
 			getTitle( record ) {
 				if ( [ 'wp_template_part', 'wp_template' ].includes( name ) ) {
-					return startCase( record.slug );
+					return (
+						record?.title?.rendered ||
+						record?.title ||
+						startCase( record.slug )
+					);
 				}
-				return record?.title?.renderd || record?.title || record.id;
+				return record?.title?.rendered || record?.title || record.id;
 			},
 		};
 	} );

--- a/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-editing.test.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { kebabCase } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import {
@@ -186,7 +181,7 @@ describe( 'Multi-entity editor states', () => {
 			await trashAllPosts( 'wp_template_part' );
 			await createNewPost( {
 				postType: 'wp_template',
-				title: kebabCase( templateName ),
+				title: templateName,
 			} );
 			await publishPost();
 			await createTemplatePart( templatePartName );


### PR DESCRIPTION
## Description

Update the `getTitle` function used when making changes to entities so that `wp_template` and `wp_template_part` entities follow roughly the same logic of any other entity, and attempt to return the title before falling back to their identifier.

The major difference is that templates and template parts rely on the `slug` as identifier, so we use that as fallback instead of the `id`.

The PR also fixes a typo introduced in #26653 ("renderd" instead of "rendered").

### Note

I've tried this for a while, and apparently no entity have `title.rendered`, so they all just use the simple `title`.
Is this as intended? Am I missing something essential?

## How has this been tested?

- Open the Site Editor and start doing changes all over the place.
  - Select a template part block, and change it.
  - Try to modify the template itself (make sure you're not modifying an inner block of a template part block).
  - From the sidebar, select a content, e.g. a page, and modify it as well.
- Click on the "Update Design" button, and then on "Review Changes".
- Check that all the modified entities show up in the changes list.
- Make sure they all use the relevant titles, instead of falling back to their identifier.
  - Note: for templates and template parts it's very likely that their `title` is identical to their `startCase( slug )`, making this harder to double check.

## Types of changes
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
