### PR TITLE
Fix improper e2e assertion in template-part.test

### DIFF
--- a/packages/e2e-tests/specs/experiments/template-part.test.js
+++ b/packages/e2e-tests/specs/experiments/template-part.test.js
@@ -65,9 +65,9 @@ describe( 'Template Part', () => {
 
 			// Verify that the header template part is updated.
 			const [ headerTemplatePart ] = await page.$x(
-				'//*[@data-type="core/template-part"][//p[text()="Header Template Part123"]]'
+				'//*[@data-type="core/template-part"][//p[text()="Header Template Part 123"]]'
 			);
-			expect( headerTemplatePart ).not.toBeNull();
+			expect( headerTemplatePart ).not.toBeUndefined();
 		} );
 	} );
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
There are two problems here.
1. The test adds text "Header Template Part 123" but checks for text "Header Template Part123".
2. This `expect` checks whether or not the item destructured from the array results are not `null`.   An item destructured from an empty array is `undefined` (which indeed is not `null` and is why this test never failed previously due to item 1.)

I think the check part 1 was originally correct when this was used long in the past and we only added "123" to the existing demo template part at the time.  However, it seems problem 2 has existed since this test was originally implemented months ago.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
