### PR TITLE
Tweak some menu items.

### DIFF
--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -40,6 +40,7 @@ $tree-item-height: 36px;
 		color: $gray-900;
 		border-radius: 2px;
 		position: relative;
+		white-space: nowrap;
 
 		&.is-dropping-before::before {
 			content: "";

--- a/packages/edit-site/src/components/header/document-actions/style.scss
+++ b/packages/edit-site/src/components/header/document-actions/style.scss
@@ -67,4 +67,5 @@
 
 .edit-site-document-actions__info-dropdown > .components-popover__content > div {
 	padding: 0;
+	min-width: 240px;
 }


### PR DESCRIPTION
In #25218 I removed the `min-width` that's applied to popovers. This allows the popover to scale to the content inside and behave more predictably.

In a few cases that had relied on this min-width, that caused some sub-optimal text wrapping:

<img width="185" alt="Screenshot 2020-11-05 at 10 13 54" src="https://user-images.githubusercontent.com/1204802/98222164-c2254800-1f50-11eb-9ef0-5f776ca8bc33.png">

<img width="237" alt="Screenshot 2020-11-05 at 10 14 12" src="https://user-images.githubusercontent.com/1204802/98222197-cbaeb000-1f50-11eb-85e9-e594829eda09.png">

This PR fixes that:

<img width="360" alt="Screenshot 2020-11-05 at 10 19 49" src="https://user-images.githubusercontent.com/1204802/98222202-ce110a00-1f50-11eb-9c8d-2f78f0b68894.png">

<img width="275" alt="Screenshot 2020-11-05 at 10 20 02" src="https://user-images.githubusercontent.com/1204802/98222210-cf423700-1f50-11eb-9a34-2c6075bb630a.png">
