### PR TITLE
[RNMobile] Fix padding bottom in inserter

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.native.js
+++ b/packages/block-editor/src/components/inserter/menu.native.js
@@ -137,10 +137,7 @@ export class InserterMenu extends Component {
 			>
 				<TouchableHighlight accessible={ false }>
 					<BottomSheetConsumer>
-						{ ( {
-							listProps,
-							safeAreaBottomInset = styles.list.paddingBottom,
-						} ) => (
+						{ ( { listProps, safeAreaBottomInset } ) => (
 							<FlatList
 								onLayout={ this.onLayout }
 								key={ `InserterUI-${ numberOfColumns }` } //re-render when numberOfColumns changes
@@ -160,7 +157,9 @@ export class InserterMenu extends Component {
 								contentContainerStyle={ [
 									...listProps.contentContainerStyle,
 									{
-										paddingBottom: safeAreaBottomInset,
+										paddingBottom:
+											safeAreaBottomInset ||
+											styles.list.paddingBottom,
 									},
 								] }
 							/>

--- a/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/navigation-screen.native.js
+++ b/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/navigation-screen.native.js
@@ -36,7 +36,7 @@ const BottomSheetNavigationScreen = ( {
 		shouldEnableBottomSheetMaxHeight,
 		setIsFullScreen,
 		listProps,
-		safeAreaBottomInset = styles.scrollableContent.paddingBottom,
+		safeAreaBottomInset,
 	} = useContext( BottomSheetContext );
 
 	const { setHeight } = useContext( BottomSheetNavigationContext );
@@ -88,7 +88,9 @@ const BottomSheetNavigationScreen = ( {
 						{ ! isNested && (
 							<View
 								style={ {
-									height: safeAreaBottomInset,
+									height:
+										safeAreaBottomInset ||
+										styles.scrollableContent.paddingBottom,
 								} }
 							/>
 						) }


### PR DESCRIPTION
## Description
This is a fix for regression that came with this PR https://github.com/WordPress/gutenberg/pull/26204 and was reported here: https://github.com/WordPress/gutenberg/pull/26206#issuecomment-722190875

The safeAreaBottomInset is set to 0 and the default value doesn't overwrite it. I had to change the default value to the expression and everything works fine :)

## How has this been tested?
- Open inserter on a phone that doesn't need a safe area
- You should be able to scroll to the very bottom of the inserter

## Screenshots <!-- if applicable -->

before | after
--- | ---
![Screenshot_1604571280](https://user-images.githubusercontent.com/16336501/98229384-1e409a00-1f5a-11eb-8457-61b9d5871bcc.png) | ![Screenshot_1604571997](https://user-images.githubusercontent.com/16336501/98229402-24367b00-1f5a-11eb-9fab-7997680a133e.png)



## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
