### PR TITLE
Minimize the calls in useSelect by subscribing to only the stores needed

### DIFF
--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -187,9 +187,7 @@ export default function useSelect( _mapSelect, deps ) {
 			}
 		};
 
-		const unsubscribers = [
-			...listeningStores.current,
-		].map( ( storeKey ) =>
+		const unsubscribers = listeningStores.current.map( ( storeKey ) =>
 			registry.stores[ storeKey ].subscribe( onChange )
 		);
 		const unsubscribe = () => {
@@ -201,7 +199,7 @@ export default function useSelect( _mapSelect, deps ) {
 			unsubscribe();
 			renderQueue.flush( queueContext );
 			// Reset the registered stores when mapSelect changes. In case it subscribes to different stores.
-			listeningStores.current = new Set();
+			listeningStores.current = [];
 		};
 	}, [ registry, onStoreChange, mapSelect ] );
 

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -173,25 +173,27 @@ export default function useSelect( _mapSelect, deps ) {
 		}
 	} );
 
-	const onStoreChange = useCallback( () => {
-		if ( isMountedAndNotUnsubscribing.current ) {
-			try {
-				const newMapOutput = trapSelect( () =>
-					latestMapSelect.current( registry.select, registry )
-				);
-
-				if ( isShallowEqual( latestMapOutput.current, newMapOutput ) ) {
-					return;
-				}
-				latestMapOutput.current = newMapOutput;
-			} catch ( error ) {
-				latestMapOutputError.current = error;
-			}
-			forceRender();
-		}
-	}, [ registry ] );
-
 	useIsomorphicLayoutEffect( () => {
+		const onStoreChange = () => {
+			if ( isMountedAndNotUnsubscribing.current ) {
+				try {
+					const newMapOutput = trapSelect( () =>
+						latestMapSelect.current( registry.select, registry )
+					);
+
+					if (
+						isShallowEqual( latestMapOutput.current, newMapOutput )
+					) {
+						return;
+					}
+					latestMapOutput.current = newMapOutput;
+				} catch ( error ) {
+					latestMapOutputError.current = error;
+				}
+				forceRender();
+			}
+		};
+
 		// catch any possible state changes during mount before the subscription
 		// could be set.
 		if ( latestIsAsync.current ) {
@@ -225,7 +227,7 @@ export default function useSelect( _mapSelect, deps ) {
 			// Reset the registered stores when mapSelect changes. In case it subscribes to different stores.
 			listeningStores.current = [];
 		};
-	}, [ registry, onStoreChange, depsChangedFlag ] );
+	}, [ registry, trapSelect, depsChangedFlag ] );
 
 	return mapOutput;
 }

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -224,7 +224,7 @@ export default function useSelect( _mapSelect, deps ) {
 			isMountedAndNotUnsubscribing.current = false;
 			unsubscribe();
 			renderQueue.flush( queueContext );
-			// Reset the registered stores when mapSelect changes. In case it subscribes to different stores.
+			// Reset the registered stores when depsChangedFlag changes. In case it subscribes to different stores.
 			listeningStores.current = [];
 		};
 	}, [ registry, trapSelect, depsChangedFlag ] );

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -94,6 +94,8 @@ export default function useSelect( _mapSelect, deps ) {
 	const latestMapOutputError = useRef();
 	const isMountedAndNotUnsubscribing = useRef();
 
+	// Keep track of the stores being selected in the mapSelect function,
+	// and only subscribe to those stores later.
 	const registeredStores = useRef( [] );
 	const trapSelect = useCallback(
 		( storeKey ) => {
@@ -129,6 +131,7 @@ export default function useSelect( _mapSelect, deps ) {
 		}
 	}
 
+	// Reset the registered stores when mapSelect changes. In case it subscribes to different stores.
 	useIsomorphicLayoutEffect( () => {
 		registeredStores.current = [];
 	}, [ mapSelect ] );
@@ -186,9 +189,9 @@ export default function useSelect( _mapSelect, deps ) {
 			}
 		};
 
-		const unsubscribers = registeredStores.current.map( ( storeKey ) => {
-			return registry.stores[ storeKey ].subscribe( onChange );
-		} );
+		const unsubscribers = registeredStores.current.map( ( storeKey ) =>
+			registry.stores[ storeKey ].subscribe( onChange )
+		);
 		const unsubscribe = () => {
 			unsubscribers.map( ( unsubscriber ) => unsubscriber() );
 		};

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -182,9 +182,7 @@ export default function useSelect( _mapSelect, deps ) {
 		} else {
 			onStoreChange();
 		}
-	}, [ onStoreChange ] );
 
-	useIsomorphicLayoutEffect( () => {
 		const onChange = () => {
 			if ( latestIsAsync.current ) {
 				renderQueue.add( queueContext, onStoreChange );

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -193,14 +193,13 @@ export default function useSelect( _mapSelect, deps ) {
 			}
 		};
 
-		const unsubscribe = registry.__experimentalSubscribeStores(
-			listeningStores.current,
-			onChange
+		const unsubscribers = listeningStores.current.map( ( storeName ) =>
+			registry.__experimentalSubscribeStore( storeName, onChange )
 		);
 
 		return () => {
 			isMountedAndNotUnsubscribing.current = false;
-			unsubscribe();
+			unsubscribers.forEach( ( unsubscribe ) => unsubscribe() );
 			renderQueue.flush( queueContext );
 		};
 	}, [ registry, trapSelect, depsChangedFlag ] );

--- a/packages/data/src/components/use-select/test/index.js
+++ b/packages/data/src/components/use-select/test/index.js
@@ -116,7 +116,6 @@ describe( 'useSelect', () => {
 		} );
 
 		// rerender with dependency changed
-		// rerender with non dependency changed
 		act( () => {
 			renderer.update(
 				<RegistryProvider value={ registry }>
@@ -126,7 +125,7 @@ describe( 'useSelect', () => {
 		} );
 
 		expect( selectSpyFoo ).toHaveBeenCalledTimes( 2 );
-		expect( selectSpyBar ).toHaveBeenCalledTimes( 1 );
+		expect( selectSpyBar ).toHaveBeenCalledTimes( 2 );
 		expect( TestComponent ).toHaveBeenCalledTimes( 3 );
 
 		// ensure expected state was rendered
@@ -387,9 +386,19 @@ describe( 'useSelect', () => {
 				setDep( 1 );
 			} );
 
-			expect( selectCount1AndDep ).toHaveBeenCalledTimes( 3 );
+			expect( selectCount1AndDep ).toHaveBeenCalledTimes( 4 );
 			expect( testInstance.findByType( 'div' ).props.data ).toEqual( {
 				count1: 0,
+				dep: 1,
+			} );
+
+			act( () => {
+				registry.dispatch( 'store-1' ).increment();
+			} );
+
+			expect( selectCount1AndDep ).toHaveBeenCalledTimes( 5 );
+			expect( testInstance.findByType( 'div' ).props.data ).toEqual( {
+				count1: 1,
 				dep: 1,
 			} );
 		} );
@@ -503,7 +512,7 @@ describe( 'useSelect', () => {
 				toggle();
 			} );
 
-			expect( selectCount1 ).toHaveBeenCalledTimes( 1 );
+			expect( selectCount1 ).toHaveBeenCalledTimes( 2 );
 			expect( selectCount2 ).toHaveBeenCalledTimes( 2 );
 			expect( testInstance.findByType( 'div' ).props.data ).toBe(
 				'count1'

--- a/packages/data/src/components/with-select/test/index.js
+++ b/packages/data/src/components/with-select/test/index.js
@@ -670,7 +670,7 @@ describe( 'withSelect', () => {
 		// - 1 on initial render
 		// - 1 on effect before subscription set.
 		// - 1 child subscription fires.
-		expect( childMapSelectToProps ).toHaveBeenCalledTimes( 3 );
+		expect( childMapSelectToProps ).toHaveBeenCalledTimes( 2 );
 		expect( parentMapSelectToProps ).toHaveBeenCalledTimes( 4 );
 		expect( ChildOriginalComponent ).toHaveBeenCalledTimes( 1 );
 		expect( ParentOriginalComponent ).toHaveBeenCalledTimes( 2 );

--- a/packages/data/src/components/with-select/test/index.js
+++ b/packages/data/src/components/with-select/test/index.js
@@ -666,10 +666,6 @@ describe( 'withSelect', () => {
 			registry.dispatch( 'childRender' ).toggleRender();
 		} );
 
-		// 3 times because
-		// - 1 on initial render
-		// - 1 on effect before subscription set.
-		// - 1 child subscription fires.
 		expect( childMapSelectToProps ).toHaveBeenCalledTimes( 2 );
 		expect( parentMapSelectToProps ).toHaveBeenCalledTimes( 4 );
 		expect( ChildOriginalComponent ).toHaveBeenCalledTimes( 1 );

--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -136,7 +136,7 @@ export default function createReduxStore( key, options ) {
 				store &&
 				( ( listener ) => {
 					let lastState = store.__unstableOriginalGetState();
-					store.subscribe( () => {
+					return store.subscribe( () => {
 						const state = store.__unstableOriginalGetState();
 						const hasChanged = state !== lastState;
 						lastState = state;

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -50,6 +50,7 @@ import createCoreDataStore from './store';
 export function createRegistry( storeConfigs = {}, parent = null ) {
 	const stores = {};
 	let listeners = [];
+	const __experimentalListeningStores = new Set();
 
 	/**
 	 * Global listener called for each store's update.
@@ -85,12 +86,20 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 		const storeName = isObject( storeNameOrDefinition )
 			? storeNameOrDefinition.name
 			: storeNameOrDefinition;
+		__experimentalListeningStores.add( storeName );
 		const store = stores[ storeName ];
 		if ( store ) {
 			return store.getSelectors();
 		}
 
 		return parent && parent.select( storeName );
+	}
+
+	function __experimentalMarkListeningStores( callback, ref ) {
+		__experimentalListeningStores.clear();
+		const result = callback.call( this );
+		ref.current = Array.from( __experimentalListeningStores );
+		return result;
 	}
 
 	const getResolveSelectors = memize(
@@ -223,6 +232,7 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 		dispatch,
 		use,
 		register,
+		__experimentalMarkListeningStores,
 	};
 
 	/**

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -223,6 +223,7 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 	}
 
 	let registry = {
+		parent,
 		registerGenericStore,
 		stores,
 		namespaces: stores, // TODO: Deprecate/remove this.

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -303,10 +303,15 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 	// This function will be deprecated as soon as it is no longer internally referenced.
 	//
 	function use( plugin, options ) {
+		const storesMap = StoresMap.get( registry );
+
 		registry = {
 			...registry,
 			...plugin( registry, options ),
 		};
+
+		// We don't need to do this once `use` is removed.
+		StoresMap.set( registry, storesMap );
 
 		return registry;
 	}

--- a/packages/data/src/test/registry.js
+++ b/packages/data/src/test/registry.js
@@ -736,6 +736,9 @@ describe( 'createRegistry', () => {
 						if ( key === 'stores' ) {
 							return expect.any( Object );
 						}
+						if ( key === 'parent' ) {
+							return expect.any( Object ) || null;
+						}
 						// TODO: Remove this after namsespaces is removed.
 						if ( key === 'namespaces' ) {
 							return registry.stores;

--- a/packages/data/src/test/registry.js
+++ b/packages/data/src/test/registry.js
@@ -736,9 +736,6 @@ describe( 'createRegistry', () => {
 						if ( key === 'stores' ) {
 							return expect.any( Object );
 						}
-						if ( key === 'parent' ) {
-							return expect.any( Object ) || null;
-						}
 						// TODO: Remove this after namsespaces is removed.
 						if ( key === 'namespaces' ) {
 							return registry.stores;

--- a/packages/edit-post/src/components/editor-initialization/test/listener-hooks.js
+++ b/packages/edit-post/src/components/editor-initialization/test/listener-hooks.js
@@ -6,7 +6,7 @@ import TestRenderer, { act } from 'react-test-renderer';
 /**
  * WordPress dependencies
  */
-import { RegistryProvider } from '@wordpress/data';
+import { RegistryProvider, createRegistry } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -18,42 +18,62 @@ import {
 import { STORE_NAME } from '../../../store/constants';
 
 describe( 'listener hook tests', () => {
+	const storeConfig = {
+		actions: {
+			forceUpdate: jest.fn( () => ( { type: 'FORCE_UPDATE' } ) ),
+		},
+		reducer: ( state = {}, action ) =>
+			action.type === 'FORCE_UPDATE' ? { ...state } : state,
+	};
 	const mockStores = {
 		'core/block-editor': {
-			getBlockSelectionStart: jest.fn(),
+			...storeConfig,
+			selectors: {
+				getBlockSelectionStart: jest.fn(),
+			},
 		},
 		'core/editor': {
-			getCurrentPost: jest.fn(),
+			...storeConfig,
+			selectors: {
+				getCurrentPost: jest.fn(),
+			},
 		},
 		'core/viewport': {
-			isViewportMatch: jest.fn(),
+			...storeConfig,
+			selectors: {
+				isViewportMatch: jest.fn(),
+			},
 		},
 		[ STORE_NAME ]: {
-			isEditorSidebarOpened: jest.fn(),
-			openGeneralSidebar: jest.fn(),
-			closeGeneralSidebar: jest.fn(),
-			getActiveGeneralSidebarName: jest.fn(),
+			...storeConfig,
+			actions: {
+				...storeConfig.actions,
+				openGeneralSidebar: jest.fn( () => ( {
+					type: 'OPEN_GENERAL_SIDEBAR',
+				} ) ),
+				closeGeneralSidebar: jest.fn( () => ( {
+					type: 'CLOSE_GENERAL_SIDEBAR',
+				} ) ),
+			},
+			selectors: {
+				isEditorSidebarOpened: jest.fn(),
+				getActiveGeneralSidebarName: jest.fn(),
+			},
 		},
 	};
-	let subscribeTrigger;
-	const registry = {
-		select: jest
-			.fn()
-			.mockImplementation( ( storeName ) => mockStores[ storeName ] ),
-		dispatch: jest
-			.fn()
-			.mockImplementation( ( storeName ) => mockStores[ storeName ] ),
-		subscribe: ( subscription ) => {
-			subscribeTrigger = subscription;
-		},
-	};
+
+	let registry;
+	beforeEach( () => {
+		registry = createRegistry( mockStores );
+	} );
+
 	const setMockReturnValue = ( store, functionName, value ) => {
-		mockStores[ store ][ functionName ] = jest
-			.fn()
-			.mockReturnValue( value );
+		mockStores[ store ].selectors[ functionName ].mockReturnValue( value );
 	};
 	const getSpyedFunction = ( store, functionName ) =>
-		mockStores[ store ][ functionName ];
+		mockStores[ store ].selectors[ functionName ];
+	const getSpyedAction = ( store, actionName ) =>
+		mockStores[ store ].actions[ actionName ];
 	const renderComponent = ( testedHook, id, renderer = null ) => {
 		const TestComponent = ( { postId } ) => {
 			testedHook( postId );
@@ -70,11 +90,13 @@ describe( 'listener hook tests', () => {
 	};
 	afterEach( () => {
 		Object.values( mockStores ).forEach( ( storeMocks ) => {
-			Object.values( storeMocks ).forEach( ( mock ) => {
+			Object.values( storeMocks.selectors ).forEach( ( mock ) => {
+				mock.mockClear();
+			} );
+			Object.values( storeMocks.actions || {} ).forEach( ( mock ) => {
 				mock.mockClear();
 			} );
 		} );
-		subscribeTrigger = undefined;
 	} );
 	describe( 'useBlockSelectionListener', () => {
 		it( 'does nothing when editor sidebar is not open', () => {
@@ -86,7 +108,7 @@ describe( 'listener hook tests', () => {
 				getSpyedFunction( STORE_NAME, 'isEditorSidebarOpened' )
 			).toHaveBeenCalled();
 			expect(
-				getSpyedFunction( STORE_NAME, 'openGeneralSidebar' )
+				getSpyedAction( STORE_NAME, 'openGeneralSidebar' )
 			).toHaveBeenCalledTimes( 0 );
 		} );
 		it( 'opens block sidebar if block is selected', () => {
@@ -100,7 +122,7 @@ describe( 'listener hook tests', () => {
 				renderComponent( useBlockSelectionListener, 10 );
 			} );
 			expect(
-				getSpyedFunction( STORE_NAME, 'openGeneralSidebar' )
+				getSpyedAction( STORE_NAME, 'openGeneralSidebar' )
 			).toHaveBeenCalledWith( 'edit-post/block' );
 		} );
 		it( 'opens document sidebar if block is not selected', () => {
@@ -114,7 +136,7 @@ describe( 'listener hook tests', () => {
 				renderComponent( useBlockSelectionListener, 10 );
 			} );
 			expect(
-				getSpyedFunction( STORE_NAME, 'openGeneralSidebar' )
+				getSpyedAction( STORE_NAME, 'openGeneralSidebar' )
 			).toHaveBeenCalledWith( 'edit-post/document' );
 		} );
 	} );
@@ -149,6 +171,9 @@ describe( 'listener hook tests', () => {
 			expect( setAttribute ).not.toHaveBeenCalled();
 		} );
 		it( 'only calls document query selector once across renders', () => {
+			setMockReturnValue( 'core/editor', 'getCurrentPost', {
+				link: 'foo',
+			} );
 			act( () => {
 				const renderer = renderComponent(
 					useUpdatePostLinkListener,
@@ -158,7 +183,7 @@ describe( 'listener hook tests', () => {
 			} );
 			expect( mockSelector ).toHaveBeenCalledTimes( 1 );
 			act( () => {
-				subscribeTrigger();
+				registry.dispatch( 'core/editor' ).forceUpdate();
 			} );
 			expect( mockSelector ).toHaveBeenCalledTimes( 1 );
 		} );
@@ -169,8 +194,9 @@ describe( 'listener hook tests', () => {
 			act( () => {
 				renderComponent( useUpdatePostLinkListener, 10 );
 			} );
+			expect( setAttribute ).toHaveBeenCalledTimes( 1 );
 			act( () => {
-				subscribeTrigger();
+				registry.dispatch( 'core/editor' ).forceUpdate();
 			} );
 			expect( setAttribute ).toHaveBeenCalledTimes( 1 );
 		} );
@@ -181,11 +207,14 @@ describe( 'listener hook tests', () => {
 			act( () => {
 				renderComponent( useUpdatePostLinkListener, 10 );
 			} );
+			expect( setAttribute ).toHaveBeenCalledTimes( 1 );
+			expect( setAttribute ).toHaveBeenCalledWith( 'href', 'foo' );
+
 			setMockReturnValue( 'core/editor', 'getCurrentPost', {
 				link: 'bar',
 			} );
 			act( () => {
-				subscribeTrigger();
+				registry.dispatch( 'core/editor' ).forceUpdate();
 			} );
 			expect( setAttribute ).toHaveBeenCalledTimes( 2 );
 			expect( setAttribute ).toHaveBeenCalledWith( 'href', 'bar' );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Minimize the calls of the selectors in `useSelect` by only subscribing to the stores needed.

### The problem

Currently, `useSelect` works by subscribing to the `registry` instance and calls the `mapSelect` (the first argument of `useSelect`) function every time the store changes. It works fine, but it also fires many unnecessary `mapSelect` calls when we know that the store updates won't cause a re-render.

Most components subscribe to the default `registry`, and most stores also registered to that same `registry`. Let's say that some component has a `counter` store and multiple other stores like `core`, `core/editor`, `core/block-editor`, etc. The `counter` store has a selector `getCounter`, which simply gets the `count` state from the store. A component using this selector could look like this.

```js
function TestComponent() {
	const { count } = useSelect( select => ({
		count: select( 'counter' ).getCounter(),
	}), [] );

	return count;
}
```

It's clear that this component doesn't care about state updates from stores other than `counter`. However, the selector still gets called when we dispatch any actions no matter if the action doesn't belong to the `counter` store.

Fortunately, since the `count` state from `getCounter()` doesn't change, `<TestComponent>` doesn't have to re-render. Still, it's an unnecessary call of the `getCounter` selector. In this specific case, it doesn't matter much, but it would matter if the `mapSelect` function is very complex or slow. Especially when we have `resolver` for each `selector`, which could potentially cause unwanted side-effects to be introduced.

### The solution

This PR propose a solution to minimize the calls of the `mapSelect` function as much as possible. The idea is to only call the `mapSelect` function if and only if the store this `mapSelect` has referenced to gets updated.

For instance,

```js
useSelect( select => ({
	count: select( 'counter' ).getCounter(),
}), [] );
```

this `useSelect` only cares about updates within the `counter` store itself and nothing else. We only have to re-run the `mapSelect` function whenever the state from the `counter` store updates.

Another example,

```js
useSelect( select => ({
	count: select( 'counter' ).getCounter(),
	isPublished: select( 'core/editor' ).isCurrentPostPublished(),
}), [] );
```

this `useSelect` cares about state updates from two different stores: `counter` and `core/editor`. Whenever either one of the store updates, we need to re-run the `mapSelect` function.

This is done by _trapping_ the `select` function of the `registry` to keep track of every store it has called. It works very similarly like monkey-patching the `select` function as follow (the actual implementation is slightly different because of some issues with legacy features with `use` and `withPlugins`):

```js
const listeningStores = [];

const originalSelect = registry.select;
registry.select = function trapSelect( storeKey ) {
	listeningStores.push( storeKey );
	return originalSelect.call( this, storeKey );
};
```

Whenever `reigstry.select( storeKey )` is called, we'll push the `storeKey` to the `listeningStores`. Later, we can then only subscribe to those stores rather than subscribing to the whole `registry`.

```diff js
- registry.subscribe( onChange );
+ listeningStores.forEach( storeKey => registry.stores[ storeKey ].subscribe( onChange ) );
```

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Added a bunch of unit tests and also fixed some tests.
End-to-end tests should also be passing.

### Performance tests

```
>> post-editor

┌─────────┬───────────┬────────────┬────────────┬─────────────┬─────────────┬────────────┬─────────────┐
│ (index) │   load    │    type    │  minType   │   maxType   │    focus    │  minFocus  │  maxFocus   │
├─────────┼───────────┼────────────┼────────────┼─────────────┼─────────────┼────────────┼─────────────┤
│ This PR │ '6733 ms' │ '44.5 ms'  │ '40.78 ms' │ '100.23 ms' │ '98.93 ms'  │ '73.53 ms' │ '131.48 ms' │
│ master  │ '7360 ms' │ '53.59 ms' │ '46.28 ms' │ '113.3 ms'  │ '105.19 ms' │ '65.89 ms' │ '143.31 ms' │
└─────────┴───────────┴────────────┴────────────┴─────────────┴─────────────┴────────────┴─────────────┘

>> site-editor

┌─────────┬──────────────┐
│ (index) │     load     │
├─────────┼──────────────┤
│ This PR │  '1243 ms'   │
│ master  │ '1255.33 ms' │
└─────────┴──────────────┘
```

As seen in the report, this PR out-performs every test. However, the difference is not that big though, it might be just a micro-optimization in the end.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
