### PR TITLE
[NRMobile] Style separator block to extend until the edges

### DIFF
--- a/packages/primitives/src/horizontal-rule/index.native.js
+++ b/packages/primitives/src/horizontal-rule/index.native.js
@@ -10,5 +10,12 @@ export const HorizontalRule = ( props ) => {
 		...props.lineStyle,
 	};
 
-	return <Hr { ...props } lineStyle={ lineStyle } />;
+	return (
+		<Hr
+			{ ...props }
+			lineStyle={ lineStyle }
+			marginLeft={ 0 }
+			marginRight={ 0 }
+		/>
+	);
 };

--- a/packages/primitives/src/horizontal-rule/index.native.js
+++ b/packages/primitives/src/horizontal-rule/index.native.js
@@ -3,19 +3,27 @@
  */
 import Hr from 'react-native-hr';
 
-export const HorizontalRule = ( props ) => {
-	const lineStyle = {
-		backgroundColor: '#555d66',
-		height: 2,
-		...props.lineStyle,
-	};
+/**
+ * WordPress dependencies
+ */
+import { withPreferredColorScheme } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import styles from './styles.scss';
+
+const HR = ( { getStylesFromColorScheme, ...props } ) => {
+	const lineStyle = getStylesFromColorScheme( styles.line, styles.lineDark );
 
 	return (
 		<Hr
 			{ ...props }
-			lineStyle={ lineStyle }
+			lineStyle={ [ lineStyle, props.lineStyle ] }
 			marginLeft={ 0 }
 			marginRight={ 0 }
 		/>
 	);
 };
+
+export const HorizontalRule = withPreferredColorScheme( HR );

--- a/packages/primitives/src/horizontal-rule/styles.native.scss
+++ b/packages/primitives/src/horizontal-rule/styles.native.scss
@@ -1,0 +1,8 @@
+.line {
+	background-color: $gray-lighten-20;
+	height: 2;
+}
+
+.lineDark {
+	background-color: $gray-50;
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/2018

## Description
<!-- Please describe what you have changed or added -->

This PR styles the Separator block to extend the HR line until the edges:

![Simulator Screen Shot - iPhone 11 - 2020-11-05 at 12 55 32](https://user-images.githubusercontent.com/9772967/98238218-56e67080-1f66-11eb-8603-6b0a4b718928.png)


cc @iamthomasbishop 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

- Run the project.
- Add a Separator block.
- Check that the line extends to the edges.
  - Can compare with `More` block.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
