### PR TITLE
Components: Introduce a isDisabled prop to the Disabled component

### DIFF
--- a/packages/components/src/disabled/README.md
+++ b/packages/components/src/disabled/README.md
@@ -49,3 +49,28 @@ function CustomButton() {
 	);
 }
 ```
+
+A component can be conditionally wrapped in a `<Disabled>` with the help of `<Disableable>`.
+
+```jsx
+import { Button, Disableable, TextControl } from '@wordpress/components';
+
+const MyDisabled = withState( {
+	isDisabled: true,
+} )( ( { isDisabled, setState } ) => {
+	const toggleDisabled = () => {
+		setState( ( state ) => ( { isDisabled: ! state.isDisabled } ) );
+	};
+
+	return (
+		<div>
+			<Disableable disabled={ isDisabled }>
+				<TextControl label="Input" onChange={ () => {} } />
+			</Disableable>
+			<Button isPrimary onClick={ toggleDisabled }>
+				Toggle Disabled
+			</Button>
+		</div>
+	);
+} );
+```

--- a/packages/components/src/disabled/README.md
+++ b/packages/components/src/disabled/README.md
@@ -50,27 +50,14 @@ function CustomButton() {
 }
 ```
 
-A component can be conditionally wrapped in a `<Disabled>` with the help of `<Disableable>`.
+### Props
 
-```jsx
-import { Button, Disableable, TextControl } from '@wordpress/components';
+The component accepts the following props:
 
-const MyDisabled = withState( {
-	isDisabled: true,
-} )( ( { isDisabled, setState } ) => {
-	const toggleDisabled = () => {
-		setState( ( state ) => ( { isDisabled: ! state.isDisabled } ) );
-	};
+#### isDisabled
 
-	return (
-		<div>
-			<Disableable disabled={ isDisabled }>
-				<TextControl label="Input" onChange={ () => {} } />
-			</Disableable>
-			<Button isPrimary onClick={ toggleDisabled }>
-				Toggle Disabled
-			</Button>
-		</div>
-	);
-} );
-```
+Whether to disable all the descendant fields. Defaults to `true`.
+
+- Type: `Boolean`
+- Required: No
+- Default: `true`

--- a/packages/components/src/disabled/index.js
+++ b/packages/components/src/disabled/index.js
@@ -9,7 +9,6 @@ import classnames from 'classnames';
  */
 import {
 	createContext,
-	Fragment,
 	useCallback,
 	useLayoutEffect,
 	useRef,
@@ -42,7 +41,11 @@ const DISABLED_ELIGIBLE_NODE_NAMES = [
 	'TEXTAREA',
 ];
 
-function Disabled( { className, children, ...props } ) {
+const defaultProps = {
+	isDisabled: true,
+};
+
+function Disabled( { className, children, isDisabled, ...props } ) {
 	const node = useRef();
 
 	const disable = () => {
@@ -76,6 +79,10 @@ function Disabled( { className, children, ...props } ) {
 	);
 
 	useLayoutEffect( () => {
+		if ( ! isDisabled ) {
+			return;
+		}
+
 		disable();
 
 		const observer = new window.MutationObserver( debouncedDisable );
@@ -91,6 +98,10 @@ function Disabled( { className, children, ...props } ) {
 		};
 	}, [] );
 
+	if ( ! isDisabled ) {
+		return <Provider value={ false }>{ children }</Provider>;
+	}
+
 	return (
 		<Provider value={ true }>
 			<StyledWrapper
@@ -104,11 +115,8 @@ function Disabled( { className, children, ...props } ) {
 	);
 }
 
-Disabled.Consumer = Consumer;
+Disabled.defaultProps = defaultProps;
 
-export function Disableable( { children, disabled } ) {
-	const WrapperComponent = disabled ? Disabled : Fragment;
-	return <WrapperComponent>{ children }</WrapperComponent>;
-}
+Disabled.Consumer = Consumer;
 
 export default Disabled;

--- a/packages/components/src/disabled/index.js
+++ b/packages/components/src/disabled/index.js
@@ -9,6 +9,7 @@ import classnames from 'classnames';
  */
 import {
 	createContext,
+	Fragment,
 	useCallback,
 	useLayoutEffect,
 	useRef,
@@ -104,5 +105,10 @@ function Disabled( { className, children, ...props } ) {
 }
 
 Disabled.Consumer = Consumer;
+
+export function Disableable( { children, disabled } ) {
+	const WrapperComponent = disabled ? Disabled : Fragment;
+	return <WrapperComponent>{ children }</WrapperComponent>;
+}
 
 export default Disabled;

--- a/packages/components/src/disabled/index.js
+++ b/packages/components/src/disabled/index.js
@@ -41,11 +41,7 @@ const DISABLED_ELIGIBLE_NODE_NAMES = [
 	'TEXTAREA',
 ];
 
-const defaultProps = {
-	isDisabled: true,
-};
-
-function Disabled( { className, children, isDisabled, ...props } ) {
+function Disabled( { className, children, isDisabled = true, ...props } ) {
 	const node = useRef();
 
 	const disable = () => {
@@ -114,8 +110,6 @@ function Disabled( { className, children, isDisabled, ...props } ) {
 		</Provider>
 	);
 }
-
-Disabled.defaultProps = defaultProps;
 
 Disabled.Consumer = Consumer;
 

--- a/packages/components/src/disabled/stories/index.js
+++ b/packages/components/src/disabled/stories/index.js
@@ -6,7 +6,7 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import Disabled, { Disableable as DisableableComponent } from '../';
+import Disabled from '../';
 import Button from '../../button/';
 import SelectControl from '../../select-control/';
 import TextControl from '../../text-control/';
@@ -42,19 +42,19 @@ export const _default = () => {
 	);
 };
 
-export const Disableable = () => {
-	const [ isDisabled, setState ] = useState( false );
+export const DisabledWithProp = () => {
+	const [ isDisabled, setState ] = useState( true );
 	const toggleDisabled = () => {
 		setState( () => ! isDisabled );
 	};
 
 	return (
 		<div>
-			<DisableableComponent disabled={ isDisabled }>
+			<Disabled isDisabled={ isDisabled }>
 				<Form />
-			</DisableableComponent>
+			</Disabled>
 			<Button isPrimary onClick={ toggleDisabled }>
-				Toggle Disabled
+				Set isDisabled to { isDisabled ? 'false' : 'true' }
 			</Button>
 		</div>
 	);

--- a/packages/components/src/disabled/stories/index.js
+++ b/packages/components/src/disabled/stories/index.js
@@ -1,7 +1,13 @@
 /**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
-import Disabled from '../';
+import Disabled, { Disableable as DisableableComponent } from '../';
+import Button from '../../button/';
 import SelectControl from '../../select-control/';
 import TextControl from '../../text-control/';
 import TextareaControl from '../../textarea-control/';
@@ -11,21 +17,45 @@ export default {
 	component: Disabled,
 };
 
+const Form = () => (
+	<div>
+		<TextControl label="Text Control" />
+		<TextareaControl label="TextArea Control" />
+		<SelectControl
+			label="Select Control"
+			onChange={ () => {} }
+			options={ [
+				{ value: null, label: 'Select an option', disabled: true },
+				{ value: 'a', label: 'Option A' },
+				{ value: 'b', label: 'Option B' },
+				{ value: 'c', label: 'Option C' },
+			] }
+		/>
+	</div>
+);
+
 export const _default = () => {
 	return (
 		<Disabled>
-			<TextControl label="Text Control" />
-			<TextareaControl label="TextArea Control" />
-			<SelectControl
-				label="Select Control"
-				onChange={ () => {} }
-				options={ [
-					{ value: null, label: 'Select an option', disabled: true },
-					{ value: 'a', label: 'Option A' },
-					{ value: 'b', label: 'Option B' },
-					{ value: 'c', label: 'Option C' },
-				] }
-			/>
+			<Form />
 		</Disabled>
+	);
+};
+
+export const Disableable = () => {
+	const [ isDisabled, setState ] = useState( false );
+	const toggleDisabled = () => {
+		setState( () => ! isDisabled );
+	};
+
+	return (
+		<div>
+			<DisableableComponent disabled={ isDisabled }>
+				<Form />
+			</DisableableComponent>
+			<Button isPrimary onClick={ toggleDisabled }>
+				Toggle Disabled
+			</Button>
+		</div>
 	);
 };

--- a/packages/components/src/disabled/test/index.js
+++ b/packages/components/src/disabled/test/index.js
@@ -11,7 +11,7 @@ import { Component } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import Disabled, { Disableable } from '../';
+import Disabled from '../';
 
 jest.mock( '@wordpress/dom', () => {
 	const focus = jest.requireActual( '../../../../dom/src' ).focus;
@@ -68,9 +68,9 @@ describe( 'Disabled', () => {
 	// this is needed because TestUtils does not accept a stateless component.
 	class DisabledComponent extends Component {
 		render() {
-			const { children } = this.props;
+			const { children, isDisabled } = this.props;
 
-			return <Disabled>{ children }</Disabled>;
+			return <Disabled isDisabled={ isDisabled }>{ children }</Disabled>;
 		}
 	}
 
@@ -133,6 +133,46 @@ describe( 'Disabled', () => {
 		expect( div.hasAttribute( 'tabindex' ) ).toBe( true );
 	} );
 
+	it( 'will disable descendant fields if isDisabled prop is set to true', () => {
+		const wrapper = TestUtils.renderIntoDocument(
+			<DisabledComponent isDisabled>
+				<Form />
+			</DisabledComponent>
+		);
+
+		const input = TestUtils.findRenderedDOMComponentWithTag(
+			wrapper,
+			'input'
+		);
+		const div = TestUtils.scryRenderedDOMComponentsWithTag(
+			wrapper,
+			'div'
+		)[ 1 ];
+
+		expect( input.hasAttribute( 'disabled' ) ).toBe( true );
+		expect( div.getAttribute( 'contenteditable' ) ).toBe( 'false' );
+	} );
+
+	it( 'will not disable descendant fields if isDisabled prop is set to false', () => {
+		const wrapper = TestUtils.renderIntoDocument(
+			<DisabledComponent isDisabled={ false }>
+				<Form />
+			</DisabledComponent>
+		);
+
+		const input = TestUtils.findRenderedDOMComponentWithTag(
+			wrapper,
+			'input'
+		);
+		const div = TestUtils.scryRenderedDOMComponentsWithTag(
+			wrapper,
+			'div'
+		)[ 0 ];
+
+		expect( input.hasAttribute( 'disabled' ) ).toBe( false );
+		expect( div.getAttribute( 'contenteditable' ) ).not.toBe( 'false' );
+	} );
+
 	// Ideally, we'd have two more test cases here:
 	//
 	//  - it( 'will disable all fields on component render change' )
@@ -170,6 +210,19 @@ describe( 'Disabled', () => {
 			expect( wrapperElement.textContent ).toBe( 'Disabled' );
 		} );
 
+		test( "lets components know that they're not disabled via context when isDisabled is false", () => {
+			const wrapper = TestUtils.renderIntoDocument(
+				<DisabledComponent isDisabled={ false }>
+					<DisabledStatus />
+				</DisabledComponent>
+			);
+			const wrapperElement = TestUtils.findRenderedDOMComponentWithTag(
+				wrapper,
+				'p'
+			);
+			expect( wrapperElement.textContent ).toBe( 'Not disabled' );
+		} );
+
 		test( "lets components know that they're not disabled via context", () => {
 			const wrapper = TestUtils.renderIntoDocument( <DisabledStatus /> );
 			const wrapperElement = TestUtils.findRenderedDOMComponentWithTag(
@@ -177,60 +230,6 @@ describe( 'Disabled', () => {
 				'p'
 			);
 			expect( wrapperElement.textContent ).toBe( 'Not disabled' );
-		} );
-	} );
-
-	describe( 'Disableable', () => {
-		class DisableableComponent extends Component {
-			render() {
-				const { children, disabled } = this.props;
-
-				return (
-					<Disableable disabled={ disabled }>
-						{ children }
-					</Disableable>
-				);
-			}
-		}
-
-		it( 'will not disable fields by default', () => {
-			const wrapper = TestUtils.renderIntoDocument(
-				<DisableableComponent>
-					<Form />
-				</DisableableComponent>
-			);
-
-			const input = TestUtils.findRenderedDOMComponentWithTag(
-				wrapper,
-				'input'
-			);
-			const div = TestUtils.scryRenderedDOMComponentsWithTag(
-				wrapper,
-				'div'
-			)[ 0 ];
-
-			expect( input.hasAttribute( 'disabled' ) ).toBe( false );
-			expect( div.getAttribute( 'contenteditable' ) ).not.toBe( 'false' );
-		} );
-
-		it( 'will disable all fields if disabled prop is true', () => {
-			const wrapper = TestUtils.renderIntoDocument(
-				<DisableableComponent disabled>
-					<Form />
-				</DisableableComponent>
-			);
-
-			const input = TestUtils.findRenderedDOMComponentWithTag(
-				wrapper,
-				'input'
-			);
-			const div = TestUtils.scryRenderedDOMComponentsWithTag(
-				wrapper,
-				'div'
-			)[ 1 ];
-
-			expect( input.hasAttribute( 'disabled' ) ).toBe( true );
-			expect( div.getAttribute( 'contenteditable' ) ).toBe( 'false' );
 		} );
 	} );
 } );

--- a/packages/components/src/disabled/test/index.js
+++ b/packages/components/src/disabled/test/index.js
@@ -11,7 +11,7 @@ import { Component } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import Disabled from '../';
+import Disabled, { Disableable } from '../';
 
 jest.mock( '@wordpress/dom', () => {
 	const focus = jest.requireActual( '../../../../dom/src' ).focus;
@@ -177,6 +177,60 @@ describe( 'Disabled', () => {
 				'p'
 			);
 			expect( wrapperElement.textContent ).toBe( 'Not disabled' );
+		} );
+	} );
+
+	describe( 'Disableable', () => {
+		class DisableableComponent extends Component {
+			render() {
+				const { children, disabled } = this.props;
+
+				return (
+					<Disableable disabled={ disabled }>
+						{ children }
+					</Disableable>
+				);
+			}
+		}
+
+		it( 'will not disable fields by default', () => {
+			const wrapper = TestUtils.renderIntoDocument(
+				<DisableableComponent>
+					<Form />
+				</DisableableComponent>
+			);
+
+			const input = TestUtils.findRenderedDOMComponentWithTag(
+				wrapper,
+				'input'
+			);
+			const div = TestUtils.scryRenderedDOMComponentsWithTag(
+				wrapper,
+				'div'
+			)[ 0 ];
+
+			expect( input.hasAttribute( 'disabled' ) ).toBe( false );
+			expect( div.getAttribute( 'contenteditable' ) ).not.toBe( 'false' );
+		} );
+
+		it( 'will disable all fields if disabled prop is true', () => {
+			const wrapper = TestUtils.renderIntoDocument(
+				<DisableableComponent disabled>
+					<Form />
+				</DisableableComponent>
+			);
+
+			const input = TestUtils.findRenderedDOMComponentWithTag(
+				wrapper,
+				'input'
+			);
+			const div = TestUtils.scryRenderedDOMComponentsWithTag(
+				wrapper,
+				'div'
+			)[ 1 ];
+
+			expect( input.hasAttribute( 'disabled' ) ).toBe( true );
+			expect( div.getAttribute( 'contenteditable' ) ).toBe( 'false' );
 		} );
 	} );
 } );

--- a/packages/components/src/disabled/test/index.js
+++ b/packages/components/src/disabled/test/index.js
@@ -133,12 +133,23 @@ describe( 'Disabled', () => {
 		expect( div.hasAttribute( 'tabindex' ) ).toBe( true );
 	} );
 
-	it( 'will disable descendant fields if isDisabled prop is set to true', () => {
-		const wrapper = TestUtils.renderIntoDocument(
-			<DisabledComponent isDisabled>
-				<Form />
-			</DisabledComponent>
-		);
+	it( 'will disable or enable descendant fields based on the isDisabled prop value', () => {
+		class MaybeDisable extends Component {
+			constructor() {
+				super( ...arguments );
+				this.state = { isDisabled: true };
+			}
+
+			render() {
+				return (
+					<DisabledComponent isDisabled={ this.state.isDisabled }>
+						<Form />
+					</DisabledComponent>
+				);
+			}
+		}
+
+		const wrapper = TestUtils.renderIntoDocument( <MaybeDisable /> );
 
 		const input = TestUtils.findRenderedDOMComponentWithTag(
 			wrapper,
@@ -151,26 +162,20 @@ describe( 'Disabled', () => {
 
 		expect( input.hasAttribute( 'disabled' ) ).toBe( true );
 		expect( div.getAttribute( 'contenteditable' ) ).toBe( 'false' );
-	} );
 
-	it( 'will not disable descendant fields if isDisabled prop is set to false', () => {
-		const wrapper = TestUtils.renderIntoDocument(
-			<DisabledComponent isDisabled={ false }>
-				<Form />
-			</DisabledComponent>
-		);
+		wrapper.setState( { isDisabled: false } );
 
-		const input = TestUtils.findRenderedDOMComponentWithTag(
+		const input2 = TestUtils.findRenderedDOMComponentWithTag(
 			wrapper,
 			'input'
 		);
-		const div = TestUtils.scryRenderedDOMComponentsWithTag(
+		const div2 = TestUtils.scryRenderedDOMComponentsWithTag(
 			wrapper,
 			'div'
 		)[ 0 ];
 
-		expect( input.hasAttribute( 'disabled' ) ).toBe( false );
-		expect( div.getAttribute( 'contenteditable' ) ).not.toBe( 'false' );
+		expect( input2.hasAttribute( 'disabled' ) ).toBe( false );
+		expect( div2.getAttribute( 'contenteditable' ) ).not.toBe( 'false' );
 	} );
 
 	// Ideally, we'd have two more test cases here:

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -39,7 +39,7 @@ export { default as CustomSelectControl } from './custom-select-control';
 export { default as Dashicon } from './dashicon';
 export { default as DateTimePicker, DatePicker, TimePicker } from './date-time';
 export { default as __experimentalDimensionControl } from './dimension-control';
-export { default as Disabled } from './disabled';
+export { default as Disabled, Disableable } from './disabled';
 export { default as Draggable } from './draggable';
 export {
 	default as DropZone,

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -39,7 +39,7 @@ export { default as CustomSelectControl } from './custom-select-control';
 export { default as Dashicon } from './dashicon';
 export { default as DateTimePicker, DatePicker, TimePicker } from './date-time';
 export { default as __experimentalDimensionControl } from './dimension-control';
-export { default as Disabled, Disableable } from './disabled';
+export { default as Disabled } from './disabled';
 export { default as Draggable } from './draggable';
 export {
 	default as DropZone,


### PR DESCRIPTION
## Description

A common pattern in projects is to receive the `disabled` form state from component state or passed props. Then, in order to make one or more `@wordpress/components` components disabled, we conditionally wrap them in a `<Disabled />` component, or in a `<Fragment />`. And any time we want to do that, we have to wrap the `<Disabled />` element with such a condition. This can actually be seen in the [existing example](https://github.com/WordPress/gutenberg/blob/master/packages/components/src/disabled/README.md#usage) in the documentation of `<Disabled />`.

To make this more intuitive, this PR introduces a `isDisabled` prop to the `<Disabled />` component. Based on its boolean value (which defaults to `true`), the `<Disabled />` component will now decide whether to disable all its `children` or not. 

## How has this been tested?
- Manually - test instructions:
  * Spin up storybook locally with this branch: `npm run storybook:dev`
  * Go to `http://localhost:50240/?path=/story/components-disabled--disableable` 
  * Clicking the "Set isDisabled to `(true)|(false)`" button, verify both "disabled" and "non-disabled" states work as expected and disable/enable nested fields.
- With automated tests: `npm run test-unit /packages/components/src/disabled`

## Screenshots 

This PR doesn't introduce any visual changes.

## Types of changes

This PR introduces a new `isDisabled` prop to the `<Disabled />` component.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
