### PR TITLE
[RNMobile] Use Hermes bytecode

### DIFF
--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -10,6 +10,7 @@ For each user feature we should also add a importance categorization label  to i
 -->
 
 ## Unreleased
+* [***] Faster editor start and overall operation on Android [#26732]
 
 ## 1.39.1
 

--- a/packages/react-native-editor/package.json
+++ b/packages/react-native-editor/package.json
@@ -86,7 +86,7 @@
     "postrn-bundle": "cd ../.. && patch-package --reverse --patch-dir packages/react-native-editor/metro-patch",
     "prebundle": "npm run i18n-cache:force",
     "bundle": "npm run bundle:android && npm run bundle:ios",
-    "bundle:android": "mkdir -p bundle/android && npm run rn-bundle -- --platform android --dev false --entry-file index.js --assets-dest bundle/android --bundle-output bundle/android/App.js --sourcemap-output bundle/android/App.js.map",
+    "bundle:android": "mkdir -p bundle/android && npm run rn-bundle -- --platform android --dev false --entry-file index.js --assets-dest bundle/android --bundle-output bundle/android/App.text.js --sourcemap-output bundle/android/App.text.js.map && ./gutenberg/node_modules/hermes-engine/`node -e \"const platform=require('os').platform();console.log(platform === 'darwin' ? 'osx-bin' : (platform === 'linux' ? 'linux64-bin' : (platform === 'win32' ? 'win64-bin' : 'unsupported-os')));\"`/hermes -emit-binary -O -out bundle/android/App.js bundle/android/App.text.js -output-source-map",
     "bundle:ios": "mkdir -p bundle/ios && npm run rn-bundle -- --platform ios --dev false --entry-file index.js --assets-dest bundle/ios --bundle-output bundle/ios/App.js --sourcemap-output bundle/ios/App.js.map",
     "i18n-cache": "node i18n-cache/index.js",
     "i18n-cache:force": "cross-env REFRESH_I18N_CACHE=1 node i18n-cache/index.js",


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This PR build and uses the React Native Hermes bytecode format for the native editor bundle. This provides better performance on Android.

~Note: This PR is build on top of https://github.com/WordPress/gutenberg/pull/26691 so tests can succeed locally on Android 10 devices too.~

## How has this been tested?
Locally on an Android 10 device (Pixel 2 XL) via issuing `npm run test:e2e:android:local` and smoke testing the native demo app. See the [results of the Writing Flow manual tests in this comment](https://github.com/WordPress/gutenberg/pull/26732#issuecomment-723043019).

## Types of changes
* The Android bundle is pass through the Hermes compiler to transform it to bytecode format before using it.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
