### PR TITLE
FocusableIframe: use hooks and avoid withGlobalEvents

### DIFF
--- a/packages/components/src/focusable-iframe/index.js
+++ b/packages/components/src/focusable-iframe/index.js
@@ -8,20 +8,20 @@ export default function FocusableIframe( { iframeRef, onFocus, ...props } ) {
 	const ref = iframeRef || fallbackRef;
 
 	useEffect( () => {
+		const iframe = ref.current;
+		const { ownerDocument } = iframe;
+		const { defaultView } = ownerDocument;
+		const { FocusEvent } = defaultView;
+
 		/**
 		 * Checks whether the iframe is the activeElement, inferring that it has
 		 * then received focus, and calls the `onFocus` prop callback.
 		 */
 		function checkFocus() {
-			const iframe = ref.current;
-			const { ownerDocument } = iframe;
-
 			if ( ownerDocument.activeElement !== iframe ) {
 				return;
 			}
 
-			const { defaultView } = ownerDocument;
-			const { FocusEvent } = defaultView;
 			const focusEvent = new FocusEvent( 'focus', { bubbles: true } );
 
 			iframe.dispatchEvent( focusEvent );
@@ -31,10 +31,10 @@ export default function FocusableIframe( { iframeRef, onFocus, ...props } ) {
 			}
 		}
 
-		window.addEventListener( 'blur', checkFocus );
+		defaultView.addEventListener( 'blur', checkFocus );
 
 		return () => {
-			window.removeEventListener( 'blur', checkFocus );
+			defaultView.removeEventListener( 'blur', checkFocus );
 		};
 	}, [ onFocus ] );
 

--- a/packages/components/src/focusable-iframe/index.js
+++ b/packages/components/src/focusable-iframe/index.js
@@ -1,65 +1,46 @@
 /**
- * External dependencies
- */
-import { omit } from 'lodash';
-
-/**
  * WordPress dependencies
  */
-import { Component, createRef } from '@wordpress/element';
-import { withGlobalEvents } from '@wordpress/compose';
+import { useEffect, useRef } from '@wordpress/element';
 
-/**
- * Browser dependencies
- */
+export default function FocusableIframe( { iframeRef, onFocus, ...props } ) {
+	const fallbackRef = useRef();
+	const ref = iframeRef || fallbackRef;
 
-const { FocusEvent } = window;
+	useEffect( () => {
+		/**
+		 * Checks whether the iframe is the activeElement, inferring that it has
+		 * then received focus, and calls the `onFocus` prop callback.
+		 */
+		function checkFocus() {
+			const iframe = ref.current;
+			const { ownerDocument } = iframe;
 
-class FocusableIframe extends Component {
-	constructor( props ) {
-		super( ...arguments );
+			if ( ownerDocument.activeElement !== iframe ) {
+				return;
+			}
 
-		this.checkFocus = this.checkFocus.bind( this );
+			const { defaultView } = ownerDocument;
+			const { FocusEvent } = defaultView;
+			const focusEvent = new FocusEvent( 'focus', { bubbles: true } );
 
-		this.node = props.iframeRef || createRef();
-	}
+			iframe.dispatchEvent( focusEvent );
 
-	/**
-	 * Checks whether the iframe is the activeElement, inferring that it has
-	 * then received focus, and calls the `onFocus` prop callback.
-	 */
-	checkFocus() {
-		const iframe = this.node.current;
-
-		if ( iframe.ownerDocument.activeElement !== iframe ) {
-			return;
+			if ( onFocus ) {
+				onFocus( focusEvent );
+			}
 		}
 
-		const focusEvent = new FocusEvent( 'focus', { bubbles: true } );
-		iframe.dispatchEvent( focusEvent );
+		window.addEventListener( 'blur', checkFocus );
 
-		const { onFocus } = this.props;
-		if ( onFocus ) {
-			onFocus( focusEvent );
-		}
-	}
+		return () => {
+			window.removeEventListener( 'blur', checkFocus );
+		};
+	}, [ onFocus ] );
 
-	render() {
-		// Disable reason: The rendered iframe is a pass-through component,
-		// assigning props inherited from the rendering parent. It's the
-		// responsibility of the parent to assign a title.
-
-		/* eslint-disable jsx-a11y/iframe-has-title */
-		return (
-			<iframe
-				ref={ this.node }
-				{ ...omit( this.props, [ 'iframeRef', 'onFocus' ] ) }
-			/>
-		);
-		/* eslint-enable jsx-a11y/iframe-has-title */
-	}
+	// Disable reason: The rendered iframe is a pass-through component,
+	// assigning props inherited from the rendering parent. It's the
+	// responsibility of the parent to assign a title.
+	// eslint-disable-next-line jsx-a11y/iframe-has-title
+	return <iframe ref={ ref } { ...props } />;
 }
-
-export default withGlobalEvents( {
-	blur: 'checkFocus',
-} )( FocusableIframe );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

See also #26740, #26742 and #26743.

This is one of the few PRs on the path to deprecate `withGlobalEvents` that is used in a handful of components.

* The HoC is not so useful anymore in the age of hooks. With `useEffect`, it very easy to remove listeners.
* It's only for window events, there's no HoC for global document events.
* When we start using iframes, it shouldn't be assumed which `window` the handler should be added to.

It seems there's no good use in keeping this HoC around.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
