### PR TITLE
Scripts: Unpin ignore-emit-webpack-plugin dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18276,7 +18276,7 @@
 				"dir-glob": "^3.0.1",
 				"eslint": "^7.1.0",
 				"eslint-plugin-markdown": "^1.0.2",
-				"ignore-emit-webpack-plugin": "2.0.3",
+				"ignore-emit-webpack-plugin": "^2.0.6",
 				"jest": "^25.3.0",
 				"jest-puppeteer": "^4.4.0",
 				"markdownlint": "^0.18.0",
@@ -38282,9 +38282,9 @@
 			"dev": true
 		},
 		"ignore-emit-webpack-plugin": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/ignore-emit-webpack-plugin/-/ignore-emit-webpack-plugin-2.0.3.tgz",
-			"integrity": "sha512-ahTYD5KZ3DiZG9goS8NCxBaPEfXsPLH5JeWKmFTThD8lsPen6R4tLnWcN/mrksK5cDqyxOzmRL12feJQZjffuA==",
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/ignore-emit-webpack-plugin/-/ignore-emit-webpack-plugin-2.0.6.tgz",
+			"integrity": "sha512-/zC18RWCC2wz4ZwnS4UoujGWzvSKy28DLjtE+jrGBOXej6YdmityhBDzE8E0NlktEqi4tgdNbydX8B6G4haHSQ==",
 			"dev": true
 		},
 		"ignore-walk": {

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Autoformat TypeScript files (`*.ts` and `*.tsx`) in `format-js` script (#27138)[https://github.com/WordPress/gutenberg/pull/27138].
 
+### Internal
+
+-   The bundled `ignore-emit-webpack-plugin` dependency has been updated from requiring `2.0.3` to requiring `^2.0.6`.
+
 ## 12.5.0 (2020-10-30)
 
 ### Enhancements

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -50,7 +50,7 @@
 		"dir-glob": "^3.0.1",
 		"eslint": "^7.1.0",
 		"eslint-plugin-markdown": "^1.0.2",
-		"ignore-emit-webpack-plugin": "2.0.3",
+		"ignore-emit-webpack-plugin": "^2.0.6",
 		"jest": "^25.3.0",
 		"jest-puppeteer": "^4.4.0",
 		"markdownlint": "^0.18.0",


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

Follow-up for #26591 that temporarily fixed #26547.

https://github.com/mrbar42/ignore-emit-webpack-plugin/issues/17#issuecomment-721584970 - now that `ignore-emit-webpack-plugin` was fixed to work with both webpack v4 and v5 we can allow again to use ranges for the dependency.

## Testing

I still need to figure out if there is an alternative to enforcing the latest version in the project that uses the latest version of `@wordpress/scripts`.