### PR TITLE
WpEmbedPreview: use hooks and avoid withGlobalEvents

### DIFF
--- a/packages/block-library/src/embed/wp-embed-preview.js
+++ b/packages/block-library/src/embed/wp-embed-preview.js
@@ -1,98 +1,98 @@
 /**
  * WordPress dependencies
  */
-import { Component, createRef } from '@wordpress/element';
-import { withGlobalEvents } from '@wordpress/compose';
+import { useRef, useEffect, useMemo } from '@wordpress/element';
 
 /** @typedef {import('@wordpress/element').WPSyntheticEvent} WPSyntheticEvent */
 
-/**
- * Browser dependencies
- */
+export default function WpEmbedPreview( { html } ) {
+	const ref = useRef();
 
-const { FocusEvent, DOMParser } = window;
+	useEffect( () => {
+		const { ownerDocument } = ref.current;
+		const { defaultView } = ownerDocument;
+		const { FocusEvent } = defaultView;
 
-class WpEmbedPreview extends Component {
-	constructor() {
-		super( ...arguments );
+		/**
+		 * Checks for WordPress embed events signaling the height change when iframe
+		 * content loads or iframe's window is resized.  The event is sent from
+		 * WordPress core via the window.postMessage API.
+		 *
+		 * References:
+		 * window.postMessage: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
+		 * WordPress core embed-template on load: https://github.com/WordPress/WordPress/blob/master/wp-includes/js/wp-embed-template.js#L143
+		 * WordPress core embed-template on resize: https://github.com/WordPress/WordPress/blob/master/wp-includes/js/wp-embed-template.js#L187
+		 *
+		 * @param {WPSyntheticEvent} event Message event.
+		 */
+		function resizeWPembeds( { data: { secret, message, value } = {} } ) {
+			if (
+				[ secret, message, value ].some(
+					( attribute ) => ! attribute
+				) ||
+				message !== 'height'
+			) {
+				return;
+			}
 
-		this.checkFocus = this.checkFocus.bind( this );
-		this.node = createRef();
-	}
-
-	componentDidMount() {
-		window.addEventListener( 'message', this.resizeWPembeds );
-	}
-
-	componentWillUnmount() {
-		window.removeEventListener( 'message', this.resizeWPembeds );
-	}
-
-	/**
-	 * Checks for WordPress embed events signaling the height change when iframe
-	 * content loads or iframe's window is resized.  The event is sent from
-	 * WordPress core via the window.postMessage API.
-	 *
-	 * References:
-	 * window.postMessage: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
-	 * WordPress core embed-template on load: https://github.com/WordPress/WordPress/blob/master/wp-includes/js/wp-embed-template.js#L143
-	 * WordPress core embed-template on resize: https://github.com/WordPress/WordPress/blob/master/wp-includes/js/wp-embed-template.js#L187
-	 *
-	 * @param {WPSyntheticEvent} event Message event.
-	 */
-	resizeWPembeds( { data: { secret, message, value } = {} } ) {
-		if (
-			[ secret, message, value ].some( ( attribute ) => ! attribute ) ||
-			message !== 'height'
-		) {
-			return;
+			ownerDocument
+				.querySelectorAll( `iframe[data-secret="${ secret }"` )
+				.forEach( ( iframe ) => {
+					if ( +iframe.height !== value ) {
+						iframe.height = value;
+					}
+				} );
 		}
 
-		document
-			.querySelectorAll( `iframe[data-secret="${ secret }"` )
-			.forEach( ( iframe ) => {
-				if ( +iframe.height !== value ) {
-					iframe.height = value;
-				}
-			} );
-	}
+		/**
+		 * Checks whether the wp embed iframe is the activeElement,
+		 * if it is dispatch a focus event.
+		 */
+		function checkFocus() {
+			const { activeElement } = ownerDocument;
 
-	/**
-	 * Checks whether the wp embed iframe is the activeElement,
-	 * if it is dispatch a focus event.
-	 */
-	checkFocus() {
-		const { activeElement } = document;
+			if (
+				activeElement.tagName !== 'IFRAME' ||
+				activeElement.parentNode !== ref.current
+			) {
+				return;
+			}
 
-		if (
-			activeElement.tagName !== 'IFRAME' ||
-			activeElement.parentNode !== this.node.current
-		) {
-			return;
+			const focusEvent = new FocusEvent( 'focus', { bubbles: true } );
+			activeElement.dispatchEvent( focusEvent );
 		}
 
-		const focusEvent = new FocusEvent( 'focus', { bubbles: true } );
-		activeElement.dispatchEvent( focusEvent );
-	}
+		defaultView.addEventListener( 'message', resizeWPembeds );
+		defaultView.addEventListener( 'blur', checkFocus );
 
-	render() {
-		const { html } = this.props;
-		const doc = new DOMParser().parseFromString( html, 'text/html' );
+		return () => {
+			defaultView.removeEventListener( 'message', resizeWPembeds );
+			defaultView.removeEventListener( 'blur', checkFocus );
+		};
+	}, [] );
+
+	const __html = useMemo( () => {
+		const doc = new window.DOMParser().parseFromString( html, 'text/html' );
 		const iframe = doc.querySelector( 'iframe' );
-		if ( iframe ) iframe.removeAttribute( 'style' );
+
+		if ( iframe ) {
+			iframe.removeAttribute( 'style' );
+		}
+
 		const blockQuote = doc.querySelector( 'blockquote' );
-		if ( blockQuote ) blockQuote.style.display = 'none';
 
-		return (
-			<div
-				ref={ this.node }
-				className="wp-block-embed__wrapper"
-				dangerouslySetInnerHTML={ { __html: doc.body.innerHTML } }
-			/>
-		);
-	}
+		if ( blockQuote ) {
+			blockQuote.style.display = 'none';
+		}
+
+		return doc.body.innerHTML;
+	}, [ html ] );
+
+	return (
+		<div
+			ref={ ref }
+			className="wp-block-embed__wrapper"
+			dangerouslySetInnerHTML={ { __html } }
+		/>
+	);
 }
-
-export default withGlobalEvents( {
-	blur: 'checkFocus',
-} )( WpEmbedPreview );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

See also #26737, #26742 and #26743.

> This is one of the few PRs on the path to deprecate `withGlobalEvents` that is used in a handful of components.
>
> * The HoC is not so useful anymore in the age of hooks. With `useEffect`, it very easy to remove listeners.
> * It's only for window events, there's no HoC for global document events.
> * When we start using iframes, it shouldn't be assumed which `window` the handler should be added to.
>
> It seems there's no good use in keeping this HoC around.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
