### PR TITLE
Components: Fix FormTokenField input position when typing

### DIFF
--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -21,11 +21,13 @@
 	// Token input
 	input[type="text"].components-form-token-field__input {
 		display: inline-block;
+		flex: 1;
 		width: 100%;
 		max-width: 100%;
 		margin-left: 4px;
 		padding: 0;
 		min-height: 24px;
+		min-width: 50px;
 		background: inherit;
 		border: 0;
 		color: $gray-900;


### PR DESCRIPTION
This update improves the internal `input` element's position within the `FormTokenField`. The `input` now aligns (when possible) next the the previous token elements, rather than always jumping to the bottom (when empty).

The fix involved making the `input` width adaptive using Flexbox (`flex: 1`).

For the following screenshots, I've coloured the `input` background to make it easier to see it's position within the `FormTokenField`.

##### Before

<img width="247" alt="Screen Shot 2020-11-05 at 11 37 09 AM" src="https://user-images.githubusercontent.com/2322354/98270306-bf305480-1f5c-11eb-86de-484b8d0e7287.png">

The `input` is at the bottom.

##### After

<img width="252" alt="Screen Shot 2020-11-05 at 11 37 17 AM" src="https://user-images.githubusercontent.com/2322354/98270292-ba6ba080-1f5c-11eb-9ba1-a0f18cf0446f.png">

The `input` snaps to the left, aligning to the tokens.

##### Result

<img width="252" src="https://user-images.githubusercontent.com/2322354/98270449-e129d700-1f5c-11eb-91fe-5b917e9d3507.gif" />


## How has this been tested?

Tested locally in Gutenberg.

* `npm run dev`
* Go to a Post
* Add tags
* Ensure that the text caret is (mostly) aligned next to the added tags.

Note: I've noticed that there's still "jumping" with this interaction - more noticeable when entering tags rapidly. This issue existed before this fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [n/a] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [n/a] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [n/a] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [n/a] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
