### PR TITLE
PostLockedModal: use hooks and avoid withGlobalEvents

### DIFF
--- a/packages/editor/src/components/post-locked-modal/index.js
+++ b/packages/editor/src/components/post-locked-modal/index.js
@@ -8,11 +8,11 @@ import { get } from 'lodash';
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Modal, Button } from '@wordpress/components';
-import { withSelect, withDispatch } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
-import { Component } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 import { addAction, removeAction } from '@wordpress/hooks';
-import { compose, withGlobalEvents, withInstanceId } from '@wordpress/compose';
+import { useInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -20,220 +20,19 @@ import { compose, withGlobalEvents, withInstanceId } from '@wordpress/compose';
 import { getWPAdminURL } from '../../utils/url';
 import PostPreviewButton from '../post-preview-button';
 
-class PostLockedModal extends Component {
-	constructor() {
-		super( ...arguments );
-
-		this.sendPostLock = this.sendPostLock.bind( this );
-		this.receivePostLock = this.receivePostLock.bind( this );
-		this.releasePostLock = this.releasePostLock.bind( this );
-	}
-
-	componentDidMount() {
-		const hookName = this.getHookName();
-
-		// Details on these events on the Heartbeat API docs
-		// https://developer.wordpress.org/plugins/javascript/heartbeat-api/
-		addAction( 'heartbeat.send', hookName, this.sendPostLock );
-		addAction( 'heartbeat.tick', hookName, this.receivePostLock );
-	}
-
-	componentWillUnmount() {
-		const hookName = this.getHookName();
-
-		removeAction( 'heartbeat.send', hookName );
-		removeAction( 'heartbeat.tick', hookName );
-	}
-
-	/**
-	 * Returns a `@wordpress/hooks` hook name specific to the instance of the
-	 * component.
-	 *
-	 * @return {string} Hook name prefix.
-	 */
-	getHookName() {
-		const { instanceId } = this.props;
-		return 'core/editor/post-locked-modal-' + instanceId;
-	}
-
-	/**
-	 * Keep the lock refreshed.
-	 *
-	 * When the user does not send a heartbeat in a heartbeat-tick
-	 * the user is no longer editing and another user can start editing.
-	 *
-	 * @param {Object} data Data to send in the heartbeat request.
-	 */
-	sendPostLock( data ) {
-		const { isLocked, activePostLock, postId } = this.props;
-		if ( isLocked ) {
-			return;
-		}
-
-		data[ 'wp-refresh-post-lock' ] = {
-			lock: activePostLock,
-			post_id: postId,
-		};
-	}
-
-	/**
-	 * Refresh post locks: update the lock string or show the dialog if somebody has taken over editing.
-	 *
-	 * @param {Object} data Data received in the heartbeat request
-	 */
-	receivePostLock( data ) {
-		if ( ! data[ 'wp-refresh-post-lock' ] ) {
-			return;
-		}
-
-		const { autosave, updatePostLock } = this.props;
-		const received = data[ 'wp-refresh-post-lock' ];
-		if ( received.lock_error ) {
-			// Auto save and display the takeover modal.
-			autosave();
-			updatePostLock( {
-				isLocked: true,
-				isTakeover: true,
-				user: {
-					avatar: received.lock_error.avatar_src,
-				},
-			} );
-		} else if ( received.new_lock ) {
-			updatePostLock( {
-				isLocked: false,
-				activePostLock: received.new_lock,
-			} );
-		}
-	}
-
-	/**
-	 * Unlock the post before the window is exited.
-	 */
-	releasePostLock() {
-		const { isLocked, activePostLock, postLockUtils, postId } = this.props;
-		if ( isLocked || ! activePostLock ) {
-			return;
-		}
-
-		const data = new window.FormData();
-		data.append( 'action', 'wp-remove-post-lock' );
-		data.append( '_wpnonce', postLockUtils.unlockNonce );
-		data.append( 'post_ID', postId );
-		data.append( 'active_post_lock', activePostLock );
-
-		if ( window.navigator.sendBeacon ) {
-			window.navigator.sendBeacon( postLockUtils.ajaxUrl, data );
-		} else {
-			const xhr = new window.XMLHttpRequest();
-			xhr.open( 'POST', postLockUtils.ajaxUrl, false );
-			xhr.send( data );
-		}
-	}
-
-	render() {
-		const {
-			user,
-			postId,
-			isLocked,
-			isTakeover,
-			postLockUtils,
-			postType,
-		} = this.props;
-		if ( ! isLocked ) {
-			return null;
-		}
-
-		const userDisplayName = user.name;
-		const userAvatar = user.avatar;
-
-		const unlockUrl = addQueryArgs( 'post.php', {
-			'get-post-lock': '1',
-			lockKey: true,
-			post: postId,
-			action: 'edit',
-			_wpnonce: postLockUtils.nonce,
-		} );
-		const allPostsUrl = getWPAdminURL( 'edit.php', {
-			post_type: get( postType, [ 'slug' ] ),
-		} );
-		const allPostsLabel = __( 'Exit the Editor' );
-		return (
-			<Modal
-				title={
-					isTakeover
-						? __( 'Someone else has taken over this post.' )
-						: __( 'This post is already being edited.' )
-				}
-				focusOnMount={ true }
-				shouldCloseOnClickOutside={ false }
-				shouldCloseOnEsc={ false }
-				isDismissible={ false }
-				className="editor-post-locked-modal"
-			>
-				{ !! userAvatar && (
-					<img
-						src={ userAvatar }
-						alt={ __( 'Avatar' ) }
-						className="editor-post-locked-modal__avatar"
-					/>
-				) }
-				{ !! isTakeover && (
-					<div>
-						<div>
-							{ userDisplayName
-								? sprintf(
-										/* translators: %s: user's display name */
-										__(
-											'%s now has editing control of this post. Don’t worry, your changes up to this moment have been saved.'
-										),
-										userDisplayName
-								  )
-								: __(
-										'Another user now has editing control of this post. Don’t worry, your changes up to this moment have been saved.'
-								  ) }
-						</div>
-
-						<div className="editor-post-locked-modal__buttons">
-							<Button isPrimary href={ allPostsUrl }>
-								{ allPostsLabel }
-							</Button>
-						</div>
-					</div>
-				) }
-				{ ! isTakeover && (
-					<div>
-						<div>
-							{ userDisplayName
-								? sprintf(
-										/* translators: %s: user's display name */
-										__(
-											'%s is currently working on this post, which means you cannot make changes, unless you take over.'
-										),
-										userDisplayName
-								  )
-								: __(
-										'Another user is currently working on this post, which means you cannot make changes, unless you take over.'
-								  ) }
-						</div>
-
-						<div className="editor-post-locked-modal__buttons">
-							<Button isSecondary href={ allPostsUrl }>
-								{ allPostsLabel }
-							</Button>
-							<PostPreviewButton />
-							<Button isPrimary href={ unlockUrl }>
-								{ __( 'Take Over' ) }
-							</Button>
-						</div>
-					</div>
-				) }
-			</Modal>
-		);
-	}
-}
-
-export default compose(
-	withSelect( ( select ) => {
+export default function PostLockedModal() {
+	const instanceId = useInstanceId( PostLockedModal );
+	const hookName = 'core/editor/post-locked-modal-' + instanceId;
+	const { autosave, updatePostLock } = useDispatch( 'core/editor' );
+	const {
+		isLocked,
+		isTakeover,
+		user,
+		postId,
+		postLockUtils,
+		activePostLock,
+		postType,
+	} = useSelect( ( select ) => {
 		const {
 			isPostLocked,
 			isPostLockTakeover,
@@ -253,16 +52,181 @@ export default compose(
 			activePostLock: getActivePostLock(),
 			postType: getPostType( getEditedPostAttribute( 'type' ) ),
 		};
-	} ),
-	withDispatch( ( dispatch ) => {
-		const { autosave, updatePostLock } = dispatch( 'core/editor' );
-		return {
-			autosave,
-			updatePostLock,
+	} );
+
+	useEffect( () => {
+		/**
+		 * Keep the lock refreshed.
+		 *
+		 * When the user does not send a heartbeat in a heartbeat-tick
+		 * the user is no longer editing and another user can start editing.
+		 *
+		 * @param {Object} data Data to send in the heartbeat request.
+		 */
+		function sendPostLock( data ) {
+			if ( isLocked ) {
+				return;
+			}
+
+			data[ 'wp-refresh-post-lock' ] = {
+				lock: activePostLock,
+				post_id: postId,
+			};
+		}
+
+		/**
+		 * Refresh post locks: update the lock string or show the dialog if somebody has taken over editing.
+		 *
+		 * @param {Object} data Data received in the heartbeat request
+		 */
+		function receivePostLock( data ) {
+			if ( ! data[ 'wp-refresh-post-lock' ] ) {
+				return;
+			}
+
+			const received = data[ 'wp-refresh-post-lock' ];
+			if ( received.lock_error ) {
+				// Auto save and display the takeover modal.
+				autosave();
+				updatePostLock( {
+					isLocked: true,
+					isTakeover: true,
+					user: {
+						avatar: received.lock_error.avatar_src,
+					},
+				} );
+			} else if ( received.new_lock ) {
+				updatePostLock( {
+					isLocked: false,
+					activePostLock: received.new_lock,
+				} );
+			}
+		}
+
+		/**
+		 * Unlock the post before the window is exited.
+		 */
+		function releasePostLock() {
+			if ( isLocked || ! activePostLock ) {
+				return;
+			}
+
+			const data = new window.FormData();
+			data.append( 'action', 'wp-remove-post-lock' );
+			data.append( '_wpnonce', postLockUtils.unlockNonce );
+			data.append( 'post_ID', postId );
+			data.append( 'active_post_lock', activePostLock );
+
+			if ( window.navigator.sendBeacon ) {
+				window.navigator.sendBeacon( postLockUtils.ajaxUrl, data );
+			} else {
+				const xhr = new window.XMLHttpRequest();
+				xhr.open( 'POST', postLockUtils.ajaxUrl, false );
+				xhr.send( data );
+			}
+		}
+
+		// Details on these events on the Heartbeat API docs
+		// https://developer.wordpress.org/plugins/javascript/heartbeat-api/
+		addAction( 'heartbeat.send', hookName, sendPostLock );
+		addAction( 'heartbeat.tick', hookName, receivePostLock );
+		window.addEventListener( 'beforeunload', releasePostLock );
+
+		return () => {
+			removeAction( 'heartbeat.send', hookName );
+			removeAction( 'heartbeat.tick', hookName );
+			window.removeEventListener( 'beforeunload', releasePostLock );
 		};
-	} ),
-	withInstanceId,
-	withGlobalEvents( {
-		beforeunload: 'releasePostLock',
-	} )
-)( PostLockedModal );
+	}, [] );
+
+	if ( ! isLocked ) {
+		return null;
+	}
+
+	const userDisplayName = user.name;
+	const userAvatar = user.avatar;
+
+	const unlockUrl = addQueryArgs( 'post.php', {
+		'get-post-lock': '1',
+		lockKey: true,
+		post: postId,
+		action: 'edit',
+		_wpnonce: postLockUtils.nonce,
+	} );
+	const allPostsUrl = getWPAdminURL( 'edit.php', {
+		post_type: get( postType, [ 'slug' ] ),
+	} );
+	const allPostsLabel = __( 'Exit the Editor' );
+	return (
+		<Modal
+			title={
+				isTakeover
+					? __( 'Someone else has taken over this post.' )
+					: __( 'This post is already being edited.' )
+			}
+			focusOnMount={ true }
+			shouldCloseOnClickOutside={ false }
+			shouldCloseOnEsc={ false }
+			isDismissible={ false }
+			className="editor-post-locked-modal"
+		>
+			{ !! userAvatar && (
+				<img
+					src={ userAvatar }
+					alt={ __( 'Avatar' ) }
+					className="editor-post-locked-modal__avatar"
+				/>
+			) }
+			{ !! isTakeover && (
+				<div>
+					<div>
+						{ userDisplayName
+							? sprintf(
+									/* translators: %s: user's display name */
+									__(
+										'%s now has editing control of this post. Don’t worry, your changes up to this moment have been saved.'
+									),
+									userDisplayName
+							  )
+							: __(
+									'Another user now has editing control of this post. Don’t worry, your changes up to this moment have been saved.'
+							  ) }
+					</div>
+
+					<div className="editor-post-locked-modal__buttons">
+						<Button isPrimary href={ allPostsUrl }>
+							{ allPostsLabel }
+						</Button>
+					</div>
+				</div>
+			) }
+			{ ! isTakeover && (
+				<div>
+					<div>
+						{ userDisplayName
+							? sprintf(
+									/* translators: %s: user's display name */
+									__(
+										'%s is currently working on this post, which means you cannot make changes, unless you take over.'
+									),
+									userDisplayName
+							  )
+							: __(
+									'Another user is currently working on this post, which means you cannot make changes, unless you take over.'
+							  ) }
+					</div>
+
+					<div className="editor-post-locked-modal__buttons">
+						<Button isSecondary href={ allPostsUrl }>
+							{ allPostsLabel }
+						</Button>
+						<PostPreviewButton />
+						<Button isPrimary href={ unlockUrl }>
+							{ __( 'Take Over' ) }
+						</Button>
+					</div>
+				</div>
+			) }
+		</Modal>
+	);
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

See also #26737, #26740 and #26742.

> This is one of the few PRs on the path to deprecate `withGlobalEvents` that is used in a handful of components.
>
> * The HoC is not so useful anymore in the age of hooks. With `useEffect`, it very easy to remove listeners.
> * It's only for window events, there's no HoC for global document events.
> * When we start using iframes, it shouldn't be assumed which `window` the handler should be added to.
>
> It seems there's no good use in keeping this HoC around.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
