### PR TITLE
GitHub Actions: Build Plugin zip, store as artifact on every PR

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -1,10 +1,13 @@
-on:
-  push:
-    # Sequence of patterns matched against refs/tags
-    tags:
-    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+name: Build Gutenberg Plugin Zip
 
-name: Build Gutenberg and upload to Draft Release
+on:
+  pull_request:
+    paths-ignore:
+    - '**.md'
+  push:
+    branches: [master]
+    paths-ignore:
+    - '**.md'
 
 jobs:
   build:
@@ -37,28 +40,8 @@ jobs:
         env:
           NO_CHECKS: 'true'
 
-      - name: Set Release Version
-        id: get_release_version
-        run: echo ::set-output name=version::$(echo $GITHUB_REF | cut -d / -f 3 | sed s/^v// | sed 's/-rc./ RC/' )
-
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1.0.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ steps.get_release_version.outputs.version }}
-          draft: true
-          prerelease: ${{ contains(github.ref, 'rc') }}
-
-      - name: Upload Release Asset
-        id: upload-release-asset 
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./gutenberg.zip
-          asset_name: gutenberg.zip
-          asset_content_type: application/zip
+          name: gutenberg-plugin
+          path: ./gutenberg.zip

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -1,0 +1,64 @@
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+name: Build Gutenberg and upload to Draft Release
+
+jobs:
+  build:
+    name: Upload Release Asset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Use Node.js 12.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+
+      - name: Build Gutenberg plugin ZIP file
+        run: ./bin/build-plugin-zip.sh
+        env:
+          NO_CHECKS: 'true'
+
+      - name: Set Release Version
+        id: get_release_version
+        run: echo ::set-output name=version::$(echo $GITHUB_REF | cut -d / -f 3 | sed s/^v// | sed 's/-rc./ RC/' )
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ steps.get_release_version.outputs.version }}
+          draft: true
+          prerelease: ${{ contains(github.ref, 'rc') }}
+
+      - name: Upload Release Asset
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./gutenberg.zip
+          asset_name: gutenberg.zip
+          asset_content_type: application/zip

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    name: Upload Release Asset
+    name: Build Release Artifact
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Description
Spun off from #19626 since apparently this functionality [was found useful](https://github.com/WordPress/gutenberg/pull/19626#issuecomment-721917679) :smile: 

Build the plugin zip on every PR and store the file as an artifact so it can be used for testing outside of a dev environment.

## How has this been tested?

- At the bottom of this PR, locate the GitHub actions that were run.
- Find the 'Build Gutenberg Plugin Zip' one and click on its 'Details' link.

![image](https://user-images.githubusercontent.com/96308/98283027-54543d00-1f9f-11eb-8047-1c7ef0f7a692.png)

- Click the 'Artifacts' dropdown

![image](https://user-images.githubusercontent.com/96308/98284443-6cc55700-1fa1-11eb-94bc-aee180913888.png)

- Click the 'gutenberg-plugin` link in order to start the download

- This will download a zip named `gutenberg-plugin.zip` _which contains_ the actual plugin zip (`gutenberg.zip`). The double-zip is due to a [limitation](https://github.com/marketplace/actions/upload-a-build-artifact#zipped-artifact-downloads) of GitHub's `upload-artifacts` action. We can work around this (by changing the action to upload files individually, and rely on GH to bundle them in a zip anyway), but that might have the downside that if we want to pass artifacts between jobs (which might come in handy e.g. for e2e tests and the like), we'll _also_ have to pass artifact contents individually, which seems suboptimal. I thus opted to keep the double zip for now.

## Types of changes
New dev feature.