### PR TITLE
Deprecate the withGlobalEvents HoC

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17710,6 +17710,7 @@
 			"version": "file:packages/compose",
 			"requires": {
 				"@babel/runtime": "^7.11.2",
+				"@wordpress/deprecated": "file:packages/deprecated",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"@wordpress/priority-queue": "file:packages/priority-queue",

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -276,20 +276,11 @@ _Parameters_
 
 <a name="withGlobalEvents" href="#withGlobalEvents">#</a> **withGlobalEvents**
 
-Higher-order component creator which, given an object of DOM event types and
-values corresponding to a callback function name on the component, will
-create or update a window event handler to invoke the callback when an event
-occurs. On behalf of the consuming developer, the higher-order component
-manages unbinding when the component unmounts, and binding at most a single
-event handler for the entire application.
+> **Deprecated** 
 
 _Parameters_
 
--   _eventTypesToHandlers_ `Object<string,string>`: Object with keys of DOM event type, the value a name of the function on the original component's instance which handles the event.
-
-_Returns_
-
--   `Function`: Higher-order component.
+-   _passedArguments_ `...any`: 
 
 <a name="withInstanceId" href="#withInstanceId">#</a> **withInstanceId**
 

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -278,9 +278,20 @@ _Parameters_
 
 > **Deprecated** 
 
+Higher-order component creator which, given an object of DOM event types and
+values corresponding to a callback function name on the component, will
+create or update a window event handler to invoke the callback when an event
+occurs. On behalf of the consuming developer, the higher-order component
+manages unbinding when the component unmounts, and binding at most a single
+event handler for the entire application.
+
 _Parameters_
 
--   _passedArguments_ `...any`: 
+-   _eventTypesToHandlers_ `Object<string,string>`: Object with keys of DOM event type, the value a name of the function on the original component's instance which handles the event.
+
+_Returns_
+
+-   `Function`: Higher-order component.
 
 <a name="withInstanceId" href="#withInstanceId">#</a> **withInstanceId**
 

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -26,6 +26,7 @@
 	"sideEffects": false,
 	"dependencies": {
 		"@babel/runtime": "^7.11.2",
+		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/element": "file:../element",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/priority-queue": "file:../priority-queue",

--- a/packages/compose/src/higher-order/with-global-events/README.md
+++ b/packages/compose/src/higher-order/with-global-events/README.md
@@ -1,6 +1,8 @@
 withGlobalEvents
 ================
 
+**Deprecated**
+
 `withGlobalEvents` is a higher-order component used to facilitate responding to global events, where one would otherwise use `window.addEventListener`.
 
 On behalf of the consuming developer, the higher-order component manages:

--- a/packages/compose/src/higher-order/with-global-events/index.js
+++ b/packages/compose/src/higher-order/with-global-events/index.js
@@ -7,6 +7,7 @@ import { forEach } from 'lodash';
  * WordPress dependencies
  */
 import { Component, forwardRef } from '@wordpress/element';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -39,6 +40,10 @@ const listener = new Listener();
  * @return {Function} Higher-order component.
  */
 function withGlobalEvents( eventTypesToHandlers ) {
+	deprecated( 'wp.compose.withGlobalEvents', {
+		alternative: 'useEffect',
+	} );
+
 	return createHigherOrderComponent( ( WrappedComponent ) => {
 		class Wrapper extends Component {
 			constructor() {

--- a/packages/compose/src/higher-order/with-global-events/index.js
+++ b/packages/compose/src/higher-order/with-global-events/index.js
@@ -30,6 +30,8 @@ const listener = new Listener();
  * manages unbinding when the component unmounts, and binding at most a single
  * event handler for the entire application.
  *
+ * @deprecated
+ *
  * @param {Object<string,string>} eventTypesToHandlers Object with keys of DOM
  *                                                     event type, the value a
  *                                                     name of the function on
@@ -39,11 +41,7 @@ const listener = new Listener();
  *
  * @return {Function} Higher-order component.
  */
-function withGlobalEvents( eventTypesToHandlers ) {
-	deprecated( 'wp.compose.withGlobalEvents', {
-		alternative: 'useEffect',
-	} );
-
+export function withGlobalEvents( eventTypesToHandlers ) {
 	return createHigherOrderComponent( ( WrappedComponent ) => {
 		class Wrapper extends Component {
 			constructor() {
@@ -98,4 +96,15 @@ function withGlobalEvents( eventTypesToHandlers ) {
 	}, 'withGlobalEvents' );
 }
 
-export default withGlobalEvents;
+/**
+ * @deprecated
+ *
+ * @param {...any} passedArguments
+ */
+export default ( ...passedArguments ) => {
+	deprecated( 'wp.compose.withGlobalEvents', {
+		alternative: 'useEffect',
+	} );
+
+	return withGlobalEvents( ...passedArguments );
+};

--- a/packages/compose/src/higher-order/with-global-events/index.js
+++ b/packages/compose/src/higher-order/with-global-events/index.js
@@ -41,7 +41,11 @@ const listener = new Listener();
  *
  * @return {Function} Higher-order component.
  */
-export function withGlobalEvents( eventTypesToHandlers ) {
+export default function withGlobalEvents( eventTypesToHandlers ) {
+	deprecated( 'wp.compose.withGlobalEvents', {
+		alternative: 'useEffect',
+	} );
+
 	return createHigherOrderComponent( ( WrappedComponent ) => {
 		class Wrapper extends Component {
 			constructor() {
@@ -95,16 +99,3 @@ export function withGlobalEvents( eventTypesToHandlers ) {
 		} );
 	}, 'withGlobalEvents' );
 }
-
-/**
- * @deprecated
- *
- * @param {...any} passedArguments
- */
-export default ( ...passedArguments ) => {
-	deprecated( 'wp.compose.withGlobalEvents', {
-		alternative: 'useEffect',
-	} );
-
-	return withGlobalEvents( ...passedArguments );
-};

--- a/packages/compose/src/higher-order/with-global-events/test/index.js
+++ b/packages/compose/src/higher-order/with-global-events/test/index.js
@@ -11,7 +11,7 @@ import { Component } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import withGlobalEvents from '../';
+import { withGlobalEvents } from '../';
 import Listener from '../listener';
 
 jest.mock( '../listener', () => {

--- a/packages/compose/src/higher-order/with-global-events/test/index.js
+++ b/packages/compose/src/higher-order/with-global-events/test/index.js
@@ -11,7 +11,7 @@ import { Component } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { withGlobalEvents } from '../';
+import withGlobalEvents from '../';
 import Listener from '../listener';
 
 jest.mock( '../listener', () => {
@@ -72,6 +72,7 @@ describe( 'withGlobalEvents', () => {
 	it( 'renders with original component', () => {
 		mountEnhancedComponent();
 
+		expect( console ).toHaveWarned();
 		expect( wrapper.root.findByType( 'div' ).children[ 0 ] ).toBe(
 			'Hello'
 		);


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

With #26737, #26740, #26742 and #26743, all uses in Gutenberg of `withGlobalEvents` have been removed.

* The HoC is not so useful anymore in the age of hooks. With useEffect, it very easy to remove listeners.
* It's only for window events, there's no HoC for global document events.
* When we start using iframes, it shouldn't be assumed which window the handler should be added to.

I don't think it makes much sense to keep this component around.

To do: remove the doc block from the module read me. @nosolosw @youknowriad I'm not sure how this has been handled in the past? How do we mark components as deprecated so the doc builder doesn't include it in the module read me file?

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
