### PR TITLE
Chore: Fix: Font families property passing on TypographyPanel

### DIFF
--- a/packages/edit-site/src/components/sidebar/typography-panel.js
+++ b/packages/edit-site/src/components/sidebar/typography-panel.js
@@ -33,6 +33,7 @@ export default function TypographyPanel( {
 		<PanelBody title={ __( 'Typography' ) } initialOpen={ true }>
 			{ supports.includes( 'fontFamily' ) && (
 				<FontFamilyControl
+					fontFamilies={ fontFamilies }
 					value={ getStyleProperty( name, 'fontFamily' ) }
 					onChange={ ( value ) =>
 						setStyleProperty( name, 'fontFamily', value )
@@ -51,7 +52,6 @@ export default function TypographyPanel( {
 			) }
 			{ supports.includes( 'lineHeight' ) && (
 				<LineHeightControl
-					fontFamilies={ fontFamilies }
 					value={ getStyleProperty( name, 'lineHeight' ) }
 					onChange={ ( value ) =>
 						setStyleProperty( name, 'lineHeight', value )


### PR DESCRIPTION
Fix a small issue that happened during a rebase on https://github.com/WordPress/gutenberg/pull/24868.