### PR TITLE
Fix/column width units

### DIFF
--- a/packages/block-library/src/column/deprecated.js
+++ b/packages/block-library/src/column/deprecated.js
@@ -6,34 +6,9 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+import { InnerBlocks } from '@wordpress/block-editor';
 
 const deprecated = [
-	{
-		save( { attributes } ) {
-			const { verticalAlignment, width } = attributes;
-
-			const wrapperClasses = classnames( {
-				[ `is-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,
-			} );
-
-			let style;
-			if ( width ) {
-				style = { flexBasis: width };
-			}
-
-			return (
-				<div
-					{ ...useBlockProps.save( {
-						className: wrapperClasses,
-						style,
-					} ) }
-				>
-					<InnerBlocks.Content />
-				</div>
-			);
-		},
-	},
 	{
 		attributes: {
 			verticalAlignment: {

--- a/packages/block-library/src/column/deprecated.js
+++ b/packages/block-library/src/column/deprecated.js
@@ -6,9 +6,34 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { InnerBlocks } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
 const deprecated = [
+	{
+		save( { attributes } ) {
+			const { verticalAlignment, width } = attributes;
+
+			const wrapperClasses = classnames( {
+				[ `is-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,
+			} );
+
+			let style;
+			if ( width ) {
+				style = { flexBasis: width };
+			}
+
+			return (
+				<div
+					{ ...useBlockProps.save( {
+						className: wrapperClasses,
+						style,
+					} ) }
+				>
+					<InnerBlocks.Content />
+				</div>
+			);
+		},
+	},
 	{
 		attributes: {
 			verticalAlignment: {

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -55,9 +55,10 @@ function ColumnEdit( {
 		} );
 	};
 
+	const widthWithUnit = Number.isFinite( width ) ? width + '%' : width;
 	const blockProps = useBlockProps( {
 		className: classes,
-		style: width ? { flexBasis: width } : undefined,
+		style: widthWithUnit ? { flexBasis: widthWithUnit } : undefined,
 	} );
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		templateLock,

--- a/packages/block-library/src/column/save.js
+++ b/packages/block-library/src/column/save.js
@@ -16,7 +16,10 @@ export default function save( { attributes } ) {
 	} );
 
 	let style;
-	if ( width ) {
+
+	if ( Number.isFinite( width ) ) {
+		style = { flexBasis: width + '%' };
+	} else {
 		style = { flexBasis: width };
 	}
 

--- a/packages/block-library/src/column/save.js
+++ b/packages/block-library/src/column/save.js
@@ -17,10 +17,9 @@ export default function save( { attributes } ) {
 
 	let style;
 
-	if ( Number.isFinite( width ) ) {
-		style = { flexBasis: width + '%' };
-	} else {
-		style = { flexBasis: width };
+	if ( width ) {
+		// Numbers are handled for backward compatibility as they can be still provided with templates.
+		style = { flexBasis: Number.isFinite( width ) ? width + '%' : width };
 	}
 
 	return (

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -28,7 +28,7 @@ import {
  * Internal dependencies
  */
 import {
-	hasExplicitColumnWidths,
+	hasExplicitPercentColumnWidths,
 	getMappedColumnWidths,
 	getRedistributedColumnWidths,
 	toWidthPrecision,
@@ -145,7 +145,9 @@ const ColumnsEditContainerWrapper = withDispatch(
 			const { getBlocks } = registry.select( 'core/block-editor' );
 
 			let innerBlocks = getBlocks( clientId );
-			const hasExplicitWidths = hasExplicitColumnWidths( innerBlocks );
+			const hasExplicitWidths = hasExplicitPercentColumnWidths(
+				innerBlocks
+			);
 
 			// Redistribute available width for existing inner blocks.
 			const isAddingColumn = newColumns > previousColumns;

--- a/packages/block-library/src/columns/test/utils.js
+++ b/packages/block-library/src/columns/test/utils.js
@@ -7,7 +7,7 @@ import {
 	getTotalColumnsWidth,
 	getColumnWidths,
 	getRedistributedColumnWidths,
-	hasExplicitColumnWidths,
+	hasExplicitPercentColumnWidths,
 	getMappedColumnWidths,
 } from '../utils';
 
@@ -164,27 +164,27 @@ describe( 'getRedistributedColumnWidths', () => {
 	} );
 } );
 
-describe( 'hasExplicitColumnWidths', () => {
+describe( 'hasExplicitPercentColumnWidths', () => {
 	it( 'returns false if no blocks have explicit width', () => {
 		const blocks = [ { attributes: {} } ];
 
-		const result = hasExplicitColumnWidths( blocks );
+		const result = hasExplicitPercentColumnWidths( blocks );
 
 		expect( result ).toBe( false );
 	} );
 
-	it( 'returns true if a block has explicit width', () => {
+	it( 'returns true if a block has explicit width defined as a number', () => {
 		const blocks = [ { attributes: { width: 100 } } ];
 
-		const result = hasExplicitColumnWidths( blocks );
+		const result = hasExplicitPercentColumnWidths( blocks );
 
 		expect( result ).toBe( true );
 	} );
 
-	it( 'returns true if a block has explicit width defined as a string', () => {
+	it( 'returns true if a block has explicit percent width defined as a string', () => {
 		const blocks = [ { attributes: { width: '100%' } } ];
 
-		const result = hasExplicitColumnWidths( blocks );
+		const result = hasExplicitPercentColumnWidths( blocks );
 
 		expect( result ).toBe( true );
 	} );
@@ -195,7 +195,7 @@ describe( 'hasExplicitColumnWidths', () => {
 			{ attributes: { width: undefined } },
 		];
 
-		const result = hasExplicitColumnWidths( blocks );
+		const result = hasExplicitPercentColumnWidths( blocks );
 
 		expect( result ).toBe( false );
 	} );
@@ -206,20 +206,31 @@ describe( 'hasExplicitColumnWidths', () => {
 			{ attributes: { width: 90 } },
 		];
 
-		const result = hasExplicitColumnWidths( blocks );
+		const result = hasExplicitPercentColumnWidths( blocks );
 
 		expect( result ).toBe( true );
 	} );
 
-	it( 'returns true if blocks have width defined as strings and numbers', () => {
+	it( 'returns true if blocks have width defined as percent strings and numbers', () => {
 		const blocks = [
-			{ attributes: { width: 10 } },
+			{ attributes: { width: '10%' } },
+			{ attributes: { width: 90 } },
+		];
+
+		const result = hasExplicitPercentColumnWidths( blocks );
+
+		expect( result ).toBe( true );
+	} );
+
+	it( 'returns false if blocks have width defined as mixed unit strings', () => {
+		const blocks = [
+			{ attributes: { width: '20%' } },
 			{ attributes: { width: '90px' } },
 		];
 
-		const result = hasExplicitColumnWidths( blocks );
+		const result = hasExplicitPercentColumnWidths( blocks );
 
-		expect( result ).toBe( true );
+		expect( result ).toBe( false );
 	} );
 } );
 

--- a/packages/block-library/src/columns/test/utils.js
+++ b/packages/block-library/src/columns/test/utils.js
@@ -18,6 +18,14 @@ describe( 'toWidthPrecision', () => {
 		expect( value ).toBe( 50.11 );
 	} );
 
+	it( 'should convert a string value with unit to a number', () => {
+		expect( toWidthPrecision( '33.3%' ) ).toBe( 33.3 );
+	} );
+
+	it( 'should return undefined for an invalid string', () => {
+		expect( toWidthPrecision( 'blahblah' ) ).toBe( undefined );
+	} );
+
 	it( 'should return undefined for invalid number', () => {
 		expect( toWidthPrecision( null ) ).toBe( undefined );
 		expect( toWidthPrecision( undefined ) ).toBe( undefined );
@@ -173,6 +181,14 @@ describe( 'hasExplicitColumnWidths', () => {
 		expect( result ).toBe( true );
 	} );
 
+	it( 'returns true if a block has explicit width defined as a string', () => {
+		const blocks = [ { attributes: { width: '100%' } } ];
+
+		const result = hasExplicitColumnWidths( blocks );
+
+		expect( result ).toBe( true );
+	} );
+
 	it( 'returns false if some, not all blocks have explicit width', () => {
 		const blocks = [
 			{ attributes: { width: 10 } },
@@ -188,6 +204,17 @@ describe( 'hasExplicitColumnWidths', () => {
 		const blocks = [
 			{ attributes: { width: 10 } },
 			{ attributes: { width: 90 } },
+		];
+
+		const result = hasExplicitColumnWidths( blocks );
+
+		expect( result ).toBe( true );
+	} );
+
+	it( 'returns true if blocks have width defined as strings and numbers', () => {
+		const blocks = [
+			{ attributes: { width: 10 } },
+			{ attributes: { width: '90px' } },
 		];
 
 		const result = hasExplicitColumnWidths( blocks );

--- a/packages/block-library/src/columns/utils.js
+++ b/packages/block-library/src/columns/utils.js
@@ -101,15 +101,12 @@ export function getRedistributedColumnWidths(
  */
 export function hasExplicitPercentColumnWidths( blocks ) {
 	return blocks.every( ( block ) => {
-		if (
-			typeof block.attributes.width === 'string' &&
-			block.attributes.width.charAt(
-				block.attributes.width.length - 1
-			) === '%'
-		) {
-			return Number.isFinite( parseFloat( block.attributes.width ) );
-		}
-		return Number.isFinite( block.attributes.width );
+		const blockWidth = block.attributes.width;
+		return Number.isFinite(
+			blockWidth?.endsWith?.( '%' )
+				? parseFloat( blockWidth )
+				: blockWidth
+		);
 	} );
 }
 

--- a/packages/block-library/src/columns/utils.js
+++ b/packages/block-library/src/columns/utils.js
@@ -99,10 +99,18 @@ export function getRedistributedColumnWidths(
  *
  * @return {boolean} Whether columns have explicit widths.
  */
-export function hasExplicitColumnWidths( blocks ) {
-	return blocks.every( ( block ) =>
-		Number.isFinite( parseFloat( block.attributes.width ) )
-	);
+export function hasExplicitPercentColumnWidths( blocks ) {
+	return blocks.every( ( block ) => {
+		if (
+			typeof block.attributes.width === 'string' &&
+			block.attributes.width.charAt(
+				block.attributes.width.length - 1
+			) === '%'
+		) {
+			return Number.isFinite( parseFloat( block.attributes.width ) );
+		}
+		return Number.isFinite( block.attributes.width );
+	} );
 }
 
 /**

--- a/packages/block-library/src/columns/utils.js
+++ b/packages/block-library/src/columns/utils.js
@@ -11,9 +11,12 @@ import { sumBy, merge, mapValues } from 'lodash';
  *
  * @return {number} Value rounded to standard precision.
  */
-export const toWidthPrecision = ( value ) =>
-	Number.isFinite( value ) ? parseFloat( value.toFixed( 2 ) ) : undefined;
-
+export const toWidthPrecision = ( value ) => {
+	const unitlessValue = parseFloat( value );
+	return Number.isFinite( unitlessValue )
+		? parseFloat( unitlessValue.toFixed( 2 ) )
+		: undefined;
+};
 /**
  * Returns an effective width for a given block. An effective width is equal to
  * its attribute value if set, or a computed value assuming equal distribution.
@@ -98,7 +101,7 @@ export function getRedistributedColumnWidths(
  */
 export function hasExplicitColumnWidths( blocks ) {
 	return blocks.every( ( block ) =>
-		Number.isFinite( block.attributes.width )
+		Number.isFinite( parseFloat( block.attributes.width ) )
 	);
 }
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

Fixes #26096 and #26641

#24711 introduced two issues when column width attributes switched from being defined as numbers to strings:

* Some of the utility functions for calculating width when changing column number broke as they expected to always receive numbers;
* Templates defining widths as numbers broke as they expected a number to always be interpreted as a percent.

This PR:
* changes two of the utility functions to parse strings for numbers and use them as such; 
*  re-introduces the previous behaviour of  adding a `%` to the end of a column width when it is defined as a number. 

To avoid breaking columns already set with fixed widths, recalculation on adding/removing columns only takes into account the existing column widths if they are defined in percent, or if they are unitless (which should be interpreted as percent for back compat reasons).

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Tested in browser:
 * Add a 30/70 columns block, add a new column to it and verify new widths look as expected. 
* Add/remove columns to various blocks with explicit widths defined. Check that widths defined in `px` don't get changed when adding or removing columns.
* Check that unitless widths in a custom post type template are interpreted as `%`.

Also added a few unit tests for the changes in the utility functions.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
 Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
