### PR TITLE
Fix horizontal mover icon position.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -556,6 +556,14 @@
 				width: 100%;
 			}
 		}
+
+		.block-editor-block-mover-button.is-up-button svg {
+			top: 5px;
+		}
+
+		.block-editor-block-mover-button.is-down-button svg {
+			bottom: 5px;
+		}
 	}
 }
 

--- a/packages/block-editor/src/components/block-mover/style.scss
+++ b/packages/block-editor/src/components/block-mover/style.scss
@@ -72,10 +72,6 @@
 		// Up button.
 		.components-toolbar-group .block-editor-block-mover-button.is-up-button,
 		.components-toolbar .block-editor-block-mover-button.is-up-button {
-			svg {
-				top: 5px;
-			}
-
 			// Focus style.
 			&::before {
 				bottom: 0;
@@ -86,10 +82,6 @@
 		// Down button.
 		.components-toolbar-group .block-editor-block-mover-button.is-down-button,
 		.components-toolbar .block-editor-block-mover-button.is-down-button {
-			svg {
-				bottom: 5px;
-			}
-
 			// Focus style.
 			&::before {
 				top: 0;


### PR DESCRIPTION
Regressed in #26353. This fixes it.

Before:

<img width="236" alt="Screenshot 2020-11-06 at 08 21 40" src="https://user-images.githubusercontent.com/1204802/98337578-1c81df80-2009-11eb-8942-66ab5b82f5a4.png">

After:

<img width="236" alt="Screenshot 2020-11-06 at 08 20 10" src="https://user-images.githubusercontent.com/1204802/98337549-0ecc5a00-2009-11eb-9021-5ade7511ccf6.png">
