### PR TITLE
Block Support: Fix font size style when applying block support

### DIFF
--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -76,7 +76,7 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 		if ( $has_named_font_size ) {
 			$classes[] = sprintf( 'has-%s-font-size', $block_attributes['fontSize'] );
 		} elseif ( $has_custom_font_size ) {
-			$styles[] = sprintf( 'font-size: %spx;', $block_attributes['style']['typography']['fontSize'] );
+			$styles[] = sprintf( 'font-size: %s;', $block_attributes['style']['typography']['fontSize'] );
 		}
 	}
 


### PR DESCRIPTION
## Description
Fixes the font size block support style when applied server side. Previously, the generated style contained `pxpx` making it invalid CSS.

## How has this been tested?
Manually.

#### Testing Instructions
1. Add a navigation block (or any dynamic block using font size support) to a post
2. Set custom font size via inspector controls and confirm the incorrect style on the frontend.
3. Apply this PR
4. Refresh the frontend and confirm the style is now valid and displays correctly.

## Screenshots <!-- if applicable -->

| Before | After |
|-------|------|
| ![FontSize-Before](https://user-images.githubusercontent.com/60436221/98344363-e0796980-205e-11eb-8b22-778fd4303cf7.gif) | ![FontSize-After](https://user-images.githubusercontent.com/60436221/98344386-e7a07780-205e-11eb-96b9-6ff4fcd48979.gif) |

## Types of changes
Bug Fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
