### PR TITLE
Typo in feature-flags.md

### DIFF
--- a/docs/designers-developers/developers/feature-flags.md
+++ b/docs/designers-developers/developers/feature-flags.md
@@ -71,7 +71,7 @@ if ( 2 === 2 ) {
 }
 ```
 
- The condition will alway evaluates to `true`, so can be removed leaving just the code in the body:
+ The condition will always evaluates to `true`, so can be removed leaving just the code in the body:
  ```js
  phaseTwoFeature();
  ```


### PR DESCRIPTION
#25042  Description
Fixed doc typo. feature-flags.md
Line 74: 'alway' -> 'always'

## How has this been tested?
n/a

## Screenshots <!-- if applicable -->
n/a

## Types of changes
Bug fix

