### PR TITLE
Add support for line height at the global level

### DIFF
--- a/docs/designers-developers/developers/themes/theme-json.md
+++ b/docs/designers-developers/developers/themes/theme-json.md
@@ -320,7 +320,7 @@ These are the current typography properties supported by blocks:
 
 | Context | Font Size | Line Height |
 | --- | --- | --- |
-| Global | Yes | - |
+| Global | Yes | Yes |
 | Columns | - | - |
 | Group | - | - |
 | Heading [1] | Yes | Yes |

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -563,16 +563,17 @@ function gutenberg_experimental_global_styles_get_block_data() {
 				'global',
 				array(
 					'supports' => array(
-						'__experimentalSelector'       => ':root',
 						'__experimentalFontAppearance' => false,
 						'__experimentalFontFamily'     => true,
-						'fontSize'                     => true,
+						'__experimentalSelector'       => ':root',
 						'__experimentalTextDecoration' => true,
 						'__experimentalTextTransform'  => true,
 						'color'                        => array(
-							'linkColor' => true,
 							'gradients' => true,
+							'linkColor' => true,
 						),
+						'fontSize'                     => true,
+						'lineHeight'                   => true,
 					),
 				)
 			),


### PR DESCRIPTION
This enables the line-height property at the global level. See https://github.com/WordPress/theme-experiments/issues/76
