### PR TITLE
[RNMobile] Fix - Check if fontStyles exists inside useIsFontAppearanceDisabled

### DIFF
--- a/packages/block-editor/src/hooks/font-appearance.js
+++ b/packages/block-editor/src/hooks/font-appearance.js
@@ -76,7 +76,7 @@ export function useIsFontAppearanceDisabled( { name: blockName } = {} ) {
 	);
 	const fontStyles = useEditorFeature( 'typography.fontStyles' );
 	const fontWeights = useEditorFeature( 'typography.fontWeights' );
-	const hasFontAppearance = !! fontStyles?.length && !! fontWeights.length;
+	const hasFontAppearance = !! fontStyles.length && !! fontWeights?.length;
 
 	return notSupported || ! hasFontAppearance;
 }

--- a/packages/block-editor/src/hooks/font-appearance.js
+++ b/packages/block-editor/src/hooks/font-appearance.js
@@ -76,7 +76,7 @@ export function useIsFontAppearanceDisabled( { name: blockName } = {} ) {
 	);
 	const fontStyles = useEditorFeature( 'typography.fontStyles' );
 	const fontWeights = useEditorFeature( 'typography.fontWeights' );
-	const hasFontAppearance = !! fontStyles.length && !! fontWeights.length;
+	const hasFontAppearance = !! fontStyles?.length && !! fontWeights.length;
 
 	return notSupported || ! hasFontAppearance;
 }

--- a/packages/block-editor/src/hooks/font-appearance.js
+++ b/packages/block-editor/src/hooks/font-appearance.js
@@ -76,7 +76,7 @@ export function useIsFontAppearanceDisabled( { name: blockName } = {} ) {
 	);
 	const fontStyles = useEditorFeature( 'typography.fontStyles' );
 	const fontWeights = useEditorFeature( 'typography.fontWeights' );
-	const hasFontAppearance = !! fontStyles.length && !! fontWeights?.length;
+	const hasFontAppearance = !! fontStyles?.length && !! fontWeights?.length;
 
 	return notSupported || ! hasFontAppearance;
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
There is a crash in the mobile app right after the editor is open. This crash says that can not read property length of undefined because the `const fontStyles = useEditorFeature( 'typography.fontStyles' );` returns undefined. I added a check to avoid that crash.

## How has this been tested?
- Run editor
- There should not be a crash :)

## Screenshots <!-- if applicable -->
![Screenshot_1604659772](https://user-images.githubusercontent.com/16336501/98359325-54e4e600-2028-11eb-8988-b2deed212001.png)

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
