### PR TITLE
Adds in missing styling for toolbar when using text-only setting

### DIFF
--- a/packages/edit-post/src/components/header/header-toolbar/style.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.scss
@@ -141,6 +141,11 @@
 }
 
 .show-icon-labels {
+
+	.edit-post-header-toolbar__left > * + * {
+		margin-left: $grid-unit-10;
+	}
+
 	// Always display block toolbar under main toolbar when text labels are visible
 	.edit-post-header-toolbar__block-toolbar {
 		@include break-wide {

--- a/packages/edit-post/src/components/header/header-toolbar/style.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.scss
@@ -135,6 +135,11 @@
 	}
 }
 
+.edit-post-header-toolbar .edit-post-header-toolbar__left > .edit-post-header-toolbar__inserter-toggle.has-text.has-icon {
+	width: auto;
+	padding: 0 $grid-unit-10;
+}
+
 .show-icon-labels {
 	// Always display block toolbar under main toolbar when text labels are visible
 	.edit-post-header-toolbar__block-toolbar {

--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -189,10 +189,6 @@
 	}
 }
 
-.edit-post-header-toolbar__left > * + * {
-	margin-left: $grid-unit-10;
-}
-
 .edit-post-header__dropdown {
 	.components-menu-item__button.components-menu-item__button,
 	.components-button.editor-history__undo,

--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -189,6 +189,10 @@
 	}
 }
 
+.edit-post-header-toolbar__left > * + * {
+	margin-left: $grid-unit-05;
+}
+
 .edit-post-header__dropdown {
 	.components-menu-item__button.components-menu-item__button,
 	.components-button.editor-history__undo,

--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -190,7 +190,7 @@
 }
 
 .edit-post-header-toolbar__left > * + * {
-	margin-left: $grid-unit-05;
+	margin-left: $grid-unit-10;
 }
 
 .edit-post-header__dropdown {


### PR DESCRIPTION
This is a fix for the missing styling from and closes #26748. Props to @mapk and @tellthemachines for the historical context after this was found yesterday. I also brought in some additional space on the 'add' button and converted everything to grid variables. In the thread it was stated as being 10px margins, I used the grid 8px.

Before:
![2020-11-06 11 07 58](https://user-images.githubusercontent.com/253067/98359600-67f3b800-2020-11eb-99f7-8e55a2fd9c9f.gif)

After:

![2020-11-06 11 12 14](https://user-images.githubusercontent.com/253067/98359993-fa945700-2020-11eb-90da-f89442ed1876.gif)

## Potential extra clean-up
It seems the selected state for these have a larger height. I don't know if this is desired or a mistake so looping @jasmussen in also to double check there. @mapk you might also be able to shed some light but I couldn't see a decision on that in the issue and wanted to ensure this didn't get held up by something could happen in another PR to fix select states.

![image](https://user-images.githubusercontent.com/253067/98360150-40511f80-2021-11eb-9cc1-3969d1c4d229.png)

## Next steps
@tellthemachines if this is possible to get into the next release that would be great, you hinted it might be in the issue. I would love a review as particularly on the CSS class over-riding for text-only, unsure if that's the most desireable way of doing this.
