### PR TITLE
Refactor: ColorPicker to use hooks

### DIFF
--- a/packages/components/src/color-palette/test/__snapshots__/index.js.snap
+++ b/packages/components/src/color-palette/test/__snapshots__/index.js.snap
@@ -7,7 +7,7 @@ exports[`ColorPalette Dropdown .renderContent should render dropdown content 1`]
   <div
     className="components-color-picker__saturation"
   >
-    <Pure(WithInstanceId(Saturation))
+    <Saturation
       hsl={
         Object {
           "a": 1,
@@ -48,7 +48,7 @@ exports[`ColorPalette Dropdown .renderContent should render dropdown content 1`]
       <div
         className="components-color-picker__toggles"
       >
-        <Pure(WithInstanceId(Hue))
+        <Hue
           hsl={
             Object {
               "a": 1,

--- a/packages/components/src/color-picker/alpha.js
+++ b/packages/components/src/color-picker/alpha.js
@@ -53,33 +53,33 @@ export default function Alpha( { rgb, hsl, onChange = noop } ) {
 	};
 	const pointerLocation = { left: `${ rgb.a * 100 }%` };
 
-	const handleChange = ( e ) => {
+	function handleChange( e ) {
 		const change = calculateAlphaChange( e, { hsl }, container.current );
 		if ( change ) {
 			onChange( change, e );
 		}
-	};
+	}
 
-	const handleMouseDown = () => {
+	function handleMouseDown() {
 		window.addEventListener( 'mousemove', handleChange );
 		window.addEventListener( 'mouseup', handleMouseUp );
-	};
+	}
 
-	const handleMouseUp = () => {
+	function handleMouseUp() {
 		setMouseDown( false );
-	};
+	}
 
-	const unbindEventListeners = () => {
+	function unbindEventListeners() {
 		window.removeEventListener( 'mousemove', handleChange );
 		window.removeEventListener( 'mouseup', handleMouseUp );
-	};
+	}
 
-	const preventKeyEvents = ( event ) => {
+	function preventKeyEvents( event ) {
 		if ( event.keyCode === TAB ) {
 			return;
 		}
 		event.preventDefault();
-	};
+	}
 
 	useEffect( () => {
 		if ( mouseDown ) {
@@ -91,7 +91,7 @@ export default function Alpha( { rgb, hsl, onChange = noop } ) {
 		return unbindEventListeners;
 	}, [ mouseDown ] );
 
-	const increase = ( amount = 0.01 ) => {
+	function increase( amount = 0.01 ) {
 		amount = parseInt( amount * 100, 10 );
 		const change = {
 			h: hsl.h,
@@ -101,9 +101,9 @@ export default function Alpha( { rgb, hsl, onChange = noop } ) {
 			source: 'rgb',
 		};
 		onChange( change );
-	};
+	}
 
-	const decrease = ( amount = 0.01 ) => {
+	function decrease( amount = 0.01 ) {
 		const intValue =
 			parseInt( hsl.a * 100, 10 ) - parseInt( amount * 100, 10 );
 		const change = {
@@ -114,7 +114,7 @@ export default function Alpha( { rgb, hsl, onChange = noop } ) {
 			source: 'rgb',
 		};
 		onChange( change );
-	};
+	}
 
 	const shortcuts = {
 		up: () => increase(),

--- a/packages/components/src/color-picker/alpha.js
+++ b/packages/components/src/color-picker/alpha.js
@@ -74,12 +74,14 @@ export default function Alpha( { rgb, hsl, onChange = noop } ) {
 	useEffect( () => {
 		const { ownerDocument } = container.current;
 
-		if ( mouseDown ) {
-			ownerDocument.addEventListener( 'mousemove', handleChange );
-			ownerDocument.addEventListener( 'mouseup', handleMouseUp );
+		if ( ! mouseDown ) {
+			return;
 		}
 
-		return function cleanup() {
+		ownerDocument.addEventListener( 'mousemove', handleChange );
+		ownerDocument.addEventListener( 'mouseup', handleMouseUp );
+
+		return () => {
 			ownerDocument.removeEventListener( 'mousemove', handleChange );
 			ownerDocument.removeEventListener( 'mouseup', handleMouseUp );
 		};

--- a/packages/components/src/color-picker/alpha.js
+++ b/packages/components/src/color-picker/alpha.js
@@ -60,18 +60,8 @@ export default function Alpha( { rgb, hsl, onChange = noop } ) {
 		}
 	}
 
-	function handleMouseDown() {
-		window.addEventListener( 'mousemove', handleChange );
-		window.addEventListener( 'mouseup', handleMouseUp );
-	}
-
 	function handleMouseUp() {
 		setMouseDown( false );
-	}
-
-	function unbindEventListeners() {
-		window.removeEventListener( 'mousemove', handleChange );
-		window.removeEventListener( 'mouseup', handleMouseUp );
 	}
 
 	function preventKeyEvents( event ) {
@@ -82,8 +72,16 @@ export default function Alpha( { rgb, hsl, onChange = noop } ) {
 	}
 
 	useEffect( () => {
+		const { ownerDocument } = container.current;
+
+		function unbindEventListeners() {
+			ownerDocument.removeEventListener( 'mousemove', handleChange );
+			ownerDocument.removeEventListener( 'mouseup', handleMouseUp );
+		}
+
 		if ( mouseDown ) {
-			handleMouseDown();
+			ownerDocument.addEventListener( 'mousemove', handleChange );
+			ownerDocument.addEventListener( 'mouseup', handleMouseUp );
 		} else {
 			unbindEventListeners();
 		}

--- a/packages/components/src/color-picker/alpha.js
+++ b/packages/components/src/color-picker/alpha.js
@@ -74,19 +74,15 @@ export default function Alpha( { rgb, hsl, onChange = noop } ) {
 	useEffect( () => {
 		const { ownerDocument } = container.current;
 
-		function unbindEventListeners() {
-			ownerDocument.removeEventListener( 'mousemove', handleChange );
-			ownerDocument.removeEventListener( 'mouseup', handleMouseUp );
-		}
-
 		if ( mouseDown ) {
 			ownerDocument.addEventListener( 'mousemove', handleChange );
 			ownerDocument.addEventListener( 'mouseup', handleMouseUp );
-		} else {
-			unbindEventListeners();
 		}
 
-		return unbindEventListeners;
+		return function cleanup() {
+			ownerDocument.removeEventListener( 'mousemove', handleChange );
+			ownerDocument.removeEventListener( 'mouseup', handleMouseUp );
+		};
 	}, [ mouseDown ] );
 
 	function increase( amount = 0.01 ) {

--- a/packages/components/src/color-picker/hue.js
+++ b/packages/components/src/color-picker/hue.js
@@ -74,19 +74,15 @@ export default function Hue( { hsl, onChange = noop } ) {
 	useEffect( () => {
 		const { ownerDocument } = container.current;
 
-		function unbindEventListeners() {
-			ownerDocument.removeEventListener( 'mousemove', handleChange );
-			ownerDocument.removeEventListener( 'mouseup', handleMouseUp );
-		}
-
 		if ( mouseDown ) {
 			ownerDocument.addEventListener( 'mousemove', handleChange );
 			ownerDocument.addEventListener( 'mouseup', handleMouseUp );
-		} else {
-			unbindEventListeners();
 		}
 
-		return unbindEventListeners;
+		return function cleanup() {
+			ownerDocument.removeEventListener( 'mousemove', handleChange );
+			ownerDocument.removeEventListener( 'mouseup', handleMouseUp );
+		};
 	}, [ mouseDown ] );
 
 	function increase( amount = 1 ) {

--- a/packages/components/src/color-picker/hue.js
+++ b/packages/components/src/color-picker/hue.js
@@ -60,18 +60,8 @@ export default function Hue( { hsl, onChange = noop } ) {
 		}
 	}
 
-	function handleMouseDown() {
-		window.addEventListener( 'mousemove', handleChange );
-		window.addEventListener( 'mouseup', handleMouseUp );
-	}
-
 	function handleMouseUp() {
 		setMouseDown( false );
-	}
-
-	function unbindEventListeners() {
-		window.removeEventListener( 'mousemove', handleChange );
-		window.removeEventListener( 'mouseup', handleMouseUp );
 	}
 
 	function preventKeyEvents( event ) {
@@ -82,8 +72,16 @@ export default function Hue( { hsl, onChange = noop } ) {
 	}
 
 	useEffect( () => {
+		const { ownerDocument } = container.current;
+
+		function unbindEventListeners() {
+			ownerDocument.removeEventListener( 'mousemove', handleChange );
+			ownerDocument.removeEventListener( 'mouseup', handleMouseUp );
+		}
+
 		if ( mouseDown ) {
-			handleMouseDown();
+			ownerDocument.addEventListener( 'mousemove', handleChange );
+			ownerDocument.addEventListener( 'mouseup', handleMouseUp );
 		} else {
 			unbindEventListeners();
 		}

--- a/packages/components/src/color-picker/hue.js
+++ b/packages/components/src/color-picker/hue.js
@@ -74,12 +74,14 @@ export default function Hue( { hsl, onChange = noop } ) {
 	useEffect( () => {
 		const { ownerDocument } = container.current;
 
-		if ( mouseDown ) {
-			ownerDocument.addEventListener( 'mousemove', handleChange );
-			ownerDocument.addEventListener( 'mouseup', handleMouseUp );
+		if ( ! mouseDown ) {
+			return;
 		}
 
-		return function cleanup() {
+		ownerDocument.addEventListener( 'mousemove', handleChange );
+		ownerDocument.addEventListener( 'mouseup', handleMouseUp );
+
+		return () => {
 			ownerDocument.removeEventListener( 'mousemove', handleChange );
 			ownerDocument.removeEventListener( 'mouseup', handleMouseUp );
 		};

--- a/packages/components/src/color-picker/hue.js
+++ b/packages/components/src/color-picker/hue.js
@@ -33,9 +33,9 @@ import { noop } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { compose, pure, withInstanceId } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
-import { Component, createRef } from '@wordpress/element';
+import { useState, useEffect, useRef } from '@wordpress/element';
+import { useInstanceId } from '@wordpress/compose';
 import { TAB } from '@wordpress/keycodes';
 
 /**
@@ -45,24 +45,53 @@ import { calculateHueChange } from './utils';
 import KeyboardShortcuts from '../keyboard-shortcuts';
 import VisuallyHidden from '../visually-hidden';
 
-export class Hue extends Component {
-	constructor() {
-		super( ...arguments );
+export default function Hue( { hsl, onChange = noop } ) {
+	const [ mouseDown, setMouseDown ] = useState( false );
+	const container = useRef();
 
-		this.container = createRef();
-		this.increase = this.increase.bind( this );
-		this.decrease = this.decrease.bind( this );
-		this.handleChange = this.handleChange.bind( this );
-		this.handleMouseDown = this.handleMouseDown.bind( this );
-		this.handleMouseUp = this.handleMouseUp.bind( this );
-	}
+	const instanceId = useInstanceId( Hue );
 
-	componentWillUnmount() {
-		this.unbindEventListeners();
-	}
+	const pointerLocation = { left: `${ ( hsl.h * 100 ) / 360 }%` };
 
-	increase( amount = 1 ) {
-		const { hsl, onChange = noop } = this.props;
+	const handleChange = ( e ) => {
+		const change = calculateHueChange( e, { hsl }, container.current );
+		if ( change ) {
+			onChange( change, e );
+		}
+	};
+
+	const handleMouseDown = () => {
+		window.addEventListener( 'mousemove', handleChange );
+		window.addEventListener( 'mouseup', handleMouseUp );
+	};
+
+	const handleMouseUp = () => {
+		setMouseDown( false );
+	};
+
+	const unbindEventListeners = () => {
+		window.removeEventListener( 'mousemove', handleChange );
+		window.removeEventListener( 'mouseup', handleMouseUp );
+	};
+
+	const preventKeyEvents = ( event ) => {
+		if ( event.keyCode === TAB ) {
+			return;
+		}
+		event.preventDefault();
+	};
+
+	useEffect( () => {
+		if ( mouseDown ) {
+			handleMouseDown();
+		} else {
+			unbindEventListeners();
+		}
+
+		return unbindEventListeners;
+	}, [ mouseDown ] );
+
+	const increase = ( amount = 1 ) => {
 		const change = {
 			h: hsl.h + amount >= 359 ? 359 : hsl.h + amount,
 			s: hsl.s,
@@ -71,10 +100,9 @@ export class Hue extends Component {
 			source: 'rgb',
 		};
 		onChange( change );
-	}
+	};
 
-	decrease( amount = 1 ) {
-		const { hsl, onChange = noop } = this.props;
+	const decrease = ( amount = 1 ) => {
 		const change = {
 			h: hsl.h <= amount ? 0 : hsl.h - amount,
 			s: hsl.s,
@@ -83,102 +111,58 @@ export class Hue extends Component {
 			source: 'rgb',
 		};
 		onChange( change );
-	}
+	};
 
-	handleChange( e ) {
-		const { onChange = noop } = this.props;
-		const change = calculateHueChange(
-			e,
-			this.props,
-			this.container.current
-		);
-		if ( change ) {
-			onChange( change, e );
-		}
-	}
-
-	handleMouseDown( e ) {
-		this.handleChange( e );
-		window.addEventListener( 'mousemove', this.handleChange );
-		window.addEventListener( 'mouseup', this.handleMouseUp );
-	}
-
-	handleMouseUp() {
-		this.unbindEventListeners();
-	}
-
-	preventKeyEvents( event ) {
-		if ( event.keyCode === TAB ) {
-			return;
-		}
-		event.preventDefault();
-	}
-
-	unbindEventListeners() {
-		window.removeEventListener( 'mousemove', this.handleChange );
-		window.removeEventListener( 'mouseup', this.handleMouseUp );
-	}
-
-	render() {
-		const { hsl = {}, instanceId } = this.props;
-
-		const pointerLocation = { left: `${ ( hsl.h * 100 ) / 360 }%` };
-		const shortcuts = {
-			up: () => this.increase(),
-			right: () => this.increase(),
-			'shift+up': () => this.increase( 10 ),
-			'shift+right': () => this.increase( 10 ),
-			pageup: () => this.increase( 10 ),
-			end: () => this.increase( 359 ),
-			down: () => this.decrease(),
-			left: () => this.decrease(),
-			'shift+down': () => this.decrease( 10 ),
-			'shift+left': () => this.decrease( 10 ),
-			pagedown: () => this.decrease( 10 ),
-			home: () => this.decrease( 359 ),
-		};
-
-		return (
-			<KeyboardShortcuts shortcuts={ shortcuts }>
-				<div className="components-color-picker__hue">
-					<div className="components-color-picker__hue-gradient" />
-					{ /* eslint-disable jsx-a11y/no-static-element-interactions */ }
+	const shortcuts = {
+		up: () => increase(),
+		right: () => increase(),
+		'shift+up': () => increase( 10 ),
+		'shift+right': () => increase( 10 ),
+		pageup: () => increase( 10 ),
+		end: () => increase( 359 ),
+		down: () => decrease(),
+		left: () => decrease(),
+		'shift+down': () => decrease( 10 ),
+		'shift+left': () => decrease( 10 ),
+		pagedown: () => decrease( 10 ),
+		home: () => decrease( 359 ),
+	};
+	return (
+		<KeyboardShortcuts shortcuts={ shortcuts }>
+			<div className="components-color-picker__hue">
+				<div className="components-color-picker__hue-gradient" />
+				{ /* eslint-disable jsx-a11y/no-static-element-interactions */ }
+				<div
+					className="components-color-picker__hue-bar"
+					ref={ container }
+					onMouseDown={ () => setMouseDown( true ) }
+					onTouchMove={ handleChange }
+					onTouchStart={ handleChange }
+				>
 					<div
-						className="components-color-picker__hue-bar"
-						ref={ this.container }
-						onMouseDown={ this.handleMouseDown }
-						onTouchMove={ this.handleChange }
-						onTouchStart={ this.handleChange }
+						tabIndex="0"
+						role="slider"
+						aria-valuemax="1"
+						aria-valuemin="359"
+						aria-valuenow={ hsl.h }
+						aria-orientation="horizontal"
+						aria-label={ __(
+							'Hue value in degrees, from 0 to 359.'
+						) }
+						aria-describedby={ `components-color-picker__hue-description-${ instanceId }` }
+						className="components-color-picker__hue-pointer"
+						style={ pointerLocation }
+						onKeyDown={ preventKeyEvents }
+					/>
+					<VisuallyHidden
+						as="p"
+						id={ `components-color-picker__hue-description-${ instanceId }` }
 					>
-						<div
-							tabIndex="0"
-							role="slider"
-							aria-valuemax="1"
-							aria-valuemin="359"
-							aria-valuenow={ hsl.h }
-							aria-orientation="horizontal"
-							aria-label={ __(
-								'Hue value in degrees, from 0 to 359.'
-							) }
-							aria-describedby={ `components-color-picker__hue-description-${ instanceId }` }
-							className="components-color-picker__hue-pointer"
-							style={ pointerLocation }
-							onKeyDown={ this.preventKeyEvents }
-						/>
-						<VisuallyHidden
-							as="p"
-							id={ `components-color-picker__hue-description-${ instanceId }` }
-						>
-							{ __(
-								'Move the arrow left or right to change hue.'
-							) }
-						</VisuallyHidden>
-					</div>
-					{ /* eslint-enable jsx-a11y/no-static-element-interactions */ }
+						{ __( 'Move the arrow left or right to change hue.' ) }
+					</VisuallyHidden>
 				</div>
-			</KeyboardShortcuts>
-		);
-	}
+				{ /* eslint-enable jsx-a11y/no-static-element-interactions */ }
+			</div>
+		</KeyboardShortcuts>
+	);
 }
-
-export default compose( pure, withInstanceId )( Hue );

--- a/packages/components/src/color-picker/hue.js
+++ b/packages/components/src/color-picker/hue.js
@@ -53,33 +53,33 @@ export default function Hue( { hsl, onChange = noop } ) {
 
 	const pointerLocation = { left: `${ ( hsl.h * 100 ) / 360 }%` };
 
-	const handleChange = ( e ) => {
+	function handleChange( e ) {
 		const change = calculateHueChange( e, { hsl }, container.current );
 		if ( change ) {
 			onChange( change, e );
 		}
-	};
+	}
 
-	const handleMouseDown = () => {
+	function handleMouseDown() {
 		window.addEventListener( 'mousemove', handleChange );
 		window.addEventListener( 'mouseup', handleMouseUp );
-	};
+	}
 
-	const handleMouseUp = () => {
+	function handleMouseUp() {
 		setMouseDown( false );
-	};
+	}
 
-	const unbindEventListeners = () => {
+	function unbindEventListeners() {
 		window.removeEventListener( 'mousemove', handleChange );
 		window.removeEventListener( 'mouseup', handleMouseUp );
-	};
+	}
 
-	const preventKeyEvents = ( event ) => {
+	function preventKeyEvents( event ) {
 		if ( event.keyCode === TAB ) {
 			return;
 		}
 		event.preventDefault();
-	};
+	}
 
 	useEffect( () => {
 		if ( mouseDown ) {
@@ -91,7 +91,7 @@ export default function Hue( { hsl, onChange = noop } ) {
 		return unbindEventListeners;
 	}, [ mouseDown ] );
 
-	const increase = ( amount = 1 ) => {
+	function increase( amount = 1 ) {
 		const change = {
 			h: hsl.h + amount >= 359 ? 359 : hsl.h + amount,
 			s: hsl.s,
@@ -100,9 +100,9 @@ export default function Hue( { hsl, onChange = noop } ) {
 			source: 'rgb',
 		};
 		onChange( change );
-	};
+	}
 
-	const decrease = ( amount = 1 ) => {
+	function decrease( amount = 1 ) {
 		const change = {
 			h: hsl.h <= amount ? 0 : hsl.h - amount,
 			s: hsl.s,
@@ -111,7 +111,7 @@ export default function Hue( { hsl, onChange = noop } ) {
 			source: 'rgb',
 		};
 		onChange( change );
-	};
+	}
 
 	const shortcuts = {
 		up: () => increase(),

--- a/packages/components/src/color-picker/index.js
+++ b/packages/components/src/color-picker/index.js
@@ -29,13 +29,13 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { debounce, noop, partial } from 'lodash';
+import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
-
+import { useDebounce } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
@@ -129,6 +129,9 @@ export default function ColorPicker( {
 		draftRgb: initialColor.rgb,
 		draftHsl: initialColor.hsl,
 	} );
+
+	const debouncedOnChangeComplete = useDebounce( onChangeComplete, 100 );
+
 	const { hex, hsl, hsv, rgb, draftHex, draftHsl, draftRgb } = colors;
 
 	const classes = classnames( className, {
@@ -147,7 +150,7 @@ export default function ColorPicker( {
 				draftRgb: newColors.rgb,
 			} );
 
-			debounce( partial( onChangeComplete, newColors ), 100 );
+			debouncedOnChangeComplete( newColors );
 		}
 	}
 

--- a/packages/components/src/color-picker/index.js
+++ b/packages/components/src/color-picker/index.js
@@ -45,8 +45,11 @@ import Inputs from './inputs';
 import Saturation from './saturation';
 import { colorToState, simpleCheckForValidColor, isValidHex } from './utils';
 
-const toLowerCase = ( value ) => String( value ).toLowerCase();
-const isValueEmpty = ( data ) => {
+function toLowerCase( value ) {
+	return String( value ).toLowerCase();
+}
+
+function isValueEmpty( data ) {
 	if ( data.source === 'hex' && ! data.hex ) {
 		return true;
 	} else if (
@@ -63,9 +66,13 @@ const isValueEmpty = ( data ) => {
 		return true;
 	}
 	return false;
-};
-const isValidColor = ( colors ) =>
-	colors.hex ? isValidHex( colors.hex ) : simpleCheckForValidColor( colors );
+}
+
+function isValidColor( colors ) {
+	return colors.hex
+		? isValidHex( colors.hex )
+		: simpleCheckForValidColor( colors );
+}
 
 /**
  * Function that creates the new color object
@@ -95,7 +102,7 @@ const isValidColor = ( colors ) =>
  * @return {Object} A new color object for a specific source. For example:
  * { source: 'rgb', r: 1, g: 2, b:3, a:0 }
  */
-const dataToColors = ( oldColors, { source, valueKey, value } ) => {
+function dataToColors( oldColors, { source, valueKey, value } ) {
 	if ( source === 'hex' ) {
 		return {
 			source,
@@ -106,7 +113,7 @@ const dataToColors = ( oldColors, { source, valueKey, value } ) => {
 		source,
 		...{ ...oldColors[ source ], ...{ [ valueKey ]: value } },
 	};
-};
+}
 
 export default function ColorPicker( {
 	color = '0071a1',
@@ -130,7 +137,7 @@ export default function ColorPicker( {
 		'is-alpha-enabled': ! disableAlpha,
 	} );
 
-	const commitValues = ( data ) => {
+	function commitValues( data ) {
 		if ( isValidColor( data ) ) {
 			const newColors = colorToState( data, data.h || oldHue );
 			setColors( {
@@ -142,18 +149,18 @@ export default function ColorPicker( {
 
 			debounce( partial( onChangeComplete, newColors ), 100 );
 		}
-	};
+	}
 
-	const resetDraftValues = () => {
+	function resetDraftValues() {
 		setColors( {
 			...colors,
 			draftHex: hex,
 			draftHsl: hsl,
 			draftRgb: rgb,
 		} );
-	};
+	}
 
-	const setDraftValues = ( data ) => {
+	function setDraftValues( data ) {
 		switch ( data.source ) {
 			case 'hex':
 				setColors( {
@@ -174,9 +181,9 @@ export default function ColorPicker( {
 				} );
 				break;
 		}
-	};
+	}
 
-	const handleInputChange = ( data ) => {
+	function handleInputChange( data ) {
 		switch ( data.state ) {
 			case 'reset':
 				resetDraftValues();
@@ -191,7 +198,7 @@ export default function ColorPicker( {
 				setDraftValues( dataToColors( colors, data ) );
 				break;
 		}
-	};
+	}
 
 	return (
 		<div className={ classes }>

--- a/packages/components/src/color-picker/index.js
+++ b/packages/components/src/color-picker/index.js
@@ -34,7 +34,7 @@ import { noop } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { useState, useCallback } from '@wordpress/element';
 import { useDebounce } from '@wordpress/compose';
 /**
  * Internal dependencies
@@ -130,7 +130,10 @@ export default function ColorPicker( {
 		draftHsl: initialColor.hsl,
 	} );
 
-	const debouncedOnChangeComplete = useDebounce( onChangeComplete, 100 );
+	const debouncedOnChangeComplete = useCallback(
+		useDebounce( onChangeComplete, 100 ),
+		[ onChangeComplete ]
+	);
 
 	const { hex, hsl, hsv, rgb, draftHex, draftHsl, draftRgb } = colors;
 

--- a/packages/components/src/color-picker/inputs.js
+++ b/packages/components/src/color-picker/inputs.js
@@ -144,133 +144,133 @@ export default function Inputs( {
 		} );
 	}
 
-	function renderFields() {
-		if ( view === 'hex' ) {
-			return (
+	let fields;
+
+	if ( view === 'hex' ) {
+		fields = (
+			<div className="components-color-picker__inputs-fields">
+				<Input
+					source={ view }
+					label={ __( 'Color value in hexadecimal' ) }
+					valueKey="hex"
+					value={ hex }
+					onChange={ handleChange }
+				/>
+			</div>
+		);
+	} else if ( view === 'rgb' ) {
+		const legend = disableAlpha
+			? __( 'Color value in RGB' )
+			: __( 'Color value in RGBA' );
+		fields = (
+			<fieldset>
+				<VisuallyHidden as="legend">{ legend }</VisuallyHidden>
 				<div className="components-color-picker__inputs-fields">
 					<Input
 						source={ view }
-						label={ __( 'Color value in hexadecimal' ) }
-						valueKey="hex"
-						value={ hex }
+						label="r"
+						valueKey="r"
+						value={ rgb.r }
 						onChange={ handleChange }
+						type="number"
+						min="0"
+						max="255"
 					/>
+					<Input
+						source={ view }
+						label="g"
+						valueKey="g"
+						value={ rgb.g }
+						onChange={ handleChange }
+						type="number"
+						min="0"
+						max="255"
+					/>
+					<Input
+						source={ view }
+						label="b"
+						valueKey="b"
+						value={ rgb.b }
+						onChange={ handleChange }
+						type="number"
+						min="0"
+						max="255"
+					/>
+					{ disableAlpha ? null : (
+						<Input
+							source={ view }
+							label="a"
+							valueKey="a"
+							value={ rgb.a }
+							onChange={ handleChange }
+							type="number"
+							min="0"
+							max="1"
+							step="0.01"
+						/>
+					) }
 				</div>
-			);
-		} else if ( view === 'rgb' ) {
-			const legend = disableAlpha
-				? __( 'Color value in RGB' )
-				: __( 'Color value in RGBA' );
-			return (
-				<fieldset>
-					<VisuallyHidden as="legend">{ legend }</VisuallyHidden>
-					<div className="components-color-picker__inputs-fields">
+			</fieldset>
+		);
+	} else if ( view === 'hsl' ) {
+		const legend = disableAlpha
+			? __( 'Color value in HSL' )
+			: __( 'Color value in HSLA' );
+		fields = (
+			<fieldset>
+				<VisuallyHidden as="legend">{ legend }</VisuallyHidden>
+				<div className="components-color-picker__inputs-fields">
+					<Input
+						source={ view }
+						label="h"
+						valueKey="h"
+						value={ hsl.h }
+						onChange={ handleChange }
+						type="number"
+						min="0"
+						max="359"
+					/>
+					<Input
+						source={ view }
+						label="s"
+						valueKey="s"
+						value={ hsl.s }
+						onChange={ handleChange }
+						type="number"
+						min="0"
+						max="100"
+					/>
+					<Input
+						source={ view }
+						label="l"
+						valueKey="l"
+						value={ hsl.l }
+						onChange={ handleChange }
+						type="number"
+						min="0"
+						max="100"
+					/>
+					{ disableAlpha ? null : (
 						<Input
 							source={ view }
-							label="r"
-							valueKey="r"
-							value={ rgb.r }
+							label="a"
+							valueKey="a"
+							value={ hsl.a }
 							onChange={ handleChange }
 							type="number"
 							min="0"
-							max="255"
+							max="1"
+							step="0.05"
 						/>
-						<Input
-							source={ view }
-							label="g"
-							valueKey="g"
-							value={ rgb.g }
-							onChange={ handleChange }
-							type="number"
-							min="0"
-							max="255"
-						/>
-						<Input
-							source={ view }
-							label="b"
-							valueKey="b"
-							value={ rgb.b }
-							onChange={ handleChange }
-							type="number"
-							min="0"
-							max="255"
-						/>
-						{ disableAlpha ? null : (
-							<Input
-								source={ view }
-								label="a"
-								valueKey="a"
-								value={ rgb.a }
-								onChange={ handleChange }
-								type="number"
-								min="0"
-								max="1"
-								step="0.01"
-							/>
-						) }
-					</div>
-				</fieldset>
-			);
-		} else if ( view === 'hsl' ) {
-			const legend = disableAlpha
-				? __( 'Color value in HSL' )
-				: __( 'Color value in HSLA' );
-			return (
-				<fieldset>
-					<VisuallyHidden as="legend">{ legend }</VisuallyHidden>
-					<div className="components-color-picker__inputs-fields">
-						<Input
-							source={ view }
-							label="h"
-							valueKey="h"
-							value={ hsl.h }
-							onChange={ handleChange }
-							type="number"
-							min="0"
-							max="359"
-						/>
-						<Input
-							source={ view }
-							label="s"
-							valueKey="s"
-							value={ hsl.s }
-							onChange={ handleChange }
-							type="number"
-							min="0"
-							max="100"
-						/>
-						<Input
-							source={ view }
-							label="l"
-							valueKey="l"
-							value={ hsl.l }
-							onChange={ handleChange }
-							type="number"
-							min="0"
-							max="100"
-						/>
-						{ disableAlpha ? null : (
-							<Input
-								source={ view }
-								label="a"
-								valueKey="a"
-								value={ hsl.a }
-								onChange={ handleChange }
-								type="number"
-								min="0"
-								max="1"
-								step="0.05"
-							/>
-						) }
-					</div>
-				</fieldset>
-			);
-		}
+					) }
+				</div>
+			</fieldset>
+		);
 	}
 
 	return (
 		<div className="components-color-picker__inputs-wrapper">
-			{ renderFields() }
+			{ fields }
 			<div className="components-color-picker__inputs-toggle-wrapper">
 				<Button
 					className="components-color-picker__inputs-toggle"

--- a/packages/components/src/color-picker/inputs.js
+++ b/packages/components/src/color-picker/inputs.js
@@ -30,16 +30,16 @@ export function Input( {
 	source,
 	...props
 } ) {
-	const handleBlur = () => {
+	function handleBlur() {
 		onChange( {
 			source,
 			state: 'commit',
 			value,
 			valueKey,
 		} );
-	};
+	}
 
-	const handleChange = ( newValue ) => {
+	function handleChange( newValue ) {
 		if ( newValue.length > 4 && isValidHex( newValue ) ) {
 			onChange( {
 				source,
@@ -55,9 +55,9 @@ export function Input( {
 				valueKey,
 			} );
 		}
-	};
+	}
 
-	const handleKeyDown = ( { keyCode } ) => {
+	function handleKeyDown( { keyCode } ) {
 		if ( keyCode !== ENTER && keyCode !== UP && keyCode !== DOWN ) {
 			return;
 		}
@@ -67,7 +67,7 @@ export function Input( {
 			value,
 			valueKey,
 		} );
-	};
+	}
 
 	return (
 		<TextControl
@@ -82,7 +82,7 @@ export function Input( {
 	);
 }
 
-const normalizeValue = ( valueKey, value ) => {
+function normalizeValue( valueKey, value ) {
 	if ( valueKey !== 'a' ) {
 		return value;
 	}
@@ -93,7 +93,7 @@ const normalizeValue = ( valueKey, value ) => {
 		return 1;
 	}
 	return Math.round( value * 100 ) / 100;
-};
+}
 
 export default function Inputs( {
 	hex,
@@ -108,7 +108,7 @@ export default function Inputs( {
 		setView( 'rgb' );
 	}
 
-	const toggleViews = () => {
+	function toggleViews() {
 		if ( view === 'hex' ) {
 			setView( 'rgb' );
 			resetDraftValues();
@@ -132,24 +132,24 @@ export default function Inputs( {
 				speak( __( 'RGB mode active' ) );
 			}
 		}
-	};
+	}
 
-	const resetDraftValues = () => {
+	function resetDraftValues() {
 		return onChange( {
 			state: 'reset',
 		} );
-	};
+	}
 
-	const handleChange = ( { source, state, value, valueKey } ) => {
+	function handleChange( { source, state, value, valueKey } ) {
 		onChange( {
 			source,
 			state,
 			valueKey,
 			value: normalizeValue( valueKey, value ),
 		} );
-	};
+	}
 
-	const renderFields = () => {
+	function renderFields() {
 		if ( view === 'hex' ) {
 			return (
 				<div className="components-color-picker__inputs-fields">
@@ -271,7 +271,7 @@ export default function Inputs( {
 				</fieldset>
 			);
 		}
-	};
+	}
 
 	return (
 		<div className="components-color-picker__inputs-wrapper">

--- a/packages/components/src/color-picker/inputs.js
+++ b/packages/components/src/color-picker/inputs.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { omit } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { speak } from '@wordpress/a11y';
@@ -77,7 +72,7 @@ export function Input( {
 			onChange={ ( newValue ) => handleChange( newValue ) }
 			onBlur={ handleBlur }
 			onKeyDown={ handleKeyDown }
-			{ ...omit( props, [ 'onChange', 'valueKey', 'source' ] ) }
+			{ ...props }
 		/>
 	);
 }

--- a/packages/components/src/color-picker/saturation.js
+++ b/packages/components/src/color-picker/saturation.js
@@ -28,7 +28,7 @@
 /**
  * External dependencies
  */
-import { clamp, noop, throttle as _throttle } from 'lodash';
+import { clamp, noop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -36,7 +36,7 @@ import { clamp, noop, throttle as _throttle } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect, useRef } from '@wordpress/element';
 import { TAB } from '@wordpress/keycodes';
-import { useInstanceId } from '@wordpress/compose';
+import { useThrottle, useInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -56,9 +56,7 @@ export default function Saturation( { hsv, hsl, onChange = noop } ) {
 		left: `${ hsv.s }%`,
 	};
 
-	const throttle = _throttle( ( fn, data, e ) => {
-		fn( data, e );
-	}, 50 );
+	const throttledOnChange = useThrottle( onChange, 50 );
 
 	function saturate( amount = 0.01 ) {
 		const intSaturation = clamp(
@@ -96,7 +94,7 @@ export default function Saturation( { hsv, hsl, onChange = noop } ) {
 			{ hsl },
 			container.current
 		);
-		throttle( onChange, change, e );
+		throttledOnChange( change, e );
 	}
 
 	function handleMouseUp() {
@@ -119,7 +117,6 @@ export default function Saturation( { hsv, hsl, onChange = noop } ) {
 		}
 
 		return function cleanup() {
-			throttle.cancel();
 			ownerDocument.removeEventListener( 'mousemove', handleChange );
 			ownerDocument.removeEventListener( 'mouseup', handleMouseUp );
 		};

--- a/packages/components/src/color-picker/saturation.js
+++ b/packages/components/src/color-picker/saturation.js
@@ -113,21 +113,15 @@ export default function Saturation( { hsv, hsl, onChange = noop } ) {
 	useEffect( () => {
 		const { ownerDocument } = container.current;
 
-		function unbindEventListeners() {
-			ownerDocument.removeEventListener( 'mousemove', handleChange );
-			ownerDocument.removeEventListener( 'mouseup', handleMouseUp );
-		}
-
 		if ( mouseDown ) {
 			ownerDocument.addEventListener( 'mousemove', handleChange );
 			ownerDocument.addEventListener( 'mouseup', handleMouseUp );
-		} else {
-			unbindEventListeners();
 		}
 
-		return () => {
+		return function cleanup() {
 			throttle.cancel();
-			unbindEventListeners();
+			ownerDocument.removeEventListener( 'mousemove', handleChange );
+			ownerDocument.removeEventListener( 'mouseup', handleMouseUp );
 		};
 	}, [ mouseDown ] );
 

--- a/packages/components/src/color-picker/saturation.js
+++ b/packages/components/src/color-picker/saturation.js
@@ -60,7 +60,7 @@ export default function Saturation( { hsv, hsl, onChange = noop } ) {
 		fn( data, e );
 	}, 50 );
 
-	const saturate = ( amount = 0.01 ) => {
+	function saturate( amount = 0.01 ) {
 		const intSaturation = clamp(
 			hsv.s + Math.round( amount * 100 ),
 			0,
@@ -75,9 +75,9 @@ export default function Saturation( { hsv, hsl, onChange = noop } ) {
 		};
 
 		onChange( change );
-	};
+	}
 
-	const brighten = ( amount = 0.01 ) => {
+	function brighten( amount = 0.01 ) {
 		const intValue = clamp( hsv.v + Math.round( amount * 100 ), 0, 100 );
 		const change = {
 			h: hsv.h,
@@ -88,37 +88,37 @@ export default function Saturation( { hsv, hsl, onChange = noop } ) {
 		};
 
 		onChange( change );
-	};
+	}
 
-	const handleChange = ( e ) => {
+	function handleChange( e ) {
 		const change = calculateSaturationChange(
 			e,
 			{ hsl },
 			container.current
 		);
 		throttle( onChange, change, e );
-	};
+	}
 
-	const handleMouseDown = () => {
+	function handleMouseDown() {
 		window.addEventListener( 'mousemove', handleChange );
 		window.addEventListener( 'mouseup', handleMouseUp );
-	};
+	}
 
-	const handleMouseUp = () => {
+	function handleMouseUp() {
 		setMouseDown( false );
-	};
+	}
 
-	const preventKeyEvents = ( e ) => {
+	function preventKeyEvents( e ) {
 		if ( e.keyCode === TAB ) {
 			return;
 		}
 		e.preventDefault();
-	};
+	}
 
-	const unbindEventListeners = () => {
+	function unbindEventListeners() {
 		window.removeEventListener( 'mousemove', handleChange );
 		window.removeEventListener( 'mouseup', handleMouseUp );
-	};
+	}
 
 	useEffect( () => {
 		if ( mouseDown ) {

--- a/packages/components/src/color-picker/saturation.js
+++ b/packages/components/src/color-picker/saturation.js
@@ -34,7 +34,7 @@ import { clamp, noop } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState, useEffect, useRef } from '@wordpress/element';
+import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
 import { TAB } from '@wordpress/keycodes';
 import { useThrottle, useInstanceId } from '@wordpress/compose';
 
@@ -56,7 +56,9 @@ export default function Saturation( { hsv, hsl, onChange = noop } ) {
 		left: `${ hsv.s }%`,
 	};
 
-	const throttledOnChange = useThrottle( onChange, 50 );
+	const throttledOnChange = useCallback( useThrottle( onChange, 50 ), [
+		onChange,
+	] );
 
 	function saturate( amount = 0.01 ) {
 		const intSaturation = clamp(

--- a/packages/components/src/color-picker/saturation.js
+++ b/packages/components/src/color-picker/saturation.js
@@ -99,11 +99,6 @@ export default function Saturation( { hsv, hsl, onChange = noop } ) {
 		throttle( onChange, change, e );
 	}
 
-	function handleMouseDown() {
-		window.addEventListener( 'mousemove', handleChange );
-		window.addEventListener( 'mouseup', handleMouseUp );
-	}
-
 	function handleMouseUp() {
 		setMouseDown( false );
 	}
@@ -115,14 +110,17 @@ export default function Saturation( { hsv, hsl, onChange = noop } ) {
 		e.preventDefault();
 	}
 
-	function unbindEventListeners() {
-		window.removeEventListener( 'mousemove', handleChange );
-		window.removeEventListener( 'mouseup', handleMouseUp );
-	}
-
 	useEffect( () => {
+		const { ownerDocument } = container.current;
+
+		function unbindEventListeners() {
+			ownerDocument.removeEventListener( 'mousemove', handleChange );
+			ownerDocument.removeEventListener( 'mouseup', handleMouseUp );
+		}
+
 		if ( mouseDown ) {
-			handleMouseDown();
+			ownerDocument.addEventListener( 'mousemove', handleChange );
+			ownerDocument.addEventListener( 'mouseup', handleMouseUp );
 		} else {
 			unbindEventListeners();
 		}

--- a/packages/components/src/color-picker/saturation.js
+++ b/packages/components/src/color-picker/saturation.js
@@ -111,12 +111,14 @@ export default function Saturation( { hsv, hsl, onChange = noop } ) {
 	useEffect( () => {
 		const { ownerDocument } = container.current;
 
-		if ( mouseDown ) {
-			ownerDocument.addEventListener( 'mousemove', handleChange );
-			ownerDocument.addEventListener( 'mouseup', handleMouseUp );
+		if ( ! mouseDown ) {
+			return;
 		}
 
-		return function cleanup() {
+		ownerDocument.addEventListener( 'mousemove', handleChange );
+		ownerDocument.addEventListener( 'mouseup', handleMouseUp );
+
+		return () => {
 			ownerDocument.removeEventListener( 'mousemove', handleChange );
 			ownerDocument.removeEventListener( 'mouseup', handleMouseUp );
 		};

--- a/packages/components/src/color-picker/test/index.js
+++ b/packages/components/src/color-picker/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import TestRenderer from 'react-test-renderer';
+import { create, act } from 'react-test-renderer';
 
 /**
  * WordPress dependencies
@@ -14,105 +14,159 @@ import { DOWN, ENTER, UP } from '@wordpress/keycodes';
 import ColorPicker from '../';
 
 describe( 'ColorPicker', () => {
-	const color = '#FFF';
-	let base;
+	test( 'should render color picker', () => {
+		const color = '#FFF';
+		let renderer;
 
-	beforeEach( () => {
-		base = TestRenderer.create(
-			<ColorPicker
-				color={ color }
-				onChangeComplete={ () => {} }
-				disableAlpha
-			/>
-		);
-	} );
+		act( () => {
+			renderer = create(
+				<ColorPicker
+					color={ color }
+					onChangeComplete={ () => {} }
+					disableAlpha
+				/>
+			);
+		} );
+	});
 
 	test( 'should render color picker', () => {
 		expect( base.toJSON() ).toMatchSnapshot();
 	} );
 
 	test( 'should only update input view for draft changes', () => {
-		const testRenderer = TestRenderer.create(
-			<ColorPicker
-				color={ color }
-				onChangeComplete={ () => {} }
-				disableAlpha
-			/>
-		);
-		testRenderer.root
-			.findByType( 'input' )
-			.props.onChange( { target: { value: '#ABC' } } );
+		const color = '#FFF';
+		let testRenderer;
 
-		expect( testRenderer.toJSON() ).toMatchDiffSnapshot( base.toJSON() );
+		act( () => {
+			testRenderer = create(
+				<ColorPicker
+					color={ color }
+					onChangeComplete={ () => {} }
+					disableAlpha
+				/>
+			);
+		} );
+
+		act( () => {
+			testRenderer.root
+				.findByType( 'input' )
+				.props.onChange( { target: { value: '#ABC' } } );
+		} );
+
+		expect( testRenderer.toJSON() ).toMatchSnapshot();
 	} );
 
 	test( 'should commit changes to all views on blur', () => {
-		const testRenderer = TestRenderer.create(
-			<ColorPicker
-				color={ color }
-				onChangeComplete={ () => {} }
-				disableAlpha
-			/>
-		);
-		testRenderer.root
-			.findByType( 'input' )
-			.props.onChange( { target: { value: '#ABC' } } );
-		testRenderer.root.findByType( 'input' ).props.onBlur();
+		const color = '#FFF';
+		let testRenderer;
 
-		expect( testRenderer.toJSON() ).toMatchDiffSnapshot( base.toJSON() );
+		act( () => {
+			testRenderer = create(
+				<ColorPicker
+					color={ color }
+					onChangeComplete={ () => {} }
+					disableAlpha
+				/>
+			);
+		} );
+
+		act( () => {
+			testRenderer.root
+				.findByType( 'input' )
+				.props.onChange( { target: { value: '#ABC' } } );
+		} );
+
+		act( () => {
+			testRenderer.root.findByType( 'input' ).props.onBlur();
+		} );
+
+		expect( testRenderer.toJSON() ).toMatchSnapshot();
 	} );
 
 	test( 'should commit changes to all views on keyDown = UP', () => {
-		const testRenderer = TestRenderer.create(
-			<ColorPicker
-				color={ color }
-				onChangeComplete={ () => {} }
-				disableAlpha
-			/>
-		);
-		testRenderer.root
-			.findByType( 'input' )
-			.props.onChange( { target: { value: '#ABC' } } );
-		testRenderer.root
-			.findByType( 'input' )
-			.props.onKeyDown( { keyCode: UP } );
+		const color = '#FFF';
+		let testRenderer;
 
-		expect( testRenderer.toJSON() ).toMatchDiffSnapshot( base.toJSON() );
+		act( () => {
+			testRenderer = create(
+				<ColorPicker
+					color={ color }
+					onChangeComplete={ () => {} }
+					disableAlpha
+				/>
+			);
+		} );
+
+		act( () => {
+			testRenderer.root
+				.findByType( 'input' )
+				.props.onChange( { target: { value: '#ABC' } } );
+		} );
+
+		act( () => {
+			testRenderer.root
+				.findByType( 'input' )
+				.props.onKeyDown( { keyCode: UP } );
+		} );
+
+		expect( testRenderer.toJSON() ).toMatchSnapshot();
 	} );
 
 	test( 'should commit changes to all views on keyDown = DOWN', () => {
-		const testRenderer = TestRenderer.create(
-			<ColorPicker
-				color={ color }
-				onChangeComplete={ () => {} }
-				disableAlpha
-			/>
-		);
-		testRenderer.root
-			.findByType( 'input' )
-			.props.onChange( { target: { value: '#ABC' } } );
-		testRenderer.root
-			.findByType( 'input' )
-			.props.onKeyDown( { keyCode: DOWN } );
+		const color = '#FFF';
+		let testRenderer;
 
-		expect( testRenderer.toJSON() ).toMatchDiffSnapshot( base.toJSON() );
+		act( () => {
+			testRenderer = create(
+				<ColorPicker
+					color={ color }
+					onChangeComplete={ () => {} }
+					disableAlpha
+				/>
+			);
+		} );
+
+		act( () => {
+			testRenderer.root
+				.findByType( 'input' )
+				.props.onChange( { target: { value: '#ABC' } } );
+		} );
+
+		act( () => {
+			testRenderer.root
+				.findByType( 'input' )
+				.props.onKeyDown( { keyCode: DOWN } );
+		} );
+
+		expect( testRenderer.toJSON() ).toMatchSnapshot();
 	} );
 
 	test( 'should commit changes to all views on keyDown = ENTER', () => {
-		const testRenderer = TestRenderer.create(
-			<ColorPicker
-				color={ color }
-				onChangeComplete={ () => {} }
-				disableAlpha
-			/>
-		);
-		testRenderer.root
-			.findByType( 'input' )
-			.props.onChange( { target: { value: '#ABC' } } );
-		testRenderer.root
-			.findByType( 'input' )
-			.props.onKeyDown( { keyCode: ENTER } );
+		const color = '#FFF';
+		let testRenderer;
 
-		expect( testRenderer.toJSON() ).toMatchDiffSnapshot( base.toJSON() );
+		act( () => {
+			testRenderer = create(
+				<ColorPicker
+					color={ color }
+					onChangeComplete={ () => {} }
+					disableAlpha
+				/>
+			);
+		} );
+
+		act( () => {
+			testRenderer.root
+				.findByType( 'input' )
+				.props.onChange( { target: { value: '#ABC' } } );
+		} );
+
+		act( () => {
+			testRenderer.root
+				.findByType( 'input' )
+				.props.onKeyDown( { keyCode: ENTER } );
+		} );
+
+		expect( testRenderer.toJSON() ).toMatchSnapshot();
 	} );
 } );

--- a/packages/components/src/color-picker/test/index.js
+++ b/packages/components/src/color-picker/test/index.js
@@ -13,6 +13,23 @@ import { DOWN, ENTER, UP } from '@wordpress/keycodes';
  */
 import ColorPicker from '../';
 
+function createNodeMock( element ) {
+	if (
+		element.type === 'div' &&
+		[
+			'components-color-picker__alpha-bar',
+			'components-color-picker__hue-bar',
+			'components-color-picker__saturation-color',
+		].includes( element.props.className )
+	) {
+		return {
+			ownerDocument: document,
+		};
+	}
+
+	return null;
+}
+
 describe( 'ColorPicker', () => {
 	test( 'should render color picker', () => {
 		const color = '#FFF';
@@ -24,7 +41,8 @@ describe( 'ColorPicker', () => {
 					color={ color }
 					onChangeComplete={ () => {} }
 					disableAlpha
-				/>
+				/>,
+				{ createNodeMock }
 			);
 		} );
 	});
@@ -43,7 +61,8 @@ describe( 'ColorPicker', () => {
 					color={ color }
 					onChangeComplete={ () => {} }
 					disableAlpha
-				/>
+				/>,
+				{ createNodeMock }
 			);
 		} );
 
@@ -66,7 +85,8 @@ describe( 'ColorPicker', () => {
 					color={ color }
 					onChangeComplete={ () => {} }
 					disableAlpha
-				/>
+				/>,
+				{ createNodeMock }
 			);
 		} );
 
@@ -93,7 +113,8 @@ describe( 'ColorPicker', () => {
 					color={ color }
 					onChangeComplete={ () => {} }
 					disableAlpha
-				/>
+				/>,
+				{ createNodeMock }
 			);
 		} );
 
@@ -122,7 +143,8 @@ describe( 'ColorPicker', () => {
 					color={ color }
 					onChangeComplete={ () => {} }
 					disableAlpha
-				/>
+				/>,
+				{ createNodeMock }
 			);
 		} );
 
@@ -151,7 +173,8 @@ describe( 'ColorPicker', () => {
 					color={ color }
 					onChangeComplete={ () => {} }
 					disableAlpha
-				/>
+				/>,
+				{ createNodeMock }
 			);
 		} );
 

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -391,7 +391,7 @@ _Returns_
 
 <a name="useThrottle" href="#useThrottle">#</a> **useThrottle**
 
-Throttles a function with Lodash's `throttle`. A new throttled function will
+Throttle a function with Lodash's `throttle`. A new throttled function will
 be returned and any scheduled calls cancelled if any of the arguments change,
 including the function to throttle, so please wrap functions created on
 render in components in `useCallback`.
@@ -399,10 +399,6 @@ render in components in `useCallback`.
 _Parameters_
 
 -   _args_ `...any`: Arguments passed to Lodash's `throttle`.
-
-_Returns_
-
--   `Function`: Throttled function.
 
 <a name="useViewportMatch" href="#useViewportMatch">#</a> **useViewportMatch**
 

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -400,6 +400,10 @@ _Parameters_
 
 -   _args_ `...any`: Arguments passed to Lodash's `throttle`.
 
+_Returns_
+
+-   `Function`: returns the throttled function
+
 <a name="useViewportMatch" href="#useViewportMatch">#</a> **useViewportMatch**
 
 Returns true if the viewport matches the given query, or false otherwise.

--- a/packages/compose/src/hooks/use-throttle/index.js
+++ b/packages/compose/src/hooks/use-throttle/index.js
@@ -16,6 +16,8 @@ import { useEffect } from '@wordpress/element';
  * render in components in `useCallback`.
  *
  * @param {...any} args Arguments passed to Lodash's `throttle`.
+ *
+ * @return {Function} returns the throttled function
  */
 export default function useThrottle( ...args ) {
 	const throttled = useMemoOne( () => throttle( ...args ), args );

--- a/packages/compose/src/hooks/use-throttle/index.js
+++ b/packages/compose/src/hooks/use-throttle/index.js
@@ -10,14 +10,12 @@ import { useMemoOne } from 'use-memo-one';
 import { useEffect } from '@wordpress/element';
 
 /**
- * Throttles a function with Lodash's `throttle`. A new throttled function will
+ * Throttle a function with Lodash's `throttle`. A new throttled function will
  * be returned and any scheduled calls cancelled if any of the arguments change,
  * including the function to throttle, so please wrap functions created on
  * render in components in `useCallback`.
  *
  * @param {...any} args Arguments passed to Lodash's `throttle`.
- *
- * @return {Function} Throttled function.
  */
 export default function useThrottle( ...args ) {
 	const throttled = useMemoOne( () => throttle( ...args ), args );

--- a/packages/compose/src/index.native.js
+++ b/packages/compose/src/index.native.js
@@ -29,3 +29,4 @@ export { default as usePreferredColorSchemeStyle } from './hooks/use-preferred-c
 export { default as useResizeObserver } from './hooks/use-resize-observer';
 export { default as useDebounce } from './hooks/use-debounce';
 export { default as useMergeRefs } from './hooks/use-merge-refs';
+export { default as useThrottle } from './hooks/use-throttle';


### PR DESCRIPTION
Related to #22890

## Description
Refactored ColorPicker Components to functional components.

## How has this been tested?
I tested the component from the storybook, `npm run storybook:dev`

## Types of changes
Refactor : `ColorPicker` to functional component.
Refactor : ColorPicker `Hue` to functional component.
Refactor : ColorPicker `Saturation` to functional component.
Refactor : ColorPicker `Alpha` to functional component.
Refactor : ColorPicker `Inputs` to functional component.

Update Test : ColorPicker Tests by putting test into [TestRenderer.act()](https://reactjs.org/docs/test-renderer.html#testrendereract) function.
Update Snapshot: ColorPalette Snapshot by removing Pure and withInstance  HOCs.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [ ] My code follows the accessibility standards.
- [ ] My code has proper inline documentation. 
- [ ] I've included developer documentation if appropriate.
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR.
