### PR TITLE
Document the supports style properties that were deemed stable during 5.6 cycle

### DIFF
--- a/docs/designers-developers/developers/block-api/block-supports.md
+++ b/docs/designers-developers/developers/block-api/block-supports.md
@@ -136,12 +136,29 @@ supports: {
 
 This value signals that a block supports the font-size CSS style property. When it does, the block editor will show an UI control for the user to set its value.
 
+The values shown in this control are the ones declared by the theme via the `editor-font-sizes` [theme support](https://developer.wordpress.org/block-editor/developers/themes/theme-support/#block-font-sizes), or the default ones if none is provided.
+
 ```js
 supports: {
     // Enable UI control for font-size.
     fontSize: true,
 }
 ```
+
+When the block declares support for `fontSize`, the attributes definition is extended to include two new attributes: `fontSize` and `style`:
+
+- `fontSize`: attribute of `string` type with no default assigned. It stores the preset values set by the user. The block can apply a default alignment by specifying its own `fontSize` attribute with a default e.g.:
+
+```js
+attributes: {
+    fontSize: {
+        type: 'string',
+        default: 'some-value',
+    }
+}
+```
+
+- `style`: attribute of `object` type with no default assigned. It stores the custom values set by the user.
 
 ## html
 

--- a/docs/designers-developers/developers/block-api/block-supports.md
+++ b/docs/designers-developers/developers/block-api/block-supports.md
@@ -147,7 +147,7 @@ supports: {
 
 When the block declares support for `fontSize`, the attributes definition is extended to include two new attributes: `fontSize` and `style`:
 
-- `fontSize`: attribute of `string` type with no default assigned. It stores the preset values set by the user. The block can apply a default alignment by specifying its own `fontSize` attribute with a default e.g.:
+- `fontSize`: attribute of `string` type with no default assigned. It stores the preset values set by the user. The block can apply a default fontSize by specifying its own `fontSize` attribute with a default e.g.:
 
 ```js
 attributes: {
@@ -158,7 +158,20 @@ attributes: {
 }
 ```
 
-- `style`: attribute of `object` type with no default assigned. It stores the custom values set by the user.
+- `style`: attribute of `object` type with no default assigned. It stores the custom values set by the user. The block can apply a default style by specifying its own `style` attribute with a default e.g.:
+
+```js
+attributes: {
+    style: {
+        type: 'object',
+        default: {
+            typography: {
+                fontSize: 'value'
+            }
+        }
+    }
+}
+```
 
 ## html
 

--- a/docs/designers-developers/developers/block-api/block-supports.md
+++ b/docs/designers-developers/developers/block-api/block-supports.md
@@ -258,7 +258,7 @@ supports: {
 - Type: `boolean`
 - Default value: `false`
 
-This value signals that a block supports the line-height CSS style property. When it does, the block editor will show an UI control for the user to set its value.
+This value signals that a block supports the line-height CSS style property. When it does, the block editor will show an UI control for the user to set its value if [the theme declares support](/docs/designers-developers/developers/themes/theme-support.md#supporting-custom-line-heights).
 
 ```js
 supports: {
@@ -317,7 +317,7 @@ supports: {
 - Subproperties:
   - `padding`: type `boolean`, default value `false`
 
-This value signals that a block supports some of the CSS style properties related to spacing. When it does, the block editor will show UI controls for the user to set their values.
+This value signals that a block supports some of the CSS style properties related to spacing. When it does, the block editor will show UI controls for the user to set their values, if [the theme declares support](/docs/designers-developers/developers/themes/theme-support.md##cover-block-padding).
 
 ```js
 supports: {

--- a/docs/designers-developers/developers/block-api/block-supports.md
+++ b/docs/designers-developers/developers/block-api/block-supports.md
@@ -327,3 +327,25 @@ supports: {
     padding: true, // Enable padding color UI control.
 }
 ```
+
+When the block declares support for a specific spacing property, the attributes definition is extended to include some attributes.
+
+- `style`: attribute of `object` type with no default assigned. This is added when `padding` support is declared. It stores the custom values set by the user. The block can apply a default style by specifying its own `style` attribute with a default e.g.:
+
+```js
+attributes: {
+    style: {
+        type: 'object',
+        default: {
+            spacing: {
+                padding: {
+                    top: 'value',
+                    right: 'value',
+                    bottom: 'value',
+                    left: 'value'
+                }
+            }
+        }
+    }
+}
+```

--- a/docs/designers-developers/developers/block-api/block-supports.md
+++ b/docs/designers-developers/developers/block-api/block-supports.md
@@ -134,11 +134,11 @@ supports: {
 - Type: `boolean`
 - Default value: `false`
 
-This value signals that a block supports the font-size CSS style property. When it does, the block editor will show an UI control for the user to set the font-size value.
+This value signals that a block supports the font-size CSS style property. When it does, the block editor will show an UI control for the user to set its value.
 
 ```js
 supports: {
-    // Enable UI control for font-size
+    // Enable UI control for font-size.
     fontSize: true,
 }
 ```
@@ -154,6 +154,20 @@ By default, a block's markup can be edited individually. To disable this behavio
 supports: {
     // Remove support for an HTML mode.
     html: false
+}
+```
+
+## lineHeight
+
+- Type: `boolean`
+- Default value: `false`
+
+This value signals that a block supports the line-height CSS style property. When it does, the block editor will show an UI control for the user to set its value.
+
+```js
+supports: {
+    // Enable UI control for line-height.
+    lineHeight: true,
 }
 ```
 

--- a/docs/designers-developers/developers/block-api/block-supports.md
+++ b/docs/designers-developers/developers/block-api/block-supports.md
@@ -157,20 +157,6 @@ supports: {
 }
 ```
 
-## lineHeight
-
-- Type: `boolean`
-- Default value: `false`
-
-This value signals that a block supports the line-height CSS style property. When it does, the block editor will show an UI control for the user to set its value.
-
-```js
-supports: {
-    // Enable UI control for line-height.
-    lineHeight: true,
-}
-```
-
 ## inserter
 
 - Type: `boolean`
@@ -182,6 +168,20 @@ By default, all blocks will appear in the inserter. To hide a block so that it c
 supports: {
     // Hide this block from the inserter.
     inserter: false
+}
+```
+
+## lineHeight
+
+- Type: `boolean`
+- Default value: `false`
+
+This value signals that a block supports the line-height CSS style property. When it does, the block editor will show an UI control for the user to set its value.
+
+```js
+supports: {
+    // Enable UI control for line-height.
+    lineHeight: true,
 }
 ```
 

--- a/docs/designers-developers/developers/block-api/block-supports.md
+++ b/docs/designers-developers/developers/block-api/block-supports.md
@@ -80,6 +80,29 @@ supports: {
 }
 ```
 
+## color
+
+- Type: `Object`
+- Default value: null
+- Subproperties:
+  - `background`: type `boolean`, default value `false`
+  - `gradient`: type `boolean`, default value `false`
+  - `link`: type `boolean`, default value `false`
+  - `text`: type `boolean`, default value `false`
+
+This value enables a block to declare support for some color style properties. When it does, the block editor will show UI controls for the user to set the values of these variables.
+
+For example, this will enable all controls:
+
+```js
+supports: {
+    background: true,
+    text: true,
+    link: true,
+    text: true,
+}
+```
+
 ## customClassName
 
 - Type: `boolean`

--- a/docs/designers-developers/developers/block-api/block-supports.md
+++ b/docs/designers-developers/developers/block-api/block-supports.md
@@ -215,6 +215,21 @@ supports: {
 }
 ```
 
+When the block declares support for `lineHeight`, the attributes definition is extended to include a new attribute `style` of `object` type with no default assigned. It stores the custom value set by the user. The block can apply a default style by specifying its own `style` attribute with a default e.g.:
+
+```js
+attributes: {
+    style: {
+        type: 'object',
+        default: {
+            typography: {
+                lineHeight: 'value'
+            }
+        }
+    }
+}
+```
+
 ## multiple
 
 - Type: `boolean`

--- a/docs/designers-developers/developers/block-api/block-supports.md
+++ b/docs/designers-developers/developers/block-api/block-supports.md
@@ -92,12 +92,67 @@ supports: {
 
 This value signals that a block supports some of the CSS style properties related to color. When it does, the block editor will show UI controls for the user to set their values.
 
+The controls for background, text, and link will source their colors from the `editor-color-palette` [theme support](https://developer.wordpress.org/block-editor/developers/themes/theme-support/#block-color-palettes), while the gradient's from `editor-gradient-presets` [theme support](https://developer.wordpress.org/block-editor/developers/themes/theme-support/#block-gradient-presets).
+
 ```js
 supports: {
     background: true, // Enable background color UI control.
     gradient: true, // Enable gradients UI control.
     link: true, // Enable link color UI control.
     text: true, // Eneble text color UI control.
+}
+```
+
+When the block declares support for a specific color property, the attributes definition is extended to include some attributes.
+
+- `style`: attribute of `object` type with no default assigned. This is added when any of support color properties are declared. It stores the custom values set by the user. The block can apply a default style by specifying its own `style` attribute with a default e.g.:
+
+```js
+attributes: {
+    style: {
+        type: 'object',
+        default: {
+            color: {
+                background: 'value',
+                gradient: 'value',
+                link: 'value',
+                text: 'value'
+            }
+        }
+    }
+}
+```
+
+- When `background` support is declared: it'll be added a new `backgroundColor` attribute of type `string` with no default assigned. It stores the preset values set by the user. The block can apply a default background color by specifying its own attribute with a default e.g.:
+
+```js
+attributes: {
+    backgroundColor: {
+        type: 'string',
+        default: 'some-value',
+    }
+}
+```
+
+- When `gradient` support is declared: it'll be added a new `gradient` attribute of type `string` with no default assigned. It stores the preset values set by the user. The block can apply a default text color by specifying its own attribute with a default e.g.:
+
+```js
+attributes: {
+    gradient: {
+        type: 'string',
+        default: 'some-value',
+    }
+}
+```
+
+- When `text` support is declared: it'll be added a new `textColor` attribute of type `string` with no default assigned. It stores the preset values set by the user. The block can apply a default text color by specifying its own attribute with a default e.g.:
+
+```js
+attributes: {
+    textColor: {
+        type: 'string',
+        default: 'some-value',
+    }
 }
 ```
 

--- a/docs/designers-developers/developers/block-api/block-supports.md
+++ b/docs/designers-developers/developers/block-api/block-supports.md
@@ -87,18 +87,16 @@ supports: {
 - Subproperties:
   - `background`: type `boolean`, default value `false`
   - `gradient`: type `boolean`, default value `false`
-  - `link`: type `boolean`, default value `false`
   - `text`: type `boolean`, default value `false`
 
 This value signals that a block supports some of the CSS style properties related to color. When it does, the block editor will show UI controls for the user to set their values.
 
-The controls for background, text, and link will source their colors from the `editor-color-palette` [theme support](https://developer.wordpress.org/block-editor/developers/themes/theme-support/#block-color-palettes), while the gradient's from `editor-gradient-presets` [theme support](https://developer.wordpress.org/block-editor/developers/themes/theme-support/#block-gradient-presets).
+The controls for background and text will source their colors from the `editor-color-palette` [theme support](https://developer.wordpress.org/block-editor/developers/themes/theme-support/#block-color-palettes), while the gradient's from `editor-gradient-presets` [theme support](https://developer.wordpress.org/block-editor/developers/themes/theme-support/#block-gradient-presets).
 
 ```js
 supports: {
     background: true, // Enable background color UI control.
     gradient: true, // Enable gradients UI control.
-    link: true, // Enable link color UI control.
     text: true, // Eneble text color UI control.
 }
 ```
@@ -115,7 +113,6 @@ attributes: {
             color: {
                 background: 'value',
                 gradient: 'value',
-                link: 'value',
                 text: 'value'
             }
         }

--- a/docs/designers-developers/developers/block-api/block-supports.md
+++ b/docs/designers-developers/developers/block-api/block-supports.md
@@ -212,3 +212,18 @@ supports: {
     reusable: false
 }
 ```
+
+## spacing
+
+- Type: `Object`
+- Default value: null
+- Subproperties:
+  - `padding`: type `boolean`, default value `false`
+
+This value signals that a block supports some of the CSS style properties related to spacing. When it does, the block editor will show UI controls for the user to set their values.
+
+```js
+supports: {
+    padding: true, // Enable padding color UI control.
+}
+```

--- a/docs/designers-developers/developers/block-api/block-supports.md
+++ b/docs/designers-developers/developers/block-api/block-supports.md
@@ -90,16 +90,14 @@ supports: {
   - `link`: type `boolean`, default value `false`
   - `text`: type `boolean`, default value `false`
 
-This value enables a block to declare support for some color style properties. When it does, the block editor will show UI controls for the user to set the values of these variables.
-
-For example, this will enable all controls:
+This value signals that a block supports some of the CSS style properties related to color. When it does, the block editor will show UI controls for the user to set their values.
 
 ```js
 supports: {
-    background: true,
-    text: true,
-    link: true,
-    text: true,
+    background: true, // Enable background color UI control.
+    gradient: true, // Enable gradients UI control.
+    link: true, // Enable link color UI control.
+    text: true, // Eneble text color UI control.
 }
 ```
 
@@ -128,6 +126,20 @@ When the style picker is shown, a dropdown is displayed so the user can select a
 supports: {
     // Remove the Default Style picker.
     defaultStylePicker: false
+}
+```
+
+## fontSize
+
+- Type: `boolean`
+- Default value: `false`
+
+This value signals that a block supports the font-size CSS style property. When it does, the block editor will show an UI control for the user to set the font-size value.
+
+```js
+supports: {
+    // Enable UI control for font-size
+    fontSize: true,
 }
 ```
 


### PR DESCRIPTION
This documents how blocks declare support for some style properties -color, font size, spacing, line height- that were deemed stabled during the WordPress 5.6 release cycle.

Note that:

- the properties prepended with `__experimental` are not documented, as they are still in the experimental phase.
- the `color.link` property is no longer marked as experimental but still requires experimental theme support, so this hasn't been documented either.
