### PR TITLE
Tests: Add fixture for Column deprecation

### DIFF
--- a/packages/block-library/src/column/deprecated.js
+++ b/packages/block-library/src/column/deprecated.js
@@ -20,6 +20,9 @@ const deprecated = [
 				max: 100,
 			},
 		},
+		isEligible( { width } ) {
+			return isFinite( width );
+		},
 		migrate( attributes ) {
 			return {
 				...attributes,
@@ -33,10 +36,7 @@ const deprecated = [
 				[ `is-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,
 			} );
 
-			let style;
-			if ( Number.isFinite( width ) ) {
-				style = { flexBasis: width + '%' };
-			}
+			const style = { flexBasis: width + '%' };
 
 			return (
 				<div className={ wrapperClasses } style={ style }>

--- a/packages/e2e-tests/fixtures/blocks/core__column__deprecated-1.html
+++ b/packages/e2e-tests/fixtures/blocks/core__column__deprecated-1.html
@@ -1,0 +1,10 @@
+<!-- wp:column {"width":33.33} -->
+<div class="wp-block-column" style="flex-basis:33.33%">
+	<!-- wp:paragraph -->
+	<p>Column One, Paragraph One</p>
+	<!-- /wp:paragraph -->
+	<!-- wp:paragraph -->
+	<p>Column One, Paragraph Two</p>
+	<!-- /wp:paragraph -->
+</div>
+<!-- /wp:columns -->

--- a/packages/e2e-tests/fixtures/blocks/core__column__deprecated-1.json
+++ b/packages/e2e-tests/fixtures/blocks/core__column__deprecated-1.json
@@ -1,0 +1,35 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "core/column",
+        "isValid": true,
+        "attributes": {
+            "width": "33.33%"
+        },
+        "innerBlocks": [
+            {
+                "clientId": "_clientId_0",
+                "name": "core/paragraph",
+                "isValid": true,
+                "attributes": {
+                    "content": "Column One, Paragraph One",
+                    "dropCap": false
+                },
+                "innerBlocks": [],
+                "originalContent": "<p>Column One, Paragraph One</p>"
+            },
+            {
+                "clientId": "_clientId_1",
+                "name": "core/paragraph",
+                "isValid": true,
+                "attributes": {
+                    "content": "Column One, Paragraph Two",
+                    "dropCap": false
+                },
+                "innerBlocks": [],
+                "originalContent": "<p>Column One, Paragraph Two</p>"
+            }
+        ],
+        "originalContent": "<div class=\"wp-block-column\" style=\"flex-basis:33.33%\">\n\t\n\t\n</div>"
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__column__deprecated-1.parsed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__column__deprecated-1.parsed.json
@@ -1,0 +1,45 @@
+[
+    {
+        "blockName": "core/column",
+        "attrs": {
+            "width": 33.33
+        },
+        "innerBlocks": [
+            {
+                "blockName": "core/paragraph",
+                "attrs": {},
+                "innerBlocks": [],
+                "innerHTML": "\n\t<p>Column One, Paragraph One</p>\n\t",
+                "innerContent": [
+                    "\n\t<p>Column One, Paragraph One</p>\n\t"
+                ]
+            },
+            {
+                "blockName": "core/paragraph",
+                "attrs": {},
+                "innerBlocks": [],
+                "innerHTML": "\n\t<p>Column One, Paragraph Two</p>\n\t",
+                "innerContent": [
+                    "\n\t<p>Column One, Paragraph Two</p>\n\t"
+                ]
+            }
+        ],
+        "innerHTML": "\n<div class=\"wp-block-column\" style=\"flex-basis:33.33%\">\n\t\n\t\n</div>\n",
+        "innerContent": [
+            "\n<div class=\"wp-block-column\" style=\"flex-basis:33.33%\">\n\t",
+            null,
+            "\n\t",
+            null,
+            "\n</div>\n"
+        ]
+    },
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n",
+        "innerContent": [
+            "\n"
+        ]
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__column__deprecated-1.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__column__deprecated-1.serialized.html
@@ -1,0 +1,9 @@
+<!-- wp:column {"width":"33.33%"} -->
+<div class="wp-block-column" style="flex-basis:33.33%"><!-- wp:paragraph -->
+<p>Column One, Paragraph One</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Column One, Paragraph Two</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Follow-up for #24711.

This PR adds tests for the Column block deprecation added.

## How has this been tested?
`npm run test-unit`