### PR TITLE
Fix: LineHeightControl is not disabled at the global styles block level

### DIFF
--- a/packages/edit-site/src/components/sidebar/typography-panel.js
+++ b/packages/edit-site/src/components/sidebar/typography-panel.js
@@ -13,8 +13,18 @@ import { __ } from '@wordpress/i18n';
  */
 import { useEditorFeature } from '../editor/utils';
 
-export function useHasTypographyPanel( { supports } ) {
-	return supports.includes( 'fontSize' ) || supports.includes( 'lineHeight' );
+export function useHasTypographyPanel( { supports, name } ) {
+	return (
+		useHasLineHeightControl( { supports, name } ) ||
+		supports.includes( 'fontSize' )
+	);
+}
+
+function useHasLineHeightControl( { supports, name } ) {
+	return (
+		useEditorFeature( 'typography.customLineHeight', name ) &&
+		supports.includes( 'lineHeight' )
+	);
 }
 
 export default function TypographyPanel( {
@@ -28,6 +38,7 @@ export default function TypographyPanel( {
 		name
 	);
 	const fontFamilies = useEditorFeature( 'typography.fontFamilies', name );
+	const hasLineHeightEnabled = useHasLineHeightControl( { supports, name } );
 
 	return (
 		<PanelBody title={ __( 'Typography' ) } initialOpen={ true }>
@@ -50,7 +61,7 @@ export default function TypographyPanel( {
 					disableCustomFontSizes={ disableCustomFontSizes }
 				/>
 			) }
-			{ supports.includes( 'lineHeight' ) && (
+			{ hasLineHeightEnabled && (
 				<LineHeightControl
 					value={ getStyleProperty( name, 'lineHeight' ) }
 					onChange={ ( value ) =>


### PR DESCRIPTION
Even if themes disabled line-height for some block in global styles the line-height control would still appear for that block. This PR fixes the issue.

## Description
<!-- Please describe what you have changed or added -->

## How has this been tested?
I added the following settings to the theme.json of the active theme:
```
	"core/post-date": {
		"settings": {
			"typography": {
				"customLineHeight": false
			}
		}
	}
```

I added Post Date block I verified on the block inspector the line-height option does not appear.
I open the global styles sidebar and the Post Date panel.
I verified the line-height option does not appear. (On master it appears) 