### PR TITLE
Include button margins in width calculations

### DIFF
--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -40,6 +40,7 @@ $grid-unit-60: 6 * $grid-unit;		// 48px
  */
 
 $icon-size: 24px;
+$button-margin: 0.5em;
 $button-size: 36px;
 $button-size-small: 24px;
 $header-height: 60px;

--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -33,7 +33,8 @@ $blocks-button__height: 3.1em;
 	}
 }
 
-.wp-block-button {
+// Increased specificity needed to override margins
+.wp-block-buttons > .wp-block-button {
 	&.has-custom-width {
 		max-width: none;
 		.wp-block-button__link {
@@ -42,19 +43,21 @@ $blocks-button__height: 3.1em;
 	}
 
 	&.wp-block-button__width-25 {
-		width: 25%;
+		width: calc(25% - #{$button-margin});
 	}
 
 	&.wp-block-button__width-50 {
-		width: 50%;
+		width: calc(50% - #{$button-margin});
 	}
 
 	&.wp-block-button__width-75 {
-		width: 75%;
+		width: calc(75% - #{$button-margin});
 	}
 
 	&.wp-block-button__width-100 {
 		width: 100%;
+		margin-left: 0;
+		margin-right: 0;
 	}
 }
 

--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -43,21 +43,19 @@ $blocks-button__height: 3.1em;
 	}
 
 	&.wp-block-button__width-25 {
-		width: calc(25% - #{$button-margin});
+		width: calc(25% - #{ $button-margin });
 	}
 
 	&.wp-block-button__width-50 {
-		width: calc(50% - #{$button-margin});
+		width: calc(50% - #{ $button-margin });
 	}
 
 	&.wp-block-button__width-75 {
-		width: calc(75% - #{$button-margin});
+		width: calc(75% - #{ $button-margin });
 	}
 
 	&.wp-block-button__width-100 {
-		width: 100%;
-		margin-left: 0;
-		margin-right: 0;
+		width: calc(100% - #{ $button-margin });
 	}
 }
 

--- a/packages/block-library/src/buttons/style.scss
+++ b/packages/block-library/src/buttons/style.scss
@@ -7,8 +7,8 @@
 	> .wp-block-button {
 		display: inline-block;
 		/*rtl:ignore*/
-		margin-right: 0.5em;
-		margin-bottom: 0.5em;
+		margin-right: $button-margin;
+		margin-bottom: $button-margin;
 
 		&:last-child {
 			/*rtl:ignore*/
@@ -29,7 +29,7 @@
 
 		> .wp-block-button {
 			/*rtl:ignore*/
-			margin-left: 0.5em;
+			margin-left: $button-margin;
 			/*rtl:ignore*/
 			margin-right: 0;
 
@@ -48,7 +48,7 @@
 		/*rtl:ignore*/
 		margin-left: 0;
 		/*rtl:ignore*/
-		margin-right: 0.5em;
+		margin-right: $button-margin;
 
 		&:last-child {
 			/*rtl:ignore*/
@@ -59,7 +59,7 @@
 		/*rtl:ignore*/
 		margin-right: 0;
 		/*rtl:ignore*/
-		margin-left: 0.5em;
+		margin-left: $button-margin;
 
 		&:first-child {
 			/*rtl:ignore*/


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
#25999 added a width selector for the button block, allowing a Button to be set to 25%, 50%, 75%, or 100% width. Margins were not included in the width calculation in the initial iteration, meaning that for example two 50% buttons will not fit on the same line.

This PR includes margins in the width calculation.

## How has this been tested?
Manually with the Buttons block, testing with left/center/right alignments. Tested using Seedlet and Twenty Twenty.

### Testing Instructions
Add a Buttons block with several buttons and change their width using the width selector in the Inspector Controls.
- [ ] Test that expected widths fit together in a row (four 25%, two 50%, a 50% and two 25%, a 75% and a 25%...)
- [ ] Test that multiple buttons with width 100% are correctly aligned
- [ ] Create a grid of buttons by creating multiple rows with widths adding up to 100%, and verify that the edges of the grid are flush (see screenshots)
- [ ] Test button grids when the Buttons block is set to different alignments (right aligned, center aligned...)

## Screenshots <!-- if applicable -->

<img width="1215" alt="Screen Shot 2020-11-06 at 3 00 08 PM" src="https://user-images.githubusercontent.com/63313398/98422537-cb8ddd80-2040-11eb-839e-b62a573faa58.png">
<img width="810" alt="Screen Shot 2020-11-06 at 1 58 04 PM" src="https://user-images.githubusercontent.com/63313398/98422546-d0eb2800-2040-11eb-9be5-8426eaff2a5f.png">

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->

Fixes #26702 
