### PR TITLE
Chore: Fix: Pass clearable setting on ColorGradientControl.

### DIFF
--- a/packages/block-editor/src/components/colors-gradients/control.js
+++ b/packages/block-editor/src/components/colors-gradients/control.js
@@ -88,6 +88,7 @@ function ColorGradientControlInner( {
 	onGradientChange,
 	colorValue,
 	gradientValue,
+	clearable,
 } ) {
 	const canChooseAColor =
 		onColorChange && ( ! isEmpty( colors ) || ! disableCustomColors );
@@ -151,6 +152,7 @@ function ColorGradientControlInner( {
 								: onColorChange
 						}
 						{ ...{ colors, disableCustomColors } }
+						clearable={ clearable }
 					/>
 				) }
 				{ ( currentTab === 'gradient' || ! canChooseAColor ) && (
@@ -165,6 +167,7 @@ function ColorGradientControlInner( {
 								: onGradientChange
 						}
 						{ ...{ gradients, disableCustomGradients } }
+						clearable={ clearable }
 					/>
 				) }
 			</fieldset>


### PR DESCRIPTION
The setting clearable was not being passed to the color palette from ColorGradientControl. This setting should be passed as the other settings are. In global styles, we will need this setting because when the theme sets a default color, and the user did not set any color, we want to show the mark that there is a color, but we don't want to allow the user to clear it, we allow the user to change to another one.

