### PR TITLE
Update: Use theme and core styles as defaults on the global styles

### DIFF
--- a/packages/edit-site/src/components/editor/global-styles-provider.js
+++ b/packages/edit-site/src/components/editor/global-styles-provider.js
@@ -32,6 +32,7 @@ const GlobalStylesContext = createContext( {
 	getSetting: ( context, path ) => {},
 	setSetting: ( context, path, newValue ) => {},
 	getStyleProperty: ( context, propertyName ) => {},
+	getMergedStyleProperty: ( context, propertyName ) => {},
 	setStyleProperty: ( context, propertyName, newValue ) => {},
 	globalContext: {},
 	/* eslint-enable no-unused-vars */
@@ -85,6 +86,11 @@ export default function GlobalStylesProvider( {
 			getStyleProperty: ( context, propertyName ) =>
 				get(
 					userStyles?.[ context ]?.styles,
+					STYLE_PROPERTY[ propertyName ]
+				),
+			getMergedStyleProperty: ( context, propertyName ) =>
+				get(
+					mergedStyles?.[ context ]?.styles,
 					STYLE_PROPERTY[ propertyName ]
 				),
 			setStyleProperty: ( context, propertyName, newValue ) => {

--- a/packages/edit-site/src/components/editor/global-styles-provider.js
+++ b/packages/edit-site/src/components/editor/global-styles-provider.js
@@ -31,8 +31,7 @@ const GlobalStylesContext = createContext( {
 	/* eslint-disable no-unused-vars */
 	getSetting: ( context, path ) => {},
 	setSetting: ( context, path, newValue ) => {},
-	getStyleProperty: ( context, propertyName ) => {},
-	getMergedStyleProperty: ( context, propertyName ) => {},
+	getStyleProperty: ( context, propertyName, origin ) => {},
 	setStyleProperty: ( context, propertyName, newValue ) => {},
 	globalContext: {},
 	/* eslint-enable no-unused-vars */
@@ -83,16 +82,16 @@ export default function GlobalStylesProvider( {
 				set( contextSettings, path, newValue );
 				setContent( JSON.stringify( newContent ) );
 			},
-			getStyleProperty: ( context, propertyName ) =>
-				get(
-					userStyles?.[ context ]?.styles,
+			getStyleProperty: ( context, propertyName, origin = 'merged' ) => {
+				const styleOrigins = {
+					merged: mergedStyles,
+					user: userStyles,
+				};
+				return get(
+					styleOrigins[ origin ]?.[ context ]?.styles,
 					STYLE_PROPERTY[ propertyName ]
-				),
-			getMergedStyleProperty: ( context, propertyName ) =>
-				get(
-					mergedStyles?.[ context ]?.styles,
-					STYLE_PROPERTY[ propertyName ]
-				),
+				);
+			},
 			setStyleProperty: ( context, propertyName, newValue ) => {
 				const newContent = { ...userStyles };
 				let contextStyles = newContent?.[ context ]?.styles;

--- a/packages/edit-site/src/components/editor/global-styles-provider.js
+++ b/packages/edit-site/src/components/editor/global-styles-provider.js
@@ -83,12 +83,10 @@ export default function GlobalStylesProvider( {
 				setContent( JSON.stringify( newContent ) );
 			},
 			getStyleProperty: ( context, propertyName, origin = 'merged' ) => {
-				const styleOrigins = {
-					merged: mergedStyles,
-					user: userStyles,
-				};
+				const styles = 'user' === origin ? userStyles : mergedStyles;
+
 				return get(
-					styleOrigins[ origin ]?.[ context ]?.styles,
+					styles?.[ context ]?.styles,
 					STYLE_PROPERTY[ propertyName ]
 				);
 			},

--- a/packages/edit-site/src/components/sidebar/color-panel.js
+++ b/packages/edit-site/src/components/sidebar/color-panel.js
@@ -27,6 +27,7 @@ export function useHasColorPanel( { supports } ) {
 export default function ColorPanel( {
 	context: { supports, name },
 	getStyleProperty,
+	getMergedStyleProperty,
 	setStyleProperty,
 	getSetting,
 	setSetting,
@@ -42,7 +43,8 @@ export default function ColorPanel( {
 	const settings = [];
 
 	if ( supports.includes( 'color' ) ) {
-		const color = getStyleProperty( name, 'color' );
+		const color = getMergedStyleProperty( name, 'color' );
+		const userColor = getStyleProperty( name, 'color' );
 		settings.push( {
 			colorValue:
 				getPresetValueFromVariable( 'color', colors, color ) || color,
@@ -53,12 +55,17 @@ export default function ColorPanel( {
 					getPresetVariable( 'color', colors, value ) || value
 				),
 			label: __( 'Text color' ),
+			clearable: color === userColor,
 		} );
 	}
 
 	let backgroundSettings = {};
 	if ( supports.includes( 'backgroundColor' ) ) {
-		const backgroundColor = getStyleProperty( name, 'backgroundColor' );
+		const backgroundColor = getMergedStyleProperty(
+			name,
+			'backgroundColor'
+		);
+		const userBackgroundColor = getStyleProperty( name, 'backgroundColor' );
 		backgroundSettings = {
 			colorValue:
 				getPresetValueFromVariable(
@@ -73,11 +80,16 @@ export default function ColorPanel( {
 					getPresetVariable( 'color', colors, value ) || value
 				),
 		};
+		if ( backgroundColor ) {
+			backgroundSettings.clearable =
+				backgroundColor === userBackgroundColor;
+		}
 	}
 
 	let gradientSettings = {};
 	if ( supports.includes( 'background' ) ) {
-		const gradient = getStyleProperty( name, 'background' );
+		const gradient = getMergedStyleProperty( name, 'background' );
+		const userGradient = getStyleProperty( name, 'background' );
 		gradientSettings = {
 			gradientValue:
 				getPresetValueFromVariable( 'gradient', gradients, gradient ) ||
@@ -89,6 +101,9 @@ export default function ColorPanel( {
 					getPresetVariable( 'gradient', gradients, value ) || value
 				),
 		};
+		if ( gradient ) {
+			gradientSettings.clearable = gradient === userGradient;
+		}
 	}
 
 	if (
@@ -103,7 +118,8 @@ export default function ColorPanel( {
 	}
 
 	if ( supports.includes( LINK_COLOR ) ) {
-		const color = getStyleProperty( name, LINK_COLOR );
+		const color = getMergedStyleProperty( name, LINK_COLOR );
+		const userColor = getStyleProperty( name, LINK_COLOR );
 		settings.push( {
 			colorValue:
 				getPresetValueFromVariable( 'color', colors, color ) || color,
@@ -114,6 +130,7 @@ export default function ColorPanel( {
 					getPresetVariable( 'color', colors, value ) || value
 				),
 			label: __( 'Link color' ),
+			clearable: color === userColor,
 		} );
 	}
 	return (

--- a/packages/edit-site/src/components/sidebar/color-panel.js
+++ b/packages/edit-site/src/components/sidebar/color-panel.js
@@ -3,6 +3,7 @@
  */
 import { __experimentalPanelColorGradientSettings as PanelColorGradientSettings } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -10,7 +11,7 @@ import { __ } from '@wordpress/i18n';
 import {
 	LINK_COLOR,
 	useEditorFeature,
-	getPresetValueFromVariable,
+	getValueFromVariable,
 	getPresetVariable,
 } from '../editor/utils';
 import ColorPalettePanel from './color-palette-panel';
@@ -27,11 +28,13 @@ export function useHasColorPanel( { supports } ) {
 export default function ColorPanel( {
 	context: { supports, name },
 	getStyleProperty,
-	getMergedStyleProperty,
 	setStyleProperty,
 	getSetting,
 	setSetting,
 } ) {
+	const features = useSelect( ( select ) => {
+		return select( 'core/edit-site' ).getSettings().__experimentalFeatures;
+	} );
 	const colors = useEditorFeature( 'color.palette', name );
 	const disableCustomColors = ! useEditorFeature( 'color.custom', name );
 	const gradients = useEditorFeature( 'color.gradients', name );
@@ -43,11 +46,10 @@ export default function ColorPanel( {
 	const settings = [];
 
 	if ( supports.includes( 'color' ) ) {
-		const color = getMergedStyleProperty( name, 'color' );
-		const userColor = getStyleProperty( name, 'color' );
+		const color = getStyleProperty( name, 'color' );
+		const userColor = getStyleProperty( name, 'color', 'user' );
 		settings.push( {
-			colorValue:
-				getPresetValueFromVariable( 'color', colors, color ) || color,
+			colorValue: getValueFromVariable( features, name, color ) || color,
 			onColorChange: ( value ) =>
 				setStyleProperty(
 					name,
@@ -61,18 +63,16 @@ export default function ColorPanel( {
 
 	let backgroundSettings = {};
 	if ( supports.includes( 'backgroundColor' ) ) {
-		const backgroundColor = getMergedStyleProperty(
+		const backgroundColor = getStyleProperty( name, 'backgroundColor' );
+		const userBackgroundColor = getStyleProperty(
 			name,
-			'backgroundColor'
+			'backgroundColor',
+			'user'
 		);
-		const userBackgroundColor = getStyleProperty( name, 'backgroundColor' );
 		backgroundSettings = {
 			colorValue:
-				getPresetValueFromVariable(
-					'color',
-					colors,
-					backgroundColor
-				) || backgroundColor,
+				getValueFromVariable( features, name, backgroundColor ) ||
+				backgroundColor,
 			onColorChange: ( value ) =>
 				setStyleProperty(
 					name,
@@ -88,12 +88,11 @@ export default function ColorPanel( {
 
 	let gradientSettings = {};
 	if ( supports.includes( 'background' ) ) {
-		const gradient = getMergedStyleProperty( name, 'background' );
-		const userGradient = getStyleProperty( name, 'background' );
+		const gradient = getStyleProperty( name, 'background' );
+		const userGradient = getStyleProperty( name, 'background', 'user' );
 		gradientSettings = {
 			gradientValue:
-				getPresetValueFromVariable( 'gradient', gradients, gradient ) ||
-				gradient,
+				getValueFromVariable( features, name, gradient ) || gradient,
 			onGradientChange: ( value ) =>
 				setStyleProperty(
 					name,
@@ -118,11 +117,10 @@ export default function ColorPanel( {
 	}
 
 	if ( supports.includes( LINK_COLOR ) ) {
-		const color = getMergedStyleProperty( name, LINK_COLOR );
-		const userColor = getStyleProperty( name, LINK_COLOR );
+		const color = getStyleProperty( name, LINK_COLOR );
+		const userColor = getStyleProperty( name, LINK_COLOR, 'user' );
 		settings.push( {
-			colorValue:
-				getPresetValueFromVariable( 'color', colors, color ) || color,
+			colorValue: getValueFromVariable( features, name, color ) || color,
 			onColorChange: ( value ) =>
 				setStyleProperty(
 					name,

--- a/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
@@ -29,6 +29,7 @@ function GlobalStylesPanel( {
 	hasWrapper = true,
 	context,
 	getStyleProperty,
+	getMergedStyleProperty,
 	setStyleProperty,
 	getSetting,
 	setSetting,
@@ -46,12 +47,14 @@ function GlobalStylesPanel( {
 				<TypographyPanel
 					context={ context }
 					getStyleProperty={ getStyleProperty }
+					getMergedStyleProperty={ getMergedStyleProperty }
 					setStyleProperty={ setStyleProperty }
 				/>
 			) }
 			{ hasColorPanel && (
 				<ColorPanel
 					context={ context }
+					getMergedStyleProperty={ getMergedStyleProperty }
 					getStyleProperty={ getStyleProperty }
 					setStyleProperty={ setStyleProperty }
 					getSetting={ getSetting }
@@ -102,6 +105,7 @@ export default function GlobalStylesSidebar( {
 } ) {
 	const {
 		contexts,
+		getMergedStyleProperty,
 		getStyleProperty,
 		setStyleProperty,
 		getSetting,
@@ -154,6 +158,9 @@ export default function GlobalStylesSidebar( {
 									key={ 'panel-' + name }
 									context={ { ...context, name } }
 									getStyleProperty={ getStyleProperty }
+									getMergedStyleProperty={
+										getMergedStyleProperty
+									}
 									setStyleProperty={ setStyleProperty }
 									getSetting={ getSetting }
 									setSetting={ setSetting }
@@ -169,6 +176,7 @@ export default function GlobalStylesSidebar( {
 								name: GLOBAL_CONTEXT,
 							} }
 							getStyleProperty={ getStyleProperty }
+							getMergedStyleProperty={ getMergedStyleProperty }
 							setStyleProperty={ setStyleProperty }
 							getSetting={ getSetting }
 							setSetting={ setSetting }

--- a/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
@@ -29,7 +29,6 @@ function GlobalStylesPanel( {
 	hasWrapper = true,
 	context,
 	getStyleProperty,
-	getMergedStyleProperty,
 	setStyleProperty,
 	getSetting,
 	setSetting,
@@ -47,14 +46,12 @@ function GlobalStylesPanel( {
 				<TypographyPanel
 					context={ context }
 					getStyleProperty={ getStyleProperty }
-					getMergedStyleProperty={ getMergedStyleProperty }
 					setStyleProperty={ setStyleProperty }
 				/>
 			) }
 			{ hasColorPanel && (
 				<ColorPanel
 					context={ context }
-					getMergedStyleProperty={ getMergedStyleProperty }
 					getStyleProperty={ getStyleProperty }
 					setStyleProperty={ setStyleProperty }
 					getSetting={ getSetting }
@@ -105,7 +102,6 @@ export default function GlobalStylesSidebar( {
 } ) {
 	const {
 		contexts,
-		getMergedStyleProperty,
 		getStyleProperty,
 		setStyleProperty,
 		getSetting,
@@ -158,9 +154,6 @@ export default function GlobalStylesSidebar( {
 									key={ 'panel-' + name }
 									context={ { ...context, name } }
 									getStyleProperty={ getStyleProperty }
-									getMergedStyleProperty={
-										getMergedStyleProperty
-									}
 									setStyleProperty={ setStyleProperty }
 									getSetting={ getSetting }
 									setSetting={ setSetting }
@@ -176,7 +169,6 @@ export default function GlobalStylesSidebar( {
 								name: GLOBAL_CONTEXT,
 							} }
 							getStyleProperty={ getStyleProperty }
-							getMergedStyleProperty={ getMergedStyleProperty }
 							setStyleProperty={ setStyleProperty }
 							getSetting={ getSetting }
 							setSetting={ setSetting }

--- a/packages/edit-site/src/components/sidebar/typography-panel.js
+++ b/packages/edit-site/src/components/sidebar/typography-panel.js
@@ -29,7 +29,7 @@ function useHasLineHeightControl( { supports, name } ) {
 
 export default function TypographyPanel( {
 	context: { supports, name },
-	getStyleProperty,
+	getMergedStyleProperty,
 	setStyleProperty,
 } ) {
 	const fontSizes = useEditorFeature( 'typography.fontSizes', name );
@@ -45,7 +45,7 @@ export default function TypographyPanel( {
 			{ supports.includes( 'fontFamily' ) && (
 				<FontFamilyControl
 					fontFamilies={ fontFamilies }
-					value={ getStyleProperty( name, 'fontFamily' ) }
+					value={ getMergedStyleProperty( name, 'fontFamily' ) }
 					onChange={ ( value ) =>
 						setStyleProperty( name, 'fontFamily', value )
 					}
@@ -53,7 +53,7 @@ export default function TypographyPanel( {
 			) }
 			{ supports.includes( 'fontSize' ) && (
 				<FontSizePicker
-					value={ getStyleProperty( name, 'fontSize' ) }
+					value={ getMergedStyleProperty( name, 'fontSize' ) }
 					onChange={ ( value ) =>
 						setStyleProperty( name, 'fontSize', value )
 					}
@@ -63,7 +63,7 @@ export default function TypographyPanel( {
 			) }
 			{ hasLineHeightEnabled && (
 				<LineHeightControl
-					value={ getStyleProperty( name, 'lineHeight' ) }
+					value={ getMergedStyleProperty( name, 'lineHeight' ) }
 					onChange={ ( value ) =>
 						setStyleProperty( name, 'lineHeight', value )
 					}

--- a/packages/edit-site/src/components/sidebar/typography-panel.js
+++ b/packages/edit-site/src/components/sidebar/typography-panel.js
@@ -7,11 +7,12 @@ import {
 } from '@wordpress/block-editor';
 import { PanelBody, FontSizePicker } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import { useEditorFeature } from '../editor/utils';
+import { useEditorFeature, getValueFromVariable } from '../editor/utils';
 
 export function useHasTypographyPanel( { supports, name } ) {
 	return (
@@ -29,9 +30,12 @@ function useHasLineHeightControl( { supports, name } ) {
 
 export default function TypographyPanel( {
 	context: { supports, name },
-	getMergedStyleProperty,
+	getStyleProperty,
 	setStyleProperty,
 } ) {
+	const features = useSelect( ( select ) => {
+		return select( 'core/edit-site' ).getSettings().__experimentalFeatures;
+	} );
 	const fontSizes = useEditorFeature( 'typography.fontSizes', name );
 	const disableCustomFontSizes = ! useEditorFeature(
 		'typography.customFontSize',
@@ -40,12 +44,18 @@ export default function TypographyPanel( {
 	const fontFamilies = useEditorFeature( 'typography.fontFamilies', name );
 	const hasLineHeightEnabled = useHasLineHeightControl( { supports, name } );
 
+	const fontFamily = getStyleProperty( name, 'fontFamily' );
+	const fontSize = getStyleProperty( name, 'fontSize' );
+	const lineHeight = getStyleProperty( name, 'lineHeight' );
 	return (
 		<PanelBody title={ __( 'Typography' ) } initialOpen={ true }>
 			{ supports.includes( 'fontFamily' ) && (
 				<FontFamilyControl
 					fontFamilies={ fontFamilies }
-					value={ getMergedStyleProperty( name, 'fontFamily' ) }
+					value={
+						getValueFromVariable( features, name, fontFamily ) ||
+						fontFamily
+					}
 					onChange={ ( value ) =>
 						setStyleProperty( name, 'fontFamily', value )
 					}
@@ -53,7 +63,10 @@ export default function TypographyPanel( {
 			) }
 			{ supports.includes( 'fontSize' ) && (
 				<FontSizePicker
-					value={ getMergedStyleProperty( name, 'fontSize' ) }
+					value={
+						getValueFromVariable( features, name, fontSize ) ||
+						fontSize
+					}
 					onChange={ ( value ) =>
 						setStyleProperty( name, 'fontSize', value )
 					}
@@ -63,7 +76,10 @@ export default function TypographyPanel( {
 			) }
 			{ hasLineHeightEnabled && (
 				<LineHeightControl
-					value={ getMergedStyleProperty( name, 'lineHeight' ) }
+					value={
+						getValueFromVariable( features, name, lineHeight ) ||
+						lineHeight
+					}
 					onChange={ ( value ) =>
 						setStyleProperty( name, 'lineHeight', value )
 					}


### PR DESCRIPTION
Currently, the themes can set styles using theme.json but on the global styles editing UI even if the theme sets some styles, things appear empty, making it hard for the user the make small adjustments.

This PR makes sure the editing UI of global styles reflects the styles set by the theme and core.

## How has this been tested?
I added the following config to theme.json of 2021 blocks theme:
```
	"core/post-date": {
		"styles": {
			"typography": {
				"fontSize": "40px",
				"lineHeight": "3"
			},
			"color": {
				"background": "#f00",
				"text": "#0f0"
			}
		}
	}
```

I opened the site editor, and on the global styles sidebar, Post Date panel I verified the UI reflected the styles configured by the theme.