### PR TITLE
Add template part conversion e2e tests

### DIFF
--- a/packages/e2e-tests/specs/experiments/template-part.test.js
+++ b/packages/e2e-tests/specs/experiments/template-part.test.js
@@ -131,7 +131,9 @@ describe( 'Template Part', () => {
 			// Select the block.
 			const allBlocks = await getAllBlocks();
 			const paragraphBlock = allBlocks.find(
-				( block ) => block.name === 'core/paragraph'
+				( block ) =>
+					block.name === 'core/paragraph' &&
+					block.attributes.content === 'Some block...'
 			);
 			await selectBlockByClientId( paragraphBlock.clientId );
 

--- a/packages/e2e-tests/specs/experiments/template-part.test.js
+++ b/packages/e2e-tests/specs/experiments/template-part.test.js
@@ -116,6 +116,44 @@ describe( 'Template Part', () => {
 			);
 			expect( expectedContent ).not.toBeUndefined();
 		} );
+
+		it( 'Should convert selected block(s) to template part', async () => {
+			const initialTemplateParts = await page.$$(
+				'.wp-block-template-part'
+			);
+
+			// Add some block.
+			await insertBlock( 'Paragraph' );
+			await page.keyboard.type( 'Some block...' );
+
+			// Select the block.
+			const allBlocks = await getAllBlocks();
+			const paragraphBlock = allBlocks.find(
+				( block ) => block.name === 'core/paragraph'
+			);
+			await selectBlockByClientId( paragraphBlock.clientId );
+
+			// Convert block to a template part.
+			await clickBlockToolbarButton( 'More options' );
+			const convertButton = await page.waitForXPath(
+				'//span[contains(text(), "Make template part")]'
+			);
+			await convertButton.click();
+
+			// Verify new template part is created with expected content.
+			const newTemplatePart = await page.waitForXPath(
+				'//*[@data-type="core/template-part"][//p[text()="Some block..."]]'
+			);
+			expect( newTemplatePart ).not.toBeNull();
+
+			// Verify there is 1 more template part on the page than previously.
+			const finalTemplateParts = await page.$$(
+				'.wp-block-template-part'
+			);
+			expect(
+				finalTemplateParts.length - initialTemplateParts.length
+			).toEqual( 1 );
+		} );
 	} );
 
 	describe( 'Template part placeholder', () => {

--- a/packages/e2e-tests/specs/experiments/template-part.test.js
+++ b/packages/e2e-tests/specs/experiments/template-part.test.js
@@ -65,6 +65,7 @@ describe( 'Template Part', () => {
 			await navigationPanel.backToRoot();
 			await navigationPanel.navigate( 'Templates' );
 			await navigationPanel.clickItemByText( 'Front Page' );
+			await navigationPanel.close();
 		}
 
 		it( 'Should load customizations when in a template even if only the slug and theme attributes are set.', async () => {
@@ -108,7 +109,7 @@ describe( 'Template Part', () => {
 			);
 			expect(
 				initialTemplateParts.length - finalTemplateParts.length
-			).toEqual( 1 );
+			).toBe( 1 );
 
 			// Verify content of the template part is still present.
 			const [ expectedContent ] = await page.$x(
@@ -118,6 +119,7 @@ describe( 'Template Part', () => {
 		} );
 
 		it( 'Should convert selected block(s) to template part', async () => {
+			await page.waitForSelector( '.wp-block-template-part' );
 			const initialTemplateParts = await page.$$(
 				'.wp-block-template-part'
 			);
@@ -146,13 +148,18 @@ describe( 'Template Part', () => {
 			);
 			expect( newTemplatePart ).not.toBeNull();
 
+			// TODO: Remove when toolbar supports text fields
+			expect( console ).toHaveWarnedWith(
+				'Using custom components as toolbar controls is deprecated. Please use ToolbarItem or ToolbarButton components instead. See: https://developer.wordpress.org/block-editor/components/toolbar-button/#inside-blockcontrols'
+			);
+
 			// Verify there is 1 more template part on the page than previously.
 			const finalTemplateParts = await page.$$(
 				'.wp-block-template-part'
 			);
 			expect(
 				finalTemplateParts.length - initialTemplateParts.length
-			).toEqual( 1 );
+			).toBe( 1 );
 		} );
 	} );
 

--- a/packages/e2e-tests/specs/experiments/template-part.test.js
+++ b/packages/e2e-tests/specs/experiments/template-part.test.js
@@ -8,6 +8,9 @@ import {
 	visitAdminPage,
 	trashAllPosts,
 	activateTheme,
+	getAllBlocks,
+	selectBlockByClientId,
+	clickBlockToolbarButton,
 } from '@wordpress/e2e-test-utils';
 import { addQueryArgs } from '@wordpress/url';
 
@@ -78,15 +81,22 @@ describe( 'Template Part', () => {
 			await updateHeader();
 
 			const initialTemplateParts = await page.$$(
-				'*[data-type="core/template-part"]'
+				'.wp-block-template-part'
+			);
+
+			// Select the header template part block.
+			const allBlocks = await getAllBlocks();
+			const headerBlock = allBlocks.find(
+				( block ) => block.name === 'core/template-part'
+			);
+			await selectBlockByClientId( headerBlock.clientId );
+			// TODO: Remove when toolbar supports text fields
+			expect( console ).toHaveWarnedWith(
+				'Using custom components as toolbar controls is deprecated. Please use ToolbarItem or ToolbarButton components instead. See: https://developer.wordpress.org/block-editor/components/toolbar-button/#inside-blockcontrols'
 			);
 
 			// Detach blocks from template part using ellipsis menu.
-			await initialTemplateParts[ 0 ].click();
-			const ellipsisMenu = await page.waitForSelector(
-				'.components-dropdown-menu__toggle[aria-label="More options"]'
-			);
-			await ellipsisMenu.click();
+			await clickBlockToolbarButton( 'More options' );
 			const detachButton = await page.waitForXPath(
 				'//span[contains(text(), "Detach blocks from template part")]'
 			);
@@ -94,7 +104,7 @@ describe( 'Template Part', () => {
 
 			// Verify there is one less template part on the page.
 			const finalTemplateParts = await page.$$(
-				'*[data-type="core/template-part"]'
+				'.wp-block-template-part'
 			);
 			expect(
 				initialTemplateParts.length - finalTemplateParts.length

--- a/packages/e2e-tests/specs/experiments/template-part.test.js
+++ b/packages/e2e-tests/specs/experiments/template-part.test.js
@@ -71,7 +71,7 @@ describe( 'Template Part', () => {
 		async function triggerEllipsisMenuItem( textPrompt ) {
 			await clickBlockToolbarButton( 'More options' );
 			const button = await page.waitForXPath(
-				`//span[contains(text(), "${ textPrompt }"]`
+				`//span[contains(text(), "${ textPrompt }")]`
 			);
 			await button.click();
 		}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Adding tests for convert/detach template part flows that were added in #20445 / #26488 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Tested by running the new tests locally as well as verifying they are doing as expected in interactive/slow-mo mode.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
