### PR TITLE
Package lock update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52435,15 +52435,15 @@
 					}
 				},
 				"tar-fs": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.0.tgz",
-					"integrity": "sha512-9uW5iDvrIMCVpvasdFHW0wJPez0K4JnMZtsuIeDI7HyMGJNxmDZDOCQROr7lXyS+iL/QMpj07qcjGYTSdRFXUg==",
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+					"integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
 					"dev": true,
 					"requires": {
 						"chownr": "^1.1.1",
 						"mkdirp-classic": "^0.5.2",
 						"pump": "^3.0.0",
-						"tar-stream": "^2.0.0"
+						"tar-stream": "^2.1.4"
 					}
 				},
 				"tar-stream": {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Apparently the package-lock file is out of date again.

## How has this been tested?
1. `rm -rf node_modules` from gutenberg repo
2. `npm install`
3. commit change