### PR TITLE
Typo in block-annotations.md

### DIFF
--- a/docs/designers-developers/developers/block-api/block-annotations.md
+++ b/docs/designers-developers/developers/block-api/block-annotations.md
@@ -32,7 +32,7 @@ All available properties can be found in the API documentation of the `addAnnota
 
 The property `richTextIdentifier` is the identifier of the RichText instance the annotation applies to. This is necessary because blocks may have multiple rich text instances that are used to manage data for different attributes, so you need to pass this in order to highlight text within the correct one.
 
-For example the Paragraph block only has a single RichText instance, with the identifer `content`. The quote block type has 2 RichText instances, so if you wish to highlight text in the citation, you need to pass `citation` as the `richTextIdentifier` when adding an annotation. To target the quote content, you need to use the identifier `value`. Refer to the source code of the block type to find the correct identifier.
+For example the Paragraph block only has a single RichText instance, with the identifier `content`. The quote block type has 2 RichText instances, so if you wish to highlight text in the citation, you need to pass `citation` as the `richTextIdentifier` when adding an annotation. To target the quote content, you need to use the identifier `value`. Refer to the source code of the block type to find the correct identifier.
 
 ## Block annotation
 


### PR DESCRIPTION
## Description
typo in  block-annotations.md
34: identifer -> identifier

## How has this been tested?
n/a

## Types of changes
Bug fix