### PR TITLE
Typo in block-transforms.md

### DIFF
--- a/docs/designers-developers/developers/block-api/block-transforms.md
+++ b/docs/designers-developers/developers/block-api/block-transforms.md
@@ -290,7 +290,7 @@ transforms: {
 
 ### Raw
 
-This type of transformations support the _from_ direction, allowing blocks to be created from raw HTML nodes. They're applied when the user executes the "Convert to Blocks" action frow within the block setting UI menu, as well as when some content is pasted or dropped into the editor.
+This type of transformations support the _from_ direction, allowing blocks to be created from raw HTML nodes. They're applied when the user executes the "Convert to Blocks" action from within the block setting UI menu, as well as when some content is pasted or dropped into the editor.
 
 A transformation of type `raw` is an object that takes the following parameters:
 


### PR DESCRIPTION

## Description
typo in block-transforms.md
140: hypen -> hyphen
293: frow -> from

## How has this been tested?
n/a

## Types of changes
Bug fix