### PR TITLE
typo in data-core-block-editor.md

### DIFF
--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -281,7 +281,7 @@ Returns all block objects for the current post being edited as an array in
 the order they appear in the post. Note that this will exclude child blocks
 of nested inner block controllers.
 
-Note: It's important to memoize this selector to avoid return a new instance
+Note: It's important to memorize this selector to avoid return a new instance
 on each call. We use the block cache state for each top-level block of the
 given clientID. This way, the selector only refreshes on changes to blocks
 associated with the given entity, and does not refresh when changes are made


### PR DESCRIPTION
## Description
typo in data-core-block-editor.md
line 284: memoize -> memorize

## How has this been tested?
n/a

## Types of changes
Bug fix