### PR TITLE
Format library: add Keyboard Input (<kbd>)

### DIFF
--- a/packages/format-library/src/default-formats.js
+++ b/packages/format-library/src/default-formats.js
@@ -11,6 +11,7 @@ import { underline } from './underline';
 import { textColor } from './text-color';
 import { subscript } from './subscript';
 import { superscript } from './superscript';
+import { keyboard } from './keyboard';
 
 export default [
 	bold,
@@ -23,4 +24,5 @@ export default [
 	textColor,
 	subscript,
 	superscript,
+	keyboard,
 ];

--- a/packages/format-library/src/keyboard/index.js
+++ b/packages/format-library/src/keyboard/index.js
@@ -1,0 +1,36 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { toggleFormat } from '@wordpress/rich-text';
+import { RichTextToolbarButton } from '@wordpress/block-editor';
+import { button } from '@wordpress/icons';
+
+const name = 'core/keyboard';
+const title = __( 'Keyboard Input' );
+
+export const keyboard = {
+	name,
+	title,
+	tagName: 'kbd',
+	className: null,
+	edit( { isActive, value, onChange, onFocus } ) {
+		function onToggle() {
+			onChange( toggleFormat( value, { type: name } ) );
+		}
+
+		function onClick() {
+			onToggle();
+			onFocus();
+		}
+
+		return (
+			<RichTextToolbarButton
+				icon={ button }
+				title={ title }
+				onClick={ onClick }
+				isActive={ isActive }
+			/>
+		);
+	},
+};


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

Fixes #17879.

> But that is by far not enough. The intention of this ticket (more like feature request than a bug report) -- _**support** for `<kbd>` tags_ -- was to have any kind of _support_ for `<kbd>` tags in Gutenberg, i.e. any ability to add this tag to Visual Editor without the need to switch to Code Editor each time you need to add `<kbd>` tag.

A new button will be added in the overflow rich text menu.

As well as I can test, pasting the tags also works. For example, paste the this paragraph with this <kbd>test</kbd>.

If there's any remaining issues with `<kbd>`, please open a new issue.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

<img width="679" alt="Screenshot 2020-11-07 at 13 53 02" src="https://user-images.githubusercontent.com/4710635/98440261-90eb7a00-2100-11eb-9e8d-ba2a3513f99e.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
