### PR TITLE
Extract theme json processor 

### DIFF
--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -51,8 +51,12 @@ class WP_Theme_JSON {
 				'customFontSize'   => null,
 				'customLineHeight' => null,
 				'dropCap'          => null,
+				'fontFamilies'     => null,
 				'fontSizes'        => null,
-				'fontFamilies'     => null
+				'fontStyles'       => null,
+				'fontWeights'      => null,
+				'textDecorations'  => null,
+				'textTransforms'   => null,
 			),
 			'custom' => null,
 		),
@@ -682,10 +686,21 @@ class WP_Theme_JSON {
 					continue;
 				}
 
-				$this->contexts[ $context ][ $subtree ] = array_replace_recursive(
-					$this->contexts[ $context ][ $subtree ],
-					$incoming_data[ $context ][ $subtree ],
-				);
+				foreach ( array_keys( self::SCHEMA[ $subtree ] ) as $leaf ) {
+					if ( ! array_key_exists( $leaf, $incoming_data[ $context ][ $subtree ] ) ) {
+						continue;
+					}
+
+					if ( ! array_key_exists( $leaf, $this->contexts[ $context ][ $subtree ] ) ) {
+						$this->contexts[ $context ][ $subtree ][ $leaf ] = $incoming_data[ $context ][ $subtree ][ $leaf ];
+						continue;
+					}
+
+					$this->contexts[ $context ][ $subtree ][ $leaf ] = array_merge(
+						$this->contexts[ $context ][ $subtree ][ $leaf ],
+						$incoming_data[ $context ][ $subtree ][ $leaf ],
+					);
+				}
 			}
 		}
 	}

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -19,27 +19,33 @@ class WP_Theme_JSON {
 				'text'       => null,
 			),
 			'typography' => array(
-				'fontSize'   => null,
-				'lineHeight' => null,
+				'fontFamily'     => null,
+				'fontSize'       => null,
+				'fontStyle'      => null,
+				'fontWeight'     => null,
+				'lineHeight'     => null,
+				'textDecoration' => null,
+				'textTransform'  => null,
 			),
 		),
 		'settings' => array(
 			'color' => array(
-				'custom' => null,
+				'custom'         => null,
 				'customGradient' => null,
-				'gradients' => null,
-				'link' => null,
-				'palette' => null,
+				'gradients'      => null,
+				'link'           => null,
+				'palette'        => null,
 			),
 			'spacing' => array(
 				'customPadding' => null,
-				'units' => null,
+				'units'         => null,
 			),
 			'typography' => array(
-				'customFontSize' => null,
+				'customFontSize'   => null,
 				'customLineHeight' => null,
-				'dropCap' => null,
-				'fontSizes' => null,
+				'dropCap'          => null,
+				'fontSizes'        => null,
+				'fontFamilies'     => null
 			),
 			'custom' => null,
 		),
@@ -82,6 +88,108 @@ class WP_Theme_JSON {
 					'property' => 'font-size',
 				),
 			),
+		),
+		array(
+			'path'         => array( 'settings', 'typography', 'fontFamilies' ),
+			'value_key'    => 'fontFamily',
+			'preset_infix' => 'font-family',
+			'class' => array(
+				array(
+					'suffix'   => 'font-family',
+					'property' => 'font-family',
+				),
+			),
+		),
+		array(
+			'path'         => array( 'settings', 'typography', 'fontStyles' ),
+			'value_key'    => 'slug',
+			'preset_infix' => 'font-style',
+			'class' => array(
+				array(
+					'suffix'   => 'font-style',
+					'property' => 'font-style',
+				),
+			),
+		),
+		array(
+			'path'         => array( 'settings', 'typography', 'fontWeights' ),
+			'value_key'    => 'slug',
+			'preset_infix' => 'font-weight',
+			'class' => array(
+				array(
+					'suffix'   => 'font-weight',
+					'property' => 'font-weight',
+				),
+			),
+		),
+		array(
+			'path'         => array( 'settings', 'typography', 'textDecorations' ),
+			'value_key'    => 'value',
+			'preset_infix' => 'text-decoration',
+			'class' => array(
+				array(
+					'suffix'   => 'text-decoration',
+					'property' => 'text-decoration',
+				),
+			),
+		),
+		array(
+			'path'         => array( 'settings', 'typography', 'textTransforms' ),
+			'value_key'    => 'slug',
+			'preset_infix' => 'text-transform',
+			'class' => array(
+				array(
+					'suffix'   => 'text-transform',
+					'property' => 'text-transform',
+				),
+			),
+		),
+	);
+
+	private const SUPPORTED_PROPERTIES = array(
+		'--wp--style--color--link' => array(
+			'path'     => array( 'color', 'link' ),
+			'property' => '--wp--style--color--link',
+		),
+		'background'               => array(
+			'path'     => array( 'color', 'gradient' ),
+			'property' => 'background',
+		),
+		'backgroundColor'          => array(
+			'path'     => array( 'color', 'background' ),
+			'property' => 'background-color',
+		),
+		'color'                    => array(
+			'path'     => array( 'color', 'text' ),
+			'property' => 'color',
+		),
+		'fontFamily'               => array(
+			'path'     => array( 'typography', 'fontFamily' ),
+			'property' => 'font-family',
+		),
+		'fontSize'                 => array(
+			'path'     => array( 'typography', 'fontSize' ),
+			'property' => 'font-size'
+		),
+		'fontStyle'                => array(
+			'path'     => array( 'typography', 'fontStyle' ),
+			'property' => 'font-style',
+		),
+		'fontWeight'               => array(
+			'path'     => array( 'typography', 'fontWeight' ),
+			'property' => 'font-weight',
+		),
+		'lineHeight'               => array(
+			'path'     => array( 'typography', 'lineHeight' ),
+			'property' => 'line-height',
+		),
+		'textDecoration'           => array(
+			'path'     => array( 'typography', 'textDecoration' ),
+			'property' => 'text-decoration',
+		),
+		'textTransform'            => array(
+			'path'     => array( 'typography', 'textTransform' ),
+			'property' => 'text-transform',
 		),
 	);
 
@@ -244,33 +352,7 @@ class WP_Theme_JSON {
 			return;
 		}
 
-		$supported_properties = array(
-			'--wp--style--color--link' => array(
-				'path'     => array( 'color', 'link' ),
-				'property' => '--wp--style--color--link',
-			),
-			'background'               => array(
-				'path'     => array( 'color', 'gradient' ),
-				'property' => 'background',
-			),
-			'backgroundColor'          => array(
-				'path' => array( 'color', 'background' ),
-				'property' => 'background-color',
-			),
-			'color'                    => array(
-				'path' => array( 'color', 'text' ),
-				'property' => 'color',
-			),
-			'fontSize'                 => array(
-				'path' => array( 'typography', 'fontSize' ),
-				'property' => 'font-size'
-			),
-			'lineHeight'              => array(
-				'path' => array( 'typography', 'lineHeight' ),
-				'property' => 'line-height',
-			),
-		);
-		foreach ( $supported_properties as $name => $metadata ) {
+		foreach ( self::SUPPORTED_PROPERTIES as $name => $metadata ) {
 			if ( ! in_array( $name, $context['supports'] ) ) {
 				continue;
 			}

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -1,0 +1,483 @@
+<?php
+
+class WP_Theme_JSON {
+
+
+	/**
+	 * Container of data in theme.json format.
+	*/
+	private $contexts = array();
+
+	private const SCHEMA = array(
+		'selector' => null,
+		'supports' => null,
+		'styles' => array(
+			'color' => array(
+				'background' => null,
+				'gradient'   => null,
+				'link'       => null,
+				'text'       => null,
+			),
+			'typography' => array(
+				'fontSize'   => null,
+				'lineHeight' => null,
+			),
+		),
+		'settings' => array(
+			'color' => array(
+				'custom' => null,
+				'customGradient' => null,
+				'gradients' => null,
+				'link' => null,
+				'palette' => null,
+			),
+			'spacing' => array(
+				'customPadding' => null,
+				'units' => null,
+			),
+			'typography' => array(
+				'customFontSize' => null,
+				'customLineHeight' => null,
+				'dropCap' => null,
+				'fontSizes' => null,
+			),
+			'custom' => null,
+		),
+	);
+
+	private const PRESETS = array(
+		array(
+			'path'         => array( 'settings', 'color', 'palette' ),
+			'value_key'    => 'color',
+			'preset_infix' => 'color',
+			'class' => array(
+				array(
+					'suffix' => 'color',
+					'property' => 'color'
+				),
+				array(
+					'suffix'   => 'background-color',
+					'property' => 'background-color',
+				),
+			),
+		),
+		array(
+			'path'         => array( 'settings', 'color', 'gradients' ),
+			'value_key'    => 'gradient',
+			'preset_infix' => 'gradient',
+			'class' => array(
+				array(
+					'suffix'   => 'gradient-background',
+					'property' => 'background'
+				),
+			),
+		),
+		array(
+			'path'         => array( 'settings', 'typography', 'fontSizes' ),
+			'value_key'    => 'size',
+			'preset_infix' => 'font-size',
+			'class' => array(
+				array(
+					'suffix'   => 'font-size',
+					'property' => 'font-size',
+				),
+			),
+		),
+	);
+
+	/**
+	 * Constructor.
+	 *
+	 * @param array $contexts Denitions.
+	 */
+	public function __construct( $contexts ){
+		$this->contexts = array_map( array( $this, 'normalize_schema' ), $contexts );
+	}
+
+	private function process_key( $key, &$input, $schema ) {
+		if ( ! is_array( $input ) || ! array_key_exists( $key, $input ) ) {
+			return;
+		}
+
+		// Consider valid the input value.
+		if ( null === $schema[ $key ] ) {
+			return;
+		}
+
+		if ( ! is_array( $input[ $key ] ) ) {
+			unset( $input[ $key ] );
+			return;
+		}
+
+		$input[ $key ] = array_intersect_key(
+			$input[ $key ],
+			$schema[ $key ],
+		);
+
+		if ( 0 === count( $input[ $key ] ) ) {
+			unset( $input[ $key ] );
+		}
+	}
+
+	private function normalize_schema( $context ) {
+		// Filter out keys other than styles and settings.
+		$context = array_intersect_key( $context, self::SCHEMA );
+
+		// Filter out keys that aren't valid as defined in schema['styles'].
+		$this->process_key( 'styles', $context, self::SCHEMA );
+		if ( array_key_exists( 'styles', $context ) ) {
+			$this->process_key( 'color', $context['styles'], self::SCHEMA['styles'] );
+			$this->process_key( 'typography', $context['styles'], self::SCHEMA['styles'] );
+
+			if ( 0 === count( $context['styles'] ) ) {
+				unset( $context['styles'] );
+			}
+		}
+
+		// Filter out keys that aren't valid as defined in schema['settings'].
+		$this->process_key( 'settings', $context, self::SCHEMA );
+		if ( array_key_exists( 'settings', $context ) ) {
+			$this->process_key( 'color', $context['settings'], self::SCHEMA['settings'] );
+			$this->process_key( 'spacing', $context['settings'], self::SCHEMA['settings'] );
+			$this->process_key( 'typography', $context['settings'], self::SCHEMA['settings'] );
+
+			if ( 0 === count( $context['settings'] ) ) {
+				unset( $context['settings'] );
+			}
+		}
+
+		return $context;
+	}
+
+	private function extract_settings( $context ) {
+		if (
+			! array_key_exists( 'settings', $context ) ||
+			empty( $context['settings'] )
+		) {
+			return null;
+		}
+
+		return $context['settings'];
+	}
+
+	/**
+	 * Given a tree, it creates a flattened one
+	 * by merging the keys and binding the leaf values
+	 * to the new keys.
+	 *
+	 * It also transforms camelCase names into kebab-case
+	 * and substitutes '/' by '-'.
+	 *
+	 * This is thought to be useful to generate
+	 * CSS Custom Properties from a tree,
+	 * although there's nothing in the implementation
+	 * of this function that requires that format.
+	 *
+	 * For example, assuming the given prefix is '--wp'
+	 * and the token is '--', for this input tree:
+	 *
+	 * {
+	 *   'some/property': 'value',
+	 *   'nestedProperty': {
+	 *     'sub-property': 'value'
+	 *   }
+	 * }
+	 *
+	 * it'll return this output:
+	 *
+	 * {
+	 *   '--wp--some-property': 'value',
+	 *   '--wp--nested-property--sub-property': 'value'
+	 * }
+	 *
+	 * @param array  $tree Input tree to process.
+	 * @param string $prefix Prefix to prepend to each variable. '' by default.
+	 * @param string $token Token to use between levels. '--' by default.
+	 *
+	 * @return array The flattened tree.
+	 */
+	private function flatten_tree( $tree, $prefix = '', $token = '--' ) {
+		$result = array();
+		foreach ( $tree as $property => $value ) {
+			$new_key = $prefix . str_replace(
+				'/',
+				'-',
+				strtolower( preg_replace( '/(?<!^)[A-Z]/', '-$0', $property ) ) // CamelCase to kebab-case.
+			);
+
+			if ( is_array( $value ) ) {
+				$new_prefix = $new_key . $token;
+				$result     = array_merge(
+					$result,
+					$this->flatten_tree( $value, $new_prefix, $token )
+				);
+			} else {
+				$result[ $new_key ] = $value;
+			}
+		}
+		return $result;
+	}
+
+	private function get_from_path( $array, $path, $default = array() ) {
+		// Confirm input values are expected type to avoid notice warnings.
+		if ( ! is_array( $array ) || ! is_array( $path ) ) {
+			return $default;
+		}
+
+		$path_length = count( $path );
+		for ( $i = 0; $i < $path_length; ++$i ) {
+			if ( ! isset( $array[ $path[ $i ] ] ) ) {
+				return $default;
+			}
+			$array = $array[ $path[ $i ] ];
+		}
+		return $array;
+	}
+
+	private function compute_style_properties( &$declarations, $context ) {
+		if (
+			! array_key_exists( 'supports', $context ) ||
+			empty( $context['supports'] ) ||
+			! array_key_exists( 'styles', $context ) ||
+			empty( $context['styles'] )
+		) {
+			return;
+		}
+
+		$supported_properties = array(
+			'--wp--style--color--link' => array(
+				'path'     => array( 'color', 'link' ),
+				'property' => '--wp--style--color--link',
+			),
+			'background'               => array(
+				'path'     => array( 'color', 'gradient' ),
+				'property' => 'background',
+			),
+			'backgroundColor'          => array(
+				'path' => array( 'color', 'background' ),
+				'property' => 'background-color',
+			),
+			'color'                    => array(
+				'path' => array( 'color', 'text' ),
+				'property' => 'color',
+			),
+			'fontSize'                 => array(
+				'path' => array( 'typography', 'fontSize' ),
+				'property' => 'font-size'
+			),
+			'lineHeight'              => array(
+				'path' => array( 'typography', 'lineHeight' ),
+				'property' => 'line-height',
+			),
+		);
+		foreach ( $supported_properties as $name => $metadata ) {
+			if ( ! in_array( $name, $context['supports'] ) ) {
+				continue;
+			}
+
+			$value = $this->get_from_path( $context['styles'], $metadata['path'], '' );
+			if ( ! empty( $value ) ) {
+				$declarations[] = array(
+					'name'  => $metadata['property'],
+					'value' => $value
+				);
+			}
+		}
+
+		return $declarations;
+	}
+
+	private function compute_preset_classes( &$stylesheet, $context ) {
+		foreach ( self::PRESETS as $preset ) {
+			$values = $this->get_from_path( $context, $preset['path'], array() );
+			foreach ( $values as $value ) {
+				foreach ( $preset['class'] as $class ) {
+					$stylesheet .= $this->to_ruleset(
+						$context['selector'] . ".has-" . $value['slug'] . "-" . $class['suffix'],
+						array(
+							array(
+								'name'  => $class['property'],
+								'value' => $value[ $preset['value_key'] ]
+							)
+						)
+					);
+				}
+			}
+		}
+	}
+
+	private function compute_preset_vars( &$declarations, $context ) {
+		foreach ( self::PRESETS as $preset ) {
+			$values = $this->get_from_path( $context, $preset['path'], array() );
+			foreach ( $values as $value ) {
+				$declarations[] = array(
+					'name'  => '--wp--preset--' . $preset['preset_infix'] . '--' . $value['slug'],
+					'value' => $value[ $preset['value_key'] ],
+				);
+			}
+		}
+	}
+
+	private function compute_theme_vars( &$declarations, $context ) {
+		$custom_values = $this->get_from_path( $context, [ 'settings', 'custom' ] );
+		$css_vars      = $this->flatten_tree( $custom_values );
+		foreach ( $css_vars as $key => $value ) {
+			$declarations[] = array(
+				'name'  => '--wp--custom--' . $key,
+				'value' => $value,
+			);
+		}
+	}
+
+	/**
+	 * Given a selector and a declaration list,
+	 * creates the corresponding ruleset.
+	 *
+	 * To help debugging, will add some space
+	 * if SCRIPT_DEBUG is defined and true.
+	 *
+	 * @param string $selector CSS selector.
+	 * @param array $declarations List of declarations.
+	 *
+	 * @return string CSS ruleset.
+	 */
+	private function to_ruleset( $selector, $declarations ) {
+		$ruleset = '';
+
+		if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
+			$declaration_block = array_reduce(
+				$declarations,
+				function ( $carry, $element ) { return $carry .= "\t" . $element['name'] . ': ' . $element['value'] . ";\n"; },
+				'',
+			);
+			$ruleset .= $selector . " {\n" . $declaration_block . "}\n";
+		} else {
+			$declaration_block = array_reduce(
+				$declarations,
+				function ( $carry, $element ) { return $carry .= $element['name'] . ': ' . $element['value'] . ';'; },
+				'',
+			);
+			$ruleset .= $selector . '{' . $declaration_block . '}';
+		}
+
+		return $ruleset;
+	}
+
+	/**
+	 * Converts each context into a list of rulesets
+	 * to be appended to the stylesheet.
+	 *
+	 * See glossary at https://developer.mozilla.org/en-US/docs/Web/CSS/Syntax
+	 *
+	 * For each context this creates a new ruleset such as:
+	 *
+	 *   context-selector {
+	 *     style-property-one: value;
+	 *     --wp--preset--category--slug: value;
+	 *     --wp--custom--variable: value;
+	 *   }
+	 *
+	 * Additionally, it'll also create new rulesets
+	 * as classes for each preset value such as:
+	 *
+	 *   .has-value-color {
+	 *     color: value;
+	 *   }
+	 *
+	 *   .has-value-background-color {
+	 *     background-color: value;
+	 *   }
+	 *
+	 *   .has-value-font-size {
+	 *     font-size: value;
+	 *   }
+	 *
+	 *   .has-value-gradient-background {
+	 *     background: value;
+	 *   }
+	 *
+	 * @param string $stylesheet
+	 * @param array $context Context to be processed.
+	 *
+	 * @return string The new stylesheet.
+	 */
+	private function to_stylesheet( $stylesheet, $context ) {
+		if (
+			! array_key_exists( 'selector', $context ) ||
+			empty( $context['selector'] )
+		) {
+			return '';
+		}
+
+		$declarations = array();
+		$this->compute_style_properties( $declarations, $context );
+		$this->compute_preset_vars( $declarations, $context );
+		$this->compute_theme_vars( $declarations, $context );
+
+		// If there are no declarations at this point,
+		// it won't have any preset classes either,
+		// so bail out earlier.
+		if ( empty( $declarations ) ) {
+			return '';
+		}
+
+		// Attach the ruleset for style and custom properties.
+		$stylesheet .= $this->to_ruleset( $context['selector'], $declarations );
+
+		// Attach the rulesets for the classes.
+		$this->compute_preset_classes( $stylesheet, $context );
+
+		return $stylesheet;
+	}
+
+	public function get_settings() {
+		return array_filter(
+			array_map( array( $this, 'extract_settings' ), $this->contexts ),
+			function ( $element ) { return $element !== null; }
+		);
+	}
+
+	public function get_stylesheet() {
+		return array_reduce( $this->contexts, array( $this, 'to_stylesheet' ), '' );
+	}
+
+	/**
+	 * Merge new incoming data.
+	 *
+	 * @param WP_Theme_JSON $incoming Data to merge.
+	 */
+	public function merge( $theme_json ) {
+		$incoming_data = $theme_json->get_raw_data();
+
+		foreach ( array_keys( $incoming_data ) as $context ) {
+			$this->contexts[ $context ]['selector'] = $incoming_data[ $context ]['selector'];
+			$this->contexts[ $context ]['supports'] = $incoming_data[ $context ]['supports'];
+
+			foreach ( [ 'settings', 'styles' ] as $subtree ) {
+				if ( ! array_key_exists( $subtree, $incoming_data[ $context ] ) ) {
+					continue;
+				}
+
+				if ( ! array_key_exists( $subtree, $this->contexts[ $context ] ) ) {
+					$this->contexts[ $context ][ $subtree ] = $incoming_data[ $context ][ $subtree ];
+					continue;
+				}
+
+				$this->contexts[ $context ][ $subtree ] = array_replace_recursive(
+					$this->contexts[ $context ][ $subtree ],
+					$incoming_data[ $context ][ $subtree ],
+				);
+			}
+		}
+	}
+
+	/**
+	 * Retuns the raw data.
+	 *
+	 * @return array Raw data.
+	 */
+	public function get_raw_data() {
+		return $this->contexts;
+	}
+
+}

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -205,7 +205,7 @@ class WP_Theme_JSON {
 	 *
 	 * @param array $contexts Definitions.
 	 */
-	public function __construct( $contexts ){
+	public function __construct( $contexts = array() ){
 		$this->contexts = array();
 
 		if ( ! is_array( $contexts ) ) {

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -105,98 +105,125 @@ class WP_Theme_JSON {
 	 * Presets are a set of values that serve
 	 * to bootstrap some styles: colors, font sizes, etc.
 	 *
-	 * This contains the necessary metadata to process them.
+	 * They are a unkeyed array of values such as:
+	 *
+	 * ```php
+	 * array(
+	 *   array(
+	 *     'slug'      => 'unique-name-within-the-set',
+	 *     'name'      => 'Name for the UI',
+	 *     <value_key> => 'value'
+	 *   ),
+	 * )
+	 * ```
+	 *
+	 * This contains the necessary metadata to process them:
+	 *
+	 * - path          => where to find the preset in a theme.json context
+	 *
+	 * - value_key     => the key that represents the value
+	 *
+	 * - css_var_infix => infix to use in generating the CSS Custom Property. Example:
+	 *                   --wp--preset--<preset_infix>--<slug>: <preset_value>
+	 *
+	 * - classes      => array containing a structure with the classes to
+	 *                   generate for the presets. Each class should have
+	 *                   the class suffix and the property name. Example:
+	 *
+	 *                   .has-<slug>-<class_suffix> {
+	 *                       <property_name>: <preset_value>
+	 *                   }
 	 */
 	const PRESETS_METADATA = array(
 		array(
-			'path'         => array( 'settings', 'color', 'palette' ),
-			'value_key'    => 'color',
-			'preset_infix' => 'color',
-			'class'        => array(
+			'path'          => array( 'settings', 'color', 'palette' ),
+			'value_key'     => 'color',
+			'css_var_infix' => 'color',
+			'classes'       => array(
 				array(
-					'suffix'   => 'color',
-					'property' => 'color',
+					'class_suffix'  => 'color',
+					'property_name' => 'color',
 				),
 				array(
-					'suffix'   => 'background-color',
-					'property' => 'background-color',
-				),
-			),
-		),
-		array(
-			'path'         => array( 'settings', 'color', 'gradients' ),
-			'value_key'    => 'gradient',
-			'preset_infix' => 'gradient',
-			'class'        => array(
-				array(
-					'suffix'   => 'gradient-background',
-					'property' => 'background',
+					'class_suffix'  => 'background-color',
+					'property_name' => 'background-color',
 				),
 			),
 		),
 		array(
-			'path'         => array( 'settings', 'typography', 'fontSizes' ),
-			'value_key'    => 'size',
-			'preset_infix' => 'font-size',
-			'class'        => array(
+			'path'          => array( 'settings', 'color', 'gradients' ),
+			'value_key'     => 'gradient',
+			'css_var_infix' => 'gradient',
+			'classes'       => array(
 				array(
-					'suffix'   => 'font-size',
-					'property' => 'font-size',
+					'class_suffix'  => 'gradient-background',
+					'property_name' => 'background',
 				),
 			),
 		),
 		array(
-			'path'         => array( 'settings', 'typography', 'fontFamilies' ),
-			'value_key'    => 'fontFamily',
-			'preset_infix' => 'font-family',
-			'class'        => array(
+			'path'          => array( 'settings', 'typography', 'fontSizes' ),
+			'value_key'     => 'size',
+			'css_var_infix' => 'font-size',
+			'classes'       => array(
 				array(
-					'suffix'   => 'font-family',
-					'property' => 'font-family',
+					'class_suffix'  => 'font-size',
+					'property_name' => 'font-size',
 				),
 			),
 		),
 		array(
-			'path'         => array( 'settings', 'typography', 'fontStyles' ),
-			'value_key'    => 'slug',
-			'preset_infix' => 'font-style',
-			'class'        => array(
+			'path'          => array( 'settings', 'typography', 'fontFamilies' ),
+			'value_key'     => 'fontFamily',
+			'css_var_infix' => 'font-family',
+			'classes'       => array(
 				array(
-					'suffix'   => 'font-style',
-					'property' => 'font-style',
+					'class_suffix'  => 'font-family',
+					'property_name' => 'font-family',
 				),
 			),
 		),
 		array(
-			'path'         => array( 'settings', 'typography', 'fontWeights' ),
-			'value_key'    => 'slug',
-			'preset_infix' => 'font-weight',
-			'class'        => array(
+			'path'          => array( 'settings', 'typography', 'fontStyles' ),
+			'value_key'     => 'slug',
+			'css_var_infix' => 'font-style',
+			'classes'       => array(
 				array(
-					'suffix'   => 'font-weight',
-					'property' => 'font-weight',
+					'class_suffix'  => 'font-style',
+					'property_name' => 'font-style',
 				),
 			),
 		),
 		array(
-			'path'         => array( 'settings', 'typography', 'textDecorations' ),
-			'value_key'    => 'value',
-			'preset_infix' => 'text-decoration',
-			'class'        => array(
+			'path'          => array( 'settings', 'typography', 'fontWeights' ),
+			'value_key'     => 'slug',
+			'css_var_infix' => 'font-weight',
+			'classes'       => array(
 				array(
-					'suffix'   => 'text-decoration',
-					'property' => 'text-decoration',
+					'class_suffix'  => 'font-weight',
+					'property_name' => 'font-weight',
 				),
 			),
 		),
 		array(
-			'path'         => array( 'settings', 'typography', 'textTransforms' ),
-			'value_key'    => 'slug',
-			'preset_infix' => 'text-transform',
-			'class'        => array(
+			'path'          => array( 'settings', 'typography', 'textDecorations' ),
+			'value_key'     => 'value',
+			'css_var_infix' => 'text-decoration',
+			'classes'       => array(
 				array(
-					'suffix'   => 'text-transform',
-					'property' => 'text-transform',
+					'class_suffix'  => 'text-decoration',
+					'property_name' => 'text-decoration',
+				),
+			),
+		),
+		array(
+			'path'          => array( 'settings', 'typography', 'textTransforms' ),
+			'value_key'     => 'slug',
+			'css_var_infix' => 'text-transform',
+			'classes'       => array(
+				array(
+					'class_suffix'  => 'text-transform',
+					'property_name' => 'text-transform',
 				),
 			),
 		),
@@ -657,12 +684,12 @@ class WP_Theme_JSON {
 		foreach ( self::PRESETS_METADATA as $preset ) {
 			$values = $this->get_from_path( $context, $preset['path'], array() );
 			foreach ( $values as $value ) {
-				foreach ( $preset['class'] as $class ) {
+				foreach ( $preset['classes'] as $class ) {
 					$stylesheet .= $this->to_ruleset(
-						$context['selector'] . '.has-' . $value['slug'] . '-' . $class['suffix'],
+						$context['selector'] . '.has-' . $value['slug'] . '-' . $class['class_suffix'],
 						array(
 							array(
-								'name'  => $class['property'],
+								'name'  => $class['property_name'],
 								'value' => $value[ $preset['value_key'] ],
 							),
 						)
@@ -694,7 +721,7 @@ class WP_Theme_JSON {
 			$values = $this->get_from_path( $context, $preset['path'], array() );
 			foreach ( $values as $value ) {
 				$declarations[] = array(
-					'name'  => '--wp--preset--' . $preset['preset_infix'] . '--' . $value['slug'],
+					'name'  => '--wp--preset--' . $preset['css_var_infix'] . '--' . $value['slug'],
 					'value' => $value[ $preset['value_key'] ],
 				);
 			}

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -415,7 +415,7 @@ class WP_Theme_JSON {
 
 			$block_supports = array();
 			foreach ( self::PROPERTIES_METADATA as $key => $metadata ) {
-				if ( self::get_from_path( $block_type->supports, $metadata['block_json'] ) ) {
+				if ( gutenberg_experimental_get( $block_type->supports, $metadata['block_json'] ) ) {
 					$block_supports[] = $key;
 				}
 			}
@@ -582,30 +582,6 @@ class WP_Theme_JSON {
 	}
 
 	/**
-	 * Utility to extract a path from an array.
-	 *
-	 * @param array $array    Array we want to retrieve data from.
-	 * @param array $path     Array containing the path to retrieve.
-	 * @param array $default  Value to return if $array doesn't contain the $path.
-	 *
-	 * @return array Data at the given $path or $default.
-	 */
-	private static function get_from_path( $array, $path, $default = array() ) {
-		if ( ! is_array( $array ) || ! is_array( $path ) ) {
-			return $default;
-		}
-
-		$path_length = count( $path );
-		for ( $i = 0; $i < $path_length; ++$i ) {
-			if ( ! isset( $array[ $path[ $i ] ] ) ) {
-				return $default;
-			}
-			$array = $array[ $path[ $i ] ];
-		}
-		return $array;
-	}
-
-	/**
 	 * Returns the style property for the given path.
 	 *
 	 * It also converts CSS Custom Property stored as
@@ -618,7 +594,7 @@ class WP_Theme_JSON {
 	 * @return string Style property value.
 	 */
 	private static function get_property_value( $styles, $path ) {
-		$value = self::get_from_path( $styles, $path, '' );
+		$value = gutenberg_experimental_get( $styles, $path, '' );
 
 		if ( '' === $value ) {
 			return $value;
@@ -700,7 +676,7 @@ class WP_Theme_JSON {
 		}
 
 		foreach ( self::PRESETS_METADATA as $preset ) {
-			$values = self::get_from_path( $context, $preset['path'], array() );
+			$values = gutenberg_experimental_get( $context, $preset['path'], array() );
 			foreach ( $values as $value ) {
 				foreach ( $preset['classes'] as $class ) {
 					$stylesheet .= self::to_ruleset(
@@ -736,7 +712,7 @@ class WP_Theme_JSON {
 	 */
 	private static function compute_preset_vars( &$declarations, $context ) {
 		foreach ( self::PRESETS_METADATA as $preset ) {
-			$values = self::get_from_path( $context, $preset['path'], array() );
+			$values = gutenberg_experimental_get( $context, $preset['path'], array() );
 			foreach ( $values as $value ) {
 				$declarations[] = array(
 					'name'  => '--wp--preset--' . $preset['css_var_infix'] . '--' . $value['slug'],
@@ -764,7 +740,7 @@ class WP_Theme_JSON {
 	 * @param array $context Input context to process.
 	 */
 	private static function compute_theme_vars( &$declarations, $context ) {
-		$custom_values = self::get_from_path( $context, array( 'settings', 'custom' ) );
+		$custom_values = gutenberg_experimental_get( $context, array( 'settings', 'custom' ) );
 		$css_vars      = self::flatten_tree( $custom_values );
 		foreach ( $css_vars as $key => $value ) {
 			$declarations[] = array(

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -388,7 +388,7 @@ class WP_Theme_JSON {
 	 *
 	 * @return array Block metadata.
 	 */
-	public function get_blocks_metadata() {
+	public static function get_blocks_metadata() {
 		if ( null !== self::$blocks_metadata ) {
 			return self::$blocks_metadata;
 		}
@@ -415,7 +415,7 @@ class WP_Theme_JSON {
 
 			$block_supports = array();
 			foreach ( self::PROPERTIES_METADATA as $key => $metadata ) {
-				if ( $this->get_from_path( $block_type->supports, $metadata['block_json'] ) ) {
+				if ( self::get_from_path( $block_type->supports, $metadata['block_json'] ) ) {
 					$block_supports[] = $key;
 				}
 			}

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -28,6 +28,13 @@ class WP_Theme_JSON {
 	private static $blocks_metadata = null;
 
 	/**
+	 * The CSS selector for the global context.
+	 *
+	 * @var string
+	 */
+	const GLOBAL_SELECTOR = ':root';
+
+	/**
 	 * Data schema of each context within a theme.json.
 	 *
 	 * Example:
@@ -375,7 +382,7 @@ class WP_Theme_JSON {
 						'supports' => array(
 							'__experimentalFontAppearance' => false,
 							'__experimentalFontFamily'     => true,
-							'__experimentalSelector'       => ':root',
+							'__experimentalSelector'       => self::GLOBAL_SELECTOR,
 							'__experimentalTextDecoration' => true,
 							'__experimentalTextTransform'  => true,
 							'color'                        => array(
@@ -681,12 +688,19 @@ class WP_Theme_JSON {
 	 * @param array  $context Context to process.
 	 */
 	private function compute_preset_classes( &$stylesheet, $context ) {
+		$selector = $context['selector'];
+		if ( self::GLOBAL_SELECTOR === $selector ) {
+			// Classes at the global level do not need any CSS prefixed,
+			// and we don't want to increase its specificity.
+			$selector = '';
+		}
+
 		foreach ( self::PRESETS_METADATA as $preset ) {
 			$values = $this->get_from_path( $context, $preset['path'], array() );
 			foreach ( $values as $value ) {
 				foreach ( $preset['classes'] as $class ) {
 					$stylesheet .= $this->to_ruleset(
-						$context['selector'] . '.has-' . $value['slug'] . '-' . $class['class_suffix'],
+						$selector . '.has-' . $value['slug'] . '-' . $class['class_suffix'],
 						array(
 							array(
 								'name'  => $class['property_name'],

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -183,12 +183,7 @@ class WP_Theme_JSON {
 			'path'          => array( 'settings', 'typography', 'fontFamilies' ),
 			'value_key'     => 'fontFamily',
 			'css_var_infix' => 'font-family',
-			'classes'       => array(
-				array(
-					'class_suffix'  => 'font-family',
-					'property_name' => 'font-family',
-				),
-			),
+			'classes'       => array(),
 		),
 		array(
 			'path'          => array( 'settings', 'typography', 'fontStyles' ),

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -13,7 +13,9 @@ class WP_Theme_JSON {
 
 	/**
 	 * Container of data in theme.json format.
-	*/
+	 *
+	 * @var array
+	 */
 	private $contexts = null;
 
 	/**
@@ -52,11 +54,11 @@ class WP_Theme_JSON {
 	 *   }
 	 * }
 	 */
-	private const SCHEMA = array(
+	const SCHEMA = array(
 		'selector' => null,
 		'supports' => null,
-		'styles' => array(
-			'color' => array(
+		'styles'   => array(
+			'color'      => array(
 				'background' => null,
 				'gradient'   => null,
 				'link'       => null,
@@ -73,14 +75,14 @@ class WP_Theme_JSON {
 			),
 		),
 		'settings' => array(
-			'color' => array(
+			'color'      => array(
 				'custom'         => null,
 				'customGradient' => null,
 				'gradients'      => null,
 				'link'           => null,
 				'palette'        => null,
 			),
-			'spacing' => array(
+			'spacing'    => array(
 				'customPadding' => null,
 				'units'         => null,
 			),
@@ -95,7 +97,7 @@ class WP_Theme_JSON {
 				'textDecorations'  => null,
 				'textTransforms'   => null,
 			),
-			'custom' => null,
+			'custom'     => null,
 		),
 	);
 
@@ -105,15 +107,15 @@ class WP_Theme_JSON {
 	 *
 	 * This contains the necessary metadata to process them.
 	 */
-	private const PRESETS_METADATA = array(
+	const PRESETS_METADATA = array(
 		array(
 			'path'         => array( 'settings', 'color', 'palette' ),
 			'value_key'    => 'color',
 			'preset_infix' => 'color',
-			'class' => array(
+			'class'        => array(
 				array(
-					'suffix' => 'color',
-					'property' => 'color'
+					'suffix'   => 'color',
+					'property' => 'color',
 				),
 				array(
 					'suffix'   => 'background-color',
@@ -125,10 +127,10 @@ class WP_Theme_JSON {
 			'path'         => array( 'settings', 'color', 'gradients' ),
 			'value_key'    => 'gradient',
 			'preset_infix' => 'gradient',
-			'class' => array(
+			'class'        => array(
 				array(
 					'suffix'   => 'gradient-background',
-					'property' => 'background'
+					'property' => 'background',
 				),
 			),
 		),
@@ -136,7 +138,7 @@ class WP_Theme_JSON {
 			'path'         => array( 'settings', 'typography', 'fontSizes' ),
 			'value_key'    => 'size',
 			'preset_infix' => 'font-size',
-			'class' => array(
+			'class'        => array(
 				array(
 					'suffix'   => 'font-size',
 					'property' => 'font-size',
@@ -147,7 +149,7 @@ class WP_Theme_JSON {
 			'path'         => array( 'settings', 'typography', 'fontFamilies' ),
 			'value_key'    => 'fontFamily',
 			'preset_infix' => 'font-family',
-			'class' => array(
+			'class'        => array(
 				array(
 					'suffix'   => 'font-family',
 					'property' => 'font-family',
@@ -158,7 +160,7 @@ class WP_Theme_JSON {
 			'path'         => array( 'settings', 'typography', 'fontStyles' ),
 			'value_key'    => 'slug',
 			'preset_infix' => 'font-style',
-			'class' => array(
+			'class'        => array(
 				array(
 					'suffix'   => 'font-style',
 					'property' => 'font-style',
@@ -169,7 +171,7 @@ class WP_Theme_JSON {
 			'path'         => array( 'settings', 'typography', 'fontWeights' ),
 			'value_key'    => 'slug',
 			'preset_infix' => 'font-weight',
-			'class' => array(
+			'class'        => array(
 				array(
 					'suffix'   => 'font-weight',
 					'property' => 'font-weight',
@@ -180,7 +182,7 @@ class WP_Theme_JSON {
 			'path'         => array( 'settings', 'typography', 'textDecorations' ),
 			'value_key'    => 'value',
 			'preset_infix' => 'text-decoration',
-			'class' => array(
+			'class'        => array(
 				array(
 					'suffix'   => 'text-decoration',
 					'property' => 'text-decoration',
@@ -191,7 +193,7 @@ class WP_Theme_JSON {
 			'path'         => array( 'settings', 'typography', 'textTransforms' ),
 			'value_key'    => 'slug',
 			'preset_infix' => 'text-transform',
-			'class' => array(
+			'class'        => array(
 				array(
 					'suffix'   => 'text-transform',
 					'property' => 'text-transform',
@@ -204,7 +206,7 @@ class WP_Theme_JSON {
 	 * Metadata to know which style properties are supported
 	 * by theme.json and block.json an how to process them.
 	 */
-	private const PROPERTIES_METADATA = array(
+	const PROPERTIES_METADATA = array(
 		'--wp--style--color--link' => array(
 			'theme_json' => array( 'color', 'link' ),
 			'block_json' => array( 'color', 'link' ),
@@ -233,7 +235,7 @@ class WP_Theme_JSON {
 		'fontSize'                 => array(
 			'theme_json' => array( 'typography', 'fontSize' ),
 			'block_json' => array( 'fontSize' ),
-			'property'   => 'font-size'
+			'property'   => 'font-size',
 		),
 		'fontStyle'                => array(
 			'theme_json' => array( 'typography', 'fontStyle' ),
@@ -243,7 +245,7 @@ class WP_Theme_JSON {
 		'fontWeight'               => array(
 			'theme_json' => array( 'typography', 'fontWeight' ),
 			'block_json' => array( '__experimentalFontAppearance' ),
-			'property' => 'font-weight',
+			'property'   => 'font-weight',
 		),
 		'lineHeight'               => array(
 			'theme_json' => array( 'typography', 'lineHeight' ),
@@ -267,7 +269,7 @@ class WP_Theme_JSON {
 	 *
 	 * @param array $contexts A structure that follows the theme.json schema.
 	 */
-	public function __construct( $contexts = array() ){
+	public function __construct( $contexts = array() ) {
 		$this->contexts = array();
 
 		if ( ! is_array( $contexts ) ) {
@@ -365,9 +367,9 @@ class WP_Theme_JSON {
 							'fontSize'                     => true,
 							'lineHeight'                   => true,
 						),
-					),
+					)
 				),
-			),
+			)
 		);
 		foreach ( $blocks as $block_name => $block_type ) {
 			if (
@@ -446,8 +448,8 @@ class WP_Theme_JSON {
 	 * the nodes that aren't valid per the schema.
 	 *
 	 * @param string $key Key of the subtree to normalize.
-	 * @param array $input Whole tree to normalize.
-	 * @param array $schema Schema to use for normalization.
+	 * @param array  $input Whole tree to normalize.
+	 * @param array  $schema Schema to use for normalization.
 	 */
 	private function process_key( $key, &$input, $schema ) {
 		if ( ! is_array( $input ) || ! array_key_exists( $key, $input ) ) {
@@ -466,7 +468,7 @@ class WP_Theme_JSON {
 
 		$input[ $key ] = array_intersect_key(
 			$input[ $key ],
-			$schema[ $key ],
+			$schema[ $key ]
 		);
 
 		if ( 0 === count( $input[ $key ] ) ) {
@@ -603,7 +605,7 @@ class WP_Theme_JSON {
 				$token_out,
 				substr( $value, $prefix_len )
 			);
-			$value = "var(--wp--$unwrapped_name)";
+			$value          = "var(--wp--$unwrapped_name)";
 		}
 
 		return $value;
@@ -613,10 +615,12 @@ class WP_Theme_JSON {
 	 * Given a context, it extracts the style properties
 	 * and adds them to the $declarations array following the format:
 	 *
+	 * ```php
 	 * array(
 	 *   'name'  => 'property_name',
 	 *   'value' => 'property_value,
 	 * )
+	 * ```
 	 *
 	 * Note that this modifies the $declarations in place.
 	 *
@@ -634,7 +638,7 @@ class WP_Theme_JSON {
 		}
 
 		foreach ( self::PROPERTIES_METADATA as $name => $metadata ) {
-			if ( ! in_array( $name, $context['supports'] ) ) {
+			if ( ! in_array( $name, $context['supports'], true ) ) {
 				continue;
 			}
 
@@ -655,7 +659,7 @@ class WP_Theme_JSON {
 	 * Note this function modifies $stylesheet in place.
 	 *
 	 * @param string $stylesheet Input stylesheet to add the presets to.
-	 * @param array $context Context to process.
+	 * @param array  $context Context to process.
 	 */
 	private function compute_preset_classes( &$stylesheet, $context ) {
 		foreach ( self::PRESETS_METADATA as $preset ) {
@@ -663,12 +667,12 @@ class WP_Theme_JSON {
 			foreach ( $values as $value ) {
 				foreach ( $preset['class'] as $class ) {
 					$stylesheet .= $this->to_ruleset(
-						$context['selector'] . ".has-" . $value['slug'] . "-" . $class['suffix'],
+						$context['selector'] . '.has-' . $value['slug'] . '-' . $class['suffix'],
 						array(
 							array(
 								'name'  => $class['property'],
-								'value' => $value[ $preset['value_key'] ]
-							)
+								'value' => $value[ $preset['value_key'] ],
+							),
 						)
 					);
 				}
@@ -681,10 +685,12 @@ class WP_Theme_JSON {
 	 * for the presets and adds them to the $declarations array
 	 * following the format:
 	 *
+	 * ```php
 	 * array(
 	 *   'name'  => 'property_name',
 	 *   'value' => 'property_value,
 	 * )
+	 * ```
 	 *
 	 * Note that this modifies the $declarations in place.
 	 *
@@ -708,10 +714,12 @@ class WP_Theme_JSON {
 	 * for the custom values and adds them to the $declarations
 	 * array following the format:
 	 *
+	 * ```php
 	 * array(
 	 *   'name'  => 'property_name',
 	 *   'value' => 'property_value,
 	 * )
+	 * ```
 	 *
 	 * Note that this modifies the $declarations in place.
 	 *
@@ -719,7 +727,7 @@ class WP_Theme_JSON {
 	 * @param array $context Input context to process.
 	 */
 	private function compute_theme_vars( &$declarations, $context ) {
-		$custom_values = $this->get_from_path( $context, [ 'settings', 'custom' ] );
+		$custom_values = $this->get_from_path( $context, array( 'settings', 'custom' ) );
 		$css_vars      = $this->flatten_tree( $custom_values );
 		foreach ( $css_vars as $key => $value ) {
 			$declarations[] = array(
@@ -737,7 +745,7 @@ class WP_Theme_JSON {
 	 * if SCRIPT_DEBUG is defined and true.
 	 *
 	 * @param string $selector CSS selector.
-	 * @param array $declarations List of declarations.
+	 * @param array  $declarations List of declarations.
 	 *
 	 * @return string CSS ruleset.
 	 */
@@ -747,17 +755,19 @@ class WP_Theme_JSON {
 		if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
 			$declaration_block = array_reduce(
 				$declarations,
-				function ( $carry, $element ) { return $carry .= "\t" . $element['name'] . ': ' . $element['value'] . ";\n"; },
-				'',
+				function ( $carry, $element ) {
+					return $carry .= "\t" . $element['name'] . ': ' . $element['value'] . ";\n"; },
+				''
 			);
-			$ruleset .= $selector . " {\n" . $declaration_block . "}\n";
+			$ruleset          .= $selector . " {\n" . $declaration_block . "}\n";
 		} else {
 			$declaration_block = array_reduce(
 				$declarations,
-				function ( $carry, $element ) { return $carry .= $element['name'] . ': ' . $element['value'] . ';'; },
-				'',
+				function ( $carry, $element ) {
+					return $carry .= $element['name'] . ': ' . $element['value'] . ';'; },
+				''
 			);
-			$ruleset .= $selector . '{' . $declaration_block . '}';
+			$ruleset          .= $selector . '{' . $declaration_block . '}';
 		}
 
 		return $ruleset;
@@ -796,8 +806,8 @@ class WP_Theme_JSON {
 	 *     background: value;
 	 *   }
 	 *
-	 * @param string $stylesheet
-	 * @param array $context Context to be processed.
+	 * @param string $stylesheet Stylesheet to append new rules to.
+	 * @param array  $context Context to be processed.
 	 *
 	 * @return string The new stylesheet.
 	 */
@@ -853,7 +863,9 @@ class WP_Theme_JSON {
 	public function get_settings() {
 		return array_filter(
 			array_map( array( $this, 'extract_settings' ), $this->contexts ),
-			function ( $element ) { return $element !== null; }
+			function ( $element ) {
+				return null !== $element;
+			}
 		);
 	}
 
@@ -870,7 +882,7 @@ class WP_Theme_JSON {
 	/**
 	 * Merge new incoming data.
 	 *
-	 * @param WP_Theme_JSON $incoming Data to merge.
+	 * @param WP_Theme_JSON $theme_json Data to merge.
 	 */
 	public function merge( $theme_json ) {
 		$incoming_data = $theme_json->get_raw_data();
@@ -881,7 +893,7 @@ class WP_Theme_JSON {
 			$this->contexts[ $context ]['selector'] = $metadata[ $context ]['selector'];
 			$this->contexts[ $context ]['supports'] = $metadata[ $context ]['supports'];
 
-			foreach ( [ 'settings', 'styles' ] as $subtree ) {
+			foreach ( array( 'settings', 'styles' ) as $subtree ) {
 				if ( ! array_key_exists( $subtree, $incoming_data[ $context ] ) ) {
 					continue;
 				}
@@ -903,7 +915,7 @@ class WP_Theme_JSON {
 
 					$this->contexts[ $context ][ $subtree ][ $leaf ] = array_merge(
 						$this->contexts[ $context ][ $subtree ][ $leaf ],
-						$incoming_data[ $context ][ $subtree ][ $leaf ],
+						$incoming_data[ $context ][ $subtree ][ $leaf ]
 					);
 				}
 			}

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -203,64 +203,55 @@ class WP_Theme_JSON {
 	);
 
 	/**
-	 * Metadata to know which style properties are supported
-	 * by theme.json and block.json an how to process them.
+	 * Metadata for style properties.
+	 *
+	 * - 'theme_json' => where the property value is stored
+	 * - 'block_json' => whether the block has declared support for it
 	 */
 	const PROPERTIES_METADATA = array(
 		'--wp--style--color--link' => array(
 			'theme_json' => array( 'color', 'link' ),
 			'block_json' => array( 'color', 'link' ),
-			'property'   => '--wp--style--color--link',
 		),
 		'background'               => array(
 			'theme_json' => array( 'color', 'gradient' ),
 			'block_json' => array( 'color', 'gradients' ),
-			'property'   => 'background',
 		),
 		'backgroundColor'          => array(
 			'theme_json' => array( 'color', 'background' ),
 			'block_json' => array( 'color' ),
-			'property'   => 'background-color',
 		),
 		'color'                    => array(
 			'theme_json' => array( 'color', 'text' ),
 			'block_json' => array( 'color' ),
-			'property'   => 'color',
 		),
 		'fontFamily'               => array(
 			'theme_json' => array( 'typography', 'fontFamily' ),
 			'block_json' => array( '__experimentalFontFamily' ),
-			'property'   => 'font-family',
 		),
 		'fontSize'                 => array(
 			'theme_json' => array( 'typography', 'fontSize' ),
 			'block_json' => array( 'fontSize' ),
-			'property'   => 'font-size',
 		),
 		'fontStyle'                => array(
 			'theme_json' => array( 'typography', 'fontStyle' ),
 			'block_json' => array( '__experimentalFontAppearance' ),
-			'property'   => 'font-style',
 		),
 		'fontWeight'               => array(
 			'theme_json' => array( 'typography', 'fontWeight' ),
 			'block_json' => array( '__experimentalFontAppearance' ),
-			'property'   => 'font-weight',
 		),
 		'lineHeight'               => array(
 			'theme_json' => array( 'typography', 'lineHeight' ),
 			'block_json' => array( 'lineHeight' ),
-			'property'   => 'line-height',
 		),
 		'textDecoration'           => array(
 			'theme_json' => array( 'typography', 'textDecoration' ),
 			'block_json' => array( '__experimentalTextDecoration' ),
-			'property'   => 'text-decoration',
 		),
 		'textTransform'            => array(
 			'theme_json' => array( 'typography', 'textTransform' ),
 			'block_json' => array( '__experimentalTextTransform' ),
-			'property'   => 'text-transform',
 		),
 	);
 
@@ -644,8 +635,9 @@ class WP_Theme_JSON {
 
 			$value = $this->get_property_value( $context['styles'], $metadata['theme_json'] );
 			if ( ! empty( $value ) ) {
+				$kebabcased_name = strtolower( preg_replace( '/(?<!^)[A-Z]/', '-$0', $name ) );
 				$declarations[] = array(
-					'name'  => $metadata['property'],
+					'name'  => $kebabcased_name,
 					'value' => $value,
 				);
 			}

--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -35,6 +35,34 @@ class WP_Theme_JSON {
 	const GLOBAL_SELECTOR = ':root';
 
 	/**
+	 * The block type and name for the global context.
+	 *
+	 * @var string
+	 */
+	const GLOBAL_TYPE = 'global';
+
+	/**
+	 * The block arguments for the global context.
+	 *
+	 * @var array
+	 */
+	const GLOBAL_ARGS = array(
+		'supports' => array(
+			'__experimentalFontAppearance' => false,
+			'__experimentalFontFamily'     => true,
+			'__experimentalSelector'       => self::GLOBAL_SELECTOR,
+			'__experimentalTextDecoration' => true,
+			'__experimentalTextTransform'  => true,
+			'color'                        => array(
+				'gradients' => true,
+				'link'      => true,
+			),
+			'fontSize'                     => true,
+			'lineHeight'                   => true,
+		),
+	);
+
+	/**
 	 * Data schema of each context within a theme.json.
 	 *
 	 * Example:
@@ -370,26 +398,7 @@ class WP_Theme_JSON {
 		$registry = WP_Block_Type_Registry::get_instance();
 		$blocks   = array_merge(
 			$registry->get_all_registered(),
-			array(
-				'global' => new WP_Block_Type(
-					'global',
-					array(
-						'supports' => array(
-							'__experimentalFontAppearance' => false,
-							'__experimentalFontFamily'     => true,
-							'__experimentalSelector'       => self::GLOBAL_SELECTOR,
-							'__experimentalTextDecoration' => true,
-							'__experimentalTextTransform'  => true,
-							'color'                        => array(
-								'gradients' => true,
-								'link'      => true,
-							),
-							'fontSize'                     => true,
-							'lineHeight'                   => true,
-						),
-					)
-				),
-			)
+			array( self::GLOBAL_TYPE => new WP_Block_Type( self::GLOBAL_TYPE, self::GLOBAL_ARGS ) )
 		);
 		foreach ( $blocks as $block_name => $block_type ) {
 			if (

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -760,6 +760,34 @@ function gutenberg_experimental_global_styles_get_preset_classes( $selector, $se
 }
 
 /**
+ * Given a tree that adheres to the theme.json schema
+ * it adds the block data (selector, support) to each context.
+ *
+ * @param array $tree Tree to augment with block data.
+ *
+ * @return array Tree with block data.
+ */
+function gutenberg_experimental_global_styles_augment_with_block_data( $tree ) {
+	$block_data = gutenberg_experimental_global_styles_get_block_data();
+	foreach ( array_keys( $tree ) as $block_name ) {
+		if (
+			! array_key_exists( $block_name, $block_data ) ||
+			! array_key_exists( 'selector', $block_data[ $block_name ] ) ||
+			! array_key_exists( 'supports', $block_data[ $block_name ] )
+		) {
+			// Skip blocks that haven't declared support,
+			// because we don't know to process them.
+			continue;
+		}
+
+		$tree[ $block_name ]['selector'] = $block_data[ $block_name ]['selector'];
+		$tree[ $block_name ]['supports'] = $block_data[ $block_name ]['supports'];
+	}
+
+	return $tree;
+}
+
+/**
  * Takes a tree adhering to the theme.json schema and generates
  * the corresponding stylesheet.
  *

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -136,6 +136,7 @@ function gutenberg_experimental_global_styles_get_core() {
 	$config = gutenberg_experimental_global_styles_get_from_file(
 		__DIR__ . '/experimental-default-theme.json'
 	);
+
 	// Start i18n logic to remove when JSON i18 strings are extracted.
 	$default_colors_i18n = array(
 		'black'                 => __( 'Black', 'gutenberg' ),
@@ -151,7 +152,6 @@ function gutenberg_experimental_global_styles_get_core() {
 		'vivid-cyan-blue'       => __( 'Vivid cyan blue', 'gutenberg' ),
 		'vivid-purple'          => __( 'Vivid purple', 'gutenberg' ),
 	);
-
 	if ( ! empty( $config['global']['settings']['color']['palette'] ) ) {
 		foreach ( $config['global']['settings']['color']['palette'] as &$color ) {
 			$color['name'] = $default_colors_i18n[ $color['slug'] ];
@@ -172,7 +172,6 @@ function gutenberg_experimental_global_styles_get_core() {
 		'electric-grass'                                => __( 'Electric grass', 'gutenberg' ),
 		'midnight'                                      => __( 'Midnight', 'gutenberg' ),
 	);
-
 	if ( ! empty( $config['global']['settings']['color']['gradients'] ) ) {
 		foreach ( $config['global']['settings']['color']['gradients'] as &$gradient ) {
 			$gradient['name'] = $default_gradients_i18n[ $gradient['slug'] ];
@@ -186,7 +185,6 @@ function gutenberg_experimental_global_styles_get_core() {
 		'large'  => __( 'Large', 'gutenberg' ),
 		'huge'   => __( 'Huge', 'gutenberg' ),
 	);
-
 	if ( ! empty( $config['global']['settings']['typography']['fontSizes'] ) ) {
 		foreach ( $config['global']['settings']['typography']['fontSizes'] as &$font_size ) {
 			$font_size['name'] = $default_font_sizes_i18n[ $font_size['slug'] ];
@@ -199,7 +197,6 @@ function gutenberg_experimental_global_styles_get_core() {
 		'initial' => __( 'Initial', 'gutenberg' ),
 		'inherit' => __( 'Inherit', 'gutenberg' ),
 	);
-
 	if ( ! empty( $config['global']['settings']['typography']['fontStyles'] ) ) {
 		foreach ( $config['global']['settings']['typography']['fontStyles'] as &$font_style ) {
 			$font_style['name'] = $default_font_styles_i18n[ $font_style['slug'] ];
@@ -219,7 +216,6 @@ function gutenberg_experimental_global_styles_get_core() {
 		'initial' => __( 'Initial', 'gutenberg' ),
 		'inherit' => __( 'Inherit', 'gutenberg' ),
 	);
-
 	if ( ! empty( $config['global']['settings']['typography']['fontWeights'] ) ) {
 		foreach ( $config['global']['settings']['typography']['fontWeights'] as &$font_weight ) {
 			$font_weight['name'] = $default_font_weights_i18n[ $font_weight['slug'] ];
@@ -247,30 +243,35 @@ function gutenberg_experimental_global_styles_get_theme_support_settings() {
 		}
 		$theme_settings['global']['settings']['color']['custom'] = false;
 	}
+
 	if ( get_theme_support( 'disable-custom-gradients' ) ) {
 		if ( ! isset( $theme_settings['global']['settings']['color'] ) ) {
 			$theme_settings['global']['settings']['color'] = array();
 		}
 		$theme_settings['global']['settings']['color']['customGradient'] = false;
 	}
+
 	if ( get_theme_support( 'disable-custom-font-sizes' ) ) {
 		if ( ! isset( $theme_settings['global']['settings']['typography'] ) ) {
 			$theme_settings['global']['settings']['typography'] = array();
 		}
 		$theme_settings['global']['settings']['typography']['customFontSize'] = false;
 	}
+
 	if ( get_theme_support( 'custom-line-height' ) ) {
 		if ( ! isset( $theme_settings['global']['settings']['typography'] ) ) {
 			$theme_settings['global']['settings']['typography'] = array();
 		}
 		$theme_settings['global']['settings']['typography']['customLineHeight'] = true;
 	}
+
 	if ( get_theme_support( 'custom-spacing' ) ) {
 		if ( ! isset( $theme_settings['global']['settings']['spacing'] ) ) {
 			$theme_settings['global']['settings']['spacing'] = array();
 		}
 		$theme_settings['global']['settings']['spacing']['custom'] = true;
 	}
+
 	if ( get_theme_support( 'experimental-link-color' ) ) {
 		if ( ! isset( $theme_settings['global']['settings']['color'] ) ) {
 			$theme_settings['global']['settings']['color'] = array();

--- a/lib/load.php
+++ b/lib/load.php
@@ -120,6 +120,7 @@ require __DIR__ . '/widgets.php';
 require __DIR__ . '/navigation.php';
 require __DIR__ . '/navigation-page.php';
 require __DIR__ . '/experiments-page.php';
+require __DIR__ . '/class-wp-theme-json.php';
 require __DIR__ . '/global-styles.php';
 
 if ( ! class_exists( 'WP_Block_Supports' ) ) {

--- a/packages/edit-site/src/components/editor/global-styles-provider.js
+++ b/packages/edit-site/src/components/editor/global-styles-provider.js
@@ -33,7 +33,7 @@ const GlobalStylesContext = createContext( {
 	setSetting: ( context, path, newValue ) => {},
 	getStyleProperty: ( context, propertyName, origin ) => {},
 	setStyleProperty: ( context, propertyName, newValue ) => {},
-	globalContext: {},
+	contexts: {},
 	/* eslint-enable no-unused-vars */
 } );
 

--- a/packages/edit-site/src/components/editor/global-styles-provider.js
+++ b/packages/edit-site/src/components/editor/global-styles-provider.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { set, get, mapValues } from 'lodash';
+import { set, get, mapValues, mergeWith } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -20,10 +20,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import {
-	default as getGlobalStyles,
-	mergeTrees,
-} from './global-styles-renderer';
+import { default as getGlobalStyles } from './global-styles-renderer';
 
 const EMPTY_CONTENT = '{}';
 
@@ -36,6 +33,15 @@ const GlobalStylesContext = createContext( {
 	contexts: {},
 	/* eslint-enable no-unused-vars */
 } );
+
+const mergeTreesCustomizer = ( objValue, srcValue ) => {
+	// We only pass as arrays the presets,
+	// in which case we want the new array of values
+	// to override the old array (no merging).
+	if ( Array.isArray( srcValue ) ) {
+		return srcValue;
+	}
+};
 
 export const useGlobalStylesContext = () => useContext( GlobalStylesContext );
 
@@ -60,10 +66,17 @@ export default function GlobalStylesProvider( {
 	const [ content, setContent ] = useGlobalStylesEntityContent();
 
 	const { userStyles, mergedStyles } = useMemo( () => {
-		const parsedContent = content ? JSON.parse( content ) : {};
+		const newUserStyles = content ? JSON.parse( content ) : {};
+		const newMergedStyles = mergeWith(
+			{},
+			baseStyles,
+			newUserStyles,
+			mergeTreesCustomizer
+		);
+
 		return {
-			userStyles: parsedContent,
-			mergedStyles: mergeTrees( baseStyles, parsedContent ),
+			userStyles: newUserStyles,
+			mergedStyles: newMergedStyles,
 		};
 	}, [ content ] );
 
@@ -137,7 +150,7 @@ export default function GlobalStylesProvider( {
 			...settings,
 			__experimentalFeatures: mapValues(
 				mergedStyles,
-				( value ) => value.settings || {}
+				( value ) => value?.settings || {}
 			),
 		} );
 	}, [ mergedStyles ] );

--- a/packages/edit-site/src/components/editor/global-styles-renderer.js
+++ b/packages/edit-site/src/components/editor/global-styles-renderer.js
@@ -81,7 +81,7 @@ export default ( blockData, tree ) => {
 					const value = preset[ key ];
 					const classSelectorToUse = `.has-${ slug }-${ classSuffix }`;
 					const selectorToUse = `${ blockSelector }${ classSelectorToUse }`;
-					declarations += `${ selectorToUse } {${ property }: ${ value };}\n`;
+					declarations += `${ selectorToUse } {${ property }: ${ value };}`;
 				} );
 				return declarations;
 			},

--- a/packages/edit-site/src/components/editor/global-styles-renderer.js
+++ b/packages/edit-site/src/components/editor/global-styles-renderer.js
@@ -71,7 +71,7 @@ export default ( blockData, tree ) => {
 	 * @param {Object} blockPresets
 	 * @return {string} CSS declarations for the preset classes.
 	 */
-	const getBlockPresetClasses = ( blockSelector, blockPresets ) => {
+	const getBlockPresetClasses = ( blockSelector, blockPresets = {} ) => {
 		return reduce(
 			PRESET_CLASSES,
 			( declarations, { path, key, property }, classSuffix ) => {
@@ -162,15 +162,18 @@ export default ( blockData, tree ) => {
 			...getBlockPresetsDeclarations( tree?.[ context ]?.settings ),
 			...getCustomDeclarations( tree?.[ context ]?.settings?.custom ),
 		];
-
-		styles.push(
-			getBlockPresetClasses( blockSelector, tree[ context ].settings )
-		);
-
 		if ( blockDeclarations.length > 0 ) {
 			styles.push(
 				`${ blockSelector } { ${ blockDeclarations.join( ';' ) } }`
 			);
+		}
+
+		const presetClasses = getBlockPresetClasses(
+			blockSelector,
+			tree?.[ context ]?.settings
+		);
+		if ( presetClasses ) {
+			styles.push( presetClasses );
 		}
 	} );
 

--- a/packages/edit-site/src/components/editor/global-styles-renderer.js
+++ b/packages/edit-site/src/components/editor/global-styles-renderer.js
@@ -45,7 +45,7 @@ export default ( blockData, tree ) => {
 	 *
 	 * @return {Array} An array of style declarations.
 	 */
-	const getBlockStylesDeclarations = ( blockSupports, blockStyles ) => {
+	const getBlockStylesDeclarations = ( blockSupports, blockStyles = {} ) => {
 		const declarations = [];
 		Object.keys( STYLE_PROPERTY ).forEach( ( key ) => {
 			const cssProperty = key.startsWith( '--' ) ? key : kebabCase( key );
@@ -96,7 +96,7 @@ export default ( blockData, tree ) => {
 	 *
 	 * @return {Array} An array of style declarations.
 	 */
-	const getBlockPresetsDeclarations = ( blockPresets ) => {
+	const getBlockPresetsDeclarations = ( blockPresets = {} ) => {
 		return reduce(
 			PRESET_CATEGORIES,
 			( declarations, { path, key }, category ) => {
@@ -133,7 +133,7 @@ export default ( blockData, tree ) => {
 		return result;
 	};
 
-	const getCustomDeclarations = ( blockCustom ) => {
+	const getCustomDeclarations = ( blockCustom = {} ) => {
 		if ( Object.keys( blockCustom ).length === 0 ) {
 			return [];
 		}
@@ -154,22 +154,13 @@ export default ( blockData, tree ) => {
 	Object.keys( blockData ).forEach( ( context ) => {
 		const blockSelector = getBlockSelector( blockData[ context ].selector );
 
-		const blockStyles = tree?.[ context ]?.styles
-			? getBlockStylesDeclarations(
-					blockData[ context ].supports,
-					tree[ context ].styles
-			  )
-			: [];
-		const blockPresets = tree?.[ context ]?.presets
-			? getBlockPresetsDeclarations( tree[ context ].settings )
-			: [];
-		const blockCustom = tree?.[ context ]?.custom
-			? getCustomDeclarations( tree[ context ].settings.custom )
-			: [];
 		const blockDeclarations = [
-			...blockStyles,
-			...blockPresets,
-			...blockCustom,
+			...getBlockStylesDeclarations(
+				blockData[ context ].supports,
+				tree?.[ context ]?.styles
+			),
+			...getBlockPresetsDeclarations( tree?.[ context ]?.settings ),
+			...getCustomDeclarations( tree?.[ context ]?.settings?.custom ),
 		];
 
 		styles.push(

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -297,7 +297,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 				),
 			),
 		);
-		$udpate_presets = array(
+		$update_presets = array(
 			'global' => array(
 				'settings' => array(
 					'color' => array(

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -317,6 +317,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 			'core/paragraph' => array(
 				'selector' => 'p',
 				'supports' => array(
+					'--wp--style--color--link',
 					'backgroundColor',
 					'color',
 					'fontSize',

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -11,8 +11,6 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 	function test_contexts_not_valid_are_skipped() {
 		$theme_json = new WP_Theme_JSON( array(
 			'global' => array(
-				'selector'   => ':root',
-				'supports'   => array('fontSize', 'color'),
 				'settings'   => array(
 					'color' => array(
 						'custom'     => 'false',
@@ -20,8 +18,6 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 				),
 			),
 			'core/invalid-context' => array(
-				'selector'   => 'invalid',
-				'supports'   => array('fontSize', 'color'),
 				'settings'   => array(
 					'color' => array(
 						'custom'     => 'false',
@@ -34,7 +30,17 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 		$expected = array(
 			'global' => array(
 				'selector'   => ':root',
-				'supports'   => array('fontSize', 'color'),
+				'supports'   => array(
+					'--wp--style--color--link',
+					'background',
+					'backgroundColor',
+					'color',
+					'fontFamily',
+					'fontSize',
+					'lineHeight',
+					'textDecoration',
+					'textTransform',
+				),
 				'settings'   => array(
 					'color' => array(
 						'custom'     => 'false',
@@ -48,8 +54,6 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 	function test_properties_not_valid_are_skipped() {
 		$theme_json = new WP_Theme_JSON( array(
 			'global' => array(
-				'selector'   => ':root',
-				'supports'   => array('fontSize', 'color'),
 				'invalidKey' => 'invalid value',
 				'settings'   => array(
 					'color' => array(
@@ -75,8 +79,18 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 
 		$expected = array(
 			'global' => array(
-				'selector'   => ':root',
-				'supports'   => array('fontSize', 'color'),
+				'selector' => ':root',
+				'supports' => array(
+					'--wp--style--color--link',
+					'background',
+					'backgroundColor',
+					'color',
+					'fontFamily',
+					'fontSize',
+					'lineHeight',
+					'textDecoration',
+					'textTransform',
+				),
 				'settings'   => array(
 					'color' => array(
 						'custom'     => 'false',
@@ -130,10 +144,6 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 		$theme_json = new WP_Theme_JSON(
 			array(
 				'global' => array(
-					'selector' => '.block-selector',
-					'supports' => array(
-						'color'
-					),
 					'settings' => array(
 						'color'      => array(
 							'text' => 'value',
@@ -149,8 +159,8 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 					),
 					'styles' => array(
 						'color' => array(
-							'link' => '#333',
-							'text' => '#333',
+							'link'       => '#111',
+							'text'       => '#222',
 						),
 						'misc'  => 'value'
 					),
@@ -160,7 +170,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 		);
 
 		$result = $theme_json->get_stylesheet();
-		$stylesheet = '.block-selector{color: #333;--wp--preset--color--my-color: grey;}.block-selector.has-my-color-color{color: grey;}.block-selector.has-my-color-background-color{background-color: grey;}';
+		$stylesheet = ':root{--wp--style--color--link: #111;color: #222;--wp--preset--color--my-color: grey;}:root.has-my-color-color{color: grey;}:root.has-my-color-background-color{background-color: grey;}';
 
 		$this->assertEquals( $stylesheet, $result );
 	}
@@ -168,8 +178,6 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 	public function test_merge_incoming_data() {
 		$initial = array(
 			'global' => array(
-				'selector' => ':root',
-				'supports' => array('fontSize', 'color'),
 				'settings' => array(
 					'color' => array(
 						'custom' => 'false'
@@ -182,8 +190,6 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 				),
 			),
 			'core/paragraph' => array(
-				'selector' => 'core/paragraph',
-				'supports' => array('fontSize', 'color'),
 				'settings' => array(
 					'color' => array(
 						'custom' => 'false'
@@ -192,9 +198,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 			),
 		);
 		$add_new_context = array(
-			'core/post-title' => array(
-				'selector' => 'core/post-title',
-				'supports' => array('fontSize', 'color'),
+			'core/list' => array(
 				'settings' => array(
 					'color' => array(
 						'custom' => 'false'
@@ -213,8 +217,6 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 		);
 		$add_key_in_settings = array(
 			'global' => array(
-				'selector' => 'body',
-				'supports' => array('fontSize'),
 				'settings' => array(
 					'color' => array(
 						'customGradient' => 'true'
@@ -224,8 +226,6 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 		);
 		$update_key_in_settings = array(
 			'global' => array(
-				'selector' => 'body',
-				'supports' => array('fontSize'),
 				'settings' => array(
 					'color' => array(
 						'custom' => 'true'
@@ -235,8 +235,6 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 		);
 		$add_styles = array(
 			'core/paragraph' => array(
-				'selector' => 'core/paragraph',
-				'supports' => array('fontSize', 'color'),
 				'styles' => array(
 					'typography' => array(
 						'fontSize' => '12',
@@ -249,8 +247,6 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 		);
 		$add_key_in_styles = array(
 			'core/paragraph' => array(
-				'selector' => 'core/paragraph',
-				'supports' => array('fontSize', 'color'),
 				'styles' => array(
 					'typography' => array(
 						'lineHeight' => '12',
@@ -260,8 +256,6 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 		);
 		$add_invalid_context = array(
 			'core/para' => array(
-				'selector' => 'core/paragraph',
-				'supports' => array('fontSize', 'color'),
 				'styles' => array(
 					'typography' => array(
 					'lineHeight' => '12',
@@ -272,8 +266,18 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 
 		$expected = array(
 			'global' => array(
-				'selector' => 'body',
-				'supports' => array('fontSize'),
+				'selector' => ':root',
+				'supports' => array(
+					'--wp--style--color--link',
+					'background',
+					'backgroundColor',
+					'color',
+					'fontFamily',
+					'fontSize',
+					'lineHeight',
+					'textDecoration',
+					'textTransform',
+				),
 				'settings' => array(
 					'color' => array(
 						'custom' => 'true',
@@ -287,8 +291,13 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 				),
 			),
 			'core/paragraph' => array(
-				'selector' => 'core/paragraph',
-				'supports' => array('fontSize', 'color'),
+				'selector' => 'p',
+				'supports' => array(
+					'backgroundColor',
+					'color',
+					'fontSize',
+					'lineHeight',
+				),
 				'settings' => array(
 					'color' => array(
 						'custom' => 'false'
@@ -304,9 +313,14 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 					),
 				),
 			),
-			'core/post-title' => array(
-				'selector' => 'core/post-title',
-				'supports' => array('fontSize', 'color'),
+			'core/list' => array(
+				'selector' => '.wp-block-list',
+				'supports' => array(
+					'background',
+					'backgroundColor',
+					'color',
+					'fontSize',
+				),
 				'settings' => array(
 					'color' => array(
 						'custom' => 'false'

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -204,7 +204,17 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 			'global' => array(
 				'settings' => array(
 					'color' => array(
-						'custom' => 'false'
+						'custom'  => 'false',
+						'palette' => array(
+							array(
+								'slug'  => 'red',
+								'color' => 'red'
+							),
+							array(
+								'slug'  => 'blue',
+								'color' => 'blue'
+							),
+						),
 					),
 				),
 				'styles' => array(
@@ -287,6 +297,62 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 				),
 			),
 		);
+		$udpate_presets = array(
+			'global' => array(
+				'settings' => array(
+					'color' => array(
+						'palette' => array(
+							array(
+								'slug'  => 'color',
+								'color' => 'color',
+							),
+						),
+						'gradients' => array(
+							array(
+								'slug'     => 'gradient',
+								'gradient' => 'gradient',
+							),
+						),
+					),
+					'typography' => array(
+						'fontSizes' => array(
+							array(
+								'slug' => 'fontSize',
+								'size' => 'fontSize'
+							),
+						),
+						'fontFamilies' => array(
+							array(
+								'slug'       => 'fontFamily',
+								'fontFamily' => 'fontFamily',
+							),
+						),
+						'fontStyles' => array(
+							array(
+								'slug' => 'fontStyle',
+							),
+						),
+						'fontWeights' => array(
+							array(
+								'slug' => 'fontWeight',
+							),
+						),
+						'textDecorations' => array(
+							array(
+								'slug'  => 'textDecoration',
+								'value' => 'textDecoration'
+							),
+						),
+						'textTransforms' => array(
+							array(
+								'slug'  => 'textTransform',
+								'value' => 'textTransform'
+							),
+						),
+					),
+				),
+			),
+		);
 
 		$expected = array(
 			'global' => array(
@@ -306,11 +372,59 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 					'color' => array(
 						'custom' => 'true',
 						'customGradient' => 'true',
+						'palette' => array(
+							array(
+								'slug'  => 'color',
+								'color' => 'color',
+							),
+						),
+						'gradients' => array(
+							array(
+								'slug'     => 'gradient',
+								'gradient' => 'gradient',
+							),
+						),
+					),
+					'typography' => array(
+						'fontSizes' => array(
+							array(
+								'slug' => 'fontSize',
+								'size' => 'fontSize'
+							),
+						),
+						'fontFamilies' => array(
+							array(
+								'slug'       => 'fontFamily',
+								'fontFamily' => 'fontFamily',
+							),
+						),
+						'fontStyles' => array(
+							array(
+								'slug' => 'fontStyle',
+							),
+						),
+						'fontWeights' => array(
+							array(
+								'slug' => 'fontWeight',
+							),
+						),
+						'textDecorations' => array(
+							array(
+								'slug'  => 'textDecoration',
+								'value' => 'textDecoration'
+							),
+						),
+						'textTransforms' => array(
+							array(
+								'slug'  => 'textTransform',
+								'value' => 'textTransform'
+							),
+						),
 					),
 				),
 				'styles' => array(
 					'typography' => array(
-						'fontSize' => '12',
+						'fontSize' => '12'
 					),
 				),
 			),
@@ -370,6 +484,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 		$theme_json->merge( new WP_Theme_JSON( $add_styles ) );
 		$theme_json->merge( new WP_Theme_JSON( $add_key_in_styles ) );
 		$theme_json->merge( new WP_Theme_JSON( $add_invalid_context ) );
+		$theme_json->merge( new WP_Theme_JSON( $update_presets ) );
 		$result = $theme_json->get_raw_data();
 
 		$this->assertEqualSetsWithIndex( $expected, $result );

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -173,7 +173,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 							'text' => 'value',
 							'palette' => array(
 								array(
-									'slug' => 'my-color',
+									'slug'  => 'grey',
 									'color' => 'grey',
 								)
 							)
@@ -184,7 +184,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 					'styles' => array(
 						'color' => array(
 							'link'       => '#111',
-							'text'       => '#222',
+							'text'       => 'var:preset|color|grey',
 						),
 						'misc'  => 'value'
 					),
@@ -194,7 +194,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 		);
 
 		$result = $theme_json->get_stylesheet();
-		$stylesheet = ':root{--wp--style--color--link: #111;color: #222;--wp--preset--color--my-color: grey;}:root.has-my-color-color{color: grey;}:root.has-my-color-background-color{background-color: grey;}';
+		$stylesheet = ':root{--wp--style--color--link: #111;color: var(--wp--preset--color--grey);--wp--preset--color--grey: grey;}:root.has-grey-color{color: grey;}:root.has-grey-background-color{background-color: grey;}';
 
 		$this->assertEquals( $stylesheet, $result );
 	}
@@ -292,7 +292,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 			'core/para' => array(
 				'styles' => array(
 					'typography' => array(
-					'lineHeight' => '12',
+						'lineHeight' => '12',
 					),
 				),
 			),

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -8,7 +8,44 @@
 
 class WP_Theme_JSON_Test extends WP_UnitTestCase {
 
-	function test_properties_adhere_to_schema() {
+	function test_contexts_not_valid_are_skipped() {
+		$theme_json = new WP_Theme_JSON( array(
+			'global' => array(
+				'selector'   => ':root',
+				'supports'   => array('fontSize', 'color'),
+				'settings'   => array(
+					'color' => array(
+						'custom'     => 'false',
+					),
+				),
+			),
+			'core/invalid-context' => array(
+				'selector'   => 'invalid',
+				'supports'   => array('fontSize', 'color'),
+				'settings'   => array(
+					'color' => array(
+						'custom'     => 'false',
+					),
+				),
+			),
+		) );
+		$result = $theme_json->get_raw_data();
+
+		$expected = array(
+			'global' => array(
+				'selector'   => ':root',
+				'supports'   => array('fontSize', 'color'),
+				'settings'   => array(
+					'color' => array(
+						'custom'     => 'false',
+					),
+				),
+			),
+		);
+		$this->assertEqualSetsWithIndex( $expected, $result );
+	}
+
+	function test_properties_not_valid_are_skipped() {
 		$theme_json = new WP_Theme_JSON( array(
 			'global' => array(
 				'selector'   => ':root',
@@ -221,6 +258,18 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 				),
 			)
 		);
+		$add_invalid_context = array(
+			'core/para' => array(
+				'selector' => 'core/paragraph',
+				'supports' => array('fontSize', 'color'),
+				'styles' => array(
+					'typography' => array(
+					'lineHeight' => '12',
+					),
+				),
+			),
+		);
+
 		$expected = array(
 			'global' => array(
 				'selector' => 'body',
@@ -281,6 +330,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 		$theme_json->merge( new WP_Theme_JSON( $update_key_in_settings ) );
 		$theme_json->merge( new WP_Theme_JSON( $add_styles ) );
 		$theme_json->merge( new WP_Theme_JSON( $add_key_in_styles ) );
+		$theme_json->merge( new WP_Theme_JSON( $add_invalid_context ) );
 		$result = $theme_json->get_raw_data();
 
 		$this->assertEqualSetsWithIndex( $expected, $result );

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -8,6 +8,54 @@
 
 class WP_Theme_JSON_Test extends WP_UnitTestCase {
 
+	function test_properties_adhere_to_schema() {
+		$theme_json = new WP_Theme_JSON( array(
+			'global' => array(
+				'selector'   => ':root',
+				'supports'   => array('fontSize', 'color'),
+				'invalidKey' => 'invalid value',
+				'settings'   => array(
+					'color' => array(
+						'custom'     => 'false',
+						'invalidKey' => 'invalid value',
+					),
+					'invalidSection' => array(
+						'invalidKey' => 'invalid value'
+					),
+				),
+				'styles' => array(
+					'typography' => array(
+						'fontSize'        => '12',
+						'invalidProperty' => 'invalid value',
+					),
+					'invalidSection' => array(
+						'invalidProperty' => 'invalid value',
+					),
+				),
+			),
+		) );
+		$result = $theme_json->get_raw_data();
+
+		$expected = array(
+			'global' => array(
+				'selector'   => ':root',
+				'supports'   => array('fontSize', 'color'),
+				'settings'   => array(
+					'color' => array(
+						'custom'     => 'false',
+					),
+				),
+				'styles' => array(
+					'typography' => array(
+						'fontSize'        => '12',
+					),
+				),
+			),
+		);
+
+		$this->assertEqualSetsWithIndex( $expected, $result );
+	}
+
 	function test_get_settings() {
 		// See schema at WP_Theme_JSON::SCHEMA
 		$theme_json = new WP_Theme_JSON(

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -1,0 +1,240 @@
+<?php
+
+/**
+ * Test WP_Theme_JSON class.
+ *
+ * @package Gutenberg
+ */
+
+class WP_Theme_JSON_Test extends WP_UnitTestCase {
+
+	function test_get_settings() {
+		// See schema at WP_Theme_JSON::SCHEMA
+		$theme_json = new WP_Theme_JSON(
+			array(
+				'global' => array(
+					'settings' => array(
+						'color'      => array(
+							'link' => 'value'
+						),
+						'custom'     => 'value',
+						'typography' => 'value',
+						'misc'      => 'value'
+					),
+					'styles' => array(
+						'color' => 'value',
+						'misc'  => 'value'
+					),
+					'misc' => 'value'
+				)
+			)
+		);
+
+		$result = $theme_json->get_settings();
+
+		$this->assertArrayHasKey( 'global', $result );
+		$this->assertCount( 1, $result );
+
+		$this->assertArrayHasKey( 'color', $result['global'] );
+		$this->assertArrayHasKey( 'custom', $result['global'] );
+		$this->assertCount( 2, $result['global'] );
+	}
+
+	function test_get_stylesheet() {
+		// See schema at WP_Theme_JSON::SCHEMA
+		$theme_json = new WP_Theme_JSON(
+			array(
+				'global' => array(
+					'selector' => '.block-selector',
+					'supports' => array(
+						'color'
+					),
+					'settings' => array(
+						'color'      => array(
+							'text' => 'value',
+							'palette' => array(
+								array(
+									'slug' => 'my-color',
+									'color' => 'grey',
+								)
+							)
+						),
+						'typography' => 'value',
+						'misc'      => 'value'
+					),
+					'styles' => array(
+						'color' => array(
+							'link' => '#333',
+							'text' => '#333',
+						),
+						'misc'  => 'value'
+					),
+					'misc' => 'value'
+				)
+			)
+		);
+
+		$result = $theme_json->get_stylesheet();
+		$stylesheet = '.block-selector{color: #333;--wp--preset--color--my-color: grey;}.block-selector.has-my-color-color{color: grey;}.block-selector.has-my-color-background-color{background-color: grey;}';
+
+		$this->assertEquals( $stylesheet, $result );
+	}
+
+	public function test_merge_incoming_data() {
+		$initial = array(
+			'global' => array(
+				'selector' => ':root',
+				'supports' => array('fontSize', 'color'),
+				'settings' => array(
+					'color' => array(
+						'custom' => 'false'
+					),
+				),
+				'styles' => array(
+					'typography' => array(
+						'fontSize' => '12',
+					),
+				),
+			),
+			'core/paragraph' => array(
+				'selector' => 'core/paragraph',
+				'supports' => array('fontSize', 'color'),
+				'settings' => array(
+					'color' => array(
+						'custom' => 'false'
+					),
+				),
+			),
+		);
+		$add_new_context = array(
+			'core/post-title' => array(
+				'selector' => 'core/post-title',
+				'supports' => array('fontSize', 'color'),
+				'settings' => array(
+					'color' => array(
+						'custom' => 'false'
+					),
+				),
+				'styles' => array(
+					'typography' => array(
+						'fontSize' => '12',
+					),
+					'color' => array(
+						'link' => 'pink',
+						'background' => 'brown',
+					),
+				),
+			),
+		);
+		$add_key_in_settings = array(
+			'global' => array(
+				'selector' => 'body',
+				'supports' => array('fontSize'),
+				'settings' => array(
+					'color' => array(
+						'customGradient' => 'true'
+					),
+				),
+			)
+		);
+		$update_key_in_settings = array(
+			'global' => array(
+				'selector' => 'body',
+				'supports' => array('fontSize'),
+				'settings' => array(
+					'color' => array(
+						'custom' => 'true'
+					),
+				),
+			)
+		);
+		$add_styles = array(
+			'core/paragraph' => array(
+				'selector' => 'core/paragraph',
+				'supports' => array('fontSize', 'color'),
+				'styles' => array(
+					'typography' => array(
+						'fontSize' => '12',
+					),
+					'color' => array(
+						'link' => 'pink',
+					),
+				),
+			)
+		);
+		$add_key_in_styles = array(
+			'core/paragraph' => array(
+				'selector' => 'core/paragraph',
+				'supports' => array('fontSize', 'color'),
+				'styles' => array(
+					'typography' => array(
+						'lineHeight' => '12',
+					),
+				),
+			)
+		);
+		$expected = array(
+			'global' => array(
+				'selector' => 'body',
+				'supports' => array('fontSize'),
+				'settings' => array(
+					'color' => array(
+						'custom' => 'true',
+						'customGradient' => 'true',
+					),
+				),
+				'styles' => array(
+					'typography' => array(
+						'fontSize' => '12',
+					),
+				),
+			),
+			'core/paragraph' => array(
+				'selector' => 'core/paragraph',
+				'supports' => array('fontSize', 'color'),
+				'settings' => array(
+					'color' => array(
+						'custom' => 'false'
+					),
+				),
+				'styles' => array(
+					'typography' => array(
+						'fontSize' => '12',
+						'lineHeight' => '12',
+					),
+					'color' => array(
+						'link' => 'pink',
+					),
+				),
+			),
+			'core/post-title' => array(
+				'selector' => 'core/post-title',
+				'supports' => array('fontSize', 'color'),
+				'settings' => array(
+					'color' => array(
+						'custom' => 'false'
+					),
+				),
+				'styles' => array(
+					'typography' => array(
+						'fontSize' => '12',
+					),
+					'color' => array(
+						'link' => 'pink',
+						'background' => 'brown',
+					),
+				),
+			),
+		);
+
+		$theme_json = new WP_Theme_JSON( $initial );
+		$theme_json->merge( new WP_Theme_JSON( $add_new_context ) );
+		$theme_json->merge( new WP_Theme_JSON( $add_key_in_settings ) );
+		$theme_json->merge( new WP_Theme_JSON( $update_key_in_settings ) );
+		$theme_json->merge( new WP_Theme_JSON( $add_styles ) );
+		$theme_json->merge( new WP_Theme_JSON( $add_key_in_styles ) );
+		$result = $theme_json->get_raw_data();
+
+		$this->assertEqualSetsWithIndex( $expected, $result );
+	}
+}

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -107,6 +107,30 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 		$this->assertEqualSetsWithIndex( $expected, $result );
 	}
 
+	function test_metadata_is_attached() {
+		$theme_json = new WP_Theme_JSON( array( 'global' => array() ) );
+		$result  = $theme_json->get_raw_data();
+
+		$expected = array(
+			'global' => array(
+				'selector' => ':root',
+				'supports' => array(
+					'--wp--style--color--link',
+					'background',
+					'backgroundColor',
+					'color',
+					'fontFamily',
+					'fontSize',
+					'lineHeight',
+					'textDecoration',
+					'textTransform',
+				),
+			)
+		);
+
+		$this->assertEqualSetsWithIndex( $expected, $result );
+	}
+
 	function test_get_settings() {
 		// See schema at WP_Theme_JSON::SCHEMA
 		$theme_json = new WP_Theme_JSON(

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -9,73 +9,25 @@
 class WP_Theme_JSON_Test extends WP_UnitTestCase {
 
 	function test_contexts_not_valid_are_skipped() {
-		$theme_json = new WP_Theme_JSON( array(
-			'global' => array(
-				'settings'   => array(
-					'color' => array(
-						'custom'     => 'false',
+		$theme_json = new WP_Theme_JSON(
+			array(
+				'global'       => array(
+					'settings' => array(
+						'color' => array(
+							'custom' => 'false',
+						),
 					),
 				),
-			),
-			'core/invalid-context' => array(
-				'settings'   => array(
-					'color' => array(
-						'custom'     => 'false',
+				'core/invalid' => array(
+					'settings' => array(
+						'color' => array(
+							'custom' => 'false',
+						),
 					),
 				),
-			),
-		) );
-		$result = $theme_json->get_raw_data();
-
-		$expected = array(
-			'global' => array(
-				'selector'   => ':root',
-				'supports'   => array(
-					'--wp--style--color--link',
-					'background',
-					'backgroundColor',
-					'color',
-					'fontFamily',
-					'fontSize',
-					'lineHeight',
-					'textDecoration',
-					'textTransform',
-				),
-				'settings'   => array(
-					'color' => array(
-						'custom'     => 'false',
-					),
-				),
-			),
+			)
 		);
-		$this->assertEqualSetsWithIndex( $expected, $result );
-	}
-
-	function test_properties_not_valid_are_skipped() {
-		$theme_json = new WP_Theme_JSON( array(
-			'global' => array(
-				'invalidKey' => 'invalid value',
-				'settings'   => array(
-					'color' => array(
-						'custom'     => 'false',
-						'invalidKey' => 'invalid value',
-					),
-					'invalidSection' => array(
-						'invalidKey' => 'invalid value'
-					),
-				),
-				'styles' => array(
-					'typography' => array(
-						'fontSize'        => '12',
-						'invalidProperty' => 'invalid value',
-					),
-					'invalidSection' => array(
-						'invalidProperty' => 'invalid value',
-					),
-				),
-			),
-		) );
-		$result = $theme_json->get_raw_data();
+		$result     = $theme_json->get_raw_data();
 
 		$expected = array(
 			'global' => array(
@@ -91,14 +43,67 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 					'textDecoration',
 					'textTransform',
 				),
-				'settings'   => array(
+				'settings' => array(
 					'color' => array(
-						'custom'     => 'false',
+						'custom' => 'false',
 					),
 				),
-				'styles' => array(
+			),
+		);
+
+		$this->assertEqualSetsWithIndex( $expected, $result );
+	}
+
+	function test_properties_not_valid_are_skipped() {
+		$theme_json = new WP_Theme_JSON(
+			array(
+				'global' => array(
+					'invalidKey' => 'invalid value',
+					'settings'   => array(
+						'color'          => array(
+							'custom'     => 'false',
+							'invalidKey' => 'invalid value',
+						),
+						'invalidSection' => array(
+							'invalidKey' => 'invalid value',
+						),
+					),
+					'styles'     => array(
+						'typography'     => array(
+							'fontSize'        => '12',
+							'invalidProperty' => 'invalid value',
+						),
+						'invalidSection' => array(
+							'invalidProperty' => 'invalid value',
+						),
+					),
+				),
+			)
+		);
+		$result     = $theme_json->get_raw_data();
+
+		$expected = array(
+			'global' => array(
+				'selector' => ':root',
+				'supports' => array(
+					'--wp--style--color--link',
+					'background',
+					'backgroundColor',
+					'color',
+					'fontFamily',
+					'fontSize',
+					'lineHeight',
+					'textDecoration',
+					'textTransform',
+				),
+				'settings' => array(
+					'color' => array(
+						'custom' => 'false',
+					),
+				),
+				'styles'   => array(
 					'typography' => array(
-						'fontSize'        => '12',
+						'fontSize' => '12',
 					),
 				),
 			),
@@ -109,7 +114,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 
 	function test_metadata_is_attached() {
 		$theme_json = new WP_Theme_JSON( array( 'global' => array() ) );
-		$result  = $theme_json->get_raw_data();
+		$result     = $theme_json->get_raw_data();
 
 		$expected = array(
 			'global' => array(
@@ -125,31 +130,31 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 					'textDecoration',
 					'textTransform',
 				),
-			)
+			),
 		);
 
 		$this->assertEqualSetsWithIndex( $expected, $result );
 	}
 
 	function test_get_settings() {
-		// See schema at WP_Theme_JSON::SCHEMA
+		// See schema at WP_Theme_JSON::SCHEMA.
 		$theme_json = new WP_Theme_JSON(
 			array(
 				'global' => array(
 					'settings' => array(
 						'color'      => array(
-							'link' => 'value'
+							'link' => 'value',
 						),
 						'custom'     => 'value',
 						'typography' => 'value',
-						'misc'      => 'value'
+						'misc'       => 'value',
 					),
-					'styles' => array(
+					'styles'   => array(
 						'color' => 'value',
-						'misc'  => 'value'
+						'misc'  => 'value',
 					),
-					'misc' => 'value'
-				)
+					'misc'     => 'value',
+				),
 			)
 		);
 
@@ -164,36 +169,36 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 	}
 
 	function test_get_stylesheet() {
-		// See schema at WP_Theme_JSON::SCHEMA
+		// See schema at WP_Theme_JSON::SCHEMA.
 		$theme_json = new WP_Theme_JSON(
 			array(
 				'global' => array(
 					'settings' => array(
 						'color'      => array(
-							'text' => 'value',
+							'text'    => 'value',
 							'palette' => array(
 								array(
 									'slug'  => 'grey',
 									'color' => 'grey',
-								)
-							)
+								),
+							),
 						),
 						'typography' => 'value',
-						'misc'      => 'value'
+						'misc'       => 'value',
 					),
-					'styles' => array(
+					'styles'   => array(
 						'color' => array(
-							'link'       => '#111',
-							'text'       => 'var:preset|color|grey',
+							'link' => '#111',
+							'text' => 'var:preset|color|grey',
 						),
-						'misc'  => 'value'
+						'misc'  => 'value',
 					),
-					'misc' => 'value'
-				)
+					'misc'     => 'value',
+				),
 			)
 		);
 
-		$result = $theme_json->get_stylesheet();
+		$result     = $theme_json->get_stylesheet();
 		$stylesheet = ':root{--wp--style--color--link: #111;color: var(--wp--preset--color--grey);--wp--preset--color--grey: grey;}:root.has-grey-color{color: grey;}:root.has-grey-background-color{background-color: grey;}';
 
 		$this->assertEquals( $stylesheet, $result );
@@ -201,23 +206,23 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 
 	public function test_merge_incoming_data() {
 		$initial = array(
-			'global' => array(
+			'global'         => array(
 				'settings' => array(
 					'color' => array(
 						'custom'  => 'false',
 						'palette' => array(
 							array(
 								'slug'  => 'red',
-								'color' => 'red'
+								'color' => 'red',
 							),
 							array(
 								'slug'  => 'blue',
-								'color' => 'blue'
+								'color' => 'blue',
 							),
 						),
 					),
 				),
-				'styles' => array(
+				'styles'   => array(
 					'typography' => array(
 						'fontSize' => '12',
 					),
@@ -226,59 +231,64 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 			'core/paragraph' => array(
 				'settings' => array(
 					'color' => array(
-						'custom' => 'false'
+						'custom' => 'false',
 					),
 				),
 			),
 		);
+
 		$add_new_context = array(
 			'core/list' => array(
 				'settings' => array(
 					'color' => array(
-						'custom' => 'false'
+						'custom' => 'false',
 					),
 				),
-				'styles' => array(
+				'styles'   => array(
 					'typography' => array(
 						'fontSize' => '12',
 					),
-					'color' => array(
-						'link' => 'pink',
+					'color'      => array(
+						'link'       => 'pink',
 						'background' => 'brown',
 					),
 				),
 			),
 		);
+
 		$add_key_in_settings = array(
 			'global' => array(
 				'settings' => array(
 					'color' => array(
-						'customGradient' => 'true'
+						'customGradient' => 'true',
 					),
 				),
-			)
+			),
 		);
+
 		$update_key_in_settings = array(
 			'global' => array(
 				'settings' => array(
 					'color' => array(
-						'custom' => 'true'
+						'custom' => 'true',
 					),
 				),
-			)
+			),
 		);
+
 		$add_styles = array(
 			'core/paragraph' => array(
 				'styles' => array(
 					'typography' => array(
 						'fontSize' => '12',
 					),
-					'color' => array(
+					'color'      => array(
 						'link' => 'pink',
 					),
 				),
-			)
+			),
 		);
+
 		$add_key_in_styles = array(
 			'core/paragraph' => array(
 				'styles' => array(
@@ -286,8 +296,9 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 						'lineHeight' => '12',
 					),
 				),
-			)
+			),
 		);
+
 		$add_invalid_context = array(
 			'core/para' => array(
 				'styles' => array(
@@ -297,11 +308,12 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 				),
 			),
 		);
+
 		$update_presets = array(
 			'global' => array(
 				'settings' => array(
-					'color' => array(
-						'palette' => array(
+					'color'      => array(
+						'palette'   => array(
 							array(
 								'slug'  => 'color',
 								'color' => 'color',
@@ -315,24 +327,24 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 						),
 					),
 					'typography' => array(
-						'fontSizes' => array(
+						'fontSizes'       => array(
 							array(
 								'slug' => 'fontSize',
-								'size' => 'fontSize'
+								'size' => 'fontSize',
 							),
 						),
-						'fontFamilies' => array(
+						'fontFamilies'    => array(
 							array(
 								'slug'       => 'fontFamily',
 								'fontFamily' => 'fontFamily',
 							),
 						),
-						'fontStyles' => array(
+						'fontStyles'      => array(
 							array(
 								'slug' => 'fontStyle',
 							),
 						),
-						'fontWeights' => array(
+						'fontWeights'     => array(
 							array(
 								'slug' => 'fontWeight',
 							),
@@ -340,13 +352,13 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 						'textDecorations' => array(
 							array(
 								'slug'  => 'textDecoration',
-								'value' => 'textDecoration'
+								'value' => 'textDecoration',
 							),
 						),
-						'textTransforms' => array(
+						'textTransforms'  => array(
 							array(
 								'slug'  => 'textTransform',
-								'value' => 'textTransform'
+								'value' => 'textTransform',
 							),
 						),
 					),
@@ -355,7 +367,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 		);
 
 		$expected = array(
-			'global' => array(
+			'global'         => array(
 				'selector' => ':root',
 				'supports' => array(
 					'--wp--style--color--link',
@@ -369,16 +381,16 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 					'textTransform',
 				),
 				'settings' => array(
-					'color' => array(
-						'custom' => 'true',
+					'color'      => array(
+						'custom'         => 'true',
 						'customGradient' => 'true',
-						'palette' => array(
+						'palette'        => array(
 							array(
 								'slug'  => 'color',
 								'color' => 'color',
 							),
 						),
-						'gradients' => array(
+						'gradients'      => array(
 							array(
 								'slug'     => 'gradient',
 								'gradient' => 'gradient',
@@ -386,24 +398,24 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 						),
 					),
 					'typography' => array(
-						'fontSizes' => array(
+						'fontSizes'       => array(
 							array(
 								'slug' => 'fontSize',
-								'size' => 'fontSize'
+								'size' => 'fontSize',
 							),
 						),
-						'fontFamilies' => array(
+						'fontFamilies'    => array(
 							array(
 								'slug'       => 'fontFamily',
 								'fontFamily' => 'fontFamily',
 							),
 						),
-						'fontStyles' => array(
+						'fontStyles'      => array(
 							array(
 								'slug' => 'fontStyle',
 							),
 						),
-						'fontWeights' => array(
+						'fontWeights'     => array(
 							array(
 								'slug' => 'fontWeight',
 							),
@@ -411,20 +423,20 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 						'textDecorations' => array(
 							array(
 								'slug'  => 'textDecoration',
-								'value' => 'textDecoration'
+								'value' => 'textDecoration',
 							),
 						),
-						'textTransforms' => array(
+						'textTransforms'  => array(
 							array(
 								'slug'  => 'textTransform',
-								'value' => 'textTransform'
+								'value' => 'textTransform',
 							),
 						),
 					),
 				),
-				'styles' => array(
+				'styles'   => array(
 					'typography' => array(
-						'fontSize' => '12'
+						'fontSize' => '12',
 					),
 				),
 			),
@@ -439,20 +451,20 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 				),
 				'settings' => array(
 					'color' => array(
-						'custom' => 'false'
+						'custom' => 'false',
 					),
 				),
-				'styles' => array(
+				'styles'   => array(
 					'typography' => array(
-						'fontSize' => '12',
+						'fontSize'   => '12',
 						'lineHeight' => '12',
 					),
-					'color' => array(
+					'color'      => array(
 						'link' => 'pink',
 					),
 				),
 			),
-			'core/list' => array(
+			'core/list'      => array(
 				'selector' => '.wp-block-list',
 				'supports' => array(
 					'background',
@@ -462,15 +474,15 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 				),
 				'settings' => array(
 					'color' => array(
-						'custom' => 'false'
+						'custom' => 'false',
 					),
 				),
-				'styles' => array(
+				'styles'   => array(
 					'typography' => array(
 						'fontSize' => '12',
 					),
-					'color' => array(
-						'link' => 'pink',
+					'color'      => array(
+						'link'       => 'pink',
 						'background' => 'brown',
 					),
 				),

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -183,7 +183,18 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 								),
 							),
 						),
-						'typography' => 'value',
+						'typography' => array(
+							'fontFamilies' => array(
+								array(
+									'slug'       => 'small',
+									'fontFamily' => '14px',
+								),
+								array(
+									'slug'       => 'big',
+									'fontFamily' => '41px',
+								),
+							),
+						),
 						'misc'       => 'value',
 					),
 					'styles'   => array(
@@ -199,7 +210,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 		);
 
 		$result     = $theme_json->get_stylesheet();
-		$stylesheet = ':root{--wp--style--color--link: #111;color: var(--wp--preset--color--grey);--wp--preset--color--grey: grey;}.has-grey-color{color: grey;}.has-grey-background-color{background-color: grey;}';
+		$stylesheet = ':root{--wp--style--color--link: #111;color: var(--wp--preset--color--grey);--wp--preset--color--grey: grey;--wp--preset--font-family--small: 14px;--wp--preset--font-family--big: 41px;}.has-grey-color{color: grey;}.has-grey-background-color{background-color: grey;}';
 
 		$this->assertEquals( $stylesheet, $result );
 	}

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -199,7 +199,7 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 		);
 
 		$result     = $theme_json->get_stylesheet();
-		$stylesheet = ':root{--wp--style--color--link: #111;color: var(--wp--preset--color--grey);--wp--preset--color--grey: grey;}:root.has-grey-color{color: grey;}:root.has-grey-background-color{background-color: grey;}';
+		$stylesheet = ':root{--wp--style--color--link: #111;color: var(--wp--preset--color--grey);--wp--preset--color--grey: grey;}.has-grey-color{color: grey;}.has-grey-background-color{background-color: grey;}';
 
 		$this->assertEquals( $stylesheet, $result );
 	}


### PR DESCRIPTION
This PR does a few things:

- Fixes https://github.com/WordPress/gutenberg/issues/26804

- Fixes block.json key retrieval: it's called `link` and not linkColor.

- Fixes one of the issues noted at https://github.com/WordPress/gutenberg/issues/26802 by sending through `__experimentalFeatures` and `__experimentalGlobalStylesBaseStyles` only the relevant data to the client. It fixes the root cause: how we normalize the schema.

- Extracts the first piece out of `global-styles.php`, so that it has a structure that helps us maintain, grow, test, and merge it into WP core. More to come in subsequent PRs. It was increasingly difficult to land a big PR with so many features and people working in parallel, so I think it's best to go step by step.

## How to test

- Activate an FSE-enabled theme. Example: [demo theme](https://github.com/nosolosw/global-styles-theme/).

**Test that the link color works as expected:**

- Go to the edit site and make some changes. For example to the link color.
- Edit some values and verify that they are updated in the editor. Save and go the front-end, verify that the styles reflect the changes.

**Test that it only passes the necessary data:** https://github.com/WordPress/gutenberg/issues/26802 for details

- Go to the site editor and verify that the `core/edit-site` store only holds the necessary data within `settings.__experimentalData`. Example:

![Captura de ecrã de 2020-11-09 17-59-01](https://user-images.githubusercontent.com/583546/98571923-5545e100-22b5-11eb-84e7-072b10045c40.png)

**Test that an invalid context doesn't break the site**  https://github.com/WordPress/gutenberg/issues/26804

- Edit `lib/global-styles.php` and add a new context that doesn't represent any block's selector:

```
"core/para": {
    "settings": {
        "color": {
            "custom": false
        }
    }
}
```

- Verify that the site still works as expected (no PHP errors reported).
