### PR TITLE
Append missing </div> to post-excerpt block (#26581)

### DIFF
--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -36,7 +36,7 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 
 	$output = sprintf( '<div %1$s>', esc_attr( $wrapper_attributes ) ) . '<p class="wp-block-post-excerpt__excerpt">' . get_the_excerpt( $block->context['postId'] );
 	if ( ! isset( $attributes['showMoreOnNewLine'] ) || $attributes['showMoreOnNewLine'] ) {
-		$output .= '</p>' . '<p class="wp-block-post-excerpt__more-text">' . $more_text . '</p>';
+		$output .= '</p>' . '<p class="wp-block-post-excerpt__more-text">' . $more_text . '</p></div>';
 	} else {
 		$output .= ' ' . $more_text . '</p>' . '</div>';
 	}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
In the `core/post-excerpt` block there's logic that tests if the `showMoreOnNewLine` attribute is set.
When it was missing or true then the generated HTML was missing a trailing `</div>`.

This fix adds the missing `</div>`.


## How has this been tested?
- Tested in a local environment with WordPress 5.6-beta3
- Tested where the only plugin is Gutenberg
- Tested with the Twenty Twenty-One Blocks theme
- Added a `<wp:post-excerpt>` to a template and demonstrated  - using View Source - that the end div tag was no longer missing.

## Screenshots <!-- if applicable -->
With this simple test setup there was no visible effect to the displayed output.

## Types of changes
- Fixes #26581
- This PR replaces my previous PR https://github.com/WordPress/gutenberg/pull/26785
 
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->

I can't honestly tick some of the above in the checklist since I don't have a `wp-env` environment. 
This means I can't run the PHPUnit tests, nor other `npm run` commands that expect it.

