### PR TITLE
Short circuit post-content rendering for revisions (#26593)

### DIFF
--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -17,6 +17,9 @@ function render_block_core_post_content( $attributes, $content, $block ) {
 	if ( ! isset( $block->context['postId'] ) ) {
 		return '';
 	}
+	if ( 'revision' === $block->context['postType'] ) {
+		return '';
+	}
 
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'entry-content' ) );
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
When using Appearance > Templates to edit a template I was experiencing out of memory errors.
I tracked this down to infinite recursion while attempting to render revisions in the REST API processing for templates.
I found that the easiest fix was to short circuit the rendering for revisions.
This seemed to have no side effect on the editor; compare revisions still worked.

## How has this been tested?
- I reproduced the problem in a new WordPress Multi Site site with Twenty Twenty-One Blocks.
- I applied the fix and rebuilt using `npm run dev`
- I retried the step to edit the template.
- It succeeded. 
- I viewed Revisions to see my changes.

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/2474435/98464105-6b21ac00-21b8-11eb-8ed3-1fa0b4a089da.png)

![image](https://user-images.githubusercontent.com/2474435/98464190-0ca8fd80-21b9-11eb-96a7-a42364a27488.png)



## Types of changes
Fixes #26593 


## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->

I could not PHPUnit test the solution as I don't have a wp-env environment.
