### PR TITLE
When rendering template parts don't call wpautop() to avoid unwanted empty paragraphs (#26731)

### DIFF
--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -54,7 +54,6 @@ function render_block_core_template_part( $attributes ) {
 	$content = do_blocks( $content );
 	$content = wptexturize( $content );
 	$content = convert_smilies( $content );
-	$content = wpautop( $content );
 	$content = shortcode_unautop( $content );
 	if ( function_exists( 'wp_filter_content_tags' ) ) {
 		$content = wp_filter_content_tags( $content );


### PR DESCRIPTION
##  Description
When rendering template parts the call to `wpautop()` could produce unwanted `</p>` tags.
 
I've removed the call to `wpautop()` from the routines run against the $content in `(gutenberg_)render_block_core_template_part()` to prevent this happening. 

## How has this been tested?
I created a simple test that demonstrated the problem, then fixed the problem, and retested.

## Screenshots <!-- if applicable -->
For screenshots see the issue #26731 

## Types of changes
Fixes #26731

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->

I haven't run any PHPUnit tests. 