### PR TITLE
Check postId returns a published wp_template_part (#26734)

### DIFF
--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -15,10 +15,17 @@
 function render_block_core_template_part( $attributes ) {
 	$content = null;
 
-	if ( ! empty( $attributes['postId'] ) && get_post_status( $attributes['postId'] ) ) {
-		// If we have a post ID and the post exists, which means this template part
-		// is user-customized, render the corresponding post content.
-		$content = get_post( $attributes['postId'] )->post_content;
+	if ( ! empty( $attributes['postId'] ) ) {
+		// If we have a post ID, and it's a published template part,
+		// then render the corresponding post content.
+		// Else treat this as an error.
+		$post = get_post( $attributes['postId'] );
+		if ( $post && ( 'wp_template_part' === $post->post_type ) ) {
+			$post_status = get_post_status( $attributes['postId'] );
+			if ( 'publish' === $post_status ) {
+				$content = $post->post_content;
+			}
+		}
 	} elseif ( isset( $attributes['theme'] ) && basename( wp_get_theme()->get_stylesheet() ) === $attributes['theme'] ) {
 		$template_part_query = new WP_Query(
 			array(
@@ -47,7 +54,7 @@ function render_block_core_template_part( $attributes ) {
 	}
 
 	if ( is_null( $content ) ) {
-		return 'Template Part Not Found';
+		return 'Template Part Not Found: ' . $attributes['slug'];
 	}
 
 	// Run through the actions that are typically taken on the_content.


### PR DESCRIPTION
## Description
This PR implements some additional tests when loading a template part by `postId`.
If the post type exists but it's not a `wp_template_part` or the post status is not `publish` then the template is not loaded.

The template loading logic is now slightly different from before.
If the `postId` is set and subsequently determined to be invalid then the template part is not loaded.  
To help with problem determination the "Template Part Not Found" message now includes the `slug`.
  

## How has this been tested?
Using Twenty Twenty-One Blocks I created a `404.html` template file which contained.
```
<!-- wp:template-part {"slug":"issue-26734","theme":"twentytwentyone-blocks", "postId": 1 } /-->
```
I adjusted the `postId` attribute for each test, where the URL was for content that couldn't be found.

postId | Referenced post type | Referenced post status | Result
------- | --------------------- | ------------------------ | ----------
1 | post - Hello World | n/a | Template Part Not Found: issue-26734 
11 | wp_template_part | draft | Template Part Not Found: issue-26374
25 | wp_template_part | publish | Displayed the `header` template part. 

This change prevents posts which are not of the correct post type and status from being loaded as template parts.
It doesn't deal with other problems with invalid attributes.

In the third test the postId loaded was a template part but it was not for the given `slug` and may not have been for the selected `theme`.  This will have to be addressed once the requirements are better understood.

## Screenshots <!-- if applicable -->

## Types of changes
Fixes #26734 

<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
