### PR TITLE
Error when trying to get selection directly with window global

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -632,6 +632,7 @@ function RichTextWrapper(
 						record={ value }
 						onChange={ onChange }
 						isSelected={ nestedIsSelected }
+						contentRef={ ref }
 					>
 						{ ( { listBoxId, activeId, onKeyDown } ) => (
 							<TagName

--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -22,6 +22,7 @@ import {
 	insert,
 	isCollapsed,
 	getTextContent,
+	useAnchorRef,
 } from '@wordpress/rich-text';
 
 /**
@@ -136,11 +137,6 @@ function filterOptions( search, options = [], maxResults = 10 ) {
 	return filtered;
 }
 
-function getRange() {
-	const selection = window.getSelection();
-	return selection.rangeCount ? selection.getRangeAt( 0 ) : null;
-}
-
 const getAutoCompleterUI = ( autocompleter ) => {
 	const useItems = autocompleter.useItems
 		? autocompleter.useItems
@@ -227,8 +223,12 @@ const getAutoCompleterUI = ( autocompleter ) => {
 		onChangeOptions,
 		onSelect,
 		onReset,
+		value,
+		contentRef,
 	} ) {
 		const [ items ] = useItems( filterValue );
+		const anchorRef = useAnchorRef( { ref: contentRef, value } );
+
 		useLayoutEffect( () => {
 			onChangeOptions( items );
 		}, [ items ] );
@@ -243,7 +243,7 @@ const getAutoCompleterUI = ( autocompleter ) => {
 				onClose={ onReset }
 				position="top right"
 				className="components-autocomplete__popover"
-				anchorRef={ getRange() }
+				anchorRef={ anchorRef }
 			>
 				<div
 					id={ listBoxId }
@@ -285,6 +285,7 @@ function Autocomplete( {
 	onReplace,
 	completers,
 	debouncedSpeak,
+	contentRef,
 } ) {
 	const instanceId = useInstanceId( Autocomplete );
 	const [ selectedIndex, setSelectedIndex ] = useState( 0 );
@@ -501,6 +502,8 @@ function Autocomplete( {
 					selectedIndex={ selectedIndex }
 					onChangeOptions={ onChangeOptions }
 					onSelect={ select }
+					value={ record }
+					contentRef={ contentRef }
 				/>
 			) }
 		</>

--- a/packages/eslint-plugin/configs/custom.js
+++ b/packages/eslint-plugin/configs/custom.js
@@ -15,7 +15,11 @@ module.exports = {
 			},
 		},
 		{
-			files: [ '*.test.js', '**/test/*.js' ],
+			files: [
+				'*.test.js',
+				'**/test/*.js',
+				'packages/e2e-test-utils/**/*.js',
+			],
 			rules: {
 				'@wordpress/no-global-active-element': 'off',
 				'@wordpress/no-global-get-selection': 'off',

--- a/packages/eslint-plugin/configs/custom.js
+++ b/packages/eslint-plugin/configs/custom.js
@@ -5,7 +5,7 @@ module.exports = {
 		'@wordpress/no-base-control-with-label-without-id': 'error',
 		'@wordpress/no-unguarded-get-range-at': 'error',
 		'@wordpress/no-global-active-element': 'warn',
-		'@wordpress/no-global-get-selection': 'warn',
+		'@wordpress/no-global-get-selection': 'error',
 	},
 	overrides: [
 		{

--- a/packages/rich-text/src/component/use-anchor-ref.js
+++ b/packages/rich-text/src/component/use-anchor-ref.js
@@ -28,7 +28,7 @@ import { getActiveFormat } from '../get-active-format';
  */
 export function useAnchorRef( { ref, value, settings } ) {
 	const { tagName, className, name } = settings;
-	const activeFormat = getActiveFormat( value, name );
+	const activeFormat = name ? getActiveFormat( value, name ) : undefined;
 
 	return useMemo( () => {
 		const { ownerDocument } = ref.current;

--- a/packages/rich-text/src/component/use-anchor-ref.js
+++ b/packages/rich-text/src/component/use-anchor-ref.js
@@ -26,7 +26,7 @@ import { getActiveFormat } from '../get-active-format';
  *
  * @return {Element|Range} The active element or selection range.
  */
-export function useAnchorRef( { ref, value, settings } ) {
+export function useAnchorRef( { ref, value, settings = {} } ) {
 	const { tagName, className, name } = settings;
 	const activeFormat = name ? getActiveFormat( value, name ) : undefined;
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

This PR removes the last instance of `window.getSelection()` and updates the detection rule to error instead of warn.

Instead of using the `window` global, you must now use a ref, which can be used to access the [`ownerDocument`](https://developer.mozilla.org/en-US/docs/Web/API/Node/ownerDocument) and in turn can be used to access [`defaultView`](https://developer.mozilla.org/en-US/docs/Web/API/Document/defaultView).

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
