### PR TITLE
Focus return: make document.activeElement relative to ref

### DIFF
--- a/packages/components/src/higher-order/with-focus-return/index.js
+++ b/packages/components/src/higher-order/with-focus-return/index.js
@@ -55,7 +55,6 @@ function withFocusReturn( options ) {
 				super( ...arguments );
 
 				this.ownFocusedElements = new Set();
-				this.activeElementOnMount = document.activeElement;
 				this.setIsFocusedFalse = () => ( this.isFocused = false );
 				this.setIsFocusedTrue = ( event ) => {
 					this.ownFocusedElements.add( event.target );
@@ -64,11 +63,7 @@ function withFocusReturn( options ) {
 			}
 
 			componentWillUnmount() {
-				const {
-					activeElementOnMount,
-					isFocused,
-					ownFocusedElements,
-				} = this;
+				const { isFocused, ownFocusedElements } = this;
 
 				if ( ! isFocused ) {
 					return;
@@ -83,15 +78,13 @@ function withFocusReturn( options ) {
 					return;
 				}
 
-				const stack = [
-					...without(
-						this.props.focus.focusHistory,
-						...ownFocusedElements
-					),
-					activeElementOnMount,
-				];
+				const stack = without(
+					this.props.focus.focusHistory,
+					...ownFocusedElements
+				);
 
 				let candidate;
+
 				while ( ( candidate = stack.pop() ) ) {
 					if ( document.body.contains( candidate ) ) {
 						candidate.focus();

--- a/packages/components/src/higher-order/with-focus-return/index.js
+++ b/packages/components/src/higher-order/with-focus-return/index.js
@@ -79,7 +79,7 @@ function withFocusReturn( options ) {
 				}
 
 				const stack = without(
-					this.props.focus.focusHistory,
+					this.props.focusHistory,
 					...ownFocusedElements
 				);
 
@@ -108,7 +108,10 @@ function withFocusReturn( options ) {
 		return ( props ) => (
 			<Consumer>
 				{ ( context ) => (
-					<FocusReturn childProps={ props } focus={ context } />
+					<FocusReturn
+						childProps={ props }
+						focusHistory={ context }
+					/>
 				) }
 			</Consumer>
 		);

--- a/packages/components/src/higher-order/with-focus-return/test/index.js
+++ b/packages/components/src/higher-order/with-focus-return/test/index.js
@@ -70,11 +70,16 @@ describe( 'withFocusReturn()', () => {
 		} );
 
 		it( 'should not switch focus back to the bound focus element', () => {
-			const { unmount } = render( <Composite />, {
-				container: document.body.appendChild(
-					document.createElement( 'div' )
-				),
-			} );
+			const { unmount } = render(
+				<Provider>
+					<Composite />
+				</Provider>,
+				{
+					container: document.body.appendChild(
+						document.createElement( 'div' )
+					),
+				}
+			);
 
 			// Change activeElement.
 			switchFocusTo.focus();
@@ -86,11 +91,16 @@ describe( 'withFocusReturn()', () => {
 		} );
 
 		it( 'should switch focus back when unmounted while having focus', () => {
-			const { container, unmount } = render( <Composite />, {
-				container: document.body.appendChild(
-					document.createElement( 'div' )
-				),
-			} );
+			const { container, unmount } = render(
+				<Provider>
+					<Composite />
+				</Provider>,
+				{
+					container: document.body.appendChild(
+						document.createElement( 'div' )
+					),
+				}
+			);
 
 			const textarea = container.querySelector( 'textarea' );
 			textarea.focus();


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

There's no need to depend on `document.activeElement` on the consumer side. For the focussed node at the time of mount, we can look at the focus history that is provided. To ensure history, we can initialise the provider's history with `document.activeElement`.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
