### PR TITLE
Only consider legal block types for the block list when transforming files to blocks

### DIFF
--- a/packages/block-editor/src/components/use-on-block-drop/index.js
+++ b/packages/block-editor/src/components/use-on-block-drop/index.js
@@ -123,6 +123,7 @@ export function onBlockDrop(
  * @param {number}   targetBlockIndex      The index where the block(s) will be inserted.
  * @param {boolean}  hasUploadPermissions  Whether the user has upload permissions.
  * @param {Function} updateBlockAttributes A function that updates a block's attributes.
+ * @param {Function} canInsertBlockType    A function that returns checks whether a block type can be inserted.
  * @param {Function} insertBlocks          A function that inserts blocks.
  *
  * @return {Function} The event handler for a block-related file drop event.
@@ -132,6 +133,7 @@ export function onFilesDrop(
 	targetBlockIndex,
 	hasUploadPermissions,
 	updateBlockAttributes,
+	canInsertBlockType,
 	insertBlocks
 ) {
 	return ( files ) => {
@@ -142,7 +144,9 @@ export function onFilesDrop(
 		const transformation = findTransform(
 			getBlockTransforms( 'from' ),
 			( transform ) =>
-				transform.type === 'files' && transform.isMatch( files )
+				transform.type === 'files' &&
+				canInsertBlockType( transform.blockName, targetRootClientId ) &&
+				transform.isMatch( files )
 		);
 
 		if ( transformation ) {
@@ -188,17 +192,20 @@ export function onHTMLDrop(
  */
 export default function useOnBlockDrop( targetRootClientId, targetBlockIndex ) {
 	const {
+		canInsertBlockType,
 		getBlockIndex,
 		getClientIdsOfDescendants,
 		hasUploadPermissions,
 	} = useSelect( ( select ) => {
 		const {
+			canInsertBlockType: _canInsertBlockType,
 			getBlockIndex: _getBlockIndex,
 			getClientIdsOfDescendants: _getClientIdsOfDescendants,
 			getSettings,
 		} = select( 'core/block-editor' );
 
 		return {
+			canInsertBlockType: _canInsertBlockType,
 			getBlockIndex: _getBlockIndex,
 			getClientIdsOfDescendants: _getClientIdsOfDescendants,
 			hasUploadPermissions: getSettings().mediaUpload,
@@ -224,6 +231,7 @@ export default function useOnBlockDrop( targetRootClientId, targetBlockIndex ) {
 			targetBlockIndex,
 			hasUploadPermissions,
 			updateBlockAttributes,
+			canInsertBlockType,
 			insertBlocks
 		),
 		onHTMLDrop: onHTMLDrop(

--- a/packages/block-editor/src/components/use-on-block-drop/test/index.js
+++ b/packages/block-editor/src/components/use-on-block-drop/test/index.js
@@ -301,6 +301,7 @@ describe( 'onBlockDrop', () => {
 describe( 'onFilesDrop', () => {
 	it( 'does nothing if hasUploadPermissions is false', () => {
 		const updateBlockAttributes = jest.fn();
+		const canInsertBlockType = noop;
 		const insertBlocks = jest.fn();
 		const targetRootClientId = '1';
 		const targetBlockIndex = 0;
@@ -311,6 +312,7 @@ describe( 'onFilesDrop', () => {
 			targetBlockIndex,
 			uploadPermissions,
 			updateBlockAttributes,
+			canInsertBlockType,
 			insertBlocks
 		);
 		onFileDropHandler();
@@ -325,6 +327,7 @@ describe( 'onFilesDrop', () => {
 		findTransform.mockImplementation( noop );
 		const updateBlockAttributes = noop;
 		const insertBlocks = jest.fn();
+		const canInsertBlockType = noop;
 		const targetRootClientId = '1';
 		const targetBlockIndex = 0;
 		const uploadPermissions = true;
@@ -334,6 +337,7 @@ describe( 'onFilesDrop', () => {
 			targetBlockIndex,
 			uploadPermissions,
 			updateBlockAttributes,
+			canInsertBlockType,
 			insertBlocks
 		);
 		onFileDropHandler();
@@ -350,6 +354,7 @@ describe( 'onFilesDrop', () => {
 		const transformation = { transform: jest.fn( () => blocks ) };
 		findTransform.mockImplementation( () => transformation );
 		const updateBlockAttributes = noop;
+		const canInsertBlockType = noop;
 		const insertBlocks = jest.fn();
 		const targetRootClientId = '1';
 		const targetBlockIndex = 0;
@@ -360,6 +365,7 @@ describe( 'onFilesDrop', () => {
 			targetBlockIndex,
 			uploadPermissions,
 			updateBlockAttributes,
+			canInsertBlockType,
 			insertBlocks
 		);
 		const files = 'test';


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Proposal to fix #26815

When dropping files, the `onFilesDrop` handler searches for a matching transform.

There's a chance currently that the matching transform will fail to insert if the block list we're inserting into doesn't accept the block type—`allowedBlocks` might be specified.

This PR changes the code to only find transforms that can be inserted.

## How has this been tested?
This is hard to test right now without checking it works on #25940.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
