### PR TITLE
Add a keyboard shortcut to save changes in the site editor

### DIFF
--- a/packages/edit-site/src/components/save-button/index.js
+++ b/packages/edit-site/src/components/save-button/index.js
@@ -28,7 +28,8 @@ export default function SaveButton( { openEntitiesSavedStates } ) {
 				),
 				getDirtyEntityRecords: __experimentalGetDirtyEntityRecords,
 			};
-		}
+		},
+		[]
 	);
 	const { registerShortcut } = useDispatch( 'core/keyboard-shortcuts' );
 	const { saveEditedEntityRecord } = useDispatch( 'core' );
@@ -42,7 +43,7 @@ export default function SaveButton( { openEntitiesSavedStates } ) {
 				character: 's',
 			},
 		} );
-	} );
+	}, [] );
 
 	useShortcut(
 		'core/edit-site/save',


### PR DESCRIPTION
I found myself hitting ctrl+s  to save the changes in the site editor but it didn't work.
This PR implements that shortcut for the site editor (to match the post editor)