### PR TITLE
Try: System font for vanilla editor styles.

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -311,7 +311,7 @@ function gutenberg_register_packages_styles( $styles ) {
 		$styles,
 		'wp-block-editor',
 		gutenberg_url( 'build/block-editor/style.css' ),
-		array( 'wp-components', 'wp-editor-font' ),
+		array( 'wp-components' ),
 		filemtime( gutenberg_dir_path() . 'build/editor/style.css' )
 	);
 	$styles->add_data( 'wp-block-editor', 'rtl', 'replace' );

--- a/lib/full-site-editing/edit-site-page.php
+++ b/lib/full-site-editing/edit-site-page.php
@@ -50,7 +50,7 @@ function gutenberg_get_editor_styles() {
 	);
 
 	/* translators: Use this to specify the CSS font family for the default font. */
-	$locale_font_family = esc_html_x( 'Noto Serif', 'CSS Font Family for Editor Font', 'gutenberg' );
+	$locale_font_family = esc_html_x( '-apple-system, BlinkMacSystemFont,"Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell,"Helvetica Neue", sans-serif', 'CSS Font Family for Editor Font', 'gutenberg' );
 	$styles[]           = array(
 		'css' => "body { font-family: '$locale_font_family' }",
 	);

--- a/lib/full-site-editing/edit-site-page.php
+++ b/lib/full-site-editing/edit-site-page.php
@@ -50,7 +50,7 @@ function gutenberg_get_editor_styles() {
 	);
 
 	/* translators: Use this to specify the CSS font family for the default font. */
-	$locale_font_family = esc_html_x( '-apple-system, BlinkMacSystemFont,"Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell,"Helvetica Neue", sans-serif', 'CSS Font Family for Editor Font', 'gutenberg' );
+	$locale_font_family = '-apple-system, BlinkMacSystemFont,"Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell,"Helvetica Neue", sans-serif';
 	$styles[]           = array(
 		'css' => "body { font-family: '$locale_font_family' }",
 	);

--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -14,7 +14,6 @@
 $default-font: -apple-system, BlinkMacSystemFont,"Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell,"Helvetica Neue", sans-serif;
 $default-font-size: 13px;
 $default-line-height: 1.4;
-$editor-font: "Noto Serif", serif;
 $editor-html-font: Menlo, Consolas, monaco, monospace;
 $editor-font-size: 16px;
 $default-block-margin: 28px; // This value provides a consistent, contiguous spacing between blocks.

--- a/packages/edit-post/src/components/welcome-guide/style.scss
+++ b/packages/edit-post/src/components/welcome-guide/style.scss
@@ -23,7 +23,7 @@
 	}
 
 	&__heading {
-		font-family: $editor-font;
+		font-family: $default-font;
 		font-size: 24px;
 		line-height: 1.4;
 		margin: 0 0 $grid-unit-20 0;

--- a/packages/editor/src/components/post-title/style.scss
+++ b/packages/editor/src/components/post-title/style.scss
@@ -31,7 +31,7 @@
 
 		// Match h1 heading.
 		font-size: 2.44em;
-		font-weight: bold;
+		font-weight: 800;
 		line-height: 1.4;
 
 		&::-webkit-input-placeholder {

--- a/packages/editor/src/editor-styles.scss
+++ b/packages/editor/src/editor-styles.scss
@@ -9,7 +9,7 @@
  */
 
 body {
-	font-family: $editor-font;
+	font-family: $default-font !important;	// This !important is added temporary to start the conversation. It will need a core patch if we agree.
 	font-size: $editor-font-size;
 	line-height: $editor-line-height;
 	color: $gray-900;
@@ -32,7 +32,6 @@ h3 {
 }
 
 // These follow a Major Third type scale
-// https://type-scale.com/?size=16&scale=1.250&text=A%20Visual%20Type%20Scale&font=Noto%20Serif&fontweight=600
 // Default margins.
 h1 {
 	font-size: 2.44em;

--- a/packages/editor/src/editor-styles.scss
+++ b/packages/editor/src/editor-styles.scss
@@ -9,7 +9,7 @@
  */
 
 body {
-	font-family: $default-font !important;	// This !important is added temporary to start the conversation. It will need a core patch if we agree.
+	font-family: $default-font;
 	font-size: $editor-font-size;
 	line-height: $editor-line-height;
 	color: $gray-900;

--- a/storybook/preview-head.html
+++ b/storybook/preview-head.html
@@ -1,1 +1,0 @@
-<link href="https://fonts.googleapis.com/css?family=Noto+Serif:400,700" rel="stylesheet">

--- a/storybook/stories/playground/editor-styles.scss
+++ b/storybook/stories/playground/editor-styles.scss
@@ -1,5 +1,5 @@
 .editor-styles-wrapper {
-	font-family: $editor-font;
+	font-family: $default-font;
 	font-size: $editor-font-size;
 	line-height: $editor-line-height;
 	color: $gray-900;


### PR DESCRIPTION
In the older days of the editor, few themes provided editor styles. In order to have contrast between block UI and editor UI, a Serif font was applied. It feels like we can revisit this:

- Using system fonts allows has us load less stuff that is only ever used by themes that don't style the editor.
- Because more themes style the editor, we can reposition the vanilla interface to be more of a writing interface, embrace that it isn't WYSIWYG.
- The serif font hasn't aged well, and a sans-serif appears more legible in the context.

This is not an urgent PR, and I'm sure there will be many opinions. Please do share yours!

Before:

<img width="1474" alt="before" src="https://user-images.githubusercontent.com/1204802/98535480-793dfe00-2286-11eb-8aa0-84da2b68df57.png">

After:

<img width="1474" alt="after" src="https://user-images.githubusercontent.com/1204802/98535486-7ba05800-2286-11eb-8ef9-a18c1c72f4dd.png">
