### PR TITLE
query-loop block: Run the main query when queryId is not set (#25377)

### DIFF
--- a/packages/block-library/src/query-loop/index.php
+++ b/packages/block-library/src/query-loop/index.php
@@ -67,7 +67,7 @@ function render_block_core_query_loop( $attributes, $content, $block ) {
 		}
 	}
 
-	if ( isset( $block->content['queryId']) ) {
+	if ( isset( $block->context['queryId']) ) {
 
 		$posts = get_posts( $query );
 

--- a/packages/block-library/src/query-loop/index.php
+++ b/packages/block-library/src/query-loop/index.php
@@ -67,19 +67,58 @@ function render_block_core_query_loop( $attributes, $content, $block ) {
 		}
 	}
 
-	$posts = get_posts( $query );
+	if ( isset( $block->content['queryId']) ) {
 
-	$content = '';
-	foreach ( $posts as $post ) {
-		$content .= (
+		$posts = get_posts( $query );
+
+		$content='';
+		foreach ( $posts as $post ) {
+			$content.= (
+			new WP_Block(
+				$block->parsed_block,
+				array(
+					'postType'=>$post->post_type,
+					'postId'  =>$post->ID,
+				)
+			)
+			)->render( array( 'dynamic'=>false ) );
+		}
+	} else {
+		/**
+		* Not in context of a `core/query` block; assume this is the main query and perform the loop.
+        */
+        $content = render_block_core_query_loop_main_query($attributes, $content, $block);
+	}
+	return $content;
+}
+
+/**
+ * Renders the `core/query-loop` block for the main query on the server.
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
+ * @return string Returns the output of the query, structured using the layout defined by the block's inner blocks.
+ */
+function render_block_core_query_loop_main_query( $attributes, $content, $block ) {
+	if ( have_posts() ) {
+		$content = '';
+		while ( have_posts() ) {
+			the_post();
+			$post = get_post();
+			$content .= (
 			new WP_Block(
 				$block->parsed_block,
 				array(
 					'postType' => $post->post_type,
-					'postId'   => $post->ID,
+					'postId' => $post->ID,
 				)
 			)
-		)->render( array( 'dynamic' => false ) );
+			)->render(array('dynamic' => false));
+		}
+	} else {
+		$content = __( "No posts found." );
 	}
 	return $content;
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
- Theme developers need an easy way to get a template to run the main query
- They don't want to have to create a tempate for each category, tag, date, author, etc.
- This solution kicks in when the `core/query-post` block is not an inner post of `core/query`. 
- In this situation `$block->context['queryId']` is not set.
- When it's set we run the query defined by the outer block
- When it's not we run the main query.

The function to run the main query is basically the same loop as previously developed but using standard loop functions `have_posts()`, `the_post()` and `get_post()` to process the main query and `WP_block->render()` to render each posts content.

This solution supports standard pagination.



## How has this been tested?
- I first developed the solution for my experimental theme Fizzie, documenting the tests in https://github.com/bobbingwide/fizzie/issues/11
- I tested it with categories, tags, custom taxonomies and dates.
- Later I used the same solution for my custom post type archives.
- For this PR I used the Twenty Twenty-One Blocks theme with the following in `index.html`

```
<!-- wp:template-part {"slug":"header","theme":"twentytwentyone-blocks","align":"full", "tagName":"header","className":"site-header"} /-->

<!-- wp:query-loop -->
<!-- wp:post-title /-->
<!-- wp:post-excerpt {"showMoreOnNewLine": "false" } /-->
<!-- wp:post-tags /-->
<!-- wp:post-hierarchical-terms {"term":"category"} /-->
<!-- wp:post-date /-->

<!-- /wp:query-loop -->

<!-- wp:template-part {"slug":"footer","theme":"twentytwentyone-blocks","align":"full","tagName":"footer","className":"site-footer"} /-->
```
I created block posts with different categories, tags and dates:

title | tags | categories | date
--- | ---- | ----- | -----
Archives | | Uncategorised | 2020/11/09
Issue #26010 |  #26010 |  issues | 2020/11/09
Test #25377 | #25377 | issues, Uncategorised | 2020/11/06
Issue #26731 | #26731 | issues | 2020/10/31
Hello world! | | Uncategorised | 2020/11/06

and clicked in the links available to display categories or tags or months.

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/2474435/98541801-e736f500-2287-11eb-9c53-8acf90030973.png)



## Types of changes
Fixes #25377

I imagine that some developer and user documentation will be required to enable other developers and users
to understand how to construct templates. 
The `core/query` block will be needed when something other than the main query is to be run.  


 

<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->

- [x] I've not PHPunit tested the code. I don't have a `wp-env` environment
- [x] I expect there will be coding standard violations. I can't run lint and I don't trust my PhpStorm's Coding standards configuration one inch.
- [x] The same solution ( testing queryId )  can be used to improve the 'core/query-pagination' block.  
