### PR TITLE
withFocusReturn: use hooks and simplify

### DIFF
--- a/packages/components/src/higher-order/with-focus-return/context.js
+++ b/packages/components/src/higher-order/with-focus-return/context.js
@@ -3,7 +3,7 @@
  */
 import { createContext, useLayoutEffect, useRef } from '@wordpress/element';
 
-const context = createContext( [] );
+const context = createContext();
 
 context.Provider.displayName = 'FocusReturnProvider';
 context.Consumer.displayName = 'FocusReturnConsumer';
@@ -48,11 +48,11 @@ export function Provider( { children, className } ) {
 	}
 
 	return (
-		<context.Provider value={ focusHistory.current }>
-			<div ref={ ref } onFocus={ onFocus } className={ className }>
+		<div ref={ ref } onFocus={ onFocus } className={ className }>
+			<context.Provider value={ focusHistory.current }>
 				{ children }
-			</div>
-		</context.Provider>
+			</context.Provider>
+		</div>
 	);
 }
 

--- a/packages/components/src/higher-order/with-focus-return/context.js
+++ b/packages/components/src/higher-order/with-focus-return/context.js
@@ -42,7 +42,7 @@ export function Provider( { children, className } ) {
 
 		const overflow = focusHistory.current.length - MAX_STACK_LENGTH;
 
-		if ( overflow ) {
+		if ( overflow > 0 ) {
 			focusHistory.current.splice( 0, overflow );
 		}
 	}

--- a/packages/components/src/higher-order/with-focus-return/index.js
+++ b/packages/components/src/higher-order/with-focus-return/index.js
@@ -55,16 +55,16 @@ function withFocusReturn( options ) {
 		const focusHistory = useContext( context );
 
 		useEffect( () => {
+			const { ownerDocument } = ref.current;
+
 			// The focus history is a mutating array. Take a snapshot on mount
 			// to use later on unmount.
-			stack.current = [ ...focusHistory ];
+			stack.current = focusHistory
+				? [ ...focusHistory ]
+				: [ ownerDocument.activeElement ];
 
 			return () => {
-				const containsFocus = ref.current.contains(
-					ref.current.ownerDocument.activeElement
-				);
-
-				if ( ! containsFocus ) {
+				if ( ! ref.current.contains( ownerDocument.activeElement ) ) {
 					return;
 				}
 
@@ -80,8 +80,6 @@ function withFocusReturn( options ) {
 				let candidate;
 
 				while ( ( candidate = stack.current.pop() ) ) {
-					const { ownerDocument } = candidate;
-
 					if ( ownerDocument.body.contains( candidate ) ) {
 						candidate.focus();
 						return;

--- a/packages/components/src/higher-order/with-focus-return/index.js
+++ b/packages/components/src/higher-order/with-focus-return/index.js
@@ -51,17 +51,19 @@ function withFocusReturn( options ) {
 
 	return ( WrappedComponent ) => ( props ) => {
 		const ref = useRef();
-		const stack = useRef();
 		const focusHistory = useContext( context );
+		// The focus history is a mutating array. Take a snapshot on mount
+		// to use later on unmount.
+		const stack = useRef( [ ...focusHistory ] );
 
 		useEffect( () => {
 			const { ownerDocument } = ref.current;
 
-			// The focus history is a mutating array. Take a snapshot on mount
-			// to use later on unmount.
-			stack.current = focusHistory
-				? [ ...focusHistory ]
-				: [ ownerDocument.activeElement ];
+			// If there is no focus history, simply return focus to the active
+			// element on mount.
+			if ( ! stack.current ) {
+				stack.current = [ ownerDocument.activeElement ];
+			}
 
 			return () => {
 				if ( ! ref.current.contains( ownerDocument.activeElement ) ) {

--- a/packages/components/src/higher-order/with-focus-return/test/index.js
+++ b/packages/components/src/higher-order/with-focus-return/test/index.js
@@ -24,6 +24,14 @@ class Test extends Component {
 	}
 }
 
+const options = {
+	createNodeMock() {
+		return {
+			ownerDocument: {},
+		};
+	},
+};
+
 describe( 'withFocusReturn()', () => {
 	describe( 'testing rendering and focus handling', () => {
 		const Composite = withFocusReturn( Test );
@@ -41,7 +49,7 @@ describe( 'withFocusReturn()', () => {
 		} );
 
 		it( 'should render a basic Test component inside the HOC', () => {
-			const renderedComposite = renderer.create( <Composite /> );
+			const renderedComposite = renderer.create( <Composite />, options );
 			const wrappedElement = renderedComposite.root.findByType( Test );
 			const wrappedElementShallow = wrappedElement.children[ 0 ];
 			expect( wrappedElementShallow.props.className ).toBe( 'test' );
@@ -53,7 +61,8 @@ describe( 'withFocusReturn()', () => {
 
 		it( 'should pass own props through to the wrapped element', () => {
 			const renderedComposite = renderer.create(
-				<Composite test="test" />
+				<Composite test="test" />,
+				options
 			);
 			const wrappedElement = renderedComposite.root.findByType( Test );
 			// Ensure that the wrapped Test element has the appropriate props.
@@ -62,7 +71,8 @@ describe( 'withFocusReturn()', () => {
 
 		it( 'should not pass any withFocusReturn context props through to the wrapped element', () => {
 			const renderedComposite = renderer.create(
-				<Composite test="test" />
+				<Composite test="test" />,
+				options
 			);
 			const wrappedElement = renderedComposite.root.findByType( Test );
 			// Ensure that the wrapped Test element has the appropriate props.
@@ -70,16 +80,11 @@ describe( 'withFocusReturn()', () => {
 		} );
 
 		it( 'should not switch focus back to the bound focus element', () => {
-			const { unmount } = render(
-				<Provider>
-					<Composite />
-				</Provider>,
-				{
-					container: document.body.appendChild(
-						document.createElement( 'div' )
-					),
-				}
-			);
+			const { unmount } = render( <Composite />, {
+				container: document.body.appendChild(
+					document.createElement( 'div' )
+				),
+			} );
 
 			// Change activeElement.
 			switchFocusTo.focus();
@@ -91,16 +96,11 @@ describe( 'withFocusReturn()', () => {
 		} );
 
 		it( 'should switch focus back when unmounted while having focus', () => {
-			const { container, unmount } = render(
-				<Provider>
-					<Composite />
-				</Provider>,
-				{
-					container: document.body.appendChild(
-						document.createElement( 'div' )
-					),
-				}
-			);
+			const { container, unmount } = render( <Composite />, {
+				container: document.body.appendChild(
+					document.createElement( 'div' )
+				),
+			} );
 
 			const textarea = container.querySelector( 'textarea' );
 			textarea.focus();


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

After digging a bit in `withFocusReturn`, I noticed that there's no need to use state for the focus history, which means any children of the history provider don't need to re-render every time focus is moved to a different element. The history can keep a reference throughout the lifecycle and mutate it. The history is only important for consumers on mount, so there's no component that has to **react** to history changes.

Additionally, there's no need for the consumer to record focussed nodes within. The consumer should just take a snapshot of the history on mount so it knows where to place focus on unmount.

This also lays the groundwork for a potential `useFocusReturn( ref )` hook, which could replace the HoC and the need for an extra wrapper `div`.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
