### PR TITLE
Add server side pagination for the main query (#26557)

### DIFF
--- a/packages/block-library/src/query-pagination/index.php
+++ b/packages/block-library/src/query-pagination/index.php
@@ -15,6 +15,25 @@
  * @return string Returns the pagination for the query.
  */
 function render_block_core_query_pagination( $attributes, $content, $block ) {
+	if ( isset( $block->context['queryId'] ) ) {
+		$html = render_block_core_query_pagination_selected_query( $attributes, $content, $block );
+	} else {
+		$html = render_block_core_query_pagination_main_query( $attributes, $content, $block );
+	}
+	return $html;
+}
+
+/**
+ * Renders the `core/query-pagination` block on the server for the selected query.
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
+ * @return string Returns the pagination for the query.
+ */
+function render_block_core_query_pagination_selected_query( $attributes, $content, $block ) {
+
 	$page_key = isset( $block->context['queryId'] ) ? 'query-' . $block->context['queryId'] . '-page' : 'query-page';
 	$page     = empty( $_GET[ $page_key ] ) ? 1 : filter_var( $_GET[ $page_key ], FILTER_VALIDATE_INT );
 
@@ -34,6 +53,22 @@ function render_block_core_query_pagination( $attributes, $content, $block ) {
 		);
 	}
 	return $content;
+}
+
+/**
+ * Renders the `core/query-pagination` block on the server for the main query.
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
+ * @return string Returns the pagination for the query.
+ */
+function render_block_core_query_pagination_main_query( $attributes, $content, $block ) {
+	$html = '<div class="wp-block-query-pagination">';
+	$html .= paginate_links( [ 'type' => 'list'] );
+	$html .= "</div>";
+	return $html;
 }
 
 /**


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
In this change I have added some logic to enable the `core/query-pagination` block to apply to output displayed by
`core/query-loop` when run against the main query.

- I have only added the PHP logic to paginate the main query.
- It uses the core `paginate_links` function to do the hard work.
- The pagination for a _selected_ query ( one specfied using `core/query`) has been put into a separate function, but remains untouched.

## How has this been tested?
- Use Twenty Twenty-One Blocks theme
- Set Blog pages show at most **2** posts - depending on how many posts you've got
- Apply the fix developed for #25377 
 ( PR https://github.com/WordPress/gutenberg/pull/26825 )
- Edit `index.html` to be:

```
<!-- wp:template-part {"slug":"header","theme":"twentytwentyone-blocks","align":"full", "tagName":"header","className":"site-header"} /-->

<!-- wp:query-pagination /-->
<!-- wp:query-loop -->
<!-- wp:post-title /-->
<!-- wp:post-excerpt {"showMoreOnNewLine": "false" } /-->
<!-- wp:post-tags /-->
<!-- wp:post-hierarchical-terms {"term":"category"} /-->
<!-- wp:post-date /-->

<!-- /wp:query-loop -->
<!-- wp:query-pagination /-->

<!-- wp:template-part {"slug":"footer","theme":"twentytwentyone-blocks","align":"full","tagName":"footer","className":"site-footer"} /-->
```

Edit `style.css` to add some basic styling of the list generated by `paginate_links()`.
```
.wp-block-query-pagination {
	clear: both;
}

ul.page-numbers {
	display: block;
	padding-left: 0px;
}

.page-numbers li {
	display: inline-block;
}

.page-numbers li a {
	background-color: #f5f5f5;
	color: #333;
	cursor: pointer;
	display: inline-block;
	font-size: 16px;
	font-weight: 600;
	margin-bottom: 4px;
	text-decoration: none;
	padding: 8px 12px;
}
```
- Run similar tests as before: categories, tags, dates
- Check pagination is as expected.



## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/2474435/98560831-148f9d00-22a0-11eb-8743-f81e6458f343.png)


## Types of changes
Part fix for #26557 

As with the PR for running the main query in `core/query-loop`, this will require documentation explaining how to use the block.
In order to implement the styling options specified in the requirements there will have to be a mapping between the attributes set in the block editor and the parameters to `paginate_links`.

It seems likely that the pagination for queries defined using `core/query` will need to be changed to use the `paginate_links()` function as well. 

<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
