### PR TITLE
activeElement: error if accessed with a global

### DIFF
--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -83,7 +83,7 @@ class GalleryImage extends Component {
 
 	onRemoveImage( event ) {
 		if (
-			this.container === document.activeElement &&
+			this.container === this.container.ownerDocument.activeElement &&
 			this.props.isSelected &&
 			[ BACKSPACE, DELETE ].indexOf( event.keyCode ) !== -1
 		) {

--- a/packages/components/src/angle-picker-control/angle-circle.js
+++ b/packages/components/src/angle-picker-control/angle-circle.js
@@ -28,11 +28,12 @@ function AngleCircle( { value, onChange, ...props } ) {
 
 	const changeAngleToPosition = ( event ) => {
 		const { x: centerX, y: centerY } = angleCircleCenter.current;
+		const { ownerDocument } = angleCircleRef.current;
 		// Prevent (drag) mouse events from selecting and accidentally
 		// triggering actions from other elements.
 		event.preventDefault();
 		// Ensure the input isn't focused as preventDefault would leave it
-		document.activeElement.blur();
+		ownerDocument.activeElement.blur();
 		onChange( getAngle( centerX, centerY, event.clientX, event.clientY ) );
 	};
 

--- a/packages/components/src/date-time/date.js
+++ b/packages/components/src/date-time/date.js
@@ -37,10 +37,14 @@ class DatePicker extends Component {
 		if ( ! this.nodeRef.current ) {
 			return;
 		}
+
+		const { ownerDocument } = this.nodeRef.current;
+		const { activeElement } = ownerDocument;
+
 		// If focus was lost.
 		if (
-			! document.activeElement ||
-			! this.nodeRef.current.contains( document.activeElement )
+			! activeElement ||
+			! this.nodeRef.current.contains( ownerDocument.activeElement )
 		) {
 			// Retrieve the focus region div.
 			const focusRegion = this.nodeRef.current.querySelector(

--- a/packages/components/src/date-time/index.js
+++ b/packages/components/src/date-time/index.js
@@ -8,7 +8,7 @@ import 'react-dates/initialize';
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { useState, forwardRef } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 
 /**
@@ -20,169 +20,149 @@ import { default as TimePicker } from './time';
 
 export { DatePicker, TimePicker };
 
-export class DateTimePicker extends Component {
-	constructor() {
-		super( ...arguments );
+function DateTimePicker(
+	{
+		currentDate,
+		is12Hour,
+		isInvalidDate,
+		onMonthPreviewed,
+		onChange,
+		events,
+	},
+	ref
+) {
+	const [ calendarHelpIsVisible, setCalendarHelpIsVisible ] = useState(
+		false
+	);
 
-		this.state = { calendarHelpIsVisible: false };
-
-		this.onClickDescriptionToggle = this.onClickDescriptionToggle.bind(
-			this
-		);
+	function onClickDescriptionToggle() {
+		setCalendarHelpIsVisible( ! calendarHelpIsVisible );
 	}
 
-	onClickDescriptionToggle() {
-		this.setState( {
-			calendarHelpIsVisible: ! this.state.calendarHelpIsVisible,
-		} );
-	}
-
-	render() {
-		const {
-			currentDate,
-			is12Hour,
-			isInvalidDate,
-			onMonthPreviewed,
-			onChange,
-			events,
-		} = this.props;
-
-		return (
-			<div className="components-datetime">
-				{ ! this.state.calendarHelpIsVisible && (
-					<>
-						<TimePicker
-							currentTime={ currentDate }
-							onChange={ onChange }
-							is12Hour={ is12Hour }
-						/>
-						<DatePicker
-							currentDate={ currentDate }
-							onChange={ onChange }
-							isInvalidDate={ isInvalidDate }
-							onMonthPreviewed={ onMonthPreviewed }
-							events={ events }
-						/>
-					</>
-				) }
-
-				{ this.state.calendarHelpIsVisible && (
-					<>
-						<div className="components-datetime__calendar-help">
-							<h4>{ __( 'Click to Select' ) }</h4>
-							<ul>
-								<li>
-									{ __(
-										'Click the right or left arrows to select other months in the past or the future.'
+	return (
+		<div ref={ ref } className="components-datetime">
+			{ ! calendarHelpIsVisible && (
+				<>
+					<TimePicker
+						currentTime={ currentDate }
+						onChange={ onChange }
+						is12Hour={ is12Hour }
+					/>
+					<DatePicker
+						currentDate={ currentDate }
+						onChange={ onChange }
+						isInvalidDate={ isInvalidDate }
+						onMonthPreviewed={ onMonthPreviewed }
+						events={ events }
+					/>
+				</>
+			) }
+			{ calendarHelpIsVisible && (
+				<>
+					<div className="components-datetime__calendar-help">
+						<h4>{ __( 'Click to Select' ) }</h4>
+						<ul>
+							<li>
+								{ __(
+									'Click the right or left arrows to select other months in the past or the future.'
+								) }
+							</li>
+							<li>
+								{ __( 'Click the desired day to select it.' ) }
+							</li>
+						</ul>
+						<h4>{ __( 'Navigating with a keyboard' ) }</h4>
+						<ul>
+							<li>
+								<abbr
+									aria-label={ _x(
+										'Enter',
+										'keyboard button'
 									) }
-								</li>
-								<li>
-									{ __(
-										'Click the desired day to select it.'
-									) }
-								</li>
-							</ul>
-
-							<h4>{ __( 'Navigating with a keyboard' ) }</h4>
-							<ul>
-								<li>
-									<abbr
-										aria-label={ _x(
-											'Enter',
-											'keyboard button'
-										) }
-									>
-										↵
-									</abbr>
-									{
-										' ' /* JSX removes whitespace, but a space is required for screen readers. */
-									}
-									<span>
-										{ __( 'Select the date in focus.' ) }
-									</span>
-								</li>
-								<li>
-									<abbr
-										aria-label={ __(
-											'Left and Right Arrows'
-										) }
-									>
-										←/→
-									</abbr>
-									{
-										' ' /* JSX removes whitespace, but a space is required for screen readers. */
-									}
-									{ __(
-										'Move backward (left) or forward (right) by one day.'
-									) }
-								</li>
-								<li>
-									<abbr
-										aria-label={ __(
-											'Up and Down Arrows'
-										) }
-									>
-										↑/↓
-									</abbr>
-									{
-										' ' /* JSX removes whitespace, but a space is required for screen readers. */
-									}
-									{ __(
-										'Move backward (up) or forward (down) by one week.'
-									) }
-								</li>
-								<li>
-									<abbr
-										aria-label={ __(
-											'Page Up and Page Down'
-										) }
-									>
-										{ __( 'PgUp/PgDn' ) }
-									</abbr>
-									{
-										' ' /* JSX removes whitespace, but a space is required for screen readers. */
-									}
-									{ __(
-										'Move backward (PgUp) or forward (PgDn) by one month.'
-									) }
-								</li>
-								<li>
-									<abbr aria-label={ __( 'Home and End' ) }>
-										{ __( 'Home/End' ) }
-									</abbr>
-									{
-										' ' /* JSX removes whitespace, but a space is required for screen readers. */
-									}
-									{ __(
-										'Go to the first (home) or last (end) day of a week.'
-									) }
-								</li>
-							</ul>
-						</div>
-					</>
-				) }
-
-				<div className="components-datetime__buttons">
-					{ ! this.state.calendarHelpIsVisible && currentDate && (
-						<Button
-							className="components-datetime__date-reset-button"
-							isLink
-							onClick={ () => onChange( null ) }
-						>
-							{ __( 'Reset' ) }
-						</Button>
-					) }
+								>
+									↵
+								</abbr>
+								{
+									' ' /* JSX removes whitespace, but a space is required for screen readers. */
+								}
+								<span>
+									{ __( 'Select the date in focus.' ) }
+								</span>
+							</li>
+							<li>
+								<abbr
+									aria-label={ __( 'Left and Right Arrows' ) }
+								>
+									←/→
+								</abbr>
+								{
+									' ' /* JSX removes whitespace, but a space is required for screen readers. */
+								}
+								{ __(
+									'Move backward (left) or forward (right) by one day.'
+								) }
+							</li>
+							<li>
+								<abbr aria-label={ __( 'Up and Down Arrows' ) }>
+									↑/↓
+								</abbr>
+								{
+									' ' /* JSX removes whitespace, but a space is required for screen readers. */
+								}
+								{ __(
+									'Move backward (up) or forward (down) by one week.'
+								) }
+							</li>
+							<li>
+								<abbr
+									aria-label={ __( 'Page Up and Page Down' ) }
+								>
+									{ __( 'PgUp/PgDn' ) }
+								</abbr>
+								{
+									' ' /* JSX removes whitespace, but a space is required for screen readers. */
+								}
+								{ __(
+									'Move backward (PgUp) or forward (PgDn) by one month.'
+								) }
+							</li>
+							<li>
+								<abbr aria-label={ __( 'Home and End' ) }>
+									{ __( 'Home/End' ) }
+								</abbr>
+								{
+									' ' /* JSX removes whitespace, but a space is required for screen readers. */
+								}
+								{ __(
+									'Go to the first (home) or last (end) day of a week.'
+								) }
+							</li>
+						</ul>
+					</div>
+				</>
+			) }
+			<div className="components-datetime__buttons">
+				{ ! calendarHelpIsVisible && currentDate && (
 					<Button
-						className="components-datetime__date-help-toggle"
+						className="components-datetime__date-reset-button"
 						isLink
-						onClick={ this.onClickDescriptionToggle }
+						onClick={ () => onChange( null ) }
 					>
-						{ this.state.calendarHelpIsVisible
-							? __( 'Close' )
-							: __( 'Calendar Help' ) }
+						{ __( 'Reset' ) }
 					</Button>
-				</div>
+				) }
+				<Button
+					className="components-datetime__date-help-toggle"
+					isLink
+					onClick={ onClickDescriptionToggle }
+				>
+					{ calendarHelpIsVisible
+						? __( 'Close' )
+						: __( 'Calendar Help' ) }
+				</Button>
 			</div>
-		);
-	}
+		</div>
+	);
 }
+
+export default forwardRef( DateTimePicker );

--- a/packages/components/src/guide/finish-button.js
+++ b/packages/components/src/guide/finish-button.js
@@ -8,28 +8,19 @@ import { useRef, useLayoutEffect } from '@wordpress/element';
  */
 import Button from '../button';
 
-export default function FinishButton( { className, onClick, children } ) {
-	const button = useRef( null );
+export default function FinishButton( props ) {
+	const ref = useRef();
 
 	// Focus the button on mount if nothing else is focused. This prevents a
 	// focus loss when the 'Next' button is swapped out.
 	useLayoutEffect( () => {
-		if (
-			! document.activeElement ||
-			document.activeElement === document.body
-		) {
-			button.current.focus();
-		}
-	}, [ button ] );
+		const { ownerDocument } = ref.current;
+		const { activeElement, body } = ownerDocument;
 
-	return (
-		<Button
-			ref={ button }
-			className={ className }
-			isPrimary
-			onClick={ onClick }
-		>
-			{ children }
-		</Button>
-	);
+		if ( ! activeElement || activeElement === body ) {
+			ref.current.focus();
+		}
+	}, [] );
+
+	return <Button { ...props } ref={ ref } />;
 }

--- a/packages/components/src/guide/test/finish-button.js
+++ b/packages/components/src/guide/test/finish-button.js
@@ -30,7 +30,7 @@ describe( 'FinishButton', () => {
 	it( 'receives focus on mount when nothing is focused', () => {
 		const focus = jest.fn();
 		create( <FinishButton />, {
-			createNodeMock: () => ( { focus } ),
+			createNodeMock: () => ( { focus, ownerDocument: document } ),
 		} );
 		expect( focus ).toHaveBeenCalled();
 	} );
@@ -42,7 +42,7 @@ describe( 'FinishButton', () => {
 
 		const focus = jest.fn();
 		create( <FinishButton />, {
-			createNodeMock: () => ( { focus } ),
+			createNodeMock: () => ( { focus, ownerDocument: document } ),
 		} );
 		expect( focus ).not.toHaveBeenCalled();
 	} );

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -37,7 +37,7 @@ export { default as ColorPicker } from './color-picker';
 export { default as ComboboxControl } from './combobox-control';
 export { default as CustomSelectControl } from './custom-select-control';
 export { default as Dashicon } from './dashicon';
-export { DateTimePicker, DatePicker, TimePicker } from './date-time';
+export { default as DateTimePicker, DatePicker, TimePicker } from './date-time';
 export { default as __experimentalDimensionControl } from './dimension-control';
 export { default as Disabled } from './disabled';
 export { default as Draggable } from './draggable';

--- a/packages/editor/src/components/post-schedule/index.js
+++ b/packages/editor/src/components/post-schedule/index.js
@@ -5,12 +5,10 @@ import { __experimentalGetSettings } from '@wordpress/date';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { DateTimePicker } from '@wordpress/components';
+import { useRef } from '@wordpress/element';
 
 export function PostSchedule( { date, onUpdateDate } ) {
-	const onChange = ( newDate ) => {
-		onUpdateDate( newDate );
-		document.activeElement.blur();
-	};
+	const ref = useRef();
 	const settings = __experimentalGetSettings();
 	// To know if the current timezone is a 12 hour time with look for "a" in the time format
 	// We also make sure this a is not escaped by a "/"
@@ -23,9 +21,15 @@ export function PostSchedule( { date, onUpdateDate } ) {
 			.join( '' ) // Reverse the string and test for "a" not followed by a slash
 	);
 
+	function onChange( newDate ) {
+		onUpdateDate( newDate );
+		const { ownerDocument } = ref.current;
+		ownerDocument.activeElement.blur();
+	}
+
 	return (
 		<DateTimePicker
-			key="date-time-picker"
+			ref={ ref }
 			currentDate={ date }
 			onChange={ onChange }
 			is12Hour={ is12HourTime }

--- a/packages/eslint-plugin/configs/custom.js
+++ b/packages/eslint-plugin/configs/custom.js
@@ -4,7 +4,7 @@ module.exports = {
 		'@wordpress/no-unused-vars-before-return': 'error',
 		'@wordpress/no-base-control-with-label-without-id': 'error',
 		'@wordpress/no-unguarded-get-range-at': 'error',
-		'@wordpress/no-global-active-element': 'warn',
+		'@wordpress/no-global-active-element': 'error',
 		'@wordpress/no-global-get-selection': 'error',
 	},
 	overrides: [

--- a/packages/eslint-plugin/rules/__tests__/no-global-active-element.js
+++ b/packages/eslint-plugin/rules/__tests__/no-global-active-element.js
@@ -23,7 +23,12 @@ ruleTester.run( 'no-global-active-element', rule, {
 	invalid: [
 		{
 			code: 'document.activeElement;',
-			errors: [ { message: 'Avoid global active element' } ],
+			errors: [
+				{
+					message:
+						'Avoid accessing the active element with a global. Use the ownerDocument property on a node ref instead.',
+				},
+			],
 		},
 	],
 } );

--- a/packages/eslint-plugin/rules/__tests__/no-global-get-selection.js
+++ b/packages/eslint-plugin/rules/__tests__/no-global-get-selection.js
@@ -23,7 +23,12 @@ ruleTester.run( 'no-global-get-selection', rule, {
 	invalid: [
 		{
 			code: 'window.getSelection();',
-			errors: [ { message: 'Avoid global selection getting' } ],
+			errors: [
+				{
+					message:
+						'Avoid accessing the selection with a global. Use the ownerDocument.defaultView property on a node ref instead.',
+				},
+			],
 		},
 	],
 } );

--- a/packages/eslint-plugin/rules/no-global-active-element.js
+++ b/packages/eslint-plugin/rules/no-global-active-element.js
@@ -10,7 +10,8 @@ module.exports = {
 			) {
 				context.report( {
 					node,
-					message: 'Avoid global active element',
+					message:
+						'Avoid accessing the active element with a global. Use the ownerDocument property on a node ref instead.',
 				} );
 			},
 		};

--- a/packages/eslint-plugin/rules/no-global-get-selection.js
+++ b/packages/eslint-plugin/rules/no-global-get-selection.js
@@ -10,7 +10,8 @@ module.exports = {
 			) {
 				context.report( {
 					node,
-					message: 'Avoid global selection getting',
+					message:
+						'Avoid accessing the selection with a global. Use the ownerDocument.defaultView property on a node ref instead.',
 				} );
 			},
 		};


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

Fixes all instances where `activeElement` is accessed from the global `document`.
Error instead of warn with ESLint.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
