### PR TITLE
Update workflows to use Node 14.x

### DIFF
--- a/.github/workflows/create-block.yml
+++ b/.github/workflows/create-block.yml
@@ -34,10 +34,10 @@ jobs:
           ${{ runner.os }}-build-
           ${{ runner.os }}-
 
-    - name: Use Node.js 12.x
+    - name: Use Node.js 14.x
       uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 14.x
 
     - name: npm install, build, format and lint
       run: |

--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -31,10 +31,10 @@ jobs:
           ${{ runner.os }}-build-
           ${{ runner.os }}-
 
-    - name: Use Node.js 12.x
+    - name: Use Node.js 14.x
       uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 14.x
 
     - name: Npm install and build
       run: |
@@ -72,10 +72,10 @@ jobs:
           ${{ runner.os }}-build-
           ${{ runner.os }}-
 
-    - name: Use Node.js 12.x
+    - name: Use Node.js 14.x
       uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 14.x
 
     - name: Npm install and build
       run: |
@@ -113,10 +113,10 @@ jobs:
           ${{ runner.os }}-build-
           ${{ runner.os }}-
 
-    - name: Use Node.js 12.x
+    - name: Use Node.js 14.x
       uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 14.x
 
     - name: Npm install and build
       run: |
@@ -154,10 +154,10 @@ jobs:
           ${{ runner.os }}-build-
           ${{ runner.os }}-
 
-    - name: Use Node.js 12.x
+    - name: Use Node.js 14.x
       uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 14.x
 
     - name: Npm install and build
       run: |

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -27,10 +27,10 @@ jobs:
           ${{ runner.os }}-build-
           ${{ runner.os }}-
 
-    - name: Use Node.js 12.x
+    - name: Use Node.js 14.x
       uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 14.x
 
     - name: Npm install
       run: |

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -27,10 +27,10 @@ jobs:
           ${{ runner.os }}-build-
           ${{ runner.os }}-
 
-    - name: Use Node.js 12.x
+    - name: Use Node.js 14.x
       uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 14.x
 
     - name: Npm install and build
       # A "full" install is executed, since `npm ci` does not always exit

--- a/.github/workflows/storybook-pages.yml
+++ b/.github/workflows/storybook-pages.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v1
       with:
-        node-version: '12.x'
+        node-version: '14.x'
 
     - name: Install Dependencies
       run: npm ci

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -31,10 +31,10 @@ jobs:
           ${{ runner.os }}-build-
           ${{ runner.os }}-
 
-    - name: Use Node.js 12.x
+    - name: Use Node.js 14.x
       uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 14.x
 
     - name: Npm install and build
       # It's not necessary to run the full build, since Jest can interpret
@@ -68,10 +68,10 @@ jobs:
           ${{ runner.os }}-build-
           ${{ runner.os }}-
 
-    - name: Use Node.js 12.x
+    - name: Use Node.js 14.x
       uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 14.x
 
     - name: Npm install and build
       run: |
@@ -107,10 +107,10 @@ jobs:
           ${{ runner.os }}-build-
           ${{ runner.os }}-
 
-    - name: Use Node.js 12.x
+    - name: Use Node.js 14.x
       uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 14.x
 
     - name: Npm install and build
       # It's not necessary to run the full build, since Jest can interpret


### PR DESCRIPTION
## Description

The Gutenberg project goal is to build against the current Node LTS version.
On Oct 27, 2020 Node v14.15.0 was transitioned to the current LTS version, [see release notes](https://nodejs.org/en/blog/release/v14.15.0/)

This PR updates the GitHub workflows to use Node 14.x 

## How has this been tested?

- Confirmed build and test locally works for Node 14.15.0 and npm 6.14.8
- Creating this PR and confirming the tests passed

## Types of changes

- Updates workflow docs to use Node 14.x
