### PR TITLE
Encourage the use of npm ci to avoid package-lock conflict

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -99,7 +99,7 @@ done
 
 # Run the build.
 status "Installing dependencies... 📦"
-npm install
+npm ci
 status "Generating build... 👷‍♀️"
 npm run build
 

--- a/docs/contributors/getting-started-native-mobile.md
+++ b/docs/contributors/getting-started-native-mobile.md
@@ -27,7 +27,7 @@ Before running the demo app, you need to download and install the project depend
 
 ```
 nvm install --latest-npm
-npm install
+npm ci
 ```
 
 ## Run

--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -12,7 +12,7 @@ After installing Node, you can build Gutenberg by running the following from wit
 
 
 ```bash
-npm install
+npm ci
 npm run build
 ```
 
@@ -124,7 +124,7 @@ Tools like MAMP tend to configure MySQL to use ports other than the default 3306
 
 You can use a remote server in development by building locally and then uploading the built files as a plugin to the remote server.
 
-To build: open a terminal (or if on Windows, a command prompt) and navigate to the repository you cloned. Now type `npm install` to get the dependencies all set up. Once that finishes, you can type `npm run build`.
+To build: open a terminal (or if on Windows, a command prompt) and navigate to the repository you cloned. Now type `npm ci` to get the dependencies all set up. Once that finishes, you can type `npm run build`.
 
 After building the cloned gutenberg directory contains the complete plugin, you can upload the entire repository to your `wp-content/plugins` directory and activate the plugin from the WordPress admin.
 


### PR DESCRIPTION
#  Description

The recent package-lock conflicts highlighted that we should be using `npm ci` to make sure setups are being pulled in from the package-lock.json and not updating packages a developer might be unintending too.

Also updated the zip build to use `npm ci`

See the documentation at: https://docs.npmjs.com/cli/v6/commands/npm-ci

## How has this been tested?

- Using `npm ci` instead of `npm install` will not update package.json or any dependencies and only use the packages specified in the package-lock.json giving
- Confirm everything still works as expected when building

## Types of changes

Update docs to use `npm ci` and update build zip script to use `npm ci`
