### PR TITLE
Update Legacy Widget toolbar button font to match UI when displayed in Widget Screen

### DIFF
--- a/packages/edit-widgets/src/components/widget-areas-block-editor-content/style.scss
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-content/style.scss
@@ -3,11 +3,10 @@
 
 	// The button element easily inherits styles that are meant for the editor style.
 	// These rules enhance the specificity to reduce that inheritance.
-	// This is copied from edit-post/src/components/style.scss.
+	// This is copied from edit-post/src/components/style.scss but without the padding.
 	& .components-button {
 		font-family: $default-font;
 		font-size: $default-font-size;
-		padding: 6px 12px;
 
 		&.is-tertiary,
 		&.has-icon {

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-content/style.scss
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-content/style.scss
@@ -1,3 +1,17 @@
 .edit-widgets-block-editor {
 	position: relative;
+
+	// The button element easily inherits styles that are meant for the editor style.
+	// These rules enhance the specificity to reduce that inheritance.
+	// This is copied from edit-post/src/components/style.scss.
+	& .components-button {
+		font-family: $default-font;
+		font-size: $default-font-size;
+		padding: 6px 12px;
+
+		&.is-tertiary,
+		&.has-icon {
+			padding: 6px;
+		}
+	}
 }


### PR DESCRIPTION
Fixes #26213. 
Updates the block toolbar button font to match ui. Focusing on the "Edit" and "Preview" buttons in the Legacy Widget block toolbar.

## How has this been tested?
Locally.

## Screenshots

**BEFORE**

![Screen Shot 2020-11-09 at 2 40 50 PM](https://user-images.githubusercontent.com/617986/98605014-97612980-2299-11eb-9f7b-46deb06c8419.png)

**AFTER**

![Screen Shot 2020-11-09 at 2 41 25 PM](https://user-images.githubusercontent.com/617986/98605080-bc559c80-2299-11eb-8704-632167cd6d27.png)


## Types of changes
CSS changes.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
