### PR TITLE
Sandbox: increase selector scope when targeting to iframe element

### DIFF
--- a/packages/components/src/sandbox/index.js
+++ b/packages/components/src/sandbox/index.js
@@ -79,13 +79,13 @@ const style = `
 	html,
 	body,
 	body > div,
-	body > div > iframe {
+	body > div iframe {
 		width: 100%;
 	}
 	html.wp-has-aspect-ratio,
 	body.wp-has-aspect-ratio,
 	body.wp-has-aspect-ratio > div,
-	body.wp-has-aspect-ratio > div > iframe {
+	body.wp-has-aspect-ratio > div iframe {
 		height: 100%;
 		overflow: hidden; /* If it has an aspect ratio, it shouldn't scroll. */
 	}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This PR changes the default CSS code in order to increase the selector scope when targeting the iframe.

## How has this been tested?
It shouldn't affect the current implementations. Just confirm that the Sandbox styles are applied properly after these changes.


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->