### PR TITLE
Site Editor: Remove dashboard button focus on mount

### DIFF
--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/templates-navigation.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/templates-navigation.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { useRef, useEffect } from '@wordpress/element';
 import {
 	__experimentalNavigation as Navigation,
 	__experimentalNavigationMenu as NavigationMenu,
@@ -19,14 +18,6 @@ import TemplatePartsMenu from './menus/template-parts';
 import { MENU_ROOT, MENU_TEMPLATE_PARTS, MENU_TEMPLATES } from './constants';
 
 export default function TemplatesNavigation() {
-	const ref = useRef();
-
-	useEffect( () => {
-		if ( ref.current ) {
-			ref.current.focus();
-		}
-	}, [ ref ] );
-
 	const { templateId, templatePartId, templateType, activeMenu } = useSelect(
 		( select ) => {
 			const {
@@ -63,7 +54,6 @@ export default function TemplatesNavigation() {
 					backButtonLabel={ __( 'Dashboard' ) }
 					className="edit-site-navigation-panel__back-to-dashboard"
 					href="index.php"
-					ref={ ref }
 				/>
 			) }
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
As discussed here: https://github.com/WordPress/gutenberg/pull/25884#issuecomment-705750281
We don't need the auto-focus on the Dashboard button anymore.

## How has this been tested?
- Open Site Editor
- Open Navigation Panel
- Make sure focus is on the "Toggle Navigation" button

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
