### PR TITLE
Add command to format PHP files

### DIFF
--- a/package.json
+++ b/package.json
@@ -223,6 +223,7 @@
 		"fixtures:generate": "cross-env GENERATE_MISSING_FIXTURES=y npm run test-unit",
 		"fixtures:regenerate": "npm run fixtures:clean && npm run fixtures:generate",
 		"format-js": "wp-scripts format-js",
+		"format-php": "wp-env run composer run-script format",
 		"lint": "concurrently \"npm run lint-lockfile\" \"npm run lint-js\" \"npm run lint-pkg-json\" \"npm run lint-css\"",
 		"lint-js": "wp-scripts lint-js",
 		"lint-js:fix": "npm run lint-js -- --fix",


### PR DESCRIPTION
This PR exposes through npm the command to format PHP files, as we do for the command for linting PHP or the command for formatting JS.

## How to test

- Edit a PHP file and add some spaces somewhere.
- Run `npm run format-php`.
- Verify that the spaces were corrected and the PHP file is back to proper spacing.
