### PR TITLE
Mark AWAIT_PROMISE as unstable API

### DIFF
--- a/packages/core-data/src/locks/actions.js
+++ b/packages/core-data/src/locks/actions.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { awaitPromise } from '@wordpress/data-controls';
+import { __unstableAwaitPromise } from '@wordpress/data-controls';
 import { controls } from '@wordpress/data';
 
 export function* __unstableAcquireStoreLock( store, path, { exclusive } ) {
@@ -9,7 +9,7 @@ export function* __unstableAcquireStoreLock( store, path, { exclusive } ) {
 		exclusive,
 	} );
 	yield* __unstableProcessPendingLockRequests();
-	return yield awaitPromise( promise );
+	return yield __unstableAwaitPromise( promise );
 }
 
 export function* __unstableEnqueueLockRequest( store, path, { exclusive } ) {

--- a/packages/data-controls/README.md
+++ b/packages/data-controls/README.md
@@ -45,10 +45,6 @@ _Returns_
 
 -   `Object`: The control descriptor.
 
-<a name="awaitPromise" href="#awaitPromise">#</a> **awaitPromise**
-
-Undocumented declaration.
-
 <a name="controls" href="#controls">#</a> **controls**
 
 The default export is what you use to register the controls with your custom

--- a/packages/data-controls/src/index.js
+++ b/packages/data-controls/src/index.js
@@ -73,7 +73,26 @@ export function dispatch( ...args ) {
 	return dataControls.dispatch( ...args );
 }
 
-export const awaitPromise = function ( promise ) {
+/**
+ * Dispatches a control action for awaiting on a promise to be resolved.
+ *
+ * @param {Object} promise Promise to wait for.
+ *
+ * @example
+ * ```js
+ * import { __unstableAwaitPromise } from '@wordpress/data-controls';
+ *
+ * // Action generator using apiFetch
+ * export function* myAction() {
+ * 	const promise = getItemsAsync();
+ * 	const items = yield __unstableAwaitPromise( promise );
+ * 	// do something with the items.
+ * }
+ * ```
+ *
+ * @return {Object} The control descriptor.
+ */
+export const __unstableAwaitPromise = function ( promise ) {
 	return {
 		type: 'AWAIT_PROMISE',
 		promise,


### PR DESCRIPTION
**Description**

This is a follow-up to https://github.com/WordPress/gutenberg/pull/26389 that makes the AWAIT_PROMISE control unstable for now.

**Testing instructions**

1. Confirm all the tests pass
2. Confirm you are able to use the post editor and the site editor just like before applying this PR
3. Apply this PR on top of #26387 and confirm the issue from its description is not manifested
