### PR TITLE
Add default block widths to the full-site editor

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -681,3 +681,21 @@
 	}
 	/* stylelint-enable function-comma-space-after */
 }
+
+/**
+ * These are default block editor widths in case the theme doesn't provide them.
+ */
+@mixin default-block-widths {
+
+	.wp-block {
+		max-width: $content-width;
+
+		&[data-align="wide"] {
+			max-width: $wide-content-width;
+		}
+
+		&[data-align="full"] {
+			max-width: none;
+		}
+	}
+}

--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -73,6 +73,7 @@ $shadow-modal: 0 3px 30px rgba($black, 0.2);
 
 $sidebar-width: 280px;
 $content-width: 840px;
+$wide-content-width: 1100px;
 $widget-area-width: 700px;
 
 /**

--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -94,18 +94,5 @@ body.block-editor-page {
 	}
 }
 
-
-// These are default block editor styles in case the theme doesn't provide them.
-.wp-block {
-	max-width: $content-width;
-
-	&[data-align="wide"] {
-		max-width: 1100px;
-	}
-
-	&[data-align="full"] {
-		max-width: none;
-	}
-}
-
+@include default-block-widths();
 @include wordpress-admin-schemes();

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -77,3 +77,4 @@ body.toplevel_page_gutenberg-edit-site {
 }
 
 @include wordpress-admin-schemes();
+@include default-block-widths();

--- a/packages/editor/src/editor-styles.scss
+++ b/packages/editor/src/editor-styles.scss
@@ -127,7 +127,7 @@ ol ul {
 	}
 
 	&.wp-align-wide {
-		max-width: 1100px;
+		max-width: $content-width;
 	}
 }
 

--- a/storybook/stories/playground/editor-styles.scss
+++ b/storybook/stories/playground/editor-styles.scss
@@ -44,7 +44,7 @@
 	}
 	.wp-block[data-align="wide"],
 	.wp-block.alignwide {
-		max-width: 1100px;
+		max-width: $content-width;
 	}
 	.wp-block[data-align="full"],
 	.wp-block.alignfull {


### PR DESCRIPTION
Fixes #26630. 

The full-site editor does not currently set the default widths for blocks, leaving all blocks to appear full-width unless a theme specifically adds a max-width. 

This PR brings the max-width rules from `edit-post` into `edit-site` too. I created a mixin for them to avoid duplicating code. I also moved the wide-content width (1100px) into a new variable since it was used in multiple places. 

## Testing

1. Activate a block-based theme that does not set the default width for blocks in its editor styles.*
2. Add default, wide, and full-width blocks in the full site editor. Verify that they appear similar to the way they do in the post editor. 

_*You can use [Twenty Twenty-One Blocks](https://github.com/WordPress/theme-experiments/tree/master/twentytwentyone-blocks) if you remove [these lines](https://github.com/WordPress/theme-experiments/blob/ba1a7f86e0a1f8f9de1e68bde45ded8dea093e8c/twentytwentyone-blocks/assets/css/style-editor.css#L1-L15)._ 

Before|After
---|---
![Screen Shot 2020-11-10 at 8 59 13 AM](https://user-images.githubusercontent.com/1202812/98683737-65040a80-2333-11eb-93c0-d4931b2dc8fc.png)|![Screen Shot 2020-11-10 at 8 55 38 AM](https://user-images.githubusercontent.com/1202812/98683734-646b7400-2333-11eb-8ba6-1fb28a4c12a0.png)
