### PR TITLE
Fix Fatal for unregistered taxonomy (#26851)

### DIFF
--- a/packages/block-library/src/post-hierarchical-terms/index.php
+++ b/packages/block-library/src/post-hierarchical-terms/index.php
@@ -19,6 +19,9 @@ function render_block_core_post_hierarchical_terms( $attributes, $content, $bloc
 	}
 
 	$post_hierarchical_terms = get_the_terms( $block->context['postId'], $attributes['term'] );
+	if ( is_wp_error( $post_hierarchical_terms ) ) {
+		return '';
+	}
 	if ( empty( $post_hierarchical_terms ) ) {
 		return '';
 	}


### PR DESCRIPTION
## Description
When the `core/post-hierarchical-terms` block has been passed an invalid taxonomy name for the `term` attribute it produced a Fatal error due to not detecting a WordPress error (  `WP_error` object )  returned from `get_the_terms()`.

This fix adds an `is_wp_error()` test, returning an empty string when detected. 

## How has this been tested?
Tested with Twenty Twenty-One Blocks in WordPress 5.6-beta3

I manually created a post using the code editor containing.
```
<!-- wp:post-hierarchical-terms {"term":"26851"} /-->

<!-- wp:post-hierarchical-terms {"term":"category"} /-->
```
Prior to applying the fix I got the Fatal error.
After applying the fix the output showed the taxonomy terms associated with Categories.
There was no visible output for the unknown taxonomy.
With the fix applied the post could be viewed and edited, using both the Code and Visual editor.


## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/2474435/98688289-98aa5900-2362-11eb-90e9-5a9581369da5.png)


## Types of changes
Fixes #26851 

<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->


