### PR TITLE
I18n: Add changelog entry for #26171

### DIFF
--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+- Improve type declarations for translation functions ([#26171](https://github.com/WordPress/gutenberg/pull/26171))
+
 ## 3.12.0 (2020-04-30)
 
 ### Bug Fix


### PR DESCRIPTION
## Description
This is just a CHANGELOG entry from https://github.com/WordPress/gutenberg/pull/26171

## Types of changes
Internal / documentation.