### PR TITLE
Update docs for custom spacing

### DIFF
--- a/docs/designers-developers/developers/themes/theme-support.md
+++ b/docs/designers-developers/developers/themes/theme-support.md
@@ -388,9 +388,9 @@ To make the content resize and keep its aspect ratio, the `<body>` element needs
 add_theme_support( 'responsive-embeds' );
 ```
 
-## Cover block padding
+## Spacing control
 
-Some blocks can provide padding controls in the editor for users. This is off by default, and requires the theme to opt in by declaring support:
+Using the Gutenberg plugin (version 8.3 or later), some blocks can provide padding controls in the editor for users. This is off by default, and requires the theme to opt in by declaring support:
 
 ```php
 add_theme_support('custom-spacing');


### PR DESCRIPTION
In https://github.com/WordPress/gutenberg/pull/25788 we made `custom-spacing` stable. However, it didn't make it to WordPress 5.6, so it still requires the plugin to work. This PR adds a note about that.

See also [this conversation](https://github.com/WordPress/gutenberg/pull/26771#discussion_r519633507).