### PR TITLE
make social list block align right able on published page & preview

### DIFF
--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -57,6 +57,17 @@
 	&.has-huge-icon-size {
 		font-size: 48px;
 	}
+
+	// Center flex items. This has an equivalent in editor.scss.
+	// It also needs to override some of the default classes usually applied to the centering class.
+	// align left must not be set, because this is the default (flex-start).
+	&.aligncenter {
+		justify-content: center;
+		display: flex;
+	}
+	&.alignright {
+		justify-content: flex-end;
+	}
 }
 
 .wp-social-link {
@@ -86,13 +97,6 @@
 	&:hover {
 		transform: scale(1.1);
 	}
-}
-
-// Center flex items. This has an equivalent in editor.scss.
-// It also needs to override some of the default classes usually applied to the centering class.
-.wp-block-social-links.aligncenter {
-	justify-content: center;
-	display: flex;
 }
 
 


### PR DESCRIPTION
## Description
Fixes a bug in the social list block where you could not right-align it on the published page or preview (because css rule was missing).
Unfortunately there is no issue for this. I noticed this while creating a website in gutenberg.
Because align left and center was set with flexbox, i used it for alignright too.
Found on the latest version of gutenberg.

Also i have moved / cleaned the code a little bit, because style lint was giving me an "warning".

## How has this been tested?
tested the css change in multiple browsers and viewports.
Browsers: Safari, Chrome, Firefox.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
