### PR TITLE
Add: Font appearance control on global styles

### DIFF
--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -29,6 +29,7 @@ export { default as ContrastChecker } from './contrast-checker';
 export { default as __experimentalGradientPicker } from './gradient-picker';
 export { default as __experimentalGradientPickerControl } from './gradient-picker/control';
 export { default as __experimentalGradientPickerPanel } from './gradient-picker/panel';
+export { default as __experimentalFontAppearanceControl } from './font-appearance-control';
 export { default as __experimentalFontFamilyControl } from './font-family';
 export { default as __experimentalColorGradientControl } from './colors-gradients/control';
 export { default as __experimentalPanelColorGradientSettings } from './colors-gradients/panel-color-gradient-settings';

--- a/packages/edit-site/src/components/sidebar/typography-panel.js
+++ b/packages/edit-site/src/components/sidebar/typography-panel.js
@@ -4,6 +4,7 @@
 import {
 	LineHeightControl,
 	__experimentalFontFamilyControl as FontFamilyControl,
+	__experimentalFontAppearanceControl as FontAppearanceControl,
 } from '@wordpress/block-editor';
 import { PanelBody, FontSizePicker } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -14,9 +15,10 @@ import { __ } from '@wordpress/i18n';
 import { useEditorFeature } from '../editor/utils';
 
 export function useHasTypographyPanel( { supports, name } ) {
+	const hasLineHeight = useHasLineHeightControl( { supports, name } );
+	const hasFontAppearence = useHasAppearenceControl( { supports, name } );
 	return (
-		useHasLineHeightControl( { supports, name } ) ||
-		supports.includes( 'fontSize' )
+		hasLineHeight || hasFontAppearence || supports.includes( 'fontSize' )
 	);
 }
 
@@ -24,6 +26,18 @@ function useHasLineHeightControl( { supports, name } ) {
 	return (
 		useEditorFeature( 'typography.customLineHeight', name ) &&
 		supports.includes( 'lineHeight' )
+	);
+}
+
+function useHasAppearenceControl( { supports, name } ) {
+	const fontStyles = useEditorFeature( 'typography.fontStyles', name );
+	const fontWeights = useEditorFeature( 'typography.fontWeights', name );
+	const hasFontAppearance = !! fontStyles?.length && !! fontWeights?.length;
+
+	return (
+		hasFontAppearance &&
+		supports.includes( 'fontStyle' ) &&
+		supports.includes( 'fontWeight' )
 	);
 }
 
@@ -38,7 +52,10 @@ export default function TypographyPanel( {
 		name
 	);
 	const fontFamilies = useEditorFeature( 'typography.fontFamilies', name );
+	const fontStyles = useEditorFeature( 'typography.fontStyles', name );
+	const fontWeights = useEditorFeature( 'typography.fontWeights', name );
 	const hasLineHeightEnabled = useHasLineHeightControl( { supports, name } );
+	const hasAppearenceControl = useHasAppearenceControl( { supports, name } );
 
 	return (
 		<PanelBody title={ __( 'Typography' ) } initialOpen={ true }>
@@ -67,6 +84,19 @@ export default function TypographyPanel( {
 					onChange={ ( value ) =>
 						setStyleProperty( name, 'lineHeight', value )
 					}
+				/>
+			) }
+			{ hasAppearenceControl && (
+				<FontAppearanceControl
+					value={ {
+						fontStyle: getStyleProperty( name, 'fontStyle' ),
+						fontWeight: getStyleProperty( name, 'fontWeight' ),
+					} }
+					options={ { fontStyles, fontWeights } }
+					onChange={ ( { fontStyle, fontWeight } ) => {
+						setStyleProperty( name, 'fontStyle', fontStyle );
+						setStyleProperty( name, 'fontWeight', fontWeight );
+					} }
 				/>
 			) }
 		</PanelBody>


### PR DESCRIPTION
Follow up from https://github.com/WordPress/gutenberg/pull/26444.

Adds the font appearance control to global styles.

## How has this been tested?
I enabled the 2021 blocks theme.
I went to the site editor.
I opened the global styles sidebar, I went to the navigation block panel and I verified I could change the Font appearance.
