### PR TITLE
[RNMobile] File Block - Add Link To functionality

### DIFF
--- a/packages/block-editor/src/components/block-icon/index.native.js
+++ b/packages/block-editor/src/components/block-icon/index.native.js
@@ -8,15 +8,33 @@ import { View } from 'react-native';
  */
 import { Icon } from '@wordpress/components';
 import { blockDefault } from '@wordpress/icons';
+import { withPreferredColorScheme } from '@wordpress/compose';
 
-export default function BlockIcon( { icon, showColors = false } ) {
+/**
+ * Internal dependencies
+ */
+import styles from './style.scss';
+
+export function BlockIcon( {
+	icon,
+	showColors = false,
+	getStylesFromColorScheme,
+} ) {
 	if ( icon?.src === 'block-default' ) {
 		icon = {
 			src: blockDefault,
 		};
 	}
 
-	const renderedIcon = <Icon icon={ icon && icon.src ? icon.src : icon } />;
+	const renderedIcon = (
+		<Icon
+			icon={ icon && icon.src ? icon.src : icon }
+			{ ...getStylesFromColorScheme(
+				styles.iconPlaceholder,
+				styles.iconPlaceholderDark
+			) }
+		/>
+	);
 	const style = showColors
 		? {
 				backgroundColor: icon && icon.background,
@@ -26,3 +44,5 @@ export default function BlockIcon( { icon, showColors = false } ) {
 
 	return <View style={ style }>{ renderedIcon }</View>;
 }
+
+export default withPreferredColorScheme( BlockIcon );

--- a/packages/block-editor/src/components/block-icon/style.native.scss
+++ b/packages/block-editor/src/components/block-icon/style.native.scss
@@ -1,0 +1,7 @@
+.iconPlaceholder {
+	fill: $gray-dark;
+}
+
+.iconPlaceholderDark {
+	fill: $white;
+}

--- a/packages/block-library/src/file/edit.native.js
+++ b/packages/block-library/src/file/edit.native.js
@@ -252,7 +252,6 @@ export class FileEdit extends Component {
 							{ this.getInspectorControls( attributes ) }
 							<RichText
 								__unstableMobileNoFocusOnMount
-								fontSize={ 14 }
 								onChange={ this.onChangeFileName }
 								placeholder={ __( 'File name' ) }
 								rootTagsToEliminate={ [ 'p' ] }
@@ -272,6 +271,7 @@ export class FileEdit extends Component {
 									] }
 								>
 									<PlainText
+										style={ styles.buttonText }
 										value={ downloadButtonText }
 										onChange={
 											this.onChangeDownloadButtonText

--- a/packages/block-library/src/file/edit.native.js
+++ b/packages/block-library/src/file/edit.native.js
@@ -240,14 +240,19 @@ export class FileEdit extends Component {
 				}
 				onFinishMediaUploadWithFailure={ () => {} }
 				onMediaUploadStateReset={ this.mediaUploadStateReset }
-				renderContent={ ( { isUploadFailed, retryMessage } ) => {
+				renderContent={ ( {
+					isUploadInProgress,
+					isUploadFailed,
+					retryMessage,
+				} ) => {
 					if ( isUploadFailed ) {
 						return this.getErrorComponent( retryMessage );
 					}
 
 					return (
 						<View>
-							{ this.getToolbarEditButton( openMediaOptions ) }
+							{ isUploadInProgress ||
+								this.getToolbarEditButton( openMediaOptions ) }
 							{ getMediaOptions() }
 							{ this.getInspectorControls( attributes ) }
 							<RichText

--- a/packages/block-library/src/file/edit.native.js
+++ b/packages/block-library/src/file/edit.native.js
@@ -188,6 +188,31 @@ export class FileEdit extends Component {
 		);
 	}
 
+	getStyleForAlignment( align ) {
+		const getFlexAlign = ( alignment ) => {
+			switch ( alignment ) {
+				case 'right':
+					return 'flex-end';
+				case 'center':
+					return 'center';
+				default:
+					return 'flex-start';
+			}
+		};
+		return { alignSelf: getFlexAlign( align ) };
+	}
+
+	getTextAlignmentForAlignment( align ) {
+		switch ( align ) {
+			case 'right':
+				return 'right';
+			case 'center':
+				return 'center';
+			default:
+				return 'left';
+		}
+	}
+
 	getFileComponent( openMediaOptions, getMediaOptions ) {
 		const { attributes } = this.props;
 		const {
@@ -195,6 +220,7 @@ export class FileEdit extends Component {
 			downloadButtonText,
 			id,
 			showDownloadButton,
+			align,
 		} = attributes;
 
 		const dimmedStyle =
@@ -234,9 +260,17 @@ export class FileEdit extends Component {
 								underlineColorAndroid="transparent"
 								value={ fileName }
 								deleteEnter={ true }
+								textAlign={ this.getTextAlignmentForAlignment(
+									align
+								) }
 							/>
 							{ showDownloadButton && (
-								<View style={ finalButtonStyle }>
+								<View
+									style={ [
+										finalButtonStyle,
+										this.getStyleForAlignment( align ),
+									] }
+								>
 									<PlainText
 										value={ downloadButtonText }
 										onChange={

--- a/packages/block-library/src/file/edit.native.js
+++ b/packages/block-library/src/file/edit.native.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { View, Text } from 'react-native';
+import { View, Text, Clipboard } from 'react-native';
 import React from 'react';
 
 /**
@@ -22,17 +22,21 @@ import {
 	ToolbarGroup,
 	PanelBody,
 	ToggleControl,
+	BottomSheet,
+	withNotices,
 } from '@wordpress/components';
 import { file as icon, replace, button } from '@wordpress/icons';
 import { Component } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
+import { compose } from '@wordpress/compose';
+import { withDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import styles from './style.scss';
 
-export default class FileEdit extends Component {
+export class FileEdit extends Component {
 	constructor( props ) {
 		super( props );
 
@@ -53,6 +57,7 @@ export default class FileEdit extends Component {
 		this.onChangeDownloadButtonVisibility = this.onChangeDownloadButtonVisibility.bind(
 			this
 		);
+		this.onCopyURL = this.onCopyURL.bind( this );
 	}
 
 	componentDidMount() {
@@ -85,6 +90,13 @@ export default class FileEdit extends Component {
 
 	onChangeDownloadButtonVisibility( showDownloadButton ) {
 		this.props.setAttributes( { showDownloadButton } );
+	}
+
+	onCopyURL() {
+		const { href } = this.props.attributes;
+		Clipboard.setString( href );
+		this.props.closeSettings();
+		this.props.createInfoNotice( __( 'Copied!' ) );
 	}
 
 	updateMediaProgress( payload ) {
@@ -132,7 +144,7 @@ export default class FileEdit extends Component {
 			<BlockControls>
 				<ToolbarGroup>
 					<ToolbarButton
-						title={ __( 'Edit image' ) }
+						title={ __( 'Edit file' ) }
 						icon={ replace }
 						onClick={ open }
 					/>
@@ -151,6 +163,10 @@ export default class FileEdit extends Component {
 						label={ __( 'Show download button' ) }
 						checked={ showDownloadButton }
 						onChange={ this.onChangeDownloadButtonVisibility }
+					/>
+					<BottomSheet.Cell
+						label={ __( 'Copy file URL' ) }
+						onPress={ this.onCopyURL }
 					/>
 				</PanelBody>
 			</InspectorControls>
@@ -252,3 +268,16 @@ export default class FileEdit extends Component {
 		);
 	}
 }
+
+export default compose( [
+	withDispatch( ( dispatch ) => {
+		const { createInfoNotice } = dispatch( 'core/editor' );
+		return {
+			closeSettings() {
+				dispatch( 'core/edit-post' ).closeGeneralSidebar();
+			},
+			createInfoNotice,
+		};
+	} ),
+	withNotices,
+] )( FileEdit );

--- a/packages/block-library/src/file/edit.native.js
+++ b/packages/block-library/src/file/edit.native.js
@@ -25,7 +25,7 @@ import {
 	BottomSheet,
 	withNotices,
 } from '@wordpress/components';
-import { file as icon, replace, button } from '@wordpress/icons';
+import { file as icon, replace, button, external } from '@wordpress/icons';
 import { Component } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
@@ -58,6 +58,9 @@ export class FileEdit extends Component {
 			this
 		);
 		this.onCopyURL = this.onCopyURL.bind( this );
+		this.onChangeOpenInNewWindow = this.onChangeOpenInNewWindow.bind(
+			this
+		);
 	}
 
 	componentDidMount() {
@@ -97,6 +100,12 @@ export class FileEdit extends Component {
 		Clipboard.setString( href );
 		this.props.closeSettings();
 		this.props.createInfoNotice( __( 'Copied!' ) );
+	}
+
+	onChangeOpenInNewWindow( newValue ) {
+		this.props.setAttributes( {
+			textLinkTarget: newValue ? '_blank' : false,
+		} );
 	}
 
 	updateMediaProgress( payload ) {
@@ -153,11 +162,17 @@ export class FileEdit extends Component {
 		);
 	}
 
-	getInspectorControls( { showDownloadButton } ) {
+	getInspectorControls( { showDownloadButton, textLinkTarget } ) {
 		return (
 			<InspectorControls>
 				<PanelBody title={ __( 'File block settings' ) } />
 				<PanelBody>
+					<ToggleControl
+						icon={ external }
+						label={ __( 'Open in new tab' ) }
+						checked={ textLinkTarget === '_blank' }
+						onChange={ this.onChangeOpenInNewWindow }
+					/>
 					<ToggleControl
 						icon={ button }
 						label={ __( 'Show download button' ) }

--- a/packages/block-library/src/file/edit.native.js
+++ b/packages/block-library/src/file/edit.native.js
@@ -15,9 +15,15 @@ import {
 	PlainText,
 	BlockControls,
 	MediaUpload,
+	InspectorControls,
 } from '@wordpress/block-editor';
-import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
-import { file as icon, replace } from '@wordpress/icons';
+import {
+	ToolbarButton,
+	ToolbarGroup,
+	PanelBody,
+	ToggleControl,
+} from '@wordpress/components';
+import { file as icon, replace, button } from '@wordpress/icons';
 import { Component } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 
@@ -44,6 +50,9 @@ export default class FileEdit extends Component {
 			this
 		);
 		this.getFileComponent = this.getFileComponent.bind( this );
+		this.onChangeDownloadButtonVisibility = this.onChangeDownloadButtonVisibility.bind(
+			this
+		);
 	}
 
 	componentDidMount() {
@@ -72,6 +81,10 @@ export default class FileEdit extends Component {
 
 	onChangeDownloadButtonText( downloadButtonText ) {
 		this.props.setAttributes( { downloadButtonText } );
+	}
+
+	onChangeDownloadButtonVisibility( showDownloadButton ) {
+		this.props.setAttributes( { showDownloadButton } );
 	}
 
 	updateMediaProgress( payload ) {
@@ -128,9 +141,30 @@ export default class FileEdit extends Component {
 		);
 	}
 
+	getInspectorControls( { showDownloadButton } ) {
+		return (
+			<InspectorControls>
+				<PanelBody title={ __( 'File block settings' ) } />
+				<PanelBody>
+					<ToggleControl
+						icon={ button }
+						label={ __( 'Show download button' ) }
+						checked={ showDownloadButton }
+						onChange={ this.onChangeDownloadButtonVisibility }
+					/>
+				</PanelBody>
+			</InspectorControls>
+		);
+	}
+
 	getFileComponent( openMediaOptions, getMediaOptions ) {
 		const { attributes } = this.props;
-		const { fileName, downloadButtonText, id } = attributes;
+		const {
+			fileName,
+			downloadButtonText,
+			id,
+			showDownloadButton,
+		} = attributes;
 
 		const dimmedStyle =
 			this.state.isUploadInProgress && styles.disabledButton;
@@ -158,6 +192,7 @@ export default class FileEdit extends Component {
 						<View>
 							{ this.getToolbarEditButton( openMediaOptions ) }
 							{ getMediaOptions() }
+							{ this.getInspectorControls( attributes ) }
 							<RichText
 								__unstableMobileNoFocusOnMount
 								fontSize={ 14 }
@@ -169,12 +204,16 @@ export default class FileEdit extends Component {
 								value={ fileName }
 								deleteEnter={ true }
 							/>
-							<View style={ finalButtonStyle }>
-								<PlainText
-									value={ downloadButtonText }
-									onChange={ this.onChangeDownloadButtonText }
-								/>
-							</View>
+							{ showDownloadButton && (
+								<View style={ finalButtonStyle }>
+									<PlainText
+										value={ downloadButtonText }
+										onChange={
+											this.onChangeDownloadButtonText
+										}
+									/>
+								</View>
+							) }
 						</View>
 					);
 				} }

--- a/packages/block-library/src/file/edit.native.js
+++ b/packages/block-library/src/file/edit.native.js
@@ -114,6 +114,14 @@ export default class FileEdit extends Component {
 		const { attributes } = this.props;
 		const { href, fileName, downloadButtonText, id } = attributes;
 
+		const dimmedStyle =
+			this.state.isUploadInProgress && styles.disabledButton;
+		const finalButtonStyle = Object.assign(
+			{},
+			styles.defaultButton,
+			dimmedStyle
+		);
+
 		if ( ! href ) {
 			return (
 				<MediaPlaceholder
@@ -156,7 +164,7 @@ export default class FileEdit extends Component {
 								value={ fileName }
 								deleteEnter={ true }
 							/>
-							<View style={ styles.defaultButton }>
+							<View style={ finalButtonStyle }>
 								<PlainText
 									value={ downloadButtonText }
 									onChange={ this.onChangeDownloadButtonText }

--- a/packages/block-library/src/file/edit.native.js
+++ b/packages/block-library/src/file/edit.native.js
@@ -13,8 +13,11 @@ import {
 	MediaUploadProgress,
 	RichText,
 	PlainText,
+	BlockControls,
+	MediaUpload,
 } from '@wordpress/block-editor';
-import { file as icon } from '@wordpress/icons';
+import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
+import { file as icon, replace } from '@wordpress/icons';
 import { Component } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 
@@ -40,6 +43,7 @@ export default class FileEdit extends Component {
 		this.finishMediaUploadWithSuccess = this.finishMediaUploadWithSuccess.bind(
 			this
 		);
+		this.getFileComponent = this.getFileComponent.bind( this );
 	}
 
 	componentDidMount() {
@@ -110,9 +114,23 @@ export default class FileEdit extends Component {
 		);
 	}
 
-	render() {
+	getToolbarEditButton( open ) {
+		return (
+			<BlockControls>
+				<ToolbarGroup>
+					<ToolbarButton
+						title={ __( 'Edit image' ) }
+						icon={ replace }
+						onClick={ open }
+					/>
+				</ToolbarGroup>
+			</BlockControls>
+		);
+	}
+
+	getFileComponent( openMediaOptions, getMediaOptions ) {
 		const { attributes } = this.props;
-		const { href, fileName, downloadButtonText, id } = attributes;
+		const { fileName, downloadButtonText, id } = attributes;
 
 		const dimmedStyle =
 			this.state.isUploadInProgress && styles.disabledButton;
@@ -121,21 +139,6 @@ export default class FileEdit extends Component {
 			styles.defaultButton,
 			dimmedStyle
 		);
-
-		if ( ! href ) {
-			return (
-				<MediaPlaceholder
-					icon={ <BlockIcon icon={ icon } /> }
-					labels={ {
-						title: __( 'File' ),
-						instructions: __( 'CHOOSE A FILE' ),
-					} }
-					onSelect={ this.onSelectFile }
-					onFocus={ this.props.onFocus }
-					allowedTypes={ [ 'other' ] }
-				/>
-			);
-		}
 
 		return (
 			<MediaUploadProgress
@@ -153,6 +156,8 @@ export default class FileEdit extends Component {
 
 					return (
 						<View>
+							{ this.getToolbarEditButton( openMediaOptions ) }
+							{ getMediaOptions() }
 							<RichText
 								__unstableMobileNoFocusOnMount
 								fontSize={ 14 }
@@ -172,6 +177,37 @@ export default class FileEdit extends Component {
 							</View>
 						</View>
 					);
+				} }
+			/>
+		);
+	}
+
+	render() {
+		const { attributes } = this.props;
+		const { href } = attributes;
+
+		if ( ! href ) {
+			return (
+				<MediaPlaceholder
+					icon={ <BlockIcon icon={ icon } /> }
+					labels={ {
+						title: __( 'File' ),
+						instructions: __( 'CHOOSE A FILE' ),
+					} }
+					onSelect={ this.onSelectFile }
+					onFocus={ this.props.onFocus }
+					allowedTypes={ [ 'other' ] }
+				/>
+			);
+		}
+
+		return (
+			<MediaUpload
+				allowedTypes={ [ 'other' ] }
+				isReplacingMedia={ true }
+				onSelect={ this.onSelectFile }
+				render={ ( { open, getMediaOptions } ) => {
+					return this.getFileComponent( open, getMediaOptions );
 				} }
 			/>
 		);

--- a/packages/block-library/src/file/edit.native.js
+++ b/packages/block-library/src/file/edit.native.js
@@ -27,13 +27,14 @@ import {
 import { file as icon, replace, button, external } from '@wordpress/icons';
 import { Component } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
+import { withPreferredColorScheme } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
 import styles from './style.scss';
 
-export default class FileEdit extends Component {
+export class FileEdit extends Component {
 	constructor( props ) {
 		super( props );
 
@@ -108,7 +109,7 @@ export default class FileEdit extends Component {
 		this.setState( { isUrlCopied: true } );
 		this.timerRef = setTimeout( () => {
 			this.setState( { isUrlCopied: false } );
-		}, 1000 );
+		}, 1500 );
 	}
 
 	onChangeOpenInNewWindow( newValue ) {
@@ -172,6 +173,11 @@ export default class FileEdit extends Component {
 	}
 
 	getInspectorControls( { showDownloadButton, textLinkTarget } ) {
+		const actionButtonStyle = this.props.getStylesFromColorScheme(
+			styles.actionButton,
+			styles.actionButtonDark
+		);
+
 		return (
 			<InspectorControls>
 				<PanelBody title={ __( 'File block settings' ) } />
@@ -193,6 +199,9 @@ export default class FileEdit extends Component {
 							this.state.isUrlCopied
 								? __( 'Copied!' )
 								: __( 'Copy file URL' )
+						}
+						labelStyle={
+							this.state.isUrlCopied || actionButtonStyle
 						}
 						onPress={ this.onCopyURL }
 					/>
@@ -335,3 +344,5 @@ export default class FileEdit extends Component {
 		);
 	}
 }
+
+export default withPreferredColorScheme( FileEdit );

--- a/packages/block-library/src/file/edit.native.js
+++ b/packages/block-library/src/file/edit.native.js
@@ -34,6 +34,8 @@ import { withPreferredColorScheme } from '@wordpress/compose';
  */
 import styles from './style.scss';
 
+const URL_COPIED_NOTIFICATION_DURATION_MS = 1500;
+
 export class FileEdit extends Component {
 	constructor( props ) {
 		super( props );
@@ -109,7 +111,7 @@ export class FileEdit extends Component {
 		this.setState( { isUrlCopied: true } );
 		this.timerRef = setTimeout( () => {
 			this.setState( { isUrlCopied: false } );
-		}, 1500 );
+		}, URL_COPIED_NOTIFICATION_DURATION_MS );
 	}
 
 	onChangeOpenInNewWindow( newValue ) {

--- a/packages/block-library/src/file/edit.native.js
+++ b/packages/block-library/src/file/edit.native.js
@@ -174,12 +174,19 @@ export class FileEdit extends Component {
 		);
 	}
 
-	getInspectorControls( { showDownloadButton, textLinkTarget } ) {
+	getInspectorControls(
+		{ showDownloadButton, textLinkTarget },
+		isUploadInProgress,
+		isUploadFailed
+	) {
 		const actionButtonStyle = this.props.getStylesFromColorScheme(
 			styles.actionButton,
 			styles.actionButtonDark
 		);
 
+		const isCopyUrlDisabled = isUploadFailed || isUploadInProgress;
+		const shouldStyleCopyUrlButton =
+			! isCopyUrlDisabled && ! this.state.isUrlCopied;
 		return (
 			<InspectorControls>
 				<PanelBody title={ __( 'File block settings' ) } />
@@ -197,13 +204,14 @@ export class FileEdit extends Component {
 						onChange={ this.onChangeDownloadButtonVisibility }
 					/>
 					<BottomSheet.Cell
+						disabled={ isCopyUrlDisabled }
 						label={
 							this.state.isUrlCopied
 								? __( 'Copied!' )
 								: __( 'Copy file URL' )
 						}
 						labelStyle={
-							this.state.isUrlCopied || actionButtonStyle
+							shouldStyleCopyUrlButton && actionButtonStyle
 						}
 						onPress={ this.onCopyURL }
 					/>
@@ -278,7 +286,11 @@ export class FileEdit extends Component {
 							{ isUploadInProgress ||
 								this.getToolbarEditButton( openMediaOptions ) }
 							{ getMediaOptions() }
-							{ this.getInspectorControls( attributes ) }
+							{ this.getInspectorControls(
+								attributes,
+								isUploadInProgress,
+								isUploadFailed
+							) }
 							<RichText
 								__unstableMobileNoFocusOnMount
 								onChange={ this.onChangeFileName }

--- a/packages/block-library/src/file/edit.native.js
+++ b/packages/block-library/src/file/edit.native.js
@@ -23,11 +23,19 @@ import {
 	PanelBody,
 	ToggleControl,
 	BottomSheet,
+	SelectControl,
 } from '@wordpress/components';
-import { file as icon, replace, button, external } from '@wordpress/icons';
+import {
+	file as icon,
+	replace,
+	button,
+	external,
+	link,
+} from '@wordpress/icons';
 import { Component } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
-import { withPreferredColorScheme } from '@wordpress/compose';
+import { compose, withPreferredColorScheme } from '@wordpress/compose';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -45,7 +53,6 @@ export class FileEdit extends Component {
 		};
 
 		this.timerRef = null;
-
 		this.onSelectFile = this.onSelectFile.bind( this );
 		this.onChangeFileName = this.onChangeFileName.bind( this );
 		this.onChangeDownloadButtonText = this.onChangeDownloadButtonText.bind(
@@ -61,6 +68,10 @@ export class FileEdit extends Component {
 		);
 		this.onCopyURL = this.onCopyURL.bind( this );
 		this.onChangeOpenInNewWindow = this.onChangeOpenInNewWindow.bind(
+			this
+		);
+
+		this.onChangeLinkDestinationOption = this.onChangeLinkDestinationOption.bind(
 			this
 		);
 	}
@@ -99,6 +110,11 @@ export class FileEdit extends Component {
 
 	onChangeDownloadButtonVisibility( showDownloadButton ) {
 		this.props.setAttributes( { showDownloadButton } );
+	}
+
+	onChangeLinkDestinationOption( newHref ) {
+		// Choose Media File or Attachment Page (when file is in Media Library)
+		this.props.setAttributes( { textLinkHref: newHref } );
 	}
 
 	onCopyURL() {
@@ -175,10 +191,21 @@ export class FileEdit extends Component {
 	}
 
 	getInspectorControls(
-		{ showDownloadButton, textLinkTarget },
+		{ showDownloadButton, textLinkTarget, href, textLinkHref },
+		media,
 		isUploadInProgress,
 		isUploadFailed
 	) {
+		let linkDestinationOptions = [ { value: href, label: __( 'URL' ) } ];
+		const attachmentPage = media && media.link;
+
+		if ( attachmentPage ) {
+			linkDestinationOptions = [
+				{ value: href, label: __( 'Media file' ) },
+				{ value: attachmentPage, label: __( 'Attachment page' ) },
+			];
+		}
+
 		const actionButtonStyle = this.props.getStylesFromColorScheme(
 			styles.actionButton,
 			styles.actionButtonDark
@@ -191,6 +218,13 @@ export class FileEdit extends Component {
 			<InspectorControls>
 				<PanelBody title={ __( 'File block settings' ) } />
 				<PanelBody>
+					<SelectControl
+						icon={ link }
+						label={ __( 'Link to' ) }
+						value={ textLinkHref }
+						onChange={ this.onChangeLinkDestinationOption }
+						options={ linkDestinationOptions }
+					/>
 					<ToggleControl
 						icon={ external }
 						label={ __( 'Open in new tab' ) }
@@ -246,7 +280,8 @@ export class FileEdit extends Component {
 	}
 
 	getFileComponent( openMediaOptions, getMediaOptions ) {
-		const { attributes } = this.props;
+		const { attributes, media } = this.props;
+
 		const {
 			fileName,
 			downloadButtonText,
@@ -288,6 +323,7 @@ export class FileEdit extends Component {
 							{ getMediaOptions() }
 							{ this.getInspectorControls(
 								attributes,
+								media,
 								isUploadInProgress,
 								isUploadFailed
 							) }
@@ -359,4 +395,14 @@ export class FileEdit extends Component {
 	}
 }
 
-export default withPreferredColorScheme( FileEdit );
+export default compose( [
+	withSelect( ( select, props ) => {
+		const { attributes } = props;
+		const { id } = attributes;
+		return {
+			media:
+				id === undefined ? undefined : select( 'core' ).getMedia( id ),
+		};
+	} ),
+	withPreferredColorScheme,
+] )( FileEdit );

--- a/packages/block-library/src/file/style.native.scss
+++ b/packages/block-library/src/file/style.native.scss
@@ -4,7 +4,12 @@
 	border-width: $border-width;
 	margin-top: $grid-unit-20;
 	background-color: $button-fallback-bg;
+}
+
+.buttonText {
+	background-color: transparent;
 	color: $white;
+	font-size: 16;
 }
 
 .disabledButton {

--- a/packages/block-library/src/file/style.native.scss
+++ b/packages/block-library/src/file/style.native.scss
@@ -8,6 +8,10 @@
 	align-self: flex-start;
 }
 
+.disabledButton {
+	opacity: 0.4;
+}
+
 .uploadFailedText {
 	color: #fff;
 	font-size: 14;

--- a/packages/block-library/src/file/style.native.scss
+++ b/packages/block-library/src/file/style.native.scss
@@ -5,7 +5,6 @@
 	margin-top: $grid-unit-20;
 	background-color: $button-fallback-bg;
 	color: $white;
-	align-self: flex-start;
 }
 
 .disabledButton {

--- a/packages/block-library/src/file/style.native.scss
+++ b/packages/block-library/src/file/style.native.scss
@@ -26,3 +26,11 @@
 	flex: 1;
 	background-color: "rgba(0, 0, 0, 0.5)";
 }
+
+.actionButton {
+	color: $blue-50;
+}
+
+.actionButtonDark {
+	color: $blue-30;
+}

--- a/packages/react-native-editor/ios/Podfile.lock
+++ b/packages/react-native-editor/ios/Podfile.lock
@@ -416,9 +416,9 @@ SPEC CHECKSUMS:
   react-native-get-random-values: 03edb8dcc2d3f43e55aa67ea13b61b6723bbf047
   react-native-keyboard-aware-scroll-view: 6cb84879bf07e4cc1caed18b11fb928e142adac6
   react-native-safe-area: c9cf765aa2dd96159476a99633e7d462ce5bb94f
-  react-native-safe-area-context: 133d77d86b13cf694e014ab03dc2944ee3125d97
+  react-native-safe-area-context: c8da723dcddabe15afe95c9d31c56a0cf2b0141c
   react-native-slider: 2e42dc91e7ab8b35a9c7f2eb3532729a41d0dbe2
-  react-native-video: e5dd0649534076cd6d09a0db51c617fa668d534a
+  react-native-video: b8767f54061e475ddd38c22375f46f4d93e5fdfd
   React-RCTActionSheet: 600b4d10e3aea0913b5a92256d2719c0cdd26d76
   React-RCTAnimation: 791a87558389c80908ed06cc5dfc5e7920dfa360
   React-RCTBlob: d89293cc0236d9cb0933d85e430b0bbe81ad1d72
@@ -430,7 +430,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: a49a1f42bf8f5acf1c3e297097517c6b3af377ad
   ReactCommon: 198c7c8d3591f975e5431bec1b0b3b581aa1c5dd
   ReactNativeDarkMode: 6d807bc8373b872472c8541fc3341817d979a6fb
-  RNCMaskedView: dfeba59697c44d36abec79c062aeb1ea343d610d
+  RNCMaskedView: 66caacf33c86eaa7d22b43178dd998257d5c2e4d
   RNGestureHandler: 7a377d0580c9f07df99e590bbcefd616ee0e2626
   RNReanimated: f05baf4cd76b6eab2e4d7e2b244424960b968918
   RNScreens: 953633729a42e23ad0c93574d676b361e3335e8b


### PR DESCRIPTION
Gutenberg Mobile PR https://github.com/wordpress-mobile/gutenberg-mobile/pull/2810
WP Android PR https://github.com/wordpress-mobile/WordPress-Android/pull/13405

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
This PR adds the `Link To` functionality in the File Block settings. When you select this option you will be greeted with a modal that allows you to select either an Attachment File or Media File as the link of the File Block. Doing so will add the appropriate `<a href>` tag to the block. 

## How has this been tested?

To properly test this behavior you will need to use one of the parent apps as the `getMedia` function requires the file to exist within the site. So if you test this PR here, you will see the URL as the only Link To option as seen below.

<kbd><img src="https://user-images.githubusercontent.com/1509205/99341781-86e01e80-2858-11eb-9421-06210babf8c1.png" width="320"></kbd>

Once you have this PR's submodule reference updated in the respective parent app project, you can follow the testing instructions below. 

#### Media File

1. Create a new post. 
2. Add a File Block. 
3. Add a file. 
4. Click the settings button. 
5. Ensure the Link To is set to Media File. 
6. Close this modal. 
7. Switch to HTML mode. 
8. Go to the File Block within the html.
9. Observe that the href within the first a tag has a link to the media file. To be sure, you will see the file's extension here.
 
<kbd><img src="https://user-images.githubusercontent.com/1509205/99327669-6d36db00-2848-11eb-9fd0-07173d2d5022.png" width="320"></kbd>

#### Attachment Page

1. Create a new post. 
2. Add a File Block. 
3. Add a file. 
4. Click the settings button. 
5. Ensure the Link To is set to Attachment Page. 
6. Close this modal. 
7. Switch to HTML mode. 
8. Go to the File Block within the html.
9. Observe that the the href within the first a tag has a link to a WordPress page. 

<kbd><img src="https://user-images.githubusercontent.com/1509205/99327710-850e5f00-2848-11eb-8e6d-eee095086565.png" width="320"></kbd>

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
