### PR TITLE
Render template part preview as div

### DIFF
--- a/packages/block-library/src/template-part/edit/selection/template-part-previews.js
+++ b/packages/block-library/src/template-part/edit/selection/template-part-previews.js
@@ -59,6 +59,7 @@ function TemplatePartItem( {
 
 	return (
 		<CompositeItem
+			as="div"
 			className="wp-block-template-part__selection-preview-item"
 			role="option"
 			onClick={ onClick }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
While trying to figure out the axe-core e2e issue, I observed a react error which can occur when the template part preview opens:

<img width="2373" alt="Screen Shot 2020-11-10 at 6 10 46 PM" src="https://user-images.githubusercontent.com/6265975/98756780-1597fb80-2380-11eb-9930-b710db999028.png">

The fix is to render the preview button as a div instead of a button.

## How has this been tested?
1. Clear all template parts and templates, and activate the twenty-twentyone theme.
2. In the normal post editor, insert a template part (footer) and publish the post.
3. Select the template part block and open the template part switching dropdown.

Before:
4. Error would display in console.
After:
4. Error does not display.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
