### PR TITLE
Modifies the widgets dashboard link to point to the new widgets editor

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -127,8 +127,17 @@ function modify_admin_bar( $wp_admin_bar ) {
 }
 add_action( 'admin_bar_menu', 'modify_admin_bar', 40 );
 
+
 remove_action( 'welcome_panel', 'wp_welcome_panel' );
-function modify_welcome_panel( $wp_admin_bar ) {
+/**
+ * Modify Dashboard welcome panel.
+ *
+ * When widgets are merged in core this should go into `wp-admin/includes/dashboard.php`
+ * and replace the widgets link in the `wp_welcome_panel` checking for the same condition,
+ * because then `gutenberg_use_widgets_block_editor` will exist in core.
+ * 
+ */
+function modify_welcome_panel() {
 	ob_start();
 	wp_welcome_panel();
 	$welcome_panel = ob_get_clean();

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -127,6 +127,23 @@ function modify_admin_bar( $wp_admin_bar ) {
 }
 add_action( 'admin_bar_menu', 'modify_admin_bar', 40 );
 
+remove_action( 'welcome_panel', 'wp_welcome_panel' );
+function modify_welcome_panel( $wp_admin_bar ) {
+	ob_start();
+	wp_welcome_panel();
+	$welcome_panel = ob_get_clean();
+	if ( gutenberg_use_widgets_block_editor() ) {
+		echo str_replace(
+			admin_url( 'widgets.php' ),
+			admin_url( 'themes.php?page=gutenberg-widgets' ),
+			$welcome_panel
+		);
+	} else {
+		echo $welcome_panel;
+	}
+}
+add_action( 'welcome_panel', 'modify_welcome_panel', 40 );
+
 /**
  * Display a version notice and deactivate the Gutenberg plugin.
  *

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -135,7 +135,6 @@ remove_action( 'welcome_panel', 'wp_welcome_panel' );
  * When widgets are merged in core this should go into `wp-admin/includes/dashboard.php`
  * and replace the widgets link in the `wp_welcome_panel` checking for the same condition,
  * because then `gutenberg_use_widgets_block_editor` will exist in core.
- * 
  */
 function modify_welcome_panel() {
 	ob_start();


### PR DESCRIPTION
Closes #26563:

![image](https://user-images.githubusercontent.com/107534/98791371-a4068e80-240d-11eb-854c-621aaca2b95e.png)

- Uses output buffering to replace the widgets link in the dashboard welcome panel.