### PR TITLE
Try: Show reduced UI on hover

### DIFF
--- a/packages/block-editor/src/components/preview-options/style.scss
+++ b/packages/block-editor/src/components/preview-options/style.scss
@@ -39,3 +39,27 @@
 		}
 	}
 }
+
+
+// Reduced UI.
+.edit-post-header.has-reduced-ui {
+	// Apply transition to first two buttons.
+	.edit-post-header__settings .editor-post-saved-state,
+	.edit-post-header__settings .block-editor-post-preview__button-toggle {
+		transition: opacity 0.1s linear;
+		@include reduce-motion("transition");
+	}
+
+	// Zero out opacity unless hovered.
+	&:not(:hover) {
+		.edit-post-header__settings .editor-post-saved-state,
+		.edit-post-header__settings .block-editor-post-preview__button-toggle {
+			opacity: 0;
+		}
+
+		// ... or opened.
+		.edit-post-header__settings .block-editor-post-preview__button-toggle.is-opened {
+			opacity: 1;
+		}
+	}
+}

--- a/packages/block-editor/src/components/preview-options/style.scss
+++ b/packages/block-editor/src/components/preview-options/style.scss
@@ -40,7 +40,6 @@
 	}
 }
 
-
 // Reduced UI.
 .edit-post-header.has-reduced-ui {
 	// Apply transition to first two buttons.

--- a/packages/block-editor/src/components/preview-options/style.scss
+++ b/packages/block-editor/src/components/preview-options/style.scss
@@ -44,6 +44,7 @@
 // Reduced UI.
 .edit-post-header.has-reduced-ui {
 	// Apply transition to first two buttons.
+	.edit-post-header__settings .editor-post-save-draft,
 	.edit-post-header__settings .editor-post-saved-state,
 	.edit-post-header__settings .block-editor-post-preview__button-toggle {
 		transition: opacity 0.1s linear;
@@ -52,6 +53,7 @@
 
 	// Zero out opacity unless hovered.
 	&:not(:hover) {
+		.edit-post-header__settings .editor-post-save-draft,
 		.edit-post-header__settings .editor-post-saved-state,
 		.edit-post-header__settings .block-editor-post-preview__button-toggle {
 			opacity: 0;

--- a/packages/block-editor/src/components/preview-options/style.scss
+++ b/packages/block-editor/src/components/preview-options/style.scss
@@ -42,25 +42,27 @@
 
 // Reduced UI.
 .edit-post-header.has-reduced-ui {
-	// Apply transition to first two buttons.
-	.edit-post-header__settings .editor-post-save-draft,
-	.edit-post-header__settings .editor-post-saved-state,
-	.edit-post-header__settings .block-editor-post-preview__button-toggle {
-		transition: opacity 0.1s linear;
-		@include reduce-motion("transition");
-	}
-
-	// Zero out opacity unless hovered.
-	&:not(:hover) {
+	@include break-small() {
+		// Apply transition to first two buttons.
 		.edit-post-header__settings .editor-post-save-draft,
 		.edit-post-header__settings .editor-post-saved-state,
 		.edit-post-header__settings .block-editor-post-preview__button-toggle {
-			opacity: 0;
+			transition: opacity 0.1s linear;
+			@include reduce-motion("transition");
 		}
 
-		// ... or opened.
-		.edit-post-header__settings .block-editor-post-preview__button-toggle.is-opened {
-			opacity: 1;
+		// Zero out opacity unless hovered.
+		&:not(:hover) {
+			.edit-post-header__settings .editor-post-save-draft,
+			.edit-post-header__settings .editor-post-saved-state,
+			.edit-post-header__settings .block-editor-post-preview__button-toggle {
+				opacity: 0;
+			}
+
+			// ... or opened.
+			.edit-post-header__settings .block-editor-post-preview__button-toggle.is-opened {
+				opacity: 1;
+			}
 		}
 	}
 }

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -29,7 +29,6 @@ function HeaderToolbar() {
 	const inserterButton = useRef();
 	const { setIsInserterOpened } = useDispatch( 'core/edit-post' );
 	const {
-		hasReducedUI,
 		hasFixedToolbar,
 		isInserterEnabled,
 		isInserterOpened,
@@ -65,9 +64,6 @@ function HeaderToolbar() {
 				'showIconLabels'
 			),
 			isNavigationTool: select( 'core/block-editor' ).isNavigationMode(),
-			hasReducedUI: select( 'core/edit-post' ).isFeatureActive(
-				'reducedUI'
-			),
 		};
 	}, [] );
 	const isLargeViewport = useViewportMatch( 'medium' );
@@ -141,7 +137,7 @@ function HeaderToolbar() {
 				>
 					{ showIconLabels && __( 'Add' ) }
 				</ToolbarItem>
-				{ ! hasReducedUI && ( isWideViewport || ! showIconLabels ) && (
+				{ ( isWideViewport || ! showIconLabels ) && (
 					<>
 						{ isLargeViewport && (
 							<ToolbarItem
@@ -164,55 +160,50 @@ function HeaderToolbar() {
 						{ overflowItems }
 					</>
 				) }
-				{ ! hasReducedUI &&
-					! isWideViewport &&
-					! isSmallViewport &&
-					showIconLabels && (
-						<DropdownMenu
-							position="bottom right"
-							label={
-								/* translators: button label text should, if possible, be under 16
-	characters. */
-								__( 'Tools' )
-							}
-						>
-							{ () => (
-								<div className="edit-post-header__dropdown">
-									<MenuGroup label={ __( 'Modes' ) }>
-										<MenuItemsChoice
-											value={
-												isNavigationTool
-													? 'select'
-													: 'edit'
-											}
-											onSelect={ onSwitchMode }
-											choices={ [
-												{
-													value: 'edit',
-													label: __( 'Edit' ),
-												},
-												{
-													value: 'select',
-													label: __( 'Select' ),
-												},
-											] }
-										/>
-									</MenuGroup>
-									<MenuGroup label={ __( 'Edit' ) }>
-										<EditorHistoryUndo
-											showTooltip={ ! showIconLabels }
-											isTertiary={ showIconLabels }
-										/>
-										<EditorHistoryRedo
-											showTooltip={ ! showIconLabels }
-											isTertiary={ showIconLabels }
-										/>
-									</MenuGroup>
-									<MenuGroup>{ overflowItems }</MenuGroup>
-								</div>
-							) }
-						</DropdownMenu>
-					) }
+				{ ! isWideViewport && ! isSmallViewport && showIconLabels && (
+					<DropdownMenu
+						position="bottom right"
+						label={
+							/* translators: button label text should, if possible, be under 16
+characters. */
+							__( 'Tools' )
+						}
+					>
+						{ () => (
+							<div className="edit-post-header__dropdown">
+								<MenuGroup label={ __( 'Modes' ) }>
+									<MenuItemsChoice
+										value={
+											isNavigationTool ? 'select' : 'edit'
+										}
+										onSelect={ onSwitchMode }
+										choices={ [
+											{
+												value: 'edit',
+												label: __( 'Edit' ),
+											},
+											{
+												value: 'select',
+												label: __( 'Select' ),
+											},
+										] }
+									/>
+								</MenuGroup>
+								<MenuGroup label={ __( 'Edit' ) }>
+									<EditorHistoryUndo
+										showTooltip={ ! showIconLabels }
+										isTertiary={ showIconLabels }
+									/>
+									<EditorHistoryRedo
+										showTooltip={ ! showIconLabels }
+										isTertiary={ showIconLabels }
+									/>
+								</MenuGroup>
+								<MenuGroup>{ overflowItems }</MenuGroup>
+							</div>
+						) }
+					</DropdownMenu>
+				) }
 			</div>
 
 			{ displayBlockToolbar && (

--- a/packages/edit-post/src/components/header/header-toolbar/style.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.scss
@@ -48,6 +48,22 @@
 	}
 }
 
+// Reduced UI.
+.edit-post-header.has-reduced-ui {
+	// Apply transition to every button but the first one.
+	.edit-post-header-toolbar__left > * + .components-button,
+	.edit-post-header-toolbar__left > * + .components-dropdown > [aria-expanded="false"] {
+		transition: opacity 0.1s linear;
+		@include reduce-motion("transition");
+	}
+
+	// Zero out opacity unless hovered.
+	&:not(:hover) .edit-post-header-toolbar__left > * + .components-button,
+	&:not(:hover) .edit-post-header-toolbar__left > * + .components-dropdown > [aria-expanded="false"] {
+		opacity: 0;
+	}
+}
+
 .edit-post-header-toolbar__left {
 	display: inline-flex;
 	align-items: center;

--- a/packages/edit-post/src/components/header/header-toolbar/style.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.scss
@@ -50,17 +50,19 @@
 
 // Reduced UI.
 .edit-post-header.has-reduced-ui {
-	// Apply transition to every button but the first one.
-	.edit-post-header-toolbar__left > * + .components-button,
-	.edit-post-header-toolbar__left > * + .components-dropdown > [aria-expanded="false"] {
-		transition: opacity 0.1s linear;
-		@include reduce-motion("transition");
-	}
+	@include break-small () {
+		// Apply transition to every button but the first one.
+		.edit-post-header-toolbar__left > * + .components-button,
+		.edit-post-header-toolbar__left > * + .components-dropdown > [aria-expanded="false"] {
+			transition: opacity 0.1s linear;
+			@include reduce-motion("transition");
+		}
 
-	// Zero out opacity unless hovered.
-	&:not(:hover) .edit-post-header-toolbar__left > * + .components-button,
-	&:not(:hover) .edit-post-header-toolbar__left > * + .components-dropdown > [aria-expanded="false"] {
-		opacity: 0;
+		// Zero out opacity unless hovered.
+		&:not(:hover) .edit-post-header-toolbar__left > * + .components-button,
+		&:not(:hover) .edit-post-header-toolbar__left > * + .components-dropdown > [aria-expanded="false"] {
+			opacity: 0;
+		}
 	}
 }
 

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { PostSavedState, PostPreviewButton } from '@wordpress/editor';
@@ -44,8 +49,13 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 
 	const isLargeViewport = useViewportMatch( 'large' );
 
+	const classes = classnames( {
+		'edit-post-header': true,
+		'has-reduced-ui': hasReducedUI,
+	} );
+
 	return (
-		<div className="edit-post-header">
+		<div className={ classes }>
 			<MainDashboardButton.Slot>
 				<FullscreenModeClose />
 			</MainDashboardButton.Slot>
@@ -53,7 +63,7 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 				<HeaderToolbar />
 			</div>
 			<div className="edit-post-header__settings">
-				{ ! hasReducedUI && (
+				{
 					<>
 						{ ! isPublishSidebarOpened && (
 							// This button isn't completely hidden by the publish sidebar.
@@ -73,7 +83,7 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 							forcePreviewLink={ isSaving ? null : undefined }
 						/>
 					</>
-				) }
+				}
 				<PostPublishButtonOrToggle
 					forceIsDirty={ hasActiveMetaboxes }
 					forceIsSaving={ isSaving }

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -49,8 +49,7 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 
 	const isLargeViewport = useViewportMatch( 'large' );
 
-	const classes = classnames( {
-		'edit-post-header': true,
+	const classes = classnames( 'edit-post-header', {
 		'has-reduced-ui': hasReducedUI,
 	} );
 
@@ -63,27 +62,23 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 				<HeaderToolbar />
 			</div>
 			<div className="edit-post-header__settings">
-				{
-					<>
-						{ ! isPublishSidebarOpened && (
-							// This button isn't completely hidden by the publish sidebar.
-							// We can't hide the whole toolbar when the publish sidebar is open because
-							// we want to prevent mounting/unmounting the PostPublishButtonOrToggle DOM node.
-							// We track that DOM node to return focus to the PostPublishButtonOrToggle
-							// when the publish sidebar has been closed.
-							<PostSavedState
-								forceIsDirty={ hasActiveMetaboxes }
-								forceIsSaving={ isSaving }
-								showIconLabels={ showIconLabels }
-							/>
-						) }
-						<DevicePreview />
-						<PostPreviewButton
-							forceIsAutosaveable={ hasActiveMetaboxes }
-							forcePreviewLink={ isSaving ? null : undefined }
-						/>
-					</>
-				}
+				{ ! isPublishSidebarOpened && (
+					// This button isn't completely hidden by the publish sidebar.
+					// We can't hide the whole toolbar when the publish sidebar is open because
+					// we want to prevent mounting/unmounting the PostPublishButtonOrToggle DOM node.
+					// We track that DOM node to return focus to the PostPublishButtonOrToggle
+					// when the publish sidebar has been closed.
+					<PostSavedState
+						forceIsDirty={ hasActiveMetaboxes }
+						forceIsSaving={ isSaving }
+						showIconLabels={ showIconLabels }
+					/>
+				) }
+				<DevicePreview />
+				<PostPreviewButton
+					forceIsAutosaveable={ hasActiveMetaboxes }
+					forcePreviewLink={ isSaving ? null : undefined }
+				/>
 				<PostPublishButtonOrToggle
 					forceIsDirty={ hasActiveMetaboxes }
 					forceIsSaving={ isSaving }


### PR DESCRIPTION
In options, there's a non-default toggle to provide a reduced UI — a more focused writing experience. Here:

<img width="436" alt="Screenshot 2020-11-11 at 09 41 46" src="https://user-images.githubusercontent.com/1204802/98792146-589cb200-2406-11eb-8d29-7713ccee28f0.png">

I've always liked that idea as an option for people to choose a leaner writing experience. But I also felt that the removal of items in the top toolbar was frustrating when waiting for autosave to kick in, or when wanting to preview. 

This PR tries to keep to the spirit of the reduced UI, but bringing back those options **until you hover the top toolbar**. Before:

![before](https://user-images.githubusercontent.com/1204802/98792370-ae715a00-2406-11eb-9bc2-2db0d5a44957.gif)

After:

![after](https://user-images.githubusercontent.com/1204802/98792376-b0d3b400-2406-11eb-90f3-2d2efeccf331.gif)

Let me know your thoughts!