### PR TITLE
Enforce curly braces in eslint config

### DIFF
--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bug Fixes
 
 -   Fix TypeError for projects without a local Prettier configuration.
+-   Re-enable 'curly' rule, which prettier disables.
 
 ## 7.2.0 (2020-09-03)
 

--- a/packages/eslint-plugin/configs/prettier-overrides.js
+++ b/packages/eslint-plugin/configs/prettier-overrides.js
@@ -1,0 +1,11 @@
+// Prettier can conflict with particular eslint rules, so its config disables
+// them. Some rules however, are subtler and particular options can be
+// renabled. This ruleset re-enables some rules that are in the WordPress
+// JavaScript coding standards and are mentioned in the prettier docs as
+// not causing a conflict:
+// https://github.com/prettier/eslint-config-prettier#special-rules
+module.exports = {
+	rules: {
+		curly: [ 'error', 'all' ],
+	},
+};

--- a/packages/eslint-plugin/configs/recommended.js
+++ b/packages/eslint-plugin/configs/recommended.js
@@ -17,6 +17,7 @@ module.exports = {
 		require.resolve( './recommended-with-formatting.js' ),
 		'plugin:prettier/recommended',
 		'prettier/react',
+		require.resolve( './prettier-overrides.js' ),
 	],
 	rules: {
 		'prettier/prettier': [ 'error', prettierConfig ],


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
On a few PRs recently I've noticed the eslint 'curly' rule that requires curly braces for if, else, for, while, or do statements isn't resulting in errors.

The cause is prettier's eslint config which purposely disabled some rules that could cause a conflict with prettier's formatting. 

However, the docs mention that some of these rules can be re-enabled when configured in a particular way:
https://github.com/prettier/eslint-config-prettier#curly

Curly is one of those rules if configured using the 'all' option, which just happens to be what WordPress also requires.

## How has this been tested?
1. Checkout this PR
2. Write an if statement in your editor without curly braces
3. There should be a linting error (some editors may need to be restarted for the rule to take effect)
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
<img width="387" alt="Screenshot 2020-11-11 at 6 37 17 pm" src="https://user-images.githubusercontent.com/677833/98801607-003cd300-244d-11eb-9627-55a88c715c6e.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
