### PR TITLE
Try: Don't wrap menu items.

### DIFF
--- a/packages/components/src/dropdown-menu/style.scss
+++ b/packages/components/src/dropdown-menu/style.scss
@@ -14,6 +14,7 @@
 		padding: 6px;
 		outline: none;
 		cursor: pointer;
+		white-space: nowrap;
 
 		&.has-separator {
 			margin-top: 6px;


### PR DESCRIPTION
I recently merged a change that removes the min-width that was applied to all popover menus (#25218). This allows menus that are better sized according to their contents.

Only, this type of menu item did not look very good: 

<img width="349" alt="Screenshot 2020-11-11 at 12 33 15" src="https://user-images.githubusercontent.com/1204802/98807298-b89d5380-241a-11eb-893d-0a19ab1f4c67.png">

This PR makes that menu item not wrap:

<img width="375" alt="Screenshot 2020-11-11 at 12 34 33" src="https://user-images.githubusercontent.com/1204802/98807310-bcc97100-241a-11eb-9abe-156e3c3bda98.png">
