### PR TITLE
Site Editor: Navigation panel add blue dot to customized templates

### DIFF
--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
@@ -135,7 +135,7 @@
 
 .edit-site-navigation-panel__template-item-customized-dot {
 	position: absolute;
-	right: $grid-unit-05;
+	right: 0;
 	top: 50%;
 	margin-top: -$grid-unit-05;
 	width: $grid-unit-10;
@@ -143,4 +143,5 @@
 	display: block;
 	background: var(--wp-admin-theme-color);
 	border-radius: 50%;
+	cursor: default;
 }

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
@@ -143,5 +143,5 @@
 	display: block;
 	background: var(--wp-admin-theme-color);
 	border-radius: 50%;
-	cursor: default;
+	cursor: help;
 }

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
@@ -97,8 +97,8 @@
 		}
 	}
 
-	.components-button,
-	button {
+	button,
+	.components-button {
 		display: flex;
 		flex-direction: column;
 		align-items: flex-start;

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
@@ -87,7 +87,18 @@
 .edit-site-navigation-panel__template-item {
 	display: block;
 
-	.components-button {
+	&.is-active {
+		.edit-site-navigation-panel__template-item-description {
+			color: $gray-100;
+		}
+
+		.edit-site-navigation-panel__template-item-customized-dot {
+			background: #fff;
+		}
+	}
+
+	.components-button,
+	button {
 		display: flex;
 		flex-direction: column;
 		align-items: flex-start;
@@ -114,4 +125,22 @@
 	button {
 		margin: 0;
 	}
+}
+
+.edit-site-navigation-panel__template-item-title {
+	display: inline-block;
+	padding-right: $grid-unit-20;
+	position: relative;
+}
+
+.edit-site-navigation-panel__template-item-customized-dot {
+	position: absolute;
+	right: $grid-unit-05;
+	top: 50%;
+	margin-top: -$grid-unit-05;
+	width: $grid-unit-10;
+	height: $grid-unit-10;
+	display: block;
+	background: var(--wp-admin-theme-color);
+	border-radius: 50%;
 }

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
@@ -93,7 +93,7 @@
 		}
 
 		.edit-site-navigation-panel__template-item-customized-dot {
-			background: #fff;
+			background: $white;
 		}
 	}
 

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/template-navigation-item.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/template-navigation-item.js
@@ -44,7 +44,9 @@ export default function TemplateNavigationItem( { item } ) {
 					{ item.type === 'wp_template' &&
 						item.status !== 'auto-draft' && (
 							<Tooltip
-								text={ __( 'This theme template has been customized' ) }
+								text={ __(
+									'This theme template has been customized'
+								) }
 								position="top center"
 							>
 								<span className="edit-site-navigation-panel__template-item-customized-dot" />

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/template-navigation-item.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/template-navigation-item.js
@@ -3,10 +3,12 @@
  */
 import {
 	Button,
+	Tooltip,
 	__experimentalNavigationItem as NavigationItem,
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -37,7 +39,18 @@ export default function TemplateNavigationItem( { item } ) {
 				onMouseEnter={ () => setIsPreviewVisible( true ) }
 				onMouseLeave={ () => setIsPreviewVisible( false ) }
 			>
-				{ title }
+				<div className="edit-site-navigation-panel__template-item-title">
+					{ title }
+					{ item.type === 'wp_template' &&
+						item.status !== 'auto-draft' && (
+							<Tooltip
+								text={ __( 'Customized' ) }
+								position="top center"
+							>
+								<span className="edit-site-navigation-panel__template-item-customized-dot" />
+							</Tooltip>
+						) }
+				</div>
 				{ description && (
 					<div className="edit-site-navigation-panel__template-item-description">
 						{ description }

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/template-navigation-item.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/template-navigation-item.js
@@ -42,7 +42,8 @@ export default function TemplateNavigationItem( { item } ) {
 				<div className="edit-site-navigation-panel__template-item-title">
 					{ title }
 					{ item.type === 'wp_template' &&
-						item.status !== 'auto-draft' && (
+						item.status !== 'auto-draft' &&
+						item.file_based && (
 							<Tooltip
 								text={ __(
 									'This theme template has been customized'

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/template-navigation-item.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/template-navigation-item.js
@@ -44,7 +44,7 @@ export default function TemplateNavigationItem( { item } ) {
 					{ item.type === 'wp_template' &&
 						item.status !== 'auto-draft' && (
 							<Tooltip
-								text={ __( 'Customized' ) }
+								text={ __( 'This theme template has been customized' ) }
 								position="top center"
 							>
 								<span className="edit-site-navigation-panel__template-item-customized-dot" />


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Resolves https://github.com/WordPress/gutenberg/issues/26451

Add a blue dot to customized templates.

## How has this been tested?
- Open site editor
- Open navigation panel
- Navigate to Templates
- Customized templates should have a blue dot next to their name

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/2256104/98823428-5f411e80-2432-11eb-8a68-22f3b8974c33.png)
![image](https://user-images.githubusercontent.com/2256104/98823446-66682c80-2432-11eb-8148-8a64e3d03e00.png)

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
