### PR TITLE
Site Logo: Delete sitelogo option rather than syncing it when setting theme mod

### DIFF
--- a/packages/block-library/src/site-logo/index.php
+++ b/packages/block-library/src/site-logo/index.php
@@ -49,7 +49,7 @@ function register_block_core_site_logo() {
 			'render_callback' => 'render_block_core_site_logo',
 		)
 	);
-	add_filter( 'pre_set_theme_mod_custom_logo', 'sync_site_logo_to_theme_mod' );
+	add_filter( 'pre_set_theme_mod_custom_logo', 'delete_site_logo_when_setting_theme_mod' );
 	add_filter( 'theme_mod_custom_logo', 'override_custom_logo_theme_mod' );
 }
 add_action( 'init', 'register_block_core_site_logo' );
@@ -67,15 +67,15 @@ function override_custom_logo_theme_mod( $custom_logo ) {
 }
 
 /**
- * Syncs the site logo with the theme modified logo.
+ * Delete the site logo upon setting the custom logo theme mod.
  *
  * @param string $custom_logo The custom logo set by a theme.
  *
  * @return string The custom logo.
  */
-function sync_site_logo_to_theme_mod( $custom_logo ) {
+function delete_site_logo_when_setting_theme_mod( $custom_logo ) {
 	if ( $custom_logo ) {
-		update_option( 'sitelogo', $custom_logo );
+		delete_option( 'sitelogo' );
 	}
 	return $custom_logo;
 }


### PR DESCRIPTION
## Description
Tentative fix for #25173. Will update with more details and testing instructions a bit later today.

The Site Logo block (introduced in #18811) uses the [custom logo](https://developer.wordpress.org/themes/functionality/custom-logo/) theme mod concept. This allows it to be set both through the actual Site Block UI, and through the customizer. However, being a theme mod, a custom logo is stored per-theme, and is lost when switching themes.

The Site Logo block thus tapped into two hooks to extend the theme mod behavior, so a site logo would persist across theme changes:
- `theme_mod_custom_logo` is called when the `get_custom_logo()` is called (e.g. by a theme, or the Site Block). The Site Block added the `override_custom_logo_theme_mod` in order to return the `sitelogo` option if it's set, and otherwise fall back to the custom logo theme mod.
- `pre_set_theme_mod_custom_logo` is called whenever a custom logo is set via `set_theme_mod()` (e.g. by the customizer). The Site Block added the `sync_site_logo_to_theme_mod` filter to it, and propagated the changes to the `sitelogo` option.

The latter caused #25173: If a custom logo was _removed_ via `remove_theme_mod` through the customizer, the `pre_set_theme_mod_custom_logo` filter isn't run (there are no filters run from inside `remove_theme_mod`). Thus, while the custom logo theme mod was deleted, the `sitelogo` remained untouched. This means the next time `get_custom_logo` was called, the `override_custom_logo_theme_mod` filter would kick in, and return the `sitelogo` option.

One way to fix this would be to add a filter or hook to `remove_theme_mod` that we can tap into (props @sirreal ), but that's a change that would need to be made in Core.

I think we can get away with a simpler fix:

We change the `pre_set_theme_mod_custom_logo` filter to a function called `delete_site_logo_when_setting_theme_mod`, which does just that: When the custom logo theme mod is set (customizer), it deletes the `sitelogo` option. That way, the `override_custom_logo_theme_mod` won't find a site logo, and return the custom logo theme mod.

All other behavior should be retained as desired.

## How has this been tested?
See #25173 for instructions how to repro the issue, and verify that it's fixed.
Furthermore, this issue was caught by the `test_get_custom_logo` and `test_has_custom_logo` Core unit tests when run against GB 9.3. Verify that with this change, they now pass.

## Types of changes
Bugfix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->

cc/ @carolinan @sirreal @scruffian @pablinos @creativecoder 