### PR TITLE
[RNMobile] Fix Shortcode, Code, and Preformatted background colors

### DIFF
--- a/packages/react-native-editor/sass-transformer.js
+++ b/packages/react-native-editor/sass-transformer.js
@@ -48,9 +48,9 @@ const autoImportIncludePaths = [
 	path.join( path.dirname( __filename ), '../base-styles' ),
 ];
 const autoImportAssets = [
+	'_variables.scss',
 	'_colors.scss',
 	'_breakpoints.scss',
-	'_variables.scss',
 	'_native.scss',
 	'_mixins.scss',
 	'_animations.scss',


### PR DESCRIPTION
This PR fixes https://github.com/wordpress-mobile/gutenberg-mobile/pull/2787#issuecomment-725027459

Somehow https://github.com/WordPress/gutenberg/blob/f4a6965f1044179064cad0930d46aeb6f5e169fd/packages/base-styles/_variables.scss#L1 is finding `_colors.scss` directly, and importing all its content when `_variables.scss` is loaded, overwriting the values from the previously loaded `_colors.native.scss`.

Loading `_variables.scss` first makes `_colors.native.scss` overwrite `_colors.scss` instead, which is more expected.

This misbehaviour was introduced by https://github.com/WordPress/gutenberg/pull/25628, so this feels like an issue on the Dart sass compiler.

This PR provides a temporal workaround. The real intention would be that `@import "./colors";`  would always load `_colors.native.scss`, and `_colors.scss` is never loaded.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

- Clean and run Metro server `npm run native start:reset`
- Add a Shortcode, Code, or Preformatted block on dark mode.
- Check that the background is dark as shown on the screenshot.

## Screenshots <!-- if applicable -->

![Screenshot 2020-11-11 at 17 16 22](https://user-images.githubusercontent.com/9772967/98837665-818f6800-2443-11eb-91b9-82374737ba4a.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
