### PR TITLE
Remain back compatible with existing settings

### DIFF
--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -102,7 +102,7 @@ function gutenberg_edit_site_init( $hook ) {
 	$current_screen->is_block_editor( true );
 
 	$settings = array_merge(
-		gutenberg_get_block_editor_settings_common(),
+		gutenberg_get_common_block_editor_settings(),
 		array(
 			'alignWide'    => get_theme_support( 'align-wide' ),
 			'siteUrl'      => site_url(),

--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -108,7 +108,7 @@ function gutenberg_edit_site_init( $hook ) {
 			'siteUrl'      => site_url(),
 			'postsPerPage' => get_option( 'posts_per_page' ),
 			'styles'       => gutenberg_get_editor_styles(),
-		),
+		)
 	);
 	$settings = gutenberg_experimental_global_styles_settings( $settings );
 

--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -101,41 +101,16 @@ function gutenberg_edit_site_init( $hook ) {
 	 */
 	$current_screen->is_block_editor( true );
 
-	// Get editor settings.
-	$max_upload_size = wp_max_upload_size();
-	if ( ! $max_upload_size ) {
-		$max_upload_size = 0;
-	}
-
-	// This filter is documented in wp-admin/includes/media.php.
-	$image_size_names      = apply_filters(
-		'image_size_names_choose',
+	$settings = array_merge(
+		gutenberg_get_block_editor_settings_common(),
 		array(
-			'thumbnail' => __( 'Thumbnail', 'gutenberg' ),
-			'medium'    => __( 'Medium', 'gutenberg' ),
-			'large'     => __( 'Large', 'gutenberg' ),
-			'full'      => __( 'Full Size', 'gutenberg' ),
-		)
+			'alignWide'    => get_theme_support( 'align-wide' ),
+			'siteUrl'      => site_url(),
+			'postsPerPage' => get_option( 'posts_per_page' ),
+			'styles'       => gutenberg_get_editor_styles(),
+		),
 	);
-	$available_image_sizes = array();
-	foreach ( $image_size_names as $image_size_slug => $image_size_name ) {
-		$available_image_sizes[] = array(
-			'slug' => $image_size_slug,
-			'name' => $image_size_name,
-		);
-	}
-
-	$settings = array(
-		'alignWide'         => get_theme_support( 'align-wide' ),
-		'imageSizes'        => $available_image_sizes,
-		'isRTL'             => is_rtl(),
-		'maxUploadFileSize' => $max_upload_size,
-		'siteUrl'           => site_url(),
-		'postsPerPage'      => get_option( 'posts_per_page' ),
-	);
-
-	$settings['styles'] = gutenberg_get_editor_styles();
-	$settings           = gutenberg_experimental_global_styles_settings( $settings );
+	$settings = gutenberg_experimental_global_styles_settings( $settings );
 
 	// Preload block editor paths.
 	// most of these are copied from edit-forms-blocks.php.
@@ -165,7 +140,7 @@ function gutenberg_edit_site_init( $hook ) {
 			'wp.domReady( function() {
 				wp.editSite.initialize( "edit-site-editor", %s );
 			} );',
-			wp_json_encode( gutenberg_experiments_editor_settings( $settings ) )
+			wp_json_encode( $settings )
 		)
 	);
 

--- a/lib/editor-settings.php
+++ b/lib/editor-settings.php
@@ -52,6 +52,12 @@ function gutenberg_get_common_block_editor_settings() {
 
 	$font_sizes = current( (array) get_theme_support( 'editor-font-sizes' ) );
 	if ( false !== $font_sizes ) {
+		// Back-compatibility for presets without units.
+		foreach ( $font_sizes as &$font_size ) {
+			if ( is_numeric( $font_size['size'] ) ) {
+				$font_size['size'] = $font_size['size'] . 'px';
+			}
+		}
 		$settings['fontSizes'] = $font_sizes;
 	}
 

--- a/lib/editor-settings.php
+++ b/lib/editor-settings.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Utilities to manage editor settings.
+ *
+ * @package gutenberg
+ */
 
 /**
  * Returns editor settings that are common to all editors:
@@ -17,7 +22,7 @@ function gutenberg_get_common_block_editor_settings() {
 
 	$available_image_sizes = array();
 	// This filter is documented in wp-admin/includes/media.php.
-	$image_size_names      = apply_filters(
+	$image_size_names = apply_filters(
 		'image_size_names_choose',
 		array(
 			'thumbnail' => __( 'Thumbnail', 'gutenberg' ),
@@ -69,7 +74,14 @@ function gutenberg_get_common_block_editor_settings() {
 	return $settings;
 }
 
-function gutenberg_extend_post_editor_settings( $settings ){
+/**
+ * Extends the block editor with settings that are only in the plugin.
+ *
+ * @param array $settings Existing editor settings.
+ *
+ * @return array Filtered settings.
+ */
+function gutenberg_extend_post_editor_settings( $settings ) {
 	$settings['__unstableEnableFullSiteEditingBlocks'] = gutenberg_is_fse_theme();
 	return $settings;
 }

--- a/lib/editor-settings.php
+++ b/lib/editor-settings.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Returns editor settings that are common to all editors:
+ * post, site, widgets, and navigation.
+ *
+ * All these settings are already part of core,
+ * see edit-form-blocks.php
+ *
+ * @return array Common editor settings.
+ */
+function gutenberg_get_common_block_editor_settings() {
+	$max_upload_size = wp_max_upload_size();
+	if ( ! $max_upload_size ) {
+		$max_upload_size = 0;
+	}
+
+	$available_image_sizes = array();
+	// This filter is documented in wp-admin/includes/media.php.
+	$image_size_names      = apply_filters(
+		'image_size_names_choose',
+		array(
+			'thumbnail' => __( 'Thumbnail', 'gutenberg' ),
+			'medium'    => __( 'Medium', 'gutenberg' ),
+			'large'     => __( 'Large', 'gutenberg' ),
+			'full'      => __( 'Full Size', 'gutenberg' ),
+		)
+	);
+	foreach ( $image_size_names as $image_size_slug => $image_size_name ) {
+		$available_image_sizes[] = array(
+			'slug' => $image_size_slug,
+			'name' => $image_size_name,
+		);
+	};
+
+	$settings = array(
+		'__unstableEnableFullSiteEditingBlocks' => gutenberg_is_fse_theme(),
+		'disableCustomColors'                   => get_theme_support( 'disable-custom-colors' ),
+		'disableCustomFontSizes'                => get_theme_support( 'disable-custom-font-sizes' ),
+		'disableCustomGradients'                => get_theme_support( 'disable-custom-gradients' ),
+		'enableCustomLineHeight'                => get_theme_support( 'custom-line-height' ),
+		'enableCustomUnits'                     => get_theme_support( 'custom-units' ),
+		'imageSizes'                            => $available_image_sizes,
+		'isRTL'                                 => is_rtl(),
+		'maxUploadFileSize'                     => $max_upload_size,
+	);
+
+	$color_palette = current( (array) get_theme_support( 'editor-color-palette' ) );
+	if ( false !== $color_palette ) {
+		$settings['colors'] = $color_palette;
+	}
+
+	$font_sizes = current( (array) get_theme_support( 'editor-font-sizes' ) );
+	if ( false !== $font_sizes ) {
+		$settings['fontSizes'] = $font_sizes;
+	}
+
+	$gradient_presets = current( (array) get_theme_support( 'editor-gradient-presets' ) );
+	if ( false !== $gradient_presets ) {
+		$settings['gradients'] = $gradient_presets;
+	}
+
+	return $settings;
+}
+
+function gutenberg_extend_post_editor_settings( $settings ){
+	$settings['__unstableEnableFullSiteEditingBlocks'] = gutenberg_is_fse_theme();
+	return $settings;
+}
+add_filter( 'block_editor_settings', 'gutenberg_extend_post_editor_settings' );

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -88,23 +88,3 @@ function gutenberg_display_experiment_section() {
 
 	<?php
 }
-
-/**
- * Extends default editor settings with experiments settings.
- *
- * @param array $settings Default editor settings.
- *
- * @return array Filtered editor settings.
- */
-function gutenberg_experiments_editor_settings( $settings ) {
-	$experiments_settings = array(
-		'__unstableEnableFullSiteEditingBlocks' => gutenberg_is_fse_theme(),
-	);
-	$gradient_presets     = current( (array) get_theme_support( 'editor-gradient-presets' ) );
-	if ( false !== $gradient_presets ) {
-		$experiments_settings['gradients'] = $gradient_presets;
-	}
-
-	return array_merge( $settings, $experiments_settings );
-}
-add_filter( 'block_editor_settings', 'gutenberg_experiments_editor_settings' );

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -239,78 +239,49 @@ function gutenberg_experimental_global_styles_get_theme_support_settings( $setti
 	$theme_settings['global']['settings'] = array();
 
 	// Deprecated theme supports.
-	if (
-		array_key_exists( 'disableCustomColors', $settings ) &&
-		$settings['disableCustomColors']
-	) {
+	if ( isset( $settings['disableCustomColors'] ) ) {
 		if ( ! isset( $theme_settings['global']['settings']['color'] ) ) {
 			$theme_settings['global']['settings']['color'] = array();
 		}
-		$theme_settings['global']['settings']['color']['custom'] = false;
+		$theme_settings['global']['settings']['color']['custom'] = $settings['disableCustomColors'];
 		unset( $settings['disableCustomColors'] );
 	}
 
-	if (
-		array_key_exists( 'disableCustomGradients', $settings ) &&
-		$settings['disableCustomGradients']
-	) {
+	if ( isset( $settings['disableCustomGradients'] ) ) {
 		if ( ! isset( $theme_settings['global']['settings']['color'] ) ) {
 			$theme_settings['global']['settings']['color'] = array();
 		}
-		$theme_settings['global']['settings']['color']['customGradient'] = false;
+		$theme_settings['global']['settings']['color']['customGradient'] = $settings['disableCustomGradients'];
 		unset( $settings['disableCustomGradients'] );
 	}
 
-	if (
-		array_key_exists( 'disableCustomFontSizes', $settings ) &&
-		$settings['disableCustomFontSizes']
-	) {
+	if ( isset( $settings['disableCustomFontSizes'] ) ) {
 		if ( ! isset( $theme_settings['global']['settings']['typography'] ) ) {
 			$theme_settings['global']['settings']['typography'] = array();
 		}
-		$theme_settings['global']['settings']['typography']['customFontSize'] = false;
+		$theme_settings['global']['settings']['typography']['customFontSize'] = $settings['disableCustomFontSizes'];
 		unset( $settings['disableCustomFontSizes'] );
 	}
 
-	if (
-		array_key_exists( 'enableCustomLineHeight', $settings ) &&
-		$settings['enableCustomLineHeight']
-	) {
+	if ( isset( $settings['enableCustomLineHeight'] ) ) {
 		if ( ! isset( $theme_settings['global']['settings']['typography'] ) ) {
 			$theme_settings['global']['settings']['typography'] = array();
 		}
-		$theme_settings['global']['settings']['typography']['customLineHeight'] = true;
+		$theme_settings['global']['settings']['typography']['customLineHeight'] = $settings['enableCustomLineHeight'];
+		unset( $settings['enableCustomLineHeight'] );
 	}
 
-	if ( get_theme_support( 'custom-spacing' ) ) {
+	if ( isset( $settings['enableCustomUnits'] ) ) {
 		if ( ! isset( $theme_settings['global']['settings']['spacing'] ) ) {
 			$theme_settings['global']['settings']['spacing'] = array();
 		}
-		$theme_settings['global']['settings']['spacing']['custom'] = true;
-	}
-
-	if ( get_theme_support( 'experimental-link-color' ) ) {
-		if ( ! isset( $theme_settings['global']['settings']['color'] ) ) {
-			$theme_settings['global']['settings']['color'] = array();
-		}
-		$theme_settings['global']['settings']['color']['link'] = true;
-	}
-
-	$custom_units = array_key_exists( 'enableCustomUnits', $settings ) ? $settings['enableCustomUnits'] : false;
-	if ( $custom_units ) {
-		if ( ! isset( $theme_settings['global']['settings']['spacing'] ) ) {
-			$theme_settings['global']['settings']['spacing'] = array();
-		}
-		$theme_settings['global']['settings']['spacing']['units'] = ( true === $custom_units ) ?
+		$theme_settings['global']['settings']['spacing']['units'] = ( true === $settings['enableCustomUnits'] ) ?
 			array( 'px', 'em', 'rem', 'vh', 'vw' ) :
-			$custom_units;
+			$settings['enableCustomUnits'];
 		unset( $settings['enableCustomUnits'] );
 	}
 
-	if (
-		array_key_exists( 'colors', $settings ) &&
-		$settings['colors']
-	) {
+	if ( isset( $settings['colors'] ) ) {
 		if ( ! isset( $theme_settings['global']['settings']['color'] ) ) {
 			$theme_settings['global']['settings']['color'] = array();
 		}
@@ -318,10 +289,7 @@ function gutenberg_experimental_global_styles_get_theme_support_settings( $setti
 		unset( $settings['colors'] );
 	}
 
-	if (
-		array_key_exists( 'gradients', $settings ) &&
-		$settings['gradients']
-	) {
+	if ( isset( $settings['gradients'] ) ) {
 		if ( ! isset( $theme_settings['global']['settings']['color'] ) ) {
 			$theme_settings['global']['settings']['color'] = array();
 		}
@@ -329,10 +297,7 @@ function gutenberg_experimental_global_styles_get_theme_support_settings( $setti
 		unset( $settings['gradients'] );
 	}
 
-	if (
-		array_key_exists( 'fontSizes', $settings ) &&
-		$settings['fontSizes']
-	) {
+	if ( isset( $settings['fontSizes'] ) ) {
 		if ( ! isset( $theme_settings['global']['settings']['typography'] ) ) {
 			$theme_settings['global']['settings']['typography'] = array();
 		}

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -348,7 +348,7 @@ function gutenberg_experimental_global_styles_get_theme_support_settings( $setti
 		$theme_settings['global']['settings']['spacing']['custom'] = true;
 	}
 
-	if ( current ( (array) get_theme_support( 'experimental-link-color' ) ) ) {
+	if ( current( (array) get_theme_support( 'experimental-link-color' ) ) ) {
 		if ( ! isset( $theme_settings['global']['settings']['color'] ) ) {
 			$theme_settings['global']['settings']['color'] = array();
 		}

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -239,7 +239,10 @@ function gutenberg_experimental_global_styles_get_theme_support_settings( $setti
 	$theme_settings['global']['settings'] = array();
 
 	// Deprecated theme supports.
-	if ( $settings( 'disableCustomColors' ) ) {
+	if (
+		array_key_exists( 'disableCustomColors', $settings ) &&
+		$settings['disableCustomColors']
+	) {
 		if ( ! isset( $theme_settings['global']['settings']['color'] ) ) {
 			$theme_settings['global']['settings']['color'] = array();
 		}
@@ -247,7 +250,10 @@ function gutenberg_experimental_global_styles_get_theme_support_settings( $setti
 		unset( $settings['disableCustomColors'] );
 	}
 
-	if ( $settings( 'disableCustomGradients' ) ) {
+	if (
+		array_key_exists( 'disableCustomGradients', $settings ) &&
+		$settings['disableCustomGradients']
+	) {
 		if ( ! isset( $theme_settings['global']['settings']['color'] ) ) {
 			$theme_settings['global']['settings']['color'] = array();
 		}
@@ -255,7 +261,10 @@ function gutenberg_experimental_global_styles_get_theme_support_settings( $setti
 		unset( $settings['disableCustomGradients'] );
 	}
 
-	if ( $settings( 'disableCustomFontSizes' ) ) {
+	if (
+		array_key_exists( 'disableCustomFontSizes', $settings ) &&
+		$settings['disableCustomFontSizes']
+	) {
 		if ( ! isset( $theme_settings['global']['settings']['typography'] ) ) {
 			$theme_settings['global']['settings']['typography'] = array();
 		}
@@ -263,7 +272,10 @@ function gutenberg_experimental_global_styles_get_theme_support_settings( $setti
 		unset( $settings['disableCustomFontSizes'] );
 	}
 
-	if ( $settings( 'enableCustomLineHeight' ) ) {
+	if (
+		array_key_exists( 'enableCustomLineHeight', $settings ) &&
+		$settings['enableCustomLineHeight']
+	) {
 		if ( ! isset( $theme_settings['global']['settings']['typography'] ) ) {
 			$theme_settings['global']['settings']['typography'] = array();
 		}
@@ -284,7 +296,7 @@ function gutenberg_experimental_global_styles_get_theme_support_settings( $setti
 		$theme_settings['global']['settings']['color']['link'] = true;
 	}
 
-	$custom_units = $settings( 'enableCustomUnits' );
+	$custom_units = array_key_exists( 'enableCustomUnits', $settings ) ? $settings['enableCustomUnits'] : false;
 	if ( $custom_units ) {
 		if ( ! isset( $theme_settings['global']['settings']['spacing'] ) ) {
 			$theme_settings['global']['settings']['spacing'] = array();
@@ -295,7 +307,10 @@ function gutenberg_experimental_global_styles_get_theme_support_settings( $setti
 		unset( $settings['enableCustomUnits'] );
 	}
 
-	if ( $settings['colors'] ) {
+	if (
+		array_key_exists( 'colors', $settings ) &&
+		$settings['colors']
+	) {
 		if ( ! isset( $theme_settings['global']['settings']['color'] ) ) {
 			$theme_settings['global']['settings']['color'] = array();
 		}
@@ -303,7 +318,10 @@ function gutenberg_experimental_global_styles_get_theme_support_settings( $setti
 		unset( $settings['colors'] );
 	}
 
-	if ( $settings['gradients'] ) {
+	if (
+		array_key_exists( 'gradients', $settings ) &&
+		$settings['gradients']
+	) {
 		if ( ! isset( $theme_settings['global']['settings']['color'] ) ) {
 			$theme_settings['global']['settings']['color'] = array();
 		}
@@ -311,7 +329,10 @@ function gutenberg_experimental_global_styles_get_theme_support_settings( $setti
 		unset( $settings['gradients'] );
 	}
 
-	if ( $settings['fontSizes'] ) {
+	if (
+		array_key_exists( 'fontSizes', $settings ) &&
+		$settings['fontSizes']
+	) {
 		if ( ! isset( $theme_settings['global']['settings']['typography'] ) ) {
 			$theme_settings['global']['settings']['typography'] = array();
 		}
@@ -320,14 +341,14 @@ function gutenberg_experimental_global_styles_get_theme_support_settings( $setti
 	}
 
 	// Things that didn't land in core yet, so didn't have a setting assigned.
-	if ( get_theme_support( 'custom-spacing' ) ) {
+	if ( current( (array) get_theme_support( 'custom-spacing' ) ) ) {
 		if ( ! isset( $theme_settings['global']['settings']['spacing'] ) ) {
 			$theme_settings['global']['settings']['spacing'] = array();
 		}
 		$theme_settings['global']['settings']['spacing']['custom'] = true;
 	}
 
-	if ( get_theme_support( 'experimental-link-color' ) ) {
+	if ( current ( (array) get_theme_support( 'experimental-link-color' ) ) ) {
 		if ( ! isset( $theme_settings['global']['settings']['color'] ) ) {
 			$theme_settings['global']['settings']['color'] = array();
 		}
@@ -508,5 +529,5 @@ function gutenberg_experimental_global_styles_register_cpt() {
 }
 
 add_action( 'init', 'gutenberg_experimental_global_styles_register_cpt' );
-add_filter( 'block_editor_settings', 'gutenberg_experimental_global_styles_settings' );
+add_filter( 'block_editor_settings', 'gutenberg_experimental_global_styles_settings', PHP_INT_MAX );
 add_action( 'wp_enqueue_scripts', 'gutenberg_experimental_global_styles_enqueue_assets' );

--- a/lib/load.php
+++ b/lib/load.php
@@ -102,6 +102,7 @@ require_once __DIR__ . '/widgets-page.php';
 
 require __DIR__ . '/compat.php';
 require __DIR__ . '/utils.php';
+require __DIR__ . '/editor-settings.php';
 
 require __DIR__ . '/full-site-editing.php';
 require __DIR__ . '/templates-sync.php';

--- a/lib/navigation-page.php
+++ b/lib/navigation-page.php
@@ -33,7 +33,7 @@ function gutenberg_navigation_init( $hook ) {
 	}
 
 	$settings = array_merge(
-		gutenberg_get_block_editor_settings_common(),
+		gutenberg_get_common_block_editor_settings(),
 		array(
 			'blockNavMenus' => get_theme_support( 'block-nav-menus' ),
 		)

--- a/lib/navigation-page.php
+++ b/lib/navigation-page.php
@@ -32,44 +32,12 @@ function gutenberg_navigation_init( $hook ) {
 			return;
 	}
 
-	// Media settings.
-	$max_upload_size = wp_max_upload_size();
-	if ( ! $max_upload_size ) {
-		$max_upload_size = 0;
-	}
-
-	/** This filter is documented in wp-admin/includes/media.php */
-	$image_size_names = apply_filters(
-		'image_size_names_choose',
+	$settings = array_merge(
+		gutenberg_get_block_editor_settings_common(),
 		array(
-			'thumbnail' => __( 'Thumbnail', 'gutenberg' ),
-			'medium'    => __( 'Medium', 'gutenberg' ),
-			'large'     => __( 'Large', 'gutenberg' ),
-			'full'      => __( 'Full Size', 'gutenberg' ),
+			'blockNavMenus' => get_theme_support( 'block-nav-menus' ),
 		)
 	);
-
-	$available_image_sizes = array();
-	foreach ( $image_size_names as $image_size_slug => $image_size_name ) {
-		$available_image_sizes[] = array(
-			'slug' => $image_size_slug,
-			'name' => $image_size_name,
-		);
-	}
-
-	$settings = array(
-		'imageSizes'        => $available_image_sizes,
-		'isRTL'             => is_rtl(),
-		'maxUploadFileSize' => $max_upload_size,
-		'blockNavMenus'     => get_theme_support( 'block-nav-menus' ),
-	);
-
-	list( $font_sizes, ) = (array) get_theme_support( 'editor-font-sizes' );
-
-	if ( false !== $font_sizes ) {
-		$settings['fontSizes'] = $font_sizes;
-	}
-
 	$settings = gutenberg_experimental_global_styles_settings( $settings );
 
 	wp_add_inline_script(
@@ -78,7 +46,7 @@ function gutenberg_navigation_init( $hook ) {
 			'wp.domReady( function() {
 				wp.editNavigation.initialize( "navigation-editor", %s );
 			} );',
-			wp_json_encode( gutenberg_experiments_editor_settings( $settings ) )
+			wp_json_encode( $settings )
 		)
 	);
 

--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -43,37 +43,8 @@ function gutenberg_widgets_init( $hook ) {
 
 	$initializer_name = 'initialize';
 
-	// Media settings.
-	$max_upload_size = wp_max_upload_size();
-	if ( ! $max_upload_size ) {
-		$max_upload_size = 0;
-	}
-
-	/** This filter is documented in wp-admin/includes/media.php */
-	$image_size_names = apply_filters(
-		'image_size_names_choose',
-		array(
-			'thumbnail' => __( 'Thumbnail', 'gutenberg' ),
-			'medium'    => __( 'Medium', 'gutenberg' ),
-			'large'     => __( 'Large', 'gutenberg' ),
-			'full'      => __( 'Full Size', 'gutenberg' ),
-		)
-	);
-
-	$available_image_sizes = array();
-	foreach ( $image_size_names as $image_size_slug => $image_size_name ) {
-		$available_image_sizes[] = array(
-			'slug' => $image_size_slug,
-			'name' => $image_size_name,
-		);
-	}
-
 	$settings = array_merge(
-		array(
-			'imageSizes'        => $available_image_sizes,
-			'isRTL'             => is_rtl(),
-			'maxUploadFileSize' => $max_upload_size,
-		),
+		gutenberg_get_block_editor_settings_common(),
 		gutenberg_get_legacy_widget_settings()
 	);
 
@@ -109,7 +80,7 @@ function gutenberg_widgets_init( $hook ) {
 				wp.editWidgets.%s( "widgets-editor", %s );
 			} );',
 			$initializer_name,
-			wp_json_encode( gutenberg_experiments_editor_settings( $settings ) )
+			wp_json_encode( $settings )
 		)
 	);
 

--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -44,7 +44,7 @@ function gutenberg_widgets_init( $hook ) {
 	$initializer_name = 'initialize';
 
 	$settings = array_merge(
-		gutenberg_get_block_editor_settings_common(),
+		gutenberg_get_common_block_editor_settings(),
 		gutenberg_get_legacy_widget_settings()
 	);
 

--- a/lib/widgets.php
+++ b/lib/widgets.php
@@ -200,7 +200,7 @@ function gutenberg_get_legacy_widget_settings() {
 
 	$settings['availableLegacyWidgets'] = $available_legacy_widgets;
 
-	return gutenberg_experiments_editor_settings( $settings );
+	return $settings;
 }
 
 /**


### PR DESCRIPTION
Supersedes https://github.com/WordPress/gutenberg/pull/26540
Fixes https://github.com/WordPress/gutenberg/issues/26537

## How to test

- Activate a theme that doesn't have support for line-height.
  - For example, install latest [TwentyTwentyOneBlocks](https://github.com/WordPress/theme-experiments/tree/master/twentytwentyone-blocks) 
  - In functions.php, remove [this line](https://github.com/WordPress/theme-experiments/blob/master/twentytwentyone-blocks/functions.php#L218): `add_theme_support( 'custom-line-height' );`
  - In its theme.json, remove [this line](https://github.com/WordPress/theme-experiments/blob/master/twentytwentyone-blocks/experimental-theme.json#L101): `customLineHeight: true`
- Filter the editor settings to enable line-height. For example, paste this code into global-styles.php

```php
function gs_set_custom_line_height( $settings ) {
	$settings['enableCustomLineHeight'] = true;
	return $settings;
}
add_filter('block_editor_settings', 'gs_set_custom_line_height');
```

- Go to the post editor and add a paragraph. The expected result is that:

  - the line height UI control is enabled and visible in the block control sidebar
  - there's no `enableCustomLineHeight` settings passed down to the editor initialization or stored in the `settings` key of the `core/block-editor` store.
