### PR TITLE
Update base 64 in package lock (again)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52301,9 +52301,9 @@
 					"dev": true
 				},
 				"base64-js": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.0.tgz",
-					"integrity": "sha512-Jrdy04F2EKcNggUDfubMUPNAZg2vMquLQSm8sKLYJvz40ClFL1S8GKyDshGkNsbNNE5Z+fQavzU7nSK1I9JUGA==",
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
 					"dev": true
 				},
 				"bl": {
@@ -60565,9 +60565,9 @@
 			},
 			"dependencies": {
 				"base64-js": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.0.tgz",
-					"integrity": "sha512-Jrdy04F2EKcNggUDfubMUPNAZg2vMquLQSm8sKLYJvz40ClFL1S8GKyDshGkNsbNNE5Z+fQavzU7nSK1I9JUGA==",
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
 					"dev": true
 				},
 				"buffer": {


### PR DESCRIPTION
Though we already [did this once today](https://github.com/WordPress/gutenberg/pull/26888), it looks like base-64-js got a patch release, so it needs bumped once more. 🙃 