### PR TITLE
Buttons block: Fix default alignment icon in toolbar to reflect the actual default alignment of buttons

### DIFF
--- a/packages/block-library/src/buttons/content-justification-dropdown.js
+++ b/packages/block-library/src/buttons/content-justification-dropdown.js
@@ -30,7 +30,7 @@ const CONTROLS = {
 	},
 };
 
-const DEFAULT_ICON = CONTROLS.center.icon;
+const DEFAULT_ICON = CONTROLS.left.icon;
 
 /**
  * Dropdown for selecting a content justification option.


### PR DESCRIPTION
Fixes #26909. 
Updates the alignment icon in the toolbar to default to "Left" since that is how the buttons are defaulted. This also now aligns with the Navigation block which also defaults to showing the "Left" alignment icon.

## How has this been tested?
Locally.

## Screenshots

**BEFORE**

![Screen Shot 2020-11-11 at 4 02 58 PM](https://user-images.githubusercontent.com/617986/98878268-674f8d00-2437-11eb-8b26-2c8db250bc08.png)

**AFTER**

![Screen Shot 2020-11-11 at 4 03 06 PM](https://user-images.githubusercontent.com/617986/98878278-6d456e00-2437-11eb-9e96-302047d89d95.png)


## Types of changes
Non-breaking changes.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
