### PR TITLE
Fix pullquote alignment for solid color style

### DIFF
--- a/packages/block-library/src/pullquote/editor.scss
+++ b/packages/block-library/src/pullquote/editor.scss
@@ -13,9 +13,6 @@
 }
 
 .wp-block-pullquote.is-style-solid-color {
-	margin-left: 0;
-	margin-right: 0;
-
 	& blockquote p {
 		font-size: 32px;
 	}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
When using default editor styles (theme styles disabled), the pullquote block's solid color style has an incorrect alignment in the editor. It ends up on the left of the page, while it should be aligned the same as other blocks with text centered.

This is the same issue we've seen previously with Image (#26376) and Quote (#26680), the block's styles are overriding the editor's margin auto rules.

## How has this been tested?
1. Start a new post.
2. In the preferences, disable the 'Use theme styles' option.
3. Add a pullquote block and select the Solid color style
4. The block should be centrally aligned.

## Screenshots <!-- if applicable -->
### Before
<img width="852" alt="Screenshot 2020-11-12 at 11 00 16 am" src="https://user-images.githubusercontent.com/677833/98890175-573aba80-24d6-11eb-90d2-ad88894a2be9.png">

### After
<img width="739" alt="Screenshot 2020-11-12 at 11 00 44 am" src="https://user-images.githubusercontent.com/677833/98890190-5efa5f00-24d6-11eb-8448-3f885fa28209.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
