### PR TITLE
Add regresion E2E test for the empty reusable block causing WSODs issue

### DIFF
--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -3049,7 +3049,7 @@ describe( '__experimentalGetParsedReusableBlock', () => {
 	};
 
 	// Regression test for https://github.com/WordPress/gutenberg/issues/26485. See https://github.com/WordPress/gutenberg/issues/26548.
-	it( 'Should not throw an exception if reusable content.raw is an empty string', () => {
+	it( "should not throw an exception if reusable block's content.raw is an empty string", () => {
 		expect( () =>
 			__experimentalGetParsedReusableBlock( state, 1 )
 		).not.toThrowError();

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -3049,9 +3049,9 @@ describe( '__experimentalGetParsedReusableBlock', () => {
 	};
 
 	// Regression test for https://github.com/WordPress/gutenberg/issues/26485. See https://github.com/WordPress/gutenberg/issues/26548.
-	it( "should not throw an exception if reusable block's content.raw is an empty string", () => {
-		expect( () =>
-			__experimentalGetParsedReusableBlock( state, 1 )
-		).not.toThrowError();
+	it( "Should return an empty array if reusable block's content.raw is an empty string", () => {
+		expect( __experimentalGetParsedReusableBlock( state, 1 ) ).toEqual(
+			[]
+		);
 	} );
 } );

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -69,6 +69,7 @@ const {
 	__experimentalGetLastBlockAttributeChanges,
 	getLowestCommonAncestorWithSelectedBlock,
 	__experimentalGetActiveBlockIdByBlockNames: getActiveBlockIdByBlockNames,
+	__experimentalGetParsedReusableBlock,
 } = selectors;
 
 describe( 'selectors', () => {
@@ -3032,5 +3033,25 @@ describe( 'selectors', () => {
 				] )
 			).toEqual( 'client-id-03' );
 		} );
+	} );
+} );
+
+describe( '__experimentalGetParsedReusableBlock', () => {
+	const state = {
+		settings: {
+			__experimentalReusableBlocks: [
+				{
+					id: 1,
+					content: { raw: '' },
+				},
+			],
+		},
+	};
+
+	// Regression test for https://github.com/WordPress/gutenberg/issues/26485. See https://github.com/WordPress/gutenberg/issues/26548.
+	it( 'Should not throw an exception if reusable content.raw is an empty string', () => {
+		expect( () =>
+			__experimentalGetParsedReusableBlock( state, 1 )
+		).not.toThrowError();
 	} );
 } );

--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -600,6 +600,10 @@ running the test is not already the admin user).
 Switches the current user to whichever user we should be
 running the tests as (if we're not already that user).
 
+<a name="toggleGlobalBlockInserter" href="#toggleGlobalBlockInserter">#</a> **toggleGlobalBlockInserter**
+
+Toggles the global inserter.
+
 <a name="toggleMoreMenu" href="#toggleMoreMenu">#</a> **toggleMoreMenu**
 
 Toggles the More Menu.

--- a/packages/e2e-test-utils/src/index.js
+++ b/packages/e2e-test-utils/src/index.js
@@ -37,6 +37,7 @@ export {
 	insertBlockDirectoryBlock,
 	openGlobalBlockInserter,
 	closeGlobalBlockInserter,
+	toggleGlobalBlockInserter,
 } from './inserter';
 export { installPlugin } from './install-plugin';
 export { installTheme } from './install-theme';

--- a/packages/e2e-test-utils/src/inserter.js
+++ b/packages/e2e-test-utils/src/inserter.js
@@ -44,8 +44,10 @@ async function isGlobalInserterOpen() {
 		);
 	} );
 }
-
-async function toggleGlobalBlockInserter() {
+/**
+ * Toggles the global inserter.
+ */
+export async function toggleGlobalBlockInserter() {
 	await page.click(
 		'.edit-post-header [aria-label="Add block"], .edit-site-header [aria-label="Add block"]'
 	);

--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -72,7 +72,6 @@ describe( 'Reusable blocks', () => {
 		const block = await page.$(
 			'.block-editor-block-list__block[data-type="core/block"]'
 		);
-
 		expect( block ).not.toBeNull();
 
 		// Check that its title is displayed
@@ -362,7 +361,6 @@ describe( 'Reusable blocks', () => {
 
 		// Save the reusable block
 		await page.click( '.editor-post-publish-button__button' );
-
 		await page.waitForXPath(
 			'//*[contains(@class, "components-snackbar")]/*[text()="Reusable Block updated."]'
 		);

--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -11,6 +11,8 @@ import {
 	searchForReusableBlock,
 	getEditedPostContent,
 	trashAllPosts,
+	visitAdminPage,
+	toggleGlobalBlockInserter,
 } from '@wordpress/e2e-test-utils';
 
 function waitForAndAcceptDialog() {
@@ -70,6 +72,7 @@ describe( 'Reusable blocks', () => {
 		const block = await page.$(
 			'.block-editor-block-list__block[data-type="core/block"]'
 		);
+
 		expect( block ).not.toBeNull();
 
 		// Check that its title is displayed
@@ -329,5 +332,45 @@ describe( 'Reusable blocks', () => {
 
 		// Check that we have two paragraph blocks on the page
 		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'will not break the editor if empty', async () => {
+		await insertReusableBlock( 'Awesome block' );
+
+		await visitAdminPage( 'edit.php', [ 'post_type=wp_block' ] );
+
+		const [ editButton ] = await page.$x(
+			`//a[contains(@aria-label, 'Awesome block')]`
+		);
+		await editButton.click();
+
+		await page.waitForNavigation();
+
+		// Give focus to the editor
+		await page.click( '.block-editor-writing-flow' );
+
+		// Move focus to the paragraph block
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Tab' );
+
+		// Delete the block, leaving the reusable block empty
+		await clickBlockToolbarButton( 'More options' );
+		const deleteButton = await page.waitForXPath(
+			'//button/span[text()="Remove block"]'
+		);
+		deleteButton.click();
+
+		// Save the reusable block
+		await page.click( '.editor-post-publish-button__button' );
+
+		await page.waitForXPath(
+			'//*[contains(@class, "components-snackbar")]/*[text()="Reusable Block updated."]'
+		);
+
+		await createNewPost();
+
+		await toggleGlobalBlockInserter();
+
+		expect( console ).not.toHaveErrored();
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -346,6 +346,7 @@ describe( 'Reusable blocks', () => {
 		await page.waitForNavigation();
 
 		// Give focus to the editor
+		await page.waitForSelector( '.block-editor-writing-flow' );
 		await page.click( '.block-editor-writing-flow' );
 
 		// Move focus to the paragraph block


### PR DESCRIPTION
## Description

Issue:  https://github.com/WordPress/gutenberg/issues/26548

Adds a regression test in the client block E2E spec to avoid the regression of this issue: https://github.com/WordPress/gutenberg/issues/26485.

## How to test

- Check out this branch, and apply the following diff (effectively reverting the fix in https://github.com/WordPress/gutenberg/pull/26484):

```diff
diff --git c/packages/block-editor/src/store/selectors.js w/packages/block-editor/src/store/selectors.js
index c2153ee33c..9432c252bb 100644
--- c/packages/block-editor/src/store/selectors.js
+++ w/packages/block-editor/src/store/selectors.js
@@ -1704,11 +1704,7 @@ export const __experimentalGetParsedReusableBlock = createSelector(
 
 		// Only reusableBlock.content.raw should be used here, `reusableBlock.content` is a
 		// workaround until #22127 is fixed.
-		return parse(
-			typeof reusableBlock.content.raw === 'string'
-				? reusableBlock.content.raw
-				: reusableBlock.content
-		);
+		return parse( reusableBlock.content.raw || reusableBlock.content );
 	},
 	( state ) => [ getReusableBlocks( state ) ]
 );

```

#### Prepare the env

- Run `npm run build` and `npm run wp-env-start`;
- Access your wp-env instance and make sure Gutenberg is active.

#### Run the E2E test

- Run `npm run test-e2e packages/e2e-tests/specs/editor/various/reusable-blocks.test.js`;
- The test will create a reusable block, then edit it and make it empty, then try to insert a block in a new post. Verify that the error happens and that the test fails;
- Now remove the patch (`git checkout -- packages/block-editor/src/store/selectors.js`), and rebuild (`npm run build`);
- Re-run the e2e test. It should pass this time.

#### Run the unit test

- Run `npm run  test-unit-js packages/block-editor/src/store/test/selectors.js`. 
- The test will create a reusable block, then edit it and make it empty, then try to insert a block in a new post. Verify that the error happens and that the test fails.
- Now remove the patch (`git checkout -- packages/block-editor/src/store/selectors.js`), and rebuild (`npm run build`).
- Re-run the unit test. It should pass this time.

## Types of changes

New E2E test.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
