### PR TITLE
Block Pattern: Show the focus bug in the block inserter

### DIFF
--- a/lib/block-patterns.php
+++ b/lib/block-patterns.php
@@ -55,6 +55,7 @@ function gutenberg_register_block_patterns() {
 		register_block_pattern( 'core/three-buttons', gutenberg_load_block_pattern( 'three-buttons' ) );
 		register_block_pattern( 'core/heading-paragraph', gutenberg_load_block_pattern( 'heading-paragraph' ) );
 		register_block_pattern( 'core/quote', gutenberg_load_block_pattern( 'quote' ) );
+		register_block_pattern( 'core/list-with-image', gutenberg_load_block_pattern( 'list-with-image' ) );
 	}
 
 	register_block_pattern_category( 'buttons', array( 'label' => _x( 'Buttons', 'Block pattern category', 'gutenberg' ) ) );

--- a/lib/patterns/list-with-image.php
+++ b/lib/patterns/list-with-image.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Large header block pattern.
+ *
+ * @package gutenberg
+ */
+
+return array(
+	'title'         => __( 'List with Image', 'gutenberg' ),
+	'content'       => '<!-- wp:group {"align":"full","style":{"color":{"background":"#ffffff","text":"#151515"}}} -->
+<div class="wp-block-group alignfull has-text-color has-background" style="background-color:#ffffff;color:#151515"><div class="wp-block-group__inner-container"><!-- wp:spacer {"height":64} -->
+<div style="height:64px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:columns {"align":"wide"} -->
+<div class="wp-block-columns alignwide"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:heading {"style":{"typography":{"fontSize":50,"lineHeight":"1.2"}}} -->
+<h2 style="font-size:50px;line-height:1.2">Your membership includes:</h2>
+<!-- /wp:heading --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:list -->
+<ul><li>An in-depth, personalized consultation to set goals and establish a plan</li><li>Check-ins with me every 2 weeks</li><li>5 workout regimens a week catered to your goals and progress</li><li>Nutrition recommendations to support your target goals</li></ul>
+<!-- /wp:list --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div></div>
+<!-- /wp:group -->
+
+<!-- wp:spacer {"height":30} -->
+<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:cover {"url":"https://dotcompatterns.files.wordpress.com/2020/10/elena-kloppenburg-eruc4fttcuo-unsplash-2.jpg","id":2720,"dimRatio":0,"focalPoint":{"x":"0.50","y":"0.40"},"minHeight":580,"minHeightUnit":"px","align":"full"} -->
+<div class="wp-block-cover alignfull" style="background-image:url(https://dotcompatterns.files.wordpress.com/2020/10/elena-kloppenburg-eruc4fttcuo-unsplash-2.jpg);min-height:580px;background-position:50% 40%"><div class="wp-block-cover__inner-container"></div></div>
+<!-- /wp:cover -->', 
+	'viewportWidth' => 1000,
+	'categories'    => array( 'header' ),
+	'description'   => _x( 'A test of the list with image pattern.', 'Block pattern description', 'gutenberg' ),
+);


### PR DESCRIPTION
## Description

This is not intended to be merged, and is to demonstrate a potential bug
with block pattern previews. The List with Image pattern has a cover
block with no inner blocks, which causes it to be initialised with the
template. Focus is then passed to the inner block. In the preview
context, this is a problem as it can cause focus to be lost from
elsewhere, specifically the block inserter input.

## How has this been tested?

It shows the issue. Open the block inserter on the right hand side of the editor, and type `li`. Focus will be lost.

## Screenshots <!-- if applicable -->

![insert-bug](https://user-images.githubusercontent.com/96462/98908425-5430d180-24b8-11eb-813e-7f6e7ab31a3f.gif)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
