### PR TITLE
Writing flow: improve vertical edge checking

### DIFF
--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -105,7 +105,9 @@ function isEdge( container, isReverse, onlyVertical ) {
 	}
 
 	const computedStyle = getComputedStyle( container );
-	const lineHeight = parseInt( computedStyle.lineHeight, 10 ) || 0;
+	const lineHeight =
+		// Line height may not be in pixels, so fall back to range height.
+		parseInt( computedStyle.lineHeight, 10 ) || rangeRect.height;
 
 	// Only consider the multiline selection at the edge if the direction is
 	// towards the edge.
@@ -117,44 +119,24 @@ function isEdge( container, isReverse, onlyVertical ) {
 		return false;
 	}
 
-	const padding =
-		parseInt(
-			computedStyle[ `padding${ isReverse ? 'Top' : 'Bottom' }` ],
-			10
-		) || 0;
-
-	// Calculate a buffer that is half the line height. In some browsers, the
-	// selection rectangle may not fill the entire height of the line, so we add
-	// 3/4 the line height to the selection rectangle to ensure that it is well
-	// over its line boundary.
-	const buffer = ( 3 * parseInt( lineHeight, 10 ) ) / 4;
-	const containerRect = container.getBoundingClientRect();
-	const originalRangeRect = getRectangleFromRange( originalRange );
-	const verticalEdge = isReverse
-		? containerRect.top + padding > originalRangeRect.top - buffer
-		: containerRect.bottom - padding < originalRangeRect.bottom + buffer;
-
-	if ( ! verticalEdge ) {
-		return false;
-	}
-
-	if ( onlyVertical ) {
-		return true;
-	}
-
 	// In the case of RTL scripts, the horizontal edge is at the opposite side.
 	const { direction } = computedStyle;
 	const isReverseDir = direction === 'rtl' ? ! isReverse : isReverse;
 
-	// To calculate the horizontal position, we insert a test range and see if
-	// this test range has the same horizontal position. This method proves to
-	// be better than a DOM-based calculation, because it ignores empty text
-	// nodes and a trailing line break element. In other words, we need to check
-	// visual positioning, not DOM positioning.
+	const containerRect = container.getBoundingClientRect();
+
+	// To check if a selection is at the edge, we insert a test selection at the
+	// edge of the container and check if the selections have the same vertical
+	// or horizontal position. If they do, the selection is at the edge.
+	// This method proves to be better than a DOM-based calculation for the
+	// horizontal edge, since it ignores empty textnodes and a trailing line
+	// break element. In other words, we need to check visual positioning, not
+	// DOM positioning.
+	// It also proves better than using the computed style for the vertical
+	// edge, because we cannot know the padding and line height reliably in
+	// pixels. `getComputedStyle` may return a value with different units.
 	const x = isReverseDir ? containerRect.left + 1 : containerRect.right - 1;
-	const y = isReverse
-		? containerRect.top + buffer
-		: containerRect.bottom - buffer;
+	const y = isReverse ? containerRect.top + 1 : containerRect.bottom - 1;
 	const testRange = hiddenCaretRangeFromPoint(
 		ownerDocument,
 		x,
@@ -166,8 +148,23 @@ function isEdge( container, isReverse, onlyVertical ) {
 		return false;
 	}
 
-	const side = isReverseDir ? 'left' : 'right';
 	const testRect = getRectangleFromRange( testRange );
+	const originalRangeRect = getRectangleFromRange( originalRange );
+	const verticalSide = isReverse ? 'top' : 'bottom';
+	const verticalEdge =
+		Math.abs(
+			testRect[ verticalSide ] - originalRangeRect[ verticalSide ]
+		) <= 1;
+
+	if ( ! verticalEdge ) {
+		return false;
+	}
+
+	if ( onlyVertical ) {
+		return true;
+	}
+
+	const side = isReverseDir ? 'left' : 'right';
 
 	// Allow the position to be 1px off.
 	return Math.abs( testRect[ side ] - rangeRect[ side ] ) <= 1;

--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -165,22 +165,24 @@ function isEdge( container, isReverse, onlyVertical ) {
 	}
 
 	const testRect = getRectangleFromRange( testRange );
-	const verticalSide = isReverse ? 'top' : 'bottom';
-	const verticalEdge =
-		Math.abs( testRect[ verticalSide ] - rangeRect[ verticalSide ] ) <= 1;
 
-	if ( ! verticalEdge ) {
+	if ( ! testRect ) {
 		return false;
 	}
 
-	if ( onlyVertical ) {
-		return true;
-	}
-
-	const side = isReverseDir ? 'left' : 'right';
+	const verticalSide = isReverse ? 'top' : 'bottom';
+	const horizontalSide = isReverseDir ? 'left' : 'right';
+	const verticalDiff = testRect[ verticalSide ] - rangeRect[ verticalSide ];
+	const horizontalDiff =
+		testRect[ horizontalSide ] - collapsedRangeRect[ horizontalSide ];
 
 	// Allow the position to be 1px off.
-	return Math.abs( testRect[ side ] - collapsedRangeRect[ side ] ) <= 1;
+	const hasVerticalDiff = Math.abs( verticalDiff ) <= 1;
+	const hasHorizontalDiff = Math.abs( horizontalDiff ) <= 1;
+
+	return onlyVertical
+		? hasVerticalDiff
+		: hasVerticalDiff && hasHorizontalDiff;
 }
 
 /**

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/multi-block-selection.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/multi-block-selection.test.js.snap
@@ -137,5 +137,9 @@ exports[`Multi-block selection should set attributes for multiple paragraphs 1`]
 exports[`Multi-block selection should use selection direction to determine vertical edge 1`] = `
 "<!-- wp:paragraph -->
 <p>1<br>2.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>3</p>
 <!-- /wp:paragraph -->"
 `;

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/writing-flow.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/writing-flow.test.js.snap
@@ -148,6 +148,16 @@ exports[`Writing Flow should navigate around nested inline boundaries 2`] = `
 <!-- /wp:paragraph -->"
 `;
 
+exports[`Writing Flow should navigate contenteditable with normal line height 1`] = `
+"<!-- wp:paragraph -->
+<p>1</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->"
+`;
+
 exports[`Writing Flow should navigate contenteditable with padding 1`] = `
 "<!-- wp:paragraph -->
 <p>1</p>

--- a/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
+++ b/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
@@ -148,6 +148,9 @@ describe( 'Multi-block selection', () => {
 		await clickBlockAppender();
 		await page.keyboard.type( '1' );
 		await pressKeyWithModifier( 'shift', 'Enter' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '3' );
+		await page.keyboard.press( 'ArrowUp' );
 		await page.keyboard.type( '2' );
 
 		await pressKeyWithModifier( 'shift', 'ArrowUp' );

--- a/packages/e2e-tests/specs/editor/various/writing-flow.test.js
+++ b/packages/e2e-tests/specs/editor/various/writing-flow.test.js
@@ -397,6 +397,18 @@ describe( 'Writing Flow', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
+	it( 'should navigate contenteditable with normal line height', async () => {
+		await clickBlockAppender();
+		await page.keyboard.press( 'Enter' );
+		await page.evaluate( () => {
+			document.activeElement.style.lineHeight = 'normal';
+		} );
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.type( '1' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
 	it( 'should not prematurely multi-select', async () => {
 		await clickBlockAppender();
 		await page.keyboard.type( '1' );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

Vertical edge checking is currently severely flawed for themes that are setting line height and padding in units other than pixels. We currently assume that the units returned by `getComputedStyle` will be pixels, which is wrong.

Additionally, there's no reliable way in JS to get the line height and padding in pixels without `getComputedStyle`.

In this PR, I'm using the same method we use for horizontal edge checking, which uses a test range inserted at the edge to compare positions. As a bonus, it turns out this test can be used for both calculations.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
