### PR TITLE
Navigation block: fix color support declaration

### DIFF
--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -52,10 +52,7 @@
 		"fontSize": true,
 		"__experimentalFontAppearance": true,
 		"__experimentalTextTransform": true,
-		"color": {
-			"textColor": true,
-			"backgroundColor": true
-		},
+		"color": true,
 		"__experimentalFontFamily": true,
 		"__experimentalTextDecoration": true
 	}


### PR DESCRIPTION
This fixes the keys to declare color support for background and text.

Essentially, we have two ways to do this:

```js
"supports": {
  "color": true
}
```

or 

```js
"supports": {
  "color": {
    "text": true,
    "background": true
  }
}
```
