### PR TITLE
Template navigation: Reverse menu order of drilldowns / links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16388,16 +16388,6 @@
 				}
 			}
 		},
-		"@testing-library/react-hooks": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-3.4.2.tgz",
-			"integrity": "sha512-RfPG0ckOzUIVeIqlOc1YztKgFW+ON8Y5xaSPbiBkfj9nMkkiLhLeBXT5icfPX65oJV/zCZu4z8EVnUc6GY9C5A==",
-			"dev": true,
-			"requires": {
-				"@babel/runtime": "^7.5.4",
-				"@types/testing-library__react-hooks": "^3.4.0"
-			}
-		},
 		"@types/anymatch": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
@@ -16801,15 +16791,6 @@
 				"@types/react": "*"
 			}
 		},
-		"@types/react-test-renderer": {
-			"version": "16.9.3",
-			"resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-16.9.3.tgz",
-			"integrity": "sha512-wJ7IlN5NI82XMLOyHSa+cNN4Z0I+8/YaLl04uDgcZ+W+ExWCmCiVTLT/7fRNqzy4OhStZcUwIqLNF7q+AdW43Q==",
-			"dev": true,
-			"requires": {
-				"@types/react": "*"
-			}
-		},
 		"@types/react-textarea-autosize": {
 			"version": "4.3.5",
 			"resolved": "https://registry.npmjs.org/@types/react-textarea-autosize/-/react-textarea-autosize-4.3.5.tgz",
@@ -16986,15 +16967,6 @@
 					"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
 					"dev": true
 				}
-			}
-		},
-		"@types/testing-library__react-hooks": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/@types/testing-library__react-hooks/-/testing-library__react-hooks-3.4.1.tgz",
-			"integrity": "sha512-G4JdzEcq61fUyV6wVW9ebHWEiLK2iQvaBuCHHn9eMSbZzVh4Z4wHnUGIvQOYCCYeu5DnUtFyNYuAAgbSaO/43Q==",
-			"dev": true,
-			"requires": {
-				"@types/react-test-renderer": "*"
 			}
 		},
 		"@types/tinycolor2": {

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/templates.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/templates.js
@@ -51,6 +51,12 @@ export default function TemplatesMenu() {
 			titleAction={ <NewTemplateDropdown /> }
 			parentMenu={ MENU_ROOT }
 		>
+			{ map( generalTemplates, ( template ) => (
+				<TemplateNavigationItem
+					item={ template }
+					key={ `wp_template-${ template.id }` }
+				/>
+			) ) }
 			<NavigationItem
 				navigateToMenu={ MENU_TEMPLATES_ALL }
 				title={ _x( 'All', 'all templates' ) }
@@ -63,18 +69,8 @@ export default function TemplatesMenu() {
 				navigateToMenu={ MENU_TEMPLATES_POSTS }
 				title={ __( 'Posts' ) }
 			/>
-
-			{ map( generalTemplates, ( template ) => (
-				<TemplateNavigationItem
-					item={ template }
-					key={ `wp_template-${ template.id }` }
-				/>
-			) ) }
-
 			<TemplatesPostsMenu templates={ templates } />
-
 			<TemplatesPagesMenu templates={ templates } />
-
 			<TemplatesAllMenu templates={ templates } />
 		</NavigationMenu>
 	);


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Resolves: https://github.com/WordPress/gutenberg/issues/26926

This PR changes the order of the `Templates navigation` as proposed in the issue.

-- Also fixes out of sync package-lock.json.