### PR TITLE
Constrain tabbing to the popover in media replace flow

### DIFF
--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -19,7 +19,7 @@ import {
 	withFilters,
 } from '@wordpress/components';
 import { withDispatch, useSelect } from '@wordpress/data';
-import { DOWN } from '@wordpress/keycodes';
+import { DOWN, TAB, ESCAPE } from '@wordpress/keycodes';
 import { compose } from '@wordpress/compose';
 import { upload, media as mediaIcon } from '@wordpress/icons';
 
@@ -168,10 +168,18 @@ const MediaReplaceFlow = ( {
 						<form
 							className="block-editor-media-flow__url-input"
 							onKeyDown={ ( event ) => {
-								event.stopPropagation();
+								if (
+									! [ TAB, ESCAPE ].includes( event.keyCode )
+								) {
+									event.stopPropagation();
+								}
 							} }
 							onKeyPress={ ( event ) => {
-								event.stopPropagation();
+								if (
+									! [ TAB, ESCAPE ].includes( event.keyCode )
+								) {
+									event.stopPropagation();
+								}
 							} }
 						>
 							<span className="block-editor-media-replace-flow__image-url-label">


### PR DESCRIPTION
Fixes #24800

This is close to the original implementation of the replace menu. However in this PR instead of using a `<form>` to group the current URL label and the link edit component I use a `<div>`  with `role` set to `menuitem`.

Can a menu item be more complex than a single choice? On the initial implementation @afercia noted that items with `role` set to `menu` should not contain forms as the focused elements are not direct actions like the other menu items. This is still true now, but the contents of the menu item are announced better, although still not great.

Can a `menuitem` have a dialog already shown? Tabbing through this with VO makes sense, more or less.

I was surprised that simply using a [TabbableContainer](https://github.com/WordPress/gutenberg/blob/master/packages/components/src/navigable-container/tabbable.js#L12) didn't allow me to move the items outside of Navigable menu. Still with things in the navigable menu at least the correct number of actionable items are announced (3) when replace is activated.

cc @talldan pinging you for some input / help here 😄 