### PR TITLE
Edit Site - make nav panel mount on load again.

### DIFF
--- a/packages/edit-site/src/components/navigation-sidebar/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/index.js
@@ -3,7 +3,6 @@
  */
 import { createSlotFill } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -21,22 +20,11 @@ export default function NavigationSidebar() {
 		return select( 'core/edit-site' ).isNavigationOpened();
 	} );
 
-	// Don't mount navigation panel until it is triggered.
-	// This prevents bugs as noted in #26613.
-	// We can revert this once the underlying bugs are fixed.
-	const [ hasOpened, setHasOpened ] = useState( false );
 	return (
 		<>
-			<NavigationToggle
-				isOpen={ isNavigationOpen }
-				setHasOpened={ setHasOpened }
-			/>
-			{ hasOpened && (
-				<>
-					<NavigationPanel isOpen={ isNavigationOpen } />
-					<NavigationPanelPreviewSlot />
-				</>
-			) }
+			<NavigationToggle isOpen={ isNavigationOpen } />
+			<NavigationPanel isOpen={ isNavigationOpen } />
+			<NavigationPanelPreviewSlot />
 		</>
 	);
 }

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/index.js
@@ -6,7 +6,7 @@ import { Button, Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
 
-function NavigationToggle( { icon, isOpen, setHasOpened } ) {
+function NavigationToggle( { icon, isOpen } ) {
 	const { isActive, isRequestingSiteIcon, siteIconUrl } = useSelect(
 		( select ) => {
 			const { isFeatureActive } = select( 'core/edit-site' );
@@ -29,10 +29,6 @@ function NavigationToggle( { icon, isOpen, setHasOpened } ) {
 	);
 
 	const { setIsNavigationPanelOpened } = useDispatch( 'core/edit-site' );
-	const onClick = () => {
-		setHasOpened( true );
-		setIsNavigationPanelOpened( ! isOpen );
-	};
 
 	if ( ! isActive ) {
 		return null;
@@ -63,7 +59,7 @@ function NavigationToggle( { icon, isOpen, setHasOpened } ) {
 			<Button
 				className="edit-site-navigation-toggle__button has-icon"
 				label={ __( 'Toggle navigation' ) }
-				onClick={ onClick }
+				onClick={ () => setIsNavigationPanelOpened( ! isOpen ) }
 				showTooltip
 			>
 				{ buttonIcon }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
This was temporarily changed in #26613 to not mount until it was first used due to some underlying bugs.  Testing to see if this is safe to mount on load again with recent made to auto-draft creation.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Re-testing the manual flow as outlined in #26613 and verify the bugs do not exist.
Running CI a bunch of times to ensure we don't go back to having that 'header not found' failure.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
