### PR TITLE
Fix/ie11 interface bugs

### DIFF
--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -142,8 +142,9 @@ html.interface-interface-skeleton__html-container {
 	flex-shrink: 0;
 	border-top: $border-width solid $gray-200;
 	color: $gray-900;
-	position: fixed;
+	position: absolute;
 	bottom: 0;
+	left: 0;
 	width: 100%;
 	background-color: $white;
 	z-index: z-index(".interface-interface-skeleton__footer");

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -37,7 +37,7 @@ html.interface-interface-skeleton__html-container {
 	display: flex;
 	flex-direction: column;
 	flex-grow: 1;
-	max-width: 100%;
+	width: 100%;
 }
 
 @include editor-left(".interface-interface-skeleton");

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -36,8 +36,7 @@ html.interface-interface-skeleton__html-container {
 .interface-interface-skeleton__editor {
 	display: flex;
 	flex-direction: column;
-	flex-grow: 1;
-	width: 100%;
+	flex: 0 1 100%;
 }
 
 @include editor-left(".interface-interface-skeleton");


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes #26932 IE11 bugs:
- first commit: made breadcrumbs show up in footer 
- second commit: made block editor fit into browser window

## How has this been tested?
Tested on Windows 10: IE11, Chrome 86, Opera (latest), Firefox (latest)
IOS 14: Chrome, Safari

## Screenshots 
![Screenshot_6](https://user-images.githubusercontent.com/70915/98975628-6433ca00-2527-11eb-903a-5652cf971528.jpg)


## Types of changes
Footer CSS (.interface-interface-skeleton__footer):
1. Made footer absolutely positioned istead if fixed positioned. Beacuse it is inside fixed positioned container, this shouldn't break anything. 
2. Added _left:0_ to the footer because in non-IE browsers the footer was positioned correctly in horizontal direction during static positioning stage. IE static positioning stage doesn't bring the footer to _left:0_.

Editor CSS (.interface-interface-skeleton__editor):
max-width: 100% => width: 100%;
max-width doesn't work with IE flexbox in some cases.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->

