### PR TITLE
Add: Mechanism to detect if a block instance matches a global styles selector

### DIFF
--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -452,12 +452,16 @@ class WP_Theme_JSON {
 				isset( $block_type->supports['__experimentalSelector'] ) &&
 				is_array( $block_type->supports['__experimentalSelector'] )
 			) {
-				foreach ( $block_type->supports['__experimentalSelector'] as $key => $selector ) {
+				foreach ( $block_type->supports['__experimentalSelector'] as $key => $selector_data ) {
 					self::$blocks_metadata[ $key ] = array(
-						'selector'  => $selector,
-						'supports'  => $block_supports,
-						'blockName' => $block_name,
+						'selector'   => $selector_data['selector'],
+						'supports'   => $block_supports,
+						'blockName'  => $block_name,
+						'attributes' => $selector_data['attributes'],
 					);
+					if ( isset( $selector_data['title'] ) ) {
+						self::$blocks_metadata[ $key ]['title'] = $selector_data['title'];
+					}
 				}
 			} else {
 				self::$blocks_metadata[ $block_name ] = array(

--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -30,12 +30,48 @@
 		"fontSize": true,
 		"lineHeight": true,
 		"__experimentalSelector": {
-			"core/heading/h1": "h1",
-			"core/heading/h2": "h2",
-			"core/heading/h3": "h3",
-			"core/heading/h4": "h4",
-			"core/heading/h5": "h5",
-			"core/heading/h6": "h6"
+			"core/heading/h1": {
+				"selector": "h1",
+				"title": "h1",
+				"attributes": {
+					"level": 1
+				}
+			},
+			"core/heading/h2": {
+				"selector": "h2",
+				"title": "h2",
+				"attributes": {
+					"level": 2
+				}
+			},
+			"core/heading/h3": {
+				"selector": "h3",
+				"title": "h3",
+				"attributes": {
+					"level": 3
+				}
+			},
+			"core/heading/h4": {
+				"selector": "h4",
+				"title": "h4",
+				"attributes": {
+					"level": 4
+				}
+			},
+			"core/heading/h5": {
+				"selector": "h5",
+				"title": "h5",
+				"attributes": {
+					"level": 5
+				}
+			},
+			"core/heading/h6": {
+				"selector": "h6",
+				"title": "h6",
+				"attributes": {
+					"level": 6
+				}
+			}
 		},
 		"__unstablePasteTextInline": true
 	}

--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -38,12 +38,48 @@
 		"lineHeight": true,
 		"__experimentalFontFamily": true,
 		"__experimentalSelector": {
-			"core/post-title/h1": "h1",
-			"core/post-title/h2": "h2",
-			"core/post-title/h3": "h3",
-			"core/post-title/h4": "h4",
-			"core/post-title/h5": "h5",
-			"core/post-title/h6": "h6"
+			"core/post-title/h1": {
+				"title": "h1",
+				"selector": "h1.wp-block-post-title",
+				"attributes": {
+					"level": 1
+				}
+			},
+			"core/post-title/h2": {
+				"title": "h2",
+				"selector": "h2.wp-block-post-title",
+				"attributes": {
+					"level": 2
+				}
+			},
+			"core/post-title/h3": {
+				"title": "h3",
+				"selector": "h3.wp-block-post-title",
+				"attributes": {
+					"level": 3
+				}
+			},
+			"core/post-title/h4": {
+				"title": "h4",
+				"selector": "h4.wp-block-post-title",
+				"attributes": {
+					"level": 4
+				}
+			},
+			"core/post-title/h5": {
+				"title": "h5",
+				"selector": "h5.wp-block-post-title",
+				"attributes": {
+					"level": 5
+				}
+			},
+			"core/post-title/h6": {
+				"title": "h6",
+				"selector": "h6.wp-block-post-title",
+				"attributes": {
+					"level": 6
+				}
+			}
 		}
 	}
 }

--- a/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
@@ -84,7 +84,7 @@ function GlobalStylesPanel( {
 
 	let panelTitle = blockType.title;
 	if ( 'object' === typeof blockType?.supports?.__experimentalSelector ) {
-		panelTitle += ` (${ context.selector })`;
+		panelTitle += ` (${ context.title })`;
 	}
 
 	return (


### PR DESCRIPTION
Alternative to https://github.com/WordPress/gutenberg/pull/24423.

This PR adds a mechanism to detect at run time if global styles selector affects a given block instance.
Basically, the selector defines a set of attributes and we consider a block matches a selector if all the attributes defined in the selector have the same value on the block.


## How has this been tested?
I added the following information to the theme.json
```
	"core/heading/h1": {
		"settings": {
			"color": {
				"palette": [
					{
						"slug": "pink",
						"color": "#FFC0CB",
						"name": "Pink"
					}
				]
			}
		}
	},
	"core/heading/h2": {
		"settings": {
			"color": {
				"palette": [
					{
						"slug": "brown",
						"color": "#8B4513",
						"name": "Brown"
					}
				]
			}
		}
	},

````

I created a new post.
I added a heading block.
I verified that the available colors change depending on if I select heading levels 1 or 2.
