### PR TITLE
Navigation Block: Placeholder empty state

### DIFF
--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -58,6 +58,19 @@ function Navigation( {
 		clientId
 	);
 
+	const emptyStatePlaceholder = (
+		<div
+			style={ {
+				fontSize: '13px',
+				backgroundColor: 'purple',
+				color: 'white',
+				padding: '4px',
+			} }
+		>
+			Click [+] to add links
+		</div>
+	);
+
 	const innerBlocksProps = useInnerBlocksProps(
 		{
 			className: 'wp-block-navigation__container',
@@ -81,6 +94,7 @@ function Navigation( {
 			// Block on the experimental menus screen does not
 			// inherit templateLock={ 'all' }.
 			templateLock: false,
+			placeholder: emptyStatePlaceholder,
 		}
 	);
 

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -26,6 +26,7 @@ import { __ } from '@wordpress/i18n';
 import useBlockNavigator from './use-block-navigator';
 import * as navIcons from './icons';
 import NavigationPlaceholder from './placeholder';
+import PlaceholderPreview from './placeholder-preview';
 
 function Navigation( {
 	selectedBlockHasDescendants,
@@ -58,19 +59,6 @@ function Navigation( {
 		clientId
 	);
 
-	const emptyStatePlaceholder = (
-		<div
-			style={ {
-				fontSize: '13px',
-				backgroundColor: 'purple',
-				color: 'white',
-				padding: '4px',
-			} }
-		>
-			Click [+] to add links
-		</div>
-	);
-
 	const innerBlocksProps = useInnerBlocksProps(
 		{
 			className: 'wp-block-navigation__container',
@@ -94,7 +82,7 @@ function Navigation( {
 			// Block on the experimental menus screen does not
 			// inherit templateLock={ 'all' }.
 			templateLock: false,
-			placeholder: emptyStatePlaceholder,
+			placeholder: <PlaceholderPreview />,
 		}
 	);
 

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -225,11 +225,6 @@ $color-control-label-height: 20px;
 	flex-direction: row;
 	align-items: center;
 
-	// Hide when selected.
-	.is-selected & {
-		display: none;
-	}
-
 	// Style skeleton elements.
 	// Needs specificity.
 	.wp-block-navigation-link.wp-block-navigation-link {
@@ -243,6 +238,13 @@ $color-control-label-height: 20px;
 	.wp-block-navigation-link.wp-block-navigation-link,
 	svg {
 		opacity: 0.3;
+	}
+}
+
+.wp-block-navigation-placeholder__preview_select_hide {
+	// Hide when selected.
+	.is-selected & {
+		display: none;
 	}
 }
 

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -239,10 +239,7 @@ $color-control-label-height: 20px;
 	svg {
 		opacity: 0.3;
 	}
-}
 
-.wp-block-navigation-placeholder__preview_select_hide {
-	// Hide when selected.
 	.is-selected & {
 		display: none;
 	}

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -1,6 +1,3 @@
-$navigation-height: 60px;
-$navigation-item-height: 46px;
-
 // Undo default editor styles.
 .editor-styles-wrapper .wp-block-navigation ul,
 .editor-styles-wrapper .wp-block-navigation ol {
@@ -30,7 +27,7 @@ $navigation-item-height: 46px;
 
 // Ensure that an empty block has space around the appender.
 .wp-block-navigation__container {
-	min-height: $navigation-item-height;
+	min-height: $grid-unit-05 + $grid-unit-05 + $button-size;
 }
 
 // Ensure sub-menus stay open and visible when a nested block is selected.
@@ -161,6 +158,8 @@ $color-control-label-height: 20px;
 }
 
 .wp-block-navigation-placeholder {
+	min-height: $grid-unit-05 + $grid-unit-05 + $button-size;
+
 	.components-spinner {
 		margin-top: -4px;
 		margin-left: 4px;
@@ -220,10 +219,16 @@ $color-control-label-height: 20px;
 
 // Unselected state.
 .wp-block-navigation-placeholder__preview {
-	min-height: $grid-unit-10 + $grid-unit-10 + $button-size;
+	position: absolute;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
 	display: flex;
 	flex-direction: row;
 	align-items: center;
+	transition: all 0.1s ease-in-out;
+	@include reduce-motion("transition");
 
 	// Style skeleton elements.
 	// Needs specificity.
@@ -241,19 +246,21 @@ $color-control-label-height: 20px;
 	}
 
 	.is-selected & {
-		display: none;
+		opacity: 0.2;
 	}
 }
 
 // Selected state.
 .wp-block-navigation-placeholder__controls {
-	padding: $grid-unit-10;
+	padding: $grid-unit-05 $grid-unit-10;
 	border-radius: $radius-block-ui;
 	background-color: $white;
 	box-shadow: inset 0 0 0 $border-width $gray-900;
 	flex-direction: row;
 	align-items: center;
 	display: none;
+	position: relative;
+	z-index: 1;
 
 	// Show when selected.
 	.is-selected & {

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -286,7 +286,9 @@ $color-control-label-height: 20px;
 }
 
 // When block is vertical.
-.is-vertical .wp-block-navigation-placeholder {
+.is-vertical .wp-block-navigation-placeholder,
+.is-vertical .wp-block-navigation-placeholder__preview,
+.is-vertical .wp-block-navigation-placeholder__controls {
 	min-height: $icon-size + ($grid-unit-20 + $grid-unit-05 + $grid-unit-15 + $grid-unit-15) * 3;
 }
 

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -285,16 +285,16 @@ $color-control-label-height: 20px;
 	}
 }
 
-// Both, when block is vertical.
-.wp-block-navigation-placeholder__preview,
-.wp-block-navigation-placeholder__controls {
-	.is-vertical & {
-		flex-direction: column;
-		align-items: flex-start;
-		min-height: $icon-size + ($grid-unit-20 + $grid-unit-15 + $grid-unit-15) * 3;
-	}
+// When block is vertical.
+.is-vertical .wp-block-navigation-placeholder {
+	min-height: $icon-size + ($grid-unit-20 + $grid-unit-05 + $grid-unit-15 + $grid-unit-15) * 3;
 }
 
+.is-vertical .wp-block-navigation-placeholder__preview,
+.is-vertical .wp-block-navigation-placeholder__controls {
+	flex-direction: column;
+	align-items: flex-start;
+}
 
 .wp-block-navigation-placeholder__actions {
 	display: flex;

--- a/packages/block-library/src/navigation/placeholder-preview.js
+++ b/packages/block-library/src/navigation/placeholder-preview.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { Icon, search } from '@wordpress/icons';
+
+const PlaceholderPreview = ( { hideSelected } ) => {
+	const classes = classNames( 'wp-block-navigation-placeholder__preview', {
+		'wp-block-navigation-placeholder__preview_select_hide': hideSelected,
+	} );
+
+	return (
+		<div className={ classes }>
+			<span className="wp-block-navigation-link"></span>
+			<span className="wp-block-navigation-link"></span>
+			<span className="wp-block-navigation-link"></span>
+			<Icon icon={ search } />
+		</div>
+	);
+};
+
+export default PlaceholderPreview;

--- a/packages/block-library/src/navigation/placeholder-preview.js
+++ b/packages/block-library/src/navigation/placeholder-preview.js
@@ -1,20 +1,11 @@
 /**
- * External dependencies
- */
-import classNames from 'classnames';
-
-/**
  * WordPress dependencies
  */
 import { Icon, search } from '@wordpress/icons';
 
-const PlaceholderPreview = ( { hideSelected } ) => {
-	const classes = classNames( 'wp-block-navigation-placeholder__preview', {
-		'wp-block-navigation-placeholder__preview_select_hide': hideSelected,
-	} );
-
+const PlaceholderPreview = () => {
 	return (
-		<div className={ classes }>
+		<div className="wp-block-navigation-placeholder__preview">
 			<span className="wp-block-navigation-link"></span>
 			<span className="wp-block-navigation-link"></span>
 			<span className="wp-block-navigation-link"></span>

--- a/packages/block-library/src/navigation/placeholder.js
+++ b/packages/block-library/src/navigation/placeholder.js
@@ -22,12 +22,13 @@ import {
 	useEffect,
 } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Icon, chevronDown, search } from '@wordpress/icons';
+import { chevronDown } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import createDataTree from './create-data-tree';
+import PlaceholderPreview from './placeholder-preview';
 
 /**
  * A recursive function that maps menu item nodes to blocks.
@@ -235,12 +236,7 @@ function NavigationPlaceholder( { onCreate }, ref ) {
 
 	return (
 		<div className="wp-block-navigation-placeholder">
-			<div className="wp-block-navigation-placeholder__preview">
-				<span className="wp-block-navigation-link"></span>
-				<span className="wp-block-navigation-link"></span>
-				<span className="wp-block-navigation-link"></span>
-				<Icon icon={ search } />
-			</div>
+			<PlaceholderPreview hideSelected={ true } />
 
 			<div className="wp-block-navigation-placeholder__controls">
 				{ isLoading && (

--- a/packages/block-library/src/navigation/placeholder.js
+++ b/packages/block-library/src/navigation/placeholder.js
@@ -236,7 +236,7 @@ function NavigationPlaceholder( { onCreate }, ref ) {
 
 	return (
 		<div className="wp-block-navigation-placeholder">
-			<PlaceholderPreview hideSelected={ true } />
+			<PlaceholderPreview />
 
 			<div className="wp-block-navigation-placeholder__controls">
 				{ isLoading && (


### PR DESCRIPTION
## Description

There are already a couple of issues around Navigator block placeholder, but those are around the big white placeholder spot and not the InnerBlocks when empty. See gifs below for visual explanation.

With #25941 a new placeholder property was introduced to help Social Links initial empty state, this PR is to use that same property to help the Navigation block empty state (no menu selected)

## How has this been tested?

**DRAFT**

- Add Navigation block
- Choose create empty Navigation


## Screenshots

This capture shows the current existing behavior, when creating a new empty Navigation it is confusing, particular if you click away.

![navigation-current](https://user-images.githubusercontent.com/45363/98987729-7e47bb00-24db-11eb-923e-a919e3055342.gif)


This is the updated placeholder to show when a new empty Navigation is inserted, this is obviously not the final design but to illustrate the location and potential.

![navigation-update](https://user-images.githubusercontent.com/45363/98987824-9d464d00-24db-11eb-994c-1a25c7c32dd2.gif)


## Types of changes

- Use InnerBlocks placeholder property for Navigation

