### PR TITLE
Site Editor - Nav Panel - Only show auto-draft template parts corresponding to current theme.

### DIFF
--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/template-parts.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/template-parts.js
@@ -21,34 +21,19 @@ import { MENU_ROOT, MENU_TEMPLATE_PARTS } from '../constants';
 
 export default function TemplatePartsMenu() {
 	const templateParts = useSelect( ( select ) => {
-		const publishedTemplateParts = select( 'core' ).getEntityRecords(
-			'postType',
-			'wp_template_part',
-			{
+		const publishedTemplateParts =
+			select( 'core' ).getEntityRecords( 'postType', 'wp_template_part', {
 				status: [ 'publish' ],
 				per_page: -1,
-			}
-		);
+			} ) || [];
 		const currentTheme = select( 'core' ).getCurrentTheme()?.stylesheet;
-		const themeTemplateParts = select( 'core' ).getEntityRecords(
-			'postType',
-			'wp_template_part',
-			{
+		const themeTemplateParts =
+			select( 'core' ).getEntityRecords( 'postType', 'wp_template_part', {
 				status: [ 'auto-draft' ],
 				per_page: -1,
 				theme: currentTheme,
-			}
-		);
-		// Results above can be 'null' in early steps of editor loading,
-		// so we must check before using the spread operator to combine them.
-		const combinedTemplateParts = [];
-		if ( publishedTemplateParts ) {
-			combinedTemplateParts.push( ...publishedTemplateParts );
-		}
-		if ( themeTemplateParts ) {
-			combinedTemplateParts.push( ...themeTemplateParts );
-		}
-		return combinedTemplateParts;
+			} ) || [];
+		return [ ...themeTemplateParts, ...publishedTemplateParts ];
 	}, [] );
 
 	return (

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/template-parts.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/template-parts.js
@@ -21,19 +21,16 @@ import { MENU_ROOT, MENU_TEMPLATE_PARTS } from '../constants';
 
 export default function TemplatePartsMenu() {
 	const templateParts = useSelect( ( select ) => {
-		const publishedTemplateParts =
+		const unfilteredTemplateParts =
 			select( 'core' ).getEntityRecords( 'postType', 'wp_template_part', {
-				status: [ 'publish' ],
+				status: [ 'publish', 'auto-draft' ],
 				per_page: -1,
 			} ) || [];
 		const currentTheme = select( 'core' ).getCurrentTheme()?.stylesheet;
-		const themeTemplateParts =
-			select( 'core' ).getEntityRecords( 'postType', 'wp_template_part', {
-				status: [ 'auto-draft' ],
-				per_page: -1,
-				theme: currentTheme,
-			} ) || [];
-		return [ ...themeTemplateParts, ...publishedTemplateParts ];
+		return unfilteredTemplateParts.filter(
+			( item ) =>
+				item.status === 'publish' || item.meta.theme === currentTheme
+		);
 	}, [] );
 
 	return (

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/template-parts.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/menus/template-parts.js
@@ -21,14 +21,34 @@ import { MENU_ROOT, MENU_TEMPLATE_PARTS } from '../constants';
 
 export default function TemplatePartsMenu() {
 	const templateParts = useSelect( ( select ) => {
-		return select( 'core' ).getEntityRecords(
+		const publishedTemplateParts = select( 'core' ).getEntityRecords(
 			'postType',
 			'wp_template_part',
 			{
-				status: [ 'publish', 'auto-draft' ],
+				status: [ 'publish' ],
 				per_page: -1,
 			}
 		);
+		const currentTheme = select( 'core' ).getCurrentTheme()?.stylesheet;
+		const themeTemplateParts = select( 'core' ).getEntityRecords(
+			'postType',
+			'wp_template_part',
+			{
+				status: [ 'auto-draft' ],
+				per_page: -1,
+				theme: currentTheme,
+			}
+		);
+		// Results above can be 'null' in early steps of editor loading,
+		// so we must check before using the spread operator to combine them.
+		const combinedTemplateParts = [];
+		if ( publishedTemplateParts ) {
+			combinedTemplateParts.push( ...publishedTemplateParts );
+		}
+		if ( themeTemplateParts ) {
+			combinedTemplateParts.push( ...themeTemplateParts );
+		}
+		return combinedTemplateParts;
 	}, [] );
 
 	return (


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
As noted in #26402 if you switch themes a few times, auto-drafts of template parts build up and they are all shown in the Nav panel.  This PR updates the nav panel to only show auto-drafts that correspond to the currently active theme.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
* Activate a block based theme, load the site editor.
* Switch to another block based theme, load the site editor again.
* verify the first themes template part auto-drafts are not present in the nav panel.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
