### PR TITLE
Add explicit dismiss button and on dismiss callback to snackbar

### DIFF
--- a/docs/designers-developers/developers/data/data-core-notices.md
+++ b/docs/designers-developers/developers/data/data-core-notices.md
@@ -78,6 +78,8 @@ _Parameters_
 -   _options.speak_ `[boolean]`: Whether the notice content should be announced to screen readers.
 -   _options.actions_ `[Array<WPNoticeAction>]`: User actions to be presented with notice.
 -   _options.icon_ `[Object]`: An icon displayed with the notice.
+-   _options.explicitDismiss_ `[boolean]`: Whether the notice includes an explict dismiss button and can't be dismissed by clicking the body of the notice.
+-   _options.onDismiss_ `[Function]`: Called when the notice is dismissed.
 
 _Returns_
 

--- a/packages/components/src/snackbar/index.js
+++ b/packages/components/src/snackbar/index.js
@@ -123,7 +123,7 @@ function Snackbar(
 							isTertiary
 							onClick={ ( event ) => {
 								event.stopPropagation();
-								if ( explicitDismiss) {
+								if ( explicitDismiss ) {
 									onRemove();
 								}
 								if ( onClick ) {

--- a/packages/components/src/snackbar/index.js
+++ b/packages/components/src/snackbar/index.js
@@ -56,6 +56,8 @@ function Snackbar(
 	},
 	ref
 ) {
+	onDismiss = onDismiss || noop;
+
 	function dismissMe( event ) {
 		if ( event && event.preventDefault ) {
 			event.preventDefault();
@@ -71,8 +73,8 @@ function Snackbar(
 	useEffect( () => {
 		const timeoutHandle = setTimeout( () => {
 			if ( ! explicitDismiss ) {
-				onRemove();
 				onDismiss();
+				onRemove();
 			}
 		}, NOTICE_TIMEOUT );
 

--- a/packages/components/src/snackbar/index.js
+++ b/packages/components/src/snackbar/index.js
@@ -123,6 +123,9 @@ function Snackbar(
 							isTertiary
 							onClick={ ( event ) => {
 								event.stopPropagation();
+								if ( explicitDismiss) {
+									onRemove();
+								}
 								if ( onClick ) {
 									onClick( event );
 								}

--- a/packages/components/src/snackbar/index.js
+++ b/packages/components/src/snackbar/index.js
@@ -66,18 +66,22 @@ function Snackbar(
 	}
 
 	useSpokenMessage( spokenMessage, politeness );
+
+	// Only set up the timeout dismiss if we're not explicitly dismissing.
 	useEffect( () => {
 		const timeoutHandle = setTimeout( () => {
-			onRemove();
 			if ( ! explicitDismiss ) {
+				onRemove();
 				onDismiss();
 			}
 		}, NOTICE_TIMEOUT );
 
 		return () => clearTimeout( timeoutHandle );
-	}, [ explicitDismiss, onDismiss, onRemove ] );
+	}, [ onDismiss, onRemove ] );
 
-	const classes = classnames( className, 'components-snackbar' );
+	const classes = classnames( className, 'components-snackbar', {
+		'components-snackbar-explicit-dismiss': !! explicitDismiss,
+	} );
 	if ( actions && actions.length > 1 ) {
 		// we need to inform developers that snackbar only accepts 1 action
 		warning(

--- a/packages/components/src/snackbar/index.js
+++ b/packages/components/src/snackbar/index.js
@@ -70,10 +70,8 @@ function Snackbar(
 	function onActionClick( event, onClick ) {
 		event.stopPropagation();
 
-		if ( explicitDismiss ) {
-			onRemove();
-		}
-
+		onRemove();
+		
 		if ( onClick ) {
 			onClick( event );
 		}

--- a/packages/components/src/snackbar/index.js
+++ b/packages/components/src/snackbar/index.js
@@ -67,6 +67,18 @@ function Snackbar(
 		onRemove();
 	}
 
+	function onActionClick( event, onClick ) {
+		event.stopPropagation();
+
+		if ( explicitDismiss ) {
+			onRemove();
+		}
+		
+		if ( onClick ) {
+			onClick( event );
+		}
+	}
+
 	useSpokenMessage( spokenMessage, politeness );
 
 	// Only set up the timeout dismiss if we're not explicitly dismissing.
@@ -121,15 +133,9 @@ function Snackbar(
 							key={ index }
 							href={ url }
 							isTertiary
-							onClick={ ( event ) => {
-								event.stopPropagation();
-								if ( explicitDismiss ) {
-									onRemove();
-								}
-								if ( onClick ) {
-									onClick( event );
-								}
-							} }
+							onClick={ ( event ) => 
+								onActionClick( event, onClick )
+							}
 							className="components-snackbar__action"
 						>
 							{ label }

--- a/packages/components/src/snackbar/index.js
+++ b/packages/components/src/snackbar/index.js
@@ -147,7 +147,7 @@ function Snackbar(
 						role="button"
 						aria-label="Dismiss this notice"
 						tabIndex="0"
-						className="components-snackbar__explicit-dismiss"
+						className="components-snackbar__dismiss-button"
 						onClick={ dismissMe }
 						onKeyPress={ dismissMe }
 					>

--- a/packages/components/src/snackbar/index.js
+++ b/packages/components/src/snackbar/index.js
@@ -73,7 +73,7 @@ function Snackbar(
 		if ( explicitDismiss ) {
 			onRemove();
 		}
-		
+
 		if ( onClick ) {
 			onClick( event );
 		}
@@ -133,7 +133,7 @@ function Snackbar(
 							key={ index }
 							href={ url }
 							isTertiary
-							onClick={ ( event ) => 
+							onClick={ ( event ) =>
 								onActionClick( event, onClick )
 							}
 							className="components-snackbar__action"

--- a/packages/components/src/snackbar/index.js
+++ b/packages/components/src/snackbar/index.js
@@ -71,7 +71,7 @@ function Snackbar(
 		event.stopPropagation();
 
 		onRemove();
-		
+
 		if ( onClick ) {
 			onClick( event );
 		}

--- a/packages/components/src/snackbar/stories/index.js
+++ b/packages/components/src/snackbar/stories/index.js
@@ -53,3 +53,12 @@ export const withIcon = () => {
 		</Snackbar>
 	);
 };
+
+export const withExplicitDismiss = () => {
+	const content = text(
+		'Content',
+		'Add a cross to explicitly close the snackbar, and do not hide it automatically'
+	);
+
+	return <Snackbar explicitDismiss={ true }>{ content }</Snackbar>;
+};

--- a/packages/components/src/snackbar/stories/index.js
+++ b/packages/components/src/snackbar/stories/index.js
@@ -62,3 +62,25 @@ export const withExplicitDismiss = () => {
 
 	return <Snackbar explicitDismiss={ true }>{ content }</Snackbar>;
 };
+
+export const withActionAndExpicitDismiss = () => {
+	const content = text(
+		'Content',
+		'Add an action and a cross to explicitly close the snackbar, and do not hide it automatically'
+	);
+	const actions = [
+		{
+			label: text( 'Label', 'Open WP.org' ),
+			url: text( 'URL', 'https://wordpress.org' ),
+		}
+	];
+
+	return (
+		<Snackbar
+			actions={ actions }
+			explicitDismiss={ true }
+		>
+			{ content }
+		</Snackbar>
+	);
+};

--- a/packages/components/src/snackbar/stories/index.js
+++ b/packages/components/src/snackbar/stories/index.js
@@ -72,14 +72,11 @@ export const withActionAndExpicitDismiss = () => {
 		{
 			label: text( 'Label', 'Open WP.org' ),
 			url: text( 'URL', 'https://wordpress.org' ),
-		}
+		},
 	];
 
 	return (
-		<Snackbar
-			actions={ actions }
-			explicitDismiss={ true }
-		>
+		<Snackbar actions={ actions } explicitDismiss={ true }>
 			{ content }
 		</Snackbar>
 	);

--- a/packages/components/src/snackbar/style.scss
+++ b/packages/components/src/snackbar/style.scss
@@ -21,6 +21,10 @@
 			0 0 0 3px var(--wp-admin-theme-color);
 	}
 
+	&.components-snackbar-explicit-dismiss {
+		cursor: default;
+	}
+
 	.components-snackbar__content-with-icon {
 		margin-left: 24px;
 	}
@@ -33,6 +37,7 @@
 
 	.components-snackbar__explicit-dismiss {
 		margin-left: 32px;
+		cursor: pointer;
 	}
 }
 

--- a/packages/components/src/snackbar/style.scss
+++ b/packages/components/src/snackbar/style.scss
@@ -22,13 +22,17 @@
 	}
 
 	.components-snackbar__content-with-icon {
-		margin-left: 32px;
+		margin-left: 24px;
 	}
 
 	.components-snackbar__icon {
 		position: absolute;
 		top: 24px;
-		left: 26px;
+		left: 28px;
+	}
+
+	.components-snackbar__explicit-dismiss {
+		margin-left: 32px;
 	}
 }
 

--- a/packages/components/src/snackbar/style.scss
+++ b/packages/components/src/snackbar/style.scss
@@ -35,7 +35,7 @@
 		left: 28px;
 	}
 
-	.components-snackbar__explicit-dismiss {
+	.components-snackbar__dismiss-button {
 		margin-left: 32px;
 		cursor: pointer;
 	}

--- a/packages/notices/src/store/actions.js
+++ b/packages/notices/src/store/actions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { uniqueId } from 'lodash';
+import { noop, uniqueId } from 'lodash';
 
 /**
  * Internal dependencies
@@ -41,6 +41,11 @@ import { DEFAULT_CONTEXT, DEFAULT_STATUS } from './constants';
  * @param {Array<WPNoticeAction>} [options.actions]            User actions to be
  *                                                             presented with notice.
  * @param {Object}                [options.icon]               An icon displayed with the notice.
+ * @param {boolean}               [options.explicitDismiss]    Whether the notice includes
+ *                                                             an explict dismiss button and
+ *                                                             can't be dismissed by clicking
+ *                                                             the body of the notice.
+ * @param {Function}              [options.onDismiss]          Called when the notice is dismissed.
  *
  * @return {Object} Action object.
  */
@@ -54,6 +59,8 @@ export function createNotice( status = DEFAULT_STATUS, content, options = {} ) {
 		type = 'default',
 		__unstableHTML,
 		icon = null,
+		explicitDismiss = false,
+		onDismiss = noop,
 	} = options;
 
 	// The supported value shape of content is currently limited to plain text
@@ -74,6 +81,8 @@ export function createNotice( status = DEFAULT_STATUS, content, options = {} ) {
 			actions,
 			type,
 			icon,
+			explicitDismiss,
+			onDismiss,
 		},
 	};
 }

--- a/packages/notices/src/store/actions.js
+++ b/packages/notices/src/store/actions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { noop, uniqueId } from 'lodash';
+import { uniqueId } from 'lodash';
 
 /**
  * Internal dependencies
@@ -60,7 +60,7 @@ export function createNotice( status = DEFAULT_STATUS, content, options = {} ) {
 		__unstableHTML,
 		icon = null,
 		explicitDismiss = false,
-		onDismiss = noop,
+		onDismiss = null,
 	} = options;
 
 	// The supported value shape of content is currently limited to plain text

--- a/packages/notices/src/store/test/actions.js
+++ b/packages/notices/src/store/test/actions.js
@@ -75,6 +75,8 @@ describe( 'actions', () => {
 					actions: [],
 					type: 'default',
 					icon: '🌮',
+					explicitDismiss: false,
+					onDismiss: null,
 				},
 			} );
 		} );
@@ -104,6 +106,8 @@ describe( 'actions', () => {
 					actions: [],
 					type: 'default',
 					icon: null,
+					explicitDismiss: false,
+					onDismiss: null,
 				},
 			} );
 		} );

--- a/packages/notices/src/store/test/reducer.js
+++ b/packages/notices/src/store/test/reducer.js
@@ -34,6 +34,8 @@ describe( 'reducer', () => {
 					actions: [],
 					type: 'default',
 					icon: null,
+					explicitDismiss: false,
+					onDismiss: null,
 				},
 			],
 		} );
@@ -57,6 +59,8 @@ describe( 'reducer', () => {
 					actions: [],
 					type: 'default',
 					icon: null,
+					explicitDismiss: false,
+					onDismiss: null,
 				},
 			],
 		} );
@@ -81,6 +85,8 @@ describe( 'reducer', () => {
 					actions: [],
 					type: 'default',
 					icon: null,
+					explicitDismiss: false,
+					onDismiss: null,
 				},
 				{
 					id: expect.any( String ),
@@ -92,6 +98,8 @@ describe( 'reducer', () => {
 					actions: [],
 					type: 'default',
 					icon: null,
+					explicitDismiss: false,
+					onDismiss: null,
 				},
 			],
 		} );
@@ -156,6 +164,8 @@ describe( 'reducer', () => {
 					actions: [],
 					type: 'default',
 					icon: null,
+					explicitDismiss: false,
+					onDismiss: null,
 				},
 			],
 		} );


### PR DESCRIPTION
## Description

- Adds an explicit dismiss button to the snackbar. When an explicit dismiss button is used, the snackbar stops disappearing automatically and clicking on the body of the snackbar does nothing - to dismiss the snackbar you have to click the dismiss button.
- Added a on dismiss callback to the snackbar, so that actions can be taken by the consumer when the snackbar is dismissed.

## How has this been tested?
- Snackbar component has been tested in Storybook
- We've forked the component in WooCommerce Admin to iterate and test locally faster, and this feature has been tested in woocommerce/woocommerce-admin#5623

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/224531/99037245-0eb2f800-25cf-11eb-9018-1b9a81bf1410.png)

## Types of changes
- New features - this should not break existing code. This adds an optional `explicitlyDismiss` flag and an `onDismiss` callback function to the snackbar.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
