### PR TITLE
Try: Better social links placeholder.

### DIFF
--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -44,9 +44,13 @@ export function SocialLinksEdit( props ) {
 
 	const SocialPlaceholder = (
 		<div className="wp-block-social-links__social-placeholder">
-			<div className="wp-social-link wp-social-link-facebook"></div>
-			<div className="wp-social-link wp-social-link-twitter"></div>
-			<div className="wp-social-link wp-social-link-instagram"></div>
+			<div className="wp-social-link"></div>
+			<div className="wp-block-social-links__social-placeholder-icons">
+				<div className="wp-social-link"></div>
+				<div className="wp-social-link wp-social-link-facebook"></div>
+				<div className="wp-social-link wp-social-link-twitter"></div>
+				<div className="wp-social-link wp-social-link-instagram"></div>
+			</div>
 		</div>
 	);
 

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -46,9 +46,8 @@ export function SocialLinksEdit( props ) {
 		<div className="wp-block-social-links__social-placeholder">
 			<div className="wp-social-link"></div>
 			<div className="wp-block-social-links__social-placeholder-icons">
-				<div className="wp-social-link"></div>
-				<div className="wp-social-link wp-social-link-facebook"></div>
 				<div className="wp-social-link wp-social-link-twitter"></div>
+				<div className="wp-social-link wp-social-link-facebook"></div>
 				<div className="wp-social-link wp-social-link-instagram"></div>
 			</div>
 		</div>

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -19,6 +19,12 @@
 .wp-block-social-links__social-placeholder {
 	display: flex;
 	opacity: 0.8;
+	transition: all 0.1s ease-in-out;
+	@include reduce-motion("transition");
+
+	.is-selected & {
+		opacity: 0.1;
+	}
 
 	// Use the first link to set the height.
 	> .wp-social-link {

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -20,6 +20,24 @@
 	display: flex;
 	opacity: 0.8;
 
+	// Use the first link to set the height.
+	> .wp-social-link {
+		// Use !important to keep the selector simple.
+		padding-left: 0 !important;
+		margin-left: 0 !important;
+		padding-right: 0 !important;
+		margin-right: 0 !important;
+		width: 0 !important;
+		visibility: hidden;
+	}
+
+	// Wrap the remaining placeholders in a container so the plus can overlap.
+	> .wp-block-social-links__social-placeholder-icons {
+		display: flex;
+		position: absolute;
+	}
+
+	& + .block-list-appender,
 	.wp-social-link {
 		padding: 0.25em;
 
@@ -44,15 +62,31 @@
 
 // Polish the Appender.
 .wp-block-social-links .block-list-appender {
-	margin: -$grid-unit-10 0;
 	display: flex;
 	align-items: center;
+	justify-content: center;
+	margin: 0;
 
-	svg {
-		width: $icon-size;
-		height: $icon-size;
+	&::before {
+		content: "";
+		display: block;
+		width: 1em;
+		height: 1em;
+	}
+
+	.block-editor-inserter {
+		position: absolute;
+	}
+
+	.block-editor-button-block-appender.block-list-appender__toggle {
+		margin: 0;
 	}
 }
+
+.wp-block-social-links.is-style-logos-only .block-list-appender {
+	padding: 4px;
+}
+
 
 // Center flex items. This has an equivalent in style.scss.
 .wp-block[data-align="center"] > .wp-block-social-links {


### PR DESCRIPTION
As we've explored and polished the social links placeholder to look more like the end result, there was recently some confusion around the dummy icons not being clickable:

<img width="646" alt="Screenshot 2020-11-13 at 09 18 42" src="https://user-images.githubusercontent.com/1204802/99049655-65044480-2597-11eb-98b5-0ac88726a65c.png">

This PR changes how the setup state works, so that the "plus" to append is overlaid on the placeholder itself:

![after](https://user-images.githubusercontent.com/1204802/99049690-70577000-2597-11eb-979d-fb22cf05c3c6.gif)
