### PR TITLE
Polish custom select menu styles.

### DIFF
--- a/packages/components/src/custom-select-control/index.js
+++ b/packages/components/src/custom-select-control/index.js
@@ -148,13 +148,13 @@ export default function CustomSelectControl( {
 								style: item.style,
 							} ) }
 						>
+							{ item.name }
 							{ item === selectedItem && (
 								<Icon
 									icon={ check }
 									className="components-custom-select-control__item-icon"
 								/>
 							) }
-							{ item.name }
 						</li>
 					) ) }
 			</ul>

--- a/packages/components/src/custom-select-control/style.scss
+++ b/packages/components/src/custom-select-control/style.scss
@@ -36,16 +36,17 @@
 }
 
 .components-custom-select-control__menu {
-	background-color: $white;
-
-	// Show border around the dropdown menu when open.
-	&:focus {
-		// Block UI appearance.
-		border: $border-width solid $gray-900;
-		border-radius: $radius-block-ui;
-		outline: none;
-		transition: none;
+	// Hide when collapsed.
+	&[aria-hidden="true"] {
+		display: none;
 	}
+
+	// Block UI appearance.
+	border: $border-width solid $gray-900;
+	background-color: $white;
+	border-radius: $radius-block-ui;
+	outline: none;
+	transition: none;
 
 	max-height: 400px;
 	min-width: 100%;

--- a/packages/components/src/custom-select-control/style.scss
+++ b/packages/components/src/custom-select-control/style.scss
@@ -60,16 +60,21 @@
 	align-items: center;
 	display: flex;
 	list-style-type: none;
-	padding: 10px 5px 10px 25px;
+	padding: $grid-unit-10;
 	cursor: default;
+	line-height: $icon-size + $grid-unit-05;
 
 
 	&.is-highlighted {
 		background: $gray-300;
 	}
 
-	&-icon {
-		margin-left: -20px;
+	.components-custom-select-control__item-icon {
 		margin-right: 0;
+		margin-left: auto;
+	}
+
+	&:last-child {
+		margin-bottom: 0;
 	}
 }


### PR DESCRIPTION
The custom select menu had some visual issues where the border would animate badly, and could disappear when focus was taken elsewhere without the menu already closed. Tricky, but achievable:

<img width="388" alt="Screenshot 2020-11-13 at 11 33 29" src="https://user-images.githubusercontent.com/1204802/99065570-dea42e80-25a7-11eb-9992-a6b15762b267.png">

This PR polishes that up a bit:

<img width="420" alt="Screenshot 2020-11-13 at 11 58 45" src="https://user-images.githubusercontent.com/1204802/99065579-e532a600-25a7-11eb-8f99-42aa1c9bf677.png">
