### PR TITLE
[e2e screenshots] Janitorial PR - add /artifacts to .gitignore and use process.cwd() instead of __dirname

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ gutenberg.zip
 phpcs.xml
 yarn.lock
 /wordpress
+/artifacts
 
 playground/dist
 .cache

--- a/packages/e2e-tests/config/setup-debug-artifacts.js
+++ b/packages/e2e-tests/config/setup-debug-artifacts.js
@@ -3,7 +3,7 @@
  */
 const fs = require( 'fs' );
 const util = require( 'util' );
-const root = process.env.GITHUB_WORKSPACE || __dirname + '/../../../';
+const root = process.env.GITHUB_WORKSPACE || process.cwd();
 const ARTIFACTS_PATH = root + '/artifacts';
 
 const writeFile = util.promisify( fs.writeFile );


### PR DESCRIPTION
Follow up after https://github.com/WordPress/gutenberg/pull/26664 to:

* add /artifacts to .gitignore
* use process.cwd() instead of __dirname

cc @gziolo 