### PR TITLE
Site Editor: Add Missing Styles

### DIFF
--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -12,11 +12,7 @@
  */
 function gutenberg_edit_site_page() {
 	?>
-	<div
-		id="edit-site-editor"
-		class="edit-site"
-	>
-	</div>
+	<div id="edit-site-editor" class="edit-site block-editor"></div>
 	<?php
 }
 

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -454,15 +454,14 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 		$settings['__experimentalGlobalStylesUserEntityId'] = gutenberg_experimental_global_styles_get_user_cpt_id();
 		$settings['__experimentalGlobalStylesContexts']     = $base->get_blocks_metadata();
 		$settings['__experimentalGlobalStylesBaseStyles']   = $base->get_raw_data();
-	} else {
-		// STEP 3 - OTHERWISE, ADD STYLES
-		//
-		// If we are in a block editor context, but not in edit-site,
-		// we need to add the styles via the settings. This is because
-		// we want them processed as if they were added via add_editor_styles,
-		// which adds the editor wrapper class.
-		$settings['styles'][] = array( 'css' => gutenberg_experimental_global_styles_get_stylesheet( $all ) );
 	}
+
+	// STEP 3 - OTHERWISE, ADD STYLES
+	//
+	// If we are in a block editor context we need to add the styles via the settings.
+	// This is because we want them processed as if they were added via add_editor_styles,
+	// which adds the editor wrapper class.
+	$settings['styles'][] = array( 'css' => gutenberg_experimental_global_styles_get_stylesheet( $all ) );
 
 	return $settings;
 }


### PR DESCRIPTION
## Description

- Add the `.block-editor` class to the Site Editor.
- Load experimental global styles in the Site Editor.

The Site Editor is initialized in a very different way compared to the Post Editor, and there are plenty of inconsistencies to be found.

I stumbled upon this issue when trying the HTML block in the Site Editor: its textarea didn't have any styles applied.
I then noticed that some styles depend on the `.block-editor` class, which is [created by Core WordPress](https://github.com/WordPress/WordPress/blob/0bc22bb1fc3a7ed3a9698cf72a1137c7443ad4ae/wp-admin/edit-form-blocks.php#L439) when rendering `edit-post`. `edit-site` is not initialized in the same way, and didn't have that class, making a few components and blocks (e.g. [`PlainText`](https://github.com/WordPress/gutenberg/blob/9db42e0462b7cf62d6db156cf211c379bd35f433/packages/block-editor/src/components/plain-text/style.scss#L1)) not working as intended.

After fixing the plain text view of the HTML block, I also noticed that its preview was broken as well.
As it turned out, we don't add the experimental global styles to the block-editor settings in `edit-site`.
I'm not sure why, though, and I can't tell if I'm causing any regressions here.
Pinging @nosolosw as author of the original PR for some pointers: https://github.com/WordPress/gutenberg/pull/24250

## How has this been tested?

- Open the Site Editor.
- Add the HTML block, and make sure it's styled appropriately.
- Insert some HTML, and click on "Preview" in the block toolbar.
- Make sure the preview is styled appropriately.

## Screenshots <!-- if applicable -->

| Before | After |
| - | - |
| <img width="859" alt="Screenshot 2020-11-13 at 12 34 40" src="https://user-images.githubusercontent.com/2070010/99072821-a9e6a600-25ac-11eb-949f-87d7a622cc0f.png"> | <img width="864" alt="Screenshot 2020-11-13 at 12 32 44" src="https://user-images.githubusercontent.com/2070010/99072829-ad7a2d00-25ac-11eb-8ffb-50cf7ee5f51c.png"> |
| <img width="857" alt="Screenshot 2020-11-13 at 12 34 46" src="https://user-images.githubusercontent.com/2070010/99072838-b0751d80-25ac-11eb-85a2-cc4cc0275cfa.png"> | <img width="857" alt="Screenshot 2020-11-13 at 12 32 53" src="https://user-images.githubusercontent.com/2070010/99072848-b3700e00-25ac-11eb-80ee-bf7a64a7397c.png"> |

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
