### PR TITLE
[try] Record failed e2e tests as artifacts

### DIFF
--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -41,6 +41,9 @@ jobs:
         npm ci
         FORCE_REDUCED_MOTION=true npm run build
 
+    - name: Install ffmpeg
+      run: sudo apt-get install ffmpeg
+
     - name: Install WordPress
       run: |
         chmod -R 767 ./ # TODO: Possibly integrate in wp-env
@@ -88,6 +91,9 @@ jobs:
       run: |
         npm ci
         FORCE_REDUCED_MOTION=true npm run build
+
+    - name: Install ffmpeg
+      run: sudo apt-get install ffmpeg
 
     - name: Install WordPress
       run: |
@@ -137,6 +143,9 @@ jobs:
         npm ci
         FORCE_REDUCED_MOTION=true npm run build
 
+    - name: Install ffmpeg
+      run: sudo apt-get install ffmpeg
+
     - name: Install WordPress
       run: |
         chmod -R 767 ./ # TODO: Possibly integrate in wp-env
@@ -184,6 +193,9 @@ jobs:
       run: |
         npm ci
         FORCE_REDUCED_MOTION=true npm run build
+
+    - name: Install ffmpeg
+      run: sudo apt-get install ffmpeg
 
     - name: Install WordPress
       run: |

--- a/packages/e2e-tests/config/setup-debug-artifacts.js
+++ b/packages/e2e-tests/config/setup-debug-artifacts.js
@@ -2,15 +2,20 @@
  * External dependencies
  */
 const fs = require( 'fs' );
+const { spawn } = require( 'child_process' );
 const util = require( 'util' );
 const root = process.env.GITHUB_WORKSPACE || __dirname + '/../../../';
 const ARTIFACTS_PATH = root + '/artifacts';
+const TMP_PATH = ARTIFACTS_PATH + '/tmp';
 
 const writeFile = util.promisify( fs.writeFile );
 
-if ( ! fs.existsSync( ARTIFACTS_PATH ) ) {
-	fs.mkdirSync( ARTIFACTS_PATH );
+for ( const path of [ ARTIFACTS_PATH, TMP_PATH ] ) {
+	if ( ! fs.existsSync( path ) ) {
+		fs.mkdirSync( path );
+	}
 }
+// afterAll( () => fs.rmdirSync( TMP_PATH ) );
 
 /**
  * Gutenberg uses the default jest-jasmine2 test runner that comes with Jest.
@@ -23,6 +28,7 @@ if ( ! fs.existsSync( ARTIFACTS_PATH ) ) {
 let artifactsPromise;
 // eslint-disable-next-line jest/no-jasmine-globals
 jasmine.getEnv().addReporter( {
+	specStarted: () => startVideo(),
 	specDone: ( result ) => {
 		if ( result.status === 'failed' ) {
 			artifactsPromise = storeArtifacts( result.fullName );
@@ -35,6 +41,8 @@ afterAll( () => artifactsPromise );
 
 async function storeArtifacts( testName ) {
 	const slug = slugify( testName );
+	await stopVideo();
+	await encodeVideo( `${ ARTIFACTS_PATH }/${ slug }-video.mp4` );
 	await writeFile(
 		`${ ARTIFACTS_PATH }/${ slug }-snapshot.html`,
 		await page.content()
@@ -52,3 +60,61 @@ function slugify( testName ) {
 		.replace( / /g, '-' );
 	return slug;
 }
+
+let frames = [];
+let session;
+
+const startVideo = async () => {
+	frames = [];
+	if ( ! session ) {
+		session = await page.target().createCDPSession();
+	}
+	await session.send( 'Page.startScreencast', {
+		format: 'png',
+		everyNthFrame: 1,
+	} );
+	session.on( 'Page.screencastFrame', ( event ) => {
+		frames.push( Buffer.from( event.data, 'base64' ) );
+	} );
+};
+const stopVideo = () => {
+	session.send( 'Page.stopScreencast' );
+};
+const encodeVideo = async ( outfile ) => {
+	if ( ! frames.length ) {
+		return;
+	}
+
+	for ( let i = 0, max = frames.length; i < max; i++ ) {
+		fs.writeFileSync( `${ TMP_PATH }/${ i }.png`, frames[ i ] );
+	}
+
+	const ffmpeg = spawn( 'ffmpeg', [
+		'-framerate',
+		'5',
+		'-pattern_type',
+		'glob',
+		'-i',
+		`${ TMP_PATH }/*.png`,
+		'-c:v',
+		'libx264',
+		'-r',
+		'30',
+		'-pix_fmt',
+		'yuv420p',
+		outfile,
+	] );
+
+	const closed = new Promise( ( resolve, reject ) => {
+		ffmpeg.on( 'error', reject );
+		ffmpeg.on( 'close', resolve );
+	} );
+
+	await closed;
+
+	for ( let i = 0, max = frames.length; i < max; i++ ) {
+		try {
+			fs.unlinkSync( `${ TMP_PATH }/${ i }.png` );
+		} catch ( e ) {}
+	}
+};


### PR DESCRIPTION
This is an exploratory PR to record mp4 videos of failed e2e tests, inspired by this comment by @noahtallen:

https://github.com/WordPress/gutenberg/pull/26664#pullrequestreview-527674249

It captures png screenshots using chrome devtools protocol, stores them on disk, and uses ffmpeg to encode an mp4 video.

Concerns:
* Is there any way to make chromium expose a screencast instead of screenshots? I thought about using WebRTC, but won't work in chromium, we'd need chrome.
* If not, could those screenshots be in jpg format?
* Also, could we directly pipe the screenshots to `ffmpeg`?
* Are there any disk space limitations for artifacts this would cause us to exceed?
* Are screenshots alone good enough? Is this worth pursuing?

cc @noahtallen @noisysocks @talldan @gziolo @draganescu 