### PR TITLE
Added missing docs for the `wrapperProps` property for the `BlockListBlock` component returned by the `editor.blockListEdit` filter.

### DIFF
--- a/docs/reference-guides/filters/block-filters.md
+++ b/docs/reference-guides/filters/block-filters.md
@@ -268,6 +268,49 @@ wp.hooks.addFilter(
 
 {% end %}
 
+Adding new properties to the block's wrapper component can be achieved by adding them to the `wrapperProps` property of the returned component.
+
+_Example:_
+
+{% codetabs %}
+{% ESNext %}
+```js
+const { createHigherOrderComponent } = wp.compose;
+const withMyWrapperProp = createHigherOrderComponent( ( BlockListBlock ) => {
+	return ( props ) => {
+		const wrapperProps = {
+		    ...props.wrapperProps,
+		    'data-my-property': 'the-value',
+		};
+		return <BlockListBlock { ...props } wrapperProps={ wrapperProps } />;
+	};
+}, 'withMyWrapperProp' );
+wp.hooks.addFilter( 'editor.BlockListBlock', 'my-plugin/with-my-wrapper-prop', withMyWrapperProp );
+```
+{% ES5 %}
+```js
+var el = wp.element.createElement;
+var hoc = wp.compose.createHigherOrderComponent;
+
+var withMyWrapperProp = hoc( function( BlockListBlock ) {
+	return function( props ) {
+		var newProps = {
+			...props,
+			wrapperProps: {
+				...props.wrapperProps,
+				'data-my-property': 'the-value'
+			}
+		};
+		return el(
+			BlockListBlock,
+			newProps
+		);
+	};
+}, 'withMyWrapperProp' );
+wp.hooks.addFilter( 'editor.BlockListBlock', 'my-plugin/with-my-wrapper-prop', withMyWrapperProp );
+```
+{% end %}
+
 ## Removing Blocks
 
 ### Using a deny list


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->
Fixes https://github.com/WordPress/gutenberg/issues/24864

Adds missing documentation on how to use the `wrapperProps` property on the `BlockListBlock` component to add (custom) properties to a block's wrapper component, using the `editor.blockListEdit` filter.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
I tested the added code samples by creating a minimal plugin that extended the block editor using the steps [as described in the Gutenberg Handbook](https://developer.wordpress.org/block-editor/tutorials/javascript/js-build-setup/). Once using the ES5 syntax, once using the ESNext syntax.

## Screenshots <!-- if applicable -->
N/A

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Added missing documentation.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
