### PR TITLE
Site Editor (Experiment): Automatically open the sidebar to the appropriate menu

### DIFF
--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
@@ -6,9 +6,11 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
+import { usePrevious } from '@wordpress/compose';
+import { store as coreDataStore } from '@wordpress/core-data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { useState, useEffect, useRef } from '@wordpress/element';
 import { ESCAPE } from '@wordpress/keycodes';
-import { useSelect, useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -22,7 +24,7 @@ const NavigationPanel = ( { isOpen } ) => {
 	const [ contentActiveMenu, setContentActiveMenu ] = useState( MENU_ROOT );
 	const { templatesActiveMenu, siteTitle } = useSelect( ( select ) => {
 		const { getNavigationPanelActiveMenu } = select( editSiteStore );
-		const { getEntityRecord } = select( 'core' );
+		const { getEntityRecord } = select( coreDataStore );
 
 		const siteData =
 			getEntityRecord( 'root', '__unstableBase', undefined ) || {};
@@ -41,6 +43,15 @@ const NavigationPanel = ( { isOpen } ) => {
 			panelRef.current.focus();
 		}
 	}, [ templatesActiveMenu ] );
+
+	// Resets the content menu to its root whenever the navigation opens to avoid
+	// having it stuck on a sub-menu, interfering with the normal navigation behavior.
+	const prevIsOpen = usePrevious( isOpen );
+	useEffect( () => {
+		if ( contentActiveMenu !== MENU_ROOT && isOpen && ! prevIsOpen ) {
+			setContentActiveMenu( MENU_ROOT );
+		}
+	}, [ contentActiveMenu, isOpen ] );
 
 	const { setIsNavigationPanelOpened } = useDispatch( editSiteStore );
 
@@ -69,8 +80,7 @@ const NavigationPanel = ( { isOpen } ) => {
 				</div>
 
 				<div className="edit-site-navigation-panel__scroll-container">
-					{ ( contentActiveMenu === MENU_ROOT ||
-						templatesActiveMenu !== MENU_ROOT ) && (
+					{ contentActiveMenu === MENU_ROOT && (
 						<TemplatesNavigation />
 					) }
 					{ templatesActiveMenu === MENU_ROOT && (

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
@@ -73,8 +73,7 @@ const NavigationPanel = ( { isOpen } ) => {
 						templatesActiveMenu !== MENU_ROOT ) && (
 						<TemplatesNavigation />
 					) }
-					{ ( templatesActiveMenu === MENU_ROOT ||
-						contentActiveMenu !== MENU_ROOT ) && (
+					{ templatesActiveMenu === MENU_ROOT && (
 						<ContentNavigation
 							onActivateMenu={ setContentActiveMenu }
 						/>

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/index.js
@@ -43,7 +43,7 @@ function NavigationToggle( { icon, isOpen } ) {
 
 	const toggleNavigationPanel = () => {
 		if ( isOpen ) {
-			setIsNavigationPanelOpened( ! isOpen );
+			setIsNavigationPanelOpened( false );
 			return;
 		}
 		openNavigationPanelToMenu( navigationPanelMenu );

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/index.js
@@ -5,30 +5,54 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { Button, Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
+import { store as coreDataStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
 import { store as editSiteStore } from '../../../store';
+import {
+	MENU_TEMPLATE_PARTS,
+	MENU_TEMPLATES,
+} from '../navigation-panel/constants';
 
 function NavigationToggle( { icon, isOpen } ) {
-	const { isRequestingSiteIcon, siteIconUrl } = useSelect( ( select ) => {
-		const { getEntityRecord } = select( 'core' );
-		const { isResolving } = select( 'core/data' );
-		const siteData =
-			getEntityRecord( 'root', '__unstableBase', undefined ) || {};
+	const { isRequestingSiteIcon, templateType, siteIconUrl } = useSelect(
+		( select ) => {
+			const { getTemplateType } = select( editSiteStore );
+			const { getEntityRecord, isResolving } = select( coreDataStore );
+			const siteData =
+				getEntityRecord( 'root', '__unstableBase', undefined ) || {};
 
-		return {
-			isRequestingSiteIcon: isResolving( 'core', 'getEntityRecord', [
-				'root',
-				'__unstableBase',
-				undefined,
-			] ),
-			siteIconUrl: siteData.site_icon_url,
-		};
-	}, [] );
+			return {
+				isRequestingSiteIcon: isResolving( 'core', 'getEntityRecord', [
+					'root',
+					'__unstableBase',
+					undefined,
+				] ),
+				templateType: getTemplateType(),
+				siteIconUrl: siteData.site_icon_url,
+			};
+		},
+		[]
+	);
 
-	const { setIsNavigationPanelOpened } = useDispatch( editSiteStore );
+	const {
+		openNavigationPanelToMenu,
+		setIsNavigationPanelOpened,
+	} = useDispatch( editSiteStore );
+
+	const toggleNavigationPanel = () => {
+		if ( isOpen ) {
+			setIsNavigationPanelOpened( ! isOpen );
+			return;
+		}
+		openNavigationPanelToMenu(
+			'wp_template' === templateType
+				? MENU_TEMPLATES
+				: MENU_TEMPLATE_PARTS
+		);
+	};
 
 	let buttonIcon = <Icon size="36px" icon={ wordpress } />;
 
@@ -55,7 +79,7 @@ function NavigationToggle( { icon, isOpen } ) {
 			<Button
 				className="edit-site-navigation-toggle__button has-icon"
 				label={ __( 'Toggle navigation' ) }
-				onClick={ () => setIsNavigationPanelOpened( ! isOpen ) }
+				onClick={ toggleNavigationPanel }
 				showTooltip
 			>
 				{ buttonIcon }

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/index.js
@@ -19,7 +19,7 @@ import {
 function NavigationToggle( { icon, isOpen } ) {
 	const { isRequestingSiteIcon, templateType, siteIconUrl } = useSelect(
 		( select ) => {
-			const { getTemplateType } = select( editSiteStore );
+			const { getEditedPostType } = select( editSiteStore );
 			const { getEntityRecord, isResolving } = select( coreDataStore );
 			const siteData =
 				getEntityRecord( 'root', '__unstableBase', undefined ) || {};
@@ -30,7 +30,7 @@ function NavigationToggle( { icon, isOpen } ) {
 					'__unstableBase',
 					undefined,
 				] ),
-				templateType: getTemplateType(),
+				templateType: getEditedPostType(),
 				siteIconUrl: siteData.site_icon_url,
 			};
 		},

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/index.js
@@ -11,31 +11,30 @@ import { store as coreDataStore } from '@wordpress/core-data';
  * Internal dependencies
  */
 import { store as editSiteStore } from '../../../store';
-import {
-	MENU_TEMPLATE_PARTS,
-	MENU_TEMPLATES,
-} from '../navigation-panel/constants';
 
 function NavigationToggle( { icon, isOpen } ) {
-	const { isRequestingSiteIcon, templateType, siteIconUrl } = useSelect(
-		( select ) => {
-			const { getEditedPostType } = select( editSiteStore );
-			const { getEntityRecord, isResolving } = select( coreDataStore );
-			const siteData =
-				getEntityRecord( 'root', '__unstableBase', undefined ) || {};
+	const {
+		isRequestingSiteIcon,
+		navigationPanelMenu,
+		siteIconUrl,
+	} = useSelect( ( select ) => {
+		const { getCurrentTemplateNavigationPanelSubMenu } = select(
+			editSiteStore
+		);
+		const { getEntityRecord, isResolving } = select( coreDataStore );
+		const siteData =
+			getEntityRecord( 'root', '__unstableBase', undefined ) || {};
 
-			return {
-				isRequestingSiteIcon: isResolving( 'core', 'getEntityRecord', [
-					'root',
-					'__unstableBase',
-					undefined,
-				] ),
-				templateType: getEditedPostType(),
-				siteIconUrl: siteData.site_icon_url,
-			};
-		},
-		[]
-	);
+		return {
+			isRequestingSiteIcon: isResolving( 'core', 'getEntityRecord', [
+				'root',
+				'__unstableBase',
+				undefined,
+			] ),
+			navigationPanelMenu: getCurrentTemplateNavigationPanelSubMenu(),
+			siteIconUrl: siteData.site_icon_url,
+		};
+	}, [] );
 
 	const {
 		openNavigationPanelToMenu,
@@ -47,11 +46,7 @@ function NavigationToggle( { icon, isOpen } ) {
 			setIsNavigationPanelOpened( ! isOpen );
 			return;
 		}
-		openNavigationPanelToMenu(
-			'wp_template' === templateType
-				? MENU_TEMPLATES
-				: MENU_TEMPLATE_PARTS
-		);
+		openNavigationPanelToMenu( navigationPanelMenu );
 	};
 
 	let buttonIcon = <Icon size="36px" icon={ wordpress } />;

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/test/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/test/index.js
@@ -29,11 +29,11 @@ describe( 'NavigationToggle', () => {
 		it( 'should display a user uploaded site icon if it exists', () => {
 			useSelect.mockImplementation( ( cb ) => {
 				return cb( () => ( {
-					isResolving: () => false,
-					isFeatureActive: () => true,
+					getCurrentTemplateNavigationPanelSubMenu: () => 'root',
 					getEntityRecord: () => ( {
 						site_icon_url: 'https://fakeUrl.com',
 					} ),
+					isResolving: () => false,
 				} ) );
 			} );
 
@@ -48,11 +48,11 @@ describe( 'NavigationToggle', () => {
 		it( 'should display a default site icon if no user uploaded site icon exists', () => {
 			useSelect.mockImplementation( ( cb ) => {
 				return cb( () => ( {
-					isResolving: () => false,
-					isFeatureActive: () => true,
+					getCurrentTemplateNavigationPanelSubMenu: () => 'root',
 					getEntityRecord: () => ( {
 						site_icon_url: '',
 					} ),
+					isResolving: () => false,
 				} ) );
 			} );
 

--- a/packages/edit-site/src/store/test/selectors.js
+++ b/packages/edit-site/src/store/test/selectors.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { store as coreDataStore } from '@wordpress/core-data';
+
+/**
  * Internal dependencies
  */
 import {
@@ -71,7 +76,7 @@ describe( 'selectors', () => {
 			expect( getCanUserCreateMedia() ).toBe( true );
 			expect(
 				getCanUserCreateMedia.registry.select
-			).toHaveBeenCalledWith( 'core' );
+			).toHaveBeenCalledWith( coreDataStore );
 			expect( canUser ).toHaveBeenCalledWith( 'create', 'media' );
 		} );
 	} );


### PR DESCRIPTION
## Description

Fixes #26924

Clicking on the navigation toggle button will open the navigation sidebar to the appropriate menu, either Templates or Template Parts, depending on the template type that is being currently edited.

## How has this been tested?

- Open the Site Editor.
- Click on the navigation toggle button (WP icon / site logo).
- Make sure the sidebar opens to the "Templates" menu.
- Navigate back to "Themes" and then into "Template Parts". Click a template part to focus on that.
- Close and reopen the sidebar with the navigation toggle button.
- Make sure the sidebar opens to the "Template Parts" menu.

## Screenshots <!-- if applicable -->

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
