### PR TITLE
Animate: Add types and simplify API

### DIFF
--- a/packages/components/src/animate/README.md
+++ b/packages/components/src/animate/README.md
@@ -1,6 +1,6 @@
 # Animate
 
-Simple interface to introduce animations to components. 
+Simple interface to introduce animations to components.
 
 ## Usage
 
@@ -8,7 +8,7 @@ Simple interface to introduce animations to components.
 import { Animate } from '@wordpress/components';
 
 const MyAnimatedNotice = () => (
-	<Animate todo="Add missing props">
+	<Animate type="appear" origin="top">
 		{ ( { className } ) => (
 			<Notice className={ className } status="success">
 				<p>Animation finished.</p>
@@ -20,27 +20,27 @@ const MyAnimatedNotice = () => (
 
 ## Props
 
-Name | Type | Default | Description
---- | --- | --- | ---
-`type` | `string` | `undefined` | Type of the animation to use.
-`options` | `object` | `{}` | Options of the chosen animation.
-`children` | `function` | `undefined` | A callback receiving a list of props ( `className` ) to apply to the DOM element to animate.
+| Name       | Type       | Description                                                                               |
+| ---------- | ---------- | ----------------------------------------------------------------------------------------- |
+| `type`     | `string`   | Type of the animation to use.                                                             |
+| `children` | `function` | A callback receiving a props object (`className`) to apply to the DOM element to animate. |
+| ...options | `object`   | Additional options based on the type of animation. See below.                             |
 
 ## Available Animation Types
 
 ### appear
 
-This animation is meant for popover/modal content, such as menus appearing. It shows the height and width of the animated element scaling from 0 to full size, from its point of origin. 
+This animation is meant for popover/modal content, such as menus appearing. It shows the height and width of the animated element scaling from 0 to full size, from its point of origin.
 
 #### Options
 
-Name | Type | Default | Description
---- | --- | --- | ---
-`origin` | `string` | `top center` | Point of origin (`top`, `bottom`,` middle right`, `left`, `center`).
+| Name     | Type     | Default      | Description                                                          |
+| -------- | -------- | ------------ | -------------------------------------------------------------------- |
+| `origin` | `string` | `top center` | Point of origin (`top`, `bottom`, `middle right`, `left`, `center`). |
 
 ### loading
 
-This animation is meant to be used to indicate that activity is happening in the background. It is an infinitely-looping fade from 50% to full opacity. This animation has no options, and should be removed as soon as its relevant operation is completed. 
+This animation is meant to be used to indicate that activity is happening in the background. It is an infinitely-looping fade from 50% to full opacity. This animation has no options, and should be removed as soon as its relevant operation is completed.
 
 ### slide-in
 
@@ -48,6 +48,6 @@ This animation is meant for sidebars and sliding menus. It shows the height and 
 
 #### Options
 
-Name | Type | Default | Description
---- | --- | --- | ---
-`origin` | `string` | `left` | Point of origin (`left`).
+| Name     | Type     | Default | Description               |
+| -------- | -------- | ------- | ------------------------- |
+| `origin` | `string` | `left`  | Point of origin (`left`). |

--- a/packages/components/src/animate/index.js
+++ b/packages/components/src/animate/index.js
@@ -74,7 +74,7 @@ export default function Animate( {
 } ) {
 	if ( Boolean( _deprecatedOptions ) ) {
 		deprecated( '<Animate /> options prop', {
-			version: '9.4',
+			version: '9.6',
 			hint: 'Pass options directly as props instead.',
 		} );
 	}

--- a/packages/components/src/animate/index.js
+++ b/packages/components/src/animate/index.js
@@ -73,8 +73,8 @@ export default function Animate( {
 	...options
 } ) {
 	if ( Boolean( _deprecatedOptions ) ) {
-		deprecated( '<Animate> options prop', {
-			version: '9.3',
+		deprecated( '<Animate /> options prop', {
+			version: '9.4',
 			hint: 'Pass options directly as props instead.',
 		} );
 	}

--- a/packages/components/src/animate/index.js
+++ b/packages/components/src/animate/index.js
@@ -4,46 +4,40 @@
 import classnames from 'classnames';
 
 /**
- * @typedef {'top' | 'top left' | 'top right' | 'bottom' | 'bottom left' | 'bottom right'} AppearOrigin
+ * WordPress dependencies
  */
-/**
- * @typedef {'appear' | 'loading' | 'slide-in'} Type
- */
-/**
- * @typedef {'left' | 'right'} SlideInOrigin
- */
+import deprecated from '@wordpress/deprecated';
 
 /**
- * @param {Type} type The animation type
+ * @typedef {'top' | 'top left' | 'top right' | 'middle' | 'middle left' | 'middle right' | 'bottom' | 'bottom left' | 'bottom right'} AppearOrigin
+ * @typedef {'left' | 'right'} SlideInOrigin
+ * @typedef {{type: 'appear'; origin?: AppearOrigin}} AppearOptions
+ * @typedef {{type: 'slide-in'; origin?: SlideInOrigin}} SlideInOptions
+ * @typedef {{type: 'loading'}} LoadingOptions
+ * @typedef {AppearOptions|SlideInOptions|LoadingOptions} UseAnimateOptions
+ */
+
+/* eslint-disable jsdoc/valid-types */
+/**
+ * @param {UseAnimateOptions['type']} type The animation type
  * @return {'top'|'left'} Default origin
  */
 function getDefaultOrigin( type ) {
 	return type === 'appear' ? 'top' : 'left';
 }
+/* eslint-enable jsdoc/valid-types */
 
 /**
- * @typedef AppearOptions
- * @property {'appear'} type The type of animation.
- * @property {AppearOrigin} origin The origin of the appearance.
- */
-
-/**
- * @typedef SlideInOptions
- * @property {'slide-in'} type The type of animation.
- * @property {SlideInOrigin} origin The origin of the appearance.
- */
-
-/**
- * @typedef LoadingOptions
- * @property {'loading'} type The type of animation.
- * @property {never} origin .
- */
-
-/**
- * @param {AppearOptions | SlideInOptions | LoadingOptions} options
+ * @param {UseAnimateOptions} options
  * @return {string | undefined} Classname that applies the animations
  */
-export function useAnimate( { type, origin = getDefaultOrigin( type ) } ) {
+export function useAnimate( { type } ) {
+	if ( type === 'loading' ) {
+		return classnames( 'components-animate__loading' );
+	}
+
+	const origin = getDefaultOrigin( type );
+
 	if ( type === 'appear' ) {
 		const [ yAxis, xAxis = 'center' ] = origin.split( ' ' );
 		return classnames( 'components-animate__appear', {
@@ -59,61 +53,29 @@ export function useAnimate( { type, origin = getDefaultOrigin( type ) } ) {
 		);
 	}
 
-	if ( type === 'loading' ) {
-		return classnames( 'components-animate__loading' );
-	}
-
 	return undefined;
 }
 
 /**
- * @typedef AppearPropsOptions
- * @property {AppearOrigin} origin The origin of the appearance.
+ *
+ * @todo Remove options when deprecated handling has been removed.
+ *
+ * @param {{options?: any; children: (props: {className?: string})=> JSX.Element;} & UseAnimateOptions} props
+ * @return {JSX.Element} Element
  */
-
-/**
- * @typedef SlideInPropsOptions
- * @property {SlideInOrigin} origin The origin of the appearance.
- */
-
-/**
- * @typedef ChildrenProps
- * @property {string} className Classnames for the animation.
- */
-
-/**
- * @callback children
- * @param {ChildrenProps} props
- * @return {JSX.Element}
- */
-
-/**
- * @typedef AppearProps
- * @property {'appear'} type The animation type.
- * @property {AppearPropsOptions} options Options for the animation.
- * @property {children} children Children as a function.
- */
-
-/**
- * @typedef SlideInProps
- * @property {'slide-in'} type The animation type.
- * @property {SlideInPropsOptions} options Options for the animation.
- * @property {children} children Children as a function.
- */
-
-/**
- * @typedef LoadingProps
- * @property {'loading'} type The animation type.
- * @property {never} options Unused options
- * @property {children} children Children as a function.
- */
-
-/**
- * @param {AppearProps | SlideInProps | LoadingProps} props Props.
- * @return {JSX.Element} Element.
- */
-export default function Animate( { type, options, children } ) {
+export default function Animate( {
+	type,
+	options: _deprecatedOptions,
+	children,
+	...options
+} ) {
+	if ( Boolean( _deprecatedOptions ) ) {
+		deprecated( '<Animate> options prop', {
+			version: '9.3',
+			hint: 'Pass options directly as props instead.',
+		} );
+	}
 	return children( {
-		className: useAnimate( { type, ...( options || {} ) } ),
+		className: useAnimate( { type, ..._deprecatedOptions, ...options } ),
 	} );
 }

--- a/packages/components/src/animate/index.js
+++ b/packages/components/src/animate/index.js
@@ -3,10 +3,46 @@
  */
 import classnames from 'classnames';
 
+/**
+ * @typedef {'top' | 'top left' | 'top right' | 'bottom' | 'bottom left' | 'bottom right'} AppearOrigin
+ */
+/**
+ * @typedef {'appear' | 'loading' | 'slide-in'} Type
+ */
+/**
+ * @typedef {'left' | 'right'} SlideInOrigin
+ */
+
+/**
+ * @param {Type} type The animation type
+ * @return {'top'|'left'} Default origin
+ */
 function getDefaultOrigin( type ) {
 	return type === 'appear' ? 'top' : 'left';
 }
 
+/**
+ * @typedef AppearOptions
+ * @property {'appear'} type The type of animation.
+ * @property {AppearOrigin} origin The origin of the appearance.
+ */
+
+/**
+ * @typedef SlideInOptions
+ * @property {'slide-in'} type The type of animation.
+ * @property {SlideInOrigin} origin The origin of the appearance.
+ */
+
+/**
+ * @typedef LoadingOptions
+ * @property {'loading'} type The type of animation.
+ * @property {never} origin .
+ */
+
+/**
+ * @param {AppearOptions | SlideInOptions | LoadingOptions} options
+ * @return {string | undefined} Classname that applies the animations
+ */
 export function useAnimate( { type, origin = getDefaultOrigin( type ) } ) {
 	if ( type === 'appear' ) {
 		const [ yAxis, xAxis = 'center' ] = origin.split( ' ' );
@@ -26,10 +62,58 @@ export function useAnimate( { type, origin = getDefaultOrigin( type ) } ) {
 	if ( type === 'loading' ) {
 		return classnames( 'components-animate__loading' );
 	}
+
+	return undefined;
 }
 
-export default function Animate( { type, options = {}, children } ) {
+/**
+ * @typedef AppearPropsOptions
+ * @property {AppearOrigin} origin The origin of the appearance.
+ */
+
+/**
+ * @typedef SlideInPropsOptions
+ * @property {SlideInOrigin} origin The origin of the appearance.
+ */
+
+/**
+ * @typedef ChildrenProps
+ * @property {string} className Classnames for the animation.
+ */
+
+/**
+ * @callback children
+ * @param {ChildrenProps} props
+ * @return {JSX.Element}
+ */
+
+/**
+ * @typedef AppearProps
+ * @property {'appear'} type The animation type.
+ * @property {AppearPropsOptions} options Options for the animation.
+ * @property {children} children Children as a function.
+ */
+
+/**
+ * @typedef SlideInProps
+ * @property {'slide-in'} type The animation type.
+ * @property {SlideInPropsOptions} options Options for the animation.
+ * @property {children} children Children as a function.
+ */
+
+/**
+ * @typedef LoadingProps
+ * @property {'loading'} type The animation type.
+ * @property {never} options Unused options
+ * @property {children} children Children as a function.
+ */
+
+/**
+ * @param {AppearProps | SlideInProps | LoadingProps} props Props.
+ * @return {JSX.Element} Element.
+ */
+export default function Animate( { type, options, children } ) {
 	return children( {
-		className: useAnimate( { type, ...options } ),
+		className: useAnimate( { type, ...( options || {} ) } ),
 	} );
 }

--- a/packages/components/src/animate/index.js
+++ b/packages/components/src/animate/index.js
@@ -6,6 +6,8 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
+// Ignore due to missing types: https://github.com/WordPress/gutenberg/pull/26429
+// @ts-ignore
 import deprecated from '@wordpress/deprecated';
 
 /**

--- a/packages/components/src/animate/index.js
+++ b/packages/components/src/animate/index.js
@@ -6,8 +6,6 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-// Ignore due to missing types: https://github.com/WordPress/gutenberg/pull/26429
-// @ts-ignore
 import deprecated from '@wordpress/deprecated';
 
 /**

--- a/packages/components/src/animate/index.js
+++ b/packages/components/src/animate/index.js
@@ -31,12 +31,15 @@ function getDefaultOrigin( type ) {
  * @param {UseAnimateOptions} options
  * @return {string | undefined} Classname that applies the animations
  */
-export function useAnimate( { type } ) {
+export function useAnimate( options ) {
+	const { type } = options;
 	if ( type === 'loading' ) {
 		return classnames( 'components-animate__loading' );
 	}
 
-	const origin = getDefaultOrigin( type );
+	const {
+		origin = getDefaultOrigin( type ),
+	} = /** @type {AppearOptions|SlideInOptions} */ ( options );
 
 	if ( type === 'appear' ) {
 		const [ yAxis, xAxis = 'center' ] = origin.split( ' ' );

--- a/packages/components/src/animate/stories/index.js
+++ b/packages/components/src/animate/stories/index.js
@@ -1,4 +1,10 @@
 /**
+ * External dependencies
+ */
+import { button, radios } from '@storybook/addon-knobs';
+import { useMemo, useState } from 'react';
+
+/**
  * Internal dependencies
  */
 import Animate from '../';
@@ -6,54 +12,51 @@ import Notice from '../../notice';
 
 export default { title: 'Components/Animate', component: Animate };
 
-export const _default = () => (
-	<Animate>
-		{ ( { className } ) => (
-			<Notice className={ className } status="success">
-				<p>{ `No default animation. Use one of type = "appear", "slide-in", or "loading".` }</p>
-			</Notice>
-		) }
-	</Animate>
-);
+export const _default = () => {
+	const typeToOrigin = useMemo(
+		() => ( {
+			appear: [
+				[
+					'top',
+					'top left',
+					'top right',
+					'middle',
+					'middle left',
+					'middle right',
+					'bottom',
+					'bottom left',
+					'bottom right',
+				],
+				'top left',
+			],
+			'slide-in': [ [ 'left', 'right' ], 'left' ],
+			loading: [ [], undefined ],
+		} ),
+		[]
+	);
+	const [ k, setK ] = useState( Number.MIN_SAFE_INTEGER );
+	button( 'Replay animation', () => setK( ( prevK ) => prevK + 1 ) );
+	const type = radios(
+		'Type',
+		[ 'appear', 'slide-in', 'loading' ],
+		'appear'
+	);
+	const origin = radios( 'Origin', ...typeToOrigin[ type ] );
 
-// Unexported helper for different origins.
-const Appear = ( { origin } ) => (
-	<Animate type="appear" origin={ origin }>
-		{ ( { className } ) => (
-			<Notice className={ className } status="success">
-				<p>Appear animation. Origin: { origin }.</p>
-			</Notice>
-		) }
-	</Animate>
-);
-
-export const appearTopLeft = () => <Appear origin="top left" />;
-export const appearTopRight = () => <Appear origin="top right" />;
-export const appearBottomLeft = () => <Appear origin="bottom left" />;
-export const appearBottomRight = () => <Appear origin="bottom right" />;
-export const appearMiddle = () => <Appear origin="middle" />;
-export const appearMiddleLeft = () => <Appear origin="middle left" />;
-export const appearMiddleRight = () => <Appear origin="middle right" />;
-
-export const loading = () => (
-	<Animate type="loading">
-		{ ( { className } ) => (
-			<Notice className={ className } status="success">
-				<p>Loading animation.</p>
-			</Notice>
-		) }
-	</Animate>
-);
-
-const SlideIn = ( { origin } ) => (
-	<Animate type="slide-in" origin={ origin }>
-		{ ( { className } ) => (
-			<Notice className={ className } status="success">
-				<p>Slide-in animation. Origin: { origin }.</p>
-			</Notice>
-		) }
-	</Animate>
-);
-
-export const slideInLeft = () => <SlideIn origin="left" />;
-export const slideInight = () => <SlideIn origin="right" />;
+	return (
+		<Animate type={ type } origin={ origin } key={ k }>
+			{ ( { className } ) => (
+				<Notice className={ className } status="success">
+					<p>
+						<code>{ type }</code> animation.
+					</p>
+					{ origin && (
+						<p>
+							Origin: <code>{ origin }</code>.
+						</p>
+					) }
+				</Notice>
+			) }
+		</Animate>
+	);
+};

--- a/packages/components/src/animate/stories/index.js
+++ b/packages/components/src/animate/stories/index.js
@@ -18,7 +18,7 @@ export const _default = () => (
 
 // Unexported helper for different origins.
 const Appear = ( { origin } ) => (
-	<Animate type="appear" options={ { origin } }>
+	<Animate type="appear" origin={ origin }>
 		{ ( { className } ) => (
 			<Notice className={ className } status="success">
 				<p>Appear animation. Origin: { origin }.</p>
@@ -31,6 +31,9 @@ export const appearTopLeft = () => <Appear origin="top left" />;
 export const appearTopRight = () => <Appear origin="top right" />;
 export const appearBottomLeft = () => <Appear origin="bottom left" />;
 export const appearBottomRight = () => <Appear origin="bottom right" />;
+export const appearMiddle = () => <Appear origin="middle" />;
+export const appearMiddleLeft = () => <Appear origin="middle left" />;
+export const appearMiddleRight = () => <Appear origin="middle right" />;
 
 export const loading = () => (
 	<Animate type="loading">
@@ -42,12 +45,15 @@ export const loading = () => (
 	</Animate>
 );
 
-export const slideIn = () => (
-	<Animate type="slide-in">
+const SlideIn = ( { origin } ) => (
+	<Animate type="slide-in" origin={ origin }>
 		{ ( { className } ) => (
 			<Notice className={ className } status="success">
-				<p>Slide-in animation.</p>
+				<p>Slide-in animation. Origin: { origin }.</p>
 			</Notice>
 		) }
 	</Animate>
 );
+
+export const slideInLeft = () => <SlideIn origin="left" />;
+export const slideInight = () => <SlideIn origin="right" />;

--- a/packages/components/src/navigation/menu/menu-title.js
+++ b/packages/components/src/navigation/menu/menu-title.js
@@ -82,7 +82,7 @@ export default function NavigationMenuTitle( {
 			) }
 
 			{ isSearching && (
-				<Animate type="slide-in" options={ { origin: 'left' } }>
+				<Animate type="slide-in" origin="left">
 					{ ( { className: animateClassName } ) => (
 						<div className={ animateClassName }>
 							<MenuTitleSearch

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -11,6 +11,7 @@
 		{ "path": "../primitives" }
 	],
 	"include": [
+		"src/animate/**/*",
 		"src/base-control/**/*",
 		"src/dashicon/**/*",
 		"src/tip/**/*",


### PR DESCRIPTION
# Description

- Add types to `Animate` component.
- Simplify `Animate` component API.

`useAnimate` accepts an `options` object which is a string `type` + some options based on the type.
`Animate` component accepted `type` property (the same) an `options` object (the other options) and a `children` render function property.

The options prop doesn't correspond to `useAnimate` options (it doesn't include the type) and there seems to be no benefit to wrapping the options in an object. `Animate` can pass its props (excluding `children`) to `useAnimate`.

```jsx
// Before
<Animate type="appear" options={ { origin: "top" } }>{ () => <div /> }</Animate>
// After
<Animate type="appear" origin="top">{ () => <div /> }</Animate>
```

Options are still accepted although deprecated and scheduled for removal in 9.6.

Supersedes https://github.com/WordPress/gutenberg/pull/26176

I've replaced the usage in Gutenberg that I found (just one case).
I've also updated the Animate storybook. It now uses knobs to adjust the options on the fly.

## How has this been tested?

Types pass.
Storybook examples work as expected.

## Screenshots

![story](https://user-images.githubusercontent.com/841763/99128237-a1bd5380-260a-11eb-9ed5-502c4a1caafa.gif)

When using `options` prop, you'll see this deprecation warning (it says 9.4 but I've changed it to 9.6):

<img width="1042" alt="Screen Shot 2020-11-13 at 23 49 58" src="https://user-images.githubusercontent.com/841763/99128407-0082cd00-260b-11eb-968b-abb463d296c3.png">

## Types of changes

New feature: Add types to the Animate component.

This change deprecates the `Animate` options prop and schedules it to be removed in two releases: 9.6. It will be a _breaking change_ when this is removed.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
