### PR TITLE
Site Editor: refactor menu creation code

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -66,22 +66,6 @@ function gutenberg_menu() {
 			);
 		}
 	}
-
-	if ( gutenberg_is_fse_theme() ) {
-		add_menu_page(
-			__( 'Site Editor (beta)', 'gutenberg' ),
-			sprintf(
-				/* translators: %s: "beta" label. */
-				__( 'Site Editor %s', 'gutenberg' ),
-				'<span class="awaiting-mod">' . __( 'beta', 'gutenberg' ) . '</span>'
-			),
-			'edit_theme_options',
-			'gutenberg-edit-site',
-			'gutenberg_edit_site_page',
-			'dashicons-layout'
-		);
-	}
-
 	if ( current_user_can( 'edit_posts' ) ) {
 		add_submenu_page(
 			'gutenberg',
@@ -109,6 +93,31 @@ function gutenberg_menu() {
 	);
 }
 add_action( 'admin_menu', 'gutenberg_menu', 9 );
+
+/**
+ * Site editor's Menu.
+ *
+ * Adds a new wp-admin menu item for the Site editor.
+ *
+ * @since 9.4.0
+ */
+function site_editor_menu() {
+	if ( gutenberg_is_fse_theme() ) {
+		add_menu_page(
+			__( 'Site Editor (beta)', 'gutenberg' ),
+			sprintf(
+			/* translators: %s: "beta" label. */
+				__( 'Site Editor %s', 'gutenberg' ),
+				'<span class="awaiting-mod">' . __( 'beta', 'gutenberg' ) . '</span>'
+			),
+			'edit_theme_options',
+			'gutenberg-edit-site',
+			'gutenberg_edit_site_page',
+			'dashicons-layout'
+		);
+	}
+}
+add_action( 'admin_menu', 'site_editor_menu', 9 );
 
 /**
  * Modify WP admin bar.

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -101,7 +101,7 @@ add_action( 'admin_menu', 'gutenberg_menu', 9 );
  *
  * @since 9.4.0
  */
-function site_editor_menu() {
+function gutenberg_site_editor_menu() {
 	if ( gutenberg_is_fse_theme() ) {
 		add_menu_page(
 			__( 'Site Editor (beta)', 'gutenberg' ),
@@ -117,7 +117,7 @@ function site_editor_menu() {
 		);
 	}
 }
-add_action( 'admin_menu', 'site_editor_menu', 9 );
+add_action( 'admin_menu', 'gutenberg_site_editor_menu', 9 );
 
 /**
  * Modify WP admin bar.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

Since site editor is not nested within Gutenberg submenu anymore, I think it makes sense to move it in a separate menu action for easier action filtering. All of the other items within the existing function except this one are subitems of the Gutenberg menu.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

There should be no functional changes. We should make sure that Site Editor and Gutenberg menu still work as expected.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
