### PR TITLE
Global Styles: Abstract preset variable retrieving and setting

### DIFF
--- a/packages/edit-site/src/components/editor/global-styles-provider.js
+++ b/packages/edit-site/src/components/editor/global-styles-provider.js
@@ -21,7 +21,11 @@ import { useSelect, useDispatch } from '@wordpress/data';
  * Internal dependencies
  */
 import { default as getGlobalStyles } from './global-styles-renderer';
-import { GLOBAL_CONTEXT } from './utils';
+import {
+	GLOBAL_CONTEXT,
+	getValueFromVariable,
+	getPresetVariable,
+} from './utils';
 
 const EMPTY_CONTENT = '{}';
 
@@ -155,10 +159,11 @@ export default function GlobalStylesProvider( { children, baseStyles } ) {
 			getStyleProperty: ( context, propertyName, origin = 'merged' ) => {
 				const styles = 'user' === origin ? userStyles : mergedStyles;
 
-				return get(
+				const value = get(
 					styles?.[ context ]?.styles,
 					STYLE_PROPERTY[ propertyName ].value
 				);
+				return getValueFromVariable( mergedStyles, context, value );
 			},
 			setStyleProperty: ( context, propertyName, newValue ) => {
 				const newContent = { ...userStyles };
@@ -170,7 +175,12 @@ export default function GlobalStylesProvider( { children, baseStyles } ) {
 				set(
 					contextStyles,
 					STYLE_PROPERTY[ propertyName ].value,
-					newValue
+					getPresetVariable(
+						mergedStyles,
+						context,
+						propertyName,
+						newValue
+					)
 				);
 				setContent( JSON.stringify( newContent ) );
 			},

--- a/packages/edit-site/src/components/editor/utils.js
+++ b/packages/edit-site/src/components/editor/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, find, camelCase, isString } from 'lodash';
+import { get, find, camelCase, kebabCase, isString } from 'lodash';
 /**
  * WordPress dependencies
  */
@@ -54,6 +54,13 @@ export const PRESET_CLASSES = {
 		property: 'font-size',
 	},
 };
+
+const STYLE_PROPERTIES_TO_PRESETS = {
+	backgroundColor: 'color',
+	LINK_COLOR: 'color',
+	background: 'gradient',
+};
+
 export const LINK_COLOR = '--wp--style--color--link';
 export const LINK_COLOR_DECLARATION = `a { color: var(${ LINK_COLOR }, #00e); }`;
 
@@ -76,35 +83,48 @@ export function useEditorFeature(
 	);
 }
 
-export function getPresetVariable( presetCategory, presets, value ) {
+export function getPresetVariable( styles, blockName, propertyName, value ) {
 	if ( ! value ) {
-		return;
+		return value;
+	}
+	const presetCategory =
+		STYLE_PROPERTIES_TO_PRESETS[ propertyName ] || propertyName;
+	if ( ! presetCategory ) {
+		return value;
 	}
 	const presetData = PRESET_CATEGORIES[ presetCategory ];
-	const { key } = presetData;
+	if ( ! presetData ) {
+		return value;
+	}
+	const { key, path } = presetData;
+	const presets =
+		get( styles, [ blockName, 'settings', ...path ] ) ??
+		get( styles, [ GLOBAL_CONTEXT, 'settings', ...path ] );
 	const presetObject = find( presets, ( preset ) => {
 		return preset[ key ] === value;
 	} );
-	return (
-		presetObject && `var:preset|${ presetCategory }|${ presetObject.slug }`
-	);
+	if ( ! presetObject ) {
+		return value;
+	}
+	return `var:preset|${ kebabCase( presetCategory ) }|${ presetObject.slug }`;
 }
 
 function getValueFromPresetVariable(
-	features,
+	styles,
 	blockName,
+	variable,
 	[ presetType, slug ]
 ) {
 	presetType = camelCase( presetType );
 	const presetData = PRESET_CATEGORIES[ presetType ];
 	if ( ! presetData ) {
-		return;
+		return variable;
 	}
 	const presets =
-		get( features, [ blockName, ...presetData.path ] ) ??
-		get( features, [ GLOBAL_CONTEXT_NAME, ...presetData.path ] );
+		get( styles, [ blockName, 'settings', ...presetData.path ] ) ??
+		get( styles, [ GLOBAL_CONTEXT_NAME, 'settings', ...presetData.path ] );
 	if ( ! presets ) {
-		return;
+		return variable;
 	}
 	const presetObject = find( presets, ( preset ) => {
 		return preset.slug === slug;
@@ -112,21 +132,25 @@ function getValueFromPresetVariable(
 	if ( presetObject ) {
 		const { key } = presetData;
 		const result = presetObject[ key ];
-		return getValueFromVariable( features, blockName, result ) || result;
+		return getValueFromVariable( styles, blockName, result );
 	}
+	return variable;
 }
 
-function getValueFromCustomVariable( features, blockName, path ) {
+function getValueFromCustomVariable( styles, blockName, variable, path ) {
 	const result =
-		get( features, [ blockName, 'custom', ...path ] ) ??
-		get( features, [ GLOBAL_CONTEXT_NAME, 'custom', ...path ] );
+		get( styles, [ blockName, 'settings', 'custom', ...path ] ) ??
+		get( styles, [ GLOBAL_CONTEXT_NAME, 'settings', 'custom', ...path ] );
+	if ( ! result ) {
+		return variable;
+	}
 	// A variable may reference another variable so we need recursion until we find the value.
-	return getValueFromVariable( features, blockName, result ) || result;
+	return getValueFromVariable( styles, blockName, result );
 }
 
-export function getValueFromVariable( features, blockName, variable ) {
+export function getValueFromVariable( styles, blockName, variable ) {
 	if ( ! variable || ! isString( variable ) ) {
-		return;
+		return variable;
 	}
 	let parsedVar;
 	const INTERNAL_REFERENCE_PREFIX = 'var:';
@@ -144,14 +168,15 @@ export function getValueFromVariable( features, blockName, variable ) {
 			.slice( CSS_REFERENCE_PREFIX.length, -CSS_REFERENCE_SUFFIX.length )
 			.split( '--' );
 	} else {
-		return;
+		return variable;
 	}
 
 	const [ type, ...path ] = parsedVar;
 	if ( type === 'preset' ) {
-		return getValueFromPresetVariable( features, blockName, path );
+		return getValueFromPresetVariable( styles, blockName, variable, path );
 	}
 	if ( type === 'custom' ) {
-		return getValueFromCustomVariable( features, blockName, path );
+		return getValueFromCustomVariable( styles, blockName, variable, path );
 	}
+	return variable;
 }

--- a/packages/edit-site/src/components/sidebar/color-panel.js
+++ b/packages/edit-site/src/components/sidebar/color-panel.js
@@ -3,17 +3,11 @@
  */
 import { __experimentalPanelColorGradientSettings as PanelColorGradientSettings } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import {
-	LINK_COLOR,
-	useEditorFeature,
-	getValueFromVariable,
-	getPresetVariable,
-} from '../editor/utils';
+import { LINK_COLOR, useEditorFeature } from '../editor/utils';
 import ColorPalettePanel from './color-palette-panel';
 
 export function useHasColorPanel( { supports } ) {
@@ -32,9 +26,6 @@ export default function ColorPanel( {
 	getSetting,
 	setSetting,
 } ) {
-	const features = useSelect( ( select ) => {
-		return select( 'core/edit-site' ).getSettings().__experimentalFeatures;
-	} );
 	const colors = useEditorFeature( 'color.palette', name );
 	const disableCustomColors = ! useEditorFeature( 'color.custom', name );
 	const gradients = useEditorFeature( 'color.gradients', name );
@@ -49,13 +40,9 @@ export default function ColorPanel( {
 		const color = getStyleProperty( name, 'color' );
 		const userColor = getStyleProperty( name, 'color', 'user' );
 		settings.push( {
-			colorValue: getValueFromVariable( features, name, color ) || color,
+			colorValue: color,
 			onColorChange: ( value ) =>
-				setStyleProperty(
-					name,
-					'color',
-					getPresetVariable( 'color', colors, value ) || value
-				),
+				setStyleProperty( name, 'color', value ),
 			label: __( 'Text color' ),
 			clearable: color === userColor,
 		} );
@@ -70,15 +57,9 @@ export default function ColorPanel( {
 			'user'
 		);
 		backgroundSettings = {
-			colorValue:
-				getValueFromVariable( features, name, backgroundColor ) ||
-				backgroundColor,
+			colorValue: backgroundColor,
 			onColorChange: ( value ) =>
-				setStyleProperty(
-					name,
-					'backgroundColor',
-					getPresetVariable( 'color', colors, value ) || value
-				),
+				setStyleProperty( name, 'backgroundColor', value ),
 		};
 		if ( backgroundColor ) {
 			backgroundSettings.clearable =
@@ -91,14 +72,9 @@ export default function ColorPanel( {
 		const gradient = getStyleProperty( name, 'background' );
 		const userGradient = getStyleProperty( name, 'background', 'user' );
 		gradientSettings = {
-			gradientValue:
-				getValueFromVariable( features, name, gradient ) || gradient,
+			gradientValue: gradient,
 			onGradientChange: ( value ) =>
-				setStyleProperty(
-					name,
-					'background',
-					getPresetVariable( 'gradient', gradients, value ) || value
-				),
+				setStyleProperty( name, 'background', value ),
 		};
 		if ( gradient ) {
 			gradientSettings.clearable = gradient === userGradient;
@@ -120,13 +96,9 @@ export default function ColorPanel( {
 		const color = getStyleProperty( name, LINK_COLOR );
 		const userColor = getStyleProperty( name, LINK_COLOR, 'user' );
 		settings.push( {
-			colorValue: getValueFromVariable( features, name, color ) || color,
+			colorValue: color,
 			onColorChange: ( value ) =>
-				setStyleProperty(
-					name,
-					LINK_COLOR,
-					getPresetVariable( 'color', colors, value ) || value
-				),
+				setStyleProperty( name, LINK_COLOR, value ),
 			label: __( 'Link color' ),
 			clearable: color === userColor,
 		} );

--- a/packages/edit-site/src/components/sidebar/typography-panel.js
+++ b/packages/edit-site/src/components/sidebar/typography-panel.js
@@ -8,12 +8,11 @@ import {
 } from '@wordpress/block-editor';
 import { PanelBody, FontSizePicker } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import { useEditorFeature, getValueFromVariable } from '../editor/utils';
+import { useEditorFeature } from '../editor/utils';
 
 export function useHasTypographyPanel( { supports, name } ) {
 	const hasLineHeight = useHasLineHeightControl( { supports, name } );
@@ -47,9 +46,6 @@ export default function TypographyPanel( {
 	getStyleProperty,
 	setStyleProperty,
 } ) {
-	const features = useSelect( ( select ) => {
-		return select( 'core/edit-site' ).getSettings().__experimentalFeatures;
-	} );
 	const fontSizes = useEditorFeature( 'typography.fontSizes', name );
 	const disableCustomFontSizes = ! useEditorFeature(
 		'typography.customFontSize',
@@ -61,18 +57,12 @@ export default function TypographyPanel( {
 	const hasLineHeightEnabled = useHasLineHeightControl( { supports, name } );
 	const hasAppearenceControl = useHasAppearenceControl( { supports, name } );
 
-	const fontFamily = getStyleProperty( name, 'fontFamily' );
-	const fontSize = getStyleProperty( name, 'fontSize' );
-	const lineHeight = getStyleProperty( name, 'lineHeight' );
 	return (
 		<PanelBody title={ __( 'Typography' ) } initialOpen={ true }>
 			{ supports.includes( 'fontFamily' ) && (
 				<FontFamilyControl
 					fontFamilies={ fontFamilies }
-					value={
-						getValueFromVariable( features, name, fontFamily ) ||
-						fontFamily
-					}
+					value={ getStyleProperty( name, 'fontFamily' ) }
 					onChange={ ( value ) =>
 						setStyleProperty( name, 'fontFamily', value )
 					}
@@ -80,10 +70,7 @@ export default function TypographyPanel( {
 			) }
 			{ supports.includes( 'fontSize' ) && (
 				<FontSizePicker
-					value={
-						getValueFromVariable( features, name, fontSize ) ||
-						fontSize
-					}
+					value={ getStyleProperty( name, 'fontSize' ) }
 					onChange={ ( value ) =>
 						setStyleProperty( name, 'fontSize', value )
 					}
@@ -93,10 +80,7 @@ export default function TypographyPanel( {
 			) }
 			{ hasLineHeightEnabled && (
 				<LineHeightControl
-					value={
-						getValueFromVariable( features, name, lineHeight ) ||
-						lineHeight
-					}
+					value={ getStyleProperty( name, 'lineHeight' ) }
 					onChange={ ( value ) =>
 						setStyleProperty( name, 'lineHeight', value )
 					}


### PR DESCRIPTION
This PR abstracts the retrieving and setting of preset variables inside getStyleProperty and setStyleProperty. With this change, the code inside the Global Style panels does not even need to know about presets, custom vars, etc.

## How has this been tested?
I verified the variable styles set in 2021 are correctly reflected on the global styles UI.
I changed some values on the global styles UI to use some of the presets (font sizes, font family, colors, gradients) and verified using the browser dev tools the CSS vars are output in the generated CSS code.
