### PR TITLE
Chore: Fix: Table block global styles selector

### DIFF
--- a/packages/block-library/src/table/block.json
+++ b/packages/block-library/src/table/block.json
@@ -125,6 +125,6 @@
 	"supports": {
 		"anchor": true,
 		"align": true,
-		"__experimentalSelector": ".wp-block-button > table"
+		"__experimentalSelector": ".wp-block-table > table"
 	}
 }


### PR DESCRIPTION
Fixes an obvious copy-paste mistake on the table block global styles selector.
