### PR TITLE
FSE: Prevent warnings if selector_data fields not defined in theme.json

### DIFF
--- a/lib/class-wp-theme-json.php
+++ b/lib/class-wp-theme-json.php
@@ -454,10 +454,10 @@ class WP_Theme_JSON {
 			) {
 				foreach ( $block_type->supports['__experimentalSelector'] as $key => $selector_data ) {
 					self::$blocks_metadata[ $key ] = array(
-						'selector'   => $selector_data['selector'],
+						'selector'   => isset( $selector_data['selector'] ) ? $selector_data['selector'] : null,
 						'supports'   => $block_supports,
 						'blockName'  => $block_name,
-						'attributes' => $selector_data['attributes'],
+						'attributes' => isset( $selector_data['attributes'] ) ? $selector_data['attributes']  : null,
 					);
 					if ( isset( $selector_data['title'] ) ) {
 						self::$blocks_metadata[ $key ]['title'] = $selector_data['title'];


### PR DESCRIPTION

## Description

While testing something unrelated on latest master I noticed warnings started appearing.
This change prevents the warnings from showing if theme.json data is not defined.

## How has this been tested?

Using non-FSE site without a theme.json and saw the warnings prior
Applying this fix prevents warnings from showing.
