### PR TITLE
Cover: Add Background size support

### DIFF
--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -19,6 +19,7 @@
 		},
 		"backgroundSize": {
 			"type": "string",
+			"default": "cover",
 			"enum": [ "cover", "contain", "initial", "custom" ]
 		},
 		"dimRatio": {

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -19,8 +19,7 @@
 		},
 		"backgroundSize": {
 			"type": "string",
-			"default": "cover",
-			"enum": [ "cover", "contain", "initial", "custom" ]
+			"default": "cover"
 		},
 		"dimRatio": {
 			"type": "number",

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -17,6 +17,10 @@
 			"type": "boolean",
 			"default": false
 		},
+		"backgroundSize": {
+			"type": "string",
+			"enum": [ "cover", "contain", "initial", "custom" ]
+		},
 		"dimRatio": {
 			"type": "number",
 			"default": 50

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -289,6 +289,7 @@ function CoverEdit( {
 		contentPosition,
 		id,
 		backgroundType,
+		backgroundSize,
 		dimRatio,
 		focalPoint,
 		hasParallax,
@@ -341,6 +342,7 @@ function CoverEdit( {
 		...( isImageBackground ? backgroundImageStyles( url ) : {} ),
 		backgroundColor: overlayColor.color,
 		minHeight: temporaryMinHeight || minHeightWithUnit || undefined,
+		backgroundSize,
 	};
 
 	if ( gradientValue && ! url ) {
@@ -403,7 +405,14 @@ function CoverEdit( {
 									onChange={ toggleIsRepeated }
 								/>
 
-								<BackgroundSizeControl />
+								<BackgroundSizeControl
+									size={ backgroundSize }
+									onSelect={ ( newSize ) =>
+										setAttributes( {
+											backgroundSize: newSize,
+										} )
+									}
+								/>
 							</Fragment>
 						) }
 						{ showFocalPointPicker && (

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -21,7 +21,7 @@ import {
 	ToggleControl,
 	withNotices,
 	ButtonGroup,
-	 __experimentalUnitControl as BaseUnitControl,
+	__experimentalUnitControl as BaseUnitControl,
 	__experimentalBoxControl as BoxControl,
 } from '@wordpress/components';
 import { compose, withInstanceId, useInstanceId } from '@wordpress/compose';
@@ -129,19 +129,22 @@ function BackgroundSizeControl( { size = 'cover', onSelect } ) {
 			label={ __( ' Background size' ) }
 			id={ 'background-size' }
 		>
-			<ButtonGroup label={ __( 'Size' ) } defaultChecked="size-content">
-				{ SIZE_OPTIONS.map( ( { slug, label } ) => (
+			<ButtonGroup
+				label={ __( 'Size' ) }
+				defaultChecked="size-content"
+				className="background-size-options"
+			>
+				{ SIZE_OPTIONS.map( ( { slug, label, icon: sizeIcon } ) => (
 					<Button
 						key={ slug }
-						isSmall
+						icon={ sizeIcon }
+						label={ label }
 						isPressed={
 							slug === size ||
 							( slug === 'custom' && isCustomSize )
 						}
 						onClick={ () => onSelect( slug ) }
-					>
-						{ label }
-					</Button>
+					/>
 				) ) }
 			</ButtonGroup>
 

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -20,6 +20,7 @@ import {
 	Spinner,
 	ToggleControl,
 	withNotices,
+	ButtonGroup,
 	__experimentalBoxControl as BoxControl,
 } from '@wordpress/components';
 import { compose, withInstanceId, useInstanceId } from '@wordpress/compose';
@@ -80,6 +81,47 @@ function retrieveFastAverageColor() {
 		retrieveFastAverageColor.fastAverageColor = new FastAverageColor();
 	}
 	return retrieveFastAverageColor.fastAverageColor;
+}
+
+const backgroundSizesOptions = [
+	{
+		slug: 'cover',
+		label: __( 'Cover' ),
+	},
+	{
+		slug: 'contain',
+		label: __( 'Contain' ),
+	},
+	{
+		slug: 'initial',
+		label: __( 'Original' ),
+	},
+	{
+		slug: 'custom',
+		label: __( 'Custom' ),
+	},
+];
+
+function BackgroundSizeControl( { size = 'cover', onSelect } ) {
+	return (
+		<BaseControl
+			label={ __( ' Background size' ) }
+			id={ 'background-size' }
+		>
+			<ButtonGroup label={ __( 'Size' ) } defaultChecked="size-content">
+				{ backgroundSizesOptions.map( ( { slug, label } ) => (
+					<Button
+						key={ slug }
+						isSmall
+						isPressed={ slug === size }
+						onClick={ () => onSelect( slug ) }
+					>
+						{ label }
+					</Button>
+				) ) }
+			</ButtonGroup>
+		</BaseControl>
+	);
 }
 
 function CoverHeightInput( {
@@ -360,6 +402,8 @@ function CoverEdit( {
 									checked={ isRepeated }
 									onChange={ toggleIsRepeated }
 								/>
+
+								<BackgroundSizeControl />
 							</Fragment>
 						) }
 						{ showFocalPointPicker && (

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -203,7 +203,7 @@ function CustomSizeControl( { value, onSelect } ) {
  * @param {string} size - Background size
  * @return {boolean} True if size is custom. Otherwise, False.
  */
-function isCustomSize( size ) {
+export function isCustomSize( size ) {
 	return (
 		SIZE_OPTIONS.map( ( opt ) => opt.slug ).indexOf( size ) < 0 ||
 		size === 'custom'

--- a/packages/block-library/src/cover/save.js
+++ b/packages/block-library/src/cover/save.js
@@ -25,6 +25,8 @@ import {
 	getPositionClassName,
 } from './shared';
 
+import { isCustomSize } from './edit';
+
 export default function save( { attributes } ) {
 	const {
 		backgroundType,
@@ -40,6 +42,7 @@ export default function save( { attributes } ) {
 		url,
 		minHeight: minHeightProp,
 		minHeightUnit,
+		backgroundSize,
 	} = attributes;
 	const overlayColorClass = getColorClassName(
 		'background-color',
@@ -64,6 +67,11 @@ export default function save( { attributes } ) {
 		style.background = customGradient;
 	}
 	style.minHeight = minHeight || undefined;
+
+	const hasCustomBackgroundSize = isCustomSize( backgroundSize );
+	if ( hasCustomBackgroundSize ) {
+		style.backgroundSize = backgroundSize;
+	}
 
 	let positionValue;
 
@@ -93,6 +101,10 @@ export default function save( { attributes } ) {
 			'has-custom-content-position': ! isContentPositionCenter(
 				contentPosition
 			),
+			'has-background-size': backgroundSize,
+			[ ! hasCustomBackgroundSize
+				? `is-${ backgroundSize }-background-size`
+				: null ]: ! hasCustomBackgroundSize,
 		},
 		getPositionClassName( contentPosition )
 	);

--- a/packages/block-library/src/cover/shared.js
+++ b/packages/block-library/src/cover/shared.js
@@ -4,6 +4,7 @@
 import { getBlobTypeByURL, isBlobURL } from '@wordpress/blob';
 import { __ } from '@wordpress/i18n';
 import { Platform } from '@wordpress/element';
+import { SVG, Rect, Path } from '@wordpress/components';
 
 const POSITION_CLASSNAMES = {
 	'top left': 'is-position-top-left',
@@ -59,18 +60,65 @@ export const SIZE_OPTIONS = [
 	{
 		slug: 'cover',
 		label: __( 'Cover' ),
+		icon: (
+			<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+				<Rect height="20" width="20" y="2" x="2" />
+			</SVG>
+		),
 	},
 	{
 		slug: 'contain',
 		label: __( 'Contain' ),
+		icon: (
+			<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+				<Rect
+					x="2"
+					y="2"
+					fill="none"
+					width="20"
+					height="20"
+					stroke="currentColor"
+					strokeWidth="2"
+				/>
+				<Rect x="7" y="2" width="10" height="20" />
+			</SVG>
+		),
 	},
 	{
 		slug: 'initial',
 		label: __( 'Original' ),
+		icon: (
+			<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+				<Rect
+					x="2"
+					y="2"
+					fill="none"
+					width="20"
+					height="20"
+					stroke="currentColor"
+					strokeWidth="2"
+				/>
+				<Rect x="8" y="4" width="8" height="16" />
+			</SVG>
+		),
 	},
 	{
 		slug: 'custom',
 		label: __( 'Custom' ),
+		icon: (
+			<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+				<Rect
+					x="2"
+					y="2"
+					fill="none"
+					width="20"
+					height="20"
+					stroke="currentColor"
+					strokeWidth="2"
+				/>
+				<Rect x="5" y="7" width="14" height="10" />
+			</SVG>
+		),
 	},
 ];
 

--- a/packages/block-library/src/cover/shared.js
+++ b/packages/block-library/src/cover/shared.js
@@ -116,7 +116,7 @@ export const SIZE_OPTIONS = [
 					stroke="currentColor"
 					strokeWidth="2"
 				/>
-				<Rect x="5" y="7" width="14" height="10" />
+				<Rect x="7" y="8" width="10" height="8" />
 			</SVG>
 		),
 	},

--- a/packages/block-library/src/cover/shared.js
+++ b/packages/block-library/src/cover/shared.js
@@ -55,6 +55,25 @@ export const CSS_UNITS = [
 	},
 ];
 
+export const SIZE_OPTIONS = [
+	{
+		slug: 'cover',
+		label: __( 'Cover' ),
+	},
+	{
+		slug: 'contain',
+		label: __( 'Contain' ),
+	},
+	{
+		slug: 'initial',
+		label: __( 'Original' ),
+	},
+	{
+		slug: 'custom',
+		label: __( 'Custom' ),
+	},
+];
+
 export function dimRatioToClass( ratio ) {
 	return ratio === 0 || ratio === 50 || ! ratio
 		? null

--- a/packages/block-library/src/cover/shared.js
+++ b/packages/block-library/src/cover/shared.js
@@ -4,7 +4,7 @@
 import { getBlobTypeByURL, isBlobURL } from '@wordpress/blob';
 import { __ } from '@wordpress/i18n';
 import { Platform } from '@wordpress/element';
-import { SVG, Rect, Path } from '@wordpress/components';
+import { SVG, Rect } from '@wordpress/components';
 
 const POSITION_CLASSNAMES = {
 	'top left': 'is-position-top-left',
@@ -78,7 +78,7 @@ export const SIZE_OPTIONS = [
 					width="20"
 					height="20"
 					stroke="currentColor"
-					strokeWidth="2"
+					strokeWidth="1"
 				/>
 				<Rect x="7" y="2" width="10" height="20" />
 			</SVG>
@@ -96,7 +96,7 @@ export const SIZE_OPTIONS = [
 					width="20"
 					height="20"
 					stroke="currentColor"
-					strokeWidth="2"
+					strokeWidth="1"
 				/>
 				<Rect x="8" y="4" width="8" height="16" />
 			</SVG>
@@ -114,7 +114,7 @@ export const SIZE_OPTIONS = [
 					width="20"
 					height="20"
 					stroke="currentColor"
-					strokeWidth="2"
+					strokeWidth="1"
 				/>
 				<Rect x="7" y="8" width="10" height="8" />
 			</SVG>

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -182,6 +182,15 @@
 	object-fit: cover;
 }
 
+// Tweak sidebar settings
+.components-button-group.background-size-options {
+	display: flex;
+
+	.components-button {
+		box-shadow: none;
+	}
+}
+
 // Styles bellow only exist to support older versions of the block.
 // Versions that not had inner blocks and used an h2 heading had a section (and not a div) with a class wp-block-cover-image (and not a wp-block-cover).
 // We are using the previous referred differences to target old versions.

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -36,6 +36,18 @@
 		background-repeat: repeat;
 	}
 
+	&.is-cover-background-size {
+		background-size: cover;
+	}
+
+	&.is-contain-background-size {
+		background-size: contain;
+	}
+
+	&.is-initial-background-size {
+		background-size: initial;
+	}
+
 	/**
 	 * Set a default background color for has-background-dim _unless_ it includes another
 	 * background-color class (e.g. has-green-background-color). The presence of another

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -182,12 +182,33 @@
 	object-fit: cover;
 }
 
-// Tweak sidebar settings
+// Tweak block settings sidebar.
 .components-button-group.background-size-options {
 	display: flex;
-
 	.components-button {
-		box-shadow: none;
+		box-shadow: 0 0 1px inset;
+	}
+}
+
+.background-size-custom-options {
+	display: flex;
+
+	.components-base-control:first-child {
+		margin-right: 10px;
+		margin-bottom: 8px;
+	}
+
+	.components-base-control__field {
+		display: flex;
+		align-items: center;
+
+		.components-base-control__label {
+			margin: 0 12px 0 0;
+		}
+	}
+
+	.components-unit-control-wrapper {
+		width: 65px;
 	}
 }
 

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -1,10 +1,6 @@
 .wp-block-cover-image,
 .wp-block-cover {
 	position: relative;
-	background-size: cover;
-	background-position: center center;
-	min-height: 430px;
-	height: 100%;
 	width: 100%;
 	display: flex;
 	justify-content: center;
@@ -12,6 +8,13 @@
 	padding: 1em;
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
+
+	// Default settings values.
+	min-height: 430px;
+	height: 100%;
+	background-size: cover;
+	background-position: center center;
+	background-repeat: no-repeat;
 
 	&.has-parallax {
 		background-attachment: fixed;
@@ -31,7 +34,6 @@
 
 	&.is-repeated {
 		background-repeat: repeat;
-		background-size: auto;
 	}
 
 	/**


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This PR adds the background-size control section to the Cover block, in the block settings sidebar.

## Demo Video

https://cloudup.com/cLE07dcijeQ

## How has this been tested?

Add a cover block. Set an image background, and play with the background-size options.

<img width="1578" alt="Screen Shot 2020-11-13 at 9 26 06 PM" src="https://user-images.githubusercontent.com/77539/99132970-f060f280-25f6-11eb-9adf-81c9b4b295d2.png">

## Background Size options

It supports four size options: `cover`, `contain`, `original`, and `custom`. _Note: please feel free to destroy the icons 😅_

<img src="https://user-images.githubusercontent.com/77539/99133559-3cad3200-25f9-11eb-8a58-18397112e54e.png" width="300px" />

### Cover (default)

Applies `cover` CSS background-size property to the image.

<img width="1564" alt="Screen Shot 2020-11-13 at 9 35 54 PM" src="https://user-images.githubusercontent.com/77539/99133324-45513880-25f8-11eb-9b2d-8269d3df8976.png">

### Contain

Applies `contain` CSS background-size property to the image.

<img width="1563" alt="Screen Shot 2020-11-13 at 9 36 40 PM" src="https://user-images.githubusercontent.com/77539/99133350-6154da00-25f8-11eb-9c31-25e470f3cb1c.png">

### Original

Applies `initial` CSS background-size property to the image.

<img width="1564" alt="Screen Shot 2020-11-13 at 9 37 24 PM" src="https://user-images.githubusercontent.com/77539/99133371-79c4f480-25f8-11eb-9a6e-16e9d36f6adf.png">

### Custom

It opens a secondary panel that allows defining the background-size with value + units, with the `width`, `height`, and `Width & Height` modes.

<img src="https://user-images.githubusercontent.com/77539/99133478-ecce6b00-25f8-11eb-958e-cea8eb0c7d48.png" width="300px" />

* `width`: It will apply width size to the image, and `auto` to the height. It keeps doesn't change the image proportion.
* `height`: It will apply height size to the image, and `auto` to the width. It keeps doesn't change the image proportion.
* `Width & Height`: apply width and height values. The image could change its proportions.

width | height | Width & Height
------|--------|----------
<img width="1564" alt="Screen Shot 2020-11-13 at 9 38 30 PM" src="https://user-images.githubusercontent.com/77539/99133412-a4af4880-25f8-11eb-8476-417a76b72e7e.png"> | <img width="1569" alt="Screen Shot 2020-11-13 at 9 39 57 PM" src="https://user-images.githubusercontent.com/77539/99133455-dcb68b80-25f8-11eb-8330-74724106802c.png"> |<img width="1568" alt="Screen Shot 2020-11-13 at 9 41 28 PM" src="https://user-images.githubusercontent.com/77539/99133564-420a7c80-25f9-11eb-873b-b81afb344eb3.png">

The available units are `px` and `%`.

## CSS class and inline styles.

In the editor canvas, the styles are applied using inline styles. On another hand, the styles are applied via CSS classes, less the custom mode, since it uses value + unit notation.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
