### PR TITLE
Revert "Add regresion E2E test for the empty reusable block causing W…

### DIFF
--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -69,7 +69,6 @@ const {
 	__experimentalGetLastBlockAttributeChanges,
 	getLowestCommonAncestorWithSelectedBlock,
 	__experimentalGetActiveBlockIdByBlockNames: getActiveBlockIdByBlockNames,
-	__experimentalGetParsedReusableBlock,
 } = selectors;
 
 describe( 'selectors', () => {
@@ -3033,25 +3032,5 @@ describe( 'selectors', () => {
 				] )
 			).toEqual( 'client-id-03' );
 		} );
-	} );
-} );
-
-describe( '__experimentalGetParsedReusableBlock', () => {
-	const state = {
-		settings: {
-			__experimentalReusableBlocks: [
-				{
-					id: 1,
-					content: { raw: '' },
-				},
-			],
-		},
-	};
-
-	// Regression test for https://github.com/WordPress/gutenberg/issues/26485. See https://github.com/WordPress/gutenberg/issues/26548.
-	it( "Should return an empty array if reusable block's content.raw is an empty string", () => {
-		expect( __experimentalGetParsedReusableBlock( state, 1 ) ).toEqual(
-			[]
-		);
 	} );
 } );

--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -600,10 +600,6 @@ running the test is not already the admin user).
 Switches the current user to whichever user we should be
 running the tests as (if we're not already that user).
 
-<a name="toggleGlobalBlockInserter" href="#toggleGlobalBlockInserter">#</a> **toggleGlobalBlockInserter**
-
-Toggles the global inserter.
-
 <a name="toggleMoreMenu" href="#toggleMoreMenu">#</a> **toggleMoreMenu**
 
 Toggles the More Menu.

--- a/packages/e2e-test-utils/src/index.js
+++ b/packages/e2e-test-utils/src/index.js
@@ -37,7 +37,6 @@ export {
 	insertBlockDirectoryBlock,
 	openGlobalBlockInserter,
 	closeGlobalBlockInserter,
-	toggleGlobalBlockInserter,
 } from './inserter';
 export { installPlugin } from './install-plugin';
 export { installTheme } from './install-theme';

--- a/packages/e2e-test-utils/src/inserter.js
+++ b/packages/e2e-test-utils/src/inserter.js
@@ -44,10 +44,8 @@ async function isGlobalInserterOpen() {
 		);
 	} );
 }
-/**
- * Toggles the global inserter.
- */
-export async function toggleGlobalBlockInserter() {
+
+async function toggleGlobalBlockInserter() {
 	await page.click(
 		'.edit-post-header [aria-label="Add block"], .edit-site-header [aria-label="Add block"]'
 	);

--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -11,8 +11,6 @@ import {
 	searchForReusableBlock,
 	getEditedPostContent,
 	trashAllPosts,
-	visitAdminPage,
-	toggleGlobalBlockInserter,
 } from '@wordpress/e2e-test-utils';
 
 function waitForAndAcceptDialog() {
@@ -331,45 +329,5 @@ describe( 'Reusable blocks', () => {
 
 		// Check that we have two paragraph blocks on the page
 		expect( await getEditedPostContent() ).toMatchSnapshot();
-	} );
-
-	it( 'will not break the editor if empty', async () => {
-		await insertReusableBlock( 'Awesome block' );
-
-		await visitAdminPage( 'edit.php', [ 'post_type=wp_block' ] );
-
-		const [ editButton ] = await page.$x(
-			`//a[contains(@aria-label, 'Awesome block')]`
-		);
-		await editButton.click();
-
-		await page.waitForNavigation();
-
-		// Give focus to the editor
-		await page.waitForSelector( '.block-editor-writing-flow' );
-		await page.click( '.block-editor-writing-flow' );
-
-		// Move focus to the paragraph block
-		await page.keyboard.press( 'Tab' );
-		await page.keyboard.press( 'Tab' );
-
-		// Delete the block, leaving the reusable block empty
-		await clickBlockToolbarButton( 'More options' );
-		const deleteButton = await page.waitForXPath(
-			'//button/span[text()="Remove block"]'
-		);
-		deleteButton.click();
-
-		// Save the reusable block
-		await page.click( '.editor-post-publish-button__button' );
-		await page.waitForXPath(
-			'//*[contains(@class, "components-snackbar")]/*[text()="Reusable Block updated."]'
-		);
-
-		await createNewPost();
-
-		await toggleGlobalBlockInserter();
-
-		expect( console ).not.toHaveErrored();
 	} );
 } );


### PR DESCRIPTION
…SODs issue (#26913)"

This reverts commit 1b2d6632d59201e4de69468bb02bf57498e05228.

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

The newly added test fails on the `master` branch.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
