### PR TITLE
Revert the reversion of https://github.com/WordPress/gutenberg/pull/26913 and fix flakiness

### DIFF
--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -69,6 +69,7 @@ const {
 	__experimentalGetLastBlockAttributeChanges,
 	getLowestCommonAncestorWithSelectedBlock,
 	__experimentalGetActiveBlockIdByBlockNames: getActiveBlockIdByBlockNames,
+	__experimentalGetParsedReusableBlock,
 } = selectors;
 
 describe( 'selectors', () => {
@@ -3032,5 +3033,25 @@ describe( 'selectors', () => {
 				] )
 			).toEqual( 'client-id-03' );
 		} );
+	} );
+} );
+
+describe( '__experimentalGetParsedReusableBlock', () => {
+	const state = {
+		settings: {
+			__experimentalReusableBlocks: [
+				{
+					id: 1,
+					content: { raw: '' },
+				},
+			],
+		},
+	};
+
+	// Regression test for https://github.com/WordPress/gutenberg/issues/26485. See https://github.com/WordPress/gutenberg/issues/26548.
+	it( "Should return an empty array if reusable block's content.raw is an empty string", () => {
+		expect( __experimentalGetParsedReusableBlock( state, 1 ) ).toEqual(
+			[]
+		);
 	} );
 } );

--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -600,6 +600,10 @@ running the test is not already the admin user).
 Switches the current user to whichever user we should be
 running the tests as (if we're not already that user).
 
+<a name="toggleGlobalBlockInserter" href="#toggleGlobalBlockInserter">#</a> **toggleGlobalBlockInserter**
+
+Toggles the global inserter.
+
 <a name="toggleMoreMenu" href="#toggleMoreMenu">#</a> **toggleMoreMenu**
 
 Toggles the More Menu.

--- a/packages/e2e-test-utils/src/index.js
+++ b/packages/e2e-test-utils/src/index.js
@@ -37,6 +37,7 @@ export {
 	insertBlockDirectoryBlock,
 	openGlobalBlockInserter,
 	closeGlobalBlockInserter,
+	toggleGlobalBlockInserter,
 } from './inserter';
 export { installPlugin } from './install-plugin';
 export { installTheme } from './install-theme';

--- a/packages/e2e-test-utils/src/inserter.js
+++ b/packages/e2e-test-utils/src/inserter.js
@@ -44,8 +44,10 @@ async function isGlobalInserterOpen() {
 		);
 	} );
 }
-
-async function toggleGlobalBlockInserter() {
+/**
+ * Toggles the global inserter.
+ */
+export async function toggleGlobalBlockInserter() {
 	await page.click(
 		'.edit-post-header [aria-label="Add block"], .edit-site-header [aria-label="Add block"]'
 	);

--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -345,13 +345,10 @@ describe( 'Reusable blocks', () => {
 
 		await page.waitForNavigation();
 
-		// Give focus to the editor
-		await page.waitForSelector( '.block-editor-writing-flow' );
-		await page.click( '.block-editor-writing-flow' );
-
-		// Move focus to the paragraph block
-		await page.keyboard.press( 'Tab' );
-		await page.keyboard.press( 'Tab' );
+		// Click the block to give it focus
+		const blockSelector = 'p[data-title="Paragraph"]';
+		await page.waitForSelector( blockSelector );
+		await page.click( blockSelector );
 
 		// Delete the block, leaving the reusable block empty
 		await clickBlockToolbarButton( 'More options' );

--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -11,6 +11,8 @@ import {
 	searchForReusableBlock,
 	getEditedPostContent,
 	trashAllPosts,
+	visitAdminPage,
+	toggleGlobalBlockInserter,
 } from '@wordpress/e2e-test-utils';
 
 function waitForAndAcceptDialog() {
@@ -329,5 +331,45 @@ describe( 'Reusable blocks', () => {
 
 		// Check that we have two paragraph blocks on the page
 		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'will not break the editor if empty', async () => {
+		await insertReusableBlock( 'Awesome block' );
+
+		await visitAdminPage( 'edit.php', [ 'post_type=wp_block' ] );
+
+		const [ editButton ] = await page.$x(
+			`//a[contains(@aria-label, 'Awesome block')]`
+		);
+		await editButton.click();
+
+		await page.waitForNavigation();
+
+		// Give focus to the editor
+		await page.waitForSelector( '.block-editor-writing-flow' );
+		await page.click( '.block-editor-writing-flow' );
+
+		// Move focus to the paragraph block
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Tab' );
+
+		// Delete the block, leaving the reusable block empty
+		await clickBlockToolbarButton( 'More options' );
+		const deleteButton = await page.waitForXPath(
+			'//button/span[text()="Remove block"]'
+		);
+		deleteButton.click();
+
+		// Save the reusable block
+		await page.click( '.editor-post-publish-button__button' );
+		await page.waitForXPath(
+			'//*[contains(@class, "components-snackbar")]/*[text()="Reusable Block updated."]'
+		);
+
+		await createNewPost();
+
+		await toggleGlobalBlockInserter();
+
+		expect( console ).not.toHaveErrored();
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -357,8 +357,14 @@ describe( 'Reusable blocks', () => {
 		);
 		deleteButton.click();
 
+		// Wait for the Update button to become enabled
+		const publishButtonSelector = '.editor-post-publish-button__button';
+		await page.waitForSelector(
+			publishButtonSelector + '[aria-disabled="false"]'
+		);
+
 		// Save the reusable block
-		await page.click( '.editor-post-publish-button__button' );
+		await page.click( publishButtonSelector );
 		await page.waitForXPath(
 			'//*[contains(@class, "components-snackbar")]/*[text()="Reusable Block updated."]'
 		);


### PR DESCRIPTION
### What 

Reverts the reversion of https://github.com/WordPress/gutenberg/pull/26913 on `master` due to tests failing on CI.

### Why

The tests in the previous PR were failing on CI but passing locally for me because I was always passing the `--puppeteer-interactive` flag, which also sets the `slowmo` option. 🤦🏻 This made my local env considerably different from CI due to the speed at which elements were rendered. Slowmo is still useful sometimes, but not for all the runs ;)

### The fix

I've made the test more resilient, and also ran it locally both headless and headful modes, and without the `--puppeteer-interactive` flag. It consistently passes now.

### TODO

- [X] ~Investigate why it's flaky on CI, possibly related to the block focus code [here](https://github.com/WordPress/gutenberg/pull/26913/files#diff-14f924f0d68b1152cec79211daf18fabe937b79290244615498e6d46198a8666R350-R354).~

