### PR TITLE
Fix IE11 quirks in Block Toolbar

### DIFF
--- a/packages/block-editor/src/components/block-mover/style.scss
+++ b/packages/block-editor/src/components/block-mover/style.scss
@@ -13,7 +13,7 @@
 
 	.block-editor-block-mover__move-button-container,
 	.components-toolbar {
-		flex: 1;
+		flex-grow: 1;
 
 		// Increase touch targets on mobile.
 		flex-direction: row;

--- a/packages/block-editor/src/components/block-mover/style.scss
+++ b/packages/block-editor/src/components/block-mover/style.scss
@@ -76,6 +76,7 @@
 			&::before {
 				bottom: 0;
 				height: calc(100% - #{ $border-width });
+				top: auto;
 			}
 		}
 

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -80,15 +80,7 @@
 }
 
 .block-editor-block-toolbar__slot {
-	// Required for IE11.
-	display: inline-block;
-	// Fix for toolbar button misalignment on IE11
-	line-height: 0;
-
-	// IE11 doesn't read rules inside this query. They are applied only to modern browsers.
-	@supports (position: sticky) {
-		display: inline-flex;
-	}
+	display: inline-flex;
 }
 
 .block-editor-block-toolbar__block-parent-selector-wrapper {

--- a/packages/components/src/toolbar/style.scss
+++ b/packages/components/src/toolbar/style.scss
@@ -37,6 +37,8 @@
 			// Position the focus rectangle.
 			left: $grid-unit-10;
 			right: $grid-unit-10;
+			// Required in IE11 because it doesn't apply { justify-content: center; } to pseudo elements
+			top: calc(50% - #{$grid-unit-40 / 2});
 			z-index: -1;
 
 			// Animate in.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes #21389 plus a couple of other Block Toolbar bugs in IE11

## How has this been tested?
Tested on Windows 10: IE11, Chrome (latest), Opera (latest), Firefox (latest), Edge (EdgeHTML 18)
MacOS: Chrome (latest),  Safari (latest)
iOS 14: Chrome (latest),  Safari (latest)
Android 9 (via browserstack): Chrome

## Screenshots 
Before
![Screenshot_2](https://user-images.githubusercontent.com/70915/99199141-1aa8e080-27ae-11eb-8bf3-c3f99fe62901.jpg)

After commit 1
![Screenshot_1](https://user-images.githubusercontent.com/70915/99199236-bc303200-27ae-11eb-9105-405b0106b4d5.jpg)

After all commits
![Screenshot_3](https://user-images.githubusercontent.com/70915/99199156-3ad89f80-27ae-11eb-94db-f77c1a986033.jpg)


## Types of changes
To fix buttons misalignment in IE11 when Media Replace button is visible:
- Removed some outdated  code that was introduced earlier specifically for IE11. Now IE11 and non-IE browsers use the same code.

To fix overlaid block move buttons in IE11:
- Changed _flex: 1;_ to _flex-grow: 1;_. Both properties mean the same in modern browsers, but  _flex: 1;_  is interpreted incorrectly in IE11.

To fix focus rectangle misalignment in IE11:
- Added _top: calc(50% - #{$grid-unit-40 / 2});_ to position focus rect vertically in IE. In other browsers it was aligned by flex property of container _justify-content: center;_, but it doesn't work on pseudo elements in IE. This may break in the future if focus rectangle height is changed, but the break will be immediately noticeable in all browsers.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
