### PR TITLE
Fix Query block's Toolbar popover width

### DIFF
--- a/packages/block-library/src/query/editor.scss
+++ b/packages/block-library/src/query/editor.scss
@@ -1,3 +1,7 @@
 .editor-styles-wrapper .wp-block.wp-block-query {
 	max-width: 100%;
 }
+
+.block-library-query-toolbar__popover .components-popover__content {
+	min-width: 230px;
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes: https://github.com/WordPress/gutenberg/issues/26918

This PR fixes the truncated Query block's Toolbar popover.
## Screenshots <!-- if applicable -->
#### Before

![Screenshot(2)](https://user-images.githubusercontent.com/16275880/99237413-18bc3d00-2801-11eb-90f9-54e3c9bfd219.png)

#### After

![Screenshot(1)](https://user-images.githubusercontent.com/16275880/99237266-e7437180-2800-11eb-8150-e6f797540f99.png)


