### PR TITLE
Insertion point: avoid wrapper div

### DIFF
--- a/packages/block-editor/src/components/block-list/root-container.js
+++ b/packages/block-editor/src/components/block-list/root-container.js
@@ -14,7 +14,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
  */
 import useMultiSelection from './use-multi-selection';
 import { getBlockClientId } from '../../utils/dom';
-import InsertionPoint from './insertion-point';
+import useInsertionPoint from './insertion-point';
 import BlockPopover from './block-popover';
 
 /** @typedef {import('@wordpress/element').WPSyntheticEvent} WPSyntheticEvent */
@@ -77,25 +77,25 @@ function RootContainer( { children, className }, ref ) {
 	}
 
 	const [ blockNodes, setBlockNodes ] = useState( {} );
+	const insertionPoint = useInsertionPoint( ref );
 
 	return (
-		<InsertionPoint containerRef={ ref }>
-			<BlockNodes.Provider value={ blockNodes }>
-				<BlockPopover />
-				<div
-					ref={ ref }
-					className={ classnames( className, 'is-root-container' ) }
-					onFocus={ onFocus }
-					onDragStart={ onDragStart }
-				>
-					<SetBlockNodes.Provider value={ setBlockNodes }>
-						<Context.Provider value={ onSelectionStart }>
-							{ children }
-						</Context.Provider>
-					</SetBlockNodes.Provider>
-				</div>
-			</BlockNodes.Provider>
-		</InsertionPoint>
+		<BlockNodes.Provider value={ blockNodes }>
+			{ insertionPoint }
+			<BlockPopover />
+			<div
+				ref={ ref }
+				className={ classnames( className, 'is-root-container' ) }
+				onFocus={ onFocus }
+				onDragStart={ onDragStart }
+			>
+				<SetBlockNodes.Provider value={ setBlockNodes }>
+					<Context.Provider value={ onSelectionStart }>
+						{ children }
+					</Context.Provider>
+				</SetBlockNodes.Provider>
+			</div>
+		</BlockNodes.Provider>
 	);
 }
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

We can use the root container to attach an event handler instead.

The larger goal is to reduce many layers of nested divs.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
