### PR TITLE
remove unused variables

### DIFF
--- a/lib/block-supports/generated-classname.php
+++ b/lib/block-supports/generated-classname.php
@@ -35,11 +35,10 @@ function gutenberg_get_block_default_classname( $block_name ) {
  * Add the generated classnames to the output.
  *
  * @param  WP_Block_Type $block_type       Block Type.
- * @param  array         $block_attributes Block attributes.
  *
  * @return array Block CSS classes and inline styles.
  */
-function gutenberg_apply_generated_classname_support( $block_type, $block_attributes ) {
+function gutenberg_apply_generated_classname_support( $block_type ) {
 	$has_generated_classname_support = true;
 	$attributes                      = array();
 	if ( property_exists( $block_type, 'supports' ) ) {

--- a/lib/class-wp-block-supports.php
+++ b/lib/class-wp-block-supports.php
@@ -88,7 +88,7 @@ class WP_Block_Supports {
 		}
 
 		$output = array();
-		foreach ( $this->block_supports as $name => $block_support_config ) {
+		foreach ( $this->block_supports as $block_support_config ) {
 			if ( ! isset( $block_support_config['apply'] ) ) {
 				continue;
 			}
@@ -127,7 +127,7 @@ class WP_Block_Supports {
 				$block_type->attributes = array();
 			}
 
-			foreach ( $this->block_supports as $name => $block_support_config ) {
+			foreach ( $this->block_supports as $block_support_config ) {
 				if ( ! isset( $block_support_config['register_attribute'] ) ) {
 					continue;
 				}

--- a/lib/class-wp-rest-block-types-controller.php
+++ b/lib/class-wp-rest-block-types-controller.php
@@ -133,7 +133,7 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 			$namespace = $request['namespace'];
 		}
 
-		foreach ( $block_types as $slug => $obj ) {
+		foreach ( $block_types as $obj ) {
 			if ( $namespace ) {
 				$pieces          = explode( '/', $obj->name );
 				$block_namespace = $pieces[0];

--- a/lib/class-wp-rest-customizer-nonces.php
+++ b/lib/class-wp-rest-customizer-nonces.php
@@ -43,10 +43,9 @@ class WP_Rest_Customizer_Nonces extends WP_REST_Controller {
 	/**
 	 * Checks if a given request has access to read menu items if they have access to edit them.
 	 *
-	 * @param WP_REST_Request $request Full details about the request.
 	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
 	 */
-	public function permissions_check( $request ) {
+	public function permissions_check() {
 		$post_type = get_post_type_object( 'nav_menu_item' );
 		if ( ! current_user_can( $post_type->cap->edit_posts ) ) {
 			return new WP_Error( 'rest_forbidden_context', __( 'Sorry, you are not allowed to edit posts in this post type.', 'gutenberg' ), array( 'status' => rest_authorization_required_code() ) );

--- a/lib/class-wp-rest-widget-types-controller.php
+++ b/lib/class-wp-rest-widget-types-controller.php
@@ -197,7 +197,7 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 		global $wp_registered_widgets;
 
 		$widgets = array();
-		foreach ( $wp_registered_widgets as $slug => $widget ) {
+		foreach ( $wp_registered_widgets as $widget ) {
 			$widget_callback = $widget['callback'];
 			unset( $widget['callback'] );
 

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -438,9 +438,8 @@ function gutenberg_inject_default_block_context( $args ) {
 				return $block_render_callback( $attributes, $content );
 			}
 
-			$registry = WP_Block_Type_Registry::get_instance();
+			$registry   = WP_Block_Type_Registry::get_instance();
 			$block_type = $registry->get_registered( $block->name );
-
 
 			// For WordPress versions that don't support the context API.
 			if ( ! $block->context ) {

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -61,9 +61,8 @@ add_filter( 'rest_request_after_callbacks', 'gutenberg_filter_oembed_result', 10
  *
  * @param WP_REST_Response $response The response object.
  * @param WP_Theme         $theme    Theme object used to create response.
- * @param WP_REST_Request  $request  Request object.
  */
-function gutenberg_filter_rest_prepare_theme( $response, $theme, $request ) {
+function gutenberg_filter_rest_prepare_theme( $response, $theme ) {
 	$data   = $response->get_data();
 	$fields = array_keys( $data );
 
@@ -125,7 +124,7 @@ function gutenberg_filter_rest_prepare_theme( $response, $theme, $request ) {
 	$response->set_data( $data );
 	return $response;
 }
-add_filter( 'rest_prepare_theme', 'gutenberg_filter_rest_prepare_theme', 10, 3 );
+add_filter( 'rest_prepare_theme', 'gutenberg_filter_rest_prepare_theme', 10, 2 );
 
 /**
  * Registers the block directory.

--- a/phpunit/class-rest-nav-menu-items-controller-test.php
+++ b/phpunit/class-rest-nav-menu-items-controller-test.php
@@ -842,7 +842,7 @@ class REST_Nav_Menu_Items_Controller_Test extends WP_Test_REST_Post_Type_Control
 			$this->assertEquals( $links['about'][0]['href'], rest_url( 'wp/v2/types/' . self::POST_TYPE ) );
 
 			$num = 0;
-			foreach ( $taxonomies as $key => $taxonomy ) {
+			foreach ( $taxonomies as $taxonomy ) {
 				$this->assertEquals( $taxonomy->name, $links['https://api.w.org/term'][ $num ]['attributes']['taxonomy'] );
 				$this->assertEquals( add_query_arg( 'post', $data['id'], rest_url( 'wp/v2/' . $taxonomy->rest_base ) ), $links['https://api.w.org/term'][ $num ]['href'] );
 				$num ++;


### PR DESCRIPTION
I think there might be some phpcs rule that changed on Core causing the tests to fail here in Gutenberg.
This PR tries to fix the failing ones.

There are two cases where I don't know how to fix it. it's about unused function arguments but we can't remove the arguments otherwise the signature of the function is incorrect.