### PR TITLE
Fix formatting dates toISOString

### DIFF
--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -7,6 +7,7 @@ import {
 	getDaysInMonth,
 	isFuture,
 	isLeapYear,
+	formatISO,
 	parseISO,
 	toDate,
 } from 'date-fns';
@@ -306,7 +307,9 @@ const formatMap = {
 		);
 	},
 	// Full date/time
-	c: 'yyyy-MM-DDTHH:mm:ssZ', // .toISOString
+	c( dateValue ) {
+		return formatISO( dateValue ); // .toISOString
+	},
 	r: 'ddd, D MMM yyyy HH:mm:ss ZZ',
 	U( dateValue ) {
 		return formatTZ(


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes: https://github.com/WordPress/gutenberg/issues/26995

When using `c` option `dateI18n` function from `Date package` an error is thrown. This PR fixes that.

<!-- Please describe what you have changed or added -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
