### PR TITLE
Fix c and r formats, add tests.

### DIFF
--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -8,12 +8,12 @@ import {
 	isFuture,
 	isLeapYear,
 	parseISO,
-	toDate,
 } from 'date-fns';
 import {
 	format as formatTZ,
 	utcToZonedTime,
 	zonedTimeToUtc,
+	toDate,
 } from 'date-fns-tz';
 import originalLocale from 'date-fns/locale/en-US/index';
 import buildLocalizeFn from 'date-fns/locale/_lib/buildLocalizeFn';
@@ -306,8 +306,30 @@ const formatMap = {
 		);
 	},
 	// Full date/time
-	c: 'yyyy-MM-DDTHH:mm:ssZ', // .toISOString
-	r: 'ddd, D MMM yyyy HH:mm:ss ZZ',
+	c( dateValue ) {
+		return formatTZ(
+			utcToZonedTime(
+				zonedTimeToUtc( dateValue, getActualTimezone() ),
+				'UTC'
+			), // Offsets the time to the correct timezone
+			"yyyy-MM-dd'T'HH:mm:ssXXX",
+			{
+				timeZone: getActualTimezone(), // Adds the timezone offset to the Date object that will be formatted.
+			}
+		);
+	}, // .toISOString
+	r( dateValue ) {
+		return formatTZ(
+			utcToZonedTime(
+				zonedTimeToUtc( dateValue, getActualTimezone() ),
+				'UTC'
+			), // Offsets the time to the correct timezone
+			'iii, d MMM yyyy HH:mm:ss XX',
+			{
+				timeZone: getActualTimezone(), // Adds the timezone offset to the Date object that will be formatted.
+			}
+		);
+	},
 	U( dateValue ) {
 		return formatTZ(
 			zonedTimeToUtc( dateValue, getActualTimezone() ),

--- a/packages/date/src/test/index.js
+++ b/packages/date/src/test/index.js
@@ -471,22 +471,35 @@ describe( 'PHP Format Tokens', () => {
 		setSettings( settings );
 	} );
 
-	it.skip( 'should support "c" to obtain ISO 8601 date', () => {
+	it( 'should support "c" to obtain ISO 8601 date', () => {
 		const settings = __experimentalGetSettings();
 
 		setSettings( {
 			...settings,
-			timezone: { offset: -2 },
+			timezone: { offset: -5, string: 'America/Bogota' },
 		} );
 
 		const formattedDate = dateNoI18n( 'c', '2019-06-18T11:00:00.000Z' );
 
-		expect( formattedDate ).toBe( '2019-06-18T11:00:00-02:00' );
+		expect( formattedDate ).toBe( '2019-06-18T11:00:00-05:00' );
 
 		setSettings( settings );
 	} );
 
-	it( 'should support "r" RFC 2822 formatted date', () => {} );
+	it( 'should support "r" RFC 2822 formatted date', () => {
+		const settings = __experimentalGetSettings();
+
+		setSettings( {
+			...settings,
+			timezone: { offset: -5, string: 'America/Bogota' },
+		} );
+
+		const formattedDate = dateNoI18n( 'r', '2019-06-18T11:00:00.000Z' );
+
+		expect( formattedDate ).toBe( 'Tue, 18 Jun 2019 11:00:00 -0500' );
+
+		setSettings( settings );
+	} );
 
 	it( 'should support "U" to get epoc for given date', () => {
 		const settings = __experimentalGetSettings();


### PR DESCRIPTION
Raised [here](https://github.com/WordPress/gutenberg/issues/26995). The issue was related to having to offset the actual time, and the timezone offset on the Date object as well.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
