### PR TITLE
Respect filtered settings when they're ported to theme.json format

### DIFF
--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -101,41 +101,16 @@ function gutenberg_edit_site_init( $hook ) {
 	 */
 	$current_screen->is_block_editor( true );
 
-	// Get editor settings.
-	$max_upload_size = wp_max_upload_size();
-	if ( ! $max_upload_size ) {
-		$max_upload_size = 0;
-	}
-
-	// This filter is documented in wp-admin/includes/media.php.
-	$image_size_names      = apply_filters(
-		'image_size_names_choose',
+	$settings = array_merge(
+		gutenberg_get_common_block_editor_settings(),
 		array(
-			'thumbnail' => __( 'Thumbnail', 'gutenberg' ),
-			'medium'    => __( 'Medium', 'gutenberg' ),
-			'large'     => __( 'Large', 'gutenberg' ),
-			'full'      => __( 'Full Size', 'gutenberg' ),
+			'alignWide'    => get_theme_support( 'align-wide' ),
+			'siteUrl'      => site_url(),
+			'postsPerPage' => get_option( 'posts_per_page' ),
+			'styles'       => gutenberg_get_editor_styles(),
 		)
 	);
-	$available_image_sizes = array();
-	foreach ( $image_size_names as $image_size_slug => $image_size_name ) {
-		$available_image_sizes[] = array(
-			'slug' => $image_size_slug,
-			'name' => $image_size_name,
-		);
-	}
-
-	$settings = array(
-		'alignWide'         => get_theme_support( 'align-wide' ),
-		'imageSizes'        => $available_image_sizes,
-		'isRTL'             => is_rtl(),
-		'maxUploadFileSize' => $max_upload_size,
-		'siteUrl'           => site_url(),
-		'postsPerPage'      => get_option( 'posts_per_page' ),
-	);
-
-	$settings['styles'] = gutenberg_get_editor_styles();
-	$settings           = gutenberg_experimental_global_styles_settings( $settings );
+	$settings = gutenberg_experimental_global_styles_settings( $settings );
 
 	// Preload block editor paths.
 	// most of these are copied from edit-forms-blocks.php.
@@ -165,7 +140,7 @@ function gutenberg_edit_site_init( $hook ) {
 			'wp.domReady( function() {
 				wp.editSite.initialize( "edit-site-editor", %s );
 			} );',
-			wp_json_encode( gutenberg_experiments_editor_settings( $settings ) )
+			wp_json_encode( $settings )
 		)
 	);
 

--- a/lib/editor-settings.php
+++ b/lib/editor-settings.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Utilities to manage editor settings.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Returns editor settings that are common to all editors:
+ * post, site, widgets, and navigation.
+ *
+ * All these settings are already part of core,
+ * see edit-form-blocks.php
+ *
+ * @return array Common editor settings.
+ */
+function gutenberg_get_common_block_editor_settings() {
+	$max_upload_size = wp_max_upload_size();
+	if ( ! $max_upload_size ) {
+		$max_upload_size = 0;
+	}
+
+	$available_image_sizes = array();
+	// This filter is documented in wp-admin/includes/media.php.
+	$image_size_names = apply_filters(
+		'image_size_names_choose',
+		array(
+			'thumbnail' => __( 'Thumbnail', 'gutenberg' ),
+			'medium'    => __( 'Medium', 'gutenberg' ),
+			'large'     => __( 'Large', 'gutenberg' ),
+			'full'      => __( 'Full Size', 'gutenberg' ),
+		)
+	);
+	foreach ( $image_size_names as $image_size_slug => $image_size_name ) {
+		$available_image_sizes[] = array(
+			'slug' => $image_size_slug,
+			'name' => $image_size_name,
+		);
+	};
+
+	$settings = array(
+		'__unstableEnableFullSiteEditingBlocks' => gutenberg_is_fse_theme(),
+		'disableCustomColors'                   => get_theme_support( 'disable-custom-colors' ),
+		'disableCustomFontSizes'                => get_theme_support( 'disable-custom-font-sizes' ),
+		'disableCustomGradients'                => get_theme_support( 'disable-custom-gradients' ),
+		'enableCustomLineHeight'                => get_theme_support( 'custom-line-height' ),
+		'enableCustomUnits'                     => get_theme_support( 'custom-units' ),
+		'imageSizes'                            => $available_image_sizes,
+		'isRTL'                                 => is_rtl(),
+		'maxUploadFileSize'                     => $max_upload_size,
+	);
+
+	$color_palette = current( (array) get_theme_support( 'editor-color-palette' ) );
+	if ( false !== $color_palette ) {
+		$settings['colors'] = $color_palette;
+	}
+
+	$font_sizes = current( (array) get_theme_support( 'editor-font-sizes' ) );
+	if ( false !== $font_sizes ) {
+		// Back-compatibility for presets without units.
+		foreach ( $font_sizes as &$font_size ) {
+			if ( is_numeric( $font_size['size'] ) ) {
+				$font_size['size'] = $font_size['size'] . 'px';
+			}
+		}
+		$settings['fontSizes'] = $font_sizes;
+	}
+
+	$gradient_presets = current( (array) get_theme_support( 'editor-gradient-presets' ) );
+	if ( false !== $gradient_presets ) {
+		$settings['gradients'] = $gradient_presets;
+	}
+
+	return $settings;
+}
+
+/**
+ * Extends the block editor with settings that are only in the plugin.
+ *
+ * @param array $settings Existing editor settings.
+ *
+ * @return array Filtered settings.
+ */
+function gutenberg_extend_post_editor_settings( $settings ) {
+	$settings['__unstableEnableFullSiteEditingBlocks'] = gutenberg_is_fse_theme();
+	return $settings;
+}
+add_filter( 'block_editor_settings', 'gutenberg_extend_post_editor_settings' );

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -88,23 +88,3 @@ function gutenberg_display_experiment_section() {
 
 	<?php
 }
-
-/**
- * Extends default editor settings with experiments settings.
- *
- * @param array $settings Default editor settings.
- *
- * @return array Filtered editor settings.
- */
-function gutenberg_experiments_editor_settings( $settings ) {
-	$experiments_settings = array(
-		'__unstableEnableFullSiteEditingBlocks' => gutenberg_is_fse_theme(),
-	);
-	$gradient_presets     = current( (array) get_theme_support( 'editor-gradient-presets' ) );
-	if ( false !== $gradient_presets ) {
-		$experiments_settings['gradients'] = $gradient_presets;
-	}
-
-	return array_merge( $settings, $experiments_settings );
-}
-add_filter( 'block_editor_settings', 'gutenberg_experiments_editor_settings' );

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -229,95 +229,87 @@ function gutenberg_experimental_global_styles_get_core() {
 /**
  * Returns the theme presets registered via add_theme_support, if any.
  *
+ * @param array $settings Existing editor settings.
+ *
  * @return array Config that adheres to the theme.json schema.
  */
-function gutenberg_experimental_global_styles_get_theme_support_settings() {
+function gutenberg_experimental_global_styles_get_theme_support_settings( $settings ) {
 	$theme_settings                       = array();
 	$theme_settings['global']             = array();
 	$theme_settings['global']['settings'] = array();
 
 	// Deprecated theme supports.
-	if ( get_theme_support( 'disable-custom-colors' ) ) {
+	if ( isset( $settings['disableCustomColors'] ) ) {
 		if ( ! isset( $theme_settings['global']['settings']['color'] ) ) {
 			$theme_settings['global']['settings']['color'] = array();
 		}
-		$theme_settings['global']['settings']['color']['custom'] = false;
+		$theme_settings['global']['settings']['color']['custom'] = $settings['disableCustomColors'];
 	}
 
-	if ( get_theme_support( 'disable-custom-gradients' ) ) {
+	if ( isset( $settings['disableCustomGradients'] ) ) {
 		if ( ! isset( $theme_settings['global']['settings']['color'] ) ) {
 			$theme_settings['global']['settings']['color'] = array();
 		}
-		$theme_settings['global']['settings']['color']['customGradient'] = false;
+		$theme_settings['global']['settings']['color']['customGradient'] = $settings['disableCustomGradients'];
 	}
 
-	if ( get_theme_support( 'disable-custom-font-sizes' ) ) {
+	if ( isset( $settings['disableCustomFontSizes'] ) ) {
 		if ( ! isset( $theme_settings['global']['settings']['typography'] ) ) {
 			$theme_settings['global']['settings']['typography'] = array();
 		}
-		$theme_settings['global']['settings']['typography']['customFontSize'] = false;
+		$theme_settings['global']['settings']['typography']['customFontSize'] = $settings['disableCustomFontSizes'];
 	}
 
-	if ( get_theme_support( 'custom-line-height' ) ) {
+	if ( isset( $settings['enableCustomLineHeight'] ) ) {
 		if ( ! isset( $theme_settings['global']['settings']['typography'] ) ) {
 			$theme_settings['global']['settings']['typography'] = array();
 		}
-		$theme_settings['global']['settings']['typography']['customLineHeight'] = true;
+		$theme_settings['global']['settings']['typography']['customLineHeight'] = $settings['enableCustomLineHeight'];
 	}
 
-	if ( get_theme_support( 'custom-spacing' ) ) {
+	if ( isset( $settings['enableCustomUnits'] ) ) {
+		if ( ! isset( $theme_settings['global']['settings']['spacing'] ) ) {
+			$theme_settings['global']['settings']['spacing'] = array();
+		}
+		$theme_settings['global']['settings']['spacing']['units'] = ( true === $settings['enableCustomUnits'] ) ?
+			array( 'px', 'em', 'rem', 'vh', 'vw' ) :
+			$settings['enableCustomUnits'];
+	}
+
+	if ( isset( $settings['colors'] ) ) {
+		if ( ! isset( $theme_settings['global']['settings']['color'] ) ) {
+			$theme_settings['global']['settings']['color'] = array();
+		}
+		$theme_settings['global']['settings']['color']['palette'] = $settings['colors'];
+	}
+
+	if ( isset( $settings['gradients'] ) ) {
+		if ( ! isset( $theme_settings['global']['settings']['color'] ) ) {
+			$theme_settings['global']['settings']['color'] = array();
+		}
+		$theme_settings['global']['settings']['color']['gradients'] = $settings['gradients'];
+	}
+
+	if ( isset( $settings['fontSizes'] ) ) {
+		if ( ! isset( $theme_settings['global']['settings']['typography'] ) ) {
+			$theme_settings['global']['settings']['typography'] = array();
+		}
+		$theme_settings['global']['settings']['typography']['fontSizes'] = $settings['fontSizes'];
+	}
+
+	// Things that didn't land in core yet, so didn't have a setting assigned.
+	if ( current( (array) get_theme_support( 'custom-spacing' ) ) ) {
 		if ( ! isset( $theme_settings['global']['settings']['spacing'] ) ) {
 			$theme_settings['global']['settings']['spacing'] = array();
 		}
 		$theme_settings['global']['settings']['spacing']['custom'] = true;
 	}
 
-	if ( get_theme_support( 'experimental-link-color' ) ) {
+	if ( current( (array) get_theme_support( 'experimental-link-color' ) ) ) {
 		if ( ! isset( $theme_settings['global']['settings']['color'] ) ) {
 			$theme_settings['global']['settings']['color'] = array();
 		}
 		$theme_settings['global']['settings']['color']['link'] = true;
-	}
-
-	$custom_units_theme_support = get_theme_support( 'custom-units' );
-	if ( $custom_units_theme_support ) {
-		if ( ! isset( $theme_settings['global']['settings']['spacing'] ) ) {
-			$theme_settings['global']['settings']['spacing'] = array();
-		}
-		$theme_settings['global']['settings']['spacing'] ['units'] = true === $custom_units_theme_support ? array( 'px', 'em', 'rem', 'vh', 'vw' ) : $custom_units_theme_support;
-	}
-
-	$theme_colors = get_theme_support( 'editor-color-palette' );
-	if ( ! empty( $theme_colors[0] ) ) {
-		if ( ! isset( $theme_settings['global']['settings']['color'] ) ) {
-			$theme_settings['global']['settings']['color'] = array();
-		}
-		$theme_settings['global']['settings']['color']['palette'] = array();
-		$theme_settings['global']['settings']['color']['palette'] = $theme_colors[0];
-	}
-
-	$theme_gradients = get_theme_support( 'editor-gradient-presets' );
-	if ( ! empty( $theme_gradients[0] ) ) {
-		if ( ! isset( $theme_settings['global']['settings']['color'] ) ) {
-			$theme_settings['global']['settings']['color'] = array();
-		}
-		$theme_settings['global']['settings']['color']['gradients'] = array();
-		$theme_settings['global']['settings']['color']['gradients'] = $theme_gradients[0];
-	}
-
-	$theme_font_sizes = get_theme_support( 'editor-font-sizes' );
-	if ( ! empty( $theme_font_sizes[0] ) ) {
-		if ( ! isset( $theme_settings['global']['settings']['typography'] ) ) {
-			$theme_settings['global']['settings']['typography'] = array();
-		}
-		$theme_settings['global']['settings']['typography']['fontSizes'] = array();
-		// Back-compatibility for presets without units.
-		foreach ( $theme_font_sizes[0] as &$font_size ) {
-			if ( is_numeric( $font_size['size'] ) ) {
-				$font_size['size'] = $font_size['size'] . 'px';
-			}
-		}
-		$theme_settings['global']['settings']['typography']['fontSizes'] = $theme_font_sizes[0];
 	}
 
 	return $theme_settings;
@@ -329,21 +321,22 @@ function gutenberg_experimental_global_styles_get_theme_support_settings() {
  * It also fetches the existing presets the theme declared via add_theme_support
  * and uses them if the theme hasn't declared any via theme.json.
  *
+ * @param array $settings Existing editor settings.
+ *
  * @return WP_Theme_JSON Entity that holds theme data.
  */
-function gutenberg_experimental_global_styles_get_theme() {
-	$theme_support_data = gutenberg_experimental_global_styles_get_theme_support_settings();
+function gutenberg_experimental_global_styles_get_theme( $settings ) {
+	$theme_support_data = gutenberg_experimental_global_styles_get_theme_support_settings( $settings );
 	$theme_json_data    = gutenberg_experimental_global_styles_get_from_file(
 		locate_template( 'experimental-theme.json' )
 	);
 
 	/*
-	 * We want the presets declared in theme.json
+	 * We want the presets and settings declared in theme.json
 	 * to override the ones declared via add_theme_support.
 	 */
 	$result = new WP_Theme_JSON( $theme_support_data );
-	$all    = new WP_Theme_JSON( $theme_json_data );
-	$result->merge( $all );
+	$result->merge( new WP_Theme_JSON( $theme_json_data ) );
 
 	return $result;
 }
@@ -398,8 +391,9 @@ function gutenberg_experimental_global_styles_get_stylesheet( $tree ) {
  * and enqueues the resulting stylesheet.
  */
 function gutenberg_experimental_global_styles_enqueue_assets() {
-	$all = gutenberg_experimental_global_styles_get_core();
-	$all->merge( gutenberg_experimental_global_styles_get_theme() );
+	$settings = gutenberg_get_common_block_editor_settings();
+	$all      = gutenberg_experimental_global_styles_get_core();
+	$all->merge( gutenberg_experimental_global_styles_get_theme( $settings ) );
 	$all->merge( gutenberg_experimental_global_styles_get_user() );
 
 	$stylesheet = gutenberg_experimental_global_styles_get_stylesheet( $all );
@@ -419,26 +413,28 @@ function gutenberg_experimental_global_styles_enqueue_assets() {
  * @return array New block editor settings
  */
 function gutenberg_experimental_global_styles_settings( $settings ) {
-	$base = gutenberg_experimental_global_styles_get_core();
-	$base->merge( gutenberg_experimental_global_styles_get_theme() );
+	$base  = gutenberg_experimental_global_styles_get_core();
+	$all   = gutenberg_experimental_global_styles_get_core();
+	$theme = gutenberg_experimental_global_styles_get_theme( $settings );
+	$user  = gutenberg_experimental_global_styles_get_user();
 
-	$all = gutenberg_experimental_global_styles_get_core();
-	$all->merge( gutenberg_experimental_global_styles_get_theme() );
-	$all->merge( gutenberg_experimental_global_styles_get_user() );
+	$base->merge( $theme );
+
+	$all->merge( $theme );
+	$all->merge( $user );
 
 	// STEP 1: ADD FEATURES
 	// These need to be added to settings always.
 	// We also need to unset the deprecated settings defined by core.
 	$settings['__experimentalFeatures'] = $all->get_settings();
-
 	unset( $settings['colors'] );
-	unset( $settings['gradients'] );
-	unset( $settings['fontSizes'] );
 	unset( $settings['disableCustomColors'] );
-	unset( $settings['disableCustomGradients'] );
 	unset( $settings['disableCustomFontSizes'] );
+	unset( $settings['disableCustomGradients'] );
 	unset( $settings['enableCustomLineHeight'] );
 	unset( $settings['enableCustomUnits'] );
+	unset( $settings['fontSizes'] );
+	unset( $settings['gradients'] );
 
 	// STEP 2 - IF EDIT-SITE, ADD DATA REQUIRED FOR GLOBAL STYLES SIDEBAR
 	// The client needs some information to be able to access/update the user styles.
@@ -501,5 +497,5 @@ function gutenberg_experimental_global_styles_register_cpt() {
 }
 
 add_action( 'init', 'gutenberg_experimental_global_styles_register_cpt' );
-add_filter( 'block_editor_settings', 'gutenberg_experimental_global_styles_settings' );
+add_filter( 'block_editor_settings', 'gutenberg_experimental_global_styles_settings', PHP_INT_MAX );
 add_action( 'wp_enqueue_scripts', 'gutenberg_experimental_global_styles_enqueue_assets' );

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -243,21 +243,21 @@ function gutenberg_experimental_global_styles_get_theme_support_settings( $setti
 		if ( ! isset( $theme_settings['global']['settings']['color'] ) ) {
 			$theme_settings['global']['settings']['color'] = array();
 		}
-		$theme_settings['global']['settings']['color']['custom'] = $settings['disableCustomColors'];
+		$theme_settings['global']['settings']['color']['custom'] = ! $settings['disableCustomColors'];
 	}
 
 	if ( isset( $settings['disableCustomGradients'] ) ) {
 		if ( ! isset( $theme_settings['global']['settings']['color'] ) ) {
 			$theme_settings['global']['settings']['color'] = array();
 		}
-		$theme_settings['global']['settings']['color']['customGradient'] = $settings['disableCustomGradients'];
+		$theme_settings['global']['settings']['color']['customGradient'] = ! $settings['disableCustomGradients'];
 	}
 
 	if ( isset( $settings['disableCustomFontSizes'] ) ) {
 		if ( ! isset( $theme_settings['global']['settings']['typography'] ) ) {
 			$theme_settings['global']['settings']['typography'] = array();
 		}
-		$theme_settings['global']['settings']['typography']['customFontSize'] = $settings['disableCustomFontSizes'];
+		$theme_settings['global']['settings']['typography']['customFontSize'] = ! $settings['disableCustomFontSizes'];
 	}
 
 	if ( isset( $settings['enableCustomLineHeight'] ) ) {

--- a/lib/load.php
+++ b/lib/load.php
@@ -102,6 +102,7 @@ require_once __DIR__ . '/widgets-page.php';
 
 require __DIR__ . '/compat.php';
 require __DIR__ . '/utils.php';
+require __DIR__ . '/editor-settings.php';
 
 require __DIR__ . '/full-site-editing.php';
 require __DIR__ . '/templates-sync.php';

--- a/lib/navigation-page.php
+++ b/lib/navigation-page.php
@@ -32,44 +32,12 @@ function gutenberg_navigation_init( $hook ) {
 			return;
 	}
 
-	// Media settings.
-	$max_upload_size = wp_max_upload_size();
-	if ( ! $max_upload_size ) {
-		$max_upload_size = 0;
-	}
-
-	/** This filter is documented in wp-admin/includes/media.php */
-	$image_size_names = apply_filters(
-		'image_size_names_choose',
+	$settings = array_merge(
+		gutenberg_get_common_block_editor_settings(),
 		array(
-			'thumbnail' => __( 'Thumbnail', 'gutenberg' ),
-			'medium'    => __( 'Medium', 'gutenberg' ),
-			'large'     => __( 'Large', 'gutenberg' ),
-			'full'      => __( 'Full Size', 'gutenberg' ),
+			'blockNavMenus' => get_theme_support( 'block-nav-menus' ),
 		)
 	);
-
-	$available_image_sizes = array();
-	foreach ( $image_size_names as $image_size_slug => $image_size_name ) {
-		$available_image_sizes[] = array(
-			'slug' => $image_size_slug,
-			'name' => $image_size_name,
-		);
-	}
-
-	$settings = array(
-		'imageSizes'        => $available_image_sizes,
-		'isRTL'             => is_rtl(),
-		'maxUploadFileSize' => $max_upload_size,
-		'blockNavMenus'     => get_theme_support( 'block-nav-menus' ),
-	);
-
-	list( $font_sizes, ) = (array) get_theme_support( 'editor-font-sizes' );
-
-	if ( false !== $font_sizes ) {
-		$settings['fontSizes'] = $font_sizes;
-	}
-
 	$settings = gutenberg_experimental_global_styles_settings( $settings );
 
 	wp_add_inline_script(
@@ -78,7 +46,7 @@ function gutenberg_navigation_init( $hook ) {
 			'wp.domReady( function() {
 				wp.editNavigation.initialize( "navigation-editor", %s );
 			} );',
-			wp_json_encode( gutenberg_experiments_editor_settings( $settings ) )
+			wp_json_encode( $settings )
 		)
 	);
 

--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -43,37 +43,8 @@ function gutenberg_widgets_init( $hook ) {
 
 	$initializer_name = 'initialize';
 
-	// Media settings.
-	$max_upload_size = wp_max_upload_size();
-	if ( ! $max_upload_size ) {
-		$max_upload_size = 0;
-	}
-
-	/** This filter is documented in wp-admin/includes/media.php */
-	$image_size_names = apply_filters(
-		'image_size_names_choose',
-		array(
-			'thumbnail' => __( 'Thumbnail', 'gutenberg' ),
-			'medium'    => __( 'Medium', 'gutenberg' ),
-			'large'     => __( 'Large', 'gutenberg' ),
-			'full'      => __( 'Full Size', 'gutenberg' ),
-		)
-	);
-
-	$available_image_sizes = array();
-	foreach ( $image_size_names as $image_size_slug => $image_size_name ) {
-		$available_image_sizes[] = array(
-			'slug' => $image_size_slug,
-			'name' => $image_size_name,
-		);
-	}
-
 	$settings = array_merge(
-		array(
-			'imageSizes'        => $available_image_sizes,
-			'isRTL'             => is_rtl(),
-			'maxUploadFileSize' => $max_upload_size,
-		),
+		gutenberg_get_common_block_editor_settings(),
 		gutenberg_get_legacy_widget_settings()
 	);
 
@@ -109,7 +80,7 @@ function gutenberg_widgets_init( $hook ) {
 				wp.editWidgets.%s( "widgets-editor", %s );
 			} );',
 			$initializer_name,
-			wp_json_encode( gutenberg_experiments_editor_settings( $settings ) )
+			wp_json_encode( $settings )
 		)
 	);
 

--- a/lib/widgets.php
+++ b/lib/widgets.php
@@ -200,7 +200,7 @@ function gutenberg_get_legacy_widget_settings() {
 
 	$settings['availableLegacyWidgets'] = $available_legacy_widgets;
 
-	return gutenberg_experiments_editor_settings( $settings );
+	return $settings;
 }
 
 /**

--- a/phpunit/class-global-styles-test.php
+++ b/phpunit/class-global-styles-test.php
@@ -1,0 +1,200 @@
+<?php
+
+/**
+ * Test Global Styles functions.
+ *
+ * @package Gutenberg
+ */
+
+class Global_Styles_Test extends WP_UnitTestCase {
+
+	function get_editor_settings_no_theme_support() {
+		return array(
+			'__unstableEnableFullSiteEditingBlocks' => false,
+			'disableCustomColors'                   => false,
+			'disableCustomFontSizes'                => false,
+			'disableCustomGradients'                => false,
+			'enableCustomLineHeight'                => false,
+			'enableCustomUnits'                     => false,
+			'imageSizes'                            => array(
+				array(
+					'slug' => 'thumbnail',
+					'name' => 'Thumbnail',
+				),
+				array(
+					'slug' => 'medium',
+					'name' => 'Medium',
+				),
+				array(
+					'slug' => 'large',
+					'name' => 'Large',
+				),
+				array(
+					'slug' => 'full',
+					'name' => 'Full Size',
+				),
+			),
+			'isRTL'                                 => false,
+			'maxUploadFileSize'                     => 2097152,
+		);
+	}
+
+	function test_editor_settings_no_theme_support() {
+		$expected = $this->get_editor_settings_no_theme_support();
+		$actual   = gutenberg_get_common_block_editor_settings();
+
+		$this->assertEqualSetsWithIndex( $expected, $actual );
+	}
+
+
+	function test_legacy_settings_blank() {
+		$input    = array();
+		$expected = array(
+			'global' => array(
+				'settings' => array(),
+			),
+		);
+
+		$actual = gutenberg_experimental_global_styles_get_theme_support_settings( $input );
+
+		$this->assertEqualSetsWithIndex( $expected, $actual );
+	}
+
+	function test_legacy_settings_no_theme_support() {
+		$input    = $this->get_editor_settings_no_theme_support();
+		$expected = array(
+			'global' => array(
+				'settings' => array(
+					'color'      => array(
+						'custom'         => true,
+						'customGradient' => true,
+					),
+					'spacing'    => array(
+						'units' => false,
+					),
+					'typography' => array(
+						'customFontSize'   => true,
+						'customLineHeight' => false,
+					),
+				),
+			),
+		);
+
+		$actual = gutenberg_experimental_global_styles_get_theme_support_settings( $input );
+
+		$this->assertEqualSetsWithIndex( $expected, $actual );
+	}
+
+	function test_legacy_settings_custom_units_can_be_disabled() {
+		add_theme_support( 'custom-units', array() );
+		$input = gutenberg_get_common_block_editor_settings();
+
+		$expected = array(
+			'units' => array( array() ),
+		);
+
+		$actual = gutenberg_experimental_global_styles_get_theme_support_settings( $input );
+
+		$this->assertEqualSetsWithIndex( $expected, $actual['global']['settings']['spacing'] );
+	}
+
+	function test_legacy_settings_custom_units_can_be_enabled() {
+		add_theme_support( 'custom-units' );
+		$input = gutenberg_get_common_block_editor_settings();
+
+		$expected = array(
+			'units' => array( 'px', 'em', 'rem', 'vh', 'vw' ),
+		);
+
+		$actual = gutenberg_experimental_global_styles_get_theme_support_settings( $input );
+
+		$this->assertEqualSetsWithIndex( $expected, $actual['global']['settings']['spacing'] );
+	}
+
+	function test_legacy_settings_custom_units_can_be_filtered() {
+		add_theme_support( 'custom-units', 'rem', 'em' );
+		$input = gutenberg_get_common_block_editor_settings();
+
+		$expected = array(
+			'units' => array( 'rem', 'em' ),
+		);
+
+		$actual = gutenberg_experimental_global_styles_get_theme_support_settings( $input );
+
+		$this->assertEqualSetsWithIndex( $expected, $actual['global']['settings']['spacing'] );
+	}
+
+	function test_legacy_settings_filled() {
+		$input = array(
+			'disableCustomColors'    => true,
+			'disableCustomGradients' => true,
+			'disableCustomFontSizes' => true,
+			'enableCustomLineHeight' => true,
+			'enableCustomUnits'      => true,
+			'colors'                 => array(
+				array(
+					'slug'  => 'color-slug',
+					'name'  => 'Color Name',
+					'color' => 'colorvalue',
+				),
+			),
+			'gradients'              => array(
+				array(
+					'slug'     => 'gradient-slug',
+					'name'     => 'Gradient Name',
+					'gradient' => 'gradientvalue',
+				),
+			),
+			'fontSizes'             => array(
+				array(
+					'slug' => 'size-slug',
+					'name' => 'Size Name',
+					'size' => 'sizevalue',
+				),
+			),
+		);
+
+		$expected = array(
+			'global' => array(
+				'settings' => array(
+					'color' => array(
+						'custom'         => false,
+						'customGradient' => false,
+						'gradients'      => array(
+							array(
+								'slug'     => 'gradient-slug',
+								'name'     => 'Gradient Name',
+								'gradient' => 'gradientvalue',
+							),
+						),
+						'palette'        => array(
+							array(
+								'slug'  => 'color-slug',
+								'name'  => 'Color Name',
+								'color' => 'colorvalue',
+							),
+						),
+					),
+					'spacing'    => array(
+						'units' => array( 'px', 'em', 'rem', 'vh', 'vw' ),
+					),
+					'typography' => array(
+						'customFontSize'    => false,
+						'customLineHeight'  => true,
+						'fontSizes'         => array(
+							array(
+								'slug' => 'size-slug',
+								'name' => 'Size Name',
+								'size' => 'sizevalue',
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$actual = gutenberg_experimental_global_styles_get_theme_support_settings( $input );
+
+		$this->assertEqualSetsWithIndex( $expected, $actual );
+	}
+}

--- a/phpunit/class-theme-json-legacy-settings-test.php
+++ b/phpunit/class-theme-json-legacy-settings-test.php
@@ -1,12 +1,13 @@
 <?php
 
 /**
- * Test Global Styles functions.
+ * Test that legacy settings are properly
+ * reorganized into the theme.json structure.
  *
  * @package Gutenberg
  */
 
-class Global_Styles_Test extends WP_UnitTestCase {
+class Theme_JSON_Legacy_Settings_Test extends WP_UnitTestCase {
 
 	function get_editor_settings_no_theme_support() {
 		return array(
@@ -35,17 +36,9 @@ class Global_Styles_Test extends WP_UnitTestCase {
 				),
 			),
 			'isRTL'                                 => false,
-			'maxUploadFileSize'                     => 2097152,
+			'maxUploadFileSize'                     => 123,
 		);
 	}
-
-	function test_editor_settings_no_theme_support() {
-		$expected = $this->get_editor_settings_no_theme_support();
-		$actual   = gutenberg_get_common_block_editor_settings();
-
-		$this->assertEqualSetsWithIndex( $expected, $actual );
-	}
-
 
 	function test_legacy_settings_blank() {
 		$input    = array();


### PR DESCRIPTION
This PR reverts https://github.com/WordPress/gutenberg/pull/27004 which reverted https://github.com/WordPress/gutenberg/pull/26903 So, essentially, tries to merge 26903 again.

## How to test

- Activate a theme that doesn't have support for line-height.
  - For example, install latest [TwentyTwentyOneBlocks](https://github.com/WordPress/theme-experiments/tree/master/twentytwentyone-blocks) 
  - In functions.php, remove [this line](https://github.com/WordPress/theme-experiments/blob/master/twentytwentyone-blocks/functions.php#L218): `add_theme_support( 'custom-line-height' );`
  - In its theme.json, remove [this line](https://github.com/WordPress/theme-experiments/blob/master/twentytwentyone-blocks/experimental-theme.json#L101): `customLineHeight: true`
- Filter the editor settings to enable line-height. For example, paste this code into global-styles.php

```php
function gs_set_custom_line_height( $settings ) {
	$settings['enableCustomLineHeight'] = true;
	return $settings;
}
add_filter('block_editor_settings', 'gs_set_custom_line_height');
```

- Go to the post editor and add a paragraph. The expected result is that:

  - the line height UI control is enabled and visible in the block control sidebar
  - there's no `enableCustomLineHeight` settings passed down to the editor initialization or stored in the `settings` key of the `core/block-editor` store.
