### PR TITLE
Blocks: Implement recursion checking and reporting for template-parts, post-content and reusable blocks (#26923)

### DIFF
--- a/lib/block-recursion-control.php
+++ b/lib/block-recursion-control.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Blocks API: Block recursion control functions.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Determines whether or not to process this content.
+ *
+ * @param string|integer $id Unique ID for the content.
+ * @param string $block_name Block name.
+ * @return bool - true if recursion hasn't been detected.
+ */
+function gutenberg_process_this_content( $id, $block_name ) {
+	$recursion_control = WP_Block_Recursion_Control::get_instance();
+	return $recursion_control->process_this_content( $id, $block_name );
+}
+
+/**
+ * Pops the last item of processed content.
+ *
+ * As we return to the previous level we can clear the processed content.
+ * Basically this is something we have to do while processing certain inner blocks:
+ *
+ * - core/post-content
+ * - core/template-part
+ * - core/block
+ * - core/post-excerpt - possibly
+ *
+ * Note: The top level is within the template, which loads the template parts and/or queries.
+ */
+function gutenberg_clear_processed_content() {
+	$recursion_control = WP_Block_Recursion_Control::get_instance();
+	$recursion_control->clear_processed_content();
+}

--- a/lib/block-recursion-error.php
+++ b/lib/block-recursion-error.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Blocks API: Block recursion error handling.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Reports a recursion error to the user.
+ *
+ * If WP_DEBUG is true then additional information is displayed.
+ * Use the $class parameter to override default behavior.
+ *
+ * @param $id string|integer recursive ID detected
+ * @param $type string content type
+ * @return string HTML reporting the error to the user
+ */
+function gutenberg_report_recursion_error( $message=null, $class=null ) {
+	$recursion_control = WP_Block_Recursion_Control::get_instance();
+	if ( $class && class_exists( $class ) ) {
+		$recursion_error = new $class( $recursion_control );
+	} else {
+		$recursion_error = new WP_Block_Recursion_Error( $recursion_control );
+	}
+	$html = $recursion_error->report_recursion_error( $message );
+	return $html;
+}

--- a/lib/class-wp-block-recursion-control.php
+++ b/lib/class-wp-block-recursion-control.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Blocks API: WP_Block_Recursion_Control class
+ *
+ * @package Gutenberg
+ */
+
+/**
+ * Class for detecting recursion in inner blocks.
+ *
+ * Implements the recursion control functions.
+ * Blocks use the public API passing the unique ID and block name for their block.
+ *
+ * ```
+ * if (  gutenberg_process_this_content( $id, $block_name ) ) {
+ *  	$html = process the block;
+ * 		gutenberg_clear_processed_content();
+ * } else {
+ * 		$html = gutenberg_report_recursion_error( $message, $class );
+ * }
+ * return $html;
+ * ```
+ *
+ * Blocks wishing to report a recursion error should use
+ * gutenberg_report_recursion_error( $message, $class )
+ *
+ * These functions will be implemented by methods accessed using WP_Block_Recursion_Control::get_instance()
+ *
+ * @property array $processed_content
+ * @property integer|string $id
+ * @property string $block_name
+ */
+class WP_Block_Recursion_Control {
+	/**
+	 * Stack of recursive blocks unique keys.
+	 *
+	 * @var array
+	 *
+	 */
+	public $processed_content = [];
+
+	/**
+	 * ID of latest block. This could be the last straw.
+	 */
+	public $id;
+
+	/**
+	 * Block name of the latest block
+	 */
+	public $block_name;
+
+	/**
+	 * Container for the main instance of the class.
+	 *
+	 * @var WP_Block_Recursion_Control|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * Utility method to retrieve the main instance of the class.
+	 *
+	 * The instance will be created if it does not exist yet.
+	 *
+	 * @since
+	 *
+	 * @return WP_Block_Recursion_Control The main instance.
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Determines whether or not to process this content.
+	 *
+	 * @param string|integer $id Unique ID for the content
+	 * @param string $block_name Block name e.g. core/post-content
+	 * @return bool True if the post has not been processed. false otherwise
+	 */
+	function process_this_content( $id, $block_name ) {
+		$this->id = $id;
+		$this->block_name = $block_name;
+		$processed = isset( $this->processed_content[ $id ] );
+		if ( !$processed ) {
+			$this->processed_content[$id] = "$block_name $id" ;
+		}
+		return !$processed;
+	}
+
+	/**
+	 * Pops or clears the array of processed content.
+	 *
+	 * As we return to the previous level we can clear the processed content.
+	 * Basically this is something we have to do while processing certain inner blocks:
+	 *
+	 * - core/post-content
+	 * - core/template-part
+	 * - core/post-excerpt - possibly
+	 * - core/block - possibly
+	 *
+	 * Note: The top level is within the template, which loads the template parts and/or queries.
+	 */
+	function clear_processed_content() {
+		array_pop( $this->processed_content );
+	}
+
+	/**
+	 * Returns the unique ID of the last block.
+	 *
+	 * Used when a recursion error has been detected.
+	 * @return int|string
+	 */
+	function get_id() {
+		return $this->id;
+	}
+
+	/**
+	 * Returns the block stack.
+	 *
+	 * Used when a recursion error has been detected.
+	 * @return int|string
+	 */
+	function get_processed_content() {
+		return $this->processed_content;
+	}
+
+	/**
+	 * Returns the block name.
+	 *
+	 * Used when a recursion error has been detected.
+	 * @return int|string
+	 */
+	function get_block_name() {
+		return $this->block_name;
+	}
+
+}

--- a/lib/class-wp-block-recursion-error.php
+++ b/lib/class-wp-block-recursion-error.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Blocks API: WP_Block_Recursion_Error class
+ *
+ * @package Gutenberg
+ */
+
+/**
+ * Implements the recursion error functions in an extendable class.
+ * The extending class may be specified as the $class parameter.
+ *
+ * ```
+ * $html = gutenberg_report_recursion_error( $message, $class=null )
+ * ```
+ */
+class WP_Block_Recursion_Error {
+
+	private $recursion_control = null;
+	protected $bad_id = null;
+	protected $bad_processed_content = [];
+	protected $block_name = null; // The block name
+	protected $message = null;
+
+	public function __construct( $recursion_control = null ) {
+		if ( $recursion_control ) {
+			$this->recursion_control = $recursion_control;
+		} else {
+			$this->recursion_control = WP_Block_Recursion_Control::get_instance();
+		}
+	}
+
+	/**
+	 * Start to produce the error block to be displayed on the front end.
+	 *
+	 * @TODO Implement as a core message block, when available.
+	 *
+	 * @return string
+	 */
+	function start_error_block() {
+		$content = '<div class="recursion-error">';
+		return $content;
+	}
+
+	/**
+	 * Complete the error block to be displayed on the front end.
+	 *
+	 * @TODO Implement as a core message block, when available.
+	 *
+	 * @return string
+	 */
+	function complete_error_block() {
+		$content = '</div>';
+		return $content;
+	}
+
+	/**
+	 * Returns the message.
+	 *
+	 * The default message varies depending on the block type where recursion was detected.
+	 *
+	 * @return string
+	 */
+	function get_message() 	{
+		if ( !$this->message ) {
+			switch ($this->block_name) {
+				case 'core/post-content':
+					$this->message = __('Content not available; already processed.', 'gutenberg');
+					break;
+				case 'core/template-part':
+					$this->message = __('Template part not processed to avoid infinite recursion', 'gutenberg');
+					break;
+				case 'core/block':
+					$this->message = __('Reusable block not processed to avoid infinite recursion', 'gutenberg');
+					break;
+				default:
+					$this->message = __('Infinite recursion error prevented', 'gutenberg');
+					$this->message .= sprintf(__('Block name: %1$s', 'gutenberg'), $this->block_name);
+			}
+		}
+		return $this->message;
+	}
+
+	/**
+	 * Returns details to help with problem determination.
+	 *
+	 * This is only done when WP_DEBUG is true.
+	 *
+	 * @TODO Also check if the user is logged in.
+	 * @TODO Also check the user's capability with regards to fixing the problem.
+	 *
+	 * @return string HTML with additional details.
+	 */
+	function report_debug_details() {
+		$content = [];
+		if (defined('WP_DEBUG') && WP_DEBUG) {
+			$content[] = "<span class=\"recursion-error-context \">";
+			$content[] = '<br />';
+			$content[] = sprintf( __( 'Block unique ID: %1$s', 'gutenberg' ), $this->bad_id );
+			$content[] = '<br />';
+			$content[] = sprintf( __( 'Block name: %1$s', 'gutenberg' ), $this->block_name );
+			$content[] = '<br />';
+			$content[] = sprintf( __('Stack: %1$s', 'gutenberg'), implode(',', $this->bad_processed_content) );
+			$content[] = '</span>';
+		}
+		$content = implode(" \n", $content);
+		return $content;
+	}
+
+	/**
+	 * Reports a recursion error to the user.
+	 *
+	 * If WP_DEBUG is true then additional information is displayed.
+	 *
+	 * @param $message string
+	 * @return string
+	 */
+	public function report_recursion_error( $message = null ) {
+		$this->bad_id = $this->recursion_control->get_id();
+		$this->block_name = $this->recursion_control->get_block_name();
+		$this->bad_processed_content = $this->recursion_control->get_processed_content();
+		$this->set_message( $message );
+		$content = $this->start_error_block();
+		$content .= $this->get_message();
+		$content .= $this->report_debug_details();
+		$content .= $this->complete_error_block();
+		return $content;
+	}
+
+	/**
+	 * Sets the message to be displayed.
+	 *
+	 * Note: If the message is null then a default message is displayed.
+	 *
+	 * @param null $message
+	 */
+	public function set_message( $message=null ) {
+		$this->message = $message;
+	}
+}

--- a/lib/load.php
+++ b/lib/load.php
@@ -132,3 +132,7 @@ if ( !class_exists( 'WP_Block_Recursion_Control') ) {
 	require_once __DIR__ . '/class-wp-block-recursion-control.php';
 }
 require_once __DIR__ . '/block-recursion-control.php';
+if ( !class_exists( 'WP_Block_Recursion_Error') ) {
+	require_once __DIR__ . '/class-wp-block-recursion-error.php';
+}
+require_once __DIR__ . '/block-recursion-error.php';

--- a/lib/load.php
+++ b/lib/load.php
@@ -127,3 +127,8 @@ require dirname( __FILE__ ) . '/block-supports/colors.php';
 require dirname( __FILE__ ) . '/block-supports/align.php';
 require dirname( __FILE__ ) . '/block-supports/typography.php';
 require dirname( __FILE__ ) . '/block-supports/custom-classname.php';
+
+if ( !class_exists( 'WP_Block_Recursion_Control') ) {
+	require_once __DIR__ . '/class-wp-block-recursion-control.php';
+}
+require_once __DIR__ . '/block-recursion-control.php';

--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -17,6 +17,9 @@ function render_block_core_post_content( $attributes, $content, $block ) {
 	if ( ! isset( $block->context['postId'] ) ) {
 		return '';
 	}
+	if ( 'revision' === $block->context['postType'] ) {
+		return '';
+	}
 
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'entry-content' ) );
 

--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -17,17 +17,22 @@ function render_block_core_post_content( $attributes, $content, $block ) {
 	if ( ! isset( $block->context['postId'] ) ) {
 		return '';
 	}
-	if ( 'revision' === $block->context['postType'] ) {
-		return '';
+
+	if ( gutenberg_process_this_content( $block->context['postId'], $block->name ) ) {
+		if ('revision' === $block->context['postType']) {
+			return '';
+		}
+
+		$wrapper_attributes = get_block_wrapper_attributes(array('class' => 'entry-content'));
+
+		$html = '<div ' . $wrapper_attributes . '>' .
+			apply_filters('the_content', str_replace(']]>', ']]&gt;', get_the_content(null, false, $block->context['postId']))) .
+			'</div>';
+		gutenberg_clear_processed_content();
+	} else {
+		$html = gutenberg_report_recursion_error();
 	}
-
-	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'entry-content' ) );
-
-	return (
-		'<div ' . $wrapper_attributes . '>' .
-			apply_filters( 'the_content', str_replace( ']]>', ']]&gt;', get_the_content( null, false, $block->context['postId'] ) ) ) .
-		'</div>'
-	);
+	return $html;
 }
 
 /**

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -14,10 +14,10 @@
  *
  * @return string The render.
  */
-function render_block_core_template_part( $attributes, $content, $block ) {
+function render_block_core_template_part_safely( $attributes, $content, $block ) {
 	$template_id = render_block_core_template_get_template_id( $attributes );
 	if ( gutenberg_process_this_content( $template_id, $block->name ) ) {
-		$html = render_block_core_template_part_details( $attributes );
+		$html = render_block_core_template_part( $attributes );
 		gutenberg_clear_processed_content();
 	} else {
 		$html = gutenberg_report_recursion_error();
@@ -26,14 +26,13 @@ function render_block_core_template_part( $attributes, $content, $block ) {
 }
 
 /**
- * Safely renders the `core/template-part` block on the server.
+ * Renders the `core/template-part` block on the server.
  *
  * @param array $attributes The block attributes.
  *
  * @return string The render.
  */
-
-function render_block_core_template_part_details( $attributes ) 	{
+function render_block_core_template_part( $attributes ) 	{
 	$content = null;
 	if ( ! empty( $attributes['postId'] ) && get_post_status( $attributes['postId'] ) ) {
 		// If we have a post ID and the post exists, which means this template part
@@ -113,7 +112,7 @@ function register_block_core_template_part() {
 	register_block_type_from_metadata(
 		__DIR__ . '/template-part',
 		array(
-			'render_callback' => 'render_block_core_template_part',
+			'render_callback' => 'render_block_core_template_part_safely',
 		)
 	);
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
- In #26923 I documented some scenarios where block rendering results in infinite recursion. 
- The problems are easy to create in Full Site Editing using the `core/template-part` and/or `core/post-content` blocks.
- A very similar problem with Reusable blocks ( `core/block` ) was reported #18704.
- In #26951 @carlomanf has developed a solution that checks for recursion for any block within `WP_Block` class.
- In my solution the recursion checking is only performed by block types which can go infinitely recursive.
  - `core/post-content`
 - `core/template-part`
 - `core/block` 
 - I believe it should be possible to cause `core/post-excerpt` to recurse.  

Both solutions rely on a test to see if the block that's about to be rendered is already being processed.

The logic implemented in each solution is:

- Check if the block that's about to be rendered is already being rendered.
- If it isn't already being rendered. ie It's safe to render
  - add it to the stack of blocks being rendered.
  - render the block
  - pop it from the stack
- else don't render it


- In the `WP_Block` fix the recursive block is rendered as an empty string. Neither the end user nor the site administrator is made aware that there was a recursion problem. 
- In this solution, there is an option to report the recursion error. 
- The level of detail reported depends on the setting for `WP_DEBUG`
- This solution also supports extending the base solution for reporting recursion errors.


### Regarding the reusable blocks issue ( #18704 )
- I've developed an extension class for the reusable block recursion problem that attempts to deal with the problem when encountered in a REST request.  
- This error reporting extension for reusable blocks is not (yet) part of this PR. 
- While it is able to deal with a self recursive reusable block
- It is unable to prevent the block editor from going recursive when a user inserts a reusable block that's been returned in the request to fetch reusable blocks. 

## How has this been tested?

### Environment

- Tested with WordPress 5.6-beta3
- Active theme: Twenty Twenty-One Blocks, with some additional template parts, some template parts _commented_ out  and modified CSS.
- Active plugins: Gutenberg
- Plus, used to aid understanding of the post-content output:  
 - oik - for the [bw_list] shortcode
- And during development - oik-bwtrace - used to trace server events


## Screenshots
### Scenarios
#### Front end
- Tested recursion detection and reporting for template-parts using the `404.html` template and a couple of recursive template parts. 
- Tested recursion detection and reporting for post-content within the query / query loop in multiple pages
- Tested recursion detection for a self recursive reusable block.
![image](https://user-images.githubusercontent.com/2474435/99282662-e542d800-282b-11eb-9cfc-3789e8d3b44a.png)


![image](https://user-images.githubusercontent.com/2474435/99282597-d0fedb00-282b-11eb-8851-2c10aeee4787.png)

![image](https://user-images.githubusercontent.com/2474435/99282730-fab80200-282b-11eb-9f08-945accb897e0.png)


## Types of changes
- Fixes #26923
- Fixes #26593 - recently recreated then retested

These changes also include the fixes applied for:
- #26772 
- #26731 

The solution introduces
-  4 new files included in `load.php`
- which implement 2 classes 
  - WP_Block_Recursion_Control 
  - WP_Block_Recursion_Error
- and 3 APIs:
  - gutenberg_process_this_content - performs the check for recursion
  - gutenberg_clear_processed_content - pops the last item processed
  - gutenberg_report_recursion_error


<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->

- I've not delivered any automated tests.
- I imagine the new functions will need documenting so that they can be used by other block developers who may have had to develop their own recursion checking.
