### PR TITLE
Dependency Extraction Webpack Plugin: Add defaultDependencies

### DIFF
--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### New feature
 
 - Include TypeScript type declarations ([#22498](https://github.com/WordPress/gutenberg/pull/22498))
+- Add new option parameter `defaultDependencies` to add values to dependency arrays by default.
 
 ## 2.5.0 (2020-04-01)
 

--- a/packages/dependency-extraction-webpack-plugin/README.md
+++ b/packages/dependency-extraction-webpack-plugin/README.md
@@ -145,6 +145,13 @@ Pass `useDefaults: false` to disable the default request handling.
 Force `wp-polyfill` to be included in each entry point's dependency list. This would be the same as
 adding `import '@wordpress/polyfill';` to each entry point.
 
+##### `defaultDependencies`
+
+- Type: Array
+- Default: `false`
+
+Supply an array of strings to be added to the dependency array by default for each entry point.
+
 ##### `requestToExternal`
 
 - Type: function

--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -56,6 +56,7 @@ const {
  * @property {RequestToHandle|undefined}   [requestToHandle]   Map module requests to a script handle.
  * @property {string|null}                 combinedOutputFile  This option is useful only when the combineAssets option is enabled. It allows providing a custom output file for the generated single assets file. It's possible to provide a path that is relative to the output directory.
  * @property {boolean|undefined}           combineAssets       By default, one asset file is created for each entry point. When this flag is set to true, all information about assets is combined into a single assets.(json|php) file generated in the output directory.
+ * @property {string[]|undefined}          defaultDependencies An array of dependencies to be added by default for each entry point. 
  */
 
 class DependencyExtractionWebpackPlugin {
@@ -184,6 +185,7 @@ class DependencyExtractionWebpackPlugin {
 				combinedOutputFile,
 				injectPolyfill,
 				outputFormat,
+				defaultDependencies,
 			} = this.options;
 
 			/** @type {Record<string, AssetData>} */
@@ -198,6 +200,12 @@ class DependencyExtractionWebpackPlugin {
 				const entrypointExternalizedWpDeps = new Set();
 				if ( injectPolyfill ) {
 					entrypointExternalizedWpDeps.add( 'wp-polyfill' );
+				}
+				
+				if ( defaultDependencies && Array.isArray( defaultDependencies ) ) {
+					defaultDependencies.forEach( dependency => {
+						entrypointExternalizedWpDeps.add( dependency );
+					} );
 				}
 
 				// Search for externalized modules in all chunks.


### PR DESCRIPTION
## Description

Users of the Dependency Extraction Webpack Plugin may want to manually add a dependency to every entry point. This PR introduces an option property `defaultDependencies` that accepts an array of strings to be added as default dependencies when registering a script.

## Use Case

Extensions looking to use SlotFill to enhance WC Admin need to sure that the plugin is loaded first. Since Fills are gathered from a package, Dependency Extraction Webpack Plugin will correctly add the package as a dependency, but won't add the dependency on WC Admin itself. These users would be using an [extension of this package](https://github.com/woocommerce/woocommerce-admin/tree/main/packages/dependency-extraction-webpack-plugin).

If an extension imports a Fill:

```js
import { WooNavigationItem } from "@woocommerce/navigation";
```
The resulting dependency array should also declare WC Admin as a dependency to ensure WC Admin is loaded first.

```php
array( 'wc-admin-app', 'wc-navigation' )
```

## Testing Instructions

A test repo is required to test this. You can create a new one using [wp-scripts](https://github.com/WordPress/gutenberg/blob/master/packages/scripts/README.md) or use one that I created for the purpose called [test-g-dewps](https://github.com/psealock/test-g-dewps).

1. `npm run build` on this branch.
2. `cd packages/dependency-extraction-webpack-plugin`
3. `npm link`
4. `cd ../../../`
5. `git clone git@github.com:psealock/test-g-dewps.git`
6. `cd test-g-dewps && npm install`
7. `npm link @wordpress/dependency-extraction-webpack-plugin`
8. Note the extra dependencies added in `webpack.config.js`:

```js
new DependencyExtractionWebpackPlugin({
    defaultDependencies: ["apples", "oranges", "bananas"],
}),
```
9. `npm run build`
10. Confirm the dependencies array in `build/index.assets.php`

```php
array('apples', 'bananas', 'oranges')
```

## Types of changes

This PR introduces a new non-breaking options parameter to add default dependencies to Dependency Extraction Webpack Plugin.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
