### PR TITLE
Fix php test suite

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -447,11 +447,11 @@ function gutenberg_inject_default_block_context( $args ) {
 			}
 
 			// Inject the post context if not done by Core.
-			$needs_post_id = empty( $block_type->uses_context ) && in_array( 'postId', $block_type->uses_context, true );
+			$needs_post_id = ! empty( $block_type->uses_context ) && in_array( 'postId', $block_type->uses_context, true );
 			if ( $post instanceof WP_Post && $needs_post_id ) {
 				$block->context['postId'] = $post->ID;
 			}
-			$needs_post_type = empty( $block_type->uses_context ) && in_array( 'postType', $block_type->uses_context, true );
+			$needs_post_type = ! empty( $block_type->uses_context ) && in_array( 'postType', $block_type->uses_context, true );
 			if ( $post instanceof WP_Post && $needs_post_type ) {
 				/*
 				* The `postType` context is largely unnecessary server-side, since the
@@ -463,7 +463,7 @@ function gutenberg_inject_default_block_context( $args ) {
 			}
 
 			// Inject the query context if not done by Core.
-			$needs_query = empty( $block_type->uses_context ) && in_array( 'query', $block_type->uses_context, true );
+			$needs_query = ! empty( $block_type->uses_context ) && in_array( 'query', $block_type->uses_context, true );
 			if ( ! isset( $block->context['query'] ) && $needs_query ) {
 				if ( isset( $wp_query->tax_query->queried_terms['category'] ) ) {
 					$block->context['query'] = array( 'categoryIds' => array() );

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -447,11 +447,11 @@ function gutenberg_inject_default_block_context( $args ) {
 			}
 
 			// Inject the post context if not done by Core.
-			$needs_post_id = ! empty( $block_type->uses_context ) && in_array( 'postId', $block_type->uses_context, true );
+			$needs_post_id = is_array( $block_type->uses_context ) && in_array( 'postId', $block_type->uses_context, true );
 			if ( $post instanceof WP_Post && $needs_post_id ) {
 				$block->context['postId'] = $post->ID;
 			}
-			$needs_post_type = ! empty( $block_type->uses_context ) && in_array( 'postType', $block_type->uses_context, true );
+			$needs_post_type = is_array( $block_type->uses_context ) && in_array( 'postType', $block_type->uses_context, true );
 			if ( $post instanceof WP_Post && $needs_post_type ) {
 				/*
 				* The `postType` context is largely unnecessary server-side, since the
@@ -463,7 +463,7 @@ function gutenberg_inject_default_block_context( $args ) {
 			}
 
 			// Inject the query context if not done by Core.
-			$needs_query = ! empty( $block_type->uses_context ) && in_array( 'query', $block_type->uses_context, true );
+			$needs_query = is_array( $block_type->uses_context ) && in_array( 'query', $block_type->uses_context, true );
 			if ( ! isset( $block->context['query'] ) && $needs_query ) {
 				if ( isset( $wp_query->tax_query->queried_terms['category'] ) ) {
 					$block->context['query'] = array( 'categoryIds' => array() );

--- a/lib/templates-sync.php
+++ b/lib/templates-sync.php
@@ -163,10 +163,10 @@ add_action( 'trash_wp_template_part', 'gutenberg_clear_synchronize_last_checks' 
 /**
  * Clear synchronization last check timestamps after deleting a template or template part.
  *
- * @param int     $postid ID of the deleted post.
+ * @param int     $post_id ID of the deleted post.
  * @param WP_Post $post WP_Post instance of the deleted post.
  */
-function gutenberg_clear_synchronize_last_checks_after_delete( $postid, $post ) {
+function gutenberg_clear_synchronize_last_checks_after_delete( $post_id, $post ) {
 	if ( 'wp_template' !== $post->post_type || 'wp_template_part' !== $post->post_type ) {
 		gutenberg_clear_synchronize_last_checks();
 	}

--- a/lib/templates-sync.php
+++ b/lib/templates-sync.php
@@ -163,7 +163,7 @@ add_action( 'trash_wp_template_part', 'gutenberg_clear_synchronize_last_checks' 
 /**
  * Clear synchronization last check timestamps after deleting a template or template part.
  *
- * @param int     $post_id ID of the deleted post.
+ * @param int     $postid ID of the deleted post.
  * @param WP_Post $post WP_Post instance of the deleted post.
  */
 function gutenberg_clear_synchronize_last_checks_after_delete( $postid, $post ) {


### PR DESCRIPTION
There were a couple of issues with the PHP unit test suite:

1. A lint was failing
2. That lint was hiding a phpunit failure, caused by some logic which needed to be flipped around. (needed to change from `empty( $foo ) && in_array( $bar, $foo )` to `is_array( $foo ) && in_array( $bar, $foo )`