### PR TITLE
Fix GH actions "cancel" step

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -7,7 +7,7 @@ jobs:
     timeout-minutes: 3
     steps:
       - name: Get all workflow ids and set to env variable
-        run: echo ::set-env name=WORKFLOW_IDS_TO_CANCEL::$(curl https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows -s | jq -r '.workflows | map(.id|tostring) | join(",")')
+        run: echo "WORKFLOW_IDS_TO_CANCEL=$(curl https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows -s | jq -r '.workflows | map(.id|tostring) | join(",")')" >> $GITHUB_ENV
 
       - uses: styfle/cancel-workflow-action@0.4.0
         with:

--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPUnit bootstrap file
+ * PHPUnit bootstrap files
  *
  * @package Gutenberg
  */

--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPUnit bootstrap files
+ * PHPUnit bootstrap file
  *
  * @package Gutenberg
  */


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
The `set-env` command has been deprecated, which is causing our cancel step to fail. (more info at https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/)

This PR updates it to use the new syntax. (see https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable)

## Testing

To verify, just look at one of the early commits in this PR and make sure that its actions were all cancelled. Additionally, check that the cancel action passes successfully.