### PR TITLE
Full Site Editing: Extend the wp_template admin list with new views and columns

### DIFF
--- a/lib/templates.php
+++ b/lib/templates.php
@@ -69,12 +69,11 @@ function gutenberg_register_template_post_type() {
 		'supports'          => array(
 			'title',
 			'slug',
+			'excerpt',
 			'editor',
 			'revisions',
 		),
 	);
-
-	register_post_type( 'wp_template', $args );
 
 	$meta_args = array(
 		'object_subtype' => 'wp_template',
@@ -187,7 +186,9 @@ add_action( 'admin_menu', 'gutenberg_fix_template_admin_menu_entry' );
  * @return array Filtered $columns.
  */
 function gutenberg_filter_template_list_table_columns( array $columns ) {
-	$columns['slug'] = __( 'Slug', 'gutenberg' );
+	$columns['slug']        = __( 'Slug', 'gutenberg' );
+	$columns['description'] = __( 'Description', 'gutenberg' );
+	$columns['status']      = __( 'Status', 'gutenberg' );
 	if ( isset( $columns['date'] ) ) {
 		unset( $columns['date'] );
 	}
@@ -202,13 +203,72 @@ add_filter( 'manage_wp_template_posts_columns', 'gutenberg_filter_template_list_
  * @param int    $post_id     Post ID.
  */
 function gutenberg_render_template_list_table_column( $column_name, $post_id ) {
-	if ( 'slug' !== $column_name ) {
+	if ( 'slug' === $column_name ) {
+		$post = get_post( $post_id );
+		echo esc_html( $post->post_name );
 		return;
 	}
-	$post = get_post( $post_id );
-	echo esc_html( $post->post_name );
+
+	if ( 'description' === $column_name ) {
+		the_excerpt( $post_id );
+		return;
+	}
+
+	if ( 'status' === $column_name ) {
+		$post_status        = get_post_status( $post_id );
+		// The auto-draft status doesn't have localized labels
+		if ( 'auto-draft' === $post_status ) {
+			echo esc_html_x( 'Auto-Draft', 'Post status', 'gutenberg' );
+			return;
+		}
+		$post_status_object = get_post_status_object( $post_status );
+		echo esc_html( $post_status_object->label );
+		return;
+	}
 }
 add_action( 'manage_wp_template_posts_custom_column', 'gutenberg_render_template_list_table_column', 10, 2 );
+
+/**
+ * Adds the auto-draft view to the 'wp_template' post type list.
+ *
+ * @param array $query The query to filter.
+ */
+function gutenberg_filter_templates_edit_views( $views ) {
+	$url               = add_query_arg( array(
+		'post_type'   => 'wp_template',
+		'post_status' => 'auto-draft',
+	), 'edit.php' );
+	$is_autodraft_view = isset( $_REQUEST['post_status'] ) && 'auto-draft' === $_REQUEST['post_status'];
+	$class_html        = $is_autodraft_view ? ' class="current"' : '';
+	$aria_current      = $is_autodraft_view ? ' aria-current="page"' : '';
+	$post_count        = wp_count_posts( 'wp_template', 'readable' );
+	// The auto-draft status doesn't have localized labels
+	$label             = sprintf(
+		translate_nooped_plural(
+			/* translators: %s: Number of auto-draft posts. */
+			_nx_noop(
+				'Auto-Draft <span class="count">(%s)</span>',
+				'Auto-Drafts <span class="count">(%s)</span>',
+				'Post status',
+				'gutenberg'
+			),
+			$post_count->{'auto-draft'}
+		),
+		number_format_i18n( $post_count->{'auto-draft'} )
+	);
+	$auto_draft_view   = sprintf(
+		'<a href="%s"%s%s>%s</a>',
+		esc_url( $url ),
+		$class_html,
+		$aria_current,
+		$label
+	);
+
+	array_splice( $views, -1, 0, array( 'auto-draft' => $auto_draft_view ) );
+
+	return $views;
+}
+add_filter( 'views_edit-wp_template', 'gutenberg_filter_templates_edit_views' );
 
 /**
  * Filter for adding a `resolved` parameter to `wp_template` queries.

--- a/lib/templates.php
+++ b/lib/templates.php
@@ -234,18 +234,18 @@ add_action( 'manage_wp_template_posts_custom_column', 'gutenberg_render_template
  * @param array $views The edit views to filter.
  */
 function gutenberg_filter_templates_edit_views( $views ) {
-	$url               = add_query_arg(
+	$url                = add_query_arg(
 		array(
 			'post_type'   => 'wp_template',
 			'post_status' => 'auto-draft',
 		),
 		'edit.php'
 	);
-	$is_autodraft_view = isset( $_REQUEST['post_status'] ) && 'auto-draft' === $_REQUEST['post_status'];
-	$class_html        = $is_autodraft_view ? ' class="current"' : '';
-	$aria_current      = $is_autodraft_view ? ' aria-current="page"' : '';
-	$post_count        = wp_count_posts( 'wp_template', 'readable' );
-	$label             = sprintf(
+	$is_auto_draft_view = isset( $_REQUEST['post_status'] ) && 'auto-draft' === $_REQUEST['post_status'];
+	$class_html         = $is_auto_draft_view ? ' class="current"' : '';
+	$aria_current       = $is_auto_draft_view ? ' aria-current="page"' : '';
+	$post_count         = wp_count_posts( 'wp_template', 'readable' );
+	$label              = sprintf(
 		// The auto-draft status doesn't have localized labels.
 		translate_nooped_plural(
 			/* translators: %s: Number of auto-draft posts. */
@@ -268,7 +268,7 @@ function gutenberg_filter_templates_edit_views( $views ) {
 		$label
 	);
 
-	array_splice( $views, -1, 0, array( 'auto-draft' => $auto_draft_view ) );
+	array_splice( $views, 1, 0, array( 'auto-draft' => $auto_draft_view ) );
 
 	return $views;
 }

--- a/lib/templates.php
+++ b/lib/templates.php
@@ -215,8 +215,8 @@ function gutenberg_render_template_list_table_column( $column_name, $post_id ) {
 	}
 
 	if ( 'status' === $column_name ) {
-		$post_status        = get_post_status( $post_id );
-		// The auto-draft status doesn't have localized labels
+		$post_status = get_post_status( $post_id );
+		// The auto-draft status doesn't have localized labels.
 		if ( 'auto-draft' === $post_status ) {
 			echo esc_html_x( 'Auto-Draft', 'Post status', 'gutenberg' );
 			return;
@@ -231,19 +231,22 @@ add_action( 'manage_wp_template_posts_custom_column', 'gutenberg_render_template
 /**
  * Adds the auto-draft view to the 'wp_template' post type list.
  *
- * @param array $query The query to filter.
+ * @param array $views The edit views to filter.
  */
 function gutenberg_filter_templates_edit_views( $views ) {
-	$url               = add_query_arg( array(
-		'post_type'   => 'wp_template',
-		'post_status' => 'auto-draft',
-	), 'edit.php' );
+	$url               = add_query_arg(
+		array(
+			'post_type'   => 'wp_template',
+			'post_status' => 'auto-draft',
+		),
+		'edit.php'
+	);
 	$is_autodraft_view = isset( $_REQUEST['post_status'] ) && 'auto-draft' === $_REQUEST['post_status'];
 	$class_html        = $is_autodraft_view ? ' class="current"' : '';
 	$aria_current      = $is_autodraft_view ? ' aria-current="page"' : '';
 	$post_count        = wp_count_posts( 'wp_template', 'readable' );
-	// The auto-draft status doesn't have localized labels
 	$label             = sprintf(
+		// The auto-draft status doesn't have localized labels.
 		translate_nooped_plural(
 			/* translators: %s: Number of auto-draft posts. */
 			_nx_noop(
@@ -256,7 +259,8 @@ function gutenberg_filter_templates_edit_views( $views ) {
 		),
 		number_format_i18n( $post_count->{'auto-draft'} )
 	);
-	$auto_draft_view   = sprintf(
+
+	$auto_draft_view = sprintf(
 		'<a href="%s"%s%s>%s</a>',
 		esc_url( $url ),
 		$class_html,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

This PR was originally part of #26636.

- Added support for `excerpts` to the `wp_template` CPT, used to store the template description.
- Updated the Templates wp-admin list to display more details (title, slug, excerpt, status), so that now it's at least slightly useful.
- Updated the Templates wp-admin list with a new Auto-Drafts view that list `auto-draft` templates, at least temporarily.

## How has this been tested?

- Open `wp-admin/edit.php?post_status=publish&post_type=wp_template`.
- Make sure the list now has all the new columns.
- Make sure there is an "auto-draft" view.

## Screenshots

<img width="1084" alt="Screenshot 2020-11-17 at 12 36 45" src="https://user-images.githubusercontent.com/2070010/99391122-9d768c00-28d1-11eb-9928-9375efc2e0bd.png">
<img width="1081" alt="Screenshot 2020-11-17 at 12 36 56" src="https://user-images.githubusercontent.com/2070010/99391128-9f404f80-28d1-11eb-936b-eea33d65caa8.png">


## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
