### PR TITLE
Visual editor: remove 4 wrapper divs

### DIFF
--- a/packages/block-editor/src/components/block-selection-clearer/index.js
+++ b/packages/block-editor/src/components/block-selection-clearer/index.js
@@ -19,10 +19,8 @@ export function useBlockSelectionClearer( ref ) {
 			return;
 		}
 
-		function onFocus( event ) {
-			if ( event.target === event.currentTarget ) {
-				clearSelectedBlock();
-			}
+		function onFocus() {
+			clearSelectedBlock();
 		}
 
 		ref.current.addEventListener( 'focus', onFocus );

--- a/packages/block-editor/src/components/block-selection-clearer/index.js
+++ b/packages/block-editor/src/components/block-selection-clearer/index.js
@@ -2,8 +2,9 @@
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
+import { useEffect, useRef } from '@wordpress/element';
 
-function useBlockSelectionClearer() {
+function useBlockSelectionClearer( ref ) {
 	const hasSelection = useSelect( ( select ) => {
 		const { hasSelectedBlock, hasMultiSelection } = select(
 			'core/block-editor'
@@ -13,14 +14,27 @@ function useBlockSelectionClearer() {
 	} );
 	const { clearSelectedBlock } = useDispatch( 'core/block-editor' );
 
-	return ( event ) => {
-		if ( event.target === event.currentTarget && hasSelection ) {
-			clearSelectedBlock();
+	useEffect( () => {
+		if ( ! hasSelection ) {
+			return;
 		}
-	};
+
+		function onFocus( event ) {
+			if ( event.target === event.currentTarget ) {
+				clearSelectedBlock();
+			}
+		}
+
+		ref.current.addEventListener( 'focus', onFocus );
+
+		return () => {
+			ref.current.removeEventListener( 'focus', onFocus );
+		};
+	}, [ hasSelection, clearSelectedBlock ] );
 }
 
 export default function BlockSelectionClearer( props ) {
-	const onFocus = useBlockSelectionClearer();
-	return <div tabIndex={ -1 } onFocus={ onFocus } { ...props } />;
+	const ref = useRef();
+	useBlockSelectionClearer( ref );
+	return <div tabIndex={ -1 } ref={ ref } { ...props } />;
 }

--- a/packages/block-editor/src/components/block-selection-clearer/index.js
+++ b/packages/block-editor/src/components/block-selection-clearer/index.js
@@ -4,7 +4,7 @@
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
 
-function useBlockSelectionClearer( ref ) {
+export function useBlockSelectionClearer( ref ) {
 	const hasSelection = useSelect( ( select ) => {
 		const { hasSelectedBlock, hasMultiSelection } = select(
 			'core/block-editor'

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -71,7 +71,7 @@ export function useNotifyCopy() {
 	}, [] );
 }
 
-function useClipboardHandler( ref ) {
+export function useClipboardHandler( ref ) {
 	const {
 		getBlocksByClientId,
 		getSelectedBlockClientIds,

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, useRef } from '@wordpress/element';
+import { useCallback, useEffect, useRef } from '@wordpress/element';
 import { serialize, pasteHandler } from '@wordpress/blocks';
 import {
 	documentHasSelection,
@@ -71,97 +71,99 @@ export function useNotifyCopy() {
 	}, [] );
 }
 
-function CopyHandler( { children } ) {
-	const containerRef = useRef();
-
+function useClipboardHandler( ref ) {
 	const {
 		getBlocksByClientId,
 		getSelectedBlockClientIds,
 		hasMultiSelection,
 		getSettings,
 	} = useSelect( ( select ) => select( 'core/block-editor' ), [] );
-
 	const { flashBlock, removeBlocks, replaceBlocks } = useDispatch(
 		'core/block-editor'
 	);
-
 	const notifyCopy = useNotifyCopy();
 
-	const {
-		__experimentalCanUserUseUnfilteredHTML: canUserUseUnfilteredHTML,
-	} = getSettings();
+	useEffect( () => {
+		function handler( event ) {
+			const selectedBlockClientIds = getSelectedBlockClientIds();
 
-	const handler = ( event ) => {
-		const selectedBlockClientIds = getSelectedBlockClientIds();
-
-		if ( selectedBlockClientIds.length === 0 ) {
-			return;
-		}
-
-		// Always handle multiple selected blocks.
-		if ( ! hasMultiSelection() ) {
-			const { target } = event;
-			const { ownerDocument } = target;
-			// If copying, only consider actual text selection as selection.
-			// Otherwise, any focus on an input field is considered.
-			const hasSelection =
-				event.type === 'copy' || event.type === 'cut'
-					? documentHasUncollapsedSelection( ownerDocument )
-					: documentHasSelection( ownerDocument );
-
-			// Let native copy behaviour take over in input fields.
-			if ( hasSelection ) {
+			if ( selectedBlockClientIds.length === 0 ) {
 				return;
 			}
-		}
 
-		if ( ! containerRef.current.contains( event.target ) ) {
-			return;
-		}
-		event.preventDefault();
+			// Always handle multiple selected blocks.
+			if ( ! hasMultiSelection() ) {
+				const { target } = event;
+				const { ownerDocument } = target;
+				// If copying, only consider actual text selection as selection.
+				// Otherwise, any focus on an input field is considered.
+				const hasSelection =
+					event.type === 'copy' || event.type === 'cut'
+						? documentHasUncollapsedSelection( ownerDocument )
+						: documentHasSelection( ownerDocument );
 
-		if ( event.type === 'copy' || event.type === 'cut' ) {
-			if ( selectedBlockClientIds.length === 1 ) {
-				flashBlock( selectedBlockClientIds[ 0 ] );
+				// Let native copy behaviour take over in input fields.
+				if ( hasSelection ) {
+					return;
+				}
 			}
-			notifyCopy( event.type, selectedBlockClientIds );
-			const blocks = getBlocksByClientId( selectedBlockClientIds );
-			const serialized = serialize( blocks );
 
-			event.clipboardData.setData( 'text/plain', serialized );
-			event.clipboardData.setData( 'text/html', serialized );
+			if ( ! ref.current.contains( event.target ) ) {
+				return;
+			}
+			event.preventDefault();
+
+			if ( event.type === 'copy' || event.type === 'cut' ) {
+				if ( selectedBlockClientIds.length === 1 ) {
+					flashBlock( selectedBlockClientIds[ 0 ] );
+				}
+				notifyCopy( event.type, selectedBlockClientIds );
+				const blocks = getBlocksByClientId( selectedBlockClientIds );
+				const serialized = serialize( blocks );
+
+				event.clipboardData.setData( 'text/plain', serialized );
+				event.clipboardData.setData( 'text/html', serialized );
+			}
+
+			if ( event.type === 'cut' ) {
+				removeBlocks( selectedBlockClientIds );
+			} else if ( event.type === 'paste' ) {
+				const {
+					__experimentalCanUserUseUnfilteredHTML: canUserUseUnfilteredHTML,
+				} = getSettings();
+				const { plainText, html } = getPasteEventData( event );
+				const blocks = pasteHandler( {
+					HTML: html,
+					plainText,
+					mode: 'BLOCKS',
+					canUserUseUnfilteredHTML,
+				} );
+
+				replaceBlocks(
+					selectedBlockClientIds,
+					blocks,
+					blocks.length - 1,
+					-1
+				);
+			}
 		}
 
-		if ( event.type === 'cut' ) {
-			removeBlocks( selectedBlockClientIds );
-		} else if ( event.type === 'paste' ) {
-			const { plainText, html } = getPasteEventData( event );
-			const blocks = pasteHandler( {
-				HTML: html,
-				plainText,
-				mode: 'BLOCKS',
-				canUserUseUnfilteredHTML,
-			} );
+		ref.current.addEventListener( 'copy', handler );
+		ref.current.addEventListener( 'cut', handler );
+		ref.current.addEventListener( 'paste', handler );
 
-			replaceBlocks(
-				selectedBlockClientIds,
-				blocks,
-				blocks.length - 1,
-				-1
-			);
-		}
-	};
+		return () => {
+			ref.current.removeEventListener( 'copy', handler );
+			ref.current.removeEventListener( 'cut', handler );
+			ref.current.removeEventListener( 'paste', handler );
+		};
+	}, [] );
+}
 
-	return (
-		<div
-			ref={ containerRef }
-			onCopy={ handler }
-			onCut={ handler }
-			onPaste={ handler }
-		>
-			{ children }
-		</div>
-	);
+function CopyHandler( { children } ) {
+	const ref = useRef();
+	useClipboardHandler( ref );
+	return <div ref={ ref }>{ children }</div>;
 }
 
 export default CopyHandler;

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -83,24 +83,39 @@ export {
 } from './block-list/block-wrapper';
 export { default as BlockMover } from './block-mover';
 export { default as BlockPreview } from './block-preview';
-export { default as BlockSelectionClearer } from './block-selection-clearer';
+export {
+	default as BlockSelectionClearer,
+	useBlockSelectionClearer as __unstableUseBlockSelectionClearer,
+} from './block-selection-clearer';
 export { default as BlockSettingsMenu } from './block-settings-menu';
 export { default as BlockSettingsMenuControls } from './block-settings-menu-controls';
 export { default as BlockTitle } from './block-title';
 export { default as BlockToolbar } from './block-toolbar';
-export { default as CopyHandler } from './copy-handler';
+export {
+	default as CopyHandler,
+	useClipboardHandler as __unstableUseClipboardHandler,
+} from './copy-handler';
 export { default as DefaultBlockAppender } from './default-block-appender';
 export { default as __unstableEditorStyles } from './editor-styles';
 export { default as Inserter } from './inserter';
 export { default as __experimentalLibrary } from './inserter/library';
 export { default as __experimentalSearchForm } from './inserter/search-form';
 export { default as BlockEditorKeyboardShortcuts } from './keyboard-shortcuts';
-export { default as MultiSelectScrollIntoView } from './multi-select-scroll-into-view';
+export {
+	default as MultiSelectScrollIntoView,
+	useScrollMultiSelectionIntoView as __unstableUseScrollMultiSelectionIntoView,
+} from './multi-select-scroll-into-view';
 export { default as NavigableToolbar } from './navigable-toolbar';
-export { default as ObserveTyping } from './observe-typing';
+export {
+	default as ObserveTyping,
+	useTypingObserver as __unstableUseTypingObserver,
+} from './observe-typing';
 export { default as PreserveScrollInReorder } from './preserve-scroll-in-reorder';
 export { default as SkipToSelectedBlock } from './skip-to-selected-block';
-export { default as Typewriter } from './typewriter';
+export {
+	default as Typewriter,
+	useTypewriter as __unstableUseTypewriter,
+} from './typewriter';
 export { default as Warning } from './warning';
 export { default as WritingFlow } from './writing-flow';
 

--- a/packages/block-editor/src/components/multi-select-scroll-into-view/index.js
+++ b/packages/block-editor/src/components/multi-select-scroll-into-view/index.js
@@ -15,32 +15,29 @@ import { getScrollContainer } from '@wordpress/dom';
  */
 import { getBlockDOMNode } from '../../utils/dom';
 
-/**
- * Scrolls the multi block selection end into view if not in view already. This
- * is important to do after selection by keyboard.
- */
-export default function MultiSelectScrollIntoView() {
-	const selector = ( select ) => {
+export function useScrollMultiSelectionIntoView( ref ) {
+	const selectionEnd = useSelect( ( select ) => {
 		const {
 			getBlockSelectionEnd,
 			hasMultiSelection,
 			isMultiSelecting,
 		} = select( 'core/block-editor' );
 
-		return {
-			selectionEnd: getBlockSelectionEnd(),
-			isMultiSelection: hasMultiSelection(),
-			isMultiSelecting: isMultiSelecting(),
-		};
-	};
-	const { isMultiSelection, selectionEnd, isMultiSelecting } = useSelect(
-		selector,
-		[]
-	);
-	const ref = useRef();
+		const blockSelectionEnd = getBlockSelectionEnd();
+
+		if (
+			! blockSelectionEnd ||
+			isMultiSelecting() ||
+			! hasMultiSelection()
+		) {
+			return;
+		}
+
+		return blockSelectionEnd;
+	}, [] );
 
 	useEffect( () => {
-		if ( ! selectionEnd || isMultiSelecting || ! isMultiSelection ) {
+		if ( ! selectionEnd ) {
 			return;
 		}
 
@@ -62,7 +59,15 @@ export default function MultiSelectScrollIntoView() {
 		scrollIntoView( extentNode, scrollContainer, {
 			onlyScrollIfNeeded: true,
 		} );
-	}, [ isMultiSelection, selectionEnd, isMultiSelecting ] );
+	}, [ selectionEnd ] );
+}
 
+/**
+ * Scrolls the multi block selection end into view if not in view already. This
+ * is important to do after selection by keyboard.
+ */
+export default function MultiSelectScrollIntoView() {
+	const ref = useRef();
+	useScrollMultiSelectionIntoView( ref );
 	return <div ref={ ref } />;
 }

--- a/packages/block-editor/src/components/observe-typing/index.js
+++ b/packages/block-editor/src/components/observe-typing/index.js
@@ -43,7 +43,7 @@ function isKeyDownEligibleForStartTyping( event ) {
 	return ! shiftKey && KEY_DOWN_ELIGIBLE_KEY_CODES.has( keyCode );
 }
 
-function useTypingObserver( ref ) {
+export function useTypingObserver( ref ) {
 	const isTyping = useSelect( ( select ) =>
 		select( 'core/block-editor' ).isTyping()
 	);

--- a/packages/block-editor/src/components/typewriter/index.js
+++ b/packages/block-editor/src/components/typewriter/index.js
@@ -10,8 +10,7 @@ const isIE = window.navigator.userAgent.indexOf( 'Trident' ) !== -1;
 const arrowKeyCodes = new Set( [ UP, DOWN, LEFT, RIGHT ] );
 const initialTriggerPercentage = 0.75;
 
-function Typewriter( { children } ) {
-	const ref = useRef();
+export function useTypewriter( ref ) {
 	const hasSelectedBlock = useSelect( ( select ) =>
 		select( 'core/block-editor' ).hasSelectedBlock()
 	);
@@ -242,7 +241,11 @@ function Typewriter( { children } ) {
 			defaultView.cancelAnimationFrame( onKeyDownRafId );
 		};
 	}, [ hasSelectedBlock ] );
+}
 
+function Typewriter( { children } ) {
+	const ref = useRef();
+	useTypewriter( ref );
 	return (
 		<div ref={ ref } className="block-editor__typewriter">
 			{ children }

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -708,7 +708,7 @@ export default function WritingFlow( { children } ) {
 	// bubbling events from children to determine focus transition intents.
 	/* eslint-disable jsx-a11y/no-static-element-interactions */
 	return (
-		<div className={ className }>
+		<>
 			<FocusCapture
 				ref={ focusCaptureBeforeRef }
 				selectedClientId={ selectedBlockClientId }
@@ -719,6 +719,7 @@ export default function WritingFlow( { children } ) {
 			/>
 			<div
 				ref={ container }
+				className={ className }
 				onKeyDown={ onKeyDown }
 				onMouseDown={ onMouseDown }
 			>
@@ -751,7 +752,7 @@ export default function WritingFlow( { children } ) {
 				onClick={ focusLastTextField }
 				className="block-editor-writing-flow__click-redirect"
 			/>
-		</div>
+		</>
 	);
 	/* eslint-enable jsx-a11y/no-static-element-interactions */
 }

--- a/packages/e2e-tests/specs/editor/various/keyboard-navigable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/keyboard-navigable-blocks.test.js
@@ -110,7 +110,7 @@ describe( 'Order of block keyboard navigation', () => {
 
 		// Clear the selected block and put focus in front of the block list.
 		await page.evaluate( () => {
-			document.querySelector( '.edit-post-visual-editor' ).focus();
+			document.querySelector( '.editor-styles-wrapper' ).focus();
 		} );
 
 		await page.keyboard.press( 'Tab' );
@@ -145,7 +145,7 @@ describe( 'Order of block keyboard navigation', () => {
 
 		// Clear the selected block and put focus behind the block list.
 		await page.evaluate( () => {
-			document.querySelector( '.edit-post-visual-editor' ).focus();
+			document.querySelector( '.editor-styles-wrapper' ).focus();
 			document
 				.querySelector( '.interface-interface-skeleton__sidebar' )
 				.focus();

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -7,16 +7,17 @@ import {
 } from '@wordpress/editor';
 import {
 	WritingFlow,
-	Typewriter,
-	ObserveTyping,
 	BlockList,
-	CopyHandler,
-	BlockSelectionClearer,
-	MultiSelectScrollIntoView,
+	__unstableUseBlockSelectionClearer as useBlockSelectionClearer,
+	__unstableUseTypewriter as useTypewriter,
+	__unstableUseClipboardHandler as useClipboardHandler,
+	__unstableUseTypingObserver as useTypingObserver,
+	__unstableUseScrollMultiSelectionIntoView as useScrollMultiSelectionIntoView,
 	__experimentalBlockSettingsMenuFirstItem,
 	__experimentalUseResizeCanvas as useResizeCanvas,
 } from '@wordpress/block-editor';
 import { Popover } from '@wordpress/components';
+import { useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -24,40 +25,41 @@ import { Popover } from '@wordpress/components';
 import BlockInspectorButton from './block-inspector-button';
 import { useSelect } from '@wordpress/data';
 
-function VisualEditor() {
+export default function VisualEditor() {
+	const ref = useRef();
+	const inlineStyles = useResizeCanvas( deviceType );
 	const deviceType = useSelect( ( select ) => {
 		return select( 'core/edit-post' ).__experimentalGetPreviewDeviceType();
 	}, [] );
 
-	const inlineStyles = useResizeCanvas( deviceType );
+	useScrollMultiSelectionIntoView( ref );
+	useBlockSelectionClearer( ref );
+	useTypewriter( ref );
+	useClipboardHandler( ref );
+	useTypingObserver( ref );
 
 	return (
-		<BlockSelectionClearer
-			className="edit-post-visual-editor editor-styles-wrapper"
-			style={ inlineStyles }
-		>
+		<>
 			<VisualEditorGlobalKeyboardShortcuts />
-			<MultiSelectScrollIntoView />
 			<Popover.Slot name="block-toolbar" />
-			<Typewriter>
-				<CopyHandler>
-					<WritingFlow>
-						<ObserveTyping>
-							<div className="edit-post-visual-editor__post-title-wrapper">
-								<PostTitle />
-							</div>
-							<BlockList />
-						</ObserveTyping>
-					</WritingFlow>
-				</CopyHandler>
-			</Typewriter>
+			<div
+				ref={ ref }
+				className=" edit-post-visual-editor editor-styles-wrapper"
+				tabIndex="-1"
+				style={ inlineStyles }
+			>
+				<WritingFlow>
+					<div className="edit-post-visual-editor__post-title-wrapper">
+						<PostTitle />
+					</div>
+					<BlockList />
+				</WritingFlow>
+			</div>
 			<__experimentalBlockSettingsMenuFirstItem>
 				{ ( { onClose } ) => (
 					<BlockInspectorButton onClick={ onClose } />
 				) }
 			</__experimentalBlockSettingsMenuFirstItem>
-		</BlockSelectionClearer>
+		</>
 	);
 }
-
-export default VisualEditor;

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -27,10 +27,10 @@ import { useSelect } from '@wordpress/data';
 
 export default function VisualEditor() {
 	const ref = useRef();
-	const inlineStyles = useResizeCanvas( deviceType );
 	const deviceType = useSelect( ( select ) => {
 		return select( 'core/edit-post' ).__experimentalGetPreviewDeviceType();
 	}, [] );
+	const inlineStyles = useResizeCanvas( deviceType );
 
 	useScrollMultiSelectionIntoView( ref );
 	useBlockSelectionClearer( ref );
@@ -39,12 +39,12 @@ export default function VisualEditor() {
 	useTypingObserver( ref );
 
 	return (
-		<>
+		<div className="edit-post-visual-editor">
 			<VisualEditorGlobalKeyboardShortcuts />
 			<Popover.Slot name="block-toolbar" />
 			<div
 				ref={ ref }
-				className=" edit-post-visual-editor editor-styles-wrapper"
+				className="editor-styles-wrapper"
 				tabIndex="-1"
 				style={ inlineStyles }
 			>
@@ -60,6 +60,6 @@ export default function VisualEditor() {
 					<BlockInspectorButton onClick={ onClose } />
 				) }
 			</__experimentalBlockSettingsMenuFirstItem>
-		</>
+		</div>
 	);
 }

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -1,6 +1,5 @@
 .edit-post-visual-editor {
 	position: relative;
-	padding-top: 50px;
 	// Default background color so that grey .edit-post-editor-regions__content color doesn't show through.
 	background-color: $white;
 

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -27,6 +27,11 @@
 	}
 }
 
+.editor-styles-wrapper,
+.editor-styles-wrapper > .block-editor-writing-flow__click-redirect {
+	height: 100%;
+}
+
 .edit-post-visual-editor .block-editor-writing-flow__click-redirect {
 	// Allow the page to be scrolled with the last block in the middle.
 	min-height: 40vh;

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -28,11 +28,6 @@
 	}
 }
 
-.edit-post-visual-editor > .block-editor-writing-flow,
-.edit-post-visual-editor > .block-editor-writing-flow > .block-editor-writing-flow__click-redirect {
-	height: 100%;
-}
-
 .edit-post-visual-editor .block-editor-writing-flow__click-redirect {
 	// Allow the page to be scrolled with the last block in the middle.
 	min-height: 40vh;

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -28,10 +28,8 @@
 	}
 }
 
-.edit-post-visual-editor > .block-editor__typewriter,
-.edit-post-visual-editor > .block-editor__typewriter > div,
-.edit-post-visual-editor > .block-editor__typewriter > div > .block-editor-writing-flow,
-.edit-post-visual-editor > .block-editor__typewriter > div > .block-editor-writing-flow > .block-editor-writing-flow__click-redirect {
+.edit-post-visual-editor > .block-editor-writing-flow,
+.edit-post-visual-editor > .block-editor-writing-flow > .block-editor-writing-flow__click-redirect {
 	height: 100%;
 }
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

This PRs removes 4 wrapper divs and one empty div from the visual editor. These divs were used to bind events, which can also be done with access to the ref alone.

Another div was removed in #26994 from the root container earlier.

Aside from simplifying things, this is also useful (though not strictly necessary) when we iframe the editor content. Ideally, the content of the iframe is purely the content without any wrapper divs. Again, this is not strictly necessary, but it will make it easier to style content later on by third parties.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
