### PR TITLE
Full Site Editing: Add Support for Templates Default and Custom Titles and Descriptions (PHP Side)

### DIFF
--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -104,10 +104,11 @@ function gutenberg_edit_site_init( $hook ) {
 	$settings = array_merge(
 		gutenberg_get_common_block_editor_settings(),
 		array(
-			'alignWide'    => get_theme_support( 'align-wide' ),
-			'siteUrl'      => site_url(),
-			'postsPerPage' => get_option( 'posts_per_page' ),
-			'styles'       => gutenberg_get_editor_styles(),
+			'alignWide'            => get_theme_support( 'align-wide' ),
+			'siteUrl'              => site_url(),
+			'postsPerPage'         => get_option( 'posts_per_page' ),
+			'styles'               => gutenberg_get_editor_styles(),
+			'defaultTemplateTypes' => gutenberg_get_indexed_default_template_types(),
 		)
 	);
 	$settings = gutenberg_experimental_global_styles_settings( $settings );

--- a/lib/full-site-editing/default-template-types.php
+++ b/lib/full-site-editing/default-template-types.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Template types.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Returns a filtered list of default template types, containing their
+ * localized titles and descriptions.
+ *
+ * @return array The default template types.
+ */
+function gutenberg_get_default_template_types() {
+	$default_template_types = array(
+		'index'          => array(
+			'title'       => _x( 'Default (Index)', 'Template name', 'gutenberg' ),
+			'description' => __( 'Main template, applied when no other template is found', 'gutenberg' ),
+		),
+		'home'           => array(
+			'title'       => _x( 'Home', 'Template name', 'gutenberg' ),
+			'description' => __( 'Template for the latest blog posts', 'gutenberg' ),
+		),
+		'front-page'     => array(
+			'title'       => _x( 'Front Page', 'Template name', 'gutenberg' ),
+			'description' => __( 'Front page template, whether it displays the blog posts index or a static page', 'gutenberg' ),
+		),
+		'singular'       => array(
+			'title'       => _x( 'Default Singular', 'Template name', 'gutenberg' ),
+			'description' => __( 'Displays any content on a single page', 'gutenberg' ),
+		),
+		'single'         => array(
+			'title'       => _x( 'Default Single', 'Template name', 'gutenberg' ),
+			'description' => __( 'Applied to individual content like a blog post', 'gutenberg' ),
+		),
+		'page'           => array(
+			'title'       => _x( 'Default Page', 'Template name', 'gutenberg' ),
+			'description' => __( 'Applied to individual pages', 'gutenberg' ),
+		),
+		'archive'        => array(
+			'title'       => _x( 'Default Archive', 'Template name', 'gutenberg' ),
+			'description' => __( 'Applied to archives like your posts page, categories, or tags', 'gutenberg' ),
+		),
+		'author'         => array(
+			'title'       => _x( 'Default Author Archive', 'Template name', 'gutenberg' ),
+			'description' => __( 'Displays a list of posts by a single author', 'gutenberg' ),
+		),
+		'category'       => array(
+			'title'       => _x( 'Default Post Category Archive', 'Template name', 'gutenberg' ),
+			'description' => __( 'Displays a list of posts in a category', 'gutenberg' ),
+		),
+		'taxonomy'       => array(
+			'title'       => _x( 'Default Taxonomy Archive', 'Template name', 'gutenberg' ),
+			'description' => __( 'Displays a list of posts in a taxonomy', 'gutenberg' ),
+		),
+		'date'           => array(
+			'title'       => _x( 'Default Date Archive', 'Template name', 'gutenberg' ),
+			'description' => __( 'Displays a list of posts in a date range', 'gutenberg' ),
+		),
+		'tag'            => array(
+			'title'       => _x( 'Default Tag Archive', 'Template name', 'gutenberg' ),
+			'description' => __( 'Displays a list of posts with a tag', 'gutenberg' ),
+		),
+		'attachment'     => array(
+			'title'       => __( 'Media', 'gutenberg' ),
+			'description' => __( 'Displays media content', 'gutenberg' ),
+		),
+		'search'         => array(
+			'title'       => __( 'Search Results', 'gutenberg' ),
+			'description' => __( 'Applied to search results', 'gutenberg' ),
+		),
+		'privacy-policy' => array(
+			'title'       => __( 'Privacy Policy', 'gutenberg' ),
+			'description' => '',
+		),
+		'404'            => array(
+			'title'       => _x( '404 (Not Found)', 'Template name', 'gutenberg' ),
+			'description' => __( 'Applied when content cannot be found', 'gutenberg' ),
+		),
+		'embed'          => array(
+			'title'       => __( 'Embed', 'gutenberg' ),
+			'description' => __( '[Currently unsupported]', 'gutenberg' ),
+		),
+	);
+
+	/**
+	 * Filters the list of template types.
+	 *
+	 * @param array $default_template_types An array of template types, formatted as [ slug => [ title, description ] ].
+	 *
+	 * @since 5.x.x
+	 */
+	return apply_filters( 'default_template_types', $default_template_types );
+}
+
+/**
+ * Converts the default template types array from associative to indexed,
+ * to be used in JS, where numeric keys (e.g. '404') always appear before alphabetical
+ * ones, regardless of the actual order of the array.
+ *
+ * From slug-keyed associative array:
+ * `[ 'index' => [ 'title' => 'Index', 'description' => 'Index template' ] ]`
+ *
+ * ...to indexed array with slug as property:
+ * `[ [ 'slug' => 'index', 'title' => 'Index', 'description' => 'Index template' ] ]`
+ *
+ * @return array The default template types as an indexed array.
+ */
+function gutenberg_get_indexed_default_template_types() {
+	$indexed_template_types = array();
+	$default_template_types = gutenberg_get_default_template_types();
+	foreach ( $default_template_types as $slug => $template_type ) {
+		$template_type['slug']    = (string) $slug;
+		$indexed_template_types[] = $template_type;
+	}
+	return $indexed_template_types;
+}

--- a/lib/full-site-editing/default-template-types.php
+++ b/lib/full-site-editing/default-template-types.php
@@ -115,3 +115,14 @@ function gutenberg_get_indexed_default_template_types() {
 	}
 	return $indexed_template_types;
 }
+
+/**
+ * Return a list of all overrideable default template type slugs.
+ *
+ * @see get_query_template
+ *
+ * @return string[] List of all overrideable default template type slugs.
+ */
+function gutenberg_get_template_type_slugs() {
+	return array_keys( gutenberg_get_default_template_types() );
+}

--- a/lib/full-site-editing/default-template-types.php
+++ b/lib/full-site-editing/default-template-types.php
@@ -77,10 +77,6 @@ function gutenberg_get_default_template_types() {
 			'title'       => _x( '404 (Not Found)', 'Template name', 'gutenberg' ),
 			'description' => __( 'Applied when content cannot be found', 'gutenberg' ),
 		),
-		'embed'          => array(
-			'title'       => __( 'Embed', 'gutenberg' ),
-			'description' => __( '[Currently unsupported]', 'gutenberg' ),
-		),
 	);
 
 	/**

--- a/lib/load.php
+++ b/lib/load.php
@@ -105,6 +105,7 @@ require __DIR__ . '/utils.php';
 require __DIR__ . '/editor-settings.php';
 
 require __DIR__ . '/full-site-editing.php';
+require __DIR__ . '/full-site-editing/default-template-types.php';
 require __DIR__ . '/templates-sync.php';
 require __DIR__ . '/templates.php';
 require __DIR__ . '/template-parts.php';

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -13,25 +13,7 @@
  * @return string[] List of all overrideable default template types.
  */
 function get_template_types() {
-	return array(
-		'index',
-		'404',
-		'archive',
-		'author',
-		'category',
-		'tag',
-		'taxonomy',
-		'date',
-		'embed',
-		'home',
-		'front-page',
-		'privacy-policy',
-		'page',
-		'search',
-		'single',
-		'singular',
-		'attachment',
-	);
+	return array_keys( gutenberg_get_default_template_types() );
 }
 
 /**

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -6,17 +6,6 @@
  */
 
 /**
- * Return a list of all overrideable default template types.
- *
- * @see get_query_template
- *
- * @return string[] List of all overrideable default template types.
- */
-function get_template_types() {
-	return array_keys( gutenberg_get_default_template_types() );
-}
-
-/**
  * Adds necessary filters to use 'wp_template' posts instead of theme template files.
  */
 function gutenberg_add_template_loader_filters() {
@@ -24,7 +13,7 @@ function gutenberg_add_template_loader_filters() {
 		return;
 	}
 
-	foreach ( get_template_types() as $template_type ) {
+	foreach ( gutenberg_get_template_type_slugs() as $template_type ) {
 		if ( 'embed' === $template_type ) { // Skip 'embed' for now because it is not a regular template type.
 			continue;
 		}
@@ -42,7 +31,7 @@ add_action( 'wp_loaded', 'gutenberg_add_template_loader_filters' );
  * @return string[] A list of template candidates, in descending order of priority.
  */
 function get_template_hierarchy( $template_type ) {
-	if ( ! in_array( $template_type, get_template_types(), true ) ) {
+	if ( ! in_array( $template_type, gutenberg_get_template_type_slugs(), true ) ) {
 		return array();
 	}
 

--- a/lib/templates.php
+++ b/lib/templates.php
@@ -317,7 +317,7 @@ apply_filters( 'rest_wp_template_collection_params', 'filter_rest_wp_template_co
 function filter_rest_wp_template_query( $args, $request ) {
 	if ( $request['resolved'] ) {
 		$template_ids   = array( 0 ); // Return nothing by default (the 0 is needed for `post__in`).
-		$template_types = $request['slug'] ? $request['slug'] : get_template_types();
+		$template_types = $request['slug'] ? $request['slug'] : gutenberg_get_template_type_slugs();
 
 		foreach ( $template_types as $template_type ) {
 			// Skip 'embed' for now because it is not a regular template type.

--- a/lib/templates.php
+++ b/lib/templates.php
@@ -376,16 +376,3 @@ function filter_rest_prepare_add_wp_theme_slug_and_file_based( $response ) {
 }
 add_filter( 'rest_prepare_wp_template', 'filter_rest_prepare_add_wp_theme_slug_and_file_based' );
 add_filter( 'rest_prepare_wp_template_part', 'filter_rest_prepare_add_wp_theme_slug_and_file_based' );
-
-/**
- * Filter the default template types to temporarily remove 'embed',
- * because it is not a regular template type.
- *
- * @param array $default_template_types The array of template types definitions.
- * @return array Filtered $default_template_types.
- */
-function gutenberg_filter_default_template_types( $default_template_types ) {
-	unset( $default_template_types['embed'] );
-	return $default_template_types;
-}
-add_filter( 'default_template_types', 'gutenberg_filter_default_template_types' );

--- a/lib/templates.php
+++ b/lib/templates.php
@@ -376,3 +376,16 @@ function filter_rest_prepare_add_wp_theme_slug_and_file_based( $response ) {
 }
 add_filter( 'rest_prepare_wp_template', 'filter_rest_prepare_add_wp_theme_slug_and_file_based' );
 add_filter( 'rest_prepare_wp_template_part', 'filter_rest_prepare_add_wp_theme_slug_and_file_based' );
+
+/**
+ * Filter the default template types to temporarily remove 'embed',
+ * because it is not a regular template type.
+ *
+ * @param array $default_template_types The array of template types definitions.
+ * @return array Filtered $default_template_types.
+ */
+function gutenberg_filter_default_template_types( $default_template_types ) {
+	unset( $default_template_types['embed'] );
+	return $default_template_types;
+}
+add_filter( 'default_template_types', 'gutenberg_filter_default_template_types' );


### PR DESCRIPTION
## Description

This PR was originally part of #26636.

- Added support for `excerpts` to the `wp_template` CPT, used to store the template description.
- Created a list of default template types definitions in PHP containing titles and descriptions for all the "generic" templates.
- The list is filterable with the new `default_template_types` filter, already used to temporarily remove the `embed` definition which it's currently not supported.
- The list is available in JS via Redux through the new `getDefaultTemplateTypes()`, `getDefaultTemplateType()`, and `getTemplateInfo()` selectors of `core/edit-site`.
- Templates imported from files will automatically obtain the title and excerpt from the default definitions, if possible.

## How has this been tested?

See #27038

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
