### PR TITLE
Correct the SlotFills docs

### DIFF
--- a/docs/designers-developers/developers/slotfills/README.md
+++ b/docs/designers-developers/developers/slotfills/README.md
@@ -95,7 +95,7 @@ const PostStatus = ( { isOpened, onTogglePanel } ) => (
 
 ## Currently available SlotFills and examples
 
-There are currently eight available SlotFills in the `edit-post` package. Please refer to the individual items below for usage and example details:
+The following SlotFills are available in the `edit-post` package. Please refer to the individual items below for usage and example details:
 
 * [MainDashboardButton](/docs/designers-developers/developers/slotfills/main-dashboard-button.md)
 * [PluginBlockSettingsMenuItem](/docs/designers-developers/developers/slotfills/plugin-block-settings-menu-item.md)


### PR DESCRIPTION
## Description

Quick documentation update to remove the current number of slots, which is incorrect (there are nine now).

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
