### PR TITLE
Site Editor: Show theme badge for non customized theme templates in navigation panel

### DIFF
--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
@@ -101,6 +101,23 @@
 	}
 }
 
+.edit-site-navigation-panel__template-item-title {
+	display: inline-block;
+	padding-right: $grid-unit-20;
+	position: relative;
+}
+
+.edit-site-navigation-panel__template-item-theme-template {
+	display: inline-block;
+	margin-left: $grid-unit-10;
+	padding: 0 $grid-unit-05;
+	border-radius: $grid-unit-10;
+	background-color: #ca4a1f;
+	color: $white;
+	font-size: 11px;
+	text-align: center;
+}
+
 .edit-site-navigation-panel__template-item-description {
 	padding-top: $grid-unit-05;
 	font-size: 12px;

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/template-navigation-item.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/template-navigation-item.js
@@ -7,6 +7,7 @@ import {
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -37,7 +38,16 @@ export default function TemplateNavigationItem( { item } ) {
 				onMouseEnter={ () => setIsPreviewVisible( true ) }
 				onMouseLeave={ () => setIsPreviewVisible( false ) }
 			>
-				{ title }
+				<div className="edit-site-navigation-panel__template-item-title">
+					{ title }
+					{ item.type === 'wp_template' &&
+						item.status === 'auto-draft' && (
+							<span className="edit-site-navigation-panel__template-item-theme-template">
+								{ __( 'theme' ) }
+							</span>
+						) }
+				</div>
+
 				{ description && (
 					<div className="edit-site-navigation-panel__template-item-description">
 						{ description }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
I find the blue dot idea in the navigation panel confusing. I think it would make more sense to show an icon/badge for original theme template files. (Theme templates that weren't modified)

This PR adds a `theme` badge next to the original theme templates.

## How has this been tested?
- Open site editor
- Open navigation panel
- On a clean install all templates should have a `theme` badge
- Edit a template with a `theme` badge and save it
- `theme` badge should disappear

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/2256104/99404062-788f1280-28eb-11eb-9bfc-383a5dd95e6b.png)

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
