### PR TITLE
Fix custom spacing support

### DIFF
--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -302,7 +302,7 @@ function gutenberg_experimental_global_styles_get_theme_support_settings( $setti
 		if ( ! isset( $theme_settings['global']['settings']['spacing'] ) ) {
 			$theme_settings['global']['settings']['spacing'] = array();
 		}
-		$theme_settings['global']['settings']['spacing']['custom'] = true;
+		$theme_settings['global']['settings']['spacing']['customPadding'] = true;
 	}
 
 	if ( current( (array) get_theme_support( 'experimental-link-color' ) ) ) {


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/26662

https://github.com/WordPress/gutenberg/pull/25301 reorganized the theme.json keys to use `spacing.customSpacing` in the client and theme.json, while the settings processing still used `spacing.custom`. See [docs](https://developer.wordpress.org/block-editor/developers/themes/theme-json/#settings) as well.

## How to test

- Install and activate a theme that declares support for custom spacing via `add_theme_support('custom-spacing')`.
- Test that cover & group blocks have the spacing controls in the block sidebar (they don't in master).