### PR TITLE
Site Editor: Show document title on small screens with nav sidebar open

### DIFF
--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -63,6 +63,21 @@ body.is-navigation-sidebar-open {
 	}
 }
 
+// Centred document title on small screens with sidebar open
+@media ( max-width: #{ ($break-medium - 1) } ) {
+	body.is-navigation-sidebar-open .edit-site-header {
+		.edit-site-header_start {
+			flex-basis: 0;
+		}
+		.block-editor-post-preview__button-toggle {
+			display: none;
+		}
+		.edit-site-save-button__button {
+			margin-right: 0;
+		}
+	}
+}
+
 .edit-site-header__toolbar {
 	display: flex;
 	align-items: center;


### PR DESCRIPTION


<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

There are still some things to clean up for responsive views. The document title would previously be totally hidden when browsing templates in the nav sidebar.

Fixes #26755


## How has this been tested?

1. Enable the site editor locally
2. Navigate to the site editor
3. Shrink the viewport <782px
4. Click on the document title
5. Click on "browse all templates"
6. Confirm that the document title is shown (and the other buttons are more or less where they should be)

## Screenshots <!-- if applicable -->

![dt](https://user-images.githubusercontent.com/5414230/98307545-d2521d00-1f7a-11eb-9f56-10e147943ae2.png)
^ Before

<img width="664" alt="Screen Shot 2020-11-17 at 15 06 15" src="https://user-images.githubusercontent.com/195089/99450513-7d9d9300-28e6-11eb-8511-b458e9f4e879.png">
^ After


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
