### PR TITLE
wp-env: Improve docs for "run" command

### DIFF
--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -258,6 +258,8 @@ Options:
 
 For example:
 
+#### Displaying the users on the development instance:
+
 ```sh
 wp-env run cli wp user list
 ⠏ Running `wp user list` in 'cli'.
@@ -268,6 +270,8 @@ ID      user_login      display_name    user_email      user_registered roles
 ✔ Ran `wp user list` in 'cli'. (in 2s 374ms)
 ```
 
+#### Creating a post on the tests instance:
+
 ```sh
 npx wp-env run tests-cli "wp post create --post_type=page --post_title='Ready'"
 
@@ -276,6 +280,8 @@ npx wp-env run tests-cli "wp post create --post_type=page --post_title='Ready'"
 Success: Created post 5.
 ✔ Ran `wp post create --post_type=page --post_title='Ready'` in 'tests-cli'. (in 3s 293ms)
 ```
+
+#### Opening the WordPress shell on the tests instance and running PHP commands:
 
 ```sh
 wp-env run tests-cli wp shell

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -243,7 +243,7 @@ bash and the WordPress shell in the WordPress instance. For example, `wp-env run
 cli bash` will open bash in the development WordPress instance. When using long
 commands with arguments and quotation marks, you need to wrap the "command"
 param in quotation marks. For example: `wp-env run tests-cli "wp post create
---post_type=page --post_title='Test'" will create a post on the tests WordPress
+--post_type=page --post_title='Test'"` will create a post on the tests WordPress
 instance.
 
 Positionals:

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -273,7 +273,7 @@ ID      user_login      display_name    user_email      user_registered roles
 #### Creating a post on the tests instance:
 
 ```sh
-npx wp-env run tests-cli "wp post create --post_type=page --post_title='Ready'"
+wp-env run tests-cli "wp post create --post_type=page --post_title='Ready'"
 
 ℹ Starting 'wp post create --post_type=page --post_title='Ready'' on the tests-cli container.
 

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -235,10 +235,15 @@ Positionals:
 ```sh
 wp-env run <container> [command..]
 
-Runs an arbitrary command in one of the underlying Docker containers. For
-example, it can be useful for running wp cli commands. You can also use it to
-open shell sessions like bash and the WordPress shell in the WordPress instance.
-For example, `wp-env run cli bash` will open bash in the development WordPress
+Runs an arbitrary command in one of the underlying Docker containers. The
+"container" param should reference one of the underlying Docker services like
+"development", "tests", or "cli". To run a wp-cli command, use the "cli" or
+"tests-cli" service. You can also use this command to open shell sessions like
+bash and the WordPress shell in the WordPress instance. For example, `wp-env run
+cli bash` will open bash in the development WordPress instance. When using long
+commands with arguments and quotation marks, you need to wrap the "command"
+param in quotation marks. For example: `wp-env run tests-cli "wp post create
+--post_type=page --post_title='Test'" will create a post on the tests WordPress
 instance.
 
 Positionals:
@@ -261,6 +266,15 @@ ID      user_login      display_name    user_email      user_registered roles
 1       admin   admin   wordpress@example.com   2020-03-05 10:45:14     administrator
 
 ✔ Ran `wp user list` in 'cli'. (in 2s 374ms)
+```
+
+```sh
+npx wp-env run tests-cli "wp post create --post_type=page --post_title='Ready'"
+
+ℹ Starting 'wp post create --post_type=page --post_title='Ready'' on the tests-cli container.
+
+Success: Created post 5.
+✔ Ran `wp post create --post_type=page --post_title='Ready'` in 'tests-cli'. (in 3s 293ms)
 ```
 
 ```sh

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -147,7 +147,7 @@ module.exports = function cli() {
 	);
 	yargs.command(
 		'run <container> [command..]',
-		'Runs an arbitrary command in one of the underlying Docker containers. The "container" param should reference one of the underlying Docker services like "development", "tests", or "cli". To run a wp-cli command, use the "cli" or "tests-cli" service. You can also use this command to open shell sessions like bash and the WordPress shell in the WordPress instance. For example, `wp-env run cli bash` will open bash in the development WordPress instance. When using long commands with arguments and quotation marks, you need to wrap the "command" param in quotation marks. For example: `wp-env run tests-cli "wp post create --post_type=page --post_title=\'Test\'" will create a post on the tests WordPress instance.',
+		'Runs an arbitrary command in one of the underlying Docker containers. The "container" param should reference one of the underlying Docker services like "development", "tests", or "cli". To run a wp-cli command, use the "cli" or "tests-cli" service. You can also use this command to open shell sessions like bash and the WordPress shell in the WordPress instance. For example, `wp-env run cli bash` will open bash in the development WordPress instance. When using long commands with arguments and quotation marks, you need to wrap the "command" param in quotation marks. For example: `wp-env run tests-cli "wp post create --post_type=page --post_title=\'Test\'"` will create a post on the tests WordPress instance.',
 		( args ) => {
 			args.positional( 'container', {
 				type: 'string',

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -147,7 +147,7 @@ module.exports = function cli() {
 	);
 	yargs.command(
 		'run <container> [command..]',
-		'Runs an arbitrary command in one of the underlying Docker containers. For example, it can be useful for running wp cli commands. You can also use it to open shell sessions like bash and the WordPress shell in the WordPress instance. For example, `wp-env run cli bash` will open bash in the development WordPress instance.',
+		'Runs an arbitrary command in one of the underlying Docker containers. The "container" param should reference one of the underlying Docker services like "development", "tests", or "cli". To run a wp-cli command, use the "cli" or "tests-cli" service. You can also use this command to open shell sessions like bash and the WordPress shell in the WordPress instance. For example, `wp-env run cli bash` will open bash in the development WordPress instance. When using long commands with arguments and quotation marks, you need to wrap the "command" param in quotation marks. For example: `wp-env run tests-cli "wp post create --post_type=page --post_title=\'Test\'" will create a post on the tests WordPress instance.',
 		( args ) => {
 			args.positional( 'container', {
 				type: 'string',


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Adds some important details to the documentation for the `wp-env run` command. Resolves #26832

## How has this been tested?
Locally in the gutenberg repo, run `npx wp-env run --help` will display the improved docs

## Types of changes
Documentation