### PR TITLE
Decrease scrim when in a modal overlay

### DIFF
--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -5,7 +5,7 @@
 	right: 0;
 	bottom: 0;
 	left: 0;
-	background-color: rgba($black, 0.7);
+	background-color: rgba($black, 0.35);
 	z-index: z-index(".components-modal__screen-overlay");
 
 	// This animates the appearance of the white background.


### PR DESCRIPTION
This is a little PR that certainly needs feedback. The problem it is designed to solve is specifically when you change a setting on preferences, it's hard to see what the change was. You can see that here:

![2020-11-17 18 36 55](https://user-images.githubusercontent.com/253067/99456226-f4578200-2920-11eb-81f0-3d97f162e005.gif)

By increasing the transparency, you are able to more easily see the change in effect as it happens:

![2020-11-17 22 06 02](https://user-images.githubusercontent.com/253067/99456340-24068a00-2921-11eb-8b1a-0e0f4f2e0354.gif)

This is useful when words are hard to describe what is going on. At times, simply seeing in the interface is a great help. I did explore having partial scrims and even none, they all resulted in a more negative experience or visual hitch.

## Feedback
There are a few specific areas along with more general feedback that would be good to get input on whether there was a reason this was set to the opacity it was and by unsetting there is an impact.