### PR TITLE
New icon for settings to be included in Query block toolbar

### DIFF
--- a/packages/block-library/src/query/edit/query-toolbar.js
+++ b/packages/block-library/src/query/edit/query-toolbar.js
@@ -10,7 +10,7 @@ import {
 	__experimentalNumberControl as NumberControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { postList } from '@wordpress/icons';
+import { settings } from '@wordpress/icons';
 
 export default function QueryToolbar( { query, setQuery } ) {
 	return (
@@ -19,8 +19,8 @@ export default function QueryToolbar( { query, setQuery } ) {
 				contentClassName="block-library-query-toolbar__popover"
 				renderToggle={ ( { onToggle } ) => (
 					<ToolbarButton
-						icon={ postList }
-						label={ __( 'Query' ) }
+						icon={ settings }
+						label={ __( 'Display settings' ) }
 						onClick={ onToggle }
 					/>
 				) }

--- a/packages/icons/src/index.js
+++ b/packages/icons/src/index.js
@@ -150,6 +150,7 @@ export { default as rotateRight } from './library/rotate-right';
 export { default as rss } from './library/rss';
 export { default as search } from './library/search';
 export { default as separator } from './library/separator';
+export { default as settings } from './library/settings';
 export { default as share } from './library/share';
 export { default as shortcode } from './library/shortcode';
 export { default as stack } from './library/stack';

--- a/packages/icons/src/library/settings.js
+++ b/packages/icons/src/library/settings.js
@@ -1,0 +1,12 @@
+/**
+ * WordPress dependencies
+ */
+import { SVG, Path } from '@wordpress/primitives';
+
+const settings = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+        <Path d="M17 4h-2v4.5h2V7h3V5.5h-3V4zM4 5.5h9V7H4V5.5zm16 5.75h-9v1.5h9v-1.5zm-16 0h3V10h2v4.25H7v-1.5H4v-1.5zM9 17H4v1.5h5V17zm4 0h7v1.5h-7V20h-2v-4.25h2V17z" />
+    </SVG>
+);
+
+export default settings;

--- a/packages/icons/src/library/settings.js
+++ b/packages/icons/src/library/settings.js
@@ -5,8 +5,8 @@ import { SVG, Path } from '@wordpress/primitives';
 
 const settings = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-        <Path d="M17 4h-2v4.5h2V7h3V5.5h-3V4zM4 5.5h9V7H4V5.5zm16 5.75h-9v1.5h9v-1.5zm-16 0h3V10h2v4.25H7v-1.5H4v-1.5zM9 17H4v1.5h5V17zm4 0h7v1.5h-7V20h-2v-4.25h2V17z" />
-    </SVG>
+		<Path d="M17 4h-2v4.5h2V7h3V5.5h-3V4zM4 5.5h9V7H4V5.5zm16 5.75h-9v1.5h9v-1.5zm-16 0h3V10h2v4.25H7v-1.5H4v-1.5zM9 17H4v1.5h5V17zm4 0h7v1.5h-7V20h-2v-4.25h2V17z" />
+	</SVG>
 );
 
 export default settings;


### PR DESCRIPTION
See #27044. 
Added a new settings icon which can be used in the Query block. The icon there now is also used as the Latest Posts block icon, so replacing it in the Query block toolbar makes sense.

## How has this been tested?
Tested locally.

## Screenshots

![Screen Shot 2020-11-17 at 4 06 18 PM](https://user-images.githubusercontent.com/617986/99466044-82ffdb00-28f0-11eb-9870-3af2d283e7cb.png)


## Types of changes
Non-breaking changes. Added new icon to package.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
