### PR TITLE
Template/site editor: prevent classic block from loading

### DIFF
--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -87,6 +87,9 @@ import * as postFeaturedImage from './post-featured-image';
 import * as postHierarchicalTerms from './post-hierarchical-terms';
 import * as postTags from './post-tags';
 
+const isClassicEnabled =
+	window.wpEditorL10n && window.wp && window.wp.oldEditor;
+
 /**
  * Function to register an individual block.
  *
@@ -139,7 +142,7 @@ export const __experimentalGetCoreBlocks = () => [
 	embed,
 	file,
 	group,
-	window.wp && window.wp.oldEditor ? classic : null, // Only add the classic block in WP Context
+	isClassicEnabled ? classic : null, // Only add the classic block in WP Context
 	html,
 	mediaText,
 	latestComments,
@@ -182,7 +185,7 @@ export const registerCoreBlocks = (
 	blocks.forEach( registerBlock );
 
 	setDefaultBlockName( paragraph.name );
-	if ( window.wp && window.wp.oldEditor ) {
+	if ( isClassicEnabled ) {
 		setFreeformContentHandlerName( classic.name );
 	}
 	setUnregisteredTypeHandlerName( missing.name );

--- a/packages/block-library/src/missing/edit.js
+++ b/packages/block-library/src/missing/edit.js
@@ -16,18 +16,25 @@ function MissingBlockWarning( { attributes, convertToHTML } ) {
 	const actions = [];
 	let messageHTML;
 	if ( hasContent && hasHTMLBlock ) {
-		messageHTML = sprintf(
-			/* translators: %s: block name */
-			__(
-				'Your site doesn’t include support for the "%s" block. You can leave this block intact, convert its content to a Custom HTML block, or remove it entirely.'
-			),
-			originalName
-		);
-		actions.push(
-			<Button key="convert" onClick={ convertToHTML } isPrimary>
-				{ __( 'Keep as HTML' ) }
-			</Button>
-		);
+		if ( originalName ) {
+			messageHTML = sprintf(
+				/* translators: %s: block name */
+				__(
+					'Your site doesn’t include support for the "%s" block. You can leave this block intact, convert its content to a Custom HTML block, or remove it entirely.'
+				),
+				originalName
+			);
+
+			actions.push(
+				<Button key="convert" onClick={ convertToHTML } isPrimary>
+					{ __( 'Keep as HTML' ) }
+				</Button>
+			);
+		} else {
+			messageHTML = __(
+				'Legacy content cannot be edited in this context.'
+			);
+		}
 	} else {
 		messageHTML = sprintf(
 			/* translators: %s: block name */

--- a/test/unit/__mocks__/@wordpress/block-library.js
+++ b/test/unit/__mocks__/@wordpress/block-library.js
@@ -1,5 +1,6 @@
 // Make sure the classic block is registered.
 window.wp = window.wp || {};
 window.wp.oldEditor = {};
+window.wpEditorL10n = {};
 
 export * from '../../../../packages/block-library/src';


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

See #26915.

Currently the classic block is available in the site editor and triggers an error when loading because `window.wpEditorL10n` is not set.

In the site editor, ideally any scripts for the classic editor should not load and the block should not be available.

If there is free form content in the post content, the content can be previewed through the missing block mechanism.

<img width="1280" alt="Screenshot 2020-11-18 at 11 09 58" src="https://user-images.githubusercontent.com/4710635/99509611-a5483600-298e-11eb-892d-2529f94c34cd.png">

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
