### PR TITLE
Data: Improve documentation for new API added around stores

### DIFF
--- a/packages/annotations/CHANGELOG.md
+++ b/packages/annotations/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Feature
+
+-   Added a store definition `store` for the annotations namespace to use with `@wordpress/data` API ([#26655](https://github.com/WordPress/gutenberg/pull/26655)).
+
 ## 1.0.5 (2019-01-03)
 
 ## 1.0.4 (2018-12-12)
@@ -16,4 +20,4 @@
 
 ### New Features
 
-- Implement annotations API in the editor.
+-   Implement annotations API in the editor.

--- a/packages/block-directory/CHANGELOG.md
+++ b/packages/block-directory/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Feature
+
+-   Added a store definition `store` for the block directory namespace to use with `@wordpress/data` API ([#26655](https://github.com/WordPress/gutenberg/pull/26655)).
+
 ## 1.0.0 (2019-09-16)
 
 -   Initial release.

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -2,12 +2,15 @@
 
 ## Unreleased
 
+### New Feature
+
+-   Added a store definition `store` for the block editor namespace to use with `@wordpress/data` API ([#26655](https://github.com/WordPress/gutenberg/pull/26655)).
+
 ## 5.0.0 (2020-10-06)
 
 ### Breaking Changes
 
-- The block editor does not contain default colors, gradients, and font sizes anymore. If one wants to take advantage of these features, please explicitly pass colors, gradients, and/or settings or use the new __experimentalFeatures setting that is available.
-
+-   The block editor does not contain default colors, gradients, and font sizes anymore. If one wants to take advantage of these features, please explicitly pass colors, gradients, and/or settings or use the new \_\_experimentalFeatures setting that is available.
 
 ## 4.0.0 (2020-05-28)
 

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -2,38 +2,42 @@
 
 ## Unreleased
 
+### New Feature
+
+-   Added a store definition `store` for the blocks namespace to use with `@wordpress/data` API ([#26655](https://github.com/WordPress/gutenberg/pull/26655)).
+
 ## 6.13.0 (2020-04-01)
 
 ### New Feature
 
-- Blocks can now be registered with an `defaultStylePicker` flag in the `supports` setting, allowing the default style picker to be removed.
+-   Blocks can now be registered with an `defaultStylePicker` flag in the `supports` setting, allowing the default style picker to be removed.
 
 ## 6.4.0 (2019-08-05)
 
 ### Improvements
 
-- Omitting `attributes` or `keywords` settings will now stub default values (an empty object or empty array, respectively).
+-   Omitting `attributes` or `keywords` settings will now stub default values (an empty object or empty array, respectively).
 
 ### Bug Fixes
 
-- The `'blocks.registerBlockType'` filter is now applied to each of a block's deprecated settings as well as the block's main settings. Ensures `supports` settings like `anchor` work for deprecations.
+-   The `'blocks.registerBlockType'` filter is now applied to each of a block's deprecated settings as well as the block's main settings. Ensures `supports` settings like `anchor` work for deprecations.
 
 ## 6.3.0 (2019-05-21)
 
 ### New Feature
 
-- Added a default implementation for `save` setting in `registerBlockType` which saves no markup in the post content.
-- Added wildcard block transforms which allows for transforming all/any blocks in another block.
+-   Added a default implementation for `save` setting in `registerBlockType` which saves no markup in the post content.
+-   Added wildcard block transforms which allows for transforming all/any blocks in another block.
 
 ## 6.1.0 (2019-03-06)
 
 ### New Feature
 
-- Blocks' `transforms` will receive `innerBlocks` as the second argument (or an array of each block's respective `innerBlocks` for a multi-transform).
+-   Blocks' `transforms` will receive `innerBlocks` as the second argument (or an array of each block's respective `innerBlocks` for a multi-transform).
 
 ### Bug Fixes
 
-- Block validation will now correctly validate character references, resolving some issues where a standalone ampersand `&` followed later in markup by a character reference (e.g. `&amp;`) could wrongly mark a block as being invalid. ([#13512](https://github.com/WordPress/gutenberg/pull/13512))
+-   Block validation will now correctly validate character references, resolving some issues where a standalone ampersand `&` followed later in markup by a character reference (e.g. `&amp;`) could wrongly mark a block as being invalid. ([#13512](https://github.com/WordPress/gutenberg/pull/13512))
 
 ## 6.0.5 (2019-01-03)
 
@@ -49,11 +53,11 @@
 
 ### Breaking Changes
 
-- `isValidBlock` has been removed. Please use `isValidBlockContent` instead but keep in mind that the order of params has changed.
+-   `isValidBlock` has been removed. Please use `isValidBlockContent` instead but keep in mind that the order of params has changed.
 
 ### Bug Fix
 
-- The block validator is more lenient toward equivalent encoding forms.
+-   The block validator is more lenient toward equivalent encoding forms.
 
 ## 5.3.1 (2018-11-12)
 
@@ -61,14 +65,14 @@
 
 ### New feature
 
-- `getBlockAttributes`, `getBlockTransforms`, `getSaveContent`, `getSaveElement` and `isValidBlockContent` methods can now take also block's name as the first param ([#11490](https://github.com/WordPress/gutenberg/pull/11490)). Passing a block's type object continues to work as before.
-- `registerBlockStyles` and `unregisterBlockStyles` can be triggered at any moment (before or after block registration).
+-   `getBlockAttributes`, `getBlockTransforms`, `getSaveContent`, `getSaveElement` and `isValidBlockContent` methods can now take also block's name as the first param ([#11490](https://github.com/WordPress/gutenberg/pull/11490)). Passing a block's type object continues to work as before.
+-   `registerBlockStyles` and `unregisterBlockStyles` can be triggered at any moment (before or after block registration).
 
 ## 5.2.0 (2018-11-09)
 
-- Paste: Google Docs: fix nested formatting, sub, sup and del.
-- Expose @wordpress/editor to Gutenberg mobile.
-- Separate Paste Handler.
+-   Paste: Google Docs: fix nested formatting, sub, sup and del.
+-   Expose @wordpress/editor to Gutenberg mobile.
+-   Separate Paste Handler.
 
 ## 5.1.2 (2018-11-03)
 
@@ -78,23 +82,23 @@
 
 ### New features
 
-- `isValidBlockContent` function has been added ([#10891](https://github.com/WordPress/gutenberg/pull/10891)).
+-   `isValidBlockContent` function has been added ([#10891](https://github.com/WordPress/gutenberg/pull/10891)).
 
 ### Deprecation
 
-- `isValidBlock` function has been deprecated ([#10891](https://github.com/WordPress/gutenberg/pull/10891)). Use `isValidBlockContent` instead.
+-   `isValidBlock` function has been deprecated ([#10891](https://github.com/WordPress/gutenberg/pull/10891)). Use `isValidBlockContent` instead.
 
 ## 5.0.0 (2018-10-29)
 
 ### Breaking Changes
 
-- Attribute type coercion has been removed. Omit the source to preserve type via serialized comment demarcation.
-- `setUnknownTypeHandlerName` has been removed. Please use `setFreeformContentHandlerName` and `setUnregisteredTypeHandlerName` instead.
-- `getUnknownTypeHandlerName` has been removed. Please use `getFreeformContentHandlerName` and `getUnregisteredTypeHandlerName` instead.
+-   Attribute type coercion has been removed. Omit the source to preserve type via serialized comment demarcation.
+-   `setUnknownTypeHandlerName` has been removed. Please use `setFreeformContentHandlerName` and `setUnregisteredTypeHandlerName` instead.
+-   `getUnknownTypeHandlerName` has been removed. Please use `getFreeformContentHandlerName` and `getUnregisteredTypeHandlerName` instead.
 
 ### New Feature
 
-- Added a `unregisterBlockStyle()` function to remove a block style variation.
+-   Added a `unregisterBlockStyle()` function to remove a block style variation.
 
 ## 4.0.4 (2018-10-19)
 
@@ -104,15 +108,15 @@
 
 ### Breaking Changes
 
-- `getDefaultBlockForPostFormat` has been removed.
+-   `getDefaultBlockForPostFormat` has been removed.
 
 ## 3.0.0 (2018-09-05)
 
 ### Breaking Changes
 
-- The `isSharedBlock` function is removed. Use `isReusableBlock` instead.
-- Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)). If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.
+-   The `isSharedBlock` function is removed. Use `isReusableBlock` instead.
+-   Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)). If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.
 
 ### Deprecations
 
-- The `getDefaultBlockForPostFormat` function has been deprecated.
+-   The `getDefaultBlockForPostFormat` function has been deprecated.

--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -2,26 +2,30 @@
 
 ## Unreleased
 
+### New Feature
+
+-   Added a store definition `store` for the core data namespace to use with `@wordpress/data` API ([#26655](https://github.com/WordPress/gutenberg/pull/26655)).
+
 ## 2.21.0 (2020-09-03)
 
 ### New Feature
 
-- The `deleteEntityRecord` and `removeItems` actions have been added.
-- The `isDeletingEntityRecord` and `getLastEntityDeleteError` selectors have been added.
-- A `delete<entity.name>` helper is created for every registered entity.
+-   The `deleteEntityRecord` and `removeItems` actions have been added.
+-   The `isDeletingEntityRecord` and `getLastEntityDeleteError` selectors have been added.
+-   A `delete<entity.name>` helper is created for every registered entity.
 
 ## 2.3.0 (2019-05-21)
 
 ### New features
 
-- The `getAutosave`, `getAutosaves` and `getCurrentUser` selectors have been added.
-- The `receiveAutosaves` and `receiveCurrentUser` actions have been added.
+-   The `getAutosave`, `getAutosaves` and `getCurrentUser` selectors have been added.
+-   The `receiveAutosaves` and `receiveCurrentUser` actions have been added.
 
 ## 2.0.16 (2019-01-03)
 
 ### Bug Fixes
 
-- Fixed the `hasUploadPermissions` selector to always return a boolean. Previously, it may have returned an empty object. This should have no impact for most consumers, assuming usage as a [truthy value](https://developer.mozilla.org/en-US/docs/Glossary/Truthy) in conditions.
+-   Fixed the `hasUploadPermissions` selector to always return a boolean. Previously, it may have returned an empty object. This should have no impact for most consumers, assuming usage as a [truthy value](https://developer.mozilla.org/en-US/docs/Glossary/Truthy) in conditions.
 
 ## 2.0.15 (2018-12-12)
 
@@ -49,10 +53,10 @@
 
 ### Breaking Change
 
-- `dispatch("core").receiveTerms` has been deprecated. Please use `dispatch("core").receiveEntityRecords` instead.
-- `getCategories` resolvers has been deprecated. Please use `getEntityRecords` resolver instead.
-- `select("core").getTerms` has been deprecated. Please use `select("core").getEntityRecords` instead.
-- `select("core").getCategories` has been deprecated. Please use `select("core").getEntityRecords` instead.
-- `wp.data.select("core").isRequestingCategories` has been deprecated. Please use `wp.data.select("core/data").isResolving` instead.
-- `select("core").isRequestingTerms` has been deprecated. Please use `select("core").isResolving` instead.
-- Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)). If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.
+-   `dispatch("core").receiveTerms` has been deprecated. Please use `dispatch("core").receiveEntityRecords` instead.
+-   `getCategories` resolvers has been deprecated. Please use `getEntityRecords` resolver instead.
+-   `select("core").getTerms` has been deprecated. Please use `select("core").getEntityRecords` instead.
+-   `select("core").getCategories` has been deprecated. Please use `select("core").getEntityRecords` instead.
+-   `wp.data.select("core").isRequestingCategories` has been deprecated. Please use `wp.data.select("core/data").isResolving` instead.
+-   `select("core").isRequestingTerms` has been deprecated. Please use `select("core").isResolving` instead.
+-   Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)). If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.

--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
--   Added new `register` factory function for registering a standard `@wordpress/data` store definition ([#26655](https://github.com/WordPress/gutenberg/pull/26655)).
+-   Added new `register` function for registering a standard `@wordpress/data` store definition ([#26655](https://github.com/WordPress/gutenberg/pull/26655)).
 -   Added new `createReduxStore` factory function that creates a data store definition for the provided Redux store options to use with `register` function ([#26655](https://github.com/WordPress/gutenberg/pull/26655)).
 -   Extended `select` and `dispatch` functions to accept a data store definition as their first param in addition to a string-based store name value [#26655](https://github.com/WordPress/gutenberg/pull/26655)).
 -   Extended `useDispatch` hook to accept a data store definition as their first param in addition to a string-based store name value [#26655](https://github.com/WordPress/gutenberg/pull/26655)).

--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -2,54 +2,61 @@
 
 ## Unreleased
 
+### New Features
+
+-   Added new `register` factory function for registering a standard `@wordpress/data` store definition ([#26655](https://github.com/WordPress/gutenberg/pull/26655)).
+-   Added new `createReduxStore` factory function that creates a data store definition for the provided Redux store options to use with `register` function ([#26655](https://github.com/WordPress/gutenberg/pull/26655)).
+-   Extended `select` and `dispatch` functions to accept a data store definition as their first param in addition to a string-based store name value [#26655](https://github.com/WordPress/gutenberg/pull/26655)).
+-   Extended `useDispatch` hook to accept a data store definition as their first param in addition to a string-based store name value [#26655](https://github.com/WordPress/gutenberg/pull/26655)).
+
 ## 4.6.0 (2019-06-12)
 
 ### New Feature
 
-- Expose `useSelect` hook for usage in functional components. ([#15737](https://github.com/WordPress/gutenberg/pull/15737))
-- Expose `useDispatch` hook for usage in functional components. ([#15896](https://github.com/WordPress/gutenberg/pull/15896))
+-   Expose `useSelect` hook for usage in functional components. ([#15737](https://github.com/WordPress/gutenberg/pull/15737))
+-   Expose `useDispatch` hook for usage in functional components. ([#15896](https://github.com/WordPress/gutenberg/pull/15896))
 
 ### Enhancements
 
-- `withSelect` internally uses the new `useSelect` hook. ([#15737](https://github.com/WordPress/gutenberg/pull/15737).  **Note:** This _could_ impact performance of code using `withSelect` in edge-cases. To avoid impact, memoize passed in `mapSelectToProps` callbacks or implement `useSelect` directly with dependencies.
-- `withDispatch` internally uses a new `useDispatchWithMap` hook (an internal only api) ([#15896](https://github.com/WordPress/gutenberg/pull/15896))
+-   `withSelect` internally uses the new `useSelect` hook. ([#15737](https://github.com/WordPress/gutenberg/pull/15737). **Note:** This _could_ impact performance of code using `withSelect` in edge-cases. To avoid impact, memoize passed in `mapSelectToProps` callbacks or implement `useSelect` directly with dependencies.
+-   `withDispatch` internally uses a new `useDispatchWithMap` hook (an internal only api) ([#15896](https://github.com/WordPress/gutenberg/pull/15896))
 
 ## 4.5.0 (2019-05-21)
 
 ### Bug Fix
 
-- Restore functionality of action-generators returning a Promise.  Clarify intent and behaviour for `wp.data.dispatch` behaviour. Dispatch actions now always
- return a promise ([#14830](https://github.com/WordPress/gutenberg/pull/14830)
+-   Restore functionality of action-generators returning a Promise. Clarify intent and behaviour for `dispatch` behaviour. Dispatch actions now always
+    return a promise ([#14830](https://github.com/WordPress/gutenberg/pull/14830)
 
 ### Enhancements
 
-- Expose `hasResolver` property on returned selectors indicating whether the selector has a corresponding resolver.
+-   Expose `hasResolver` property on returned selectors indicating whether the selector has a corresponding resolver.
 
 ## 4.3.0 (2019-03-06)
 
 ### Enhancements
 
-- The `registerStore` function now accepts an optional `initialState` option value.
-- Introduce new `invalidateResolutionForStore` dispatch action for signalling to invalidate the resolution cache for an entire given store.
-- Introduce new `invalidateResolutionForStoreSelector` dispatch action for signalling to invalidate the resolution cache for a store selector (and all variations of arguments on that selector).
+-   The `registerStore` function now accepts an optional `initialState` option value.
+-   Introduce new `invalidateResolutionForStore` dispatch action for signalling to invalidate the resolution cache for an entire given store.
+-   Introduce new `invalidateResolutionForStoreSelector` dispatch action for signalling to invalidate the resolution cache for a store selector (and all variations of arguments on that selector).
 
 ### Bug Fix
 
-- Resolves issue in the persistence plugin where passing `persist` as an array of reducer keys would wrongly replace state values for the unpersisted reducer keys.
-- Restores a behavior in the persistence plugin where a default state provided as an object will be deeply merged as a base for the persisted value. This allows for a developer to include additional new keys in a persisted value default in future iterations of their store.
+-   Resolves issue in the persistence plugin where passing `persist` as an array of reducer keys would wrongly replace state values for the unpersisted reducer keys.
+-   Restores a behavior in the persistence plugin where a default state provided as an object will be deeply merged as a base for the persisted value. This allows for a developer to include additional new keys in a persisted value default in future iterations of their store.
 
 ## 4.2.0 (2019-01-03)
 
 ### Enhancements
 
-- Optimized performance of selector execution (~511% improvement)
+-   Optimized performance of selector execution (~511% improvement)
 
 ## 4.1.0 (2018-12-12)
 
 ### New Feature
 
-- `withDispatch`'s `mapDispatchToProps` function takes the `registry` object as the 3rd param ([#11851](https://github.com/WordPress/gutenberg/pull/11851)).
-- `withSelect`'s `mapSelectToProps` function takes the `registry` object as the 3rd param ([#11851](https://github.com/WordPress/gutenberg/pull/11851)).
+-   `withDispatch`'s `mapDispatchToProps` function takes the `registry` object as the 3rd param ([#11851](https://github.com/WordPress/gutenberg/pull/11851)).
+-   `withSelect`'s `mapSelectToProps` function takes the `registry` object as the 3rd param ([#11851](https://github.com/WordPress/gutenberg/pull/11851)).
 
 ## 4.0.1 (2018-11-20)
 
@@ -57,14 +64,14 @@
 
 ### Breaking Changes
 
-- `registry.registerReducer` has been removed. Use `registry.registerStore` instead.
-- `registry.registerSelectors` has been removed. Use `registry.registerStore` instead.
-- `registry.registerActions` has been removed. Use `registry.registerStore` instead.
-- `registry.registerResolvers` has been removed. Use `registry.registerStore` instead.
+-   `registry.registerReducer` has been removed. Use `registry.registerStore` instead.
+-   `registry.registerSelectors` has been removed. Use `registry.registerStore` instead.
+-   `registry.registerActions` has been removed. Use `registry.registerStore` instead.
+-   `registry.registerResolvers` has been removed. Use `registry.registerStore` instead.
 
 ### Bug Fix
 
-- Resolve an issue where `withSelect`'s `mapSelectToProps` would not be rerun if the wrapped component had incurred a store change during its mount lifecycle.
+-   Resolve an issue where `withSelect`'s `mapSelectToProps` would not be rerun if the wrapped component had incurred a store change during its mount lifecycle.
 
 ## 3.1.2 (2018-11-09)
 
@@ -74,26 +81,26 @@
 
 ### New Features
 
-- `registry.registerGenericStore` has been added to support integration with existing data systems.
+-   `registry.registerGenericStore` has been added to support integration with existing data systems.
 
 ### Deprecations
 
-- `registry.registerReducer` has been deprecated. Use `registry.registerStore` instead.
-- `registry.registerSelectors` has been deprecated. Use `registry.registerStore` instead.
-- `registry.registerActions` has been deprecated. Use `registry.registerStore` instead.
-- `registry.registerResolvers` has been deprecated. Use `registry.registerStore` instead.
+-   `registry.registerReducer` has been deprecated. Use `registry.registerStore` instead.
+-   `registry.registerSelectors` has been deprecated. Use `registry.registerStore` instead.
+-   `registry.registerActions` has been deprecated. Use `registry.registerStore` instead.
+-   `registry.registerResolvers` has been deprecated. Use `registry.registerStore` instead.
 
 ## 3.0.1 (2018-10-30)
 
 ### Internal
 
-- Replace Redux implementation of `combineReducers` with in-place-compatible `turbo-combine-reducers`.
+-   Replace Redux implementation of `combineReducers` with in-place-compatible `turbo-combine-reducers`.
 
 ## 3.0.0 (2018-10-29)
 
 ### Breaking Changes
 
-- Writing resolvers as async generators has been removed. Use the controls plugin instead.
+-   Writing resolvers as async generators has been removed. Use the controls plugin instead.
 
 ## 2.1.4 (2018-10-19)
 
@@ -103,25 +110,25 @@
 
 ### New Features
 
-- Adding support for using controls in resolvers using the controls plugin.
+-   Adding support for using controls in resolvers using the controls plugin.
 
 ### Polish
 
-- Updated `redux` dependency to the latest version.
+-   Updated `redux` dependency to the latest version.
 
 ### Deprecations
 
-- Writing resolvers as async generators has been deprecated. Use the controls plugin instead.
+-   Writing resolvers as async generators has been deprecated. Use the controls plugin instead.
 
 ### Bug Fixes
 
-- Fix the promise middleware in Firefox.
+-   Fix the promise middleware in Firefox.
 
 ## 2.0.0 (2018-09-05)
 
 ### Breaking Change
 
-- The `withRehdyration` function is removed. Use the persistence plugin instead.
-- The `loadAndPersist` function is removed. Use the persistence plugin instead.
-- `restrictPersistence`, `setPersistenceStorage` and `setupPersistence` functions have been removed. Please use the data persistence plugin instead.
-- Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)). If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.
+-   The `withRehdyration` function is removed. Use the persistence plugin instead.
+-   The `loadAndPersist` function is removed. Use the persistence plugin instead.
+-   `restrictPersistence`, `setPersistenceStorage` and `setupPersistence` functions have been removed. Please use the data persistence plugin instead.
+-   Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)). If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -347,7 +347,8 @@ Undocumented declaration.
 
 <a name="createReduxStore" href="#createReduxStore">#</a> **createReduxStore**
 
-Creates a namespace object with a store derived from the reducer given.
+Creates a data store definition for the provided Redux store options containing
+properties describing reducer, actions, selectors, controls and resolvers.
 
 _Usage_
 
@@ -678,7 +679,7 @@ const SaleButton = ( { children } ) => {
 
 _Parameters_
 
--   _storeName_ `[string]`: Optionally provide the name of the store from which to retrieve action creators. If not provided, the registry.dispatch function is returned instead.
+-   _storeNameOrDefinition_ `[(string|WPDataStoreDefinition)]`: Optionally provide the name of the store or its definition from which to retrieve action creators. If not provided, the registry.dispatch function is returned instead.
 
 _Returns_
 

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -19,8 +19,8 @@ _This package assumes that your code will run in an **ES2015+** environment. If 
 Use the `registerStore` function to add your own store to the centralized data registry. This function accepts two arguments: a name to identify the module, and an object with values describing how your state is represented, modified, and accessed. At a minimum, you must provide a reducer function describing the shape of your state and how it changes in response to actions dispatched to the store.
 
 ```js
-const { apiFetch } = wp;
-const { registerStore } = wp.data;
+import apiFetch from '@wordpress/api-fetch';
+import { registerStore } from '@wordpress/data';
 
 const DEFAULT_STATE = {
 	prices: {},
@@ -164,7 +164,7 @@ import existingSelectors from './existing-app/selectors';
 import existingActions from './existing-app/actions';
 import createStore from './existing-app/store';
 
-const { registerGenericStore } = wp.data;
+import { registerGenericStore } from 'wordpress/data';
 
 const reduxStore = createStore();
 
@@ -204,7 +204,7 @@ It is also possible to implement a completely custom store from scratch:
 _Example:_
 
 ```js
-const { registerGenericStore } = wp.data;
+import { registerGenericStore } from '@wordpress/data';
 
 function createCustomStore() {
 	let storeChanged = () => {};
@@ -308,7 +308,7 @@ reducing functions into a single reducing function you can pass to registerReduc
 _Usage_
 
 ```js
-const { combineReducers, registerStore } = wp.data;
+import { combineReducers, registerStore } from '@wordpress/data';
 
 const prices = ( state = {}, action ) => {
 	return action.type === 'SET_PRICE' ?
@@ -352,11 +352,11 @@ Creates a namespace object with a store derived from the reducer given.
 _Parameters_
 
 -   _key_ `string`: Unique namespace identifier.
--   _options_ (unknown type): Registered store options, with properties describing reducer, actions, selectors, and resolvers.
+-   _options_ `WPDataReduxStoreConfig`: Registered store options, with properties describing reducer, actions, selectors, and resolvers.
 
 _Returns_
 
--   (unknown type): Store Object.
+-   `WPDataStoreDefinition`: Store Object.
 
 <a name="createRegistry" href="#createRegistry">#</a> **createRegistry**
 
@@ -458,7 +458,7 @@ they are called.
 _Usage_
 
 ```js
-const { dispatch } = wp.data;
+import { dispatch } from '@wordpress/data';
 
 dispatch( 'my-shop' ).setPrice( 'hammer', 9.75 );
 ```
@@ -487,9 +487,15 @@ _Type_
 
 Registers a standard `@wordpress/data` store definition.
 
+_Usage_
+
+```js
+import { register } from '@wordpress/data';
+```
+
 _Parameters_
 
--   _store_ (unknown type): Store definition.
+-   _store_ `WPDataStore`: Store definition.
 
 <a name="registerGenericStore" href="#registerGenericStore">#</a> **registerGenericStore**
 
@@ -524,11 +530,11 @@ You can read more about the react context api here:
 _Usage_
 
 ```js
-const {
+import {
   RegistryProvider,
   RegistryConsumer,
   createRegistry
-} = wp.data;
+} from '@wordpress/data';
 
 const registry = createRegistry( {} );
 
@@ -563,7 +569,7 @@ As a consumer, you need only pass arguments of the selector, if applicable.
 _Usage_
 
 ```js
-const { select } = wp.data;
+import { select } from '@wordpress/data';
 
 select( 'my-shop' ).getPrice( 'hammer' );
 ```
@@ -585,7 +591,7 @@ function used to stop the subscription.
 _Usage_
 
 ```js
-const { subscribe } = wp.data;
+import { subscribe } from '@wordpress/data';
 
 const unsubscribe = subscribe( () => {
 	// You could use this opportunity to test whether the derived result of a
@@ -624,8 +630,8 @@ the server via the `useSelect` hook to use in combination with the dispatch
 action.
 
 ```jsx
-const { useDispatch, useSelect } = wp.data;
-const { useCallback } = wp.element;
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useCallback } from '@wordpress/element';
 
 function Button( { onClick, children } ) {
   return <button type="button" onClick={ onClick }>{ children }</button>
@@ -668,18 +674,18 @@ this hook.
 It acts similarly to the `useContext` react hook.
 
 Note: Generally speaking, `useRegistry` is a low level hook that in most cases
-won't be needed for implementation. Most interactions with the wp.data api
-can be performed via the `useSelect` hook,  or the `withSelect` and
+won't be needed for implementation. Most interactions with the `@wordpress/data`
+API can be performed via the `useSelect` hook,  or the `withSelect` and
 `withDispatch` higher order components.
 
 _Usage_
 
 ```js
-const {
+import {
   RegistryProvider,
   createRegistry,
   useRegistry,
-} = wp.data
+} from '@wordpress/data';
 
 const registry = createRegistry( {} );
 
@@ -710,7 +716,7 @@ In general, this custom React hook follows the
 _Usage_
 
 ```js
-const { useSelect } = wp.data;
+import { useSelect } from '@wordpress/data';
 
 function HammerPriceDisplay( { currency } ) {
   const price = useSelect( ( select ) => {
@@ -754,7 +760,7 @@ function Button( { onClick, children } ) {
     return <button type="button" onClick={ onClick }>{ children }</button>;
 }
 
-const { withDispatch } = wp.data;
+import { withDispatch } from '@wordpress/data';
 
 const SaleButton = withDispatch( ( dispatch, ownProps ) => {
     const { startSale } = dispatch( 'my-shop' );
@@ -790,7 +796,7 @@ function Button( { onClick, children } ) {
     return <button type="button" onClick={ onClick }>{ children }</button>;
 }
 
-const { withDispatch } = wp.data;
+import { withDispatch } from '@wordpress/data';
 
 const SaleButton = withDispatch( ( dispatch, ownProps, { select } ) => {
    // Stock number changes frequently.
@@ -842,14 +848,14 @@ selectors.
 _Usage_
 
 ```js
+import { withSelect } from '@wordpress/data';
+
 function PriceDisplay( { price, currency } ) {
 	return new Intl.NumberFormat( 'en-US', {
 		style: 'currency',
 		currency,
 	} ).format( price );
 }
-
-const { withSelect } = wp.data;
 
 const HammerPriceDisplay = withSelect( ( select, ownProps ) => {
 	const { getPrice } = select( 'my-shop' );

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -349,6 +349,19 @@ Undocumented declaration.
 
 Creates a namespace object with a store derived from the reducer given.
 
+_Usage_
+
+```js
+import { createReduxStore } from '@wordpress/data';
+
+const store = createReduxStore( 'demo', {
+    reducer: ( state = 'OK' ) => state,
+    selectors: {
+        getValue: ( state ) => state,
+    },
+} );
+```
+
 _Parameters_
 
 -   _key_ `string`: Unique namespace identifier.
@@ -490,7 +503,15 @@ Registers a standard `@wordpress/data` store definition.
 _Usage_
 
 ```js
-import { register } from '@wordpress/data';
+import { createReduxStore, register } from '@wordpress/data';
+
+const store = createReduxStore( 'demo', {
+    reducer: ( state = 'OK' ) => state,
+    selectors: {
+        getValue: ( state ) => state,
+    },
+} );
+registry.register( store );
 ```
 
 _Parameters_

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -370,7 +370,7 @@ _Parameters_
 
 _Returns_
 
--   `WPDataStoreDefinition`: Store Object.
+-   `WPDataStore`: Store Object.
 
 <a name="createRegistry" href="#createRegistry">#</a> **createRegistry**
 
@@ -679,7 +679,7 @@ const SaleButton = ( { children } ) => {
 
 _Parameters_
 
--   _storeNameOrDefinition_ `[(string|WPDataStoreDefinition)]`: Optionally provide the name of the store or its definition from which to retrieve action creators. If not provided, the registry.dispatch function is returned instead.
+-   _storeNameOrDefinition_ `[(string|WPDataStore)]`: Optionally provide the name of the store or its definition from which to retrieve action creators. If not provided, the registry.dispatch function is returned instead.
 
 _Returns_
 

--- a/packages/data/src/components/registry-provider/context.js
+++ b/packages/data/src/components/registry-provider/context.js
@@ -21,11 +21,11 @@ const { Consumer, Provider } = Context;
  *
  * @example
  * ```js
- * const {
+ * import {
  *   RegistryProvider,
  *   RegistryConsumer,
  *   createRegistry
- * } = wp.data;
+ * } from '@wordpress/data';
  *
  * const registry = createRegistry( {} );
  *

--- a/packages/data/src/components/registry-provider/use-registry.js
+++ b/packages/data/src/components/registry-provider/use-registry.js
@@ -18,17 +18,17 @@ import { Context } from './context';
  * It acts similarly to the `useContext` react hook.
  *
  * Note: Generally speaking, `useRegistry` is a low level hook that in most cases
- * won't be needed for implementation. Most interactions with the wp.data api
- * can be performed via the `useSelect` hook,  or the `withSelect` and
+ * won't be needed for implementation. Most interactions with the `@wordpress/data`
+ * API can be performed via the `useSelect` hook,  or the `withSelect` and
  * `withDispatch` higher order components.
  *
  * @example
  * ```js
- * const {
+ * import {
  *   RegistryProvider,
  *   createRegistry,
  *   useRegistry,
- * } = wp.data
+ * } from '@wordpress/data';
  *
  * const registry = createRegistry( {} );
  *

--- a/packages/data/src/components/use-dispatch/use-dispatch.js
+++ b/packages/data/src/components/use-dispatch/use-dispatch.js
@@ -3,16 +3,19 @@
  */
 import useRegistry from '../registry-provider/use-registry';
 
+/** @typedef {import('./types').WPDataStoreDefinition} WPDataStoreDefinition */
+
 /**
  * A custom react hook returning the current registry dispatch actions creators.
  *
  * Note: The component using this hook must be within the context of a
  * RegistryProvider.
  *
- * @param {string} [storeName]  Optionally provide the name of the store from
- *                             which to retrieve action creators. If not
- *                             provided, the registry.dispatch function is
- *                             returned instead.
+ * @param {string|WPDataStoreDefinition} [storeNameOrDefinition] Optionally provide the name of the
+ *                                                               store or its definition from which to
+ *                                                               retrieve action creators. If not
+ *                                                               provided, the registry.dispatch
+ *                                                               function is returned instead.
  *
  * @example
  * This illustrates a pattern where you may need to retrieve dynamic data from
@@ -46,9 +49,11 @@ import useRegistry from '../registry-provider/use-registry';
  * ```
  * @return {Function}  A custom react hook.
  */
-const useDispatch = ( storeName ) => {
+const useDispatch = ( storeNameOrDefinition ) => {
 	const { dispatch } = useRegistry();
-	return storeName === void 0 ? dispatch : dispatch( storeName );
+	return storeNameOrDefinition === void 0
+		? dispatch
+		: dispatch( storeNameOrDefinition );
 };
 
 export default useDispatch;

--- a/packages/data/src/components/use-dispatch/use-dispatch.js
+++ b/packages/data/src/components/use-dispatch/use-dispatch.js
@@ -20,8 +20,8 @@ import useRegistry from '../registry-provider/use-registry';
  * action.
  *
  * ```jsx
- * const { useDispatch, useSelect } = wp.data;
- * const { useCallback } = wp.element;
+ * import { useDispatch, useSelect } from '@wordpress/data';
+ * import { useCallback } from '@wordpress/element';
  *
  * function Button( { onClick, children } ) {
  *   return <button type="button" onClick={ onClick }>{ children }</button>

--- a/packages/data/src/components/use-dispatch/use-dispatch.js
+++ b/packages/data/src/components/use-dispatch/use-dispatch.js
@@ -3,7 +3,7 @@
  */
 import useRegistry from '../registry-provider/use-registry';
 
-/** @typedef {import('./types').WPDataStoreDefinition} WPDataStoreDefinition */
+/** @typedef {import('./types').WPDataStore} WPDataStore */
 
 /**
  * A custom react hook returning the current registry dispatch actions creators.
@@ -11,11 +11,11 @@ import useRegistry from '../registry-provider/use-registry';
  * Note: The component using this hook must be within the context of a
  * RegistryProvider.
  *
- * @param {string|WPDataStoreDefinition} [storeNameOrDefinition] Optionally provide the name of the
- *                                                               store or its definition from which to
- *                                                               retrieve action creators. If not
- *                                                               provided, the registry.dispatch
- *                                                               function is returned instead.
+ * @param {string|WPDataStore} [storeNameOrDefinition] Optionally provide the name of the
+ *                                                     store or its definition from which to
+ *                                                     retrieve action creators. If not
+ *                                                     provided, the registry.dispatch
+ *                                                     function is returned instead.
  *
  * @example
  * This illustrates a pattern where you may need to retrieve dynamic data from

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -53,7 +53,7 @@ const renderQueue = createQueue();
  *
  * @example
  * ```js
- * const { useSelect } = wp.data;
+ * import { useSelect } from '@wordpress/data';
  *
  * function HammerPriceDisplay( { currency } ) {
  *   const price = useSelect( ( select ) => {

--- a/packages/data/src/components/with-dispatch/index.js
+++ b/packages/data/src/components/with-dispatch/index.js
@@ -25,7 +25,7 @@ import { useDispatchWithMap } from '../use-dispatch';
  *     return <button type="button" onClick={ onClick }>{ children }</button>;
  * }
  *
- * const { withDispatch } = wp.data;
+ * import { withDispatch } from '@wordpress/data';
  *
  * const SaleButton = withDispatch( ( dispatch, ownProps ) => {
  *     const { startSale } = dispatch( 'my-shop' );
@@ -62,7 +62,7 @@ import { useDispatchWithMap } from '../use-dispatch';
  *     return <button type="button" onClick={ onClick }>{ children }</button>;
  * }
  *
- * const { withDispatch } = wp.data;
+ * import { withDispatch } from '@wordpress/data';
  *
  * const SaleButton = withDispatch( ( dispatch, ownProps, { select } ) => {
  *    // Stock number changes frequently.

--- a/packages/data/src/components/with-select/index.js
+++ b/packages/data/src/components/with-select/index.js
@@ -18,14 +18,14 @@ import useSelect from '../use-select';
  *
  * @example
  * ```js
+ * import { withSelect } from '@wordpress/data';
+ *
  * function PriceDisplay( { price, currency } ) {
  * 	return new Intl.NumberFormat( 'en-US', {
  * 		style: 'currency',
  * 		currency,
  * 	} ).format( price );
  * }
- *
- * const { withSelect } = wp.data;
  *
  * const HammerPriceDisplay = withSelect( ( select, ownProps ) => {
  * 	const { getPrice } = select( 'my-shop' );

--- a/packages/data/src/components/with-select/test/index.js
+++ b/packages/data/src/components/with-select/test/index.js
@@ -34,7 +34,7 @@ describe( 'withSelect', () => {
 		// In normal circumstances, the fact that we have to add an arbitrary
 		// prefix to the variable name would be concerning, and perhaps an
 		// argument that we ought to expect developer to use select from the
-		// wp.data export. But in-fact, this serves as a good deterrent for
+		// `@wordpress/data` export. But in-fact, this serves as a good deterrent for
 		// including both `withSelect` and `select` in the same scope, which
 		// shouldn't occur for a typical component, and if it did might wrongly
 		// encourage the developer to use `select` within the component itself.

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -9,6 +9,8 @@ import combineReducers from 'turbo-combine-reducers';
 import defaultRegistry from './default-registry';
 import * as plugins from './plugins';
 
+/** @typedef {import('./types').WPDataStore} WPDataStore */
+
 export { default as withSelect } from './components/with-select';
 export { default as withDispatch } from './components/with-dispatch';
 export { default as withRegistry } from './components/with-registry';
@@ -43,7 +45,7 @@ export { plugins };
  *
  * @example
  * ```js
- * const { combineReducers, registerStore } = wp.data;
+ * import { combineReducers, registerStore } from '@wordpress/data';
  *
  * const prices = ( state = {}, action ) => {
  * 	return action.type === 'SET_PRICE' ?
@@ -82,7 +84,7 @@ export { combineReducers };
  *
  * @example
  * ```js
- * const { select } = wp.data;
+ * import { select } from '@wordpress/data';
  *
  * select( 'my-shop' ).getPrice( 'hammer' );
  * ```
@@ -101,7 +103,7 @@ export const select = defaultRegistry.select;
  *
  * @example
  * ```js
- * const { __experimentalResolveSelect } = wp.data;
+ * import { __experimentalResolveSelect } from '@wordpress/data';
  *
  * __experimentalResolveSelect( 'my-shop' ).getPrice( 'hammer' ).then(console.log)
  * ```
@@ -122,7 +124,7 @@ export const __experimentalResolveSelect =
  *
  * @example
  * ```js
- * const { dispatch } = wp.data;
+ * import { dispatch } from '@wordpress/data';
  *
  * dispatch( 'my-shop' ).setPrice( 'hammer', 9.75 );
  * ```
@@ -139,7 +141,7 @@ export const dispatch = defaultRegistry.dispatch;
  *
  * @example
  * ```js
- * const { subscribe } = wp.data;
+ * import { subscribe } from '@wordpress/data';
  *
  * const unsubscribe = subscribe( () => {
  * 	// You could use this opportunity to test whether the derived result of a
@@ -182,6 +184,11 @@ export const use = defaultRegistry.use;
 /**
  * Registers a standard `@wordpress/data` store definition.
  *
- * @param {import('./types').WPDataStore} store Store definition.
+ * @example
+ * ```js
+ * import { register } from '@wordpress/data';
+ * ```
+ *
+ * @param {WPDataStore} store Store definition.
  */
 export const register = defaultRegistry.register;

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -186,7 +186,15 @@ export const use = defaultRegistry.use;
  *
  * @example
  * ```js
- * import { register } from '@wordpress/data';
+ * import { createReduxStore, register } from '@wordpress/data';
+ *
+ * const store = createReduxStore( 'demo', {
+ *     reducer: ( state = 'OK' ) => state,
+ *     selectors: {
+ *         getValue: ( state ) => state,
+ *     },
+ * } );
+ * registry.register( store );
  * ```
  *
  * @param {WPDataStore} store Store definition.

--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -54,7 +54,8 @@ function createResolversCache() {
 }
 
 /**
- * Creates a namespace object with a store derived from the reducer given.
+ * Creates a data store definition for the provided Redux store options containing
+ * properties describing reducer, actions, selectors, controls and resolvers.
  *
  * @example
  * ```js

--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -21,6 +21,10 @@ import metadataReducer from './metadata/reducer';
 import * as metadataSelectors from './metadata/selectors';
 import * as metadataActions from './metadata/actions';
 
+/** @typedef {import('../types').WPDataRegistry} WPDataRegistry */
+/** @typedef {import('../types').WPDataStoreDefinition} WPDataStoreDefinition */
+/** @typedef {import('../types').WPDataReduxStoreConfig} WPDataReduxStoreConfig */
+
 /**
  * Create a cache to track whether resolvers started running or not.
  *
@@ -52,12 +56,12 @@ function createResolversCache() {
 /**
  * Creates a namespace object with a store derived from the reducer given.
  *
- * @param {string}                                    key      Unique namespace identifier.
- * @param {import('../types').WPDataReduxStoreConfig} options  Registered store options, with properties
- *                                                             describing reducer, actions, selectors, and
- *                                                             resolvers.
+ * @param {string}                 key      Unique namespace identifier.
+ * @param {WPDataReduxStoreConfig} options  Registered store options, with properties
+ *                                          describing reducer, actions, selectors,
+ *                                          and resolvers.
  *
- * @return {import('../types').WPDataStoreDefinition} Store Object.
+ * @return {WPDataStoreDefinition} Store Object.
  */
 export default function createReduxStore( key, options ) {
 	return {
@@ -149,11 +153,11 @@ export default function createReduxStore( key, options ) {
 /**
  * Creates a redux store for a namespace.
  *
- * @param {string}                            key      Unique namespace identifier.
- * @param {Object}                            options  Registered store options, with properties
- *                                                     describing reducer, actions, selectors, and
- *                                                     resolvers.
- * @param {import('../types').WPDataRegistry} registry Registry reference.
+ * @param {string}         key      Unique namespace identifier.
+ * @param {Object}         options  Registered store options, with properties
+ *                                  describing reducer, actions, selectors,
+ *                                  and resolvers.
+ * @param {WPDataRegistry} registry Registry reference.
  *
  * @return {Object} Newly created redux store.
  */

--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -56,6 +56,18 @@ function createResolversCache() {
 /**
  * Creates a namespace object with a store derived from the reducer given.
  *
+ * @example
+ * ```js
+ * import { createReduxStore } from '@wordpress/data';
+ *
+ * const store = createReduxStore( 'demo', {
+ *     reducer: ( state = 'OK' ) => state,
+ *     selectors: {
+ *         getValue: ( state ) => state,
+ *     },
+ * } );
+ * ```
+ *
  * @param {string}                 key      Unique namespace identifier.
  * @param {WPDataReduxStoreConfig} options  Registered store options, with properties
  *                                          describing reducer, actions, selectors,

--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -22,7 +22,7 @@ import * as metadataSelectors from './metadata/selectors';
 import * as metadataActions from './metadata/actions';
 
 /** @typedef {import('../types').WPDataRegistry} WPDataRegistry */
-/** @typedef {import('../types').WPDataStoreDefinition} WPDataStoreDefinition */
+/** @typedef {import('../types').WPDataStore} WPDataStore */
 /** @typedef {import('../types').WPDataReduxStoreConfig} WPDataReduxStoreConfig */
 
 /**
@@ -74,7 +74,7 @@ function createResolversCache() {
  *                                          describing reducer, actions, selectors,
  *                                          and resolvers.
  *
- * @return {WPDataStoreDefinition} Store Object.
+ * @return {WPDataStore} Store Object.
  */
 export default function createReduxStore( key, options ) {
 	return {

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -10,6 +10,9 @@ import memize from 'memize';
 import createReduxStore from './redux-store';
 import createCoreDataStore from './store';
 
+/** @typedef {import('./types').WPDataStore} WPDataStore */
+/** @typedef {import('./types').WPDataStoreDefinition} WPDataStoreDefinition */
+
 /**
  * @typedef {Object} WPDataRegistry An isolated orchestrator of store registrations.
  *
@@ -74,7 +77,7 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 	/**
 	 * Calls a selector given the current state and extra arguments.
 	 *
-	 * @param {string|import('./types').WPDataStoreDefinition} storeNameOrDefinition Unique namespace identifier for the store
+	 * @param {string|WPDataStoreDefinition} storeNameOrDefinition Unique namespace identifier for the store
 	 *                                                                               or the store definition.
 	 *
 	 * @return {*} The selector's returned value.
@@ -150,7 +153,7 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 	/**
 	 * Returns the available actions for a part of the state.
 	 *
-	 * @param {string|import('./types').WPDataStoreDefinition} storeNameOrDefinition Unique namespace identifier for the store
+	 * @param {string|WPDataStoreDefinition} storeNameOrDefinition Unique namespace identifier for the store
 	 *                                                                               or the store definition.
 	 *
 	 * @return {*} The action's returned value.
@@ -205,7 +208,7 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 	/**
 	 * Registers a new store.
 	 *
-	 * @param {import('./types').WPDataStore} store Store definition.
+	 * @param {WPDataStore} store Store definition.
 	 */
 	function register( store ) {
 		registerGenericStore( store.name, store.instantiate( registry ) );

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -206,7 +206,7 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 	}
 
 	/**
-	 * Registers a new store.
+	 * Registers a new store definition.
 	 *
 	 * @param {WPDataStore} store Store definition.
 	 */

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -11,7 +11,6 @@ import createReduxStore from './redux-store';
 import createCoreDataStore from './store';
 
 /** @typedef {import('./types').WPDataStore} WPDataStore */
-/** @typedef {import('./types').WPDataStoreDefinition} WPDataStoreDefinition */
 
 /**
  * @typedef {Object} WPDataRegistry An isolated orchestrator of store registrations.
@@ -77,8 +76,8 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 	/**
 	 * Calls a selector given the current state and extra arguments.
 	 *
-	 * @param {string|WPDataStoreDefinition} storeNameOrDefinition Unique namespace identifier for the store
-	 *                                                                               or the store definition.
+	 * @param {string|WPDataStore} storeNameOrDefinition Unique namespace identifier for the store
+	 *                                                   or the store definition.
 	 *
 	 * @return {*} The selector's returned value.
 	 */
@@ -153,8 +152,8 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 	/**
 	 * Returns the available actions for a part of the state.
 	 *
-	 * @param {string|WPDataStoreDefinition} storeNameOrDefinition Unique namespace identifier for the store
-	 *                                                                               or the store definition.
+	 * @param {string|WPDataStore} storeNameOrDefinition Unique namespace identifier for the store
+	 *                                                   or the store definition.
 	 *
 	 * @return {*} The action's returned value.
 	 */

--- a/packages/data/src/test/registry.js
+++ b/packages/data/src/test/registry.js
@@ -697,8 +697,7 @@ describe( 'createRegistry', () => {
 		} );
 
 		it( 'should work with the store object as param for dispatch', async () => {
-			const STORE_NAME = 'demo';
-			const store = registry.registerStore( STORE_NAME, {
+			const store = createReduxStore( 'demo', {
 				reducer( state = 'OK', action ) {
 					if ( action.type === 'UPDATE' ) {
 						return 'UPDATED';
@@ -710,11 +709,15 @@ describe( 'createRegistry', () => {
 						return { type: 'UPDATE' };
 					},
 				},
+				selectors: {
+					getValue: ( state ) => state,
+				},
 			} );
+			registry.register( store );
 
-			expect( store.getState() ).toBe( 'OK' );
-			await registry.dispatch( STORE_NAME ).update();
-			expect( store.getState() ).toBe( 'UPDATED' );
+			expect( registry.select( store ).getValue() ).toBe( 'OK' );
+			await registry.dispatch( store ).update();
+			expect( registry.select( store ).getValue() ).toBe( 'UPDATED' );
 		} );
 	} );
 

--- a/packages/data/src/test/registry.js
+++ b/packages/data/src/test/registry.js
@@ -506,6 +506,44 @@ describe( 'createRegistry', () => {
 		} );
 	} );
 
+	describe( 'register', () => {
+		it( 'should work with the store definition as param for select', () => {
+			const store = createReduxStore( 'demo', {
+				reducer: ( state = 'OK' ) => state,
+				selectors: {
+					getValue: ( state ) => state,
+				},
+			} );
+			registry.register( store );
+
+			expect( registry.select( store ).getValue() ).toBe( 'OK' );
+		} );
+
+		it( 'should work with the store definition as param for dispatch', async () => {
+			const store = createReduxStore( 'demo', {
+				reducer( state = 'OK', action ) {
+					if ( action.type === 'UPDATE' ) {
+						return 'UPDATED';
+					}
+					return state;
+				},
+				actions: {
+					update() {
+						return { type: 'UPDATE' };
+					},
+				},
+				selectors: {
+					getValue: ( state ) => state,
+				},
+			} );
+			registry.register( store );
+
+			expect( registry.select( store ).getValue() ).toBe( 'OK' );
+			await registry.dispatch( store ).update();
+			expect( registry.select( store ).getValue() ).toBe( 'UPDATED' );
+		} );
+	} );
+
 	describe( 'select', () => {
 		it( 'registers multiple selectors to the public API', () => {
 			const selector1 = jest.fn( () => 'result1' );
@@ -550,20 +588,6 @@ describe( 'createRegistry', () => {
 			expect( registry.select( 'reducer2' ).selector2() ).toEqual(
 				'result1'
 			);
-		} );
-
-		it( 'should work with the store definition as param for select', () => {
-			const STORE_NAME = 'demo';
-			const store = createReduxStore( STORE_NAME, {
-				reducer: ( state = 'OK' ) => state,
-				selectors: {
-					getValue: ( state ) => state,
-				},
-				resolvers: {},
-			} );
-			registry.register( store );
-
-			expect( registry.select( store ).getValue() ).toBe( 'OK' );
 		} );
 
 		it( 'should run the registry selector from a non-registry selector', () => {
@@ -694,30 +718,6 @@ describe( 'createRegistry', () => {
 			} );
 			registry.dispatch( 'counter' ).increment( 4 ); // state = 5
 			expect( store.getState() ).toBe( 5 );
-		} );
-
-		it( 'should work with the store object as param for dispatch', async () => {
-			const store = createReduxStore( 'demo', {
-				reducer( state = 'OK', action ) {
-					if ( action.type === 'UPDATE' ) {
-						return 'UPDATED';
-					}
-					return state;
-				},
-				actions: {
-					update() {
-						return { type: 'UPDATE' };
-					},
-				},
-				selectors: {
-					getValue: ( state ) => state,
-				},
-			} );
-			registry.register( store );
-
-			expect( registry.select( store ).getValue() ).toBe( 'OK' );
-			await registry.dispatch( store ).update();
-			expect( registry.select( store ).getValue() ).toBe( 'UPDATED' );
 		} );
 	} );
 

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -2,191 +2,196 @@
 
 ## Unreleased
 
+### New Feature
+
+-   Added a store definition `store` for the editor namespace to use with `@wordpress/data` API ([#26655](https://github.com/WordPress/gutenberg/pull/26655)).
+
 ## 9.21.0 (2020-09-03)
 
 ### Enhancement
 
-- The `UnsavedChangesWarning` component is now using `__experimentalGetDirtyEntityRecords` to determine if there were changes.
+-   The `UnsavedChangesWarning` component is now using `__experimentalGetDirtyEntityRecords` to determine if there were changes.
 
 ## 9.4.0 (2019-06-12)
 
 ### Deprecations
 
-- The following components are deprecated as moved to the `@wordpress/block-editor` package:
-  - Autocomplete,
-  - AlignmentToolbar,
-  - BlockAlignmentToolbar,
-  - BlockControls,
-  - BlockEdit,
-  - BlockEditorKeyboardShortcuts,
-  - BlockFormatControls,
-  - BlockIcon,
-  - BlockInspector,
-  - BlockList,
-  - BlockMover,
-  - BlockNavigationDropdown,
-  - BlockSelectionClearer,
-  - BlockSettingsMenu,
-  - BlockTitle,
-  - BlockToolbar,
-  - ColorPalette,
-  - ContrastChecker,
-  - CopyHandler,
-  - createCustomColorsHOC,
-  - DefaultBlockAppender,
-  - FontSizePicker,
-  - getColorClassName,
-  - getColorObjectByAttributeValues,
-  - getColorObjectByColorValue,
-  - getFontSize,
-  - getFontSizeClass,
-  - Inserter,
-  - InnerBlocks,
-  - InspectorAdvancedControls,
-  - InspectorControls,
-  - PanelColorSettings,
-  - PlainText,
-  - RichText,
-  - RichTextShortcut,
-  - RichTextToolbarButton,
-  - RichTextInserterItem,
-  - MediaPlaceholder,
-  - MediaUpload,
-  - MediaUploadCheck,
-  - MultiBlocksSwitcher,
-  - MultiSelectScrollIntoView,
-  - NavigableToolbar,
-  - ObserveTyping,
-  - PreserveScrollInReorder,
-  - SkipToSelectedBlock,
-  - URLInput,
-  - URLInputButton,
-  - URLPopover,
-  - Warning,
-  - WritingFlow,
-  - withColorContext,
-  - withColors,
-  - withFontSizes.
-- The following actions are deprecated as moved to the `core/block-editor` store:
-  - resetBlocks,
-  - receiveBlocks,
-  - updateBlock,
-  - updateBlockAttributes,
-  - selectBlock,
-  - startMultiSelect,
-  - stopMultiSelect,
-  - multiSelect,
-  - clearSelectedBlock,
-  - toggleSelection,
-  - replaceBlocks,
-  - replaceBlock,
-  - moveBlocksDown,
-  - moveBlocksUp,
-  - moveBlockToPosition,
-  - insertBlock,
-  - insertBlocks,
-  - showInsertionPoint,
-  - hideInsertionPoint,
-  - setTemplateValidity,
-  - synchronizeTemplate,
-  - mergeBlocks,
-  - removeBlocks,
-  - removeBlock,
-  - toggleBlockMode,
-  - startTyping,
-  - stopTyping,
-  - enterFormattedText,
-  - exitFormattedText,
-  - insertDefaultBlock,
-  - updateBlockListSettings.
-- The following selectors are deprecated as moved to the `core/block-editor` store:
-  - getBlockDependantsCacheBust,
-  - getBlockName,
-  - isBlockValid,
-  - getBlockAttributes,
-  - getBlock,
-  - getBlocks,
-  - getClientIdsOfDescendants,
-  - getClientIdsWithDescendants,
-  - getGlobalBlockCount,
-  - getBlocksByClientId,
-  - getBlockCount,
-  - getBlockSelectionStart,
-  - getBlockSelectionEnd,
-  - getSelectedBlockCount,
-  - hasSelectedBlock,
-  - getSelectedBlockClientId,
-  - getSelectedBlock,
-  - getBlockRootClientId,
-  - getBlockHierarchyRootClientId,
-  - getAdjacentBlockClientId,
-  - getPreviousBlockClientId,
-  - getNextBlockClientId,
-  - getSelectedBlocksInitialCaretPosition,
-  - getMultiSelectedBlockClientIds,
-  - getMultiSelectedBlocks,
-  - getFirstMultiSelectedBlockClientId,
-  - getLastMultiSelectedBlockClientId,
-  - isFirstMultiSelectedBlock,
-  - isBlockMultiSelected,
-  - isAncestorMultiSelected,
-  - getMultiSelectedBlocksStartClientId,
-  - getMultiSelectedBlocksEndClientId,
-  - getBlockOrder,
-  - getBlockIndex,
-  - isBlockSelected,
-  - hasSelectedInnerBlock,
-  - isBlockWithinSelection,
-  - hasMultiSelection,
-  - isMultiSelecting,
-  - isSelectionEnabled,
-  - getBlockMode =,
-  - isTyping,
-  - isCaretWithinFormattedText,
-  - getBlockInsertionPoint,
-  - isBlockInsertionPointVisible,
-  - isValidTemplate,
-  - getTemplate,
-  - getTemplateLock,
-  - canInsertBlockType,
-  - getInserterItems,
-  - hasInserterItems,
-  - getBlockListSettings.
+-   The following components are deprecated as moved to the `@wordpress/block-editor` package:
+    -   Autocomplete,
+    -   AlignmentToolbar,
+    -   BlockAlignmentToolbar,
+    -   BlockControls,
+    -   BlockEdit,
+    -   BlockEditorKeyboardShortcuts,
+    -   BlockFormatControls,
+    -   BlockIcon,
+    -   BlockInspector,
+    -   BlockList,
+    -   BlockMover,
+    -   BlockNavigationDropdown,
+    -   BlockSelectionClearer,
+    -   BlockSettingsMenu,
+    -   BlockTitle,
+    -   BlockToolbar,
+    -   ColorPalette,
+    -   ContrastChecker,
+    -   CopyHandler,
+    -   createCustomColorsHOC,
+    -   DefaultBlockAppender,
+    -   FontSizePicker,
+    -   getColorClassName,
+    -   getColorObjectByAttributeValues,
+    -   getColorObjectByColorValue,
+    -   getFontSize,
+    -   getFontSizeClass,
+    -   Inserter,
+    -   InnerBlocks,
+    -   InspectorAdvancedControls,
+    -   InspectorControls,
+    -   PanelColorSettings,
+    -   PlainText,
+    -   RichText,
+    -   RichTextShortcut,
+    -   RichTextToolbarButton,
+    -   RichTextInserterItem,
+    -   MediaPlaceholder,
+    -   MediaUpload,
+    -   MediaUploadCheck,
+    -   MultiBlocksSwitcher,
+    -   MultiSelectScrollIntoView,
+    -   NavigableToolbar,
+    -   ObserveTyping,
+    -   PreserveScrollInReorder,
+    -   SkipToSelectedBlock,
+    -   URLInput,
+    -   URLInputButton,
+    -   URLPopover,
+    -   Warning,
+    -   WritingFlow,
+    -   withColorContext,
+    -   withColors,
+    -   withFontSizes.
+-   The following actions are deprecated as moved to the `core/block-editor` store:
+    -   resetBlocks,
+    -   receiveBlocks,
+    -   updateBlock,
+    -   updateBlockAttributes,
+    -   selectBlock,
+    -   startMultiSelect,
+    -   stopMultiSelect,
+    -   multiSelect,
+    -   clearSelectedBlock,
+    -   toggleSelection,
+    -   replaceBlocks,
+    -   replaceBlock,
+    -   moveBlocksDown,
+    -   moveBlocksUp,
+    -   moveBlockToPosition,
+    -   insertBlock,
+    -   insertBlocks,
+    -   showInsertionPoint,
+    -   hideInsertionPoint,
+    -   setTemplateValidity,
+    -   synchronizeTemplate,
+    -   mergeBlocks,
+    -   removeBlocks,
+    -   removeBlock,
+    -   toggleBlockMode,
+    -   startTyping,
+    -   stopTyping,
+    -   enterFormattedText,
+    -   exitFormattedText,
+    -   insertDefaultBlock,
+    -   updateBlockListSettings.
+-   The following selectors are deprecated as moved to the `core/block-editor` store:
+    -   getBlockDependantsCacheBust,
+    -   getBlockName,
+    -   isBlockValid,
+    -   getBlockAttributes,
+    -   getBlock,
+    -   getBlocks,
+    -   getClientIdsOfDescendants,
+    -   getClientIdsWithDescendants,
+    -   getGlobalBlockCount,
+    -   getBlocksByClientId,
+    -   getBlockCount,
+    -   getBlockSelectionStart,
+    -   getBlockSelectionEnd,
+    -   getSelectedBlockCount,
+    -   hasSelectedBlock,
+    -   getSelectedBlockClientId,
+    -   getSelectedBlock,
+    -   getBlockRootClientId,
+    -   getBlockHierarchyRootClientId,
+    -   getAdjacentBlockClientId,
+    -   getPreviousBlockClientId,
+    -   getNextBlockClientId,
+    -   getSelectedBlocksInitialCaretPosition,
+    -   getMultiSelectedBlockClientIds,
+    -   getMultiSelectedBlocks,
+    -   getFirstMultiSelectedBlockClientId,
+    -   getLastMultiSelectedBlockClientId,
+    -   isFirstMultiSelectedBlock,
+    -   isBlockMultiSelected,
+    -   isAncestorMultiSelected,
+    -   getMultiSelectedBlocksStartClientId,
+    -   getMultiSelectedBlocksEndClientId,
+    -   getBlockOrder,
+    -   getBlockIndex,
+    -   isBlockSelected,
+    -   hasSelectedInnerBlock,
+    -   isBlockWithinSelection,
+    -   hasMultiSelection,
+    -   isMultiSelecting,
+    -   isSelectionEnabled,
+    -   getBlockMode =,
+    -   isTyping,
+    -   isCaretWithinFormattedText,
+    -   getBlockInsertionPoint,
+    -   isBlockInsertionPointVisible,
+    -   isValidTemplate,
+    -   getTemplate,
+    -   getTemplateLock,
+    -   canInsertBlockType,
+    -   getInserterItems,
+    -   hasInserterItems,
+    -   getBlockListSettings.
 
 ## 9.3.0 (2019-05-21)
 
 ### Deprecations
-- The `getAutosave`, `getAutosaveAttribute`, and `hasAutosave` selectors are deprecated. Please use the `getAutosave` selector in the `@wordpress/core-data` package.
-- The `resetAutosave` action is deprecated. An equivalent action `receiveAutosaves` has been added to the `@wordpress/core-data` package.
-- `ServerSideRender` component was deprecated. The component is now available in `@wordpress/server-side-render`.
+
+-   The `getAutosave`, `getAutosaveAttribute`, and `hasAutosave` selectors are deprecated. Please use the `getAutosave` selector in the `@wordpress/core-data` package.
+-   The `resetAutosave` action is deprecated. An equivalent action `receiveAutosaves` has been added to the `@wordpress/core-data` package.
+-   `ServerSideRender` component was deprecated. The component is now available in `@wordpress/server-side-render`.
 
 ### Internal
 
-- Refactor setupEditor effects to action-generator using controls ([#14513](https://github.com/WordPress/gutenberg/pull/14513))
-- Remove redux-multi dependency (no longer needed/used with above refactor)
-- Replace internal controls definitions with usage of new @wordpress/data-controls package (see [#15435](https://github.com/WordPress/gutenberg/pull/15435)
+-   Refactor setupEditor effects to action-generator using controls ([#14513](https://github.com/WordPress/gutenberg/pull/14513))
+-   Remove redux-multi dependency (no longer needed/used with above refactor)
+-   Replace internal controls definitions with usage of new @wordpress/data-controls package (see [#15435](https://github.com/WordPress/gutenberg/pull/15435)
 
 ## 9.1.0 (2019-03-06)
 
 ### New Features
 
-- Added `createCustomColorsHOC` for creating a higher order `withCustomColors` component.
-- Added a new `TextEditorGlobalKeyboardShortcuts` component.
+-   Added `createCustomColorsHOC` for creating a higher order `withCustomColors` component.
+-   Added a new `TextEditorGlobalKeyboardShortcuts` component.
 
 ### Deprecations
 
-- `EditorGlobalKeyboardShortcuts` has been deprecated in favor of `VisualEditorGlobalKeyboardShortcuts`.
+-   `EditorGlobalKeyboardShortcuts` has been deprecated in favor of `VisualEditorGlobalKeyboardShortcuts`.
 
 ### Bug Fixes
 
-- BlockSwitcher will now consistently render an icon for block multi-selections.
+-   BlockSwitcher will now consistently render an icon for block multi-selections.
 
 ### Internal
 
-- Removed `jQuery` dependency.
-- Removed `TinyMCE` dependency.
-- RichText: improve format boundaries.
-- Refactor all post effects to action-generators using controls ([#13716](https://github.com/WordPress/gutenberg/pull/13716))
+-   Removed `jQuery` dependency.
+-   Removed `TinyMCE` dependency.
+-   RichText: improve format boundaries.
+-   Refactor all post effects to action-generators using controls ([#13716](https://github.com/WordPress/gutenberg/pull/13716))
 
 ## 9.0.7 (2019-01-03)
 
@@ -194,14 +199,14 @@
 
 ### Bug Fixes
 
-- Restore the `block` prop in the `BlockListBlock` filter.
+-   Restore the `block` prop in the `BlockListBlock` filter.
 
 ## 9.0.5 (2018-12-12)
 
 ### Bug Fixes
 
-- `getEditedPostAttribute` now correctly returns the merged result of edits as a partial change when given `'meta'` as the `attributeName`.
-- Fixes an error and unrecoverable state which occurs on autosave completion for a `'publicly_queryable' => false` post type.
+-   `getEditedPostAttribute` now correctly returns the merged result of edits as a partial change when given `'meta'` as the `attributeName`.
+-   Fixes an error and unrecoverable state which occurs on autosave completion for a `'publicly_queryable' => false` post type.
 
 ## 9.0.4 (2018-11-30)
 
@@ -215,105 +220,105 @@
 
 ### Breaking Changes
 
-- `PostPublishPanelToggle` has been removed. Use `PostPublishButton` instead.
+-   `PostPublishPanelToggle` has been removed. Use `PostPublishButton` instead.
 
 ## 8.0.0 (2018-11-15)
 
 ### Breaking Changes
 
-- The reusable blocks actions and selectors have been marked as experimental.
+-   The reusable blocks actions and selectors have been marked as experimental.
 
 ### Bug Fixes
 
-- Stop propagating to DOM elements the `focusOnMount` prop from `NavigableToolbar` components
+-   Stop propagating to DOM elements the `focusOnMount` prop from `NavigableToolbar` components
 
 ## 7.0.1 (2018-11-12)
 
 ### Polish
 
-- Remove unnecessary `locale` prop usage [#11649](https://github.com/WordPress/gutenberg/pull/11649)
+-   Remove unnecessary `locale` prop usage [#11649](https://github.com/WordPress/gutenberg/pull/11649)
 
 ### Bug Fixes
 
-- Fix multi-selection triggering too often when using floated blocks.
+-   Fix multi-selection triggering too often when using floated blocks.
 
 ## 7.0.0 (2018-11-12)
 
 ### Breaking Change
 
-- The `PanelColor` component has been removed.
+-   The `PanelColor` component has been removed.
 
 ### New Feature
 
-- In `NavigableToolbar`, a property focusOnMount was added, if true, the toolbar will get focus as soon as it mounted. Defaults to false.
+-   In `NavigableToolbar`, a property focusOnMount was added, if true, the toolbar will get focus as soon as it mounted. Defaults to false.
 
 ### Bug Fixes
 
-- Avoid unnecessary re-renders when navigating between blocks.
-- PostPublishPanel: return focus to element that opened the panel
-- Capture focus on self in InsertionPoint inserter
-- Correct insertion point opacity selector
-- Set code editor as RTL
+-   Avoid unnecessary re-renders when navigating between blocks.
+-   PostPublishPanel: return focus to element that opened the panel
+-   Capture focus on self in InsertionPoint inserter
+-   Correct insertion point opacity selector
+-   Set code editor as RTL
 
 ## 6.2.1 (2018-11-09)
 
 ### Deprecations
 
-- `PostPublishPanelToggle` has been deprecated in favor of `PostPublishButton`.
+-   `PostPublishPanelToggle` has been deprecated in favor of `PostPublishButton`.
 
 ### Polish
 
-- Reactive block styles.
+-   Reactive block styles.
 
 ## 6.2.0 (2018-11-09)
 
 ### New Features
 
-- Adjust a11y roles for menu items, and make sure screen readers can properly use BlockNavigationList ([#11431](https://github.com/WordPress/gutenberg/issues/11431)).
+-   Adjust a11y roles for menu items, and make sure screen readers can properly use BlockNavigationList ([#11431](https://github.com/WordPress/gutenberg/issues/11431)).
 
 ## 6.1.1 (2018-11-03)
 
 ### Polish
 
-- Remove `findDOMNode` usage from the `Inserter` component.
-- Remove `findDOMNode` usage from the `Block` component.
-- Remove `findDOMNode` usage from the `NavigableToolbar` component.
+-   Remove `findDOMNode` usage from the `Inserter` component.
+-   Remove `findDOMNode` usage from the `Block` component.
+-   Remove `findDOMNode` usage from the `NavigableToolbar` component.
 
 ## 6.1.0 (2018-10-30)
 
 ### Deprecations
 
-- The Reusable blocks Data API is marked as experimental as it's subject to change in the future ([#11230](https://github.com/WordPress/gutenberg/pull/11230)).
+-   The Reusable blocks Data API is marked as experimental as it's subject to change in the future ([#11230](https://github.com/WordPress/gutenberg/pull/11230)).
 
 ## 6.0.1 (2018-10-30)
 
 ### Bug Fixes
 
-- Tweak the vanilla style sheet for consistency.
-- Fix the "Copy Post Text" button not copying the post text.
+-   Tweak the vanilla style sheet for consistency.
+-   Fix the "Copy Post Text" button not copying the post text.
 
 ## 6.0.0 (2018-10-29)
 
 ### Breaking Changes
 
-- The `labels.name` property has been removed from `MediaPlaceholder` in favor of the new `labels.instructions` prop.
-- The `UnsavedChangesWarning` component no longer accepts a `forceIsDirty` prop.
-- `mediaDetails` in object passed to `onFileChange` callback of `mediaUpload`. Please use `media_details` property instead.
+-   The `labels.name` property has been removed from `MediaPlaceholder` in favor of the new `labels.instructions` prop.
+-   The `UnsavedChangesWarning` component no longer accepts a `forceIsDirty` prop.
+-   `mediaDetails` in object passed to `onFileChange` callback of `mediaUpload`. Please use `media_details` property instead.
 
 ### New Features
 
-- In `MediaPlaceholder`, provide default values for title and instructions labels when allowed type is one of image, audio or video.
-- New actions `lockPostSaving` and `unlockPostSaving` were introduced ([#10649](https://github.com/WordPress/gutenberg/pull/10649)).
-- New selector `isPostSavingLocked` was introduced ([#10649](https://github.com/WordPress/gutenberg/pull/10649)).
+-   In `MediaPlaceholder`, provide default values for title and instructions labels when allowed type is one of image, audio or video.
+-   New actions `lockPostSaving` and `unlockPostSaving` were introduced ([#10649](https://github.com/WordPress/gutenberg/pull/10649)).
+-   New selector `isPostSavingLocked` was introduced ([#10649](https://github.com/WordPress/gutenberg/pull/10649)).
 
 ### Polish
 
-- Add animated logo to preview interstitial screen.
-- Tweak the editor styles support.
+-   Add animated logo to preview interstitial screen.
+-   Tweak the editor styles support.
 
 ### Bug Fixes
 
-- Made preview interstitial text translatable.
+-   Made preview interstitial text translatable.
 
 ## 5.0.1 (2018-10-22)
 
@@ -321,15 +326,15 @@
 
 ### Breaking Changes
 
-- The `checkTemplateValidity` action has been removed. Validity is verified automatically upon block reset.
+-   The `checkTemplateValidity` action has been removed. Validity is verified automatically upon block reset.
 
 ### Deprecations
 
-- `PanelColor` has been deprecated in favor of `PanelColorSettings`.
+-   `PanelColor` has been deprecated in favor of `PanelColorSettings`.
 
 ### New Features
 
-- Added `onClose` prop to `URLPopover` component.
+-   Added `onClose` prop to `URLPopover` component.
 
 ## 4.0.3 (2018-10-18)
 
@@ -337,46 +342,46 @@
 
 ### Breaking Changes
 
-- `getColorName` has been removed. Use `getColorObjectByColorValue` instead.
-- `getColorClass` has been renamed. Use `getColorClassName` instead.
-- The `value` property in color objects passed by `withColors` has been removed. Use `color` property instead.
-- `RichText` `getSettings` prop has been removed. The `unstableGetSettings` prop is available if continued use is required. Unstable APIs are strongly discouraged to be used, and are subject to removal without notice, even as part of a minor release.
-- `RichText` `onSetup` prop has been removed. The `unstableOnSetup` prop is available if continued use is required. Unstable APIs are strongly discouraged to be used, and are subject to removal without notice, even as part of a minor release.
-- `RichTextProvider` has been removed. Please use `wp.data.select( 'core/editor' )` methods instead.
+-   `getColorName` has been removed. Use `getColorObjectByColorValue` instead.
+-   `getColorClass` has been renamed. Use `getColorClassName` instead.
+-   The `value` property in color objects passed by `withColors` has been removed. Use `color` property instead.
+-   `RichText` `getSettings` prop has been removed. The `unstableGetSettings` prop is available if continued use is required. Unstable APIs are strongly discouraged to be used, and are subject to removal without notice, even as part of a minor release.
+-   `RichText` `onSetup` prop has been removed. The `unstableOnSetup` prop is available if continued use is required. Unstable APIs are strongly discouraged to be used, and are subject to removal without notice, even as part of a minor release.
+-   `RichTextProvider` has been removed. Please use `wp.data.select( 'core/editor' )` methods instead.
 
 ### Deprecations
 
-- The `checkTemplateValidity` action has been deprecated. Validity is verified automatically upon block reset.
-- The `UnsavedChangesWarning` component `forceIsDirty` prop has been deprecated.
+-   The `checkTemplateValidity` action has been deprecated. Validity is verified automatically upon block reset.
+-   The `UnsavedChangesWarning` component `forceIsDirty` prop has been deprecated.
 
 ## 3.0.0 (2018-09-05)
 
 ### New Features
 
-- Add editor styles support.
+-   Add editor styles support.
 
 ### Breaking Changes
 
-- The `wideAlign` block supports hook has been removed. Use `alignWide` instead.
-- `fetchSharedBlocks` action has been removed. Use `fetchReusableBlocks` instead.
-- `receiveSharedBlocks` action has been removed. Use `receiveReusableBlocks` instead.
-- `saveSharedBlock` action has been removed. Use `saveReusableBlock` instead.
-- `deleteSharedBlock` action has been removed. Use `deleteReusableBlock` instead.
-- `updateSharedBlockTitle` action has been removed. Use `updateReusableBlockTitle` instead.
-- `convertBlockToSaved` action has been removed. Use `convertBlockToReusable` instead.
-- `getSharedBlock` selector has been removed. Use `getReusableBlock` instead.
-- `isSavingSharedBlock` selector has been removed. Use `isSavingReusableBlock` instead.
-- `isFetchingSharedBlock` selector has been removed. Use `isFetchingReusableBlock` instead.
-- `getSharedBlocks` selector has been removed. Use `getReusableBlocks` instead.
-- `editorMediaUpload` has been removed. Use `mediaUpload` instead.
-- Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)). If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.
-- `DocumentTitle` component has been removed.
-- `getDocumentTitle` selector (`core/editor`) has been removed.
+-   The `wideAlign` block supports hook has been removed. Use `alignWide` instead.
+-   `fetchSharedBlocks` action has been removed. Use `fetchReusableBlocks` instead.
+-   `receiveSharedBlocks` action has been removed. Use `receiveReusableBlocks` instead.
+-   `saveSharedBlock` action has been removed. Use `saveReusableBlock` instead.
+-   `deleteSharedBlock` action has been removed. Use `deleteReusableBlock` instead.
+-   `updateSharedBlockTitle` action has been removed. Use `updateReusableBlockTitle` instead.
+-   `convertBlockToSaved` action has been removed. Use `convertBlockToReusable` instead.
+-   `getSharedBlock` selector has been removed. Use `getReusableBlock` instead.
+-   `isSavingSharedBlock` selector has been removed. Use `isSavingReusableBlock` instead.
+-   `isFetchingSharedBlock` selector has been removed. Use `isFetchingReusableBlock` instead.
+-   `getSharedBlocks` selector has been removed. Use `getReusableBlocks` instead.
+-   `editorMediaUpload` has been removed. Use `mediaUpload` instead.
+-   Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)). If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.
+-   `DocumentTitle` component has been removed.
+-   `getDocumentTitle` selector (`core/editor`) has been removed.
 
 ### Deprecations
 
-- `RichTextProvider` flagged for deprecation. Please use `wp.data.select( 'core/editor' )` methods instead.
+-   `RichTextProvider` flagged for deprecation. Please use `wp.data.select( 'core/editor' )` methods instead.
 
 ### Bug Fixes
 
-- The `PostTextEditor` component will respect its in-progress state edited value, even if the assigned prop value changes.
+-   The `PostTextEditor` component will respect its in-progress state edited value, even if the assigned prop value changes.

--- a/packages/interface/CHANGELOG.md
+++ b/packages/interface/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Feature
+
+-   Added a store definition `store` for the interface namespace to use with `@wordpress/data` API ([#26655](https://github.com/WordPress/gutenberg/pull/26655)).
+
 ### Deprecations
 
 -   `leftSidebar` prop in `InterfaceSkeleton` component has been deprecated ([#26517](https://github.com/WordPress/gutenberg/pull/26517). Use `secondarySidebar` prop instead.

--- a/packages/keyboard-shortcuts/CHANGELOG.md
+++ b/packages/keyboard-shortcuts/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Feature
+
+-   Added a store definition `store` for the keyboard shortcuts namespace to use with `@wordpress/data` API ([#26655](https://github.com/WordPress/gutenberg/pull/26655)).
+
 ## 1.0.0 (2020-02-04)
 
 Initial release.

--- a/packages/notices/CHANGELOG.md
+++ b/packages/notices/CHANGELOG.md
@@ -2,17 +2,21 @@
 
 ## Unreleased
 
+### New Feature
+
+-   Added a store definition `store` for the notices namespace to use with `@wordpress/data` API ([#26655](https://github.com/WordPress/gutenberg/pull/26655)).
+
 ## 2.0.0 (2020-02-10)
 
 ### Breaking Change
 
-- A notices message is no longer spoken as a result of notice creation, but rather by its display in the interface by its corresponding [`Notice` component](https://github.com/WordPress/gutenberg/tree/master/packages/components/src/notice).
+-   A notices message is no longer spoken as a result of notice creation, but rather by its display in the interface by its corresponding [`Notice` component](https://github.com/WordPress/gutenberg/tree/master/packages/components/src/notice).
 
 ## 1.5.0 (2019-06-12)
 
 ### New Features
 
-- Support a new `snackbar` notice type in the `createNotice` action.
+-   Support a new `snackbar` notice type in the `createNotice` action.
 
 ## 1.1.2 (2019-01-03)
 
@@ -22,11 +26,11 @@
 
 ### New Feature
 
-- New option `speak` enables control as to whether the notice content is announced to screen readers (defaults to `true`)
+-   New option `speak` enables control as to whether the notice content is announced to screen readers (defaults to `true`)
 
 ### Bug Fixes
 
-- While `createNotice` only explicitly supported content of type `string`, it was not previously enforced. This has been corrected.
+-   While `createNotice` only explicitly supported content of type `string`, it was not previously enforced. This has been corrected.
 
 ## 1.0.5 (2018-11-15)
 
@@ -40,4 +44,4 @@
 
 ## 1.0.0 (2018-10-29)
 
-- Initial release.
+-   Initial release.

--- a/packages/nux/CHANGELOG.md
+++ b/packages/nux/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## Unreleased
 
+### New Feature
+
+-   Added a store definition `store` for the core data namespace to use with `@wordpress/data` API ([#26655](https://github.com/WordPress/gutenberg/pull/26655)).
+
 # 3.1.0 (2019-06-03)
 
-- The `@wordpress/nux` package has been deprecated. Please use the `Guide` component in `@wordpress/components` to show a user guide.
+-   The `@wordpress/nux` package has been deprecated. Please use the `Guide` component in `@wordpress/components` to show a user guide.
 
 ## 3.0.6 (2019-01-03)
 
@@ -22,7 +26,7 @@
 
 ### Breaking Changes
 
-- The id prop of DotTip has been removed. Please use the tipId prop instead.
+-   The id prop of DotTip has been removed. Please use the tipId prop instead.
 
 ## 2.0.13 (2018-11-12)
 
@@ -40,7 +44,7 @@
 
 ### Deprecations
 
-- The id prop of DotTip has been deprecated. Please use the tipId prop instead.
+-   The id prop of DotTip has been deprecated. Please use the tipId prop instead.
 
 ## 2.0.6 (2018-10-22)
 
@@ -52,4 +56,4 @@
 
 ### Breaking Change
 
-- Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)). If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.
+-   Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)). If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.

--- a/packages/reusable-blocks/CHANGELOG.md
+++ b/packages/reusable-blocks/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 ## Unreleased
 
+### New Feature
+
+-   Added a store definition `store` for the reusable blocks namespace to use with `@wordpress/data` API ([#26655](https://github.com/WordPress/gutenberg/pull/26655)).
+
 ## 1.0.0 (2020-10-19)
 
 ### Internal
 
-- Reusable block utilities moved from `@wordpress/editor` to `@wordpress/reusable-blocks`.
+-   Reusable block utilities moved from `@wordpress/editor` to `@wordpress/reusable-blocks`.

--- a/packages/rich-text/CHANGELOG.md
+++ b/packages/rich-text/CHANGELOG.md
@@ -2,33 +2,37 @@
 
 ## Unreleased
 
+### New Feature
+
+-   Added a store definition `store` for the rich-text namespace to use with `@wordpress/data` API ([#26655](https://github.com/WordPress/gutenberg/pull/26655)).
+
 ## 3.3.0 (2019-05-21)
 
 ### Internal
 
-- Removed and renamed undocumented functions and constants:
-  * Removed `charAt`
-  * Removed `getSelectionStart`
-  * Removed `getSelectionEnd`
-  * Removed `insertLineBreak`
-  * Renamed `isEmptyLine` to `__unstableIsEmptyLine`
-  * Renamed `insertLineSeparator` to `__unstableInsertLineSeparator`
-  * Renamed `apply` to `__unstableApply`
-  * Renamed `unstableToDom` to `__unstableToDom`
-  * Renamed `LINE_SEPARATOR` to `__UNSTABLE_LINE_SEPARATOR`
-  * Renamed `indentListItems` to `__unstableIndentListItems`
-  * Renamed `outdentListItems` to `__unstableOutdentListItems`
-  * Renamed `changeListType` to `__unstableChangeListType`
+-   Removed and renamed undocumented functions and constants:
+    -   Removed `charAt`
+    -   Removed `getSelectionStart`
+    -   Removed `getSelectionEnd`
+    -   Removed `insertLineBreak`
+    -   Renamed `isEmptyLine` to `__unstableIsEmptyLine`
+    -   Renamed `insertLineSeparator` to `__unstableInsertLineSeparator`
+    -   Renamed `apply` to `__unstableApply`
+    -   Renamed `unstableToDom` to `__unstableToDom`
+    -   Renamed `LINE_SEPARATOR` to `__UNSTABLE_LINE_SEPARATOR`
+    -   Renamed `indentListItems` to `__unstableIndentListItems`
+    -   Renamed `outdentListItems` to `__unstableOutdentListItems`
+    -   Renamed `changeListType` to `__unstableChangeListType`
 
 ## 3.1.0 (2019-03-06)
 
 ### Enhancement
 
-- Added format boundaries.
-- Removed parameters from `create` to filter out content.
-- Removed the `createLinePadding` from `apply`, which is now built in.
-- Improved format placeholder.
-- Improved dom diffing.
+-   Added format boundaries.
+-   Removed parameters from `create` to filter out content.
+-   Removed the `createLinePadding` from `apply`, which is now built in.
+-   Improved format placeholder.
+-   Improved dom diffing.
 
 ## 3.0.4 (2019-01-03)
 
@@ -36,7 +40,7 @@
 
 ### Internal
 
-- Internal performance optimizations to avoid excessive expensive creation of DOM documents.
+-   Internal performance optimizations to avoid excessive expensive creation of DOM documents.
 
 ## 3.0.2 (2018-11-21)
 
@@ -46,7 +50,7 @@
 
 ### Breaking Changes
 
-- `toHTMLString` always expects an object instead of multiple arguments.
+-   `toHTMLString` always expects an object instead of multiple arguments.
 
 ## 2.0.4 (2018-11-09)
 
@@ -54,8 +58,8 @@
 
 ### Bug Fix
 
-- Fix Format Type Assignment During Parsing.
-- Fix applying formats on multiline values without wrapper tags.
+-   Fix Format Type Assignment During Parsing.
+-   Fix applying formats on multiline values without wrapper tags.
 
 ## 2.0.2 (2018-11-03)
 
@@ -63,7 +67,7 @@
 
 ## 2.0.0 (2018-10-30)
 
-- Remove `@wordpress/blocks` as a dependency.
+-   Remove `@wordpress/blocks` as a dependency.
 
 ## 1.0.2 (2018-10-29)
 
@@ -71,4 +75,4 @@
 
 ## 1.0.0 (2018-10-18)
 
-- Initial release.
+-   Initial release.

--- a/packages/viewport/CHANGELOG.md
+++ b/packages/viewport/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 ## Unreleased
 
+### New Feature
+
+-   Added a store definition `store` for the viewport namespace to use with `@wordpress/data` API ([#26655](https://github.com/WordPress/gutenberg/pull/26655)).
+
 ## 2.1.0 (2019-01-03)
 
 ### Improvements
 
-- The initial viewport state is assigned synchronously, rather than on the next process tick. This should have an impact of fewer callbacks made to data subscribers.
+-   The initial viewport state is assigned synchronously, rather than on the next process tick. This should have an impact of fewer callbacks made to data subscribers.
 
 ## 2.0.13 (2018-12-12)
 
@@ -30,4 +34,4 @@
 
 ### Breaking Change
 
-- Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)). If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.
+-   Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)). If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.

--- a/packages/viewport/README.md
+++ b/packages/viewport/README.md
@@ -27,19 +27,25 @@ The standard set of breakpoint thresholds is as follows:
 
 ### Data Module
 
-The Viewport module registers itself under the `core/viewport` data namespace.
+The Viewport module registers itself under the `core/viewport` data namespace and is exposed from the package as `store`.
 
 ```js
-const isSmall = select( 'core/viewport' ).isViewportMatch( '< medium' );
+import { select } from '@wordpress/data';
+import { store } from '@wordpress/viewport';
+
+const isSmall = select( store ).isViewportMatch( '< medium' );
 ```
 
 The `isViewportMatch` selector accepts a single string argument `query`. It consists of an optional operator and breakpoint name, separated with a space. The operator can be `<` or `>=`, defaulting to `>=`.
 
 ```js
-const { isViewportMatch } = select( 'core/viewport' );
+import { select } from '@wordpress/data';
+import { store } from '@wordpress/viewport';
+
+const { isViewportMatch } = select( store );
 const isSmall = isViewportMatch( '< medium' );
 const isWideOrHuge = isViewportMatch( '>= wide' );
-// Equivalent: 
+// Equivalent:
 //  const isWideOrHuge = isViewportMatch( 'wide' );
 ```
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
This PR improves `@wordpress/data` documentation based on the changes introduced in  #26655. Some of the points were raised by @jsnajdr:

> The data package adds a new API without breaking changes, so it deserves a minor version bump on next release.
> 
> Then, some other packages, like annotations, started to rely on the new data API, and would need a major bump. In a sense, they support only on the latest version of the underlying "operating system" and won't run on older versions.
> 
> The annotations package also adds a new named export (store) that wasn't there before. That would warrant a minor version bump if the package didn't already have a major one for a different reason.
> 
> The core-data package removes the storeConfig export (breaking change that warrants a major bump) and add a new store export (minor bump).
> 
> And so on for all other affected packages...

In a gist, this PR ensures that:
- [x] new API methods are properly documented in the README file of `@wordpress/data` ana listed in CHANGELOG file
- [x] unit tests for API changes are added
- [x] `wp.data` global gets replaced with import statements for `@wordpress/data`
- [x] CHANGELOG files for all packages that expose store definitions are updated
- [x] ~decide what to do about~ omit `storeConfig` from `@wordpress/core-data` as it was never published to npm

## How has this been tested?
`npm run test-unit`
`npm run docs:build`