### PR TITLE
Fix typo

### DIFF
--- a/docs/designers-developers/developers/block-api/block-supports.md
+++ b/docs/designers-developers/developers/block-api/block-supports.md
@@ -86,8 +86,8 @@ supports: {
 - Default value: null
 - Subproperties:
   - `background`: type `boolean`, default value `true`
-  - `gradient`: type `boolean`, default value `true`
-  - `text`: type `boolean`, default value `false`
+  - `gradient`: type `boolean`, default value `false`
+  - `text`: type `boolean`, default value `true`
 
 This value signals that a block supports some of the CSS style properties related to color. When it does, the block editor will show UI controls for the user to set their values.
 


### PR DESCRIPTION
This fixes a typo in the documentation for blocks support (color key).