### PR TITLE
Remove .block-editor selector dependency

### DIFF
--- a/packages/block-editor/src/components/plain-text/style.scss
+++ b/packages/block-editor/src/components/plain-text/style.scss
@@ -1,4 +1,4 @@
-.block-editor .block-editor-plain-text {
+.block-editor-plain-text {
 	box-shadow: none;
 	font-family: inherit;
 	font-size: inherit;

--- a/packages/block-library/src/archives/editor.scss
+++ b/packages/block-library/src/archives/editor.scss
@@ -1,3 +1,3 @@
-.block-editor ul.wp-block-archives {
+ul.wp-block-archives {
 	padding-left: 2.5em;
 }

--- a/packages/block-library/src/categories/editor.scss
+++ b/packages/block-library/src/categories/editor.scss
@@ -1,4 +1,4 @@
-.block-editor .wp-block-categories ul {
+.wp-block-categories ul {
 	padding-left: 2.5em;
 
 	ul {

--- a/packages/block-library/src/latest-posts/editor.scss
+++ b/packages/block-library/src/latest-posts/editor.scss
@@ -1,4 +1,4 @@
-.block-editor .wp-block-latest-posts {
+.wp-block-latest-posts {
 	padding-left: 2.5em;
 	&.is-grid {
 		padding-left: 0;

--- a/packages/block-library/src/more/editor.scss
+++ b/packages/block-library/src/more/editor.scss
@@ -5,7 +5,7 @@
 	margin-bottom: $default-block-margin;
 }
 
-.block-editor .wp-block-more { // needs specificity
+.wp-block-more {
 	display: block;
 	text-align: center;
 	white-space: nowrap;

--- a/packages/block-library/src/rss/editor.scss
+++ b/packages/block-library/src/rss/editor.scss
@@ -1,4 +1,4 @@
-.block-editor .wp-block-rss {
+.wp-block-rss {
 	padding-left: 2.5em;
 	&.is-grid {
 		padding-left: 0;

--- a/packages/block-library/src/shortcode/editor.scss
+++ b/packages/block-library/src/shortcode/editor.scss
@@ -8,7 +8,6 @@
 	}
 }
 
-.block-editor .blocks-shortcode__textarea,
 .blocks-shortcode__textarea {
 	@include input-control;
 }

--- a/packages/block-library/src/tag-cloud/editor.scss
+++ b/packages/block-library/src/tag-cloud/editor.scss
@@ -1,4 +1,4 @@
-.block-editor .wp-block-tag-cloud {
+.wp-block-tag-cloud {
 	a {
 		display: inline-block;
 		margin-right: 5px;


### PR DESCRIPTION
Related https://github.com/WordPress/gutenberg/pull/10783

In https://github.com/WordPress/gutenberg/pull/26958 it was reported that some blocks don't behave properly in edit-site regarding its styles. The issue is that they depend on the `.block-editor` selector that is only present in the post editor, but not in edit site, widgets, or navigation.

We can either remove that dependency from blocks or add the class to all editors. This PR removes that dependency.

The blocks that are directly affected are: archives, categories, latest-posts, more, rss, shortcode, tag-cloud.
This also removes the class from the plain-text component, which affects to the following blocks: file, HTML, shortcode.

## How to test

- Make sure those blocks look the same in all editors that can have them.
