### PR TITLE
Update stylesheet generation at edit site

### DIFF
--- a/packages/edit-site/src/components/editor/global-styles-provider.js
+++ b/packages/edit-site/src/components/editor/global-styles-provider.js
@@ -123,15 +123,17 @@ export default function GlobalStylesProvider( {
 	const { updateSettings } = useDispatch( 'core/edit-site' );
 
 	useEffect( () => {
-		const newStyles = settings.styles.filter( style => ! style.isGlobalStyles );
+		const newStyles = settings.styles.filter(
+			( style ) => ! style.isGlobalStyles
+		);
 		updateSettings( {
 			...settings,
 			styles: [
 				...newStyles,
 				{
 					css: getGlobalStyles( contexts, mergedStyles ),
-					isGlobalStyles: true
-				}
+					isGlobalStyles: true,
+				},
 			],
 			__experimentalFeatures: mapValues(
 				mergedStyles,

--- a/packages/edit-site/src/components/editor/global-styles-provider.js
+++ b/packages/edit-site/src/components/editor/global-styles-provider.js
@@ -117,43 +117,28 @@ export default function GlobalStylesProvider( {
 		[ contexts, content ]
 	);
 
-	useEffect( () => {
-		if (
-			typeof contexts !== 'object' ||
-			typeof baseStyles !== 'object' ||
-			typeof userStyles !== 'object'
-		) {
-			return;
-		}
-
-		const embeddedStylesheetId = 'global-styles-inline-css';
-		let styleNode = document.getElementById( embeddedStylesheetId );
-
-		if ( ! styleNode ) {
-			styleNode = document.createElement( 'style' );
-			styleNode.id = embeddedStylesheetId;
-			document
-				.getElementsByTagName( 'head' )[ 0 ]
-				.appendChild( styleNode );
-		}
-
-		styleNode.innerText = getGlobalStyles( contexts, mergedStyles );
-	}, [ contexts, baseStyles, content ] );
-
 	const settings = useSelect( ( select ) =>
 		select( 'core/edit-site' ).getSettings()
 	);
 	const { updateSettings } = useDispatch( 'core/edit-site' );
 
 	useEffect( () => {
+		const newStyles = settings.styles.filter( style => ! style.isGlobalStyles );
 		updateSettings( {
 			...settings,
+			styles: [
+				...newStyles,
+				{
+					css: getGlobalStyles( contexts, mergedStyles ),
+					isGlobalStyles: true
+				}
+			],
 			__experimentalFeatures: mapValues(
 				mergedStyles,
 				( value ) => value?.settings || {}
 			),
 		} );
-	}, [ mergedStyles ] );
+	}, [ contexts, mergedStyles ] );
 
 	return (
 		<GlobalStylesContext.Provider value={ nextValue }>

--- a/packages/edit-site/src/components/editor/global-styles-renderer.js
+++ b/packages/edit-site/src/components/editor/global-styles-renderer.js
@@ -141,18 +141,8 @@ export default ( blockData, tree ) => {
 		return flattenTree( blockCustom, '--wp--custom--', '--' );
 	};
 
-	const getBlockSelector = ( selector ) => {
-		// Can we hook into the styles generation mechanism
-		// so we can avoid having to increase the class specificity here
-		// and remap :root?
-		if ( ':root' === selector ) {
-			selector = '';
-		}
-		return `.editor-styles-wrapper.editor-styles-wrapper ${ selector }`;
-	};
-
 	Object.keys( blockData ).forEach( ( context ) => {
-		const blockSelector = getBlockSelector( blockData[ context ].selector );
+		const blockSelector = blockData[ context ].selector;
 
 		const blockDeclarations = [
 			...getBlockStylesDeclarations(


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/pull/26958#issuecomment-727985308

Global styles are passed via the settings.styles to all editors but edit-site. This is because, in edit-site, we need to recalculate the stylesheet upon user changes so we need to have a way to take a hold of it to update it. The way we implemented this was by adding a new embedded stylesheet node to the editor, called `global-styles-inline-css`. 

This is causing issues with some blocks ― for example, the HTML preview, that uses iframe. Potentially others as well (classic, shortcode, etc). This PR removes our custom mechanism and, instead, taps into the settings.styles _in the client_, so the existing editor wrapper mechanism takes is used.

## How to test

Test that it still works as expected:

- Install & activate TwentyTwentyOne blocks theme.
- Load the site editor and make sure global styles are applied.
- Change some style in TwentyTwentyOne blocks' theme.json and make sure it takes effect.
- Update some styles via the global styles sidebar and makes sure it takes effect.

Test that it fixes the issue with HTML block:

- Insert a HTML block.
- Add some content in uppercase
- See the preview and verify that the content renders a non-serif font.

Note that there's an issue by which the HTML block is missing some styles in edit-site (the input isn't styled) but this is a different issue, see https://github.com/WordPress/gutenberg/pull/27063