### PR TITLE
Interface: remove regions wrapper div

### DIFF
--- a/packages/components/src/higher-order/navigate-regions/index.js
+++ b/packages/components/src/higher-order/navigate-regions/index.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useCallback, useState, useRef } from '@wordpress/element';
+import { useCallback, useState, useRef, useEffect } from '@wordpress/element';
 import {
 	createHigherOrderComponent,
 	useKeyboardShortcut,
@@ -18,56 +18,64 @@ const defaultShortcuts = {
 	next: [ 'ctrl+`', rawShortcut.access( 'n' ) ],
 };
 
-export default createHigherOrderComponent( ( WrappedComponent ) => {
-	return ( { shortcuts = defaultShortcuts, ...props } ) => {
-		const container = useRef();
-		const [ isFocusingRegions, setIsFocusingRegions ] = useState( false );
-		const className = classnames( 'components-navigate-regions', {
-			'is-focusing-regions': isFocusingRegions,
-		} );
+export function useNavigateRegions( ref, shortcuts = defaultShortcuts ) {
+	const [ isFocusingRegions, setIsFocusingRegions ] = useState( false );
 
-		function focusRegion( offset ) {
-			const regions = Array.from(
-				container.current.querySelectorAll( '[role="region"]' )
-			);
-			if ( ! regions.length ) {
-				return;
-			}
-			let nextRegion = regions[ 0 ];
-			const selectedIndex = regions.indexOf(
-				container.current.ownerDocument.activeElement
-			);
-			if ( selectedIndex !== -1 ) {
-				let nextIndex = selectedIndex + offset;
-				nextIndex = nextIndex === -1 ? regions.length - 1 : nextIndex;
-				nextIndex = nextIndex === regions.length ? 0 : nextIndex;
-				nextRegion = regions[ nextIndex ];
-			}
-
-			nextRegion.focus();
-			setIsFocusingRegions( true );
+	function focusRegion( offset ) {
+		const regions = Array.from(
+			ref.current.querySelectorAll( '[role="region"]' )
+		);
+		if ( ! regions.length ) {
+			return;
 		}
-		const focusPrevious = useCallback( () => focusRegion( -1 ), [
-			container,
-		] );
-		const focusNext = useCallback( () => focusRegion( 1 ), [ container ] );
+		let nextRegion = regions[ 0 ];
+		const selectedIndex = regions.indexOf(
+			ref.current.ownerDocument.activeElement
+		);
+		if ( selectedIndex !== -1 ) {
+			let nextIndex = selectedIndex + offset;
+			nextIndex = nextIndex === -1 ? regions.length - 1 : nextIndex;
+			nextIndex = nextIndex === regions.length ? 0 : nextIndex;
+			nextRegion = regions[ nextIndex ];
+		}
 
-		useKeyboardShortcut( shortcuts.previous, focusPrevious, {
-			bindGlobal: true,
-		} );
-		useKeyboardShortcut( shortcuts.next, focusNext, { bindGlobal: true } );
+		nextRegion.focus();
+		setIsFocusingRegions( true );
+	}
+	const focusPrevious = useCallback( () => focusRegion( -1 ), [] );
+	const focusNext = useCallback( () => focusRegion( 1 ), [] );
 
-		// Disable reason: Clicking the editor should dismiss the regions focus style
-		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
+	useKeyboardShortcut( shortcuts.previous, focusPrevious, {
+		bindGlobal: true,
+	} );
+	useKeyboardShortcut( shortcuts.next, focusNext, { bindGlobal: true } );
+
+	useEffect( () => {
+		function onClick() {
+			setIsFocusingRegions( false );
+		}
+
+		ref.current.addEventListener( 'click', onClick );
+
+		return () => {
+			ref.current.removeEventListener( 'click', onClick );
+		};
+	}, [ setIsFocusingRegions ] );
+
+	return classnames( {
+		'is-focusing-regions': isFocusingRegions,
+	} );
+}
+
+export default createHigherOrderComponent(
+	( Component ) => ( { shortcuts, ...props } ) => {
+		const ref = useRef();
+		const className = useNavigateRegions( ref, shortcuts );
 		return (
-			<div
-				ref={ container }
-				className={ className }
-				onClick={ () => setIsFocusingRegions( false ) }
-			>
-				<WrappedComponent { ...props } />
+			<div ref={ ref } className={ className }>
+				<Component { ...props } />
 			</div>
 		);
-		/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
-	};
-}, 'navigateRegions' );
+	},
+	'navigateRegions'
+);

--- a/packages/components/src/higher-order/navigate-regions/index.js
+++ b/packages/components/src/higher-order/navigate-regions/index.js
@@ -1,12 +1,7 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
-import { useCallback, useState, useRef, useEffect } from '@wordpress/element';
+import { useCallback, useRef } from '@wordpress/element';
 import {
 	createHigherOrderComponent,
 	useKeyboardShortcut,
@@ -19,8 +14,6 @@ const defaultShortcuts = {
 };
 
 export function useNavigateRegions( ref, shortcuts = defaultShortcuts ) {
-	const [ isFocusingRegions, setIsFocusingRegions ] = useState( false );
-
 	function focusRegion( offset ) {
 		const regions = Array.from(
 			ref.current.querySelectorAll( '[role="region"]' )
@@ -40,7 +33,6 @@ export function useNavigateRegions( ref, shortcuts = defaultShortcuts ) {
 		}
 
 		nextRegion.focus();
-		setIsFocusingRegions( true );
 	}
 	const focusPrevious = useCallback( () => focusRegion( -1 ), [] );
 	const focusNext = useCallback( () => focusRegion( 1 ), [] );
@@ -49,30 +41,14 @@ export function useNavigateRegions( ref, shortcuts = defaultShortcuts ) {
 		bindGlobal: true,
 	} );
 	useKeyboardShortcut( shortcuts.next, focusNext, { bindGlobal: true } );
-
-	useEffect( () => {
-		function onClick() {
-			setIsFocusingRegions( false );
-		}
-
-		ref.current.addEventListener( 'click', onClick );
-
-		return () => {
-			ref.current.removeEventListener( 'click', onClick );
-		};
-	}, [ setIsFocusingRegions ] );
-
-	return classnames( {
-		'is-focusing-regions': isFocusingRegions,
-	} );
 }
 
 export default createHigherOrderComponent(
 	( Component ) => ( { shortcuts, ...props } ) => {
 		const ref = useRef();
-		const className = useNavigateRegions( ref, shortcuts );
+		useNavigateRegions( ref, shortcuts );
 		return (
-			<div ref={ ref } className={ className }>
+			<div ref={ ref }>
 				<Component { ...props } />
 			</div>
 		);

--- a/packages/components/src/higher-order/navigate-regions/style.scss
+++ b/packages/components/src/higher-order/navigate-regions/style.scss
@@ -1,4 +1,4 @@
-.is-focusing-regions [role="region"] {
+[role="region"] {
 	position: relative;
 
 	// For browsers that don't support outline-offset (IE11).

--- a/packages/components/src/higher-order/navigate-regions/style.scss
+++ b/packages/components/src/higher-order/navigate-regions/style.scss
@@ -1,4 +1,4 @@
-.components-navigate-regions.is-focusing-regions [role="region"] {
+.is-focusing-regions [role="region"] {
 	position: relative;
 
 	// For browsers that don't support outline-offset (IE11).

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -130,7 +130,10 @@ export {
 } from './slot-fill';
 
 // Higher-Order Components
-export { default as navigateRegions } from './higher-order/navigate-regions';
+export {
+	default as navigateRegions,
+	useNavigateRegions as __unstableUseNavigateRegions,
+} from './higher-order/navigate-regions';
 export { default as withConstrainedTabbing } from './higher-order/with-constrained-tabbing';
 export { default as withFallbackStyles } from './higher-order/with-fallback-styles';
 export { default as withFilters } from './higher-order/with-filters';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -29,6 +29,7 @@
 		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/element": "file:../element",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
+		"@wordpress/keycodes": "file:../keycodes",
 		"@wordpress/priority-queue": "file:../priority-queue",
 		"clipboard": "^2.0.1",
 		"lodash": "^4.17.19",

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -29,7 +29,6 @@
 		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/element": "file:../element",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
-		"@wordpress/keycodes": "file:../keycodes",
 		"@wordpress/priority-queue": "file:../priority-queue",
 		"clipboard": "^2.0.1",
 		"lodash": "^4.17.19",

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -45,7 +45,7 @@
 		}
 
 		// Keep it open on focus to avoid conflict with navigate-regions animation.
-		.is-focusing-regions & {
+		[role="region"]:focus & {
 			transform: translateX(0%);
 		}
 	}

--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -88,10 +88,6 @@ body.block-editor-page {
 	iframe {
 		width: 100%;
 	}
-
-	.components-navigate-regions {
-		height: 100%;
-	}
 }
 
 @include default-block-widths();

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -44,10 +44,6 @@ body.toplevel_page_gutenberg-edit-site {
 		min-height: calc(100vh - #{$admin-bar-height});
 	}
 
-	> .components-navigate-regions {
-		height: 100%;
-	}
-
 	// Todo: Remove this rule when edit site gets support
 	// for opening unpinned sidebar items.
 	.interface-complementary-area__pin-unpin-item.components-button {

--- a/packages/edit-widgets/src/style.scss
+++ b/packages/edit-widgets/src/style.scss
@@ -43,10 +43,6 @@ body.widgets-php {
 		min-height: calc(100vh - #{ $admin-bar-height });
 	}
 
-	> .components-navigate-regions {
-		height: 100%;
-	}
-
 	.interface-interface-skeleton__content {
 		background-color: #f1f1f1;
 	}

--- a/packages/interface/src/components/interface-skeleton/index.js
+++ b/packages/interface/src/components/interface-skeleton/index.js
@@ -46,8 +46,7 @@ function InterfaceSkeleton(
 
 	ref = ref || fallbackRef;
 
-	const regionsClassName = useNavigateRegions( ref, shortcuts );
-
+	useNavigateRegions( ref, shortcuts );
 	useHTMLClass( 'interface-interface-skeleton__html-container' );
 
 	const defaultLabels = {
@@ -82,9 +81,8 @@ function InterfaceSkeleton(
 		<div
 			ref={ ref }
 			className={ classnames(
-				'interface-interface-skeleton',
 				className,
-				regionsClassName
+				'interface-interface-skeleton'
 			) }
 		>
 			{ !! drawer && (

--- a/packages/interface/src/components/interface-skeleton/index.js
+++ b/packages/interface/src/components/interface-skeleton/index.js
@@ -6,8 +6,8 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useEffect } from '@wordpress/element';
-import { navigateRegions } from '@wordpress/components';
+import { forwardRef, useEffect, useRef } from '@wordpress/element';
+import { __unstableUseNavigateRegions as useNavigateRegions } from '@wordpress/components';
 import deprecated from '@wordpress/deprecated';
 import { __ } from '@wordpress/i18n';
 
@@ -25,19 +25,29 @@ function useHTMLClass( className ) {
 	}, [ className ] );
 }
 
-function InterfaceSkeleton( {
-	footer,
-	header,
-	sidebar,
-	secondarySidebar,
-	content,
-	drawer,
-	actions,
-	labels,
-	className,
-	// Deprecated props.
-	leftSidebar,
-} ) {
+function InterfaceSkeleton(
+	{
+		footer,
+		header,
+		sidebar,
+		secondarySidebar,
+		content,
+		drawer,
+		actions,
+		labels,
+		className,
+		// Deprecated props.
+		leftSidebar,
+		shortcuts,
+	},
+	ref
+) {
+	const fallbackRef = useRef();
+
+	ref = ref || fallbackRef;
+
+	const regionsClassName = useNavigateRegions( ref, shortcuts );
+
 	useHTMLClass( 'interface-interface-skeleton__html-container' );
 
 	const defaultLabels = {
@@ -70,9 +80,11 @@ function InterfaceSkeleton( {
 
 	return (
 		<div
+			ref={ ref }
 			className={ classnames(
+				'interface-interface-skeleton',
 				className,
-				'interface-interface-skeleton'
+				regionsClassName
 			) }
 		>
 			{ !! drawer && (
@@ -150,4 +162,4 @@ function InterfaceSkeleton( {
 	);
 }
 
-export default navigateRegions( InterfaceSkeleton );
+export default forwardRef( InterfaceSkeleton );

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -148,13 +148,6 @@ html.interface-interface-skeleton__html-container {
 	background-color: $white;
 	z-index: z-index(".interface-interface-skeleton__footer");
 
-	// When the navigate regions shortcut is used it applies position: relative
-	// to regions. The footer should always stay stuck to the bottom though, so
-	// override using a more specific selector with position: fixed.
-	.is-focusing-regions &[role="region"] {
-		position: fixed;
-	}
-
 	// On Mobile the footer is hidden
 	display: none;
 	@include break-medium() {

--- a/storybook/stories/playground/style.scss
+++ b/storybook/stories/playground/style.scss
@@ -22,10 +22,6 @@
 	iframe {
 		width: 100%;
 	}
-
-	.components-navigate-regions {
-		height: 100%;
-	}
 }
 
 .playground__sidebar {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

This PR removes the wrapper div of `navigateRegions` and transforms the HoC into a hook adding the **behaviour**.

There's no need for the `is-focusing-regions` because the `:focus` selector should be enough and no region element should unintentionally be focussed.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
