### PR TITLE
Site Editor: fix synchronization checks after template deletion

### DIFF
--- a/lib/templates-sync.php
+++ b/lib/templates-sync.php
@@ -167,7 +167,7 @@ add_action( 'trash_wp_template_part', 'gutenberg_clear_synchronize_last_checks' 
  * @param WP_Post $post WP_Post instance of the deleted post.
  */
 function gutenberg_clear_synchronize_last_checks_after_delete( $post_id, $post ) {
-	if ( 'wp_template' !== $post->post_type || 'wp_template_part' !== $post->post_type ) {
+	if ( 'wp_template' === $post->post_type || 'wp_template_part' === $post->post_type ) {
 		gutenberg_clear_synchronize_last_checks();
 	}
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description

This is a follow-up fix to https://github.com/WordPress/gutenberg/pull/26383. The function called on template delete action was checking for wrong post types.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

- Delete a customize template CPT.
- Verify that `gutenberg_last_synchronize_theme_template_checks` is empty.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
