### PR TITLE
Fix Separator editor styles

### DIFF
--- a/packages/block-library/src/separator/editor.scss
+++ b/packages/block-library/src/separator/editor.scss
@@ -2,9 +2,4 @@
 	// Prevent margin collapsing so the area to select the separator is bigger.
 	padding-top: 0.1px;
 	padding-bottom: 0.1px;
-
-	&.block-editor-block-list__block { // Needs specificity.
-		margin-top: 0;
-		margin-bottom: 0;
-	}
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Fixes: https://github.com/WordPress/gutenberg/issues/26808

Sequential Separator blocks in the editor overlap.This is caused because block wrappers were removed in the editor (check @tellthemachines 's comment here: https://github.com/WordPress/gutenberg/issues/26808#issuecomment-727675463)
<!-- Please describe what you have changed or added -->
