### PR TITLE
Site Editor: Fix synchronization error on Windows

### DIFF
--- a/lib/templates-sync.php
+++ b/lib/templates-sync.php
@@ -125,7 +125,7 @@ function _gutenberg_synchronize_theme_templates( $template_type ) {
 		$slug    = substr(
 			$path,
 			// Starting position of slug.
-			strpos( $path, $template_base_path . '/' ) + 1 + strlen( $template_base_path ),
+			strpos( $path, $template_base_path . DIRECTORY_SEPARATOR ) + 1 + strlen( $template_base_path ),
 			// Subtract ending '.html'.
 			-5
 		);


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/master/docs/contributors/repository-management.md#pull-requests. -->

## Description
Replaces hardcoded directory separator with the predefined constant: `DIRECTORY_SEPARATOR`

## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
