### PR TITLE
Add alignment controls to the featured image block

### DIFF
--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -13,6 +13,7 @@
 		"postType"
 	],
 	"supports": {
+		"align": [ "left", "right", "center", "wide", "full" ],
 		"html": false
 	}
 }


### PR DESCRIPTION
Adds left, right, center, wide, and full alignment options to the featured image block to bring it closer to be on par with the Image block. 

![Screen Shot 2020-11-18 at 1 37 35 PM](https://user-images.githubusercontent.com/1202812/99572952-6c668c00-29a3-11eb-96dd-a222a1e8fe72.png)
