### PR TITLE
Add: PHP util function equivalent to lodash set.

### DIFF
--- a/lib/utils.php
+++ b/lib/utils.php
@@ -31,3 +31,63 @@ function gutenberg_experimental_get( $array, $path, $default = array() ) {
 	}
 	return $array;
 }
+
+/**
+ * Sets an array in depth based on a path of keys.
+ *
+ * It is the PHP equivalent of JavaScript's `lodash.set()` and mirroring it may help other components
+ * retain some symmetry between client and server implementations.
+ *
+ * Example usage:
+ *
+ *     $array = array();
+ *     _wp_array_set( $array, array( 'a', 'b', 'c', 1 );
+ *     $array becomes:
+ *     array(
+ *         'a' => array(
+ *             'b' => array(
+ *                 'c' => 1,
+ *             ),
+ *         ),
+ *     );
+ *
+ * @param array $array   An array that we want to mutate to include a specific value in a path.
+ * @param array $path    An array of keys describing the path that we want to mutate.
+ * @param mixed $value   The value that will be set.
+ */
+function gutenberg_experimental_set( &$array, $path, $value = null ) {
+	// Confirm $array is valid.
+	if ( ! is_array( $array ) ) {
+		return;
+	}
+
+	// Confirm $path is valid.
+	if ( ! is_array( $path ) ) {
+		return;
+	}
+	$path_length = count( $path );
+	if ( 0 === $path_length ) {
+		return;
+	}
+	foreach ( $path as $path_element ) {
+		if (
+			! is_string( $path_element ) && ! is_integer( $path_element ) &&
+			! is_null( $path_element )
+		) {
+			return;
+		}
+	}
+
+	$i;
+	for ( $i = 0; $i < $path_length - 1; ++$i ) {
+		$path_element = $path[ $i ];
+		if (
+			! array_key_exists( $path_element, $array ) ||
+			! is_array( $array[ $path_element ] )
+		) {
+			$array[ $path_element ] = array();
+		}
+		$array = &$array[ $path_element ];
+	}
+	$array[ $path[ $i ] ] = $value;
+}

--- a/phpunit/class-gutenberg-utils-test.php
+++ b/phpunit/class-gutenberg-utils-test.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Test Gutenberg Utils.
+ *
+ * @package Gutenberg
+ */
+
+/**
+ * Test WP_Theme_JSON class.
+ *
+ * @package Gutenberg
+ */
+class Gutenberg_Utils_Test extends WP_UnitTestCase {
+	/**
+	 * Test gutenberg_experimental_set() with simple non subtree path.
+	 */
+	public function test_simple_not_subtree_set() {
+		$test_array = array();
+		gutenberg_experimental_set( $test_array, array( 'a' ), 1 );
+		$this->assertSame(
+			$test_array,
+			array( 'a' => 1 )
+		);
+
+		$test_array = array( 'a' => 2 );
+		gutenberg_experimental_set( $test_array, array( 'a' ), 3 );
+		$this->assertSame(
+			$test_array,
+			array( 'a' => 3 )
+		);
+
+		$test_array = array( 'b' => 1 );
+		gutenberg_experimental_set( $test_array, array( 'a' ), 3 );
+		$this->assertSame(
+			$test_array,
+			array(
+				'b' => 1,
+				'a' => 3,
+			)
+		);
+	}
+
+	/**
+	 * Test gutenberg_experimental_set() with subtree paths.
+	 */
+	public function test_subtree_set() {
+		$test_array = array();
+		gutenberg_experimental_set( $test_array, array( 'a', 'b', 'c' ), 1 );
+		$this->assertSame(
+			$test_array,
+			array( 'a' => array( 'b' => array( 'c' => 1 ) ) )
+		);
+
+		$test_array = array( 'b' => 3 );
+		gutenberg_experimental_set( $test_array, array( 'a', 'b', 'c' ), 1 );
+		$this->assertSame(
+			$test_array,
+			array(
+				'b' => 3,
+				'a' => array( 'b' => array( 'c' => 1 ) ),
+			)
+		);
+
+		$test_array = array(
+			'b' => 3,
+			'a' => 1,
+		);
+		gutenberg_experimental_set( $test_array, array( 'a', 'b', 'c' ), 1 );
+		$this->assertSame(
+			$test_array,
+			array(
+				'b' => 3,
+				'a' => array( 'b' => array( 'c' => 1 ) ),
+			)
+		);
+
+		$test_array = array(
+			'b' => 3,
+			'a' => array(),
+		);
+		gutenberg_experimental_set( $test_array, array( 'a', 'b', 'c' ), 1 );
+		$this->assertSame(
+			$test_array,
+			array(
+				'b' => 3,
+				'a' => array( 'b' => array( 'c' => 1 ) ),
+			)
+		);
+	}
+
+	/**
+	 * Test gutenberg_experimental_set() with invalid parameters.
+	 */
+	public function test_invalid_parameters_set() {
+		$test = 3;
+		gutenberg_experimental_set( $test, array( 'a' ), 1 );
+		$this->assertSame(
+			$test,
+			3
+		);
+
+		$test_array = array( 'a' => 2 );
+		gutenberg_experimental_set( $test_array, 'a', 3 );
+		$this->assertSame(
+			$test_array,
+			array( 'a' => 2 )
+		);
+
+		$test_array = array( 'a' => 2 );
+		gutenberg_experimental_set( $test_array, null, 3 );
+		$this->assertSame(
+			$test_array,
+			array( 'a' => 2 )
+		);
+
+		$test_array = array( 'a' => 2 );
+		gutenberg_experimental_set( $test_array, array(), 3 );
+		$this->assertSame(
+			$test_array,
+			array( 'a' => 2 )
+		);
+
+		$test_array = array( 'a' => 2 );
+		gutenberg_experimental_set( $test_array, array( 'a', array() ), 3 );
+		$this->assertSame(
+			$test_array,
+			array( 'a' => 2 )
+		);
+	}
+}


### PR DESCRIPTION
This PR adds a lodash set equivalent. We already have a lodash get equivalent. Having a set equivalent will be useful to for example apply a new preset etc.

## How has this been tested?
I verified the PHP unit tests pass.
