### PR TITLE
Global Styles: keep core and theme preset variables and classes even if they are overwritten

### DIFF
--- a/packages/edit-site/src/components/editor/global-styles-renderer.js
+++ b/packages/edit-site/src/components/editor/global-styles-renderer.js
@@ -64,13 +64,21 @@ export default ( blockData, tree, metadata ) => {
 	 *
 	 * @param {string} blockSelector
 	 * @param {Object} blockPresets
+	 * @param {Object} deactivatedPresets
 	 * @return {string} CSS declarations for the preset classes.
 	 */
-	const getBlockPresetClasses = ( blockSelector, blockPresets = {} ) => {
+	const getBlockPresetClasses = (
+		blockSelector,
+		blockPresets = {},
+		deactivatedPresets = {}
+	) => {
 		return reduce(
 			PRESET_CLASSES,
 			( declarations, { path, key, property }, classSuffix ) => {
-				const presets = get( blockPresets, path, [] );
+				const presets = [
+					...get( deactivatedPresets, path, [] ),
+					...get( blockPresets, path, [] ),
+				];
 				presets.forEach( ( preset ) => {
 					const slug = preset.slug;
 					const value = preset[ key ];
@@ -88,14 +96,21 @@ export default ( blockData, tree, metadata ) => {
 	 * Transform given preset tree into a set of style declarations.
 	 *
 	 * @param {Object} blockPresets
+	 * @param {Object} deactivatedPresets
 	 *
 	 * @return {Array} An array of style declarations.
 	 */
-	const getBlockPresetsDeclarations = ( blockPresets = {} ) => {
+	const getBlockPresetsDeclarations = (
+		blockPresets = {},
+		deactivatedPresets = {}
+	) => {
 		return reduce(
 			PRESET_CATEGORIES,
 			( declarations, { path, key }, category ) => {
-				const preset = get( blockPresets, path, [] );
+				const preset = [
+					...get( deactivatedPresets, path, [] ),
+					...get( blockPresets, path, [] ),
+				];
 				preset.forEach( ( value ) => {
 					declarations.push(
 						`--wp--preset--${ kebabCase( category ) }--${
@@ -144,7 +159,10 @@ export default ( blockData, tree, metadata ) => {
 				blockData[ context ].supports,
 				tree?.[ context ]?.styles
 			),
-			...getBlockPresetsDeclarations( tree?.[ context ]?.settings ),
+			...getBlockPresetsDeclarations(
+				tree?.[ context ]?.settings,
+				tree?.[ context ]?.deactivatedSettings
+			),
 			...getCustomDeclarations( tree?.[ context ]?.settings?.custom ),
 		];
 		if ( blockDeclarations.length > 0 ) {
@@ -155,7 +173,8 @@ export default ( blockData, tree, metadata ) => {
 
 		const presetClasses = getBlockPresetClasses(
 			blockSelector,
-			tree?.[ context ]?.settings
+			tree?.[ context ]?.settings,
+			tree?.[ context ]?.deactivatedSettings
 		);
 		if ( presetClasses ) {
 			styles.push( presetClasses );

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -458,6 +458,20 @@ class WP_Theme_JSON_Test extends WP_UnitTestCase {
 						'fontSize' => '12',
 					),
 				),
+				'deactivatedSettings' => array(
+					'color' => array(
+						'palette' => array(
+							array(
+								'slug'  => 'red',
+								'color' => 'red',
+							),
+							array(
+								'slug'  => 'blue',
+								'color' => 'blue',
+							),
+						),
+					),
+				),
 			),
 			'core/paragraph' => array(
 				'selector' => 'p',


### PR DESCRIPTION
Depends on: https://github.com/WordPress/gutenberg/pull/27077

This PR makes sure core and global styles preset variables and classes are kept even if they are overwritten.

Users may change or delete the presets, and the UI (e.g: color palette) should reflect that. But if the theme is using the preset variable in other place we should not break the theme and should still have the variable present. This PR makes sure the variables and classes are always present.

## How has this been tested?
I added the 2021 blocks theme.
I deleted the preset background color.
I verified the background color was still applied,