### PR TITLE
Update: Include px units on default font sizes defined on theme.json

### DIFF
--- a/lib/experimental-default-theme.json
+++ b/lib/experimental-default-theme.json
@@ -138,27 +138,27 @@
 					{
 						"name": "Small",
 						"slug": "small",
-						"size": 13
+						"size": "13px"
 					},
 					{
 						"name": "Normal",
 						"slug": "normal",
-						"size": 16
+						"size": "16px"
 					},
 					{
 						"name": "Medium",
 						"slug": "medium",
-						"size": 20
+						"size": "20px"
 					},
 					{
 						"name": "Large",
 						"slug": "large",
-						"size": 36
+						"size": "36px"
 					},
 					{
 						"name": "Huge",
 						"slug": "huge",
-						"size": 42
+						"size": "42px"
 					}
 				],
 				"fontStyles": [

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/font-size-picker.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/font-size-picker.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Font Size Picker should apply a custom font size using the font size input 1`] = `
-"<!-- wp:paragraph {\\"style\\":{\\"typography\\":{\\"fontSize\\":23}}} -->
+"<!-- wp:paragraph {\\"style\\":{\\"typography\\":{\\"fontSize\\":\\"23px\\"}}} -->
 <p style=\\"font-size:23px\\">Paragraph to be made \\"small\\"</p>
 <!-- /wp:paragraph -->"
 `;


### PR DESCRIPTION
Now we require that font sizes on theme.json contain the units, but we missed an update to the default theme.json file. This PR makes the update.
